### PR TITLE
fix: sglang prefill handler should pass dp rank.

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -114,7 +114,12 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         }
 
         input_param = self._get_input_param(inner_request)
-        priority = (inner_request.get("routing") or {}).get("priority")
+        routing = inner_request.get("routing") or {}
+        priority = routing.get("priority")
+        dp_rank = routing.get("dp_rank")
+
+        if dp_rank is not None and dp_rank == 2**32 - 1:
+            dp_rank = None
 
         trace_header = self._get_trace_header(context) if self.enable_trace else None
 
@@ -127,6 +132,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             bootstrap_room=bootstrap_room,
             external_trace_header=trace_header,
             rid=trace_id,
+            data_parallel_rank=dp_rank,
             **self._priority_kwargs(priority),
         )
 

--- a/lib/llm/src/kv_router/prefill_router.rs
+++ b/lib/llm/src/kv_router/prefill_router.rs
@@ -537,7 +537,7 @@ impl PrefillRouter {
                     r.peek_next_worker()
                 }
                 .ok_or_else(|| anyhow::anyhow!("No workers available for prefill"))?;
-                Ok((worker_id, 0))
+                Ok((worker_id, u32::MAX))
             }
         }
     }


### PR DESCRIPTION
For sglang, prefill kv router select data parallel rank should pass into sglagn engine.

Also to avoid no kv router mode always select dp 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced routing data extraction and configuration handling for distributed request processing
  * Optimized data parallel rank normalization for distributed system deployments to address edge-case scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->