### PR TITLE
docs: reorganize sidebar — slim Getting Started, add Resources section

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -22,6 +22,10 @@ navigation:
     contents:
       - page: Quickstart
         path: getting-started/quickstart.md
+
+  # ==================== Resources ====================
+  - section: Resources
+    contents:
       - page: Support Matrix
         path: reference/support-matrix.md
       - page: Feature Matrix

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -108,7 +108,7 @@ TensorRT-LLM delivers maximum inference performance and optimization, with full 
 ---
 
 
-{/* Backend READMEs — paths relative to rendered URL /getting-started/feature-matrix */}
+{/* Backend READMEs — paths relative to rendered URL /resources/feature-matrix */}
 [vllm-readme]: ../backends/v-llm
 [sglang-readme]: ../backends/sg-lang
 [trtllm-readme]: ../backends/tensor-rt-llm

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,7 @@ Platform-specific deployment guides for production environments:
 - **[Amazon EKS](/examples/deployments/EKS/)** - Deploy Dynamo on Amazon Elastic Kubernetes Service
 - **[Azure AKS](/examples/deployments/AKS/)** - Deploy Dynamo on Azure Kubernetes Service
 - **[Amazon ECS](/examples/deployments/ECS/)** - Deploy Dynamo on Amazon Elastic Container Service
-- **Google GKE** - _Coming soon_
+- **[Google GKE](/examples/deployments/GKE/)** - Deploy Dynamo on Google Kubernetes Engine
 
 ## Runtime Examples
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -34,6 +34,14 @@ redirects:
     destination: "/dynamo/"
   - source: "/dynamo/latest/index.html"
     destination: "/dynamo/"
+  - source: "/dynamo/getting-started/support-matrix"
+    destination: "/dynamo/resources/support-matrix"
+  - source: "/dynamo/getting-started/feature-matrix"
+    destination: "/dynamo/resources/feature-matrix"
+  - source: "/dynamo/getting-started/release-artifacts"
+    destination: "/dynamo/resources/release-artifacts"
+  - source: "/dynamo/getting-started/examples"
+    destination: "/dynamo/resources/examples"
 
 # GitHub repository link in navbar
 navbar-links:


### PR DESCRIPTION
## Summary

- Slim down **Getting Started** to just the Quickstart guide
- Add new **Resources** section directly below Getting Started containing Support Matrix, Feature Matrix, Release Artifacts, and Examples
- Add Fern redirects from old `/getting-started/*` URLs to new `/resources/*` URLs
- Link GKE deployment guide in examples README (from #7249)

## Test Plan

- [ ] Verify `fern check` passes in CI
- [ ] Confirm sidebar renders correctly on docs site
- [ ] Verify redirects work for old URLs

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Resources" section to documentation navigation, positioned after the Quickstart guide.
  * Google Kubernetes Engine deployment guide is now available and properly linked.
  * Documentation content reorganized for improved structure and findability.
  * Automatic redirects maintain compatibility with previously-shared documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->