### PR TITLE
fix: add kv transfer config to planner vllm examples

### DIFF
--- a/tests/planner/perf_test_configs/disagg_8b_planner.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_planner.yaml
@@ -190,6 +190,8 @@ spec:
             - nvidia/Llama-3.1-8B-Instruct-FP8
             - --disaggregation-mode
             - prefill
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
             - --no-enable-prefix-caching
             - --block-size
             - "128"

--- a/tests/planner/scaling/disagg_planner_load.yaml
+++ b/tests/planner/scaling/disagg_planner_load.yaml
@@ -74,3 +74,5 @@ spec:
             - nvidia/Llama-3.1-8B-Instruct-FP8
             - --disaggregation-mode
             - prefill
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'

--- a/tests/planner/scaling/disagg_planner_throughput.yaml
+++ b/tests/planner/scaling/disagg_planner_throughput.yaml
@@ -68,3 +68,5 @@ spec:
             - nvidia/Llama-3.1-8B-Instruct-FP8
             - --disaggregation-mode
             - prefill
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'


### PR DESCRIPTION
close https://linear.app/nvidia/issue/DYN-2403/dynamorelease100plannerk8s-test-manifests-in-testsplannerscaling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added KV transfer configuration testing across disaggregated inference scenarios to validate system behavior under new operational parameters
  * Extended test coverage for multiple scaling configurations including performance benchmarks and load testing with new connector and role settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->