### PR TITLE
fix: Phase out llava and make EPD single GPU

### DIFF
--- a/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/decode.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/decode.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+tensor_parallel_size: 1
+moe_expert_parallel_size: 1
+enable_attention_dp: false
+max_num_tokens: 8192
+max_batch_size: 16
+trust_remote_code: true
+backend: pytorch
+enable_chunked_prefill: true
+disable_overlap_scheduler: false
+kv_cache_config:
+  free_gpu_memory_fraction: 0.30
+  enable_block_reuse: false
+
+cache_transceiver_config:
+  backend: DEFAULT

--- a/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/decode.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/decode.yaml
@@ -15,15 +15,15 @@
 tensor_parallel_size: 1
 moe_expert_parallel_size: 1
 enable_attention_dp: false
-max_num_tokens: 2048
-max_batch_size: 8
+max_num_tokens: 1024
+max_batch_size: 4
 max_seq_len: 4096
 trust_remote_code: true
 backend: pytorch
 enable_chunked_prefill: true
 disable_overlap_scheduler: false
 kv_cache_config:
-  free_gpu_memory_fraction: 0.15
+  free_gpu_memory_fraction: 0.10
   enable_block_reuse: false
 
 cache_transceiver_config:

--- a/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/decode.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/decode.yaml
@@ -15,14 +15,15 @@
 tensor_parallel_size: 1
 moe_expert_parallel_size: 1
 enable_attention_dp: false
-max_num_tokens: 8192
-max_batch_size: 16
+max_num_tokens: 2048
+max_batch_size: 8
+max_seq_len: 4096
 trust_remote_code: true
 backend: pytorch
 enable_chunked_prefill: true
 disable_overlap_scheduler: false
 kv_cache_config:
-  free_gpu_memory_fraction: 0.30
+  free_gpu_memory_fraction: 0.15
   enable_block_reuse: false
 
 cache_transceiver_config:

--- a/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/encode.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/encode.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+tensor_parallel_size: 1
+moe_expert_parallel_size: 1
+enable_attention_dp: false
+max_num_tokens: 8192
+max_batch_size: 16
+trust_remote_code: true
+backend: pytorch
+enable_chunked_prefill: true
+# Overlap scheduler not currently supported in prefill only workers.
+disable_overlap_scheduler: true
+
+# Note: kv_cache_config is not needed for encode workers since MultimodalEncoder
+# only runs vision encoder + projector and doesn't need KV cache memory.
+
+cache_transceiver_config:
+  backend: DEFAULT

--- a/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/encode.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/encode.yaml
@@ -15,7 +15,7 @@
 tensor_parallel_size: 1
 moe_expert_parallel_size: 1
 enable_attention_dp: false
-max_num_tokens: 2048
+max_num_tokens: 1024
 max_batch_size: 4
 trust_remote_code: true
 backend: pytorch

--- a/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/encode.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/encode.yaml
@@ -15,16 +15,14 @@
 tensor_parallel_size: 1
 moe_expert_parallel_size: 1
 enable_attention_dp: false
-max_num_tokens: 8192
-max_batch_size: 16
+max_num_tokens: 2048
+max_batch_size: 4
 trust_remote_code: true
 backend: pytorch
 enable_chunked_prefill: true
 # Overlap scheduler not currently supported in prefill only workers.
 disable_overlap_scheduler: true
 
-# Note: kv_cache_config is not needed for encode workers since MultimodalEncoder
-# only runs vision encoder + projector and doesn't need KV cache memory.
-
-cache_transceiver_config:
-  backend: DEFAULT
+# Note: Encode workers use MultimodalEncoder (vision encoder + projector only),
+# which ignores most engine_args. No kv_cache_config or cache_transceiver_config
+# is needed since MultimodalEncoder doesn't allocate KV cache or transfer buffers.

--- a/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/prefill.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/prefill.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+tensor_parallel_size: 1
+moe_expert_parallel_size: 1
+enable_attention_dp: false
+max_num_tokens: 8192
+max_batch_size: 16
+trust_remote_code: true
+backend: pytorch
+enable_chunked_prefill: true
+# Overlap scheduler not currently supported in prefill only workers.
+disable_overlap_scheduler: true
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.30
+  enable_block_reuse: false
+
+cache_transceiver_config:
+  backend: DEFAULT

--- a/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/prefill.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/prefill.yaml
@@ -15,8 +15,9 @@
 tensor_parallel_size: 1
 moe_expert_parallel_size: 1
 enable_attention_dp: false
-max_num_tokens: 8192
-max_batch_size: 16
+max_num_tokens: 2048
+max_batch_size: 8
+max_seq_len: 4096
 trust_remote_code: true
 backend: pytorch
 enable_chunked_prefill: true
@@ -24,7 +25,7 @@ enable_chunked_prefill: true
 disable_overlap_scheduler: true
 
 kv_cache_config:
-  free_gpu_memory_fraction: 0.30
+  free_gpu_memory_fraction: 0.15
   enable_block_reuse: false
 
 cache_transceiver_config:

--- a/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/prefill.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/prefill.yaml
@@ -15,8 +15,8 @@
 tensor_parallel_size: 1
 moe_expert_parallel_size: 1
 enable_attention_dp: false
-max_num_tokens: 2048
-max_batch_size: 8
+max_num_tokens: 1024
+max_batch_size: 4
 max_seq_len: 4096
 trust_remote_code: true
 backend: pytorch
@@ -25,7 +25,7 @@ enable_chunked_prefill: true
 disable_overlap_scheduler: true
 
 kv_cache_config:
-  free_gpu_memory_fraction: 0.15
+  free_gpu_memory_fraction: 0.10
   enable_block_reuse: false
 
 cache_transceiver_config:

--- a/examples/backends/trtllm/launch/epd_multimodal_image_and_embeddings.sh
+++ b/examples/backends/trtllm/launch/epd_multimodal_image_and_embeddings.sh
@@ -29,7 +29,8 @@ trap cleanup EXIT INT TERM
 
 
 # run frontend
-python3 -m dynamo.frontend --http-port 8000 &
+# dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
+python3 -m dynamo.frontend &
 DYNAMO_PID=$!
 
 # run encode worker

--- a/examples/backends/trtllm/launch/epd_multimodal_image_and_embeddings.sh
+++ b/examples/backends/trtllm/launch/epd_multimodal_image_and_embeddings.sh
@@ -16,7 +16,7 @@ export ENCODE_ENDPOINT=${ENCODE_ENDPOINT:-"dyn://dynamo.tensorrt_llm_encode.gene
 export MODALITY=${MODALITY:-"multimodal"}
 export ALLOWED_LOCAL_MEDIA_PATH=${ALLOWED_LOCAL_MEDIA_PATH:-"/tmp"}
 export MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
-export CUSTOM_TEMPLATE=${CUSTOM_TEMPLATE:-"$DYNAMO_HOME/examples/backends/trtllm/templates/llava_multimodal.jinja"}
+
 
 # Setup cleanup trap
 cleanup() {

--- a/examples/backends/trtllm/launch/epd_multimodal_image_and_embeddings.sh
+++ b/examples/backends/trtllm/launch/epd_multimodal_image_and_embeddings.sh
@@ -4,14 +4,14 @@
 
 # Environment variables with defaults
 export DYNAMO_HOME=${DYNAMO_HOME:-"/workspace"}
-export MODEL_PATH=${MODEL_PATH:-"llava-hf/llava-v1.6-mistral-7b-hf"}
-export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"llava-v1.6-mistral-7b-hf"}
-export PREFILL_ENGINE_ARGS=${PREFILL_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/prefill.yaml"}
-export DECODE_ENGINE_ARGS=${DECODE_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/decode.yaml"}
-export ENCODE_ENGINE_ARGS=${ENCODE_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/encode.yaml"}
+export MODEL_PATH=${MODEL_PATH:-"Qwen/Qwen3-VL-2B-Instruct"}
+export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"Qwen/Qwen3-VL-2B-Instruct"}
+export PREFILL_ENGINE_ARGS=${PREFILL_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/prefill.yaml"}
+export DECODE_ENGINE_ARGS=${DECODE_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/decode.yaml"}
+export ENCODE_ENGINE_ARGS=${ENCODE_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/encode.yaml"}
 export PREFILL_CUDA_VISIBLE_DEVICES=${PREFILL_CUDA_VISIBLE_DEVICES:-"0"}
-export DECODE_CUDA_VISIBLE_DEVICES=${DECODE_CUDA_VISIBLE_DEVICES:-"1"}
-export ENCODE_CUDA_VISIBLE_DEVICES=${ENCODE_CUDA_VISIBLE_DEVICES:-"2"}
+export DECODE_CUDA_VISIBLE_DEVICES=${DECODE_CUDA_VISIBLE_DEVICES:-"0"}
+export ENCODE_CUDA_VISIBLE_DEVICES=${ENCODE_CUDA_VISIBLE_DEVICES:-"0"}
 export ENCODE_ENDPOINT=${ENCODE_ENDPOINT:-"dyn://dynamo.tensorrt_llm_encode.generate"}
 export MODALITY=${MODALITY:-"multimodal"}
 export ALLOWED_LOCAL_MEDIA_PATH=${ALLOWED_LOCAL_MEDIA_PATH:-"/tmp"}
@@ -50,8 +50,7 @@ CUDA_VISIBLE_DEVICES=$PREFILL_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --extra-engine-args "$PREFILL_ENGINE_ARGS" \
   --modality "$MODALITY" \
   --disaggregation-mode prefill \
-  --encode-endpoint "$ENCODE_ENDPOINT" \
-  --custom-jinja-template "$CUSTOM_TEMPLATE" &
+  --encode-endpoint "$ENCODE_ENDPOINT" &
 PREFILL_PID=$!
 
 # run decode worker
@@ -62,8 +61,7 @@ CUDA_VISIBLE_DEVICES=$DECODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --modality "$MODALITY" \
   --allowed-local-media-path "$ALLOWED_LOCAL_MEDIA_PATH" \
   --max-file-size-mb "$MAX_FILE_SIZE_MB" \
-  --disaggregation-mode decode \
-  --custom-jinja-template "$CUSTOM_TEMPLATE" &
+  --disaggregation-mode decode &
 DECODE_PID=$!
 
 wait $DYNAMO_PID

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -199,8 +199,8 @@ trtllm_configs = {
         delayed_start=60,
         request_payloads=[multimodal_payload_default()],
     ),
-    # TensorRT-LLM EPD (Encode-Prefill-Decode) multimodal test for nightly CI
-    # Uses llava model with 2 GPUs (encode shares GPU with prefill)
+    # TensorRT-LLM EPD (Encode-Prefill-Decode) multimodal test for pre-merge CI
+    # Uses Qwen3-VL-2B-Instruct model with 1 GPU (all workers share same GPU)
     #
     # TODO: Add Llama-4-Scout multimodal tests (agg_multimodal_llama, disagg_multimodal_llama)
     #       once CI supports gpu_8 runners and launch scripts are available

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -207,14 +207,14 @@ trtllm_configs = {
     "epd_multimodal": TRTLLMConfig(
         name="epd_multimodal",
         directory=trtllm_dir,
-        script_name="epd_multimodal_image.sh",
+        script_name="epd_multimodal_image_and_embeddings.sh",
         marks=[
-            pytest.mark.gpu_2,
+            pytest.mark.gpu_1,
             pytest.mark.trtllm,
             pytest.mark.multimodal,
-            pytest.mark.nightly,
+            pytest.mark.pre_merge,
         ],
-        model="llava-hf/llava-v1.6-mistral-7b-hf",
+        model="Qwen/Qwen3-VL-2B-Instruct",
         frontend_port=DefaultPort.FRONTEND.value,
         timeout=900,
         delayed_start=120,
@@ -225,9 +225,8 @@ trtllm_configs = {
             )
         ],
         env={
-            # Override GPU assignments to fit on 2 GPUs (encode shares with prefill)
             "PREFILL_CUDA_VISIBLE_DEVICES": "0",
-            "DECODE_CUDA_VISIBLE_DEVICES": "1",
+            "DECODE_CUDA_VISIBLE_DEVICES": "0",
             "ENCODE_CUDA_VISIBLE_DEVICES": "0",
         },
     ),


### PR DESCRIPTION
#### Overview:

EPD script fixes for stabilty

Closes DYN-2229

#### Details:

Remove model specific variables from launch script.
Add scripts for Qwen/Qwen3-VL-2B-Instruct
Make EPD test run on 1 gpu

#### Where should the reviewer start?

`examples/backends/trtllm/launch/epd_multimodal_image_and_embeddings.sh`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Qwen3-VL-2B-Instruct multimodal model with optimized engine configurations for prefill, encode, and decode stages.

* **Chores**
  * Updated default model configuration in multimodal examples from Llava-Mistral to Qwen3-VL-2B-Instruct.
  * Simplified GPU device allocation defaults to single-GPU setup for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->