### PR TITLE
fix(frontend): remove worker_count race in is_displayable that hides models from /v1/models

### DIFF
--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -153,6 +153,10 @@ impl Model {
     }
 
     /// Whether this model should be visible in /v1/models.
+    /// A model is displayable if any WorkerSet has a serving engine or is a prefill set.
+    /// We don't gate on worker_count() here because the instance watcher starts empty
+    /// and populates asynchronously — a WorkerSet exists only because a worker registered
+    /// its MDC, so there is always at least one worker even if the count hasn't propagated.
     pub fn is_displayable(&self) -> bool {
         let has_serving_engine = |ws: &WorkerSet| {
             ws.has_chat_engine()
@@ -170,9 +174,6 @@ impl Model {
 
         self.worker_sets.iter().any(|entry| {
             let ws = entry.value();
-            if ws.worker_count() == 0 {
-                return false;
-            }
             has_serving_engine(ws.as_ref()) || (!has_any_serving_engine && ws.is_prefill_set())
         })
     }


### PR DESCRIPTION
## Summary
- Remove `worker_count() == 0` guard from `Model::is_displayable()` (introduced in #6966)
- This guard races with instance discovery: a WorkerSet is added when the MDC arrives, but the instance watcher channel starts empty and populates asynchronously, so `worker_count()` returns 0 during the gap
- The result is `/v1/models` returning empty even though workers are registered, causing mocker e2e tests (and real deployments) to time out waiting for model discovery
- The routing paths (`select_worker_set`) keep their `worker_count()` guards since those need actual live workers to route to

Fixes DYN-2365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WorkerSets with active serving engines (chat, completions, embeddings, images, tensor, or videos) are now properly displayed in the interface even when zero workers are assigned, improving visibility of service configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->