### PR TITLE
fix: populate input_tokens in Anthropic streaming message_start

### DIFF
--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -193,6 +193,13 @@ async fn anthropic_messages(
         .as_ref()
         .is_some_and(|t| t.thinking_type == "enabled");
 
+    // Estimate input tokens before consuming the request.
+    // The real Anthropic API sends input_tokens in `message_start`, but we
+    // don't have a tokenizer in the frontend — the engine only reports prompt
+    // token counts on the final streaming chunk. Use a len/3 heuristic so
+    // clients (e.g. Claude Code) see a non-zero value in `message_start`.
+    let estimated_input_tokens = orig_request.estimate_input_tokens();
+
     // Convert Anthropic request -> Chat Completion request
     let chat_request: NvCreateChatCompletionRequest =
         orig_request.try_into().map_err(|e: anyhow::Error| {
@@ -269,7 +276,7 @@ async fn anthropic_messages(
 
         use std::sync::atomic::{AtomicBool, Ordering};
 
-        let mut converter = AnthropicStreamConverter::new(model_for_resp);
+        let mut converter = AnthropicStreamConverter::new(model_for_resp, estimated_input_tokens);
         let start_events = converter.emit_start_events();
 
         let converter = std::sync::Arc::new(std::sync::Mutex::new(converter));

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1614,15 +1614,37 @@ async fn list_models_openai(
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
+
+    // Build a lookup from display_name -> context_length using model cards.
+    // Clients (e.g. Claude Code) read context_window from this response to
+    // determine how much context the model supports.
+    let cards = state.manager().get_model_cards();
+    let card_map: std::collections::HashMap<String, u32> = cards
+        .iter()
+        .map(|c| (c.display_name.clone(), c.context_length))
+        .collect();
+
+    // Allow env var override (applies to all models).
+    let context_window_override: Option<u64> = std::env::var("DYN_CONTEXT_WINDOW")
+        .ok()
+        .and_then(|v| v.parse().ok());
+    let max_output_tokens: Option<u64> = std::env::var("DYN_MAX_OUTPUT_TOKENS")
+        .ok()
+        .and_then(|v| v.parse().ok());
+
     let mut data = Vec::new();
 
     let models: HashSet<String> = state.manager().model_display_names();
     for model_name in models {
+        let context_window = context_window_override
+            .or_else(|| card_map.get(&model_name).map(|&cl| cl as u64));
         data.push(ModelListing {
             id: model_name.clone(),
             object: "model", // Per OpenAI spec, this should be "model"
             created,
             owned_by: "nvidia".to_string(),
+            context_window,
+            max_output_tokens,
         });
     }
 
@@ -1645,6 +1667,10 @@ struct ModelListing {
     object: &'static str, // always "model" per OpenAI spec
     created: u64,         // Seconds since epoch
     owned_by: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context_window: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_output_tokens: Option<u64>,
 }
 
 /// Create an Axum [`Router`] for the OpenAI API Completions endpoint

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -53,7 +53,7 @@ struct ToolCallState {
 }
 
 impl AnthropicStreamConverter {
-    pub fn new(model: String) -> Self {
+    pub fn new(model: String, estimated_input_tokens: u32) -> Self {
         Self {
             model,
             message_id: format!("msg_{}", Uuid::new_v4().simple()),
@@ -63,7 +63,7 @@ impl AnthropicStreamConverter {
             text_block_started: false,
             text_block_closed: false,
             text_block_index: 0,
-            input_token_count: 0,
+            input_token_count: estimated_input_tokens,
             output_token_count: 0,
             cached_token_count: None,
             tool_call_states: Vec::new(),
@@ -84,7 +84,7 @@ impl AnthropicStreamConverter {
             stop_reason: None,
             stop_sequence: None,
             usage: AnthropicUsage {
-                input_tokens: 0,
+                input_tokens: self.input_token_count,
                 output_tokens: 0,
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: None,
@@ -766,7 +766,7 @@ mod tests {
     /// events and fail to execute tool calls ("Error editing file").
     #[test]
     fn test_text_block_stops_before_tool_block_starts() {
-        let mut conv = AnthropicStreamConverter::new("test-model".into());
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
 
         // Stream some text
         let text_events = conv.process_chunk_tagged(&text_chunk("I'll edit the file."));
@@ -830,7 +830,7 @@ mod tests {
     /// Tool-only response (no preceding text): no spurious stop events.
     #[test]
     fn test_tool_only_response_no_text_block() {
-        let mut conv = AnthropicStreamConverter::new("test-model".into());
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
 
         let tool_events = conv.process_chunk_tagged(&tool_call_chunk(
             0,
@@ -853,7 +853,7 @@ mod tests {
     /// Text-only response: stop emitted in end events (no early close).
     #[test]
     fn test_text_only_response_stop_in_end_events() {
-        let mut conv = AnthropicStreamConverter::new("test-model".into());
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
 
         conv.process_chunk_tagged(&text_chunk("Hello world"));
 

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -181,6 +181,54 @@ pub struct ThinkingConfig {
     pub budget_tokens: Option<u32>,
 }
 
+impl AnthropicCreateMessageRequest {
+    /// Estimate input token count using a `len/3` heuristic.
+    ///
+    /// Used to populate `input_tokens` in the streaming `message_start` event,
+    /// since the engine only reports prompt token counts on the final chunk.
+    /// The real Anthropic API sends `input_tokens` in `message_start`, so
+    /// clients (e.g. Claude Code) expect a non-zero value there.
+    pub fn estimate_input_tokens(&self) -> u32 {
+        let mut total_len: usize = 0;
+
+        if let Some(system) = &self.system {
+            total_len += system.len();
+        }
+
+        for msg in &self.messages {
+            total_len += match msg.role {
+                AnthropicRole::User => 4,
+                AnthropicRole::Assistant => 9,
+            };
+            match &msg.content {
+                AnthropicMessageContent::Text { content } => total_len += content.len(),
+                AnthropicMessageContent::Blocks { content } => {
+                    for block in content {
+                        total_len += estimate_block_len(block);
+                    }
+                }
+            }
+        }
+
+        if let Some(tools) = &self.tools {
+            for tool in tools {
+                total_len += tool.name.len();
+                if let Some(desc) = &tool.description {
+                    total_len += desc.len();
+                }
+                total_len += tool.input_schema.to_string().len();
+            }
+        }
+
+        let tokens = total_len / 3;
+        if tokens == 0 && total_len > 0 {
+            1
+        } else {
+            tokens as u32
+        }
+    }
+}
+
 /// A single message in the conversation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AnthropicMessage {


### PR DESCRIPTION
## Summary

Two fixes for the Anthropic Messages API that improve Claude Code compatibility when connecting directly to Dynamo (without cc-proxy).

### 1. Populate `input_tokens` in streaming `message_start` event

The real Anthropic API sends `input_tokens` in the `message_start` SSE event. Dynamo was sending `0` because the inference engine only reports prompt token counts on the final chunk (`message_delta`). Clients like **Claude Code** read `input_tokens` from `message_start` and don't fall back to `message_delta`, resulting in token counts jumping between real values and 0 on alternating turns.

**Fix:** Compute a `chars/3` estimate from the original request before streaming begins. The engine's real count still populates `message_delta` for clients that read it there.

### 2. Add `context_window` and `max_output_tokens` to `/v1/models`

Claude Code reads `context_window` from the `/v1/models` response to determine how much context a model supports. Without it, Claude Code falls back to a conservative default and may not utilize the model's full context window.

**Fix:** Pull `context_length` from the `ModelDeploymentCard` (which the engine populates during discovery) and expose it as `context_window` in the model listing. This works automatically — no manual configuration needed.

Optional env var overrides are also supported:
- `DYN_CONTEXT_WINDOW` — override context_window for all models (e.g., to cap below the model's native limit)
- `DYN_MAX_OUTPUT_TOKENS` — advertise max_output_tokens (not in the model card)

### Files changed

- **`types.rs`**: Add `estimate_input_tokens()` to `AnthropicCreateMessageRequest`
- **`stream_converter.rs`**: Accept estimated input tokens in constructor, use in `message_start`
- **`anthropic.rs`**: Compute estimate before streaming, pass to converter
- **`openai.rs`**: Add `context_window` (from model card) and `max_output_tokens` fields to model listing

## Test plan

- [ ] Verify `message_start` has non-zero `input_tokens` via `curl --stream`
- [ ] Verify Claude Code displays token counts when connected directly (no proxy)
- [ ] Verify `/v1/models` includes `context_window` from the model card automatically
- [ ] Verify `DYN_CONTEXT_WINDOW` env var overrides the card value
- [ ] Verify fields are omitted when no card and no env var (backwards compatible)
- [ ] Existing unit tests pass (updated constructor signature)