### PR TITLE
fix: mypy type fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "transformers>=4.56.0",
     "pytest>=8.3.4",
     "types-psutil>=7.0.0.20250218",
+    "types-requests>=2.32.4.20260107",
     "kubernetes>=32.0.1,<33.0.0",
     "fastapi>=0.115.0",
     "distro",


### PR DESCRIPTION
#### Overview:

Fix mypy type errors in test utilities to ensure mypy-status passes for migration test files. This adds the missing `types-requests` stub package and resolves type inference issues in `payloads.py`.

#### Details:

- **`pyproject.toml`**: Add `types-requests>=2.32.4.20260107` as a dependency, following the same pattern as the existing `types-psutil` entry. This resolves `[import-untyped]` errors across all test files that `import requests`.

- **`tests/utils/payloads.py`**:
  - Add `cast` to typing imports.
  - Annotate the `events` local variable in `ResponsesStreamPayload.extract_content` as `list[tuple[str, Any]]` to resolve `[index]` errors when subscripting SSE event data.
  - Wrap lambdas that use `lbl=label_name` default-parameter captures with `cast(Callable[...], ...)` in `VLLMMetricsPayload`, `SGLangMetricsPayload`, and `TRTLLMMetricsPayload`.

#### Where should the reviewer start?

- `pyproject.toml` — single-line addition of `types-requests`.
- `tests/utils/payloads.py:557` — the `events` type annotation fix.
- `tests/utils/payloads.py:993` — the `cast()` pattern for loop-capturing lambdas.

DYN-2251
https://nvbugspro.nvidia.com/bug/5936450



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies for improved type checking.

* **Tests**
  * Refined type annotations in test utilities for better code quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->