### PR TITLE
fix(recipes): switch Qwen3-235B TRT-LLM disagg KV cache backend to NIXL

### DIFF
--- a/recipes/qwen3-235b-a22b-fp8/README.md
+++ b/recipes/qwen3-235b-a22b-fp8/README.md
@@ -75,3 +75,4 @@ This is a large MoE model requiring significant GPU resources:
 - Model download may take 30-60 minutes
 - Uses KV-aware routing for efficient cache utilization
 - Chunked prefill enabled for aggregated mode (disabled for disaggregated)
+- **Disaggregated mode requires InfiniBand (NIXL/RDMA).** The disagg recipe sets `cache_transceiver_config.backend: NIXL` for KV cache transfer. Clusters without InfiniBand must override this to `TCP` or `DEFAULT` via a cluster-specific overlay.

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/deploy.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/deploy.yaml
@@ -18,7 +18,7 @@ data:
       free_gpu_memory_fraction: 0.7
       dtype: fp8
     cache_transceiver_config:
-      backend: DEFAULT
+      backend: NIXL
     cuda_graph_config:
       enable_padding: true
       max_batch_size: 2
@@ -43,7 +43,7 @@ data:
       free_gpu_memory_fraction: 0.95
       dtype: fp8
     cache_transceiver_config:
-      backend: DEFAULT
+      backend: NIXL
     cuda_graph_config:
       enable_padding: true
       max_batch_size: 512


### PR DESCRIPTION
## Problem

The `qwen3-235b-a22b-fp8/trtllm/disagg` recipe set `cache_transceiver_config.backend: DEFAULT`, which falls back to TCP when InfiniBand is not auto-detected.

## Changes

- `recipes/qwen3-235b-a22b-fp8/trtllm/disagg/deploy.yaml` — set `cache_transceiver_config.backend: NIXL` for both the prefill and decode ConfigMaps
- `recipes/qwen3-235b-a22b-fp8/README.md` — document the InfiniBand requirement for disaggregated mode; note that clusters without InfiniBand should override to `TCP` or `DEFAULT`

## Notes

- Clusters without InfiniBand must supply a cluster-specific overlay overriding the backend to `TCP` or `DEFAULT`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added deployment guidance covering networking infrastructure requirements and configuration options for disaggregated mode operations.

* **Configuration Updates**
  * Updated cache transfer backend configuration settings in deployment manifests to optimize distributed operation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->