### PR TITLE
fix: proper DGD prefix for naive fallback in DGDR

### DIFF
--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -137,7 +137,7 @@ def _run_naive_fallback(
         "best_config_df": pd.DataFrame(),
         "best_latencies": {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0},
         "dgd_config": dgd_config,
-        "chosen_exp": None,
+        "chosen_exp": "agg", # AIC's naive route always generate agg config
     }
 
 

--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -137,7 +137,7 @@ def _run_naive_fallback(
         "best_config_df": pd.DataFrame(),
         "best_latencies": {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0},
         "dgd_config": dgd_config,
-        "chosen_exp": "agg", # AIC's naive route always generate agg config
+        "chosen_exp": "agg",  # AIC's naive route always generate agg config
     }
 
 


### PR DESCRIPTION
the "None" feedback cause the generated DGD fail to deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the profiler's fallback mechanism to properly initialize with a default configuration, ensuring consistent behavior when experiment selection is unavailable during optimization analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->