### PR TITLE
fix: strip None args when profiler generating configs

### DIFF
--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -141,6 +141,29 @@ def remove_valued_arguments(args: list[str], key: str) -> list[str]:
     return args
 
 
+def sanitize_cli_args(args: list[str]) -> list[str]:
+    """Strip valued arguments whose value is the literal string ``"None"``.
+
+    AIC's rule engine uses Jinja2 ``compile_expression`` which converts
+    undefined variables to Python ``None``.  When that ``None`` is
+    serialized into CLI args it becomes the four-character string
+    ``"None"``, which is never a valid CLI value and causes backends
+    (e.g. sglang ``--kv-cache-dtype None``) to reject the argument.
+    """
+    result = list(args)
+    i = 0
+    while i < len(result) - 1:
+        if result[i].startswith("--") and result[i + 1] == "None":
+            logger.warning(
+                "Stripping CLI arg %s with invalid value 'None'",
+                result[i],
+            )
+            del result[i : i + 2]
+        else:
+            i += 1
+    return result
+
+
 def append_argument(args: list[str], to_append) -> list[str]:
     idx = find_arg_index(args)
     if isinstance(to_append, list):

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -27,6 +27,7 @@ from dynamo.profiler.utils.config import (
     ServiceResources,
     break_arguments,
     get_service_name_by_type,
+    sanitize_cli_args,
     set_argument_value,
     update_image,
 )
@@ -562,7 +563,7 @@ class BaseConfigModifier:
         service.resources.limits["gpu"] = str(gpus)
 
         if service.extraPodSpec and service.extraPodSpec.mainContainer:
-            service.extraPodSpec.mainContainer.args = list(cli_args)
+            service.extraPodSpec.mainContainer.args = sanitize_cli_args(list(cli_args))
 
     @classmethod
     def _apply_disagg_workers(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced CLI argument processing to automatically remove invalid argument pairs, improving configuration reliability when launching the profiler via command-line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->