### PR TITLE
feat: dp rank setable on the fly in publisher

### DIFF
--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -119,7 +119,8 @@ impl KvEventPublisher {
     ///     endpoint: The Dynamo component endpoint for this worker.
     ///     worker_id: Identifier of this worker (default 0).
     ///     kv_block_size: KV cache block size in tokens; must be > 0.
-    ///     dp_rank: Data-parallel rank of this worker (default 0).
+    ///     dp_rank: Default data-parallel rank used when per-event `dp_rank`
+    ///         override is not provided (default 0).
     ///     enable_local_indexer: When True, a local KV indexer is kept in-process
     ///         so that routers can recover events directly from this worker.
     ///     zmq_endpoint: Optional ZMQ SUB endpoint to read raw engine events from.
@@ -175,8 +176,19 @@ impl KvEventPublisher {
         })
     }
 
+    /// Publish a KV stored event.
+    ///
+    /// Args:
+    ///     token_ids: Token IDs for the stored blocks.
+    ///     num_block_tokens: Number of tokens in each block.
+    ///     block_hashes: Block hashes corresponding to stored blocks.
+    ///     parent_hash: Optional parent block hash.
+    ///     block_mm_infos: Optional multimodal metadata per block.
+    ///     lora_name: Optional LoRA adapter name.
+    ///     dp_rank: Optional per-event data-parallel rank override.
+    ///         When omitted, the publisher's constructor `dp_rank` is used.
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (token_ids, num_block_tokens, block_hashes, parent_hash=None, block_mm_infos=None, lora_name=None))]
+    #[pyo3(signature = (token_ids, num_block_tokens, block_hashes, parent_hash=None, block_mm_infos=None, lora_name=None, dp_rank=None))]
     fn publish_stored(
         &self,
         py: Python,
@@ -186,9 +198,10 @@ impl KvEventPublisher {
         parent_hash: Option<i64>,
         block_mm_infos: Option<Bound<PyAny>>,
         lora_name: Option<String>,
+        dp_rank: Option<DpRank>,
     ) -> PyResult<()> {
         let kv_block_size = self.kv_block_size as u32;
-        let dp_rank = self.dp_rank;
+        let dp_rank = dp_rank.unwrap_or(self.dp_rank);
         let warning_count = self.warning_count.clone();
         let inner = self.inner.clone();
 
@@ -222,8 +235,20 @@ impl KvEventPublisher {
         })
     }
 
-    fn publish_removed(&self, py: Python, block_hashes: Vec<i64>) -> PyResult<()> {
-        let dp_rank = self.dp_rank;
+    /// Publish a KV removed event.
+    ///
+    /// Args:
+    ///     block_hashes: List of block hashes to remove.
+    ///     dp_rank: Optional per-event data-parallel rank override.
+    ///         When omitted, the publisher's constructor `dp_rank` is used.
+    #[pyo3(signature = (block_hashes, dp_rank=None))]
+    fn publish_removed(
+        &self,
+        py: Python,
+        block_hashes: Vec<i64>,
+        dp_rank: Option<DpRank>,
+    ) -> PyResult<()> {
+        let dp_rank = dp_rank.unwrap_or(self.dp_rank);
         let inner = self.inner.clone();
 
         // Use shared monotonic event_id counter from the inner publisher

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -703,7 +703,10 @@ class ApproxKvIndexer:
 
 class KvEventPublisher:
     """
-    A KV event publisher will publish KV events corresponding to the component.
+    Publish KV cache events for a worker/component.
+
+    The constructor `dp_rank` is the default rank. You can override it per event
+    in `publish_stored(..., dp_rank=...)` and `publish_removed(..., dp_rank=...)`.
     """
 
     ...
@@ -730,7 +733,8 @@ class KvEventPublisher:
             endpoint: The endpoint to extract component information from for event publishing
             worker_id: The worker ID (unused, inferred from endpoint)
             kv_block_size: The KV block size (must be > 0)
-            dp_rank: The data parallel rank (defaults to 0)
+            dp_rank: Default data parallel rank used when publish calls omit
+                `dp_rank` (defaults to 0)
             enable_local_indexer: Enable worker-local KV indexer
             zmq_endpoint: Optional ZMQ endpoint for relay mode (e.g. "tcp://127.0.0.1:5557")
             zmq_topic: ZMQ topic to subscribe to (defaults to "" when zmq_endpoint is set)
@@ -744,6 +748,7 @@ class KvEventPublisher:
         parent_hash: Optional[int] = None,
         block_mm_infos: Optional[List[Optional[Dict[str, Any]]]] = None,
         lora_name: Optional[str] = None,
+        dp_rank: Optional[int] = None,
     ) -> None:
         """
         Publish a KV stored event.
@@ -759,10 +764,14 @@ class KvEventPublisher:
                 Each item is either None or a dict with "mm_objects" key containing
                 a list of {"mm_hash": int, "offsets": [[start, end], ...]} dicts.
             lora_name: Optional LoRA adapter name for adapter-aware block hashing.
+            dp_rank: Optional override for this event's data parallel rank.
+                When omitted, constructor `dp_rank` is used.
         """
         ...
 
-    def publish_removed(self, block_hashes: List[int]) -> None:
+    def publish_removed(
+        self, block_hashes: List[int], dp_rank: Optional[int] = None
+    ) -> None:
         """
         Publish a KV removed event.
 
@@ -770,6 +779,8 @@ class KvEventPublisher:
 
         Args:
             block_hashes: List of block hashes to remove (signed 64-bit integers)
+            dp_rank: Optional override for this event's data parallel rank.
+                When omitted, constructor `dp_rank` is used.
         """
         ...
 
@@ -1690,4 +1701,3 @@ class VirtualConnectorClient:
     async def wait(self) -> None:
         """Blocks until there is a new decision to fetch using 'get'"""
         ...
-


### PR DESCRIPTION
Signed-off-by: michaelfeil <63565275+michaelfeil@users.noreply.github.com>

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

In trt-llm dp events are broadcasted to mpi rank 0. As result, we do not spawn a exporter per mpi rank. I am not sure if each dp_rank maintains its own event id sequence, of if "ids" are for all dp ranks (in which case the indexer would complain about "gaps", which are patched with my previous pr (https://github.com/ai-dynamo/dynamo/commit/fca0a801dc8f0b91343dd702125de31290643f4f). 

I assume I can close this PR, just wanted to check.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

```python
class KvPublisherRegistry:
      def __init__(self, endpoint, worker_id, kv_block_size, enable_local_indexer):
          self._cfg = (endpoint, worker_id, kv_block_size, enable_local_indexer)
          self._pubs = {}
          self._lock = threading.Lock()

      def get_or_init(self, dp_rank: int) -> KvEventPublisher:
          pub = self._pubs.get(dp_rank)
          if pub is not None:
              return pub
          with self._lock:
              pub = self._pubs.get(dp_rank)
              if pub is None:
                  endpoint, worker_id, kv_block_size, enable_local_indexer = self._cfg
                  pub = KvEventPublisher(
                      endpoint=endpoint,
                      worker_id=worker_id,
                      kv_block_size=kv_block_size,
                      dp_rank=dp_rank,
                      enable_local_indexer=enable_local_indexer,
                  )
                  self._pubs[dp_rank] = pub
              return pub

  At event send

  dp_rank = event.get("attention_dp_rank", 0)
  registry.get_or_init(dp_rank).publish_stored(...)
```