### PR TITLE
fix(recipe): require NIXL backend and fix frontend liveness probe in …

### DIFF
--- a/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
@@ -16,6 +16,13 @@ spec:
     Frontend:
       componentType: frontend
       replicas: 1
+      livenessProbe:
+        httpGet:
+          path: /live
+          port: 8000
+        periodSeconds: 600
+        timeoutSeconds: 30
+        failureThreshold: 3
       volumeMounts:
         - name: model-cache
           mountPoint: /opt/model
@@ -60,6 +67,8 @@ spec:
             - --skip-tokenizer-init
             - --disaggregation-mode
             - decode
+            - --disaggregation-transfer-backend
+            - nixl
             - --disaggregation-bootstrap-port
             - "30001"
             - --mem-fraction-static
@@ -104,6 +113,8 @@ spec:
             - --skip-tokenizer-init
             - --disaggregation-mode
             - prefill
+            - --disaggregation-transfer-backend
+            - nixl
             - --disaggregation-bootstrap-port
             - "30001"
             - --mem-fraction-static


### PR DESCRIPTION
## Problem

Two independent issues caused the `deepseek-r1/sglang/disagg-16gpu` recipe to fail:

**1. Mooncake is broken on CUDA 13 images**

The disagg-16gpu recipe targets CUDA 13 images (required for the SGLang 0.5.8+ multi-node prefill fix). Mooncake's pip wheel links against `libcudart.so.12`, which does not exist on CUDA 13 — resulting in an `ImportError` at init and silently broken KV transfer.

NIXL is compiled from source inside the container against the actual CUDA version, avoiding the ABI mismatch. NIXL does **not** require InfiniBand; it falls back to TCP automatically.

**2. Frontend pod killed under high-concurrency load**

The DGD operator's default liveness probe uses `timeoutSeconds: 1`, which kills the frontend pod ~30 seconds into benchmarks when 1080 concurrent SSE connections saturate the event loop.

## Changes

`recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml`:
- Add `--disaggregation-transfer-backend nixl` to both `decode` and `prefill` worker args
- Add `livenessProbe` override on `Frontend` with `periodSeconds: 600` / `timeoutSeconds: 30` / `failureThreshold: 3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced system health monitoring with improved liveness checks for the frontend service.
  * Updated backend infrastructure configuration to optimize disaggregation transfer handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->