### PR TITLE
docs(kubernetes): fix vLLM aggregated deployment example

### DIFF
--- a/docs/kubernetes/installation-guide.md
+++ b/docs/kubernetes/installation-guide.md
@@ -300,10 +300,10 @@ kubectl get pods -n ${NAMESPACE}
 1. **Deploy Model/Workflow**
    ```bash
    # Example: Deploy a vLLM workflow with Qwen3-0.6B using aggregated serving
-   kubectl apply -f examples/backends/vllm/deploy/agg.yaml -n ${NAMESPACE}
+   kubectl apply -f examples/backends/vllm/deploy/agg.yaml
 
    # Port forward and test
-   kubectl port-forward svc/agg-vllm-frontend 8000:8000 -n ${NAMESPACE}
+   kubectl port-forward svc/vllm-agg-frontend 8000:8000
    curl http://localhost:8000/v1/models
    ```
 

--- a/examples/backends/vllm/deploy/agg.yaml
+++ b/examples/backends/vllm/deploy/agg.yaml
@@ -8,14 +8,12 @@ metadata:
 spec:
   services:
     Frontend:
-      envFromSecret: hf-token-secret
       componentType: frontend
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0
     VllmDecodeWorker:
-      envFromSecret: hf-token-secret
       componentType: worker
       replicas: 1
       resources:
@@ -27,7 +25,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3


### PR DESCRIPTION
#### Overview:

This PR makes the documentation more user-friendly, especially for the first-time users.

#### Details:

envFromSecret is removed because the example uses Qwen/Qwen3-0.6B model which does not need hugging face token for downloading the model weights.

Update the vLLM image tag from `my-tag` to `0.9.0` so users can directly use the example without needing to build their own image.

Remove the `-n ${NAMESPACE}` flag from the port-forward command in the docs since the example deployment can be deployed in any namespace not just the default one.

Update the port-forward with the correct service name `vllm-agg-frontend` instead of `agg-vllm-frontend`.

---

> **NOTE**: I could only find 0.9.0 as the latest version on the [ngc repo](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime/tags). But the upstream latest vLLM version is [0.16.0](https://hub.docker.com/r/vllm/vllm-openai).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Kubernetes installation guide with revised example deployment commands for simplified cluster configuration

* **Updates**
  * Container images upgraded to official NVIDIA vLLM Runtime version 0.9.0
  * Deployment configuration simplified by removing custom environment credential requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->