### PR TITLE
fix(test): fix vllm disaggregated cancellation tests

### DIFF
--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.fault_tolerance,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
     pytest.mark.e2e,
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
     pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True),
@@ -46,7 +45,7 @@ class DynamoWorkerProcess(ManagedProcess):
         self,
         request,
         frontend_port: int,
-        is_prefill: bool = False,
+        is_prefill: bool | None = None,
     ):
         # Allocate system port for this worker
         system_port = allocate_port(9100)
@@ -66,16 +65,35 @@ class DynamoWorkerProcess(ManagedProcess):
             "16384",
         ]
 
-        # Configure health check based on worker type
-        if is_prefill:
-            # Prefill workers check their own status endpoint
+        # Configure disaggregation mode, KV transfer, and health checks per worker type
+        if is_prefill is True:
+            # Prefill worker: disaggregated prefill mode; check own status endpoint only
             command.extend(["--disaggregation-mode", "prefill"])
+            command.extend(
+                [
+                    "--kv-transfer-config",
+                    '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',
+                ]
+            )
             health_check_urls = [
                 (f"http://localhost:{system_port}/health", self.is_ready)
             ]
+        elif is_prefill is False:
+            # Decode worker: disaggregated decode mode; also verify frontend sees the model
+            command.extend(["--disaggregation-mode", "decode"])
+            command.extend(
+                [
+                    "--kv-transfer-config",
+                    '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',
+                ]
+            )
+            health_check_urls = [
+                (f"http://localhost:{system_port}/health", self.is_ready),
+                (f"http://localhost:{frontend_port}/v1/models", check_models_api),
+                (f"http://localhost:{frontend_port}/health", check_health_generate),
+            ]
         else:
-            # Decode workers should also check their own status endpoint first,
-            # then verify the frontend sees the model
+            # Aggregated worker: no disaggregation mode; verify frontend sees the model
             health_check_urls = [
                 (f"http://localhost:{system_port}/health", self.is_ready),
                 (f"http://localhost:{frontend_port}/v1/models", check_models_api),
@@ -98,7 +116,7 @@ class DynamoWorkerProcess(ManagedProcess):
 
         # Set KV events config and NIXL side channel port only for prefill worker
         # to avoid conflicts with decode worker
-        if is_prefill:
+        if is_prefill is True:
             command.extend(
                 [
                     "--kv-events-config",
@@ -117,7 +135,12 @@ class DynamoWorkerProcess(ManagedProcess):
             ] = "5601"  # TODO: use dynamic port allocation
 
         # Set log directory based on worker type
-        worker_type = "prefill_worker" if is_prefill else "worker"
+        if is_prefill is True:
+            worker_type = "prefill_worker"
+        elif is_prefill is False:
+            worker_type = "decode_worker"
+        else:
+            worker_type = "worker"
         log_dir = f"{request.node.name}_{worker_type}"
 
         # Clean up any existing log directory from previous runs
@@ -179,6 +202,7 @@ class DynamoWorkerProcess(ManagedProcess):
 
 @pytest.mark.timeout(110)  # 3x average
 @pytest.mark.post_merge
+@pytest.mark.gpu_1
 def test_request_cancellation_vllm_aggregated(
     request, runtime_services_dynamic_ports, predownload_models
 ):
@@ -261,6 +285,7 @@ def test_request_cancellation_vllm_aggregated(
 
 @pytest.mark.timeout(150)  # 3x average
 @pytest.mark.nightly
+@pytest.mark.gpu_2
 def test_request_cancellation_vllm_decode_cancel(
     request, runtime_services_dynamic_ports, set_ucx_tls_no_mm, predownload_models
 ):
@@ -343,6 +368,7 @@ def test_request_cancellation_vllm_decode_cancel(
 
 @pytest.mark.timeout(150)  # 3x average
 @pytest.mark.nightly
+@pytest.mark.gpu_2
 def test_request_cancellation_vllm_prefill_cancel(
     request, runtime_services_dynamic_ports, set_ucx_tls_no_mm, predownload_models
 ):


### PR DESCRIPTION
#### Overview:

Fix three bugs in the vLLM disaggregated cancellation tests that caused them to never run in nightly CI and would have caused them to fail even if they did run.

#### Details:

**Bug 1 – Wrong GPU marker caused disaggregated tests to be skipped in nightly CI**

`gpu_1` was in the module-level `pytestmark`, so all three tests matched the single-GPU CI job (`nightly and vllm and gpu_1`). The two disaggregated tests require 2 GPUs and should match the multi-GPU job (`nightly and vllm and (gpu_2 or gpu_4)`). Fix: remove `gpu_1` from `pytestmark` and add per-test `@pytest.mark.gpu_1` / `@pytest.mark.gpu_2` markers.

**Bug 2 – Decode worker missing `--disaggregation-mode decode`**

`DynamoWorkerProcess` used `is_prefill: bool = False`, so `is_prefill` was `False` for both the decode worker and the aggregated worker. The decode branch was effectively dead code — decode workers silently started in aggregated mode instead of disaggregated decode mode. Fix: change signature to `is_prefill: bool | None = None` and use identity checks (`is True` / `is False` / `else`) for three-way branching, matching the pattern used in `tests/fault_tolerance/migration/test_vllm.py`.

**Bug 3 – Prefill worker missing `--kv-transfer-config`**

`args.py` raises a `ValueError` at startup if `--disaggregation-mode prefill` is set without `--kv-transfer-config`. The prefill worker was missing this flag, so it would crash immediately. The decode worker also needs it. Fix: add `--kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'` to both prefill and decode branches, matching `examples/backends/vllm/launch/disagg.sh`.

#### Where should the reviewer start?

- [tests/fault_tolerance/cancellation/test_vllm.py](tests/fault_tolerance/cancellation/test_vllm.py) — the only file changed; start with `DynamoWorkerProcess.__init__` to review the three-way branching fix, then check the per-test marker additions near the bottom.
- Compare against [tests/fault_tolerance/migration/test_vllm.py](tests/fault_tolerance/migration/test_vllm.py) and [tests/fault_tolerance/cancellation/test_sglang.py](tests/fault_tolerance/cancellation/test_sglang.py) as reference for the correct patterns.


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

[DYN-2267](https://linear.app/nvidia/issue/DYN-2267/dynamorelease100ftvllm-vllm-disaggregated-cancellation-tests-missing)

https://nvbugspro.nvidia.com/bug/5941305


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for request cancellation and worker mode handling, including support for aggregated, prefill, and decode modes with enhanced health check validation and GPU-specific test scenario coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->