### PR TITLE
fix: allow optimizationType latency with other SLAs

### DIFF
--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -29,6 +29,7 @@ from dynamo.profiler.utils.dgdr_v1beta1_types import DynamoGraphDeploymentReques
 from dynamo.profiler.utils.profile_common import (
     derive_backend_image,
     needs_profile_data,
+    rerank_by_optimization_type,
 )
 
 logger = logging.getLogger(__name__)
@@ -270,6 +271,7 @@ def _run_default_sim(
             )
 
     best_config_df = best_configs.get(chosen, pd.DataFrame())
+    best_config_df = rerank_by_optimization_type(best_config_df, dgdr)
     best_latencies = best_latencies_map.get(
         chosen, {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0}
     )

--- a/components/src/dynamo/profiler/thorough.py
+++ b/components/src/dynamo/profiler/thorough.py
@@ -49,6 +49,7 @@ from dynamo.profiler.utils.profile_common import (
     derive_backend_image,
     get_profiling_job_tolerations,
     inject_tolerations_into_dgd,
+    rerank_by_optimization_type,
 )
 from dynamo.profiler.utils.profile_decode import get_num_request_range
 
@@ -430,6 +431,7 @@ async def run_thorough(
     )
 
     best_config_df = result.get("best_config_df", pd.DataFrame())
+    best_config_df = rerank_by_optimization_type(best_config_df, dgdr)
 
     # --- Stage 4: DGD generation ---
     task = TaskConfig(

--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -101,11 +101,14 @@ class WorkloadSpec(BaseModel):
 class SLASpec(BaseModel):
     """Service-level agreement targets.
 
-    Provide exactly one of:
+    ``optimizationType`` is a config-ranking hint and may be combined with
+    explicit latency targets.  Provide latency targets as one of:
 
     - ``ttft`` + ``itl``: explicit latency targets (default: 2000 ms / 30 ms)
-    - ``e2eLatency``: end-to-end latency target
-    - ``optimizationType``: high-level objective without explicit numeric targets"""
+    - ``e2eLatency``: end-to-end latency target (mutually exclusive with ttft/itl)
+
+    Optionally pair either form with ``optimizationType`` to control how the
+    profiler ranks candidate configs that satisfy the targets."""
 
     optimizationType: Optional[OptimizationType] = Field(
         default=None,
@@ -125,20 +128,23 @@ class SLASpec(BaseModel):
 
     @model_validator(mode="after")
     def _validate_sla_options(self) -> "SLASpec":
-        """Ensure at most one SLA mode is active."""
+        """Validate SLA field combinations.
+
+        ``optimizationType`` is a config-ranking hint and may be combined with
+        explicit latency targets (``ttft`` + ``itl``).  The only invalid
+        combination is mixing ``e2eLatency`` with ``ttft``/``itl``, as they are
+        two different ways to express the same latency constraint.
+        """
         has_e2e = self.e2eLatency is not None
-        has_opt = self.optimizationType is not None
         ttft_itl_touched = (
             "ttft" in self.model_fields_set or "itl" in self.model_fields_set
         )
-        has_ttft_itl = (self.ttft is not None and self.itl is not None) and (
-            ttft_itl_touched or (not has_e2e and not has_opt)
+        has_ttft_itl = (self.ttft is not None or self.itl is not None) and (
+            ttft_itl_touched
         )
-        options_count = sum([has_ttft_itl, has_e2e, has_opt])
-        if options_count > 1:
+        if has_e2e and has_ttft_itl:
             raise ValueError(
-                "SLA must specify exactly one of: (ttft and itl), e2eLatency, "
-                "or optimizationType — not multiple."
+                "SLA must specify either (ttft and itl) or e2eLatency, not both."
             )
         if (self.ttft is not None) != (self.itl is not None):
             raise ValueError("ttft and itl must both be provided together.")

--- a/components/src/dynamo/profiler/utils/profile_common.py
+++ b/components/src/dynamo/profiler/utils/profile_common.py
@@ -234,6 +234,35 @@ def warn_gpu_shortage(
         )
 
 
+def rerank_by_optimization_type(
+    df: pd.DataFrame,
+    dgdr: DynamoGraphDeploymentRequestSpec,
+) -> pd.DataFrame:
+    """
+    Sort a picked-config DataFrame based on throughput (default) or latency.
+    """
+    from dynamo.profiler.utils.dgdr_v1beta1_types import OptimizationType
+
+    if df is None or df.empty:
+        return df
+    opt = dgdr.sla.optimizationType if dgdr.sla else None
+    if opt != OptimizationType.Latency:
+        return df
+    sort_cols = [c for c in ("ttft", "tpot", "request_latency") if c in df.columns]
+    if not sort_cols:
+        logger.debug(
+            "optimizationType=latency requested but no latency columns found in "
+            "best_config_df; keeping AIC ordering."
+        )
+        return df
+    logger.info(
+        "optimizationType=latency: re-ranking %d configs by %s ascending.",
+        len(df),
+        sort_cols,
+    )
+    return df.sort_values(sort_cols, ascending=True).reset_index(drop=True)
+
+
 def get_profiling_job_tolerations(dgdr: DynamoGraphDeploymentRequestSpec) -> list:
     """Return tolerations from overrides.profilingJob.template.spec.tolerations."""
     try:

--- a/deploy/operator/api/scripts/generate_pydantic_from_go.py
+++ b/deploy/operator/api/scripts/generate_pydantic_from_go.py
@@ -53,10 +53,12 @@ _IMPORT_OVERRIDES: dict[str, tuple[str, str, bool]] = {
 _STRUCT_DOCSTRINGS: dict = {
     "SLASpec": (
         "Service-level agreement targets.\n\n"
-        "    Provide exactly one of:\n\n"
+        "    ``optimizationType`` is a config-ranking hint and may be combined with\n"
+        "    explicit latency targets.  Provide latency targets as one of:\n\n"
         "    - ``ttft`` + ``itl``: explicit latency targets (default: 2000 ms / 30 ms)\n"
-        "    - ``e2eLatency``: end-to-end latency target\n"
-        "    - ``optimizationType``: high-level objective without explicit numeric targets"
+        "    - ``e2eLatency``: end-to-end latency target (mutually exclusive with ttft/itl)\n\n"
+        "    Optionally pair either form with ``optimizationType`` to control how the\n"
+        "    profiler ranks candidate configs that satisfy the targets."
     ),
 }
 
@@ -66,18 +68,23 @@ _STRUCT_EXTRAS: dict = {
     "SLASpec": """\
     @model_validator(mode="after")
     def _validate_sla_options(self) -> "SLASpec":
-        \"\"\"Ensure at most one SLA mode is active.\"\"\"
+        \"\"\"Validate SLA field combinations.
+
+        ``optimizationType`` is a config-ranking hint and may be combined with
+        explicit latency targets (``ttft`` + ``itl``).  The only invalid
+        combination is mixing ``e2eLatency`` with ``ttft``/``itl``, as they are
+        two different ways to express the same latency constraint.
+        \"\"\"
         has_e2e = self.e2eLatency is not None
-        has_opt = self.optimizationType is not None
-        ttft_itl_touched = "ttft" in self.model_fields_set or "itl" in self.model_fields_set
-        has_ttft_itl = (self.ttft is not None and self.itl is not None) and (
-            ttft_itl_touched or (not has_e2e and not has_opt)
+        ttft_itl_touched = (
+            "ttft" in self.model_fields_set or "itl" in self.model_fields_set
         )
-        options_count = sum([has_ttft_itl, has_e2e, has_opt])
-        if options_count > 1:
+        has_ttft_itl = (self.ttft is not None or self.itl is not None) and (
+            ttft_itl_touched
+        )
+        if has_e2e and has_ttft_itl:
             raise ValueError(
-                "SLA must specify exactly one of: (ttft and itl), e2eLatency, "
-                "or optimizationType \u2014 not multiple."
+                "SLA must specify either (ttft and itl) or e2eLatency, not both."
             )
         if (self.ttft is not None) != (self.itl is not None):
             raise ValueError("ttft and itl must both be provided together.")

--- a/tests/profiler/test_helpers_profile_sla.py
+++ b/tests/profiler/test_helpers_profile_sla.py
@@ -273,6 +273,24 @@ class TestValidDgdrSpec:
         with pytest.raises(ValueError, match="ttft.*itl.*e2eLatency"):
             valid_dgdr_spec(dgdr)
 
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_optimization_type_with_ttft_itl_accepted(self):
+        """optimizationType + ttft/itl is a valid combination (regression: TC-21.4)."""
+        sla = SLASpec(optimizationType="latency", ttft=300.0, itl=25.0)
+        dgdr = _make_dgdr(sla=sla)
+        valid_dgdr_spec(dgdr)
+        assert dgdr.sla.optimizationType == "latency"
+        assert dgdr.sla.ttft == 300.0
+        assert dgdr.sla.itl == 25.0
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_e2e_latency_with_ttft_itl_raises(self):
+        """e2eLatency and ttft/itl together must be rejected."""
+        with pytest.raises(ValueError, match="e2eLatency"):
+            SLASpec(ttft=300.0, itl=25.0, e2eLatency=500.0)
+
 
 # ---------------------------------------------------------------------------
 # validate_dgdr_dynamo_features


### PR DESCRIPTION
#### Overview:

`optimizationType` and `ttft/itl` are not mutually exclusive and shouldn't be treated as such. Only reject e2eLatency combined with ttft/itl. Adds `rerank_by_optimization_type` so that `optimizationType: latency` actually re-sorts AIC's throughput-ranked results by latency before config selection.


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration reranking when latency optimization type is selected during profiling runs.

* **Bug Fixes / Behavior Changes**
  * Updated SLA validation to allow explicit latency targets with optimization type specification while preventing simultaneous use with end-to-end latency targets.

* **Tests**
  * Added validation test coverage for latency optimization with explicit targets.
  * Added validation test coverage for mutual exclusivity between latency specification methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->