### PR TITLE
ci: skip completions_only test

### DIFF
--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -271,6 +271,7 @@ trtllm_configs = {
             pytest.mark.gpu_1,
             pytest.mark.trtllm,
             pytest.mark.post_merge,
+            pytest.mark.skip(reason="DIS-1566"),
             pytest.mark.timeout(
                 480
             ),  # 3x measured time (83.85s) + download time (210s) for 7B model


### PR DESCRIPTION
#### Overview:

Skip tests/serve/test_trtllm.py[completions_only] until trtllm + logprobs issue is resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test configuration to skip specific TRTLLM test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->