### PR TITLE
fix: Update UCX Ref for Performance

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -24,7 +24,7 @@ dynamo:
   etcd_version: v3.5.21
 
   nixl_ref: 0.10.1
-  nixl_ucx_ref: v1.20.0
+  nixl_ucx_ref: v1.20.x
   nixl_gdrcopy_ref: v2.5.1
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
   nixl_libfabric_ref: v2.3.0


### PR DESCRIPTION
NIXL v0.10.0 and later require more recent UCX since CUDA context management is handled by UCX. This commit is the same one used with NIXL v1.0.0 testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version reference configuration to use a less restrictive pattern, allowing greater flexibility in version compatibility across minor releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->