### PR TITLE
chore: bump aic to v0.7.0rc11

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@7287307c4e3861b90927198da74e1adda53a4caf",
+    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@4e7799d19f67ab7ee093b1276b4d0771eafb6936",
     "aiperf @ git+https://github.com/ai-dynamo/aiperf.git@c3fc969e9e30e9ddad35b2f613aa7c1d418f2de9",
     "matplotlib",
     "networkx",

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -12,7 +12,7 @@
 
 # For Multimodal EPD (required for device_map="auto" in vision model loading)
 accelerate
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@7287307c4e3861b90927198da74e1adda53a4caf
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@4e7799d19f67ab7ee093b1276b4d0771eafb6936
 aiofiles
 aiperf @ git+https://github.com/ai-dynamo/aiperf.git@54cd6dc820bff8bfebc875da104e59d745e14f75
 av==15.0.0


### PR DESCRIPTION
#### Overview:

bumps AIConfigurator reference to [v0.7.0rc11](https://github.com/ai-dynamo/aiconfigurator/commit/4e7799d19f67ab7ee093b1276b4d0771eafb6936)


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to OPS-3516


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated aiconfigurator dependency to a newer version across benchmark and container configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->