### PR TITLE
chore: update aiperf to 0.6.0 and aic v0.7.0rc14

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@c59086c9e4fd88159db1f4c4259600ce2ca5435a",
+    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@9b4a3d2750293cfeaf3e1c2a5058162a1e2c586e",
     "aiperf==0.6.0",
     "matplotlib",
     "networkx",

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 
 dependencies = [
     "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@c59086c9e4fd88159db1f4c4259600ce2ca5435a",
-    "aiperf @ git+https://github.com/ai-dynamo/aiperf.git@0746a7cdeb259f365e1124ffa94b2a976207b668",
+    "aiperf==0.6.0",
     "matplotlib",
     "networkx",
     "numpy",

--- a/container/deps/requirements.benchmark.txt
+++ b/container/deps/requirements.benchmark.txt
@@ -3,5 +3,5 @@
 
 # Benchmark and profiling tool dependencies.
 
-aiperf @ git+https://github.com/ai-dynamo/aiperf.git@0746a7cdeb259f365e1124ffa94b2a976207b668
+aiperf==0.6.0
 genai-perf==0.0.15

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -3,7 +3,7 @@
 
 # Dependencies for planner, profiler, global_planner, and deploy utils.
 
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@c59086c9e4fd88159db1f4c4259600ce2ca5435a
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@9b4a3d2750293cfeaf3e1c2a5058162a1e2c586e
 aiofiles<=25.1.0
 filterpy==1.4.5
 kubernetes==32.0.1

--- a/recipes/deepseek-v32-fp4/trtllm/agg-round-robin/perf.yaml
+++ b/recipes/deepseek-v32-fp4/trtllm/agg-round-robin/perf.yaml
@@ -49,7 +49,7 @@ spec:
           echo 1024 > /proc/sys/fs/inotify/max_user_instances 2>/dev/null || true
           apt-get update && apt-get install -y curl jq procps git && apt-get clean
           # pip install git+https://github.com/ai-dynamo/aiperf.git
-          pip install aiperf==0.5.0
+          pip install aiperf==0.6.0
           echo "aiperf installation completed"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200

--- a/recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml
+++ b/recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml
@@ -49,7 +49,7 @@ spec:
           echo 1024 > /proc/sys/fs/inotify/max_user_instances 2>/dev/null || true
           apt-get update && apt-get install -y curl jq procps git && apt-get clean
           # pip install git+https://github.com/ai-dynamo/aiperf.git
-          pip install aiperf==0.5.0
+          pip install aiperf==0.6.0
           echo "aiperf installation completed"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200


### PR DESCRIPTION
#### Overview:

Update AIPerf to v0.6.0

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to OPS-3516
Relates to OPS-3871

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated aiperf dependency to version 0.6.0 across benchmarking and performance testing configurations. Dependency specifications now reference fixed PyPI versions instead of git URLs, improving consistency and reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->