### PR TITLE
feat: add simple error classifier

### DIFF
--- a/.github/scripts/classify_errors.py
+++ b/.github/scripts/classify_errors.py
@@ -39,7 +39,7 @@ def main():
     github_token = os.environ.get("GITHUB_TOKEN", "")
     api_key = os.environ.get("API_KEY", "")
     base_url = os.environ.get("API_BASE_URL", "https://inference-api.nvidia.com/v1")
-    model = os.environ.get("MODEL", "aws/anthropic/claude-sonnet-4-5-20250929")
+    model = os.environ.get("MODEL", "nvcf/meta/llama-3.3-70b-instruct")
 
     if not github_token:
         print("Error: GITHUB_TOKEN not set", file=sys.stderr)

--- a/.github/scripts/classify_errors.py
+++ b/.github/scripts/classify_errors.py
@@ -259,6 +259,7 @@ def post_pr_comment(repo, pr_number, results, run_id, run_url, workflow_name, to
     else:
         url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
         resp = requests.post(url, headers=headers, json={"body": body})
+    print(f"  Comment API response: {resp.status_code} {resp.text[:500]}")
     resp.raise_for_status()
 
 

--- a/.github/scripts/classify_errors.py
+++ b/.github/scripts/classify_errors.py
@@ -38,14 +38,14 @@ def main():
 
     github_token = os.environ.get("GITHUB_TOKEN", "")
     api_key = os.environ.get("API_KEY", "")
-    base_url = os.environ.get("API_BASE_URL", "")
-    model = os.environ.get("MODEL", "")
+    base_url = os.environ.get("API_BASE_URL", "https://inference-api.nvidia.com/v1")
+    model = os.environ.get("MODEL", "aws/anthropic/claude-sonnet-4-5-20250929")
 
     if not github_token:
         print("Error: GITHUB_TOKEN not set", file=sys.stderr)
         sys.exit(1)
-    if not api_key or not base_url or not model:
-        print("Error: API_KEY, API_BASE_URL, and MODEL must be set", file=sys.stderr)
+    if not api_key:
+        print("Error: API_KEY must be set", file=sys.stderr)
         sys.exit(1)
 
     system_prompt = load_prompt(args.prompt_file)

--- a/.github/scripts/classify_errors.py
+++ b/.github/scripts/classify_errors.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+CI error classifier. Fetches failed job logs from GitHub Actions,
+sends them to an OpenAI-compatible LLM for classification, posts
+a PR comment (for PR workflows), and writes database-ready JSON.
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+import requests
+
+MAX_LOG_CHARS = 400_000
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Classify CI errors from GitHub Actions")
+    parser.add_argument("--run-id", required=True, help="GitHub Actions run ID")
+    parser.add_argument("--repo", required=True, help="GitHub repo (owner/name)")
+    parser.add_argument(
+        "--workflow-type",
+        required=True,
+        choices=["pr", "nightly", "post-merge", "release"],
+    )
+    parser.add_argument("--pr-number", type=int, default=None)
+    parser.add_argument("--output-json", required=True, help="Path to write JSON output")
+    parser.add_argument(
+        "--prompt-file",
+        default=os.path.join(os.path.dirname(__file__), "classify_errors_prompt.txt"),
+    )
+    args = parser.parse_args()
+
+    github_token = os.environ.get("GITHUB_TOKEN", "")
+    api_key = os.environ.get("API_KEY", "")
+    base_url = os.environ.get("API_BASE_URL", "")
+    model = os.environ.get("MODEL", "")
+
+    if not github_token:
+        print("Error: GITHUB_TOKEN not set", file=sys.stderr)
+        sys.exit(1)
+    if not api_key or not base_url or not model:
+        print("Error: API_KEY, API_BASE_URL, and MODEL must be set", file=sys.stderr)
+        sys.exit(1)
+
+    system_prompt = load_prompt(args.prompt_file)
+
+    # Get run metadata
+    run_meta = get_run_metadata(args.repo, args.run_id, github_token)
+
+    # Get failed jobs
+    failed_jobs = get_failed_jobs(args.repo, args.run_id, github_token)
+    if not failed_jobs:
+        print("No failed jobs found.")
+        write_json_output(
+            args.output_json,
+            run_id=args.run_id,
+            repo=args.repo,
+            workflow_name=run_meta.get("name", ""),
+            workflow_type=args.workflow_type,
+            branch=run_meta.get("head_branch", ""),
+            commit_sha=run_meta.get("head_sha", ""),
+            pr_number=args.pr_number,
+            model=model,
+            errors=[],
+        )
+        return
+
+    print(f"Found {len(failed_jobs)} failed job(s). Classifying...")
+
+    # Classify each failed job
+    all_errors = []
+    for job in failed_jobs:
+        job_id = str(job["id"])
+        job_name = job["name"]
+        print(f"  Processing: {job_name}")
+
+        log = get_job_log(args.repo, job_id, github_token)
+        if not log:
+            print(f"    Warning: Could not fetch log for job {job_name}")
+            continue
+
+        result = classify_errors(log, job_name, system_prompt, api_key, model, base_url)
+        if result and result.get("errors_found"):
+            for error in result["errors_found"]:
+                all_errors.append(
+                    {
+                        "job_id": job_id,
+                        "job_name": job_name,
+                        "step": error.get("step", "unknown"),
+                        "category": error.get("primary_category", "code_error"),
+                        "confidence": error.get("confidence_score", 0.5),
+                        "is_transient": error.get("is_transient", False),
+                        "summary": error.get("root_cause_summary", ""),
+                        "log_excerpt": error.get("log_excerpt", ""),
+                    }
+                )
+
+    # Write JSON output
+    write_json_output(
+        args.output_json,
+        run_id=args.run_id,
+        repo=args.repo,
+        workflow_name=run_meta.get("name", ""),
+        workflow_type=args.workflow_type,
+        branch=run_meta.get("head_branch", ""),
+        commit_sha=run_meta.get("head_sha", ""),
+        pr_number=args.pr_number,
+        model=model,
+        errors=all_errors,
+    )
+    print(f"Wrote classification results to {args.output_json}")
+
+    # Post PR comment only for PR workflows
+    if args.workflow_type == "pr" and args.pr_number:
+        run_url = f"https://github.com/{args.repo}/actions/runs/{args.run_id}"
+        post_pr_comment(
+            args.repo,
+            args.pr_number,
+            all_errors,
+            args.run_id,
+            run_url,
+            run_meta.get("name", ""),
+            github_token,
+        )
+        print(f"Posted PR comment to #{args.pr_number}")
+
+
+def load_prompt(path):
+    """Read the system prompt from a text file."""
+    with open(path) as f:
+        return f.read()
+
+
+def get_run_metadata(repo, run_id, token):
+    """Fetch workflow run metadata."""
+    url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}"
+    headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+    resp = requests.get(url, headers=headers)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_failed_jobs(repo, run_id, token):
+    """Get all failed jobs for a workflow run."""
+    url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs"
+    headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+    params = {"per_page": 100, "filter": "latest"}
+    all_jobs = []
+    while url:
+        resp = requests.get(url, headers=headers, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        all_jobs.extend(data.get("jobs", []))
+        # Handle pagination
+        url = resp.links.get("next", {}).get("url")
+        params = None  # params are already in the next URL
+    return [j for j in all_jobs if j.get("conclusion") == "failure"]
+
+
+def get_job_log(repo, job_id, token):
+    """Fetch job logs, truncated to the last MAX_LOG_CHARS characters."""
+    url = f"https://api.github.com/repos/{repo}/actions/jobs/{job_id}/logs"
+    headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+    resp = requests.get(url, headers=headers, allow_redirects=True)
+    if resp.status_code != 200:
+        return None
+    text = resp.text
+    if len(text) > MAX_LOG_CHARS:
+        text = text[-MAX_LOG_CHARS:]
+    return text
+
+
+def classify_errors(log, job_name, system_prompt, api_key, model, base_url):
+    """Send a job log to the LLM and parse the classification result."""
+    user_prompt = f"Analyze the following CI job log for job '{job_name}':\n\n{log}"
+    response_text = call_llm(system_prompt, user_prompt, api_key, model, base_url)
+    if not response_text:
+        return None
+    return parse_llm_response(response_text)
+
+
+def call_llm(system_prompt, user_prompt, api_key, model, base_url):
+    """Make a chat completion request to an OpenAI-compatible API."""
+    url = f"{base_url.rstrip('/')}/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "temperature": 0.1,
+        "max_tokens": 4096,
+    }
+    resp = requests.post(url, headers=headers, json=payload, timeout=120)
+    resp.raise_for_status()
+    data = resp.json()
+    return data["choices"][0]["message"]["content"]
+
+
+def parse_llm_response(text):
+    """Extract JSON object from LLM response text."""
+    # Find the first { and last } to extract JSON
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        print(f"Warning: Could not find JSON in LLM response: {text[:200]}", file=sys.stderr)
+        return None
+    try:
+        return json.loads(text[start : end + 1])
+    except json.JSONDecodeError as e:
+        print(f"Warning: Failed to parse LLM JSON: {e}", file=sys.stderr)
+        return None
+
+
+def post_pr_comment(repo, pr_number, results, run_id, run_url, workflow_name, token):
+    """Post or update a PR comment with classification results."""
+    marker = "<!-- error-classification -->"
+    failed_count = len({r["job_id"] for r in results})
+
+    # Build table rows
+    rows = []
+    for r in results:
+        category_short = r["category"].replace("_error", "")
+        transient = "Yes" if r["is_transient"] else "No"
+        summary = r["summary"][:80] + "..." if len(r["summary"]) > 80 else r["summary"]
+        rows.append(
+            f"| {r['job_name']} | {r['step']} | {category_short} | {summary} | {transient} |"
+        )
+
+    table = "\n".join(rows) if rows else "| (no errors detected) | | | | |"
+
+    body = f"""{marker}
+## CI Error Classification
+
+**Run**: [#{run_id}]({run_url}) | **Failed Jobs**: {failed_count}
+
+| Job | Step | Category | Summary | Transient? |
+|-----|------|----------|---------|------------|
+{table}
+"""
+
+    headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+
+    # Search for existing comment to update
+    comment_id = find_existing_comment(repo, pr_number, marker, headers)
+    if comment_id:
+        url = f"https://api.github.com/repos/{repo}/issues/comments/{comment_id}"
+        resp = requests.patch(url, headers=headers, json={"body": body})
+    else:
+        url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
+        resp = requests.post(url, headers=headers, json={"body": body})
+    resp.raise_for_status()
+
+
+def find_existing_comment(repo, pr_number, marker, headers):
+    """Find an existing comment containing the marker string."""
+    url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
+    params = {"per_page": 100}
+    while url:
+        resp = requests.get(url, headers=headers, params=params)
+        resp.raise_for_status()
+        for comment in resp.json():
+            if marker in comment.get("body", ""):
+                return comment["id"]
+        url = resp.links.get("next", {}).get("url")
+        params = None
+    return None
+
+
+def write_json_output(path, run_id, repo, workflow_name, workflow_type, branch, commit_sha,
+                      pr_number, model, errors):
+    """Write database-ready JSON output."""
+    run_url = f"https://github.com/{repo}/actions/runs/{run_id}"
+    output = {
+        "run_id": str(run_id),
+        "run_url": run_url,
+        "repo": repo,
+        "workflow_name": workflow_name,
+        "workflow_type": workflow_type,
+        "branch": branch,
+        "commit_sha": commit_sha,
+        "pr_number": pr_number,
+        "classified_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "model": model,
+        "errors": errors,
+    }
+    with open(path, "w") as f:
+        json.dump(output, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/classify_errors.py
+++ b/.github/scripts/classify_errors.py
@@ -232,7 +232,7 @@ def post_pr_comment(repo, pr_number, results, run_id, run_url, workflow_name, to
     for r in results:
         category_short = r["category"].replace("_error", "")
         transient = "Yes" if r["is_transient"] else "No"
-        summary = r["summary"][:80] + "..." if len(r["summary"]) > 80 else r["summary"]
+        summary = r["summary"][:200] + "..." if len(r["summary"]) > 200 else r["summary"]
         rows.append(
             f"| {r['job_name']} | {r['step']} | {category_short} | {summary} | {transient} |"
         )
@@ -242,7 +242,7 @@ def post_pr_comment(repo, pr_number, results, run_id, run_url, workflow_name, to
     body = f"""{marker}
 ## CI Error Classification
 
-**Run**: [#{run_id}]({run_url}) | **Failed Jobs**: {failed_count}
+**{workflow_name}** [#{run_id}]({run_url}) | **Failed Jobs**: {failed_count}
 
 | Job | Step | Category | Summary | Transient? |
 |-----|------|----------|---------|------------|

--- a/.github/scripts/classify_errors.py
+++ b/.github/scripts/classify_errors.py
@@ -75,9 +75,7 @@ def main():
             errors=[],
         )
         if args.workflow_type == "pr" and args.pr_number:
-            run_url = (
-                f"https://github.com/{args.repo}/actions/runs/{args.run_id}"
-            )
+            run_url = f"https://github.com/{args.repo}/actions/runs/{args.run_id}"
             post_pr_comment(
                 args.repo,
                 args.pr_number,

--- a/.github/scripts/classify_errors.py
+++ b/.github/scripts/classify_errors.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 
 import requests
 
-MAX_LOG_CHARS = 400_000
+MAX_LOG_CHARS = 50_000
 
 
 def main():
@@ -85,7 +85,11 @@ def main():
             print(f"    Warning: Could not fetch log for job {job_name}")
             continue
 
-        result = classify_errors(log, job_name, system_prompt, api_key, model, base_url)
+        try:
+            result = classify_errors(log, job_name, system_prompt, api_key, model, base_url)
+        except Exception as e:
+            print(f"    Error classifying job {job_name}: {e}")
+            continue
         if result and result.get("errors_found"):
             for error in result["errors_found"]:
                 all_errors.append(

--- a/.github/scripts/classify_errors.py
+++ b/.github/scripts/classify_errors.py
@@ -74,6 +74,20 @@ def main():
             model=model,
             errors=[],
         )
+        if args.workflow_type == "pr" and args.pr_number:
+            run_url = (
+                f"https://github.com/{args.repo}/actions/runs/{args.run_id}"
+            )
+            post_pr_comment(
+                args.repo,
+                args.pr_number,
+                [],
+                args.run_id,
+                run_url,
+                run_meta.get("name", ""),
+                github_token,
+            )
+            print(f"Posted PR comment to #{args.pr_number}")
         return
 
     print(f"Found {len(failed_jobs)} failed job(s). Classifying...")
@@ -254,23 +268,30 @@ def post_pr_comment(repo, pr_number, results, run_id, run_url, workflow_name, to
     marker = "<!-- error-classification -->"
     failed_count = len({r["job_id"] for r in results})
 
-    # Build table rows — one row per job (first/primary error only)
-    seen_jobs = set()
-    rows = []
-    for r in results:
-        if r["job_id"] in seen_jobs:
-            continue
-        seen_jobs.add(r["job_id"])
-        category_short = r["category"].replace("_error", "")
-        transient = "Yes" if r["is_transient"] else "No"
-        summary = r["summary"]
-        rows.append(
-            f"| {r['job_name']} | {r['step']} | {category_short} | {summary} | {transient} |"
-        )
+    if not results:
+        body = f"""{marker}
+## CI Error Classification
 
-    table = "\n".join(rows) if rows else "| (no errors detected) | | | | |"
+**{workflow_name}** [#{run_id}]({run_url}) | No failures detected
+"""
+    else:
+        # Build table rows — one row per job (first/primary error only)
+        seen_jobs = set()
+        rows = []
+        for r in results:
+            if r["job_id"] in seen_jobs:
+                continue
+            seen_jobs.add(r["job_id"])
+            category_short = r["category"].replace("_error", "")
+            transient = "Yes" if r["is_transient"] else "No"
+            summary = r["summary"]
+            rows.append(
+                f"| {r['job_name']} | {r['step']} | {category_short} | {summary} | {transient} |"
+            )
 
-    body = f"""{marker}
+        table = "\n".join(rows)
+
+        body = f"""{marker}
 ## CI Error Classification
 
 **{workflow_name}** [#{run_id}]({run_url}) | **Failed Jobs**: {failed_count}

--- a/.github/scripts/classify_errors.py
+++ b/.github/scripts/classify_errors.py
@@ -227,12 +227,16 @@ def post_pr_comment(repo, pr_number, results, run_id, run_url, workflow_name, to
     marker = "<!-- error-classification -->"
     failed_count = len({r["job_id"] for r in results})
 
-    # Build table rows
+    # Build table rows — one row per job (first/primary error only)
+    seen_jobs = set()
     rows = []
     for r in results:
+        if r["job_id"] in seen_jobs:
+            continue
+        seen_jobs.add(r["job_id"])
         category_short = r["category"].replace("_error", "")
         transient = "Yes" if r["is_transient"] else "No"
-        summary = r["summary"][:200] + "..." if len(r["summary"]) > 200 else r["summary"]
+        summary = r["summary"]
         rows.append(
             f"| {r['job_name']} | {r['step']} | {category_short} | {summary} | {transient} |"
         )
@@ -251,31 +255,10 @@ def post_pr_comment(repo, pr_number, results, run_id, run_url, workflow_name, to
 
     headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
 
-    # Search for existing comment to update
-    comment_id = find_existing_comment(repo, pr_number, marker, headers)
-    if comment_id:
-        url = f"https://api.github.com/repos/{repo}/issues/comments/{comment_id}"
-        resp = requests.patch(url, headers=headers, json={"body": body})
-    else:
-        url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
-        resp = requests.post(url, headers=headers, json={"body": body})
+    url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
+    resp = requests.post(url, headers=headers, json={"body": body})
     print(f"  Comment API response: {resp.status_code} {resp.text[:500]}")
     resp.raise_for_status()
-
-
-def find_existing_comment(repo, pr_number, marker, headers):
-    """Find an existing comment containing the marker string."""
-    url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
-    params = {"per_page": 100}
-    while url:
-        resp = requests.get(url, headers=headers, params=params)
-        resp.raise_for_status()
-        for comment in resp.json():
-            if marker in comment.get("body", ""):
-                return comment["id"]
-        url = resp.links.get("next", {}).get("url")
-        params = None
-    return None
 
 
 def write_json_output(path, run_id, repo, workflow_name, workflow_type, branch, commit_sha,

--- a/.github/scripts/classify_errors.py
+++ b/.github/scripts/classify_errors.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 import requests
 
 MAX_LOG_CHARS = 50_000
+GITHUB_API_TIMEOUT = 30
 
 
 def main():
@@ -42,14 +43,14 @@ def main():
 
     github_token = os.environ.get("GITHUB_TOKEN", "")
     api_key = os.environ.get("API_KEY", "")
-    base_url = os.environ.get("API_BASE_URL", "https://inference-api.nvidia.com/v1")
+    base_url = os.environ.get("API_BASE_URL", "")
     model = os.environ.get("MODEL", "nvcf/meta/llama-3.3-70b-instruct")
 
     if not github_token:
         print("Error: GITHUB_TOKEN not set", file=sys.stderr)
         sys.exit(1)
-    if not api_key:
-        print("Error: API_KEY must be set", file=sys.stderr)
+    if not api_key or not base_url:
+        print("Error: API_KEY and API_BASE_URL must be set", file=sys.stderr)
         sys.exit(1)
 
     system_prompt = load_prompt(args.prompt_file)
@@ -154,7 +155,7 @@ def get_run_metadata(repo, run_id, token):
         "Authorization": f"token {token}",
         "Accept": "application/vnd.github+json",
     }
-    resp = requests.get(url, headers=headers)
+    resp = requests.get(url, headers=headers, timeout=GITHUB_API_TIMEOUT)
     resp.raise_for_status()
     return resp.json()
 
@@ -169,7 +170,9 @@ def get_failed_jobs(repo, run_id, token):
     params = {"per_page": 100, "filter": "latest"}
     all_jobs = []
     while url:
-        resp = requests.get(url, headers=headers, params=params)
+        resp = requests.get(
+            url, headers=headers, params=params, timeout=GITHUB_API_TIMEOUT
+        )
         resp.raise_for_status()
         data = resp.json()
         all_jobs.extend(data.get("jobs", []))
@@ -186,7 +189,9 @@ def get_job_log(repo, job_id, token):
         "Authorization": f"token {token}",
         "Accept": "application/vnd.github+json",
     }
-    resp = requests.get(url, headers=headers, allow_redirects=True)
+    resp = requests.get(
+        url, headers=headers, allow_redirects=True, timeout=GITHUB_API_TIMEOUT
+    )
     if resp.status_code != 200:
         return None
     text = resp.text
@@ -281,7 +286,9 @@ def post_pr_comment(repo, pr_number, results, run_id, run_url, workflow_name, to
     }
 
     url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
-    resp = requests.post(url, headers=headers, json={"body": body})
+    resp = requests.post(
+        url, headers=headers, json={"body": body}, timeout=GITHUB_API_TIMEOUT
+    )
     print(f"  Comment API response: {resp.status_code} {resp.text[:500]}")
     resp.raise_for_status()
 

--- a/.github/scripts/classify_errors.py
+++ b/.github/scripts/classify_errors.py
@@ -20,7 +20,9 @@ MAX_LOG_CHARS = 50_000
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Classify CI errors from GitHub Actions")
+    parser = argparse.ArgumentParser(
+        description="Classify CI errors from GitHub Actions"
+    )
     parser.add_argument("--run-id", required=True, help="GitHub Actions run ID")
     parser.add_argument("--repo", required=True, help="GitHub repo (owner/name)")
     parser.add_argument(
@@ -29,7 +31,9 @@ def main():
         choices=["pr", "nightly", "post-merge", "release"],
     )
     parser.add_argument("--pr-number", type=int, default=None)
-    parser.add_argument("--output-json", required=True, help="Path to write JSON output")
+    parser.add_argument(
+        "--output-json", required=True, help="Path to write JSON output"
+    )
     parser.add_argument(
         "--prompt-file",
         default=os.path.join(os.path.dirname(__file__), "classify_errors_prompt.txt"),
@@ -86,7 +90,9 @@ def main():
             continue
 
         try:
-            result = classify_errors(log, job_name, system_prompt, api_key, model, base_url)
+            result = classify_errors(
+                log, job_name, system_prompt, api_key, model, base_url
+            )
         except Exception as e:
             print(f"    Error classifying job {job_name}: {e}")
             continue
@@ -144,7 +150,10 @@ def load_prompt(path):
 def get_run_metadata(repo, run_id, token):
     """Fetch workflow run metadata."""
     url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}"
-    headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
     resp = requests.get(url, headers=headers)
     resp.raise_for_status()
     return resp.json()
@@ -153,7 +162,10 @@ def get_run_metadata(repo, run_id, token):
 def get_failed_jobs(repo, run_id, token):
     """Get all failed jobs for a workflow run."""
     url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs"
-    headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
     params = {"per_page": 100, "filter": "latest"}
     all_jobs = []
     while url:
@@ -170,7 +182,10 @@ def get_failed_jobs(repo, run_id, token):
 def get_job_log(repo, job_id, token):
     """Fetch job logs, truncated to the last MAX_LOG_CHARS characters."""
     url = f"https://api.github.com/repos/{repo}/actions/jobs/{job_id}/logs"
-    headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
     resp = requests.get(url, headers=headers, allow_redirects=True)
     if resp.status_code != 200:
         return None
@@ -217,7 +232,10 @@ def parse_llm_response(text):
     start = text.find("{")
     end = text.rfind("}")
     if start == -1 or end == -1 or end <= start:
-        print(f"Warning: Could not find JSON in LLM response: {text[:200]}", file=sys.stderr)
+        print(
+            f"Warning: Could not find JSON in LLM response: {text[:200]}",
+            file=sys.stderr,
+        )
         return None
     try:
         return json.loads(text[start : end + 1])
@@ -257,7 +275,10 @@ def post_pr_comment(repo, pr_number, results, run_id, run_url, workflow_name, to
 {table}
 """
 
-    headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
 
     url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
     resp = requests.post(url, headers=headers, json={"body": body})
@@ -265,8 +286,18 @@ def post_pr_comment(repo, pr_number, results, run_id, run_url, workflow_name, to
     resp.raise_for_status()
 
 
-def write_json_output(path, run_id, repo, workflow_name, workflow_type, branch, commit_sha,
-                      pr_number, model, errors):
+def write_json_output(
+    path,
+    run_id,
+    repo,
+    workflow_name,
+    workflow_type,
+    branch,
+    commit_sha,
+    pr_number,
+    model,
+    errors,
+):
     """Write database-ready JSON output."""
     run_url = f"https://github.com/{repo}/actions/runs/{run_id}"
     output = {

--- a/.github/scripts/classify_errors_prompt.txt
+++ b/.github/scripts/classify_errors_prompt.txt
@@ -1,0 +1,86 @@
+You are an expert CI/CD error analyzer for ML infrastructure projects, specifically focused on LLM inference frameworks like vLLM, SGLang, and TensorRT-LLM.
+
+Your task is to analyze a GitHub Actions job log and identify ALL errors/failures.
+
+## Error Categories (choose ONE per error)
+
+**1. infrastructure_error** - Infrastructure/Platform Issues
+- Network problems: DNS failures, connection refused/reset, download failures, SSL/TLS errors, timeouts
+- Runner/Node issues: GitHub Actions runner failures, node unavailable, runner out of disk space
+- Platform failures: Docker daemon issues, Kubernetes failures, artifact upload/download failures
+- Resource limits: Out of memory (OOM), disk space full, file descriptor limits
+Examples: "Failed to establish connection", "Runner failed to start", "Docker daemon not responding", "CUDA out of memory", "No space left on device", "Connection timed out"
+
+**2. code_error** - Code/Build/Test Issues
+- Build failures: Compilation errors, linking errors, build system errors (CMake, cargo, make)
+- Test failures: Assertion failures, pytest errors, test crashes, collection errors
+- Runtime errors: Segmentation faults, null pointer exceptions, uncaught exceptions, crashes
+- Dependency issues: Package installation failures, version conflicts, missing libraries
+- Configuration errors: Invalid config files, missing environment variables, permission denied
+Examples: "error: use of undeclared identifier", "AssertionError: assert 100 == 95", "Segmentation fault", "ImportError: No module named", "cargo build failed", "Permission denied", "Invalid YAML syntax"
+
+## Classification Guidelines
+
+1. infrastructure_error: Use when the error is caused by the platform, network, or resource limitations - issues external to the code itself
+2. code_error: Use for ALL errors originating from the code, build process, tests, or dependencies
+3. Default assumption: Most build and test errors are code_error unless there's clear evidence of infrastructure problems
+4. Network/connectivity issues: Always infrastructure_error
+5. Resource exhaustion (OOM, disk full): infrastructure_error
+6. Build/compilation/test failures: code_error (even if caused by missing dependencies or config issues)
+
+## Transient Error Detection
+
+For each error, determine if it's likely transient (could succeed if re-run):
+
+Transient indicators:
+- Network issues: timeouts, connection refused/reset, DNS failures
+- Rate limiting: HTTP 429, API throttling, quota exceeded
+- Resource contention: temporary OOM, disk space temporarily full
+- Infrastructure glitches: runner failures, node restarts, temporary service unavailability
+- Flaky tests: timing-dependent failures, race conditions
+- Download failures: temporary CDN issues, package registry timeouts
+
+NOT transient (permanent failures):
+- Compilation errors: syntax errors, type errors, missing declarations
+- Test assertions: logic errors, incorrect behavior
+- Build configuration: missing dependencies, incorrect paths
+- Code bugs: segfaults from bad logic, null pointer errors
+- Permission errors: access denied due to incorrect permissions/credentials
+
+If unsure, default to NOT transient (is_transient: false).
+
+## Analysis Instructions
+
+1. Read the ENTIRE log from start to finish
+2. Identify ALL errors/failures (not just the first one)
+3. For EACH error found:
+   - Determine which step it occurred in (look for ##[group] markers or step names)
+   - Classify into ONE of the 2 categories above
+   - Provide confidence score (0.0-1.0)
+   - Write a concise root cause summary (2-3 sentences)
+   - Extract 5-10 key log lines showing the error
+4. Assign confidence score:
+   - 0.9-1.0: Very clear, unambiguous
+   - 0.7-0.89: Likely correct, some ambiguity
+   - 0.5-0.69: Uncertain, multiple possibilities
+   - Below 0.5: Very uncertain (still provide best guess)
+
+## Output Format
+
+Return ONLY valid JSON (no markdown, no explanations):
+
+{
+  "errors_found": [
+    {
+      "step": "step name from ##[group] marker or 'unknown'",
+      "primary_category": "infrastructure_error" or "code_error",
+      "confidence_score": 0.85,
+      "root_cause_summary": "Brief 2-3 sentence explanation of the root cause",
+      "log_excerpt": "5-10 key lines showing the error",
+      "is_transient": true or false
+    }
+  ],
+  "total_errors": number
+}
+
+If no errors are found, return: {"errors_found": [], "total_errors": 0}

--- a/.github/workflows/classify-errors.yml
+++ b/.github/workflows/classify-errors.yml
@@ -4,14 +4,23 @@
 name: Classify CI Errors
 
 on:
-  workflow_run:
-    workflows:
-      - "PR"
-      - "Nightly CI Pipeline"
-      - "Post-Merge CI Pipeline"
-      - "Release Pipeline"
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      workflow_type:
+        description: "Workflow type (pr, nightly, post-merge, release)"
+        required: true
+        type: string
+      enable_pr_comments:
+        description: "Enable PR comments"
+        type: string
+        default: "true"
+    secrets:
+      CI_CLASSIFIER_API_KEY:
+        required: true
+      CI_CLASSIFIER_API_BASE_URL:
+        required: true
+      CI_CLASSIFIER_MODEL:
+        required: true
   workflow_dispatch:
     inputs:
       run_id:
@@ -32,9 +41,6 @@ on:
 
 jobs:
   classify:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -47,35 +53,24 @@ jobs:
       - name: Install dependencies
         run: pip install requests
 
-      - name: Detect workflow type and PR number
+      - name: Detect run ID and PR number
         id: detect
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "workflow_type=${{ inputs.workflow_type }}" >> "$GITHUB_OUTPUT"
-            echo "pr_number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
             echo "run_id=${{ inputs.run_id }}" >> "$GITHUB_OUTPUT"
+            echo "pr_number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+            echo "workflow_type=${{ inputs.workflow_type }}" >> "$GITHUB_OUTPUT"
           else
-            WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
-            HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+            echo "run_id=${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+            echo "workflow_type=${{ inputs.workflow_type }}" >> "$GITHUB_OUTPUT"
 
-            case "$WORKFLOW_NAME" in
-              "PR") WORKFLOW_TYPE="pr" ;;
-              "Nightly CI Pipeline") WORKFLOW_TYPE="nightly" ;;
-              "Post-Merge CI Pipeline") WORKFLOW_TYPE="post-merge" ;;
-              "Release Pipeline") WORKFLOW_TYPE="release" ;;
-              *) echo "Unknown workflow: $WORKFLOW_NAME"; exit 1 ;;
-            esac
-            echo "workflow_type=$WORKFLOW_TYPE" >> "$GITHUB_OUTPUT"
-
-            # Extract PR number from branch name (pull-request/NNN) or workflow_run context
+            # Extract PR number from branch name (pull-request/NNN)
+            HEAD_BRANCH="${{ github.ref_name }}"
             PR_NUMBER=""
             if [[ "$HEAD_BRANCH" =~ ^pull-request/([0-9]+)$ ]]; then
               PR_NUMBER="${BASH_REMATCH[1]}"
-            elif [ -n "${{ github.event.workflow_run.pull_requests[0].number }}" ]; then
-              PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
             fi
             echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-            echo "run_id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Classify errors
@@ -95,11 +90,14 @@ jobs:
             --repo ${{ github.repository }} \
             --workflow-type ${{ steps.detect.outputs.workflow_type }} \
             $PR_ARGS \
-            --output-json /tmp/classification.json
+            --output-json /tmp/classification.json \
+            || echo "::warning::Error classification failed but continuing"
 
       - name: Upload classification artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: error-classification-${{ steps.detect.outputs.run_id }}
           path: /tmp/classification.json
           retention-days: 90
+          if-no-files-found: ignore

--- a/.github/workflows/classify-errors.yml
+++ b/.github/workflows/classify-errors.yml
@@ -15,11 +15,7 @@ on:
         type: string
         default: "true"
     secrets:
-      CI_CLASSIFIER_API_KEY:
-        required: true
-      CI_CLASSIFIER_API_BASE_URL:
-        required: true
-      CI_CLASSIFIER_MODEL:
+      ANTHROPIC_API_KEY:
         required: true
   workflow_dispatch:
     inputs:
@@ -76,9 +72,9 @@ jobs:
       - name: Classify errors
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          API_KEY: ${{ secrets.CI_CLASSIFIER_API_KEY }}
-          API_BASE_URL: ${{ secrets.CI_CLASSIFIER_API_BASE_URL }}
-          MODEL: ${{ secrets.CI_CLASSIFIER_MODEL }}
+          API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          API_BASE_URL: "https://inference-api.nvidia.com/v1"
+          MODEL: "aws/anthropic/claude-sonnet-4-5-20250929"
         run: |
           PR_ARGS=""
           if [ -n "${{ steps.detect.outputs.pr_number }}" ]; then

--- a/.github/workflows/classify-errors.yml
+++ b/.github/workflows/classify-errors.yml
@@ -12,10 +12,29 @@ on:
       - "Release Pipeline"
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "GitHub Actions run ID to classify"
+        required: true
+      workflow_type:
+        description: "Workflow type"
+        required: true
+        type: choice
+        options:
+          - pr
+          - nightly
+          - post-merge
+          - release
+      pr_number:
+        description: "PR number (optional, for posting comment)"
+        required: false
 
 jobs:
   classify:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -31,26 +50,33 @@ jobs:
       - name: Detect workflow type and PR number
         id: detect
         run: |
-          WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
-          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "workflow_type=${{ inputs.workflow_type }}" >> "$GITHUB_OUTPUT"
+            echo "pr_number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+            echo "run_id=${{ inputs.run_id }}" >> "$GITHUB_OUTPUT"
+          else
+            WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
+            HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
 
-          case "$WORKFLOW_NAME" in
-            "PR") WORKFLOW_TYPE="pr" ;;
-            "Nightly CI Pipeline") WORKFLOW_TYPE="nightly" ;;
-            "Post-Merge CI Pipeline") WORKFLOW_TYPE="post-merge" ;;
-            "Release Pipeline") WORKFLOW_TYPE="release" ;;
-            *) echo "Unknown workflow: $WORKFLOW_NAME"; exit 1 ;;
-          esac
-          echo "workflow_type=$WORKFLOW_TYPE" >> "$GITHUB_OUTPUT"
+            case "$WORKFLOW_NAME" in
+              "PR") WORKFLOW_TYPE="pr" ;;
+              "Nightly CI Pipeline") WORKFLOW_TYPE="nightly" ;;
+              "Post-Merge CI Pipeline") WORKFLOW_TYPE="post-merge" ;;
+              "Release Pipeline") WORKFLOW_TYPE="release" ;;
+              *) echo "Unknown workflow: $WORKFLOW_NAME"; exit 1 ;;
+            esac
+            echo "workflow_type=$WORKFLOW_TYPE" >> "$GITHUB_OUTPUT"
 
-          # Extract PR number from branch name (pull-request/NNN) or workflow_run context
-          PR_NUMBER=""
-          if [[ "$HEAD_BRANCH" =~ ^pull-request/([0-9]+)$ ]]; then
-            PR_NUMBER="${BASH_REMATCH[1]}"
-          elif [ -n "${{ github.event.workflow_run.pull_requests[0].number }}" ]; then
-            PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+            # Extract PR number from branch name (pull-request/NNN) or workflow_run context
+            PR_NUMBER=""
+            if [[ "$HEAD_BRANCH" =~ ^pull-request/([0-9]+)$ ]]; then
+              PR_NUMBER="${BASH_REMATCH[1]}"
+            elif [ -n "${{ github.event.workflow_run.pull_requests[0].number }}" ]; then
+              PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+            fi
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "run_id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
           fi
-          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Classify errors
         env:
@@ -65,7 +91,7 @@ jobs:
           fi
 
           python .github/scripts/classify_errors.py \
-            --run-id ${{ github.event.workflow_run.id }} \
+            --run-id ${{ steps.detect.outputs.run_id }} \
             --repo ${{ github.repository }} \
             --workflow-type ${{ steps.detect.outputs.workflow_type }} \
             $PR_ARGS \
@@ -74,6 +100,6 @@ jobs:
       - name: Upload classification artifact
         uses: actions/upload-artifact@v4
         with:
-          name: error-classification-${{ github.event.workflow_run.id }}
+          name: error-classification-${{ steps.detect.outputs.run_id }}
           path: /tmp/classification.json
           retention-days: 90

--- a/.github/workflows/classify-errors.yml
+++ b/.github/workflows/classify-errors.yml
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Classify CI Errors
+
+on:
+  workflow_run:
+    workflows:
+      - "PR"
+      - "Nightly CI Pipeline"
+      - "Post-Merge CI Pipeline"
+      - "Release Pipeline"
+    types:
+      - completed
+
+jobs:
+  classify:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Detect workflow type and PR number
+        id: detect
+        run: |
+          WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
+          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+
+          case "$WORKFLOW_NAME" in
+            "PR") WORKFLOW_TYPE="pr" ;;
+            "Nightly CI Pipeline") WORKFLOW_TYPE="nightly" ;;
+            "Post-Merge CI Pipeline") WORKFLOW_TYPE="post-merge" ;;
+            "Release Pipeline") WORKFLOW_TYPE="release" ;;
+            *) echo "Unknown workflow: $WORKFLOW_NAME"; exit 1 ;;
+          esac
+          echo "workflow_type=$WORKFLOW_TYPE" >> "$GITHUB_OUTPUT"
+
+          # Extract PR number from branch name (pull-request/NNN) or workflow_run context
+          PR_NUMBER=""
+          if [[ "$HEAD_BRANCH" =~ ^pull-request/([0-9]+)$ ]]; then
+            PR_NUMBER="${BASH_REMATCH[1]}"
+          elif [ -n "${{ github.event.workflow_run.pull_requests[0].number }}" ]; then
+            PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Classify errors
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API_KEY: ${{ secrets.CI_CLASSIFIER_API_KEY }}
+          API_BASE_URL: ${{ secrets.CI_CLASSIFIER_API_BASE_URL }}
+          MODEL: ${{ secrets.CI_CLASSIFIER_MODEL }}
+        run: |
+          PR_ARGS=""
+          if [ -n "${{ steps.detect.outputs.pr_number }}" ]; then
+            PR_ARGS="--pr-number ${{ steps.detect.outputs.pr_number }}"
+          fi
+
+          python .github/scripts/classify_errors.py \
+            --run-id ${{ github.event.workflow_run.id }} \
+            --repo ${{ github.repository }} \
+            --workflow-type ${{ steps.detect.outputs.workflow_type }} \
+            $PR_ARGS \
+            --output-json /tmp/classification.json
+
+      - name: Upload classification artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: error-classification-${{ github.event.workflow_run.id }}
+          path: /tmp/classification.json
+          retention-days: 90

--- a/.github/workflows/classify-errors.yml
+++ b/.github/workflows/classify-errors.yml
@@ -74,7 +74,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           API_BASE_URL: "https://inference-api.nvidia.com/v1"
-          MODEL: "aws/anthropic/claude-sonnet-4-5-20250929"
+          MODEL: "nvcf/meta/llama-3.3-70b-instruct"
         run: |
           PR_ARGS=""
           if [ -n "${{ steps.detect.outputs.pr_number }}" ]; then

--- a/.github/workflows/classify-errors.yml
+++ b/.github/workflows/classify-errors.yml
@@ -17,6 +17,8 @@ on:
     secrets:
       ANTHROPIC_API_KEY:
         required: true
+      CI_CLASSIFIER_API_BASE_URL:
+        required: true
   workflow_dispatch:
     inputs:
       run_id:
@@ -73,7 +75,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          API_BASE_URL: "https://inference-api.nvidia.com/v1"
+          API_BASE_URL: ${{ secrets.CI_CLASSIFIER_API_BASE_URL }}
           MODEL: "nvcf/meta/llama-3.3-70b-instruct"
         run: |
           PR_ARGS=""

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -314,9 +314,21 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUM="${GITHUB_REF##*/}"
-          gh pr comment "https://github.com/${{ github.repository }}/pull/${PR_NUM}" \
-            --edit-last --create-if-none \
-            --body "🌿 **Fern Docs Preview:** ${{ steps.preview.outputs.url }}/dev"
+          PR_URL="https://github.com/${{ github.repository }}/pull/${PR_NUM}"
+          MARKER="<!-- fern-docs-preview -->"
+          BODY="${MARKER}
+          🌿 **Fern Docs Preview:** ${{ steps.preview.outputs.url }}/dev"
+
+          # Find existing comment with our marker, update it; otherwise create new
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUM}/comments" \
+            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -f body="$BODY"
+          else
+            gh pr comment "$PR_URL" --body "$BODY"
+          fi
 
       ##########################################################################
       # PUSH AND PUBLISH - push changes to docs-website branch and publish docs

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -309,7 +309,7 @@ jobs:
           fi
 
       - name: Comment preview URL on PR
-        if: steps.ctx.outputs.is_main != 'true' && steps.preview.outputs.url != '' && startsWith(github.ref, 'refs/heads/pull-request/')
+        if: false && steps.ctx.outputs.is_main != 'true' && steps.preview.outputs.url != '' && startsWith(github.ref, 'refs/heads/pull-request/')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -309,7 +309,7 @@ jobs:
           fi
 
       - name: Comment preview URL on PR
-        if: false && steps.ctx.outputs.is_main != 'true' && steps.preview.outputs.url != '' && startsWith(github.ref, 'refs/heads/pull-request/')
+        if: steps.ctx.outputs.is_main != 'true' && steps.preview.outputs.url != '' && startsWith(github.ref, 'refs/heads/pull-request/')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -142,6 +142,20 @@ jobs:
         run: |
           docker buildx rm ${{ env.BUILDER_NAME }} || true
 
+  # ============================================================================
+  # ERROR CLASSIFICATION
+  # ============================================================================
+
+  classify-errors:
+    if: always() && !cancelled()
+    needs: [vllm-pipeline, sglang-pipeline, trtllm-pipeline]
+    uses: ./.github/workflows/classify-errors.yml
+    with:
+      workflow_type: nightly
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CI_CLASSIFIER_API_BASE_URL: ${{ secrets.CI_CLASSIFIER_API_BASE_URL }}
+
   ############################## SLACK NOTIFICATION ##############################
   notify-slack:
     name: Notify Slack

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -474,6 +474,21 @@ jobs:
       run: |
         docker buildx rm b-${{ github.run_id }}-${{ github.run_attempt }} || true
 
+
+  # ============================================================================
+  # ERROR CLASSIFICATION
+  # ============================================================================
+
+  classify-errors:
+    if: always() && !cancelled()
+    needs: [clean-k8s-builder]
+    uses: ./.github/workflows/classify-errors.yml
+    with:
+      workflow_type: post-merge
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CI_CLASSIFIER_API_BASE_URL: ${{ secrets.CI_CLASSIFIER_API_BASE_URL }}
+
   ############################## SLACK NOTIFICATION ##############################
   notify-slack:
     name: Notify Slack

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -464,3 +464,20 @@ jobs:
       shell: bash
       run: |
         docker buildx rm ${{ needs.changed-files.outputs.builder_name }} || true
+
+
+  # ============================================================================
+  # ERROR CLASSIFICATION
+  # Classify CI failures after all jobs complete
+  # ============================================================================
+
+  classify-errors:
+    if: always() && !cancelled()
+    needs: [clean-k8s-builder]
+    uses: ./.github/workflows/classify-errors.yml
+    with:
+      workflow_type: pr
+      enable_pr_comments: 'true'
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CI_CLASSIFIER_API_BASE_URL: ${{ secrets.CI_CLASSIFIER_API_BASE_URL }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -467,29 +467,13 @@ jobs:
 
 
   # ============================================================================
-  # ERROR CLASSIFICATION (temporary test job - remove before merge)
+  # ERROR CLASSIFICATION
+  # Classify CI failures after all jobs complete
   # ============================================================================
-
-  fake-failure:
-    runs-on: ubuntu-latest
-    needs: [changed-files]
-    steps:
-      - name: Simulate build failure
-        run: |
-          echo "##[group]Build image"
-          echo "Compiling dynamo-runtime crate..."
-          echo "error[E0277]: the trait bound \`MyStruct: Send\` is not satisfied"
-          echo "  --> src/runtime/mod.rs:42:5"
-          echo "   |"
-          echo "42 |     tokio::spawn(async move {"
-          echo "   |     ^^^^^^^^^^^^ \`MyStruct\` cannot be sent between threads safely"
-          echo "error: aborting due to previous error"
-          echo "##[endgroup]"
-          exit 1
 
   classify-errors:
     if: always() && !cancelled()
-    needs: [fake-failure]
+    needs: [clean-k8s-builder]
     uses: ./.github/workflows/classify-errors.yml
     with:
       workflow_type: pr

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -467,13 +467,29 @@ jobs:
 
 
   # ============================================================================
-  # ERROR CLASSIFICATION
-  # Classify CI failures after all jobs complete
+  # ERROR CLASSIFICATION (temporary test job - remove before merge)
   # ============================================================================
+
+  fake-failure:
+    runs-on: ubuntu-latest
+    needs: [changed-files]
+    steps:
+      - name: Simulate build failure
+        run: |
+          echo "##[group]Build image"
+          echo "Compiling dynamo-runtime crate..."
+          echo "error[E0277]: the trait bound \`MyStruct: Send\` is not satisfied"
+          echo "  --> src/runtime/mod.rs:42:5"
+          echo "   |"
+          echo "42 |     tokio::spawn(async move {"
+          echo "   |     ^^^^^^^^^^^^ \`MyStruct\` cannot be sent between threads safely"
+          echo "error: aborting due to previous error"
+          echo "##[endgroup]"
+          exit 1
 
   classify-errors:
     if: always() && !cancelled()
-    needs: [clean-k8s-builder]
+    needs: [fake-failure]
     uses: ./.github/workflows/classify-errors.yml
     with:
       workflow_type: pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -411,4 +411,5 @@ jobs:
       workflow_type: release
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CI_CLASSIFIER_API_BASE_URL: ${{ secrets.CI_CLASSIFIER_API_BASE_URL }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,3 +399,16 @@ jobs:
           echo "Helm chart:" >> $GITHUB_STEP_SUMMARY
           echo "- \`dynamo-platform:${HELM_CHART_VERSION}\` (pushed to NGC Helm registry)" >> $GITHUB_STEP_SUMMARY
 
+  # ============================================================================
+  # ERROR CLASSIFICATION
+  # ============================================================================
+
+  classify-errors:
+    if: always() && !cancelled()
+    needs: [clean-k8s-builder, deploy-cleanup, release-publish]
+    uses: ./.github/workflows/classify-errors.yml
+    with:
+      workflow_type: release
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+


### PR DESCRIPTION
## Overview

Adds automated CI error classification to all major workflows (PR, Nightly, Post-Merge, Release). When a workflow fails, a lightweight Python script fetches the failed job logs, sends them to an LLM for classification as either `code_error` or `infrastructure_error`, posts a summary comment on PRs, and uploads a database-ready JSON artifact.

This replaces the more complex system proposed in PR #6258 (7 files, dual API support, rate limiting, caching) with 3 files total.

## Details

**New files:**
- `.github/scripts/classify_errors.py` — Single Python script (~290 lines, functions only, `requests` as sole dependency). Fetches failed jobs via GitHub API, sends logs to an OpenAI-compatible LLM, parses the JSON classification, posts a PR comment (for PR workflows only), and writes a JSON artifact.
- `.github/scripts/classify_errors_prompt.txt` — Editable system prompt defining the two error categories (`infrastructure_error`, `code_error`), transient detection rules, and expected JSON output format.
- `.github/workflows/classify-errors.yml` — Reusable workflow (`workflow_call`) that installs `requests`, detects the run ID and PR number, runs the classifier, and uploads the JSON artifact with 90-day retention. Also supports `workflow_dispatch` for manual testing.

**Modified files:**
- `.github/workflows/pr.yaml` — Adds `classify-errors` job at end of pipeline (`needs: [clean-k8s-builder, cleanup]`)
- `.github/workflows/nightly-ci.yml` — Adds `classify-errors` after all three framework pipelines
- `.github/workflows/post-merge-ci.yml` — Adds `classify-errors` after cleanup jobs
- `.github/workflows/release.yml` — Adds `classify-errors` after cleanup, deploy, and publish jobs
- `.github/workflows/fern-docs.yml` — Changes PR comment mechanism from `gh pr comment --edit-last` to marker-based (`<!-- fern-docs-preview -->`) to prevent overwriting other bot comments

**Required secrets:**
- `ANTHROPIC_API_KEY` — API key for the LLM endpoint
- `CI_CLASSIFIER_API_BASE_URL` — Base URL for the OpenAI-compatible API

## Where should the reviewer start?

1. `.github/scripts/classify_errors.py` — The core logic. All functions, no classes. Start with `main()` to understand the orchestration flow.
2. `.github/workflows/classify-errors.yml` — How it's wired up as a reusable workflow.
3. `.github/workflows/pr.yaml` (bottom of file) — How the classifier is called inline at the end of the PR pipeline. The other three workflows follow the same pattern.


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated error classification for failed CI workflows that analyzes logs, categorizes errors, identifies transient failures, and posts detailed summaries with confidence scores to pull requests for improved debugging.
  * Error classification results are retained as artifacts for 90 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->