### PR TITLE
fix: kill TRT-LLM EngineCore child process in mm_router test teardown

### DIFF
--- a/tests/mm_router/test_mm_router_e2e.py
+++ b/tests/mm_router/test_mm_router_e2e.py
@@ -122,6 +122,7 @@ class TRTLLMWorkerProcess(ManagedProcess):
                 (f"http://localhost:{system_port}/health", _check_ready)
             ],
             timeout=900,
+            stragglers=["TRTLLM:EngineCore"],
             straggler_commands=["-m dynamo.trtllm"],
             log_dir=_prepare_log_dir(request, "trtllm-worker"),
             **_COMMON_PROCESS_KWARGS,


### PR DESCRIPTION
The trtllm-cuda13.1-amd64 GPU tests (test_deployment and test_chat_only_aggregated_with_test_logits_processor) have been failing with CUDA OOM since commit d993f9d3db ("fix: support TRT-LLM 1.3 apply_mm_hashes API #6810") added pytest.mark.pre_merge to the mm_router e2e tests.

Before that commit, mm_router tests only ran in post-merge/nightly CI. After it, they run in the same pre-merge pytest session as the serve deployment tests, sequentially on a single 22 GiB GPU.

The mm_router TRTLLMWorkerProcess launches `python3 -m dynamo.trtllm`, which internally spawns an MPI child process named `TRTLLM:EngineCore`. When the module-scoped fixture tears down after the mm_router tests:

1. _terminate_process_group() kills the parent process group
2. _cleanup_stragglers() searches for "-m dynamo.trtllm" in cmdlines, but the MPI child (TRTLLM:EngineCore) has a different cmdline and is not matched
3. The orphaned EngineCore process (PID 671 in CI logs) continues holding ~20.46 GiB of GPU memory
4. The subsequent test_deployment tests try to load Qwen/Qwen3-0.6B with only ~0.98 GiB free and fail with torch.OutOfMemoryError

The fix adds stragglers=["TRTLLM:EngineCore"] to the mm_router's TRTLLMWorkerProcess, matching the same pattern already used by tests/serve/test_trtllm.py (line 35). This ensures the MPI child process is found by process name and terminated during fixture teardown, freeing GPU memory for subsequent tests.

Failing tests (all OOM):
- test_deployment[aggregated-2]
- test_deployment[aggregated_logprobs-2]
- test_deployment[aggregated_router-2]
- test_deployment[epd_multimodal-2]
- test_chat_only_aggregated_with_test_logits_processor

See: https://github.com/ai-dynamo/dynamo/actions/runs/22852945871/job/66286027059
