### PR TITLE
fix: broken link in profiler guide

### DIFF
--- a/docs/components/profiler/profiler_guide.md
+++ b/docs/components/profiler/profiler_guide.md
@@ -643,4 +643,4 @@ kubectl create secret docker-registry nvcr-imagepullsecret \
 
 - [DGDR Examples](../../../components/src/dynamo/profiler/deploy/) - Complete DGDR YAML examples
 - [DGDR API Reference](/docs/kubernetes/api_reference.md) - DGDR specification
-- [Profiler Arguments Reference](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/profiler/utils/profiler_argparse.py) - Full CLI reference
+- [Profiler Arguments Reference](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py) - Full Configuration Reference


### PR DESCRIPTION
close https://linear.app/nvidia/issue/DYN-2259/fix-profiler-argparsepy-reference-in-profiler-guidemd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Profiler documentation reference links for improved access to configuration information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->