### PR TITLE
fix(ft-tests): avoid shlex.split corrupting JSON args in ServiceSpec setters [cherry-pick #7012 → v1.0.0]

### DIFF
--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 import secrets
-import shlex
 import time
 from dataclasses import dataclass, field
 from typing import Any, List, Optional

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -107,28 +107,23 @@ class ServiceSpec:
             return
 
         args_list = self._spec["extraPodSpec"]["mainContainer"].get("args", [])
-        args_str = " ".join(args_list)
-        parts = shlex.split(args_str)
 
-        # Try to update --model first, then --model-path
+        # Scan the list directly for --model / --model-path and update its value.
+        # Do NOT join+shlex.split: shlex strips internal double-quotes, which
+        # corrupts any JSON args present in the list (e.g. --kv-transfer-config).
         model_index = None
-        for i, part in enumerate(parts):
-            if part in ["--model", "--model-path"]:
+        for i, arg in enumerate(args_list):
+            if arg in ["--model", "--model-path"]:
                 model_index = i
                 break
 
         if model_index is not None:
-            if model_index + 1 < len(parts):
-                parts[model_index + 1] = value
+            if model_index + 1 < len(args_list):
+                args_list[model_index + 1] = value
             else:
                 return
         else:
             return
-
-        # Store args as a list of separate strings for proper command-line parsing
-        # WRONG: [" ".join(parts)] creates ["--model Qwen/Qwen3-0.6B"] (single string)
-        # RIGHT: parts creates ["--model", "Qwen/Qwen3-0.6B"] (separate strings)
-        self._spec["extraPodSpec"]["mainContainer"]["args"] = parts
 
     # ----- GPUs -----
     @property
@@ -169,32 +164,26 @@ class ServiceSpec:
             return
 
         args_list = self._spec["extraPodSpec"]["mainContainer"].get("args", [])
-        args_str = " ".join(args_list)
-        parts = shlex.split(args_str)
 
-        # Find existing tensor-parallel-size argument
+        # Work directly on the list to avoid shlex.split stripping quotes from
+        # JSON argument values (e.g. --kv-transfer-config '{"k":"v"}').
         tp_index = None
-        for i, part in enumerate(parts):
-            if part == "--tensor-parallel-size":
+        for i, arg in enumerate(args_list):
+            if arg == "--tensor-parallel-size":
                 tp_index = i
                 break
 
         if tp_index is not None:
             # Update existing value
-            if tp_index + 1 < len(parts):
-                parts[tp_index + 1] = str(value)
+            if tp_index + 1 < len(args_list):
+                args_list[tp_index + 1] = str(value)
             else:
-                parts.append(str(value))
+                args_list.append(str(value))
         else:
             # Add new argument
-            parts.extend(["--tensor-parallel-size", str(value)])
+            args_list.extend(["--tensor-parallel-size", str(value)])
 
-        # Store args as a list of separate strings for proper command-line parsing
-        # When TP > 1, this setter is called and adds --tensor-parallel-size to args.
-        # WRONG: [" ".join(parts)] would create ["--model Qwen/Qwen3-0.6B --tensor-parallel-size 2"]
-        #        causing argparse to fail with "IndexError: list index out of range"
-        # RIGHT: parts creates ["--model", "Qwen/Qwen3-0.6B", "--tensor-parallel-size", "2"]
-        self._spec["extraPodSpec"]["mainContainer"]["args"] = parts
+        self._spec["extraPodSpec"]["mainContainer"]["args"] = args_list
 
         # Auto-adjust GPU count to match tensor parallel size
         self.gpus = value

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -76,6 +76,25 @@ class ServiceSpec:
     def envs(self, value: list[dict[str, str]]):
         self._spec["envs"] = value
 
+    def _get_args(self) -> list[str]:
+        """Return the container args list, normalising scalar strings to a list in-place.
+
+        Always returns the same list object that is stored in the spec, so
+        in-place mutations (append / index assignment) are reflected immediately
+        without an explicit writeback.
+        """
+        try:
+            container = self._spec["extraPodSpec"]["mainContainer"]
+        except KeyError:
+            return []
+        if "args" not in container:
+            container["args"] = []
+        args = container["args"]
+        if isinstance(args, str):
+            args = args.split()
+            container["args"] = args
+        return args
+
     # ----- Replicas -----
     @property
     def replicas(self) -> int:
@@ -88,42 +107,21 @@ class ServiceSpec:
     @property
     def model(self) -> Optional[str]:
         """Model being served by this service (checks both --model and --model-path)"""
-        try:
-            args_list = self._spec["extraPodSpec"]["mainContainer"]["args"]
-        except KeyError:
-            return None
-        args_str = " ".join(args_list)
-        parts = shlex.split(args_str)
-        for i, part in enumerate(parts):
-            if part in ["--model", "--model-path"]:
-                return parts[i + 1] if i + 1 < len(parts) else None
+        args = self._get_args()
+        for i, arg in enumerate(args):
+            if arg in ["--model", "--model-path"]:
+                if i + 1 < len(args) and not args[i + 1].startswith("-"):
+                    return args[i + 1]
         return None
 
     @model.setter
     def model(self, value: str):
-        if "extraPodSpec" not in self._spec:
-            return
-        if "mainContainer" not in self._spec["extraPodSpec"]:
-            return
-
-        args_list = self._spec["extraPodSpec"]["mainContainer"].get("args", [])
-
-        # Scan the list directly for --model / --model-path and update its value.
-        # Do NOT join+shlex.split: shlex strips internal double-quotes, which
-        # corrupts any JSON args present in the list (e.g. --kv-transfer-config).
-        model_index = None
-        for i, arg in enumerate(args_list):
+        args = self._get_args()
+        for i, arg in enumerate(args):
             if arg in ["--model", "--model-path"]:
-                model_index = i
-                break
-
-        if model_index is not None:
-            if model_index + 1 < len(args_list):
-                args_list[model_index + 1] = value
-            else:
+                if i + 1 < len(args) and not args[i + 1].startswith("-"):
+                    args[i + 1] = value
                 return
-        else:
-            return
 
     # ----- GPUs -----
     @property
@@ -144,48 +142,26 @@ class ServiceSpec:
     @property
     def tensor_parallel_size(self) -> int:
         """Get tensor parallel size from vLLM arguments"""
-        try:
-            args_list = self._spec["extraPodSpec"]["mainContainer"]["args"]
-        except KeyError:
-            return 1  # Default tensor parallel size
-
-        args_str = " ".join(args_list)
-        parts = shlex.split(args_str)
-        for i, part in enumerate(parts):
-            if part == "--tensor-parallel-size":
-                return int(parts[i + 1]) if i + 1 < len(parts) else 1
+        args = self._get_args()
+        for i, arg in enumerate(args):
+            if arg == "--tensor-parallel-size":
+                if i + 1 < len(args) and not args[i + 1].startswith("-"):
+                    return int(args[i + 1])
+                return 1
         return 1
 
     @tensor_parallel_size.setter
     def tensor_parallel_size(self, value: int):
-        if "extraPodSpec" not in self._spec:
-            return
-        if "mainContainer" not in self._spec["extraPodSpec"]:
-            return
-
-        args_list = self._spec["extraPodSpec"]["mainContainer"].get("args", [])
-
-        # Work directly on the list to avoid shlex.split stripping quotes from
-        # JSON argument values (e.g. --kv-transfer-config '{"k":"v"}').
-        tp_index = None
-        for i, arg in enumerate(args_list):
+        args = self._get_args()
+        for i, arg in enumerate(args):
             if arg == "--tensor-parallel-size":
-                tp_index = i
-                break
-
-        if tp_index is not None:
-            # Update existing value
-            if tp_index + 1 < len(args_list):
-                args_list[tp_index + 1] = str(value)
-            else:
-                args_list.append(str(value))
-        else:
-            # Add new argument
-            args_list.extend(["--tensor-parallel-size", str(value)])
-
-        self._spec["extraPodSpec"]["mainContainer"]["args"] = args_list
-
-        # Auto-adjust GPU count to match tensor parallel size
+                if i + 1 < len(args) and not args[i + 1].startswith("-"):
+                    args[i + 1] = str(value)
+                else:
+                    args.append(str(value))
+                self.gpus = value
+                return
+        args.extend(["--tensor-parallel-size", str(value)])
         self.gpus = value
 
 


### PR DESCRIPTION
#### Overview:

Cherry-pick of #7012 onto `release/1.0.0`.

Fixes a bug where `shlex.split` corrupted JSON arguments passed to `ServiceSpec` setters in fault-tolerance tests, causing KV transfer config corruption.

#### Details:

- `fix(ft-tests)`: avoid shlex.split corrupting JSON args in ServiceSpec setters
- `refactor(ft-tests)`: consolidate args normalisation into `_get_args()` helper
- `chore(ft-tests)`: remove unused top-level shlex import

#### Where should the reviewer start?

`tests/utils/managed_deployment.py` — the core fix and refactor are here.

Fixes: DYN-2379