### PR TITLE
test: skip flaky router mocker tests

### DIFF
--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -46,7 +46,7 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.integration,
     pytest.mark.model(MODEL_NAME),
-    pytest.mark.skip(reason="Flaky, temporarily disabled"),
+    pytest.mark.skip(reason="DYN-2365 - Flaky, temporarily disabled"),
 ]
 NUM_MOCKERS = 2
 SPEEDUP_RATIO = 10.0

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -46,6 +46,7 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.integration,
     pytest.mark.model(MODEL_NAME),
+    pytest.mark.skip(reason="Flaky, temporarily disabled"),
 ]
 NUM_MOCKERS = 2
 SPEEDUP_RATIO = 10.0


### PR DESCRIPTION
Router tests causing timeout in pytest action, 

https://github.com/ai-dynamo/dynamo/actions/runs/22857288676/job/66302433470

https://github.com/ai-dynamo/dynamo/actions/runs/22859220007/job/66309904718?pr=7084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Temporarily disabled end-to-end router tests due to flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->