### PR TITLE
fix: set correct component type in agg planner

### DIFF
--- a/components/src/dynamo/planner/utils/agg_planner.py
+++ b/components/src/dynamo/planner/utils/agg_planner.py
@@ -64,9 +64,8 @@ class AggPlanner:
             shared_state=self.shared_state,
             prometheus_metrics=prometheus_metrics,
             start_prometheus_server=True,
+            component_type=SubComponentType.DECODE,
         )
-        # Override: agg planner uses component_type DECODE for metrics fetching
-        self.planner.component_type = SubComponentType.DECODE
 
         # Create both regression models (agg needs both TTFT and ITL)
         self.ttft_regression = LoadBasedRegressionModel(

--- a/components/src/dynamo/planner/utils/planner_core.py
+++ b/components/src/dynamo/planner/utils/planner_core.py
@@ -257,7 +257,11 @@ class BasePlanner:
         prometheus_engine_client: Optional[DirectRouterMetricsClient] = None,
         connector=None,
         start_prometheus_server: bool = True,
+        component_type: Optional[SubComponentType] = None,
     ):
+        if component_type is not None:
+            self.component_type = component_type
+
         self.config = config
         self.dryrun = dryrun
         self.shared_state = shared_state or PlannerSharedState()


### PR DESCRIPTION
close https://linear.app/nvidia/issue/DYN-2415/dynamorelease100-dgdr-tc-232-aggplanner-crashes-on-init-attributeerror

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal component initialization by allowing configuration at construction time rather than post-instantiation, streamlining code structure with no changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->