### PR TITLE
docs: update v1.0.0 backend versions in support matrix

### DIFF
--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -28,7 +28,7 @@ The following table shows the backend framework versions included with each Dyna
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
 | **main (ToT)** | `0.5.9` | `1.3.0rc5` | `0.16.0` | `0.10.1` |
-| **v1.0.0** *(in progress)* | `0.5.9` | `1.3.0rc5` | `0.15.1` | `0.10.1` |
+| **v1.0.0** *(in progress)* | `0.5.9` | `1.3.0rc5.post1` | `0.16.0` | `0.10.1` |
 | **v0.9.1** *(in progress)* | `0.5.8` | `1.3.0rc3` | `0.14.1` | `0.9.0` |
 | **v0.9.0** | `0.5.8` | `1.3.0rc1` | `0.14.1` | `0.9.0` |
 | **v0.8.1.post3** | `0.5.6.post2` | `1.2.0rc6.post3` | `0.12.0` | `0.8.0` |


### PR DESCRIPTION
## Summary
- Update TensorRT-LLM version for v1.0.0: `1.3.0rc5` → `1.3.0rc5.post1`
- Update vLLM version for v1.0.0: `0.15.1` → `0.16.0`

## Details
Corrects the target backend versions in the support matrix for the upcoming v1.0.0 release.

## Where should the reviewer start?
`docs/reference/support-matrix.md` — single line change in the backend dependencies table.

## Test Plan
- [ ] CI passes (docs linting, link checks)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated support matrix documentation with the latest backend dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->