### PR TITLE
docs: document NIXL Prometheus telemetry metrics in observability guide

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -18,7 +18,7 @@ Dynamo provides built-in metrics capabilities through the Dynamo metrics API, wh
 |----------|-------------|---------|---------|
 | `DYN_SYSTEM_PORT` | Backend component metrics/health port | `-1` (disabled) | `8081` |
 | `DYN_HTTP_PORT` | Frontend HTTP port (also configurable via `--http-port` flag) | `8000` | `8000` |
-| `NIXL_TELEMETRY_ENABLE` | Enable NIXL telemetry (see [NIXL Telemetry Metrics](#nixl-telemetry-metrics)) | Disabled | `y` |
+| `NIXL_TELEMETRY_ENABLE` | Enable NIXL telemetry (see [NIXL Telemetry Metrics](#nixl-telemetry-metrics)). Options: `y`, `n` | `n` (disabled) | `y` |
 
 ## Getting Started Quickly
 
@@ -288,12 +288,12 @@ To enable, set these environment variables on your worker process:
 # Prefill worker
 NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_EXPORTER=prometheus \
   NIXL_TELEMETRY_PROMETHEUS_PORT=19090 DYN_SYSTEM_PORT=8081 \
-  python -m dynamo.vllm --model <model> --is-prefill-worker
+  python -m dynamo.vllm --model <model> --disaggregation-mode prefill
 
 # Decode worker (different NIXL port to avoid collision)
 NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_EXPORTER=prometheus \
   NIXL_TELEMETRY_PROMETHEUS_PORT=19091 DYN_SYSTEM_PORT=8082 \
-  python -m dynamo.vllm --model <model>
+  python -m dynamo.vllm --model <model> --disaggregation-mode decode
 
 # Scrape NIXL metrics (separate from Dynamo metrics on 8081/8082)
 curl http://localhost:19090/metrics

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -18,6 +18,7 @@ Dynamo provides built-in metrics capabilities through the Dynamo metrics API, wh
 |----------|-------------|---------|---------|
 | `DYN_SYSTEM_PORT` | Backend component metrics/health port | `-1` (disabled) | `8081` |
 | `DYN_HTTP_PORT` | Frontend HTTP port (also configurable via `--http-port` flag) | `8000` | `8000` |
+| `NIXL_TELEMETRY_ENABLE` | Enable NIXL telemetry (see [NIXL Telemetry Metrics](#nixl-telemetry-metrics)) | Disabled | `y` |
 
 ## Getting Started Quickly
 
@@ -276,6 +277,29 @@ These appear once workers register and begin serving requests. They are register
 | `worker_type` | `prefill` or `decode` | Worker role |
 
 In disaggregated mode, the `worker_type` label shows both `"prefill"` and `"decode"` values; in aggregated mode, all workers report as `"decode"`.
+
+## NIXL Telemetry Metrics
+
+[NIXL](https://github.com/ai-dynamo/nixl) exposes its own Prometheus metrics on a **separate port** from Dynamo metrics. These metrics track KV cache and embedding data transfers and are only populated during **disaggregated serving** or **multimodal embedding transfers**.
+
+To enable, set these environment variables on your worker process:
+
+```bash
+# Prefill worker
+NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_EXPORTER=prometheus \
+  NIXL_TELEMETRY_PROMETHEUS_PORT=19090 DYN_SYSTEM_PORT=8081 \
+  python -m dynamo.vllm --model <model> --is-prefill-worker
+
+# Decode worker (different NIXL port to avoid collision)
+NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_EXPORTER=prometheus \
+  NIXL_TELEMETRY_PROMETHEUS_PORT=19091 DYN_SYSTEM_PORT=8082 \
+  python -m dynamo.vllm --model <model>
+
+# Scrape NIXL metrics (separate from Dynamo metrics on 8081/8082)
+curl http://localhost:19090/metrics
+```
+
+For the full list of metrics, configuration options, and architecture details, see the upstream [NIXL Telemetry documentation](https://github.com/ai-dynamo/nixl/blob/main/docs/telemetry.md) and [Prometheus exporter README](https://github.com/ai-dynamo/nixl/blob/main/src/plugins/telemetry/prometheus/README.md). For Kubernetes, see [Enable NIXL Telemetry](../kubernetes/observability/metrics.md#enable-nixl-telemetry-optional).
 
 ## Related Documentation
 


### PR DESCRIPTION
#### Overview:

Document NIXL Prometheus telemetry metrics in the local observability guide so
users know how to enable and scrape NIXL transfer metrics during disaggregated
serving.

#### Details:

- Add `NIXL_TELEMETRY_ENABLE` to the environment variables table in `docs/observability/metrics.md`
- Add "NIXL Telemetry Metrics" section with a disaggregated-mode launch example (prefill + decode workers on separate NIXL ports)
- Cross-reference upstream NIXL telemetry docs, the Prometheus exporter plugin README, and the existing K8s observability guide

#### Where should the reviewer start?

`docs/observability/metrics.md` — the only file changed (+24 lines)

#### Related Issues:

Relates to DIS-1318

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Documentation**
  * Updated observability documentation with instructions for enabling NIXL telemetry via a new environment variable.
  * Added guidance on telemetry metrics collection, including port configuration and example monitoring commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->