### PR TITLE
chore: Update AWS SDK version used

### DIFF
--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -251,7 +251,7 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
 
 {% if framework == "vllm" %}
 # Build and install AWS SDK C++ (required for NIXL OBJ backend / S3 support)
-ARG AWS_SDK_CPP_VERSION=1.11.581
+ARG AWS_SDK_CPP_VERSION=1.11.760
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${ARCH}}" && \


### PR DESCRIPTION
NIXL is moving to the latest SDK as there is a use-after-free bug in the S3 CRT SDK. Lets move Dynamo components too.

See: https://github.com/ai-dynamo/nixl/pull/1387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS SDK dependency to the latest compatible version, improving library compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->