### PR TITLE
chore: bump aiconfigurator to 0.7.0rc10

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@e7625204c82da8e176da3d648aac447ebfd9e2be",
+    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@5c5ecac04b2b8afb6395ec6c35bf45d05f8a686c",
     "aiperf @ git+https://github.com/ai-dynamo/aiperf.git@6450d7280de2e844ce5e98c5f6a4edb4b7773e8b",
     "matplotlib",
     "networkx",

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -12,7 +12,7 @@
 
 # For Multimodal EPD (required for device_map="auto" in vision model loading)
 accelerate
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@e7625204c82da8e176da3d648aac447ebfd9e2be
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@5c5ecac04b2b8afb6395ec6c35bf45d05f8a686c
 aiofiles
 aiperf @ git+https://github.com/ai-dynamo/aiperf.git@6450d7280de2e844ce5e98c5f6a4edb4b7773e8b
 av==15.0.0


### PR DESCRIPTION
#### Overview:

Bump AIConfigurator to the [commit of RC10](https://github.com/ai-dynamo/aiconfigurator/commit/5c5ecac04b2b8afb6395ec6c35bf45d05f8a686c)

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to: OPS-3516
