### PR TITLE
chore: bump versions to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,7 +1814,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-bench"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap 4.5.60",
@@ -1867,14 +1867,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-config"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-kv-router"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "aho-corasick",
  "aligned-vec",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-mocker"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "dashmap 6.1.0",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "bs58",
  "bytemuck",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-kernels"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "clap 4.5.60",
  "cudarc",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-logical"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3944,7 +3944,7 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libdynamo_llm"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-once-cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.0"
+version = "1.0.0"
 edition = "2024"
 description = "Dynamo Inference Framework"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
@@ -33,18 +33,17 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 
 [workspace.dependencies]
 # Local crates
-dynamo-runtime = { path = "lib/runtime", version = "0.9.0" }
-dynamo-llm = { path = "lib/llm", version = "0.9.0" }
-dynamo-config = { path = "lib/config", version = "0.9.0" }
-dynamo-tokens = { path = "lib/tokens", version = "0.9.0" }
-dynamo-memory = { path = "lib/memory", version = "0.9.0" }
-dynamo-mocker = { path = "lib/mocker", version = "0.9.0" }
-dynamo-kv-router = { path = "lib/kv-router", version = "0.9.0", features = ["metrics"] }
-dynamo-async-openai = { path = "lib/async-openai", version = "0.9.0", features = ["byot"] }
-dynamo-parsers = { path = "lib/parsers", version = "0.9.0" }
-kvbm-kernels = { path = "lib/kvbm-kernels", version = "0.9.0" }
-kvbm-logical = { path = "lib/kvbm-logical", version = "0.9.0" }
-
+dynamo-runtime = { path = "lib/runtime", version = "1.0.0" }
+dynamo-llm = { path = "lib/llm", version = "1.0.0" }
+dynamo-config = { path = "lib/config", version = "1.0.0" }
+dynamo-tokens = { path = "lib/tokens", version = "1.0.0" }
+dynamo-memory = { path = "lib/memory", version = "1.0.0" }
+dynamo-mocker = { path = "lib/mocker", version = "1.0.0" }
+dynamo-kv-router = { path = "lib/kv-router", version = "1.0.0", features = ["metrics"] }
+dynamo-async-openai = { path = "lib/async-openai", version = "1.0.0", features = ["byot"] }
+dynamo-parsers = { path = "lib/parsers", version = "1.0.0" }
+kvbm-kernels = { path = "lib/kvbm-kernels", version = "1.0.0" }
+kvbm-logical = { path = "lib/kvbm-logical", version = "1.0.0" }
 # External dependencies
 anyhow = { version = "1" }
 async-nats = { version = "0.45.0", features = ["service"] }

--- a/deploy/helm/charts/platform/Chart.yaml
+++ b/deploy/helm/charts/platform/Chart.yaml
@@ -19,11 +19,11 @@ maintainers:
     url: https://www.nvidia.com
 description: A Helm chart for NVIDIA Dynamo Platform.
 type: application
-version: 1.0.0-dev
+version: 1.0.0
 home: https://nvidia.com
 dependencies:
   - name: dynamo-operator
-    version: 1.0.0-dev
+    version: 1.0.0
     repository: file://components/operator
     condition: dynamo-operator.enabled
   - name: nats

--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -97,7 +97,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://components/operator | dynamo-operator | 1.0.0-dev |
+| file://components/operator | dynamo-operator | 1.0.0 |
 | https://charts.bitnami.com/bitnami | etcd | 12.0.18 |
 | https://nats-io.github.io/k8s/helm/charts/ | nats | 1.3.2 |
 | oci://ghcr.io/ai-dynamo/grove | grove(grove-charts) | v0.1.0-alpha.6 |

--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 A Helm chart for NVIDIA Dynamo Platform.
 
-![Version: 1.0.0-dev](https://img.shields.io/badge/Version-1.0.0--dev-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## 🚀 Overview
 

--- a/deploy/helm/charts/platform/components/operator/Chart.yaml
+++ b/deploy/helm/charts/platform/components/operator/Chart.yaml
@@ -27,9 +27,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0-dev
+version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0-dev"
+appVersion: "1.0.0"

--- a/deploy/operator/internal/featuregate/gates.go
+++ b/deploy/operator/internal/featuregate/gates.go
@@ -25,9 +25,9 @@ import semver "github.com/Masterminds/semver/v3"
 var (
 	// VLLMMultiprocessing gates the use of vLLM native multiprocessing (mp)
 	// instead of Ray for multi-node deployments. Enabled for DGDs originally
-	// created by operator >= 1.0.0-dev.
+	// created by operator >= 1.0.0.
 	VLLMMultiprocessing = OperatorOriginFeatureGate{
 		Name:             "VLLMMultiprocessing",
-		MinOriginVersion: *semver.MustParse("1.0.0-dev"),
+		MinOriginVersion: *semver.MustParse("1.0.0"),
 	}
 )

--- a/deploy/operator/internal/featuregate/operator_origin_test.go
+++ b/deploy/operator/internal/featuregate/operator_origin_test.go
@@ -27,7 +27,7 @@ import (
 func TestOperatorOriginFeatureGate_IsEnabled(t *testing.T) {
 	gate := OperatorOriginFeatureGate{
 		Name:             "TestFeature",
-		MinOriginVersion: *semver.MustParse("1.0.0-dev"),
+		MinOriginVersion: *semver.MustParse("1.0.0"),
 	}
 
 	tests := []struct {
@@ -55,7 +55,7 @@ func TestOperatorOriginFeatureGate_IsEnabled(t *testing.T) {
 		{
 			name: "origin version at threshold = enabled",
 			annotations: map[string]string{
-				consts.KubeAnnotationDynamoOperatorOriginVersion: "1.0.0-dev",
+				consts.KubeAnnotationDynamoOperatorOriginVersion: "1.0.0",
 			},
 			want: true,
 		},

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -790,7 +790,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					Name:      "test-graph",
 					Namespace: "default",
 					Annotations: map[string]string{
-						consts.KubeAnnotationDynamoOperatorOriginVersion: "1.0.0-dev",
+						consts.KubeAnnotationDynamoOperatorOriginVersion: "1.0.0",
 					},
 				},
 				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentSpec{

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1481,7 +1481,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -1508,14 +1508,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-config"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-kv-router"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "aho-corasick",
  "aligned-vec",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-mocker"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "dashmap 6.1.0",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "bs58",
  "bytemuck",
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-py3"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "cudarc",

--- a/lib/bindings/kvbm/Cargo.toml
+++ b/lib/bindings/kvbm/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "kvbm-py3"
-version = "0.9.0"
+version = "1.0.0"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/bindings/kvbm/pyproject.toml
+++ b/lib/bindings/kvbm/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "kvbm"
-version = "0.9.0"
+version = "1.0.0"
 description = "Dynamo KVBM"
 readme = "README.md"
 authors = [

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1489,7 +1489,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -1516,14 +1516,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-config"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-kv-router"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "aho-corasick",
  "aligned-vec",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-mocker"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "dashmap 6.1.0",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-py3"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "bs58",
  "bytemuck",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "dynamo-py3"
-version = "0.9.0"
+version = "1.0.0"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "ai-dynamo-runtime"
-version = "0.9.0"
+version = "1.0.0"
 description = "Dynamo Inference Framework Runtime"
 readme = "README.md"
 authors = [

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -799,14 +799,14 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamo-config"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1304,7 +1304,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello_world"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "dynamo-runtime",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "service_metrics"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "dynamo-runtime",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "system_metrics"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "dynamo-runtime",

--- a/lib/runtime/examples/Cargo.toml
+++ b/lib/runtime/examples/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.0"
+version = "1.0.0"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "ai-dynamo"
-version = "0.9.0"
+version = "1.0.0"
 description = "Distributed Inference Framework"
 readme = "README.md"
 authors = [
@@ -13,7 +13,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "ai-dynamo-runtime==0.9.0",
+    "ai-dynamo-runtime==1.0.0",
     "transformers>=4.56.0",
     "pytest>=8.3.4",
     "types-psutil>=7.0.0.20250218",


### PR DESCRIPTION
#### Overview:

Bump version of project ahead of `release/1.0.0` branch cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all package versions to 1.0.0 across Rust crates and Python bindings.
  * Updated Helm chart and operator versions to 1.0.0.
  * Updated feature gate version thresholds to 1.0.0.
  * Added new local crate dependencies for kernels and logical components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->