### PR TITLE
feat: standalone planner/profiler docker image

### DIFF
--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -30,6 +30,7 @@ from dynamo.profiler.utils.config import (
     DgdPlannerServiceConfig,
     set_argument_value,
 )
+from dynamo.profiler.utils.profile_common import derive_planner_image
 
 # Path to mocker disagg config relative to workspace
 MOCKER_DISAGG_CONFIG_PATH = "examples/backends/mocker/deploy/disagg.yaml"
@@ -86,8 +87,10 @@ def generate_dgd_config_with_planner(
 
     # --- Add planner service to DGD ---
     planner_service = DgdPlannerServiceConfig()
-    if planner_service.extraPodSpec.mainContainer:
-        planner_service.extraPodSpec.mainContainer.image = dgdr.image
+    if planner_service.extraPodSpec.mainContainer and dgdr.image:
+        planner_service.extraPodSpec.mainContainer.image = derive_planner_image(
+            dgdr.image
+        )
 
     planner_dict = planner_service.model_dump(exclude_unset=False)
     config_dict = config.model_dump(exclude_unset=False)

--- a/container/Dockerfile.template
+++ b/container/Dockerfile.template
@@ -13,6 +13,11 @@
         {% include "templates/dynamo_base.Dockerfile" %}
         {% include "templates/wheel_builder.Dockerfile" %}
         {% include "templates/frontend.Dockerfile" %}
+    {% elif target == "planner" %}
+        {% include "templates/dynamo_base.Dockerfile" %}
+        {% include "templates/wheel_builder.Dockerfile" %}
+        {% include "templates/dynamo_runtime.Dockerfile" %}
+        {% include "templates/planner.Dockerfile" %}
     {% elif target == "runtime" or target == "dev" or target == "local-dev" %}
         {% include "templates/dynamo_base.Dockerfile" %}
         {% include "templates/wheel_builder.Dockerfile" %}

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Version Pinning Strategy:
+# - Use == for packages that are pure Python and well-tested
+# - Use <= or < for packages that may have platform-specific versions
+# - Never use >= as it allows untested future versions that may introduce breaking changes,
+#   create non-reproducible builds, and cause dependency conflicts. Every installed version
+#   should be explicitly tested, not an unknown future release.
+
+# Dependencies used exclusively by the planner and profiler components.
+# These are installed only in the dynamo-planner image (--target=planner).
+
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@7287307c4e3861b90927198da74e1adda53a4caf
+filterpy==1.4.5
+matplotlib==3.10.7
+pmdarima==2.1.1
+prometheus-api-client==0.6.0
+prophet==1.2.1
+scikit-learn==1.7.2
+scipy<1.14.0  # Upper bound for pmdarima compatibility

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -12,12 +12,10 @@
 
 # For Multimodal EPD (required for device_map="auto" in vision model loading)
 accelerate
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@7287307c4e3861b90927198da74e1adda53a4caf
 aiofiles
 aiperf @ git+https://github.com/ai-dynamo/aiperf.git@54cd6dc820bff8bfebc875da104e59d745e14f75
 av==15.0.0
 fastapi==0.120.1
-filterpy==1.4.5
 ftfy==6.3.1
 genai-perf==0.0.15
 grpcio-tools<=1.76.0  # May have platform-specific builds
@@ -25,7 +23,6 @@ httpx==0.28.1
 kr8s==0.20.13
 kubernetes==32.0.1
 kubernetes_asyncio<=32.1.1  # May vary by platform
-matplotlib==3.10.7
 msgpack==1.1.2
 msgspec==0.19.0
 mypy==1.18.2
@@ -34,18 +31,13 @@ opentelemetry-api<=1.38.0  # May need to stay in sync with other components
 opentelemetry-exporter-otlp<=1.38.0  # May need to stay in sync with other components
 opentelemetry-sdk<=1.38.0  # May need to stay in sync with other components
 pip<=25.0.1  # System pip, varies by platform
-pmdarima==2.1.1
 pre-commit==4.5.0
-prometheus-api-client==0.6.0
 prometheus_client==0.23.1
-prophet==1.2.1
 protobuf>=5.29.5,<7.0.0
 pydantic>=2.11.4,<2.13  # vllm==0.12.0 depends on pydantic>=2.12.0
 pydantic-settings<2.13.0  # tensorrt_llm DynamicYamlWithDeepMergeSettingsSource incompatible with 2.13.0+ deep_merge param
 pyright==1.1.407
 PyYAML==6.0.3
-scikit-learn==1.7.2
-scipy<1.14.0  # Upper bound for pmdarima compatibility
 sentencepiece==0.2.1
 # Required by kr8s
 # https://github.com/kr8s-org/kr8s/blob/750022c3ebbb7988cddb5a979aca2ee8074a1069/examples/kubectl-ng/uv.lock#L988

--- a/container/render.py
+++ b/container/render.py
@@ -95,6 +95,7 @@ def validate_args(args):
                 "dev",
                 "local-dev",
                 "frontend",
+                "planner",
                 "wheel_builder",
                 "base",
             ],

--- a/container/templates/planner.Dockerfile
+++ b/container/templates/planner.Dockerfile
@@ -1,0 +1,19 @@
+{#
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#}
+# === BEGIN templates/planner.Dockerfile ===
+##############################################
+########## Planner / Profiler image ##########
+##############################################
+# Extends the dynamo runtime with planner- and profiler-specific
+# Python dependencies that are not needed by the base runtime,
+# frontend, or backend framework images.
+
+FROM runtime AS planner
+
+# Install planner/profiler-specific Python dependencies
+RUN --mount=type=bind,source=./container/deps/requirements.planner.txt,target=/tmp/requirements.planner.txt \
+    --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775 \
+    export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
+    uv pip install --requirement /tmp/requirements.planner.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,6 +250,7 @@ markers = [
     "aiconfigurator: marks e2e tests that cover aiconfigurator functionality",
     "router: marks tests for router component",
     "planner: marks tests for planner component",
+    "profiler: marks tests for profiler component",
     "kvbm: marks tests for KV behavior and model determinism",
     "kvbm_concurrency: marks concurrency stress tests for KVBM (runs separately)",
     "model: model id used by a test or parameter",

--- a/tests/planner/test_replica_calculation.py
+++ b/tests/planner/test_replica_calculation.py
@@ -24,7 +24,7 @@ from dynamo.planner.utils.planner_core import (
 from dynamo.planner.utils.prefill_planner import PrefillPlanner
 from dynamo.planner.utils.prometheus import Metrics
 
-pytestmark = [pytest.mark.pre_merge, pytest.mark.gpu_0]
+pytestmark = [pytest.mark.pre_merge, pytest.mark.gpu_0, pytest.mark.planner]
 
 
 class PlannerHarness:

--- a/tests/planner/test_scaling_e2e.py
+++ b/tests/planner/test_scaling_e2e.py
@@ -19,7 +19,11 @@ import urllib.request
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
+import pytest
+
 from utils.load_generator import LoadGenerator
+
+pytestmark = [pytest.mark.planner]
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"

--- a/tests/profiler/test_helpers_profile_sla.py
+++ b/tests/profiler/test_helpers_profile_sla.py
@@ -46,6 +46,8 @@ try:
 except ImportError as e:
     pytest.skip(f"Skip (missing dependency): {e}", allow_module_level=True)
 
+pytestmark = [pytest.mark.profiler]
+
 
 # ---------------------------------------------------------------------------
 # Shared fixtures

--- a/tests/profiler/test_helpers_rapid.py
+++ b/tests/profiler/test_helpers_rapid.py
@@ -30,6 +30,8 @@ try:
 except ImportError as e:
     pytest.skip(f"Skip (missing dependency): {e}", allow_module_level=True)
 
+pytestmark = [pytest.mark.profiler]
+
 
 # ---------------------------------------------------------------------------
 # Shared fixtures

--- a/tests/profiler/test_helpers_thorough.py
+++ b/tests/profiler/test_helpers_thorough.py
@@ -30,6 +30,8 @@ try:
 except ImportError as e:
     pytest.skip(f"Skip (missing dependency): {e}", allow_module_level=True)
 
+pytestmark = [pytest.mark.profiler]
+
 
 # ---------------------------------------------------------------------------
 # Shared fixtures

--- a/tests/profiler/test_profile_sla_dgdr.py
+++ b/tests/profiler/test_profile_sla_dgdr.py
@@ -34,6 +34,8 @@ try:
 except ImportError as _e:
     pytest.skip(f"Skip testing (refactor in progress): {_e}", allow_module_level=True)
 
+pytestmark = [pytest.mark.profiler]
+
 
 @pytest.fixture(autouse=True)
 def logger(request):


### PR DESCRIPTION
# Create separate `dynamo-planner` Docker image for planner/profiler components

## Summary

- Creates a new `dynamo-planner` Docker image target that extends the dynamo runtime with planner/profiler-specific Python dependencies
- Moves 8 planner/profiler-only packages out of the shared `requirements.txt` into a dedicated `requirements.planner.txt`
- Adds proper `planner`/`profiler` pytest markers to all planner and profiler test files
- Updates DGD generation to derive the planner service image as `dynamo-planner` (instead of reusing the frontend image)

## Motivation

The planner and profiler components have heavy dependencies (`prophet`, `pmdarima`, `scikit-learn`, `filterpy`, `aiconfigurator[webapp]`, etc.) that are not needed by the frontend, backend runtime, or other framework images. Bundling them into every image increases build time and image size unnecessarily. This PR separates them into a dedicated `dynamo-planner` image so that:

1. Frontend and backend images remain lean
2. The planner k8s service runs from its own purpose-built image
3. Test markers clearly identify which tests belong to planner vs profiler

## Changes

### New files

- **`container/deps/requirements.planner.txt`** — Planner/profiler-only dependencies: `aiconfigurator[webapp]`, `filterpy`, `matplotlib`, `pmdarima`, `prometheus-api-client`, `prophet`, `scikit-learn`, `scipy`
- **`container/templates/planner.Dockerfile`** — Extends the `runtime` stage with planner-specific deps

### Modified files

- **`container/deps/requirements.txt`** — Removed the 8 packages listed above (moved to `requirements.planner.txt`)
- **`container/render.py`** — Added `"planner"` as a valid target under `framework=dynamo`
- **`container/Dockerfile.template`** — Added `{% elif target == "planner" %}` branch that chains: `dynamo_base` → `wheel_builder` → `dynamo_runtime` → `planner`
- **`components/src/dynamo/profiler/utils/profile_common.py`** — Added `PLANNER_IMAGE_NAME`, `_replace_image_name()` shared helper, `derive_planner_image()` function; refactored `derive_backend_image()` to use the shared helper
- **`components/src/dynamo/profiler/utils/dgd_generation.py`** — Planner service image now uses `derive_planner_image(dgdr.image)` instead of `dgdr.image`
- **`components/src/dynamo/profiler/utils/config.py`** — `update_image()` now skips services with `componentType == "planner"` to prevent backend config modifiers from overwriting the planner image
- **`tests/planner/test_replica_calculation.py`** — Added `pytest.mark.planner` to `pytestmark`
- **`tests/planner/test_scaling_e2e.py`** — Added `pytestmark = [pytest.mark.planner]` (had no markers)
- **`tests/profiler/test_helpers_thorough.py`** — Added `pytestmark = [pytest.mark.profiler]`
- **`tests/profiler/test_helpers_profile_sla.py`** — Added `pytestmark = [pytest.mark.profiler]`
- **`tests/profiler/test_helpers_rapid.py`** — Added `pytestmark = [pytest.mark.profiler]`
- **`tests/profiler/test_profile_sla_dgdr.py`** — Added `pytestmark = [pytest.mark.profiler]`
- **`pyproject.toml`** — Registered `"profiler"` marker (`"planner"` was already registered)

## How to build

```bash
# Build the planner image
python container/render.py --framework=dynamo --target=planner --output-short-filename
docker build -t dynamo:planner -f rendered.Dockerfile .
```

## TODOs for Operations Team

### CI pipeline updates

1. **Build the `dynamo-planner` image in CI** — Create a workflow (similar to `build-frontend-image.yaml`) that builds and pushes the planner image using `--framework=dynamo --target=planner`. Publish it as `dynamo-planner` alongside the existing `dynamo-frontend` image.

2. **Update `container-validation-dynamo.yml`** — Planner/profiler tests currently run in the dynamo runtime image via `pre_merge and not parallel and not (vllm or sglang or trtllm) and gpu_0`. Since those deps were removed from the base requirements, these tests now need to run in the **planner** image. Options:
   - Add a separate pytest job using the planner image with markers `pre_merge and (planner or profiler) and gpu_0`
   - Exclude `planner`/`profiler` markers from the existing dynamo runtime test jobs

3. **Update framework pipeline test markers** — Planner tests tagged with `vllm`/`sglang` (e.g., `test_prometheus.py`, `test_virtual_connector.py`) currently run in framework runtime images. Those images no longer have planner-specific deps (`filterpy`, `prometheus-api-client`, etc.). Either:
   - Run those tests in the planner image instead
   - Or install `requirements.planner.txt` in the framework runtime images too

4. **Check `requirements.test.txt` overlap** — The test requirements file still includes `pmdarima`, `prometheus-api-client`, and `matplotlib` which overlap with `requirements.planner.txt`. Decide whether to also remove them from test requirements (they would only be needed in the planner image).

5. **Published image naming** — Ensure the planner image is published as `dynamo-planner` in the container registry (e.g., `nvcr.io/nvidia/ai-dynamo/dynamo-planner:<tag>`) so that `derive_planner_image()` correctly resolves it from the frontend image name.
