### PR TITLE
fix(examples): add missing --kv-transfer-config to disagg_router.yaml (#6897)

### DIFF
--- a/examples/basics/kubernetes/Distributed_Inference/disagg_router.yaml
+++ b/examples/basics/kubernetes/Distributed_Inference/disagg_router.yaml
@@ -69,4 +69,4 @@ spec:
             - /bin/sh
             - -c
           args:
-            - python3 -m dynamo.vllm --model meta-llama/Llama-3.1-70B-Instruct -tp 4 --disaggregation-mode prefill --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+            - python3 -m dynamo.vllm --model meta-llama/Llama-3.1-70B-Instruct -tp 4 --disaggregation-mode prefill --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'


### PR DESCRIPTION
## Summary
- Cherry-pick of #6897 to release/1.0.0
- Adds the required `--kv-transfer-config` parameter to VllmPrefillWorker in the AIConfigurator disaggregated serving example

Fixes DYN-2294

## Original PR
- Main PR: #6897
- Merge commit: 93529753cda1a8cba52fd7d5cc57d1273633337a

## Test Plan
- [ ] CI passes
- [ ] Verified fix works on release branch

Made with [Cursor](https://cursor.com)