### PR TITLE
docs: update v1.0.0 backend versions in support matrix

### DIFF
--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -28,7 +28,7 @@ The following table shows the backend framework versions included with each Dyna
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
 | **main (ToT)** | `0.5.9` | `1.3.0rc5` | `0.16.0` | `0.10.1` |
-| **v1.0.0** *(in progress)* | `0.5.9` | `1.3.0rc5` | `0.15.1` | `0.10.1` |
+| **v1.0.0** *(in progress)* | `0.5.9` | `1.3.0rc5.post1` | `0.16.0` | `0.10.1` |
 | **v0.9.1** *(in progress)* | `0.5.8` | `1.3.0rc3` | `0.14.1` | `0.9.0` |
 | **v0.9.0** | `0.5.8` | `1.3.0rc1` | `0.14.1` | `0.9.0` |
 | **v0.8.1.post3** | `0.5.6.post2` | `1.2.0rc6.post3` | `0.12.0` | `0.8.0` |


### PR DESCRIPTION
## Summary
- Cherry-pick of #7004 to release/1.0.0
- Updates backend version numbers in the support matrix for v1.0.0

## Original PR
- Main PR: #7004
- Merge commit: 8381e28a3e4a68bffa059810e0ccb69fa77fd254

## Test Plan
- [ ] CI Passes
- [ ] Verified fix works on release branch

Made with [Cursor](https://cursor.com)