### PR TITLE
feat: dual-mode kube discovery granularity (pod vs container)

### DIFF
--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -42,6 +42,7 @@ const (
 
 	KubeAnnotationDisableImagePullSecretDiscovery = "nvidia.com/disable-image-pull-secret-discovery"
 	KubeAnnotationDynamoDiscoveryBackend          = "nvidia.com/dynamo-discovery-backend"
+	KubeAnnotationDynamoKubeDiscoveryGranularity  = "nvidia.com/dynamo-kube-discovery-granularity"
 
 	KubeLabelDynamoGraphDeploymentName = "nvidia.com/dynamo-graph-deployment-name"
 	KubeLabelDynamoComponent           = "nvidia.com/dynamo-component"

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -1077,6 +1077,15 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 
 	podLabels[commonconsts.KubeLabelDynamoSelector] = kubeName
 
+	// Inject kube discovery granularity env var into all containers if annotation is set
+	if granularity, ok := opt.dynamoComponentDeployment.Spec.Annotations[commonconsts.KubeAnnotationDynamoKubeDiscoveryGranularity]; ok && granularity != "" {
+		for i := range podSpec.Containers {
+			podSpec.Containers[i].Env = append(podSpec.Containers[i].Env,
+				corev1.EnvVar{Name: "DYN_KUBE_DISCOVERY_GRANULARITY", Value: granularity},
+			)
+		}
+	}
+
 	extraPodMetadata := opt.dynamoComponentDeployment.Spec.ExtraPodMetadata
 
 	if extraPodMetadata != nil {

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1297,6 +1297,7 @@ func GeneratePodSpecForComponent(
 var dgdPropagatedAnnotationKeys = []string{
 	commonconsts.KubeAnnotationEnableMetrics,
 	commonconsts.KubeAnnotationDynamoDiscoveryBackend,
+	commonconsts.KubeAnnotationDynamoKubeDiscoveryGranularity,
 	commonconsts.KubeAnnotationDynamoOperatorOriginVersion,
 	commonconsts.KubeAnnotationVLLMDistributedExecutorBackend,
 }
@@ -1424,6 +1425,16 @@ func GenerateGrovePodCliqueSet(
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate podSpec for role %s: %w", r.Name, err)
 			}
+
+			// Inject kube discovery granularity env var into all containers if annotation is set
+			if granularity, ok := component.Annotations[commonconsts.KubeAnnotationDynamoKubeDiscoveryGranularity]; ok && granularity != "" {
+				for i := range podSpec.Containers {
+					podSpec.Containers[i].Env = append(podSpec.Containers[i].Env,
+						corev1.EnvVar{Name: "DYN_KUBE_DISCOVERY_GRANULARITY", Value: granularity},
+					)
+				}
+			}
+
 			if operatorConfig.Checkpoint.Enabled {
 				if err := checkpoint.InjectCheckpointIntoPodSpec(
 					ctx,

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -370,6 +370,15 @@ pub mod zmq_broker {
     pub const ZMQ_BROKER_NAMESPACE: &str = "ZMQ_BROKER_NAMESPACE";
 }
 
+/// Kubernetes discovery environment variables
+pub mod kube_discovery {
+    /// Discovery granularity: "pod" (default) or "container".
+    /// Pod mode uses EndpointSlice reflector with one identity per pod.
+    /// Container mode uses Pod reflector with one identity per container,
+    /// required for failover pods with multiple engine containers.
+    pub const DYN_KUBE_DISCOVERY_GRANULARITY: &str = "DYN_KUBE_DISCOVERY_GRANULARITY";
+}
+
 /// CUDA and GPU environment variables
 pub mod cuda {
     /// Path to custom CUDA fatbin file.
@@ -503,6 +512,8 @@ mod tests {
             zmq_broker::ZMQ_BROKER_XSUB_BIND,
             zmq_broker::ZMQ_BROKER_XPUB_BIND,
             zmq_broker::ZMQ_BROKER_NAMESPACE,
+            // Kube Discovery
+            kube_discovery::DYN_KUBE_DISCOVERY_GRANULARITY,
             // CUDA
             cuda::DYN_FATBIN_PATH,
             // Build

--- a/lib/runtime/src/discovery/kube.rs
+++ b/lib/runtime/src/discovery/kube.rs
@@ -6,11 +6,12 @@ mod daemon;
 mod utils;
 
 pub use crd::{DynamoWorkerMetadata, DynamoWorkerMetadataSpec};
+// hash_pod_name is used by C bindings (EPP) for pod-level worker ID mapping.
 pub use utils::hash_pod_name;
 
 use crd::{apply_cr, build_cr};
 use daemon::DiscoveryDaemon;
-use utils::PodInfo;
+use utils::{KubeDiscoveryGranularity, PodInfo};
 
 use crate::CancellationToken;
 use crate::discovery::{
@@ -19,7 +20,7 @@ use crate::discovery::{
 };
 use anyhow::Result;
 use async_trait::async_trait;
-use kube::Client as KubeClient;
+use kube::{Api, Client as KubeClient, api::DeleteParams};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -45,11 +46,16 @@ impl KubeDiscoveryClient {
         cancel_token: CancellationToken,
     ) -> Result<Self> {
         let pod_info = PodInfo::from_env()?;
-        let instance_id = hash_pod_name(&pod_info.pod_name);
+        let g = pod_info.granularity;
+        let instance_id = g.instance_id(&pod_info.pod_name, &pod_info.container_name);
+        let cr_name = g.cr_name(&pod_info.pod_name, &pod_info.container_name);
 
         tracing::info!(
-            "Initializing KubeDiscoveryClient: pod_name={}, instance_id={:x}, namespace={}, pod_uid={}",
+            "Initializing KubeDiscoveryClient: pod_name={}, container_name={}, granularity={:?}, cr_name={}, instance_id={:x}, namespace={}, pod_uid={}",
             pod_info.pod_name,
+            pod_info.container_name,
+            g,
+            cr_name,
             instance_id,
             pod_info.pod_namespace,
             pod_info.pod_uid
@@ -58,6 +64,27 @@ impl KubeDiscoveryClient {
         let kube_client = KubeClient::try_default()
             .await
             .map_err(|e| anyhow::anyhow!("Failed to create Kubernetes client: {}", e))?;
+
+        // In container mode, delete any stale CR from a previous incarnation of this container.
+        // In failover pods, the pod stays alive when a container crashes and restarts,
+        // so the old CR persists. Deleting it ensures the daemon doesn't see stale data.
+        // In pod mode this is unnecessary — pod restart creates a new pod (and new CR name).
+        if g == KubeDiscoveryGranularity::Container {
+            let cr_api: Api<DynamoWorkerMetadata> =
+                Api::namespaced(kube_client.clone(), &pod_info.pod_namespace);
+            match cr_api.delete(&cr_name, &DeleteParams::default()).await {
+                Ok(_) => tracing::info!("Deleted stale CR: {}", cr_name),
+                Err(kube::Error::Api(err_resp)) if err_resp.code == 404 => {
+                    tracing::debug!("No stale CR to delete: {}", cr_name);
+                }
+                Err(e) => {
+                    panic!(
+                        "Failed to clear stale CR '{}': {} — cannot start with stale discovery state",
+                        cr_name, e
+                    );
+                }
+            }
+        }
 
         // Create watch channel with initial empty snapshot
         let (watch_tx, watch_rx) = tokio::sync::watch::channel(Arc::new(MetadataSnapshot::empty()));
@@ -151,7 +178,16 @@ impl Discovery for KubeDiscoveryClient {
 
         // Build and apply the CR with the updated metadata
         // This persists the metadata to Kubernetes for other pods to discover
-        let cr = build_cr(&self.pod_info.pod_name, &self.pod_info.pod_uid, &metadata)?;
+        let cr_name = self
+            .pod_info
+            .granularity
+            .cr_name(&self.pod_info.pod_name, &self.pod_info.container_name);
+        let cr = build_cr(
+            &cr_name,
+            &self.pod_info.pod_name,
+            &self.pod_info.pod_uid,
+            &metadata,
+        )?;
 
         if let Err(e) = apply_cr(&self.kube_client, &self.pod_info.pod_namespace, &cr).await {
             // Rollback local state on CR persistence failure
@@ -223,7 +259,16 @@ impl Discovery for KubeDiscoveryClient {
 
         // Build and apply the CR with the updated metadata
         // This persists the removal to Kubernetes for other pods to see
-        let cr = build_cr(&self.pod_info.pod_name, &self.pod_info.pod_uid, &metadata)?;
+        let cr_name = self
+            .pod_info
+            .granularity
+            .cr_name(&self.pod_info.pod_name, &self.pod_info.container_name);
+        let cr = build_cr(
+            &cr_name,
+            &self.pod_info.pod_name,
+            &self.pod_info.pod_uid,
+            &metadata,
+        )?;
 
         if let Err(e) = apply_cr(&self.kube_client, &self.pod_info.pod_namespace, &cr).await {
             // Rollback local state on CR persistence failure

--- a/lib/runtime/src/discovery/kube/crd.rs
+++ b/lib/runtime/src/discovery/kube/crd.rs
@@ -45,30 +45,33 @@ impl DynamoWorkerMetadataSpec {
 
 /// Build a DynamoWorkerMetadata CR with owner reference set to the pod
 /// # Arguments
-/// * `pod_name` - Name of the pod (used as CR name and in owner reference)
-/// * `pod_uid` - UID of the pod (for owner reference - enables garbage collection)
+/// * `cr_name` - Name of the CR (e.g., pod name in pod mode, or `"{pod}-{container}"` in container mode)
+/// * `pod_name` - Name of the owning pod (for owner reference - enables garbage collection)
+/// * `pod_uid` - UID of the owning pod (for owner reference)
 /// * `metadata` - The DiscoveryMetadata to serialize into the CR's data field
 ///
 /// # Returns
 /// A `DynamoWorkerMetadata` CR ready to be applied to the cluster
 pub fn build_cr(
+    cr_name: &str,
     pod_name: &str,
     pod_uid: &str,
     metadata: &DiscoveryMetadata,
 ) -> Result<DynamoWorkerMetadata> {
     let data = serde_json::to_value(metadata)?;
     let spec = DynamoWorkerMetadataSpec::new(data);
-    let mut cr = DynamoWorkerMetadata::new(pod_name, spec);
+    let mut cr = DynamoWorkerMetadata::new(cr_name, spec);
 
-    // Set owner reference to the pod for automatic garbage collection
+    // Set owner reference to the pod for automatic garbage collection.
+    // When the pod is deleted, all owned CRs are GC'd.
+    // In pod mode (cr_name == pod_name), this is the controlling owner (1:1).
+    // In container mode (cr_name != pod_name), multiple CRs share one pod owner.
     cr.metadata.owner_references = Some(vec![OwnerReference {
         api_version: "v1".to_string(),
         kind: "Pod".to_string(),
         name: pod_name.to_string(),
         uid: pod_uid.to_string(),
-        // Mark pod as the controlling owner - CR will be garbage collected when pod is deleted
-        controller: Some(true),
-        // Don't block pod deletion - allow CR cleanup to happen asynchronously
+        controller: Some(cr_name == pod_name),
         block_owner_deletion: Some(false),
     }]);
 

--- a/lib/runtime/src/discovery/kube/daemon.rs
+++ b/lib/runtime/src/discovery/kube/daemon.rs
@@ -5,6 +5,7 @@ use crate::CancellationToken;
 use crate::discovery::{DiscoveryMetadata, MetadataSnapshot};
 use anyhow::Result;
 use futures::StreamExt;
+use k8s_openapi::api::core::v1::Pod;
 use k8s_openapi::api::discovery::v1::EndpointSlice;
 use kube::{
     Api, Client as KubeClient,
@@ -16,9 +17,38 @@ use tokio::sync::Notify;
 use tokio::time::{Duration, timeout};
 
 use super::crd::DynamoWorkerMetadata;
-use super::utils::{PodInfo, extract_endpoint_info};
+use super::utils::{
+    KubeDiscoveryGranularity, PodInfo, extract_endpoint_info, extract_ready_containers,
+};
 
 const DEBOUNCE_DURATION: Duration = Duration::from_millis(500);
+
+/// Holds the readiness reflector store, abstracting over the K8s resource type.
+/// Both variants produce `Vec<(instance_id, cr_correlation_key)>` via `ready_entries()`.
+enum ReadinessReader {
+    /// EndpointSlice-based: one entry per ready pod (pod granularity)
+    EndpointSlice(reflector::Store<EndpointSlice>),
+    /// Pod-based: one entry per ready container (container granularity)
+    Pod(reflector::Store<Pod>),
+}
+
+impl ReadinessReader {
+    /// Extract `(instance_id, cr_key)` tuples from the current reflector state.
+    fn ready_entries(&self) -> Vec<(u64, String)> {
+        match self {
+            Self::EndpointSlice(reader) => reader
+                .state()
+                .iter()
+                .flat_map(|s| extract_endpoint_info(s.as_ref()))
+                .collect(),
+            Self::Pod(reader) => reader
+                .state()
+                .iter()
+                .flat_map(|p| extract_ready_containers(p.as_ref()))
+                .collect(),
+        }
+    }
+}
 
 /// Discovers and aggregates metadata from DynamoWorkerMetadata CRs in the cluster
 #[derive(Clone)]
@@ -44,57 +74,95 @@ impl DiscoveryDaemon {
 
     /// Run the discovery daemon
     ///
-    /// Watches both EndpointSlices (to know which pods are ready) and
-    /// DynamoWorkerMetadata CRs (to get the metadata for each pod).
-    /// A pod is included in the snapshot only if:
-    /// 1. It appears as ready in an EndpointSlice
-    /// 2. It has a corresponding DynamoWorkerMetadata CR
+    /// Watches a readiness source (EndpointSlices or Pods depending on granularity)
+    /// and DynamoWorkerMetadata CRs. An entry is included in the snapshot only if:
+    /// 1. It appears as ready in the readiness source
+    /// 2. It has a corresponding DynamoWorkerMetadata CR (matched by CR name)
     pub async fn run(
         self,
         watch_tx: tokio::sync::watch::Sender<Arc<MetadataSnapshot>>,
     ) -> Result<()> {
         tracing::info!("Discovery daemon starting");
 
-        // Create notify for watch-driven updates (shared by both reflectors)
+        // Create notify for watch-driven updates (shared by all reflectors)
         let notify = Arc::new(Notify::new());
 
-        // --- EndpointSlice Reflector ---
-        let endpoint_slices: Api<EndpointSlice> =
-            Api::namespaced(self.kube_client.clone(), &self.pod_info.pod_namespace);
+        // --- Readiness reflector: EndpointSlice or Pod depending on granularity ---
+        let readiness_reader = match self.pod_info.granularity {
+            KubeDiscoveryGranularity::Pod => {
+                let api: Api<EndpointSlice> =
+                    Api::namespaced(self.kube_client.clone(), &self.pod_info.pod_namespace);
+                let (reader, writer) = reflector::store();
+                let config = Config::default()
+                    .labels("nvidia.com/dynamo-discovery-backend=kubernetes")
+                    .labels("nvidia.com/dynamo-discovery-enabled=true");
 
-        let (ep_reader, ep_writer) = reflector::store();
+                tracing::info!(
+                    "Daemon watching EndpointSlices (pod granularity) with labels: nvidia.com/dynamo-discovery-backend=kubernetes, nvidia.com/dynamo-discovery-enabled=true"
+                );
 
-        let ep_watch_config = Config::default()
-            .labels("nvidia.com/dynamo-discovery-backend=kubernetes")
-            .labels("nvidia.com/dynamo-discovery-enabled=true");
+                let notify_clone = notify.clone();
+                let stream = reflector(writer, watcher(api, config))
+                    .default_backoff()
+                    .touched_objects()
+                    .for_each(move |res| {
+                        match res {
+                            Ok(obj) => {
+                                tracing::debug!(
+                                    name = obj.metadata.name.as_deref().unwrap_or("?"),
+                                    "EndpointSlice reflector updated"
+                                );
+                                notify_clone.notify_one();
+                            }
+                            Err(e) => {
+                                tracing::warn!("EndpointSlice reflector error: {e}");
+                                notify_clone.notify_one();
+                            }
+                        }
+                        futures::future::ready(())
+                    });
+                tokio::spawn(stream);
 
-        tracing::info!(
-            "Daemon watching EndpointSlices with labels: nvidia.com/dynamo-discovery-backend=kubernetes, nvidia.com/dynamo-discovery-enabled=true"
-        );
+                ReadinessReader::EndpointSlice(reader)
+            }
 
-        let notify_ep = notify.clone();
-        let ep_reflector_stream = reflector(ep_writer, watcher(endpoint_slices, ep_watch_config))
-            .default_backoff()
-            .touched_objects()
-            .for_each(move |res| {
-                match res {
-                    Ok(obj) => {
-                        tracing::debug!(
-                            slice_name = obj.metadata.name.as_deref().unwrap_or("unknown"),
-                            "EndpointSlice reflector updated"
-                        );
-                        notify_ep.notify_one();
-                    }
-                    Err(e) => {
-                        tracing::warn!("EndpointSlice reflector error: {e}");
-                        notify_ep.notify_one();
-                    }
-                }
-                // for_each expects a Future; ready(()) is an immediately-complete one
-                futures::future::ready(())
-            });
+            KubeDiscoveryGranularity::Container => {
+                let api: Api<Pod> =
+                    Api::namespaced(self.kube_client.clone(), &self.pod_info.pod_namespace);
+                let (reader, writer) = reflector::store();
+                let config = Config::default()
+                    .labels("nvidia.com/dynamo-discovery-backend=kubernetes")
+                    .labels("nvidia.com/dynamo-discovery-enabled=true");
 
-        tokio::spawn(ep_reflector_stream);
+                tracing::info!(
+                    "Daemon watching Pods (container granularity) with labels: nvidia.com/dynamo-discovery-backend=kubernetes, nvidia.com/dynamo-discovery-enabled=true"
+                );
+
+                let notify_clone = notify.clone();
+                let stream = reflector(writer, watcher(api, config))
+                    .default_backoff()
+                    .touched_objects()
+                    .for_each(move |res| {
+                        match res {
+                            Ok(obj) => {
+                                tracing::debug!(
+                                    name = obj.metadata.name.as_deref().unwrap_or("?"),
+                                    "Pod reflector updated"
+                                );
+                                notify_clone.notify_one();
+                            }
+                            Err(e) => {
+                                tracing::warn!("Pod reflector error: {e}");
+                                notify_clone.notify_one();
+                            }
+                        }
+                        futures::future::ready(())
+                    });
+                tokio::spawn(stream);
+
+                ReadinessReader::Pod(reader)
+            }
+        };
 
         // --- DynamoWorkerMetadata CR Reflector ---
         let metadata_crs: Api<DynamoWorkerMetadata> =
@@ -128,7 +196,6 @@ impl DiscoveryDaemon {
                         notify_cr.notify_one();
                     }
                 }
-                // for_each expects a Future; ready(()) is an immediately-complete one
                 futures::future::ready(())
             });
 
@@ -150,7 +217,7 @@ impl DiscoveryDaemon {
 
                     tracing::trace!("Debounce window elapsed, processing snapshot");
 
-                    match self.aggregate_snapshot(&ep_reader, &cr_reader, sequence).await {
+                    match self.aggregate_snapshot(&readiness_reader, &cr_reader, sequence).await {
                         Ok(snapshot) => {
                             if snapshot.has_changes_from(&prev_snapshot) {
                                 prev_snapshot = snapshot.clone();
@@ -180,33 +247,27 @@ impl DiscoveryDaemon {
         Ok(())
     }
 
-    /// Aggregate metadata from EndpointSlices and DynamoWorkerMetadata CRs into a snapshot
+    /// Aggregate metadata from the readiness source and DynamoWorkerMetadata CRs into a snapshot.
     ///
-    /// A pod is included in the snapshot only if:
-    /// 1. It appears as ready in an EndpointSlice
-    /// 2. It has a corresponding DynamoWorkerMetadata CR (CR name = pod name)
+    /// An entry is included only if it appears ready AND has a matching CR (by name).
     async fn aggregate_snapshot(
         &self,
-        ep_reader: &reflector::Store<EndpointSlice>,
+        readiness: &ReadinessReader,
         cr_reader: &reflector::Store<DynamoWorkerMetadata>,
         sequence: u64,
     ) -> Result<MetadataSnapshot> {
         let start = std::time::Instant::now();
 
-        // Extract ready pods from EndpointSlices: (instance_id, pod_name)
-        let ready_pods: Vec<(u64, String)> = ep_reader
-            .state()
-            .iter()
-            .flat_map(|arc_slice| extract_endpoint_info(arc_slice.as_ref()))
-            .collect();
+        // Extract ready entries: (instance_id, cr_key)
+        let ready_entries = readiness.ready_entries();
 
         tracing::trace!(
-            "Daemon found {} ready pods from EndpointSlices",
-            ready_pods.len()
+            "Daemon found {} ready entries (granularity={:?})",
+            ready_entries.len(),
+            self.pod_info.granularity,
         );
 
         // Single read of CR state to extract metadata and generations atomically
-        // We store (metadata, generation) tuples keyed by CR name (= pod name)
         let cr_state = cr_reader.state();
         let mut cr_map: HashMap<String, (Arc<DiscoveryMetadata>, i64)> = HashMap::new();
 
@@ -217,7 +278,6 @@ impl DiscoveryDaemon {
 
             let generation = arc_cr.metadata.generation.unwrap_or(0);
 
-            // Deserialize the data field to DiscoveryMetadata
             match serde_json::from_value::<DiscoveryMetadata>(arc_cr.spec.data.clone()) {
                 Ok(metadata) => {
                     tracing::trace!("Loaded metadata from CR '{cr_name}'");
@@ -235,26 +295,24 @@ impl DiscoveryDaemon {
 
         tracing::trace!("Daemon loaded {} DynamoWorkerMetadata CRs", cr_map.len());
 
-        // Correlate: ready pod + CR exists = include in snapshot
-        // Both instances and generations are keyed by instance_id with matching keys
+        // Correlate: ready entry + CR exists = include in snapshot
         let mut instances: HashMap<u64, Arc<DiscoveryMetadata>> = HashMap::new();
         let mut generations: HashMap<u64, i64> = HashMap::new();
 
-        for (instance_id, pod_name) in ready_pods {
-            // CR name is the pod name
-            if let Some((metadata, generation)) = cr_map.get(&pod_name) {
+        for (instance_id, cr_key) in ready_entries {
+            if let Some((metadata, generation)) = cr_map.get(&cr_key) {
                 instances.insert(instance_id, metadata.clone());
                 generations.insert(instance_id, *generation);
                 tracing::trace!(
-                    "Included pod '{}' (instance_id={:x}, generation={}) in snapshot",
-                    pod_name,
+                    "Included '{}' (instance_id={:x}, generation={}) in snapshot",
+                    cr_key,
                     instance_id,
                     generation
                 );
             } else {
                 tracing::trace!(
-                    "Skipping pod '{}' (instance_id={:x}): no DynamoWorkerMetadata CR found",
-                    pod_name,
+                    "Skipping '{}' (instance_id={:x}): no DynamoWorkerMetadata CR found",
+                    cr_key,
                     instance_id
                 );
             }

--- a/lib/runtime/src/discovery/kube/utils.rs
+++ b/lib/runtime/src/discovery/kube/utils.rs
@@ -2,23 +2,84 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use k8s_openapi::api::core::v1::Pod;
 use k8s_openapi::api::discovery::v1::EndpointSlice;
 use std::collections::hash_map::DefaultHasher;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
 
-/// Hash a pod name to get a consistent instance ID
+use crate::config::environment_names::kube_discovery;
+
+/// Mask to clear top 11 bits, ensuring the instance ID can be safely
+/// round-tripped through IEEE-754 f64 (JSON number).
+const INSTANCE_ID_MASK: u64 = 0x001F_FFFF_FFFF_FFFFu64;
+
+/// The operator's standard name for single-container pods.
+/// Containers with this name use pod-level identity even in container mode,
+/// ensuring backward compatibility with pod-mode CRs.
+const MAIN_CONTAINER_NAME: &str = "main";
+
+/// Kubernetes discovery granularity determines whether identity is per-pod or per-container.
+///
+/// - `Pod`: one identity per pod (backward-compatible default). Uses EndpointSlice
+///   reflector and `hash(pod_name)` for instance ID.
+/// - `Container`: one identity per container. Uses Pod reflector. Containers named
+///   "main" use pod-level identity for cross-compatibility. Other containers
+///   (e.g., "engine-0") get `hash("{pod}-{container}")` identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum KubeDiscoveryGranularity {
+    Pod,
+    Container,
+}
+
+impl KubeDiscoveryGranularity {
+    /// Read granularity from `DYN_KUBE_DISCOVERY_GRANULARITY` env var.
+    /// Defaults to `Pod` if unset or unrecognized.
+    pub fn from_env() -> Self {
+        match std::env::var(kube_discovery::DYN_KUBE_DISCOVERY_GRANULARITY).as_deref() {
+            Ok("container") => Self::Container,
+            _ => Self::Pod,
+        }
+    }
+
+    /// CR name for this discovery participant.
+    ///
+    /// - Pod mode: returns `pod_name`.
+    /// - Container mode with `container_name == "main"`: returns `pod_name`
+    ///   (backward compat — "main" is the operator's default single-container name).
+    /// - Container mode with any other name: returns `"{pod_name}-{container_name}"`.
+    pub fn cr_name(&self, pod_name: &str, container_name: &str) -> String {
+        match self {
+            Self::Pod => pod_name.to_string(),
+            Self::Container if container_name == MAIN_CONTAINER_NAME => pod_name.to_string(),
+            Self::Container => format!("{}-{}", pod_name, container_name),
+        }
+    }
+
+    /// Deterministic instance ID. Hashes the `cr_name` output so the two
+    /// are always derived from the same key.
+    pub fn instance_id(&self, pod_name: &str, container_name: &str) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.cr_name(pod_name, container_name).hash(&mut hasher);
+        hasher.finish() & INSTANCE_ID_MASK
+    }
+}
+
+/// Hash a pod name to get a consistent instance ID (pod-level granularity).
+///
+/// This is the backward-compatible function used by external consumers
+/// (e.g., C bindings / EPP).
 pub fn hash_pod_name(pod_name: &str) -> u64 {
-    // Clear top 11 bits to ensure it can be safely rounded to IEEE-754 f64
-    const INSTANCE_ID_MASK: u64 = 0x001F_FFFF_FFFF_FFFFu64;
     let mut hasher = DefaultHasher::new();
     pod_name.hash(&mut hasher);
     hasher.finish() & INSTANCE_ID_MASK
 }
 
-/// Extract endpoint information from an EndpointSlice
-/// Returns (instance_id, pod_name) tuples for ready endpoints
+/// Extract endpoint information from an EndpointSlice (pod-level granularity).
+///
+/// Returns `(instance_id, pod_name)` tuples for ready endpoints.
+/// Used by the daemon in `Pod` granularity mode.
 pub(super) fn extract_endpoint_info(slice: &EndpointSlice) -> Vec<(u64, String)> {
     let mut result = Vec::new();
 
@@ -43,20 +104,55 @@ pub(super) fn extract_endpoint_info(slice: &EndpointSlice) -> Vec<(u64, String)>
         }
 
         let instance_id = hash_pod_name(pod_name);
-
         result.push((instance_id, pod_name.to_string()));
     }
 
     result
 }
 
+/// Extract ready containers from a Pod (container-level granularity).
+///
+/// Returns `(instance_id, cr_name)` tuples for each container whose
+/// `containerStatuses[].ready` is `true`. Containers named "main" produce
+/// pod-level identity for backward compatibility. Init containers and sidecars
+/// that never call `register()` are naturally excluded by the daemon's
+/// CR correlation step (no matching CR → not included in snapshot).
+pub(super) fn extract_ready_containers(pod: &Pod) -> Vec<(u64, String)> {
+    let pod_name = match pod.metadata.name.as_deref() {
+        Some(name) => name,
+        None => return vec![],
+    };
+
+    let container_statuses = match pod
+        .status
+        .as_ref()
+        .and_then(|s| s.container_statuses.as_ref())
+    {
+        Some(statuses) => statuses,
+        None => return vec![],
+    };
+
+    let g = KubeDiscoveryGranularity::Container;
+    container_statuses
+        .iter()
+        .filter(|cs| cs.ready)
+        .map(|cs| {
+            let id = g.instance_id(pod_name, &cs.name);
+            let name = g.cr_name(pod_name, &cs.name);
+            (id, name)
+        })
+        .collect()
+}
+
 /// Pod information extracted from environment
 #[derive(Debug, Clone)]
 pub(super) struct PodInfo {
     pub pod_name: String,
+    pub container_name: String,
     pub pod_namespace: String,
     pub pod_uid: String,
     pub system_port: u16,
+    pub granularity: KubeDiscoveryGranularity,
 }
 
 /// Default path for Kubernetes Downward API volume mount
@@ -89,6 +185,8 @@ impl PodInfo {
     /// - `POD_NAME`: Name of the pod (required)
     /// - `POD_UID`: UID of the pod (required for CR owner reference)
     /// - `POD_NAMESPACE`: Namespace of the pod (defaults to "default")
+    /// - `CONTAINER_NAME`: Name of this container (required when granularity is Container)
+    /// - `DYN_KUBE_DISCOVERY_GRANULARITY`: "container" or "pod" (default: "pod")
     pub fn from_env() -> Result<Self> {
         let podinfo_path = Path::new(DEFAULT_PODINFO_PATH);
 
@@ -104,6 +202,21 @@ impl PodInfo {
                     tracing::warn!("POD_NAMESPACE not set, defaulting to 'default'");
                     "default".to_string()
                 });
+
+        let granularity = KubeDiscoveryGranularity::from_env();
+
+        let container_name = match granularity {
+            KubeDiscoveryGranularity::Container => {
+                std::env::var("CONTAINER_NAME").map_err(|_| {
+                    anyhow::anyhow!(
+                        "CONTAINER_NAME is required when DYN_KUBE_DISCOVERY_GRANULARITY=container"
+                    )
+                })?
+            }
+            KubeDiscoveryGranularity::Pod => {
+                std::env::var("CONTAINER_NAME").unwrap_or_else(|_| "main".to_string())
+            }
+        };
 
         // Log where we got the pod info from for debugging
         if podinfo_path.join("pod_name").exists() {
@@ -121,9 +234,11 @@ impl PodInfo {
 
         Ok(Self {
             pod_name,
+            container_name,
             pod_namespace,
             pod_uid,
             system_port,
+            granularity,
         })
     }
 }
@@ -133,8 +248,63 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_hash_json_serialization_roundtrip() {
-        // Verify that JSON serialization/deserialization preserves exact values
+    fn test_pod_mode_instance_id_matches_hash_pod_name() {
+        let pod_names = ["worker-0", "worker-99999", "fake-name-1-0-worker-nrdfv"];
+        for pod_name in &pod_names {
+            assert_eq!(
+                KubeDiscoveryGranularity::Pod.instance_id(pod_name, "anything"),
+                hash_pod_name(pod_name),
+                "Pod mode instance_id must equal hash_pod_name for '{}'",
+                pod_name
+            );
+        }
+    }
+
+    #[test]
+    fn test_pod_mode_cr_name_is_pod_name() {
+        assert_eq!(
+            KubeDiscoveryGranularity::Pod.cr_name("worker-0", "engine-0"),
+            "worker-0"
+        );
+    }
+
+    #[test]
+    fn test_container_mode_main_uses_pod_naming() {
+        let g = KubeDiscoveryGranularity::Container;
+        // "main" container should use pod-level naming
+        assert_eq!(g.cr_name("worker-0", "main"), "worker-0");
+        assert_eq!(g.instance_id("worker-0", "main"), hash_pod_name("worker-0"));
+    }
+
+    #[test]
+    fn test_container_mode_non_main_uses_container_naming() {
+        let g = KubeDiscoveryGranularity::Container;
+        assert_eq!(g.cr_name("worker-0", "engine-0"), "worker-0-engine-0");
+        // Should differ from pod-level hash
+        assert_ne!(
+            g.instance_id("worker-0", "engine-0"),
+            hash_pod_name("worker-0")
+        );
+    }
+
+    #[test]
+    fn test_container_mode_instance_id_differs_by_container() {
+        let g = KubeDiscoveryGranularity::Container;
+        let id0 = g.instance_id("worker-0", "engine-0");
+        let id1 = g.instance_id("worker-0", "engine-1");
+        assert_ne!(id0, id1);
+    }
+
+    #[test]
+    fn test_container_mode_instance_id_differs_by_pod() {
+        let g = KubeDiscoveryGranularity::Container;
+        let id0 = g.instance_id("worker-0", "engine-0");
+        let id1 = g.instance_id("worker-1", "engine-0");
+        assert_ne!(id0, id1);
+    }
+
+    #[test]
+    fn test_instance_id_json_roundtrip() {
         let pod_names = [
             "worker-0",
             "worker-99999",
@@ -143,21 +313,20 @@ mod tests {
         ];
 
         for pod_name in &pod_names {
-            let original_hash = hash_pod_name(pod_name);
-            let json = serde_json::to_string(&original_hash).unwrap();
-            let deserialized_hash: u64 = serde_json::from_str(&json).unwrap();
+            let original = hash_pod_name(pod_name);
+            let json = serde_json::to_string(&original).unwrap();
+            let deserialized: u64 = serde_json::from_str(&json).unwrap();
 
             assert_eq!(
-                original_hash, deserialized_hash,
-                "JSON roundtrip changed hash value for pod_name={:?}: {} -> {} (json: {})",
-                pod_name, original_hash, deserialized_hash, json
+                original, deserialized,
+                "JSON roundtrip changed value for pod_name={:?}: {} -> {} (json: {})",
+                pod_name, original, deserialized, json
             );
         }
     }
 
     #[test]
-    fn test_hash_in_struct_serialization() {
-        // Test serialization when the hash is embedded in a struct
+    fn test_instance_id_in_struct_serialization() {
         #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
         struct WorkerInfo {
             instance_id: u64,


### PR DESCRIPTION
## Summary

Adds configurable discovery granularity for the Kubernetes discovery backend. Today, discovery is 1:1 with pods (EndpointSlice reflector). This PR adds a container-level mode (Pod reflector) needed for failover pods with multiple engine containers.

**Mode selection:** DGD annotation `nvidia.com/dynamo-kube-discovery-granularity: container`. Propagates to all services. No annotation = pod mode (backward compatible, no behavior change).

**Key design decisions:**
- `KubeDiscoveryGranularity` enum on `PodInfo` — gates reflector type, CR naming, and instance_id computation
- Containers named `main` use pod-level identity even in container mode, so container-mode frontends discover both pod-mode and container-mode workers
- `instance_id()` calls `cr_name()` — single derivation, no duplicate logic
- Stale CR cleanup only in container mode (pod restarts create new pods; container restarts within a living pod don't)
- `controller` owner reference: `true` when CR name == pod name (pod mode), `false` otherwise (multiple CRs per pod)
- Env var `DYN_KUBE_DISCOVERY_GRANULARITY` registered in `environment_names.rs`

## Changes

**Rust (5 files):**
- `config/environment_names.rs` — new `kube_discovery` module with `DYN_KUBE_DISCOVERY_GRANULARITY`
- `discovery/kube/utils.rs` — `KubeDiscoveryGranularity` enum, `extract_ready_containers()`, `extract_endpoint_info()` (both retained), `PodInfo` gains `container_name` + `granularity`
- `discovery/kube/daemon.rs` — `ReadinessReader` enum abstracting EndpointSlice vs Pod reflector
- `discovery/kube/crd.rs` — `build_cr` accepts separate `cr_name` param, dynamic `controller` flag
- `discovery/kube.rs` — granularity-aware identity, conditional stale CR cleanup

**Go (3 files):**
- `consts/consts.go` — `KubeAnnotationDynamoKubeDiscoveryGranularity` constant
- `dynamo/graph.go` — annotation in `dgdPropagatedAnnotationKeys`, env var injection in Grove path
- `controller/dynamocomponentdeployment_controller.go` — env var injection in DCD path

## Test plan

- [x] `cargo check`, `cargo clippy -D warnings`, `cargo fmt --check`
- [x] `cargo test` — 10/10 (8 discovery unit tests + 2 env_names dedup/convention tests)
- [x] `make test` (operator) — all packages pass
- [ ] E2E: non-failover DGD (pod mode) — inference 200, CR name = pod name
- [ ] E2E: failover DGD with annotation (container mode) — per-container CRs, frontend discovers workers, inference 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)