### PR TITLE
test: Fix cancellation test

### DIFF
--- a/lib/bindings/python/tests/cancellation/test_cancellation.py
+++ b/lib/bindings/python/tests/cancellation/test_cancellation.py
@@ -7,7 +7,11 @@ import pytest
 
 from dynamo.runtime import Context
 
-pytestmark = pytest.mark.pre_merge
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+]
 
 
 class MockServer:
@@ -162,7 +166,6 @@ async def client(runtime, namespace):
     return client
 
 
-@pytest.mark.pre_merge
 @pytest.mark.forked
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
@@ -197,7 +200,6 @@ async def test_client_context_cancel(temp_file_store, server, client):
     # TODO: Test with _generate_until_asyncio_cancelled server handler
 
 
-@pytest.mark.pre_merge
 @pytest.mark.forked
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
@@ -231,7 +233,6 @@ async def test_client_loop_break(temp_file_store, server, client):
     # TODO: Test with _generate_until_asyncio_cancelled server handler
 
 
-@pytest.mark.pre_merge
 @pytest.mark.forked
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
@@ -259,7 +260,6 @@ async def test_server_context_cancel(temp_file_store, server, client):
     assert not handler.context_is_killed
 
 
-@pytest.mark.pre_merge
 @pytest.mark.forked
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
@@ -288,7 +288,6 @@ async def test_server_raise_cancelled(temp_file_store, server, client):
     assert not handler.context_is_killed
 
 
-@pytest.mark.pre_merge
 @pytest.mark.forked
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
@@ -312,7 +311,6 @@ async def test_client_context_already_cancelled(temp_file_store, server, client)
     assert not handler.context_is_killed
 
 
-@pytest.mark.pre_merge
 @pytest.mark.forked
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)

--- a/lib/bindings/python/tests/cancellation/test_cancellation.py
+++ b/lib/bindings/python/tests/cancellation/test_cancellation.py
@@ -162,6 +162,7 @@ async def client(runtime, namespace):
     return client
 
 
+@pytest.mark.pre_merge
 @pytest.mark.forked
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
@@ -196,6 +197,7 @@ async def test_client_context_cancel(temp_file_store, server, client):
     # TODO: Test with _generate_until_asyncio_cancelled server handler
 
 
+@pytest.mark.pre_merge
 @pytest.mark.forked
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
@@ -229,6 +231,7 @@ async def test_client_loop_break(temp_file_store, server, client):
     # TODO: Test with _generate_until_asyncio_cancelled server handler
 
 
+@pytest.mark.pre_merge
 @pytest.mark.forked
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
@@ -256,6 +259,7 @@ async def test_server_context_cancel(temp_file_store, server, client):
     assert not handler.context_is_killed
 
 
+@pytest.mark.pre_merge
 @pytest.mark.forked
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
@@ -284,6 +288,7 @@ async def test_server_raise_cancelled(temp_file_store, server, client):
     assert not handler.context_is_killed
 
 
+@pytest.mark.pre_merge
 @pytest.mark.forked
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
@@ -307,6 +312,7 @@ async def test_client_context_already_cancelled(temp_file_store, server, client)
     assert not handler.context_is_killed
 
 
+@pytest.mark.pre_merge
 @pytest.mark.forked
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)

--- a/lib/bindings/python/tests/cancellation/test_cancellation.py
+++ b/lib/bindings/python/tests/cancellation/test_cancellation.py
@@ -247,7 +247,9 @@ async def test_server_context_cancel(temp_file_store, server, client):
     except ValueError as e:
         # Verify the expected cancellation exception is received
         # TODO: Should this be a asyncio.CancelledError?
-        assert str(e).startswith("Stream ended before generation completed")
+        assert str(e).startswith(
+            "Disconnected: Stream ended before generation completed"
+        )
 
     # Verify server context cancellation status
     assert handler.context_is_stopped
@@ -272,9 +274,8 @@ async def test_server_raise_cancelled(temp_file_store, server, client):
     except ValueError as e:
         # Verify the expected cancellation exception is received
         # TODO: Should this be a asyncio.CancelledError?
-        assert (
-            str(e)
-            == "a python exception was caught while processing the async generator: CancelledError: "
+        assert str(e).endswith(
+            "a python exception was caught while processing the async generator: CancelledError: "
         )
 
     # Verify server context cancellation status


### PR DESCRIPTION
`pytest -x -v -m pre_merge lib/bindings/python/tests` now works locally!

The error text was changed at some point (likely #6303), and these tests will have been failing ever since.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated Python cancellation tests to align with refined error messages in cancellation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->