### PR TITLE
feat(trtllm): use exclude-based metric filtering for unprefixed engine metrics

### DIFF
--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -410,7 +410,7 @@ async def init_llm_worker(
                 register_engine_metrics_callback(
                     endpoint=endpoint,
                     registry=REGISTRY,
-                    metric_prefix_filters=["trtllm_"],
+                    exclude_prefixes=["python_", "process_", "gc_"],
                     namespace_name=config.namespace,
                     component_name=config.component,
                     endpoint_name="generate",


### PR DESCRIPTION
## Summary

Switch from include-based metric filtering (`metric_prefix_filters=["trtllm_"]`) to exclude-based filtering (`exclude_prefixes=["python_", "process_", "gc_"]`) for the `register_engine_metrics_callback` call in `llm_worker.py`.

### Why

This change depends on [NVIDIA/TensorRT-LLM#11768](https://github.com/NVIDIA/TensorRT-LLM/pull/11768) which removes the `trtllm_` prefix from TRT-LLM's `MetricsCollector`. With unprefixed engine metrics, the include filter `["trtllm_"]` would match nothing. The exclude approach passes through all engine metrics while filtering out prometheus_client internal metrics (`python_*`, `process_*`, `gc_*`).

This aligns with the pattern used by vLLM's unified metrics, where the metric reader filter was changed from including `vllm:`-prefixed metrics to excluding `python_`, `process_`, `prometheus_`, `gc_` prefixes.

### Changes

- `components/src/dynamo/trtllm/workers/llm_worker.py`: 1-line change

### Dependency

- **Depends on**: [NVIDIA/TensorRT-LLM#11768](https://github.com/NVIDIA/TensorRT-LLM/pull/11768) (TRT-LLM prefix removal)
- **Should be merged after** the TRT-LLM PR to avoid breaking the metric callback

## E2E validation

Validated end-to-end on H100 NVL (computelab-sc-01) with Qwen3-4B, 10 requests, with `--publish-events-and-metrics --enable-unified-metrics` and `DYN_SYSTEM_PORT=8001`:

- **15/15 metric presence checks pass** — all 5 unprefixed engine metrics + 10 additional metrics + 2 hierarchy labels
- **12/14 validation tests pass** — 2 failures are a known handler_base.py TTFT bug fixed by [#6668](https://github.com/ai-dynamo/dynamo/pull/6668)
- Unprefixed engine metrics confirmed on DRT system port:
  ```
  request_success_total{dynamo_namespace="...",dynamo_component="...",...} 10.0
  e2e_request_latency_seconds_bucket{...} ...
  time_to_first_token_seconds_bucket{...} ...
  ```
- No `trtllm_` prefixed metrics in output
- The `exclude_prefixes` approach correctly filters out `python_*`, `process_*`, `gc_*` while passing through all engine and additional metrics

## Test plan

- [x] Syntax check passes
- [x] E2E: Start with `--publish-events-and-metrics`, verify unprefixed engine metrics appear via DRT callback
- [x] No `trtllm_` prefixed metrics in `/metrics` output
- [x] `python_*`, `process_*`, `gc_*` metrics correctly excluded
- [x] Hierarchy labels (`dynamo_namespace`, `dynamo_component`) present on all metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)