### PR TITLE
fix: use checked arithmetic in `TwoPartCodec` to prevent integer overflow

### DIFF
--- a/lib/runtime/src/pipeline/network/codec/two_part.rs
+++ b/lib/runtime/src/pipeline/network/codec/two_part.rs
@@ -55,7 +55,10 @@ impl Decoder for TwoPartCodec {
         let body_len = cursor.get_u64() as usize;
         let _checksum = cursor.get_u64();
 
-        let total_len = 24 + header_len + body_len;
+        let total_len = 24usize
+            .checked_add(header_len)
+            .and_then(|n| n.checked_add(body_len))
+            .ok_or(TwoPartCodecError::MessageTooLarge(usize::MAX, 0))?;
 
         // Check if total_len exceeds max_message_size
         if let Some(max_size) = self.max_message_size
@@ -109,7 +112,10 @@ impl Encoder<TwoPartMessage> for TwoPartCodec {
         let header_len = item.header.len();
         let body_len = item.data.len();
 
-        let total_len = 24 + header_len + body_len; // 24 bytes for lengths and checksum
+        let total_len = 24usize
+            .checked_add(header_len)
+            .and_then(|n| n.checked_add(body_len))
+            .ok_or(TwoPartCodecError::MessageTooLarge(usize::MAX, 0))?;
 
         // Check if total_len exceeds max_message_size
         if let Some(max_size) = self.max_message_size


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

[ref: https://github.com/ai-dynamo/dynamo/issues/6955]

Replace unchecked `24 + header_len + body_len` with `checked_add()` in both the decode and encode paths. The unchecked addition overflows on crafted input: in debug builds this panics, and in release builds the wrapped value silently bypasses the `max_message_size` guard. Found via fuzzing with cargo-fuzz / libfuzzer.

#### Details:

<!-- Describe the changes made in this PR. -->
See above, self-explanatory.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

`lib/runtime/src/pipeline/network/codec/two_part.rs`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #6955 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential integer overflow in message size validation during encoding and decoding. The codec now properly returns an error when message size calculations would overflow, preventing silent overflow behavior and improving system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->