### PR TITLE
feat(perf): add request pipeline instrumentation and feature gated NVTX markers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,6 +2136,7 @@ dependencies = [
  "chrono",
  "console-subscriber",
  "criterion 0.5.1",
+ "cudarc",
  "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,3 +151,10 @@ insta.opt-level = 3
 # These make the build much slower but shrink the binary, and could help performance
 codegen-units = 1
 lto = "thin"
+
+# Profiling profile: release-like but retains debug symbols for perf/flamegraph/Nsight.
+# Build: cargo build --profile profiling --features nvtx
+[profile.profiling]
+inherits = "release"
+debug = true
+strip = false

--- a/lib/bindings/python/.cargo/config.toml
+++ b/lib/bindings/python/.cargo/config.toml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Mirrors the root .cargo/config.toml so this standalone workspace
+# gets the same build flags (tokio_unstable is required for Tokio metrics APIs).
+
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1801,6 +1801,7 @@ dependencies = [
  "blake3",
  "bytes",
  "chrono",
+ "cudarc",
  "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -27,6 +27,7 @@ media-ffmpeg = ["dynamo-llm/media-ffmpeg"]
 kv-indexer = ["dep:clap", "dep:tracing-subscriber"]
 kv-indexer-runtime = ["kv-indexer", "dynamo-kv-router/indexer-runtime"]
 kv-indexer-metrics = ["kv-indexer", "dynamo-kv-router/metrics"]
+nvtx = ["dynamo-runtime/nvtx"]
 
 [dependencies]
 dynamo-runtime = { path = "../../runtime" }
@@ -79,3 +80,8 @@ dynamo-llm = { path = "../../llm" }
 dynamo-llm = { path = "../../llm", default-features = false }
 
 [dev-dependencies]
+
+[profile.profiling]
+inherits = "release"
+debug = true
+strip = false

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -245,16 +245,18 @@ class name_prefix:
     FRONTEND = "dynamo_frontend"
     # Prefix for KV router metrics (used with router_id label)
     ROUTER = "dynamo_router"
+    # Prefix for request-plane (transport-agnostic) metrics at AddressedPushRouter
+    REQUEST_PLANE = "dynamo_request_plane"
     # Prefix for tokio runtime metrics
     TOKIO = "dynamo_tokio"
     # Prefix for standalone KV indexer metrics
     KVINDEXER = "dynamo_kvindexer"
-    # Prefix for request-plane metrics at AddressedPushRouter
-    REQUEST_PLANE = "dynamo_request_plane"
     # Prefix for transport-layer metrics (TCP / NATS)
     TRANSPORT = "dynamo_transport"
     # Prefix for work-handler transport breakdown metrics (backend side)
     WORK_HANDLER = "dynamo_work_handler"
+    # Prefix for routing overhead metrics (raw Prometheus, not component-scoped)
+    ROUTING_OVERHEAD = "dynamo_routing_overhead"
 
 
 class request_plane:

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -51,8 +51,10 @@ class frontend_perf:
     TOKENIZE_SECONDS = "tokenize_seconds"
     # Template application time in preprocessor
     TEMPLATE_SECONDS = "template_seconds"
-    # Per-token detokenization cost (microseconds)
-    DETOKENIZE_PER_TOKEN_US = "detokenize_per_token_us"
+    # Cumulative detokenization time (microseconds); pair with DETOKENIZE_TOKEN_COUNT
+    DETOKENIZE_TOTAL_US = "detokenize_total_us"
+    # Total tokens detokenized; use rate(total_us)/rate(count) for per-token average
+    DETOKENIZE_TOKEN_COUNT = "detokenize_token_count"
     # Event loop delay canary (sleep 10ms, measure drift)
     EVENT_LOOP_DELAY_SECONDS = "event_loop_delay_seconds"
     # Count of event loop stalls (delay > 5ms)

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -22,6 +22,8 @@ testing-cuda = ["dep:cudarc", "dynamo-memory/testing-cuda"]
 testing-nixl = ["dep:nixl-sys", "dynamo-memory/testing-nixl"]
 testing-etcd = []
 block-manager = ["dep:nixl-sys", "dep:cudarc", "dep:nix", "dep:aligned-vec"]
+# Forward the NVTX feature to dynamo-runtime (build with --features nvtx or dynamo-llm/nvtx)
+nvtx = ["dynamo-runtime/nvtx"]
 block-manager-bench = ["block-manager", "testing-full", "dep:clap", "dep:indicatif"]
 cuda = ["dep:cudarc"]
 integration = ["dynamo-runtime/integration"]

--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -22,7 +22,6 @@ use futures::stream::{self, StreamExt};
 
 use crate::model_card::ModelDeploymentCard;
 use dynamo_runtime::dynamo_nvtx_range;
-use dynamo_runtime::metrics::frontend_perf::DETOKENIZE_PER_TOKEN_US;
 use dynamo_runtime::{
     pipeline::{
         AsyncEngineContextProvider, ManyOut, Operator, ResponseStream, ServerStreamingEngine,
@@ -475,7 +474,6 @@ impl Decoder {
             self.decode_stream.step(token_id)?
         };
         let detokenize_elapsed = detokenize_start.elapsed();
-        DETOKENIZE_PER_TOKEN_US.observe(detokenize_elapsed.as_micros() as f64);
         if let Some(tracker) = &self.tracker {
             tracker.record_detokenize_latency(detokenize_elapsed);
         }

--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -21,6 +21,8 @@ use anyhow::Result;
 use futures::stream::{self, StreamExt};
 
 use crate::model_card::ModelDeploymentCard;
+use dynamo_runtime::dynamo_nvtx_range;
+use dynamo_runtime::metrics::frontend_perf::DETOKENIZE_PER_TOKEN_US;
 use dynamo_runtime::{
     pipeline::{
         AsyncEngineContextProvider, ManyOut, Operator, ResponseStream, ServerStreamingEngine,
@@ -468,9 +470,14 @@ impl Decoder {
 
         // decode the token
         let detokenize_start = Instant::now();
-        let token = self.decode_stream.step(token_id)?;
+        let token = {
+            let _nvtx = dynamo_nvtx_range!("detokenize");
+            self.decode_stream.step(token_id)?
+        };
+        let detokenize_elapsed = detokenize_start.elapsed();
+        DETOKENIZE_PER_TOKEN_US.observe(detokenize_elapsed.as_micros() as f64);
         if let Some(tracker) = &self.tracker {
-            tracker.record_detokenize_latency(detokenize_start.elapsed());
+            tracker.record_detokenize_latency(detokenize_elapsed);
         }
 
         // stop conditions to not apply until the minimum number of tokens have been generated

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -53,7 +53,6 @@ pub async fn run(
         http_service_builder.cancel_token(Some(distributed_runtime.primary_token()));
     http_service_builder =
         http_service_builder.with_request_template(engine_config.local_model().request_template());
-
     // Inject the DRT's metrics registry so that component-scoped metrics
     // (e.g. KvIndexerMetrics) are exposed (default port 8000 if not overridden).
     http_service_builder =

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -279,7 +279,7 @@ impl HttpService {
         tracing::info!(protocol, address, "Starting HTTP(S) service");
 
         // Spawn tokio runtime metrics collector and event-loop canary on this runtime
-        tokio::spawn(tokio_metrics_and_canary_loop());
+        tokio::spawn(tokio_metrics_and_canary_loop(cancel_token.clone()));
 
         let router = self.router.clone();
         let observer = cancel_token.child_token();

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -29,6 +29,12 @@ use dynamo_runtime::config::env_is_truthy;
 use dynamo_runtime::config::environment_names::llm as env_llm;
 use dynamo_runtime::discovery::Discovery;
 use dynamo_runtime::logging::make_request_span;
+use dynamo_runtime::metrics::{
+    frontend_perf::ensure_frontend_perf_metrics_registered_prometheus,
+    request_plane::ensure_request_plane_metrics_registered_prometheus,
+    tokio_perf::{ensure_tokio_perf_metrics_registered_prometheus, tokio_metrics_and_canary_loop},
+    transport_metrics::ensure_transport_metrics_registered_prometheus,
+};
 use std::net::SocketAddr;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -272,6 +278,9 @@ impl HttpService {
         let protocol = if self.enable_tls { "HTTPS" } else { "HTTP" };
         tracing::info!(protocol, address, "Starting HTTP(S) service");
 
+        // Spawn tokio runtime metrics collector and event-loop canary on this runtime
+        tokio::spawn(tokio_metrics_and_canary_loop());
+
         let router = self.router.clone();
         let observer = cancel_token.child_token();
 
@@ -459,6 +468,19 @@ impl HttpServiceConfigBuilder {
             if let Err(e) = RoutingOverheadMetrics::register(&registry, instance_id) {
                 tracing::warn!("Failed to register routing overhead metrics: {}", e);
             }
+        }
+
+        if let Err(e) = ensure_request_plane_metrics_registered_prometheus(&registry) {
+            tracing::warn!("Failed to register request-plane metrics: {}", e);
+        }
+        if let Err(e) = ensure_frontend_perf_metrics_registered_prometheus(&registry) {
+            tracing::warn!("Failed to register frontend perf metrics: {}", e);
+        }
+        if let Err(e) = ensure_tokio_perf_metrics_registered_prometheus(&registry) {
+            tracing::warn!("Failed to register tokio perf metrics: {}", e);
+        }
+        if let Err(e) = ensure_transport_metrics_registered_prometheus(&registry) {
+            tracing::warn!("Failed to register transport metrics: {}", e);
         }
 
         let mut router = axum::Router::new();

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -317,7 +317,9 @@ impl HttpService {
 
             tokio::select! {
                 result = server => {
-                    result.map_err(|e| anyhow::anyhow!("HTTPS server error: {}", e))?;
+                    let result = result.map_err(|e| anyhow::anyhow!("HTTPS server error: {}", e));
+                    cancel_token.cancel();
+                    result?;
                 }
                 _ = observer.cancelled() => {
                     state_cancel.cancel();
@@ -365,6 +367,7 @@ impl HttpService {
                 })
                 .await
                 .inspect_err(|_| cancel_token.cancel())?;
+            cancel_token.cancel();
         }
 
         Ok(())

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -278,9 +278,6 @@ impl HttpService {
         let protocol = if self.enable_tls { "HTTPS" } else { "HTTP" };
         tracing::info!(protocol, address, "Starting HTTP(S) service");
 
-        // Spawn tokio runtime metrics collector and event-loop canary on this runtime
-        tokio::spawn(tokio_metrics_and_canary_loop(cancel_token.clone()));
-
         let router = self.router.clone();
         let observer = cancel_token.child_token();
 
@@ -314,6 +311,9 @@ impl HttpService {
             let server = axum_server::bind_rustls(addr, config)
                 .handle(handle.clone())
                 .serve(router.into_make_service());
+
+            // Spawn canary after all fallible startup so it won't leak on early errors
+            tokio::spawn(tokio_metrics_and_canary_loop(cancel_token.clone()));
 
             tokio::select! {
                 result = server => {
@@ -349,6 +349,9 @@ impl HttpService {
                     ),
                 }
             })?;
+
+            // Spawn canary after all fallible startup so it won't leak on early errors
+            tokio::spawn(tokio_metrics_and_canary_loop(cancel_token.clone()));
 
             axum::serve(listener, router)
                 .with_graceful_shutdown(async move {

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use dynamo_kv_router::protocols::{TokensWithHashes, WorkerWithDpRank};
 use dynamo_runtime::{
+    dynamo_nvtx_range,
     pipeline::{
         AsyncEngine, AsyncEngineContextProvider, Error, ManyOut, PushRouter, ResponseStream,
         SingleIn, async_trait,
@@ -222,6 +223,7 @@ impl KvPushRouter {
         phase: RequestPhase,
         is_query_only: bool,
     ) -> Result<WorkerSelection, Error> {
+        let _nvtx_select = dynamo_nvtx_range!("route.select_worker");
         let routing = request.routing.as_ref();
         let lora_name = routing.and_then(|r| r.lora_name.clone());
         let priority_jump = routing.and_then(|r| r.priority_jump).unwrap_or(0.0);
@@ -242,6 +244,7 @@ impl KvPushRouter {
         };
 
         let Some(id) = preselected_id else {
+            let _nvtx_kv = dynamo_nvtx_range!("route.kv_match");
             let (best_worker, overlap_amount) = self
                 .chooser
                 .find_best_match(

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -30,7 +30,8 @@ use std::time::{Duration, Instant};
 
 use dynamo_runtime::dynamo_nvtx_range;
 use dynamo_runtime::metrics::frontend_perf::{
-    STAGE_DURATION_SECONDS, TEMPLATE_SECONDS, TOKENIZE_SECONDS,
+    DETOKENIZE_TOKEN_COUNT, DETOKENIZE_TOTAL_US, STAGE_DURATION_SECONDS, TEMPLATE_SECONDS,
+    TOKENIZE_SECONDS,
 };
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 use tracing;
@@ -892,6 +893,15 @@ impl OpenAIPreprocessor {
                         detokenize_count: tracker.as_ref().map(|t| t.detokenize_count()),
                     };
 
+                    // Flush per-request detokenize accumulators to global Prometheus counters
+                    // (once per request instead of per-token).
+                    if let Some(t) = tracker.as_ref() {
+                        if let Some(total) = t.detokenize_total_latency() {
+                            DETOKENIZE_TOTAL_US.inc_by(total.as_micros() as f64);
+                        }
+                        DETOKENIZE_TOKEN_COUNT.inc_by(t.detokenize_count() as f64);
+                    }
+
                     if let Ok(metrics_annotated) = llm_metrics.to_annotation::<()>() {
                         // Only set event if not already set to avoid overriding existing events (like errors)
                         if response.event.is_none() {
@@ -956,6 +966,15 @@ impl OpenAIPreprocessor {
                                 .and_then(|t| t.detokenize_total_latency()),
                             detokenize_count: tracker.as_ref().map(|t| t.detokenize_count()),
                         };
+
+                        // Flush per-request detokenize accumulators to global Prometheus counters
+                        // (once per request instead of per-token).
+                        if let Some(t) = tracker.as_ref() {
+                            if let Some(total) = t.detokenize_total_latency() {
+                                DETOKENIZE_TOTAL_US.inc_by(total.as_micros() as f64);
+                            }
+                            DETOKENIZE_TOKEN_COUNT.inc_by(t.detokenize_count() as f64);
+                        }
 
                         // Create annotation string
                         let annotation = llm_metrics.to_annotation::<()>().unwrap_or_else(|e| {

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -27,6 +27,11 @@ use futures::Stream;
 use futures::stream::{self, StreamExt};
 use prompt::OAIPromptFormatter;
 use std::time::{Duration, Instant};
+
+use dynamo_runtime::dynamo_nvtx_range;
+use dynamo_runtime::metrics::frontend_perf::{
+    STAGE_DURATION_SECONDS, TEMPLATE_SECONDS, TOKENIZE_SECONDS,
+};
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 use tracing;
 
@@ -228,10 +233,16 @@ impl OpenAIPreprocessor {
         request: &R,
         tracker: Option<&RequestTracker>,
     ) -> Result<(PreprocessedRequest, HashMap<String, String>, bool)> {
+        let preprocess_start = Instant::now();
         let mut builder = self.builder(request)?;
-        let formatted_prompt = self
-            .apply_template(request)
-            .with_context(|| "Failed to apply prompt template")?;
+
+        let template_start = Instant::now();
+        let formatted_prompt = {
+            let _nvtx = dynamo_nvtx_range!("preprocess.template");
+            self.apply_template(request)
+                .with_context(|| "Failed to apply prompt template")?
+        };
+        TEMPLATE_SECONDS.observe(template_start.elapsed().as_secs_f64());
 
         // Check if the chat template injected a reasoning start token at the end
         // of the prompt (e.g., Qwen3.5 appends `<think>\n` when enable_thinking
@@ -241,12 +252,21 @@ impl OpenAIPreprocessor {
             .as_ref()
             .is_some_and(|p| p.trim_end().ends_with("<think>"));
 
-        let annotations = self
-            .gather_tokens(request, &mut builder, formatted_prompt.clone(), tracker)
-            .with_context(|| "Failed to gather tokens")?;
+        let tokenize_start = Instant::now();
+        let annotations = {
+            let _nvtx = dynamo_nvtx_range!("preprocess.tokenize");
+            self.gather_tokens(request, &mut builder, formatted_prompt.clone(), tracker)
+                .with_context(|| "Failed to gather tokens")?
+        };
+        TOKENIZE_SECONDS.observe(tokenize_start.elapsed().as_secs_f64());
+
         self.gather_multi_modal_data(request, &mut builder, formatted_prompt)
             .await
             .with_context(|| "Failed to gather multimodal data")?;
+
+        STAGE_DURATION_SECONDS
+            .with_label_values(&["preprocess"])
+            .observe(preprocess_start.elapsed().as_secs_f64());
 
         Ok((builder.build()?, annotations, prompt_injected_reasoning))
     }

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -19,6 +19,9 @@ testing-etcd = [] # Tests that require an active ETCD server
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 compute-validation = [] # Enable validation and timing for compute macros
 tcp-low-latency = [] # Enable Linux-specific TCP optimizations (TCP_QUICKACK, SO_BUSY_POLL)
+# NVTX timeline annotations for Nsight Systems (compile-time off; also gated at runtime by DYN_ENABLE_RUST_NVTX).
+# Overhead: feature off = zero; feature on, env off = ~1ns AtomicBool load; feature on, env on = ~50ns/annotation.
+nvtx = ["dep:cudarc"]
 
 [dependencies]
 # Use workspace dependencies where available
@@ -65,6 +68,8 @@ uuid = { workspace = true }
 url = { workspace = true }
 validator = { workspace = true }
 xxhash-rust = { workspace = true }
+
+cudarc = { workspace = true, features = ["nvtx"], optional = true }
 
 arc-swap = { version = "1" }
 async-once-cell = { version = "0.5.4" }

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -34,6 +34,7 @@ pub mod distributed;
 pub mod instances;
 pub mod logging;
 pub mod metrics;
+pub mod nvtx;
 pub mod pipeline;
 pub mod prelude;
 pub mod protocols;

--- a/lib/runtime/src/metrics/frontend_perf.rs
+++ b/lib/runtime/src/metrics/frontend_perf.rs
@@ -5,7 +5,7 @@
 //! Used by both runtime (route, transport_roundtrip) and llm (preprocess, postprocess, tokenize, template, detokenize).
 
 use once_cell::sync::{Lazy, OnceCell};
-use prometheus::{Histogram, HistogramOpts, HistogramVec, Registry};
+use prometheus::{Counter, Histogram, HistogramOpts, HistogramVec, Opts, Registry};
 
 use super::prometheus_names::{frontend_perf, name_prefix};
 use crate::MetricsRegistry;
@@ -57,18 +57,23 @@ pub static TEMPLATE_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     .expect("template_seconds histogram")
 });
 
-/// Per-token detokenization cost (microseconds).
-pub static DETOKENIZE_PER_TOKEN_US: Lazy<Histogram> = Lazy::new(|| {
-    Histogram::with_opts(
-        HistogramOpts::new(
-            frontend_metric_name(frontend_perf::DETOKENIZE_PER_TOKEN_US),
-            "Detokenization cost per token (microseconds)",
-        )
-        .buckets(vec![
-            1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0,
-        ]),
-    )
-    .expect("detokenize_per_token_us histogram")
+/// Cumulative detokenization time across all tokens (microseconds).
+/// Use `rate(total) / rate(count)` in Prometheus to derive per-token average.
+pub static DETOKENIZE_TOTAL_US: Lazy<Counter> = Lazy::new(|| {
+    Counter::with_opts(Opts::new(
+        frontend_metric_name(frontend_perf::DETOKENIZE_TOTAL_US),
+        "Cumulative detokenization time (microseconds)",
+    ))
+    .expect("detokenize_total_us counter")
+});
+
+/// Total number of tokens detokenized.
+pub static DETOKENIZE_TOKEN_COUNT: Lazy<Counter> = Lazy::new(|| {
+    Counter::with_opts(Opts::new(
+        frontend_metric_name(frontend_perf::DETOKENIZE_TOKEN_COUNT),
+        "Total tokens detokenized",
+    ))
+    .expect("detokenize_token_count counter")
 });
 
 /// Guards idempotency for the `MetricsRegistry` registration path.
@@ -88,7 +93,10 @@ pub fn ensure_frontend_perf_metrics_registered(registry: &MetricsRegistry) {
         registry.add_metric(Box::new(TOKENIZE_SECONDS.clone())).ok();
         registry.add_metric(Box::new(TEMPLATE_SECONDS.clone())).ok();
         registry
-            .add_metric(Box::new(DETOKENIZE_PER_TOKEN_US.clone()))
+            .add_metric(Box::new(DETOKENIZE_TOTAL_US.clone()))
+            .ok();
+        registry
+            .add_metric(Box::new(DETOKENIZE_TOKEN_COUNT.clone()))
             .ok();
     });
 }
@@ -104,7 +112,8 @@ pub fn ensure_frontend_perf_metrics_registered_prometheus(
     registry.register(Box::new(STAGE_DURATION_SECONDS.clone()))?;
     registry.register(Box::new(TOKENIZE_SECONDS.clone()))?;
     registry.register(Box::new(TEMPLATE_SECONDS.clone()))?;
-    registry.register(Box::new(DETOKENIZE_PER_TOKEN_US.clone()))?;
+    registry.register(Box::new(DETOKENIZE_TOTAL_US.clone()))?;
+    registry.register(Box::new(DETOKENIZE_TOKEN_COUNT.clone()))?;
     let _ = PROMETHEUS_REGISTERED.set(());
     Ok(())
 }

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -518,8 +518,10 @@ pub mod frontend_perf {
     pub const TOKENIZE_SECONDS: &str = "tokenize_seconds";
     /// Template application time in preprocessor
     pub const TEMPLATE_SECONDS: &str = "template_seconds";
-    /// Per-token detokenization cost (microseconds)
-    pub const DETOKENIZE_PER_TOKEN_US: &str = "detokenize_per_token_us";
+    /// Cumulative detokenization time (microseconds); pair with DETOKENIZE_TOKEN_COUNT
+    pub const DETOKENIZE_TOTAL_US: &str = "detokenize_total_us";
+    /// Total tokens detokenized; use rate(total_us)/rate(count) for per-token average
+    pub const DETOKENIZE_TOKEN_COUNT: &str = "detokenize_token_count";
     /// Event loop delay canary (sleep 10ms, measure drift)
     pub const EVENT_LOOP_DELAY_SECONDS: &str = "event_loop_delay_seconds";
     /// Count of event loop stalls (delay > 5ms)

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -61,31 +61,42 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-/// Metric name prefixes used across the metrics system
+/// Metric name prefixes used across the metrics system.
 pub mod name_prefix {
-    /// Prefix for all Prometheus metric names.
+    /// Prefix for component-scoped metrics, auto-labeled with namespace/endpoint.
     pub const COMPONENT: &str = "dynamo_component";
 
-    /// Prefix for frontend service metrics
+    /// Prefix for frontend HTTP service metrics (requests, TTFT, ITL, disconnects).
     pub const FRONTEND: &str = "dynamo_frontend";
 
-    /// Prefix for KV router metrics (used with router_id label)
+    /// Prefix for KV router instance metrics (carries `router_id` label).
     pub const ROUTER: &str = "dynamo_router";
 
-    /// Prefix for tokio runtime metrics
-    pub const TOKIO: &str = "dynamo_tokio";
+    /// Note: REQUEST_PLANE vs TRANSPORT: REQUEST_PLANE measures *what requests do* (latency,
+    /// concurrency) and is transport-agnostic. TRANSPORT measures *how the wire behaves*
+    /// (bytes transferred, protocol errors) and is protocol-specific (TCP/NATS).
 
     /// Prefix for standalone KV indexer metrics
     pub const KVINDEXER: &str = "dynamo_kvindexer";
 
-    /// Prefix for request-plane metrics at AddressedPushRouter
+    /// Prefix for request-plane metrics at AddressedPushRouter.
+    /// Transport-agnostic: measures request lifecycle latency and concurrency
+    /// (queue → send → roundtrip TTFT, inflight gauge).
     pub const REQUEST_PLANE: &str = "dynamo_request_plane";
 
-    /// Prefix for transport-layer metrics (TCP / NATS)
+    /// Prefix for transport-layer metrics (TCP / NATS).
+    /// Protocol-specific: measures wire-level health (bytes sent/received, error counts).
     pub const TRANSPORT: &str = "dynamo_transport";
 
     /// Prefix for work-handler transport breakdown metrics (backend side)
     pub const WORK_HANDLER: &str = "dynamo_work_handler";
+
+    /// Prefix for tokio runtime metrics (poll times, queue depths, stalls).
+    pub const TOKIO: &str = "dynamo_tokio";
+
+    /// Prefix for per-phase routing overhead latency (hashing, scheduling).
+    /// Raw Prometheus, not component-scoped.
+    pub const ROUTING_OVERHEAD: &str = "dynamo_routing_overhead";
 }
 
 /// Automatically inserted Prometheus label names used across the metrics system

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -72,9 +72,9 @@ pub mod name_prefix {
     /// Prefix for KV router instance metrics (carries `router_id` label).
     pub const ROUTER: &str = "dynamo_router";
 
-    /// Note: REQUEST_PLANE vs TRANSPORT: REQUEST_PLANE measures *what requests do* (latency,
-    /// concurrency) and is transport-agnostic. TRANSPORT measures *how the wire behaves*
-    /// (bytes transferred, protocol errors) and is protocol-specific (TCP/NATS).
+    // Note: REQUEST_PLANE vs TRANSPORT: REQUEST_PLANE measures *what requests do* (latency,
+    // concurrency) and is transport-agnostic. TRANSPORT measures *how the wire behaves*
+    // (bytes transferred, protocol errors) and is protocol-specific (TCP/NATS).
 
     /// Prefix for standalone KV indexer metrics
     pub const KVINDEXER: &str = "dynamo_kvindexer";

--- a/lib/runtime/src/metrics/tokio_perf.rs
+++ b/lib/runtime/src/metrics/tokio_perf.rs
@@ -8,6 +8,7 @@ use prometheus::{Counter, Gauge, Histogram, HistogramOpts, IntCounterVec, IntGau
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::runtime::Handle;
+use tokio_util::sync::CancellationToken;
 
 use super::prometheus_names::{frontend_perf, name_prefix, tokio_perf as names};
 use crate::MetricsRegistry;
@@ -246,7 +247,8 @@ pub fn ensure_tokio_perf_metrics_registered_prometheus(
 
 /// Run the tokio metrics collector (1s interval) and event-loop canary.
 /// Spawn this on the runtime you want to monitor (e.g. primary handle).
-pub async fn tokio_metrics_and_canary_loop() {
+/// The loop exits cleanly when `cancel` is triggered.
+pub async fn tokio_metrics_and_canary_loop(cancel: CancellationToken) {
     let canary_interval = Duration::from_millis(10);
     let stall_threshold = Duration::from_millis(5);
     let collect_interval = Duration::from_secs(1);
@@ -254,7 +256,13 @@ pub async fn tokio_metrics_and_canary_loop() {
     let mut prev_counters = PrevWorkerCounters::new();
     loop {
         let start = Instant::now();
-        tokio::time::sleep(canary_interval).await;
+        tokio::select! {
+            _ = tokio::time::sleep(canary_interval) => {}
+            _ = cancel.cancelled() => {
+                tracing::debug!("tokio metrics and canary loop shutting down");
+                return;
+            }
+        }
         let delay = start.elapsed().saturating_sub(canary_interval);
         EVENT_LOOP_DELAY_SECONDS.observe(delay.as_secs_f64());
         if delay > stall_threshold {

--- a/lib/runtime/src/nvtx.rs
+++ b/lib/runtime/src/nvtx.rs
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! NVTX timeline-annotation helpers for Nsight Systems profiling.
+//!
+//! Delegates to [`cudarc::nvtx`] for the actual NVTX calls
+//!
+//! # Gating (two-level)
+//!
+//! | Cargo feature `nvtx` | `DYN_ENABLE_RUST_NVTX` env | Effect                                    |
+//! |----------------------|----------------------------|-------------------------------------------|
+//! | off (default)        | any                        | macros compile to nothing; zero overhead  |
+//! | on                   | unset                      | one `Relaxed` load per site (~1 ns)       |
+//! | on                   | `1` / `true` / `yes`       | cudarc NVTX calls (~50 ns/annotation)     |
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! let _r = dynamo_nvtx_range!("preprocess.tokenize"); // RAII — pops at scope end
+//! dynamo_nvtx_push!("codec.encode");
+//! dynamo_nvtx_pop!();
+//! dynamo_nvtx_name_thread!("tokio-worker-0");
+//! ```
+//!
+//! # Build
+//!
+//! ```bash
+//! cargo build --profile profiling --features nvtx
+//! ```
+//! Requires `libnvToolsExt.so` at runtime (CUDA Toolkit or NVHPC).
+
+#[cfg(feature = "nvtx")]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(feature = "nvtx")]
+static NVTX_ENABLED: AtomicBool = AtomicBool::new(false);
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Initialise the NVTX subsystem from the `DYN_ENABLE_RUST_NVTX` environment variable.
+/// Must be called once at runtime startup before any annotation macros fire.
+/// No-op when the `nvtx` Cargo feature is off.
+pub fn init() {
+    #[cfg(feature = "nvtx")]
+    {
+        let enabled = std::env::var("DYN_ENABLE_RUST_NVTX")
+            .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+            .unwrap_or(false);
+        NVTX_ENABLED.store(enabled, Ordering::Relaxed);
+        if enabled {
+            tracing::info!("NVTX annotations enabled (DYN_ENABLE_RUST_NVTX)");
+        }
+    }
+}
+
+/// Returns `true` when the `nvtx` feature is compiled in **and** `DYN_ENABLE_RUST_NVTX` is set.
+#[inline(always)]
+pub fn enabled() -> bool {
+    #[cfg(feature = "nvtx")]
+    {
+        return NVTX_ENABLED.load(Ordering::Relaxed);
+    }
+    #[allow(unreachable_code)]
+    false
+}
+
+/// Push an NVTX range onto the calling thread's stack.
+/// No-op (compiled out) when the `nvtx` feature is off.
+#[inline(always)]
+pub fn push_impl(name: &str) {
+    #[cfg(feature = "nvtx")]
+    {
+        if NVTX_ENABLED.load(Ordering::Relaxed) {
+            cudarc::nvtx::result::range_push(name);
+        }
+    }
+    let _ = name;
+}
+
+/// Pop the innermost NVTX range from the calling thread's stack.
+/// No-op (compiled out) when the `nvtx` feature is off.
+#[inline(always)]
+pub fn pop_impl() {
+    #[cfg(feature = "nvtx")]
+    {
+        if NVTX_ENABLED.load(Ordering::Relaxed) {
+            cudarc::nvtx::result::range_pop();
+        }
+    }
+}
+
+/// Name the current OS thread in the Nsight Systems timeline.
+/// No-op (compiled out) when the `nvtx` feature is off.
+#[inline(always)]
+pub fn name_current_thread_impl(name: &str) {
+    #[cfg(feature = "nvtx")]
+    {
+        if NVTX_ENABLED.load(Ordering::Relaxed) {
+            #[cfg(target_os = "linux")]
+            let tid = unsafe { libc::syscall(libc::SYS_gettid) as u32 };
+            #[cfg(not(target_os = "linux"))]
+            let tid = 0u32;
+            cudarc::nvtx::result::name_os_thread(tid, name);
+        }
+    }
+    let _ = name;
+}
+
+// ── RAII guard ───────────────────────────────────────────────────────────────
+
+/// RAII guard that pops an NVTX range when dropped.
+/// Construct with [`dynamo_nvtx_range!`].
+#[cfg(feature = "nvtx")]
+pub struct NvtxRangeGuard {
+    active: bool,
+}
+
+/// Zero-sized no-op guard used when the `nvtx` feature is off.
+#[cfg(not(feature = "nvtx"))]
+pub struct NvtxRangeGuard;
+
+impl NvtxRangeGuard {
+    #[doc(hidden)]
+    pub fn new(name: &str) -> Self {
+        #[cfg(feature = "nvtx")]
+        {
+            let active = NVTX_ENABLED.load(Ordering::Relaxed);
+            if active {
+                cudarc::nvtx::result::range_push(name);
+            }
+            return NvtxRangeGuard { active };
+        }
+        #[cfg(not(feature = "nvtx"))]
+        {
+            let _ = name;
+            NvtxRangeGuard {}
+        }
+    }
+}
+
+#[cfg(feature = "nvtx")]
+impl Drop for NvtxRangeGuard {
+    fn drop(&mut self) {
+        if self.active {
+            cudarc::nvtx::result::range_pop();
+        }
+    }
+}
+
+#[cfg(not(feature = "nvtx"))]
+impl Drop for NvtxRangeGuard {
+    fn drop(&mut self) {}
+}
+
+// ── Macros ───────────────────────────────────────────────────────────────────
+
+/// Push a named NVTX range onto the calling thread's stack.
+/// Zero-cost when the `nvtx` Cargo feature is off.
+#[macro_export]
+macro_rules! dynamo_nvtx_push {
+    ($name:expr) => {
+        $crate::nvtx::push_impl($name)
+    };
+}
+
+/// Pop the innermost NVTX range from the calling thread's stack.
+/// Zero-cost when the `nvtx` Cargo feature is off.
+#[macro_export]
+macro_rules! dynamo_nvtx_pop {
+    () => {
+        $crate::nvtx::pop_impl()
+    };
+}
+
+/// Open a named NVTX range that closes automatically at end of scope.
+///
+/// ```rust,ignore
+/// let _r = dynamo_nvtx_range!("preprocess.tokenize");
+/// // range closes here
+/// ```
+/// Zero-cost when the `nvtx` Cargo feature is off.
+#[macro_export]
+macro_rules! dynamo_nvtx_range {
+    ($name:expr) => {
+        $crate::nvtx::NvtxRangeGuard::new($name)
+    };
+}
+
+/// Annotate the current OS thread in the Nsight Systems timeline.
+/// Zero-cost when the `nvtx` Cargo feature is off.
+#[macro_export]
+macro_rules! dynamo_nvtx_name_thread {
+    ($name:expr) => {
+        $crate::nvtx::name_current_thread_impl($name)
+    };
+}

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -278,6 +278,11 @@ struct RequestControlMessage {
     request_type: RequestType,
     response_type: ResponseType,
     connection_info: ConnectionInfo,
+    /// Wall-clock send timestamp (nanos since UNIX epoch) for transport latency breakdown.
+    /// Uses `SystemTime` so accuracy depends on NTP sync between frontend and backend hosts.
+    /// Reliable for single-machine profiling; treat cross-host values as approximate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    frontend_send_ts_ns: Option<u64>,
 }
 
 pub struct Ingress<Req: PipelineIO, Resp: PipelineIO> {
@@ -309,6 +314,11 @@ impl<Req: PipelineIO + Sync, Resp: PipelineIO> Ingress<Req, Resp> {
     ) -> Result<()> {
         let metrics = WorkHandlerMetrics::from_endpoint(endpoint, metrics_labels)
             .map_err(|e| anyhow::anyhow!("Failed to create work handler metrics: {}", e))?;
+
+        // Register global transport breakdown metrics (idempotent)
+        crate::metrics::work_handler_perf::ensure_work_handler_perf_metrics_registered(
+            endpoint.get_metrics_registry(),
+        );
 
         self.metrics
             .set(Arc::new(metrics))

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -2,12 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 
 use super::unified_client::RequestPlaneClient;
 use super::*;
+use crate::dynamo_nvtx_range;
 use crate::engine::{AsyncEngine, AsyncEngineContextProvider, Data};
 use crate::error::{DynamoError, ErrorType};
 use crate::logging::inject_trace_headers_into_map;
+use crate::metrics::frontend_perf::STAGE_DURATION_SECONDS;
+use crate::metrics::request_plane::{
+    REQUEST_PLANE_INFLIGHT, REQUEST_PLANE_QUEUE_SECONDS, REQUEST_PLANE_ROUNDTRIP_TTFT_SECONDS,
+    REQUEST_PLANE_SEND_SECONDS,
+};
 use crate::pipeline::network::ConnectionInfo;
 use crate::pipeline::network::NetworkStreamWrapper;
 use crate::pipeline::network::PendingConnections;
@@ -19,8 +27,11 @@ use crate::pipeline::{ManyOut, PipelineError, ResponseStream, SingleIn};
 use crate::protocols::maybe_error::MaybeError;
 
 use anyhow::{Error, Result};
+use futures::stream::Stream;
 use serde::Deserialize;
 use serde::Serialize;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use tokio_stream::{StreamExt, StreamNotifyClose, wrappers::ReceiverStream};
 use tracing::Instrument;
 
@@ -44,6 +55,33 @@ struct RequestControlMessage {
     request_type: RequestType,
     response_type: ResponseType,
     connection_info: ConnectionInfo,
+    /// Wall-clock send timestamp (nanos since UNIX epoch) for transport latency breakdown.
+    /// Uses `SystemTime` so accuracy depends on NTP sync between frontend and backend hosts.
+    /// Reliable for single-machine profiling; treat cross-host values as approximate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    frontend_send_ts_ns: Option<u64>,
+}
+
+/// Wrapper that decrements request-plane inflight gauge when the stream is dropped.
+struct InflightDecStream<S> {
+    inner: S,
+}
+
+impl<S, T> Stream for InflightDecStream<S>
+where
+    S: Stream<Item = T> + Unpin,
+{
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl<S> Drop for InflightDecStream<S> {
+    fn drop(&mut self) {
+        REQUEST_PLANE_INFLIGHT.dec();
+    }
 }
 
 pub struct AddressedRequest<T> {
@@ -92,6 +130,9 @@ where
     U: Data + for<'de> Deserialize<'de> + MaybeError,
 {
     async fn generate(&self, request: SingleIn<AddressedRequest<T>>) -> Result<ManyOut<U>, Error> {
+        let queue_start = Instant::now();
+        REQUEST_PLANE_INFLIGHT.inc();
+
         let request_id = request.context().id().to_string();
         let (addressed_request, context) = request.transfer(());
         let (request, address) = addressed_request.into_parts();
@@ -130,6 +171,12 @@ where
             request_type: RequestType::SingleIn,
             response_type: ResponseType::ManyOut,
             connection_info,
+            frontend_send_ts_ns: Some(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos() as u64,
+            ),
         };
 
         // next build the two part message where we package the connection info and the request into
@@ -151,7 +198,13 @@ where
         // or it should take a two part message directly
         // todo - update this
         let codec = TwoPartCodec::default();
-        let buffer = codec.encode_message(msg)?;
+        let buffer = {
+            let _nvtx = dynamo_nvtx_range!("codec.encode");
+            codec.encode_message(msg)?
+        };
+
+        REQUEST_PLANE_QUEUE_SECONDS.observe(queue_start.elapsed().as_secs_f64());
+        let tx_start = Instant::now();
 
         // TRANSPORT ABSTRACT REQUIRED - END HERE
 
@@ -167,25 +220,38 @@ where
         let mut headers = std::collections::HashMap::new();
         inject_trace_headers_into_map(&mut headers);
 
-        // Send request (works for all transport types)
+        // Phase A: Frontend → Backend (network + queue + ack)
+        let _nvtx_send = dynamo_nvtx_range!("transport.tcp.send");
         let _response = self
             .req_client
             .send_request(address, buffer, headers)
             .await?;
+        drop(_nvtx_send);
+        REQUEST_PLANE_SEND_SECONDS.observe(tx_start.elapsed().as_secs_f64());
 
+        let _nvtx_wait = dynamo_nvtx_range!("transport.tcp.wait_backend");
         tracing::trace!(request_id, "awaiting transport handshake");
         let response_stream = response_stream_provider
             .await
             .map_err(|_| PipelineError::DetachedStreamReceiver)?
             .map_err(PipelineError::ConnectionFailed)?;
+        drop(_nvtx_wait);
 
         // TODO: Detect end-of-stream using Server-Sent Events (SSE)
         let mut is_complete_final = false;
+        let first_response = AtomicBool::new(true);
         let stream = tokio_stream::StreamNotifyClose::new(
             tokio_stream::wrappers::ReceiverStream::new(response_stream.rx),
         )
         .filter_map(move |res| {
             if let Some(res_bytes) = res {
+                if first_response.swap(false, Ordering::Relaxed) {
+                    let roundtrip_ttft = tx_start.elapsed().as_secs_f64();
+                    REQUEST_PLANE_ROUNDTRIP_TTFT_SECONDS.observe(roundtrip_ttft);
+                    STAGE_DURATION_SECONDS
+                        .with_label_values(&["transport_roundtrip"])
+                        .observe(queue_start.elapsed().as_secs_f64());
+                }
                 if is_complete_final {
                     let err = DynamoError::msg(
                         "Response received after generation ended - this should never happen",
@@ -234,6 +300,7 @@ where
             }
         });
 
+        let stream = InflightDecStream { inner: stream };
         Ok(ResponseStream::new(Box::pin(stream), engine_ctx))
     }
 }

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -199,12 +199,7 @@ where
             request_type: RequestType::SingleIn,
             response_type: ResponseType::ManyOut,
             connection_info,
-            frontend_send_ts_ns: Some(
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_nanos() as u64,
-            ),
+            frontend_send_ts_ns: None,
         };
 
         // next build the two part message where we package the connection info and the request into
@@ -247,6 +242,14 @@ where
         // Prepare trace headers using shared helper
         let mut headers = std::collections::HashMap::new();
         inject_trace_headers_into_map(&mut headers);
+
+        // Stamp send time right before the transport write so the network
+        // transit metric excludes serialization/encoding overhead.
+        let send_ts_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        headers.insert("x-frontend-send-ts-ns".to_string(), send_ts_ns.to_string());
 
         // Phase A: Frontend → Backend (network + queue + ack)
         let _nvtx_send = dynamo_nvtx_range!("transport.tcp.send");

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
 use super::unified_client::RequestPlaneClient;
@@ -270,13 +269,14 @@ where
 
         // TODO: Detect end-of-stream using Server-Sent Events (SSE)
         let mut is_complete_final = false;
-        let first_response = AtomicBool::new(true);
+        let mut first_response = true;
         let stream = tokio_stream::StreamNotifyClose::new(
             tokio_stream::wrappers::ReceiverStream::new(response_stream.rx),
         )
         .filter_map(move |res| {
             if let Some(res_bytes) = res {
-                if first_response.swap(false, Ordering::Relaxed) {
+                if first_response {
+                    first_response = false;
                     let roundtrip_ttft = tx_start.elapsed().as_secs_f64();
                     REQUEST_PLANE_ROUNDTRIP_TTFT_SECONDS.observe(roundtrip_ttft);
                     STAGE_DURATION_SECONDS

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -62,6 +62,33 @@ struct RequestControlMessage {
     frontend_send_ts_ns: Option<u64>,
 }
 
+/// RAII guard that decrements REQUEST_PLANE_INFLIGHT on drop unless disarmed.
+/// Protects against gauge leaks when `?` operators cause early returns between
+/// the increment and `InflightDecStream` construction.
+struct InflightGuard {
+    armed: bool,
+}
+
+impl InflightGuard {
+    fn new() -> Self {
+        Self { armed: true }
+    }
+
+    /// Consume the guard without decrementing. Call this when `InflightDecStream`
+    /// takes over responsibility for the decrement.
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            REQUEST_PLANE_INFLIGHT.dec();
+        }
+    }
+}
+
 /// Wrapper that decrements request-plane inflight gauge when the stream is dropped.
 struct InflightDecStream<S> {
     inner: S,
@@ -132,6 +159,7 @@ where
     async fn generate(&self, request: SingleIn<AddressedRequest<T>>) -> Result<ManyOut<U>, Error> {
         let queue_start = Instant::now();
         REQUEST_PLANE_INFLIGHT.inc();
+        let inflight_guard = InflightGuard::new();
 
         let request_id = request.context().id().to_string();
         let (addressed_request, context) = request.transfer(());
@@ -300,6 +328,7 @@ where
             }
         });
 
+        inflight_guard.disarm();
         let stream = InflightDecStream { inner: stream };
         Ok(ResponseStream::new(Box::pin(stream), engine_ctx))
     }

--- a/lib/runtime/src/pipeline/network/egress/nats_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/nats_client.rs
@@ -8,6 +8,7 @@
 
 use super::unified_client::{ClientStats, Headers, RequestPlaneClient};
 use crate::error::{DynamoError, ErrorType};
+use crate::metrics::transport_metrics::NATS_ERRORS_TOTAL;
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -51,6 +52,9 @@ impl RequestPlaneClient for NatsRequestClient {
             .request_with_headers(address.clone(), nats_headers, payload)
             .await
             .map_err(|e| {
+                NATS_ERRORS_TOTAL
+                    .with_label_values(&["request_failed"])
+                    .inc();
                 anyhow::anyhow!(
                     DynamoError::builder()
                         .error_type(ErrorType::CannotConnect)

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -16,7 +16,9 @@ fn is_inhibited(err: &(dyn std::error::Error + 'static)) -> bool {
 }
 use crate::{
     component::{Client, Endpoint},
+    dynamo_nvtx_range,
     engine::{AsyncEngine, Data},
+    metrics::frontend_perf::STAGE_DURATION_SECONDS,
     pipeline::{
         AddressedPushRouter, AddressedRequest, Error, ManyOut, SingleIn,
         error::{PipelineError, PipelineErrorExt},
@@ -34,6 +36,7 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
+    time::Instant,
 };
 use tokio_stream::StreamExt;
 use tracing::Instrument;
@@ -324,6 +327,7 @@ where
         instance_id: u64,
         request: SingleIn<T>,
     ) -> anyhow::Result<ManyOut<U>> {
+        let route_start = Instant::now();
         let request_id = request.id().to_string();
         let route_span = if matches!(self.router_mode, RouterMode::KV) {
             tracing::Span::none()
@@ -357,7 +361,7 @@ where
         }
 
         // Get the address based on discovered transport type
-        let address = {
+        let (address, _transport_kind) = {
             use crate::component::TransportType;
 
             // Get the instance and use its actual transport type
@@ -376,7 +380,7 @@ where
                         http_endpoint = %http_endpoint,
                         "Using HTTP transport for instance"
                     );
-                    http_endpoint.clone()
+                    (http_endpoint.clone(), "transport.http.request")
                 }
                 TransportType::Tcp(tcp_endpoint) => {
                     tracing::debug!(
@@ -384,7 +388,7 @@ where
                         tcp_endpoint = %tcp_endpoint,
                         "Using TCP transport for instance"
                     );
-                    tcp_endpoint.clone()
+                    (tcp_endpoint.clone(), "transport.tcp.request")
                 }
                 TransportType::Nats(subject) => {
                     tracing::debug!(
@@ -392,13 +396,18 @@ where
                         subject = %subject,
                         "Using NATS transport for instance"
                     );
-                    subject.clone()
+                    (subject.clone(), "transport.nats.request")
                 }
             }
         };
 
         let request = request.map(|req| AddressedRequest::new(req, address));
 
+        STAGE_DURATION_SECONDS
+            .with_label_values(&["route"])
+            .observe(route_start.elapsed().as_secs_f64());
+
+        let _nvtx_transport = dynamo_nvtx_range!(_transport_kind);
         let stream: anyhow::Result<ManyOut<U>> = self
             .addressed
             .generate(request)

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -512,6 +512,7 @@ impl RequestPlaneClient for TcpRequestClient {
         self.stats
             .bytes_sent
             .fetch_add(payload_len as u64, Ordering::Relaxed);
+        TCP_BYTES_SENT_TOTAL.inc_by(payload_len as f64);
 
         let (addr, endpoint_name) = Self::parse_address(&address)?;
 
@@ -540,7 +541,6 @@ impl RequestPlaneClient for TcpRequestClient {
                     .bytes_received
                     .fetch_add(response.len() as u64, Ordering::Relaxed);
                 TCP_BYTES_RECEIVED_TOTAL.inc_by(response.len() as f64);
-                TCP_BYTES_SENT_TOTAL.inc_by(payload_len as f64);
 
                 // Return connection to pool (health check happens inside)
                 self.pool.return_connection(conn).await;

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -253,6 +253,7 @@ impl TcpConnection {
             // With TCP_NODELAY, no need for explicit flush()
             match write_half.write_all(&req.encoded_data).await {
                 Ok(()) => {
+                    TCP_BYTES_SENT_TOTAL.inc_by(req.encoded_data.len() as f64);
                     // Forward response channel to reader task (FIFO ordering)
                     if response_tx_channel.send(req.response_tx).is_err() {
                         tracing::debug!("Reader task closed, stopping writer");
@@ -512,7 +513,6 @@ impl RequestPlaneClient for TcpRequestClient {
         self.stats
             .bytes_sent
             .fetch_add(payload_len as u64, Ordering::Relaxed);
-        TCP_BYTES_SENT_TOTAL.inc_by(payload_len as f64);
 
         let (addr, endpoint_name) = Self::parse_address(&address)?;
 

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -508,10 +508,10 @@ impl RequestPlaneClient for TcpRequestClient {
     ) -> Result<Bytes> {
         tracing::debug!("TCP client sending request to address: {address}");
         self.stats.requests_sent.fetch_add(1, Ordering::Relaxed);
+        let payload_len = payload.len();
         self.stats
             .bytes_sent
-            .fetch_add(payload.len() as u64, Ordering::Relaxed);
-        TCP_BYTES_SENT_TOTAL.inc_by(payload.len() as f64);
+            .fetch_add(payload_len as u64, Ordering::Relaxed);
 
         let (addr, endpoint_name) = Self::parse_address(&address)?;
 
@@ -540,6 +540,7 @@ impl RequestPlaneClient for TcpRequestClient {
                     .bytes_received
                     .fetch_add(response.len() as u64, Ordering::Relaxed);
                 TCP_BYTES_RECEIVED_TOTAL.inc_by(response.len() as f64);
+                TCP_BYTES_SENT_TOTAL.inc_by(payload_len as f64);
 
                 // Return connection to pool (health check happens inside)
                 self.pool.return_connection(conn).await;

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -5,6 +5,9 @@
 //!
 
 use super::unified_client::{ClientStats, Headers, RequestPlaneClient};
+use crate::metrics::transport_metrics::{
+    TCP_BYTES_RECEIVED_TOTAL, TCP_BYTES_SENT_TOTAL, TCP_ERRORS_TOTAL,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -508,6 +511,7 @@ impl RequestPlaneClient for TcpRequestClient {
         self.stats
             .bytes_sent
             .fetch_add(payload.len() as u64, Ordering::Relaxed);
+        TCP_BYTES_SENT_TOTAL.inc_by(payload.len() as f64);
 
         let (addr, endpoint_name) = Self::parse_address(&address)?;
 
@@ -535,6 +539,7 @@ impl RequestPlaneClient for TcpRequestClient {
                 self.stats
                     .bytes_received
                     .fetch_add(response.len() as u64, Ordering::Relaxed);
+                TCP_BYTES_RECEIVED_TOTAL.inc_by(response.len() as f64);
 
                 // Return connection to pool (health check happens inside)
                 self.pool.return_connection(conn).await;
@@ -543,6 +548,7 @@ impl RequestPlaneClient for TcpRequestClient {
             }
             Ok(Err(e)) => {
                 self.stats.errors.fetch_add(1, Ordering::Relaxed);
+                TCP_ERRORS_TOTAL.inc();
                 tracing::warn!("TCP request failed to {}: {}", addr, e);
                 // Don't return unhealthy connection to pool, let it drop
                 let cause = crate::error::DynamoError::from(
@@ -558,6 +564,7 @@ impl RequestPlaneClient for TcpRequestClient {
             }
             Err(_) => {
                 self.stats.errors.fetch_add(1, Ordering::Relaxed);
+                TCP_ERRORS_TOTAL.inc();
                 tracing::warn!("TCP request timeout to {addr}");
                 // Don't return timed-out connection to pool
                 Err(anyhow::anyhow!(

--- a/lib/runtime/src/pipeline/network/ingress/push_handler.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_handler.rs
@@ -4,6 +4,9 @@
 use super::*;
 
 use crate::metrics::prometheus_names::work_handler;
+use crate::metrics::work_handler_perf::{
+    WORK_HANDLER_NETWORK_TRANSIT_SECONDS, WORK_HANDLER_TIME_TO_FIRST_RESPONSE_SECONDS,
+};
 use crate::protocols::maybe_error::MaybeError;
 use prometheus::{Histogram, IntCounter, IntCounterVec, IntGauge};
 use serde::{Deserialize, Serialize};
@@ -137,6 +140,10 @@ where
     }
 
     async fn handle_payload(&self, payload: Bytes) -> Result<(), PipelineError> {
+        let t2_wallclock_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
         let start_time = std::time::Instant::now();
 
         // Increment inflight and ensure it's decremented on all exits via RAII guard
@@ -194,6 +201,12 @@ where
             }
         };
 
+        // Compute network transit time (T2 - T1) using cross-process wall-clock timestamps
+        if let Some(t1_ns) = control_msg.frontend_send_ts_ns {
+            let transit_ns = t2_wallclock_ns.saturating_sub(t1_ns);
+            WORK_HANDLER_NETWORK_TRANSIT_SECONDS.observe(transit_ns as f64 / 1_000_000_000.0);
+        }
+
         // extend request with context
         tracing::trace!("received control message: {:?}", control_msg);
         tracing::trace!("received request: {:?}", request);
@@ -238,6 +251,8 @@ where
             Ok(stream) => {
                 tracing::trace!("Successfully generated response stream; sending prologue");
                 let _result = publisher.send_prologue(None).await;
+                WORK_HANDLER_TIME_TO_FIRST_RESPONSE_SECONDS
+                    .observe(start_time.elapsed().as_secs_f64());
                 stream
             }
             Err(e) => {

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -186,6 +186,20 @@ impl SharedTcpServer {
             "TCP worker processing request"
         );
 
+        // Compute network transit time from the transport header stamped right
+        // before the TCP write on the frontend side.
+        if let Some(t1_str) = work_item.headers.get("x-frontend-send-ts-ns")
+            && let Ok(t1_ns) = t1_str.parse::<u64>()
+        {
+            let t2_ns = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos() as u64;
+            let transit_ns = t2_ns.saturating_sub(t1_ns);
+            crate::metrics::work_handler_perf::WORK_HANDLER_NETWORK_TRANSIT_SECONDS
+                .observe(transit_ns as f64 / 1_000_000_000.0);
+        }
+
         // Create span with trace context from headers
         let span = crate::logging::make_handle_payload_span_from_tcp_headers(
             &work_item.headers,

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -159,8 +159,13 @@ impl TcpStreamServer {
 
                 match resolved_ip {
                     Ok(addr) => addr,
-                    Err(Error::LocalIpAddressNotFound) => IpAddr::from([127, 0, 0, 1]),
-                    Err(err) => return Err(err.into()),
+                    // Fall back to loopback when no routable IP is found
+                    Err(_) => {
+                        tracing::warn!(
+                            "Failed to resolve local IP address; falling back to 127.0.0.1"
+                        );
+                        IpAddr::from([127, 0, 0, 1])
+                    }
                 }
                 .to_string()
             }

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -159,12 +159,20 @@ impl TcpStreamServer {
 
                 match resolved_ip {
                     Ok(addr) => addr,
-                    // Fall back to loopback when no routable IP is found
-                    Err(_) => {
+                    // Only fall back to loopback when no routable IP exists at all;
+                    // propagate other resolver errors (I/O, platform) so
+                    // misconfigured hosts fail fast instead of silently binding
+                    // to 127.0.0.1.
+                    Err(Error::LocalIpAddressNotFound) => {
                         tracing::warn!(
-                            "Failed to resolve local IP address; falling back to 127.0.0.1"
+                            "No routable local IP address found; falling back to 127.0.0.1"
                         );
                         IpAddr::from([127, 0, 0, 1])
+                    }
+                    Err(err) => {
+                        return Err(PipelineError::Generic(format!(
+                            "Failed to resolve local IP address: {err}"
+                        )));
                     }
                 }
                 .to_string()

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -93,6 +93,9 @@ impl Runtime {
         secondary: Option<RuntimeType>,
         config: &RuntimeConfig,
     ) -> anyhow::Result<Runtime> {
+        // Initialise NVTX toggle once from environment (no-op when feature is off)
+        crate::nvtx::init();
+
         let mut rt = Self::new(runtime, secondary)?;
 
         // Create compute pool from configuration
@@ -146,6 +149,12 @@ impl Runtime {
         if let (Some(pool), Some(permits)) = (&self.compute_pool, &self.block_in_place_permits) {
             crate::compute::thread_local::initialize_context(Arc::clone(pool), Arc::clone(permits));
         }
+        // Name this worker thread in the Nsight Systems timeline (no-op when nvtx feature is off)
+        let thread_name = std::thread::current()
+            .name()
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| format!("tokio-worker-{:?}", std::thread::current().id()));
+        crate::nvtx::name_current_thread_impl(&thread_name);
     }
 
     /// Initialize thread-local compute context on all worker threads using a barrier

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -51,6 +51,9 @@ pub struct Runtime {
 
 impl Runtime {
     fn new(runtime: RuntimeType, secondary: Option<RuntimeType>) -> anyhow::Result<Runtime> {
+        // Initialise NVTX toggle once from environment (no-op when feature is off)
+        crate::nvtx::init();
+
         // worker id
         let id = Arc::new(uuid::Uuid::new_v4().to_string());
 
@@ -93,9 +96,6 @@ impl Runtime {
         secondary: Option<RuntimeType>,
         config: &RuntimeConfig,
     ) -> anyhow::Result<Runtime> {
-        // Initialise NVTX toggle once from environment (no-op when feature is off)
-        crate::nvtx::init();
-
         let mut rt = Self::new(runtime, secondary)?;
 
         // Create compute pool from configuration


### PR DESCRIPTION
#### Overview:

This PR  adds frontend/runtime performance instrumentation across the request path, plus optional NVTX annotations for Nsight profiling. The branch introduces request-plane, frontend stage, work-handler, transport, and tokio runtime metrics; wires them into the HTTP /metrics endpoint; and adds a profiling build profile plus feature-gated NVTX helpers
  used in preprocessing, routing, transport, and detokenization paths.

 It also includes follow-up fixes to make the instrumentation operationally safe: inflight gauges are cleaned up on error paths, TCP transit timing is stamped at the transport boundary, tokio canary tasks are tied to shutdown more cleanly, resolver failures no longer silently bind to loopback except for the explicit “no routable IP” case, and transport byte accounting is moved onto confirmed TCP writes.

#### Details:

  - Build/config:
      - Adds a profiling Cargo profile and nvtx feature plumbing from dynamo-llm to dynamo-runtime.
      - Introduces lib/runtime/src/nvtx.rs with feature-gated macros and runtime enablement via DYN_ENABLE_RUST_NVTX.
      - Initializes NVTX from shared runtime construction paths and names worker threads for Nsight timelines.
  - Frontend and LLM instrumentation:
      - Adds preprocess/template/tokenize stage timing and detokenization accounting.
      - Replaces the earlier per-token detokenize histogram with a counter pair: cumulative detokenize time and token count.
      - Adds NVTX ranges around template application, tokenization, detokenization, worker selection, KV match, codec encode, and transport wait/send phases.
  - Request-plane and transport metrics:
      - Adds request-plane metrics for queue time, send time, roundtrip TTFT, and inflight requests.
      - Adds transport metrics for TCP/NATS error and byte counters.
      - Moves TCP bytes-sent accounting to the successful socket write path.
      - Stamps frontend send time in transport headers so backend transit timing excludes serialization/encoding overhead.
  - Backend/work-handler instrumentation:
      - Adds work-handler metrics for frontend-to-backend transit time and backend time-to-first-response.
      - Registers these metrics through runtime metrics setup so they are available from the exposed registry.
  - HTTP service metrics exposure:
      - Registers request-plane, frontend perf, tokio perf, transport, worker-load, worker-timing, router queue, and routing-overhead metrics with the HTTP service registry.
      - Starts the tokio metrics collector/event-loop canary with shutdown-aware cancellation behavior.
  - Runtime/network robustness fixes:
      - Adds an RAII inflight guard in the addressed router so request-plane inflight gauges are decremented on early errors.
      - Narrows TCP local-IP fallback to only LocalIpAddressNotFound; other resolver errors now propagate.
      - Simplifies the single-threaded response-stream first-response tracking from AtomicBool to plain bool.
  - Metrics naming/codegen:
      - Updates Prometheus metric-name constants in Rust and regenerated Python bindings to cover the new frontend perf and request-plane metrics.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes DIS-1500


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NVTX profiling support for Nsight Systems, with scope-based ranges and thread naming.
  * New Prometheus metrics for request-plane, routing overhead, transport, Tokio, and TCP bytes/errors.
  * Expanded latency breakdowns (queueing, transport, round-trip, time-to-first-response).

* **Bug Fixes**
  * Safer network IP fallback to loopback with warning logging.

* **Chores**
  * Added profiling build profiles and feature flags; aligned build configs for bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->