### PR TITLE
fix: allow x-kubernetes-preserve-unknown-fields

### DIFF
--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
@@ -1024,6 +1024,7 @@ spec:
                                 Standard object's metadata.
                                 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                               type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             spec:
                               description: |-
                                 Specification of the desired behavior of the pod.

--- a/deploy/operator/Makefile
+++ b/deploy/operator/Makefile
@@ -87,6 +87,10 @@ manifests: controller-gen ensure-yq ## Generate WebhookConfiguration, ClusterRol
 	for file in config/crd/bases/*.yaml; do \
 		yq eval '(.. | select(has("parameters")) | .parameters | select(has("format") and .format == "byte")) |= (del(.format) | del(.type) | .x-kubernetes-preserve-unknown-fields = true)' -i --indent 2 $$file || exit 1; \
 	done
+	echo "Fixing profilingJob template metadata: controller-gen emits bare type: object for metav1.ObjectMeta, add x-kubernetes-preserve-unknown-fields so labels/annotations are accepted"
+	for file in config/crd/bases/*.yaml; do \
+		yq eval '(.. | select(has("profilingJob")) | .profilingJob.properties.template.properties.metadata)."x-kubernetes-preserve-unknown-fields" = true' -i --indent 2 $$file || exit 1; \
+	done
 	echo "Adding NVIDIA header to CRD files"
 	for file in config/crd/bases/*.yaml; do \
 		if ! head -20 "$$file" | grep -q "NVIDIA CORPORATION"; then \

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
@@ -1024,6 +1024,7 @@ spec:
                                 Standard object's metadata.
                                 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                               type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             spec:
                               description: |-
                                 Specification of the desired behavior of the pod.


### PR DESCRIPTION
#### Overview:

Allow setting of labels + annotations on the profiling job pod

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DynamoGraphDeploymentRequest CRD schema to preserve unknown fields in pod template metadata, enabling custom metadata and annotations without validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->