### PR TITLE
fix: guard SGLang/vLLM memory occupation control endpoints

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -196,6 +196,16 @@ class BaseWorkerHandler(BaseGenerativeHandler):
 
         body = body or {}
         tags = self._normalize_memory_tags(body.get("tags", body.get("tag")))
+        tokenizer_manager = (
+            getattr(self.engine, "tokenizer_manager", None)
+            if self.engine is not None
+            else None
+        )
+        if tokenizer_manager is None:
+            return {
+                "status": "error",
+                "message": "memory control not supported on this worker",
+            }
 
         async with self._memory_occupation_lock:
             tags_to_release = [
@@ -219,13 +229,11 @@ class BaseWorkerHandler(BaseGenerativeHandler):
                             )
 
                     pause_req = PauseGenerationReqInput()
-                    await self.engine.tokenizer_manager.pause_generation(pause_req)
+                    await tokenizer_manager.pause_generation(pause_req)
                     self._memory_serving_active = False
 
                 release_req = ReleaseMemoryOccupationReqInput(tags=tags_to_release)
-                await self.engine.tokenizer_manager.release_memory_occupation(
-                    release_req, None
-                )
+                await tokenizer_manager.release_memory_occupation(release_req, None)
                 self._released_memory_tags.update(tags_to_release)
 
                 return {
@@ -255,28 +263,20 @@ class BaseWorkerHandler(BaseGenerativeHandler):
 
         body = body or {}
         tags = self._normalize_memory_tags(body.get("tags", body.get("tag")))
+        tokenizer_manager = (
+            getattr(self.engine, "tokenizer_manager", None)
+            if self.engine is not None
+            else None
+        )
+        if tokenizer_manager is None:
+            return {
+                "status": "error",
+                "message": "memory control not supported on this worker",
+            }
 
         async with self._memory_occupation_lock:
             tags_to_resume = [tag for tag in tags if tag in self._released_memory_tags]
             if not tags_to_resume:
-                if not self._memory_serving_active:
-                    try:
-                        continue_req = ContinueGenerationReqInput()
-                        await self.engine.tokenizer_manager.continue_generation(
-                            continue_req
-                        )
-                        self._memory_serving_active = True
-
-                        if self.generate_endpoint is not None:
-                            try:
-                                await self.generate_endpoint.register_endpoint_instance()
-                            except Exception as reg_err:
-                                logging.warning(
-                                    f"Failed to re-register endpoint to discovery: {reg_err}"
-                                )
-                    except Exception as e:
-                        logging.error(f"Failed to resume memory occupation: {e}")
-                        return {"status": "error", "message": str(e)}
                 return {
                     "status": "ok",
                     "message": f"Memory already resumed for tags: {tags}",
@@ -284,17 +284,13 @@ class BaseWorkerHandler(BaseGenerativeHandler):
 
             try:
                 resume_req = ResumeMemoryOccupationReqInput(tags=tags_to_resume)
-                await self.engine.tokenizer_manager.resume_memory_occupation(
-                    resume_req, None
-                )
+                await tokenizer_manager.resume_memory_occupation(resume_req, None)
                 self._released_memory_tags.difference_update(tags_to_resume)
 
                 # Resume serving only after all released tags have been restored.
                 if not self._released_memory_tags:
                     continue_req = ContinueGenerationReqInput()
-                    await self.engine.tokenizer_manager.continue_generation(
-                        continue_req
-                    )
+                    await tokenizer_manager.continue_generation(continue_req)
                     self._memory_serving_active = True
 
                     if self.generate_endpoint is not None:

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -19,6 +19,10 @@ from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
 
+# Keep default tags minimal and safe for general use.
+# "cuda_graph" can still be requested explicitly, but it requires LD_PRELOAD setup.
+DEFAULT_MEMORY_OCCUPATION_TAGS = ["kv_cache", "weights"]
+
 
 class BaseGenerativeHandler(ABC):
     """Minimal base class for all generative handlers (LLM, diffusion, etc.).
@@ -144,18 +148,41 @@ class BaseWorkerHandler(BaseGenerativeHandler):
             # have an sgl.Engine.
             self.input_param_manager = InputParamManager(None)
             self._engine_supports_priority = False
+        self._memory_occupation_lock = asyncio.Lock()
+        self._released_memory_tags: set[str] = set()
+        self._memory_serving_active = True
 
     def _priority_kwargs(self, priority: Any) -> Dict[str, Any]:
         if priority is not None and self._engine_supports_priority:
             return {"priority": priority}
         return {}
 
+    @staticmethod
+    def _normalize_memory_tags(raw_tags: Any) -> list[str]:
+        if raw_tags is None:
+            return list(DEFAULT_MEMORY_OCCUPATION_TAGS)
+
+        if isinstance(raw_tags, str):
+            candidates = [raw_tags]
+        else:
+            candidates = list(raw_tags)
+
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for tag in candidates:
+            tag_str = str(tag)
+            if tag_str in seen:
+                continue
+            seen.add(tag_str)
+            deduped.append(tag_str)
+        return deduped
+
     async def release_memory_occupation(self, body: dict) -> dict:
         """Release GPU memory occupation and unregister from discovery.
 
         Args:
             body: Dict with optional 'tags' key for which memory to release.
-                  Default: ["kv_cache", "weights", "cuda_graph"]
+                  Default: ["kv_cache", "weights"]
 
         Order of operations:
         1. Unregister from discovery - stop accepting new requests
@@ -167,43 +194,54 @@ class BaseWorkerHandler(BaseGenerativeHandler):
             ReleaseMemoryOccupationReqInput,
         )
 
-        tags = body.get("tags", body.get("tag", None))
-        if tags is None:
-            tags = ["kv_cache", "weights", "cuda_graph"]
+        body = body or {}
+        tags = self._normalize_memory_tags(body.get("tags", body.get("tag")))
 
-        try:
-            # Step 1: Unregister endpoint from discovery FIRST
+        async with self._memory_occupation_lock:
+            tags_to_release = [
+                tag for tag in tags if tag not in self._released_memory_tags
+            ]
+            if not tags_to_release:
+                return {
+                    "status": "ok",
+                    "message": f"Memory already released for tags: {tags}",
+                }
+
             try:
-                await self.generate_endpoint.unregister_endpoint_instance()
-            except Exception as unreg_err:
-                logging.warning(
-                    f"Failed to unregister endpoint from discovery: {unreg_err}"
+                # Stop new requests and drain in-flight work once when entering released state.
+                if not self._released_memory_tags:
+                    if self.generate_endpoint is not None:
+                        try:
+                            await self.generate_endpoint.unregister_endpoint_instance()
+                        except Exception as unreg_err:
+                            logging.warning(
+                                f"Failed to unregister endpoint from discovery: {unreg_err}"
+                            )
+
+                    pause_req = PauseGenerationReqInput()
+                    await self.engine.tokenizer_manager.pause_generation(pause_req)
+                    self._memory_serving_active = False
+
+                release_req = ReleaseMemoryOccupationReqInput(tags=tags_to_release)
+                await self.engine.tokenizer_manager.release_memory_occupation(
+                    release_req, None
                 )
+                self._released_memory_tags.update(tags_to_release)
 
-            # Step 2: Pause generation to drain in-flight requests
-            pause_req = PauseGenerationReqInput()
-            await self.engine.tokenizer_manager.pause_generation(pause_req)
-
-            # Step 3: Release memory now that it's safe
-            release_req = ReleaseMemoryOccupationReqInput(tags=tags)
-            await self.engine.tokenizer_manager.release_memory_occupation(
-                release_req, None
-            )
-
-            return {
-                "status": "ok",
-                "message": f"Memory released for tags: {tags}",
-            }
-        except Exception as e:
-            logging.error(f"Failed to release memory occupation: {e}")
-            return {"status": "error", "message": str(e)}
+                return {
+                    "status": "ok",
+                    "message": f"Memory released for tags: {tags_to_release}",
+                }
+            except Exception as e:
+                logging.error(f"Failed to release memory occupation: {e}")
+                return {"status": "error", "message": str(e)}
 
     async def resume_memory_occupation(self, body: dict) -> dict:
         """Resume GPU memory occupation and re-register to discovery.
 
         Args:
             body: Dict with optional 'tags' key for which memory to resume.
-                  Default: ["kv_cache", "weights", "cuda_graph"]
+                  Default: ["kv_cache", "weights"]
 
         Order of operations:
         1. Resume memory - restore GPU allocations
@@ -215,36 +253,65 @@ class BaseWorkerHandler(BaseGenerativeHandler):
             ResumeMemoryOccupationReqInput,
         )
 
-        tags = body.get("tags", body.get("tag", None))
-        if tags is None:
-            tags = ["kv_cache", "weights", "cuda_graph"]
+        body = body or {}
+        tags = self._normalize_memory_tags(body.get("tags", body.get("tag")))
 
-        try:
-            # Step 1: Resume memory first - must be ready before accepting requests
-            resume_req = ResumeMemoryOccupationReqInput(tags=tags)
-            await self.engine.tokenizer_manager.resume_memory_occupation(
-                resume_req, None
-            )
+        async with self._memory_occupation_lock:
+            tags_to_resume = [tag for tag in tags if tag in self._released_memory_tags]
+            if not tags_to_resume:
+                if not self._memory_serving_active:
+                    try:
+                        continue_req = ContinueGenerationReqInput()
+                        await self.engine.tokenizer_manager.continue_generation(
+                            continue_req
+                        )
+                        self._memory_serving_active = True
 
-            # Step 2: Continue generation
-            continue_req = ContinueGenerationReqInput()
-            await self.engine.tokenizer_manager.continue_generation(continue_req)
+                        if self.generate_endpoint is not None:
+                            try:
+                                await self.generate_endpoint.register_endpoint_instance()
+                            except Exception as reg_err:
+                                logging.warning(
+                                    f"Failed to re-register endpoint to discovery: {reg_err}"
+                                )
+                    except Exception as e:
+                        logging.error(f"Failed to resume memory occupation: {e}")
+                        return {"status": "error", "message": str(e)}
+                return {
+                    "status": "ok",
+                    "message": f"Memory already resumed for tags: {tags}",
+                }
 
-            # Step 3: Re-register to discovery so frontend can route to us
             try:
-                await self.generate_endpoint.register_endpoint_instance()
-            except Exception as reg_err:
-                logging.warning(
-                    f"Failed to re-register endpoint to discovery: {reg_err}"
+                resume_req = ResumeMemoryOccupationReqInput(tags=tags_to_resume)
+                await self.engine.tokenizer_manager.resume_memory_occupation(
+                    resume_req, None
                 )
+                self._released_memory_tags.difference_update(tags_to_resume)
 
-            return {
-                "status": "ok",
-                "message": f"Memory resumed for tags: {tags}",
-            }
-        except Exception as e:
-            logging.error(f"Failed to resume memory occupation: {e}")
-            return {"status": "error", "message": str(e)}
+                # Resume serving only after all released tags have been restored.
+                if not self._released_memory_tags:
+                    continue_req = ContinueGenerationReqInput()
+                    await self.engine.tokenizer_manager.continue_generation(
+                        continue_req
+                    )
+                    self._memory_serving_active = True
+
+                    if self.generate_endpoint is not None:
+                        try:
+                            await self.generate_endpoint.register_endpoint_instance()
+                        except Exception as reg_err:
+                            logging.warning(
+                                f"Failed to re-register endpoint to discovery: {reg_err}"
+                            )
+
+                return {
+                    "status": "ok",
+                    "message": f"Memory resumed for tags: {tags_to_resume}",
+                }
+            except Exception as e:
+                logging.error(f"Failed to resume memory occupation: {e}")
+                return {"status": "error", "message": str(e)}
 
     async def start_profile(self, body: dict) -> dict:
         """Start profiling on the engine.

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -149,7 +149,7 @@ class BaseWorkerHandler(BaseGenerativeHandler):
             self.input_param_manager = InputParamManager(None)
             self._engine_supports_priority = False
         self._memory_occupation_lock = asyncio.Lock()
-        self._released_memory_tags: set[str] = set()
+        self._memory_released = False
         self._memory_serving_active = True
 
     def _priority_kwargs(self, priority: Any) -> Dict[str, Any]:
@@ -157,32 +157,11 @@ class BaseWorkerHandler(BaseGenerativeHandler):
             return {"priority": priority}
         return {}
 
-    @staticmethod
-    def _normalize_memory_tags(raw_tags: Any) -> list[str]:
-        if raw_tags is None:
-            return list(DEFAULT_MEMORY_OCCUPATION_TAGS)
-
-        if isinstance(raw_tags, str):
-            candidates = [raw_tags]
-        else:
-            candidates = list(raw_tags)
-
-        deduped: list[str] = []
-        seen: set[str] = set()
-        for tag in candidates:
-            tag_str = str(tag)
-            if tag_str in seen:
-                continue
-            seen.add(tag_str)
-            deduped.append(tag_str)
-        return deduped
-
     async def release_memory_occupation(self, body: dict) -> dict:
         """Release GPU memory occupation and unregister from discovery.
 
         Args:
-            body: Dict with optional 'tags' key for which memory to release.
-                  Default: ["kv_cache", "weights"]
+            body: Unused. Release always targets default tags.
 
         Order of operations:
         1. Unregister from discovery - stop accepting new requests
@@ -194,8 +173,7 @@ class BaseWorkerHandler(BaseGenerativeHandler):
             ReleaseMemoryOccupationReqInput,
         )
 
-        body = body or {}
-        tags = self._normalize_memory_tags(body.get("tags", body.get("tag")))
+        tags = list(DEFAULT_MEMORY_OCCUPATION_TAGS)
         tokenizer_manager = (
             getattr(self.engine, "tokenizer_manager", None)
             if self.engine is not None
@@ -208,37 +186,28 @@ class BaseWorkerHandler(BaseGenerativeHandler):
             }
 
         async with self._memory_occupation_lock:
-            tags_to_release = [
-                tag for tag in tags if tag not in self._released_memory_tags
-            ]
-            if not tags_to_release:
+            if self._memory_released:
                 return {
                     "status": "ok",
-                    "message": f"Memory already released for tags: {tags}",
+                    "message": "Memory already released",
                 }
 
             try:
-                # Stop new requests and drain in-flight work once when entering released state.
-                if not self._released_memory_tags:
-                    if self.generate_endpoint is not None:
-                        try:
-                            await self.generate_endpoint.unregister_endpoint_instance()
-                        except Exception as unreg_err:
-                            logging.warning(
-                                f"Failed to unregister endpoint from discovery: {unreg_err}"
-                            )
+                # Stop new requests and drain in-flight work before releasing memory.
+                if self.generate_endpoint is not None:
+                    await self.generate_endpoint.unregister_endpoint_instance()
 
-                    pause_req = PauseGenerationReqInput()
-                    await tokenizer_manager.pause_generation(pause_req)
-                    self._memory_serving_active = False
+                pause_req = PauseGenerationReqInput()
+                await tokenizer_manager.pause_generation(pause_req)
+                self._memory_serving_active = False
 
-                release_req = ReleaseMemoryOccupationReqInput(tags=tags_to_release)
+                release_req = ReleaseMemoryOccupationReqInput(tags=tags)
                 await tokenizer_manager.release_memory_occupation(release_req, None)
-                self._released_memory_tags.update(tags_to_release)
+                self._memory_released = True
 
                 return {
                     "status": "ok",
-                    "message": f"Memory released for tags: {tags_to_release}",
+                    "message": f"Memory released for tags: {tags}",
                 }
             except Exception as e:
                 logging.error(f"Failed to release memory occupation: {e}")
@@ -248,8 +217,7 @@ class BaseWorkerHandler(BaseGenerativeHandler):
         """Resume GPU memory occupation and re-register to discovery.
 
         Args:
-            body: Dict with optional 'tags' key for which memory to resume.
-                  Default: ["kv_cache", "weights"]
+            body: Unused. Resume always targets default tags.
 
         Order of operations:
         1. Resume memory - restore GPU allocations
@@ -261,8 +229,7 @@ class BaseWorkerHandler(BaseGenerativeHandler):
             ResumeMemoryOccupationReqInput,
         )
 
-        body = body or {}
-        tags = self._normalize_memory_tags(body.get("tags", body.get("tag")))
+        tags = list(DEFAULT_MEMORY_OCCUPATION_TAGS)
         tokenizer_manager = (
             getattr(self.engine, "tokenizer_manager", None)
             if self.engine is not None
@@ -275,35 +242,27 @@ class BaseWorkerHandler(BaseGenerativeHandler):
             }
 
         async with self._memory_occupation_lock:
-            tags_to_resume = [tag for tag in tags if tag in self._released_memory_tags]
-            if not tags_to_resume:
+            if not self._memory_released:
                 return {
                     "status": "ok",
-                    "message": f"Memory already resumed for tags: {tags}",
+                    "message": "Memory already resumed",
                 }
 
             try:
-                resume_req = ResumeMemoryOccupationReqInput(tags=tags_to_resume)
+                resume_req = ResumeMemoryOccupationReqInput(tags=tags)
                 await tokenizer_manager.resume_memory_occupation(resume_req, None)
-                self._released_memory_tags.difference_update(tags_to_resume)
+                continue_req = ContinueGenerationReqInput()
+                await tokenizer_manager.continue_generation(continue_req)
+                self._memory_serving_active = True
 
-                # Resume serving only after all released tags have been restored.
-                if not self._released_memory_tags:
-                    continue_req = ContinueGenerationReqInput()
-                    await tokenizer_manager.continue_generation(continue_req)
-                    self._memory_serving_active = True
+                if self.generate_endpoint is not None:
+                    await self.generate_endpoint.register_endpoint_instance()
 
-                    if self.generate_endpoint is not None:
-                        try:
-                            await self.generate_endpoint.register_endpoint_instance()
-                        except Exception as reg_err:
-                            logging.warning(
-                                f"Failed to re-register endpoint to discovery: {reg_err}"
-                            )
+                self._memory_released = False
 
                 return {
                     "status": "ok",
-                    "message": f"Memory resumed for tags: {tags_to_resume}",
+                    "message": f"Memory resumed for tags: {tags}",
                 }
             except Exception as e:
                 logging.error(f"Failed to resume memory occupation: {e}")

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -150,7 +150,6 @@ class BaseWorkerHandler(BaseGenerativeHandler):
             self._engine_supports_priority = False
         self._memory_occupation_lock = asyncio.Lock()
         self._memory_released = False
-        self._memory_serving_active = True
 
     def _priority_kwargs(self, priority: Any) -> Dict[str, Any]:
         if priority is not None and self._engine_supports_priority:
@@ -199,7 +198,6 @@ class BaseWorkerHandler(BaseGenerativeHandler):
 
                 pause_req = PauseGenerationReqInput()
                 await tokenizer_manager.pause_generation(pause_req)
-                self._memory_serving_active = False
 
                 release_req = ReleaseMemoryOccupationReqInput(tags=tags)
                 await tokenizer_manager.release_memory_occupation(release_req, None)
@@ -253,7 +251,6 @@ class BaseWorkerHandler(BaseGenerativeHandler):
                 await tokenizer_manager.resume_memory_occupation(resume_req, None)
                 continue_req = ContinueGenerationReqInput()
                 await tokenizer_manager.continue_generation(continue_req)
-                self._memory_serving_active = True
 
                 if self.generate_endpoint is not None:
                     await self.generate_endpoint.register_endpoint_instance()

--- a/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+class _TestWorkerHandler(BaseWorkerHandler):
+    async def generate(self, request, context):
+        yield {}
+
+
+def _make_handler() -> _TestWorkerHandler:
+    handler = _TestWorkerHandler.__new__(_TestWorkerHandler)
+    handler.engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            pause_generation=AsyncMock(),
+            release_memory_occupation=AsyncMock(),
+            resume_memory_occupation=AsyncMock(),
+            continue_generation=AsyncMock(),
+        )
+    )
+    handler.generate_endpoint = SimpleNamespace(
+        unregister_endpoint_instance=AsyncMock(),
+        register_endpoint_instance=AsyncMock(),
+    )
+    handler._memory_occupation_lock = asyncio.Lock()
+    handler._released_memory_tags = set()
+    handler._memory_serving_active = True
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_resume_before_release_is_noop():
+    handler = _make_handler()
+
+    result = await handler.resume_memory_occupation({})
+
+    assert result["status"] == "ok"
+    handler.engine.tokenizer_manager.resume_memory_occupation.assert_not_awaited()
+    handler.engine.tokenizer_manager.continue_generation.assert_not_awaited()
+    handler.generate_endpoint.register_endpoint_instance.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_release_and_resume_are_idempotent():
+    handler = _make_handler()
+
+    first_release = await handler.release_memory_occupation({})
+    second_release = await handler.release_memory_occupation({})
+
+    first_resume = await handler.resume_memory_occupation({})
+    second_resume = await handler.resume_memory_occupation({})
+
+    assert first_release["status"] == "ok"
+    assert second_release["status"] == "ok"
+    assert first_resume["status"] == "ok"
+    assert second_resume["status"] == "ok"
+
+    handler.engine.tokenizer_manager.pause_generation.assert_awaited_once()
+    handler.engine.tokenizer_manager.release_memory_occupation.assert_awaited_once()
+    handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
+
+    handler.engine.tokenizer_manager.resume_memory_occupation.assert_awaited_once()
+    handler.engine.tokenizer_manager.continue_generation.assert_awaited_once()
+    handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_partial_resume_keeps_worker_paused_until_all_tags_resumed():
+    handler = _make_handler()
+
+    await handler.release_memory_occupation({"tags": ["weights", "kv_cache"]})
+    partial_resume = await handler.resume_memory_occupation({"tags": ["weights"]})
+
+    assert partial_resume["status"] == "ok"
+    handler.engine.tokenizer_manager.continue_generation.assert_not_awaited()
+    handler.generate_endpoint.register_endpoint_instance.assert_not_awaited()
+
+    final_resume = await handler.resume_memory_occupation({"tags": ["kv_cache"]})
+
+    assert final_resume["status"] == "ok"
+    handler.engine.tokenizer_manager.continue_generation.assert_awaited_once()
+    handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resume_retries_continue_when_memory_is_already_restored():
+    handler = _make_handler()
+    handler._memory_serving_active = False
+
+    result = await handler.resume_memory_occupation({})
+
+    assert result["status"] == "ok"
+    handler.engine.tokenizer_manager.resume_memory_occupation.assert_not_awaited()
+    handler.engine.tokenizer_manager.continue_generation.assert_awaited_once()
+    handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()

--- a/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
@@ -7,7 +7,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
+from dynamo.sglang.request_handlers.handler_base import (
+    DEFAULT_MEMORY_OCCUPATION_TAGS,
+    BaseWorkerHandler,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -68,6 +71,16 @@ async def test_release_and_resume_are_idempotent():
     assert second_release["status"] == "ok"
     assert first_resume["status"] == "ok"
     assert second_resume["status"] == "ok"
+    assert DEFAULT_MEMORY_OCCUPATION_TAGS == ["kv_cache", "weights"]
+
+    release_req = (
+        handler.engine.tokenizer_manager.release_memory_occupation.await_args.args[0]
+    )
+    resume_req = (
+        handler.engine.tokenizer_manager.resume_memory_occupation.await_args.args[0]
+    )
+    assert release_req.tags == DEFAULT_MEMORY_OCCUPATION_TAGS
+    assert resume_req.tags == DEFAULT_MEMORY_OCCUPATION_TAGS
 
     handler.engine.tokenizer_manager.pause_generation.assert_awaited_once()
     handler.engine.tokenizer_manager.release_memory_occupation.assert_awaited_once()
@@ -97,7 +110,7 @@ async def test_partial_resume_keeps_worker_paused_until_all_tags_resumed():
 
 
 @pytest.mark.asyncio
-async def test_resume_retries_continue_when_memory_is_already_restored():
+async def test_resume_with_no_sleeping_tags_is_noop_even_if_serving_flag_is_false():
     handler = _make_handler()
     handler._memory_serving_active = False
 
@@ -105,5 +118,33 @@ async def test_resume_retries_continue_when_memory_is_already_restored():
 
     assert result["status"] == "ok"
     handler.engine.tokenizer_manager.resume_memory_occupation.assert_not_awaited()
-    handler.engine.tokenizer_manager.continue_generation.assert_awaited_once()
-    handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
+    handler.engine.tokenizer_manager.continue_generation.assert_not_awaited()
+    handler.generate_endpoint.register_endpoint_instance.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_release_returns_error_when_worker_has_no_tokenizer_manager():
+    handler = _make_handler()
+    handler.engine = None
+
+    result = await handler.release_memory_occupation({})
+
+    assert result == {
+        "status": "error",
+        "message": "memory control not supported on this worker",
+    }
+    handler.generate_endpoint.unregister_endpoint_instance.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resume_returns_error_when_worker_has_no_tokenizer_manager():
+    handler = _make_handler()
+    handler.engine = None
+
+    result = await handler.resume_memory_occupation({})
+
+    assert result == {
+        "status": "error",
+        "message": "memory control not supported on this worker",
+    }
+    handler.generate_endpoint.register_endpoint_instance.assert_not_awaited()

--- a/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
@@ -61,7 +61,6 @@ def _make_handler() -> _TestWorkerHandler:
     )
     handler._memory_occupation_lock = asyncio.Lock()
     handler._memory_released = False
-    handler._memory_serving_active = True
     return handler
 
 
@@ -131,9 +130,8 @@ async def test_resume_uses_default_tags_even_when_request_specifies_subset():
 
 
 @pytest.mark.asyncio
-async def test_resume_with_no_sleeping_state_is_noop_even_if_serving_flag_is_false():
+async def test_resume_with_no_sleeping_state_is_noop():
     handler = _make_handler()
-    handler._memory_serving_active = False
 
     result = await handler.resume_memory_occupation({})
 

--- a/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import sys
+import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -18,6 +20,24 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
+
+
+@pytest.fixture(autouse=True)
+def _stub_sglang_io_struct(monkeypatch):
+    """Keep unit tests independent from CUDA-only sglang imports."""
+
+    io_struct = types.ModuleType("sglang.srt.managers.io_struct")
+
+    class _Req:
+        def __init__(self, tags=None):
+            self.tags = tags
+
+    io_struct.PauseGenerationReqInput = _Req
+    io_struct.ReleaseMemoryOccupationReqInput = _Req
+    io_struct.ResumeMemoryOccupationReqInput = _Req
+    io_struct.ContinueGenerationReqInput = _Req
+
+    monkeypatch.setitem(sys.modules, "sglang.srt.managers.io_struct", io_struct)
 
 
 class _TestWorkerHandler(BaseWorkerHandler):

--- a/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
@@ -60,7 +60,7 @@ def _make_handler() -> _TestWorkerHandler:
         register_endpoint_instance=AsyncMock(),
     )
     handler._memory_occupation_lock = asyncio.Lock()
-    handler._released_memory_tags = set()
+    handler._memory_released = False
     handler._memory_serving_active = True
     return handler
 
@@ -72,6 +72,7 @@ async def test_resume_before_release_is_noop():
     result = await handler.resume_memory_occupation({})
 
     assert result["status"] == "ok"
+    assert result["message"] == "Memory already resumed"
     handler.engine.tokenizer_manager.resume_memory_occupation.assert_not_awaited()
     handler.engine.tokenizer_manager.continue_generation.assert_not_awaited()
     handler.generate_endpoint.register_endpoint_instance.assert_not_awaited()
@@ -91,6 +92,8 @@ async def test_release_and_resume_are_idempotent():
     assert second_release["status"] == "ok"
     assert first_resume["status"] == "ok"
     assert second_resume["status"] == "ok"
+    assert second_release["message"] == "Memory already released"
+    assert second_resume["message"] == "Memory already resumed"
     assert DEFAULT_MEMORY_OCCUPATION_TAGS == ["kv_cache", "weights"]
 
     release_req = (
@@ -112,31 +115,30 @@ async def test_release_and_resume_are_idempotent():
 
 
 @pytest.mark.asyncio
-async def test_partial_resume_keeps_worker_paused_until_all_tags_resumed():
+async def test_resume_uses_default_tags_even_when_request_specifies_subset():
     handler = _make_handler()
 
-    await handler.release_memory_occupation({"tags": ["weights", "kv_cache"]})
-    partial_resume = await handler.resume_memory_occupation({"tags": ["weights"]})
+    await handler.release_memory_occupation({"tags": ["weights"]})
+    resume_result = await handler.resume_memory_occupation({"tags": ["weights"]})
 
-    assert partial_resume["status"] == "ok"
-    handler.engine.tokenizer_manager.continue_generation.assert_not_awaited()
-    handler.generate_endpoint.register_endpoint_instance.assert_not_awaited()
-
-    final_resume = await handler.resume_memory_occupation({"tags": ["kv_cache"]})
-
-    assert final_resume["status"] == "ok"
+    assert resume_result["status"] == "ok"
+    resume_req = (
+        handler.engine.tokenizer_manager.resume_memory_occupation.await_args.args[0]
+    )
+    assert resume_req.tags == DEFAULT_MEMORY_OCCUPATION_TAGS
     handler.engine.tokenizer_manager.continue_generation.assert_awaited_once()
     handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_resume_with_no_sleeping_tags_is_noop_even_if_serving_flag_is_false():
+async def test_resume_with_no_sleeping_state_is_noop_even_if_serving_flag_is_false():
     handler = _make_handler()
     handler._memory_serving_active = False
 
     result = await handler.resume_memory_occupation({})
 
     assert result["status"] == "ok"
+    assert result["message"] == "Memory already resumed"
     handler.engine.tokenizer_manager.resume_memory_occupation.assert_not_awaited()
     handler.engine.tokenizer_manager.continue_generation.assert_not_awaited()
     handler.generate_endpoint.register_endpoint_instance.assert_not_awaited()

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -46,6 +46,7 @@ IMAGE_URL_KEY: Final = "image_url"
 VIDEO_URL_KEY: Final = "video_url"
 URL_VARIANT_KEY: Final = "Url"
 DECODED_VARIANT_KEY: Final = "Decoded"
+DEFAULT_VLLM_SLEEP_TAGS: Final[frozenset[str]] = frozenset({"weights", "kv_cache"})
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
@@ -331,7 +332,7 @@ class BaseWorkerHandler(ABC):
 
         self.dp_range = get_dp_range_for_worker(self.engine_client.vllm_config)
         self._sleep_wake_lock = asyncio.Lock()
-        self._engine_is_sleeping = False
+        self._sleeping_tags: set[str] = set()
 
         # Initialize InputParamManager for text-in-text-out mode
         tokenizer = None
@@ -341,6 +342,45 @@ class BaseWorkerHandler(ABC):
 
         # Store shutdown event for graceful shutdown monitoring
         self.shutdown_event = shutdown_event
+
+    @staticmethod
+    def _normalize_wake_tags(raw_tags: Any) -> list[str] | None:
+        if raw_tags is None:
+            return None
+
+        if isinstance(raw_tags, str):
+            candidates = [raw_tags]
+        else:
+            candidates = list(raw_tags)
+
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for tag in candidates:
+            tag_str = str(tag)
+            if tag_str in seen:
+                continue
+            seen.add(tag_str)
+            deduped.append(tag_str)
+        return deduped
+
+    @staticmethod
+    def _is_benign_discovery_error(exc: Exception, operation: str) -> bool:
+        message = str(exc).lower()
+        if operation == "unregister":
+            benign_patterns = (
+                "already absent",
+                "not found",
+                "not registered",
+                "unknown endpoint",
+                "does not exist",
+            )
+        else:
+            benign_patterns = (
+                "already registered",
+                "already exists",
+                "duplicate",
+            )
+        return any(pattern in message for pattern in benign_patterns)
 
     async def sleep(self, body: dict) -> dict:
         """Sleep the engine to release GPU memory and unregister from discovery.
@@ -355,35 +395,61 @@ class BaseWorkerHandler(ABC):
         """
         body = body or {}
         level = body.get("level", 1)
+        requested_sleep_tags = set(DEFAULT_VLLM_SLEEP_TAGS)
         async with self._sleep_wake_lock:
-            if self._engine_is_sleeping:
+            if requested_sleep_tags.issubset(self._sleeping_tags):
                 return {
                     "status": "ok",
-                    "message": f"Engine already sleeping (level={level})",
+                    "message": (
+                        "Engine already sleeping for tags: "
+                        f"{sorted(requested_sleep_tags)}"
+                    ),
                 }
 
             try:
-                # Step 1: Unregister endpoint instance FIRST to stop new requests from arriving
-                if self.generate_endpoint is not None:
+                # Step 1: Unregister endpoint instance once when entering sleeping state.
+                if not self._sleeping_tags and self.generate_endpoint is not None:
                     try:
                         await self.generate_endpoint.unregister_endpoint_instance()
                         logger.info(
                             "[Sleep] Unregistered endpoint from discovery - worker removed from routing pool"
                         )
                     except Exception as unreg_err:
-                        logger.warning(
-                            f"[Sleep] Failed to unregister endpoint from discovery: {unreg_err}"
-                        )
+                        if self._is_benign_discovery_error(
+                            unreg_err, operation="unregister"
+                        ):
+                            logger.info(
+                                "[Sleep] Endpoint already absent from discovery: %s",
+                                unreg_err,
+                            )
+                        else:
+                            logger.error(
+                                "[Sleep] Unexpected discovery unregister failure: %s",
+                                unreg_err,
+                            )
+                            return {
+                                "status": "error",
+                                "message": (
+                                    "Failed to unregister endpoint from discovery: "
+                                    f"{unreg_err}"
+                                ),
+                            }
 
                 # Step 2: Abort in-flight requests and wait for them to drain so the
                 # GPU is fully quiesced before unmapping memory.
-                await self.engine_client.pause_generation()
+                if not self._sleeping_tags:
+                    await self.engine_client.pause_generation()
 
                 # Step 3: Now safe to sleep - no in-flight GPU work
                 await self.engine_client.sleep(level)
-                self._engine_is_sleeping = True
+                self._sleeping_tags.update(requested_sleep_tags)
 
-                return {"status": "ok", "message": f"Engine slept (level={level})"}
+                return {
+                    "status": "ok",
+                    "message": (
+                        f"Engine slept (level={level}, sleeping_tags={sorted(self._sleeping_tags)})"
+                    ),
+                }
             except Exception as e:
                 logger.error(f"Failed to sleep engine: {e}")
                 return {"status": "error", "message": str(e)}
@@ -399,35 +465,71 @@ class BaseWorkerHandler(ABC):
         2. Re-register endpoint instance - allow frontend to route requests here again
         """
         body = body or {}
-        tags = body.get("tags")
+        requested_tags = self._normalize_wake_tags(body.get("tags"))
         async with self._sleep_wake_lock:
-            if not self._engine_is_sleeping:
+            if requested_tags is None:
+                tags_to_wake = set(self._sleeping_tags)
+            else:
+                unknown_tags = [
+                    tag for tag in requested_tags if tag not in self._sleeping_tags
+                ]
+                if unknown_tags:
+                    return {
+                        "status": "ok",
+                        "message": f"Engine already awake for tags: {unknown_tags}",
+                    }
+                tags_to_wake = set(requested_tags)
+
+            if not tags_to_wake:
                 return {
                     "status": "ok",
-                    "message": f"Engine already awake (tags={tags})",
+                    "message": "Engine already awake for requested tags",
                 }
 
             try:
                 # Step 1: Wake engine first - must be ready before accepting requests
-                await self.engine_client.wake_up(tags)
+                await self.engine_client.wake_up(
+                    None if requested_tags is None else sorted(tags_to_wake)
+                )
+                self._sleeping_tags.difference_update(tags_to_wake)
 
-                # Step 2: Resume generation so new requests can be processed
-                await self.engine_client.resume_generation()
-                self._engine_is_sleeping = False
+                # Step 2: Resume generation and re-register only after full restore.
+                if not self._sleeping_tags:
+                    await self.engine_client.resume_generation()
+                    if self.generate_endpoint is not None:
+                        try:
+                            await self.generate_endpoint.register_endpoint_instance()
+                            logger.info(
+                                "[Wake] Re-registered endpoint to discovery - worker added back to routing pool"
+                            )
+                        except Exception as reg_err:
+                            if self._is_benign_discovery_error(
+                                reg_err, operation="register"
+                            ):
+                                logger.info(
+                                    "[Wake] Endpoint already registered in discovery: %s",
+                                    reg_err,
+                                )
+                            else:
+                                logger.error(
+                                    "[Wake] Unexpected discovery register failure: %s",
+                                    reg_err,
+                                )
+                                return {
+                                    "status": "error",
+                                    "message": (
+                                        "Failed to register endpoint to discovery: "
+                                        f"{reg_err}"
+                                    ),
+                                }
 
-                # Step 3: Re-register endpoint instance to discovery so frontend can route to us again
-                if self.generate_endpoint is not None:
-                    try:
-                        await self.generate_endpoint.register_endpoint_instance()
-                        logger.info(
-                            "[Wake] Re-registered endpoint to discovery - worker added back to routing pool"
-                        )
-                    except Exception as reg_err:
-                        logger.warning(
-                            f"[Wake] Failed to re-register endpoint to discovery: {reg_err}"
-                        )
-
-                return {"status": "ok", "message": f"Engine woke (tags={tags})"}
+                return {
+                    "status": "ok",
+                    "message": (
+                        f"Engine woke (woken_tags={sorted(tags_to_wake)}, "
+                        f"remaining_sleeping_tags={sorted(self._sleeping_tags)})"
+                    ),
+                }
             except Exception as e:
                 logger.error(f"Failed to wake up engine: {e}")
                 return {"status": "error", "message": str(e)}

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -330,6 +330,8 @@ class BaseWorkerHandler(ABC):
         self.use_vllm_tokenizer = use_vllm_tokenizer
 
         self.dp_range = get_dp_range_for_worker(self.engine_client.vllm_config)
+        self._sleep_wake_lock = asyncio.Lock()
+        self._engine_is_sleeping = False
 
         # Initialize InputParamManager for text-in-text-out mode
         tokenizer = None
@@ -351,30 +353,40 @@ class BaseWorkerHandler(ABC):
         2. Abort and drain in-flight requests
         3. Sleep engine - safe now that GPU is quiesced
         """
+        body = body or {}
         level = body.get("level", 1)
-        try:
-            # Step 1: Unregister endpoint instance FIRST to stop new requests from arriving
+        async with self._sleep_wake_lock:
+            if self._engine_is_sleeping:
+                return {
+                    "status": "ok",
+                    "message": f"Engine already sleeping (level={level})",
+                }
+
             try:
-                await self.generate_endpoint.unregister_endpoint_instance()
-                logger.info(
-                    "[Sleep] Unregistered endpoint from discovery - worker removed from routing pool"
-                )
-            except Exception as unreg_err:
-                logger.warning(
-                    f"[Sleep] Failed to unregister endpoint from discovery: {unreg_err}"
-                )
+                # Step 1: Unregister endpoint instance FIRST to stop new requests from arriving
+                if self.generate_endpoint is not None:
+                    try:
+                        await self.generate_endpoint.unregister_endpoint_instance()
+                        logger.info(
+                            "[Sleep] Unregistered endpoint from discovery - worker removed from routing pool"
+                        )
+                    except Exception as unreg_err:
+                        logger.warning(
+                            f"[Sleep] Failed to unregister endpoint from discovery: {unreg_err}"
+                        )
 
-            # Step 2: Abort in-flight requests and wait for them to drain so the
-            # GPU is fully quiesced before unmapping memory.
-            await self.engine_client.pause_generation()
+                # Step 2: Abort in-flight requests and wait for them to drain so the
+                # GPU is fully quiesced before unmapping memory.
+                await self.engine_client.pause_generation()
 
-            # Step 3: Now safe to sleep - no in-flight GPU work
-            await self.engine_client.sleep(level)
+                # Step 3: Now safe to sleep - no in-flight GPU work
+                await self.engine_client.sleep(level)
+                self._engine_is_sleeping = True
 
-            return {"status": "ok", "message": f"Engine slept (level={level})"}
-        except Exception as e:
-            logger.error(f"Failed to sleep engine: {e}")
-            return {"status": "error", "message": str(e)}
+                return {"status": "ok", "message": f"Engine slept (level={level})"}
+            except Exception as e:
+                logger.error(f"Failed to sleep engine: {e}")
+                return {"status": "error", "message": str(e)}
 
     async def wake_up(self, body: dict) -> dict:
         """Wake the engine to restore GPU memory and re-register to discovery.
@@ -386,29 +398,39 @@ class BaseWorkerHandler(ABC):
         1. Wake engine - restore GPU memory
         2. Re-register endpoint instance - allow frontend to route requests here again
         """
+        body = body or {}
         tags = body.get("tags")
-        try:
-            # Step 1: Wake engine first - must be ready before accepting requests
-            await self.engine_client.wake_up(tags)
+        async with self._sleep_wake_lock:
+            if not self._engine_is_sleeping:
+                return {
+                    "status": "ok",
+                    "message": f"Engine already awake (tags={tags})",
+                }
 
-            # Step 2: Resume generation so new requests can be processed
-            await self.engine_client.resume_generation()
-
-            # Step 3: Re-register endpoint instance to discovery so frontend can route to us again
             try:
-                await self.generate_endpoint.register_endpoint_instance()
-                logger.info(
-                    "[Wake] Re-registered endpoint to discovery - worker added back to routing pool"
-                )
-            except Exception as reg_err:
-                logger.warning(
-                    f"[Wake] Failed to re-register endpoint to discovery: {reg_err}"
-                )
+                # Step 1: Wake engine first - must be ready before accepting requests
+                await self.engine_client.wake_up(tags)
 
-            return {"status": "ok", "message": f"Engine woke (tags={tags})"}
-        except Exception as e:
-            logger.error(f"Failed to wake up engine: {e}")
-            return {"status": "error", "message": str(e)}
+                # Step 2: Resume generation so new requests can be processed
+                await self.engine_client.resume_generation()
+                self._engine_is_sleeping = False
+
+                # Step 3: Re-register endpoint instance to discovery so frontend can route to us again
+                if self.generate_endpoint is not None:
+                    try:
+                        await self.generate_endpoint.register_endpoint_instance()
+                        logger.info(
+                            "[Wake] Re-registered endpoint to discovery - worker added back to routing pool"
+                        )
+                    except Exception as reg_err:
+                        logger.warning(
+                            f"[Wake] Failed to re-register endpoint to discovery: {reg_err}"
+                        )
+
+                return {"status": "ok", "message": f"Engine woke (tags={tags})"}
+            except Exception as e:
+                logger.error(f"Failed to wake up engine: {e}")
+                return {"status": "error", "message": str(e)}
 
     @abstractmethod
     async def generate(self, request, context) -> AsyncGenerator[dict, None]:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -46,7 +46,6 @@ IMAGE_URL_KEY: Final = "image_url"
 VIDEO_URL_KEY: Final = "video_url"
 URL_VARIANT_KEY: Final = "Url"
 DECODED_VARIANT_KEY: Final = "Decoded"
-DEFAULT_VLLM_SLEEP_TAGS: Final[frozenset[str]] = frozenset({"weights", "kv_cache"})
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
@@ -332,7 +331,7 @@ class BaseWorkerHandler(ABC):
 
         self.dp_range = get_dp_range_for_worker(self.engine_client.vllm_config)
         self._sleep_wake_lock = asyncio.Lock()
-        self._sleeping_tags: set[str] = set()
+        self._engine_is_sleeping = False
 
         # Initialize InputParamManager for text-in-text-out mode
         tokenizer = None
@@ -342,45 +341,6 @@ class BaseWorkerHandler(ABC):
 
         # Store shutdown event for graceful shutdown monitoring
         self.shutdown_event = shutdown_event
-
-    @staticmethod
-    def _normalize_wake_tags(raw_tags: Any) -> list[str] | None:
-        if raw_tags is None:
-            return None
-
-        if isinstance(raw_tags, str):
-            candidates = [raw_tags]
-        else:
-            candidates = list(raw_tags)
-
-        deduped: list[str] = []
-        seen: set[str] = set()
-        for tag in candidates:
-            tag_str = str(tag)
-            if tag_str in seen:
-                continue
-            seen.add(tag_str)
-            deduped.append(tag_str)
-        return deduped
-
-    @staticmethod
-    def _is_benign_discovery_error(exc: Exception, operation: str) -> bool:
-        message = str(exc).lower()
-        if operation == "unregister":
-            benign_patterns = (
-                "already absent",
-                "not found",
-                "not registered",
-                "unknown endpoint",
-                "does not exist",
-            )
-        else:
-            benign_patterns = (
-                "already registered",
-                "already exists",
-                "duplicate",
-            )
-        return any(pattern in message for pattern in benign_patterns)
 
     async def sleep(self, body: dict) -> dict:
         """Sleep the engine to release GPU memory and unregister from discovery.
@@ -395,60 +355,32 @@ class BaseWorkerHandler(ABC):
         """
         body = body or {}
         level = body.get("level", 1)
-        requested_sleep_tags = set(DEFAULT_VLLM_SLEEP_TAGS)
         async with self._sleep_wake_lock:
-            if requested_sleep_tags.issubset(self._sleeping_tags):
+            if self._engine_is_sleeping:
                 return {
                     "status": "ok",
-                    "message": (
-                        "Engine already sleeping for tags: "
-                        f"{sorted(requested_sleep_tags)}"
-                    ),
+                    "message": "Engine already sleeping",
                 }
 
             try:
-                # Step 1: Unregister endpoint instance once when entering sleeping state.
-                if not self._sleeping_tags and self.generate_endpoint is not None:
-                    try:
-                        await self.generate_endpoint.unregister_endpoint_instance()
-                        logger.info(
-                            "[Sleep] Unregistered endpoint from discovery - worker removed from routing pool"
-                        )
-                    except Exception as unreg_err:
-                        if self._is_benign_discovery_error(
-                            unreg_err, operation="unregister"
-                        ):
-                            logger.info(
-                                "[Sleep] Endpoint already absent from discovery: %s",
-                                unreg_err,
-                            )
-                        else:
-                            logger.error(
-                                "[Sleep] Unexpected discovery unregister failure: %s",
-                                unreg_err,
-                            )
-                            return {
-                                "status": "error",
-                                "message": (
-                                    "Failed to unregister endpoint from discovery: "
-                                    f"{unreg_err}"
-                                ),
-                            }
+                # Step 1: Unregister endpoint instance before memory transitions.
+                if self.generate_endpoint is not None:
+                    await self.generate_endpoint.unregister_endpoint_instance()
+                    logger.info(
+                        "[Sleep] Unregistered endpoint from discovery - worker removed from routing pool"
+                    )
 
                 # Step 2: Abort in-flight requests and wait for them to drain so the
                 # GPU is fully quiesced before unmapping memory.
-                if not self._sleeping_tags:
-                    await self.engine_client.pause_generation()
+                await self.engine_client.pause_generation()
 
                 # Step 3: Now safe to sleep - no in-flight GPU work
                 await self.engine_client.sleep(level)
-                self._sleeping_tags.update(requested_sleep_tags)
+                self._engine_is_sleeping = True
 
                 return {
                     "status": "ok",
-                    "message": (
-                        f"Engine slept (level={level}, sleeping_tags={sorted(self._sleeping_tags)})"
-                    ),
+                    "message": f"Engine slept (level={level})",
                 }
             except Exception as e:
                 logger.error(f"Failed to sleep engine: {e}")
@@ -458,77 +390,33 @@ class BaseWorkerHandler(ABC):
         """Wake the engine to restore GPU memory and re-register to discovery.
 
         Args:
-            body: Dict with optional 'tags' key (e.g., ["weights", "kv_cache"]). None wakes all.
+            body: Unused. Wake always restores all sleep-managed memory.
 
         Order of operations:
         1. Wake engine - restore GPU memory
         2. Re-register endpoint instance - allow frontend to route requests here again
         """
-        body = body or {}
-        requested_tags = self._normalize_wake_tags(body.get("tags"))
         async with self._sleep_wake_lock:
-            if requested_tags is None:
-                tags_to_wake = set(self._sleeping_tags)
-            else:
-                unknown_tags = [
-                    tag for tag in requested_tags if tag not in self._sleeping_tags
-                ]
-                if unknown_tags:
-                    return {
-                        "status": "ok",
-                        "message": f"Engine already awake for tags: {unknown_tags}",
-                    }
-                tags_to_wake = set(requested_tags)
-
-            if not tags_to_wake:
-                return {
-                    "status": "ok",
-                    "message": "Engine already awake for requested tags",
-                }
+            if not self._engine_is_sleeping:
+                return {"status": "ok", "message": "Engine already awake"}
 
             try:
                 # Step 1: Wake engine first - must be ready before accepting requests
-                await self.engine_client.wake_up(
-                    None if requested_tags is None else sorted(tags_to_wake)
-                )
-                self._sleeping_tags.difference_update(tags_to_wake)
+                await self.engine_client.wake_up()
 
-                # Step 2: Resume generation and re-register only after full restore.
-                if not self._sleeping_tags:
-                    await self.engine_client.resume_generation()
-                    if self.generate_endpoint is not None:
-                        try:
-                            await self.generate_endpoint.register_endpoint_instance()
-                            logger.info(
-                                "[Wake] Re-registered endpoint to discovery - worker added back to routing pool"
-                            )
-                        except Exception as reg_err:
-                            if self._is_benign_discovery_error(
-                                reg_err, operation="register"
-                            ):
-                                logger.info(
-                                    "[Wake] Endpoint already registered in discovery: %s",
-                                    reg_err,
-                                )
-                            else:
-                                logger.error(
-                                    "[Wake] Unexpected discovery register failure: %s",
-                                    reg_err,
-                                )
-                                return {
-                                    "status": "error",
-                                    "message": (
-                                        "Failed to register endpoint to discovery: "
-                                        f"{reg_err}"
-                                    ),
-                                }
+                # Step 2: Resume generation and re-register.
+                await self.engine_client.resume_generation()
+                if self.generate_endpoint is not None:
+                    await self.generate_endpoint.register_endpoint_instance()
+                    logger.info(
+                        "[Wake] Re-registered endpoint to discovery - worker added back to routing pool"
+                    )
+
+                self._engine_is_sleeping = False
 
                 return {
                     "status": "ok",
-                    "message": (
-                        f"Engine woke (woken_tags={sorted(tags_to_wake)}, "
-                        f"remaining_sleeping_tags={sorted(self._sleeping_tags)})"
-                    ),
+                    "message": "Engine woke",
                 }
             except Exception as e:
                 logger.error(f"Failed to wake up engine: {e}")

--- a/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dynamo.vllm.handlers import BaseWorkerHandler
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+class _TestWorkerHandler(BaseWorkerHandler):
+    async def generate(self, request, context):
+        yield {}
+
+
+def _make_handler() -> _TestWorkerHandler:
+    handler = _TestWorkerHandler.__new__(_TestWorkerHandler)
+    handler.engine_client = SimpleNamespace(
+        pause_generation=AsyncMock(),
+        sleep=AsyncMock(),
+        wake_up=AsyncMock(),
+        resume_generation=AsyncMock(),
+    )
+    handler.generate_endpoint = SimpleNamespace(
+        unregister_endpoint_instance=AsyncMock(),
+        register_endpoint_instance=AsyncMock(),
+    )
+    handler._sleep_wake_lock = asyncio.Lock()
+    handler._engine_is_sleeping = False
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_wake_up_before_sleep_is_noop():
+    handler = _make_handler()
+
+    result = await handler.wake_up({})
+
+    assert result["status"] == "ok"
+    handler.engine_client.wake_up.assert_not_awaited()
+    handler.engine_client.resume_generation.assert_not_awaited()
+    handler.generate_endpoint.register_endpoint_instance.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sleep_and_wake_are_idempotent():
+    handler = _make_handler()
+
+    first_sleep = await handler.sleep({"level": 2})
+    second_sleep = await handler.sleep({"level": 2})
+
+    first_wake = await handler.wake_up({"tags": ["weights"]})
+    second_wake = await handler.wake_up({"tags": ["weights"]})
+
+    assert first_sleep["status"] == "ok"
+    assert second_sleep["status"] == "ok"
+    assert first_wake["status"] == "ok"
+    assert second_wake["status"] == "ok"
+
+    handler.engine_client.pause_generation.assert_awaited_once()
+    handler.engine_client.sleep.assert_awaited_once_with(2)
+    handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
+
+    handler.engine_client.wake_up.assert_awaited_once_with(["weights"])
+    handler.engine_client.resume_generation.assert_awaited_once()
+    handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()

--- a/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
@@ -3,7 +3,7 @@
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
 import pytest
 
@@ -35,7 +35,7 @@ def _make_handler() -> _TestWorkerHandler:
         register_endpoint_instance=AsyncMock(),
     )
     handler._sleep_wake_lock = asyncio.Lock()
-    handler._engine_is_sleeping = False
+    handler._sleeping_tags = set()
     return handler
 
 
@@ -52,24 +52,94 @@ async def test_wake_up_before_sleep_is_noop():
 
 
 @pytest.mark.asyncio
-async def test_sleep_and_wake_are_idempotent():
+async def test_sleep_and_wake_are_tag_aware_and_resume_on_full_restore():
     handler = _make_handler()
 
     first_sleep = await handler.sleep({"level": 2})
-    second_sleep = await handler.sleep({"level": 2})
-
-    first_wake = await handler.wake_up({"tags": ["weights"]})
-    second_wake = await handler.wake_up({"tags": ["weights"]})
+    partial_wake = await handler.wake_up({"tags": ["weights"]})
+    final_wake = await handler.wake_up({"tags": ["kv_cache"]})
 
     assert first_sleep["status"] == "ok"
-    assert second_sleep["status"] == "ok"
-    assert first_wake["status"] == "ok"
-    assert second_wake["status"] == "ok"
+    assert partial_wake["status"] == "ok"
+    assert final_wake["status"] == "ok"
 
     handler.engine_client.pause_generation.assert_awaited_once()
     handler.engine_client.sleep.assert_awaited_once_with(2)
     handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
 
-    handler.engine_client.wake_up.assert_awaited_once_with(["weights"])
+    assert handler.engine_client.wake_up.await_args_list == [
+        call(["weights"]),
+        call(["kv_cache"]),
+    ]
     handler.engine_client.resume_generation.assert_awaited_once()
     handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_repeated_sleep_is_idempotent():
+    handler = _make_handler()
+
+    first_sleep = await handler.sleep({"level": 1})
+    second_sleep = await handler.sleep({"level": 1})
+
+    assert first_sleep["status"] == "ok"
+    assert second_sleep["status"] == "ok"
+    handler.engine_client.sleep.assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_sleep_returns_error_for_unexpected_unregister_failure():
+    handler = _make_handler()
+    handler.generate_endpoint.unregister_endpoint_instance = AsyncMock(
+        side_effect=RuntimeError("discovery backend down")
+    )
+
+    result = await handler.sleep({"level": 1})
+
+    assert result["status"] == "error"
+    handler.engine_client.pause_generation.assert_not_awaited()
+    handler.engine_client.sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sleep_ignores_benign_unregister_failure():
+    handler = _make_handler()
+    handler.generate_endpoint.unregister_endpoint_instance = AsyncMock(
+        side_effect=RuntimeError("endpoint already absent")
+    )
+
+    result = await handler.sleep({"level": 1})
+
+    assert result["status"] == "ok"
+    handler.engine_client.pause_generation.assert_awaited_once()
+    handler.engine_client.sleep.assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_wake_up_returns_error_for_unexpected_register_failure():
+    handler = _make_handler()
+    handler._sleeping_tags = {"weights"}
+    handler.generate_endpoint.register_endpoint_instance = AsyncMock(
+        side_effect=RuntimeError("discovery write timeout")
+    )
+
+    result = await handler.wake_up({"tags": ["weights"]})
+
+    assert result["status"] == "error"
+    handler.engine_client.wake_up.assert_awaited_once_with(["weights"])
+    handler.engine_client.resume_generation.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_wake_up_ignores_benign_register_failure():
+    handler = _make_handler()
+    handler._sleeping_tags = {"weights"}
+    handler.generate_endpoint.register_endpoint_instance = AsyncMock(
+        side_effect=RuntimeError("already registered")
+    )
+
+    result = await handler.wake_up({"tags": ["weights"]})
+
+    assert result["status"] == "ok"
+    handler.engine_client.wake_up.assert_awaited_once_with(["weights"])
+    handler.engine_client.resume_generation.assert_awaited_once()

--- a/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
@@ -3,7 +3,7 @@
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -35,7 +35,7 @@ def _make_handler() -> _TestWorkerHandler:
         register_endpoint_instance=AsyncMock(),
     )
     handler._sleep_wake_lock = asyncio.Lock()
-    handler._sleeping_tags = set()
+    handler._engine_is_sleeping = False
     return handler
 
 
@@ -52,43 +52,30 @@ async def test_wake_up_before_sleep_is_noop():
 
 
 @pytest.mark.asyncio
-async def test_sleep_and_wake_are_tag_aware_and_resume_on_full_restore():
+async def test_sleep_and_wake_are_idempotent():
     handler = _make_handler()
 
     first_sleep = await handler.sleep({"level": 2})
-    partial_wake = await handler.wake_up({"tags": ["weights"]})
-    final_wake = await handler.wake_up({"tags": ["kv_cache"]})
+    second_sleep = await handler.sleep({"level": 2})
+    first_wake = await handler.wake_up({})
+    second_wake = await handler.wake_up({})
 
     assert first_sleep["status"] == "ok"
-    assert partial_wake["status"] == "ok"
-    assert final_wake["status"] == "ok"
+    assert second_sleep["status"] == "ok"
+    assert first_wake["status"] == "ok"
+    assert second_wake["status"] == "ok"
 
     handler.engine_client.pause_generation.assert_awaited_once()
     handler.engine_client.sleep.assert_awaited_once_with(2)
     handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
 
-    assert handler.engine_client.wake_up.await_args_list == [
-        call(["weights"]),
-        call(["kv_cache"]),
-    ]
+    handler.engine_client.wake_up.assert_awaited_once_with()
     handler.engine_client.resume_generation.assert_awaited_once()
     handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_repeated_sleep_is_idempotent():
-    handler = _make_handler()
-
-    first_sleep = await handler.sleep({"level": 1})
-    second_sleep = await handler.sleep({"level": 1})
-
-    assert first_sleep["status"] == "ok"
-    assert second_sleep["status"] == "ok"
-    handler.engine_client.sleep.assert_awaited_once_with(1)
-
-
-@pytest.mark.asyncio
-async def test_sleep_returns_error_for_unexpected_unregister_failure():
+async def test_sleep_returns_error_for_unregister_failure():
     handler = _make_handler()
     handler.generate_endpoint.unregister_endpoint_instance = AsyncMock(
         side_effect=RuntimeError("discovery backend down")
@@ -102,44 +89,15 @@ async def test_sleep_returns_error_for_unexpected_unregister_failure():
 
 
 @pytest.mark.asyncio
-async def test_sleep_ignores_benign_unregister_failure():
+async def test_wake_up_returns_error_for_register_failure():
     handler = _make_handler()
-    handler.generate_endpoint.unregister_endpoint_instance = AsyncMock(
-        side_effect=RuntimeError("endpoint already absent")
-    )
-
-    result = await handler.sleep({"level": 1})
-
-    assert result["status"] == "ok"
-    handler.engine_client.pause_generation.assert_awaited_once()
-    handler.engine_client.sleep.assert_awaited_once_with(1)
-
-
-@pytest.mark.asyncio
-async def test_wake_up_returns_error_for_unexpected_register_failure():
-    handler = _make_handler()
-    handler._sleeping_tags = {"weights"}
+    handler._engine_is_sleeping = True
     handler.generate_endpoint.register_endpoint_instance = AsyncMock(
         side_effect=RuntimeError("discovery write timeout")
     )
 
-    result = await handler.wake_up({"tags": ["weights"]})
+    result = await handler.wake_up({})
 
     assert result["status"] == "error"
-    handler.engine_client.wake_up.assert_awaited_once_with(["weights"])
-    handler.engine_client.resume_generation.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_wake_up_ignores_benign_register_failure():
-    handler = _make_handler()
-    handler._sleeping_tags = {"weights"}
-    handler.generate_endpoint.register_endpoint_instance = AsyncMock(
-        side_effect=RuntimeError("already registered")
-    )
-
-    result = await handler.wake_up({"tags": ["weights"]})
-
-    assert result["status"] == "ok"
-    handler.engine_client.wake_up.assert_awaited_once_with(["weights"])
+    handler.engine_client.wake_up.assert_awaited_once_with()
     handler.engine_client.resume_generation.assert_awaited_once()


### PR DESCRIPTION
## Summary
- make SGLang `release_memory_occupation` / `resume_memory_occupation` idempotent and order-safe in Dynamo handlers
- make vLLM `sleep` / `wake_up` idempotent and order-safe in Dynamo handlers
- default SGLang handler tags to `kv_cache` + `weights` (keep `cuda_graph` opt-in)
- add focused unit tests for no-op-on-out-of-order and repeated-call behavior

## Why
Calling resume/wake without a prior release/sleep can propagate invalid transitions into backend internals. In SGLang this can raise `KeyError` from `offload_tags.remove(...)` and crash the scheduler process.

## Validation
- `python3 -m compileall` on changed files
- `pytest` is not installed in this environment, so unit tests were not executed locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized memory-occupation management with normalized memory tags (kv_cache, weights).
  * Worker sleep/wake synchronization to safely pause and resume processing.

* **Bug Fixes**
  * Idempotent memory release/resume flows to avoid duplicate actions.
  * Idempotent, thread-safe worker sleep/wake operations with serialized transitions.

* **Tests**
  * Added tests for memory occupation lifecycle, partial resume behavior, and idempotency.
  * Added tests for sleep/wake handler behavior and edge-case error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->