### PR TITLE
fix: snapshot children before process group kill to prevent GPU memory leaks

### DIFF
--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -289,7 +289,7 @@ class ManagedProcess:
             # reparented to init, so psutil can no longer find them via the parent
             # PID. We must capture them now while the parent is still alive.
             orphan_candidates = []
-            if self.proc and self.proc.poll() is None:
+            if self.proc:
                 try:
                     parent = psutil.Process(self.proc.pid)
                     orphan_candidates = parent.children(recursive=True)

--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -260,14 +260,17 @@ class ManagedProcess:
 
         Termination Strategy (Graceful → Escalate to Force):
         =====================================================
-        1. Send SIGTERM to process group immediately (no delay before SIGTERM)
-        2. Wait up to 2s (poll every 0.1s) for processes to exit
-        3. If still alive after 2s: Send SIGKILL (force kill)
-        4. Terminate individual processes (self.proc, tee, sed):
+        1. Snapshot child processes (before killing parent, so we can find them)
+        2. Send SIGTERM to process group immediately (no delay before SIGTERM)
+        3. Wait up to 2s (poll every 0.1s) for processes to exit
+        4. If still alive after 2s: Send SIGKILL (force kill)
+        5. Terminate individual processes (self.proc, tee, sed):
            - Send SIGTERM immediately (no delay)
            - Wait up to 10s for exit
            - If still alive after 10s: Send SIGKILL (force kill)
-        5. Clean up straggler processes (if configured)
+        6. Kill any orphaned child processes that escaped the process group
+           (e.g. TRT-LLM engine workers started via MPI in separate PGIDs)
+        7. Clean up straggler processes (if configured)
 
         Signal Details:
         - SIGTERM (15): Graceful - allows cleanup handlers to run
@@ -280,6 +283,19 @@ class ManagedProcess:
         This ALWAYS runs regardless of terminate_all_matching_process_names setting.
         """
         try:
+            # Snapshot all child processes BEFORE killing the parent.
+            # Some frameworks (e.g. TRT-LLM via MPI) spawn children in separate
+            # process groups. After the parent dies these children become orphans
+            # reparented to init, so psutil can no longer find them via the parent
+            # PID. We must capture them now while the parent is still alive.
+            orphan_candidates = []
+            if self.proc and self.proc.poll() is None:
+                try:
+                    parent = psutil.Process(self.proc.pid)
+                    orphan_candidates = parent.children(recursive=True)
+                except psutil.NoSuchProcess:
+                    pass
+
             self._terminate_process_group()
 
             process_list = [self.proc, self._tee_proc, self._sed_proc]
@@ -294,6 +310,22 @@ class ManagedProcess:
                         process.wait()
                     except Exception as e:
                         self._logger.warning("Error terminating process: %s", e)
+
+            # Kill any child processes that survived the process group kill.
+            # This catches children in different PGIDs (e.g. MPI workers, engine
+            # cores) that os.killpg() could not reach.
+            for child in orphan_candidates:
+                try:
+                    if child.is_running():
+                        self._logger.info(
+                            "Killing orphaned child process: PID %s name=%s",
+                            child.pid,
+                            child.name(),
+                        )
+                        terminate_process_tree(child.pid, self._logger)
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+
             if self.data_dir:
                 self._remove_directory(self.data_dir)
         finally:


### PR DESCRIPTION
## Summary
- Fix ~50% flake rate on single-GPU TRT-LLM CI tests (DYN-2402)
- Root cause: TRT-LLM starts engine workers via MPI (`orted`), which creates child processes in **separate process groups**. `ManagedProcess.__exit__()` killed only the parent's PGID, then `terminate_process_tree()` on the dead parent returned immediately (`NoSuchProcess`). Orphaned engine workers retained ~20.46 GiB GPU memory on 22 GiB CI runners, causing all subsequent `test_deployment` tests to OOM.
- Fix: snapshot child processes **before** killing the parent, then explicitly kill any survivors after the process group kill

## Root Cause Details

`ManagedProcess.__exit__()` cleanup sequence was:
1. `_terminate_process_group()` — sends SIGTERM/SIGKILL to parent's PGID
2. `terminate_process_tree(proc.pid)` — tries `psutil.Process(pid)` → **NoSuchProcess** (parent already dead) → returns immediately
3. Children spawned by MPI in separate PGIDs (verified: engine worker PGID ≠ parent PGID) are never killed

After fix:
1. Snapshot children while parent is alive
2. Kill process group
3. Explicitly kill any surviving orphaned children

## Reproduction

Verified locally that TRT-LLM engine worker runs in a different process group:
```
Parent:        PID=1094  PGID=1094  (python3 -m dynamo.trtllm)
MPI daemon:    PID=1118  PGID=1118  (orted — DIFFERENT PGID)
Engine worker: PID=1206  PGID=1206  (mpi4py.futures.server — DIFFERENT PGID)
```

After `os.killpg(1094, SIGKILL)`:
- `psutil.Process(1094).children()` → **raises NoSuchProcess** (parent dead, children orphaned to init)
- Engine worker survives with 82 GiB GPU memory allocated

After fix: engine worker is explicitly killed from the pre-captured snapshot.

## Test plan
- [ ] `trtllm-pipeline / trtllm-cuda13.1-amd64 / Test` CI job passes (was ~50% flake before)
- [ ] No regressions in other test suites (vllm, sglang pipelines)

Fixes: DYN-2402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
- Enhanced process cleanup in test utilities to better identify and terminate orphaned child processes, improving test reliability and reducing straggler processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->