### PR TITLE
fix: hide inactive models from /v1/models (cherry-pick #6966)

### DIFF
--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -152,6 +152,31 @@ impl Model {
             .any(|entry| entry.value().has_videos_engine())
     }
 
+    /// Whether this model should be visible in /v1/models.
+    pub fn is_displayable(&self) -> bool {
+        let has_serving_engine = |ws: &WorkerSet| {
+            ws.has_chat_engine()
+                || ws.has_completions_engine()
+                || ws.has_embeddings_engine()
+                || ws.has_images_engine()
+                || ws.has_tensor_engine()
+                || ws.has_videos_engine()
+        };
+
+        let has_any_serving_engine = self.worker_sets.iter().any(|entry| {
+            let ws = entry.value();
+            has_serving_engine(ws.as_ref())
+        });
+
+        self.worker_sets.iter().any(|entry| {
+            let ws = entry.value();
+            if ws.worker_count() == 0 {
+                return false;
+            }
+            has_serving_engine(ws.as_ref()) || (!has_any_serving_engine && ws.is_prefill_set())
+        })
+    }
+
     /// Check if a candidate checksum is valid for this model.
     /// Returns `Some(true)` if it matches the canonical checksum, `Some(false)` if it
     /// doesn't match, or `None` if no canonical checksum has been set yet (no WorkerSets).

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -194,21 +194,11 @@ impl ModelManager {
     }
 
     pub fn model_display_names(&self) -> HashSet<String> {
-        let mut names = HashSet::new();
-        for entry in self.models.iter() {
-            let model = entry.value();
-            if model.has_chat_engine()
-                || model.has_completions_engine()
-                || model.has_embeddings_engine()
-                || model.has_images_engine()
-                || model.has_tensor_engine()
-                || model.has_videos_engine()
-                || model.has_prefill()
-            {
-                names.insert(entry.key().clone());
-            }
-        }
-        names
+        self.models
+            .iter()
+            .filter(|entry| entry.value().is_displayable())
+            .map(|entry| entry.key().clone())
+            .collect()
     }
 
     pub fn list_chat_completions_models(&self) -> Vec<String> {


### PR DESCRIPTION
Cherry-picks #6966 into `release/1.0.0`.

Original PR: https://github.com/ai-dynamo/dynamo/pull/6966
Original merge commit on `main`: `a9064c5113b80398fbba10f15dad7dc13c8149e9`
Cherry-pick commit on this branch: `8f8b5b9c5`
Dependencies: none

## Problem
When `sleep` is called on a vLLM engine or `release_memory_occupation` is called on a SGLang engine, requests may fail with `404 Model not found`, but `/v1/models` can still list that model.

This causes a discovery and routing mismatch:
- Discovery plane says model is available (`/v1/models`)
- Routing plane treats the model as unavailable (no active workers)

## Fix
Make `/v1/models` display logic worker-availability aware:
- add `Model::is_displayable()`
- only advertise models with at least one active worker set that can actually serve traffic
- preserve prefill-only behavior when the model has no serving engines

## Validation
- `cargo fmt -- --check`
- `cargo check -p dynamo-llm`
