### PR TITLE
fix(kvbm): prevent scheduler crash from race between abort and request completion

### DIFF
--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/leader.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/leader.rs
@@ -572,7 +572,21 @@ impl Leader for KvConnectorLeader {
                 "request_finished called for request_id: {request_id} but slot is not found"
             );
             self.inflight_requests.remove(&request_id);
-            return Ok(false);
+            // We must return `true` here even though the leader slot is gone.
+            //
+            // Within a single call to vLLM's `update_from_output()`, two things
+            // happen in sequence:
+            //   1. Stopped requests call _free_request() → request_finished() (here)
+            //   2. Worker's finished_sending is processed by _update_from_kv_xfer_finished()
+            //
+            // The worker's get_finished() ran during the forward pass and may have
+            // reported this request in finished_sending for this same step. If we
+            // return `false`, vLLM deletes the request from self.requests at step 1.
+            // Then step 2 hits `assert req_id in self.requests` and crashes.
+            //
+            // Returning `true` keeps the request in self.requests so step 2 can
+            // process finished_sending and call _free_blocks() properly.
+            return Ok(true);
         }
 
         // grab the slot

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
@@ -419,11 +419,15 @@ impl Worker for KvConnectorWorker {
                     tracing::debug!(request_id, "request slot is not finished");
                 }
             } else {
-                // made this condition more strict slot existence checks were added as a prerequesite
-                // to be added to the maybe_finished_offloading set.
-                panic!(
-                    "request slot missing for {request_id}; however, it was present when added to the maybe finished offloading set"
+                // Slot was removed between when we added it to
+                // maybe_finished_offloading and now. Signal completion so
+                // vLLM can free the request via _free_blocks().
+                tracing::warn!(
+                    request_id,
+                    "request slot missing from maybe_finished_offloading set; \
+                     signaling completion"
                 );
+                is_finished_offloading.insert(request_id.clone());
             }
         }
 
@@ -453,9 +457,15 @@ impl Worker for KvConnectorWorker {
                     tracing::debug!(request_id, "request slot is not finished");
                 }
             } else {
-                panic!(
-                    "request slot missing for {request_id}; however, it was present when added to the maybe finished onboarding set"
+                // Slot was removed between when we added it to
+                // maybe_finished_onboarding and now. Signal completion so
+                // vLLM can free the request via _free_blocks().
+                tracing::warn!(
+                    request_id,
+                    "request slot missing from maybe_finished_onboarding set; \
+                     signaling completion"
                 );
+                is_finished_onboarding.insert(request_id.clone());
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes a race condition in the KVBM connector that crashes the vLLM EngineCore scheduler with `assert req_id in self.requests` in `_update_from_kv_xfer_finished`. The crash is deterministic under streaming load in aggregated inference mode with KVBM.

## Root Cause

The race is between `_process_aborts_queue()` and `update_from_output()` within a single `EngineCore.step()`. When a request's abort and stop condition coincide in the same step:

1. **`execute_model()`** — worker reports `finished_sending` (KV offload complete)
2. **`_process_aborts_queue()`** — abort arrives, calls `request_finished()`, slot removed, returns `true` (request stays in `self.requests`)
3. **`update_from_output()`** — same request hit a stop condition, calls `request_finished()` again, slot is gone, returns `false` → vLLM deletes from `self.requests`
4. **`update_from_output()` continues** — `_update_from_kv_xfer_finished()` processes `finished_sending` → `assert req_id in self.requests` → crash

This is specific to KVBM because KV blocks are offloaded incrementally during generation via `save_kv_layer()`. The final offload can complete in the same step the request finishes, so `finished_sending` contains the request at the same time it's being freed.

## Changes

- **leader.rs:** Return `true` when slot is missing in `request_finished()`, keeping the request alive in `self.requests` so `_update_from_kv_xfer_finished()` can process `finished_sending` and free blocks properly. Aligns with the existing TODO comment (L577-587) that the return value should always be `true`.
- **worker.rs:** Replace two `panic!()` calls with `tracing::warn!()` + signal completion when slots disappear from `maybe_finished_offloading`/`maybe_finished_onboarding` sets between iterations.

## Error observed

\`\`\`
AssertionError at scheduler.py:1950
  assert req_id in self.requests
  in _update_from_kv_xfer_finished
\`\`\`

Preceded by:
\`\`\`
WARN: request_finished called for request_id: ... but slot is not found
WARN: finished request received for unknown request_id; assuming never started
\`\`\`

## Environment

Dynamo v0.9.0, vLLM 0.15.1+cu130, KVBM connector in aggregated inference on L40S GPUs.

## Related

- vllm-project/vllm#25562 (original KeyError variant, closed as stale)
- vllm-project/vllm#25067 (added the always return true invariant comment)

## Test plan

- [ ] Existing CI tests pass (Rust compile + unit tests)
- [ ] Verify with aggregated inference workload under load that the assert req_id in self.requests crash no longer occurs
- [ ] Verify no request leaks (requests stuck in self.requests forever) by monitoring scheduler queue depth under sustained traffic