### PR TITLE
fix(mocker): move runtime config construction back to Rust side

### DIFF
--- a/components/src/dynamo/mocker/main.py
+++ b/components/src/dynamo/mocker/main.py
@@ -10,7 +10,6 @@ import json
 import logging
 import os
 import signal
-import socket
 import tempfile
 from pathlib import Path
 
@@ -18,14 +17,7 @@ import uvloop
 
 os.environ.setdefault("DYN_COMPUTE_THREADS", "0")
 
-from dynamo.llm import (
-    EngineType,
-    EntrypointArgs,
-    ModelRuntimeConfig,
-    fetch_model,
-    make_engine,
-    run_input,
-)
+from dynamo.llm import EngineType, EntrypointArgs, fetch_model, make_engine, run_input
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -144,46 +136,6 @@ def compute_stagger_delay(num_workers: int, stagger_delay: float) -> float:
         return 0.2
 
 
-def _build_runtime_config(
-    engine_args: dict,
-) -> tuple[int, ModelRuntimeConfig]:
-    """Build a ModelRuntimeConfig from the engine args dict.
-
-    Returns (kv_cache_block_size, runtime_config). Defaults match
-    the Rust MockEngineArgsBuilder so hand-crafted JSON files that
-    omit fields behave identically.
-    """
-    is_prefill = engine_args.get("is_prefill", False)
-    is_decode = engine_args.get("is_decode", False)
-
-    rc = ModelRuntimeConfig()
-    rc.total_kv_blocks = engine_args.get("num_gpu_blocks", 16384)
-    if (v := engine_args.get("max_num_seqs")) is not None:
-        rc.max_num_seqs = v
-    if (v := engine_args.get("max_num_batched_tokens")) is not None:
-        rc.max_num_batched_tokens = v
-    rc.enable_local_indexer = (
-        engine_args.get("enable_local_indexer", False) and not is_decode
-    )
-    rc.data_parallel_size = engine_args.get("dp_size", 1)
-
-    bootstrap_port = engine_args.get("bootstrap_port")
-    if is_prefill and bootstrap_port is not None:
-        host = os.environ.get(
-            "DYN_HTTP_RPC_HOST", socket.gethostbyname(socket.gethostname())
-        )
-        rc.set_disaggregated_endpoint(
-            bootstrap_host=host, bootstrap_port=bootstrap_port
-        )
-        logger.info(
-            "Mocker prefill worker: publishing bootstrap endpoint to discovery "
-            f"(bootstrap_port={bootstrap_port})"
-        )
-
-    block_size = engine_args.get("block_size", 64)
-    return block_size, rc
-
-
 async def launch_workers(args: argparse.Namespace, extra_engine_args_path: Path):
     """Launch mocker worker(s) with isolated DistributedRuntime instances.
 
@@ -213,13 +165,14 @@ async def launch_workers(args: argparse.Namespace, extra_engine_args_path: Path)
             f"(estimated total: {total_time:.1f}s)"
         )
 
-    # Always load base engine args for runtime config construction
-    with open(extra_engine_args_path) as f:
-        base_engine_args = json.load(f)
-
+    # Load base engine args if we need to create per-worker files
     needs_per_worker_args = bool(
         args.bootstrap_ports_list or args.zmq_kv_events_ports_list
     )
+    base_engine_args = None
+    if needs_per_worker_args:
+        with open(extra_engine_args_path) as f:
+            base_engine_args = json.load(f)
 
     for worker_id in range(args.num_workers):
         logger.info(f"Creating mocker worker {worker_id + 1}/{args.num_workers}")
@@ -232,9 +185,10 @@ async def launch_workers(args: argparse.Namespace, extra_engine_args_path: Path)
         )
         runtimes.append(runtime)
 
-        # Determine which engine args file and dict to use
+        # Determine which engine args file to use
         worker_engine_args_path: Path | str
         if needs_per_worker_args:
+            assert base_engine_args is not None
             worker_args = base_engine_args.copy()
             if args.bootstrap_ports_list:
                 worker_args["bootstrap_port"] = args.bootstrap_ports_list[worker_id]
@@ -250,10 +204,7 @@ async def launch_workers(args: argparse.Namespace, extra_engine_args_path: Path)
             per_worker_temp_files.append(worker_engine_args_path)
             logger.debug(f"Worker {worker_id}: per-worker args {worker_args}")
         else:
-            worker_args = base_engine_args
             worker_engine_args_path = extra_engine_args_path
-
-        kv_cache_block_size, runtime_config = _build_runtime_config(worker_args)
 
         # Create EntrypointArgs for this worker
         entrypoint_args = EntrypointArgs(
@@ -262,8 +213,6 @@ async def launch_workers(args: argparse.Namespace, extra_engine_args_path: Path)
             model_name=args.model_name,
             endpoint_id=args.endpoint,
             extra_engine_args=str(worker_engine_args_path),
-            runtime_config=runtime_config,
-            kv_cache_block_size=kv_cache_block_size,
             is_prefill=args.is_prefill_worker,
         )
 

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -21,11 +21,14 @@ use dynamo_llm::local_model::{LocalModel, LocalModelBuilder};
 use dynamo_llm::mocker::make_mocker_engine;
 use dynamo_llm::model_card::ModelDeploymentCard as RsModelDeploymentCard;
 use dynamo_llm::types::openai::chat_completions::OpenAIChatCompletionsStreamingEngine;
-use dynamo_mocker::common::protocols::MockEngineArgs;
+use dynamo_mocker::common::protocols::{MockEngineArgs, WorkerType};
 use dynamo_runtime::discovery::ModelCardInstanceId as RsModelCardInstanceId;
 use dynamo_runtime::protocols::EndpointId;
+use dynamo_runtime::utils::get_http_rpc_host_from_env;
+use dynamo_llm::local_model::runtime_config::{
+    DisaggregatedEndpoint, ModelRuntimeConfig as RsModelRuntimeConfig,
+};
 
-use super::local_model::ModelRuntimeConfig;
 use super::model_card::ModelDeploymentCard;
 use crate::RouterMode;
 use crate::engine::PythonAsyncEngine;
@@ -185,7 +188,6 @@ pub(crate) struct EntrypointArgs {
     tls_cert_path: Option<PathBuf>,
     tls_key_path: Option<PathBuf>,
     extra_engine_args: Option<PathBuf>,
-    runtime_config: Option<ModelRuntimeConfig>,
     namespace: Option<String>,
     namespace_prefix: Option<String>,
     is_prefill: bool,
@@ -197,7 +199,7 @@ pub(crate) struct EntrypointArgs {
 impl EntrypointArgs {
     #[allow(clippy::too_many_arguments)]
     #[new]
-    #[pyo3(signature = (engine_type, model_path=None, model_name=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, http_metrics_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None, runtime_config=None, namespace=None, namespace_prefix=None, is_prefill=false, migration_limit=0, chat_engine_factory=None))]
+    #[pyo3(signature = (engine_type, model_path=None, model_name=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, http_metrics_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None, namespace=None, namespace_prefix=None, is_prefill=false, migration_limit=0, chat_engine_factory=None))]
     pub fn new(
         py: Python<'_>,
         engine_type: EngineType,
@@ -214,7 +216,6 @@ impl EntrypointArgs {
         tls_cert_path: Option<PathBuf>,
         tls_key_path: Option<PathBuf>,
         extra_engine_args: Option<PathBuf>,
-        runtime_config: Option<ModelRuntimeConfig>,
         namespace: Option<String>,
         namespace_prefix: Option<String>,
         is_prefill: bool,
@@ -261,7 +262,6 @@ impl EntrypointArgs {
             tls_cert_path,
             tls_key_path,
             extra_engine_args,
-            runtime_config,
             namespace,
             namespace_prefix,
             is_prefill,
@@ -306,9 +306,37 @@ pub fn make_engine<'p>(
         .tls_key_path(args.tls_key_path.clone())
         .is_mocker(matches!(args.engine_type, EngineType::Mocker))
         .extra_engine_args(args.extra_engine_args.clone())
-        .runtime_config(args.runtime_config.clone().unwrap_or_default().inner)
         .namespace(args.namespace.clone())
         .namespace_prefix(args.namespace_prefix.clone());
+
+    // For mocker engines, override runtime config from the engine args JSON
+    if matches!(args.engine_type, EngineType::Mocker) {
+        if let Some(ref path) = args.extra_engine_args {
+            if let Ok(mocker_args) = MockEngineArgs::from_json_file(path) {
+                builder.kv_cache_block_size(Some(mocker_args.block_size as u32));
+
+                let mut rc = RsModelRuntimeConfig::default();
+                rc.total_kv_blocks = Some(mocker_args.num_gpu_blocks as u64);
+                rc.max_num_seqs = mocker_args.max_num_seqs.map(|v| v as u64);
+                rc.max_num_batched_tokens =
+                    mocker_args.max_num_batched_tokens.map(|v| v as u64);
+                rc.enable_local_indexer =
+                    mocker_args.enable_local_indexer && mocker_args.worker_type != WorkerType::Decode;
+                rc.data_parallel_size = mocker_args.dp_size;
+
+                if mocker_args.worker_type == WorkerType::Prefill {
+                    if let Some(port) = mocker_args.bootstrap_port {
+                        rc.disaggregated_endpoint = Some(DisaggregatedEndpoint {
+                            bootstrap_host: Some(get_http_rpc_host_from_env()),
+                            bootstrap_port: Some(port),
+                        });
+                    }
+                }
+
+                builder.runtime_config(rc);
+            }
+        }
+    }
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         if let Some(model_path) = args.model_path.clone() {
             let local_path = if model_path.exists() {

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1611,7 +1611,6 @@ class EntrypointArgs:
         tls_cert_path: Optional[str] = None,
         tls_key_path: Optional[str] = None,
         extra_engine_args: Optional[str] = None,
-        runtime_config: Optional[ModelRuntimeConfig] = None,
         namespace: Optional[str] = None,
         namespace_prefix: Optional[str] = None,
         is_prefill: bool = False,
@@ -1636,7 +1635,6 @@ class EntrypointArgs:
             tls_cert_path: TLS certificate path (PEM format)
             tls_key_path: TLS key path (PEM format)
             extra_engine_args: Path to extra engine arguments file
-            runtime_config: Optional runtime configuration for discovery registration
             namespace: Dynamo namespace for model discovery scoping
             namespace_prefix: Optional namespace prefix
             is_prefill: Whether this is a prefill worker


### PR DESCRIPTION
Reverts #6942 — mocker runtime config (kv_cache_block_size, total_kv_blocks, enable_local_indexer, etc.) is now constructed in Rust `make_engine` instead of Python `_build_runtime_config`. The Python-side construction caused model discovery failures in file-backend tests because the MDC registration timing changed.