### PR TITLE
fix: ETCD cluster unhealthy when adding new member during E2E test & fix vLLM disagg launch config changed

### DIFF
--- a/tests/fault_tolerance/etcd_ha/test_vllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_vllm.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import shutil
+from typing import Optional
 
 import pytest
 
@@ -31,7 +32,12 @@ pytestmark = [
 class DynamoWorkerProcess(ManagedProcess):
     """Process manager for Dynamo worker with vLLM backend and ETCD HA support"""
 
-    def __init__(self, request, etcd_endpoints: list, is_prefill: bool = False):
+    def __init__(
+        self,
+        request,
+        etcd_endpoints: list,
+        is_prefill: Optional[bool] = None,
+    ):
         command = [
             "python3",
             "-m",
@@ -48,14 +54,19 @@ class DynamoWorkerProcess(ManagedProcess):
         # Set port based on worker type
         port = "8082" if is_prefill else "8081"
 
-        # Configure health check based on worker type
-        if is_prefill:
-            # Prefill workers check their own status endpoint
+        # Configure disaggregation mode, KV transfer, and health checks per worker type
+        if is_prefill is True:
             command.extend(["--disaggregation-mode", "prefill"])
             health_check_urls = [(f"http://localhost:{port}/health", self.is_ready)]
+        elif is_prefill is False:
+            command.extend(["--disaggregation-mode", "decode"])
+            health_check_urls = [
+                (f"http://localhost:{port}/health", self.is_ready),
+                (f"http://localhost:{FRONTEND_PORT}/v1/models", check_models_api),
+                (f"http://localhost:{FRONTEND_PORT}/health", check_health_generate),
+            ]
         else:
-            # Decode workers should also check their own status endpoint first,
-            # then verify the frontend sees the model
+            # Aggregated mode: no disaggregation
             health_check_urls = [
                 (f"http://localhost:{port}/health", self.is_ready),
                 (f"http://localhost:{FRONTEND_PORT}/v1/models", check_models_api),
@@ -69,7 +80,22 @@ class DynamoWorkerProcess(ManagedProcess):
         env["DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS"] = '["generate"]'
         env["DYN_SYSTEM_PORT"] = port
 
-        if is_prefill:
+        # Both prefill and decode workers need kv-transfer-config for disaggregated mode
+        if is_prefill is not None:
+            command.extend(
+                [
+                    "--kv-transfer-config",
+                    json.dumps(
+                        {
+                            "kv_connector": "NixlConnector",
+                            "kv_role": "kv_both",
+                        }
+                    ),
+                ]
+            )
+
+        # KV events config and NIXL side channel port only for prefill worker
+        if is_prefill is True:
             command.extend(
                 [
                     "--kv-events-config",

--- a/tests/fault_tolerance/etcd_ha/test_vllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_vllm.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import shutil
-from typing import Optional
+from enum import Enum
 
 import pytest
 
@@ -29,6 +29,12 @@ pytestmark = [
 ]
 
 
+class WorkerMode(Enum):
+    AGGREGATED = "aggregated"
+    PREFILL = "prefill"
+    DECODE = "decode"
+
+
 class DynamoWorkerProcess(ManagedProcess):
     """Process manager for Dynamo worker with vLLM backend and ETCD HA support"""
 
@@ -36,7 +42,7 @@ class DynamoWorkerProcess(ManagedProcess):
         self,
         request,
         etcd_endpoints: list,
-        is_prefill: Optional[bool] = None,
+        mode: WorkerMode = WorkerMode.AGGREGATED,
     ):
         command = [
             "python3",
@@ -52,21 +58,15 @@ class DynamoWorkerProcess(ManagedProcess):
         ]
 
         # Set port based on worker type
-        port = "8082" if is_prefill else "8081"
+        port = "8082" if mode == WorkerMode.PREFILL else "8081"
 
         # Configure disaggregation mode, KV transfer, and health checks per worker type
-        if is_prefill is True:
+        if mode == WorkerMode.PREFILL:
             command.extend(["--disaggregation-mode", "prefill"])
             health_check_urls = [(f"http://localhost:{port}/health", self.is_ready)]
-        elif is_prefill is False:
-            command.extend(["--disaggregation-mode", "decode"])
-            health_check_urls = [
-                (f"http://localhost:{port}/health", self.is_ready),
-                (f"http://localhost:{FRONTEND_PORT}/v1/models", check_models_api),
-                (f"http://localhost:{FRONTEND_PORT}/health", check_health_generate),
-            ]
         else:
-            # Aggregated mode: no disaggregation
+            if mode == WorkerMode.DECODE:
+                command.extend(["--disaggregation-mode", "decode"])
             health_check_urls = [
                 (f"http://localhost:{port}/health", self.is_ready),
                 (f"http://localhost:{FRONTEND_PORT}/v1/models", check_models_api),
@@ -81,7 +81,7 @@ class DynamoWorkerProcess(ManagedProcess):
         env["DYN_SYSTEM_PORT"] = port
 
         # Both prefill and decode workers need kv-transfer-config for disaggregated mode
-        if is_prefill is not None:
+        if mode != WorkerMode.AGGREGATED:
             command.extend(
                 [
                     "--kv-transfer-config",
@@ -95,7 +95,7 @@ class DynamoWorkerProcess(ManagedProcess):
             )
 
         # KV events config and NIXL side channel port only for prefill worker
-        if is_prefill is True:
+        if mode == WorkerMode.PREFILL:
             command.extend(
                 [
                     "--kv-events-config",
@@ -112,7 +112,7 @@ class DynamoWorkerProcess(ManagedProcess):
             env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = "5601"
 
         # Set log directory based on worker type
-        worker_type = "prefill_worker" if is_prefill else "worker"
+        worker_type = "prefill_worker" if mode == WorkerMode.PREFILL else "worker"
         log_dir = f"{request.node.name}_{worker_type}"
 
         # Clean up any existing log directory from previous runs
@@ -138,20 +138,18 @@ class DynamoWorkerProcess(ManagedProcess):
             log_dir=log_dir,
         )
 
-        self.is_prefill = is_prefill
+        self.mode = mode
 
     def is_ready(self, response) -> bool:
         """Check the health of the worker process"""
+        worker_type = "Prefill worker" if self.mode == WorkerMode.PREFILL else "Worker"
         try:
             data = response.json()
             if data.get("status") == "ready":
-                worker_type = "Prefill worker" if self.is_prefill else "Worker"
                 logger.info(f"{worker_type} status is ready")
                 return True
-            worker_type = "Prefill worker" if self.is_prefill else "Worker"
             logger.warning(f"{worker_type} status is not ready: {data.get('status')}")
         except ValueError:
-            worker_type = "Prefill worker" if self.is_prefill else "Worker"
             logger.warning(f"{worker_type} health response is not valid JSON")
         return False
 
@@ -268,11 +266,15 @@ def test_etcd_ha_failover_vllm_disaggregated(
                 logger.info("Frontend started successfully")
 
                 # Step 4: Start the prefill worker
-                with DynamoWorkerProcess(request, etcd_endpoints, is_prefill=True):
+                with DynamoWorkerProcess(
+                    request, etcd_endpoints, mode=WorkerMode.PREFILL
+                ):
                     logger.info("Prefill worker started successfully")
 
                     # Step 5: Start the decode worker
-                    with DynamoWorkerProcess(request, etcd_endpoints, is_prefill=False):
+                    with DynamoWorkerProcess(
+                        request, etcd_endpoints, mode=WorkerMode.DECODE
+                    ):
                         logger.info("Decode worker started successfully")
 
                         # Step 6: Send initial inference request to verify system is working
@@ -395,13 +397,13 @@ def test_etcd_non_ha_shutdown_vllm_disaggregated(
 
                 # Step 4: Start the prefill worker
                 with DynamoWorkerProcess(
-                    request, etcd_endpoints, is_prefill=True
+                    request, etcd_endpoints, mode=WorkerMode.PREFILL
                 ) as prefill_worker:
                     logger.info("Prefill worker started successfully")
 
                     # Step 5: Start the decode worker
                     with DynamoWorkerProcess(
-                        request, etcd_endpoints, is_prefill=False
+                        request, etcd_endpoints, mode=WorkerMode.DECODE
                     ) as decode_worker:
                         logger.info("Decode worker started successfully")
 

--- a/tests/fault_tolerance/etcd_ha/utils.py
+++ b/tests/fault_tolerance/etcd_ha/utils.py
@@ -294,9 +294,12 @@ class EtcdCluster:
         except Exception as e:
             raise RuntimeError(f"Error during member removal: {e}")
 
-        # Add the new member to the cluster
+        # Add the new member to the cluster, retrying if the cluster is temporarily unhealthy
+        # after member removal (etcd may reject adds until raft peers are fully connected)
         logger.info(f"Adding new member {name} to cluster with peer URL {peer_url}")
-        try:
+        max_attempts = 20
+        last_err = ""
+        for attempt in range(max_attempts):
             add_result = subprocess.run(
                 ["etcdctl", "member", "add", name, f"--peer-urls={peer_url}"],
                 env=etcdctl_env,
@@ -304,11 +307,18 @@ class EtcdCluster:
                 text=True,
                 timeout=5,
             )
-            if add_result.returncode != 0:
-                raise RuntimeError(f"Failed to add new member: {add_result.stderr}")
-            logger.info(f"Successfully added new member {name}")
-        except Exception as e:
-            raise RuntimeError(f"Error adding new member: {e}")
+            if add_result.returncode == 0:
+                logger.info(f"Successfully added new member {name}")
+                break
+            last_err = add_result.stderr.strip()
+            logger.warning(
+                f"Member add attempt {attempt + 1}/{max_attempts} failed: {last_err}"
+            )
+            time.sleep(0.5)  # time for cluster to stabilize before retrying
+        else:
+            raise RuntimeError(
+                f"Failed to add new member after {max_attempts} attempts: {last_err}"
+            )
 
     def start(self):
         """Start ETCD cluster with configured number of replicas"""


### PR DESCRIPTION
#### Overview:

Allow retries on failures when adding a new member to the ETCD cluster during E2E test.

Fix ETCD HA test vLLM disagg worker launch due to new required argument `--kv-transfer-config` being added.

#### Details:

ETCD may reject adds until raft peers are fully connected. Example after fix:
```
[TEST] 2026-03-06T00:29:30 INFO tests.fault_tolerance.etcd_ha.utils: Cluster is healthy with leader at etcd-0
[TEST] 2026-03-06T00:29:30 INFO tests.fault_tolerance.etcd_ha.utils: Getting member list to find etcd-1
[TEST] 2026-03-06T00:29:30 INFO tests.fault_tolerance.etcd_ha.utils: Removing member with ID ... (hex: ...)
[TEST] 2026-03-06T00:29:30 INFO tests.fault_tolerance.etcd_ha.utils: Successfully removed old member etcd-1
[TEST] 2026-03-06T00:29:30 INFO tests.fault_tolerance.etcd_ha.utils: Adding new member etcd-1 to cluster with peer URL http://127.0.0.1:2382
[TEST] 2026-03-06T00:29:30 WARNING tests.fault_tolerance.etcd_ha.utils: Member add attempt 1/20 failed: {...,"msg":"retrying of unary invoker failed",...}
Error: etcdserver: unhealthy cluster
[TEST] 2026-03-06T00:29:30 WARNING tests.fault_tolerance.etcd_ha.utils: Member add attempt 2/20 failed: {...,"msg":"retrying of unary invoker failed",...}
Error: etcdserver: unhealthy cluster
[TEST] 2026-03-06T00:29:31 INFO tests.fault_tolerance.etcd_ha.utils: Successfully added new member etcd-1
```

ETCD HA tests are passing after the fix, on 1.0.0rc5-cuda13:
```
dynamo@dynamo:/workspace/tests$ pytest fault_tolerance/etcd_ha -m "vllm or mypy" -v
======================================================================================================================= test session starts =======================================================================================================================
platform linux -- Python 3.12.3, pytest-8.4.2, pluggy-1.6.0 -- /opt/dynamo/venv/bin/python3
cachedir: .pytest_cache
benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /workspace
configfile: pyproject.toml
plugins: cov-7.0.0, pytest_httpserver-1.1.3, mock-3.15.1, order-1.3.0, asyncio-1.3.0, md-report-0.7.0, benchmark-5.2.3, xdist-3.8.0, forked-1.6.0, pytest_codeblocks-0.17.0, mypy-1.0.1, ai-dynamo-1.0.0, dash-3.1.1, timeout-2.4.0, anyio-4.12.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 18 items / 8 deselected / 10 selected                                                                                                                                                                                                                   

fault_tolerance/etcd_ha/__init__.py::mypy PASSED                                                                                                                                                                                                            [ 10%]
fault_tolerance/etcd_ha/__init__.py::mypy-status PASSED                                                                                                                                                                                                     [ 20%]
fault_tolerance/etcd_ha/test_sglang.py::mypy PASSED                                                                                                                                                                                                         [ 30%]
fault_tolerance/etcd_ha/test_trtllm.py::mypy PASSED                                                                                                                                                                                                         [ 40%]
fault_tolerance/etcd_ha/test_vllm.py::mypy PASSED                                                                                                                                                                                                           [ 50%]
fault_tolerance/etcd_ha/test_vllm.py::test_etcd_ha_failover_vllm_aggregated PASSED                                                                                                                                                                          [ 60%]
fault_tolerance/etcd_ha/test_vllm.py::test_etcd_ha_failover_vllm_disaggregated PASSED                                                                                                                                                                       [ 70%]
fault_tolerance/etcd_ha/test_vllm.py::test_etcd_non_ha_shutdown_vllm_aggregated PASSED                                                                                                                                                                      [ 80%]
fault_tolerance/etcd_ha/test_vllm.py::test_etcd_non_ha_shutdown_vllm_disaggregated PASSED                                                                                                                                                                   [ 90%]
fault_tolerance/etcd_ha/utils.py::mypy PASSED                                                                                                                                                                                                               [100%]
============================================================================================================================== mypy ===============================================================================================================================

Success: no issues found in 5 source files
========================================================================================================== 10 passed, 8 deselected in 187.02s (0:03:07) ===========================================================================================================
```

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced configuration support for prefill worker processes in high-availability fault tolerance testing scenarios
  * Strengthened etcd cluster stability with intelligent retry mechanisms for critical cluster operations, improving resilience against transient failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->