### PR TITLE
fix: strip apiVersion/kind/metadata from overrides.dgd before merging

### DIFF
--- a/components/src/dynamo/profiler/tests/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/test_profiler_protocol.py
@@ -11,6 +11,7 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
+    pytest.mark.parallel,
 ]
 
 

--- a/components/src/dynamo/profiler/tests/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/test_profiler_protocol.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for profiler config_modifiers/protocol helpers."""
+
+import pytest
+
+from dynamo.profiler.utils.config_modifiers.protocol import apply_dgd_overrides
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_apply_dgd_overrides_strips_envelope() -> None:
+    """Envelope fields are stripped; nested payload keys are deep-merged."""
+    dgd_config = {
+        "apiVersion": "dynamo.ai/v1alpha1",
+        "kind": "DynamoGraphDeployment",
+        "metadata": {"name": "my-deployment", "namespace": "default"},
+        "spec": {
+            "services": {
+                "Frontend": {"replicas": 1},
+            }
+        },
+    }
+    overrides = {
+        # Envelope fields — must be stripped entirely.
+        "apiVersion": "dynamo.ai/v1beta1",
+        "kind": "SomethingElse",
+        # metadata identity keys must be stripped; labels/annotations kept.
+        "metadata": {
+            "name": "injected-name",
+            "namespace": "injected-ns",
+            "uid": "abc-123",
+            "resourceVersion": "999",
+            "labels": {"team": "infra"},
+            "annotations": {"note": "perf-run"},
+        },
+        # Regular payload key — must be deep-merged.
+        "spec": {
+            "services": {
+                "Frontend": {"replicas": 3},
+            }
+        },
+    }
+
+    result = apply_dgd_overrides(dgd_config, overrides)
+
+    # apiVersion and kind must not be changed.
+    assert result["apiVersion"] == "dynamo.ai/v1alpha1"
+    assert result["kind"] == "DynamoGraphDeployment"
+
+    # Identity metadata keys must not be overwritten.
+    assert result["metadata"]["name"] == "my-deployment"
+    assert result["metadata"]["namespace"] == "default"
+    assert "uid" not in result["metadata"]
+    assert "resourceVersion" not in result["metadata"]
+
+    # Safe metadata keys must be merged in.
+    assert result["metadata"]["labels"] == {"team": "infra"}
+    assert result["metadata"]["annotations"] == {"note": "perf-run"}
+
+    # Regular spec overrides must be applied.
+    assert result["spec"]["services"]["Frontend"]["replicas"] == 3
+
+    # Original dicts must not be mutated.
+    assert dgd_config["apiVersion"] == "dynamo.ai/v1alpha1"
+    assert dgd_config["spec"]["services"]["Frontend"]["replicas"] == 1
+
+
+def test_apply_dgd_overrides_no_metadata_in_overrides() -> None:
+    """When overrides contain no metadata key, existing metadata is untouched."""
+    dgd_config = {
+        "apiVersion": "dynamo.ai/v1alpha1",
+        "kind": "DynamoGraphDeployment",
+        "metadata": {"name": "svc", "namespace": "ns"},
+        "spec": {"services": {"Backend": {"replicas": 2}}},
+    }
+    overrides = {"spec": {"services": {"Backend": {"replicas": 5}}}}
+
+    result = apply_dgd_overrides(dgd_config, overrides)
+
+    assert result["metadata"] == {"name": "svc", "namespace": "ns"}
+    assert result["spec"]["services"]["Backend"]["replicas"] == 5
+
+
+def test_apply_dgd_overrides_metadata_only_identity_keys_dropped_entirely() -> None:
+    """If metadata override contains only identity keys, nothing is merged into metadata."""
+    dgd_config = {
+        "apiVersion": "dynamo.ai/v1alpha1",
+        "kind": "DynamoGraphDeployment",
+        "metadata": {"name": "svc"},
+        "spec": {},
+    }
+    overrides = {
+        "metadata": {"name": "other", "namespace": "other-ns", "uid": "x"},
+    }
+
+    result = apply_dgd_overrides(dgd_config, overrides)
+
+    # Only original metadata should remain — no extra keys added.
+    assert result["metadata"] == {"name": "svc"}

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -728,7 +728,7 @@ def apply_dgd_overrides(dgd_config: dict, overrides: dict) -> dict:
     # DGDR spec would change v1alpha1 → v1beta1 causing a 400 Bad Request).
     stripped_top = [k for k in ("apiVersion", "kind") if k in overrides]
     if stripped_top:
-        logger.warning(
+        logger.info(
             "Ignoring envelope field(s) %s from overrides.dgd — these are "
             "controlled by the deployment template and cannot be overridden.",
             stripped_top,
@@ -738,26 +738,21 @@ def apply_dgd_overrides(dgd_config: dict, overrides: dict) -> dict:
         for k, v in overrides.items()
         if k not in ("apiVersion", "kind", "metadata")
     }
-    # For metadata: strip identity/owner keys (name, namespace, uid,
-    # resourceVersion) which are template-controlled, but preserve safe fields
-    # such as labels and annotations supplied by the user.
+    # For metadata: only copy explicit safe keys (labels, annotations) to avoid
+    # leaking runtime-managed fields like ownerReferences, finalizers, managedFields.
+    _METADATA_SAFE_KEYS = frozenset({"labels", "annotations"})
     if "metadata" in overrides and isinstance(overrides["metadata"], dict):
-        _METADATA_IDENTITY_KEYS = frozenset(
-            {"name", "namespace", "uid", "resourceVersion"}
-        )
-        stripped_meta = [
-            k for k in overrides["metadata"] if k in _METADATA_IDENTITY_KEYS
+        ignored_meta = [
+            k for k in overrides["metadata"] if k not in _METADATA_SAFE_KEYS
         ]
-        if stripped_meta:
-            logger.warning(
+        if ignored_meta:
+            logger.info(
                 "Ignoring metadata identity field(s) %s from overrides.dgd — "
                 "use the DGD template to set these.",
-                stripped_meta,
+                ignored_meta,
             )
         sanitized_metadata = {
-            k: v
-            for k, v in overrides["metadata"].items()
-            if k not in _METADATA_IDENTITY_KEYS
+            k: v for k, v in overrides["metadata"].items() if k in _METADATA_SAFE_KEYS
         }
         if sanitized_metadata:
             filtered["metadata"] = sanitized_metadata

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -723,5 +723,43 @@ def apply_dgd_overrides(dgd_config: dict, overrides: dict) -> dict:
         A new dict with the overrides applied (the original is not mutated).
     """
     result = copy.deepcopy(dgd_config)
-    _deep_merge_overrides(result, overrides, path=[])
+    # Strip K8s envelope fields — these are controlled by the template and must
+    # not be overwritten by user-supplied overrides (e.g. apiVersion from a
+    # DGDR spec would change v1alpha1 → v1beta1 causing a 400 Bad Request).
+    stripped_top = [k for k in ("apiVersion", "kind") if k in overrides]
+    if stripped_top:
+        logger.warning(
+            "Ignoring envelope field(s) %s from overrides.dgd — these are "
+            "controlled by the deployment template and cannot be overridden.",
+            stripped_top,
+        )
+    filtered = {
+        k: v
+        for k, v in overrides.items()
+        if k not in ("apiVersion", "kind", "metadata")
+    }
+    # For metadata: strip identity/owner keys (name, namespace, uid,
+    # resourceVersion) which are template-controlled, but preserve safe fields
+    # such as labels and annotations supplied by the user.
+    if "metadata" in overrides and isinstance(overrides["metadata"], dict):
+        _METADATA_IDENTITY_KEYS = frozenset(
+            {"name", "namespace", "uid", "resourceVersion"}
+        )
+        stripped_meta = [
+            k for k in overrides["metadata"] if k in _METADATA_IDENTITY_KEYS
+        ]
+        if stripped_meta:
+            logger.warning(
+                "Ignoring metadata identity field(s) %s from overrides.dgd — "
+                "use the DGD template to set these.",
+                stripped_meta,
+            )
+        sanitized_metadata = {
+            k: v
+            for k, v in overrides["metadata"].items()
+            if k not in _METADATA_IDENTITY_KEYS
+        }
+        if sanitized_metadata:
+            filtered["metadata"] = sanitized_metadata
+    _deep_merge_overrides(result, filtered, path=[])
     return result


### PR DESCRIPTION
#### Overview:

https://github.com/ai-dynamo/dynamo/pull/7025 but fixes the CI

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Configuration override validation now prevents users from modifying template-controlled fields, reducing the risk of invalid configuration conflicts.
  * Added warning notifications when override attempts include restricted fields.

* **Tests**
  * Comprehensive test coverage added for override filtering and metadata handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->