### PR TITLE
ci: fit sglang multimodal EPD test on 1 GPU

### DIFF
--- a/examples/backends/sglang/launch/multimodal_epd.sh
+++ b/examples/backends/sglang/launch/multimodal_epd.sh
@@ -86,6 +86,10 @@ if [[ "$SINGLE_GPU" == "true" ]]; then
     WORKER_EXTRA_ARGS="--mem-fraction-static ${DYN_WORKER_GPU_MEM} --delete-ckpt-after-loading --max-running-requests 2 --chunked-prefill-size 4096 --max-prefill-tokens 4096"
 fi
 
+# Prevent port collisions: the test framework exports DYN_SYSTEM_PORT which all
+# child processes would inherit. Unset it so only workers that need it set their own.
+unset DYN_SYSTEM_PORT
+
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 if [[ "$SINGLE_GPU" == "true" ]]; then
     GPU_LABEL="1 GPU"

--- a/examples/backends/sglang/launch/multimodal_epd.sh
+++ b/examples/backends/sglang/launch/multimodal_epd.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Multimodal E/PD: separate vision encoder (GPU 0) + combined PD worker (GPU 1).
-# GPUs: 2
+# GPUs: 2 (or 1 with --single-gpu)
 
 set -e
 trap 'echo Cleaning up...; kill 0' EXIT
@@ -15,6 +15,12 @@ source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 MODEL_NAME="Qwen/Qwen2.5-VL-7B-Instruct"
 CHAT_TEMPLATE="qwen2-vl"
 PROVIDED_CHAT_TEMPLATE=""
+
+# --single-gpu: Packs both workers (encode, PD) onto a single GPU.
+# This is intended for functional testing with small models (e.g. 2B) where CI
+# only has 1 GPU available. It uses lower mem-fraction-static values to share the GPU
+# and enables memory-saving options.
+SINGLE_GPU=false
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -31,12 +37,17 @@ while [[ $# -gt 0 ]]; do
             PROVIDED_CHAT_TEMPLATE=$2
             shift 2
             ;;
+        --single-gpu)
+            SINGLE_GPU=true
+            shift
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo "Options:"
             echo "  --model <model_name> Specify the model to use (default: $MODEL_NAME)"
             echo "  --served-model-name <served_model_name> Specify the served model name to use (default: empty)"
             echo "  --chat-template <template> Specify the SGLang chat template to use (default: $CHAT_TEMPLATE)"
+            echo "  --single-gpu         Pack both workers on 1 GPU (for small models, e.g. 2B)"
             echo "  -h, --help           Show this help message"
             exit 0
             ;;
@@ -59,8 +70,29 @@ if [[ -n "$SERVED_MODEL_NAME" ]]; then
     SERVED_MODEL_ARG="--served-model-name $SERVED_MODEL_NAME"
 fi
 
+# GPU assignments (override via environment variables)
+DYN_ENCODE_WORKER_GPU=${DYN_ENCODE_WORKER_GPU:-0}
+DYN_WORKER_GPU=${DYN_WORKER_GPU:-1}
+
+# GPU memory fractions for workers (used with --mem-fraction-static)
+DYN_ENCODE_GPU_MEM=${DYN_ENCODE_GPU_MEM:-0.9}
+DYN_WORKER_GPU_MEM=${DYN_WORKER_GPU_MEM:-0.9}
+
+ENCODE_EXTRA_ARGS=""
+WORKER_EXTRA_ARGS=""
+
+if [[ "$SINGLE_GPU" == "true" ]]; then
+    ENCODE_EXTRA_ARGS="--mem-fraction-static ${DYN_ENCODE_GPU_MEM}"
+    WORKER_EXTRA_ARGS="--mem-fraction-static ${DYN_WORKER_GPU_MEM} --delete-ckpt-after-loading --max-running-requests 2 --chunked-prefill-size 4096 --max-prefill-tokens 4096"
+fi
+
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
-print_launch_banner --multimodal "Launching Multimodal E/PD (2 GPUs)" "$MODEL_NAME" "$HTTP_PORT"
+if [[ "$SINGLE_GPU" == "true" ]]; then
+    GPU_LABEL="1 GPU"
+else
+    GPU_LABEL="2 GPUs"
+fi
+print_launch_banner --multimodal "Launching Multimodal E/PD ($GPU_LABEL)" "$MODEL_NAME" "$HTTP_PORT"
 
 # run ingress
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
@@ -70,12 +102,23 @@ python3 -m dynamo.frontend &
 python3 -m dynamo.sglang --multimodal-processor --model-path "$MODEL_NAME" $SERVED_MODEL_ARG --chat-template "$CHAT_TEMPLATE" &
 
 # run SGLang multimodal encode worker
-CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.sglang --multimodal-encode-worker --model-path "$MODEL_NAME" $SERVED_MODEL_ARG --chat-template "$CHAT_TEMPLATE" &
+echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (GPU mem: $DYN_ENCODE_GPU_MEM)..."
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
+CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU python3 -m dynamo.sglang --multimodal-encode-worker --model-path "$MODEL_NAME" $SERVED_MODEL_ARG --chat-template "$CHAT_TEMPLATE" $ENCODE_EXTRA_ARGS &
+
+if [[ "$SINGLE_GPU" == "true" ]]; then
+    # Wait for encode worker to initialize before starting PD worker.
+    # This prevents both workers from competing for GPU memory simultaneously, which can cause OOM.
+    echo "Waiting for encode worker to initialize..."
+    sleep 5
+fi
 
 # run SGLang multimodal inference worker
 # TODO: Remove disable-radix-cache once the issue is fixed.
 # See https://github.com/sgl-project/sglang/pull/11203.
-CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang \
+echo "Starting PD worker on GPU $DYN_WORKER_GPU (GPU mem: $DYN_WORKER_GPU_MEM)..."
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
+CUDA_VISIBLE_DEVICES=$DYN_WORKER_GPU python3 -m dynamo.sglang \
   --multimodal-worker \
   --model-path "$MODEL_NAME" \
   $SERVED_MODEL_ARG \
@@ -84,7 +127,8 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang \
   --trust-remote-code \
   --skip-tokenizer-init \
   --disable-radix-cache \
-  --disaggregation-transfer-backend nixl &
+  --disaggregation-transfer-backend nixl \
+  $WORKER_EXTRA_ARGS &
 
 # Exit on first worker failure; kill 0 in the EXIT trap tears down the rest
 wait_any_exit

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -169,15 +169,22 @@ sglang_configs = {
             )
         ],
     ),
+    # NOTE: Pack all workers on 1 GPU for lower CI resource requirements
     "multimodal_epd_qwen": SGLangConfig(
-        # E/PD architecture: Encode worker (GPU 0) + Prefill/Decode worker (GPU 1)
+        # E/P/D architecture: Encode, Prefill, Decode workers all on GPU 0
         name="multimodal_epd_qwen",
         directory=sglang_dir,
         script_name="multimodal_epd.sh",
-        marks=[pytest.mark.gpu_2, pytest.mark.nightly],
-        model="Qwen/Qwen2.5-VL-7B-Instruct",
-        delayed_start=0,
+        marks=[pytest.mark.gpu_1, pytest.mark.pre_merge],
+        model="Qwen/Qwen3-VL-2B-Instruct",
+        script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct", "--single-gpu"],
         timeout=360,
+        env={
+            "DYN_ENCODE_WORKER_GPU": "0",
+            "DYN_WORKER_GPU": "0",
+            "DYN_ENCODE_GPU_MEM": "0.1",
+            "DYN_WORKER_GPU_MEM": "0.4",
+        },
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
             chat_payload(
@@ -196,6 +203,7 @@ sglang_configs = {
                 # approach to validation for this test to be stable.
                 expected_response=["image"],
                 temperature=0.0,
+                max_tokens=100,
             )
         ],
     ),


### PR DESCRIPTION
#### Overview:

- Add `--single-gpu` flag to SGLang `multimodal_epd.sh` to pack encode + PD workers on a single GPU with env var overrides for GPU assignment and memory fractions
- Switch `multimodal_epd_qwen` test to `Qwen/Qwen3-VL-2B-Instruct` (2B) and run on 1 GPU with encode at 10% and PD worker at 40% memory

Closes: DIS-1573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Introduced single-GPU mode for multimodal inference via new `--single-gpu` flag
* Enables memory-efficient deployment by consolidating workers onto a single GPU with automatic memory optimizations

**Tests**
* Updated multimodal test configurations to validate single-GPU deployment scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->