### PR TITLE
fix: always emit pvc block in operator configmap when checkpoint storage type is pvc (#6752)

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/operator-config.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/operator-config.yaml
@@ -128,19 +128,13 @@ data:
       readyForCheckpointFilePath: {{ .Values.checkpoint.readyForCheckpointFilePath | quote }}
       {{- end }}
       storage:
-        {{- if ne (.Values.checkpoint.storage.type | toString) "pvc" }}
+        {{- if and .Values.checkpoint.storage.type (ne (.Values.checkpoint.storage.type | toString) "pvc") }}
         type: {{ .Values.checkpoint.storage.type | quote }}
         {{- end }}
-        {{- if eq .Values.checkpoint.storage.type "pvc" }}
-        {{- if or (ne (.Values.checkpoint.storage.pvc.pvcName | toString) "chrek-pvc") (ne (.Values.checkpoint.storage.pvc.basePath | toString) "/checkpoints") }}
+        {{- if or (eq (.Values.checkpoint.storage.type | toString) "pvc") (not .Values.checkpoint.storage.type) }}
         pvc:
-          {{- if ne (.Values.checkpoint.storage.pvc.pvcName | toString) "chrek-pvc" }}
-          pvcName: {{ .Values.checkpoint.storage.pvc.pvcName | quote }}
-          {{- end }}
-          {{- if ne (.Values.checkpoint.storage.pvc.basePath | toString) "/checkpoints" }}
-          basePath: {{ .Values.checkpoint.storage.pvc.basePath | quote }}
-          {{- end }}
-        {{- end }}
+          pvcName: {{ (.Values.checkpoint.storage.pvc.pvcName | default "chrek-pvc") | quote }}
+          basePath: {{ (.Values.checkpoint.storage.pvc.basePath | default "/checkpoints") | quote }}
         {{- end }}
         {{- if eq .Values.checkpoint.storage.type "s3" }}
         s3:


### PR DESCRIPTION
cherry-pick of #6752 

