### PR TITLE
chore: migrate vllm e/p/d test from gpu_2 -> gpu_1

### DIFF
--- a/examples/backends/vllm/launch/disagg_multimodal_epd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_epd.sh
@@ -11,8 +11,9 @@ MODEL_NAME="llava-hf/llava-1.5-7b-hf"
 # This is intended for functional testing with small models (e.g. 2B) where CI
 # only has 1 GPU available. It reduces performance by:
 #   - Enabling --enforce-eager (disables torch.compile and CUDA graph capture)
-#   - Limiting --max-model-len to 4096 tokens
+#   - Limiting --max-model-len to 4096 tokens on P/D workers
 #   - Skipping multimodal encoder profiling (--skip-mm-prof)
+#   - Limiting P/D workers to image=1,video=0,audio=0 (--limit-mm-per-prompt)
 #   - Using lower gpu-memory-utilization fractions to share the GPU
 SINGLE_GPU=false
 
@@ -82,7 +83,7 @@ DYN_DECODE_GPU_MEM=${DYN_DECODE_GPU_MEM:-0.9}
 
 if [[ "$SINGLE_GPU" == "true" ]]; then
     EXTRA_ARGS="--enforce-eager --skip-mm-prof"
-    PD_EXTRA_ARGS="--max-model-len 4096"
+    PD_EXTRA_ARGS='--max-model-len 4096 --limit-mm-per-prompt {"image":1,"video":0,"audio":0}'
 fi
 
 # Start encode worker

--- a/examples/backends/vllm/launch/disagg_multimodal_epd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_epd.sh
@@ -8,6 +8,8 @@ trap 'echo Cleaning up...; kill 0' EXIT
 MODEL_NAME="llava-hf/llava-1.5-7b-hf"
 
 # Parse command line arguments
+# All extra arguments are passed through to each worker's dynamo.vllm
+EXTRA_ARGS=()
 while [[ $# -gt 0 ]]; do
     case $1 in
         --model)
@@ -15,7 +17,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -h|--help)
-            echo "Usage: $0 [OPTIONS]"
+            echo "Usage: $0 [OPTIONS] [EXTRA_ARGS...]"
             echo ""
             echo "Disaggregated multimodal serving with separate Encode/Prefill/Decode workers"
             echo ""
@@ -24,17 +26,19 @@ while [[ $# -gt 0 ]]; do
             echo "                                LLaVA 1.5 7B, Qwen2.5-VL, and Phi3V models have predefined templates"
             echo "  -h, --help                    Show this help message"
             echo ""
+            echo "All additional arguments are passed through to each worker's dynamo.vllm."
+            echo ""
             echo "Examples:"
             echo "  $0 --model llava-hf/llava-1.5-7b-hf"
             echo "  $0 --model microsoft/Phi-3.5-vision-instruct"
             echo "  $0 --model Qwen/Qwen2.5-VL-7B-Instruct"
+            echo "  $0 --model Qwen/Qwen3-VL-2B-Instruct --enforce-eager --max-model-len 4096"
             echo ""
             exit 0
             ;;
         *)
-            echo "Unknown option: $1"
-            echo "Use --help for usage information"
-            exit 1
+            EXTRA_ARGS+=("$1")
+            shift
             ;;
     esac
 done
@@ -52,8 +56,6 @@ echo "Starting frontend..."
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
 python -m dynamo.frontend &
 
-EXTRA_ARGS="${DYN_EXTRA_VLLM_ARGS:-}"
-
 # GPU assignments (override via environment variables)
 DYN_ENCODE_WORKER_GPU=${DYN_ENCODE_WORKER_GPU:-0}
 DYN_PREFILL_WORKER_GPU=${DYN_PREFILL_WORKER_GPU:-1}
@@ -66,17 +68,17 @@ DYN_DECODE_GPU_MEM=${DYN_DECODE_GPU_MEM:-0.9}
 
 # Start encode worker
 echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (GPU mem: $DYN_ENCODE_GPU_MEM)..."
-VLLM_NIXL_SIDE_CHANNEL_PORT=20097 CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU python -m dynamo.vllm --multimodal-encode-worker --enable-multimodal --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080"}' &
+VLLM_NIXL_SIDE_CHANNEL_PORT=20097 CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU python -m dynamo.vllm --multimodal-encode-worker --enable-multimodal --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM "${EXTRA_ARGS[@]}" --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080"}' &
 
 # Start prefill worker (also handles encode routing via --route-to-encoder)
 echo "Starting prefill worker on GPU $DYN_PREFILL_WORKER_GPU (GPU mem: $DYN_PREFILL_GPU_MEM)..."
 VLLM_NIXL_SIDE_CHANNEL_PORT=20098 \
-CUDA_VISIBLE_DEVICES=$DYN_PREFILL_WORKER_GPU python -m dynamo.vllm --multimodal-worker --route-to-encoder --disaggregation-mode prefill --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_PREFILL_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081"}' &
+CUDA_VISIBLE_DEVICES=$DYN_PREFILL_WORKER_GPU python -m dynamo.vllm --multimodal-worker --route-to-encoder --disaggregation-mode prefill --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_PREFILL_GPU_MEM "${EXTRA_ARGS[@]}" --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081"}' &
 
 # Start decode worker
 echo "Starting decode worker on GPU $DYN_DECODE_WORKER_GPU (GPU mem: $DYN_DECODE_GPU_MEM)..."
 VLLM_NIXL_SIDE_CHANNEL_PORT=20099 \
-CUDA_VISIBLE_DEVICES=$DYN_DECODE_WORKER_GPU python -m dynamo.vllm --multimodal-decode-worker --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_DECODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20082"}' &
+CUDA_VISIBLE_DEVICES=$DYN_DECODE_WORKER_GPU python -m dynamo.vllm --multimodal-decode-worker --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_DECODE_GPU_MEM "${EXTRA_ARGS[@]}" --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20082"}' &
 
 echo "=================================================="
 echo "All components started. Waiting for initialization..."

--- a/examples/backends/vllm/launch/disagg_multimodal_epd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_epd.sh
@@ -7,38 +7,49 @@ trap 'echo Cleaning up...; kill 0' EXIT
 # Default values
 MODEL_NAME="llava-hf/llava-1.5-7b-hf"
 
+# --single-gpu: Packs all 3 workers (encode, prefill, decode) onto a single GPU.
+# This is intended for functional testing with small models (e.g. 2B) where CI
+# only has 1 GPU available. It reduces performance by:
+#   - Enabling --enforce-eager (disables torch.compile and CUDA graph capture)
+#   - Limiting --max-model-len to 4096 tokens
+#   - Skipping multimodal encoder profiling (--skip-mm-prof)
+#   - Using lower gpu-memory-utilization fractions to share the GPU
+SINGLE_GPU=false
+
 # Parse command line arguments
-# All extra arguments are passed through to each worker's dynamo.vllm
-EXTRA_ARGS=()
 while [[ $# -gt 0 ]]; do
     case $1 in
         --model)
             MODEL_NAME=$2
             shift 2
             ;;
+        --single-gpu)
+            SINGLE_GPU=true
+            shift
+            ;;
         -h|--help)
-            echo "Usage: $0 [OPTIONS] [EXTRA_ARGS...]"
+            echo "Usage: $0 [OPTIONS]"
             echo ""
             echo "Disaggregated multimodal serving with separate Encode/Prefill/Decode workers"
             echo ""
             echo "Options:"
             echo "  --model <model_name>          Specify the VLM model to use (default: $MODEL_NAME)"
             echo "                                LLaVA 1.5 7B, Qwen2.5-VL, and Phi3V models have predefined templates"
+            echo "  --single-gpu                  Pack all 3 workers on 1 GPU (for small models, e.g. 2B)"
             echo "  -h, --help                    Show this help message"
-            echo ""
-            echo "All additional arguments are passed through to each worker's dynamo.vllm."
             echo ""
             echo "Examples:"
             echo "  $0 --model llava-hf/llava-1.5-7b-hf"
             echo "  $0 --model microsoft/Phi-3.5-vision-instruct"
             echo "  $0 --model Qwen/Qwen2.5-VL-7B-Instruct"
-            echo "  $0 --model Qwen/Qwen3-VL-2B-Instruct --enforce-eager --max-model-len 4096"
+            echo "  $0 --model Qwen/Qwen3-VL-2B-Instruct --single-gpu"
             echo ""
             exit 0
             ;;
         *)
-            EXTRA_ARGS+=("$1")
-            shift
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
             ;;
     esac
 done
@@ -56,6 +67,9 @@ echo "Starting frontend..."
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
 python -m dynamo.frontend &
 
+EXTRA_ARGS=""
+PD_EXTRA_ARGS=""
+
 # GPU assignments (override via environment variables)
 DYN_ENCODE_WORKER_GPU=${DYN_ENCODE_WORKER_GPU:-0}
 DYN_PREFILL_WORKER_GPU=${DYN_PREFILL_WORKER_GPU:-1}
@@ -66,19 +80,24 @@ DYN_ENCODE_GPU_MEM=${DYN_ENCODE_GPU_MEM:-0.9}
 DYN_PREFILL_GPU_MEM=${DYN_PREFILL_GPU_MEM:-0.9}
 DYN_DECODE_GPU_MEM=${DYN_DECODE_GPU_MEM:-0.9}
 
+if [[ "$SINGLE_GPU" == "true" ]]; then
+    EXTRA_ARGS="--enforce-eager --skip-mm-prof"
+    PD_EXTRA_ARGS="--max-model-len 4096"
+fi
+
 # Start encode worker
 echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (GPU mem: $DYN_ENCODE_GPU_MEM)..."
-VLLM_NIXL_SIDE_CHANNEL_PORT=20097 CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU python -m dynamo.vllm --multimodal-encode-worker --enable-multimodal --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM "${EXTRA_ARGS[@]}" --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080"}' &
+VLLM_NIXL_SIDE_CHANNEL_PORT=20097 CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU python -m dynamo.vllm --multimodal-encode-worker --enable-multimodal --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080"}' &
 
 # Start prefill worker (also handles encode routing via --route-to-encoder)
 echo "Starting prefill worker on GPU $DYN_PREFILL_WORKER_GPU (GPU mem: $DYN_PREFILL_GPU_MEM)..."
 VLLM_NIXL_SIDE_CHANNEL_PORT=20098 \
-CUDA_VISIBLE_DEVICES=$DYN_PREFILL_WORKER_GPU python -m dynamo.vllm --multimodal-worker --route-to-encoder --disaggregation-mode prefill --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_PREFILL_GPU_MEM "${EXTRA_ARGS[@]}" --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081"}' &
+CUDA_VISIBLE_DEVICES=$DYN_PREFILL_WORKER_GPU python -m dynamo.vllm --multimodal-worker --route-to-encoder --disaggregation-mode prefill --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_PREFILL_GPU_MEM $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081"}' &
 
 # Start decode worker
 echo "Starting decode worker on GPU $DYN_DECODE_WORKER_GPU (GPU mem: $DYN_DECODE_GPU_MEM)..."
 VLLM_NIXL_SIDE_CHANNEL_PORT=20099 \
-CUDA_VISIBLE_DEVICES=$DYN_DECODE_WORKER_GPU python -m dynamo.vllm --multimodal-decode-worker --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_DECODE_GPU_MEM "${EXTRA_ARGS[@]}" --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20082"}' &
+CUDA_VISIBLE_DEVICES=$DYN_DECODE_WORKER_GPU python -m dynamo.vllm --multimodal-decode-worker --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_DECODE_GPU_MEM $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20082"}' &
 
 echo "=================================================="
 echo "All components started. Waiting for initialization..."
@@ -86,4 +105,3 @@ echo "=================================================="
 
 # Wait for all background processes to complete
 wait
-

--- a/examples/backends/vllm/launch/disagg_multimodal_epd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_epd.sh
@@ -52,7 +52,7 @@ echo "Starting frontend..."
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
 python -m dynamo.frontend &
 
-EXTRA_ARGS=""
+EXTRA_ARGS="${DYN_EXTRA_VLLM_ARGS:-}"
 
 # GPU assignments (override via environment variables)
 DYN_ENCODE_WORKER_GPU=${DYN_ENCODE_WORKER_GPU:-0}

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -343,7 +343,13 @@ vllm_configs = {
         script_name="disagg_multimodal_epd.sh",
         marks=[pytest.mark.gpu_1, pytest.mark.pre_merge],
         model="Qwen/Qwen3-VL-2B-Instruct",
-        script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct"],
+        script_args=[
+            "--model",
+            "Qwen/Qwen3-VL-2B-Instruct",
+            "--enforce-eager",
+            "--max-model-len",
+            "4096",
+        ],
         env={
             "DYN_ENCODE_WORKER_GPU": "0",
             "DYN_PREFILL_WORKER_GPU": "0",
@@ -351,7 +357,6 @@ vllm_configs = {
             "DYN_ENCODE_GPU_MEM": "0.30",
             "DYN_PREFILL_GPU_MEM": "0.30",
             "DYN_DECODE_GPU_MEM": "0.30",
-            "DYN_EXTRA_VLLM_ARGS": "--enforce-eager --max-model-len 4096",
         },
         request_payloads=[
             chat_payload(

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -343,20 +343,14 @@ vllm_configs = {
         script_name="disagg_multimodal_epd.sh",
         marks=[pytest.mark.gpu_1, pytest.mark.pre_merge],
         model="Qwen/Qwen3-VL-2B-Instruct",
-        script_args=[
-            "--model",
-            "Qwen/Qwen3-VL-2B-Instruct",
-            "--enforce-eager",
-            "--max-model-len",
-            "4096",
-        ],
+        script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct", "--single-gpu"],
         env={
             "DYN_ENCODE_WORKER_GPU": "0",
             "DYN_PREFILL_WORKER_GPU": "0",
             "DYN_DECODE_WORKER_GPU": "0",
-            "DYN_ENCODE_GPU_MEM": "0.30",
-            "DYN_PREFILL_GPU_MEM": "0.30",
-            "DYN_DECODE_GPU_MEM": "0.30",
+            "DYN_ENCODE_GPU_MEM": "0.10",
+            "DYN_PREFILL_GPU_MEM": "0.40",
+            "DYN_DECODE_GPU_MEM": "0.40",
         },
         request_payloads=[
             chat_payload(

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -344,13 +344,14 @@ vllm_configs = {
         marks=[pytest.mark.gpu_1, pytest.mark.pre_merge],
         model="Qwen/Qwen3-VL-2B-Instruct",
         script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct", "--single-gpu"],
+        timeout=360,
         env={
             "DYN_ENCODE_WORKER_GPU": "0",
             "DYN_PREFILL_WORKER_GPU": "0",
             "DYN_DECODE_WORKER_GPU": "0",
             "DYN_ENCODE_GPU_MEM": "0.10",
-            "DYN_PREFILL_GPU_MEM": "0.40",
-            "DYN_DECODE_GPU_MEM": "0.40",
+            "DYN_PREFILL_GPU_MEM": "0.45",
+            "DYN_DECODE_GPU_MEM": "0.45",
         },
         request_payloads=[
             chat_payload(

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -349,9 +349,9 @@ vllm_configs = {
             "DYN_ENCODE_WORKER_GPU": "0",
             "DYN_PREFILL_WORKER_GPU": "0",
             "DYN_DECODE_WORKER_GPU": "0",
-            "DYN_ENCODE_GPU_MEM": "0.10",
-            "DYN_PREFILL_GPU_MEM": "0.45",
-            "DYN_DECODE_GPU_MEM": "0.45",
+            "DYN_ENCODE_GPU_MEM": "0.1",
+            "DYN_PREFILL_GPU_MEM": "0.4",
+            "DYN_DECODE_GPU_MEM": "0.4",
         },
         request_payloads=[
             chat_payload(

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -339,16 +339,16 @@ vllm_configs = {
         name="multimodal_disagg_qwen3vl_2b_epd",
         directory=vllm_dir,
         script_name="disagg_multimodal_epd.sh",
-        marks=[pytest.mark.gpu_2, pytest.mark.pre_merge],
+        marks=[pytest.mark.gpu_1, pytest.mark.pre_merge],
         model="Qwen/Qwen3-VL-2B-Instruct",
         script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct"],
         env={
             "DYN_ENCODE_WORKER_GPU": "0",
             "DYN_PREFILL_WORKER_GPU": "0",
-            "DYN_DECODE_WORKER_GPU": "1",
-            "DYN_ENCODE_GPU_MEM": "0.4",
-            "DYN_PREFILL_GPU_MEM": "0.4",
-            "DYN_DECODE_GPU_MEM": "0.85",
+            "DYN_DECODE_WORKER_GPU": "0",
+            "DYN_ENCODE_GPU_MEM": "0.30",
+            "DYN_PREFILL_GPU_MEM": "0.30",
+            "DYN_DECODE_GPU_MEM": "0.30",
         },
         request_payloads=[
             chat_payload(

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -276,6 +276,7 @@ vllm_configs = {
             completion_payload_default(),
         ],
     ),
+    # NOTE: Pack all workers on 1 GPU for lower CI resource requirements
     "multimodal_disagg_qwen3vl_2b_e_pd": VLLMConfig(
         name="multimodal_disagg_qwen3vl_2b_e_pd",
         directory=vllm_dir,
@@ -335,6 +336,7 @@ vllm_configs = {
             )
         ],
     ),
+    # NOTE: Pack all workers on 1 GPU for lower CI resource requirements
     "multimodal_disagg_qwen3vl_2b_epd": VLLMConfig(
         name="multimodal_disagg_qwen3vl_2b_epd",
         directory=vllm_dir,
@@ -349,6 +351,7 @@ vllm_configs = {
             "DYN_ENCODE_GPU_MEM": "0.30",
             "DYN_PREFILL_GPU_MEM": "0.30",
             "DYN_DECODE_GPU_MEM": "0.30",
+            "DYN_EXTRA_VLLM_ARGS": "--enforce-eager --max-model-len 4096",
         },
         request_payloads=[
             chat_payload(


### PR DESCRIPTION
Overview:
- Convert the multimodal E/P/D (Encode/Prefill/Decode) disaggregated test to run on a single GPU, reducing CI GPU requirements from 2 GPUs to 1.

Details:
- Updated the `multimodal_disagg_qwen3vl_2b_epd` test config to place all three workers (encode, prefill, decode) on GPU 0 with 0.30 memory fraction each (total 0.90). The Qwen3-VL-2B model is small enough (~4GB) that three instances fit comfortably within a single 48GB L40 GPU. Changed the pytest mark from `gpu_2` to `gpu_1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted GPU resource allocation and worker configuration for a multimodal model test variant to optimize resource utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->