### PR TITLE
chore: Build for slightly more modern CPUs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,8 +7,9 @@ rustflags = ["--cfg", "tokio_unstable"]
 
 # Target Haswell (2013) era+ machines. That gets us AVX-2
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=x86-64-v3"]
+rustflags = ["-C", "target-cpu=x86-64-v3", "--cfg", "tokio_unstable"]
 
-# Target Graviton 2 / Ampere Ultra + machines. NEON vector, and LSE atomics.
+# Target Graviton 2 / Ampere Altra + machines. NEON vector, and LSE atomics.
 [target.aarch64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=neoverse-n1"]
+rustflags = ["-C", "target-cpu=neoverse-n1", "--cfg", "tokio_unstable"]
+

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,11 @@
 [build]
 # tokio-console needs this
 rustflags = ["--cfg", "tokio_unstable"]
+
+# Target Haswell (2013) era+ machines. That gets us AVX-2
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=x86-64-v3"]
+
+# Target Graviton 2 / Ampere Ultra + machines. NEON vector, and LSE atomics.
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=neoverse-n1"]


### PR DESCRIPTION
By default Rust will target a very safe set of CPU features, something Pentium era. That is slow. We're building a data center product, we can rely on more recent features.

# x86_64

Switch our build to use x86-64-v3. Here is Gemini's explanation:

- x86-64-v1 (Default/Generic): The baseline. Supports SSE2. Compatible with almost everything 64-bit (back to ~2003). Too slow.
- x86-64-v2: Adds SSE4.2 and SSSE3. Roughly Intel Nehalem (2008). Better, but still misses modern vectorization.
- x86-64-v3 (Recommended): Adds AVX and AVX2, plus BMI1/BMI2/FMA.
Intel Support: Haswell (2013) and newer.
AMD Support: Excavator (2015) / Zen (2017) and newer.
Performance: AVX2 is the biggest single jump in x86 performance for data-heavy tasks. Rust's auto-vectorization loves AVX2.
- x86-64-v4: Adds AVX-512.
Risk: Support is patchy. Intel 11th/12th Gen supported it, then 12th/13th/14th Gen consumer chips dropped it, though Xeons have it. AMD Zen 4 added it. It is not safe enough for a general distribution yet.

ChatGPT concurs with Gemini:
> x86-64-v3 is the typical safe baseline for modern data center deployments.

## ARM

For ARM we should do neoverse-n1, or if we know it's Grace-only then neoverse-v2.

Gemini again:

ARM licenses its core designs to other companies. The Neoverse N1 core is the "Haswell moment" for ARM servers—it established the baseline for modern performance.
- AWS Graviton 2: Uses Neoverse N1 cores.
- Ampere Altra: Uses Neoverse N1 cores. (Oracle Cloud, Azure, Google Cloud use these).
- AWS Graviton 3 / 4: Use newer cores (V1 / V2) but are backward compatible with N1 instructions.
- NVIDIA Grace: Uses Neoverse V2, also backward compatible.

By targeting neoverse-n1, you enable critical server-class features that the generic aarch64 target might skip, specifically better LSE (Large System Extensions) atomics and specific NEON vector optimizations suited for server workloads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration for enhanced performance on x86-64 and ARM64 Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->