### PR TITLE
chore: update nixl version to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4642,9 +4642,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3a8dbbcf3542aa080e8e6112cecc4f6e14d5b107a535802319d5e24801b42a"
+checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -22,7 +22,7 @@ dynamo:
   nats_version: v2.10.28
   etcd_version: v3.5.21
 
-  nixl_ref: 0.10.0
+  nixl_ref: 0.10.1
   nixl_ucx_ref: v1.20.0
   nixl_gdrcopy_ref: v2.5.1
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76

--- a/container/deps/trtllm/install_nixl.sh
+++ b/container/deps/trtllm/install_nixl.sh
@@ -27,7 +27,7 @@ UCX_VERSION="v1.20.0"
 UCX_INSTALL_PATH="/usr/local/ucx/"
 CUDA_PATH="/usr/local/cuda"
 
-NIXL_COMMIT="31c2b7710a3dc96709c869b3a33aad2a982f42ff"
+NIXL_COMMIT="0.10.1"
 
 UCX_REPO="https://github.com/openucx/ucx.git"
 NIXL_REPO="https://github.com/ai-dynamo/nixl.git"

--- a/deploy/pre-deployment/nixl/README.md
+++ b/deploy/pre-deployment/nixl/README.md
@@ -95,11 +95,11 @@ The script only prompts for Docker registry information when needed:
 ## What Each Step Does
 
 ### Step 1: Build nixlbench Docker Image
-- Downloads NIXL source code (version 0.10.0) from GitHub
+- Downloads NIXL source code (version 0.10.1) from GitHub
 - Extracts and navigates to the build directory
 - Pauses for user confirmation before building
 - Builds Docker image with specified registry and architecture
-- Tags image as: `{registry}/nixlbench:0.10.0-{arch}`
+- Tags image as: `{registry}/nixlbench:0.10.1-{arch}`
 
 ### Step 2: Update Deployment YAML File
 - Copies base deployment template (`nixlbench-deployment.yaml`)
@@ -231,7 +231,7 @@ This will help diagnose:
 
 2. **Image Pull Issues**:
    - Verify registry credentials are configured
-   - Check image exists: `docker pull {registry}/nixlbench:0.10.0-{arch}`
+   - Check image exists: `docker pull {registry}/nixlbench:0.10.1-{arch}`
    - Ensure image was pushed successfully after build
 
 3. **Build Failures**:

--- a/deploy/pre-deployment/nixl/build_and_deploy.sh
+++ b/deploy/pre-deployment/nixl/build_and_deploy.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 
-NIXL_VERSION="0.10.0"
+NIXL_VERSION="0.10.1"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Function to check if a command exists

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -27,7 +27,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.9` | `1.3.0rc5` | `0.16.0` | `0.10.0` |
+| **main (ToT)** | `0.5.9` | `1.3.0rc5` | `0.16.0` | `0.10.1` |
 | **v1.0.0** *(in progress)* | `0.5.9` | `1.3.0rc5` | `0.15.1` | `0.10.1` |
 | **v0.9.1** *(in progress)* | `0.5.8` | `1.3.0rc3` | `0.14.1` | `0.9.0` |
 | **v0.9.0** | `0.5.8` | `1.3.0rc1` | `0.14.1` | `0.9.0` |

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -3870,9 +3870,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3a8dbbcf3542aa080e8e6112cecc4f6e14d5b107a535802319d5e24801b42a"
+checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/lib/bindings/kvbm/pyproject.toml
+++ b/lib/bindings/kvbm/pyproject.toml
@@ -26,7 +26,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "nixl[cu12]==0.10.0",
+    "nixl[cu12]==0.10.1",
     "pydantic>=2.0"
 ]
 classifiers = [
@@ -45,8 +45,8 @@ classifiers = [
 keywords = ["llm", "genai", "inference", "nvidia", "kvcache", "dynamo"]
 
 [project.optional-dependencies]
-cu12 = ["nixl[cu12]==0.10.0"]
-cu13 = ["nixl[cu13]==0.10.0"]
+cu12 = ["nixl[cu12]==0.10.1"]
+cu13 = ["nixl[cu13]==0.10.1"]
 test = [
     "pytest>=8.3.4",
     "pytest-mypy",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -3918,9 +3918,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3a8dbbcf3542aa080e8e6112cecc4f6e14d5b107a535802319d5e24801b42a"
+checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -108,7 +108,7 @@ dialoguer = { version = "0.11", default-features = false, features = [
 
 # block_manager
 aligned-vec = { version = "0.6.4", optional = true }
-nixl-sys = { version = "=0.10.0", optional = true }
+nixl-sys = { version = "=0.10.1", optional = true }
 cudarc = { workspace = true, optional = true }
 nix = { version = "0.26", optional = true }
 

--- a/lib/memory/Cargo.toml
+++ b/lib/memory/Cargo.toml
@@ -27,7 +27,7 @@ dynamo-config = { workspace = true }
 
 anyhow = { workspace = true }
 cudarc = { workspace = true }
-nixl-sys = { version = "0.10" }
+nixl-sys = { version = "=0.10.1" }
 serde = { workspace = true}
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ trtllm =[
 
 vllm = [
     "uvloop",
-    "nixl[cu12]<=0.10.0",
+    "nixl[cu12]<=0.10.1",
     "vllm[flashinfer,runai]==0.16.0",
     # vllm-omni 0.16.0rc1 is not on PyPI; installed from source in container builds
     # (see container/deps/vllm/install_vllm.sh). pip install ai-dynamo[vllm] will
@@ -69,7 +69,7 @@ vllm = [
 sglang = [
     "uvloop",
     "sglang[diffusion]==0.5.9",
-    "nixl[cu12]<=0.10.0",
+    "nixl[cu12]<=0.10.1",
     "cupy-cuda12x>=13.0.0",
 ]
 


### PR DESCRIPTION
closes: OPS-3565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NIXL version from 0.10.0 to 0.10.1 across all dependencies, build configurations, and deployment scripts.

* **Documentation**
  * Updated version references in deployment and backend compatibility documentation to reflect the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->