### PR TITLE
ci: enable EFA builds in post-merge and release pipelines 

### DIFF
--- a/.github/workflows/build-test-distribute-flavor-matrix.yml
+++ b/.github/workflows/build-test-distribute-flavor-matrix.yml
@@ -103,6 +103,11 @@ on:
         required: false
         type: boolean
         default: true
+      make_efa:
+        description: 'Enable AWS EFA support in the build'
+        required: false
+        type: boolean
+        default: false
     secrets:
       AWS_DEFAULT_REGION:
         required: true
@@ -156,4 +161,5 @@ jobs:
       multi_gpu_test_timeout_minutes: ${{ inputs.multi_gpu_test_timeout_minutes }}
       copy_to_acr: ${{ inputs.copy_to_acr && matrix.platform == 'amd64' }} # no reason to copy ARM images to ACR
       copy_timeout_minutes: ${{ inputs.copy_timeout_minutes }}
+      make_efa: ${{ inputs.make_efa }}
     secrets: inherit

--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -113,6 +113,11 @@ on:
         required: false
         type: boolean
         default: false
+      make_efa:
+        description: 'Enable AWS EFA support in the build'
+        required: false
+        type: boolean
+        default: false
     secrets:
       AWS_DEFAULT_REGION:
         required: true
@@ -191,7 +196,11 @@ jobs:
         run: |
           CUDA_VERSION_RAW=${{ inputs.cuda_version }}
           CUDA_VERSION=${CUDA_VERSION_RAW%%.*}
-          TARGET_TAG_PLAIN="${{ github.sha }}-${{ inputs.framework }}"
+          EFA_SUFFIX=""
+          if [ "${{ inputs.make_efa }}" == "true" ]; then
+            EFA_SUFFIX="-efa"
+          fi
+          TARGET_TAG_PLAIN="${{ github.sha }}-${{ inputs.framework }}${EFA_SUFFIX}"
           DEFAULT_TARGET_IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${TARGET_TAG_PLAIN}-cuda${CUDA_VERSION}-${{ inputs.platform }}"
           echo "default_target_image_uri=${DEFAULT_TARGET_IMAGE_URI}" >> $GITHUB_OUTPUT
           echo "target_tag_plain=${TARGET_TAG_PLAIN}" >> $GITHUB_OUTPUT
@@ -219,11 +228,16 @@ jobs:
         shell: bash
         run: |
           echo "Generating Dockerfile for target: ${{ inputs.target }} and framework: ${{ inputs.framework }}"
+          MAKE_EFA_FLAG=""
+          if [ "${{ inputs.make_efa }}" == "true" ]; then
+            MAKE_EFA_FLAG="--make-efa"
+          fi
           python ./container/render.py \
               --target=${{ inputs.target }} \
               --framework=${{ inputs.framework }} \
               --platform=${{ inputs.platform }} \
               --cuda-version=${{ inputs.cuda_version }} \
+              ${MAKE_EFA_FLAG} \
               --show-result \
               --output-short-filename
       - name: Build Container

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - 'release/*.*.*'
+      - 'anants/enable-efa'  # TEMP: remove before merge
 
 permissions:
   contents: read

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -84,12 +84,59 @@ jobs:
       multi_gpu_test_timeout_minutes: 60
     secrets: inherit
 
+  # ============================================================================
+  # EFA PIPELINES (Build only, amd64)
+  # ============================================================================
+  # ============================================================================
+  # VLLM EFA PIPELINE
+  # ============================================================================
+  vllm-efa-pipeline:
+    uses: ./.github/workflows/build-test-distribute-flavor-matrix.yml
+    with:
+      framework: vllm
+      target: runtime
+      platforms: '["amd64"]'
+      cuda_versions: '["12.9"]'
+      make_efa: true
+      extra_tags: |
+        ${{ github.ref_name == 'main' && 'main-vllm-efa' || '' }}
+        ${{ github.ref_name == 'main' && format('main-vllm-efa-{0}', github.sha) || '' }}
+      builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
+      build_timeout_minutes: ${{ github.ref_name == 'main' && 120 || 60 }}
+      run_cpu_only_tests: false
+      run_single_gpu_tests: false
+      run_multi_gpu_tests: false
+      copy_to_acr: false
+    secrets: inherit
+
+  # ============================================================================
+  # TRTLLM EFA PIPELINE
+  # ============================================================================
+  trtllm-efa-pipeline:
+    uses: ./.github/workflows/build-test-distribute-flavor-matrix.yml
+    with:
+      framework: trtllm
+      target: runtime
+      platforms: '["amd64"]'
+      cuda_versions: '["13.1"]'
+      make_efa: true
+      extra_tags: |
+        ${{ github.ref_name == 'main' && 'main-trtllm-efa' || '' }}
+        ${{ github.ref_name == 'main' && format('main-trtllm-efa-{0}', github.sha) || '' }}
+      builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
+      build_timeout_minutes: ${{ github.ref_name == 'main' && 120 || 60 }}
+      run_cpu_only_tests: false
+      run_single_gpu_tests: false
+      run_multi_gpu_tests: false
+      copy_to_acr: false
+    secrets: inherit
+
   ############################## SLACK NOTIFICATION ##############################
   notify-slack:
     name: Notify Slack
     runs-on: prod-builder-amd-v1
     if: always() && failure()
-    needs: [ vllm-pipeline, sglang-pipeline, trtllm-pipeline ]
+    needs: [ vllm-pipeline, sglang-pipeline, trtllm-pipeline, vllm-efa-pipeline, trtllm-efa-pipeline ]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - 'release/*.*.*'
-      - 'anants/enable-efa'  # TEMP: remove before merge
 
 permissions:
   contents: read

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -104,7 +104,8 @@ jobs:
         ${{ github.ref_name == 'main' && format('main-vllm-efa-{0}', github.sha) || '' }}
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       build_timeout_minutes: ${{ github.ref_name == 'main' && 120 || 60 }}
-      run_cpu_only_tests: false
+      cpu_only_test_markers: '(pre_merge or post_merge) and vllm and gpu_0'
+      cpu_only_test_timeout_minutes: 60
       run_single_gpu_tests: false
       run_multi_gpu_tests: false
       copy_to_acr: false
@@ -126,7 +127,8 @@ jobs:
         ${{ github.ref_name == 'main' && format('main-trtllm-efa-{0}', github.sha) || '' }}
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       build_timeout_minutes: ${{ github.ref_name == 'main' && 120 || 60 }}
-      run_cpu_only_tests: false
+      cpu_only_test_markers: '(pre_merge or post_merge) and trtllm and gpu_0'
+      cpu_only_test_timeout_minutes: 60
       run_single_gpu_tests: false
       run_multi_gpu_tests: false
       copy_to_acr: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -464,7 +464,7 @@ jobs:
     if: |
       always() && !cancelled() &&
       needs.prepare-release.result == 'success' &&
-      (needs.vllm-pipeline.result == 'success' || needs.sglang-pipeline.result == 'success' || needs.trtllm-pipeline.result == 'success' || needs.vllm-efa-pipeline.result == 'success' || needs.trtllm-efa-pipeline.result == 'success')
+      (needs.vllm-pipeline.result == 'success' || needs.sglang-pipeline.result == 'success' || needs.trtllm-pipeline.result == 'success')
     runs-on: cpu-amd-m5-4xlarge
     environment: automated-release
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,58 @@ jobs:
     secrets: inherit
 
   # ============================================================================
+  # EFA PIPELINES (Build only, amd64)
+  # ============================================================================
+
+  vllm-efa-pipeline:
+    name: vllm EFA builds
+    needs: [prepare-release, manual-approval]
+    if: |
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      (github.event_name == 'push' || needs.manual-approval.result == 'success')
+    uses: ./.github/workflows/build-test-distribute-flavor-matrix.yml
+    with:
+      framework: vllm
+      target: runtime
+      platforms: '["amd64"]'
+      cuda_versions: '["12.9"]'
+      make_efa: true
+      extra_tags: |
+        ${{ needs.prepare-release.outputs.image_prefix }}-vllm-efa
+      builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
+      build_timeout_minutes: 120
+      run_cpu_only_tests: false
+      run_single_gpu_tests: false
+      run_multi_gpu_tests: false
+      copy_to_acr: false
+    secrets: inherit
+
+  trtllm-efa-pipeline:
+    name: trtllm EFA builds
+    needs: [prepare-release, manual-approval]
+    if: |
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      (github.event_name == 'push' || needs.manual-approval.result == 'success')
+    uses: ./.github/workflows/build-test-distribute-flavor-matrix.yml
+    with:
+      framework: trtllm
+      target: runtime
+      platforms: '["amd64"]'
+      cuda_versions: '["13.1"]'
+      make_efa: true
+      extra_tags: |
+        ${{ needs.prepare-release.outputs.image_prefix }}-trtllm-efa
+      builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
+      build_timeout_minutes: 120
+      run_cpu_only_tests: false
+      run_single_gpu_tests: false
+      run_multi_gpu_tests: false
+      copy_to_acr: false
+    secrets: inherit
+
+  # ============================================================================
   # RELEASE-SPECIFIC BUILDS
   # ============================================================================
 
@@ -238,7 +290,7 @@ jobs:
     name: Clean K8s builder if exists
     runs-on: prod-default-small-v2
     if: always()
-    needs: [vllm-pipeline, sglang-pipeline, trtllm-pipeline]
+    needs: [vllm-pipeline, sglang-pipeline, trtllm-pipeline, vllm-efa-pipeline, trtllm-efa-pipeline]
     steps:
     - uses: actions/checkout@v4
     - name: Create K8s builders (skip bootstrap)
@@ -406,11 +458,11 @@ jobs:
 
   release-publish:
     name: Tag RC & Publish to NGC
-    needs: [prepare-release, vllm-pipeline, sglang-pipeline, trtllm-pipeline, operator-build, frontend-build]
+    needs: [prepare-release, vllm-pipeline, sglang-pipeline, trtllm-pipeline, vllm-efa-pipeline, trtllm-efa-pipeline, operator-build, frontend-build]
     if: |
       always() && !cancelled() &&
       needs.prepare-release.result == 'success' &&
-      (needs.vllm-pipeline.result == 'success' || needs.sglang-pipeline.result == 'success' || needs.trtllm-pipeline.result == 'success')
+      (needs.vllm-pipeline.result == 'success' || needs.sglang-pipeline.result == 'success' || needs.trtllm-pipeline.result == 'success' || needs.vllm-efa-pipeline.result == 'success' || needs.trtllm-efa-pipeline.result == 'success')
     runs-on: cpu-amd-m5-4xlarge
     environment: automated-release
     env:
@@ -590,6 +642,20 @@ jobs:
               "${NGC_NAME}:${NGC_VERSION_TAG}-cuda13"
           done
 
+          # ---- EFA runtime images (amd64 only, no multi-arch manifest needed) ----
+          echo ""
+          echo "=== EFA Runtime Images ==="
+
+          # vllm EFA (CUDA 12, amd64 only)
+          SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${IMAGE_PREFIX}-vllm-efa-cuda12-amd64"
+          TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/vllm-runtime-efa:${NGC_VERSION_TAG}"
+          copy_image "${SOURCE}" "${TARGET}" "vllm-runtime-efa:${NGC_VERSION_TAG}"
+
+          # trtllm EFA (CUDA 13, amd64 only)
+          SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${IMAGE_PREFIX}-trtllm-efa-cuda13-amd64"
+          TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/tensorrtllm-runtime-efa:${NGC_VERSION_TAG}"
+          copy_image "${SOURCE}" "${TARGET}" "tensorrtllm-runtime-efa:${NGC_VERSION_TAG}"
+
           # ---- Frontend images ----
           echo ""
           echo "=== Frontend Images ==="
@@ -712,6 +778,10 @@ jobs:
           echo "- \`vllm-runtime:${NGC_VERSION_TAG}-cuda13\` (multi-arch)" >> $GITHUB_STEP_SUMMARY
           echo "- \`sglang-runtime:${NGC_VERSION_TAG}-cuda13\` (multi-arch)" >> $GITHUB_STEP_SUMMARY
           echo "- \`tensorrtllm-runtime:${NGC_VERSION_TAG}-cuda13\` (multi-arch)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "EFA runtime images (amd64 only):" >> $GITHUB_STEP_SUMMARY
+          echo "- \`vllm-runtime-efa:${NGC_VERSION_TAG}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`tensorrtllm-runtime-efa:${NGC_VERSION_TAG}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Operator image:" >> $GITHUB_STEP_SUMMARY
           echo "- \`kubernetes-operator:${NGC_VERSION_TAG}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -650,13 +650,13 @@ jobs:
 
           # vllm EFA (CUDA 12, amd64 only)
           SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${IMAGE_PREFIX}-vllm-efa-cuda12-amd64"
-          TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/vllm-runtime-efa:${NGC_VERSION_TAG}"
-          copy_image "${SOURCE}" "${TARGET}" "vllm-runtime-efa:${NGC_VERSION_TAG}"
+          TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/vllm-runtime:${NGC_VERSION_TAG}-efa"
+          copy_image "${SOURCE}" "${TARGET}" "vllm-runtime:${NGC_VERSION_TAG}-efa"
 
           # trtllm EFA (CUDA 13, amd64 only)
           SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${IMAGE_PREFIX}-trtllm-efa-cuda13-amd64"
-          TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/tensorrtllm-runtime-efa:${NGC_VERSION_TAG}"
-          copy_image "${SOURCE}" "${TARGET}" "tensorrtllm-runtime-efa:${NGC_VERSION_TAG}"
+          TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/tensorrtllm-runtime:${NGC_VERSION_TAG}-efa"
+          copy_image "${SOURCE}" "${TARGET}" "tensorrtllm-runtime:${NGC_VERSION_TAG}-efa"
 
           # ---- Frontend images ----
           echo ""
@@ -782,8 +782,8 @@ jobs:
           echo "- \`tensorrtllm-runtime:${NGC_VERSION_TAG}-cuda13\` (multi-arch)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "EFA runtime images (amd64 only):" >> $GITHUB_STEP_SUMMARY
-          echo "- \`vllm-runtime-efa:${NGC_VERSION_TAG}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`tensorrtllm-runtime-efa:${NGC_VERSION_TAG}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`vllm-runtime:${NGC_VERSION_TAG}-efa\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`tensorrtllm-runtime:${NGC_VERSION_TAG}-efa\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Operator image:" >> $GITHUB_STEP_SUMMARY
           echo "- \`kubernetes-operator:${NGC_VERSION_TAG}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,8 @@ jobs:
         ${{ needs.prepare-release.outputs.image_prefix }}-vllm-efa
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       build_timeout_minutes: 120
-      run_cpu_only_tests: false
+      cpu_only_test_markers: '(pre_merge or post_merge) and vllm and gpu_0'
+      cpu_only_test_timeout_minutes: 60
       run_single_gpu_tests: false
       run_multi_gpu_tests: false
       copy_to_acr: false
@@ -203,7 +204,8 @@ jobs:
         ${{ needs.prepare-release.outputs.image_prefix }}-trtllm-efa
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       build_timeout_minutes: 120
-      run_cpu_only_tests: false
+      cpu_only_test_markers: '(pre_merge or post_merge) and trtllm and gpu_0'
+      cpu_only_test_timeout_minutes: 60
       run_single_gpu_tests: false
       run_multi_gpu_tests: false
       copy_to_acr: false


### PR DESCRIPTION
Add EFA  container build variants for vllm (CUDA 12.9, amd64) and trtllm (CUDA 13.1, amd64) to the post-merge
and release CI pipelines. EFA images are build-only, runs CPU tests for basic sanity and published to NGC.

Tested build in, https://github.com/ai-dynamo/dynamo/actions/runs/22452541834

closes: OPS-3225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS EFA (Elastic Fabric Adapter) support to build pipelines for improved performance.
  * New EFA-enabled container images now available for VLLM and TRTLLM.

* **Chores**
  * Updated build workflows to generate and publish EFA variants alongside standard releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->