### PR TITLE
fix(kv-router): gate dynamo-mocker dep behind bench feature for publishing

### DIFF
--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 [features]
 default = []
 metrics = []
-bench = ["dep:clap", "dep:indicatif", "dep:serde_json", "dynamo-runtime/integration", "dep:plotters"]
+bench = ["dep:clap", "dep:indicatif", "dep:serde_json", "dynamo-runtime/integration", "dep:plotters", "dep:dynamo-mocker"]
 indexer-bin = ["metrics", "dep:axum", "dep:clap", "dep:zeromq", "dep:tracing-subscriber", "dep:serde_json"]
 
 [dependencies]
@@ -45,6 +45,7 @@ parking_lot = { workspace = true }
 rmp-serde = { workspace = true }
 
 # bench (optional)
+dynamo-mocker = { workspace = true, optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
 indicatif = { version = "0.18.0", optional = true }
 plotters = { version = "0.3", optional = true, default-features = false, features = ["svg_backend", "line_series", "point_series", "full_palette"] }
@@ -61,7 +62,6 @@ rstest = "0.18.2"
 rstest_reuse = "0.7.0"
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
-dynamo-mocker = { workspace = true }
 dynamo-tokens = { workspace = true }
 minstant = "0.1.7"
 


### PR DESCRIPTION
## Summary
- Moves `dynamo-mocker` from an unconditional `[dev-dependencies]` to an optional `[dependencies]` gated behind the `bench` feature in `dynamo-kv-router`
- Breaks the circular dependency between `dynamo-kv-router` and `dynamo-mocker` that blocks crate publishing to crates.io
- No behavior change: benchmarks already require `--features bench`, which now also pulls in mocker

## Test plan
- [ ] `cargo bench --features bench` in `lib/kv-router` still compiles and runs
- [ ] `cargo publish --dry-run` succeeds for `dynamo-kv-router` without needing `dynamo-mocker` on the registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to optimize build scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->