### PR TITLE
fix: remove costly logs in EPD

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
@@ -47,7 +47,6 @@ class AggregatedHandler(HandlerBase):
                 messages
             )
             if image_urls:
-                logging.info(f"AggregatedHandler: image_urls={image_urls}")
                 result = await fetch_embeddings_from_encoder(
                     image_urls,
                     request,

--- a/components/src/dynamo/trtllm/request_handlers/handlers.py
+++ b/components/src/dynamo/trtllm/request_handlers/handlers.py
@@ -158,7 +158,6 @@ class PrefillHandler(HandlerBase):
             # Handle image URLs (full E-PD flow with MultimodalEncoder)
             elif image_urls:
                 if self.encode_client:
-                    logging.info(f"PrefillHandler: image_urls={image_urls}")
                     result = await fetch_embeddings_from_encoder(
                         image_urls,
                         request,


### PR DESCRIPTION
When users pass base64 data as URL, the URL will become too costly to print out. 

This PR removed unnecessary logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed non-essential internal logging statements across multiple components. System functionality and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->