### PR TITLE
docs: update mm embedding cache graphs

### DIFF
--- a/docs/pages/features/multimodal/multimodal-trtllm.md
+++ b/docs/pages/features/multimodal/multimodal-trtllm.md
@@ -394,12 +394,31 @@ Dynamo supports embedding cache in both aggregated and disaggregated settings fo
 
 | Setting | Implementation | Launch Script | Status |
 |---------|---------------|---------------|--------|
-| **Disaggregated (E/PD)** | Dynamo-managed cache in the PD worker layer on top of TRT-LLM engine | `disagg_e_pd.sh` + `--multimodal-embedding-cache-capacity-gb` | Supported |
+| **Disaggregated Encoder** | Dynamo-managed cache in the PD worker layer on top of TRT-LLM engine | `disagg_e_pd.sh` + `--multimodal-embedding-cache-capacity-gb` | Supported |
 | **Aggregated** | N/A | N/A | Not yet supported |
 
 The cache uses `MultimodalEmbeddingCacheManager` to maintain an LRU cache of encoder embeddings on CPU. When the same image is seen again, the cached embedding is reused instead of re-encoding.
 
-### Disaggregated (E/PD)
+### Disaggregated Encoder (Embedding Cache in Prefill Worker)
+
+In the disaggregated setting, the Prefill Worker (P) owns a CPU-side LRU embedding cache (`EmbeddingCacheManager`). On each request P checks the cache first — on a hit, the Encode Worker is skipped entirely. On a miss, P routes to the Encode Worker (E), receives embeddings via NIXL, saves them to the cache, and then feeds the embeddings along with the request into the TRT-LLM Instance for prefill.
+
+```mermaid
+---
+title: Embedding Cache — Disaggregated Encoder
+---
+flowchart LR
+    req[Request] --> cpu_check{"CPU cache hit?<br/>(EmbeddingCacheManager)"}
+
+    subgraph P ["Prefill Worker (P)"]
+        cpu_check -. hit .-> use[Use cached embedding]
+        use --> trtllm[TRT-LLM Instance]
+    end
+
+    cpu_check -- miss --> E["Encode Worker (E)"]
+    E -- "embeddings via NIXL" --> save["Save to cache"]
+    save --> trtllm
+```
 
 The `disagg_e_pd.sh` script launches a separate encode worker and a PD worker. Extra arguments are forwarded to the PD worker. Enable embedding cache by passing `--multimodal-embedding-cache-capacity-gb`:
 


### PR DESCRIPTION
This PR updates docs with 3 graphs.

e.g. for vLLM, we have

<img width="2352" height="711" alt="output-9" src="https://github.com/user-attachments/assets/338e6fbd-9bf6-47ee-988f-35195cfd44b6" />

<img width="2352" height="831" alt="output-10" src="https://github.com/user-attachments/assets/164576ef-9993-4a2c-af9a-531c9247986f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced multimodal embedding cache documentation with improved terminology and clearer descriptions of cache flows
  * Added visual diagrams illustrating cache hit/miss interactions for encoder configurations
  * Included explicit configuration examples for enabling the embedding cache feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->