### PR TITLE
docs(examples): add missing --kv-transfer-config to disaggregated serving README

### DIFF
--- a/examples/basics/disaggregated_serving/README.md
+++ b/examples/basics/disaggregated_serving/README.md
@@ -83,6 +83,7 @@ Leave this terminal running - it will show Decode Worker logs.
 export DYN_LOG=debug # Increase log verbosity to see disaggregation
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 CUDA_VISIBLE_DEVICES=1 python -m dynamo.vllm --model Qwen/Qwen3-0.6B --disaggregation-mode prefill \
+  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'
 ```
 


### PR DESCRIPTION
## Summary

- Adds the required `--kv-transfer-config` parameter to the prefill worker command in the P/D Disaggregated Serving example documentation

Users following the example were encountering:
```
ValueError: --connector is deprecated and the default is no longer nixl.
When using --disaggregation-mode prefill, you must explicitly provide --kv-transfer-config.
```

## Test Plan

- [ ] Follow the P/D Disaggregated Serving example with the updated command
- [ ] Verify prefill worker starts successfully

Fixes DYN-2290
Related NVBug: 5945057


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated prefill worker deployment documentation to include the new kv-transfer-config argument, enabling users to configure KV transfer settings when launching prefill workers in disaggregated serving setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->