### PR TITLE
docs: add PR rebase guidelines and CI failure reproduction tips

### DIFF
--- a/.ai/pr-workflow-guidelines.md
+++ b/.ai/pr-workflow-guidelines.md
@@ -4,7 +4,8 @@ Conventions for keeping pull requests healthy and reviewable.
 
 ## Keep Your Branch Close to Main
 
-**Always flag** PRs that are more than ~25 commits behind `main`.
+Be aware of PRs targeting `main` that are more than ~25 commits behind.
+Stacked PRs targeting another branch are exempt.
 
 ### 1. Slower CI builds
 
@@ -51,5 +52,7 @@ git fetch origin && git rebase origin/main
   git fetch origin
   git rev-list --count HEAD..origin/main
   ```
-  Double digits? Rebase first.
+  Over 25? Rebase first.
 - **If CI is slow**, check your base commit age before debugging other causes.
+- **Stacked PRs** are exempt. If a PR targets another branch in a stack,
+  distance from `main` is expected and not a problem until the stack lands.

--- a/.ai/pr-workflow-guidelines.md
+++ b/.ai/pr-workflow-guidelines.md
@@ -1,0 +1,55 @@
+# PR Workflow Guidelines
+
+Conventions for keeping pull requests healthy and reviewable.
+
+## Keep Your Branch Close to Main
+
+**Always flag** PRs that are more than ~25 commits behind `main`.
+
+### 1. Slower CI builds
+
+CI builds start from a base image matching a recent `main` commit. The closer
+your branch is to `main`, the more cache hits you get. We use BuildKit with
+remote cache (`--cache-from`), but BuildKit layers are still content-addressed
+-- if a `COPY` brings in source that changed since your branch point, that
+layer and everything downstream rebuilds regardless. When your branch is far
+behind:
+
+- **Docker layer cache misses**: Changed source or Dockerfile instructions
+  since your branch point invalidate cached layers, forcing rebuilds
+  downstream.
+- **Rust compilation cache misses**: More crate sources differ from what's
+  cached, so more crates recompile from scratch.
+- **Dependency drift**: `Cargo.lock` and `requirements.txt` evolve on `main`.
+  Stale branches pull older versions that aren't cached, triggering fresh
+  downloads and builds.
+
+A branch too far behind `main` can trigger a near-cold build that takes
+45-60 minutes. A branch close to `main` reuses most of the cache and builds
+in a fraction of that time.
+
+### 2. Reviewer burden
+
+Merge commits from main pollute the diff with unrelated changes. Rebasing
+produces a clean, linear history where every commit is the PR author's.
+
+```bash
+# BAD -- merge pulls in unrelated files; reviewer has to filter them out
+git merge main
+
+# GOOD -- clean diff showing only your work
+git fetch origin && git rebase origin/main
+```
+
+### Guidance
+
+- **Rebase at least every ~25 commits behind**, or when CI builds slow down.
+- **Prefer `rebase` over `merge`** for linear history. Force-push after
+  rebasing (`git push --force-with-lease`).
+- **Before requesting review**, check your distance from main:
+  ```bash
+  git fetch origin
+  git rev-list --count HEAD..origin/main
+  ```
+  Double digits? Rebase first.
+- **If CI is slow**, check your base commit age before debugging other causes.

--- a/.ai/pr-workflow-guidelines.md
+++ b/.ai/pr-workflow-guidelines.md
@@ -44,7 +44,7 @@ git fetch origin && git rebase origin/main
 
 ### Guidance
 
-- **Rebase at least every ~25 commits behind**, or when CI builds slow down.
+- **Rebase when you are more than ~25 commits behind main.**
 - **Prefer `rebase` over `merge`** for linear history. Force-push after
   rebasing (`git push --force-with-lease`).
 - **Before requesting review**, check your distance from main:
@@ -52,7 +52,7 @@ git fetch origin && git rebase origin/main
   git fetch origin
   git rev-list --count HEAD..origin/main
   ```
-  Over 25? Rebase first.
+  More than 25? Rebase first.
 - **If CI is slow**, check your base commit age before debugging other causes.
 - **Stacked PRs** are exempt. If a PR targets another branch in a stack,
   distance from `main` is expected and not a problem until the stack lands.

--- a/.ai/pytest-guidelines.md
+++ b/.ai/pytest-guidelines.md
@@ -8,6 +8,27 @@ Rules and conventions for Python tests in this repository.
 wastes shared GPU minutes and blocks other PRs. A local run catches most
 failures in seconds.
 
+### Reproducing CI failures locally
+
+Don't guess from log snippets. Pull the same container image CI built and
+reproduce the failure locally:
+
+```bash
+# 1. Find the image:tag in the CI job's "docker build" or "docker push" step.
+
+# 2. Run it with GPU access:
+docker run --rm -it --gpus all <ci-image>:<tag> bash
+
+# 3. Run the failing test:
+python3 -m pytest -xvv tests/path/to/test_that_failed.py::test_name
+```
+
+If the test passes locally in the CI container, the failure is likely a
+resource or timing issue in CI. If it fails, you have an exact reproduction.
+
+Pull the container, reproduce, fix, verify -- in that order. Don't make
+speculative fixes from logs.
+
 Always use the venv-aware invocation -- never bare `pytest`:
 
 ```bash

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -31,6 +31,7 @@ reviews:
     - path: "**"
       instructions: |
         Flag PRs more than ~25 commits behind main. Recommend rebasing.
+        Exception: stacked PRs targeting another branch are exempt.
         See .ai/pr-workflow-guidelines.md.
     - path: "**/*.py"
       instructions: "Review against .ai/python-guidelines.md"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -28,6 +28,10 @@ reviews:
     unit_tests:
       enabled: false
   path_instructions:
+    - path: "**"
+      instructions: |
+        Flag PRs more than ~25 commits behind main. Recommend rebasing.
+        See .ai/pr-workflow-guidelines.md.
     - path: "**/*.py"
       instructions: "Review against .ai/python-guidelines.md"
     - path: "**/tests/**/*.py"


### PR DESCRIPTION
#### Overview:

Add guidance for keeping PR branches close to main and reproducing CI failures locally.

#### Details:

- New `.ai/pr-workflow-guidelines.md`: why branches >~25 commits behind main slow CI (BuildKit cache misses, Rust cache misses, dependency drift) and why rebase beats merge
- New section in `.ai/pytest-guidelines.md`: pull the CI container, reproduce locally, then fix
- New `path: "**"` in `.coderabbit.yaml` so CodeRabbit flags stale PRs

#### Where should the reviewer start?

`.ai/pr-workflow-guidelines.md`

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added PR workflow guidelines covering branch alignment, CI impacts, rebasing best practices, and step-by-step commands.
  * Added instructions to reproduce CI failures locally using the project’s containerized test environment.

* **Chores**
  * Updated review/config rules to flag PRs that are excessively behind main and recommend rebasing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->