### PR TITLE
chore: bump aiconfigurator to 0.7.0rc8

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@369d2002e7702d7b641c652d47048a7cf2bea396",
+    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@b654d8f1700691e94326eae0b5e6d3407ade9f80",
     "aiperf @ git+https://github.com/ai-dynamo/aiperf.git@6450d7280de2e844ce5e98c5f6a4edb4b7773e8b",
     "matplotlib",
     "networkx",

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@b654d8f1700691e94326eae0b5e6d3407ade9f80",
+    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@e7625204c82da8e176da3d648aac447ebfd9e2be",
     "aiperf @ git+https://github.com/ai-dynamo/aiperf.git@6450d7280de2e844ce5e98c5f6a4edb4b7773e8b",
     "matplotlib",
     "networkx",

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -12,7 +12,7 @@
 
 # For Multimodal EPD (required for device_map="auto" in vision model loading)
 accelerate
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@369d2002e7702d7b641c652d47048a7cf2bea396
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@b654d8f1700691e94326eae0b5e6d3407ade9f80
 aiofiles
 aiperf @ git+https://github.com/ai-dynamo/aiperf.git@6450d7280de2e844ce5e98c5f6a4edb4b7773e8b
 av==15.0.0

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -12,7 +12,7 @@
 
 # For Multimodal EPD (required for device_map="auto" in vision model loading)
 accelerate
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@b654d8f1700691e94326eae0b5e6d3407ade9f80
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@e7625204c82da8e176da3d648aac447ebfd9e2be
 aiofiles
 aiperf @ git+https://github.com/ai-dynamo/aiperf.git@6450d7280de2e844ce5e98c5f6a4edb4b7773e8b
 av==15.0.0


### PR DESCRIPTION
#### Overview:

Update the AIConfigurator python package to [v0.7.0rc7](https://github.com/ai-dynamo/aiconfigurator/commit/b654d8f1700691e94326eae0b5e6d3407ade9f80)

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes OPS-3604
