### PR TITLE
fix: prune MoE candidates with insufficient TP before deployment in thorough mode

### DIFF
--- a/components/src/dynamo/profiler/thorough.py
+++ b/components/src/dynamo/profiler/thorough.py
@@ -152,14 +152,21 @@ def _prune_infeasible_candidates(
     pruned: list = []
     for candidate in candidates:
         tp = candidate.tp
+        pp = getattr(candidate, "pp", 1) or 1
+        moe_tp = getattr(candidate, "moe_tp", 1) or 1
         ep = getattr(candidate, "moe_ep", 1) or 1
 
+        # Dense weights (attention, embeddings) are sharded by TP × PP.
+        total_shards_dense = tp * pp
         if model_info.is_moe:
-            # Dense weights: split by TP only (EP does not distribute them).
-            # Expert weights: split by TP × EP.
-            per_gpu_mib = dense_size_mib / tp + expert_size_mib / (tp * ep)
+            # Expert weights are additionally sharded by moe_tp × moe_ep.
+            total_shards_expert = total_shards_dense * moe_tp * ep
+            per_gpu_mib = (
+                dense_size_mib / total_shards_dense
+                + expert_size_mib / total_shards_expert
+            )
         else:
-            per_gpu_mib = model_info.model_size / tp
+            per_gpu_mib = model_info.model_size / total_shards_dense
 
         if per_gpu_mib <= usable_vram_mib:
             feasible.append(candidate)
@@ -178,9 +185,11 @@ def _prune_infeasible_candidates(
         )
         for candidate, per_gpu_mib in pruned:
             logger.warning(
-                "  Pruned %s tp=%d ep=%d: ~%.1f GiB estimated > %.1f GiB usable",
+                "  Pruned %s tp=%d pp=%d moe_tp=%d ep=%d: ~%.1f GiB estimated > %.1f GiB usable",
                 label,
                 candidate.tp,
+                getattr(candidate, "pp", 1) or 1,
+                getattr(candidate, "moe_tp", 1) or 1,
                 getattr(candidate, "moe_ep", 1) or 1,
                 per_gpu_mib / 1024,
                 usable_vram_mib / 1024,
@@ -482,8 +491,16 @@ async def run_thorough(
     # timeouts per OOM candidate.
     vram_mib = (dgdr.hardware and dgdr.hardware.vramMb) or 0.0
     if vram_mib > 0:
+        model_info = None
         try:
             model_info = get_model_info(model)
+        except (OSError, ValueError, RuntimeError) as exc:
+            logger.warning(
+                "Could not load model info for VRAM feasibility check (%s). "
+                "Skipping candidate pruning — infeasible candidates may be deployed.",
+                exc,
+            )
+        if model_info is not None:
             prefill_candidates = _prune_infeasible_candidates(
                 prefill_candidates, model_info, vram_mib, "prefill"
             )
@@ -494,12 +511,6 @@ async def run_thorough(
                 "After VRAM pruning: %d prefill candidates, %d decode candidates",
                 len(prefill_candidates),
                 len(decode_candidates),
-            )
-        except Exception as exc:
-            logger.warning(
-                "Could not load model info for VRAM feasibility check (%s). "
-                "Skipping candidate pruning — infeasible candidates may be deployed.",
-                exc,
             )
     else:
         logger.debug(

--- a/components/src/dynamo/profiler/thorough.py
+++ b/components/src/dynamo/profiler/thorough.py
@@ -44,6 +44,7 @@ from dynamo.profiler.utils.dgdr_v1beta1_types import (
     DynamoGraphDeploymentRequestSpec,
     ModelCacheSpec,
 )
+from dynamo.profiler.utils.model_info import ModelInfo, get_model_info
 from dynamo.profiler.utils.profile_common import (
     ProfilerOperationalConfig,
     derive_backend_image,
@@ -53,6 +54,139 @@ from dynamo.profiler.utils.profile_common import (
 from dynamo.profiler.utils.profile_decode import get_num_request_range
 
 logger = logging.getLogger(__name__)
+
+# Fraction of GPU VRAM assumed usable for model weights (remainder is KV cache
+# and activation workspace).
+_MODEL_GPU_MEM_FRAC = 0.9
+
+
+def _estimate_dense_size_mib(model_info: ModelInfo) -> float:
+    """Estimate the size of dense (non-expert) weights in MiB.
+
+    For non-MoE models, returns the full model size.
+    For MoE models, estimates only the attention projection and embedding
+    weights that are replicated per TP rank and are *not* distributed by EP.
+    The expert FFN weights are excluded because EP shards them.
+
+    The estimate uses the formula::
+
+        dense_params = num_hidden_layers × 4 × hidden_size²   (attention)
+                     + 2 × vocab_size × hidden_size            (embeddings + LM head)
+
+    This is intentionally conservative (may under-count some dense weights
+    such as shared experts and router networks) so that infeasible candidates
+    are pruned while over-large TP requirements are not imposed.
+
+    Returns:
+        Estimated dense weight size in MiB (model_size units).
+    """
+    if not model_info.is_moe or model_info.num_experts is None:
+        return model_info.model_size
+
+    hidden_size = model_info.hidden_size
+    num_layers = model_info.num_hidden_layers
+    vocab_size = model_info.vocab_size
+    num_experts = model_info.num_experts
+    intermediate_size = model_info.intermediate_size
+
+    if not (hidden_size and num_layers):
+        # Insufficient architecture info — fall back to full model size.
+        logger.debug(
+            "Missing hidden_size or num_hidden_layers; using full model size as "
+            "dense-layer estimate (conservative)."
+        )
+        return model_info.model_size
+
+    # Attention + embedding dense params.
+    attention_params = num_layers * 4 * hidden_size * hidden_size
+    embedding_params = 2 * (vocab_size or 0) * hidden_size
+    dense_params = attention_params + embedding_params
+
+    # Expert FFN params (sharded by EP).
+    if intermediate_size and num_experts > 0:
+        expert_params = num_layers * num_experts * 3 * hidden_size * intermediate_size
+    else:
+        expert_params = 0
+
+    total_estimated_params = dense_params + expert_params
+    if total_estimated_params == 0:
+        return model_info.model_size
+
+    dense_fraction = dense_params / total_estimated_params
+    return model_info.model_size * dense_fraction
+
+
+def _prune_infeasible_candidates(
+    candidates: list,
+    model_info: ModelInfo,
+    vram_mib: float,
+    label: str = "candidate",
+) -> list:
+    """Remove candidates whose estimated per-GPU memory exceeds available VRAM.
+
+    For MoE models, expert weights are distributed via EP across ``moe_ep``
+    GPUs, but dense weights (attention, embeddings) are *not* — they must fit
+    within ``vram_mib / tp``.  Candidates that cannot satisfy the memory
+    budget are logged and dropped, preventing guaranteed OOM deployments.
+
+    For non-MoE models all weights are TP-sharded uniformly.
+
+    Args:
+        candidates: List of profiling candidate objects (each with ``.tp``
+            and ``.moe_ep`` attributes).
+        model_info: Model architecture and weight-size metadata.
+        vram_mib: VRAM per GPU in MiB.
+        label: Human-readable name used in log messages (e.g. "prefill").
+
+    Returns:
+        Filtered list containing only memory-feasible candidates.
+    """
+    if vram_mib <= 0:
+        return candidates
+
+    dense_size_mib = _estimate_dense_size_mib(model_info)
+    expert_size_mib = max(0.0, model_info.model_size - dense_size_mib)
+    usable_vram_mib = vram_mib * _MODEL_GPU_MEM_FRAC
+
+    feasible: list = []
+    pruned: list = []
+    for candidate in candidates:
+        tp = candidate.tp
+        ep = getattr(candidate, "moe_ep", 1) or 1
+
+        if model_info.is_moe:
+            # Dense weights: split by TP only (EP does not distribute them).
+            # Expert weights: split by TP × EP.
+            per_gpu_mib = dense_size_mib / tp + expert_size_mib / (tp * ep)
+        else:
+            per_gpu_mib = model_info.model_size / tp
+
+        if per_gpu_mib <= usable_vram_mib:
+            feasible.append(candidate)
+        else:
+            pruned.append((candidate, per_gpu_mib))
+
+    if pruned:
+        logger.warning(
+            "Pruned %d infeasible %s candidate(s): estimated per-GPU memory "
+            "exceeds %.1f GiB × %.0f%% = %.1f GiB usable VRAM:",
+            len(pruned),
+            label,
+            vram_mib / 1024,
+            _MODEL_GPU_MEM_FRAC * 100,
+            usable_vram_mib / 1024,
+        )
+        for candidate, per_gpu_mib in pruned:
+            logger.warning(
+                "  Pruned %s tp=%d ep=%d: ~%.1f GiB estimated > %.1f GiB usable",
+                label,
+                candidate.tp,
+                getattr(candidate, "moe_ep", 1) or 1,
+                per_gpu_mib / 1024,
+                usable_vram_mib / 1024,
+            )
+
+    return feasible
 
 
 async def _benchmark_prefill_candidates(
@@ -340,6 +474,37 @@ async def run_thorough(
         len(prefill_candidates),
         len(decode_candidates),
     )
+
+    # --- Stage 1.5: Prune candidates that cannot fit in GPU VRAM ---
+    # For MoE models with EP, expert weights are sharded across moe_ep GPUs,
+    # but dense layers (attention, embeddings) are NOT — they must fit within
+    # vram_mib / tp.  Skipping this check wastes cluster time on 1-hour
+    # timeouts per OOM candidate.
+    vram_mib = (dgdr.hardware and dgdr.hardware.vramMb) or 0.0
+    if vram_mib > 0:
+        try:
+            model_info = get_model_info(model)
+            prefill_candidates = _prune_infeasible_candidates(
+                prefill_candidates, model_info, vram_mib, "prefill"
+            )
+            decode_candidates = _prune_infeasible_candidates(
+                decode_candidates, model_info, vram_mib, "decode"
+            )
+            logger.info(
+                "After VRAM pruning: %d prefill candidates, %d decode candidates",
+                len(prefill_candidates),
+                len(decode_candidates),
+            )
+        except Exception as exc:
+            logger.warning(
+                "Could not load model info for VRAM feasibility check (%s). "
+                "Skipping candidate pruning — infeasible candidates may be deployed.",
+                exc,
+            )
+    else:
+        logger.debug(
+            "hardware.vramMb not set; skipping per-candidate VRAM feasibility check."
+        )
 
     if dgdr.overrides and dgdr.overrides.dgd:
         for candidate in prefill_candidates:

--- a/components/src/dynamo/profiler/utils/model_info.py
+++ b/components/src/dynamo/profiler/utils/model_info.py
@@ -121,6 +121,9 @@ class ModelInfo(BaseModel):
     intermediate_size: Optional[int] = None
     num_kv_heads: Optional[int] = None
     quantization_block_size: Optional[int] = None
+    hidden_size: Optional[int] = None
+    num_hidden_layers: Optional[int] = None
+    vocab_size: Optional[int] = None
 
 
 def get_model_info(
@@ -228,6 +231,10 @@ def get_model_info(
         ):
             quantization_block_size = max(quantization_block_size)
 
+    hidden_size = getattr(config, "hidden_size", None)
+    num_hidden_layers = getattr(config, "num_hidden_layers", None)
+    vocab_size = getattr(config, "vocab_size", None)
+
     return ModelInfo(
         model_size=model_size,
         architecture=architecture,
@@ -237,6 +244,9 @@ def get_model_info(
         intermediate_size=intermediate_size,
         num_kv_heads=num_kv_heads,
         quantization_block_size=quantization_block_size,
+        hidden_size=hidden_size,
+        num_hidden_layers=num_hidden_layers,
+        vocab_size=vocab_size,
     )
 
 

--- a/tests/profiler/test_helpers_thorough.py
+++ b/tests/profiler/test_helpers_thorough.py
@@ -19,7 +19,11 @@ project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 try:
-    from dynamo.profiler.thorough import _pick_thorough_best_config
+    from dynamo.profiler.thorough import (
+        _estimate_dense_size_mib,
+        _pick_thorough_best_config,
+        _prune_infeasible_candidates,
+    )
     from dynamo.profiler.utils.aic_dataframe import build_decode_row, build_prefill_row
     from dynamo.profiler.utils.dgdr_v1beta1_types import (
         DynamoGraphDeploymentRequestSpec,
@@ -27,6 +31,7 @@ try:
         SLASpec,
         WorkloadSpec,
     )
+    from dynamo.profiler.utils.model_info import ModelInfo
 except ImportError as e:
     pytest.skip(f"Skip (missing dependency): {e}", allow_module_level=True)
 
@@ -253,3 +258,206 @@ class TestPickThoroughBestConfig:
         kwargs = mock_pick.call_args.kwargs
         assert "target_request_rate" not in kwargs
         assert "max_total_gpus" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Helpers for VRAM-pruning tests
+# ---------------------------------------------------------------------------
+
+
+def _make_model_info(
+    model_size_mib: float,
+    is_moe: bool = False,
+    num_experts: int = 0,
+    hidden_size: int = 0,
+    num_hidden_layers: int = 0,
+    vocab_size: int = 0,
+    intermediate_size: int = 0,
+) -> ModelInfo:
+    return ModelInfo(
+        model_size=model_size_mib,
+        architecture="DeepseekV3ForCausalLM" if is_moe else "LlamaForCausalLM",
+        is_moe=is_moe,
+        num_experts=num_experts or None,
+        hidden_size=hidden_size or None,
+        num_hidden_layers=num_hidden_layers or None,
+        vocab_size=vocab_size or None,
+        intermediate_size=intermediate_size or None,
+    )
+
+
+class _FakeCandidate:
+    """Minimal stand-in for an AIC profiling candidate."""
+
+    def __init__(self, tp: int, moe_ep: int = 1):
+        self.tp = tp
+        self.moe_ep = moe_ep
+
+
+# ---------------------------------------------------------------------------
+# _estimate_dense_size_mib
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateDenseSizeMib:
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_non_moe_returns_full_model_size(self):
+        """Non-MoE: dense size == total model size."""
+        info = _make_model_info(model_size_mib=100_000.0, is_moe=False)
+        assert _estimate_dense_size_mib(info) == 100_000.0
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_moe_missing_hidden_size_falls_back_to_full(self):
+        """MoE without hidden_size: conservatively returns full model size."""
+        info = _make_model_info(
+            model_size_mib=1_310_720.0, is_moe=True, num_experts=256
+        )
+        # hidden_size and num_hidden_layers are None → fallback
+        assert _estimate_dense_size_mib(info) == 1_310_720.0
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_moe_dense_fraction_less_than_total(self):
+        """MoE with architecture info: dense estimate is a fraction of total."""
+        # DeepSeek-R1 approximate numbers
+        info = _make_model_info(
+            model_size_mib=1_310_720.0,
+            is_moe=True,
+            num_experts=256,
+            hidden_size=7168,
+            num_hidden_layers=61,
+            vocab_size=129_280,
+            intermediate_size=2048,
+        )
+        dense = _estimate_dense_size_mib(info)
+        assert dense < info.model_size, "Dense estimate must be less than total"
+        assert dense > 0, "Dense estimate must be positive"
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_moe_no_intermediate_size_still_works(self):
+        """MoE without intermediate_size: expert_params=0, dense=full model."""
+        info = _make_model_info(
+            model_size_mib=1_310_720.0,
+            is_moe=True,
+            num_experts=256,
+            hidden_size=7168,
+            num_hidden_layers=61,
+            vocab_size=129_280,
+            intermediate_size=0,  # missing → expert_params = 0
+        )
+        # When expert_params == 0, dense_fraction = 1.0, so returns full size.
+        assert _estimate_dense_size_mib(info) == info.model_size
+
+
+# ---------------------------------------------------------------------------
+# _prune_infeasible_candidates  (TC-3.4 regression)
+# ---------------------------------------------------------------------------
+
+
+class TestPruneInfeasibleCandidates:
+    """Regression tests for TC-3.4: DeepSeek-R1 (671B MoE) on B200 (180 GiB)."""
+
+    # B200 VRAM in MiB
+    B200_VRAM_MIB = 180 * 1024  # 184_320
+
+    # Approximate DeepSeek-R1 BF16 model size in MiB (~1280 GiB)
+    DSR1_SIZE_MIB = 1_310_720.0
+
+    def _dsr1_info(self) -> ModelInfo:
+        return _make_model_info(
+            model_size_mib=self.DSR1_SIZE_MIB,
+            is_moe=True,
+            num_experts=256,
+            hidden_size=7168,
+            num_hidden_layers=61,
+            vocab_size=129_280,
+            intermediate_size=2048,
+        )
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_tp1_ep8_pruned_on_b200(self):
+        """tp=1, ep=8 (OOM case) must be pruned on 180 GiB B200."""
+        info = self._dsr1_info()
+        candidates = [_FakeCandidate(tp=1, moe_ep=8)]
+        result = _prune_infeasible_candidates(
+            candidates, info, self.B200_VRAM_MIB, "prefill"
+        )
+        assert result == [], "tp=1,ep=8 should be pruned (OOM on B200)"
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_tp8_ep8_kept_on_b200(self):
+        """tp=8, ep=8 (the only viable 8-GPU candidate) must survive pruning."""
+        info = self._dsr1_info()
+        candidate = _FakeCandidate(tp=8, moe_ep=8)
+        result = _prune_infeasible_candidates(
+            [candidate], info, self.B200_VRAM_MIB, "prefill"
+        )
+        assert result == [candidate], "tp=8,ep=8 should survive VRAM check on B200"
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_tp1_ep16_kept_on_b200(self):
+        """tp=1, ep=16 distributes experts enough to fit on B200."""
+        info = self._dsr1_info()
+        candidate = _FakeCandidate(tp=1, moe_ep=16)
+        result = _prune_infeasible_candidates(
+            [candidate], info, self.B200_VRAM_MIB, "prefill"
+        )
+        assert result == [
+            candidate
+        ], "tp=1,ep=16 should fit on B200 (experts split 16 ways)"
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_mixed_candidates_only_feasible_survive(self):
+        """Only memory-feasible candidates survive; infeasible ones are pruned."""
+        info = self._dsr1_info()
+        tp1_ep8 = _FakeCandidate(tp=1, moe_ep=8)
+        tp1_ep16 = _FakeCandidate(tp=1, moe_ep=16)
+        tp8_ep8 = _FakeCandidate(tp=8, moe_ep=8)
+
+        result = _prune_infeasible_candidates(
+            [tp1_ep8, tp1_ep16, tp8_ep8], info, self.B200_VRAM_MIB, "prefill"
+        )
+        assert tp1_ep8 not in result, "tp=1,ep=8 must be pruned"
+        assert tp1_ep16 in result, "tp=1,ep=16 must survive"
+        assert tp8_ep8 in result, "tp=8,ep=8 must survive"
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_no_vram_info_skips_pruning(self):
+        """When vram_mib=0, no candidates are pruned (check is skipped)."""
+        info = self._dsr1_info()
+        candidates = [
+            _FakeCandidate(tp=1, moe_ep=1),
+            _FakeCandidate(tp=1, moe_ep=8),
+        ]
+        result = _prune_infeasible_candidates(candidates, info, 0.0, "prefill")
+        assert result == candidates, "vram_mib=0 must disable pruning"
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_non_moe_pruning_uses_full_model_size(self):
+        """For a non-MoE model, the full model size is used (no EP benefit)."""
+        # 200 GiB model on a 100 GiB GPU
+        info = _make_model_info(
+            model_size_mib=200 * 1024, is_moe=False, hidden_size=4096
+        )
+        vram_mib = 100 * 1024  # 100 GiB
+
+        # tp=1: 200 GiB > 90 GiB usable → pruned
+        tp1 = _FakeCandidate(tp=1)
+        # tp=2: 100 GiB == 90 GiB usable → still pruned (not ≤)
+        tp2 = _FakeCandidate(tp=2)
+        # tp=4: 50 GiB < 90 GiB → feasible
+        tp4 = _FakeCandidate(tp=4)
+
+        result = _prune_infeasible_candidates([tp1, tp2, tp4], info, vram_mib, "decode")
+        assert tp1 not in result
+        assert tp2 not in result
+        assert tp4 in result

--- a/tests/profiler/test_helpers_thorough.py
+++ b/tests/profiler/test_helpers_thorough.py
@@ -289,9 +289,11 @@ def _make_model_info(
 class _FakeCandidate:
     """Minimal stand-in for an AIC profiling candidate."""
 
-    def __init__(self, tp: int, moe_ep: int = 1):
+    def __init__(self, tp: int, moe_ep: int = 1, pp: int = 1, moe_tp: int = 1):
         self.tp = tp
         self.moe_ep = moe_ep
+        self.pp = pp
+        self.moe_tp = moe_tp
 
 
 # ---------------------------------------------------------------------------
@@ -461,3 +463,35 @@ class TestPruneInfeasibleCandidates:
         assert tp1 not in result
         assert tp2 not in result
         assert tp4 in result
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_pp_shards_dense_weights(self):
+        """pp>1 reduces per-GPU dense-weight pressure, potentially saving a candidate."""
+        info = self._dsr1_info()
+        # tp=1, pp=1, ep=8 is pruned (OOM baseline)
+        tp1_pp1 = _FakeCandidate(tp=1, moe_ep=8, pp=1)
+        # tp=1, pp=2, ep=8: dense split across 2 pipeline stages → half the dense per GPU
+        tp1_pp2 = _FakeCandidate(tp=1, moe_ep=8, pp=2)
+        result = _prune_infeasible_candidates(
+            [tp1_pp1, tp1_pp2], info, self.B200_VRAM_MIB, "prefill"
+        )
+        assert tp1_pp1 not in result, "tp=1,pp=1,ep=8 must be pruned"
+        assert tp1_pp2 in result, "tp=1,pp=2,ep=8 should survive (pp halves dense load)"
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_moe_tp_shards_expert_weights(self):
+        """moe_tp>1 increases expert sharding, reducing per-GPU expert pressure."""
+        info = self._dsr1_info()
+        # tp=1, ep=8, moe_tp=1 → pruned
+        baseline = _FakeCandidate(tp=1, moe_ep=8, moe_tp=1)
+        # tp=1, ep=8, moe_tp=2 → expert shards = tp*pp*moe_tp*ep = 1*1*2*8 = 16
+        moe_tp2 = _FakeCandidate(tp=1, moe_ep=8, moe_tp=2)
+        result = _prune_infeasible_candidates(
+            [baseline, moe_tp2], info, self.B200_VRAM_MIB, "prefill"
+        )
+        assert baseline not in result, "tp=1,ep=8,moe_tp=1 must be pruned"
+        assert (
+            moe_tp2 in result
+        ), "tp=1,ep=8,moe_tp=2 should fit (experts split 16 ways)"


### PR DESCRIPTION
#### Overview:

In THOROUGH mode, enumerate_profiling_configs generates candidates with tp=1 for MoE models even when dense layers (attention/embeddings) cannot fit in a single GPU's VRAM — EP only shards expert weights, not dense weights. This caused guaranteed OOM failures and wasted hours of cluster time waiting for 1-hour deployment timeouts per infeasible candidate (e.g. DeepSeek-R1 671B on B200 180 GiB). The fix adds a post-enumeration pruning step that estimates per-GPU memory as `dense_size/tp + expert_size/(tp*ep)` and drops any candidate exceeding `vram * 0.9` before deployment begins.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent GPU memory estimation to automatically filter out infeasible model deployment configurations based on available VRAM.
  * Extended model metadata retrieval to include additional parameters for better resource planning.

* **Tests**
  * Added comprehensive test coverage for memory-based configuration filtering and model information extraction across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->