### PR TITLE
fix: remove the aws-ofi-nccl plugin from linker cache in regular trtllm runtime image

### DIFF
--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -143,6 +143,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     # Create libnccl.so symlink pointing to libnccl.so.2. TensorRT-LLM requires explicit libnccl.so
     ln -sf /usr/lib/${ARCH_ALT}-linux-gnu/libnccl.so.2 /usr/lib/${ARCH_ALT}-linux-gnu/libnccl.so
 
+# nvcr.io/nvidia/cuda-dl-base includes the AWS OFI NCCL plugin, which can crash TRTLLM.
+# Disable it by renaming aws-ofi-nccl.conf and refreshing the dynamic linker cache.
+RUN if [ -f /etc/ld.so.conf.d/aws-ofi-nccl.conf ]; then \
+      mv /etc/ld.so.conf.d/aws-ofi-nccl.conf /etc/ld.so.conf.d/aws-ofi-nccl.conf.disabled; \
+    fi && \
+    ldconfig
+
 {% if context.trtllm.enable_media_ffmpeg == "true" %}
 # Copy ffmpeg libraries from wheel_builder (requires root, runs before USER dynamo)
 RUN --mount=type=bind,from=wheel_builder,source=/usr/local/,target=/tmp/usr/local/ \


### PR DESCRIPTION
#### Overview:

remove the aws-ofi-nccl plugin from linker cache in regular trtllm runtime image, because the plugin can cause segfault when RDMA device is not available. 
NvBug: https://nvbugspro.nvidia.com/bug/5937711

#### Details:
The runtime base image nvcr.io/nvidia/cuda-dl-base includes the aws-ofi-nccl plugin path in the dynamic linker cache.

When TRTLLM performs NCCL collectives, NCCL may automatically attempt to load an external network plugin. Because `/opt/amazon/aws-ofi-nccl/lib` is discoverable via the linker cache, NCCL can pick up `/opt/amazon/aws-ofi-nccl/lib/libnccl-net-ofi.so`. The OFI plugin then tries to initialize RDMA devices in the runtime environment. If RDMA isn’t available (for example, a Kubernetes pod that doesn’t mount /dev/infiniband), plugin initialization can fail and may crash the process (e.g., a segfault).

segfault message:
```
kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] NCCL INFO Successfully loaded external network plugin /opt/amazon/aws-ofi-nccl/lib/libnccl-net-ofi.so
kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] NCCL INFO NET/OFI Initializing aws-ofi-nccl 1.17.0
kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] NCCL INFO NET/OFI Using Libfabric version 2.1
kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] NCCL INFO NET/OFI Using CUDA driver version 13010 with runtime 13000
kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] NCCL INFO NET/OFI Configuring AWS-specific options
kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] NCCL INFO NET/OFI Setting provider_filter to efa
kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] NCCL INFO NET/OFI Internode latency set at 35.0 us
kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] NCCL INFO NET/OFI Using transport protocol RDMA (platform set)
kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] NCCL INFO NET/OFI No eligible providers were found

[2026-03-05 00:58:36] kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t**):221 NCCL WARN NET/OFI Failed to initialize rdma protocol

[2026-03-05 00:58:36] kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t**):360 NCCL WARN NET/OFI aws-ofi-nccl initialization failed

[2026-03-05 00:58:36] kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] ncclResult_t nccl_net_ofi_init_v6(ncclDebugLogger_t):162 NCCL WARN NET/OFI Initializing plugin failed
kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] NCCL INFO plugin/net/net_v10.cc:81 -> 2
kvbm-bench-dynamo-trtllm-baseline-7fcf598d48-4wm89:268:268 [1] NCCL INFO Failed to initialize NET plugin Libfabric
!!!!!!! Segfault encountered !!!!!!!
```

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container runtime stability by disabling a network plugin that could cause compatibility conflicts during cluster deployment and distributed workloads. The safeguard ensures reliable execution in production environments by preventing potential issues with node communication and system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->