### PR TITLE
fix: update nixl version to 0.10.0

### DIFF
--- a/deploy/pre-deployment/nixl/README.md
+++ b/deploy/pre-deployment/nixl/README.md
@@ -95,11 +95,11 @@ The script only prompts for Docker registry information when needed:
 ## What Each Step Does
 
 ### Step 1: Build nixlbench Docker Image
-- Downloads NIXL source code (version 0.6.0) from GitHub
+- Downloads NIXL source code (version 0.10.0) from GitHub
 - Extracts and navigates to the build directory
 - Pauses for user confirmation before building
 - Builds Docker image with specified registry and architecture
-- Tags image as: `{registry}/nixlbench:0.6.0-{arch}`
+- Tags image as: `{registry}/nixlbench:0.10.0-{arch}`
 
 ### Step 2: Update Deployment YAML File
 - Copies base deployment template (`nixlbench-deployment.yaml`)
@@ -231,7 +231,7 @@ This will help diagnose:
 
 2. **Image Pull Issues**:
    - Verify registry credentials are configured
-   - Check image exists: `docker pull {registry}/nixlbench:0.6.0-{arch}`
+   - Check image exists: `docker pull {registry}/nixlbench:0.10.0-{arch}`
    - Ensure image was pushed successfully after build
 
 3. **Build Failures**:

--- a/deploy/pre-deployment/nixl/build_and_deploy.sh
+++ b/deploy/pre-deployment/nixl/build_and_deploy.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 
-NIXL_VERSION="0.6.0"
+NIXL_VERSION="0.10.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Function to check if a command exists


### PR DESCRIPTION
#### Overview:

Nixl version is hard coded to 0.6.0 here. This will be removed once we have nixlbench in a container - until then we'll maintain the work around.

Update to latest `NIXL_VERSION="0.10.0"` matching container/context.yaml

- closes DIS-1549
