### PR TITLE
feat: dynamic batching of client side events

### DIFF
--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -132,6 +132,22 @@ pub(crate) struct KvEventPublisher {
 
 #[pymethods]
 impl KvEventPublisher {
+    /// Create a KV event publisher that batches raw engine events before forwarding
+    /// them to NATS / the event plane.
+    ///
+    /// Args:
+    ///     endpoint: The Dynamo component endpoint for this worker.
+    ///     worker_id: Identifier of this worker (default 0).
+    ///     kv_block_size: KV cache block size in tokens; must be > 0.
+    ///     dp_rank: Data-parallel rank of this worker (default 0).
+    ///     enable_local_indexer: When True, a local KV indexer is kept in-process
+    ///         so that routers can recover events directly from this worker.
+    ///     zmq_endpoint: Optional ZMQ SUB endpoint to read raw engine events from.
+    ///     zmq_topic: ZMQ topic filter (default "").
+    ///     batching_timeout_us: Maximum time (in **microseconds**) to accumulate
+    ///         events into a single batch before flushing.
+    ///         ``None`` uses the default window of 10000 µs (10 ms).
+    ///         ``0`` disables batching: every event is published immediately.
     #[new]
     #[pyo3(signature = (endpoint, worker_id=0, kv_block_size=0, dp_rank=0, enable_local_indexer=false, zmq_endpoint=None, zmq_topic=None, batching_timeout_us=None))]
     #[allow(clippy::too_many_arguments)]

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -133,7 +133,7 @@ pub(crate) struct KvEventPublisher {
 #[pymethods]
 impl KvEventPublisher {
     #[new]
-    #[pyo3(signature = (endpoint, worker_id=0, kv_block_size=0, dp_rank=0, enable_local_indexer=false, zmq_endpoint=None, zmq_topic=None))]
+    #[pyo3(signature = (endpoint, worker_id=0, kv_block_size=0, dp_rank=0, enable_local_indexer=false, zmq_endpoint=None, zmq_topic=None, batching_timeout_ms=None))]
     fn new(
         endpoint: Endpoint,
         worker_id: WorkerId,
@@ -142,6 +142,7 @@ impl KvEventPublisher {
         enable_local_indexer: bool,
         zmq_endpoint: Option<String>,
         zmq_topic: Option<String>,
+        batching_timeout_ms: Option<u64>,
     ) -> PyResult<Self> {
         let _ = worker_id;
 
@@ -153,6 +154,10 @@ impl KvEventPublisher {
         if kv_block_size == 0 {
             return Err(to_pyerr(anyhow::anyhow!("kv_block_size cannot be 0")));
         }
+
+        // Build batching config from Python parameters (timeout only, no max batch size)
+        let batching_timeout_ms = batching_timeout_ms.unwrap_or(10);
+        // TODO use this timeout!
 
         // Extract component from endpoint
         let component = endpoint.inner.component().clone();

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -133,7 +133,7 @@ pub(crate) struct KvEventPublisher {
 #[pymethods]
 impl KvEventPublisher {
     #[new]
-    #[pyo3(signature = (endpoint, worker_id=0, kv_block_size=0, dp_rank=0, enable_local_indexer=false, zmq_endpoint=None, zmq_topic=None, batching_timeout_ms=None))]
+    #[pyo3(signature = (endpoint, worker_id=0, kv_block_size=0, dp_rank=0, enable_local_indexer=false, zmq_endpoint=None, zmq_topic=None, batching_timeout_us=None))]
     fn new(
         endpoint: Endpoint,
         worker_id: WorkerId,

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -142,7 +142,7 @@ impl KvEventPublisher {
         enable_local_indexer: bool,
         zmq_endpoint: Option<String>,
         zmq_topic: Option<String>,
-        batching_timeout_ms: Option<u64>,
+        batching_timeout_us: Option<u64>,
     ) -> PyResult<Self> {
         let _ = worker_id;
 
@@ -155,9 +155,6 @@ impl KvEventPublisher {
             return Err(to_pyerr(anyhow::anyhow!("kv_block_size cannot be 0")));
         }
 
-        // Build batching config from Python parameters (timeout only, no max batch size)
-        let batching_timeout_ms = batching_timeout_ms.unwrap_or(10);
-        // TODO use this timeout!
 
         // Extract component from endpoint
         let component = endpoint.inner.component().clone();
@@ -168,6 +165,7 @@ impl KvEventPublisher {
             source_config,
             enable_local_indexer,
             dp_rank,
+            batching_timeout_us,
         )
         .map_err(to_pyerr)?;
 

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -134,6 +134,7 @@ pub(crate) struct KvEventPublisher {
 impl KvEventPublisher {
     #[new]
     #[pyo3(signature = (endpoint, worker_id=0, kv_block_size=0, dp_rank=0, enable_local_indexer=false, zmq_endpoint=None, zmq_topic=None, batching_timeout_us=None))]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         endpoint: Endpoint,
         worker_id: WorkerId,

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -155,7 +155,6 @@ impl KvEventPublisher {
             return Err(to_pyerr(anyhow::anyhow!("kv_block_size cannot be 0")));
         }
 
-
         // Extract component from endpoint
         let component = endpoint.inner.component().clone();
 

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -76,8 +76,6 @@ struct BatchingState {
     last_flush_time: Instant,
 }
 
-
-
 impl BatchingState {
     /// Creates a new BatchingState with current timestamp
     fn new() -> Self {
@@ -478,7 +476,7 @@ async fn run_event_processor_loop<P: EventSink + Send + Sync + 'static>(
 
                 // Check if dp_rank changed before updating state
                 let dp_rank_changed = batching_state.has_pending() && event.dp_rank != batching_state.last_dp_rank;
-                
+
                 batching_state.last_event_id = event.event_id;
                 batching_state.last_dp_rank = event.dp_rank;
 
@@ -486,7 +484,7 @@ async fn run_event_processor_loop<P: EventSink + Send + Sync + 'static>(
                     KvCacheEventData::Removed(removed_data) => {
                         // Flush if switching from Stored, or if dp_rank changed
                         let should_flush = batching_state.pending_stored.is_some() || dp_rank_changed;
-                        
+
                         if should_flush {
                             batching_state.flush(&publisher, &local_indexer, worker_id).await;
                         }
@@ -3068,7 +3066,7 @@ mod event_processor_tests {
     #[tokio::test]
     async fn test_event_type_switching_causes_flush() {
         let timeout_us = 100_000; // 100ms timeout
-        
+
         let (tx, rx) = mpsc::unbounded_channel::<KvCacheEvent>();
         let publisher = MockPublisher::new();
         let publisher_clone = publisher.clone();
@@ -3086,7 +3084,8 @@ mod event_processor_tests {
                 block_hashes: vec![ExternalSequenceBlockHash(0)],
             }),
             dp_rank: 0,
-        }).unwrap();
+        })
+        .unwrap();
 
         // Small sleep
         tokio::time::sleep(tokio::time::Duration::from_micros(100)).await;
@@ -3103,7 +3102,8 @@ mod event_processor_tests {
                 }],
             }),
             dp_rank: 0,
-        }).unwrap();
+        })
+        .unwrap();
 
         // Give time for processing
         tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
@@ -3125,7 +3125,7 @@ mod event_processor_tests {
     #[tokio::test]
     async fn test_dp_rank_change_causes_flush() {
         let timeout_us = 100_000; // 100ms timeout
-        
+
         let (tx, rx) = mpsc::unbounded_channel::<KvCacheEvent>();
         let publisher = MockPublisher::new();
         let publisher_clone = publisher.clone();
@@ -3144,7 +3144,8 @@ mod event_processor_tests {
                     block_hashes: vec![ExternalSequenceBlockHash(i as u64)],
                 }),
                 dp_rank: 0,
-            }).unwrap();
+            })
+            .unwrap();
             tokio::task::yield_now().await;
         }
 
@@ -3156,7 +3157,8 @@ mod event_processor_tests {
                     block_hashes: vec![ExternalSequenceBlockHash(i as u64)],
                 }),
                 dp_rank: 1,
-            }).unwrap();
+            })
+            .unwrap();
             tokio::task::yield_now().await;
         }
 
@@ -3186,6 +3188,9 @@ mod event_processor_tests {
                 }
             })
             .sum();
-        assert_eq!(total_hashes, 6, "All 6 block hashes should be accounted for");
+        assert_eq!(
+            total_hashes, 6,
+            "All 6 block hashes should be accounted for"
+        );
     }
 }

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -399,14 +399,14 @@ impl BatchingState {
             };
             let router_event = RouterEvent::new(worker_id, event);
 
-            if let Some(indexer) = local_indexer {
-                if let Err(e) = indexer.apply_event_with_buffer(router_event.clone()).await {
-                    tracing::warn!(
-                        "Failed to send removed event to local indexer for worker {}: {}",
-                        worker_id,
-                        e
-                    );
-                }
+            if let Some(indexer) = local_indexer
+                && let Err(e) = indexer.apply_event_with_buffer(router_event.clone()).await
+            {
+                tracing::warn!(
+                    "Failed to send removed event to local indexer for worker {}: {}",
+                    worker_id,
+                    e
+                );
             }
 
             if let Err(e) = publisher.publish_event(&router_event).await {
@@ -422,14 +422,14 @@ impl BatchingState {
             };
             let router_event = RouterEvent::new(worker_id, event);
 
-            if let Some(indexer) = local_indexer {
-                if let Err(e) = indexer.apply_event_with_buffer(router_event.clone()).await {
-                    tracing::warn!(
-                        "Failed to send stored event to local indexer for worker {}: {}",
-                        worker_id,
-                        e
-                    );
-                }
+            if let Some(indexer) = local_indexer
+                && let Err(e) = indexer.apply_event_with_buffer(router_event.clone()).await
+            {
+                tracing::warn!(
+                    "Failed to send stored event to local indexer for worker {}: {}",
+                    worker_id,
+                    e
+                );
             }
 
             if let Err(e) = publisher.publish_event(&router_event).await {
@@ -540,15 +540,14 @@ async fn run_event_processor_loop<P: EventSink + Send + Sync + 'static>(
 
                         let router_event = RouterEvent::new(worker_id, event);
 
-                        if let Some(indexer) = &local_indexer {
-                            if let Err(e) = indexer.apply_event_with_buffer(router_event.clone()).await {
+                        if let Some(indexer) = &local_indexer
+                            && let Err(e) = indexer.apply_event_with_buffer(router_event.clone()).await {
                                 tracing::warn!(
                                     "Failed to send cleared event to local indexer for worker {}: {}",
                                     worker_id,
                                     e
                                 );
                             }
-                        }
 
                         if let Err(e) = publisher.publish_event(&router_event).await {
                             tracing::error!("Failed to publish cleared event: {}", e);
@@ -3273,7 +3272,11 @@ mod event_processor_tests {
 
         let events = publisher.get_events();
 
-        assert_eq!(events.len(), 2, "Should have 2 events (one per dp_rank batch)");
+        assert_eq!(
+            events.len(),
+            2,
+            "Should have 2 events (one per dp_rank batch)"
+        );
 
         // First event should have dp_rank=0 and event_id from first batch (last event_id = 12)
         assert_eq!(
@@ -3353,7 +3356,10 @@ mod event_processor_tests {
                 }
             })
             .sum();
-        assert_eq!(total_hashes, 3, "All 3 block hashes should be accounted for");
+        assert_eq!(
+            total_hashes, 3,
+            "All 3 block hashes should be accounted for"
+        );
     }
 
     /// Test that stored events with dp_rank change have correct metadata
@@ -3425,7 +3431,11 @@ mod event_processor_tests {
 
         let events = publisher.get_events();
 
-        assert_eq!(events.len(), 2, "Should have 2 events (one per dp_rank batch)");
+        assert_eq!(
+            events.len(),
+            2,
+            "Should have 2 events (one per dp_rank batch)"
+        );
 
         // First batch: dp_rank=0, event_id=101 (last event in first batch)
         assert_eq!(

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -325,6 +325,7 @@ impl MockVllmEngine {
                                 source_config,
                                 args.enable_local_indexer,
                                 dp_rank,
+                                None,
                             ) {
                                 Ok(publisher) => (
                                     Some(Arc::new(sink) as Arc<dyn KvCacheEventSink>),
@@ -353,6 +354,7 @@ impl MockVllmEngine {
                         None,
                         args.enable_local_indexer,
                         dp_rank,
+                        None,
                     ) {
                         Ok(publisher) => (
                             Some(Arc::new(KvEventSinkAdapter(publisher))


### PR DESCRIPTION
Signed-off-by: michaelfeil <63565275+michaelfeil@users.noreply.github.com>

#### Overview:

#### Details:

tl;dr:
- I read though this blog post. https://docs.nvidia.com/dynamo/dev/blog/flash-indexer 
- I remembered that we were actually bottlenecked by the rps going to the dynamo router. (router only was able to consume something between 1k and 20k rps ish, which is reasonable). 
- I remembered that the actual bottleneck was a bug (feature) in trt-llm, where trt loves to push events removed 1-by-1, even if they are pseudo sequential (within 1ms?!).  trt-llm actually just sends single-block removed events afaik, and it often does so fast in a row (e.g. when making space for a new prefill coming in)

Want to implement dynamic batching:
- delay publish for a reasonable amount of time (say 5, 10 or 20ms), without becoming stale. Try to aggregate two events into one one, on a best effort basis. (especially will happen for remove events and trt-llm).
- goal: the consumer of the event should not fall behind (consumer == all routers which is much fewer than workers). 

Issue: A lot of logic when you can batch events: Same type (removed | stored), same dp-rank (side-issue, trt-llm all events get broadcasted to rank 0, unlike vllm where you spawn 1 publisher per dp and mpi rank). 

Implementation: Push until deadline. In the idle case: Always publish. On massive ingress (100 of removed events within 5ms - try to batch as much as we can).


<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

The poem by coderabbit is pretty good:
A timeout's tick, events now batch,
Removed and stored in careful catch,
Each microsecond tells its tale,
The publisher's batching will not fail!

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
- closes issue: https://basetenlabs.slack.com/archives/C09LSE9L07L/p1762539024351979 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable event batching for KV operations with timeout-driven flushes.
  * Optional batching timeout exposed in both Rust and Python constructors for the KV event publisher.

* **Refactor**
  * Unified event-processing pipeline so all transport modes share the same batching and flush logic.

* **Tests**
  * Added tests covering batching behavior, timeout-based flushes, and edge-case scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->