### PR TITLE
fix: always run dynamo container validation on main and release branches

### DIFF
--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -26,9 +26,9 @@ jobs:
   changed-files:
     runs-on: ubuntu-latest
     outputs:
-      core: ${{ steps.changes.outputs.core }}
-      planner: ${{ steps.changes.outputs.planner }}
-      frontend: ${{ steps.changes.outputs.frontend }}
+      core: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release/') || steps.changes.outputs.core == 'true' }}
+      planner: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release/') || steps.changes.outputs.planner == 'true' }}
+      frontend: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release/') || steps.changes.outputs.frontend == 'true' }}
       builder_name: ${{ steps.export-builder-name.outputs.builder_name }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
Skip changed-files gating for main and release/* branches so all validation jobs run unconditionally, while preserving the filter for pull-request branches.

closes: OPS-3800


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration workflow to ensure consistent build execution across main and release branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->