### PR TITLE
fix: update container image to standard vllm-runtime tag

### DIFF
--- a/examples/backends/vllm/deploy/lora/agg_lora.yaml
+++ b/examples/backends/vllm/deploy/lora/agg_lora.yaml
@@ -11,7 +11,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidian/dynamo-dev/biswa:7e499b5c460f1883a9945d221123e0760051210f-39500608-vllm-amd64
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -24,7 +24,7 @@ spec:
         name: Qwen/Qwen3-0.6B
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidian/dynamo-dev/biswa:7e499b5c460f1883a9945d221123e0760051210f-39500608-vllm-amd64
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
           env:
             - name: DYN_LORA_ENABLED


### PR DESCRIPTION
#### Overview:

update container image to standard vllm-runtime tag


#### Details:


previous:          image: nvcr.io/nvidian/dynamo-dev/biswa:7e499b5c460f1883a9945d221123e0760051210f-39500608-vllm-amd64

new:         image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes DIS-1546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container images in vLLM deployment example configuration to the latest runtime version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->