### PR TITLE
fix(trtllm): remove deprecated beam_width from health check payload [cherry-pick #6879]

### DIFF
--- a/components/src/dynamo/trtllm/health_check.py
+++ b/components/src/dynamo/trtllm/health_check.py
@@ -81,7 +81,6 @@ class TrtllmHealthCheckPayload(HealthCheckPayload):
                 "temperature": 0.0,
                 "top_p": 1.0,
                 "top_k": 1,
-                "beam_width": 1,
                 "repetition_penalty": 1.0,
                 "presence_penalty": 0.0,
                 "frequency_penalty": 0.0,


### PR DESCRIPTION
## Summary

Cherry-pick of #6879 onto `release/1.0.0`.

- Removes `beam_width: 1` from the TRT-LLM canary health check `sampling_options`
- `beam_width` was removed from TRT-LLM's `SamplingParams` in v1.3.0rc5, replaced by `beam_width_array` and `use_beam_search`
- Without this fix, every canary health check raises `TypeError: SamplingParams.__init__() got an unexpected keyword argument 'beam_width'` every 30 seconds

## Test plan

Verified end-to-end against `nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.0.0rc2` with `DYN_HEALTH_CHECK_ENABLED=true` and `DYN_CANARY_WAIT_TIME=30`. Health checks pass cleanly every 30 seconds after the fix.

Closes: [DIS-1538](https://linear.app/nvidia/issue/DIS-1538)

🤖 Generated with [Claude Code](https://claude.com/claude-code)