### PR TITLE
chore(UX): Log full endpoint name when registering TCP endpoint

### DIFF
--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -294,6 +294,8 @@ impl SharedTcpServer {
         endpoint_name: String,
         system_health: Arc<Mutex<SystemHealth>>,
     ) -> Result<()> {
+        let endpoint_fqn = format!("{}.{}.{}", namespace, component_name, endpoint_name);
+
         let handler = Arc::new(EndpointHandler {
             service_handler,
             instance_id,
@@ -315,7 +317,7 @@ impl SharedTcpServer {
 
         tracing::info!(
             "Registered endpoint '{}' with shared TCP server on {}",
-            endpoint_name,
+            endpoint_fqn,
             self.actual_address().unwrap_or(self.bind_addr)
         );
 

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -294,7 +294,7 @@ impl SharedTcpServer {
         endpoint_name: String,
         system_health: Arc<Mutex<SystemHealth>>,
     ) -> Result<()> {
-        let endpoint_fqn = format!("{}.{}.{}", namespace, component_name, endpoint_name);
+        let fqn_endpoint = format!("{namespace}.{component_name}.{endpoint_name}");
 
         let handler = Arc::new(EndpointHandler {
             service_handler,
@@ -316,8 +316,7 @@ impl SharedTcpServer {
             .set_endpoint_health_status(&endpoint_name, crate::HealthStatus::Ready);
 
         tracing::info!(
-            "Registered endpoint '{}' with shared TCP server on {}",
-            endpoint_fqn,
+            "Registered endpoint '{fqn_endpoint}' with shared TCP server on {}",
             self.actual_address().unwrap_or(self.bind_addr)
         );
 


### PR DESCRIPTION

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Log the full ns/component/endponit name when registering endpoint to disambiguate when there are multiple with the same default endpoint_name like "generate" throughout.

This also matches some recent public API surface changes to reduce the "endpoint" on python bindings side to a single "{namespace}.{component}.{endpoint}" string for consistency.



#### Details:

<!-- Describe the changes made in this PR. -->

Before:
```
... "Registered endpoint 'generate' with shared TCP server on <address>
... "Registered endpoint 'generate' with shared TCP server on <address>
```

After:
```
... "Registered endpoint 'dynamo.encoder.generate' with shared TCP server on <address>
... "Registered endpoint 'dynamo.backend.generate' with shared TCP server on <address>
```

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging with more detailed endpoint identification information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->