### PR TITLE
chore: cherry-pick Fern CLI upgrade to 4.23.0 for release/1.0.0

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "3.73.0"
+  "version": "4.23.0"
 }


### PR DESCRIPTION
## Summary
- Cherry-pick of #7253 to release/1.0.0
- Upgrades Fern CLI from 3.73.0 to 4.23.0

## Original PR
- Main PR: #7253
- Merge commit: e9f740a

## Test plan
- [ ] CI passes
- [ ] Fern docs build succeeds with new version

Made with [Cursor](https://cursor.com)