### PR TITLE
test: fix kvbm disagg determinism test on GB200 by setting the kv block size to 32 

### DIFF
--- a/tests/kvbm_integration/test_determinism_disagg.py
+++ b/tests/kvbm_integration/test_determinism_disagg.py
@@ -15,6 +15,7 @@ Compared to aggregated mode, disaggregated mode has some known randomness.
 Example reference: https://github.com/vllm-project/vllm/issues/7779#issuecomment-2304967870
 """
 
+import torch
 import logging
 import os
 import signal
@@ -49,6 +50,13 @@ pytestmark = [
 
 
 SUCCESS_RATE_THRESHOLD = 0.95
+
+# TRT-LLM will crash when loading the deepseek-ai/DeepSeek-R1-Distill-Llama-8B model on GB200 with a KV block size of 16.
+# As a workaround, use a block size of 32 on GB200.
+def is_gb200() -> bool:
+    if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
+        return False
+    return "GB200" in torch.cuda.get_device_name(0).upper()
 
 
 class LLMServerManager:
@@ -185,7 +193,7 @@ class LLMServerManager:
             "/tmp/kvbm_llm_api_decode_config.yaml",
         )
 
-        KV_BLOCK_SIZE = 16
+        KV_BLOCK_SIZE = 32 if is_gb200() else 16
 
         llm_api_config: Dict[str, Any] = {}
         llm_api_config["kv_cache_config"] = {
@@ -205,7 +213,7 @@ class LLMServerManager:
         prefill_config["disable_overlap_scheduler"] = True
         prefill_config["cache_transceiver_config"] = {
             "backend": "DEFAULT",
-            "max_tokens_in_buffer": 16384,
+            "max_tokens_in_buffer": 32768 if is_gb200() else 16384,
         }
         prefill_config["cuda_graph_config"] = None
 
@@ -227,7 +235,7 @@ class LLMServerManager:
             "--model",
             model,
             "--kv-block-size",
-            "16",
+            str(KV_BLOCK_SIZE),
             "--max-num-tokens",
             "8000",
         ]
@@ -478,7 +486,9 @@ class DisaggDeterminismTester(DeterminismTester):
         """Reset the prefix cache."""
         print("Resetting prefix cache...")
         # 150 shakespeare requests (each request is 200 words, and roughly 17 blocks) could evict 150 * 17 = 2550 blocks
-        shakespeare_count = 150
+        # On GB200, the block size is 32 tokens, and each request uses roughly 6 blocks.
+        # 300 × 6 = 1800 blocks should be enough to evict the GPU cache (which holds 1000 blocks).
+        shakespeare_count = 300 if is_gb200() else 150
         for seq_idx in range(1, shakespeare_count + 1):
             start_word = (seq_idx - 1) * self.word_count
             content = self.get_shakespeare_content(start_word)

--- a/tests/kvbm_integration/test_determinism_disagg.py
+++ b/tests/kvbm_integration/test_determinism_disagg.py
@@ -15,7 +15,6 @@ Compared to aggregated mode, disaggregated mode has some known randomness.
 Example reference: https://github.com/vllm-project/vllm/issues/7779#issuecomment-2304967870
 """
 
-import torch
 import logging
 import os
 import signal
@@ -51,12 +50,15 @@ pytestmark = [
 
 SUCCESS_RATE_THRESHOLD = 0.95
 
+
 # TRT-LLM will crash when loading the deepseek-ai/DeepSeek-R1-Distill-Llama-8B model on GB200 with a KV block size of 16.
 # As a workaround, use a block size of 32 on GB200.
 def is_gb200() -> bool:
-    if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
-        return False
-    return "GB200" in torch.cuda.get_device_name(0).upper()
+    out = subprocess.check_output(
+        ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+        text=True,
+    )
+    return bool(out.strip()) and "GB200" in out.splitlines()[0].upper()
 
 
 class LLMServerManager:


### PR DESCRIPTION
#### Overview:

TRTLLM will crash when loading deepseek-ai/DeepSeek-R1-Distill-Llama-8B with kv block size 16 on GB200.

Set TRTLLM kv block size to 32 for running the test for now. 

#### Details:

error log when setting kv block size to 16
```
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dynamo/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1794, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dynamo/venv/lib/python3.12/site-packages/tensorrt_llm/_torch/modules/attention.py", line 624, in forward
    attn_output = self.forward_impl(q,
                  ^^^^^^^^^^^^^^^^^^^^
  File "/opt/dynamo/venv/lib/python3.12/site-packages/tensorrt_llm/_torch/modules/attention.py", line 547, in forward_impl
    output, output_sf = self._attn_impl(q,
                        ^^^^^^^^^^^^^^^^^^
  File "/opt/dynamo/venv/lib/python3.12/site-packages/tensorrt_llm/_torch/modules/attention.py", line 476, in _attn_impl
    attn_output = self.attn.forward(
                  ^^^^^^^^^^^^^^^^^^
  File "/opt/dynamo/venv/lib/python3.12/site-packages/tensorrt_llm/_torch/attention_backend/trtllm.py", line 1940, in forward
    self.wrapper.run(q,
  File "/opt/dynamo/venv/lib/python3.12/site-packages/tensorrt_llm/_torch/attention_backend/trtllm.py", line 620, in run
    thop.attention(
RuntimeError: CUDA out of memory. Tried to allocate 23625.21 GiB. GPU 0 has a total capacity of 184.00 GiB of which 160.93 GiB is free. Process 585331 has 752.00 MiB memory in use. Including non-PyTorch memory, this process has 22.31 GiB memory in use. 184.00 GiB allowed; Of the allocated memory 15.43 GiB is allocated by PyTorch, and 19.33 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
Exception raised from malloc at /opt/pytorch/pytorch/c10/cuda/CUDACachingAllocator.cpp:1543 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0xd4 (0xfffd45f012b4 in /opt/dynamo/venv/lib/python3.12/site-packages/torch/lib/libc10.so)
```

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite with dynamic hardware detection and configuration optimization for better performance across different GPU types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->