### PR TITLE
fix(mocker): mark dynamo-mocker as unpublished to break crates.io cycle

### DIFF
--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 [features]
 default = []
 metrics = []
-bench = ["dep:clap", "dep:indicatif", "dep:serde_json", "dynamo-runtime/integration", "dep:plotters"]
+bench = ["dep:clap", "dep:indicatif", "dep:serde_json", "dynamo-runtime/integration", "dep:plotters", "dep:dynamo-mocker"]
 indexer-bin = ["metrics", "dep:axum", "dep:clap", "dep:zeromq", "dep:tracing-subscriber", "dep:serde_json"]
 
 [dependencies]
@@ -45,6 +45,7 @@ parking_lot = { workspace = true }
 rmp-serde = { workspace = true }
 
 # bench (optional)
+dynamo-mocker = { workspace = true, optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
 indicatif = { version = "0.18.0", optional = true }
 plotters = { version = "0.3", optional = true, default-features = false, features = ["svg_backend", "line_series", "point_series", "full_palette"] }
@@ -61,7 +62,6 @@ rstest = "0.18.2"
 rstest_reuse = "0.7.0"
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
-dynamo-mocker = { workspace = true }
 dynamo-tokens = { workspace = true }
 minstant = "0.1.7"
 

--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 [features]
 default = []
 metrics = []
-bench = ["dep:clap", "dep:indicatif", "dep:serde_json", "dynamo-runtime/integration", "dep:plotters", "dep:dynamo-mocker"]
+bench = ["dep:clap", "dep:indicatif", "dep:serde_json", "dynamo-runtime/integration", "dep:plotters"]
 indexer-bin = ["metrics", "dep:axum", "dep:clap", "dep:zeromq", "dep:tracing-subscriber", "dep:serde_json"]
 
 [dependencies]
@@ -45,7 +45,6 @@ parking_lot = { workspace = true }
 rmp-serde = { workspace = true }
 
 # bench (optional)
-dynamo-mocker = { workspace = true, optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
 indicatif = { version = "0.18.0", optional = true }
 plotters = { version = "0.3", optional = true, default-features = false, features = ["svg_backend", "line_series", "point_series", "full_palette"] }
@@ -62,6 +61,7 @@ rstest = "0.18.2"
 rstest_reuse = "0.7.0"
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
+dynamo-mocker = { workspace = true }
 dynamo-tokens = { workspace = true }
 minstant = "0.1.7"
 

--- a/lib/mocker/Cargo.toml
+++ b/lib/mocker/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = false
 
 [dependencies]
 # repo


### PR DESCRIPTION
## Summary
- Adds `publish = false` to `dynamo-mocker`'s `Cargo.toml`
- This breaks the circular dev-dependency between `dynamo-kv-router` and `dynamo-mocker` that blocks crate publishing — cargo strips dev-deps pointing to unpublished crates from the published package
- `dynamo-mocker` is an internal test utility and doesn't need to be on crates.io

## Test plan
- [ ] `cargo publish --dry-run` succeeds for `dynamo-kv-router`
- [ ] `cargo bench` in `lib/kv-router` still works locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal build configuration update with no end-user impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->