### PR TITLE
fix: populate GIT_COMMIT_SHA envvar in containers built in CI (#7001)

### DIFF
--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -260,6 +260,8 @@ jobs:
           extra_tags: ${{ steps.extra-tags.outputs.tags }}
           push_image: ${{ inputs.push_image }}
           no_load: ${{ inputs.no_load }}
+          extra_build_args: |
+            DYNAMO_COMMIT_SHA=${{ github.sha }}
       - name: Show summary
         shell: bash
         if: ${{ inputs.push_image && inputs.show_summary }}


### PR DESCRIPTION
#### Overview:

Cherry-pick of PR #7001 

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes OPS-3677