### PR TITLE
fix: cherry-pick #7230 + #7186 to release/1.0.0 (CI reliability test)

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -147,10 +147,15 @@ runs:
         chmod 777 "${TEST_RESULTS_DIR}"
         echo "📁 Test results will be saved to: ${TEST_RESULTS_DIR}"
 
+        DOCKER_ENV_FLAGS=()
+        if [[ -n "${HF_TOKEN:-}" ]]; then
+          DOCKER_ENV_FLAGS+=(--env "HF_TOKEN=${HF_TOKEN}")
+        fi
+
         docker run ${GPU_FLAGS} --rm -w /workspace \
           --cpus=${NUM_CPUS} \
           --network host \
-          --env HF_TOKEN="${HF_TOKEN}" \
+          "${DOCKER_ENV_FLAGS[@]}" \
           --name ${{ env.CONTAINER_ID }}_pytest \
           -v "${TEST_RESULTS_DIR}:/workspace/test-results" \
           ${{ inputs.image_tag }} \
@@ -238,9 +243,14 @@ runs:
         echo "📁 Test results will be saved to: ${TEST_RESULTS_DIR}"
         echo "▶️ Executing: $PYTEST_CMD"
 
+        DOCKER_ENV_FLAGS=()
+        if [[ -n "${HF_TOKEN:-}" ]]; then
+          DOCKER_ENV_FLAGS+=(--env "HF_TOKEN=${HF_TOKEN}")
+        fi
+
         docker run ${GPU_FLAGS} ${DOCKER_OPTS} --rm -w /workspace \
           --network host \
-          --env HF_TOKEN="${HF_TOKEN}" \
+          "${DOCKER_ENV_FLAGS[@]}" \
           --name ${{ env.CONTAINER_ID }}_pytest \
           -v "${TEST_RESULTS_DIR}:/workspace/test-results" \
           ${{ inputs.image_tag }} \
@@ -286,6 +296,10 @@ runs:
           JUNIT_NAME="pytest_test_report_${{ inputs.framework }}_${STR_TEST_TYPE}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml"
           mv "$JUNIT_FILE" "test-results/$JUNIT_NAME"
           echo "📝 Renamed XML file to: $JUNIT_NAME"
+
+          if [[ "${TEST_EXIT_CODE}" != "0" ]]; then
+            echo "⚠️  Ignoring non-zero test container exit code ${TEST_EXIT_CODE} because JUnit XML was generated"
+          fi
         else
           echo "⚠️  JUnit XML file not found - test results may not be available for upload"
           TOTAL_TESTS=0
@@ -293,7 +307,11 @@ runs:
           ERROR_TESTS=0
         fi
 
-        # Exit with original test result to maintain workflow behavior
+        # Treat the run as successful if pytest produced a JUnit XML file.
+        if [[ -n "${JUNIT_NAME:-}" ]]; then
+          exit 0
+        fi
+
         exit ${TEST_EXIT_CODE}
 
     - name: Cleanup MinIO Service

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -296,20 +296,11 @@ runs:
           JUNIT_NAME="pytest_test_report_${{ inputs.framework }}_${STR_TEST_TYPE}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml"
           mv "$JUNIT_FILE" "test-results/$JUNIT_NAME"
           echo "📝 Renamed XML file to: $JUNIT_NAME"
-
-          if [[ "${TEST_EXIT_CODE}" != "0" ]]; then
-            echo "⚠️  Ignoring non-zero test container exit code ${TEST_EXIT_CODE} because JUnit XML was generated"
-          fi
         else
           echo "⚠️  JUnit XML file not found - test results may not be available for upload"
           TOTAL_TESTS=0
           FAILED_TESTS=1  # Treat missing XML as failure
           ERROR_TESTS=0
-        fi
-
-        # Treat the run as successful if pytest produced a JUnit XML file.
-        if [[ -n "${JUNIT_NAME:-}" ]]; then
-          exit 0
         fi
 
         exit ${TEST_EXIT_CODE}

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -183,6 +183,7 @@ jobs:
           test_type: "pre_merge_parallel"
           platform_arch: amd64
           enable_mypy: 'true'
+          hf_token: ${{ secrets.HF_TOKEN }}
           parallel_mode: '4'
           dind_as_sidecar: 'false'
 
@@ -213,5 +214,6 @@ jobs:
           test_type: "pre_merge_sequential"
           platform_arch: amd64
           enable_mypy: 'false'
+          hf_token: ${{ secrets.HF_TOKEN }}
           parallel_mode: 'none'
           dind_as_sidecar: 'false'

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -285,6 +285,10 @@ class HandlerBase(BaseGenerativeHandler):
         # Remove worker_id if present (added by prefill worker, not needed for decode)
         params_dict.pop("worker_id", None)
 
+        # Deserialize first_gen_log_probs from transport format back to
+        # TRT-LLM's internal {token_id: Logprob} dict format.
+        DisaggregatedParamsCodec.deserialize_first_gen_log_probs(params_dict)
+
         # Extract EPD metadata that was packed by prefill worker
         epd_metadata = {}
         if "_epd_metadata" in params_dict:
@@ -375,6 +379,9 @@ class HandlerBase(BaseGenerativeHandler):
 
         logging.debug("PREFILL: Successfully encoded disaggregated params")
         params_dict = asdict(encoded_params)
+
+        # Serialize first_gen_log_probs for the Rust transport layer.
+        DisaggregatedParamsCodec.serialize_first_gen_log_probs(params_dict)
 
         # Pack prefill metadata for DECODE worker optimization
         # The frontend only forwards disaggregated_params from prefill response

--- a/components/src/dynamo/trtllm/utils/disagg_utils.py
+++ b/components/src/dynamo/trtllm/utils/disagg_utils.py
@@ -16,6 +16,7 @@
 import base64
 import dataclasses
 
+from tensorrt_llm.executor.result import Logprob
 from tensorrt_llm.llmapi import DisaggregatedParams
 
 
@@ -23,6 +24,58 @@ class DisaggregatedParamsCodec:
     """
     Codec for encoding and decoding disaggregated params for network transfer.
     """
+
+    @staticmethod
+    def serialize_first_gen_log_probs(params_dict: dict) -> None:
+        """Convert first_gen_log_probs from TRT-LLM's internal format to a
+        JSON-safe transport format.
+
+        TRT-LLM stores logprobs as ``[{token_id(int): Logprob, ...}, ...]``
+        where dict keys are integer token IDs. The Rust transport layer
+        (pythonize 0.23 → serde_json::Value) requires string map keys, so
+        we flatten to a list-of-lists format matching TRT-LLM's own
+        ``_serialize_first_gen_log_probs`` in ``openai_protocol.py``::
+
+            Input:  [{4710: Logprob(-2.32, rank=1), 6771: Logprob(-2.51, rank=2)}]
+            Output: [[{"token_id": 4710, "logprob": -2.32, "rank": 1},
+                       {"token_id": 6771, "logprob": -2.51, "rank": 2}]]
+        """
+        fglp = params_dict.get("first_gen_log_probs")
+        if not fglp:
+            return
+        params_dict["first_gen_log_probs"] = [
+            [
+                {"token_id": tid, "logprob": lp["logprob"], "rank": lp.get("rank")}
+                for tid, lp in pos.items()
+            ]
+            if isinstance(pos, dict)
+            else pos
+            for pos in fglp
+        ]
+
+    @staticmethod
+    def deserialize_first_gen_log_probs(params_dict: dict) -> None:
+        """Reconstruct first_gen_log_probs from the JSON-safe transport format
+        back to TRT-LLM's internal ``{token_id(int): Logprob}`` dict format.
+
+        TRT-LLM's ``py_executor.py`` calls ``append_log_probs`` which accesses
+        the ``.logprob`` attribute on the dict values, so we must rebuild
+        ``Logprob`` dataclass instances.
+        """
+        fglp = params_dict.get("first_gen_log_probs")
+        if not fglp:
+            return
+        params_dict["first_gen_log_probs"] = [
+            {
+                item["token_id"]: Logprob(
+                    logprob=item["logprob"], rank=item.get("rank")
+                )
+                for item in pos
+            }
+            if isinstance(pos, list)
+            else pos
+            for pos in fglp
+        ]
 
     @staticmethod
     def decode(

--- a/lib/runtime/src/transports/event_plane/mod.rs
+++ b/lib/runtime/src/transports/event_plane/mod.rs
@@ -284,6 +284,7 @@ pub struct EventPublisher {
     sequence: AtomicU64,
     tx: Arc<dyn EventTransportTx>,
     codec: Arc<Codec>,
+    runtime_handle: tokio::runtime::Handle,
     /// Discovery client and registered instance for unregistration on drop
     discovery_client: Option<Arc<dyn Discovery>>,
     discovery_instance: Option<crate::discovery::DiscoveryInstance>,
@@ -335,6 +336,7 @@ impl EventPublisher {
     ) -> Result<Self> {
         let publisher_id = drt.discovery().instance_id();
         let discovery = Some(drt.discovery());
+        let runtime_handle = drt.runtime().secondary();
 
         // Use Msgpack codec for all transports
         enum TransportSetup {
@@ -464,6 +466,7 @@ impl EventPublisher {
             sequence: AtomicU64::new(0),
             tx,
             codec,
+            runtime_handle,
             discovery_client: discovery,
             discovery_instance,
         })
@@ -515,27 +518,39 @@ impl Drop for EventPublisher {
         {
             let topic = self.topic.clone();
             let instance_id = instance.instance_id();
+            let runtime_handle = self.runtime_handle.clone();
 
-            // Spawn background task for async unregister since Drop is sync
-            tokio::spawn(async move {
-                match discovery.unregister(instance).await {
-                    Ok(()) => {
-                        tracing::info!(
-                            topic = %topic,
-                            instance_id = %instance_id,
-                            "EventPublisher unregistered from discovery"
-                        );
+            // Drop can run outside any Tokio context (notably via PyO3 finalizers), so use
+            // the runtime that created the publisher rather than the ambient thread state.
+            let spawn_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+                runtime_handle.spawn(async move {
+                    match discovery.unregister(instance).await {
+                        Ok(()) => {
+                            tracing::info!(
+                                topic = %topic,
+                                instance_id = %instance_id,
+                                "EventPublisher unregistered from discovery"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                topic = %topic,
+                                instance_id = %instance_id,
+                                error = %e,
+                                "Failed to unregister EventPublisher from discovery"
+                            );
+                        }
                     }
-                    Err(e) => {
-                        tracing::warn!(
-                            topic = %topic,
-                            instance_id = %instance_id,
-                            error = %e,
-                            "Failed to unregister EventPublisher from discovery"
-                        );
-                    }
-                }
-            });
+                });
+            }));
+
+            if spawn_result.is_err() {
+                tracing::warn!(
+                    topic = %self.topic,
+                    instance_id = %instance_id,
+                    "Skipping EventPublisher unregister during drop because the runtime is unavailable"
+                );
+            }
         }
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,7 @@ filterwarnings = [
     "ignore:The pynvml package is deprecated.*:FutureWarning", # Ignore pynvml deprecation warning, temporary until upstream library updates to nvidia-ml-py
     "ignore:The behavior of DataFrame concatenation with empty or all-NA entries is deprecated.*:FutureWarning", # pandas 2.x concat deprecation in AIC SDK TODO: fix in AIC
     "ignore:Automatic KV events configuration is deprecated.*:FutureWarning", # Ignore Dynamo's own KV events deprecation warning in tests
+    "ignore:builtin type (SwigPyPacked|SwigPyObject|swigvarlink) has no __module__ attribute:DeprecationWarning", # Python 3.12 SWIG extension warning from third-party tokenizer deps
     # Pydantic V2 deprecation warnings from TRTLLM dependencies (raised at import time during collection)
     "ignore:Support for class-based `config`.*:pydantic.warnings.PydanticDeprecatedSince20",
     "ignore:Using extra keyword arguments on `Field`.*:pydantic.warnings.PydanticDeprecatedSince20",
@@ -332,4 +333,3 @@ extra_content_footer = [
    <script type="text/javascript">if (typeof _satellite !== "undefined") {_satellite.pageBottom();}</script>
    ''',
 ]
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,7 @@ def download_models(model_list=None, ignore_weights=False):
         model_list = TEST_MODELS
 
     # Check for HF_TOKEN in environment
-    hf_token = os.environ.get("HF_TOKEN")
+    hf_token = os.environ.get("HF_TOKEN", "").strip() or None
     if hf_token:
         logging.info("HF_TOKEN found in environment")
     else:
@@ -153,45 +153,50 @@ def download_models(model_list=None, ignore_weights=False):
 
     try:
         from huggingface_hub import snapshot_download
+    except ImportError as exc:
+        raise RuntimeError(
+            "huggingface_hub is required to pre-download models for tests"
+        ) from exc
 
-        for model_id in model_list:
-            logging.info(
-                f"Pre-downloading {'model (no weights)' if ignore_weights else 'model'}: {model_id}"
-            )
+    failures = []
+    for model_id in model_list:
+        logging.info(
+            f"Pre-downloading {'model (no weights)' if ignore_weights else 'model'}: {model_id}"
+        )
 
-            try:
-                if ignore_weights:
-                    # Weight file patterns to exclude (based on hub.rs implementation)
-                    weight_patterns = [
-                        "*.bin",
-                        "*.safetensors",
-                        "*.h5",
-                        "*.msgpack",
-                        "*.ckpt.index",
-                    ]
+        try:
+            if ignore_weights:
+                # Weight file patterns to exclude (based on hub.rs implementation)
+                weight_patterns = [
+                    "*.bin",
+                    "*.safetensors",
+                    "*.h5",
+                    "*.msgpack",
+                    "*.ckpt.index",
+                ]
 
-                    # Download everything except weight files
-                    snapshot_download(
-                        repo_id=model_id,
-                        token=hf_token,
-                        ignore_patterns=weight_patterns,
-                    )
-                else:
-                    # Download the full model snapshot (includes all files)
-                    snapshot_download(
-                        repo_id=model_id,
-                        token=hf_token,
-                    )
-                logging.info(f"Successfully pre-downloaded: {model_id}")
+                # Download everything except weight files
+                snapshot_download(
+                    repo_id=model_id,
+                    token=hf_token,
+                    ignore_patterns=weight_patterns,
+                )
+            else:
+                # Download the full model snapshot (includes all files)
+                snapshot_download(
+                    repo_id=model_id,
+                    token=hf_token,
+                )
+            logging.info(f"Successfully pre-downloaded: {model_id}")
 
-            except Exception as e:
-                logging.error(f"Failed to pre-download {model_id}: {e}")
-                # Don't fail the fixture - let individual tests handle missing models
+        except Exception as exc:
+            logging.error(f"Failed to pre-download {model_id}: {exc}")
+            failures.append(f"{model_id}: {exc}")
 
-    except ImportError:
-        logging.warning(
-            "huggingface_hub not installed. "
-            "Models will be downloaded during test execution."
+    if failures:
+        raise RuntimeError(
+            "Failed to pre-download required Hugging Face models:\n"
+            + "\n".join(failures)
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -434,14 +434,7 @@ class NatsServer(ManagedProcess):
     def stop(self):
         """Stop the NATS server for restart. Does not release port or clean up fully."""
         _logger.info(f"Stopping NATS server on port {self.port}")
-        self._terminate_process_group()
-        proc = self.proc  # type: ignore[has-type]
-        if proc is not None:
-            try:
-                proc.wait(timeout=10)
-            except Exception as e:
-                _logger.warning(f"Error waiting for NATS process to stop: {e}")
-            self.proc = None
+        self._stop_started_processes()
 
     def start(self):
         """Restart a stopped NATS server with fresh state."""

--- a/tests/profiler/configs/5b_rapid_unsupported_planner_throughput_error.yaml
+++ b/tests/profiler/configs/5b_rapid_unsupported_planner_throughput_error.yaml
@@ -4,7 +4,7 @@
 # Case 5b: AIC unsupported model, rapid, with planner + throughput scaling
 # This should FAIL with a ValueError because throughput-based planner
 # requires AIC support.
-model: "Qwen/Qwen3-32B"
+model: "meta-llama/Llama-3.1-8B"
 backend: vllm
 image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:latest"
 hardware:

--- a/tests/profiler/test_profile_sla_dgdr.py
+++ b/tests/profiler/test_profile_sla_dgdr.py
@@ -155,7 +155,7 @@ class TestRapidSupported:
 
 
 class TestRapidUnsupported:
-    """Rapid strategy with AIC-unsupported model (Qwen3-32B on l40s/vllm)."""
+    """Rapid strategy with AIC-unsupported model/hardware combos."""
 
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0
@@ -178,7 +178,6 @@ class TestRapidUnsupported:
         ops = _make_ops(tmp_path)
         asyncio.run(run_profile(dgdr, ops))
 
-    @pytest.mark.skip(reason="Fails with latest AIC - OPS-3852")
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0
     def test_planner_throughput_scaling_raises(self, tmp_path):

--- a/tests/profiler/test_profile_sla_dgdr.py
+++ b/tests/profiler/test_profile_sla_dgdr.py
@@ -178,6 +178,7 @@ class TestRapidUnsupported:
         ops = _make_ops(tmp_path)
         asyncio.run(run_profile(dgdr, ops))
 
+    @pytest.mark.skip(reason="Fails with latest AIC - OPS-3852")
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0
     def test_planner_throughput_scaling_raises(self, tmp_path):

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -44,6 +44,7 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.integration,
     pytest.mark.model(MODEL_NAME),
+    pytest.mark.skip(reason="DYN-2365 - Flaky, temporarily disabled"),
 ]
 NUM_MOCKERS = 2
 SPEEDUP_RATIO = 10.0

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -44,7 +44,6 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.integration,
     pytest.mark.model(MODEL_NAME),
-    pytest.mark.skip(reason="DYN-2365 - Flaky, temporarily disabled"),
 ]
 NUM_MOCKERS = 2
 SPEEDUP_RATIO = 10.0
@@ -562,7 +561,7 @@ def test_kv_router_bindings(
     ],
     indirect=["request_plane", "durable_kv_events"],
 )
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(300)
 def test_indexers_sync(
     request,
     runtime_services_dynamic_ports,
@@ -664,7 +663,7 @@ def test_query_instance_id_returns_worker_and_tokens(
         )
 
 
-@pytest.mark.timeout(90)  # bumped for xdist contention (was 29s; ~9.55s serial avg)
+@pytest.mark.timeout(300)  # bumped for xdist contention (was 29s; ~9.55s serial avg)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 @pytest.mark.parametrize(
     "durable_kv_events,use_kv_events,zmq_kv_events",

--- a/tests/serve/test_disagg_logprobs_serialization.py
+++ b/tests/serve/test_disagg_logprobs_serialization.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for disaggregated logprobs serialization round-trip.
+
+TRT-LLM PR #11727 adds first_gen_log_probs to DisaggregatedParams with
+integer token-ID dict keys ({4710: Logprob(...)}). The Dynamo Rust
+transport layer (pythonize 0.23 → serde_json::Value) requires string map
+keys. These tests verify the codec correctly converts between TRT-LLM's
+internal format and a JSON-safe transport format.
+
+Mirrors TRT-LLM's TestFirstGenLogProbsSerializeRoundtrip in
+tests/unittest/disaggregated/test_openai_disagg_service.py.
+"""
+
+import dataclasses
+import json
+
+import pytest
+
+try:
+    from tensorrt_llm.executor.result import Logprob
+
+    from dynamo.trtllm.utils.disagg_utils import DisaggregatedParamsCodec
+except ImportError as e:
+    pytest.skip(f"tensorrt_llm import failed: {e}", allow_module_level=True)
+
+
+def _to_asdict_format(logprob_dicts):
+    """Convert [{int: Logprob}] to [{int: dict}] to match what
+    dataclasses.asdict() produces in the production flow."""
+    return [
+        {tid: dataclasses.asdict(lp) for tid, lp in pos.items()}
+        for pos in logprob_dicts
+    ]
+
+
+@pytest.mark.pre_merge
+@pytest.mark.trtllm
+@pytest.mark.gpu_0
+@pytest.mark.unit
+class TestDisaggLogprobsSerializationRoundtrip:
+    """Roundtrip tests for first_gen_log_probs serialize/deserialize."""
+
+    def test_none_passthrough(self):
+        params = {"first_gen_log_probs": None}
+        DisaggregatedParamsCodec.serialize_first_gen_log_probs(params)
+        assert params["first_gen_log_probs"] is None
+        DisaggregatedParamsCodec.deserialize_first_gen_log_probs(params)
+        assert params["first_gen_log_probs"] is None
+
+    def test_missing_field_noop(self):
+        params = {"request_type": "context_only"}
+        DisaggregatedParamsCodec.serialize_first_gen_log_probs(params)
+        assert "first_gen_log_probs" not in params
+        DisaggregatedParamsCodec.deserialize_first_gen_log_probs(params)
+        assert "first_gen_log_probs" not in params
+
+    def test_single_token_roundtrip(self):
+        original = [{4710: Logprob(logprob=-2.3256, rank=1)}]
+        # In production, dataclasses.asdict() converts Logprob → dict before
+        # serialize is called. Mimic that here.
+        params = {"first_gen_log_probs": _to_asdict_format(original)}
+
+        DisaggregatedParamsCodec.serialize_first_gen_log_probs(params)
+
+        # Verify serialized format: list of lists of dicts (no int dict keys)
+        serialized = params["first_gen_log_probs"]
+        assert isinstance(serialized, list)
+        assert isinstance(serialized[0], list)
+        assert serialized[0][0]["token_id"] == 4710
+        assert serialized[0][0]["logprob"] == pytest.approx(-2.3256)
+        assert serialized[0][0]["rank"] == 1
+
+        # Verify JSON-safe (this is the actual failure point — int dict keys
+        # cause pythonize 0.23 depythonize to fail with dict_key_not_string)
+        json.dumps(params)
+
+        # Round-trip back
+        DisaggregatedParamsCodec.deserialize_first_gen_log_probs(params)
+        recovered = params["first_gen_log_probs"]
+        assert len(recovered) == 1
+        assert 4710 in recovered[0]
+        assert isinstance(recovered[0][4710], Logprob)
+        assert recovered[0][4710].logprob == pytest.approx(-2.3256)
+        assert recovered[0][4710].rank == 1
+
+    def test_multi_token_topk_roundtrip(self):
+        original = [
+            {
+                100: Logprob(logprob=-0.1, rank=1),
+                200: Logprob(logprob=-2.3, rank=2),
+                300: Logprob(logprob=-5.0, rank=3),
+            },
+            {
+                400: Logprob(logprob=-0.05, rank=1),
+                500: Logprob(logprob=-3.7, rank=2),
+            },
+        ]
+        params = {"first_gen_log_probs": _to_asdict_format(original)}
+
+        DisaggregatedParamsCodec.serialize_first_gen_log_probs(params)
+        json.dumps(params)  # Must be JSON-safe
+        DisaggregatedParamsCodec.deserialize_first_gen_log_probs(params)
+
+        recovered = params["first_gen_log_probs"]
+        assert len(recovered) == 2
+        assert set(recovered[0].keys()) == {100, 200, 300}
+        assert set(recovered[1].keys()) == {400, 500}
+        for orig_pos, rec_pos in zip(original, recovered, strict=True):
+            for tid in orig_pos:
+                assert rec_pos[tid].logprob == pytest.approx(orig_pos[tid].logprob)
+                assert rec_pos[tid].rank == orig_pos[tid].rank
+
+    def test_rank_none_preserved(self):
+        original = _to_asdict_format([{42: Logprob(logprob=-1.0, rank=None)}])
+        params = {"first_gen_log_probs": original}
+
+        DisaggregatedParamsCodec.serialize_first_gen_log_probs(params)
+        DisaggregatedParamsCodec.deserialize_first_gen_log_probs(params)
+
+        assert params["first_gen_log_probs"][0][42].rank is None
+
+    def test_empty_list_passthrough(self):
+        params = {"first_gen_log_probs": []}
+        DisaggregatedParamsCodec.serialize_first_gen_log_probs(params)
+        assert params["first_gen_log_probs"] == []

--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -94,6 +94,33 @@ def terminate_process_tree(
     psutil.wait_procs(alive, timeout=timeout)
 
 
+class ManagedProcessStopError(RuntimeError):
+    """Raised when a ManagedProcess subprocess cannot be stopped cleanly."""
+
+    def __init__(self, attr_name: str, pid: int, detail: str):
+        super().__init__(
+            f"Failed to stop managed process '{attr_name}' (pid={pid}): {detail}"
+        )
+        self.attr_name = attr_name
+        self.pid = pid
+        self.detail = detail
+
+
+class ManagedProcessStopTimeoutError(ManagedProcessStopError):
+    """Raised when a subprocess remains alive after forceful shutdown."""
+
+    def __init__(self, attr_name: str, pid: int, wait_timeout: float):
+        super().__init__(
+            attr_name,
+            pid,
+            (
+                "process did not exit after forceful shutdown "
+                f"within {wait_timeout:.1f}s"
+            ),
+        )
+        self.wait_timeout = wait_timeout
+
+
 @dataclass
 class ManagedProcess:
     """Manages a subprocess with health checks and automatic cleanup.
@@ -280,25 +307,148 @@ class ManagedProcess:
         This ALWAYS runs regardless of terminate_all_matching_process_names setting.
         """
         try:
-            self._terminate_process_group()
+            # Snapshot all child processes BEFORE killing the parent.
+            # Some frameworks (e.g. TRT-LLM via MPI) spawn children in separate
+            # process groups. After the parent dies these children become orphans
+            # reparented to init, so psutil can no longer find them via the parent
+            # PID. We must capture them now while the parent is still alive.
+            orphan_candidates = []
+            if self.proc:
+                try:
+                    parent = psutil.Process(self.proc.pid)
+                    orphan_candidates = parent.children(recursive=True)
+                except psutil.NoSuchProcess:
+                    pass
 
-            process_list = [self.proc, self._tee_proc, self._sed_proc]
-            for process in process_list:
-                if process:
-                    try:
-                        if process.stdout:
-                            process.stdout.close()
-                        if process.stdin:
-                            process.stdin.close()
-                        terminate_process_tree(process.pid, self._logger)
-                        process.wait()
-                    except Exception as e:
-                        self._logger.warning("Error terminating process: %s", e)
+            self._stop_started_processes()
+
+            # Kill any child processes that survived the process group kill.
+            # This catches children in different PGIDs (e.g. MPI workers, engine
+            # cores) that os.killpg() could not reach.
+            for child in orphan_candidates:
+                try:
+                    if child.is_running():
+                        self._logger.info(
+                            "Killing orphaned child process: PID %s name=%s",
+                            child.pid,
+                            child.name(),
+                        )
+                        terminate_process_tree(child.pid, self._logger)
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
             if self.data_dir:
                 self._remove_directory(self.data_dir)
         finally:
             # Always run straggler cleanup, even if interrupted
             self._cleanup_stragglers()
+
+    def _stop_started_processes(self, wait_timeout: float = 10.0):
+        """Terminate launched subprocesses and close any open pipe handles.
+
+        This is used both during normal teardown and when a managed service
+        needs to stop and restart in-place without releasing higher-level
+        resources such as ports.
+        """
+        self._terminate_process_group()
+
+        process_entries = [
+            ("proc", self.proc),
+            ("_tee_proc", self._tee_proc),
+            ("_sed_proc", self._sed_proc),
+        ]
+        for attr_name, process in process_entries:
+            if process is None:
+                continue
+
+            try:
+                for stream_name in ("stdout", "stdin", "stderr"):
+                    stream = getattr(process, stream_name, None)
+                    if stream is not None:
+                        stream.close()
+            except OSError as e:
+                self._logger.warning("Error closing process streams: %s", e)
+
+            try:
+                terminate_process_tree(process.pid, self._logger)
+                process.wait(timeout=wait_timeout)
+            except (psutil.TimeoutExpired, subprocess.TimeoutExpired) as e:
+                self._logger.warning(
+                    "Process '%s' (pid=%s) timed out during shutdown: %s. "
+                    "Retrying with forceful termination.",
+                    attr_name,
+                    process.pid,
+                    e,
+                )
+                self._force_stop_process(process, attr_name, wait_timeout)
+            except OSError as e:
+                if process.poll() is None:
+                    self._logger.warning(
+                        "Process '%s' (pid=%s) hit an OS error during shutdown: %s. "
+                        "Retrying with forceful termination.",
+                        attr_name,
+                        process.pid,
+                        e,
+                    )
+                    self._force_stop_process(process, attr_name, wait_timeout)
+
+            if process.poll() is None:
+                raise ManagedProcessStopTimeoutError(
+                    attr_name, process.pid, wait_timeout
+                )
+
+            setattr(self, attr_name, None)
+
+        self._pgid = None
+
+    def _force_stop_process(
+        self,
+        process: subprocess.Popen,
+        attr_name: str,
+        wait_timeout: float,
+    ) -> None:
+        """Forcefully stop a process tree and confirm the launched child exits."""
+        try:
+            terminate_process_tree(
+                process.pid,
+                self._logger,
+                immediate_kill=True,
+                timeout=0,
+            )
+        except (psutil.TimeoutExpired, OSError) as e:
+            self._logger.warning(
+                "Forceful tree termination failed for process '%s' (pid=%s): %s. "
+                "Falling back to process.kill().",
+                attr_name,
+                process.pid,
+                e,
+            )
+            try:
+                process.kill()
+            except OSError as kill_err:
+                if process.poll() is None:
+                    raise ManagedProcessStopError(
+                        attr_name,
+                        process.pid,
+                        f"forceful shutdown failed: {kill_err}",
+                    ) from kill_err
+
+        try:
+            process.wait(timeout=wait_timeout)
+        except subprocess.TimeoutExpired as e:
+            if process.poll() is None:
+                raise ManagedProcessStopTimeoutError(
+                    attr_name, process.pid, wait_timeout
+                ) from e
+        except OSError as e:
+            if process.poll() is None:
+                raise ManagedProcessStopError(
+                    attr_name,
+                    process.pid,
+                    f"error waiting for exit after forceful shutdown: {e}",
+                ) from e
+
+        if process.poll() is None:
+            raise ManagedProcessStopTimeoutError(attr_name, process.pid, wait_timeout)
 
     def _start_process(self):
         assert self._command_name
@@ -399,6 +549,11 @@ class ManagedProcess:
         poll_interval = 0.1
         elapsed = 0.0
         while elapsed < timeout:
+            # Reap the launched child if it has already exited. Without this,
+            # the child can remain as a zombie and keep killpg(..., 0) reporting
+            # the process group as alive until the timeout expires.
+            if self.proc is not None:
+                self.proc.poll()
             try:
                 # Check if any process in the group is still alive
                 os.killpg(self._pgid, 0)  # Signal 0 = check existence (no kill)


### PR DESCRIPTION
## Summary
- Cherry-picks #7230 (pytest sequential reliability improvements) and #7186 (disagg logprobs fix) together onto `release/1.0.0`
- Goal: verify whether #7230's process cleanup fixes resolve the intermittent `test_trtllm_kv_router_basic[tcp]` timeout (DYN-2365) seen in #7186's CI

## Commits included
1. `9bfb716` fix: Fix Intermittent KV router + mocker errors (#7108)
2. `1a44c60` fix: Dont ignore non-zero exitcodes after running tests (#7149)
3. `40a94c1` test: update unsupported model name after AIC increase coverage (#7161)
4. `116ee05` fix: Fix mocker+router segfaults + reliability fixes (#7162)
5. `2443308` fix: serialize disagg first_gen_log_probs int keys for Rust transport (#7145)

## Context
- `test_trtllm_kv_router_basic[tcp]` timed out in #7186's CI (known flaky test DYN-2365)
- The test passes locally on both base and PR images — failure is CI resource contention
- #7230 improves process cleanup (zombie reaping, orphan child termination, EventPublisher Drop fix) which may reduce contention
- This PR tests whether combining both fixes resolves the CI failure

## Test plan
- [ ] Watch `trtllm-pipeline / trtllm-cuda13.1-amd64 / Test trtllm-cuda13.1-amd64` CI job
- [ ] Compare with #7186's CI results
- [ ] If CI passes, confirms #7230 should be merged first, then #7186