### PR TITLE
Fix EPP namespace handling for kgateway support

### DIFF
--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -368,6 +368,13 @@ func generateSingleDCD(
 	if len(parentDGD.Spec.Envs) > 0 {
 		deployment.Spec.Envs = MergeEnvs(parentDGD.Spec.Envs, deployment.Spec.Envs)
 	}
+	if workerNamespace, ok := getEPPWorkerNamespaceOverride(component.ComponentType, dynamoNamespace, rollingUpdateCtx.NewWorkerHash); ok &&
+		!hasEnvVar(component.Envs, commonconsts.DynamoNamespaceEnvVar) {
+		deployment.Spec.Envs = append(deployment.Spec.Envs, corev1.EnvVar{
+			Name:  commonconsts.DynamoNamespaceEnvVar,
+			Value: workerNamespace,
+		})
+	}
 
 	if err := updateDynDeploymentConfig(deployment, commonconsts.DynamoServicePort); err != nil {
 		return nil, err
@@ -488,6 +495,22 @@ func MergeEnvs(common, specific []corev1.EnvVar) []corev1.EnvVar {
 		return merged[i].Name < merged[j].Name
 	})
 	return merged
+}
+
+func getEPPWorkerNamespaceOverride(componentType, dynamoNamespace, workerHash string) (string, bool) {
+	if componentType != commonconsts.ComponentTypeEPP || workerHash == "" || workerHash == commonconsts.LegacyWorkerHash {
+		return "", false
+	}
+	return dynamoNamespace + "-" + workerHash, true
+}
+
+func hasEnvVar(envs []corev1.EnvVar, name string) bool {
+	for _, env := range envs {
+		if env.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // GetDCDResourceName returns the Kubernetes resource name for a DynamoComponentDeployment.

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -6875,6 +6875,74 @@ func TestGenerateSingleDCD_RollingUpdateContext(t *testing.T) {
 	assert.Equal(t, int32(1), *frontendDCD.Spec.Replicas)
 }
 
+func TestGenerateSingleDCD_EPPWorkerNamespaceOverride(t *testing.T) {
+	tests := []struct {
+		name             string
+		eppEnvs          []corev1.EnvVar
+		newWorkerHash    string
+		wantNamespace    string
+		wantNamespaceEnv bool
+	}{
+		{
+			name:             "hashed worker namespace is injected for EPP",
+			newWorkerHash:    "aabb1122",
+			wantNamespace:    "ns-my-dgd-aabb1122",
+			wantNamespaceEnv: true,
+		},
+		{
+			name: "explicit EPP namespace override is preserved",
+			eppEnvs: []corev1.EnvVar{
+				{Name: commonconsts.DynamoNamespaceEnvVar, Value: "custom-epp-namespace"},
+			},
+			newWorkerHash:    "aabb1122",
+			wantNamespace:    "custom-epp-namespace",
+			wantNamespaceEnv: true,
+		},
+		{
+			name:             "legacy worker hash does not inject hashed namespace",
+			newWorkerHash:    commonconsts.LegacyWorkerHash,
+			wantNamespaceEnv: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dgd := &v1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-dgd", Namespace: "ns"},
+				Spec: v1alpha1.DynamoGraphDeploymentSpec{
+					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+						"decode": {
+							ComponentType: commonconsts.ComponentTypeDecode,
+							Replicas:      ptr.To(int32(1)),
+						},
+						"epp": {
+							ComponentType: commonconsts.ComponentTypeEPP,
+							Envs:          tt.eppEnvs,
+						},
+					},
+				},
+			}
+
+			dcds, err := GenerateDynamoComponentsDeployments(context.Background(), dgd, nil, &RestartState{}, nil, RollingUpdateContext{
+				NewWorkerHash:     tt.newWorkerHash,
+				OldWorkerReplicas: map[string]int32{},
+				NewWorkerReplicas: map[string]int32{},
+			})
+			assert.NoError(t, err)
+
+			eppDCD := dcds["epp"]
+			found := false
+			for _, env := range eppDCD.Spec.Envs {
+				if env.Name == commonconsts.DynamoNamespaceEnvVar {
+					found = true
+					assert.Equal(t, tt.wantNamespace, env.Value)
+				}
+			}
+			assert.Equal(t, tt.wantNamespaceEnv, found)
+		})
+	}
+}
+
 func TestGenerateSingleDCD_NoRollingUpdate(t *testing.T) {
 	dgd := &v1alpha1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-dgd", Namespace: "ns"},

--- a/docs/kubernetes/inference-gateway.md
+++ b/docs/kubernetes/inference-gateway.md
@@ -12,7 +12,7 @@ Integrate Dynamo with the Gateway API Inference Extension for intelligent KV-awa
 
 EPP's default kv-routing approach is not token-aware because the prompt is not tokenized. But the Dynamo plugin uses a token-aware KV algorithm. It employs the dynamo router which implements kv routing by running your model's tokenizer inline. The EPP plugin configuration lives in [`helm/dynamo-gaie/epp-config-dynamo.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/standalone/helm/dynamo-gaie/epp-config-dynamo.yaml) per EPP [convention](https://gateway-api-inference-extension.sigs.k8s.io/guides/epp-configuration/config-text/).
 
-Dynamo Integration with the Inference Gateway supports Aggregated and Disaggregated Serving. The epp config is the same for both. If no prefill workers found the service degrades gracefully to perform aggregated serving.
+Dynamo Integration with the Inference Gateway supports Aggregated and Disaggregated Serving. A request only exercises disaggregated routing when the EPP config defines a `prefill` profile and prefill workers are available. The shipped [`epp-config-dynamo.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/standalone/helm/dynamo-gaie/epp-config-dynamo.yaml) currently only defines a `decode` profile, so the default path behaves as decode-only / aggregated fallback. If no prefill profile or workers are present, the service degrades gracefully to perform aggregated serving.
 If you want to use LoRA deploy Dynamo without the Inference Gateway.
 
 Currently, these setups are only supported with the kGateway based Inference Gateway.
@@ -44,6 +44,7 @@ Currently, these setups are only supported with the kGateway based Inference Gat
 ### 1. Install Dynamo Platform ###
 
 [See Quickstart Guide](./README.md) to install Dynamo Kubernetes Platform.
+If you are installing from the source tree rather than a release chart, follow [Path B: Custom Build from Source](./installation-guide.md#path-b-custom-build-from-source) and run `helm dep build ./platform/` before `helm install` so the vendored subcharts match the local chart contents.
 
 ### 2. Deploy Inference Gateway ###
 


### PR DESCRIPTION
#### Overview:

Improve the current kgateway + GIE baseline before working on #6331.
This fixes the operator-generated EPP namespace mismatch that broke the
kind validation flow and tightens the GAIE docs to match the current
behavior.

#### Details:

- inject a hashed `DYN_NAMESPACE` override into generated EPP DCDs when
  worker hash suffixing is active
- preserve explicit EPP `DYN_NAMESPACE` overrides and skip the injection
  for legacy worker hashes
- add regression tests for the EPP namespace override behavior
- clarify that the shipped GAIE config currently exercises the decode-only
  path by default
- document the `helm dep build ./platform/` step for source-tree installs

Validation:
- `go test ./internal/dynamo`
- `go test ./internal/controller -run TestBuildRollingUpdateContext -count=1`

#### Where should the reviewer start?

Start with
`deploy/operator/internal/dynamo/graph.go`, then
`deploy/operator/internal/dynamo/graph_test.go`, and finish with
`docs/kubernetes/inference-gateway.md`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to GitHub issue: #6331
- Relates to GitHub issue: #7075


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced Dynamo Integration routing documentation clarifying disaggregation conditions and fallback behavior
  * Updated LoRA prerequisites and usage guidance for Inference Gateway
  * Added source build instructions for custom Helm installations from source tree

<!-- end of auto-generated comment: release notes by coderabbit.ai -->