### PR TITLE
chore: update version and repo of chrek helm chart

### DIFF
--- a/deploy/helm/charts/chrek/Chart.yaml
+++ b/deploy/helm/charts/chrek/Chart.yaml
@@ -16,8 +16,8 @@ apiVersion: v2
 name: chrek
 description: Checkpoint/Restore infrastructure for Dynamo (PVC + DaemonSet + CRIU Agent)
 type: application
-version: 0.1.0
-appVersion: "1.0"
+version: 1.0.0
+appVersion: "1.0.0"
 keywords:
   - nvidia
   - dynamo

--- a/deploy/helm/charts/chrek/values.yaml
+++ b/deploy/helm/charts/chrek/values.yaml
@@ -52,8 +52,8 @@ storage:
 daemonset:
   # Container image
   image:
-    repository: nvcr.io/nvidian/dynamo-dev/chrek-agent
-    tag: latest
+    repository: nvcr.io/nvidia/ai-dynamo/chrek-agent
+    tag: 1.0.0
     pullPolicy: Always
 
   # Image pull secrets


### PR DESCRIPTION
#### Overview:

Bringing the ChReK helm chart to 1.0.0

#### Details:

Note that we do not use `latest` tag for artifacts in Dynamo so this is pinned to 1.0.0 as well even though it is not currently released.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to OPS-3560


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart to version 1.0.0, marking the stable release milestone
  * Updated container image references to version 1.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->