### PR TITLE
chore: bump aiperf and aiconfig to last RCs

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -64,11 +64,6 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.uv]
-override-dependencies = [
-    "gradio==5.47.1"
-]
-
 [tool.setuptools]
 packages = ["prefix_data_generator"]
 

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,8 +40,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@acb9e89ca5dbb360733887d795ccf55a164beb87",
-    "aiperf @ git+https://github.com/ai-dynamo/aiperf.git@c3fc969e9e30e9ddad35b2f613aa7c1d418f2de9",
+    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@c59086c9e4fd88159db1f4c4259600ce2ca5435a",
+    "aiperf @ git+https://github.com/ai-dynamo/aiperf.git@0746a7cdeb259f365e1124ffa94b2a976207b668",
     "matplotlib",
     "networkx",
     "numpy",

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -12,9 +12,9 @@
 
 # For Multimodal EPD (required for device_map="auto" in vision model loading)
 accelerate
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@acb9e89ca5dbb360733887d795ccf55a164beb87
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@c59086c9e4fd88159db1f4c4259600ce2ca5435a
 aiofiles
-aiperf @ git+https://github.com/ai-dynamo/aiperf.git@54cd6dc820bff8bfebc875da104e59d745e14f75
+aiperf @ git+https://github.com/ai-dynamo/aiperf.git@0746a7cdeb259f365e1124ffa94b2a976207b668
 av==15.0.0
 fastapi==0.120.1
 filterpy==1.4.5


### PR DESCRIPTION
#### Overview:

Bump the versions of tools:
* AIC 0.7.0rc13
* AIP 0.6.0rc6

Relates to OPS-3516
Relates to OPS-3843


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to newer versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->