### PR TITLE
chore(deps): bump vLLM to 0.16.0

### DIFF
--- a/components/src/dynamo/vllm/omni/base_handler.py
+++ b/components/src/dynamo/vllm/omni/base_handler.py
@@ -27,7 +27,6 @@ class BaseOmniHandler(BaseWorkerHandler):
     def __init__(
         self,
         runtime,
-        component,
         config,
         default_sampling_params: Dict[str, Any],
         shutdown_event: asyncio.Event | None = None,
@@ -36,7 +35,6 @@ class BaseOmniHandler(BaseWorkerHandler):
 
         Args:
             runtime: Dynamo distributed runtime.
-            component: Dynamo component handle.
             config: Parsed Config object from args.py.
             default_sampling_params: Default sampling parameters dict.
             shutdown_event: Optional asyncio event for graceful shutdown.
@@ -56,7 +54,6 @@ class BaseOmniHandler(BaseWorkerHandler):
         # TODO: Kv publishers not supported yet
         # TODO: Adopt to baseworker initialization pattern
         self.runtime = runtime
-        self.component = component
         self.default_sampling_params = default_sampling_params
         self.config = config
         self.model_max_len = config.engine_args.max_model_len

--- a/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
@@ -144,7 +144,6 @@ class TestVllmRendererApi:
             "role",
             "content",
             "reasoning",
-            "reasoning_content",
             "tool_calls",
         }
         actual_fields = set(DeltaMessage.model_fields)
@@ -376,6 +375,7 @@ class TestVllmRendererApi:
             "trace_headers",
             "resumable",
             "external_req_id",
+            "reasoning_ended",
         )
         # vllm-omni monkey-patches EngineCoreRequest with an extra field
         # (only installed on amd64, not arm64)
@@ -401,6 +401,7 @@ class TestVllmRendererApi:
             "kv_transfer_params",
             "trace_headers",
             "num_cached_tokens",
+            "num_external_computed_tokens",
             "routed_experts",
             "num_nans_in_logits",
         )

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -42,9 +42,9 @@ vllm:
   cuda13.0:
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
     runtime_image_tag: 13.0.2-runtime-ubuntu24.04
-  vllm_ref: v0.15.1
-  flashinf_ref: v0.6.1
-  lmcache_ref: 0.3.13
+  vllm_ref: v0.16.0
+  flashinf_ref: v0.6.3
+  lmcache_ref: 0.3.14
   vllm_omni_ref: "0.14.0"
   max_jobs: "10"
   enable_media_ffmpeg: "false"

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -45,7 +45,7 @@ vllm:
   vllm_ref: v0.16.0
   flashinf_ref: v0.6.3
   lmcache_ref: 0.3.14
-  vllm_omni_ref: "0.14.0"
+  vllm_omni_ref: "v0.16.0rc1"
   max_jobs: "10"
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"

--- a/docs/pages/backends/vllm/vllm-omni.md
+++ b/docs/pages/backends/vllm/vllm-omni.md
@@ -10,6 +10,14 @@ Dynamo supports multimodal generation through the [vLLM-Omni](https://github.com
 
 This guide assumes familiarity with deploying Dynamo with vLLM as described in the [vLLM backend guide](/docs/pages/backends/vllm/README.md).
 
+### Installation
+
+Dynamo container images include vLLM-Omni pre-installed. If you are using `pip install ai-dynamo[vllm]`, vLLM-Omni is **not** included automatically because the matching release is not yet available on PyPI. Install it separately from source:
+
+```bash
+pip install git+https://github.com/vllm-project/vllm-omni.git@v0.16.0rc1
+```
+
 ## Supported Modalities
 
 | Modality | Endpoint(s) | `--output-modalities` |

--- a/docs/pages/reference/support-matrix.md
+++ b/docs/pages/reference/support-matrix.md
@@ -14,7 +14,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.9` | `1.3.0rc5` | `0.15.1` | `0.10.0` |
+| **main (ToT)** | `0.5.9` | `1.3.0rc5` | `0.16.0` | `0.10.0` |
 | **v1.0.0** *(in progress)* | `0.5.9` | `1.3.0rc5` | `0.15.1` | `0.10.1` |
 | **v0.9.1** | `0.5.8` | `1.3.0rc3` | `0.14.1` | `0.9.0` |
 | **v0.9.0** *(in progress)* | `0.5.8` | `1.3.0rc1` | `0.14.1` | `0.9.0` |

--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/connector_leader.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/connector_leader.py
@@ -74,10 +74,8 @@ class KvConnectorLeader:
         consolidator_output_endpoint = None
         self._consolidator_output_port = None
 
-        if (
-            hasattr(vllm_config, "consolidator_endpoints")
-            and vllm_config.consolidator_endpoints
-        ):
+        _consolidator_eps = vllm_config.additional_config.get("consolidator_endpoints")
+        if _consolidator_eps:
             # Unpack all three endpoints
             # [0]: vllm_endpoint (for consolidator to subscribe to vLLM)
             # [1]: output_bind_endpoint (for consolidator to bind/publish)
@@ -86,7 +84,7 @@ class KvConnectorLeader:
                 consolidator_vllm_endpoint,
                 consolidator_output_endpoint,
                 _consolidator_output_connect_endpoint,  # Not needed here
-            ) = vllm_config.consolidator_endpoints
+            ) = _consolidator_eps
             self._consolidator_output_port = int(
                 consolidator_output_endpoint.split(":")[-1]
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ trtllm =[
 vllm = [
     "uvloop",
     "nixl[cu12]<=0.9.0",
-    "vllm[flashinfer,runai]==0.15.1",
+    "vllm[flashinfer,runai]==0.16.0",
     "vllm-omni==0.14.0",
     "blake3>=1.0.0,<2.0.0",
 ]
@@ -188,6 +188,7 @@ filterwarnings = [
     "ignore:.*Exception ignored in.*:pytest.PytestUnraisableExceptionWarning", # Ignore unraisable exception warnings
     "ignore:The pynvml package is deprecated.*:FutureWarning", # Ignore pynvml deprecation warning, temporary until upstream library updates to nvidia-ml-py
     "ignore:The behavior of DataFrame concatenation with empty or all-NA entries is deprecated.*:FutureWarning", # pandas 2.x concat deprecation in AIC SDK TODO: fix in AIC
+    "ignore:Automatic KV events configuration is deprecated.*:FutureWarning", # Ignore Dynamo's own KV events deprecation warning in tests
     # Pydantic V2 deprecation warnings from TRTLLM dependencies (raised at import time during collection)
     "ignore:Support for class-based `config`.*:pydantic.warnings.PydanticDeprecatedSince20",
     "ignore:Using extra keyword arguments on `Field`.*:pydantic.warnings.PydanticDeprecatedSince20",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,10 @@ vllm = [
     "uvloop",
     "nixl[cu12]<=0.9.0",
     "vllm[flashinfer,runai]==0.16.0",
-    "vllm-omni==0.14.0",
+    # vllm-omni 0.16.0rc1 is not on PyPI; installed from source in container builds
+    # (see container/deps/vllm/install_vllm.sh). pip install ai-dynamo[vllm] will
+    # not include vllm-omni — install it separately from source if needed.
+    # "vllm-omni==0.16.0rc1",
     "blake3>=1.0.0,<2.0.0",
 ]
 


### PR DESCRIPTION
## Summary
- Bump vLLM from 0.15.1 to 0.16.0 (483 commits upstream)
- Update FlashInfer from 0.6.1 to 0.6.3
- Update LMCache from 0.3.13 to 0.3.14
- Unify `install_vllm.sh` to try PyPI first, fall back to GitHub release (for both CUDA 12 and CUDA 13)
- Fix vLLM 0.16.0 API contract changes in tests

## Changes
| File | Change |
|------|--------|
| `container/context.yaml` | `vllm_ref` v0.15.1 → v0.16.0, `flashinf_ref` v0.6.1 → v0.6.3, `lmcache_ref` 0.3.13 → 0.3.14 |
| `container/deps/vllm/install_vllm.sh` | Version defaults updated; unified PyPI-first + GitHub-fallback install for cu12/cu13 |
| `pyproject.toml` | `vllm[flashinfer,runai]==0.16.0`; added FutureWarning filter for KV events deprecation |
| `docs/pages/reference/support-matrix.md` | main (ToT): 0.15.1 → 0.16.0 |
| `test_vllm_renderer_api.py` | Updated field contracts: `-reasoning_content`, `+reasoning_ended`, `+num_external_computed_tokens` |

## vLLM 0.16.0 API changes detected
- `DeltaMessage`: `reasoning_content` field removed (only `reasoning` remains)
- `EngineCoreRequest`: `reasoning_ended` field added
- `EngineCoreOutput`: `num_external_computed_tokens` field added

## Note on PyPI availability
vLLM 0.16.0 is not yet published to PyPI (GitHub release assets are available). The updated `install_vllm.sh` now tries PyPI first and falls back to GitHub release wheels for both CUDA 12 and CUDA 13, so container builds will work regardless.

## Test plan
- [x] Pre-bump validation: vLLM unit tests — **138 passed, 1 skipped**
- [x] Pre-bump validation: KVBM + vLLM import tests — **8 passed**
- [x] Pre-bump validation: `deploy/sanity_check.py` — all green
- [ ] Pre-bump validation: e2e gpu_1 tests — **running** (87/176 scenarios completed, no failures observed)
- [ ] CI pipeline validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reasoning state tracking and external token metrics in API responses.

* **Chores**
  * Upgraded vLLM to v0.16.0, FlashInfer to v0.6.3, and LMCache to v0.3.14.
  * Improved installation process with GitHub release fallback mechanism.

* **Documentation**
  * Updated compatibility matrix for latest component versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->