### PR TITLE
fix: [DYN-2335] correct docker tag for tritonserver build

### DIFF
--- a/examples/backends/tritonserver/Dockerfile
+++ b/examples/backends/tritonserver/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG DYNAMO_BASE_IMAGE="dynamo:latest-none"
+ARG DYNAMO_BASE_IMAGE="dynamo-base:latest"
 ARG TRITON_SERVER_IMAGE="nvcr.io/nvidia/tritonserver:25.01-py3"
 
 FROM ${TRITON_SERVER_IMAGE} AS triton_source

--- a/examples/backends/tritonserver/README.md
+++ b/examples/backends/tritonserver/README.md
@@ -40,7 +40,7 @@ From the Dynamo repository root:
 ```bash
 # Build the base Dynamo image
 python container/render.py --framework=dynamo --target=runtime --output-short-filename
-docker build -f container/rendered.Dockerfile .
+docker build -f container/rendered.Dockerfile -t dynamo-base:latest .
 
 # Build the Triton worker image
 cd examples/backends/tritonserver


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes linear issue: DYN-2335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated base Docker image naming convention in Triton server backend examples to ensure consistent image tagging during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->