### PR TITLE
fix: revert changes in autogen files

### DIFF
--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -223,7 +223,7 @@ class DynamoGraphDeploymentRequestSpec(BaseModel):
         description='Model specifies the model to deploy (e.g., "Qwen/Qwen3-0.6B", "meta-llama/Llama-3-70b"). Can be a HuggingFace ID or a private model name.'
     )
     backend: BackendType = Field(
-        default=BackendType.Auto,
+        default="auto",
         description="Backend specifies the inference backend to use for profiling and deployment.",
     )
     image: Optional[str] = Field(
@@ -255,7 +255,7 @@ class DynamoGraphDeploymentRequestSpec(BaseModel):
         description="Features controls optional Dynamo platform features in the generated deployment.",
     )
     searchStrategy: SearchStrategy = Field(
-        default=SearchStrategy.Rapid,
+        default="rapid",
         description='SearchStrategy controls the profiling search depth. "rapid" performs a fast sweep; "thorough" explores more configurations.',
     )
     autoApply: Optional[bool] = Field(


### PR DESCRIPTION
#### Overview:

Revert the type change done in the autogen file. 

#### Details:

components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py is autogen, should not be touched when adding mypy typing.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected default deployment configuration values to use consistent string formatting. This update improves system compatibility and ensures proper behavior during deployment initialization, preventing potential formatting inconsistencies that could arise from type mismatches in configuration defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->