### PR TITLE
feat: enable speculative decoding on Kimi-K2.5 NVFP4 recipes

### DIFF
--- a/recipes/kimi-k2.5/README.md
+++ b/recipes/kimi-k2.5/README.md
@@ -8,12 +8,15 @@ There are two model weight variants, each with its own model download and deploy
 
 | Variant | Model | Deploy Configs | Notes |
 |---------|-------|---------------|-------|
-| **nvidia** 🚧 | `nvidia/Kimi-K2.5-NVFP4` | [`deploy.yaml`](trtllm/agg/nvidia/deploy.yaml), [`deploy-kvbm.yaml`](trtllm/agg/nvidia/deploy-kvbm.yaml) | Requires a [patched image](trtllm/agg/nvidia/patch/) |
+| **nvidia** 🚧 | `nvidia/Kimi-K2.5-NVFP4` | [`deploy.yaml`](trtllm/agg/nvidia/deploy.yaml), [`deploy-eagle-specdec.yaml`](trtllm/agg/nvidia/deploy-eagle-specdec.yaml), [`deploy-kvbm.yaml`](trtllm/agg/nvidia/deploy-kvbm.yaml) | Requires a [patched image](trtllm/agg/nvidia/patch/) |
 | **baseten** | `baseten-admin/Kimi-2.5-text-nvfp4-v3` | [`deploy.yaml`](trtllm/agg/baseten/deploy.yaml) | Works with the stock image |
 
 All configurations use TP8, EP8, aggregated mode with KV-aware routing.
 
-The **nvidia** variant also has a KVBM (KV Block Manager) deploy that enables CPU-offloaded KV cache via `deploy-kvbm.yaml`.
+
+The **nvidia** variant also includes:
+- `deploy-eagle-specdec.yaml` for EAGLE speculative decoding with a separate eagle-head checkpoint stored under `/opt/models/kimi-eagle-layers`
+- `deploy-kvbm.yaml` for CPU-offloaded KV cache via KVBM (KV Block Manager)
 
 ## Prerequisites
 

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/SPECDEC.md
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/SPECDEC.md
@@ -11,7 +11,7 @@
 
 ## Additional Model Assets
 
-`deploy-eagle-specdec.yaml` uses a separate EAGLE draft-head checkpoint in addition to the base Kimi weights. By default, the deployment recipe file loads the EAGLE checkpoint from path `/opt/models/kimi-eagle-layers` mounted from the `model-cache` PVC, so you should populate this path before deploying. 
+`deploy-eagle-specdec.yaml` uses a separate EAGLE draft-head checkpoint in addition to the base Kimi weights. By default, the deployment recipe file loads the EAGLE checkpoint from path `/opt/models/kimi-eagle-layers` mounted from the `model-cache` PVC, so you should populate this path before deploying.
 
 Expected contents under this folder:
 - `config.json`

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/SPECDEC.md
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/SPECDEC.md
@@ -6,8 +6,27 @@
 - 8 x NVIDIA B200 GPUs
 - A `hf-token-secret` Secret containing your Hugging Face token
 - A pre-existing `model-cache` PVC
-- A [patched container image](patch/) built from `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:<tag>`
-- Replace the placeholder image tag `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag-patched` in `deploy-eagle-specdec.yaml` with your actual patched image
+- An image, either:
+  - A Dynamo + TRT-LLM runtime image built from `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc5`, or:
+  - A Dynamo 1.0.0 release image with the Kimi-K2.5 patch.
+- Replace the placeholder image tag `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag-patched` in `deploy-eagle-specdec.yaml` with your actual patched image.
+
+## Build the Runtime Image
+
+To build a Dynamo+TensorRT-LLM image for this recipe:
+
+1. Start from `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc5`.
+2. Clone Dynamo at our tested commit `3dc2d053ebe7f3b858bd6955dac52cc373e730b1`.
+3. Build and install the `ai_dynamo_runtime` Rust wheel with `maturin`.
+4. Install the Dynamo Python package plus `nixl[cu12]`.
+5. Append the Kimi TensorRT-LLM patch from `patch/kimi.patch`.
+
+An example Dockerfile is available in [dockerfile.from-trtllm](dockerfile.from-trtllm). You should be able to run it with:
+
+```bash
+cd recipes/kimi-k2.5/trtllm/agg/nvidia
+docker build -f dockerfile.from-trtllm -t <your tag here> .
+```
 
 ## Additional Model Assets
 

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/SPECDEC.md
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/SPECDEC.md
@@ -8,7 +8,7 @@
 - A pre-existing `model-cache` PVC
 - An image, either:
   - A Dynamo + TRT-LLM runtime image built from `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc5`, or:
-  - A Dynamo 1.0.0 release image with the Kimi-K2.5 patch.
+  - A Dynamo 1.0.0 release image with the Kimi-K2.5 patch. Follow the [patch guide](./patch/README.md) to learn more about how to patch the Dynamo image.
 - Replace the placeholder image tag `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag-patched` in `deploy-eagle-specdec.yaml` with your actual patched image.
 
 ## Build the Runtime Image

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/SPECDEC.md
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/SPECDEC.md
@@ -1,4 +1,4 @@
-# Kimi-K2.5 Aggregated Deployment on Kubernetes with EAGLE Speculative Decoding 
+# Kimi-K2.5 Aggregated Deployment on Kubernetes with EAGLE Speculative Decoding
 
 ## Prerequisites
 
@@ -23,13 +23,13 @@ The worker config references this path via:
 speculative_config:
   decoding_type: Eagle
   max_draft_len: 3
-  speculative_model_dir: /opt/models/kimi-eagle-layers <- path is loaded here
+  speculative_model_dir: /opt/models/kimi-eagle-layers
 ```
 
 ## Deploy
 
 ```bash
-kubectl apply -f deploy-eagle-specdec.yaml
+kubectl -n ${NAMESPACE} apply -f deploy-eagle-specdec.yaml
 ```
 
 This creates:

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/SPECDEC.md
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/SPECDEC.md
@@ -1,0 +1,37 @@
+# Kimi-K2.5 Aggregated Deployment on Kubernetes with EAGLE Speculative Decoding 
+
+## Prerequisites
+
+- A Kubernetes cluster with the [Dynamo Operator](https://docs.nvidia.com/dynamo/) installed
+- 8 x NVIDIA B200 GPUs
+- A `hf-token-secret` Secret containing your Hugging Face token
+- A pre-existing `model-cache` PVC
+- A [patched container image](patch/) built from `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:<tag>`
+- Replace the placeholder image tag `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag-patched` in `deploy-eagle-specdec.yaml` with your actual patched image
+
+## Additional Model Assets
+
+`deploy-eagle-specdec.yaml` uses a separate EAGLE draft-head checkpoint in addition to the base Kimi weights. By default, the deployment recipe file loads the EAGLE checkpoint from path `/opt/models/kimi-eagle-layers` mounted from the `model-cache` PVC, so you should populate this path before deploying. 
+
+Expected contents under this folder:
+- `config.json`
+- `model.safetensors`
+
+The worker config references this path via:
+
+```yaml
+speculative_config:
+  decoding_type: Eagle
+  max_draft_len: 3
+  speculative_model_dir: /opt/models/kimi-eagle-layers <- path is loaded here
+```
+
+## Deploy
+
+```bash
+kubectl apply -f deploy-eagle-specdec.yaml
+```
+
+This creates:
+- A **ConfigMap** (`llm-config-kimi-k25-agg-eagle-specdec`) with the Eagle speculative decoding config
+- A **DynamoGraphDeployment** (`kimi-k25-agg-eagle-specdec`) with a Frontend and TrtllmWorker serving `nvidia/Kimi-K2.5-NVFP4`

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-eagle-specdec.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-eagle-specdec.yaml
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llm-config-kimi-k25-agg-eagle-specdec
+data:
+  config.yaml: |
+    backend: pytorch
+    trust_remote_code: true
+    kv_cache_config:
+      enable_block_reuse: false
+      free_gpu_memory_fraction: 0.8
+    speculative_config:
+      decoding_type: Eagle
+      max_draft_len: 3
+      speculative_model_dir: /opt/models/kimi-eagle-layers
+      allow_advanced_sampling: true
+    cuda_graph_config:
+      max_batch_size: 64
+      enable_padding: true
+    moe_config:
+      backend: TRTLLM
+    enable_chunked_prefill: true
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: kimi-k25-agg-eagle-specdec
+spec:
+  backendFramework: trtllm
+  pvcs:
+    - name: model-cache
+      create: false
+  services:
+    Frontend:
+      componentType: frontend
+      extraPodSpec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: nvidia.com/dynamo-graph-deployment-name
+                      operator: In
+                      values:
+                        - kimi-k25-agg-eagle-specdec-frontend
+                topologyKey: kubernetes.io/hostname
+        mainContainer:
+          args:
+            - python3 -m dynamo.frontend --router-mode kv --http-port 8000 --discovery-backend kubernetes
+          command:
+            - /bin/sh
+            - -c
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag-patched
+          env:
+            - name: DYN_DISCOVERY_BACKEND
+              value: kubernetes
+            - name: DYN_REQUEST_PLANE
+              value: tcp
+      replicas: 1
+    TrtllmWorker:
+      componentType: worker
+      envFromSecret: hf-token-secret
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /opt/models
+      sharedMemory:
+        size: 179Gi
+      extraPodSpec:
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: nvidia.com/gpu.present
+                      operator: In
+                      values:
+                        - "true"
+        mainContainer:
+          args:
+            - |
+              python3 -m dynamo.trtllm \
+                --model-path "${MODEL_NAME}" \
+                --served-model-name "${MODEL_NAME}" \
+                --extra-engine-args "${ENGINE_ARGS}" \
+                --tensor-parallel-size 8 \
+                --expert-parallel-size 8 \
+                --max-batch-size 64 \
+                --discovery-backend kubernetes \
+                --dyn-reasoning-parser kimi_k25 \
+                --dyn-tool-call-parser kimi_k2
+          command:
+            - /bin/sh
+            - -c
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag-patched
+          env:
+            - name: DYN_DISCOVERY_BACKEND
+              value: kubernetes
+            - name: DYN_REQUEST_PLANE
+              value: tcp
+            - name: TRTLLM_ENABLE_PDL
+              value: "1"
+            - name: MODEL_NAME
+              value: nvidia/Kimi-K2.5-NVFP4
+            - name: ENGINE_ARGS
+              value: /opt/dynamo/configs/config.yaml
+            - name: HF_HOME
+              value: /opt/models
+          volumeMounts:
+            - mountPath: /opt/dynamo/configs
+              name: llm-config-kimi-k25-agg-eagle-specdec
+              readOnly: true
+          workingDir: /workspace/examples/backends/trtllm
+        volumes:
+          - configMap:
+              name: llm-config-kimi-k25-agg-eagle-specdec
+            name: llm-config-kimi-k25-agg-eagle-specdec
+      replicas: 1
+      resources:
+        limits:
+          gpu: "8"
+        requests:
+          gpu: "8"

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/dockerfile.from-trtllm
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/dockerfile.from-trtllm
@@ -30,8 +30,6 @@ RUN pip install --no-cache-dir --break-system-packages "nixl[cu12]<=0.10.1"
 # Clean up Dynamo source and Rust toolchain to reduce image size
 RUN rm -rf /opt/dynamo-src /root/.cargo /root/.rustup
 
-USER dynamo
-
 # Patch TRT-LLM with KimiK25ForConditionalGeneration support
 # Same patch as https://github.com/NVIDIA/TensorRT-LLM/tree/feat/k25-demo
 # and dynamo/recipes/kimi-k2.5/trtllm/agg/nvidia/patch/kimi.patch

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/dockerfile.from-trtllm
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/dockerfile.from-trtllm
@@ -1,0 +1,50 @@
+FROM nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc5
+
+USER root
+
+RUN apt-get update && apt-get install -y wget curl git build-essential pkg-config libssl-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Rust toolchain (needed to build ai-dynamo-runtime from source)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install maturin (Rust<->Python build tool)
+RUN pip install --no-cache-dir --break-system-packages maturin
+
+RUN git clone https://github.com/ai-dynamo/dynamo.git /opt/dynamo-src && \
+    cd /opt/dynamo-src && \
+    git checkout 3dc2d053ebe7f3b858bd6955dac52cc373e730b1
+
+# Build and install Dynamo runtime (Rust bindings)
+RUN cd /opt/dynamo-src/lib/bindings/python && \
+    maturin build --release && \
+    pip install --no-cache-dir --break-system-packages /opt/dynamo-src/lib/bindings/python/target/wheels/ai_dynamo_runtime*.whl
+
+# Install Dynamo Python package
+RUN pip install --no-cache-dir --break-system-packages /opt/dynamo-src
+
+# Install nixl (required by dynamo.trtllm at runtime but not declared in the trtllm extra)
+RUN pip install --no-cache-dir --break-system-packages "nixl[cu12]<=0.10.1"
+
+# Clean up Dynamo source and Rust toolchain to reduce image size
+RUN rm -rf /opt/dynamo-src /root/.cargo /root/.rustup
+
+USER dynamo
+
+# Patch TRT-LLM with KimiK25ForConditionalGeneration support
+# Same patch as https://github.com/NVIDIA/TensorRT-LLM/tree/feat/k25-demo
+# and dynamo/recipes/kimi-k2.5/trtllm/agg/nvidia/patch/kimi.patch
+# Since the cloned Dynamo does not have kimi patch - we need to copy from our local disk
+COPY patch/kimi.patch /opt/kimi.patch
+RUN TARGET_FILE="$(python3 -c "from importlib.util import find_spec; print(find_spec('tensorrt_llm').submodule_search_locations[0])")/_torch/models/modeling_deepseekv3.py" && \
+    if grep -q 'KimiK25ForConditionalGeneration' "$TARGET_FILE"; then \
+        echo "Patch already applied, skipping."; \
+    else \
+        if ! head -50 "$TARGET_FILE" | grep -q '^import copy'; then \
+            sed -i '1s/^/import copy\n/' "$TARGET_FILE"; \
+        fi && \
+        echo "" >> "$TARGET_FILE" && \
+        cat /opt/kimi.patch >> "$TARGET_FILE"; \
+    fi && \
+    rm -f /opt/kimi.patch


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for EAGLE speculative decoding deployment option for Kimi-K2.5.

* **Documentation**
  * Updated deployment configuration guide with new speculative decoding setup instructions.
  * Added comprehensive documentation for Kubernetes-based deployment with EAGLE speculative decoding, including prerequisites and configuration details.
  * Clarified available deployment options (EAGLE speculative decoding and KV cache offloading via KVBM).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->