### PR TITLE
fix: always emit pvc block in operator configmap when checkpoint storage type is pvc

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/operator-config.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/operator-config.yaml
@@ -128,7 +128,7 @@ data:
       readyForCheckpointFilePath: {{ .Values.checkpoint.readyForCheckpointFilePath | quote }}
       {{- end }}
       storage:
-        {{- if ne (.Values.checkpoint.storage.type | toString) "pvc" }}
+        {{- if and .Values.checkpoint.storage.type (ne (.Values.checkpoint.storage.type | toString) "pvc") }}
         type: {{ .Values.checkpoint.storage.type | quote }}
         {{- end }}
         {{- if or (eq (.Values.checkpoint.storage.type | toString) "pvc") (not .Values.checkpoint.storage.type) }}

--- a/deploy/helm/charts/platform/components/operator/templates/operator-config.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/operator-config.yaml
@@ -131,16 +131,10 @@ data:
         {{- if ne (.Values.checkpoint.storage.type | toString) "pvc" }}
         type: {{ .Values.checkpoint.storage.type | quote }}
         {{- end }}
-        {{- if eq .Values.checkpoint.storage.type "pvc" }}
-        {{- if or (ne (.Values.checkpoint.storage.pvc.pvcName | toString) "chrek-pvc") (ne (.Values.checkpoint.storage.pvc.basePath | toString) "/checkpoints") }}
+        {{- if or (eq (.Values.checkpoint.storage.type | toString) "pvc") (not .Values.checkpoint.storage.type) }}
         pvc:
-          {{- if ne (.Values.checkpoint.storage.pvc.pvcName | toString) "chrek-pvc" }}
-          pvcName: {{ .Values.checkpoint.storage.pvc.pvcName | quote }}
-          {{- end }}
-          {{- if ne (.Values.checkpoint.storage.pvc.basePath | toString) "/checkpoints" }}
-          basePath: {{ .Values.checkpoint.storage.pvc.basePath | quote }}
-          {{- end }}
-        {{- end }}
+          pvcName: {{ (.Values.checkpoint.storage.pvc.pvcName | default "chrek-pvc") | quote }}
+          basePath: {{ (.Values.checkpoint.storage.pvc.basePath | default "/checkpoints") | quote }}
         {{- end }}
         {{- if eq .Values.checkpoint.storage.type "s3" }}
         s3:


### PR DESCRIPTION
Fixes DYN-2279


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistent volume claim (PVC) configuration handling to ensure default storage values are consistently applied, even when storage type is not explicitly specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->