### PR TITLE
fix: Skip Encoder llm creation for unsupported models in trtllm

### DIFF
--- a/components/src/dynamo/trtllm/encode_helper.py
+++ b/components/src/dynamo/trtllm/encode_helper.py
@@ -432,8 +432,15 @@ class EncodeHelper:
                     "error": "model_dir and model_type are required for full EPD encode"
                 }
                 return
-            if engine is None:
-                yield {"error": "No engine configured on encode worker for full EPD"}
+            if engine is None or not engine.encoder_available:
+                yield {
+                    "error": (
+                        "MultimodalEncoder is not available on this encode worker. "
+                        "The model architecture may not support standalone encoder "
+                        "in TRT-LLM. Use the embedding-path flow or run without "
+                        "disaggregated encode mode."
+                    )
+                }
                 return
             # Use token_ids from request (Rust preprocessor already applied
             # chat template and tokenized; token_ids then include image placeholder tokens

--- a/components/src/dynamo/trtllm/engine.py
+++ b/components/src/dynamo/trtllm/engine.py
@@ -157,9 +157,7 @@ class TensorRTLLMEngine:
         """Return True if *model_path*'s architecture is not supported by
         TRT-LLM's standalone MultimodalEncoder."""
         try:
-            config = AutoConfig.from_pretrained(
-                model_path, trust_remote_code=True
-            )
+            config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
             archs = getattr(config, "architectures", None) or []
             return any(a in _UNSUPPORTED_STANDALONE_ENCODER_ARCHS for a in archs)
         except Exception:

--- a/components/src/dynamo/trtllm/engine.py
+++ b/components/src/dynamo/trtllm/engine.py
@@ -9,10 +9,16 @@ from typing import AsyncGenerator, Optional
 
 from tensorrt_llm import LLM, MultimodalEncoder
 from tensorrt_llm.llmapi.llm import BaseLLM
+from transformers import AutoConfig
 
 from dynamo.trtllm.constants import DisaggregationMode
 
 logger = logging.getLogger(__name__)
+
+# Model architectures without standalone encoder support in TRT-LLM
+# (missing @register_vision_encoder). These handle vision encoding
+# inside the main model (prefill/decode) instead.
+_UNSUPPORTED_STANDALONE_ENCODER_ARCHS = {"Llama4ForConditionalGeneration"}
 
 
 class Backend(str, enum.Enum):
@@ -52,6 +58,11 @@ class TensorRTLLMEngine:
 
         self.engine_args = engine_args
 
+    @property
+    def encoder_available(self) -> bool:
+        """Whether the multimodal encoder LLM is initialized."""
+        return self._llm is not None
+
     async def initialize(self):
         if not self._llm:
             if self.disaggregation_mode == DisaggregationMode.ENCODE:
@@ -60,8 +71,14 @@ class TensorRTLLMEngine:
                 # (model, backend settings, kv cache config, etc.). ENCODE workers instead use
                 # TRT-LLM's `MultimodalEncoder`, which has a different constructor surface.
                 # We intentionally pass only the supported parameters to avoid unexpected kwargs.
-                max_batch_size = self.engine_args.get("max_batch_size", 1)
                 model = self.engine_args.get("model")
+
+                # Skip MultimodalEncoder for architectures that handle vision
+                # encoding inside the main model (e.g. Llama4).
+                if self._is_unsupported_encoder_arch(model):
+                    return
+
+                max_batch_size = self.engine_args.get("max_batch_size", 1)
                 logging.info(
                     f"Initializing multimodal encoder with max_batch_size: {max_batch_size}"
                 )
@@ -134,6 +151,19 @@ class TensorRTLLMEngine:
             "`%s` cannot be used with the `_autodeploy` backend. Ignoring.",
             field_name,
         )
+
+    @staticmethod
+    def _is_unsupported_encoder_arch(model_path: str) -> bool:
+        """Return True if *model_path*'s architecture is not supported by
+        TRT-LLM's standalone MultimodalEncoder."""
+        try:
+            config = AutoConfig.from_pretrained(
+                model_path, trust_remote_code=True
+            )
+            archs = getattr(config, "architectures", None) or []
+            return any(a in _UNSUPPORTED_STANDALONE_ENCODER_ARCHS for a in archs)
+        except Exception:
+            return False
 
 
 @asynccontextmanager

--- a/examples/backends/trtllm/templates/llava_multimodal.jinja
+++ b/examples/backends/trtllm/templates/llava_multimodal.jinja
@@ -5,7 +5,7 @@
 <</SYS>>
 
 {% elif message['role'] == 'user' -%}
-[INST] {% if message['content'] is string %}{{ message['content'] }}{% else %}{% for item in message['content'] %}{% if item['type'] == 'image_url' %}<image>
+[INST] {% if message['content'] is string %}{{ message['content'] }}{% else %}{% for item in message['content'] %}{% if item['type'] == 'image_url' or item['type'] == 'image' %}<image>
 {% elif item['type'] == 'text' %}{{ item['text'] }}{% endif %}{% endfor %}{% endif %} [/INST]
 {% elif message['role'] == 'assistant' -%}
 {{ message['content'] }}</s>


### PR DESCRIPTION
#### Overview:

Fix the encode worker crash in EPD disaggregation mode for Llama4 models. 
TRT-LLM's MultimodalEncoder does not support `Llama4ForConditionalGeneration` causing `epd_disagg.sh` to fail with `ValueError: Unknown architecture for AutoModelForMultimodalEncoder` 

#### Details:

1. `engine.py`: Before creating MultimodalEncoder, check the model's architecture against `_UNSUPPORTED_STANDALONE_ENCODER_ARCHS` (currently `Llama4ForConditionalGeneration`). If unsupported, skip initialization and expose the state via an encoder_available property.
2. `encode_helper.py`: Guard the full EPD flow with an encoder_available check; return a descriptive error when the encoder is unavailable.

#### Where should the reviewer start?

`dynamo/components/src/dynamo/trtllm/engine.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced encoder configuration validation with clearer error messages when the encoder is unavailable.

* **New Features**
  * Extended support to additional model architectures with varying encoder requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->