### PR TITLE
[Planner] Scale down after consecutive invalid throughput metrics

### DIFF
--- a/components/src/dynamo/planner/defaults.py
+++ b/components/src/dynamo/planner/defaults.py
@@ -74,6 +74,7 @@ class SLAPlannerDefaults(BasePlannerDefaults):
     mode: Literal["disagg", "prefill", "decode", "agg"] = "disagg"
 
     throughput_metrics_source = "frontend"  # "frontend" | "router"
+    nan_scaledown_threshold = 3  # consecutive invalid intervals before scaling to min
 
     # Scaling mode flags
     enable_throughput_scaling = True

--- a/components/src/dynamo/planner/utils/planner_config.py
+++ b/components/src/dynamo/planner/utils/planner_config.py
@@ -96,6 +96,14 @@ class PlannerConfig(BaseModel):
     throughput_metrics_source: Literal[
         "frontend", "router"
     ] = SLAPlannerDefaults.throughput_metrics_source
+    nan_scaledown_threshold: int = Field(
+        default=SLAPlannerDefaults.nan_scaledown_threshold,
+        ge=1,
+        description=(
+            "Number of consecutive invalid throughput metric intervals before "
+            "forcing scale-down to min_endpoint."
+        ),
+    )
 
     no_correction: bool = SLAPlannerDefaults.no_correction
     model_name: Optional[str] = None

--- a/components/src/dynamo/planner/utils/planner_core.py
+++ b/components/src/dynamo/planner/utils/planner_core.py
@@ -416,6 +416,7 @@ class BasePlanner:
 
         self.p_correction_factor = 1.0
         self.d_correction_factor = 1.0
+        self._consecutive_invalid_metrics_count = 0
         if self.dryrun:
             self.no_correction = True
         else:
@@ -688,12 +689,28 @@ class BasePlanner:
         self.osl_predictor.add_data_point(osl_avg)
 
     def plan_adjustment(self) -> Optional[int]:
-        # Skip adjustment if no traffic
+        # Invalid metrics often happen during zero-traffic intervals (Prometheus
+        # histogram avg division by zero). After a few consecutive invalid intervals,
+        # force a safe scale-down to min_endpoint to avoid lingering at peak replicas.
         if not self.last_metrics.is_valid():
+            self._consecutive_invalid_metrics_count += 1
+            threshold = getattr(self.config, "nan_scaledown_threshold", 3)
+            if self._consecutive_invalid_metrics_count >= threshold:
+                logger.info(
+                    "Metrics contain None or NaN values for %d consecutive intervals; "
+                    "forcing scale-down to min_endpoint=%d",
+                    self._consecutive_invalid_metrics_count,
+                    self.config.min_endpoint,
+                )
+                self._consecutive_invalid_metrics_count = 0
+                return self.config.min_endpoint
             logger.info(
-                "Metrics contain None or NaN values (no active requests), skipping adjustment"
+                "Metrics contain None or NaN values (%d/%d); skipping adjustment",
+                self._consecutive_invalid_metrics_count,
+                threshold,
             )
             return None
+        self._consecutive_invalid_metrics_count = 0
 
         if not self.no_correction:
             try:

--- a/tests/planner/unit/test_planner_config.py
+++ b/tests/planner/unit/test_planner_config.py
@@ -87,3 +87,15 @@ def test_throughput_metrics_source_invalid():
     """throughput_metrics_source rejects invalid values."""
     with pytest.raises(ValidationError):
         PlannerConfig(namespace="test-ns", throughput_metrics_source="invalid")
+
+
+def test_nan_scaledown_threshold_default():
+    """nan_scaledown_threshold defaults to 3 intervals."""
+    config = PlannerConfig(namespace="test-ns")
+    assert config.nan_scaledown_threshold == 3
+
+
+def test_nan_scaledown_threshold_must_be_positive():
+    """nan_scaledown_threshold rejects non-positive values."""
+    with pytest.raises(ValidationError):
+        PlannerConfig(namespace="test-ns", nan_scaledown_threshold=0)

--- a/tests/planner/unit/test_sla_planner_scaling.py
+++ b/tests/planner/unit/test_sla_planner_scaling.py
@@ -14,6 +14,7 @@ from dynamo.planner.utils.exceptions import DeploymentValidationError
 from dynamo.planner.utils.planner_config import PlannerConfig
 from dynamo.planner.utils.planner_core import PlannerSharedState, _initialize_gpu_counts
 from dynamo.planner.utils.prefill_planner import PrefillPlanner
+from dynamo.planner.utils.prometheus import Metrics
 
 pytestmark = [
     pytest.mark.gpu_0,
@@ -206,6 +207,62 @@ def test_disagg_scale_down():
     assert low_d == _expected_decode(config, decode_planner, samples[1])
     assert low_p < high_p
     assert low_d < high_d
+
+
+def test_invalid_metrics_scale_down_after_threshold():
+    config = _build_config()
+    config.nan_scaledown_threshold = 2
+    prefill_planner, _, shared_state = _build_planners(config, Mock())
+
+    shared_state.last_metrics = Metrics(
+        num_req=0,
+        isl=math.nan,
+        osl=math.nan,
+        ttft=math.nan,
+        itl=math.nan,
+        request_duration=math.nan,
+    )
+
+    assert prefill_planner.plan_adjustment() is None
+    assert prefill_planner.plan_adjustment() == config.min_endpoint
+
+
+def test_invalid_metrics_counter_resets_after_valid_interval():
+    config = _build_config()
+    config.nan_scaledown_threshold = 2
+    prefill_planner, _, shared_state = _build_planners(config, Mock())
+
+    shared_state.last_metrics = Metrics(
+        num_req=0,
+        isl=math.nan,
+        osl=math.nan,
+        ttft=math.nan,
+        itl=math.nan,
+        request_duration=math.nan,
+    )
+    assert prefill_planner.plan_adjustment() is None
+
+    shared_state.last_metrics = Metrics(
+        num_req=1,
+        isl=128,
+        osl=64,
+        ttft=10.0,
+        itl=10.0,
+        request_duration=1.0,
+    )
+    prefill_planner.predict_load = Mock(return_value=(None, None, None))
+    assert prefill_planner.plan_adjustment() is None
+
+    shared_state.last_metrics = Metrics(
+        num_req=0,
+        isl=math.nan,
+        osl=math.nan,
+        ttft=math.nan,
+        itl=math.nan,
+        request_duration=math.nan,
+    )
+    assert prefill_planner.plan_adjustment() is None
+    assert prefill_planner.plan_adjustment() == config.min_endpoint
 
 
 # Tests for _initialize_gpu_counts


### PR DESCRIPTION
## Summary

Fix throughput-based planner behavior when traffic drops to zero and Prometheus returns invalid histogram averages.

- Add `nan_scaledown_threshold` planner config (default `3`, validated `>= 1`).
- Track consecutive invalid metric intervals in `BasePlanner.plan_adjustment()`.
- Force scale-down to `min_endpoint` after threshold is reached, then reset counter.
- Reset invalid-metric counter after any valid interval.
- Add unit tests for threshold fallback + reset behavior and config validation.

## Why

Issue #6985 reports that when load drops to zero, metrics like TTFT/ISL/OSL can become `NaN`, causing `plan_adjustment()` to always return `None` and preventing scale-down indefinitely.

This change keeps short-lived metric gaps as no-op but releases resources after sustained invalid/no-traffic intervals.

Fixes #6985

## Validation

- `python3 -m py_compile components/src/dynamo/planner/defaults.py components/src/dynamo/planner/utils/planner_config.py components/src/dynamo/planner/utils/planner_core.py tests/planner/unit/test_sla_planner_scaling.py tests/planner/unit/test_planner_config.py`
- Attempted pytest in this environment, but full test execution is currently blocked by local dependency resolution (`ai-dynamo-runtime==1.0.0`).
