### PR TITLE
chore: bump AIC to 0.7.0rc12

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@4e7799d19f67ab7ee093b1276b4d0771eafb6936",
+    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@acb9e89ca5dbb360733887d795ccf55a164beb87",
     "aiperf @ git+https://github.com/ai-dynamo/aiperf.git@c3fc969e9e30e9ddad35b2f613aa7c1d418f2de9",
     "matplotlib",
     "networkx",

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -12,7 +12,7 @@
 
 # For Multimodal EPD (required for device_map="auto" in vision model loading)
 accelerate
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@4e7799d19f67ab7ee093b1276b4d0771eafb6936
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@acb9e89ca5dbb360733887d795ccf55a164beb87
 aiofiles
 aiperf @ git+https://github.com/ai-dynamo/aiperf.git@54cd6dc820bff8bfebc875da104e59d745e14f75
 av==15.0.0


### PR DESCRIPTION
#### Overview:

Bumps the version of AIConfigurator to [v1.0.0rc12](https://github.com/ai-dynamo/aiconfigurator/commit/acb9e89ca5dbb360733887d795ccf55a164beb87)

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to OPS-3793
Relates to OPS-3790


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to latest compatible versions across build and container configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->