### PR TITLE
feat: use model_fields_set to distinguish ttft/itl default usage

### DIFF
--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -117,9 +117,14 @@ class SLASpec(BaseModel):
     @model_validator(mode="after")
     def _validate_sla_options(self) -> "SLASpec":
         """Ensure at most one SLA mode is active."""
-        has_ttft_itl = self.ttft is not None and self.itl is not None
         has_e2e = self.e2eLatency is not None
         has_opt = self.optimizationType is not None
+        ttft_itl_touched = (
+            "ttft" in self.model_fields_set or "itl" in self.model_fields_set
+        )
+        has_ttft_itl = (self.ttft is not None and self.itl is not None) and (
+            ttft_itl_touched or (not has_e2e and not has_opt)
+        )
         options_count = sum([has_ttft_itl, has_e2e, has_opt])
         if options_count > 1:
             raise ValueError(

--- a/deploy/operator/api/scripts/generate_pydantic_from_go.py
+++ b/deploy/operator/api/scripts/generate_pydantic_from_go.py
@@ -67,9 +67,12 @@ _STRUCT_EXTRAS: dict = {
     @model_validator(mode="after")
     def _validate_sla_options(self) -> "SLASpec":
         \"\"\"Ensure at most one SLA mode is active.\"\"\"
-        has_ttft_itl = self.ttft is not None and self.itl is not None
         has_e2e = self.e2eLatency is not None
         has_opt = self.optimizationType is not None
+        ttft_itl_touched = "ttft" in self.model_fields_set or "itl" in self.model_fields_set
+        has_ttft_itl = (self.ttft is not None and self.itl is not None) and (
+            ttft_itl_touched or (not has_e2e and not has_opt)
+        )
         options_count = sum([has_ttft_itl, has_e2e, has_opt])
         if options_count > 1:
             raise ValueError(

--- a/deploy/operator/api/scripts/validate_pydantic_models.py
+++ b/deploy/operator/api/scripts/validate_pydantic_models.py
@@ -187,6 +187,13 @@ def test_sla_defaults_and_validation():
     # optimizationType mode: OK (null out ttft/itl)
     SLASpec(ttft=None, itl=None, optimizationType=OptimizationType.Throughput)
 
+    # optimizationType mode: OK without explicitly nulling defaults (TC-2.5 / TC-2.6)
+    SLASpec(optimizationType=OptimizationType.Throughput)
+    SLASpec(optimizationType=OptimizationType.Latency)
+
+    # e2eLatency mode: OK without explicitly nulling defaults
+    SLASpec(e2eLatency=500.0)
+
     # mixing modes should raise
     try:
         SLASpec(ttft=100.0, itl=10.0, e2eLatency=500.0)


### PR DESCRIPTION
#### Overview:

Fix bug causing a validation error in Profiler

#### Details:

ttft and itl carry non-None defaults; check whether the caller explicitly touched at least one of them or when no other mode was selected (pure default / fallback behaviour). This prevents a false conflict when the caller supplies only `optimizationType` without also setting `ttft=None` / `itl=None` — both are valid forms and should be accepted. Added QA test cases to validation file

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SLA validation logic to better handle latency optimization targets (TTFT and ITL) across different configuration modes, with more precise condition checking.

* **Tests**
  * Extended test coverage for SLA validation to verify additional configuration scenarios work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->