### PR TITLE
test: add regression tests for planner none-sweep naive-fallback (NVBug 5970670)

### DIFF
--- a/tests/profiler/configs/5c_rapid_unsupported_planner_none_sweep.yaml
+++ b/tests/profiler/configs/5c_rapid_unsupported_planner_none_sweep.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Case 5c: AIC unsupported model, rapid, with planner, pre_deployment_sweeping_mode: none.
+# Load-only planner does not require profiling data; the profiler must still
+# generate a valid DGD with the correct planner entrypoint (dynamo.planner,
+# NOT the non-existent dynamo.planner.planner_sla).  Regression test for
+# bug 5970670 / bug 5960287 naive-fallback code path.
+model: "Qwen/Qwen3-32B"
+backend: vllm
+image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:latest"
+hardware:
+  gpuSku: l40s
+  totalGpus: 4
+  numGpusPerNode: 4
+sla:
+  ttft: 500.0
+  itl: 50.0
+features:
+  planner:
+    pre_deployment_sweeping_mode: none
+    enable_throughput_scaling: false
+    enable_load_scaling: true
+    mode: disagg
+    backend: vllm

--- a/tests/profiler/test_helpers_profile_sla.py
+++ b/tests/profiler/test_helpers_profile_sla.py
@@ -28,6 +28,7 @@ try:
         _extract_profiler_params,
         _write_final_output,
     )
+    from dynamo.profiler.utils.config import DgdPlannerServiceConfig
     from dynamo.profiler.utils.config_modifiers.parallelization_mapping import (
         PickedParallelConfig,
     )
@@ -581,3 +582,73 @@ class TestAssembleFinalConfig:
         mock_planner.assert_not_called()
         mock_profile.assert_called_once()
         assert result == [profile_cm, mocker_base]
+
+
+# ---------------------------------------------------------------------------
+# DgdPlannerServiceConfig — regression guard for bug 5970670 / 5960287
+# ---------------------------------------------------------------------------
+
+
+class TestDgdPlannerServiceConfigEntrypoint:
+    """Ensure the planner service always uses the correct Python module entrypoint.
+
+    Both the rapid/autoscale-sim path and the naive fallback path generate the
+    Planner service via DgdPlannerServiceConfig.  The module was previously
+    hardcoded to the non-existent ``dynamo.planner.planner_sla``; it must be
+    ``dynamo.planner``.
+    """
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_planner_command_uses_dynamo_planner_not_planner_sla(self):
+        """Regression: DgdPlannerServiceConfig must not reference dynamo.planner.planner_sla."""
+        cfg = DgdPlannerServiceConfig()
+        assert cfg.extraPodSpec is not None
+        assert cfg.extraPodSpec.mainContainer is not None
+
+        cmd = cfg.extraPodSpec.mainContainer.command
+        assert cmd is not None, "Planner container must have a command"
+
+        module_arg = cmd[-1]
+        assert module_arg == "dynamo.planner", (
+            f"Planner entrypoint must be 'dynamo.planner', got '{module_arg}'. "
+            "Regression guard for bug 5970670 / 5960287: the module "
+            "'dynamo.planner.planner_sla' no longer exists."
+        )
+        assert "dynamo.planner.planner_sla" not in " ".join(cmd), (
+            "Command must not reference the removed dynamo.planner.planner_sla module."
+        )
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_add_planner_injects_correct_entrypoint(self, tmp_path):
+        """add_planner_to_config injects a Planner service with the correct entrypoint.
+
+        This tests the full planner injection path used by both the rapid and
+        naive-fallback (pre_deployment_sweeping_mode: none) code paths.
+        """
+        from dynamo.profiler.utils.dgd_generation import add_planner_to_config
+
+        planner = _make_planner(
+            enable_throughput_scaling=False,
+            enable_load_scaling=True,
+            pre_deployment_sweeping_mode=PlannerPreDeploymentSweepMode.None_,
+            mode="disagg",
+            backend="vllm",
+        )
+        dgdr = _make_dgdr(features=FeaturesSpec(planner=planner))
+        dgd_config = {"spec": {"services": {}}}
+
+        add_planner_to_config(dgdr, dgd_config)
+
+        planner_svc = dgd_config["spec"]["services"].get("Planner")
+        assert planner_svc is not None, "Planner service must be injected"
+
+        cmd = planner_svc.get("extraPodSpec", {}).get("mainContainer", {}).get("command", [])
+        assert cmd, "Planner mainContainer must have a command"
+
+        module_arg = cmd[-1]
+        assert module_arg == "dynamo.planner", (
+            f"Injected planner entrypoint must be 'dynamo.planner', got '{module_arg}'. "
+            "Regression guard for bug 5970670."
+        )

--- a/tests/profiler/test_profile_sla_dgdr.py
+++ b/tests/profiler/test_profile_sla_dgdr.py
@@ -189,6 +189,40 @@ class TestRapidUnsupported:
         with pytest.raises(ValueError, match="AIC does not support"):
             asyncio.run(run_profile(dgdr, ops))
 
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_planner_load_scaling_none_sweep_naive_fallback(self, tmp_path):
+        """Case 5c: load-only planner with pre_deployment_sweeping_mode: none on an
+        AIC-unsupported combo (Qwen3-32B / l40s / vllm).
+
+        Regression test for bug 5970670: the naive fallback code path must
+        generate ``dynamo.planner`` as the planner entrypoint, not the
+        non-existent ``dynamo.planner.planner_sla``.
+        """
+        dgdr = _load_dgdr(
+            CONFIGS_DIR / "5c_rapid_unsupported_planner_none_sweep.yaml"
+        )
+        ops = _make_ops(tmp_path)
+        asyncio.run(run_profile(dgdr, ops))
+
+        output = tmp_path / "profiling_results" / "final_config.yaml"
+        assert output.exists(), "Profiler must produce a final config"
+
+        docs = list(yaml.safe_load_all(output.read_text()))
+        dgd = next((d for d in docs if d and d.get("kind") == "DynamoGraphDeployment"), None)
+        assert dgd is not None, "Final config must contain a DynamoGraphDeployment"
+
+        planner_svc = dgd.get("spec", {}).get("services", {}).get("Planner")
+        assert planner_svc is not None, "DGD must include a Planner service"
+
+        cmd = planner_svc.get("extraPodSpec", {}).get("mainContainer", {}).get("command", [])
+        assert cmd, "Planner mainContainer must have a command"
+        module_arg = cmd[-1]
+        assert module_arg == "dynamo.planner", (
+            f"Planner entrypoint must be 'dynamo.planner', got '{module_arg}'. "
+            "Regression: bug 5970670 / 5960287 naive-fallback code path."
+        )
+
 
 class TestThoroughDryRun:
     """Thorough strategy tested with --dry-run (no real deployments)."""


### PR DESCRIPTION
## Summary

- **Bug**: NVBug [5970670](https://nvbugspro.nvidia.com/bug/5970670) — `pre_deployment_sweeping_mode: none` naive fallback path hardcoded `dynamo.planner.planner_sla` (non-existent) instead of `dynamo.planner`, causing planner `CrashLoopBackOff` for all Area 23 load-only planner tests
- The code fixes for this bug already landed in `c13652b0d` (correct `DgdPlannerServiceConfig` command) and `868d4f9b8` (route naive fallback through `build_dgd_config`)
- This PR adds **regression tests** that cover the previously untested `pre_deployment_sweeping_mode: none` + AIC-unsupported-hardware path so it cannot silently break again

## Changes

### `tests/profiler/configs/5c_rapid_unsupported_planner_none_sweep.yaml` (new)
DGDR test fixture: Qwen3-32B on l40s/vllm (AIC-unsupported combo) with `pre_deployment_sweeping_mode: none` and load-only planner — the exact scenario from the bug report.

### `tests/profiler/test_profile_sla_dgdr.py`
Added `TestRapidUnsupported::test_planner_load_scaling_none_sweep_naive_fallback`:
- Runs the full `run_profile()` pipeline with the new fixture
- Asserts the generated DGD's Planner service uses `dynamo.planner` (not `dynamo.planner.planner_sla`)

### `tests/profiler/test_helpers_profile_sla.py`
Added `TestDgdPlannerServiceConfigEntrypoint` with two unit tests:
- `test_planner_command_uses_dynamo_planner_not_planner_sla`: directly checks `DgdPlannerServiceConfig.command[-1] == "dynamo.planner"`
- `test_add_planner_injects_correct_entrypoint`: verifies `add_planner_to_config()` (used by both the rapid and naive-fallback paths) injects `dynamo.planner` for a `None_` sweep mode planner config

## Test plan
- [ ] `pytest tests/profiler/test_helpers_profile_sla.py::TestDgdPlannerServiceConfigEntrypoint -v`
- [ ] `pytest tests/profiler/test_profile_sla_dgdr.py::TestRapidUnsupported::test_planner_load_scaling_none_sweep_naive_fallback -v`

Related: NVBug 5960287 (same symptom, different code path — already fixed in rc9)

Made with [Cursor](https://cursor.com)