### PR TITLE
fix: efficiently fill dummy data to bypass vLLM preprocessor in E/P/D

### DIFF
--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -271,10 +271,10 @@ def construct_qwen_decode_mm_data(
     # WAR: Use request_id hash as seed for unique placeholder values.
     # This prevents prefix cache from incorrectly matching different images
     # that happen to have the same dimensions (same image_grid_thw).
-    seed = hash(request_id) & 0xFFFFFFFF  # Convert to positive 32-bit int
-    generator = torch.Generator().manual_seed(seed)
-    image_embeds = torch.randn(
-        embeddings_shape, dtype=dtype, device="cpu", generator=generator
+    # bit ops to convert request ID to somewhat unique value that fits in the dtype range
+    fill_value = hash(request_id) & ((1 << (dtype.itemsize * 8)) - 1)
+    image_embeds = torch.full(
+        embeddings_shape, fill_value=fill_value, dtype=dtype, device="cpu"
     )
     if image_embeds.ndim == 3:
         image_embeds = image_embeds.squeeze(0)


### PR DESCRIPTION
Signed-off-by: Guan Luo <41310872+GuanLuo@users.noreply.github.com>

#### Overview:

Previous random generation for each element is inefficient and the fill time will scale with the size of mm embedding. Current approach randomlly select fill value and apply to the whole embedding. Note that in P/D scenario, this embedding content passed to decode worker doesn't matter: the real info has been absorted as KV cache and decode will get proper KV state from KV transfer. Here we must pass dummy embedding to bypass vLLM's preprocessing check.

#### Details:

<!-- Describe the changes made in this PR. -->
Filling time for request with image_num=4, resolution 640 * 640

Before
```
2026-03-05T23:25:27.427306Z  INFO worker_handler.generate: [DECODE] preprocessing time: 272.71 milliseconds
2026-03-05T23:25:27.713930Z  INFO worker_handler.generate: [DECODE] preprocessing time: 278.27 milliseconds
```
After:
```
2026-03-05T23:34:05.079656Z  INFO worker_handler.generate: [DECODE] preprocessing time: 9.61 milliseconds
2026-03-05T23:34:05.125148Z  INFO worker_handler.generate: [DECODE] preprocessing time: 6.72 milliseconds
2026-03-05T23:34:05.143057Z  INFO worker_handler.generate: [DECODE] preprocessing time: 5.93 milliseconds
```


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multimodal data generation now produces deterministic results based on request identifiers rather than random values, ensuring consistent behavior across executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->