### PR TITLE
fix(llm): Break the llm -> mocker dependency by commenting out some code

### DIFF
--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -25,7 +25,7 @@ pub mod kv_router;
 pub mod local_model;
 pub mod lora;
 pub mod migration;
-pub mod mocker;
+// pub mod mocker;
 pub mod model_card;
 pub mod model_type;
 pub mod namespace;

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -11,10 +11,10 @@ use dynamo_runtime::discovery::DiscoverySpec;
 use dynamo_runtime::protocols::EndpointId;
 use dynamo_runtime::slug::Slug;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
-use dynamo_runtime::utils::get_http_rpc_host_from_env;
+//use dynamo_runtime::utils::get_http_rpc_host_from_env;
 
 use crate::entrypoint::RouterConfig;
-use crate::mocker::protocols::{MockEngineArgs, WorkerType};
+//use crate::mocker::protocols::{MockEngineArgs, WorkerType};
 use crate::model_card::ModelDeploymentCard;
 use crate::model_type::{ModelInput, ModelType};
 use crate::preprocessor::media::{MediaDecoder, MediaFetcher};
@@ -235,6 +235,7 @@ impl LocalModelBuilder {
             .map(RequestTemplate::load)
             .transpose()?;
 
+        /*
         // Override runtime configs with mocker engine args (applies to both paths)
         if self.is_mocker
             && let Some(path) = &self.extra_engine_args
@@ -269,6 +270,7 @@ impl LocalModelBuilder {
                 );
             }
         }
+        */
 
         // frontend and echo engine don't need a path.
         if self.model_path.is_none() {


### PR DESCRIPTION
PR https://github.com/ai-dynamo/dynamo/pull/3597 introduced a dependency from dynamo-llm crate to dynamo-mocker crate. Architecture-wise this is not something we want.

To allow us to publish dynamo-llm I'm commenting out the code that adds the dependency for now. We should revisit soon.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled internal mock-related modules and overrides to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->