### PR TITLE
docs: update support matrix and release artifacts for v0.9.1

### DIFF
--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -10,15 +10,15 @@ This document provides a comprehensive inventory of all Dynamo release artifacts
 
 Release history in this document begins at v0.6.0.
 
-## Current Release: Dynamo v0.9.0
+## Current Release: Dynamo v0.9.1
 
-- **GitHub Release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0)
-- **Docs:** [v0.9.0](https://docs.dynamo.nvidia.com/dynamo)
+- **GitHub Release:** [v0.9.1](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.1)
+- **Docs:** [v0.9.1](https://docs.dynamo.nvidia.com/dynamo)
 - **NGC Collection:** [ai-dynamo](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)
 
-### Patch Release: v0.9.0.post1 (Feb 2026)
+### Previous Patch: v0.9.0.post1 (Feb 2026)
 
-**v0.9.0.post1** is a Helm-chart-only patch release on NGC (no GitHub release). It fixes the `dynamo-platform` Helm chart which incorrectly set the operator image tag to `0.7.1` instead of `0.9.0`. Only the `dynamo-platform` chart was patched; all other artifacts remain at v0.9.0.
+**v0.9.0.post1** is a Helm-chart-only patch release on NGC (no GitHub release). It fixes the `dynamo-platform` Helm chart which incorrectly set the operator image tag to `0.7.1` instead of `0.9.0`. Only the `dynamo-platform` chart was patched; all other artifacts remain at v0.9.0. Users upgrading to v0.9.1 do not need this patch.
 
 | Artifact | Version | Change | Link |
 |----------|---------|--------|------|
@@ -31,13 +31,13 @@ Release history in this document begins at v0.6.0.
 
 | Image:Tag | Description | Backend | CUDA | Arch | NGC | Notes |
 |-----------|-------------|---------|------|------|-----|-------|
-| `vllm-runtime:0.9.0` | Runtime container for vLLM backend | vLLM `v0.14.1` | `v12.9` | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime?version=0.9.0) | |
-| `vllm-runtime:0.9.0-cuda13` | Runtime container for vLLM backend (CUDA 13) | vLLM `v0.14.1` | `v13.0` | AMD64/ARM64* | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime?version=0.9.0-cuda13) | Experimental |
-| `sglang-runtime:0.9.0` | Runtime container for SGLang backend | SGLang `v0.5.8` | `v12.9` | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/sglang-runtime?version=0.9.0) | |
-| `sglang-runtime:0.9.0-cuda13` | Runtime container for SGLang backend (CUDA 13) | SGLang `v0.5.8` | `v13.0` | AMD64/ARM64* | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/sglang-runtime?version=0.9.0-cuda13) | Experimental |
-| `tensorrtllm-runtime:0.9.0` | Runtime container for TensorRT-LLM backend | TRT-LLM `v1.3.0rc1` | `v13.0` | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/tensorrtllm-runtime?version=0.9.0) | |
-| `dynamo-frontend:0.9.0` | API gateway with Endpoint Prediction Protocol (EPP) | — | — | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/dynamo-frontend?version=0.9.0) | |
-| `kubernetes-operator:0.9.0` | Kubernetes operator for Dynamo deployments | — | — | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/kubernetes-operator?version=0.9.0) | |
+| `vllm-runtime:0.9.1` | Runtime container for vLLM backend | vLLM `v0.14.1` | `v12.9` | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime?version=0.9.1) | |
+| `vllm-runtime:0.9.1-cuda13` | Runtime container for vLLM backend (CUDA 13) | vLLM `v0.14.1` | `v13.0` | AMD64/ARM64* | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime?version=0.9.1-cuda13) | Experimental |
+| `sglang-runtime:0.9.1` | Runtime container for SGLang backend | SGLang `v0.5.8` | `v12.9` | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/sglang-runtime?version=0.9.1) | |
+| `sglang-runtime:0.9.1-cuda13` | Runtime container for SGLang backend (CUDA 13) | SGLang `v0.5.8` | `v13.0` | AMD64/ARM64* | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/sglang-runtime?version=0.9.1-cuda13) | Experimental |
+| `tensorrtllm-runtime:0.9.1` | Runtime container for TensorRT-LLM backend | TRT-LLM `v1.3.0rc3` | `v13.0` | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/tensorrtllm-runtime?version=0.9.1) | |
+| `dynamo-frontend:0.9.1` | API gateway with Endpoint Prediction Protocol (EPP) | — | — | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/dynamo-frontend?version=0.9.1) | |
+| `kubernetes-operator:0.9.1` | Kubernetes operator for Dynamo deployments | — | — | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/kubernetes-operator?version=0.9.1) | |
 
 \* Multimodal inference on CUDA 13 images: works on AMD64 for all backends; works on ARM64 only for TensorRT-LLM (`vllm-runtime:*-cuda13` and `sglang-runtime:*-cuda13` do not support multimodality on ARM64).
 
@@ -47,16 +47,16 @@ We recommend using the TensorRT-LLM NGC container instead of the `ai-dynamo[trtl
 
 | Package | Description | Python | Platform | PyPI |
 |---------|-------------|--------|----------|------|
-| `ai-dynamo==0.9.0` | Main package with backend integrations (vLLM, SGLang, TRT-LLM) | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/ai-dynamo/0.9.0/) |
-| `ai-dynamo-runtime==0.9.0` | Core Python bindings for Dynamo runtime | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/ai-dynamo-runtime/0.9.0/) |
-| `kvbm==0.9.0` | KV Block Manager for disaggregated KV cache | `3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/kvbm/0.9.0/) |
+| `ai-dynamo==0.9.1` | Main package with backend integrations (vLLM, SGLang, TRT-LLM) | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/ai-dynamo/0.9.1/) |
+| `ai-dynamo-runtime==0.9.1` | Core Python bindings for Dynamo runtime | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/ai-dynamo-runtime/0.9.1/) |
+| `kvbm==0.9.1` | KV Block Manager for disaggregated KV cache | `3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/kvbm/0.9.1/) |
 
 ### Helm Charts
 
 | Chart | Description | NGC |
 |-------|-------------|-----|
-| `dynamo-crds-0.9.0` | Custom Resource Definitions for Dynamo Kubernetes resources | [link](https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-crds-0.9.0.tgz) |
-| `dynamo-platform-0.9.0-post1` | Platform services (etcd, NATS) for Dynamo cluster | [link](https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-0.9.0-post1.tgz) |
+| `dynamo-crds-0.9.1` | Custom Resource Definitions for Dynamo Kubernetes resources | [link](https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-crds-0.9.1.tgz) |
+| `dynamo-platform-0.9.1` | Platform services (etcd, NATS) for Dynamo cluster | [link](https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-0.9.1.tgz) |
 
 > **Note:** The `dynamo-graph` Helm chart is deprecated as of v0.9.0. Use the Kubernetes operator for deployment graph management.
 
@@ -64,13 +64,13 @@ We recommend using the TensorRT-LLM NGC container instead of the `ai-dynamo[trtl
 
 | Crate | Description | MSRV (Rust) | crates.io |
 |-------|-------------|-------------|-----------|
-| `dynamo-runtime@0.9.0` | Core distributed runtime library | `v1.82` | [link](https://crates.io/crates/dynamo-runtime/0.9.0) |
-| `dynamo-llm@0.9.0` | LLM inference engine | `v1.82` | [link](https://crates.io/crates/dynamo-llm/0.9.0) |
-| `dynamo-async-openai@0.9.0` | Async OpenAI-compatible API client | `v1.82` | [link](https://crates.io/crates/dynamo-async-openai/0.9.0) |
-| `dynamo-parsers@0.9.0` | Protocol parsers (SSE, JSON streaming) | `v1.82` | [link](https://crates.io/crates/dynamo-parsers/0.9.0) |
-| `dynamo-memory@0.9.0` | Memory management utilities | `v1.82` | [link](https://crates.io/crates/dynamo-memory/0.9.0) |
-| `dynamo-config@0.9.0` | Configuration management | `v1.82` | [link](https://crates.io/crates/dynamo-config/0.9.0) |
-| `dynamo-tokens@0.9.0` | Tokenizer bindings for LLM inference | `v1.82` | [link](https://crates.io/crates/dynamo-tokens/0.9.0) |
+| `dynamo-runtime@0.9.1` | Core distributed runtime library | `v1.82` | [link](https://crates.io/crates/dynamo-runtime/0.9.1) |
+| `dynamo-llm@0.9.1` | LLM inference engine | `v1.82` | [link](https://crates.io/crates/dynamo-llm/0.9.1) |
+| `dynamo-async-openai@0.9.1` | Async OpenAI-compatible API client | `v1.82` | [link](https://crates.io/crates/dynamo-async-openai/0.9.1) |
+| `dynamo-parsers@0.9.1` | Protocol parsers (SSE, JSON streaming) | `v1.82` | [link](https://crates.io/crates/dynamo-parsers/0.9.1) |
+| `dynamo-memory@0.9.1` | Memory management utilities | `v1.82` | [link](https://crates.io/crates/dynamo-memory/0.9.1) |
+| `dynamo-config@0.9.1` | Configuration management | `v1.82` | [link](https://crates.io/crates/dynamo-config/0.9.1) |
+| `dynamo-tokens@0.9.1` | Tokenizer bindings for LLM inference | `v1.82` | [link](https://crates.io/crates/dynamo-tokens/0.9.1) |
 
 ## Quick Install Commands
 
@@ -80,17 +80,17 @@ We recommend using the TensorRT-LLM NGC container instead of the `ai-dynamo[trtl
 
 ```bash
 # Runtime containers
-docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0
-docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.9.0
-docker pull nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.9.0
+docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.1
+docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.9.1
+docker pull nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.9.1
 
 # CUDA 13 variants (experimental)
-docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0-cuda13
-docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.9.0-cuda13
+docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.1-cuda13
+docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.9.1-cuda13
 
 # Infrastructure containers
-docker pull nvcr.io/nvidia/ai-dynamo/dynamo-frontend:0.9.0
-docker pull nvcr.io/nvidia/ai-dynamo/kubernetes-operator:0.9.0
+docker pull nvcr.io/nvidia/ai-dynamo/dynamo-frontend:0.9.1
+docker pull nvcr.io/nvidia/ai-dynamo/kubernetes-operator:0.9.1
 ```
 
 ### Python Wheels (PyPI)
@@ -99,16 +99,16 @@ docker pull nvcr.io/nvidia/ai-dynamo/kubernetes-operator:0.9.0
 
 ```bash
 # Install Dynamo with a specific backend (Recommended)
-uv pip install "ai-dynamo[vllm]==0.9.0"
-uv pip install "ai-dynamo[sglang]==0.9.0"
+uv pip install "ai-dynamo[vllm]==0.9.1"
+uv pip install "ai-dynamo[sglang]==0.9.1"
 # TensorRT-LLM requires the NVIDIA PyPI index and pip
-pip install --pre --extra-index-url https://pypi.nvidia.com "ai-dynamo[trtllm]==0.9.0"
+pip install --pre --extra-index-url https://pypi.nvidia.com "ai-dynamo[trtllm]==0.9.1"
 
 # Install Dynamo core only
-uv pip install ai-dynamo==0.9.0
+uv pip install ai-dynamo==0.9.1
 
 # Install standalone KVBM (Python 3.12 only)
-uv pip install kvbm==0.9.0
+uv pip install kvbm==0.9.1
 ```
 
 ### Helm Charts (NGC)
@@ -116,8 +116,8 @@ uv pip install kvbm==0.9.0
 > For Kubernetes deployment instructions, see the [Kubernetes Installation Guide](../kubernetes/installation-guide.md).
 
 ```bash
-helm install dynamo-crds oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-crds --version 0.9.0
-helm install dynamo-platform oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform --version 0.9.0-post1
+helm install dynamo-crds oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-crds --version 0.9.1
+helm install dynamo-platform oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform --version 0.9.1
 ```
 
 ### Rust Crates (crates.io)
@@ -125,13 +125,13 @@ helm install dynamo-platform oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/d
 > For API documentation, see each crate on [docs.rs](https://docs.rs/). To build Dynamo from source, see [Building from Source](https://github.com/ai-dynamo/dynamo#building-from-source).
 
 ```bash
-cargo add dynamo-runtime@0.9.0
-cargo add dynamo-llm@0.9.0
-cargo add dynamo-async-openai@0.9.0
-cargo add dynamo-parsers@0.9.0
-cargo add dynamo-memory@0.9.0
-cargo add dynamo-config@0.9.0
-cargo add dynamo-tokens@0.9.0
+cargo add dynamo-runtime@0.9.1
+cargo add dynamo-llm@0.9.1
+cargo add dynamo-async-openai@0.9.1
+cargo add dynamo-parsers@0.9.1
+cargo add dynamo-memory@0.9.1
+cargo add dynamo-config@0.9.1
+cargo add dynamo-tokens@0.9.1
 ```
 
 **CUDA and Driver Requirements:** For detailed CUDA toolkit versions and minimum driver requirements for each container image, see the [Support Matrix](support-matrix.md#cuda-and-driver-requirements).
@@ -155,6 +155,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 ## Release History
 
+- **v0.9.1**: Updated TRT-LLM to `v1.3.0rc3`. All other backend versions unchanged from v0.9.0.
 - **v0.9.0.post1**: Fixed `dynamo-platform` Helm chart operator image tag (Helm chart only, NGC)
 - **v0.9.0**: Updated vLLM to `v0.14.1`, SGLang to `v0.5.8`, TRT-LLM to `v1.3.0rc1`, NIXL to `v0.9.0`. New `dynamo-tokens` Rust crate. Deprecated `dynamo-graph` Helm chart.
 - **v0.8.1.post1/.post2/.post3 Patches**: Experimental patch releases updating TRT-LLM only (PyPI wheels and TRT-LLM container). No other artifacts changed.
@@ -166,7 +167,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Version | Release Date | GitHub | Docs |
 |---------|--------------|--------|------|
-| `v0.9.0` | Feb 11, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0) | [Docs](https://docs.dynamo.nvidia.com/dynamo) |
+| `v0.9.1` | Mar 4, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.1) | [Docs](https://docs.dynamo.nvidia.com/dynamo) |
+| `v0.9.0` | Feb 11, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0) | [Docs](https://docs.dynamo.nvidia.com/dynamo/v-0-9-0/) |
 | `v0.8.1` | Jan 23, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.1) | [Docs](https://docs.nvidia.com/dynamo/v-0-8-1/) |
 | `v0.8.0` | Jan 15, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.0) | [Docs](https://docs.nvidia.com/dynamo/v-0-8-0/) |
 | `v0.7.1` | Dec 15, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.1) | [Docs](https://docs.nvidia.com/dynamo/v-0-7-1/) |
@@ -185,6 +187,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Image:Tag | vLLM | Arch | CUDA | Notes |
 |-----------|------|------|------|-------|
+| `vllm-runtime:0.9.1` | `v0.14.1` | AMD64/ARM64 | `v12.9` | |
+| `vllm-runtime:0.9.1-cuda13` | `v0.14.1` | AMD64/ARM64* | `v13.0` | Experimental |
 | `vllm-runtime:0.9.0` | `v0.14.1` | AMD64/ARM64 | `v12.9` | |
 | `vllm-runtime:0.9.0-cuda13` | `v0.14.1` | AMD64/ARM64* | `v13.0` | Experimental |
 | `vllm-runtime:0.8.1` | `v0.12.0` | AMD64/ARM64 | `v12.9` | |
@@ -202,6 +206,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Image:Tag | SGLang | Arch | CUDA | Notes |
 |-----------|--------|------|------|-------|
+| `sglang-runtime:0.9.1` | `v0.5.8` | AMD64/ARM64 | `v12.9` | |
+| `sglang-runtime:0.9.1-cuda13` | `v0.5.8` | AMD64/ARM64* | `v13.0` | Experimental |
 | `sglang-runtime:0.9.0` | `v0.5.8` | AMD64/ARM64 | `v12.9` | |
 | `sglang-runtime:0.9.0-cuda13` | `v0.5.8` | AMD64/ARM64* | `v13.0` | Experimental |
 | `sglang-runtime:0.8.1` | `v0.5.6.post2` | AMD64/ARM64 | `v12.9` | |
@@ -219,6 +225,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Image:Tag | TRT-LLM | Arch | CUDA | Notes |
 |-----------|---------|------|------|-------|
+| `tensorrtllm-runtime:0.9.1` | `v1.3.0rc3` | AMD64/ARM64 | `v13.0` | |
 | `tensorrtllm-runtime:0.9.0` | `v1.3.0rc1` | AMD64/ARM64 | `v13.0` | |
 | `tensorrtllm-runtime:0.8.1.post3` | `v1.2.0rc6.post3` | AMD64/ARM64 | `v13.0` | Patch |
 | `tensorrtllm-runtime:0.8.1.post1` | `v1.2.0rc6.post2` | AMD64/ARM64 | `v13.0` | Patch |
@@ -237,6 +244,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Image:Tag | Arch | Notes |
 |-----------|------|-------|
+| `dynamo-frontend:0.9.1` | AMD64/ARM64 | |
 | `dynamo-frontend:0.9.0` | AMD64/ARM64 | |
 | `dynamo-frontend:0.8.1` | AMD64/ARM64 | |
 | `dynamo-frontend:0.8.0` | AMD64/ARM64 | Initial |
@@ -245,6 +253,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Image:Tag | Arch | Notes |
 |-----------|------|-------|
+| `kubernetes-operator:0.9.1` | AMD64/ARM64 | |
 | `kubernetes-operator:0.9.0` | AMD64/ARM64 | |
 | `kubernetes-operator:0.8.1` | AMD64/ARM64 | |
 | `kubernetes-operator:0.8.0` | AMD64/ARM64 | |
@@ -264,6 +273,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Package | Python | Platform | Notes |
 |---------|--------|----------|-------|
+| `ai-dynamo==0.9.1` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
 | `ai-dynamo==0.9.0` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
 | `ai-dynamo==0.8.1.post3` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | TRT-LLM `v1.2.0rc6.post3` |
 | `ai-dynamo==0.8.1.post1` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | TRT-LLM `v1.2.0rc6.post2` |
@@ -278,6 +288,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Package | Python | Platform | Notes |
 |---------|--------|----------|-------|
+| `ai-dynamo-runtime==0.9.1` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
 | `ai-dynamo-runtime==0.9.0` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
 | `ai-dynamo-runtime==0.8.1.post3` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | TRT-LLM `v1.2.0rc6.post3` |
 | `ai-dynamo-runtime==0.8.1.post1` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | TRT-LLM `v1.2.0rc6.post2` |
@@ -292,6 +303,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Package | Python | Platform | Notes |
 |---------|--------|----------|-------|
+| `kvbm==0.9.1` | `3.12` | Linux (glibc `v2.28+`) | |
 | `kvbm==0.9.0` | `3.12` | Linux (glibc `v2.28+`) | |
 | `kvbm==0.8.1` | `3.12` | Linux (glibc `v2.28+`) | |
 | `kvbm==0.8.0` | `3.12` | Linux (glibc `v2.28+`) | |
@@ -308,6 +320,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Chart | Notes |
 |-------|-------|
+| `dynamo-crds-0.9.1` | |
 | `dynamo-crds-0.9.0` | |
 | `dynamo-crds-0.8.1` | |
 | `dynamo-crds-0.8.0` | |
@@ -320,6 +333,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Chart | Notes |
 |-------|-------|
+| `dynamo-platform-0.9.1` | |
 | `dynamo-platform-0.9.0-post1` | Helm fix: operator image tag |
 | `dynamo-platform-0.9.0` | |
 | `dynamo-platform-0.8.1` | |
@@ -352,6 +366,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-runtime@0.9.1` | `v1.82` | |
 | `dynamo-runtime@0.9.0` | `v1.82` | |
 | `dynamo-runtime@0.8.1` | `v1.82` | |
 | `dynamo-runtime@0.8.0` | `v1.82` | |
@@ -364,6 +379,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-llm@0.9.1` | `v1.82` | |
 | `dynamo-llm@0.9.0` | `v1.82` | |
 | `dynamo-llm@0.8.1` | `v1.82` | |
 | `dynamo-llm@0.8.0` | `v1.82` | |
@@ -376,6 +392,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-async-openai@0.9.1` | `v1.82` | |
 | `dynamo-async-openai@0.9.0` | `v1.82` | |
 | `dynamo-async-openai@0.8.1` | `v1.82` | |
 | `dynamo-async-openai@0.8.0` | `v1.82` | |
@@ -388,6 +405,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-parsers@0.9.1` | `v1.82` | |
 | `dynamo-parsers@0.9.0` | `v1.82` | |
 | `dynamo-parsers@0.8.1` | `v1.82` | |
 | `dynamo-parsers@0.8.0` | `v1.82` | |
@@ -400,6 +418,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-memory@0.9.1` | `v1.82` | |
 | `dynamo-memory@0.9.0` | `v1.82` | |
 | `dynamo-memory@0.8.1` | `v1.82` | |
 | `dynamo-memory@0.8.0` | `v1.82` | Initial |
@@ -408,6 +427,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-config@0.9.1` | `v1.82` | |
 | `dynamo-config@0.9.0` | `v1.82` | |
 | `dynamo-config@0.8.1` | `v1.82` | |
 | `dynamo-config@0.8.0` | `v1.82` | Initial |
@@ -416,4 +436,5 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-tokens@0.9.1` | `v1.82` | |
 | `dynamo-tokens@0.9.0` | `v1.82` | Initial |

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -9,7 +9,7 @@ subtitle: Hardware, software, and build compatibility for Dynamo
 
 ## At a Glance
 
-**Latest stable release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0) -- SGLang `0.5.8` | TensorRT-LLM `1.3.0rc1` | vLLM `0.14.1` | NIXL `0.9.0`
+**Latest stable release:** [v0.9.1](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.1) -- SGLang `0.5.8` | TensorRT-LLM `1.3.0rc3` | vLLM `0.14.1` | NIXL `0.9.0`
 
 | Requirement | Supported |
 | :--- | :--- |
@@ -29,7 +29,7 @@ The following table shows the backend framework versions included with each Dyna
 | :--- | :--- | :--- | :--- | :--- |
 | **main (ToT)** | `0.5.9` | `1.3.0rc5` | `0.16.0` | `0.10.1` |
 | **v1.0.0** *(in progress)* | `0.5.9` | `1.3.0rc5.post1` | `0.16.0` | `0.10.1` |
-| **v0.9.1** *(in progress)* | `0.5.8` | `1.3.0rc3` | `0.14.1` | `0.9.0` |
+| **v0.9.1** | `0.5.8` | `1.3.0rc3` | `0.14.1` | `0.9.0` |
 | **v0.9.0** | `0.5.8` | `1.3.0rc1` | `0.14.1` | `0.9.0` |
 | **v0.8.1.post3** | `0.5.6.post2` | `1.2.0rc6.post3` | `0.12.0` | `0.8.0` |
 | **v0.8.1.post2** | `0.5.6.post2` | `1.2.0rc6.post2` | `0.12.0` | `0.8.0` |
@@ -64,7 +64,7 @@ Dynamo container images include CUDA toolkit libraries. The host machine must ha
 | | **TensorRT-LLM** | 13.1 | 580.xx+ | |
 | | **vLLM** | 12.9 | 575.xx+ | |
 | | | 13.0 | 580.xx+ | |
-| **0.9.1** *(in progress)* | **SGLang** | 12.9 | 575.xx+ | |
+| **0.9.1** | **SGLang** | 12.9 | 575.xx+ | |
 | | **TensorRT-LLM** | 13.0 | 580.xx+ | |
 | | **vLLM** | 12.9 | 575.xx+ | |
 | **0.9.0** | **SGLang** | 12.9 | 575.xx+ | |


### PR DESCRIPTION
## Summary
- Mark v0.9.1 as the latest stable release in support matrix and release artifacts
- Add all v0.9.1 artifact entries (containers, wheels, Helm charts, Rust crates)
- Update Quick Install Commands to reference v0.9.1

## Details
v0.9.1 is a patch release updating TensorRT-LLM from `v1.3.0rc1` to `v1.3.0rc3`. All other backend versions are unchanged from v0.9.0 (SGLang `0.5.8`, vLLM `0.14.1`, NIXL `0.9.0`).

**Changes in `support-matrix.md`:**
- Updated "At a Glance" banner to v0.9.1
- Removed *(in progress)* label from v0.9.1 in backend dependencies and CUDA tables

**Changes in `release-artifacts.md`:**
- Updated "Current Release" section to v0.9.1 with all artifact links
- Updated Quick Install Commands (docker pull, pip install, helm install, cargo add)
- Added v0.9.1 to Release History and GitHub Releases table
- Added v0.9.1 rows to all container image, wheel, Helm chart, and Rust crate history tables

## Where Should the Reviewer Start?
- `docs/reference/support-matrix.md`
- `docs/reference/release-artifacts.md`

## Test Plan
- [ ] CI passes
- [ ] Fern docs build succeeds
- [ ] All v0.9.1 NGC/PyPI/crates.io links resolve correctly after release

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Released v0.9.1 with updates to container images, Python wheels, Helm charts, and Rust crates
  * Updated TensorRT-LLM dependency to version 1.3.0rc3
  * Refreshed release artifacts reference with v0.9.1 entries for all runtime and frontend components
  * Updated support matrix documentation to reflect v0.9.1 as the latest stable release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->