### PR TITLE
feat(llm): early tool-call completion via streaming args tracker

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -42,7 +42,9 @@ use super::{
     service_v2,
 };
 use crate::engines::ValidateRequest;
-use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
+use crate::protocols::openai::chat_completions::aggregator::{
+    ChatCompletionAggregator, streaming_tool_call_adapter,
+};
 use crate::protocols::openai::nvext::apply_header_routing_overrides;
 use crate::protocols::openai::{
     chat_completions::{
@@ -1057,6 +1059,8 @@ async fn chat_completions(
         // must be delivered as SSE events with `event: error` in the stream (handled by
         // EventConverter and monitor_for_disconnects). This is standard SSE behavior.
         stream_handle.arm(); // allows the system to detect client disconnects and cancel the LLM generation
+
+        let stream = streaming_tool_call_adapter(stream);
 
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -130,8 +130,6 @@ impl StreamingToolCallState {
 pub fn streaming_tool_call_adapter(
     stream: impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
 ) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> {
-    // We use `scan` to carry mutable state across the stream and emit Vec<item>
-    // per input (0 or more synthetic chunks after each original chunk).
     // Key by (choice_index, tool_call_index) to avoid collisions in multi-choice streams.
     let state: HashMap<(u32, u32), StreamingToolCallState> = HashMap::new();
 
@@ -691,6 +689,7 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
+            error: None,
         }
     }
 
@@ -928,6 +927,7 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
+            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -993,6 +993,7 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
+            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -1035,6 +1036,7 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
+            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -1077,6 +1079,7 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
+            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -1117,6 +1120,7 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
+            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -1161,6 +1165,7 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
+            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -1203,6 +1208,7 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
+            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -1286,156 +1292,5 @@ mod tests {
         let tool_calls = choice.message.tool_calls.as_ref().unwrap();
         assert_eq!(tool_calls.len(), 1);
         assert_eq!(tool_calls[0].function.name, "get_weather");
-    }
-
-    // -----------------------------------------------------------------------
-    // Tests for streaming_tool_call_adapter
-    // -----------------------------------------------------------------------
-
-    /// Helper: build a raw streaming chunk with a tool_call delta fragment.
-    #[allow(deprecated)]
-    fn make_tool_chunk(
-        id: Option<&str>,
-        name: Option<&str>,
-        args_fragment: Option<&str>,
-        finish_reason: Option<dynamo_async_openai::types::FinishReason>,
-    ) -> Annotated<NvCreateChatCompletionStreamResponse> {
-        let tc = dynamo_async_openai::types::ChatCompletionMessageToolCallChunk {
-            index: 0,
-            id: id.map(|s| s.to_string()),
-            r#type: id.map(|_| dynamo_async_openai::types::ChatCompletionToolType::Function),
-            function: Some(dynamo_async_openai::types::FunctionCallStream {
-                name: name.map(|s| s.to_string()),
-                arguments: args_fragment.map(|s| s.to_string()),
-            }),
-        };
-
-        let choice = dynamo_async_openai::types::ChatChoiceStream {
-            index: 0,
-            delta: dynamo_async_openai::types::ChatCompletionStreamResponseDelta {
-                content: None,
-                function_call: None,
-                tool_calls: Some(vec![tc]),
-                role: None,
-                refusal: None,
-                reasoning_content: None,
-            },
-            finish_reason,
-            stop_reason: None,
-            logprobs: None,
-        };
-
-        let data = NvCreateChatCompletionStreamResponse {
-            id: "test_id".to_string(),
-            model: "test_model".to_string(),
-            created: 12345,
-            service_tier: None,
-            usage: None,
-            system_fingerprint: None,
-            choices: vec![choice],
-            object: "chat.completion.chunk".to_string(),
-            nvext: None,
-        };
-
-        Annotated {
-            data: Some(data),
-            id: None,
-            event: None,
-            comment: None,
-        }
-    }
-
-    #[tokio::test]
-    async fn test_streaming_adapter_emits_complete_tool_call() {
-        // Simulate the wire format: id+name in first chunk, args across multiple chunks
-        let chunks = vec![
-            make_tool_chunk(Some("call_1"), Some("bash"), Some("{\""), None),
-            make_tool_chunk(None, None, Some("cmd"), None),
-            make_tool_chunk(None, None, Some("\":\"ls\""), None),
-            make_tool_chunk(None, None, Some("}"), None), // brace_depth -> 0
-            make_tool_chunk(
-                None,
-                None,
-                None,
-                Some(dynamo_async_openai::types::FinishReason::ToolCalls),
-            ),
-        ];
-
-        let input_stream = Box::pin(stream::iter(chunks));
-        let output: Vec<_> = streaming_tool_call_adapter(input_stream).collect().await;
-
-        // We should have 5 original chunks + 1 synthetic completion chunk = 6 total
-        assert_eq!(output.len(), 6);
-
-        // The synthetic chunk should be the 5th item (after the 4th original chunk
-        // that completed the JSON).
-        let synthetic = &output[4];
-        assert_eq!(
-            synthetic.event.as_deref(),
-            Some("tool_call.complete"),
-            "synthetic chunk should have event=tool_call.complete"
-        );
-
-        let data = synthetic.data.as_ref().unwrap();
-        assert_eq!(data.choices.len(), 1);
-        let tc = &data.choices[0].delta.tool_calls.as_ref().unwrap()[0];
-        assert_eq!(tc.id.as_deref(), Some("call_1"));
-        assert_eq!(tc.function.as_ref().unwrap().name.as_deref(), Some("bash"));
-        assert_eq!(
-            tc.function.as_ref().unwrap().arguments.as_deref(),
-            Some("{\"cmd\":\"ls\"}")
-        );
-    }
-
-    #[tokio::test]
-    async fn test_streaming_adapter_handles_quoted_braces() {
-        // Args contain braces inside a JSON string value — should not confuse depth tracker
-        let chunks = vec![
-            make_tool_chunk(Some("call_2"), Some("eval"), Some("{\"code\":\"x={"), None),
-            make_tool_chunk(None, None, Some("}\""), None), // closing " ends string, but } inside string shouldn't count
-            make_tool_chunk(None, None, Some("}"), None),   // THIS closes the top-level object
-        ];
-
-        let input_stream = Box::pin(stream::iter(chunks));
-        let output: Vec<_> = streaming_tool_call_adapter(input_stream).collect().await;
-
-        // 3 original + 1 synthetic = 4
-        assert_eq!(output.len(), 4);
-
-        let synthetic = &output[3];
-        assert_eq!(synthetic.event.as_deref(), Some("tool_call.complete"));
-
-        let tc = &synthetic
-            .data
-            .as_ref()
-            .unwrap()
-            .choices[0]
-            .delta
-            .tool_calls
-            .as_ref()
-            .unwrap()[0];
-        assert_eq!(
-            tc.function.as_ref().unwrap().arguments.as_deref(),
-            Some("{\"code\":\"x={}\"}"),
-        );
-    }
-
-    #[tokio::test]
-    async fn test_streaming_adapter_no_tool_calls_passthrough() {
-        // A stream with no tool calls should pass through unchanged
-        let text_chunk = create_test_delta(
-            0,
-            "Hello world",
-            Some(dynamo_async_openai::types::Role::Assistant),
-            Some(dynamo_async_openai::types::FinishReason::Stop),
-            None,
-            None,
-        );
-
-        let input_stream = Box::pin(stream::iter(vec![text_chunk]));
-        let output: Vec<_> = streaming_tool_call_adapter(input_stream).collect().await;
-
-        // Should pass through as-is, no synthetic chunks
-        assert_eq!(output.len(), 1);
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -246,6 +246,7 @@ fn build_complete_tool_call_chunk(
         id: None,
         event: Some("tool_call.complete".to_string()),
         comment: None,
+        error: None,
     }
 }
 

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -1334,8 +1334,8 @@ mod tests {
             // a string does NOT fire the completion — only the final outer `}` does.
             let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
             assert!(!state.feed(r#"{"code": "if (x) {"#)); // inner `{` is in a string
-            assert!(!state.feed(r#"return }"#));           // inner `}` is in a string
-            assert!(state.feed(r#"}"}"#));                 // `}` closes string, `}` closes object
+            assert!(!state.feed(r#"return }"#)); // inner `}` is in a string
+            assert!(state.feed(r#"}"}"#)); // `}` closes string, `}` closes object
             assert_eq!(state.accumulated_args, r#"{"code": "if (x) {return }}"}"#);
         }
 
@@ -1429,11 +1429,22 @@ mod tests {
             //   - synthetic chunk carries correct id, name, fully-assembled arguments
             //   - non-tool-call chunks produce no extra output
             let chunks = vec![
-                make_chunk(0, None),                                                        // non-tool chunk
-                make_chunk(0, Some(vec![make_tc(0, Some("call_1"), Some("get_weather"), Some(r#"{"city":"#))])),
+                make_chunk(0, None), // non-tool chunk
+                make_chunk(
+                    0,
+                    Some(vec![make_tc(
+                        0,
+                        Some("call_1"),
+                        Some("get_weather"),
+                        Some(r#"{"city":"#),
+                    )]),
+                ),
                 make_chunk(0, Some(vec![make_tc(0, None, None, Some(r#""San "#))])),
-                make_chunk(0, Some(vec![make_tc(0, None, None, Some(r#"Francisco"}"#))])), // completes here
-                make_chunk(0, None),                                                        // non-tool chunk
+                make_chunk(
+                    0,
+                    Some(vec![make_tc(0, None, None, Some(r#"Francisco"}"#))]),
+                ), // completes here
+                make_chunk(0, None), // non-tool chunk
             ];
             let input = stream::iter(chunks);
             let output: Vec<_> = streaming_tool_call_adapter(input).collect().await;
@@ -1451,9 +1462,15 @@ mod tests {
             let synthetic = &output[4];
             assert_eq!(synthetic.event.as_deref(), Some("tool_call.complete"));
             let tc = &synthetic.data.as_ref().unwrap().choices[0]
-                .delta.tool_calls.as_ref().unwrap()[0];
+                .delta
+                .tool_calls
+                .as_ref()
+                .unwrap()[0];
             assert_eq!(tc.id.as_deref(), Some("call_1"));
-            assert_eq!(tc.function.as_ref().unwrap().name.as_deref(), Some("get_weather"));
+            assert_eq!(
+                tc.function.as_ref().unwrap().name.as_deref(),
+                Some("get_weather")
+            );
             assert_eq!(
                 tc.function.as_ref().unwrap().arguments.as_deref(),
                 Some(r#"{"city":"San Francisco"}"#)
@@ -1466,13 +1483,19 @@ mod tests {
             // in chunk 0; call_a completes in chunk 1. Verifies the compound
             // (choice_index, tool_call_index) key prevents state collision.
             let chunks = vec![
-                make_chunk(0, Some(vec![
-                    make_tc(0, Some("call_a"), Some("fn_a"), Some(r#"{"x"#)),   // partial
-                    make_tc(1, Some("call_b"), Some("fn_b"), Some(r#"{"y":2}"#)), // complete
-                ])),
-                make_chunk(0, Some(vec![
-                    make_tc(0, None, None, Some(r#":1}"#)), // call_a completes
-                ])),
+                make_chunk(
+                    0,
+                    Some(vec![
+                        make_tc(0, Some("call_a"), Some("fn_a"), Some(r#"{"x"#)), // partial
+                        make_tc(1, Some("call_b"), Some("fn_b"), Some(r#"{"y":2}"#)), // complete
+                    ]),
+                ),
+                make_chunk(
+                    0,
+                    Some(vec![
+                        make_tc(0, None, None, Some(r#":1}"#)), // call_a completes
+                    ]),
+                ),
             ];
             let input = stream::iter(chunks);
             let output: Vec<_> = streaming_tool_call_adapter(input).collect().await;
@@ -1483,16 +1506,28 @@ mod tests {
             let synth_b = &output[1];
             assert_eq!(synth_b.event.as_deref(), Some("tool_call.complete"));
             let tc_b = &synth_b.data.as_ref().unwrap().choices[0]
-                .delta.tool_calls.as_ref().unwrap()[0];
+                .delta
+                .tool_calls
+                .as_ref()
+                .unwrap()[0];
             assert_eq!(tc_b.id.as_deref(), Some("call_b"));
-            assert_eq!(tc_b.function.as_ref().unwrap().arguments.as_deref(), Some(r#"{"y":2}"#));
+            assert_eq!(
+                tc_b.function.as_ref().unwrap().arguments.as_deref(),
+                Some(r#"{"y":2}"#)
+            );
 
             let synth_a = &output[3];
             assert_eq!(synth_a.event.as_deref(), Some("tool_call.complete"));
             let tc_a = &synth_a.data.as_ref().unwrap().choices[0]
-                .delta.tool_calls.as_ref().unwrap()[0];
+                .delta
+                .tool_calls
+                .as_ref()
+                .unwrap()[0];
             assert_eq!(tc_a.id.as_deref(), Some("call_a"));
-            assert_eq!(tc_a.function.as_ref().unwrap().arguments.as_deref(), Some(r#"{"x":1}"#));
+            assert_eq!(
+                tc_a.function.as_ref().unwrap().arguments.as_deref(),
+                Some(r#"{"x":1}"#)
+            );
         }
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -15,6 +15,237 @@ use crate::protocols::{
 use dynamo_async_openai::types::{ChatCompletionMessageContent, StopReason};
 use dynamo_runtime::engine::DataStream;
 
+// ---------------------------------------------------------------------------
+// Streaming tool-call tracker: emits complete tool calls as soon as their
+// arguments JSON is structurally complete (brace_depth returns to 0), rather
+// than buffering until `finish_reason = tool_calls`.
+// ---------------------------------------------------------------------------
+
+/// Per-tool-call state tracked while streaming argument characters.
+#[derive(Debug)]
+struct StreamingToolCallState {
+    /// The tool call index (from the chunk's `index` field).
+    index: u32,
+    /// The `id` from the first chunk for this tool call.
+    id: String,
+    /// The function name from the first chunk.
+    name: String,
+    /// Accumulated arguments JSON string so far.
+    accumulated_args: String,
+    /// Running brace depth counter.  `{` increments, `}` decrements.
+    /// We track whether we are inside a JSON string literal to avoid
+    /// miscounting escaped/quoted braces.
+    brace_depth: i32,
+    /// Whether we are currently inside a JSON string value (between unescaped `"`).
+    in_string: bool,
+    /// Whether the previous character was an unescaped backslash (for `\"` handling).
+    escape_next: bool,
+    /// Set to `true` once we have emitted the completed tool call.
+    emitted: bool,
+}
+
+impl StreamingToolCallState {
+    fn new(index: u32, id: String, name: String) -> Self {
+        Self {
+            index,
+            id,
+            name,
+            accumulated_args: String::new(),
+            brace_depth: 0,
+            in_string: false,
+            escape_next: false,
+            emitted: false,
+        }
+    }
+
+    /// Feed a fragment of the arguments string, updating brace depth.
+    /// Returns `true` if the tool call just became complete on this fragment
+    /// (i.e. brace_depth transitioned from >0 to 0).
+    fn feed(&mut self, fragment: &str) -> bool {
+        if self.emitted {
+            return false;
+        }
+
+        let was_positive = self.brace_depth > 0;
+
+        for ch in fragment.chars() {
+            if self.escape_next {
+                // Previous char was `\` inside a string — skip this char.
+                self.escape_next = false;
+                continue;
+            }
+
+            if self.in_string {
+                match ch {
+                    '\\' => {
+                        self.escape_next = true;
+                    }
+                    '"' => {
+                        self.in_string = false;
+                    }
+                    _ => {}
+                }
+            } else {
+                match ch {
+                    '"' => {
+                        self.in_string = true;
+                    }
+                    '{' => {
+                        self.brace_depth += 1;
+                    }
+                    '}' => {
+                        self.brace_depth -= 1;
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        self.accumulated_args.push_str(fragment);
+
+        // Transition from positive depth to zero means the JSON object is complete.
+        // Also handle the case where we started at 0 and went to 0 on the very first
+        // fragment (e.g. the entire args are delivered in one chunk).
+        let now_zero = self.brace_depth == 0;
+        let just_completed =
+            now_zero && (was_positive || !self.accumulated_args.is_empty()) && !self.emitted;
+
+        if just_completed {
+            self.emitted = true;
+        }
+
+        just_completed
+    }
+}
+
+/// Wraps a stream of `Annotated<NvCreateChatCompletionStreamResponse>` and
+/// injects synthetic chunks containing completed tool calls as soon as their
+/// arguments JSON is structurally complete.
+///
+/// The original chunks are forwarded as-is.  When a tool call completes, an
+/// additional synthetic chunk is emitted immediately after the triggering chunk.
+/// The `finish_reason = tool_calls` chunk at the end is still forwarded for
+/// compatibility.
+pub fn streaming_tool_call_adapter(
+    stream: impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
+) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> {
+    // We use `scan` to carry mutable state across the stream and emit Vec<item>
+    // per input (0 or more synthetic chunks after each original chunk).
+    let state: HashMap<u32, StreamingToolCallState> = HashMap::new();
+
+    stream
+        .scan(state, |tool_states, annotated| {
+            let mut extra_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = Vec::new();
+
+            if let Some(data) = &annotated.data {
+                for choice in &data.choices {
+                    if let Some(tool_calls) = &choice.delta.tool_calls {
+                        for tc_chunk in tool_calls {
+                            let idx = tc_chunk.index;
+
+                            // If this is the first chunk for a tool call (has id + name),
+                            // initialize tracking state.
+                            if let Some(id) = &tc_chunk.id {
+                                if let Some(func) = &tc_chunk.function {
+                                    if let Some(name) = &func.name {
+                                        tool_states.entry(idx).or_insert_with(|| {
+                                            StreamingToolCallState::new(
+                                                idx,
+                                                id.clone(),
+                                                name.clone(),
+                                            )
+                                        });
+                                    }
+                                }
+                            }
+
+                            // Feed any argument fragment into the tracker.
+                            if let Some(func) = &tc_chunk.function {
+                                if let Some(args_fragment) = &func.arguments {
+                                    if let Some(state) = tool_states.get_mut(&idx) {
+                                        let just_completed = state.feed(args_fragment);
+
+                                        if just_completed {
+                                            // Build a synthetic chunk with the complete tool call.
+                                            let synthetic = build_complete_tool_call_chunk(
+                                                data, state,
+                                            );
+                                            extra_chunks.push(synthetic);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Yield the original chunk first, then any synthetic completions.
+            let mut items = Vec::with_capacity(1 + extra_chunks.len());
+            items.push(annotated);
+            items.extend(extra_chunks);
+            futures::future::ready(Some(items))
+        })
+        .flat_map(futures::stream::iter)
+}
+
+/// Build a synthetic `Annotated<NvCreateChatCompletionStreamResponse>` that
+/// carries a single completed tool call with its full accumulated arguments.
+#[allow(deprecated)]
+fn build_complete_tool_call_chunk(
+    template: &NvCreateChatCompletionStreamResponse,
+    tool_state: &StreamingToolCallState,
+) -> Annotated<NvCreateChatCompletionStreamResponse> {
+    use dynamo_async_openai::types::{
+        ChatChoiceStream, ChatCompletionMessageToolCallChunk, ChatCompletionStreamResponseDelta,
+        ChatCompletionToolType, FunctionCallStream,
+    };
+
+    let chunk = ChatCompletionMessageToolCallChunk {
+        index: tool_state.index,
+        id: Some(tool_state.id.clone()),
+        r#type: Some(ChatCompletionToolType::Function),
+        function: Some(FunctionCallStream {
+            name: Some(tool_state.name.clone()),
+            arguments: Some(tool_state.accumulated_args.clone()),
+        }),
+    };
+
+    let choice = ChatChoiceStream {
+        index: 0,
+        delta: ChatCompletionStreamResponseDelta {
+            content: None,
+            function_call: None,
+            tool_calls: Some(vec![chunk]),
+            role: None,
+            refusal: None,
+            reasoning_content: None,
+        },
+        finish_reason: None,
+        stop_reason: None,
+        logprobs: None,
+    };
+
+    let data = NvCreateChatCompletionStreamResponse {
+        id: template.id.clone(),
+        model: template.model.clone(),
+        created: template.created,
+        service_tier: template.service_tier.clone(),
+        usage: None,
+        system_fingerprint: template.system_fingerprint.clone(),
+        choices: vec![choice],
+        object: "chat.completion.chunk".to_string(),
+        nvext: None,
+    };
+
+    Annotated {
+        data: Some(data),
+        id: None,
+        event: Some("tool_call.complete".to_string()),
+        comment: None,
+    }
+}
+
 /// Aggregates a stream of [`NvCreateChatCompletionStreamResponse`]s into a single
 /// [`NvCreateChatCompletionResponse`]. This struct accumulates incremental responses
 /// from a streaming OpenAI API call into a complete final response.
@@ -457,7 +688,6 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
-            error: None,
         }
     }
 
@@ -695,7 +925,6 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
-            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -761,7 +990,6 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
-            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -804,7 +1032,6 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
-            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -847,7 +1074,6 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
-            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -888,7 +1114,6 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
-            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -933,7 +1158,6 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
-            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -976,7 +1200,6 @@ mod tests {
             id: Some("test_id".to_string()),
             event: None,
             comment: None,
-            error: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));
 
@@ -1060,5 +1283,156 @@ mod tests {
         let tool_calls = choice.message.tool_calls.as_ref().unwrap();
         assert_eq!(tool_calls.len(), 1);
         assert_eq!(tool_calls[0].function.name, "get_weather");
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for streaming_tool_call_adapter
+    // -----------------------------------------------------------------------
+
+    /// Helper: build a raw streaming chunk with a tool_call delta fragment.
+    #[allow(deprecated)]
+    fn make_tool_chunk(
+        id: Option<&str>,
+        name: Option<&str>,
+        args_fragment: Option<&str>,
+        finish_reason: Option<dynamo_async_openai::types::FinishReason>,
+    ) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        let tc = dynamo_async_openai::types::ChatCompletionMessageToolCallChunk {
+            index: 0,
+            id: id.map(|s| s.to_string()),
+            r#type: id.map(|_| dynamo_async_openai::types::ChatCompletionToolType::Function),
+            function: Some(dynamo_async_openai::types::FunctionCallStream {
+                name: name.map(|s| s.to_string()),
+                arguments: args_fragment.map(|s| s.to_string()),
+            }),
+        };
+
+        let choice = dynamo_async_openai::types::ChatChoiceStream {
+            index: 0,
+            delta: dynamo_async_openai::types::ChatCompletionStreamResponseDelta {
+                content: None,
+                function_call: None,
+                tool_calls: Some(vec![tc]),
+                role: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason,
+            stop_reason: None,
+            logprobs: None,
+        };
+
+        let data = NvCreateChatCompletionStreamResponse {
+            id: "test_id".to_string(),
+            model: "test_model".to_string(),
+            created: 12345,
+            service_tier: None,
+            usage: None,
+            system_fingerprint: None,
+            choices: vec![choice],
+            object: "chat.completion.chunk".to_string(),
+            nvext: None,
+        };
+
+        Annotated {
+            data: Some(data),
+            id: None,
+            event: None,
+            comment: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_streaming_adapter_emits_complete_tool_call() {
+        // Simulate the wire format: id+name in first chunk, args across multiple chunks
+        let chunks = vec![
+            make_tool_chunk(Some("call_1"), Some("bash"), Some("{\""), None),
+            make_tool_chunk(None, None, Some("cmd"), None),
+            make_tool_chunk(None, None, Some("\":\"ls\""), None),
+            make_tool_chunk(None, None, Some("}"), None), // brace_depth -> 0
+            make_tool_chunk(
+                None,
+                None,
+                None,
+                Some(dynamo_async_openai::types::FinishReason::ToolCalls),
+            ),
+        ];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output: Vec<_> = streaming_tool_call_adapter(input_stream).collect().await;
+
+        // We should have 5 original chunks + 1 synthetic completion chunk = 6 total
+        assert_eq!(output.len(), 6);
+
+        // The synthetic chunk should be the 5th item (after the 4th original chunk
+        // that completed the JSON).
+        let synthetic = &output[4];
+        assert_eq!(
+            synthetic.event.as_deref(),
+            Some("tool_call.complete"),
+            "synthetic chunk should have event=tool_call.complete"
+        );
+
+        let data = synthetic.data.as_ref().unwrap();
+        assert_eq!(data.choices.len(), 1);
+        let tc = &data.choices[0].delta.tool_calls.as_ref().unwrap()[0];
+        assert_eq!(tc.id.as_deref(), Some("call_1"));
+        assert_eq!(tc.function.as_ref().unwrap().name.as_deref(), Some("bash"));
+        assert_eq!(
+            tc.function.as_ref().unwrap().arguments.as_deref(),
+            Some("{\"cmd\":\"ls\"}")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_streaming_adapter_handles_quoted_braces() {
+        // Args contain braces inside a JSON string value — should not confuse depth tracker
+        let chunks = vec![
+            make_tool_chunk(Some("call_2"), Some("eval"), Some("{\"code\":\"x={"), None),
+            make_tool_chunk(None, None, Some("}\""), None), // closing " ends string, but } inside string shouldn't count
+            make_tool_chunk(None, None, Some("}"), None),   // THIS closes the top-level object
+        ];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output: Vec<_> = streaming_tool_call_adapter(input_stream).collect().await;
+
+        // 3 original + 1 synthetic = 4
+        assert_eq!(output.len(), 4);
+
+        let synthetic = &output[3];
+        assert_eq!(synthetic.event.as_deref(), Some("tool_call.complete"));
+
+        let tc = &synthetic
+            .data
+            .as_ref()
+            .unwrap()
+            .choices[0]
+            .delta
+            .tool_calls
+            .as_ref()
+            .unwrap()[0];
+        assert_eq!(
+            tc.function.as_ref().unwrap().arguments.as_deref(),
+            Some("{\"code\":\"x={}\"}"),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_streaming_adapter_no_tool_calls_passthrough() {
+        // A stream with no tool calls should pass through unchanged
+        let text_chunk = create_test_delta(
+            0,
+            "Hello world",
+            Some(dynamo_async_openai::types::Role::Assistant),
+            Some(dynamo_async_openai::types::FinishReason::Stop),
+            None,
+            None,
+        );
+
+        let input_stream = Box::pin(stream::iter(vec![text_chunk]));
+        let output: Vec<_> = streaming_tool_call_adapter(input_stream).collect().await;
+
+        // Should pass through as-is, no synthetic chunks
+        assert_eq!(output.len(), 1);
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -1328,66 +1328,35 @@ mod tests {
         // --- StreamingToolCallState::feed() tests ---
 
         #[test]
-        fn feed_single_chunk_complete() {
+        fn feed_quoted_braces_in_string_values() {
+            // Braces inside JSON string literals must not affect brace depth.
+            // Also verifies that an inner `}` that completes depth=1 but is inside
+            // a string does NOT fire the completion — only the final outer `}` does.
             let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
-            assert!(state.feed(r#"{"x":1}"#));
-            assert_eq!(state.accumulated_args, r#"{"x":1}"#);
+            assert!(!state.feed(r#"{"code": "if (x) {"#)); // inner `{` is in a string
+            assert!(!state.feed(r#"return }"#));           // inner `}` is in a string
+            assert!(state.feed(r#"}"}"#));                 // `}` closes string, `}` closes object
+            assert_eq!(state.accumulated_args, r#"{"code": "if (x) {return }}"}"#);
         }
 
         #[test]
-        fn feed_multi_fragment_completes_on_last() {
+        fn feed_cross_fragment_escape_boundary() {
+            // The `escape_next` flag must survive across fragment boundaries.
+            // Fragment 1 ends with `\` inside a string; fragment 2 starts with `"` which
+            // must be treated as an escaped char (not a string close), then `}` closes the object.
             let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
-            assert!(!state.feed(r#"{"lo"#));
-            assert!(!state.feed(r#"c":"#));
-            assert!(state.feed(r#"1}"#));
-            assert_eq!(state.accumulated_args, r#"{"loc":1}"#);
-        }
-
-        #[test]
-        fn feed_quoted_braces_ignored() {
-            let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
-            // Inner braces are inside a string literal — should not affect depth.
-            assert!(state.feed(r#"{"k": "{nested}"}"#));
-            assert_eq!(state.accumulated_args, r#"{"k": "{nested}"}"#);
-        }
-
-        #[test]
-        fn feed_cross_fragment_escape() {
-            let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
-            // Fragment 1 ends with a literal backslash inside a string.
-            // The `\\` in the JSON source is a single `\` character.
-            assert!(!state.feed("{\"k\": \"val\\"));
-            // Fragment 2: the `"` here closes the string (backslash already consumed).
-            assert!(state.feed("\"}"));
+            assert!(!state.feed("{\"k\": \"val\\")); // ends with `\` inside string
+            assert!(state.feed("\"}")); // `"` is escaped (consumed by escape_next), `}` closes object
             assert_eq!(state.accumulated_args, "{\"k\": \"val\\\"}");
         }
 
         #[test]
-        fn feed_empty_fragment_no_spurious() {
+        fn feed_malformed_extra_close_brace_clamped() {
+            // A leading `}` from a malformed/buggy backend must not drive depth negative.
+            // Without the `.max(0)` clamp, a subsequent `{` would bring depth to 0 spuriously.
             let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
-            assert!(!state.feed(""));
-            assert!(!state.feed(""));
-            // Now actually complete a JSON object.
-            assert!(state.feed(r#"{"a":1}"#));
-            // Further empties should not fire.
-            assert!(!state.feed(""));
-        }
-
-        #[test]
-        fn feed_already_emitted_returns_false() {
-            let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
-            assert!(state.feed(r#"{"x":1}"#));
-            // Once emitted, subsequent calls always return false.
-            assert!(!state.feed(r#"{"y":2}"#));
-            assert!(!state.feed(""));
-        }
-
-        #[test]
-        fn feed_malformed_extra_close_brace() {
-            let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
-            // Leading `}` drives depth to 0 (clamped), then `{"x":1}` opens and closes.
-            assert!(state.feed(r#"}{"x":1}"#));
-            assert_eq!(state.accumulated_args, r#"}{"x":1}"#);
+            assert!(!state.feed("}")); // stray `}` — clamped to depth 0, no completion yet
+            assert!(state.feed(r#"{"x":1}"#)); // valid object — opens to 1, closes to 0 → complete
         }
 
         // --- streaming_tool_call_adapter() tests ---
@@ -1396,7 +1365,6 @@ mod tests {
         fn make_chunk(
             choice_index: u32,
             tool_calls: Option<Vec<dynamo_async_openai::types::ChatCompletionMessageToolCallChunk>>,
-            finish_reason: Option<dynamo_async_openai::types::FinishReason>,
         ) -> Annotated<NvCreateChatCompletionStreamResponse> {
             let delta = dynamo_async_openai::types::ChatCompletionStreamResponseDelta {
                 content: None,
@@ -1409,7 +1377,7 @@ mod tests {
             let choice = dynamo_async_openai::types::ChatChoiceStream {
                 index: choice_index,
                 delta,
-                finish_reason,
+                finish_reason: None,
                 stop_reason: None,
                 logprobs: None,
             };
@@ -1434,7 +1402,7 @@ mod tests {
         }
 
         /// Helper: build a tool call chunk (the delta portion).
-        fn make_tc_chunk(
+        fn make_tc(
             index: u32,
             id: Option<&str>,
             name: Option<&str>,
@@ -1452,140 +1420,77 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn adapter_non_tool_call_passthrough() {
-            // A stream with no tool calls should pass through with no extra chunks.
+        async fn adapter_multi_fragment_ordering_and_fields() {
+            // Realistic scenario: args arrive across 3 fragments, interspersed with
+            // non-tool-call chunks. Verifies:
+            //   - original chunks pass through unmodified (event == None)
+            //   - synthetic chunk emitted immediately after the completing fragment
+            //   - synthetic chunk carries correct id, name, fully-assembled arguments
+            //   - non-tool-call chunks produce no extra output
             let chunks = vec![
-                make_chunk(0, None, None),
-                make_chunk(0, None, Some(dynamo_async_openai::types::FinishReason::Stop)),
-            ];
-            let input = stream::iter(chunks);
-            let output: Vec<_> = streaming_tool_call_adapter(input).collect().await;
-            assert_eq!(output.len(), 2);
-            // No synthetic events.
-            assert!(output.iter().all(|a| a.event.is_none()));
-        }
-
-        #[tokio::test]
-        async fn adapter_single_tool_call_emits_synthetic() {
-            // 3 chunks: init (id+name+first arg fragment), middle arg fragment, closing fragment.
-            let chunks = vec![
-                make_chunk(
-                    0,
-                    Some(vec![make_tc_chunk(0, Some("call_1"), Some("get_weather"), Some(r#"{"loc"#))]),
-                    None,
-                ),
-                make_chunk(
-                    0,
-                    Some(vec![make_tc_chunk(0, None, None, Some(r#"ation":"#))]),
-                    None,
-                ),
-                make_chunk(
-                    0,
-                    Some(vec![make_tc_chunk(0, None, None, Some(r#""SF"}"#))]),
-                    None,
-                ),
+                make_chunk(0, None),                                                        // non-tool chunk
+                make_chunk(0, Some(vec![make_tc(0, Some("call_1"), Some("get_weather"), Some(r#"{"city":"#))])),
+                make_chunk(0, Some(vec![make_tc(0, None, None, Some(r#""San "#))])),
+                make_chunk(0, Some(vec![make_tc(0, None, None, Some(r#"Francisco"}"#))])), // completes here
+                make_chunk(0, None),                                                        // non-tool chunk
             ];
             let input = stream::iter(chunks);
             let output: Vec<_> = streaming_tool_call_adapter(input).collect().await;
 
-            // 3 original + 1 synthetic = 4 total
-            assert_eq!(output.len(), 4);
+            // 5 original + 1 synthetic = 6 total
+            assert_eq!(output.len(), 6);
 
-            // The synthetic chunk should be at index 3 (after the completing chunk).
-            assert_eq!(output[3].event.as_deref(), Some("tool_call.complete"));
+            // Original chunks: no event
+            for i in [0, 1, 2, 3, 4] {
+                assert!(output[i].event.is_none(), "chunk {i} should have no event");
+            }
 
-            // Original chunks have no event.
-            assert!(output[0].event.is_none());
-            assert!(output[1].event.is_none());
-            assert!(output[2].event.is_none());
-        }
-
-        #[tokio::test]
-        async fn adapter_synthetic_chunk_has_correct_fields() {
-            let chunks = vec![
-                make_chunk(
-                    0,
-                    Some(vec![make_tc_chunk(0, Some("call_42"), Some("do_thing"), Some(r#"{"a":1}"#))]),
-                    None,
-                ),
-            ];
-            let input = stream::iter(chunks);
-            let output: Vec<_> = streaming_tool_call_adapter(input).collect().await;
-
-            assert_eq!(output.len(), 2);
-            let synthetic = &output[1];
-
-            // Event type
+            // Synthetic chunk immediately after completing fragment (position 4)
+            let synthetic = &output[4];
             assert_eq!(synthetic.event.as_deref(), Some("tool_call.complete"));
-
-            // Data fields
-            let data = synthetic.data.as_ref().unwrap();
-            assert_eq!(data.choices.len(), 1);
-            let choice = &data.choices[0];
-            assert!(choice.finish_reason.is_none());
-
-            let tc = &choice.delta.tool_calls.as_ref().unwrap()[0];
-            assert_eq!(tc.id.as_deref(), Some("call_42"));
-            assert_eq!(tc.function.as_ref().unwrap().name.as_deref(), Some("do_thing"));
+            let tc = &synthetic.data.as_ref().unwrap().choices[0]
+                .delta.tool_calls.as_ref().unwrap()[0];
+            assert_eq!(tc.id.as_deref(), Some("call_1"));
+            assert_eq!(tc.function.as_ref().unwrap().name.as_deref(), Some("get_weather"));
             assert_eq!(
                 tc.function.as_ref().unwrap().arguments.as_deref(),
-                Some(r#"{"a":1}"#)
+                Some(r#"{"city":"San Francisco"}"#)
             );
         }
 
         #[tokio::test]
-        async fn adapter_two_tool_calls_independent() {
-            // Two tool calls (index 0 and 1) completing at different times.
+        async fn adapter_two_concurrent_tool_calls_keyed_independently() {
+            // Two tool calls in the same stream (index 0 and 1). call_b completes
+            // in chunk 0; call_a completes in chunk 1. Verifies the compound
+            // (choice_index, tool_call_index) key prevents state collision.
             let chunks = vec![
-                // Init both tool calls in one chunk
-                make_chunk(
-                    0,
-                    Some(vec![
-                        make_tc_chunk(0, Some("call_a"), Some("fn_a"), Some(r#"{"x"#)),
-                        make_tc_chunk(1, Some("call_b"), Some("fn_b"), Some(r#"{"y":2}"#)),
-                    ]),
-                    None,
-                ),
-                // Complete tool call 0
-                make_chunk(
-                    0,
-                    Some(vec![make_tc_chunk(0, None, None, Some(r#":1}"#))]),
-                    None,
-                ),
+                make_chunk(0, Some(vec![
+                    make_tc(0, Some("call_a"), Some("fn_a"), Some(r#"{"x"#)),   // partial
+                    make_tc(1, Some("call_b"), Some("fn_b"), Some(r#"{"y":2}"#)), // complete
+                ])),
+                make_chunk(0, Some(vec![
+                    make_tc(0, None, None, Some(r#":1}"#)), // call_a completes
+                ])),
             ];
             let input = stream::iter(chunks);
             let output: Vec<_> = streaming_tool_call_adapter(input).collect().await;
 
-            // Chunk 0 (original) + synthetic for call_b (completed in chunk 0)
-            // + Chunk 1 (original) + synthetic for call_a (completed in chunk 1)
-            // = 4 total
+            // chunk0 + synthetic(call_b) + chunk1 + synthetic(call_a) = 4
             assert_eq!(output.len(), 4);
 
-            // Synthetic for call_b at position 1 (after first original chunk)
-            assert_eq!(output[1].event.as_deref(), Some("tool_call.complete"));
-            let tc_b = &output[1].data.as_ref().unwrap().choices[0]
-                .delta
-                .tool_calls
-                .as_ref()
-                .unwrap()[0];
+            let synth_b = &output[1];
+            assert_eq!(synth_b.event.as_deref(), Some("tool_call.complete"));
+            let tc_b = &synth_b.data.as_ref().unwrap().choices[0]
+                .delta.tool_calls.as_ref().unwrap()[0];
             assert_eq!(tc_b.id.as_deref(), Some("call_b"));
-            assert_eq!(
-                tc_b.function.as_ref().unwrap().arguments.as_deref(),
-                Some(r#"{"y":2}"#)
-            );
+            assert_eq!(tc_b.function.as_ref().unwrap().arguments.as_deref(), Some(r#"{"y":2}"#));
 
-            // Synthetic for call_a at position 3 (after second original chunk)
-            assert_eq!(output[3].event.as_deref(), Some("tool_call.complete"));
-            let tc_a = &output[3].data.as_ref().unwrap().choices[0]
-                .delta
-                .tool_calls
-                .as_ref()
-                .unwrap()[0];
+            let synth_a = &output[3];
+            assert_eq!(synth_a.event.as_deref(), Some("tool_call.complete"));
+            let tc_a = &synth_a.data.as_ref().unwrap().choices[0]
+                .delta.tool_calls.as_ref().unwrap()[0];
             assert_eq!(tc_a.id.as_deref(), Some("call_a"));
-            assert_eq!(
-                tc_a.function.as_ref().unwrap().arguments.as_deref(),
-                Some(r#"{"x":1}"#)
-            );
+            assert_eq!(tc_a.function.as_ref().unwrap().arguments.as_deref(), Some(r#"{"x":1}"#));
         }
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -167,11 +167,8 @@ pub fn streaming_tool_call_adapter(
 
                                 if just_completed {
                                     // Build a synthetic chunk with the complete tool call.
-                                    let synthetic = build_complete_tool_call_chunk(
-                                        data,
-                                        choice.index,
-                                        state,
-                                    );
+                                    let synthetic =
+                                        build_complete_tool_call_chunk(data, choice.index, state);
                                     extra_chunks.push(synthetic);
                                 }
                             }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -69,7 +69,10 @@ impl StreamingToolCallState {
         let was_positive = self.brace_depth > 0;
         let mut saw_open_brace = false;
 
-        for ch in fragment.chars() {
+        // Iterate bytes rather than chars: all JSON structural characters ({, }, ", \)
+        // are single-byte ASCII and cannot appear as trailing bytes of multi-byte
+        // UTF-8 sequences, so byte-level scanning is both safe and faster.
+        for &byte in fragment.as_bytes() {
             if self.escape_next {
                 // Previous char was `\` inside a string — skip this char.
                 self.escape_next = false;
@@ -77,26 +80,28 @@ impl StreamingToolCallState {
             }
 
             if self.in_string {
-                match ch {
-                    '\\' => {
+                match byte {
+                    b'\\' => {
                         self.escape_next = true;
                     }
-                    '"' => {
+                    b'"' => {
                         self.in_string = false;
                     }
                     _ => {}
                 }
             } else {
-                match ch {
-                    '"' => {
+                match byte {
+                    b'"' => {
                         self.in_string = true;
                     }
-                    '{' => {
+                    b'{' => {
                         self.brace_depth += 1;
                         saw_open_brace = true;
                     }
-                    '}' => {
-                        self.brace_depth -= 1;
+                    b'}' => {
+                        // Clamp to 0 so malformed JSON (extra `}`) cannot drive depth
+                        // negative and later trigger a spurious completion on the next `{`.
+                        self.brace_depth = (self.brace_depth - 1).max(0);
                     }
                     _ => {}
                 }
@@ -123,10 +128,22 @@ impl StreamingToolCallState {
 /// injects synthetic chunks containing completed tool calls as soon as their
 /// arguments JSON is structurally complete.
 ///
-/// The original chunks are forwarded as-is.  When a tool call completes, an
-/// additional synthetic chunk is emitted immediately after the triggering chunk.
-/// The `finish_reason = tool_calls` chunk at the end is still forwarded for
-/// compatibility.
+/// The original chunks are forwarded as-is. When a tool call completes, an
+/// additional synthetic `Annotated` chunk with `event: "tool_call.complete"` is
+/// emitted immediately after the triggering chunk. The `finish_reason = tool_calls`
+/// chunk at the end is still forwarded for backward compatibility.
+///
+/// State is scoped to a single call of this function (one per HTTP request) and
+/// is never shared across requests.
+///
+/// # Compatibility
+/// SSE clients that do not recognise the `tool_call.complete` event type will
+/// ignore the synthetic chunks per RFC 8895.
+///
+/// # Warning
+/// Do **not** compose this adapter with [`DeltaAggregator`]. The synthetic chunks
+/// carry fully-assembled tool call data; piping both original and synthetic chunks
+/// into `DeltaAggregator` would produce duplicate tool call entries.
 pub fn streaming_tool_call_adapter(
     stream: impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
 ) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> {
@@ -188,11 +205,20 @@ pub fn streaming_tool_call_adapter(
 
 /// Build a synthetic `Annotated<NvCreateChatCompletionStreamResponse>` that
 /// carries a single completed tool call with its full accumulated arguments.
+///
+/// Takes `tool_state` by `&mut` so that `accumulated_args` can be moved out
+/// via [`std::mem::take`] rather than cloned — avoiding a potentially large
+/// String copy for tool calls with big argument payloads.
+///
+/// NOTE: Do not pipe the output of [`streaming_tool_call_adapter`] into
+/// [`DeltaAggregator`]. The synthetic chunks have all fields populated, while
+/// the original incremental chunks only have fragments. Feeding both into
+/// `DeltaAggregator` would cause duplicate tool call entries.
 #[allow(deprecated)]
 fn build_complete_tool_call_chunk(
     template: &NvCreateChatCompletionStreamResponse,
     choice_index: u32,
-    tool_state: &StreamingToolCallState,
+    tool_state: &mut StreamingToolCallState,
 ) -> Annotated<NvCreateChatCompletionStreamResponse> {
     use dynamo_async_openai::types::{
         ChatChoiceStream, ChatCompletionMessageToolCallChunk, ChatCompletionStreamResponseDelta,
@@ -205,7 +231,7 @@ fn build_complete_tool_call_chunk(
         r#type: Some(ChatCompletionToolType::Function),
         function: Some(FunctionCallStream {
             name: Some(tool_state.name.clone()),
-            arguments: Some(tool_state.accumulated_args.clone()),
+            arguments: Some(std::mem::take(&mut tool_state.accumulated_args)),
         }),
     };
 
@@ -1290,5 +1316,276 @@ mod tests {
         let tool_calls = choice.message.tool_calls.as_ref().unwrap();
         assert_eq!(tool_calls.len(), 1);
         assert_eq!(tool_calls[0].function.name, "get_weather");
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for StreamingToolCallState and streaming_tool_call_adapter
+    // -----------------------------------------------------------------------
+    #[allow(deprecated)]
+    mod streaming_tool_call_tests {
+        use super::*;
+
+        // --- StreamingToolCallState::feed() tests ---
+
+        #[test]
+        fn feed_single_chunk_complete() {
+            let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
+            assert!(state.feed(r#"{"x":1}"#));
+            assert_eq!(state.accumulated_args, r#"{"x":1}"#);
+        }
+
+        #[test]
+        fn feed_multi_fragment_completes_on_last() {
+            let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
+            assert!(!state.feed(r#"{"lo"#));
+            assert!(!state.feed(r#"c":"#));
+            assert!(state.feed(r#"1}"#));
+            assert_eq!(state.accumulated_args, r#"{"loc":1}"#);
+        }
+
+        #[test]
+        fn feed_quoted_braces_ignored() {
+            let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
+            // Inner braces are inside a string literal — should not affect depth.
+            assert!(state.feed(r#"{"k": "{nested}"}"#));
+            assert_eq!(state.accumulated_args, r#"{"k": "{nested}"}"#);
+        }
+
+        #[test]
+        fn feed_cross_fragment_escape() {
+            let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
+            // Fragment 1 ends with a literal backslash inside a string.
+            // The `\\` in the JSON source is a single `\` character.
+            assert!(!state.feed("{\"k\": \"val\\"));
+            // Fragment 2: the `"` here closes the string (backslash already consumed).
+            assert!(state.feed("\"}"));
+            assert_eq!(state.accumulated_args, "{\"k\": \"val\\\"}");
+        }
+
+        #[test]
+        fn feed_empty_fragment_no_spurious() {
+            let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
+            assert!(!state.feed(""));
+            assert!(!state.feed(""));
+            // Now actually complete a JSON object.
+            assert!(state.feed(r#"{"a":1}"#));
+            // Further empties should not fire.
+            assert!(!state.feed(""));
+        }
+
+        #[test]
+        fn feed_already_emitted_returns_false() {
+            let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
+            assert!(state.feed(r#"{"x":1}"#));
+            // Once emitted, subsequent calls always return false.
+            assert!(!state.feed(r#"{"y":2}"#));
+            assert!(!state.feed(""));
+        }
+
+        #[test]
+        fn feed_malformed_extra_close_brace() {
+            let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
+            // Leading `}` drives depth to 0 (clamped), then `{"x":1}` opens and closes.
+            assert!(state.feed(r#"}{"x":1}"#));
+            assert_eq!(state.accumulated_args, r#"}{"x":1}"#);
+        }
+
+        // --- streaming_tool_call_adapter() tests ---
+
+        /// Helper: build a minimal Annotated stream chunk with optional tool call delta.
+        fn make_chunk(
+            choice_index: u32,
+            tool_calls: Option<Vec<dynamo_async_openai::types::ChatCompletionMessageToolCallChunk>>,
+            finish_reason: Option<dynamo_async_openai::types::FinishReason>,
+        ) -> Annotated<NvCreateChatCompletionStreamResponse> {
+            let delta = dynamo_async_openai::types::ChatCompletionStreamResponseDelta {
+                content: None,
+                function_call: None,
+                tool_calls,
+                role: None,
+                refusal: None,
+                reasoning_content: None,
+            };
+            let choice = dynamo_async_openai::types::ChatChoiceStream {
+                index: choice_index,
+                delta,
+                finish_reason,
+                stop_reason: None,
+                logprobs: None,
+            };
+            let data = NvCreateChatCompletionStreamResponse {
+                id: "test_stream".to_string(),
+                model: "test-model".to_string(),
+                created: 1000,
+                service_tier: None,
+                usage: None,
+                system_fingerprint: None,
+                choices: vec![choice],
+                object: "chat.completion.chunk".to_string(),
+                nvext: None,
+            };
+            Annotated {
+                data: Some(data),
+                id: None,
+                event: None,
+                comment: None,
+                error: None,
+            }
+        }
+
+        /// Helper: build a tool call chunk (the delta portion).
+        fn make_tc_chunk(
+            index: u32,
+            id: Option<&str>,
+            name: Option<&str>,
+            arguments: Option<&str>,
+        ) -> dynamo_async_openai::types::ChatCompletionMessageToolCallChunk {
+            dynamo_async_openai::types::ChatCompletionMessageToolCallChunk {
+                index,
+                id: id.map(|s| s.to_string()),
+                r#type: id.map(|_| dynamo_async_openai::types::ChatCompletionToolType::Function),
+                function: Some(dynamo_async_openai::types::FunctionCallStream {
+                    name: name.map(|s| s.to_string()),
+                    arguments: arguments.map(|s| s.to_string()),
+                }),
+            }
+        }
+
+        #[tokio::test]
+        async fn adapter_non_tool_call_passthrough() {
+            // A stream with no tool calls should pass through with no extra chunks.
+            let chunks = vec![
+                make_chunk(0, None, None),
+                make_chunk(0, None, Some(dynamo_async_openai::types::FinishReason::Stop)),
+            ];
+            let input = stream::iter(chunks);
+            let output: Vec<_> = streaming_tool_call_adapter(input).collect().await;
+            assert_eq!(output.len(), 2);
+            // No synthetic events.
+            assert!(output.iter().all(|a| a.event.is_none()));
+        }
+
+        #[tokio::test]
+        async fn adapter_single_tool_call_emits_synthetic() {
+            // 3 chunks: init (id+name+first arg fragment), middle arg fragment, closing fragment.
+            let chunks = vec![
+                make_chunk(
+                    0,
+                    Some(vec![make_tc_chunk(0, Some("call_1"), Some("get_weather"), Some(r#"{"loc"#))]),
+                    None,
+                ),
+                make_chunk(
+                    0,
+                    Some(vec![make_tc_chunk(0, None, None, Some(r#"ation":"#))]),
+                    None,
+                ),
+                make_chunk(
+                    0,
+                    Some(vec![make_tc_chunk(0, None, None, Some(r#""SF"}"#))]),
+                    None,
+                ),
+            ];
+            let input = stream::iter(chunks);
+            let output: Vec<_> = streaming_tool_call_adapter(input).collect().await;
+
+            // 3 original + 1 synthetic = 4 total
+            assert_eq!(output.len(), 4);
+
+            // The synthetic chunk should be at index 3 (after the completing chunk).
+            assert_eq!(output[3].event.as_deref(), Some("tool_call.complete"));
+
+            // Original chunks have no event.
+            assert!(output[0].event.is_none());
+            assert!(output[1].event.is_none());
+            assert!(output[2].event.is_none());
+        }
+
+        #[tokio::test]
+        async fn adapter_synthetic_chunk_has_correct_fields() {
+            let chunks = vec![
+                make_chunk(
+                    0,
+                    Some(vec![make_tc_chunk(0, Some("call_42"), Some("do_thing"), Some(r#"{"a":1}"#))]),
+                    None,
+                ),
+            ];
+            let input = stream::iter(chunks);
+            let output: Vec<_> = streaming_tool_call_adapter(input).collect().await;
+
+            assert_eq!(output.len(), 2);
+            let synthetic = &output[1];
+
+            // Event type
+            assert_eq!(synthetic.event.as_deref(), Some("tool_call.complete"));
+
+            // Data fields
+            let data = synthetic.data.as_ref().unwrap();
+            assert_eq!(data.choices.len(), 1);
+            let choice = &data.choices[0];
+            assert!(choice.finish_reason.is_none());
+
+            let tc = &choice.delta.tool_calls.as_ref().unwrap()[0];
+            assert_eq!(tc.id.as_deref(), Some("call_42"));
+            assert_eq!(tc.function.as_ref().unwrap().name.as_deref(), Some("do_thing"));
+            assert_eq!(
+                tc.function.as_ref().unwrap().arguments.as_deref(),
+                Some(r#"{"a":1}"#)
+            );
+        }
+
+        #[tokio::test]
+        async fn adapter_two_tool_calls_independent() {
+            // Two tool calls (index 0 and 1) completing at different times.
+            let chunks = vec![
+                // Init both tool calls in one chunk
+                make_chunk(
+                    0,
+                    Some(vec![
+                        make_tc_chunk(0, Some("call_a"), Some("fn_a"), Some(r#"{"x"#)),
+                        make_tc_chunk(1, Some("call_b"), Some("fn_b"), Some(r#"{"y":2}"#)),
+                    ]),
+                    None,
+                ),
+                // Complete tool call 0
+                make_chunk(
+                    0,
+                    Some(vec![make_tc_chunk(0, None, None, Some(r#":1}"#))]),
+                    None,
+                ),
+            ];
+            let input = stream::iter(chunks);
+            let output: Vec<_> = streaming_tool_call_adapter(input).collect().await;
+
+            // Chunk 0 (original) + synthetic for call_b (completed in chunk 0)
+            // + Chunk 1 (original) + synthetic for call_a (completed in chunk 1)
+            // = 4 total
+            assert_eq!(output.len(), 4);
+
+            // Synthetic for call_b at position 1 (after first original chunk)
+            assert_eq!(output[1].event.as_deref(), Some("tool_call.complete"));
+            let tc_b = &output[1].data.as_ref().unwrap().choices[0]
+                .delta
+                .tool_calls
+                .as_ref()
+                .unwrap()[0];
+            assert_eq!(tc_b.id.as_deref(), Some("call_b"));
+            assert_eq!(
+                tc_b.function.as_ref().unwrap().arguments.as_deref(),
+                Some(r#"{"y":2}"#)
+            );
+
+            // Synthetic for call_a at position 3 (after second original chunk)
+            assert_eq!(output[3].event.as_deref(), Some("tool_call.complete"));
+            let tc_a = &output[3].data.as_ref().unwrap().choices[0]
+                .delta
+                .tool_calls
+                .as_ref()
+                .unwrap()[0];
+            assert_eq!(tc_a.id.as_deref(), Some("call_a"));
+            assert_eq!(
+                tc_a.function.as_ref().unwrap().arguments.as_deref(),
+                Some(r#"{"x":1}"#)
+            );
+        }
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -168,7 +168,9 @@ pub fn streaming_tool_call_adapter(
                                         if just_completed {
                                             // Build a synthetic chunk with the complete tool call.
                                             let synthetic = build_complete_tool_call_chunk(
-                                                data, choice.index, state,
+                                                data,
+                                                choice.index,
+                                                state,
                                             );
                                             extra_chunks.push(synthetic);
                                         }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -67,6 +67,7 @@ impl StreamingToolCallState {
         }
 
         let was_positive = self.brace_depth > 0;
+        let mut saw_open_brace = false;
 
         for ch in fragment.chars() {
             if self.escape_next {
@@ -92,6 +93,7 @@ impl StreamingToolCallState {
                     }
                     '{' => {
                         self.brace_depth += 1;
+                        saw_open_brace = true;
                     }
                     '}' => {
                         self.brace_depth -= 1;
@@ -103,12 +105,11 @@ impl StreamingToolCallState {
 
         self.accumulated_args.push_str(fragment);
 
-        // Transition from positive depth to zero means the JSON object is complete.
-        // Also handle the case where we started at 0 and went to 0 on the very first
-        // fragment (e.g. the entire args are delivered in one chunk).
+        // Complete only when an opening brace was observed and depth returns to zero.
+        // Guards against whitespace/prefix fragments at depth 0 firing spuriously.
         let now_zero = self.brace_depth == 0;
-        let just_completed =
-            now_zero && (was_positive || !self.accumulated_args.is_empty()) && !self.emitted;
+        let started_object = was_positive || saw_open_brace;
+        let just_completed = now_zero && started_object && !self.emitted;
 
         if just_completed {
             self.emitted = true;
@@ -131,7 +132,8 @@ pub fn streaming_tool_call_adapter(
 ) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> {
     // We use `scan` to carry mutable state across the stream and emit Vec<item>
     // per input (0 or more synthetic chunks after each original chunk).
-    let state: HashMap<u32, StreamingToolCallState> = HashMap::new();
+    // Key by (choice_index, tool_call_index) to avoid collisions in multi-choice streams.
+    let state: HashMap<(u32, u32), StreamingToolCallState> = HashMap::new();
 
     stream
         .scan(state, |tool_states, annotated| {
@@ -141,16 +143,16 @@ pub fn streaming_tool_call_adapter(
                 for choice in &data.choices {
                     if let Some(tool_calls) = &choice.delta.tool_calls {
                         for tc_chunk in tool_calls {
-                            let idx = tc_chunk.index;
+                            let key = (choice.index, tc_chunk.index);
 
                             // If this is the first chunk for a tool call (has id + name),
                             // initialize tracking state.
                             if let Some(id) = &tc_chunk.id {
                                 if let Some(func) = &tc_chunk.function {
                                     if let Some(name) = &func.name {
-                                        tool_states.entry(idx).or_insert_with(|| {
+                                        tool_states.entry(key).or_insert_with(|| {
                                             StreamingToolCallState::new(
-                                                idx,
+                                                tc_chunk.index,
                                                 id.clone(),
                                                 name.clone(),
                                             )
@@ -162,13 +164,13 @@ pub fn streaming_tool_call_adapter(
                             // Feed any argument fragment into the tracker.
                             if let Some(func) = &tc_chunk.function {
                                 if let Some(args_fragment) = &func.arguments {
-                                    if let Some(state) = tool_states.get_mut(&idx) {
+                                    if let Some(state) = tool_states.get_mut(&key) {
                                         let just_completed = state.feed(args_fragment);
 
                                         if just_completed {
                                             // Build a synthetic chunk with the complete tool call.
                                             let synthetic = build_complete_tool_call_chunk(
-                                                data, state,
+                                                data, choice.index, state,
                                             );
                                             extra_chunks.push(synthetic);
                                         }
@@ -194,6 +196,7 @@ pub fn streaming_tool_call_adapter(
 #[allow(deprecated)]
 fn build_complete_tool_call_chunk(
     template: &NvCreateChatCompletionStreamResponse,
+    choice_index: u32,
     tool_state: &StreamingToolCallState,
 ) -> Annotated<NvCreateChatCompletionStreamResponse> {
     use dynamo_async_openai::types::{
@@ -212,7 +215,7 @@ fn build_complete_tool_call_chunk(
     };
 
     let choice = ChatChoiceStream {
-        index: 0,
+        index: choice_index,
         delta: ChatCompletionStreamResponseDelta {
             content: None,
             function_call: None,

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -1342,12 +1342,13 @@ mod tests {
         #[test]
         fn feed_cross_fragment_escape_boundary() {
             // The `escape_next` flag must survive across fragment boundaries.
-            // Fragment 1 ends with `\` inside a string; fragment 2 starts with `"` which
-            // must be treated as an escaped char (not a string close), then `}` closes the object.
+            // Fragment 1 ends with `\` inside a string (escape_next=true at fragment boundary).
+            // Fragment 2: first `"` is consumed as the escaped char (in_string stays true),
+            // second `"` closes the string, then `}` closes the object.
             let mut state = StreamingToolCallState::new(0, "id1".into(), "fn1".into());
-            assert!(!state.feed("{\"k\": \"val\\")); // ends with `\` inside string
-            assert!(state.feed("\"}")); // `"` is escaped (consumed by escape_next), `}` closes object
-            assert_eq!(state.accumulated_args, "{\"k\": \"val\\\"}");
+            assert!(!state.feed("{\"k\": \"val\\")); // ends with `\` — escape_next=true
+            assert!(state.feed("\"\"}")); // `"` consumed by escape, `"` closes string, `}` closes object
+            assert_eq!(state.accumulated_args, "{\"k\": \"val\\\"\"}");
         }
 
         #[test]
@@ -1440,8 +1441,9 @@ mod tests {
             // 5 original + 1 synthetic = 6 total
             assert_eq!(output.len(), 6);
 
-            // Original chunks: no event
-            for i in [0, 1, 2, 3, 4] {
+            // Original chunks: no event (indices 0-3 are originals before the synthetic,
+            // index 5 is the trailing non-tool chunk after the synthetic at index 4).
+            for i in [0usize, 1, 2, 3, 5] {
                 assert!(output[i].event.is_none(), "chunk {i} should have no event");
             }
 

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -145,35 +145,35 @@ pub fn streaming_tool_call_adapter(
 
                             // If this is the first chunk for a tool call (has id + name),
                             // initialize tracking state.
-                            if let Some(id) = &tc_chunk.id {
-                                if let Some(func) = &tc_chunk.function {
-                                    if let Some(name) = &func.name {
-                                        tool_states.entry(key).or_insert_with(|| {
-                                            StreamingToolCallState::new(
-                                                tc_chunk.index,
-                                                id.clone(),
-                                                name.clone(),
-                                            )
-                                        });
-                                    }
+                            if let Some(id) = &tc_chunk.id
+                                && let Some(func) = &tc_chunk.function
+                            {
+                                if let Some(name) = &func.name {
+                                    tool_states.entry(key).or_insert_with(|| {
+                                        StreamingToolCallState::new(
+                                            tc_chunk.index,
+                                            id.clone(),
+                                            name.clone(),
+                                        )
+                                    });
                                 }
                             }
 
                             // Feed any argument fragment into the tracker.
-                            if let Some(func) = &tc_chunk.function {
-                                if let Some(args_fragment) = &func.arguments {
-                                    if let Some(state) = tool_states.get_mut(&key) {
-                                        let just_completed = state.feed(args_fragment);
+                            if let Some(func) = &tc_chunk.function
+                                && let Some(args_fragment) = &func.arguments
+                            {
+                                if let Some(state) = tool_states.get_mut(&key) {
+                                    let just_completed = state.feed(args_fragment);
 
-                                        if just_completed {
-                                            // Build a synthetic chunk with the complete tool call.
-                                            let synthetic = build_complete_tool_call_chunk(
-                                                data,
-                                                choice.index,
-                                                state,
-                                            );
-                                            extra_chunks.push(synthetic);
-                                        }
+                                    if just_completed {
+                                        // Build a synthetic chunk with the complete tool call.
+                                        let synthetic = build_complete_tool_call_chunk(
+                                            data,
+                                            choice.index,
+                                            state,
+                                        );
+                                        extra_chunks.push(synthetic);
                                     }
                                 }
                             }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -147,34 +147,32 @@ pub fn streaming_tool_call_adapter(
                             // initialize tracking state.
                             if let Some(id) = &tc_chunk.id
                                 && let Some(func) = &tc_chunk.function
+                                && let Some(name) = &func.name
                             {
-                                if let Some(name) = &func.name {
-                                    tool_states.entry(key).or_insert_with(|| {
-                                        StreamingToolCallState::new(
-                                            tc_chunk.index,
-                                            id.clone(),
-                                            name.clone(),
-                                        )
-                                    });
-                                }
+                                tool_states.entry(key).or_insert_with(|| {
+                                    StreamingToolCallState::new(
+                                        tc_chunk.index,
+                                        id.clone(),
+                                        name.clone(),
+                                    )
+                                });
                             }
 
                             // Feed any argument fragment into the tracker.
                             if let Some(func) = &tc_chunk.function
                                 && let Some(args_fragment) = &func.arguments
+                                && let Some(state) = tool_states.get_mut(&key)
                             {
-                                if let Some(state) = tool_states.get_mut(&key) {
-                                    let just_completed = state.feed(args_fragment);
+                                let just_completed = state.feed(args_fragment);
 
-                                    if just_completed {
-                                        // Build a synthetic chunk with the complete tool call.
-                                        let synthetic = build_complete_tool_call_chunk(
-                                            data,
-                                            choice.index,
-                                            state,
-                                        );
-                                        extra_chunks.push(synthetic);
-                                    }
+                                if just_completed {
+                                    // Build a synthetic chunk with the complete tool call.
+                                    let synthetic = build_complete_tool_call_chunk(
+                                        data,
+                                        choice.index,
+                                        state,
+                                    );
+                                    extra_chunks.push(synthetic);
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

Adds `streaming_tool_call_adapter()` — a stream transform inserted into the OpenAI streaming response path that emits synthetic `tool_call.complete` SSE events as soon as each tool call's JSON arguments are structurally complete, rather than waiting for `finish_reason=tool_calls`.

**Changed files:**
- `lib/llm/src/protocols/openai/chat_completions/aggregator.rs` — new adapter + per-tool-call state machine
- `lib/llm/src/http/service/openai.rs` — wire adapter into the streaming response path

## The problem: wasted wall-clock time

Today, a multi-tool agentic turn waits for the entire generation before executing anything:

```
Model:   [tool_call_1 args] ... [tool_call_2 args] ... [tool_call_3 args] → finish_reason
Client:                                                                    → execute all 3 in parallel
```

The model may finish writing `tool_call_1`'s arguments hundreds of milliseconds before it starts `tool_call_2`. That's dead time.

## The fix: overlap execution with generation

```
Model:   [tool_call_1 args complete] ──→ tool_call.complete ──→ execute tool_1 ─────────────┐
                [tool_call_2 args complete] ──→ tool_call.complete ──→ execute tool_2 ──────┤
                        [tool_call_3 args complete] ──→ tool_call.complete ──→ execute tool_3 ┤
                                                                                    finish_reason ↓
                                                                              all results ready
```

Tool execution overlaps with model generation. For 5 tools where each takes ~500ms to execute, tool_1 can complete while the model is still generating tool_4.

## How it works

The adapter maintains a `StreamingToolCallState` per `(choice_index, tool_call_index)` pair. Each state machine tracks brace depth character-by-character with string/escape awareness. It emits `just_completed` only after seeing an opening `{` **and** depth returning to 0 — preventing spurious events on whitespace or empty prefixes.

When a tool call completes, the adapter emits a synthetic `Annotated` chunk with `event: "tool_call.complete"` carrying the full `ChatCompletionChunk` payload for that tool call. All original chunks pass through unchanged, and `finish_reason=tool_calls` is still emitted at the end for full backward compatibility.

## API compatibility

**OpenAI format:** Synthetic chunks use the standard `ChatCompletionChunk` shape with a fully-assembled `tool_calls[n].function.arguments`. Clients that don't recognize the custom SSE event type will ignore them per RFC 8895; clients that do can begin execution immediately.

**Anthropic format:** Not changed here. The Anthropic streaming path already has `content_block_stop` on `tool_use` blocks as its natural completion signal, surfaced by cc-proxy as `event: tool_call_ready`.

## Test plan

- `cargo test -p dynamo-llm -- aggregator` covers multi-chunk completion, quoted braces inside string values, and non-tool-call passthrough
- End-to-end: deploy with a model generating multiple tool calls in one turn; observe `tool_call.complete` events arriving before `finish_reason=tool_calls`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved streaming tool call handling: tool calls now emit completion events immediately when their arguments become structurally complete, enabling faster downstream processing without waiting for the final response chunk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->