### PR TITLE
fix(operator): prevent nil pointer panic when DGD service omits replicas

### DIFF
--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -835,7 +835,11 @@ func expandRolesForService(serviceName string, serviceReplicas *int32, numberOfN
 		roles = append(roles, ServiceRole{Name: serviceName + "-" + commonconsts.GroveRoleSuffixLeader, Role: RoleLeader, Replicas: 1})
 		roles = append(roles, ServiceRole{Name: serviceName + "-" + commonconsts.GroveRoleSuffixWorker, Role: RoleWorker, Replicas: numberOfNodes - 1})
 	} else {
-		roles = append(roles, ServiceRole{Name: serviceName, Role: RoleMain, Replicas: *serviceReplicas})
+		replicas := int32(1)
+		if serviceReplicas != nil {
+			replicas = *serviceReplicas
+		}
+		roles = append(roles, ServiceRole{Name: serviceName, Role: RoleMain, Replicas: replicas})
 	}
 	return roles
 }

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -4243,14 +4243,14 @@ func TestExpandRolesForService(t *testing.T) {
 		name            string
 		serviceName     string
 		numberOfNodes   int32
-		serviceReplicas int32
+		serviceReplicas *int32
 		expected        []ServiceRole
 	}{
 		{
 			name:            "single node",
 			serviceName:     "test-service",
 			numberOfNodes:   1,
-			serviceReplicas: 2,
+			serviceReplicas: ptr.To(int32(2)),
 			expected: []ServiceRole{
 				{Name: "test-service", Role: RoleMain, Replicas: 2},
 			},
@@ -4277,7 +4277,15 @@ func TestExpandRolesForService(t *testing.T) {
 			name:            "zero nodes should return main",
 			serviceName:     "test-service",
 			numberOfNodes:   0,
-			serviceReplicas: 1,
+			serviceReplicas: ptr.To(int32(1)),
+			expected: []ServiceRole{
+				{Name: "test-service", Role: RoleMain, Replicas: 1},
+			},
+		},
+		{
+			name:          "nil replicas defaults to 1",
+			serviceName:   "test-service",
+			numberOfNodes: 1,
 			expected: []ServiceRole{
 				{Name: "test-service", Role: RoleMain, Replicas: 1},
 			},
@@ -4286,7 +4294,7 @@ func TestExpandRolesForService(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := expandRolesForService(tt.serviceName, &tt.serviceReplicas, tt.numberOfNodes)
+			result := expandRolesForService(tt.serviceName, tt.serviceReplicas, tt.numberOfNodes)
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("expandRolesForService() = %v, want %v", result, tt.expected)
 			}

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -4290,6 +4290,15 @@ func TestExpandRolesForService(t *testing.T) {
 				{Name: "test-service", Role: RoleMain, Replicas: 1},
 			},
 		},
+		{
+			name:            "zero replicas preserved",
+			serviceName:     "test-service",
+			numberOfNodes:   1,
+			serviceReplicas: ptr.To(int32(0)),
+			expected: []ServiceRole{
+				{Name: "test-service", Role: RoleMain, Replicas: 0},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler.go
@@ -51,8 +51,9 @@ func NewDGDDefaulter(operatorVersion string) *DGDDefaulter {
 }
 
 // Default implements admission.CustomDefaulter.
+// On every operation: defaults nil Replicas to 1 for all services.
 // On CREATE: stamps nvidia.com/dynamo-operator-origin-version with the operator version.
-// On UPDATE: does nothing -- the origin version is immutable once set.
+// On UPDATE/DELETE: the origin version annotation is immutable once set.
 func (d *DGDDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	logger := log.FromContext(ctx).WithName(dgdDefaultingWebhookName)
 

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler_test.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -161,6 +162,77 @@ func TestDGDDefaulter_Default(t *testing.T) {
 			if got != tt.wantAnnotation {
 				t.Errorf("annotation %q = %q, want %q",
 					consts.KubeAnnotationDynamoOperatorOriginVersion, got, tt.wantAnnotation)
+			}
+		})
+	}
+}
+
+func TestDGDDefaulter_DefaultsNilReplicas(t *testing.T) {
+	tests := []struct {
+		name         string
+		op           admissionv1.Operation
+		services     map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec
+		wantReplicas map[string]int32
+	}{
+		{
+			name: "CREATE defaults nil replicas to 1",
+			op:   admissionv1.Create,
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"Frontend":    {Replicas: nil},
+				"VllmWorker":  {Replicas: ptr.To(int32(3))},
+				"NilService":  {Replicas: nil},
+			},
+			wantReplicas: map[string]int32{
+				"Frontend":   1,
+				"VllmWorker": 3,
+				"NilService": 1,
+			},
+		},
+		{
+			name: "UPDATE defaults nil replicas to 1",
+			op:   admissionv1.Update,
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"NewService": {Replicas: nil},
+			},
+			wantReplicas: map[string]int32{
+				"NewService": 1,
+			},
+		},
+		{
+			name: "does not overwrite explicit replicas",
+			op:   admissionv1.Create,
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"Worker": {Replicas: ptr.To(int32(5))},
+			},
+			wantReplicas: map[string]int32{
+				"Worker": 5,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defaulter := NewDGDDefaulter("0.9.0")
+			dgd := &nvidiacomv1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentSpec{
+					Services: tt.services,
+				},
+			}
+
+			if err := defaulter.Default(admissionCtx(tt.op), dgd); err != nil {
+				t.Fatalf("Default() unexpected error: %v", err)
+			}
+
+			for name, want := range tt.wantReplicas {
+				svc := dgd.Spec.Services[name]
+				if svc.Replicas == nil {
+					t.Errorf("service %q: replicas is nil, want %d", name, want)
+					continue
+				}
+				if *svc.Replicas != want {
+					t.Errorf("service %q: replicas = %d, want %d", name, *svc.Replicas, want)
+				}
 			}
 		})
 	}

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler_test.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler_test.go
@@ -208,6 +208,24 @@ func TestDGDDefaulter_DefaultsNilReplicas(t *testing.T) {
 				"Worker": 5,
 			},
 		},
+		{
+			name: "preserves explicit zero replicas",
+			op:   admissionv1.Create,
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"Idle": {Replicas: ptr.To(int32(0))},
+			},
+			wantReplicas: map[string]int32{
+				"Idle": 0,
+			},
+		},
+		{
+			name: "nil service pointer in map is safe",
+			op:   admissionv1.Create,
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"Ghost": nil,
+			},
+			wantReplicas: map[string]int32{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler_test.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler_test.go
@@ -178,9 +178,9 @@ func TestDGDDefaulter_DefaultsNilReplicas(t *testing.T) {
 			name: "CREATE defaults nil replicas to 1",
 			op:   admissionv1.Create,
 			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-				"Frontend":    {Replicas: nil},
-				"VllmWorker":  {Replicas: ptr.To(int32(3))},
-				"NilService":  {Replicas: nil},
+				"Frontend":   {Replicas: nil},
+				"VllmWorker": {Replicas: ptr.To(int32(3))},
+				"NilService": {Replicas: nil},
 			},
 			wantReplicas: map[string]int32{
 				"Frontend":   1,


### PR DESCRIPTION
#### Overview:

The operator panics with a nil pointer dereference during DGD reconciliation when a service spec omits the `replicas` field. `Replicas` is `*int32` with `omitempty` — omitting it is valid per the CRD schema, but `expandRolesForService()` dereferences the pointer without a nil check.

#### Details:

Two-layer fix:

1. **Defaulting webhook** — the DGD mutating webhook now iterates `dgd.Spec.Services` and sets `Replicas` to `ptr.To(int32(1))` when nil. Applied on every operation (CREATE and UPDATE) so services added later also get the default. This is the standard K8s pattern: webhooks stamp defaults before resources reach controllers.

2. **Nil guard in `expandRolesForService()`** — defense in depth for cases where the webhook is bypassed (direct etcd writes, webhook downtime). Defaults to 1 instead of panicking.

Explicit `replicas: 0` is unaffected — a non-nil `*int32` with value 0 passes through both layers untouched.

#### Where should the reviewer start?

- `deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler.go` — the defaulting logic
- `deploy/operator/internal/dynamo/graph.go` — the nil guard in `expandRolesForService()`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #6673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nil pointer dereference in single-node deployments when service replica count is not explicitly set.
  * Added automatic defaulting of service replicas to 1 when not specified, ensuring proper deployment initialization and preventing crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->