### PR TITLE
fix: guided decoding arg placement, None guard, test cleanup

### DIFF
--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -198,6 +198,17 @@ class DynamoTrtllmArgGroup(ArgGroup):
             help="Maximum size of downloadable embedding files/Image URLs.",
         )
 
+        # --- Guided Decoding ---
+        add_argument(
+            g,
+            flag_name="--guided-decoding-backend",
+            env_var="DYN_TRTLLM_GUIDED_DECODING_BACKEND",
+            default=None,
+            choices=["xgrammar", "llguidance"],
+            help="Backend to use for guided decoding (structured output). "
+            "Options: xgrammar, llguidance.",
+        )
+
         diffusion_group = parser.add_argument_group(
             "Diffusion Options [Experimental]",
             "Options for video_diffusion modality",
@@ -409,17 +420,6 @@ class DynamoTrtllmArgGroup(ArgGroup):
             arg_type=int,
             help="FSDP size for DiT.",
         )
-        # --- Guided Decoding ---
-        add_argument(
-            g,
-            flag_name="--guided-decoding-backend",
-            env_var="DYN_TRTLLM_GUIDED_DECODING_BACKEND",
-            default=None,
-            choices=["xgrammar", "llguidance"],
-            help="Backend to use for guided decoding (structured output). "
-            "Options: xgrammar, llguidance.",
-        )
-
         add_negatable_bool_argument(
             diffusion_group,
             flag_name="--enable-async-cpu-offload",

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -883,7 +883,9 @@ class HandlerBase(BaseGenerativeHandler):
             regex = guided_decoding.get("regex")
             choice = guided_decoding.get("choice")
             if choice and not regex:
-                regex = "(" + "|".join(re.escape(c) for c in choice) + ")"
+                valid_choices = [c for c in choice if c is not None]
+                if valid_choices:
+                    regex = "(" + "|".join(re.escape(c) for c in valid_choices) + ")"
 
             overrides["guided_decoding"] = GuidedDecodingParams(
                 json=guided_decoding.get("json"),


### PR DESCRIPTION
## Summary

Follow-up to PR #5762 addressing review comments from @nv-yna:

- **Move `--guided-decoding-backend` arg to correct group**: Was placed in the Diffusion Options section but uses the main `g` (Dynamo TRT-LLM Options) group. Moved it to sit with other TRT-LLM options, before the diffusion group.
- **Guard against `None` items in choice list**: The choice→regex conversion now filters out `None` items, preventing `re.escape(None)` TypeError. If all items are `None`, no regex is produced.
- **Move `import re` to top-level in test file**: Was imported inline inside `test_choice_with_special_chars_escaped`; moved to module-level imports per convention.
- **Add tests for None-item handling**: Two new tests verify that `None` items in choice lists are properly filtered.

## Test plan

- [ ] Verify `--guided-decoding-backend` appears under "Dynamo TRT-LLM Options" in `--help`
- [ ] Verify unit tests pass: `pytest components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py -v`
- [ ] Verify `choice: [None, "yes", None, "no"]` produces regex `(yes|no)`
- [ ] Verify `choice: [None, None]` produces no regex

Signed-off-by: Yifan Jiang <yifanj@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guided decoding to properly handle and filter out invalid choice values, ensuring correct behavior in edge cases.

* **Refactor**
  * Reorganized command-line interface options, relocating the guided decoding backend flag to the primary options group.

* **Tests**
  * Added test coverage for edge cases in guided decoding choice handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->