### PR TITLE
fix(chrek): pass checkpointPath to restore (#6941)

### DIFF
--- a/deploy/chrek/pkg/criu/restore.go
+++ b/deploy/chrek/pkg/criu/restore.go
@@ -83,7 +83,7 @@ func ExecuteRestore(
 
 // BuildRestoreOpts assembles CriuOpts for a CRIU restore from the checkpoint manifest.
 // ImagesDirFd and WorkDirFd are left unset — ExecuteRestore opens them at restore time.
-func BuildRestoreOpts(m *types.CheckpointManifest, cgroupRoot string, log logr.Logger) (*criurpc.CriuOpts, error) {
+func BuildRestoreOpts(m *types.CheckpointManifest, checkpointPath string, cgroupRoot string, log logr.Logger) (*criurpc.CriuOpts, error) {
 	extMounts, err := buildRestoreExtMounts(m)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ func BuildRestoreOpts(m *types.CheckpointManifest, cgroupRoot string, log logr.L
 		}
 	}
 
-	criuConfPath := filepath.Join(settings.WorkDir, "..", criuConfFilename)
+	criuConfPath := filepath.Join(checkpointPath, criuConfFilename)
 	if _, err := os.Stat(criuConfPath); err == nil {
 		criuOpts.ConfigFile = proto.String(criuConfPath)
 	}

--- a/deploy/chrek/pkg/orchestrate/nsrestore.go
+++ b/deploy/chrek/pkg/orchestrate/nsrestore.go
@@ -42,7 +42,7 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 		"checkpoint_has_cuda", !m.CUDA.IsEmpty(),
 	)
 	// Phase 1: Configure — build CRIU opts from manifest
-	criuOpts, err := criu.BuildRestoreOpts(m, opts.CgroupRoot, log)
+	criuOpts, err := criu.BuildRestoreOpts(m, opts.CheckpointPath, opts.CgroupRoot, log)
 	if err != nil {
 		return 0, err
 	}
@@ -56,7 +56,6 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 	log.Info("nsrestore completed", "restored_pid", restoredPID, "duration", time.Since(restoreStart))
 	return restoredPID, nil
 }
-
 
 func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.CheckpointManifest, opts RestoreOptions, log logr.Logger) (int, error) {
 	// Apply rootfs diff inside the namespace (target root is /)


### PR DESCRIPTION
## Summary
Cherry-pick of #6941 onto `release/1.0.0`.

This fixes restore pod settings by passing `checkpointPath` through the restore flow so `criu.conf` can be found correctly during restore.

## Dependencies
None.

## Testing
- go test ./pkg/criu ./pkg/orchestrate