### PR TITLE
Revert "test: skip flaky router mocker tests (#7087)"

### DIFF
--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -46,7 +46,6 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.integration,
     pytest.mark.model(MODEL_NAME),
-    pytest.mark.skip(reason="DYN-2365 - Flaky, temporarily disabled"),
 ]
 NUM_MOCKERS = 2
 SPEEDUP_RATIO = 10.0


### PR DESCRIPTION
This reverts commit 48b302d37481656a91579ac2ae60f620e3f67e8a.

#### Overview:

We would like to fix tests on main rather than skipping them.
Otherwise it will just allow more bad merges to come in making everything messier

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled a previously skipped test that will now be executed as part of the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->