### PR TITLE
fix: correct planner entrypoint in profiler's planner config gen

### DIFF
--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -103,7 +103,7 @@ class DgdPlannerServiceConfig(BaseModel):
         mainContainer=Container(
             image="my-registry/dynamo-runtime:my-tag",  # placeholder
             workingDir=f"{get_workspace_dir()}/components/src/dynamo/planner",
-            command=["python3", "-m", "dynamo.planner.planner_sla"],
+            command=["python3", "-m", "dynamo.planner"],
             args=[],
         )
     )

--- a/tests/planner/perf_test_configs/disagg_8b_planner.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_planner.yaml
@@ -73,24 +73,16 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/vllm-runtime:my-tag
-          workingDir: /workspace/components/src/dynamo/planner
           ports:
             - name: metrics
               containerPort: 9085
           command:
-            - /bin/sh
-            - -c
+          - python3
+          - -m
+          - dynamo.planner
           args:
-            - >-
-              python3 -m planner_sla
-              --environment=kubernetes
-              --backend=vllm
-              --ttft 200
-              --itl 10
-              --profile-results-dir /workspace/tests/planner/profiling_results/H200_TP1P_TP1D/
-              --adjustment-interval=60
-              --prometheus-port=9085
-              --no-correction
+            - --config
+            - '{"environment": "kubernetes", "backend": "vllm", "ttft": 200, "itl": 10, "profile_results_dir": "/workspace/tests/planner/profiling_results/H200_TP1P_TP1D/", "throughput_adjustment_interval": 60, "metric_reporting_prometheus_port": 9085, "no_correction": true}'
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker


### PR DESCRIPTION
close https://linear.app/nvidia/issue/AIC-410/dynamoaic-profiler-generated-dgd-hardcodes-non-existent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized service invocation methods and configuration delivery for internal components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->