### PR TITLE
fix: rename kvbm metrics to follow dynamo metrics standard

### DIFF
--- a/deploy/observability/grafana_dashboards/kvbm.json
+++ b/deploy/observability/grafana_dashboards/kvbm.json
@@ -120,7 +120,7 @@
       "targets": [
         {
           "editorMode": "builder",
-          "expr": "kvbm_host_cache_hit_rate",
+          "expr": "dynamo_kvbm_host_cache_hit_rate",
           "interval": "",
           "legendFormat": "__auto",
           "range": true,
@@ -215,7 +215,7 @@
       "targets": [
         {
           "editorMode": "builder",
-          "expr": "kvbm_disk_cache_hit_rate",
+          "expr": "dynamo_kvbm_disk_cache_hit_rate",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -310,7 +310,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "kvbm_matched_tokens",
+          "expr": "dynamo_kvbm_matched_tokens",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
@@ -421,7 +421,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "kvbm_offload_blocks_d2h",
+          "expr": "dynamo_kvbm_offload_blocks_d2h",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
@@ -519,7 +519,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "kvbm_offload_blocks_h2d",
+          "expr": "dynamo_kvbm_offload_blocks_h2d",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
@@ -617,7 +617,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "kvbm_offload_blocks_d2d",
+          "expr": "dynamo_kvbm_offload_blocks_d2d",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
@@ -728,7 +728,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "kvbm_onboard_blocks_h2d",
+          "expr": "dynamo_kvbm_onboard_blocks_h2d",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
@@ -826,7 +826,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "kvbm_onboard_blocks_d2d",
+          "expr": "dynamo_kvbm_onboard_blocks_d2d",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",

--- a/docs/components/kvbm/kvbm-guide.md
+++ b/docs/components/kvbm/kvbm-guide.md
@@ -295,14 +295,14 @@ Access Grafana at http://localhost:3000 (default login: `dynamo`/`dynamo`) and l
 
 | Metric | Description |
 |--------|-------------|
-| `kvbm_matched_tokens` | Number of matched tokens |
-| `kvbm_offload_blocks_d2h` | Offload blocks from device to host |
-| `kvbm_offload_blocks_h2d` | Offload blocks from host to disk |
-| `kvbm_offload_blocks_d2d` | Offload blocks from device to disk (bypassing host) |
-| `kvbm_onboard_blocks_d2d` | Onboard blocks from disk to device |
-| `kvbm_onboard_blocks_h2d` | Onboard blocks from host to device |
-| `kvbm_host_cache_hit_rate` | Host cache hit rate (0.0-1.0) |
-| `kvbm_disk_cache_hit_rate` | Disk cache hit rate (0.0-1.0) |
+| `dynamo_kvbm_matched_tokens` | Number of matched tokens |
+| `dynamo_kvbm_offload_blocks_d2h` | Offload blocks from device to host |
+| `dynamo_kvbm_offload_blocks_h2d` | Offload blocks from host to disk |
+| `dynamo_kvbm_offload_blocks_d2d` | Offload blocks from device to disk (bypassing host) |
+| `dynamo_kvbm_onboard_blocks_d2d` | Onboard blocks from disk to device |
+| `dynamo_kvbm_onboard_blocks_h2d` | Onboard blocks from host to device |
+| `dynamo_kvbm_host_cache_hit_rate` | Host cache hit rate (0.0-1.0) |
+| `dynamo_kvbm_disk_cache_hit_rate` | Disk cache hit rate (0.0-1.0) |
 
 ## Benchmarking KVBM
 

--- a/lib/kvbm-logical/README.md
+++ b/lib/kvbm-logical/README.md
@@ -95,23 +95,23 @@ All metrics carry a `pool` label identifying the storage tier.
 
 | Name | Description |
 |------|-------------|
-| `kvbm_allocations_total` | Total blocks allocated from pools |
-| `kvbm_allocations_from_reset_total` | Total blocks allocated from the reset pool |
-| `kvbm_evictions_total` | Total blocks evicted from inactive pool |
-| `kvbm_registrations_total` | Total blocks registered (CompleteBlock → ImmutableBlock) |
-| `kvbm_duplicate_blocks_total` | Total duplicate blocks created (Allow policy) |
-| `kvbm_registration_dedup_total` | Total block registrations deduplicated (Reject policy) |
-| `kvbm_stagings_total` | Total MutableBlock → CompleteBlock transitions |
-| `kvbm_match_hashes_requested_total` | Total hashes requested in match_blocks calls |
-| `kvbm_match_blocks_returned_total` | Total blocks returned from match_blocks calls |
-| `kvbm_scan_hashes_requested_total` | Total hashes requested in scan_matches calls |
-| `kvbm_scan_blocks_returned_total` | Total blocks returned from scan_matches calls |
+| `dynamo_kvbm_allocations_total` | Total blocks allocated from pools |
+| `dynamo_kvbm_allocations_from_reset_total` | Total blocks allocated from the reset pool |
+| `dynamo_kvbm_evictions_total` | Total blocks evicted from inactive pool |
+| `dynamo_kvbm_registrations_total` | Total blocks registered (CompleteBlock → ImmutableBlock) |
+| `dynamo_kvbm_duplicate_blocks_total` | Total duplicate blocks created (Allow policy) |
+| `dynamo_kvbm_registration_dedup_total` | Total block registrations deduplicated (Reject policy) |
+| `dynamo_kvbm_stagings_total` | Total MutableBlock → CompleteBlock transitions |
+| `dynamo_kvbm_match_hashes_requested_total` | Total hashes requested in match_blocks calls |
+| `dynamo_kvbm_match_blocks_returned_total` | Total blocks returned from match_blocks calls |
+| `dynamo_kvbm_scan_hashes_requested_total` | Total hashes requested in scan_matches calls |
+| `dynamo_kvbm_scan_blocks_returned_total` | Total blocks returned from scan_matches calls |
 
 ### Gauges
 
 | Name | Description |
 |------|-------------|
-| `kvbm_inflight_mutable` | Current MutableBlocks held outside pool |
-| `kvbm_inflight_immutable` | Current ImmutableBlocks held outside pool |
-| `kvbm_reset_pool_size` | Current reset pool size |
-| `kvbm_inactive_pool_size` | Current inactive pool size |
+| `dynamo_kvbm_inflight_mutable` | Current MutableBlocks held outside pool |
+| `dynamo_kvbm_inflight_immutable` | Current ImmutableBlocks held outside pool |
+| `dynamo_kvbm_reset_pool_size` | Current reset pool size |
+| `dynamo_kvbm_inactive_pool_size` | Current inactive pool size |

--- a/lib/kvbm-logical/src/metrics/collector.rs
+++ b/lib/kvbm-logical/src/metrics/collector.rs
@@ -71,7 +71,10 @@ const GAUGE_DEFS: &[(&str, &str)] = &[
         "Current ImmutableBlocks held outside pool",
     ),
     ("dynamo_kvbm_reset_pool_size", "Current reset pool size"),
-    ("dynamo_kvbm_inactive_pool_size", "Current inactive pool size"),
+    (
+        "dynamo_kvbm_inactive_pool_size",
+        "Current inactive pool size",
+    ),
 ];
 
 /// Aggregates metrics from multiple `BlockPoolMetrics` sources and exports

--- a/lib/kvbm-logical/src/metrics/collector.rs
+++ b/lib/kvbm-logical/src/metrics/collector.rs
@@ -16,62 +16,62 @@ use super::pool_metrics::BlockPoolMetrics;
 /// Metric definitions: (name, help, type).
 const COUNTER_DEFS: &[(&str, &str)] = &[
     (
-        "kvbm_allocations_total",
+        "dynamo_kvbm_allocations_total",
         "Total blocks allocated from pools",
     ),
     (
-        "kvbm_allocations_from_reset_total",
+        "dynamo_kvbm_allocations_from_reset_total",
         "Total blocks allocated from the reset pool",
     ),
     (
-        "kvbm_evictions_total",
+        "dynamo_kvbm_evictions_total",
         "Total blocks evicted from inactive pool",
     ),
     (
-        "kvbm_registrations_total",
+        "dynamo_kvbm_registrations_total",
         "Total blocks registered (CompleteBlock -> ImmutableBlock)",
     ),
     (
-        "kvbm_duplicate_blocks_total",
+        "dynamo_kvbm_duplicate_blocks_total",
         "Total duplicate blocks created (Allow policy)",
     ),
     (
-        "kvbm_registration_dedup_total",
+        "dynamo_kvbm_registration_dedup_total",
         "Total block registrations deduplicated (Reject policy)",
     ),
     (
-        "kvbm_stagings_total",
+        "dynamo_kvbm_stagings_total",
         "Total MutableBlock -> CompleteBlock transitions",
     ),
     (
-        "kvbm_match_hashes_requested_total",
+        "dynamo_kvbm_match_hashes_requested_total",
         "Total hashes requested in match_blocks calls",
     ),
     (
-        "kvbm_match_blocks_returned_total",
+        "dynamo_kvbm_match_blocks_returned_total",
         "Total blocks returned from match_blocks calls",
     ),
     (
-        "kvbm_scan_hashes_requested_total",
+        "dynamo_kvbm_scan_hashes_requested_total",
         "Total hashes requested in scan_matches calls",
     ),
     (
-        "kvbm_scan_blocks_returned_total",
+        "dynamo_kvbm_scan_blocks_returned_total",
         "Total blocks returned from scan_matches calls",
     ),
 ];
 
 const GAUGE_DEFS: &[(&str, &str)] = &[
     (
-        "kvbm_inflight_mutable",
+        "dynamo_kvbm_inflight_mutable",
         "Current MutableBlocks held outside pool",
     ),
     (
-        "kvbm_inflight_immutable",
+        "dynamo_kvbm_inflight_immutable",
         "Current ImmutableBlocks held outside pool",
     ),
-    ("kvbm_reset_pool_size", "Current reset pool size"),
-    ("kvbm_inactive_pool_size", "Current inactive pool size"),
+    ("dynamo_kvbm_reset_pool_size", "Current reset pool size"),
+    ("dynamo_kvbm_inactive_pool_size", "Current inactive pool size"),
 ];
 
 /// Aggregates metrics from multiple `BlockPoolMetrics` sources and exports
@@ -285,7 +285,7 @@ mod tests {
         // Find allocations counter
         let alloc_family = families
             .iter()
-            .find(|f| f.get_name() == "kvbm_allocations_total")
+            .find(|f| f.get_name() == "dynamo_kvbm_allocations_total")
             .expect("should have allocations family");
         assert_eq!(alloc_family.get_field_type(), MetricType::COUNTER);
         let m = &alloc_family.get_metric()[0];
@@ -296,7 +296,7 @@ mod tests {
         // Find reset_pool_size gauge
         let reset_family = families
             .iter()
-            .find(|f| f.get_name() == "kvbm_reset_pool_size")
+            .find(|f| f.get_name() == "dynamo_kvbm_reset_pool_size")
             .expect("should have reset pool size family");
         assert_eq!(reset_family.get_field_type(), MetricType::GAUGE);
         assert_eq!(reset_family.get_metric()[0].get_gauge().value(), 42.0);
@@ -316,7 +316,7 @@ mod tests {
         let families = agg.collect();
         let alloc_family = families
             .iter()
-            .find(|f| f.get_name() == "kvbm_allocations_total")
+            .find(|f| f.get_name() == "dynamo_kvbm_allocations_total")
             .unwrap();
         let labels = alloc_family.get_metric()[0].get_label();
         assert_eq!(labels.len(), 3); // pool + 2 external
@@ -344,7 +344,7 @@ mod tests {
         // Families should be merged by name
         let alloc_family = families
             .iter()
-            .find(|f| f.get_name() == "kvbm_allocations_total")
+            .find(|f| f.get_name() == "dynamo_kvbm_allocations_total")
             .expect("should have allocations family");
         assert_eq!(alloc_family.get_metric().len(), 2);
 
@@ -373,7 +373,7 @@ mod tests {
 
         let alloc_family = gathered
             .iter()
-            .find(|f| f.get_name() == "kvbm_allocations_total")
+            .find(|f| f.get_name() == "dynamo_kvbm_allocations_total")
             .expect("should find allocations in gathered metrics");
         assert_eq!(alloc_family.get_metric()[0].get_counter().value(), 42.0);
     }

--- a/lib/llm/src/block_manager/metrics_kvbm.rs
+++ b/lib/llm/src/block_manager/metrics_kvbm.rs
@@ -265,7 +265,7 @@ impl Drop for KvbmMetrics {
     }
 }
 
-/// A raw, standalone Prometheus metrics registry implementation using the fixed prefix: `kvbm_`
+/// A raw, standalone Prometheus metrics registry implementation using the fixed prefix: `dynamo_kvbm_`
 #[derive(Debug, Clone)]
 pub struct KvbmMetricsRegistry {
     registry: Arc<Registry>,
@@ -276,7 +276,7 @@ impl KvbmMetricsRegistry {
     pub fn new() -> Self {
         Self {
             registry: Arc::new(Registry::new()),
-            prefix: "kvbm".to_string(),
+            prefix: "dynamo_kvbm".to_string(),
         }
     }
 

--- a/tests/kvbm_integration/common.py
+++ b/tests/kvbm_integration/common.py
@@ -791,7 +791,9 @@ class TestDeterminism:
 
             try:
                 current_metrics = fetch_kvbm_metrics(port=metrics_port)
-                current_offload = current_metrics.get("kvbm_offload_blocks_d2h", 0)
+                current_offload = current_metrics.get(
+                    "dynamo_kvbm_offload_blocks_d2h", 0
+                )
 
                 if current_offload > initial_offload:
                     offload_delta = current_offload - initial_offload
@@ -953,8 +955,8 @@ class TestDeterminism:
         print(f"{'='*70}")
         try:
             final_metrics = fetch_kvbm_metrics(port=metrics_port)
-            final_offload = final_metrics.get("kvbm_offload_blocks_d2h", 0)
-            final_onboard = final_metrics.get("kvbm_onboard_blocks_h2d", 0)
+            final_offload = final_metrics.get("dynamo_kvbm_offload_blocks_d2h", 0)
+            final_onboard = final_metrics.get("dynamo_kvbm_onboard_blocks_h2d", 0)
 
             offload_delta = final_offload - initial_offload
             print(f"Initial offload: {initial_offload} blocks")
@@ -1035,7 +1037,9 @@ class TestDeterminism:
             print("\nChecking initial KVBM metrics...")
             try:
                 initial_metrics = fetch_kvbm_metrics(port=llm_server.metrics_port)
-                initial_offload = initial_metrics.get("kvbm_offload_blocks_d2h", 0)
+                initial_offload = initial_metrics.get(
+                    "dynamo_kvbm_offload_blocks_d2h", 0
+                )
                 print(f"Initial offload: {initial_offload} blocks")
             except Exception as e:
                 print(f"Could not fetch initial metrics: {e}")
@@ -1285,11 +1289,11 @@ def parse_kvbm_metrics(metrics_text: str) -> dict:
         if line.startswith("#") or not line.strip():
             continue
         for metric_name in [
-            "kvbm_offload_blocks_d2h",
-            "kvbm_onboard_blocks_h2d",
-            "kvbm_offload_blocks_h2d",
-            "kvbm_onboard_blocks_d2d",
-            "kvbm_matched_tokens",
+            "dynamo_kvbm_offload_blocks_d2h",
+            "dynamo_kvbm_onboard_blocks_h2d",
+            "dynamo_kvbm_offload_blocks_h2d",
+            "dynamo_kvbm_onboard_blocks_d2d",
+            "dynamo_kvbm_matched_tokens",
         ]:
             if line.startswith(metric_name + " "):
                 parts = line.strip().split()

--- a/tests/kvbm_integration/test_chunked_prefill.py
+++ b/tests/kvbm_integration/test_chunked_prefill.py
@@ -69,21 +69,21 @@ def check_kvbm_metrics(phase_name: str, metrics_port: int) -> dict[str, int]:
 
     Returns:
         Dictionary containing KVBM metrics with keys:
-        - kvbm_offload_blocks_d2h: Blocks offloaded from GPU to CPU
-        - kvbm_onboard_blocks_h2d: Blocks onboarded from CPU to GPU
+        - dynamo_kvbm_offload_blocks_d2h: Blocks offloaded from GPU to CPU
+        - dynamo_kvbm_onboard_blocks_h2d: Blocks onboarded from CPU to GPU
     """
     print(f"\n--- Checking KVBM metrics after {phase_name} ---")
     metrics = fetch_kvbm_metrics(port=metrics_port)
 
-    offload_d2h = metrics.get("kvbm_offload_blocks_d2h", 0)
-    onboard_h2d = metrics.get("kvbm_onboard_blocks_h2d", 0)
+    offload_d2h = metrics.get("dynamo_kvbm_offload_blocks_d2h", 0)
+    onboard_h2d = metrics.get("dynamo_kvbm_onboard_blocks_h2d", 0)
 
-    print(f"  kvbm_offload_blocks_d2h: {offload_d2h}")
-    print(f"  kvbm_onboard_blocks_h2d: {onboard_h2d}")
+    print(f"  dynamo_kvbm_offload_blocks_d2h: {offload_d2h}")
+    print(f"  dynamo_kvbm_onboard_blocks_h2d: {onboard_h2d}")
 
     return {
-        "kvbm_offload_blocks_d2h": offload_d2h,
-        "kvbm_onboard_blocks_h2d": onboard_h2d,
+        "dynamo_kvbm_offload_blocks_d2h": offload_d2h,
+        "dynamo_kvbm_onboard_blocks_h2d": onboard_h2d,
     }
 
 
@@ -153,7 +153,7 @@ def test_chunked_prefill_offload(tester, llm_server_kvbm):  # noqa: F811
     metrics_p1 = check_kvbm_metrics("Phase 1", llm_server_kvbm.metrics_port)
 
     # Verify offload occurred
-    offloaded_blocks = metrics_p1["kvbm_offload_blocks_d2h"]
+    offloaded_blocks = metrics_p1["dynamo_kvbm_offload_blocks_d2h"]
     assert offloaded_blocks > 0, (
         "Phase 1: No blocks offloaded. KVBM may not be triggering offloads "
         "during chunked prefill."
@@ -191,7 +191,7 @@ def test_chunked_prefill_offload(tester, llm_server_kvbm):  # noqa: F811
     metrics_p3 = check_kvbm_metrics("Phase 3", llm_server_kvbm.metrics_port)
 
     # Verify onboarding occurred
-    onboarded_blocks = metrics_p3["kvbm_onboard_blocks_h2d"]
+    onboarded_blocks = metrics_p3["dynamo_kvbm_onboard_blocks_h2d"]
     assert (
         onboarded_blocks > 0
     ), "Phase 3: No blocks onboarded. Expected CPU→GPU transfer after cache eviction."

--- a/tests/kvbm_integration/test_kvbm.py
+++ b/tests/kvbm_integration/test_kvbm.py
@@ -68,21 +68,21 @@ def check_kvbm_metrics(phase_name: str, metrics_port: int) -> dict[str, int]:
 
     Returns:
         Dictionary containing KVBM metrics with keys:
-        - kvbm_offload_blocks_d2h: Blocks offloaded from GPU to CPU
-        - kvbm_onboard_blocks_h2d: Blocks onboarded from CPU to GPU
+        - dynamo_kvbm_offload_blocks_d2h: Blocks offloaded from GPU to CPU
+        - dynamo_kvbm_onboard_blocks_h2d: Blocks onboarded from CPU to GPU
     """
     print(f"\n--- Checking KVBM metrics after {phase_name} ---")
     metrics = fetch_kvbm_metrics(port=metrics_port)
 
-    offload_d2h = metrics.get("kvbm_offload_blocks_d2h", 0)
-    onboard_h2d = metrics.get("kvbm_onboard_blocks_h2d", 0)
+    offload_d2h = metrics.get("dynamo_kvbm_offload_blocks_d2h", 0)
+    onboard_h2d = metrics.get("dynamo_kvbm_onboard_blocks_h2d", 0)
 
-    print(f"  kvbm_offload_blocks_d2h: {offload_d2h}")
-    print(f"  kvbm_onboard_blocks_h2d: {onboard_h2d}")
+    print(f"  dynamo_kvbm_offload_blocks_d2h: {offload_d2h}")
+    print(f"  dynamo_kvbm_onboard_blocks_h2d: {onboard_h2d}")
 
     return {
-        "kvbm_offload_blocks_d2h": offload_d2h,
-        "kvbm_onboard_blocks_h2d": onboard_h2d,
+        "dynamo_kvbm_offload_blocks_d2h": offload_d2h,
+        "dynamo_kvbm_onboard_blocks_h2d": onboard_h2d,
     }
 
 
@@ -139,12 +139,12 @@ def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
 
     metrics = check_kvbm_metrics("Phase 1", llm_server_kvbm.metrics_port)
     assert (
-        metrics["kvbm_offload_blocks_d2h"] > 0
+        metrics["dynamo_kvbm_offload_blocks_d2h"] > 0
     ), "Phase 1: No blocks offloaded. KVBM may not be triggering offloads."
     assert (
-        metrics["kvbm_onboard_blocks_h2d"] == 0
-    ), f"Phase 1: Expected 0 onboarded blocks, got {metrics['kvbm_onboard_blocks_h2d']}"
-    print(f"✓ Phase 1: {metrics['kvbm_offload_blocks_d2h']} blocks offloaded")
+        metrics["dynamo_kvbm_onboard_blocks_h2d"] == 0
+    ), f"Phase 1: Expected 0 onboarded blocks, got {metrics['dynamo_kvbm_onboard_blocks_h2d']}"
+    print(f"✓ Phase 1: {metrics['dynamo_kvbm_offload_blocks_d2h']} blocks offloaded")
 
     # Phase 2: Reset GPU cache
     print_phase(2, "Clean up GPU cache")
@@ -159,9 +159,11 @@ def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
 
     metrics = check_kvbm_metrics("Phase 3", llm_server_kvbm.metrics_port)
     assert (
-        metrics["kvbm_onboard_blocks_h2d"] > 0
+        metrics["dynamo_kvbm_onboard_blocks_h2d"] > 0
     ), "Phase 3: No blocks onboarded. Expected CPU→GPU transfer after cache reset."
-    print(f"✓ Phase 3: {metrics['kvbm_onboard_blocks_h2d']} blocks onboarded from CPU")
+    print(
+        f"✓ Phase 3: {metrics['dynamo_kvbm_onboard_blocks_h2d']} blocks onboarded from CPU"
+    )
 
     # Verify determinism
     print_test_header("DETERMINISM VERIFICATION")
@@ -208,14 +210,14 @@ def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
     tester.make_request(prompt_1, max_tokens=MAX_TOKENS)
 
     metrics_p1 = check_kvbm_metrics("Phase 1", llm_server_kvbm.metrics_port)
-    assert metrics_p1["kvbm_offload_blocks_d2h"] >= MIN_OFFLOAD_BLOCKS, (
+    assert metrics_p1["dynamo_kvbm_offload_blocks_d2h"] >= MIN_OFFLOAD_BLOCKS, (
         f"Phase 1: Expected >= {MIN_OFFLOAD_BLOCKS} blocks offloaded, "
-        f"got {metrics_p1['kvbm_offload_blocks_d2h']}"
+        f"got {metrics_p1['dynamo_kvbm_offload_blocks_d2h']}"
     )
     assert (
-        metrics_p1["kvbm_onboard_blocks_h2d"] == 0
-    ), f"Phase 1: Expected 0 onboarded, got {metrics_p1['kvbm_onboard_blocks_h2d']}"
-    print(f"✓ Phase 1: {metrics_p1['kvbm_offload_blocks_d2h']} blocks offloaded")
+        metrics_p1["dynamo_kvbm_onboard_blocks_h2d"] == 0
+    ), f"Phase 1: Expected 0 onboarded, got {metrics_p1['dynamo_kvbm_onboard_blocks_h2d']}"
+    print(f"✓ Phase 1: {metrics_p1['dynamo_kvbm_offload_blocks_d2h']} blocks offloaded")
 
     # Phase 2: Second request may evict first from GPU
     print_phase(2, "Send second request (may evict first from GPU)")
@@ -225,13 +227,15 @@ def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
 
     metrics_p2 = check_kvbm_metrics("Phase 2", llm_server_kvbm.metrics_port)
     assert (
-        metrics_p2["kvbm_offload_blocks_d2h"] > metrics_p1["kvbm_offload_blocks_d2h"]
+        metrics_p2["dynamo_kvbm_offload_blocks_d2h"]
+        > metrics_p1["dynamo_kvbm_offload_blocks_d2h"]
     ), (
-        f"Phase 2: Expected additional offloads, got {metrics_p2['kvbm_offload_blocks_d2h']} "
-        f"(was {metrics_p1['kvbm_offload_blocks_d2h']})"
+        f"Phase 2: Expected additional offloads, got {metrics_p2['dynamo_kvbm_offload_blocks_d2h']} "
+        f"(was {metrics_p1['dynamo_kvbm_offload_blocks_d2h']})"
     )
     additional_offloads = (
-        metrics_p2["kvbm_offload_blocks_d2h"] - metrics_p1["kvbm_offload_blocks_d2h"]
+        metrics_p2["dynamo_kvbm_offload_blocks_d2h"]
+        - metrics_p1["dynamo_kvbm_offload_blocks_d2h"]
     )
     print(f"✓ Phase 2: {additional_offloads} additional blocks offloaded")
 
@@ -243,9 +247,9 @@ def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
 
     metrics_p3 = check_kvbm_metrics("Phase 3", llm_server_kvbm.metrics_port)
     assert (
-        metrics_p3["kvbm_onboard_blocks_h2d"] > 0
+        metrics_p3["dynamo_kvbm_onboard_blocks_h2d"] > 0
     ), "Phase 3: No blocks onboarded. Expected CPU→GPU retrieval after eviction."
-    print(f"✓ Phase 3: {metrics_p3['kvbm_onboard_blocks_h2d']} blocks onboarded")
+    print(f"✓ Phase 3: {metrics_p3['dynamo_kvbm_onboard_blocks_h2d']} blocks onboarded")
     print("✓ Eviction mechanics verified: offload → eviction → onboard")
 
     print("\n=== TEST PASSED ===")


### PR DESCRIPTION
`kvbm_` --> `dynamo_kvbm_`

<img width="3431" height="1308" alt="Screenshot 2026-03-03 at 3 25 51 PM" src="https://github.com/user-attachments/assets/6b31172a-bf2e-4617-b508-7a1010b43891" />


closes [KVBM-314](https://linear.app/nvidia/issue/KVBM-314/rename-kvbm-metrics-according-to-dynamo-metrics-rule)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed KVBM metrics by adding `dynamo_kvbm_` prefix to all metric identifiers (e.g., `kvbm_offload_blocks_d2h` → `dynamo_kvbm_offload_blocks_d2h`). Updated Grafana dashboards, documentation, and integration tests to reflect the new metric naming across the monitoring infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->