### PR TITLE
ci: trigger container validation dynamo on planner and frontend changes

### DIFF
--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -25,6 +25,9 @@ outputs:
   trtllm:
     description: 'Whether trtllm files changed'
     value: ${{ steps.filter.outputs.trtllm_any_modified }}
+  planner:
+    description: 'Whether planner files changed'
+    value: ${{ steps.filter.outputs.planner_any_modified }}
   frontend:
     description: 'Whether frontend files changed'
     value: ${{ steps.filter.outputs.frontend_any_modified }}

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -4,14 +4,15 @@
 #   core     -> dynamo build-test, all backend builds (vllm/sglang/trtllm), deploy tests
 #   operator -> operator build and test
 #   deploy   -> deploy-test-vllm-disagg-router
+#   planner  -> dynamo build-test
 #   vllm     -> vllm build and test
 #   sglang   -> sglang build and test
 #   trtllm   -> trtllm build and test
-#   frontend -> frontend EPP image build
+#   frontend -> frontend EPP image build, dynamo build-test
 #   docs     -> fern docs lint, sync, and version release (docs/ directory)
 #
 # Filters for coverage only (no CI triggered):
-#   examples, ignore, planner
+#   examples, ignore
 
 all:
   - '**'

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       core: ${{ steps.changes.outputs.core }}
+      planner: ${{ steps.changes.outputs.planner }}
+      frontend: ${{ steps.changes.outputs.frontend }}
       builder_name: ${{ steps.export-builder-name.outputs.builder_name }}
     steps:
       - name: Checkout code
@@ -54,7 +56,7 @@ jobs:
 
   build:
     needs: changed-files
-    if: needs.changed-files.outputs.core == 'true'
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.planner == 'true' || needs.changed-files.outputs.frontend == 'true'
     runs-on: prod-builder-v3
     name: Build
     timeout-minutes: 60
@@ -156,7 +158,7 @@ jobs:
 
   test-parallel:
     needs: [changed-files, build]
-    if: needs.changed-files.outputs.core == 'true'
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.planner == 'true' || needs.changed-files.outputs.frontend == 'true'
     runs-on: prod-builder-amd-v1
     name: Pytest (parallel)
     timeout-minutes: 30
@@ -186,7 +188,7 @@ jobs:
 
   test-sequential:
     needs: [changed-files, build]
-    if: needs.changed-files.outputs.core == 'true'
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.planner == 'true' || needs.changed-files.outputs.frontend == 'true'
     runs-on: prod-builder-amd-v1
     name: Pytest (sequential)
     timeout-minutes: 30

--- a/tests/profiler/test_helpers_rapid.py
+++ b/tests/profiler/test_helpers_rapid.py
@@ -84,7 +84,7 @@ class TestRunNaiveFallback:
             "tpot": 0.0,
             "request_latency": 0.0,
         }
-        assert result["chosen_exp"] is None
+        assert result["chosen_exp"] == "agg"
         assert isinstance(result["best_config_df"], pd.DataFrame)
         assert result["best_config_df"].empty
 


### PR DESCRIPTION
Add planner and frontend filter outputs to the changed-files job so the build, test-parallel, and test-sequential jobs also run when planner or frontend paths are modified. Rust checks remain gated on core changes only.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD validation infrastructure to enhance change detection across core system components. The workflow now properly identifies modifications to planner and frontend code alongside core changes, enabling more targeted and efficient automated build and test validation. This infrastructure improvement streamlines the deployment pipeline and ensures comprehensive validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->