### PR TITLE
fix: multi-modal vLLM worker error on text-only requests

### DIFF
--- a/components/src/dynamo/vllm/multimodal_handlers/multimodal_pd_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/multimodal_pd_worker_handler.py
@@ -202,7 +202,9 @@ class MultimodalPDWorkerHandler(BaseWorkerHandler):
             if image_embeds is not None:
                 request.embeddings_shape = list(image_embeds.shape)
 
-        logger.debug(f"Prepared multimodal data size: {len(multi_modal_data['image'])}")
+        logger.debug(
+            "Prepared multimodal data size: %s", len(multi_modal_data.get("image", []))
+        )
         logger.debug("Multimodal data keys: %s", list(multi_modal_data.keys()))
 
     @staticmethod


### PR DESCRIPTION
#### Overview:

If a VL model (e.g. Qwen-VL) takes a text-only request, the line with `multi_modal_data['image']` creates an empty list on `multi_modal_data` so that the backend vLLM worker mistakes it for a multi-modal request.

#### Details:

Fixed it to let `multi_modal_data` as `None`.

The former version prints the below error:
```
Traceback (most recent call last):                                                                                                                                                                                    
  File "/home/gpuadmin/work/llmd/dynamo/components/src/dynamo/vllm/multimodal_handlers/multimodal_pd_worker_handler.py", line 369, in generate                                                                        
    async for chunk in self._generate_agg(request, multi_modal_data):                                                                                                                                                 
  File "/home/gpuadmin/work/llmd/dynamo/components/src/dynamo/vllm/multimodal_handlers/multimodal_pd_worker_handler.py", line 264, in _generate_agg                                                                   
    async for response in gen:                                                                                                                                                                                        
  File "/home/gpuadmin/uv/dynamo/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 571, in generate                                                                                                     
    q = await self.add_request(                                                                                                                                                                                       
        ^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                       
  File "/home/gpuadmin/uv/dynamo/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 364, in add_request                                                                                                  
    request = self.input_processor.process_inputs(                                                                                                                                                                    
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                    
  File "/home/gpuadmin/uv/dynamo/lib/python3.11/site-packages/vllm/v1/engine/input_processor.py", line 568, in process_inputs                                                                                         
    self._validate_mm_uuids(prompt)                                                                                                                                                                                   
  File "/home/gpuadmin/uv/dynamo/lib/python3.11/site-packages/vllm/v1/engine/input_processor.py", line 314, in _validate_mm_uuids                                                                                     
    self._validate_singleton_mm_uuids(prompt)                                                                                                                                                                         
  File "/home/gpuadmin/uv/dynamo/lib/python3.11/site-packages/vllm/v1/engine/input_processor.py", line 295, in _validate_singleton_mm_uuids                                                                           
    raise ValueError(                                                                                                                                                                                                 
ValueError: multi_modal_data['image'] is empty but multi_modal_uuids['image'] is missing.  
```

#### Where should the reviewer start?

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system reliability by enhancing error handling for multimodal data processing. The system now gracefully manages cases where image information may be missing or incomplete, preventing unexpected failures and ensuring more stable operation in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->