### PR TITLE
fix: increase process group termination timeout from 2s to 8s

### DIFF
--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -397,18 +397,21 @@ class ManagedProcess:
                 )
             self._tee_proc = None
 
-    def _terminate_process_group(self, timeout: float = 2.0):
+    def _terminate_process_group(self, timeout: float = 8.0):
         """Terminate the entire process group/session started for the child.
 
         Kill Sequence:
         ==============
         1. Send SIGTERM to entire process group IMMEDIATELY (no delay)
-        2. Wait up to `timeout` seconds (default 2s), polling every 0.1s
+        2. Wait up to `timeout` seconds (default 8s), polling every 0.1s
         3. If still alive after timeout: Send SIGKILL (force kill, immediate)
 
         Timeout Parameter:
         - Controls how long to WAIT AFTER SIGTERM before escalating to SIGKILL
         - NOT a delay before sending SIGTERM (SIGTERM is sent immediately)
+        - 8s gives engines (TRT-LLM, vLLM, etc.) enough time to gracefully
+          shut down MPI workers, release GPU memory, and drain pending requests
+        - Polling at 0.1s intervals means fast exits are not penalized
 
         Process groups catch cases where the launcher shell exits and its
         children are reparented, leaving no parent PID to traverse, but they


### PR DESCRIPTION
## Summary
- Increase the SIGTERM → SIGKILL escalation timeout in `ManagedProcess._terminate_process_group()` from 2s to 8s
- Follow-up to #7122 based on reviewer feedback

## Why

2 seconds is not enough for most engines (TRT-LLM, vLLM, SGLang) to gracefully shut down. A graceful SIGTERM allows the parent process to:
- Properly tear down MPI workers and child processes
- Release GPU memory and CUDA contexts
- Drain pending requests
- Close network connections (NATS, etcd)

SIGKILLing after only 2s bypasses the parent's cleanup handlers, which increases the chance of orphaned child processes holding GPU memory. The orphan snapshot fix from #7122 catches these as a safety net, but giving the parent enough time to clean up gracefully is the better first line of defense.

## Impact on test duration

The polling mechanism (`poll_interval=0.1s`) means the method returns as soon as the process group exits — fast shutdowns are not penalized. The 8s timeout only applies when a process is truly stuck.

## Test plan
- [ ] CI passes (no regressions in test teardown timing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended the timeout for graceful process termination to allow engines more time to shut down cleanly, release resources, and handle pending operations before forced termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->