### PR TITLE
feat: enable intel XPU Dockerfile for Dev Target

### DIFF
--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -206,6 +206,11 @@ RUN --mount=from=wheel_builder,target=/wheel_builder \
         fi; \
     fi
 
+{% if device == "xpu" %}
+ENV NIXL_LIB_DIR=/opt/intel/intel_nixl/lib/x86_64-linux-gnu  \
+    NIXL_PLUGIN_DIR=/opt/intel/intel_nixl/lib/x86_64-linux-gnu/plugins \
+    NIXL_PREFIX=/opt/intel/intel_nixl
+{% else %}
 # NIXL is installed under lib64 (manylinux/AlmaLinux convention used by the wheel_builder).
 # All frameworks reference NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib64.
 # For vllm/trtllm/none: This resets the same values already set in runtime (no harm).
@@ -213,6 +218,7 @@ RUN --mount=from=wheel_builder,target=/wheel_builder \
 ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl \
     NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib64 \
     NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins
+{% endif %}
 
 # Set universal CUDA development environment variables (all frameworks)
 # vLLM: Dockerfile.vllm line 533, 597
@@ -362,5 +368,10 @@ RUN --mount=type=bind,source=./container/launch_message/dev.txt,target=/opt/dyna
     chmod 755 /opt/dynamo/.launch_screen && \
     echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc
 
+{% if device == "xpu" %}
+SHELL ["bash", "-c"]
+CMD ["bash", "-c", "source /root/.bashrc && exec bash"]
+{% else %}
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []
+{% endif %}

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -218,7 +218,6 @@ ENV NIXL_LIB_DIR=/opt/intel/intel_nixl/lib/x86_64-linux-gnu  \
 ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl \
     NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib64 \
     NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins
-{% endif %}
 
 # Set universal CUDA development environment variables (all frameworks)
 # vLLM: Dockerfile.vllm line 533, 597
@@ -233,6 +232,7 @@ ENV CUDA_HOME=/usr/local/cuda \
     TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas \
     TRITON_CUDART_PATH=/usr/local/cuda/include \
     NVIDIA_DRIVER_CAPABILITIES=video,compute,utility
+{% endif %}
 
 # Base LD_LIBRARY_PATH with universal paths (all frameworks have these)
 # Framework-specific paths are conditionally added in /etc/profile.d/50-framework-paths.sh

--- a/container/templates/local_dev.Dockerfile
+++ b/container/templates/local_dev.Dockerfile
@@ -78,5 +78,10 @@ RUN mkdir -p /home/$USERNAME/.cache/ \
     && chmod g+w /home/$USERNAME/.cache/ \
     && chmod g+w /home/$USERNAME/.cache/pre-commit
 
+{% if device == "xpu" %}
+SHELL ["bash", "-c"]
+CMD ["bash", "-c", "source /root/.bashrc && exec bash"]
+{% else %}
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []
+{% endif %}


### PR DESCRIPTION
Overview:

     Modify container/templates/dev.Dockerfile for intel xpu device under Dev Target after docker build

Details:

    Based on the previous PR([#6109](https://github.com/ai-dynamo/dynamo/pull/6109)) further enhance the templating dockerfiles to Dev Target. PR(#6109) is target for runtime.

Method for build/test:
   1.  Generate the dockerfile for target Dev
        `cd dynamo
        python container/render.py --framework vllm --target dev --device xpu --output-short-filename`
   2.  Build Dev Target
        `docker build -t dynamo:latest-vllm-dev -f container/rendered.Dockerfile .`
   4.  Create Container for development
       `docker run -u 0 -it --rm --privileged --group-add render --network host --shm-size=10G --ulimit memlock=-1 --ulimit stack=67108space --cap-add CAP_SYS_PTRACE --ipc host dynamo:latest-vllm-dev`
   6.  Inside Container
        `cargo build --locked --features dynamo-llm/block-manager --workspace
         cd lib/bindings/python && maturin develop --uv && cd –
         cd /workspace
         pip install -e .
         #sanity check
         deploy/sanity_check.py --runtime-check-only`
   8.  Test with Chat completion
        
<img width="1399" height="585" alt="image" src="https://github.com/user-attachments/assets/bc68e43f-aac8-4103-8fe4-88bd353e9650" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to support different device types with optimized environment setup and execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->