### PR TITLE
fix: validate initial uptime metric parsing in integration test

### DIFF
--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -1530,15 +1530,16 @@ dynamo_component_testintgauge{dynamo_namespace="ns345"} 42
 dynamo_component_testintgaugevec{dynamo_namespace="ns345",instance="server1",service="api",status="active"} 10
 dynamo_component_testintgaugevec{dynamo_namespace="ns345",instance="server2",service="api",status="inactive"} 0"#;
 
-        // Split actual output into non-uptime lines and the uptime value line.
+        // Split actual output into non-uptime lines and validate the uptime value line.
         let mut non_uptime_lines = Vec::new();
-        let mut uptime_value: Option<f64> = None;
+        let mut saw_uptime_value = false;
         for line in drt_output_raw.trim_end_matches('\n').lines() {
             if line.starts_with("dynamo_component_uptime_seconds ") {
                 let val_str = line
                     .strip_prefix("dynamo_component_uptime_seconds ")
                     .unwrap();
-                uptime_value = Some(val_str.parse::<f64>().expect("uptime should be a float"));
+                val_str.parse::<f64>().expect("uptime should be a float");
+                saw_uptime_value = true;
             } else if line.starts_with("# HELP dynamo_component_uptime_seconds")
                 || line.starts_with("# TYPE dynamo_component_uptime_seconds")
             {
@@ -1547,6 +1548,10 @@ dynamo_component_testintgaugevec{dynamo_namespace="ns345",instance="server2",ser
                 non_uptime_lines.push(line);
             }
         }
+        assert!(
+            saw_uptime_value,
+            "uptime_seconds metric should be present in initial scrape"
+        );
 
         let actual_without_uptime = non_uptime_lines.join("\n");
         assert_eq!(


### PR DESCRIPTION
#### Overview:

Fixes a clippy warning in the metrics integration test by removing an unused uptime assignment.

#### Details:

- Parse uptime inline (no unused temporary variable)
- Assert the uptime metric is present in the initial scrape

#### Where should the reviewer start?

- `lib/runtime/src/metrics.rs`

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)



/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined uptime metric validation in tests with improved verification logic and consistency across test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->