### PR TITLE
docs: add rolling-update page to kubernetes nav index

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -51,6 +51,8 @@ navigation:
             path: kubernetes/deployment/dynamomodel-guide.md
           - page: Autoscaling
             path: kubernetes/autoscaling.md
+          - page: Rolling Update
+            path: kubernetes/rolling-update.md
           - page: Inference Gateway (GAIE)
             path: kubernetes/inference-gateway.md
           - section: Checkpointing


### PR DESCRIPTION
#### Overview:

The rolling-update doc page at `docs/kubernetes/rolling-update.md` was not visible on the public docs site because it was missing from the Fern navigation index. This PR adds it to the sidebar.

#### Details:

- `docs/index.yml` — Added a `Rolling Update` nav entry under the Kubernetes Deployment > Deployment Guide section, between Autoscaling and Inference Gateway.

#### Where should the reviewer start?

`docs/index.yml` — the only changed file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Rolling Update documentation to the Kubernetes Deployment Guide, providing guidance on implementing rolling update strategies for seamless deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->