### PR TITLE
chore(deps): bump vLLM to 0.16.0 (release/1.0.0)

### DIFF
--- a/components/src/dynamo/vllm/omni/base_handler.py
+++ b/components/src/dynamo/vllm/omni/base_handler.py
@@ -27,7 +27,6 @@ class BaseOmniHandler(BaseWorkerHandler):
     def __init__(
         self,
         runtime,
-        component,
         config,
         default_sampling_params: Dict[str, Any],
         shutdown_event: asyncio.Event | None = None,
@@ -36,7 +35,6 @@ class BaseOmniHandler(BaseWorkerHandler):
 
         Args:
             runtime: Dynamo distributed runtime.
-            component: Dynamo component handle.
             config: Parsed Config object from args.py.
             default_sampling_params: Default sampling parameters dict.
             shutdown_event: Optional asyncio event for graceful shutdown.
@@ -56,7 +54,6 @@ class BaseOmniHandler(BaseWorkerHandler):
         # TODO: Kv publishers not supported yet
         # TODO: Adopt to baseworker initialization pattern
         self.runtime = runtime
-        self.component = component
         self.default_sampling_params = default_sampling_params
         self.config = config
         self.model_max_len = config.engine_args.max_model_len

--- a/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
@@ -144,7 +144,6 @@ class TestVllmRendererApi:
             "role",
             "content",
             "reasoning",
-            "reasoning_content",
             "tool_calls",
         }
         actual_fields = set(DeltaMessage.model_fields)
@@ -376,6 +375,7 @@ class TestVllmRendererApi:
             "trace_headers",
             "resumable",
             "external_req_id",
+            "reasoning_ended",
         )
         # vllm-omni monkey-patches EngineCoreRequest with an extra field
         # (only installed on amd64, not arm64)
@@ -401,6 +401,7 @@ class TestVllmRendererApi:
             "kv_transfer_params",
             "trace_headers",
             "num_cached_tokens",
+            "num_external_computed_tokens",
             "routed_experts",
             "num_nans_in_logits",
         )

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -42,10 +42,10 @@ vllm:
   cuda13.0:
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
     runtime_image_tag: 13.0.2-runtime-ubuntu24.04
-  vllm_ref: v0.15.1
-  flashinf_ref: v0.6.1
-  lmcache_ref: 0.3.13
-  vllm_omni_ref: "0.14.0"
+  vllm_ref: v0.16.0
+  flashinf_ref: v0.6.3
+  lmcache_ref: 0.3.14
+  vllm_omni_ref: "v0.16.0rc1"
   max_jobs: "10"
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"

--- a/docs/pages/backends/vllm/vllm-omni.md
+++ b/docs/pages/backends/vllm/vllm-omni.md
@@ -10,6 +10,14 @@ Dynamo supports multimodal generation through the [vLLM-Omni](https://github.com
 
 This guide assumes familiarity with deploying Dynamo with vLLM as described in the [vLLM backend guide](/docs/pages/backends/vllm/README.md).
 
+### Installation
+
+Dynamo container images include vLLM-Omni pre-installed. If you are using `pip install ai-dynamo[vllm]`, vLLM-Omni is **not** included automatically because the matching release is not yet available on PyPI. Install it separately from source:
+
+```bash
+pip install git+https://github.com/vllm-project/vllm-omni.git@v0.16.0rc1
+```
+
 ## Supported Modalities
 
 | Modality | Endpoint(s) | `--output-modalities` |

--- a/docs/pages/reference/support-matrix.md
+++ b/docs/pages/reference/support-matrix.md
@@ -14,7 +14,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.9` | `1.3.0rc5` | `0.15.1` | `0.10.0` |
+| **main (ToT)** | `0.5.9` | `1.3.0rc5` | `0.16.0` | `0.10.0` |
 | **v1.0.0** *(in progress)* | `0.5.9` | `1.3.0rc5` | `0.15.1` | `0.10.1` |
 | **v0.9.1** | `0.5.8` | `1.3.0rc3` | `0.14.1` | `0.9.0` |
 | **v0.9.0** *(in progress)* | `0.5.8` | `1.3.0rc1` | `0.14.1` | `0.9.0` |

--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/connector_leader.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/connector_leader.py
@@ -74,10 +74,8 @@ class KvConnectorLeader:
         consolidator_output_endpoint = None
         self._consolidator_output_port = None
 
-        if (
-            hasattr(vllm_config, "consolidator_endpoints")
-            and vllm_config.consolidator_endpoints
-        ):
+        _consolidator_eps = vllm_config.additional_config.get("consolidator_endpoints")
+        if _consolidator_eps:
             # Unpack all three endpoints
             # [0]: vllm_endpoint (for consolidator to subscribe to vLLM)
             # [1]: output_bind_endpoint (for consolidator to bind/publish)
@@ -86,7 +84,7 @@ class KvConnectorLeader:
                 consolidator_vllm_endpoint,
                 consolidator_output_endpoint,
                 _consolidator_output_connect_endpoint,  # Not needed here
-            ) = vllm_config.consolidator_endpoints
+            ) = _consolidator_eps
             self._consolidator_output_port = int(
                 consolidator_output_endpoint.split(":")[-1]
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,11 @@ trtllm =[
 vllm = [
     "uvloop",
     "nixl[cu12]<=0.9.0",
-    "vllm[flashinfer,runai]==0.15.1",
-    "vllm-omni==0.14.0",
+    "vllm[flashinfer,runai]==0.16.0",
+    # vllm-omni 0.16.0rc1 is not on PyPI; installed from source in container builds
+    # (see container/deps/vllm/install_vllm.sh). pip install ai-dynamo[vllm] will
+    # not include vllm-omni — install it separately from source if needed.
+    # "vllm-omni==0.16.0rc1",
     "blake3>=1.0.0,<2.0.0",
 ]
 
@@ -188,6 +191,7 @@ filterwarnings = [
     "ignore:.*Exception ignored in.*:pytest.PytestUnraisableExceptionWarning", # Ignore unraisable exception warnings
     "ignore:The pynvml package is deprecated.*:FutureWarning", # Ignore pynvml deprecation warning, temporary until upstream library updates to nvidia-ml-py
     "ignore:The behavior of DataFrame concatenation with empty or all-NA entries is deprecated.*:FutureWarning", # pandas 2.x concat deprecation in AIC SDK TODO: fix in AIC
+    "ignore:Automatic KV events configuration is deprecated.*:FutureWarning", # Ignore Dynamo's own KV events deprecation warning in tests
     # Pydantic V2 deprecation warnings from TRTLLM dependencies (raised at import time during collection)
     "ignore:Support for class-based `config`.*:pydantic.warnings.PydanticDeprecatedSince20",
     "ignore:Using extra keyword arguments on `Field`.*:pydantic.warnings.PydanticDeprecatedSince20",


### PR DESCRIPTION
## Summary
Cherry-pick of #6614 onto `release/1.0.0`.

- Bump vLLM from 0.15.1 to 0.16.0
- Bump vllm-omni to v0.16.0rc1 (source install, not on PyPI)
- Fix CUDA 13 vLLM install (cu12 wheel was pulled from PyPI instead of cu130)
- Use `VllmConfig.additional_config` for `consolidator_endpoints` (vLLM 0.16 strict dataclass serialization)
- Update support-matrix.md and vllm-omni docs

## Test plan
- [x] Pre-bump validation: `pytest -m "vllm and unit"` — passed
- [x] Pre-bump validation: `pytest -m "vllm and e2e and gpu_1"` — passed
- [x] Multimodal serve tests (multimodal_agg_frontend_decoding, multimodal_agg_qwen) — passed
- [ ] CI pipeline validation

## Commits
| Commit | Description |
|--------|-------------|
| `d871b52db` | chore(deps): bump vLLM to 0.16.0 |
| `9bdf43537` | Bump vllm-omni to v0.16.0rc1 and remove unused component param |
| `35af9f004` | Add vllm-omni source install note to docs |
| `245348040` | Fix CUDA 13 vLLM install using cu12 wheel from PyPI |
| `667c30bdf` | Use additional_config for consolidator_endpoints on VllmConfig |