### PR TITLE
test: TRT-LLM raw embedding E2E test

### DIFF
--- a/benchmarks/multimodal/sweep/experiments/embedding_cache/trtllm_e_pd.sh
+++ b/benchmarks/multimodal/sweep/experiments/embedding_cache/trtllm_e_pd.sh
@@ -14,9 +14,8 @@
 export DYNAMO_HOME=${DYNAMO_HOME:-"/workspace"}
 export MODEL_PATH="/huggingface/local/llava-v1.6-mistral-7b-hf-pinned"
 export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"llava-v1.6-mistral-7b-hf"}
-export PREFILL_ENGINE_ARGS=${PREFILL_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/prefill.yaml"}
-export DECODE_ENGINE_ARGS=${DECODE_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/decode.yaml"}
 export ENCODE_ENGINE_ARGS=${ENCODE_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/encode.yaml"}
+export PD_ENGINE_ARGS=${PD_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/agg.yaml"}
 export ENCODE_ENDPOINT=${ENCODE_ENDPOINT:-"dyn://dynamo.tensorrt_llm_encode.generate"}
 export MODALITY=${MODALITY:-"multimodal"}
 export ALLOWED_LOCAL_MEDIA_PATH=${ALLOWED_LOCAL_MEDIA_PATH:-"/tmp"}

--- a/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/agg.yaml
+++ b/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/agg.yaml
@@ -23,7 +23,7 @@ enable_chunked_prefill: true
 
 kv_cache_config:
   free_gpu_memory_fraction: 0.60
-  enable_block_reuse: false
+  enable_block_reuse: true
 
 cache_transceiver_config:
   backend: DEFAULT

--- a/examples/backends/trtllm/launch/e_pd_embedding_e2e_test.sh
+++ b/examples/backends/trtllm/launch/e_pd_embedding_e2e_test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# E2E test: Encode + PD with embedding cache for llava-v1.6-mistral-7b-hf.
+# GPU 0: Encode worker, GPU 1: PD worker.
+
+export DYNAMO_HOME=${DYNAMO_HOME:-"/workspace"}
+export MODEL_PATH=${MODEL_PATH:-"llava-hf/llava-v1.6-mistral-7b-hf"}
+export MODEL_REVISION=${MODEL_REVISION:-"52320fb52229"}
+export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"$MODEL_PATH"}
+
+# Resolve HF repo ID to local snapshot for the pinned revision
+if [[ -n "$MODEL_REVISION" && "$MODEL_PATH" != /* ]]; then
+  echo "Resolving $MODEL_PATH revision=$MODEL_REVISION to local cache..."
+  RESOLVED_PATH=$(python3 -c "
+from huggingface_hub import snapshot_download
+print(snapshot_download('$MODEL_PATH', revision='$MODEL_REVISION', local_files_only=True))
+" 2>/dev/null)
+  if [[ -n "$RESOLVED_PATH" && -d "$RESOLVED_PATH" ]]; then
+    echo "Using cached model: $RESOLVED_PATH"
+    MODEL_PATH="$RESOLVED_PATH"
+  else
+    echo "WARNING: pinned revision not cached locally, using MODEL_PATH=$MODEL_PATH as-is"
+  fi
+fi
+
+EXTRA_PD_ARGS=("$@")
+
+trap 'kill $DYNAMO_PID $ENCODE_PID $PD_PID 2>/dev/null; wait 2>/dev/null' EXIT INT TERM
+
+python3 -m dynamo.frontend &
+DYNAMO_PID=$!
+
+CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.trtllm \
+  --model-path "$MODEL_PATH" \
+  --served-model-name "$SERVED_MODEL_NAME" \
+  --extra-engine-args "$DYNAMO_HOME/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/encode.yaml" \
+  --modality multimodal \
+  --allowed-local-media-path /tmp \
+  --custom-jinja-template "$DYNAMO_HOME/examples/backends/trtllm/templates/llava_multimodal.jinja" \
+  --disaggregation-mode encode &
+ENCODE_PID=$!
+
+CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.trtllm \
+  --model-path "$MODEL_PATH" \
+  --served-model-name "$SERVED_MODEL_NAME" \
+  --extra-engine-args "$DYNAMO_HOME/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/agg.yaml" \
+  --modality multimodal \
+  --encode-endpoint "dyn://dynamo.tensorrt_llm_encode.generate" \
+  --custom-jinja-template "$DYNAMO_HOME/examples/backends/trtllm/templates/llava_multimodal.jinja" \
+  --disaggregation-mode prefill_and_decode \
+  "${EXTRA_PD_ARGS[@]}" &
+PD_PID=$!
+
+wait $DYNAMO_PID

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Generator, Optional
+from typing import Generator, List, NamedTuple, Optional
 
 import pytest
 from filelock import FileLock
@@ -131,15 +131,22 @@ def set_ucx_tls_no_mm():
     mp.undo()
 
 
-def download_models(model_list=None, ignore_weights=False):
+class ModelSpec(NamedTuple):
+    repo_id: str
+    revision: Optional[str] = None
+
+
+def download_models(
+    model_list: Optional[List[ModelSpec]] = None, ignore_weights: bool = False
+):
     """Download models - can be called directly or via fixture
 
     Args:
-        model_list: List of model IDs to download. If None, downloads TEST_MODELS.
+        model_list: List of ModelSpec to download. If None, downloads TEST_MODELS.
         ignore_weights: If True, skips downloading model weight files. Default is False.
     """
     if model_list is None:
-        model_list = TEST_MODELS
+        model_list = [ModelSpec(m) for m in TEST_MODELS]
 
     # Check for HF_TOKEN in environment
     hf_token = os.environ.get("HF_TOKEN")
@@ -155,12 +162,17 @@ def download_models(model_list=None, ignore_weights=False):
     try:
         from huggingface_hub import snapshot_download
 
-        for model_id in model_list:
+        for spec in model_list:
+            rev_info = f" (revision={spec.revision})" if spec.revision else ""
             logging.info(
-                f"Pre-downloading {'model (no weights)' if ignore_weights else 'model'}: {model_id}"
+                f"Pre-downloading {'model (no weights)' if ignore_weights else 'model'}: {spec.repo_id}{rev_info}"
             )
 
             try:
+                dl_kwargs = {"repo_id": spec.repo_id, "token": hf_token}
+                if spec.revision:
+                    dl_kwargs["revision"] = spec.revision
+
                 if ignore_weights:
                     # Weight file patterns to exclude (based on hub.rs implementation)
                     weight_patterns = [
@@ -171,22 +183,16 @@ def download_models(model_list=None, ignore_weights=False):
                         "*.ckpt.index",
                     ]
 
-                    # Download everything except weight files
                     snapshot_download(
-                        repo_id=model_id,
-                        token=hf_token,
                         ignore_patterns=weight_patterns,
+                        **dl_kwargs,
                     )
                 else:
-                    # Download the full model snapshot (includes all files)
-                    snapshot_download(
-                        repo_id=model_id,
-                        token=hf_token,
-                    )
-                logging.info(f"Successfully pre-downloaded: {model_id}")
+                    snapshot_download(**dl_kwargs)
+                logging.info(f"Successfully pre-downloaded: {spec.repo_id}{rev_info}")
 
             except Exception as e:
-                logging.error(f"Failed to pre-download {model_id}: {e}")
+                logging.error(f"Failed to pre-download {spec.repo_id}: {e}")
                 # Don't fail the fixture - let individual tests handle missing models
 
     except ImportError:
@@ -282,8 +288,8 @@ def pytest_collection_modifyitems(config, items):
     """
     This function is called to modify the list of tests to run.
     """
-    # Collect models via explicit pytest mark from final filtered items only
-    models_to_download = set()
+    # Collect models via explicit pytest mark from final filtered items only.
+    models_to_download: set[ModelSpec] = set()
     for item in items:
         # Only collect from items that are not skipped
         if any(
@@ -292,7 +298,9 @@ def pytest_collection_modifyitems(config, items):
             continue
         model_mark = item.get_closest_marker("model")
         if model_mark and model_mark.args:
-            models_to_download.add(model_mark.args[0])
+            models_to_download.add(
+                ModelSpec(model_mark.args[0], model_mark.kwargs.get("revision"))
+            )
 
     # Store models to download in pytest config for fixtures to access
     if models_to_download:

--- a/tests/serve/common.py
+++ b/tests/serve/common.py
@@ -173,6 +173,10 @@ def params_with_model_mark(configs: Mapping[str, EngineConfig]):
     params = []
     for config_name, cfg in configs.items():
         marks = list(getattr(cfg, "marks", []))
-        marks.append(pytest.mark.model(cfg.model))
+        revision = getattr(cfg, "model_revision", None)
+        if revision:
+            marks.append(pytest.mark.model(cfg.model, revision=revision))
+        else:
+            marks.append(pytest.mark.model(cfg.model))
         params.append(pytest.param(config_name, marks=marks))
     return params

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -263,6 +263,36 @@ trtllm_configs = {
             "ENCODE_CUDA_VISIBLE_DEVICES": "0",
         },
     ),
+    # E+PD with embedding cache enabled, 2 GPUs.
+    # Sends the same multimodal request twice to confirm the cached-embedding
+    # path does not crash on the second identical request.
+    "e_pd_embedding": TRTLLMConfig(
+        name="e_pd_embedding",
+        directory=trtllm_dir,
+        script_name="e_pd_embedding_e2e_test.sh",
+        script_args=["--multimodal-embedding-cache-capacity-gb", "1"],
+        marks=[
+            pytest.mark.gpu_2,
+            pytest.mark.trtllm,
+            pytest.mark.multimodal,
+            pytest.mark.post_merge,
+        ],
+        model="llava-hf/llava-v1.6-mistral-7b-hf",
+        model_revision="52320fb52229",
+        frontend_port=DefaultPort.FRONTEND.value,
+        timeout=900,
+        delayed_start=120,
+        request_payloads=[
+            multimodal_payload_default(
+                text="Describe what you see in this image.",
+                expected_response=["mountain", "rock", "trees", "road"],
+                repeat_count=1,
+            )
+        ],
+        env={
+            "HF_HUB_OFFLINE": "0",
+        },
+    ),
     "completions_only": TRTLLMConfig(
         name="completions_only",
         directory=trtllm_dir,

--- a/tests/utils/engine_process.py
+++ b/tests/utils/engine_process.py
@@ -46,6 +46,7 @@ class EngineConfig:
     script_name: Optional[str] = None
     command: Optional[List[str]] = None
     script_args: Optional[List[str]] = None
+    model_revision: Optional[str] = None
     frontend_port: int = DefaultPort.FRONTEND.value
     timeout: int = 600
     delayed_start: int = 0


### PR DESCRIPTION
## Why

The TRT-LLM embedding cache feature (E+PD disaggregation) had no automated E2E test coverage. We need a regression test that exercises the full encode → cache → prefill/decode path, including the "cache hit" scenario where a duplicate request reuses cached embeddings.

## What Changed

- Added an E2E test config (`e_pd_embedding`) and launch script for the llava-v1.6-mistral-7b-hf model in E+PD mode with `--multimodal-embedding-cache-capacity-gb 1`, sending a multimodal request twice to verify the cached-embedding path doesn't crash.
- Extended test infra (`conftest.py`, `engine_process.py`, `common.py`) with a `ModelSpec` NamedTuple so `pytest.mark.model` can pin a specific HF revision, ensuring reproducible model snapshots for tests.

## Test Plan

```
pytest tests/serve/test_trtllm.py -k "e_pd_embedding" -v -s
```

got 

```
[TEST] 2026-03-04T23:27:42 INFO tests.utils.client: Received response: status=200, elapsed=1.65s
[TEST] 2026-03-04T23:27:42 INFO tests.utils.payloads: SUCCESS: Found 4/4 expected keywords: ['mountain', 'rock', 'trees', 'road']
[TEST] 2026-03-04T23:27:42 INFO tests.utils.engine_process: Extracted content:
 The image shows a scenic view of a mountainous landscape. In the foreground, there is a winding road that curves to the right, leading the viewer's eye towards the mountains. The road is flanked by t...

...

================================= 1 passed, 15 deselected in 130.92s (0:02:10) =================================
```