### PR TITLE
fix: downgrade noisy INFO logs in tool parser and KV router scheduler to DEBUG

### DIFF
--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -463,7 +463,7 @@ impl WorkerSelector for DefaultWorkerSelector {
 
                 worker_logits.insert(worker, logit);
 
-                tracing::info!(
+                tracing::debug!(
                     "Formula for worker_id={} dp_rank={:?} with {overlap} cached blocks: {logit:.3} \
                      = {overlap_weight:.1} * prefill_blocks + decode_blocks \
                      = {overlap_weight:.1} * {potential_prefill_block:.3} + {decode_block:.3}",

--- a/lib/parsers/src/tool_calling/tools.rs
+++ b/lib/parsers/src/tool_calling/tools.rs
@@ -16,9 +16,9 @@ pub async fn try_tool_call_parse_aggregate(
     Option<String>,
 )> {
     if parser_str.is_none() {
-        tracing::info!("No tool parser provided. Trying parsing with default parser.");
+        tracing::debug!("No tool parser provided. Trying parsing with default parser.");
     } else {
-        tracing::info!("Using tool parser: {:?}", parser_str);
+        tracing::debug!("Using tool parser: {:?}", parser_str);
     }
     let (parsed, content) = detect_and_parse_tool_call(message, parser_str, tools).await?;
     if parsed.is_empty() {


### PR DESCRIPTION
## Summary

- Downgrade two `tracing::info!` calls to `tracing::debug!` that emit at extremely high frequency in production but provide no actionable information at INFO level
- These two log patterns account for ~93% of frontend log volume, making log aggregation expensive and burying genuinely useful logs

### Changes

- **`lib/parsers/src/tool_calling/tools.rs`** — `try_tool_call_parse_aggregate` is called once per streaming chunk (and up to 3× per chunk when a tool call is detected), not once per request. With token-at-a-time streaming this means the parser selection message fires for every generated token. In production this produces incredibly excessive logs.
- **`lib/llm/src/kv_router/scheduler.rs`** — scoring formula logged for every worker × dp_rank candidate in the selection loop on every scheduling decision, not once per request.

Messages remain available via `RUST_LOG=debug` or per-module log level configuration.

Closes #6621