### PR TITLE
fix(examples): add missing --kv-transfer-config to disagg_router.yaml

### DIFF
--- a/examples/basics/kubernetes/Distributed_Inference/disagg_router.yaml
+++ b/examples/basics/kubernetes/Distributed_Inference/disagg_router.yaml
@@ -69,4 +69,4 @@ spec:
             - /bin/sh
             - -c
           args:
-            - python3 -m dynamo.vllm --model meta-llama/Llama-3.1-70B-Instruct -tp 4 --disaggregation-mode prefill --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+            - python3 -m dynamo.vllm --model meta-llama/Llama-3.1-70B-Instruct -tp 4 --disaggregation-mode prefill --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'


### PR DESCRIPTION
## Summary

- Adds the required `--kv-transfer-config` parameter to VllmPrefillWorker in the AIConfigurator disaggregated serving example

The prefill worker pod was failing during initialization with:
```
ValueError: --connector is deprecated and the default is no longer nixl.
When using --disaggregation-mode prefill, you must explicitly provide --kv-transfer-config.
```

## Test Plan

- [ ] Deploy using the AIConfigurator guide and verify prefill worker starts successfully
- [ ] Verify disaggregated inference works end-to-end

Fixes DYN-2294
Related NVBug: 5946005


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated distributed inference deployment configuration to enhance key-value data transfer handling during inference operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->