### PR TITLE
ci: gate deploy tests on framework pipeline success for release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,7 +361,7 @@ jobs:
         timeout 300s kubectl rollout status deployment -n $NAMESPACE --watch
 
   deploy-test-vllm:
-    if: always() && needs.deploy-operator.result == 'success'
+    if: always() && needs.deploy-operator.result == 'success' && needs.vllm-pipeline.result == 'success'
     runs-on: prod-default-small-v2
     needs: [deploy-operator, vllm-pipeline]
     strategy:
@@ -383,7 +383,7 @@ jobs:
           platform_arch: amd64
 
   deploy-test-sglang:
-    if: always() && needs.deploy-operator.result == 'success'
+    if: always() && needs.deploy-operator.result == 'success' && needs.sglang-pipeline.result == 'success'
     runs-on: prod-default-small-v2
     needs: [deploy-operator, sglang-pipeline]
     strategy:
@@ -405,7 +405,7 @@ jobs:
           platform_arch: amd64
 
   deploy-test-trtllm:
-    if: always() && needs.deploy-operator.result == 'success'
+    if: always() && needs.deploy-operator.result == 'success' && needs.trtllm-pipeline.result == 'success'
     runs-on: prod-default-small-v2
     needs: [deploy-operator, trtllm-pipeline]
     strategy:


### PR DESCRIPTION
## Summary
- Deploy tests in the release pipeline were running even when their framework build/test/copy pipeline failed, because the `if:` condition only checked `deploy-operator.result`
- This caused all 4 TRT-LLM deploy tests to timeout for 20 min each trying to pull images that were never copied to ACR (see [release run 22831634340](https://github.com/ai-dynamo/dynamo/actions/runs/22831634340))
- Added framework pipeline result checks (`needs.<framework>-pipeline.result == 'success'`) to all three deploy test jobs so they skip when the image won't be available

## Test plan
- [ ] Verify on a release branch push where all framework pipelines succeed: deploy tests should run as before
- [ ] Verify on a release branch push where a framework pipeline fails: deploy tests for that framework should be skipped instead of timing out
- [ ] Verify `workflow_dispatch` manual trigger still works (the `always()` is preserved for the `manual-approval` skip case)

Resolves OPS-3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment safety by strengthening release workflow test gating. Deployment validation now requires additional framework pipeline gates to complete successfully alongside existing checks, ensuring comprehensive testing before deployment proceeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->