### PR TITLE
fix: add force_nonempty_content for nemotron

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1105,15 +1105,15 @@ impl OpenAIPreprocessor {
             }
             Some("nemotron_nano") | Some("nemotron3") => {
                 if let Some(args) = chat_template_args {
-                    if let Some(enable_thinking) = args.get("enable_thinking") {
-                        if enable_thinking == &serde_json::Value::Bool(false) {
-                            return true;
-                        }
+                    if let Some(enable_thinking) = args.get("enable_thinking")
+                        && enable_thinking == &serde_json::Value::Bool(false)
+                    {
+                        return true;
                     }
-                    if let Some(force_nonempty) = args.get("force_nonempty_content") {
-                        if force_nonempty == &serde_json::Value::Bool(true) {
-                            return true;
-                        }
+                    if let Some(force_nonempty) = args.get("force_nonempty_content")
+                        && force_nonempty == &serde_json::Value::Bool(true)
+                    {
+                        return true;
                     }
                 }
                 false

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1103,22 +1103,7 @@ impl OpenAIPreprocessor {
                 }
                 false
             }
-            Some("nemotron_nano") => {
-                if let Some(args) = chat_template_args {
-                    if let Some(enable_thinking) = args.get("enable_thinking") {
-                        if enable_thinking == &serde_json::Value::Bool(false) {
-                            return true;
-                        }
-                    }
-                    if let Some(force_nonempty) = args.get("force_nonempty_content") {
-                        if force_nonempty == &serde_json::Value::Bool(true) {
-                            return true;
-                        }
-                    }
-                }
-                false
-            }
-            Some("nemotron3") => {
+            Some("nemotron_nano") | Some("nemotron3") => {
                 if let Some(args) = chat_template_args {
                     if let Some(enable_thinking) = args.get("enable_thinking") {
                         if enable_thinking == &serde_json::Value::Bool(false) {

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1088,7 +1088,8 @@ impl OpenAIPreprocessor {
 
     /// Check if reasoning parsing should be disabled based on per-request parameters.
     /// For kimi_k25: disabled when chat_template_args contains "thinking": false.
-    /// For nemotron_nano: disabled when chat_template_args contains "enable_thinking": false.
+    /// For nemotron_nano: disabled when chat_template_args contains "enable_thinking": false
+    ///   or "force_nonempty_content": true.
     fn is_reasoning_disabled_by_request(
         reasoning_parser: Option<&str>,
         chat_template_args: Option<&std::collections::HashMap<String, serde_json::Value>>,
@@ -1103,10 +1104,32 @@ impl OpenAIPreprocessor {
                 false
             }
             Some("nemotron_nano") => {
-                if let Some(args) = chat_template_args
-                    && let Some(enable_thinking) = args.get("enable_thinking")
-                {
-                    return enable_thinking == &serde_json::Value::Bool(false);
+                if let Some(args) = chat_template_args {
+                    if let Some(enable_thinking) = args.get("enable_thinking") {
+                        if enable_thinking == &serde_json::Value::Bool(false) {
+                            return true;
+                        }
+                    }
+                    if let Some(force_nonempty) = args.get("force_nonempty_content") {
+                        if force_nonempty == &serde_json::Value::Bool(true) {
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
+            Some("nemotron3") => {
+                if let Some(args) = chat_template_args {
+                    if let Some(enable_thinking) = args.get("enable_thinking") {
+                        if enable_thinking == &serde_json::Value::Bool(false) {
+                            return true;
+                        }
+                    }
+                    if let Some(force_nonempty) = args.get("force_nonempty_content") {
+                        if force_nonempty == &serde_json::Value::Bool(true) {
+                            return true;
+                        }
+                    }
                 }
                 false
             }

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -250,6 +250,7 @@ mod tests {
             "mistral",
             "granite",
             "nemotron_nano",
+            "nemotron3",
             "glm45",
             "minimax_append_think",
         ];

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -31,6 +31,7 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserT
         map.insert("mistral", ReasoningParserType::Mistral);
         map.insert("granite", ReasoningParserType::Granite);
         map.insert("nemotron_nano", ReasoningParserType::DeepseekR1); // nemotron nano is ...</think>
+        map.insert("nemotron3", ReasoningParserType::DeepseekR1);
         map.insert("glm45", ReasoningParserType::NemotronDeci); // GLM-4.5/5 is <think>...</think>, no force_reasoning
         map.insert(
             "minimax_append_think",


### PR DESCRIPTION
#### Overview:

Add nemotron3 parser alias and include support for `force_nonempty_content` request arg

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the nemotron3 model, expanding available language model options
  * Enhanced reasoning behavior control with new configurable parameters, providing finer-grained control over reasoning features during inference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->