### PR TITLE
docs: link GKE guide in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,7 @@ Platform-specific deployment guides for production environments:
 - **[Amazon EKS](/examples/deployments/EKS/)** - Deploy Dynamo on Amazon Elastic Kubernetes Service
 - **[Azure AKS](/examples/deployments/AKS/)** - Deploy Dynamo on Azure Kubernetes Service
 - **[Amazon ECS](/examples/deployments/ECS/)** - Deploy Dynamo on Amazon Elastic Container Service
-- **Google GKE** - _Coming soon_
+- **[Google GKE](/examples/deployments/GKE/)** - Deploy Dynamo on Google Kubernetes Engine
 
 ## Runtime Examples
 


### PR DESCRIPTION
## Summary
- Links the GKE deployment guide in the examples README, replacing the "Coming soon" placeholder.

## Test plan
- [ ] Verify link resolves to `/examples/deployments/GKE/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Google Kubernetes Engine deployment guide is now available, providing instructions for deploying on GKE.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->