### PR TITLE
fix: KV Router Fault Tolerance Fixes

### DIFF
--- a/lib/kv-router/src/indexer/kv_indexer.rs
+++ b/lib/kv-router/src/indexer/kv_indexer.rs
@@ -64,7 +64,7 @@ impl KvIndexer {
         metrics: Arc<KvIndexerMetrics>,
         prune_config: Option<PruneConfig>,
     ) -> Self {
-        let (event_tx, event_rx) = mpsc::channel::<RouterEvent>(2048);
+        let (event_tx, event_rx) = mpsc::channel::<RouterEvent>(16384);
         let (match_tx, match_rx) = mpsc::channel::<MatchRequest>(128);
         let (remove_worker_tx, remove_worker_rx) = mpsc::channel::<WorkerId>(16);
         let (remove_worker_dp_rank_tx, remove_worker_dp_rank_rx) =

--- a/lib/kv-router/src/indexer/kv_indexer.rs
+++ b/lib/kv-router/src/indexer/kv_indexer.rs
@@ -194,6 +194,10 @@ impl KvIndexer {
                         }
 
                         Some(dump_req) = dump_rx.recv() => {
+                            // Flush pending events so tree is consistent with buffer
+                            while let Ok(event) = event_rx.try_recv() {
+                                let _ = trie.apply_event(event);
+                            }
                             let events = trie.dump_tree_as_events();
                             let _ = dump_req.resp.send(events);
                         }

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -63,7 +63,7 @@ impl LocalKvIndexer {
     /// ### Returns
     ///
     /// - `Events`: Buffered events with original IDs (when range is within buffer)
-    /// - `TreeDump`: Full tree dump with synthetic IDs (when range is too old or unspecified)
+    /// - `TreeDump`: Full tree dump with synthetic IDs and the worker's latest real event ID (when range is too old or unspecified)
     /// - `TooNew`: Error when requested range is newer than available data
     /// - `InvalidRange`: Error when end_id < start_id
     pub async fn get_events_in_id_range(
@@ -99,7 +99,10 @@ impl LocalKvIndexer {
         if start_id.is_none() {
             tracing::debug!("No start_id specified, dumping entire tree");
             let events = self.dump_events().await.unwrap_or_default();
-            return WorkerKvQueryResponse::TreeDump(events);
+            return WorkerKvQueryResponse::TreeDump {
+                events,
+                last_event_id: last_id.unwrap_or(0),
+            };
         }
 
         let start_id = start_id.unwrap();
@@ -109,7 +112,10 @@ impl LocalKvIndexer {
         let Some(first_buffered) = first_id else {
             tracing::debug!("Buffer empty, dumping entire tree");
             let events = self.dump_events().await.unwrap_or_default();
-            return WorkerKvQueryResponse::TreeDump(events);
+            return WorkerKvQueryResponse::TreeDump {
+                events,
+                last_event_id: 0,
+            };
         };
         let last_buffered = last_id.unwrap();
 
@@ -135,7 +141,10 @@ impl LocalKvIndexer {
                 "Requested start_id is older than buffer, dumping entire tree"
             );
             let events = self.dump_events().await.unwrap_or_default();
-            return WorkerKvQueryResponse::TreeDump(events);
+            return WorkerKvQueryResponse::TreeDump {
+                events,
+                last_event_id: last_buffered,
+            };
         }
 
         // Serve from buffer

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -207,15 +207,17 @@ impl LocalKvIndexer {
     ///
     /// This records the event in the buffer and forwards it to the underlying indexer.
     pub async fn apply_event_with_buffer(&self, event: RouterEvent) -> Result<(), KvRouterError> {
-        // Record in buffer
-        self.record_event(event.clone());
-
         // Forward to underlying indexer
-        self.indexer
+        let result = self
+            .indexer
             .event_sender()
-            .send(event)
+            .send(event.clone())
             .await
-            .map_err(|_| KvRouterError::IndexerOffline)
+            .map_err(|_| KvRouterError::IndexerOffline);
+        // Record in buffer
+        self.record_event(event);
+
+        result
     }
 
     /// Clear the event buffer.

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -1933,7 +1933,7 @@ async fn test_local_indexer_slice_within_range() {
     let extract_events = |resp: WorkerKvQueryResponse| -> Vec<RouterEvent> {
         match resp {
             WorkerKvQueryResponse::Events(e) => e,
-            WorkerKvQueryResponse::TreeDump(e) => e,
+            WorkerKvQueryResponse::TreeDump { events: e, .. } => e,
             _ => panic!("Unexpected response type"),
         }
     };
@@ -1954,7 +1954,7 @@ async fn test_local_indexer_slice_within_range() {
 
     // start_id=0 is before buffer (first is 1), so should trigger tree dump
     let result = indexer.get_events_in_id_range(Some(0), Some(4)).await;
-    assert!(matches!(result, WorkerKvQueryResponse::TreeDump(_)));
+    assert!(matches!(result, WorkerKvQueryResponse::TreeDump { .. }));
 
     let result = indexer.get_events_in_id_range(Some(3), Some(3)).await;
     let ids = get_ids(extract_events(result));
@@ -2008,7 +2008,7 @@ async fn test_local_indexer_get_events_in_id_range_all_cases() {
     let extract_events = |resp: WorkerKvQueryResponse| -> Vec<RouterEvent> {
         match resp {
             WorkerKvQueryResponse::Events(e) => e,
-            WorkerKvQueryResponse::TreeDump(e) => e,
+            WorkerKvQueryResponse::TreeDump { events: e, .. } => e,
             _ => panic!("Unexpected response type: {:?}", resp),
         }
     };
@@ -2030,11 +2030,11 @@ async fn test_local_indexer_get_events_in_id_range_all_cases() {
 
     // Tree dump path tests
     let result = indexer.get_events_in_id_range(None, None).await;
-    assert!(matches!(result, WorkerKvQueryResponse::TreeDump(_)));
+    assert!(matches!(result, WorkerKvQueryResponse::TreeDump { .. }));
     assert_eq!(extract_events(result).len(), 10);
 
     let result = indexer.get_events_in_id_range(Some(7), None).await;
-    assert!(matches!(result, WorkerKvQueryResponse::TreeDump(_)));
+    assert!(matches!(result, WorkerKvQueryResponse::TreeDump { .. }));
 
     // Edge cases
     let result = indexer.get_events_in_id_range(Some(15), Some(10)).await;
@@ -2042,6 +2042,98 @@ async fn test_local_indexer_get_events_in_id_range_all_cases() {
 
     let result = indexer.get_events_in_id_range(Some(100), Some(200)).await;
     assert!(matches!(result, WorkerKvQueryResponse::TooNew { .. }));
+}
+
+#[tokio::test]
+async fn test_tree_dump_includes_last_event_id() {
+    // Create indexer with small buffer (5 events max)
+    let indexer = LocalKvIndexer::new(
+        CancellationToken::new(),
+        4,
+        Arc::new(KvIndexerMetrics::new_unregistered()),
+        5,
+    );
+
+    let make_event = |id: u64| {
+        RouterEvent::new(
+            0,
+            KvCacheEvent {
+                event_id: id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: None,
+                    blocks: vec![KvCacheStoredBlockData {
+                        block_hash: ExternalSequenceBlockHash(id * 100),
+                        tokens_hash: LocalBlockHash(id * 200),
+                        mm_extra_info: None,
+                    }],
+                }),
+                dp_rank: 0,
+            },
+        )
+    };
+
+    // Add 10 events (IDs 5-14), buffer keeps last 5: events 10-14
+    for id in 5..15 {
+        indexer
+            .apply_event_with_buffer(make_event(id))
+            .await
+            .unwrap();
+    }
+    indexer.flush().await;
+
+    // Request with start_id=None -> tree dump should include last_event_id=14
+    let result = indexer.get_events_in_id_range(None, None).await;
+    match result {
+        WorkerKvQueryResponse::TreeDump {
+            last_event_id,
+            events,
+        } => {
+            assert_eq!(
+                last_event_id, 14,
+                "last_event_id should be the buffer's newest event ID"
+            );
+            assert!(!events.is_empty(), "tree dump should contain events");
+        }
+        other => panic!("Expected TreeDump, got: {other:?}"),
+    }
+
+    // Request with start_id older than buffer -> tree dump should include last_event_id=14
+    let result = indexer.get_events_in_id_range(Some(7), None).await;
+    match result {
+        WorkerKvQueryResponse::TreeDump {
+            last_event_id,
+            events,
+        } => {
+            assert_eq!(
+                last_event_id, 14,
+                "last_event_id should be the buffer's newest event ID"
+            );
+            assert!(!events.is_empty(), "tree dump should contain events");
+        }
+        other => panic!("Expected TreeDump, got: {other:?}"),
+    }
+
+    // Empty buffer case: create a fresh indexer with no events
+    let empty_indexer = LocalKvIndexer::new(
+        CancellationToken::new(),
+        4,
+        Arc::new(KvIndexerMetrics::new_unregistered()),
+        5,
+    );
+    let result = empty_indexer.get_events_in_id_range(None, None).await;
+    match result {
+        WorkerKvQueryResponse::TreeDump {
+            last_event_id,
+            events,
+        } => {
+            assert_eq!(
+                last_event_id, 0,
+                "empty buffer should return last_event_id=0"
+            );
+            assert!(events.is_empty(), "empty indexer should have no events");
+        }
+        other => panic!("Expected TreeDump, got: {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -61,8 +61,13 @@ pub struct WorkerKvQueryRequest {
 pub enum WorkerKvQueryResponse {
     /// Events served from the circular buffer (with original event IDs)
     Events(Vec<RouterEvent>),
-    /// Full tree dump (with synthetic 0-indexed event IDs)
-    TreeDump(Vec<RouterEvent>),
+    /// Full tree dump (with synthetic 0-indexed event IDs).
+    /// Includes `last_event_id`: the newest real event ID in the worker's buffer
+    /// at the time of the dump, so the caller can set its tracking cursor correctly.
+    TreeDump {
+        events: Vec<RouterEvent>,
+        last_event_id: u64,
+    },
     /// Requested range is newer than available data
     TooNew {
         requested_start: Option<u64>,

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -1890,7 +1890,7 @@ mod tests_startup_helpers {
             .await;
         let missed_events = match response {
             crate::kv_router::indexer::WorkerKvQueryResponse::Events(e) => e,
-            crate::kv_router::indexer::WorkerKvQueryResponse::TreeDump(e) => e,
+            crate::kv_router::indexer::WorkerKvQueryResponse::TreeDump { events: e, .. } => e,
             crate::kv_router::indexer::WorkerKvQueryResponse::Error(message) => {
                 panic!("Unexpected error response: {message}")
             }

--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -100,7 +100,6 @@ async fn start_kv_router_background_event_plane(
                     );
 
                     // Gap detection: check if event ID is monotonically increasing per (worker, dp_rank)
-                    // Note: event_id <= last_id is duplicate/out-of-order, apply anyway (idempotent)
                     if let Some(&last_id) = last_event_ids.get(&event_key)
                         && event_id > last_id + 1
                     {
@@ -111,24 +110,41 @@ async fn start_kv_router_background_event_plane(
                             "Event ID gap detected for worker {worker_id} dp_rank {dp_rank}, recovering events [{gap_start}, {gap_end}], gap_size: {gap_size}"
                         );
 
-                        if let Err(e) = worker_query_client
+                        match worker_query_client
                             .recover_from_worker(worker_id, dp_rank, Some(gap_start), Some(gap_end))
                             .await
                         {
-                            tracing::error!(
-                                "Failed to recover gap events for worker {worker_id} dp_rank {dp_rank} (gap_start: {gap_start}, gap_end: {gap_end}); proceeding with current event anyway: {e}"
-                            );
+                            Ok((_count, Some(last_recovered_id))) => {
+                                // Update tracking to the recovery's last event ID.
+                                // For tree dumps, this is the worker's real latest event ID,
+                                // which prevents re-triggering gap recovery for events the
+                                // tree dump already covers.
+                                last_event_ids.insert(event_key, last_recovered_id.max(event_id));
+                            }
+                            Ok((_count, None)) => {
+                                // No last_event_id returned (e.g. TooNew with 0 events).
+                                // Normal tracking below will handle it.
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to recover gap events for worker {worker_id} dp_rank {dp_rank} (gap_start: {gap_start}, gap_end: {gap_end}); proceeding with current event anyway: {e}"
+                                );
+                            }
                         }
                     }
 
-                    // Update last seen event ID (use max to handle out-of-order)
-                    last_event_ids
-                        .entry(event_key)
-                        .and_modify(|id| *id = (*id).max(event_id))
-                        .or_insert(event_id);
+                    if last_event_ids.get(&event_key).map_or(true, |id| event_id > *id) {
+                        // Update last seen event ID (use max to handle out-of-order)
+                        last_event_ids
+                            .entry(event_key)
+                            .and_modify(|id| *id = (*id).max(event_id))
+                            .or_insert(event_id);
 
-                    // Forward the RouterEvent to the indexer
-                    indexer.apply_event(event).await;
+                        // Forward the RouterEvent to the indexer
+                        indexer.apply_event(event).await;
+                    }
+
+
                 }
             }
         }

--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -134,11 +134,7 @@ async fn start_kv_router_background_event_plane(
                     }
 
                     if last_event_ids.get(&event_key).map_or(true, |id| event_id > *id) {
-                        // Update last seen event ID (use max to handle out-of-order)
-                        last_event_ids
-                            .entry(event_key)
-                            .and_modify(|id| *id = (*id).max(event_id))
-                            .or_insert(event_id);
+                        last_event_ids.insert(event_key, event_id);
 
                         // Forward the RouterEvent to the indexer
                         indexer.apply_event(event).await;

--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -119,7 +119,7 @@ async fn start_kv_router_background_event_plane(
                                 // For tree dumps, this is the worker's real latest event ID,
                                 // which prevents re-triggering gap recovery for events the
                                 // tree dump already covers.
-                                last_event_ids.insert(event_key, last_recovered_id.max(event_id));
+                                last_event_ids.insert(event_key, last_recovered_id);
                             }
                             Ok((_count, None)) => {
                                 // No last_event_id returned (e.g. TooNew with 0 events).

--- a/lib/llm/src/kv_router/worker_query.rs
+++ b/lib/llm/src/kv_router/worker_query.rs
@@ -117,7 +117,7 @@ impl WorkerQueryClient {
                             .recover_from_worker(worker_id, dp_rank, None, None)
                             .await
                         {
-                            Ok(count) => {
+                            Ok((count, _)) => {
                                 if count > 0 {
                                     tracing::info!(
                                         "Recovered {count} events from worker {worker_id} dp_rank {dp_rank}"
@@ -278,6 +278,10 @@ impl WorkerQueryClient {
 
     /// Recover missed KV events from a specific worker's dp_rank with retry logic.
     ///
+    /// Returns `(event_count, last_event_id)` where `last_event_id` is:
+    /// - For `Events`: the last event's real event ID (or `None` if empty)
+    /// - For `TreeDump`: the worker's latest real event ID at time of dump
+    ///
     /// Called both by the internal discovery loop (initial recovery) and by the
     /// event plane task in subscriber.rs (gap recovery).
     pub async fn recover_from_worker(
@@ -286,7 +290,7 @@ impl WorkerQueryClient {
         dp_rank: DpRank,
         start_event_id: Option<u64>,
         end_event_id: Option<u64>,
-    ) -> Result<usize> {
+    ) -> Result<(usize, Option<u64>)> {
         tracing::debug!(
             "Attempting recovery from worker {worker_id} dp_rank {dp_rank}, \
              start_event_id: {start_event_id:?}, end_event_id: {end_event_id:?}"
@@ -296,21 +300,25 @@ impl WorkerQueryClient {
             .query_worker_with_retry(worker_id, dp_rank, start_event_id, end_event_id)
             .await?;
 
-        let events = match response {
+        let (events, last_event_id) = match response {
             WorkerKvQueryResponse::Events(events) => {
                 tracing::debug!(
                     "Got {count} buffered events from worker {worker_id} dp_rank {dp_rank}",
                     count = events.len()
                 );
-                events
+                let last_id = events.last().map(|e| e.event.event_id);
+                (events, last_id)
             }
-            WorkerKvQueryResponse::TreeDump(events) => {
+            WorkerKvQueryResponse::TreeDump {
+                events,
+                last_event_id,
+            } => {
                 tracing::info!(
                     "Got tree dump from worker {worker_id} dp_rank {dp_rank} \
-                     (range too old or unspecified), count: {count}",
+                     (range too old or unspecified), count: {count}, last_event_id: {last_event_id}",
                     count = events.len()
                 );
-                events
+                (events, Some(last_event_id))
             }
             WorkerKvQueryResponse::TooNew {
                 requested_start,
@@ -321,7 +329,7 @@ impl WorkerQueryClient {
                     "Requested range [{requested_start:?}, {requested_end:?}] is newer than \
                      available (newest: {newest_available}) for worker {worker_id} dp_rank {dp_rank}"
                 );
-                return Ok(0);
+                return Ok((0, None));
             }
             WorkerKvQueryResponse::InvalidRange { start_id, end_id } => {
                 anyhow::bail!(
@@ -337,7 +345,7 @@ impl WorkerQueryClient {
         let count = events.len();
         if count == 0 {
             tracing::debug!("No events to recover from worker {worker_id} dp_rank {dp_rank}");
-            return Ok(0);
+            return Ok((0, last_event_id));
         }
 
         tracing::info!("Recovered {count} events from worker {worker_id} dp_rank {dp_rank}");
@@ -346,7 +354,7 @@ impl WorkerQueryClient {
             self.indexer.apply_event(event).await;
         }
 
-        Ok(count)
+        Ok((count, last_event_id))
     }
 }
 


### PR DESCRIPTION
When the KV router subscriber detects an event ID gap and triggers recovery via a tree dump, the recovered events were assigned synthetic (0-indexed) IDs. This caused the subscriber's tracking cursor to be set lower than the worker's actual latest event ID, causing subsequent real events to         
  re-trigger gap recovery in a loop.                                                                                                                                                                                                                                                                        

Changes:
- WorkerKvQueryResponse::TreeDump now carries a last_event_id field — the worker's real latest event ID at the time of the dump
- recover_from_worker returns (event_count, Option<last_event_id>) so callers can update their tracking cursor correctly
- After a successful gap recovery, the subscriber sets its cursor to max(recovered_last_id, current_event_id), preventing re-triggering
  - Duplicate/out-of-order events are now deduplicated before being applied to the indexer
  - Added tests covering the gap recovery and tree dump tracking scenarios



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cursor tracking support for better event navigation and synchronization.
  * Implemented gap recovery handling to automatically recover from missed events.

* **Improvements**
  * Enhanced error responses with additional context for better debugging.
  * Increased event buffering capacity for improved throughput and message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->