### PR TITLE
docs: move contribution guide to Getting Started section

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -22,6 +22,8 @@ navigation:
     contents:
       - page: Quickstart
         path: getting-started/quickstart.md
+      - page: Contribution Guide
+        path: contribution-guide.md
 
   # ==================== Resources ====================
   - section: Resources
@@ -34,8 +36,6 @@ navigation:
         path: reference/release-artifacts.md
       - page: Examples
         path: getting-started/examples.md
-      - page: Contribution Guide
-        path: contribution-guide.md
 
   # ==================== Kubernetes Deployment ====================
   - section: Kubernetes Deployment


### PR DESCRIPTION
## Summary
- Move the Contribution Guide from the Resources section to Getting Started, directly under Quickstart
- Improves discoverability for new contributors

## Where Should the Reviewer Start?
`docs/index.yml` — the only file changed (2-line nav reorder)

## Test Plan
- [ ] CI passes
- [ ] Fern docs preview shows Contribution Guide under Getting Started

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Contribution Guide relocated from Resources to Getting Started section for improved documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->