### PR TITLE
fix(gms): resolve socket UUIDs via CUDA driver API [cp release/1.0.0]

### DIFF
--- a/lib/gpu_memory_service/common/utils.py
+++ b/lib/gpu_memory_service/common/utils.py
@@ -5,15 +5,20 @@
 
 import os
 import tempfile
+import uuid
 
-import pynvml
+from cuda.bindings import driver as cuda
+from gpu_memory_service.common.cuda_vmm_utils import (
+    check_cuda_result,
+    ensure_cuda_initialized,
+)
 
 
 def get_socket_path(device: int) -> str:
     """Get GMS socket path for the given CUDA device.
 
-    The socket path is based on GPU UUID, making it stable across different
-    CUDA_VISIBLE_DEVICES configurations.
+    The socket path is based on GPU UUID resolved by CUDA.
+    CUDA_VISIBLE_DEVICES remapping is handled by CUDA device enumeration.
 
     Args:
         device: CUDA device index.
@@ -21,10 +26,13 @@ def get_socket_path(device: int) -> str:
     Returns:
         Socket path (e.g., "<tempdir>/gms_GPU-12345678-1234-1234-1234-123456789abc.sock").
     """
-    pynvml.nvmlInit()
-    try:
-        handle = pynvml.nvmlDeviceGetHandleByIndex(device)
-        uuid = pynvml.nvmlDeviceGetUUID(handle)
-    finally:
-        pynvml.nvmlShutdown()
-    return os.path.join(tempfile.gettempdir(), f"gms_{uuid}.sock")
+    ensure_cuda_initialized()
+
+    result, cu_device = cuda.cuDeviceGet(device)
+    check_cuda_result(result, "cuDeviceGet")
+
+    result, cu_uuid = cuda.cuDeviceGetUuid(cu_device)
+    check_cuda_result(result, "cuDeviceGetUuid")
+
+    gpu_uuid = f"GPU-{uuid.UUID(bytes=bytes(cu_uuid.bytes))}"
+    return os.path.join(tempfile.gettempdir(), f"gms_{gpu_uuid}.sock")


### PR DESCRIPTION
## Cherry Pick Of
- Main PR: https://github.com/ai-dynamo/dynamo/pull/6891
- Main merge commit: `96237ba199a1a8d0fa1ac4b5df61207400c864fe`

## Summary
- switch `get_socket_path` UUID resolution from NVML to CUDA driver API
- resolve device UUID via `cuDeviceGet` + `cuDeviceGetUuid`
- keep socket naming UUID-based (`gms_GPU-<uuid>.sock`)

## Why
Fixes GMS socket mismatch caused by ordinal mapping differences by using CUDA-device UUID resolution.

## Dependencies
- None
