### PR TITLE
test: update unsupported model name after AIC increase coverage

### DIFF
--- a/tests/profiler/configs/5b_rapid_unsupported_planner_throughput_error.yaml
+++ b/tests/profiler/configs/5b_rapid_unsupported_planner_throughput_error.yaml
@@ -4,7 +4,8 @@
 # Case 5b: AIC unsupported model, rapid, with planner + throughput scaling
 # This should FAIL with a ValueError because throughput-based planner
 # requires AIC support.
-model: "Qwen/Qwen3-32B"
+#
+model: "meta-llama/Llama-3.1-8B"
 backend: vllm
 image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:latest"
 hardware:

--- a/tests/profiler/configs/5b_rapid_unsupported_planner_throughput_error.yaml
+++ b/tests/profiler/configs/5b_rapid_unsupported_planner_throughput_error.yaml
@@ -4,7 +4,6 @@
 # Case 5b: AIC unsupported model, rapid, with planner + throughput scaling
 # This should FAIL with a ValueError because throughput-based planner
 # requires AIC support.
-#
 model: "meta-llama/Llama-3.1-8B"
 backend: vllm
 image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:latest"

--- a/tests/profiler/test_profile_sla_dgdr.py
+++ b/tests/profiler/test_profile_sla_dgdr.py
@@ -155,7 +155,7 @@ class TestRapidSupported:
 
 
 class TestRapidUnsupported:
-    """Rapid strategy with AIC-unsupported model (Qwen3-32B on l40s/vllm)."""
+    """Rapid strategy with AIC-unsupported model/hardware combos."""
 
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0
@@ -178,7 +178,6 @@ class TestRapidUnsupported:
         ops = _make_ops(tmp_path)
         asyncio.run(run_profile(dgdr, ops))
 
-    @pytest.mark.skip(reason="Fails with latest AIC - OPS-3852")
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0
     def test_planner_throughput_scaling_raises(self, tmp_path):


### PR DESCRIPTION
close https://linear.app/nvidia/issue/OPS-3852/unskip-testsprofilertest-profile-sla-dgdrpytestrapidunsupportedtest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated profiler test configuration for throughput error evaluation, switching to a different model variant.
  * Re-enabled a previously skipped test for comprehensive assessment of load scaling and fallback behavior.
  * Refined test documentation to more accurately reflect coverage of various model and hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->