### PR TITLE
fix: lychee cache - don't cache failures, save cache on main for every run after sanitizing it.

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -52,7 +52,7 @@ jobs:
             --accept "200..=299, 403, 429"
             --exclude-all-private
             --exclude 0.0.0.0
-            --verbose
+            -v
             --host-concurrency 10
             --host-request-interval 1s
             --host-stats

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Restore lychee cache
         id: restore-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
-
-      - name: Check out repository
-        uses: actions/checkout@v4
 
       # # Cache lychee results (e.g. to avoid hitting rate limits)
       # # https://lychee.cli.rs/github_action_recipes/caching/
@@ -62,7 +62,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save lychee cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         if: always()
         with:
           path: .lycheecache

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -57,6 +57,14 @@ jobs:
         run: |
           if [ -f .lycheecache ]; then
             grep -E ',2[0-9]{2},' .lycheecache > .lycheecache.tmp || true
+            cutoff=$(( $(date +%s) - 93600 ))
+            stale=$(awk -F',' -v c="$cutoff" '$3 < c' .lycheecache.tmp)
+            if [ -n "$stale" ]; then
+              echo "Removing stale cache entries (>26h old):"
+              echo "$stale"
+              awk -F',' -v c="$cutoff" '$3 >= c' .lycheecache.tmp > .lycheecache.tmp2 || true
+              mv .lycheecache.tmp2 .lycheecache.tmp
+            fi
             mv .lycheecache.tmp .lycheecache
           fi
 

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           # TODO: once DYN-2259 is fixed remove exclusion of ./docs/components/profiler/profiler_guide.md
           args: >-
+            #  ${{ github.event_name == 'pull_request' && '--offline' || '' }}
             --cache
             --no-progress
             --max-retries 4
@@ -51,7 +52,10 @@ jobs:
             --accept "200..=299, 403, 429"
             --exclude-all-private
             --exclude 0.0.0.0
-            ${{ github.event_name == 'pull_request' && '--offline' || '' }}
+            --verbose
+            --host-concurrency 10
+            --host-request-interval 1s
+            --host-stats
             .
           fail: true
         env:

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -22,23 +22,13 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
+          key: cache-lychee-${{ github.run_id }}
           restore-keys: cache-lychee-
-
-      # # Cache lychee results (e.g. to avoid hitting rate limits)
-      # # https://lychee.cli.rs/github_action_recipes/caching/
-      # - name: Restore lychee cache
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: .lycheecache
-      #     key: cache-lychee-${{ github.sha }}
-      #     restore-keys: cache-lychee-
 
       - name: Check documentation links with lychee
         uses: lycheeverse/lychee-action@v2
         with:
           # TODO: once DYN-2259 is fixed remove exclusion of ./docs/components/profiler/profiler_guide.md
-          #  ${{ github.event_name == 'pull_request' && '--offline' || '' }}
           args: >-
             --cache
             --no-progress
@@ -61,12 +51,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Strip cached errors before saving
+        if: always()
+        run: |
+          if [ -f .lycheecache ]; then
+            grep -E ',2[0-9]{2},' .lycheecache > .lycheecache.tmp || true
+            mv .lycheecache.tmp .lycheecache
+          fi
+
       - name: Save lychee cache
         uses: actions/cache/save@v5
         if: always()
         with:
           path: .lycheecache
-          key: ${{ steps.restore-cache.outputs.cache-primary-key }}
+          key: cache-lychee-${{ github.run_id }}
 
   broken-links-check:
     name: Check for broken markdown links

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Strip cached errors before saving
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         run: |
           if [ -f .lycheecache ]; then
             grep -E ',2[0-9]{2},' .lycheecache > .lycheecache.tmp || true
@@ -61,7 +61,7 @@ jobs:
 
       - name: Save lychee cache
         uses: actions/cache/save@v5
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.run_id }}

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -38,8 +38,8 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           # TODO: once DYN-2259 is fixed remove exclusion of ./docs/components/profiler/profiler_guide.md
+          #  ${{ github.event_name == 'pull_request' && '--offline' || '' }}
           args: >-
-            #  ${{ github.event_name == 'pull_request' && '--offline' || '' }}
             --cache
             --no-progress
             --max-retries 4

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -13,17 +13,26 @@ jobs:
   lychee:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
 
-      # Cache lychee results (e.g. to avoid hitting rate limits)
-      # https://lychee.cli.rs/github_action_recipes/caching/
       - name: Restore lychee cache
-        uses: actions/cache@v4
+        id: restore-cache
+        uses: actions/cache/restore@v4
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      # # Cache lychee results (e.g. to avoid hitting rate limits)
+      # # https://lychee.cli.rs/github_action_recipes/caching/
+      # - name: Restore lychee cache
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: .lycheecache
+      #     key: cache-lychee-${{ github.sha }}
+      #     restore-keys: cache-lychee-
 
       - name: Check documentation links with lychee
         uses: lycheeverse/lychee-action@v2
@@ -47,6 +56,13 @@ jobs:
           fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save lychee cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: .lycheecache
+          key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
   broken-links-check:
     name: Check for broken markdown links

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -46,6 +46,7 @@ jobs:
             --host-concurrency 10
             --host-request-interval 1s
             --host-stats
+             ${{ github.event_name == 'pull_request' && '--offline' || '' }}
             .
           fail: true
         env:


### PR DESCRIPTION
#### Overview:

Fixes lychee link-checker caching in the docs link check workflow. The previous setup used `actions/cache@v4` which only saves on job success — when lychee finds broken links and fails, the cache was discarded, causing the next run to start cold and hit rate limits.

#### Details:

**Cache reliability — split restore/save with always-save semantics**
- Replaced unified `actions/cache@v4` with separate `actions/cache/restore@v5` and `actions/cache/save@v5`
- Save step uses `if: always()` so the cache persists even when lychee reports broken links
- Cache key changed from `github.sha` to `github.run_id` — GitHub Actions caches are immutable, so SHA-based keys caused save failures on re-runs of the same commit ("Unable to reserve cache with key ...")

**Cache hygiene — don't persist errors or stale entries**
- Lychee caches errors too (e.g. timeouts, rate-limits), which caused false `Error (cached)` failures on subsequent runs for valid URLs like `kubernetes.io`
- Added a pre-save step that strips non-2xx entries so only verified-good URLs are cached
- Added a 26-hour staleness check that removes and logs old entries before saving, as a sanity check alongside lychee's built-in `--max-cache-age` expiry

**Cache scope — only main branch writes**
- Cache save (and sanitization) only runs on `refs/heads/main` to prevent PR runs from polluting the shared cache
- PR runs still restore and benefit from the cache but don't write back to it

**Rate-limit mitigations**
- Added `--host-concurrency 10` and `--host-request-interval 1s` to reduce the chance of getting rate-limited by target hosts
- Added `-v` and `--host-stats` for better diagnostics in CI logs
- PRs run in `--offline` mode (cache-only, no live HTTP requests)

#### Where should the reviewer start?

`.github/workflows/docs-link-check.yml` — this is the only file changed. The key sections are:
1. Cache restore step (lines 20-26) — new key strategy
2. Strip + stale entry removal step (lines 55-70) — cache sanitization
3. Cache save step (lines 72-77) — main-only, always-save

#### Related Issues:

- Fixes flaky `Error (cached)` failures in docs link check CI