### PR TITLE
fix: Add Env support to operator Helm chart deployment values

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -76,11 +76,13 @@ spec:
         command:
         - /manager
         env:
+        {{- with .Values.env }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         imagePullPolicy: {{ .Values.controllerManager.manager.image.pullPolicy | quote }}
-        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
-| default .Chart.AppVersion }}
+        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -21,6 +21,9 @@
 # Set to false if CRDs are managed externally (e.g., via GitOps or a separate pipeline).
 upgradeCRD: true
 
+# Environment variables to pass to operator Deployment.
+env: []
+
 # Namespace restriction configuration for the operator
 # If enabled: true and targetNamespace is empty, the operator will be restricted to the release namespace
 # If enabled: true and targetNamespace is set, the operator will be restricted to the specified namespace

--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -54,6 +54,9 @@ dynamo-operator:
   # The Job runs the operator image with the crd-apply tool to apply CRDs via server-side apply.
   upgradeCRD: true
 
+  # Environment variables to pass to operator Deployment.
+  env: []
+
   # -- NATS server address for operator communication (leave empty to use the bundled NATS chart). Format: "nats://hostname:port"
   natsAddr: ""
 


### PR DESCRIPTION
#### Overview:

[issue](https://github.com/ai-dynamo/dynamo/issues/7066)

#### Details:

Add env to the operator deployment helm values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operator deployment now supports configurable environment variables via Helm values configuration.
  * Improved container image specification with automatic tag defaulting for streamlined deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->