### PR TITLE
docs(examples): add missing --kv-transfer-config to disaggregated serving README (#6898)

### DIFF
--- a/examples/basics/disaggregated_serving/README.md
+++ b/examples/basics/disaggregated_serving/README.md
@@ -83,6 +83,7 @@ Leave this terminal running - it will show Decode Worker logs.
 export DYN_LOG=debug # Increase log verbosity to see disaggregation
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 CUDA_VISIBLE_DEVICES=1 python -m dynamo.vllm --model Qwen/Qwen3-0.6B --disaggregation-mode prefill \
+  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'
 ```
 


### PR DESCRIPTION
## Summary
- Cherry-pick of #6898 to release/1.0.0
- Adds the required `--kv-transfer-config` parameter to the prefill worker command in the P/D Disaggregated Serving example documentation

Fixes DYN-2290

## Original PR
- Main PR: #6898
- Merge commit: b356b499cf85a2fa84a9fb8955f8e8bbb983896e

## Test Plan
- [ ] CI passes
- [ ] Verified fix works on release branch

Made with [Cursor](https://cursor.com)