### PR TITLE
fix(vllm-omni): Fix call to normalize_finish_reason on OmniHandler

### DIFF
--- a/components/src/dynamo/vllm/omni/omni_handler.py
+++ b/components/src/dynamo/vllm/omni/omni_handler.py
@@ -25,6 +25,7 @@ from dynamo.common.protocols.video_protocol import (
     VideoData,
 )
 from dynamo.common.storage import upload_to_fs
+from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.common.utils.output_modalities import RequestType, parse_request_type
 from dynamo.common.utils.video_utils import (
     compute_num_frames,
@@ -513,7 +514,7 @@ class OmniHandler(BaseOmniHandler):
                         "role": "assistant",
                         "content": delta_text,
                     },
-                    "finish_reason": self._normalize_finish_reason(output.finish_reason)
+                    "finish_reason": normalize_finish_reason(output.finish_reason)
                     if output.finish_reason
                     else None,
                 }

--- a/components/src/dynamo/vllm/tests/test_vllm_omni_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_omni_handler.py
@@ -151,7 +151,6 @@ class TestFormatTextChunk:
     def test_finish_reason_included(self):
         """Final chunk includes finish_reason and usage stats."""
         handler = _make_handler()
-        handler._normalize_finish_reason = lambda r: r
         handler._build_completion_usage = lambda ro: {
             "prompt_tokens": 3,
             "completion_tokens": 1,
@@ -160,6 +159,24 @@ class TestFormatTextChunk:
         chunk = handler._format_text_chunk(ro, "req-1", "")
         assert chunk["choices"][0]["finish_reason"] == "stop"
         assert "usage" in chunk
+
+    def test_finish_reason_abort_normalized(self):
+        """Abort finish reason is normalized to 'cancelled'."""
+        handler = _make_handler()
+        handler._build_completion_usage = lambda ro: {
+            "prompt_tokens": 3,
+            "completion_tokens": 1,
+        }
+        ro = self._make_output("done", finish_reason="abort")
+        chunk = handler._format_text_chunk(ro, "req-1", "")
+        assert chunk["choices"][0]["finish_reason"] == "cancelled"
+
+    def test_finish_reason_none_when_not_finished(self):
+        """finish_reason is None when output has no finish_reason."""
+        handler = _make_handler()
+        ro = self._make_output("partial")
+        chunk = handler._format_text_chunk(ro, "req-1", "")
+        assert chunk["choices"][0]["finish_reason"] is None
 
 
 class TestFormatImageChunk:


### PR DESCRIPTION
#### Overview:

Fix `AttributeError: 'OmniHandler' object has no attribute '_normalize_finish_reason'` when serving omni models.

🗒️ NOTE for release manager: This QA bug fix is targeting release/1.0.0 branch directly to avoid complications with other inflight vllm-omni feature/refactor changes that won't be getting cherry-picked into the release branch.

#### Details:

- `OmniHandler` called `self._normalize_finish_reason()` which doesn't exist on the class. Changed to use the standalone `normalize_finish_reason()` function from `dynamo.common.utils.engine_response`, matching how the base `handlers.py` does it.
- Fixed existing test that monkeypatched the missing method onto the handler instance, masking the bug.
- Added tests for finish reason normalization (`abort` -> `cancelled`) and `None` when not finished.

#### Where should the reviewer start?

- `components/src/dynamo/vllm/omni/omni_handler.py`
- `components/src/dynamo/vllm/tests/test_vllm_omni_handler.py`

#### Related Issues:

- Closes [DYN-2291](https://linear.app/nvidia-dynamo/issue/DYN-2291)