### PR TITLE
chore: bump aiconfigurator to 0.7.0rc10 and aiperf to v0.6.0rc5 (#6975)

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -64,11 +64,6 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.uv]
-override-dependencies = [
-    "gradio==5.47.1"
-]
-
 [tool.setuptools]
 packages = ["prefix_data_generator"]
 

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,8 +40,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@7287307c4e3861b90927198da74e1adda53a4caf",
-    "aiperf @ git+https://github.com/ai-dynamo/aiperf.git@c3fc969e9e30e9ddad35b2f613aa7c1d418f2de9",
+    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@5c5ecac04b2b8afb6395ec6c35bf45d05f8a686c",
+    "aiperf @ git+https://github.com/ai-dynamo/aiperf.git@6450d7280de2e844ce5e98c5f6a4edb4b7773e8b",
     "matplotlib",
     "networkx",
     "numpy",

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -12,9 +12,9 @@
 
 # For Multimodal EPD (required for device_map="auto" in vision model loading)
 accelerate
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@7287307c4e3861b90927198da74e1adda53a4caf
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@5c5ecac04b2b8afb6395ec6c35bf45d05f8a686c
 aiofiles
-aiperf @ git+https://github.com/ai-dynamo/aiperf.git@54cd6dc820bff8bfebc875da104e59d745e14f75
+aiperf @ git+https://github.com/ai-dynamo/aiperf.git@6450d7280de2e844ce5e98c5f6a4edb4b7773e8b
 av==15.0.0
 fastapi==0.120.1
 filterpy==1.4.5


### PR DESCRIPTION
#### Overview:

Update `main` to the tip of release branches of tools as of EoD Thursday Mar 5, 2026.

<img width="918" height="254" alt="Screenshot 2026-03-05 at 23 29 01" src="https://github.com/user-attachments/assets/d7497201-ccc5-453d-8178-6a24b585de93" />
<img width="933" height="253" alt="Screenshot 2026-03-05 at 23 28 35" src="https://github.com/user-attachments/assets/495ae1d1-aa5a-4c90-a8ff-5223f0eab2e0" />


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to OPS-3516


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependencies to newer versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->