### PR TITLE
fix(trtllm): remove deprecated beam_width from health check payload

### DIFF
--- a/components/src/dynamo/trtllm/health_check.py
+++ b/components/src/dynamo/trtllm/health_check.py
@@ -81,7 +81,6 @@ class TrtllmHealthCheckPayload(HealthCheckPayload):
                 "temperature": 0.0,
                 "top_p": 1.0,
                 "top_k": 1,
-                "beam_width": 1,
                 "repetition_penalty": 1.0,
                 "presence_penalty": 0.0,
                 "frequency_penalty": 0.0,


### PR DESCRIPTION
## Summary

- Removes `beam_width: 1` from the TRT-LLM canary health check `sampling_options`
- `beam_width` was removed from TRT-LLM's `SamplingParams` in v1.3.0rc5, replaced by `beam_width_array` and `use_beam_search`
- Without this fix, every canary health check raises `TypeError: SamplingParams.__init__() got an unexpected keyword argument 'beam_width'` every 30 seconds

## Root Cause

`_override_sampling_params` in `handler_base.py` uses `dataclasses.replace(sampling_params, **overrides)` to apply request fields onto the TRT-LLM `SamplingParams` dataclass. This intentionally raises on unknown fields. The health check payload was passing the now-removed `beam_width` field, causing every canary request to fail.

## Fix

Remove `beam_width` from the health check defaults. Greedy decoding is already enforced by `temperature=0.0` + `top_k=1` — `beam_width` is not needed.


Closes: [DIS-1538](https://linear.app/nvidia/issue/DIS-1538)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined health check configuration for text generation models by removing redundant default sampling settings, keeping all other functionality unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->