### PR TITLE
fix(test): fix sglang disaggregated migration tests not running in nightly CI

### DIFF
--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.fault_tolerance,
     pytest.mark.sglang,
+    pytest.mark.gpu_1,
     pytest.mark.e2e,
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
     pytest.mark.parametrize(
@@ -209,7 +210,6 @@ class DynamoWorkerProcess(ManagedProcess):
 
 
 @pytest.mark.timeout(230)  # 3x average
-@pytest.mark.gpu_1
 @pytest.mark.post_merge
 def test_request_migration_sglang_aggregated(
     request,
@@ -262,7 +262,6 @@ def test_request_migration_sglang_aggregated(
 @pytest.mark.skip(reason="Cannot reliably migrate at Prefill that finish < 1 ms")
 @pytest.mark.xfail(strict=False, reason="Prefill migration not yet supported")
 @pytest.mark.timeout(230)  # 3x average
-@pytest.mark.gpu_2
 @pytest.mark.nightly
 def test_request_migration_sglang_prefill(
     request,
@@ -332,7 +331,6 @@ def test_request_migration_sglang_prefill(
 
 @pytest.mark.skip(reason="KV cache transfer may fail")
 @pytest.mark.timeout(230)  # 3x average
-@pytest.mark.gpu_2
 @pytest.mark.nightly
 def test_request_migration_sglang_kv_transfer(
     request,
@@ -401,7 +399,6 @@ def test_request_migration_sglang_kv_transfer(
 
 
 @pytest.mark.timeout(230)  # 3x average
-@pytest.mark.gpu_2
 @pytest.mark.nightly
 def test_request_migration_sglang_decode(
     request,

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -28,7 +28,6 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.fault_tolerance,
     pytest.mark.sglang,
-    pytest.mark.gpu_1,
     pytest.mark.e2e,
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
     pytest.mark.parametrize(
@@ -210,6 +209,7 @@ class DynamoWorkerProcess(ManagedProcess):
 
 
 @pytest.mark.timeout(230)  # 3x average
+@pytest.mark.gpu_1
 @pytest.mark.post_merge
 def test_request_migration_sglang_aggregated(
     request,
@@ -262,6 +262,7 @@ def test_request_migration_sglang_aggregated(
 @pytest.mark.skip(reason="Cannot reliably migrate at Prefill that finish < 1 ms")
 @pytest.mark.xfail(strict=False, reason="Prefill migration not yet supported")
 @pytest.mark.timeout(230)  # 3x average
+@pytest.mark.gpu_2
 @pytest.mark.nightly
 def test_request_migration_sglang_prefill(
     request,
@@ -331,6 +332,7 @@ def test_request_migration_sglang_prefill(
 
 @pytest.mark.skip(reason="KV cache transfer may fail")
 @pytest.mark.timeout(230)  # 3x average
+@pytest.mark.gpu_2
 @pytest.mark.nightly
 def test_request_migration_sglang_kv_transfer(
     request,
@@ -399,6 +401,7 @@ def test_request_migration_sglang_kv_transfer(
 
 
 @pytest.mark.timeout(230)  # 3x average
+@pytest.mark.gpu_2
 @pytest.mark.nightly
 def test_request_migration_sglang_decode(
     request,

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -603,7 +603,10 @@ def run_migration_test(
         )
     else:
         try:
-            validate_response(request_thread, response_list, validate_delay=stream)
+            # Don't validate delay: when migration is disabled, the request is expected
+            # to fail and the error may arrive late (e.g. ~10 s TCP timeout while the
+            # frontend attempts stream recreation before giving up).
+            validate_response(request_thread, response_list, validate_delay=False)
             pytest.fail("Request succeeded unexpectedly when migration was disabled")
         except Exception as e:
             # Request failed as expected - verify it's a known error type

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -580,8 +580,12 @@ def run_migration_test(
         worker1, worker2, receiving_pattern=receiving_pattern
     )
 
-    # Step 3: Optionally wait for new response before stop (for decode tests)
-    if wait_for_new_response_before_stop:
+    # Step 3: Optionally wait for new response before stop (for decode tests).
+    # Only wait when migration is enabled: we need the worker to be mid-generation
+    # so that ongoing migration can be tested.  When migration is disabled we want
+    # to kill the worker as soon as it confirms receipt of the request so that the
+    # error propagates immediately rather than after wait_for_response times out.
+    if wait_for_new_response_before_stop and migration_limit > 0:
         wait_for_response(response_list)
 
     # Step 4: Stop the worker (kill or graceful shutdown)
@@ -603,10 +607,7 @@ def run_migration_test(
         )
     else:
         try:
-            # Don't validate delay: when migration is disabled, the request is expected
-            # to fail and the error may arrive late (e.g. ~10 s TCP timeout while the
-            # frontend attempts stream recreation before giving up).
-            validate_response(request_thread, response_list, validate_delay=False)
+            validate_response(request_thread, response_list, validate_delay=stream)
             pytest.fail("Request succeeded unexpectedly when migration was disabled")
         except Exception as e:
             # Request failed as expected - verify it's a known error type


### PR DESCRIPTION
#### Overview:

Fix a false failure in `migration_disabled` decode tests where the error was expected to arrive immediately but instead arrived ~10 s later, exceeding the `validate_delay` 6 s threshold.

#### Details:

**Root cause** (`utils.py`)

In decode migration tests (`wait_for_new_response_before_stop=True`), `run_migration_test` calls `wait_for_response(response_list)` before killing the worker. The intent is to ensure the worker is mid-generation so that live migration can be exercised. However, in disaggregated decode mode, TTFT can exceed 10 s (bootstrap handshake + KV transfer from prefill worker), causing `wait_for_response` to block for its full 10 s timeout before the first token arrives. The worker is then killed at ~10 s after request start, and the error arrives at ~10.2 s — exceeding the 6 s `validate_delay` threshold and causing a spurious `AssertionError`.

With `migration_limit=0` (migration disabled), waiting for tokens before killing the worker is unnecessary: the purpose of the test is only to verify that the request fails when the worker dies. Killing immediately after the worker confirms receipt of the request (after the "New/Decode Request ID:" log) is sufficient. With this fix, the error propagates in ~0.2 s, well within the 6 s threshold.

**Fix**: guard `wait_for_response` with `migration_limit > 0`.

```python
# Before
if wait_for_new_response_before_stop:
    wait_for_response(response_list)

# After — skip the wait when migration is disabled so the error is immediate
if wait_for_new_response_before_stop and migration_limit > 0:
    wait_for_response(response_list)
```

#### Where should the reviewer start?

- `tests/fault_tolerance/migration/utils.py` — `run_migration_test`, step 3 (~line 580)