### PR TITLE
fix(trtllm): free kv cache on sleep without collective rpc

### DIFF
--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -191,14 +191,30 @@ async def async_main():
         router_mode = RouterMode.RoundRobin
         kv_router_config = None
 
-    router_config = RouterConfig(
-        router_mode,
-        kv_router_config,
-        active_decode_blocks_threshold=config.active_decode_blocks_threshold,
-        active_prefill_tokens_threshold=config.active_prefill_tokens_threshold,
-        active_prefill_tokens_threshold_frac=config.active_prefill_tokens_threshold_frac,
-        enforce_disagg=config.enforce_disagg,
-    )
+    router_config_kwargs: dict[str, Any] = {
+        "active_decode_blocks_threshold": config.active_decode_blocks_threshold,
+        "active_prefill_tokens_threshold": config.active_prefill_tokens_threshold,
+        "active_prefill_tokens_threshold_frac": config.active_prefill_tokens_threshold_frac,
+    }
+    try:
+        router_config = RouterConfig(
+            router_mode,
+            kv_router_config,
+            enforce_disagg=config.enforce_disagg,
+            **router_config_kwargs,
+        )
+    except TypeError as exc:
+        # Older runtime bindings may not expose `enforce_disagg` yet.
+        if "enforce_disagg" not in str(exc):
+            raise
+        logger.warning(
+            "RouterConfig binding does not support enforce_disagg; continuing without it"
+        )
+        router_config = RouterConfig(
+            router_mode,
+            kv_router_config,
+            **router_config_kwargs,
+        )
     kwargs: dict[str, Any] = {
         "http_host": config.http_host,
         "http_port": config.http_port,

--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -133,6 +133,27 @@ class DynamoTrtllmArgGroup(ArgGroup):
         )
         add_argument(
             g,
+            flag_name="--load-format",
+            env_var="DYN_TRTLLM_LOAD_FORMAT",
+            default="auto",
+            help="Model loading format passed to TensorRT-LLM (for example: auto, gms).",
+        )
+        add_negatable_bool_argument(
+            g,
+            flag_name="--enable-sleep",
+            env_var="DYN_TRTLLM_ENABLE_SLEEP",
+            default=False,
+            help="Enable TRT-LLM sleep/wake engine routes for memory release and resume.",
+        )
+        add_argument(
+            g,
+            flag_name="--model-loader-extra-config",
+            env_var="DYN_TRTLLM_MODEL_LOADER_EXTRA_CONFIG",
+            default="",
+            help="JSON string for model loader extra config (for example: '{\"gms_read_only\": true}').",
+        )
+        add_argument(
+            g,
             flag_name="--extra-engine-args",
             env_var="DYN_TRTLLM_EXTRA_ENGINE_ARGS",
             default="",
@@ -458,6 +479,9 @@ class DynamoTrtllmConfig(ConfigBase):
     max_seq_len: int
     max_beam_width: int
     free_gpu_memory_fraction: float
+    load_format: str
+    enable_sleep: bool
+    model_loader_extra_config: str
     extra_engine_args: str
     override_engine_args: str
     publish_events_and_metrics: bool

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -50,6 +50,8 @@ from dynamo.trtllm.utils.disagg_utils import (
 
 configure_dynamo_logging()
 
+DEFAULT_MEMORY_OCCUPATION_TAGS = ["kv_cache", "weights"]
+
 
 @dataclass
 class RequestHandlerConfig:
@@ -65,6 +67,7 @@ class RequestHandlerConfig:
     multimodal_processor: Optional[
         MultimodalRequestProcessor
     ] = None  # for multimodal support
+    generate_endpoint: Optional[Any] = None
     connector: Optional[Connector] = None
     runtime: Optional[
         DistributedRuntime
@@ -96,6 +99,7 @@ class HandlerBase(BaseGenerativeHandler):
         self.disaggregation_mode = config.disaggregation_mode
         self.encode_client = config.encode_client
         self.multimodal_processor = config.multimodal_processor
+        self.generate_endpoint = config.generate_endpoint
         self.first_generation = True
         self.connector = config.connector
         # Store runtime reference for graceful shutdown
@@ -103,6 +107,13 @@ class HandlerBase(BaseGenerativeHandler):
         self.kv_block_size: int = config.kv_block_size
         self.shutdown_event = config.shutdown_event
         self.disable_request_abort = config.disable_request_abort
+        self._sleep_wake_lock = asyncio.Lock()
+        self._inflight_lock = asyncio.Lock()
+        self._inflight_requests = 0
+        self._no_inflight_requests = asyncio.Event()
+        self._no_inflight_requests.set()
+        self._memory_released = False
+        self._reject_new_requests = False
 
     def check_error(self, result: dict) -> bool:
         """
@@ -114,6 +125,222 @@ class HandlerBase(BaseGenerativeHandler):
             return (
                 result["finish_reason"] == "stop" or result["finish_reason"] == "error"
             )
+
+    async def _set_reject_new_requests(self, reject: bool) -> None:
+        async with self._inflight_lock:
+            self._reject_new_requests = reject
+
+    async def _mark_request_started(self) -> bool:
+        async with self._inflight_lock:
+            if self._reject_new_requests:
+                return False
+            self._inflight_requests += 1
+            self._no_inflight_requests.clear()
+            return True
+
+    async def _mark_request_finished(self) -> None:
+        async with self._inflight_lock:
+            if self._inflight_requests == 0:
+                return
+            self._inflight_requests -= 1
+            if self._inflight_requests == 0:
+                self._no_inflight_requests.set()
+
+    async def _wait_for_inflight_requests(self, timeout_s: float) -> None:
+        try:
+            await asyncio.wait_for(self._no_inflight_requests.wait(), timeout_s)
+        except TimeoutError as exc:
+            async with self._inflight_lock:
+                inflight = self._inflight_requests
+            raise RuntimeError(
+                f"Timed out waiting for {inflight} in-flight request(s) to finish"
+            ) from exc
+
+    @staticmethod
+    def _normalize_memory_tags(body: dict) -> list[str]:
+        tags = body.get("tags")
+        if tags is None:
+            return list(DEFAULT_MEMORY_OCCUPATION_TAGS)
+        if not isinstance(tags, list):
+            raise ValueError("'tags' must be a list of strings")
+        normalized: list[str] = []
+        for tag in tags:
+            if not isinstance(tag, str):
+                raise ValueError("'tags' must be a list of strings")
+            candidate = tag.strip().lower()
+            if candidate not in {"kv_cache", "weights"}:
+                raise ValueError(f"Unsupported memory tag: {tag!r}")
+            if candidate not in normalized:
+                normalized.append(candidate)
+        if not normalized:
+            raise ValueError("'tags' must include at least one value")
+        return normalized
+
+    @staticmethod
+    def _split_memory_tags(tags: list[str]) -> tuple[list[str], bool]:
+        collective_tags = [tag for tag in tags if tag == "kv_cache"]
+        handle_weights = "weights" in tags
+        return collective_tags, handle_weights
+
+    @staticmethod
+    def _is_collective_rpc_unsupported(exc: Exception) -> bool:
+        return "does not support collective rpc" in str(exc).lower()
+
+    async def _call_collective_rpc(self, method: str, tags: list[str]) -> None:
+        rpc = getattr(self.engine.llm, "_collective_rpc", None)
+        if rpc is None:
+            raise RuntimeError(
+                "TensorRT-LLM runtime does not support collective RPC memory operations"
+            )
+
+        kwargs = {
+            "args": (tags,),
+            "kwargs": {},
+            "non_block": False,
+        }
+        try:
+            rpc(method, **kwargs)
+        except Exception:
+            if method != "wakeup":
+                raise
+            rpc("wake_up", **kwargs)
+
+    @staticmethod
+    def _get_gms_manager():
+        try:
+            import gpu_memory_service
+        except ImportError as exc:
+            raise RuntimeError(
+                "GPU Memory Service package is not available for TRT-LLM sleep/wake"
+            ) from exc
+
+        manager = gpu_memory_service.get_gms_client_memory_manager()
+        if manager is None:
+            raise RuntimeError("GPU Memory Service manager is not initialized")
+        return manager
+
+    async def release_memory_occupation(self, body: dict) -> dict:
+        body = body or {}
+        try:
+            tags = self._normalize_memory_tags(body)
+        except ValueError as exc:
+            return {"status": "error", "message": str(exc)}
+
+        timeout_raw = body.get("timeout_s", 30.0)
+        try:
+            timeout_s = float(timeout_raw)
+        except (TypeError, ValueError):
+            return {"status": "error", "message": "timeout_s must be a number"}
+        if timeout_s <= 0:
+            return {"status": "error", "message": "timeout_s must be > 0"}
+
+        collective_tags, handle_weights = self._split_memory_tags(tags)
+
+        async with self._sleep_wake_lock:
+            if self._memory_released:
+                return {"status": "ok", "message": "Memory already released"}
+
+            await self._set_reject_new_requests(True)
+            endpoint_unregistered = False
+            skipped_tags: list[str] = []
+            try:
+                if self.generate_endpoint is not None:
+                    await self.generate_endpoint.unregister_endpoint_instance()
+                    endpoint_unregistered = True
+
+                await self._wait_for_inflight_requests(timeout_s)
+
+                if collective_tags:
+                    try:
+                        await self._call_collective_rpc("sleep", collective_tags)
+                    except Exception as exc:
+                        if not self._is_collective_rpc_unsupported(exc):
+                            raise
+                        logging.warning(
+                            "Skipping kv_cache sleep because collective RPC is unsupported: %s",
+                            exc,
+                        )
+                        skipped_tags.append("kv_cache")
+
+                if handle_weights:
+                    manager = self._get_gms_manager()
+                    manager.unmap_all_vas()
+                    manager.disconnect()
+                    torch.cuda.synchronize()
+                    torch.cuda.empty_cache()
+
+                self._memory_released = True
+                response = {
+                    "status": "ok",
+                    "message": f"Memory released for tags: {tags}",
+                }
+                if skipped_tags:
+                    response["skipped_tags"] = skipped_tags
+                return response
+            except Exception as exc:
+                logging.error("Failed to release memory occupation: %s", exc)
+                if endpoint_unregistered and self.generate_endpoint is not None:
+                    try:
+                        await self.generate_endpoint.register_endpoint_instance()
+                    except Exception:
+                        logging.exception(
+                            "Failed to restore endpoint registration after release failure"
+                        )
+                await self._set_reject_new_requests(False)
+                return {"status": "error", "message": str(exc)}
+
+    async def resume_memory_occupation(self, body: dict) -> dict:
+        body = body or {}
+        try:
+            tags = self._normalize_memory_tags(body)
+        except ValueError as exc:
+            return {"status": "error", "message": str(exc)}
+
+        collective_tags, handle_weights = self._split_memory_tags(tags)
+
+        async with self._sleep_wake_lock:
+            if not self._memory_released:
+                return {"status": "ok", "message": "Memory already resumed"}
+
+            try:
+                skipped_tags: list[str] = []
+                if handle_weights:
+                    manager = self._get_gms_manager()
+                    if manager.is_unmapped:
+                        from gpu_memory_service.integrations import (
+                            trtllm as trtllm_integration,
+                        )
+
+                        manager.connect(trtllm_integration.get_gms_lock_mode())
+                        manager.remap_all_vas()
+
+                if collective_tags:
+                    try:
+                        await self._call_collective_rpc("wakeup", collective_tags)
+                    except Exception as exc:
+                        if not self._is_collective_rpc_unsupported(exc):
+                            raise
+                        logging.warning(
+                            "Skipping kv_cache wakeup because collective RPC is unsupported: %s",
+                            exc,
+                        )
+                        skipped_tags.append("kv_cache")
+
+                if self.generate_endpoint is not None:
+                    await self.generate_endpoint.register_endpoint_instance()
+
+                await self._set_reject_new_requests(False)
+                self._memory_released = False
+                response = {
+                    "status": "ok",
+                    "message": f"Memory resumed for tags: {tags}",
+                }
+                if skipped_tags:
+                    response["skipped_tags"] = skipped_tags
+                return response
+            except Exception as exc:
+                logging.error("Failed to resume memory occupation: %s", exc)
+                return {"status": "error", "message": str(exc)}
 
     @staticmethod
     def _extract_logprobs(
@@ -604,6 +831,34 @@ class HandlerBase(BaseGenerativeHandler):
             os._exit(1)
 
     async def generate_locally(
+        self,
+        request: dict,
+        context: Context,
+        embeddings: Optional[Union[torch.Tensor, dict]] = None,
+        ep_disaggregated_params: Optional[DisaggregatedParams] = None,
+    ) -> AsyncGenerator[dict, None]:
+        started = await self._mark_request_started()
+        if not started:
+            yield {
+                "finish_reason": {
+                    "error": "Worker is temporarily rejecting new requests"
+                },
+                "token_ids": [],
+            }
+            return
+
+        try:
+            async for chunk in self._generate_locally_impl(
+                request,
+                context,
+                embeddings,
+                ep_disaggregated_params,
+            ):
+                yield chunk
+        finally:
+            await self._mark_request_finished()
+
+    async def _generate_locally_impl(
         self,
         request: dict,
         context: Context,

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import dataclasses
+import gc
 import logging
 import os
 import re
@@ -186,6 +187,44 @@ class HandlerBase(BaseGenerativeHandler):
     def _is_collective_rpc_unsupported(exc: Exception) -> bool:
         return "does not support collective rpc" in str(exc).lower()
 
+    def _can_use_local_kv_sleep_fallback(self) -> bool:
+        """Local tag-based sleep/wake fallback is safe for single-rank executors."""
+        try:
+            llm_args = getattr(self.engine.llm, "args", None)
+            parallel_config = getattr(llm_args, "parallel_config", None)
+            world_size = int(getattr(parallel_config, "world_size", 1))
+        except Exception:
+            return False
+        return world_size == 1
+
+    @staticmethod
+    def _call_local_virtual_memory_method(method: str, tags: list[str]) -> None:
+        from tensorrt_llm._torch.virtual_memory import (
+            materialize_with_tag,
+            release_with_tag,
+            verify_sleep_wakeup_tags,
+        )
+
+        normalized_tags = [
+            str(tag.value) if hasattr(tag, "value") else str(tag)
+            for tag in verify_sleep_wakeup_tags(tags)
+        ]
+        if not normalized_tags:
+            return
+
+        torch.cuda.synchronize()
+        if method == "sleep":
+            release_with_tag(*normalized_tags)
+            torch.cuda.synchronize()
+            gc.collect()
+            torch.cuda.empty_cache()
+            return
+        if method in {"wakeup", "wake_up"}:
+            materialize_with_tag(*normalized_tags)
+            torch.cuda.synchronize()
+            return
+        raise ValueError(f"Unsupported virtual memory method: {method}")
+
     async def _call_collective_rpc(self, method: str, tags: list[str]) -> None:
         rpc = getattr(self.engine.llm, "_collective_rpc", None)
         if rpc is None:
@@ -256,11 +295,19 @@ class HandlerBase(BaseGenerativeHandler):
                     except Exception as exc:
                         if not self._is_collective_rpc_unsupported(exc):
                             raise
-                        logging.warning(
-                            "Skipping kv_cache sleep because collective RPC is unsupported: %s",
-                            exc,
-                        )
-                        skipped_tags.append("kv_cache")
+                        if self._can_use_local_kv_sleep_fallback():
+                            logging.info(
+                                "Collective RPC is unsupported; using local kv_cache sleep fallback"
+                            )
+                            self._call_local_virtual_memory_method(
+                                "sleep", collective_tags
+                            )
+                        else:
+                            logging.warning(
+                                "Skipping kv_cache sleep because collective RPC is unsupported: %s",
+                                exc,
+                            )
+                            skipped_tags.append("kv_cache")
 
                 if handle_weights:
                     manager = self._get_gms_manager()
@@ -320,11 +367,19 @@ class HandlerBase(BaseGenerativeHandler):
                     except Exception as exc:
                         if not self._is_collective_rpc_unsupported(exc):
                             raise
-                        logging.warning(
-                            "Skipping kv_cache wakeup because collective RPC is unsupported: %s",
-                            exc,
-                        )
-                        skipped_tags.append("kv_cache")
+                        if self._can_use_local_kv_sleep_fallback():
+                            logging.info(
+                                "Collective RPC is unsupported; using local kv_cache wakeup fallback"
+                            )
+                            self._call_local_virtual_memory_method(
+                                "wakeup", collective_tags
+                            )
+                        else:
+                            logging.warning(
+                                "Skipping kv_cache wakeup because collective RPC is unsupported: %s",
+                                exc,
+                            )
+                            skipped_tags.append("kv_cache")
 
                 if self.generate_endpoint is not None:
                     await self.generate_endpoint.register_endpoint_instance()

--- a/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
@@ -177,15 +177,60 @@ async def test_resume_uses_configured_gms_lock_mode(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_release_succeeds_when_collective_rpc_is_unsupported():
+async def test_release_uses_local_fallback_when_collective_rpc_is_unsupported():
     handler = _make_handler()
     handler._call_collective_rpc = AsyncMock(
         side_effect=RuntimeError(
             "Executor type <class '...'> does not support collective RPC."
         )
     )
+    handler._can_use_local_kv_sleep_fallback = MagicMock(return_value=True)
+    handler._call_local_virtual_memory_method = MagicMock()
+
+    result = await handler.release_memory_occupation({"tags": ["kv_cache"]})
+
+    assert result["status"] == "ok"
+    assert "skipped_tags" not in result
+    handler._call_local_virtual_memory_method.assert_called_once_with(
+        "sleep", ["kv_cache"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_release_skips_kv_cache_when_collective_rpc_is_unsupported_in_multi_rank():
+    handler = _make_handler()
+    handler._call_collective_rpc = AsyncMock(
+        side_effect=RuntimeError(
+            "Executor type <class '...'> does not support collective RPC."
+        )
+    )
+    handler._can_use_local_kv_sleep_fallback = MagicMock(return_value=False)
+    handler._call_local_virtual_memory_method = MagicMock()
 
     result = await handler.release_memory_occupation({"tags": ["kv_cache"]})
 
     assert result["status"] == "ok"
     assert result["skipped_tags"] == ["kv_cache"]
+    handler._call_local_virtual_memory_method.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resume_uses_local_fallback_when_collective_rpc_is_unsupported():
+    handler = _make_handler()
+    handler._memory_released = True
+    handler._reject_new_requests = True
+    handler._call_collective_rpc = AsyncMock(
+        side_effect=RuntimeError(
+            "Executor type <class '...'> does not support collective RPC."
+        )
+    )
+    handler._can_use_local_kv_sleep_fallback = MagicMock(return_value=True)
+    handler._call_local_virtual_memory_method = MagicMock()
+
+    result = await handler.resume_memory_occupation({"tags": ["kv_cache"]})
+
+    assert result["status"] == "ok"
+    assert "skipped_tags" not in result
+    handler._call_local_virtual_memory_method.assert_called_once_with(
+        "wakeup", ["kv_cache"]
+    )

--- a/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip(
+        "Skipping to avoid errors during collection with '-m gpu_0'. "
+        "CUDA/GPU not available, but tensorrt_llm import and the test require GPU.",
+        allow_module_level=True,
+    )
+
+from dynamo.trtllm.request_handlers.handler_base import HandlerBase
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+
+class _TestWorkerHandler(HandlerBase):
+    async def generate(self, request, context):
+        yield {}
+
+
+def _make_handler() -> _TestWorkerHandler:
+    handler = _TestWorkerHandler.__new__(_TestWorkerHandler)
+    handler.generate_endpoint = SimpleNamespace(
+        unregister_endpoint_instance=AsyncMock(),
+        register_endpoint_instance=AsyncMock(),
+    )
+    handler._sleep_wake_lock = asyncio.Lock()
+    handler._inflight_lock = asyncio.Lock()
+    handler._inflight_requests = 0
+    handler._no_inflight_requests = asyncio.Event()
+    handler._no_inflight_requests.set()
+    handler._memory_released = False
+    handler._reject_new_requests = False
+    handler._wait_for_inflight_requests = AsyncMock()
+    handler._call_collective_rpc = AsyncMock()
+    handler._split_memory_tags = MagicMock(return_value=(["kv_cache"], False))
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_resume_before_release_is_noop():
+    handler = _make_handler()
+
+    result = await handler.resume_memory_occupation({})
+
+    assert result["status"] == "ok"
+    assert result["message"] == "Memory already resumed"
+    handler._call_collective_rpc.assert_not_awaited()
+    handler.generate_endpoint.register_endpoint_instance.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mark_request_started_respects_reject_flag():
+    handler = _make_handler()
+    handler._reject_new_requests = True
+
+    started = await handler._mark_request_started()
+
+    assert started is False
+    assert handler._inflight_requests == 0
+
+
+@pytest.mark.asyncio
+async def test_release_and_resume_are_idempotent():
+    handler = _make_handler()
+
+    first_release = await handler.release_memory_occupation({})
+    second_release = await handler.release_memory_occupation({})
+    first_resume = await handler.resume_memory_occupation({})
+    second_resume = await handler.resume_memory_occupation({})
+
+    assert first_release["status"] == "ok"
+    assert second_release["status"] == "ok"
+    assert first_resume["status"] == "ok"
+    assert second_resume["status"] == "ok"
+    assert second_release["message"] == "Memory already released"
+    assert second_resume["message"] == "Memory already resumed"
+
+    handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
+    handler._wait_for_inflight_requests.assert_awaited_once_with(30.0)
+    handler._call_collective_rpc.assert_any_await("sleep", ["kv_cache"])
+
+    handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
+    handler._call_collective_rpc.assert_any_await("wakeup", ["kv_cache"])
+
+
+@pytest.mark.asyncio
+async def test_release_uses_tags_from_request_body():
+    handler = _make_handler()
+
+    result = await handler.release_memory_occupation({"tags": ["kv_cache"]})
+
+    assert result["status"] == "ok"
+    handler._split_memory_tags.assert_called_once_with(["kv_cache"])
+    handler._call_collective_rpc.assert_awaited_once_with("sleep", ["kv_cache"])
+
+
+@pytest.mark.asyncio
+async def test_release_returns_error_for_invalid_timeout():
+    handler = _make_handler()
+
+    result = await handler.release_memory_occupation({"timeout_s": "bad-timeout"})
+
+    assert result["status"] == "error"
+    assert "timeout_s" in result["message"]
+    handler.generate_endpoint.unregister_endpoint_instance.assert_not_awaited()
+    handler._wait_for_inflight_requests.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_release_returns_error_for_unregister_failure():
+    handler = _make_handler()
+    handler.generate_endpoint.unregister_endpoint_instance = AsyncMock(
+        side_effect=RuntimeError("discovery backend down")
+    )
+
+    result = await handler.release_memory_occupation({})
+
+    assert result["status"] == "error"
+    assert handler._reject_new_requests is False
+    handler._wait_for_inflight_requests.assert_not_awaited()
+    handler._call_collective_rpc.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resume_returns_error_for_register_failure():
+    handler = _make_handler()
+    handler._memory_released = True
+    handler._reject_new_requests = True
+    handler.generate_endpoint.register_endpoint_instance = AsyncMock(
+        side_effect=RuntimeError("discovery write timeout")
+    )
+
+    result = await handler.resume_memory_occupation({})
+
+    assert result["status"] == "error"
+    handler._call_collective_rpc.assert_awaited_once_with("wakeup", ["kv_cache"])
+    assert handler._memory_released is True
+    assert handler._reject_new_requests is True
+
+
+@pytest.mark.asyncio
+async def test_resume_uses_configured_gms_lock_mode(monkeypatch):
+    handler = _make_handler()
+    handler._memory_released = True
+    handler._split_memory_tags = MagicMock(return_value=([], True))
+
+    from gpu_memory_service.common.types import RequestedLockType
+    from gpu_memory_service.integrations import trtllm as trtllm_integration
+
+    manager = MagicMock()
+    manager.is_unmapped = True
+    monkeypatch.setattr(HandlerBase, "_get_gms_manager", staticmethod(lambda: manager))
+    monkeypatch.setattr(
+        trtllm_integration,
+        "get_gms_lock_mode",
+        lambda: RequestedLockType.RW_OR_RO,
+    )
+
+    result = await handler.resume_memory_occupation({})
+
+    assert result["status"] == "ok"
+    manager.connect.assert_called_once_with(RequestedLockType.RW_OR_RO)
+    manager.remap_all_vas.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_release_succeeds_when_collective_rpc_is_unsupported():
+    handler = _make_handler()
+    handler._call_collective_rpc = AsyncMock(
+        side_effect=RuntimeError(
+            "Executor type <class '...'> does not support collective RPC."
+        )
+    )
+
+    result = await handler.release_memory_occupation({"tags": ["kv_cache"]})
+
+    assert result["status"] == "ok"
+    assert result["skipped_tags"] == ["kv_cache"]

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -22,7 +22,11 @@ from tensorrt_llm.llmapi import (
     SchedulerConfig,
 )
 from tensorrt_llm.llmapi.llm import SamplingParams
-from tensorrt_llm.llmapi.llm_args import KvCacheConnectorConfig
+from tensorrt_llm.llmapi.llm_args import (
+    KvCacheConnectorConfig,
+    LlmArgs,
+    LoadFormat,
+)
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_options
 from tensorrt_llm.llmapi.tokenizer import tokenizer_factory
 from tensorrt_llm.metrics import MetricsCollector
@@ -109,6 +113,67 @@ def build_kv_connector_config(config: Config):
     return None
 
 
+def _parse_model_loader_extra_config(raw_value: object) -> dict[str, object]:
+    if raw_value is None:
+        return {}
+    if isinstance(raw_value, dict):
+        return raw_value
+    if isinstance(raw_value, str):
+        if not raw_value.strip():
+            return {}
+        try:
+            parsed = json.loads(raw_value)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Invalid JSON in --model-loader-extra-config: {exc}"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise ValueError(
+                "--model-loader-extra-config must decode to a JSON object"
+            )
+        return parsed
+    raise ValueError(
+        "--model-loader-extra-config must be empty, a JSON object string, or a dict"
+    )
+
+
+def _llm_supports_engine_arg(arg_name: str) -> bool:
+    model_fields = getattr(LlmArgs, "model_fields", None)
+    if isinstance(model_fields, dict):
+        return arg_name in model_fields
+    return True
+
+
+def _set_optional_engine_arg(
+    arg_map: dict[str, object],
+    arg_name: str,
+    value: object,
+    *,
+    warn_if_unsupported: bool,
+) -> None:
+    if _llm_supports_engine_arg(arg_name):
+        arg_map[arg_name] = value
+        return
+    if warn_if_unsupported:
+        logging.warning(
+            "Installed TensorRT-LLM does not support engine arg `%s`; ignoring.",
+            arg_name,
+        )
+
+
+def _is_supported_load_format(load_format: str) -> bool:
+    members = getattr(LoadFormat, "__members__", None)
+    if members is None:
+        return True
+    normalized = load_format.upper()
+    if normalized in members:
+        return True
+    for member in members.values():
+        if str(getattr(member, "value", "")).lower() == load_format.lower():
+            return True
+    return False
+
+
 async def init_llm_worker(
     runtime: DistributedRuntime,
     config: Config,
@@ -165,6 +230,28 @@ async def init_llm_worker(
         dynamic_batch_config=dynamic_batch_config,
     )
     kv_connector_config = build_kv_connector_config(config)
+    try:
+        model_loader_extra_config = _parse_model_loader_extra_config(
+            config.model_loader_extra_config
+        )
+    except ValueError as exc:
+        logging.error("%s", exc)
+        sys.exit(1)
+
+    if config.load_format == "gms":
+        try:
+            from gpu_memory_service.integrations.trtllm import setup_gms
+        except ImportError as exc:
+            raise RuntimeError(
+                "GPU Memory Service is required for --load-format gms. "
+                "Install/update the gpu-memory-service package in this environment."
+            ) from exc
+
+        setup_gms(model_loader_extra_config)
+        logging.info(
+            "TensorRT-LLM GMS integration enabled (extra=%s)",
+            model_loader_extra_config,
+        )
 
     arg_map = {
         "model": model_path,
@@ -187,6 +274,31 @@ async def init_llm_worker(
         "enable_iter_perf_stats": config.publish_events_and_metrics,
         "kv_connector_config": kv_connector_config,
     }
+    engine_load_format = config.load_format
+    if config.load_format == "gms" and not _is_supported_load_format("gms"):
+        logging.warning(
+            "Installed TensorRT-LLM does not support load_format='gms'; using "
+            "load_format='auto' for engine args while keeping GMS patches enabled."
+        )
+        engine_load_format = "auto"
+    _set_optional_engine_arg(
+        arg_map,
+        "load_format",
+        engine_load_format,
+        warn_if_unsupported=config.load_format != "auto",
+    )
+    _set_optional_engine_arg(
+        arg_map,
+        "enable_sleep",
+        config.enable_sleep,
+        warn_if_unsupported=config.enable_sleep,
+    )
+    _set_optional_engine_arg(
+        arg_map,
+        "model_loader_extra_config",
+        model_loader_extra_config,
+        warn_if_unsupported=bool(model_loader_extra_config),
+    )
 
     # Add guided decoding backend if specified
     if config.guided_decoding_backend is not None:
@@ -437,6 +549,7 @@ async def init_llm_worker(
             disaggregation_mode=config.disaggregation_mode,
             encode_client=encode_client,
             multimodal_processor=multimodal_processor,
+            generate_endpoint=endpoint,
             connector=connector,
             runtime=runtime,  # Pass runtime for graceful shutdown
             metrics_collector=metrics_collector,
@@ -510,6 +623,18 @@ async def init_llm_worker(
             ) as publisher:
                 handler_config.publisher = publisher
                 handler = RequestHandlerFactory().get_request_handler(handler_config)
+                if config.enable_sleep:
+                    runtime.register_engine_route(
+                        "release_memory_occupation",
+                        handler.release_memory_occupation,
+                    )
+                    runtime.register_engine_route(
+                        "resume_memory_occupation",
+                        handler.resume_memory_occupation,
+                    )
+                    logging.info(
+                        "Registered engine routes: /engine/release_memory_occupation, /engine/resume_memory_occupation"
+                    )
                 await endpoint.serve_endpoint(
                     handler.generate,
                     metrics_labels=metrics_labels,
@@ -521,6 +646,18 @@ async def init_llm_worker(
                 consolidator_publisher.shutdown()
         else:
             handler = RequestHandlerFactory().get_request_handler(handler_config)
+            if config.enable_sleep:
+                runtime.register_engine_route(
+                    "release_memory_occupation",
+                    handler.release_memory_occupation,
+                )
+                runtime.register_engine_route(
+                    "resume_memory_occupation",
+                    handler.resume_memory_occupation,
+                )
+                logging.info(
+                    "Registered engine routes: /engine/release_memory_occupation, /engine/resume_memory_occupation"
+                )
             await endpoint.serve_endpoint(
                 handler.generate, health_check_payload=health_check_payload
             )

--- a/lib/gpu_memory_service/README.md
+++ b/lib/gpu_memory_service/README.md
@@ -452,9 +452,9 @@ class GMSClientMemoryManager:
 
 ---
 
-## Framework Integration (vLLM / SGLang)
+## Framework Integration (vLLM / SGLang / TRT-LLM)
 
-GMS provides pre-built integrations for vLLM and SGLang. Enable GMS by passing `--load-format gms` when launching an engine.
+GMS provides pre-built integrations for vLLM, SGLang, and TRT-LLM. Enable GMS by passing `--load-format gms` when launching an engine.
 
 ### How It Works
 
@@ -495,12 +495,27 @@ The integration patches `torch_memory_saver` to route weight operations through 
 - Other tags (e.g., `"kv_cache"`) are delegated to the default torch mempool implementation
 - The `--enable-memory-saver` flag is required to activate the memory saver pathway
 
+#### TRT-LLM
+
+```bash
+python -m dynamo.trtllm \
+  --model <model> \
+  --load-format gms \
+  --enable-sleep
+```
+
+The integration patches TensorRT-LLM's model loader:
+- RW mode publishes weights to GMS and commits metadata for import
+- RO mode constructs the model in `MetaInitMode` and materializes tensors from GMS
+- `--model-loader-extra-config '{"gms_read_only": true}'` forces RO import mode
+
 ### Shadow Engine Failover (Sleep / Wake)
 
-Both integrations support releasing and reclaiming GPU memory for shadow engine patterns. The API names differ by framework:
+All integrations support releasing and reclaiming GPU memory for shadow engine patterns. The API names differ by framework:
 
 - **vLLM**: `sleep` / `wake_up` (via `/engine/sleep` and `/engine/wake_up` HTTP endpoints)
 - **SGLang**: `release_memory_occupation` / `resume_memory_occupation` (via the corresponding HTTP endpoints)
+- **TRT-LLM**: `release_memory_occupation` / `resume_memory_occupation` (via the corresponding HTTP endpoints)
 
 Under the hood, sleeping calls `unmap_all_vas()` + `disconnect()` to release GPU memory while preserving VA reservations, and waking calls `connect(RO)` + `remap_all_vas()` to re-import weights at the same virtual addresses. Tensor pointers remain valid, so no model re-initialization is needed.
 

--- a/lib/gpu_memory_service/integrations/trtllm/__init__.py
+++ b/lib/gpu_memory_service/integrations/trtllm/__init__.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GPU Memory Service integration for TensorRT-LLM.
+
+Usage:
+    from gpu_memory_service.integrations.trtllm import setup_gms
+
+    if config.load_format == "gms":
+        setup_gms(config.model_loader_extra_config)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from gpu_memory_service.integrations.common import patch_empty_cache
+from gpu_memory_service.integrations.common.utils import (
+    get_gms_lock_mode as resolve_gms_lock_mode,
+)
+from gpu_memory_service.integrations.trtllm.model_loader import (
+    get_gms_lock_mode,
+    patch_model_loader,
+    set_gms_enabled,
+    set_gms_lock_mode,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def setup_gms(model_loader_extra_config: dict[str, Any] | None = None) -> None:
+    """Setup GPU Memory Service integration for TensorRT-LLM."""
+    extra = model_loader_extra_config or {}
+    lock_mode = resolve_gms_lock_mode(extra)
+
+    set_gms_enabled(True)
+    set_gms_lock_mode(lock_mode)
+
+    patch_empty_cache()
+    patch_model_loader()
+
+    logger.info("[GMS] TensorRT-LLM integration enabled")

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -1,0 +1,271 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT-LLM model loader patches for GPU Memory Service integration."""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import TYPE_CHECKING
+
+import torch
+from gpu_memory_service import get_or_create_gms_client_memory_manager
+from gpu_memory_service.client.torch.module import materialize_module_from_gms
+from gpu_memory_service.common.types import GrantedLockType, RequestedLockType
+from gpu_memory_service.common.utils import get_socket_path
+from gpu_memory_service.integrations.common.utils import finalize_gms_write
+
+if TYPE_CHECKING:
+    from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
+
+logger = logging.getLogger(__name__)
+
+_model_loader_patched = False
+_gms_enabled = False
+_gms_lock_mode = RequestedLockType.RW_OR_RO
+_last_imported_weights_bytes = 0
+
+
+def _ptr_in_gms_mappings(gms_client: "GMSClientMemoryManager", ptr: int) -> bool:
+    for va, mapping in gms_client.mappings.items():
+        if va <= ptr < va + mapping.aligned_size:
+            return True
+    return False
+
+
+def _move_untracked_parameters_to_pool(
+    model: torch.nn.Module,
+    gms_client: "GMSClientMemoryManager",
+    target_device: torch.device,
+) -> list[str]:
+    """Move CUDA parameters not already mapped by GMS into the active mempool."""
+    from gpu_memory_service.client.torch.module import _iter_module_tensors
+
+    moved: list[str] = []
+    seen_parameter_objects: set[int] = set()
+    device_index = (
+        torch.cuda.current_device()
+        if target_device.index is None
+        else int(target_device.index)
+    )
+    with torch.no_grad():
+        for name, tensor, tensor_type in _iter_module_tensors(model):
+            if tensor_type != "parameter":
+                continue
+            tensor_obj_id = id(tensor)
+            if tensor_obj_id in seen_parameter_objects:
+                continue
+            seen_parameter_objects.add(tensor_obj_id)
+
+            if tensor is None or not tensor.is_cuda:
+                continue
+            if _ptr_in_gms_mappings(gms_client, int(tensor.data_ptr())):
+                continue
+
+            replacement = torch.empty_like(tensor, device=target_device)
+            replacement.copy_(tensor)
+            if not _ptr_in_gms_mappings(gms_client, int(replacement.data_ptr())):
+                replacement = _copy_tensor_to_gms_mapping(
+                    tensor=tensor,
+                    gms_client=gms_client,
+                    device_index=device_index,
+                )
+            tensor.data = replacement
+            moved.append(name)
+    return moved
+
+
+def _tensor_storage_nbytes(tensor: torch.Tensor) -> int:
+    element_size = int(tensor.element_size())
+    shape = list(tensor.shape)
+    stride = list(tensor.stride())
+    if shape and stride:
+        max_offset = sum(
+            int(s) * (int(d) - 1)
+            for s, d in zip(stride, shape, strict=True)
+            if int(d) > 0
+        )
+        return int((max_offset + 1) * element_size)
+    return element_size
+
+
+def _copy_tensor_to_gms_mapping(
+    tensor: torch.Tensor,
+    gms_client: "GMSClientMemoryManager",
+    device_index: int,
+) -> torch.Tensor:
+    from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
+
+    base_va = gms_client.create_mapping(
+        size=_tensor_storage_nbytes(tensor),
+        tag="weights",
+    )
+    mapped_tensor = _tensor_from_pointer(
+        int(base_va),
+        list(tensor.shape),
+        list(tensor.stride()),
+        tensor.dtype,
+        device_index,
+    )
+    mapped_tensor.copy_(tensor)
+    return mapped_tensor
+
+
+def set_gms_enabled(enabled: bool) -> None:
+    """Enable or disable GMS mode for TensorRT-LLM patches."""
+    global _gms_enabled
+    _gms_enabled = enabled
+
+
+def set_gms_lock_mode(mode: RequestedLockType) -> None:
+    """Set lock mode used by the TensorRT-LLM GMS loader."""
+    global _gms_lock_mode
+    _gms_lock_mode = mode
+
+
+def get_gms_lock_mode() -> RequestedLockType:
+    """Get lock mode used by the TensorRT-LLM GMS loader."""
+    return _gms_lock_mode
+
+
+def get_imported_weights_bytes() -> int:
+    """Return bytes of weights imported/published by last model load."""
+    return int(_last_imported_weights_bytes)
+
+
+def patch_model_loader() -> None:
+    """Patch TensorRT-LLM's model loader to support GMS weights."""
+    global _model_loader_patched
+    if _model_loader_patched:
+        return
+
+    import tensorrt_llm._torch.pyexecutor.model_loader as trt_model_loader_module
+
+    original_load = trt_model_loader_module.ModelLoader.load
+    original_get_rank_model_storage = trt_model_loader_module.get_rank_model_storage
+
+    def patched_get_rank_model_storage(model) -> int:
+        imported_bytes = get_imported_weights_bytes()
+        if imported_bytes > 0:
+            return imported_bytes
+        return int(original_get_rank_model_storage(model))
+
+    def patched_load(self, checkpoint_dir: str, checkpoint_loader):
+        if not _gms_enabled:
+            return original_load(self, checkpoint_dir, checkpoint_loader)
+        return _load_model_with_gms(
+            self=self,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_loader=checkpoint_loader,
+            original_load=original_load,
+        )
+
+    trt_model_loader_module.get_rank_model_storage = patched_get_rank_model_storage
+    trt_model_loader_module.ModelLoader.load = patched_load
+    _model_loader_patched = True
+    logger.info("[GMS] Patched TensorRT-LLM ModelLoader.load")
+
+
+def _load_model_with_gms(self, checkpoint_dir: str, checkpoint_loader, original_load):
+    """Load model with GMS-backed weights for TensorRT-LLM."""
+    device_index = torch.cuda.current_device()
+    gms_client, pool = get_or_create_gms_client_memory_manager(
+        get_socket_path(device_index),
+        device_index,
+        mode=_gms_lock_mode,
+        tag="weights",
+    )
+
+    if gms_client.granted_lock_type == GrantedLockType.RO:
+        return _load_read_mode(
+            self=self,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_loader=checkpoint_loader,
+            gms_client=gms_client,
+            device_index=device_index,
+        )
+
+    if pool is None:
+        raise RuntimeError("GMS pool is None in write mode")
+
+    gms_client.clear_all_handles()
+
+    target_device = torch.device("cuda", device_index)
+    global _last_imported_weights_bytes
+    with torch.cuda.use_mem_pool(pool, device=target_device):
+        model, moe_load_balancer = original_load(self, checkpoint_dir, checkpoint_loader)
+        moved_params = _move_untracked_parameters_to_pool(
+            model=model,
+            gms_client=gms_client,
+            target_device=target_device,
+        )
+        if moved_params:
+            logger.warning(
+                "[GMS] TensorRT-LLM moved %d parameter(s) into GMS pool: %s",
+                len(moved_params),
+                moved_params[:8],
+            )
+        torch.cuda.current_stream().synchronize()
+        _last_imported_weights_bytes = finalize_gms_write(gms_client, model)
+    logger.info(
+        "[GMS] TensorRT-LLM write mode: published %.2f GiB",
+        _last_imported_weights_bytes / (1 << 30),
+    )
+
+    return model, moe_load_balancer
+
+
+def _load_read_mode(
+    self,
+    checkpoint_dir: str,
+    checkpoint_loader,
+    gms_client: "GMSClientMemoryManager",
+    device_index: int,
+):
+    """Load model by importing weights from GMS (RO mode)."""
+    global _last_imported_weights_bytes
+
+    from tensorrt_llm._torch.models import AutoModelForCausalLM
+    from tensorrt_llm._torch.models.modeling_utils import MetaInitMode, timing
+    from tensorrt_llm._torch.modules.fused_moe.moe_load_balancer import (
+        MoeLoadBalancer,
+        maybe_create_moe_load_balancer,
+    )
+
+    config = self._load_and_validate_config(checkpoint_dir, checkpoint_loader)
+
+    with timing("Model init total"), maybe_create_moe_load_balancer(
+        config, self.mapping
+    ) as moe_load_balancer:
+        config_copy = copy.deepcopy(config)
+        try:
+            with MetaInitMode():
+                model = AutoModelForCausalLM.from_config(config_copy)
+        except Exception as exc:
+            raise RuntimeError(
+                "TensorRT-LLM GMS read mode requires successful MetaInitMode model construction"
+            ) from exc
+
+        materialize_module_from_gms(gms_client, model, device_index=device_index)
+        _last_imported_weights_bytes = int(gms_client.total_bytes)
+        logger.info(
+            "[GMS] TensorRT-LLM read mode: imported %.2f GiB",
+            _last_imported_weights_bytes / (1 << 30),
+        )
+
+        for module in model.modules():
+            if hasattr(module, "post_load_weights") and not getattr(
+                module, "_weights_removed", False
+            ):
+                module.post_load_weights()
+
+        if isinstance(moe_load_balancer, MoeLoadBalancer):
+            moe_load_balancer.register_weight_slots_after_to_cuda()
+            logger.info("[GMS] moe_load_balancer finalizing model...")
+            moe_load_balancer.finalize_model()
+            logger.info("[GMS] moe_load_balancer finalize model done")
+
+        torch.cuda.current_stream().synchronize()
+
+    return model, moe_load_balancer

--- a/lib/gpu_memory_service/setup.py
+++ b/lib/gpu_memory_service/setup.py
@@ -75,6 +75,7 @@ setup(
         "gpu_memory_service.integrations",
         "gpu_memory_service.integrations.common",
         "gpu_memory_service.integrations.sglang",
+        "gpu_memory_service.integrations.trtllm",
         "gpu_memory_service.integrations.vllm",
     ],
     package_dir={
@@ -89,6 +90,7 @@ setup(
         "gpu_memory_service.integrations": "integrations",
         "gpu_memory_service.integrations.common": "integrations/common",
         "gpu_memory_service.integrations.sglang": "integrations/sglang",
+        "gpu_memory_service.integrations.trtllm": "integrations/trtllm",
         "gpu_memory_service.integrations.vllm": "integrations/vllm",
     },
     package_data={

--- a/tests/fault_tolerance/gpu_memory_service/test_gms_shadow_failover_trtllm.py
+++ b/tests/fault_tolerance/gpu_memory_service/test_gms_shadow_failover_trtllm.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GPU Memory Service shadow-engine failover test for TensorRT-LLM."""
+
+import pytest
+
+from .utils.common import run_shadow_failover_test
+from .utils.trtllm import TRTLLM_GMS_MODEL_NAME, TRTLLMWithGMSProcess
+
+
+@pytest.mark.trtllm
+@pytest.mark.e2e
+@pytest.mark.gpu_1
+@pytest.mark.fault_tolerance
+@pytest.mark.nightly
+@pytest.mark.model(TRTLLM_GMS_MODEL_NAME)
+@pytest.mark.timeout(600)
+def test_gms_shadow_engine_failover(
+    request, runtime_services, gms_ports, predownload_models
+):
+    ports = gms_ports
+
+    run_shadow_failover_test(
+        request,
+        ports,
+        make_shadow=lambda: TRTLLMWithGMSProcess(
+            request,
+            "shadow",
+            ports["shadow_system"],
+            ports["frontend"],
+        ),
+        make_primary=lambda: TRTLLMWithGMSProcess(
+            request,
+            "primary",
+            ports["primary_system"],
+            ports["frontend"],
+        ),
+        model=TRTLLM_GMS_MODEL_NAME,
+    )

--- a/tests/fault_tolerance/gpu_memory_service/test_gms_sleep_wake_trtllm.py
+++ b/tests/fault_tolerance/gpu_memory_service/test_gms_sleep_wake_trtllm.py
@@ -9,7 +9,12 @@ import pytest
 
 from tests.utils.managed_process import DynamoFrontendProcess
 
-from .utils.common import GMSServerProcess, get_gpu_memory_used, send_completion
+from .utils.common import (
+    GMSServerProcess,
+    get_gpu_memory_used,
+    send_completion,
+    wait_for_memory_drop,
+)
 from .utils.trtllm import (
     TRTLLM_GMS_MODEL_NAME,
     TRTLLM_GMS_READ_ONLY_CONFIG,
@@ -48,15 +53,9 @@ def test_gms_basic_sleep_wake(request, runtime_services, gms_ports, predownload_
                 sleep_result = engine.sleep()
                 assert sleep_result["status"] == "ok"
 
-                mem_after_sleep = get_gpu_memory_used()
+                mem_after_sleep = wait_for_memory_drop(mem_before)
                 logger.info("Memory after sleep: %.0f MB", mem_after_sleep / (1 << 20))
-                if "kv_cache" in sleep_result.get("skipped_tags", []):
-                    logger.info(
-                        "Skipping strict memory reduction assertion: "
-                        "kv_cache sleep is unsupported in this TRT-LLM runtime."
-                    )
-                else:
-                    assert mem_after_sleep < mem_before, "Sleep should reduce memory"
+                assert mem_after_sleep < mem_before, "Sleep should reduce memory"
 
                 wake_result = engine.wake()
                 assert wake_result["status"] == "ok"

--- a/tests/fault_tolerance/gpu_memory_service/test_gms_sleep_wake_trtllm.py
+++ b/tests/fault_tolerance/gpu_memory_service/test_gms_sleep_wake_trtllm.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GPU Memory Service basic sleep/wake tests for TensorRT-LLM."""
+
+import logging
+
+import pytest
+
+from tests.utils.managed_process import DynamoFrontendProcess
+
+from .utils.common import GMSServerProcess, get_gpu_memory_used, send_completion
+from .utils.trtllm import (
+    TRTLLM_GMS_MODEL_NAME,
+    TRTLLM_GMS_READ_ONLY_CONFIG,
+    TRTLLMWithGMSProcess,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.trtllm
+@pytest.mark.e2e
+@pytest.mark.gpu_1
+@pytest.mark.fault_tolerance
+@pytest.mark.nightly
+@pytest.mark.model(TRTLLM_GMS_MODEL_NAME)
+@pytest.mark.timeout(300)
+def test_gms_basic_sleep_wake(request, runtime_services, gms_ports, predownload_models):
+    """Validate TRT-LLM sleep/wake with GMS-backed weights."""
+    ports = gms_ports
+
+    with GMSServerProcess(request, device=0):
+        with DynamoFrontendProcess(request, frontend_port=ports["frontend"]):
+            with TRTLLMWithGMSProcess(
+                request,
+                "engine",
+                ports["shadow_system"],
+                ports["frontend"],
+            ) as engine:
+                result = send_completion(ports["frontend"], model=TRTLLM_GMS_MODEL_NAME)
+                logger.info("Initial inference result: %s", result)
+                assert result["choices"]
+
+                mem_before = get_gpu_memory_used()
+                logger.info("Memory before sleep: %.0f MB", mem_before / (1 << 20))
+
+                sleep_result = engine.sleep()
+                assert sleep_result["status"] == "ok"
+
+                mem_after_sleep = get_gpu_memory_used()
+                logger.info("Memory after sleep: %.0f MB", mem_after_sleep / (1 << 20))
+                if "kv_cache" in sleep_result.get("skipped_tags", []):
+                    logger.info(
+                        "Skipping strict memory reduction assertion: "
+                        "kv_cache sleep is unsupported in this TRT-LLM runtime."
+                    )
+                else:
+                    assert mem_after_sleep < mem_before, "Sleep should reduce memory"
+
+                wake_result = engine.wake()
+                assert wake_result["status"] == "ok"
+
+                result = send_completion(
+                    ports["frontend"], "Goodbye", model=TRTLLM_GMS_MODEL_NAME
+                )
+                logger.info("Post-wake inference result: %s", result)
+                assert result["choices"]
+
+                logger.info(
+                    "Memory freed: %.0f MB", (mem_before - mem_after_sleep) / (1 << 20)
+                )
+
+
+@pytest.mark.trtllm
+@pytest.mark.e2e
+@pytest.mark.gpu_1
+@pytest.mark.fault_tolerance
+@pytest.mark.nightly
+@pytest.mark.model(TRTLLM_GMS_MODEL_NAME)
+@pytest.mark.timeout(420)
+def test_gms_read_only_import_mode(
+    request, runtime_services, gms_ports, predownload_models
+):
+    """Validate TRT-LLM imports committed weights in gms_read_only mode."""
+    ports = gms_ports
+    system_port = ports["shadow_system"]
+
+    with GMSServerProcess(request, device=0):
+        with DynamoFrontendProcess(request, frontend_port=ports["frontend"]):
+            with TRTLLMWithGMSProcess(
+                request,
+                "writer",
+                system_port,
+                ports["frontend"],
+            ):
+                result = send_completion(ports["frontend"], model=TRTLLM_GMS_MODEL_NAME)
+                logger.info("Writer inference result: %s", result)
+                assert result["choices"]
+
+            with TRTLLMWithGMSProcess(
+                request,
+                "reader_ro",
+                system_port,
+                ports["frontend"],
+                model_loader_extra_config=TRTLLM_GMS_READ_ONLY_CONFIG,
+            ):
+                result = send_completion(
+                    ports["frontend"],
+                    "Read-only import validation",
+                    model=TRTLLM_GMS_MODEL_NAME,
+                )
+                logger.info("Read-only inference result: %s", result)
+                assert result["choices"]

--- a/tests/fault_tolerance/gpu_memory_service/utils/common.py
+++ b/tests/fault_tolerance/gpu_memory_service/utils/common.py
@@ -35,6 +35,22 @@ def get_gpu_memory_used(device: int = 0) -> int:
         pynvml.nvmlShutdown()
 
 
+def wait_for_memory_drop(
+    baseline_bytes: int,
+    timeout_s: float = 30.0,
+    poll_interval_s: float = 0.5,
+) -> int:
+    """Wait until GPU memory usage drops below baseline, then return current usage."""
+    start = time.time()
+    current = get_gpu_memory_used()
+    while time.time() - start < timeout_s:
+        if current < baseline_bytes:
+            return current
+        time.sleep(poll_interval_s)
+        current = get_gpu_memory_used()
+    return current
+
+
 def kill_force(
     process: ManagedProcess,
     timeout_s: float = 30.0,
@@ -85,7 +101,11 @@ def kill_force(
 
 
 def send_completion(
-    port: int, prompt: str = "Hello", max_retries: int = 3, retry_delay: float = 1.0
+    port: int,
+    prompt: str = "Hello",
+    model: str = FAULT_TOLERANCE_MODEL_NAME,
+    max_retries: int = 3,
+    retry_delay: float = 1.0,
 ) -> dict:
     """Send a completion request to the frontend.
 
@@ -98,7 +118,7 @@ def send_completion(
             r = requests.post(
                 f"http://localhost:{port}/v1/completions",
                 json={
-                    "model": FAULT_TOLERANCE_MODEL_NAME,
+                    "model": model,
                     "prompt": prompt,
                     "max_tokens": 20,
                 },
@@ -164,6 +184,7 @@ def run_shadow_failover_test(
     ports: dict,
     make_shadow: Callable[[], ManagedProcess],
     make_primary: Callable[[], ManagedProcess],
+    model: str = FAULT_TOLERANCE_MODEL_NAME,
 ) -> None:
     """Shared shadow-engine failover flow for both vLLM and SGLang.
 
@@ -179,14 +200,14 @@ def run_shadow_failover_test(
         with DynamoFrontendProcess(request, frontend_port=frontend_port):
             with make_shadow() as shadow:
                 # Shadow inference
-                result = send_completion(frontend_port)
+                result = send_completion(frontend_port, model=model)
                 assert result["choices"], "Shadow inference failed"
                 logger.info(f"Shadow inference OK: {result}")
 
                 # Sleep shadow
                 mem_before = get_gpu_memory_used()
                 assert shadow.sleep()["status"] == "ok"
-                mem_after = get_gpu_memory_used()
+                mem_after = wait_for_memory_drop(mem_before)
                 logger.info(
                     f"Shadow sleep: {mem_before / (1 << 30):.2f} -> "
                     f"{mem_after / (1 << 30):.2f} GiB "
@@ -195,7 +216,7 @@ def run_shadow_failover_test(
 
                 # Primary: start, verify, kill -9
                 with make_primary() as primary:
-                    result = send_completion(frontend_port, "Primary test")
+                    result = send_completion(frontend_port, "Primary test", model=model)
                     assert result["choices"], "Primary inference failed"
                     logger.info(f"Primary inference OK: {result}")
                     kill_force(primary)
@@ -203,6 +224,6 @@ def run_shadow_failover_test(
                 # Wake shadow, verify 3x
                 assert shadow.wake()["status"] == "ok"
                 for i in range(3):
-                    result = send_completion(frontend_port, f"Verify {i}")
+                    result = send_completion(frontend_port, f"Verify {i}", model=model)
                     assert result["choices"], f"Verification {i} failed"
                 logger.info("All verification passed")

--- a/tests/fault_tolerance/gpu_memory_service/utils/trtllm.py
+++ b/tests/fault_tolerance/gpu_memory_service/utils/trtllm.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT-LLM-specific utilities for GPU Memory Service tests."""
+
+import logging
+import os
+import shutil
+
+import requests
+
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.managed_process import ManagedProcess
+from tests.utils.payloads import check_health_generate, check_models_api
+
+logger = logging.getLogger(__name__)
+
+TRTLLM_GMS_MODEL_NAME = os.environ.get(
+    "TRTLLM_GMS_MODEL_NAME", FAULT_TOLERANCE_MODEL_NAME
+)
+TRTLLM_GMS_READ_ONLY_CONFIG = '{"gms_read_only": true}'
+TRTLLM_GMS_FREE_GPU_MEMORY_FRACTION = os.environ.get(
+    "TRTLLM_GMS_FREE_GPU_MEMORY_FRACTION", "0.9"
+)
+TRTLLM_GMS_MAX_SEQ_LEN = os.environ.get("TRTLLM_GMS_MAX_SEQ_LEN", "256")
+TRTLLM_GMS_MAX_NUM_TOKENS = os.environ.get("TRTLLM_GMS_MAX_NUM_TOKENS", "256")
+TRTLLM_GMS_OVERRIDE_ENGINE_ARGS = os.environ.get(
+    "TRTLLM_GMS_OVERRIDE_ENGINE_ARGS",
+    '{"kv_cache_config":{"max_tokens":4096}}',
+)
+
+
+def _build_trtllm_env(system_port: int) -> dict[str, str]:
+    env = {**os.environ}
+    env["DYN_LOG"] = "debug"
+    env["DYN_SYSTEM_PORT"] = str(system_port)
+    if "CUDA_VISIBLE_DEVICES" not in env:
+        env["CUDA_VISIBLE_DEVICES"] = "0"
+    env["TLLM_WORKER_USE_SINGLE_PROCESS"] = "1"
+    env["MPI4PY_MPIABI"] = "openmpi"
+    env["OMPI_MCA_coll_ucc_enable"] = "0"
+
+    venv_path = env.get("VIRTUAL_ENV")
+    if venv_path:
+        venv_lib = os.path.join(venv_path, "lib")
+        existing = env.get("LD_LIBRARY_PATH", "")
+        env["LD_LIBRARY_PATH"] = (
+            f"{venv_lib}:{existing}" if existing else venv_lib
+        )
+
+    return env
+
+
+class TRTLLMWithGMSProcess(ManagedProcess):
+    """TensorRT-LLM engine with GPU Memory Service integration."""
+
+    def __init__(
+        self,
+        request,
+        engine_id: str,
+        system_port: int,
+        frontend_port: int,
+        model_loader_extra_config: str | None = None,
+    ):
+        self.engine_id = engine_id
+        self.system_port = system_port
+
+        log_dir = f"{request.node.name}_{engine_id}"
+        shutil.rmtree(log_dir, ignore_errors=True)
+        command = [
+            "python3",
+            "-m",
+            "dynamo.trtllm",
+            "--model",
+            TRTLLM_GMS_MODEL_NAME,
+            "--gpus-per-node",
+            "1",
+            "--load-format",
+            "gms",
+            "--enable-sleep",
+            "--free-gpu-memory-fraction",
+            TRTLLM_GMS_FREE_GPU_MEMORY_FRACTION,
+            "--max-seq-len",
+            TRTLLM_GMS_MAX_SEQ_LEN,
+            "--max-num-tokens",
+            TRTLLM_GMS_MAX_NUM_TOKENS,
+            "--override-engine-args",
+            TRTLLM_GMS_OVERRIDE_ENGINE_ARGS,
+        ]
+        if model_loader_extra_config is not None:
+            command.extend(
+                [
+                    "--model-loader-extra-config",
+                    model_loader_extra_config,
+                ]
+            )
+
+        super().__init__(
+            command=command,
+            env=_build_trtllm_env(system_port),
+            health_check_urls=[
+                (f"http://localhost:{system_port}/health", self._is_ready),
+                (f"http://localhost:{frontend_port}/v1/models", check_models_api),
+                (f"http://localhost:{frontend_port}/health", check_health_generate),
+            ],
+            timeout=300,
+            display_output=True,
+            terminate_all_matching_process_names=False,
+            stragglers=[],
+            log_dir=log_dir,
+        )
+
+    def _is_ready(self, response) -> bool:
+        try:
+            return response.json().get("status") == "ready"
+        except ValueError:
+            return False
+
+    def sleep(self) -> dict:
+        """Put the engine to sleep, offloading GPU memory."""
+        response = requests.post(
+            f"http://localhost:{self.system_port}/engine/release_memory_occupation",
+            json={},
+            timeout=30,
+        )
+        response.raise_for_status()
+        logger.info("%s release_memory_occupation: %s", self.engine_id, response.json())
+        return response.json()
+
+    def wake(self) -> dict:
+        """Wake the engine, restoring GPU memory mappings."""
+        response = requests.post(
+            f"http://localhost:{self.system_port}/engine/resume_memory_occupation",
+            json={},
+            timeout=30,
+        )
+        response.raise_for_status()
+        logger.info("%s resume_memory_occupation: %s", self.engine_id, response.json())
+        return response.json()


### PR DESCRIPTION
## Summary
- add a TRTLLM sleep/wake fallback path for non-Ray executors when collective RPC is unavailable
- use TensorRT-LLM virtual-memory tagged operations for `kv_cache` (`release_with_tag` / `materialize_with_tag`) so sleep frees KV cache without touching GMS-managed weights
- keep weights handling on the GMS `weights` path, preserving the weights/KV split that mirrors vLLM/SGLang semantics
- tighten TRTLLM sleep/wake e2e assertion to always wait for and require a post-sleep memory drop
- extend TRTLLM sleep/wake handler unit tests to cover local fallback and multi-rank skip behavior

## Validation
- `pytest -q components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py` (13 passed)
- `pytest -vv tests/fault_tolerance/gpu_memory_service/test_gms_sleep_wake_trtllm.py` (4 passed)
- `pytest -vv tests/fault_tolerance/gpu_memory_service/test_gms_shadow_failover_trtllm.py` (3 passed)
