### PR TITLE
fix(operator): disable NVIDIA runtime for CPU-only components

### DIFF
--- a/deploy/operator/internal/dynamo/component_epp.go
+++ b/deploy/operator/internal/dynamo/component_epp.go
@@ -95,6 +95,13 @@ func (e *EPPDefaults) GetBaseContainer(context ComponentContext) (corev1.Contain
 			Name:  "RUST_LOG",
 			Value: "debug,dynamo_llm::kv_router=trace",
 		},
+		{
+			// EPP is a CPU-only component. Disable NVIDIA Container
+			// Toolkit GPU injection so the pod can run on nodes without
+			// GPU drivers installed.
+			Name:  "NVIDIA_VISIBLE_DEVICES",
+			Value: "void",
+		},
 	}...)
 
 	// EPP default args

--- a/deploy/operator/internal/dynamo/component_frontend.go
+++ b/deploy/operator/internal/dynamo/component_frontend.go
@@ -80,6 +80,15 @@ func (f *FrontendDefaults) GetBaseContainer(context ComponentContext) (corev1.Co
 			Name:  commonconsts.DynamoNamespacePrefixEnvVar,
 			Value: context.DynamoNamespace,
 		},
+		{
+			// Frontend is a CPU-only component. Disable NVIDIA Container
+			// Toolkit GPU injection so the pod can run on nodes without
+			// GPU drivers installed. The base CUDA image sets
+			// NVIDIA_VISIBLE_DEVICES=all which triggers nvidia-container-cli
+			// initialization even when no GPU resources are requested.
+			Name:  "NVIDIA_VISIBLE_DEVICES",
+			Value: "void",
+		},
 	}...)
 
 	return container, nil

--- a/deploy/operator/internal/dynamo/component_planner.go
+++ b/deploy/operator/internal/dynamo/component_planner.go
@@ -35,6 +35,13 @@ func (p *PlannerDefaults) GetBaseContainer(context ComponentContext) (corev1.Con
 			Name:  "PLANNER_PROMETHEUS_PORT",
 			Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort),
 		},
+		{
+			// Planner is a CPU-only component. Disable NVIDIA Container
+			// Toolkit GPU injection so the pod can run on nodes without
+			// GPU drivers installed.
+			Name:  "NVIDIA_VISIBLE_DEVICES",
+			Value: "void",
+		},
 	}...)
 	return container, nil
 }

--- a/deploy/operator/internal/dynamo/component_planner_test.go
+++ b/deploy/operator/internal/dynamo/component_planner_test.go
@@ -71,6 +71,7 @@ func TestPlannerDefaults_GetBaseContainer(t *testing.T) {
 					}},
 					{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: "kubernetes"},
 					{Name: "PLANNER_PROMETHEUS_PORT", Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort)},
+					{Name: "NVIDIA_VISIBLE_DEVICES", Value: "void"},
 				},
 			},
 		},


### PR DESCRIPTION
#### Overview:

Frontend, EPP, and planner pods fail with `nvidia-container-cli: initialization error: nvml error: driver not loaded` when scheduled on CPU-only nodes in mixed GPU/CPU clusters.

#### Details:

The vllm-runtime base image inherits `NVIDIA_VISIBLE_DEVICES=all` from the CUDA base image. The NVIDIA Container Toolkit intercepts container creation, sees this env var, and tries to initialize the NVIDIA driver — even for pods that don't request GPU resources. On CPU-only nodes this fails because no NVIDIA drivers are installed.

The fix sets `NVIDIA_VISIBLE_DEVICES=void` in the container env for all non-GPU component types:
- **Frontend** — HTTP API router, pure CPU
- **EPP** — Endpoint Picker Plugin (gRPC), pure CPU
- **Planner** — deployment planner, pure CPU

`void` tells the NVIDIA Container Toolkit to skip GPU device injection entirely. GPU workers (worker, prefill, decode) are unaffected — the NVIDIA device plugin overrides this env var with specific GPU UUIDs when `nvidia.com/gpu` resources are allocated through the Kubernetes device plugin API.

#### Where should the reviewer start?

- `deploy/operator/internal/dynamo/component_frontend.go` — frontend env var addition
- `deploy/operator/internal/dynamo/component_epp.go` — EPP env var addition
- `deploy/operator/internal/dynamo/component_planner.go` — planner env var addition
- `deploy/operator/internal/dynamo/graph_test.go` — dedicated test covering all 6 component types (3 non-GPU assert `void`, 3 GPU assert no `void`)

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #6675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-GPU deployment components to properly run on CPU-only infrastructure by disabling NVIDIA GPU tooling, removing GPU driver dependencies and enabling cost-effective deployments.

* **Tests**
  * Updated comprehensive test cases to validate proper NVIDIA runtime configuration handling and verify all non-GPU components correctly support CPU-only deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->