### PR TITLE
fix: Use deepgemm backend for qwen3-235b recipe

### DIFF
--- a/recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml
@@ -24,6 +24,9 @@ data:
       max_batch_size: 128
     disable_overlap_scheduler: false
     print_iter_log: false
+    moe_config:
+      backend: DEEPGEMM
+      max_num_tokens: 8192
 ---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment


### PR DESCRIPTION
#### Overview:

  - tensorrt-llm==1.3.0rc5.post1 pins nvidia-cutlass-dsl==4.3.4 as a
  dependency
  - The base 4.3.4 package stubs out cute.experimental, causing
  NotImplementedError on Blackwell FP8 GEMMs

Fixes the issue by using deepgemm moe backend instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced deployment configuration with additional settings to optimize handling of specialized model architectures and improve token processing capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->