### PR TITLE
fix: Update UCX Ref for Performance

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -23,7 +23,7 @@ dynamo:
   etcd_version: v3.5.21
 
   nixl_ref: 0.10.1
-  nixl_ucx_ref: v1.20.0
+  nixl_ucx_ref: v1.20.x
   nixl_gdrcopy_ref: v2.5.1
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
   nixl_libfabric_ref: v2.3.0


### PR DESCRIPTION
## Summary
- Cherry-pick of #7212 to release/1.0.0
- Updates `nixl_ucx_ref` from `v1.20.0` to `v1.20.x` in container config for NIXL v0.10.0+ compatibility
- NIXL v0.10.0 and later require more recent UCX since CUDA context management is handled by UCX

## Original PR
- Main PR: #7212
- Merge commit: 727d32d7281db2592010b79c37412e5f6e63c626

## Test Plan
- [ ] CI passes
- [ ] Verified fix works on release branch

Made with [Cursor](https://cursor.com)