### PR TITLE
chore: restrict Dynamo Snapshot to x86_64, document backend support

### DIFF
--- a/deploy/helm/charts/snapshot/README.md
+++ b/deploy/helm/charts/snapshot/README.md
@@ -19,6 +19,7 @@ This Helm chart deploys the checkpoint/restore infrastructure for NVIDIA Dynamo,
 - Kubernetes 1.21+
 - **x86_64 (amd64) nodes only** for the snapshot agent and placeholder images
 - GPU nodes with NVIDIA runtime (`nvidia` runtime class)
+- NVIDIA driver 580.xx or newer on the target GPU nodes
 - containerd runtime (for container inspection; CRIU is bundled in Dynamo Snapshot images)
 - NVIDIA Dynamo operator installed (cluster-wide or namespace-scoped)
 - RWX (ReadWriteMany) storage class for multi-node deployments

--- a/deploy/helm/charts/snapshot/README.md
+++ b/deploy/helm/charts/snapshot/README.md
@@ -17,6 +17,7 @@ This Helm chart deploys the checkpoint/restore infrastructure for NVIDIA Dynamo,
 ⚠️ **Security Warning**: The Dynamo Snapshot DaemonSet runs in **privileged mode** with `hostPID`, `hostIPC`, and `hostNetwork` to perform CRIU checkpoint/restore operations. Workload pods do not need privileged mode. Only deploy in environments where a privileged DaemonSet is acceptable.
 
 - Kubernetes 1.21+
+- **x86_64 (amd64) nodes only** for the snapshot agent and placeholder images
 - GPU nodes with NVIDIA runtime (`nvidia` runtime class)
 - containerd runtime (for container inspection; CRIU is bundled in Dynamo Snapshot images)
 - NVIDIA Dynamo operator installed (cluster-wide or namespace-scoped)
@@ -35,9 +36,9 @@ export NAMESPACE=my-team  # Your target namespace
 export DOCKER_SERVER=your-registry.com/  # Your container registry
 export IMAGE_TAG=latest
 
-# Build Dynamo Snapshot agent image
+# Build Dynamo Snapshot agent image (amd64 only)
 cd deploy/snapshot
-docker build --target agent -t $DOCKER_SERVER/snapshot-agent:$IMAGE_TAG .
+docker build --platform linux/amd64 --target agent -t $DOCKER_SERVER/snapshot-agent:$IMAGE_TAG .
 docker push $DOCKER_SERVER/snapshot-agent:$IMAGE_TAG
 cd -
 

--- a/deploy/helm/charts/snapshot/templates/daemonset.yaml
+++ b/deploy/helm/charts/snapshot/templates/daemonset.yaml
@@ -38,10 +38,19 @@ spec:
         {{- with .Values.daemonset.tolerations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.daemonset.affinity }}
       affinity:
+        # cuda-checkpoint only supports x86_64 — never schedule on arm64 nodes
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+        {{- with .Values.daemonset.affinity }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       # CUDA checkpoint/restore requires the nvidia container runtime
       runtimeClassName: nvidia
       {{- if .Values.seccomp.deploy }}

--- a/deploy/helm/charts/snapshot/templates/daemonset.yaml
+++ b/deploy/helm/charts/snapshot/templates/daemonset.yaml
@@ -38,6 +38,9 @@ spec:
         {{- with .Values.daemonset.tolerations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if and .Values.daemonset.affinity (hasKey .Values.daemonset.affinity "nodeAffinity") }}
+      {{- fail "daemonset.affinity.nodeAffinity is not supported because the chart already enforces kubernetes.io/arch=amd64; use daemonset.nodeSelector or daemonset.affinity.podAffinity/podAntiAffinity instead" }}
+      {{- end }}
       affinity:
         # cuda-checkpoint only supports x86_64 — never schedule on arm64 nodes
         nodeAffinity:

--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -4,8 +4,8 @@
 # Unified Dockerfile for snapshot-agent and placeholder images.
 #
 # Build targets:
-#   docker build --target agent -t snapshot-agent:latest .
-#   docker build --target placeholder --build-arg BASE_IMAGE=<app-image> -t placeholder:latest .
+#   docker build --platform linux/amd64 --target agent -t snapshot-agent:latest .
+#   docker build --platform linux/amd64 --target placeholder --build-arg BASE_IMAGE=<app-image> -t placeholder:latest .
 #
 # Optional targets for CI:
 #   docker build --target linter .   # Run linting
@@ -31,10 +31,6 @@ FROM ${DOCKER_PROXY}golang:${GO_VERSION} AS go-base
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 
-# cuda-checkpoint only ships x86_64 binaries — abort early on unsupported archs
-RUN if [ "${TARGETARCH}" != "amd64" ]; then \
-      echo "ERROR: Dynamo Snapshot requires x86_64 (cuda-checkpoint has no ${TARGETARCH} binary)" && exit 1; \
-    fi
 RUN echo "Building for ${TARGETOS}/${TARGETARCH}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
@@ -113,6 +109,12 @@ RUN git clone https://github.com/NVIDIA/cuda-checkpoint.git /tmp/cuda-checkpoint
 # =============================================================================
 FROM ${AGENT_BASE_IMAGE} AS agent
 
+ARG TARGETARCH=amd64
+
+RUN if [ "${TARGETARCH}" != "amd64" ]; then \
+      echo "ERROR: Dynamo Snapshot requires x86_64 (cuda-checkpoint has no ${TARGETARCH} binary)" >&2; exit 1; \
+    fi
+
 # Install CRIU runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libbsd0 \
@@ -160,9 +162,14 @@ ENTRYPOINT ["/usr/local/bin/snapshot-agent"]
 FROM ${BASE_IMAGE} AS placeholder
 
 ARG BASE_IMAGE
+ARG TARGETARCH=amd64
 ENV ORIGINAL_BASE_IMAGE=${BASE_IMAGE}
 
 USER root
+
+RUN if [ "${TARGETARCH}" != "amd64" ]; then \
+      echo "ERROR: Dynamo Snapshot requires x86_64 (cuda-checkpoint has no ${TARGETARCH} binary)" >&2; exit 1; \
+    fi
 
 # Install minimal runtime dependencies for CRIU restore (nsrestore runs here via nsenter)
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -196,4 +203,3 @@ RUN chmod +x /usr/local/bin/nsrestore
 
 # Create directories
 RUN mkdir -p /checkpoints /var/run/criu /var/criu-work
-

--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -31,6 +31,10 @@ FROM ${DOCKER_PROXY}golang:${GO_VERSION} AS go-base
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 
+# cuda-checkpoint only ships x86_64 binaries — abort early on unsupported archs
+RUN if [ "${TARGETARCH}" != "amd64" ]; then \
+      echo "ERROR: Dynamo Snapshot requires x86_64 (cuda-checkpoint has no ${TARGETARCH} binary)" && exit 1; \
+    fi
 RUN echo "Building for ${TARGETOS}/${TARGETARCH}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \

--- a/deploy/snapshot/Makefile
+++ b/deploy/snapshot/Makefile
@@ -15,6 +15,8 @@ endif
 
 # CONTAINER_TOOL defines the container tool to be used for building images.
 CONTAINER_TOOL ?= docker
+# Snapshot runtime images ship cuda-checkpoint and are amd64-only.
+RUNTIME_IMAGE_PLATFORM ?= linux/amd64
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 SHELL = /usr/bin/env bash -o pipefail
@@ -69,8 +71,8 @@ clean: ## Remove build artifacts.
 ##@ Docker
 
 .PHONY: docker-build-agent
-docker-build-agent: ## Build snapshot-agent docker image.
-	$(CONTAINER_TOOL) build --target agent -t ${IMG} .
+docker-build-agent: ## Build snapshot-agent docker image (linux/amd64 only).
+	$(CONTAINER_TOOL) build --platform ${RUNTIME_IMAGE_PLATFORM} --target agent -t ${IMG} .
 
 .PHONY: docker-build-agent-lint
 docker-build-agent-lint: ## Build snapshot-agent docker image up to lint stage.
@@ -81,7 +83,7 @@ docker-build-agent-test: ## Build snapshot-agent docker image up to test stage.
 	$(CONTAINER_TOOL) build --target tester -t ${IMG}-test .
 
 .PHONY: docker-build-placeholder
-docker-build-placeholder: ## Build placeholder image for checkpoint restore. Requires PLACEHOLDER_BASE_IMG.
+docker-build-placeholder: ## Build placeholder image for checkpoint restore (linux/amd64 only). Requires PLACEHOLDER_BASE_IMG.
 ifndef PLACEHOLDER_BASE_IMG
 	$(error PLACEHOLDER_BASE_IMG is required. Example: make docker-build-placeholder PLACEHOLDER_BASE_IMG=nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.1-cuda13)
 endif
@@ -91,7 +93,7 @@ endif
 		BASE_IMAGE_USER="$$( $(CONTAINER_TOOL) image inspect --format '{{.Config.User}}' ${PLACEHOLDER_BASE_IMG} 2>/dev/null || true )"; \
 	fi; \
 	if [ -z "$$BASE_IMAGE_USER" ]; then BASE_IMAGE_USER=root; fi; \
-	$(CONTAINER_TOOL) build --target placeholder \
+	$(CONTAINER_TOOL) build --platform ${RUNTIME_IMAGE_PLATFORM} --target placeholder \
 		--build-arg BASE_IMAGE=${PLACEHOLDER_BASE_IMG} \
 		--build-arg BASE_IMAGE_USER=$$BASE_IMAGE_USER \
 		-t ${PLACEHOLDER_IMG} .

--- a/docs/kubernetes/snapshot/README.md
+++ b/docs/kubernetes/snapshot/README.md
@@ -87,7 +87,8 @@ helm install snapshot nvidia/snapshot \
   - Potentially compromise node security if exploited
 
 ### Technical Limitations
-- **vLLM and SGLang backends only**: TensorRT-LLM support is planned.
+- **x86_64 (amd64) only**: `cuda-checkpoint` does not support ARM64. The snapshot agent and placeholder images are built for x86_64 only.
+- **vLLM and SGLang backends only**: TensorRT-LLM is not supported.
 - **LLM workers only**: Checkpoint/restore supports LLM decode and prefill workers. Specialized workers (multimodal, embedding, diffusion) are not supported.
 - **Single-node only**: Checkpoints must be created and restored on the same node
 - **Single-GPU only**: Multi-GPU configurations not yet supported

--- a/docs/kubernetes/snapshot/README.md
+++ b/docs/kubernetes/snapshot/README.md
@@ -88,6 +88,7 @@ helm install snapshot nvidia/snapshot \
 
 ### Technical Limitations
 - **x86_64 (amd64) only**: `cuda-checkpoint` does not support ARM64. The snapshot agent and placeholder images are built for x86_64 only.
+- **NVIDIA driver 580.xx or newer required**: Dynamo Snapshot depends on `cuda-checkpoint`, which requires R580+ drivers.
 - **vLLM and SGLang backends only**: TensorRT-LLM is not supported.
 - **LLM workers only**: Checkpoint/restore supports LLM decode and prefill workers. Specialized workers (multimodal, embedding, diffusion) are not supported.
 - **Single-GPU only**: Multi-GPU configurations not yet supported
@@ -114,6 +115,7 @@ Dynamo Snapshot is best suited for:
 
 - Kubernetes 1.21+
 - GPU nodes with NVIDIA runtime (`nvidia` runtime class)
+- NVIDIA driver 580.xx or newer on the target GPU nodes
 - containerd runtime (for container inspection; CRIU is bundled in Dynamo Snapshot images)
 - RWX storage class (for multi-node deployments)
 - **Security clearance for privileged DaemonSet** (the Dynamo Snapshot agent runs privileged with hostPID/hostIPC/hostNetwork)

--- a/docs/kubernetes/snapshot/README.md
+++ b/docs/kubernetes/snapshot/README.md
@@ -60,7 +60,7 @@ helm install snapshot nvidia/snapshot \
 ### ✅ Currently Supported
 - ✅ **vLLM and SGLang backends** (TensorRT-LLM planned)
 - ✅ **LLM decode/prefill workers only** (multimodal, embedding, and diffusion workers are not supported)
-- ✅ Cross-node, single-GPU checkpoints
+- ✅ Cross-node, single-GPU checkpoints (requires RWX storage)
 - ✅ PVC storage backend (RWX for multi-node)
 - ✅ CUDA checkpoint/restore
 - ✅ PyTorch distributed state (with `GLOO_SOCKET_IFNAME=lo`)
@@ -90,7 +90,6 @@ helm install snapshot nvidia/snapshot \
 - **x86_64 (amd64) only**: `cuda-checkpoint` does not support ARM64. The snapshot agent and placeholder images are built for x86_64 only.
 - **vLLM and SGLang backends only**: TensorRT-LLM is not supported.
 - **LLM workers only**: Checkpoint/restore supports LLM decode and prefill workers. Specialized workers (multimodal, embedding, diffusion) are not supported.
-- **Single-node only**: Checkpoints must be created and restored on the same node
 - **Single-GPU only**: Multi-GPU configurations not yet supported
 - **Network state limitations**: Active TCP connections are closed during restore (use `tcp-close` CRIU option)
 - **Storage**: Only PVC storage is currently implemented (S3/OCI planned)

--- a/docs/kubernetes/snapshot/dynamo.md
+++ b/docs/kubernetes/snapshot/dynamo.md
@@ -18,6 +18,7 @@ Checkpointing captures the complete state of a running worker pod (including GPU
 - Dynamo Platform installed on a k8s cluster with **x86_64 (amd64)** GPU nodes
 - Dynamo Snapshot Helm chart installed (separate from platform)
 - RWX PVC storage (PVC is currently the only supported backend)
+- NVIDIA driver 580.xx or newer on the target GPU nodes
 - vLLM or SGLang backend (TensorRT-LLM is not supported)
 
 ## Quick Start
@@ -358,6 +359,7 @@ Or use `auto` mode and the operator will find/create it automatically.
 ## Limitations
 
 - **x86_64 (amd64) only**: `cuda-checkpoint` does not support ARM64. The snapshot agent and placeholder images are built for x86_64 only.
+- **NVIDIA driver 580.xx or newer required**: Dynamo Snapshot depends on `cuda-checkpoint`, which requires R580+ drivers.
 - **vLLM and SGLang backends only**: TensorRT-LLM is not supported.
 - **LLM workers only**: Checkpoint/restore supports LLM decode and prefill workers. Specialized workers (multimodal, embedding, diffusion) are not supported.
 - **Single-GPU only**: Multi-GPU configurations are not yet supported (planned)

--- a/docs/kubernetes/snapshot/dynamo.md
+++ b/docs/kubernetes/snapshot/dynamo.md
@@ -15,7 +15,7 @@ Checkpointing captures the complete state of a running worker pod (including GPU
 
 ## Prerequisites
 
-- Dynamo Platform installed (v0.4.0+) on k8s cluster with **x86_64 (amd64)** GPU nodes
+- Dynamo Platform installed on a k8s cluster with **x86_64 (amd64)** GPU nodes
 - Dynamo Snapshot Helm chart installed (separate from platform)
 - RWX PVC storage (PVC is currently the only supported backend)
 - vLLM or SGLang backend (TensorRT-LLM is not supported)
@@ -222,7 +222,7 @@ Checkpoints are uniquely identified by a **16-character SHA256 hash** (64 bits) 
 | Field | Required | Affects Hash | Example |
 |-------|----------|-------------|---------|
 | `model` | ✓ | ✓ | `meta-llama/Llama-3-8B` |
-| `framework` | ✓ | ✓ | `sglang`, `trtllm`, `vllm` |
+| `backendFramework` | ✓ | ✓ | `sglang`, `vllm` |
 | `dynamoVersion` | | ✓ | `0.9.0`, `1.0.0` |
 | `tensorParallelSize` | | ✓ | `1`, `2`, `4`, `8` (default: 1) |
 | `pipelineParallelSize` | | ✓ | `1`, `2` (default: 1) |
@@ -516,4 +516,3 @@ spec:
 - [Dynamo Snapshot Helm Chart README](https://github.com/ai-dynamo/dynamo/tree/main/deploy/helm/charts/snapshot/README.md) - Chart configuration
 - [Installation Guide](../installation-guide.md) - Platform installation
 - [API Reference](../api-reference.md) - Complete CRD specifications
-

--- a/docs/kubernetes/snapshot/dynamo.md
+++ b/docs/kubernetes/snapshot/dynamo.md
@@ -15,9 +15,10 @@ Checkpointing captures the complete state of a running worker pod (including GPU
 
 ## Prerequisites
 
-- Dynamo Platform installed (v0.4.0+) on k8s cluster with GPU nodes
+- Dynamo Platform installed (v0.4.0+) on k8s cluster with **x86_64 (amd64)** GPU nodes
 - Dynamo Snapshot Helm chart installed (separate from platform)
 - RWX PVC storage (PVC is currently the only supported backend)
+- vLLM or SGLang backend (TensorRT-LLM is not supported)
 
 ## Quick Start
 
@@ -356,7 +357,8 @@ Or use `auto` mode and the operator will find/create it automatically.
 
 ## Limitations
 
-- **vLLM and SGLang backends only**: TensorRT-LLM support is planned.
+- **x86_64 (amd64) only**: `cuda-checkpoint` does not support ARM64. The snapshot agent and placeholder images are built for x86_64 only.
+- **vLLM and SGLang backends only**: TensorRT-LLM is not supported.
 - **LLM workers only**: Checkpoint/restore supports LLM decode and prefill workers. Specialized workers (multimodal, embedding, diffusion) are not supported.
 - **Single-GPU only**: Multi-GPU configurations are not yet supported (planned)
 - **Network state**: Active TCP connections are closed during restore (handled with `tcp-close` CRIU option)

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -133,4 +133,4 @@ TensorRT-LLM delivers maximum inference performance and optimization, with full 
 [trtllm-eagle]: ../additional-resources/tensor-rt-llm-details/llama-4-eagle
 
 {/* Dynamo Snapshot */}
-[snapshot]: ../kubernetes-deployment/dynamo-snapshot
+[snapshot]: ../kubernetes/snapshot/README.md

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -28,6 +28,7 @@ This document provides a comprehensive compatibility matrix for key Dynamo featu
 | **LoRA** | | | ✅ | [K8s Guide][lora] |
 | **Tool Calling** | ✅ | ✅ | ✅ | [Tool Calling Doc][tools] |
 | **Speculative Decoding** | 🚧 | ✅ | ✅ | Backend READMEs |
+| **Dynamo Snapshot** | ✅ | | ✅ | [Snapshot Docs][snapshot] |
 
 ## 1. vLLM Backend
 
@@ -130,3 +131,6 @@ TensorRT-LLM delivers maximum inference performance and optimization, with full 
 [lora]: ../kubernetes-deployment/deployment-guide/managing-models-with-dynamo-model
 [vllm-spec]: ../additional-resources/speculative-decoding/speculative-decoding-with-v-llm
 [trtllm-eagle]: ../additional-resources/tensor-rt-llm-details/llama-4-eagle
+
+{/* Dynamo Snapshot */}
+[snapshot]: ../kubernetes-deployment/dynamo-snapshot

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -154,7 +154,7 @@ Dynamo Snapshot provides fast pod startup via CRIU checkpoint/restore with GPU s
 | **GPU** | Single-GPU only (multi-GPU planned) |
 | **Storage** | PVC only (S3/OCI planned) |
 
-For setup instructions, see the [Dynamo Snapshot documentation](../kubernetes-deployment/dynamo-snapshot).
+For setup instructions, see the [Dynamo Snapshot documentation](../kubernetes/snapshot/README.md).
 
 ## Cloud Service Provider Compatibility
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -141,6 +141,21 @@ Wheels are built using a manylinux_2_28-compatible environment and validated on 
 > [!Caution]
 > KV Block Manager is supported only with Python 3.12. Python 3.12 support is currently limited to Ubuntu 24.04.
 
+## Dynamo Snapshot (Checkpoint/Restore)
+
+Dynamo Snapshot provides fast pod startup via CRIU checkpoint/restore with GPU state preservation.
+
+| Requirement | Supported |
+| :--- | :--- |
+| **Architecture** | x86_64 only (ARM64 not supported — `cuda-checkpoint` has no ARM64 binary) |
+| **Backends** | SGLang, vLLM |
+| **Not Supported** | TensorRT-LLM, ARM64 nodes |
+| **Worker Types** | LLM decode and prefill only (multimodal, embedding, diffusion not supported) |
+| **GPU** | Single-GPU only (multi-GPU planned) |
+| **Storage** | PVC only (S3/OCI planned) |
+
+For setup instructions, see the [Dynamo Snapshot documentation](../kubernetes-deployment/dynamo-snapshot).
+
 ## Cloud Service Provider Compatibility
 
 ### AWS

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -141,21 +141,6 @@ Wheels are built using a manylinux_2_28-compatible environment and validated on 
 > [!Caution]
 > KV Block Manager is supported only with Python 3.12. Python 3.12 support is currently limited to Ubuntu 24.04.
 
-## Dynamo Snapshot (Checkpoint/Restore)
-
-Dynamo Snapshot provides fast pod startup via CRIU checkpoint/restore with GPU state preservation.
-
-| Requirement | Supported |
-| :--- | :--- |
-| **Architecture** | x86_64 only (ARM64 not supported — `cuda-checkpoint` has no ARM64 binary) |
-| **Backends** | SGLang, vLLM |
-| **Not Supported** | TensorRT-LLM, ARM64 nodes |
-| **Worker Types** | LLM decode and prefill only (multimodal, embedding, diffusion not supported) |
-| **GPU** | Single-GPU only (multi-GPU planned) |
-| **Storage** | PVC only (S3/OCI planned) |
-
-For setup instructions, see the [Dynamo Snapshot documentation](../kubernetes/snapshot/README.md).
-
 ## Cloud Service Provider Compatibility
 
 ### AWS


### PR DESCRIPTION
## Overview
Tighten Dynamo Snapshot's amd64-only behavior and clean up the follow-up review feedback on the x86_64 support/docs change.

## Details
- reject `daemonset.affinity.nodeAffinity` overrides because the chart now enforces `kubernetes.io/arch=amd64`
- move the amd64 runtime guard out of the shared `go-base` stage so `linter` and `tester` still work on arm64
- remove the unsupported `trtllm` backend example from the checkpoint identity docs
- reconcile the Snapshot README with the maintainer clarification that cross-node single-GPU checkpoints are supported
- drop the unnecessary `v0.4.0+` prerequisite
- make the repo-managed Snapshot runtime image build entrypoints explicitly use `linux/amd64`

## Where should the reviewer start?
- `deploy/snapshot/Dockerfile`
- `deploy/helm/charts/snapshot/templates/daemonset.yaml`
- `docs/kubernetes/snapshot/README.md`

## Related Issues
- None

## Test plan
- `git diff --check`
- `helm lint deploy/helm/charts/snapshot`
- `helm template snapshot deploy/helm/charts/snapshot`
- `helm template snapshot deploy/helm/charts/snapshot --set 'daemonset.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=foo'` and verify it fails with the new message
- `make -n docker-build-agent docker-build-placeholder PLACEHOLDER_BASE_IMG=nvcr.io/nvidia/ai-dynamo/dynamo-vllm:latest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dynamo Snapshot to the feature matrix, supporting SGLang and vLLM backends.

* **Documentation**
  * Updated system requirements: x86_64 (amd64) architecture only.
  * Added NVIDIA driver 580.xx or newer requirement for target GPU nodes.
  * Clarified RWX storage requirement for cross-node snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->