### PR TITLE
feat: Nemotron-3-Super-120B agg recipe

### DIFF
--- a/recipes/nemotron-3-super-120b-a12b/README.md
+++ b/recipes/nemotron-3-super-120b-a12b/README.md
@@ -1,0 +1,38 @@
+# Nemotron-3-Super-120B-A12B Recipe Guide
+
+This guide will help you run the Nemotron-3-Super-120B-A12B language model using Dynamo's optimized setup.
+
+## Prerequisites
+
+Follow the instructions in recipe [README.md](../README.md) to create a namespace and kubernetes secret for huggingface token.
+
+## Quick Start
+
+To run the model, simply execute this command in your terminal:
+
+```bash
+cd recipes
+./run.sh --model nemotron-3-super-120b-a12b --framework trtllm agg
+```
+
+## (Alternative) Step by Step Guide
+
+### 1. Download the Model
+
+```bash
+cd recipes/nemotron-3-super-120b-a12b
+kubectl apply -n $NAMESPACE -f ./model-cache
+```
+
+### 2. Deploy and Benchmark the Model
+
+```bash
+cd recipes/nemotron-3-super-120b-a12b
+kubectl apply -n $NAMESPACE -f ./trtllm/agg
+```
+
+### Container Image
+This recipe was tested with dynamo trtllm runtime container.
+
+## Notes
+1. storage class is not specified in the recipe, you need to specify it in the `model-cache.yaml` file.

--- a/recipes/nemotron-3-super-120b-a12b/model-cache/model-cache.yaml
+++ b/recipes/nemotron-3-super-120b-a12b/model-cache/model-cache.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: "your-storage-class-name"
+  resources:
+    requests:
+      storage: 700Gi

--- a/recipes/nemotron-3-super-120b-a12b/model-cache/model-download.yaml
+++ b/recipes/nemotron-3-super-120b-a12b/model-cache/model-download.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: python:3.10-slim
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: MODEL_NAME
+              value: nvidia/nemotron-super-rl-030326
+            - name: HF_HOME
+              value: /model-store
+            - name: HF_HUB_ENABLE_HF_TRANSFER
+              value: "1"
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub hf_transfer
+              hf download $MODEL_NAME
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-store
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache

--- a/recipes/nemotron-3-super-120b-a12b/trtllm/agg/deploy.yaml
+++ b/recipes/nemotron-3-super-120b-a12b/trtllm/agg/deploy.yaml
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llm-config
+data:
+  config.yaml: |
+    backend: pytorch
+    max_batch_size: 128
+    max_num_tokens: 262144
+    tensor_parallel_size: 4
+    enable_attention_dp: false
+    enable_chunked_prefill: True
+    pipeline_parallel_size: 1
+    print_iter_log: true
+    kv_cache_config:
+      free_gpu_memory_fraction: 0.40
+      enable_block_reuse: false
+      dtype: fp8
+    cuda_graph_config:
+      enable_padding: false
+    trust_remote_code: true
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: nemotron-3-super-120b-a12b-agg
+spec:
+  backendFramework: trtllm
+  pvcs:
+    - name: model-cache
+      create: false
+  services:
+    Frontend:
+      componentType: frontend
+      extraPodSpec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: nvidia.com/dynamo-graph-deployment-name
+                  operator: In
+                  values:
+                  - nemotron-3-super-120b-a12b-agg
+              topologyKey: kubernetes.io/hostname
+        mainContainer:
+          args:
+          - python3 -m dynamo.frontend --router-mode kv --http-port 8000
+          command:
+          - /bin/sh
+          - -c
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+      replicas: 1
+    TrtllmWorker:
+      componentType: worker
+      envFromSecret: hf-token-secret
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /opt/models
+      sharedMemory:
+        size: 80Gi
+      extraPodSpec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: nvidia.com/gpu.present
+                  operator: In
+                  values:
+                  - "true"
+        mainContainer:
+          args:
+          - |
+            python3 -m dynamo.trtllm \
+              --model-path "${MODEL_NAME}" \
+              --served-model-name "${MODEL_NAME}" \
+              --extra-engine-args "${ENGINE_ARGS}" \
+              --tensor-parallel-size 4 \
+              --dyn-reasoning-parser deepseek_r1 \
+              --dyn-tool-call-parser qwen3_coder
+          command:
+          - /bin/sh
+          - -c
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          env:
+          - name: MODEL_NAME
+            value: nvidia/nemotron-3-super-120b-a12b
+          - name: ENGINE_ARGS
+            value: /opt/dynamo/configs/config.yaml
+          - name: HF_HOME
+            value: /opt/models
+          volumeMounts:
+          - mountPath: /opt/dynamo/configs
+            name: llm-config
+            readOnly: true
+          workingDir: /workspace/examples/backends/trtllm
+        volumes:
+        - configMap:
+            name: llm-config
+          name: llm-config
+      replicas: 1
+      resources:
+        limits:
+          gpu: "4"
+        requests:
+          gpu: "4"


### PR DESCRIPTION
#### Overview:

Add intial Nemotron-3-Super deployment recipe for trtllm using private preview checkpoint model: nvidia/nemotron-super-rl-030326. This supports reasoning and tool calling.

#### Details:

Adds a TensorRT-LLM deployment recipe for the (currently preview) Nemotron-3-Super model (nvidia/nemotron-super-rl-030326) with aggregated routing, including verified reasoning parser (deepseek_r1) and tool calling parser (qwen3_coder) configuration.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added setup guide for Nemotron-3-Super-120B model deployment.

* **New Features**
  * New recipe enables deployment of Nemotron-3-Super-120B-A12B model.
  * Includes automated model download with credential management.
  * Provides Kubernetes deployment templates with GPU support and model caching configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->