### PR TITLE
fix(gms): resolve socket UUIDs via CUDA driver API

### DIFF
--- a/lib/gpu_memory_service/common/utils.py
+++ b/lib/gpu_memory_service/common/utils.py
@@ -12,8 +12,9 @@ import pynvml
 def get_socket_path(device: int) -> str:
     """Get GMS socket path for the given CUDA device.
 
-    The socket path is based on GPU UUID, making it stable across different
-    CUDA_VISIBLE_DEVICES configurations.
+    The socket path is based on GPU UUID.
+    If CUDA_VISIBLE_DEVICES is set, ``device`` is interpreted as the CUDA-local
+    ordinal in that visibility scope.
 
     Args:
         device: CUDA device index.
@@ -21,10 +22,30 @@ def get_socket_path(device: int) -> str:
     Returns:
         Socket path (e.g., "<tempdir>/gms_GPU-12345678-1234-1234-1234-123456789abc.sock").
     """
+    visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", "").strip()
+    visible_token = None
+    if visible_devices:
+        tokens = [token.strip() for token in visible_devices.split(",") if token.strip()]
+        if 0 <= device < len(tokens):
+            visible_token = tokens[device]
+
     pynvml.nvmlInit()
     try:
-        handle = pynvml.nvmlDeviceGetHandleByIndex(device)
+        if visible_token is None:
+            handle = pynvml.nvmlDeviceGetHandleByIndex(device)
+        elif visible_token.startswith("GPU-") or visible_token.startswith("MIG-"):
+            try:
+                handle = pynvml.nvmlDeviceGetHandleByUUID(visible_token)
+            except TypeError:
+                handle = pynvml.nvmlDeviceGetHandleByUUID(visible_token.encode("utf-8"))
+        else:
+            handle = pynvml.nvmlDeviceGetHandleByIndex(int(visible_token))
+
         uuid = pynvml.nvmlDeviceGetUUID(handle)
     finally:
         pynvml.nvmlShutdown()
+
+    if isinstance(uuid, bytes):
+        uuid = uuid.decode("utf-8")
+
     return os.path.join(tempfile.gettempdir(), f"gms_{uuid}.sock")

--- a/lib/gpu_memory_service/common/utils.py
+++ b/lib/gpu_memory_service/common/utils.py
@@ -25,7 +25,9 @@ def get_socket_path(device: int) -> str:
     visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", "").strip()
     visible_token = None
     if visible_devices:
-        tokens = [token.strip() for token in visible_devices.split(",") if token.strip()]
+        tokens = [
+            token.strip() for token in visible_devices.split(",") if token.strip()
+        ]
         if 0 <= device < len(tokens):
             visible_token = tokens[device]
 

--- a/lib/gpu_memory_service/common/utils.py
+++ b/lib/gpu_memory_service/common/utils.py
@@ -5,16 +5,20 @@
 
 import os
 import tempfile
+import uuid
 
-import pynvml
+from cuda.bindings import driver as cuda
+from gpu_memory_service.common.cuda_vmm_utils import (
+    check_cuda_result,
+    ensure_cuda_initialized,
+)
 
 
 def get_socket_path(device: int) -> str:
     """Get GMS socket path for the given CUDA device.
 
-    The socket path is based on GPU UUID.
-    If CUDA_VISIBLE_DEVICES is set, ``device`` is interpreted as the CUDA-local
-    ordinal in that visibility scope.
+    The socket path is based on GPU UUID resolved by CUDA.
+    CUDA_VISIBLE_DEVICES remapping is handled by CUDA device enumeration.
 
     Args:
         device: CUDA device index.
@@ -22,32 +26,13 @@ def get_socket_path(device: int) -> str:
     Returns:
         Socket path (e.g., "<tempdir>/gms_GPU-12345678-1234-1234-1234-123456789abc.sock").
     """
-    visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", "").strip()
-    visible_token = None
-    if visible_devices:
-        tokens = [
-            token.strip() for token in visible_devices.split(",") if token.strip()
-        ]
-        if 0 <= device < len(tokens):
-            visible_token = tokens[device]
+    ensure_cuda_initialized()
 
-    pynvml.nvmlInit()
-    try:
-        if visible_token is None:
-            handle = pynvml.nvmlDeviceGetHandleByIndex(device)
-        elif visible_token.startswith("GPU-") or visible_token.startswith("MIG-"):
-            try:
-                handle = pynvml.nvmlDeviceGetHandleByUUID(visible_token)
-            except TypeError:
-                handle = pynvml.nvmlDeviceGetHandleByUUID(visible_token.encode("utf-8"))
-        else:
-            handle = pynvml.nvmlDeviceGetHandleByIndex(int(visible_token))
+    result, cu_device = cuda.cuDeviceGet(device)
+    check_cuda_result(result, "cuDeviceGet")
 
-        uuid = pynvml.nvmlDeviceGetUUID(handle)
-    finally:
-        pynvml.nvmlShutdown()
+    result, cu_uuid = cuda.cuDeviceGetUuid(cu_device)
+    check_cuda_result(result, "cuDeviceGetUuid")
 
-    if isinstance(uuid, bytes):
-        uuid = uuid.decode("utf-8")
-
-    return os.path.join(tempfile.gettempdir(), f"gms_{uuid}.sock")
+    gpu_uuid = f"GPU-{uuid.UUID(bytes=bytes(cu_uuid.bytes))}"
+    return os.path.join(tempfile.gettempdir(), f"gms_{gpu_uuid}.sock")


### PR DESCRIPTION
## Summary
- switch `get_socket_path` UUID resolution from NVML to CUDA driver API
- resolve device UUID via `cuDeviceGet` + `cuDeviceGetUuid`
- keep socket naming UUID-based (`gms_GPU-<uuid>.sock`) while removing NVML/CUDA_VISIBLE_DEVICES parsing logic

## Why
The bug came from mixing CUDA-local ordinals with NVML physical indices when deriving UUIDs. Using CUDA device enumeration for UUID lookup keeps the lookup in the same ordinal scope as vLLM/SGLang worker device selection.

## Validation
- `uvx ruff check lib/gpu_memory_service/common/utils.py`
- `uvx ruff format --check lib/gpu_memory_service/common/utils.py`
- `python -m compileall lib/gpu_memory_service/common/utils.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved GPU memory service infrastructure with enhanced device identification mechanisms for better system stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->