### PR TITLE
fix(test): fix vllm disaggregated cancellation tests [cherry-pick to release/1.0.0]

### DIFF
--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.fault_tolerance,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
     pytest.mark.e2e,
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
     pytest.mark.post_merge,  # post_merge to pinpoint failure commit
@@ -47,7 +46,7 @@ class DynamoWorkerProcess(ManagedProcess):
         self,
         request,
         frontend_port: int,
-        is_prefill: bool = False,
+        is_prefill: bool | None = None,
     ):
         # Allocate system port for this worker
         system_port = allocate_port(9100)
@@ -67,16 +66,35 @@ class DynamoWorkerProcess(ManagedProcess):
             "16384",
         ]
 
-        # Configure health check based on worker type
-        if is_prefill:
-            # Prefill workers check their own status endpoint
+        # Configure disaggregation mode, KV transfer, and health checks per worker type
+        if is_prefill is True:
+            # Prefill worker: disaggregated prefill mode; check own status endpoint only
             command.extend(["--disaggregation-mode", "prefill"])
+            command.extend(
+                [
+                    "--kv-transfer-config",
+                    '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',
+                ]
+            )
             health_check_urls = [
                 (f"http://localhost:{system_port}/health", self.is_ready)
             ]
+        elif is_prefill is False:
+            # Decode worker: disaggregated decode mode; also verify frontend sees the model
+            command.extend(["--disaggregation-mode", "decode"])
+            command.extend(
+                [
+                    "--kv-transfer-config",
+                    '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',
+                ]
+            )
+            health_check_urls = [
+                (f"http://localhost:{system_port}/health", self.is_ready),
+                (f"http://localhost:{frontend_port}/v1/models", check_models_api),
+                (f"http://localhost:{frontend_port}/health", check_health_generate),
+            ]
         else:
-            # Decode workers should also check their own status endpoint first,
-            # then verify the frontend sees the model
+            # Aggregated worker: no disaggregation mode; verify frontend sees the model
             health_check_urls = [
                 (f"http://localhost:{system_port}/health", self.is_ready),
                 (f"http://localhost:{frontend_port}/v1/models", check_models_api),
@@ -99,7 +117,7 @@ class DynamoWorkerProcess(ManagedProcess):
 
         # Set KV events config and NIXL side channel port only for prefill worker
         # to avoid conflicts with decode worker
-        if is_prefill:
+        if is_prefill is True:
             command.extend(
                 [
                     "--kv-events-config",
@@ -118,7 +136,12 @@ class DynamoWorkerProcess(ManagedProcess):
             ] = "5601"  # TODO: use dynamic port allocation
 
         # Set log directory based on worker type
-        worker_type = "prefill_worker" if is_prefill else "worker"
+        if is_prefill is True:
+            worker_type = "prefill_worker"
+        elif is_prefill is False:
+            worker_type = "decode_worker"
+        else:
+            worker_type = "worker"
         log_dir = f"{request.node.name}_{worker_type}"
 
         # Clean up any existing log directory from previous runs
@@ -179,6 +202,8 @@ class DynamoWorkerProcess(ManagedProcess):
 
 
 @pytest.mark.timeout(110)  # 3x average
+@pytest.mark.post_merge
+@pytest.mark.gpu_1
 def test_request_cancellation_vllm_aggregated(
     request, runtime_services_dynamic_ports, predownload_models
 ):
@@ -260,6 +285,8 @@ def test_request_cancellation_vllm_aggregated(
 
 
 @pytest.mark.timeout(150)  # 3x average
+@pytest.mark.nightly
+@pytest.mark.gpu_2
 def test_request_cancellation_vllm_decode_cancel(
     request, runtime_services_dynamic_ports, set_ucx_tls_no_mm, predownload_models
 ):
@@ -341,6 +368,8 @@ def test_request_cancellation_vllm_decode_cancel(
 
 
 @pytest.mark.timeout(150)  # 3x average
+@pytest.mark.nightly
+@pytest.mark.gpu_2
 def test_request_cancellation_vllm_prefill_cancel(
     request, runtime_services_dynamic_ports, set_ucx_tls_no_mm, predownload_models
 ):

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -35,6 +35,7 @@ pytestmark = [
     pytest.mark.e2e,
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
     pytest.mark.post_merge,  # post_merge to pinpoint failure commit
+    pytest.mark.gpu_1,
     pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True),
 ]
 
@@ -202,8 +203,6 @@ class DynamoWorkerProcess(ManagedProcess):
 
 
 @pytest.mark.timeout(110)  # 3x average
-@pytest.mark.post_merge
-@pytest.mark.gpu_1
 def test_request_cancellation_vllm_aggregated(
     request, runtime_services_dynamic_ports, predownload_models
 ):
@@ -285,8 +284,6 @@ def test_request_cancellation_vllm_aggregated(
 
 
 @pytest.mark.timeout(150)  # 3x average
-@pytest.mark.nightly
-@pytest.mark.gpu_2
 def test_request_cancellation_vllm_decode_cancel(
     request, runtime_services_dynamic_ports, set_ucx_tls_no_mm, predownload_models
 ):
@@ -368,8 +365,6 @@ def test_request_cancellation_vllm_decode_cancel(
 
 
 @pytest.mark.timeout(150)  # 3x average
-@pytest.mark.nightly
-@pytest.mark.gpu_2
 def test_request_cancellation_vllm_prefill_cancel(
     request, runtime_services_dynamic_ports, set_ucx_tls_no_mm, predownload_models
 ):


### PR DESCRIPTION
Cherry-pick of #6758 to `release/1.0.0`.

## Summary
- Fixed wrong GPU marker that caused disaggregated tests to be skipped in nightly CI (`gpu_1` → per-test `gpu_1`/`gpu_2`)
- Fixed decode worker missing `--disaggregation-mode decode` (three-way `is_prefill: bool | None = None` branching)
- Fixed prefill/decode workers missing `--kv-transfer-config`

## Notes
The release branch already had the `DynamoWorkerProcess` fixes; only the test marker additions required conflict resolution.

Linear: DYN-2267