### PR TITLE
fix: pass through extra args in trtllm agg.sh launch script 

### DIFF
--- a/examples/backends/trtllm/launch/agg.sh
+++ b/examples/backends/trtllm/launch/agg.sh
@@ -21,6 +21,7 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 ENABLE_OTEL=false
+EXTRA_ARGS=()
 while [[ $# -gt 0 ]]; do
     case $1 in
         --enable-otel)
@@ -33,12 +34,12 @@ while [[ $# -gt 0 ]]; do
             echo "  --enable-otel        Enable OpenTelemetry tracing"
             echo "  -h, --help           Show this help message"
             echo ""
+            echo "Any additional options are passed through to dynamo.trtllm."
             exit 0
             ;;
         *)
-            echo "Unknown option: $1"
-            echo "Use --help for usage information"
-            exit 1
+            EXTRA_ARGS+=("$1")
+            shift
             ;;
     esac
 done
@@ -67,4 +68,4 @@ python3 -m dynamo.trtllm \
   --modality "$MODALITY" \
   --extra-engine-args "$AGG_ENGINE_ARGS" \
   "${TRACE_ARGS[@]}" \
-  "$@"
+  "${EXTRA_ARGS[@]}"

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -245,7 +245,6 @@ trtllm_configs = {
             pytest.mark.gpu_1,
             pytest.mark.trtllm,
             pytest.mark.post_merge,
-            pytest.mark.skip(reason="DYN-2262"),
             pytest.mark.timeout(
                 480
             ),  # 3x measured time (83.85s) + download time (210s) for 7B model


### PR DESCRIPTION
#### Overview:

The trtllm `agg.sh` script rejected any unrecognized CLI flags with `exit 1`, preventing test script_args (e.g. `--dyn-endpoint-types`) from reaching `python3 -m dynamo.trtllm`. Collect unknown args into `EXTRA_ARGS` and forward them, matching the pattern used by the vllm launch scripts.

Closes DIS-1547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing additional options through to the TensorRT-LLM backend process.

* **Tests**
  * Re-enabled TensorRT-LLM completions test in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->