### PR TITLE
ci: disable Docker layer cache for nightly builds

### DIFF
--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -307,9 +307,15 @@ jobs:
             PUSH_ARGS="--load"
           fi
 
+          NO_CACHE_ARG=""
+          if [ "${{ inputs.no_cache }}" == "true" ]; then
+            NO_CACHE_ARG="--no-cache"
+          fi
+
           docker buildx build \
             --progress=plain \
             ${PUSH_ARGS} \
+            ${NO_CACHE_ARG} \
             --platform linux/${{ inputs.platform }} \
             -f container/Dockerfile.test \
             --build-arg BASE_IMAGE=${{ steps.calculate-target-tag.outputs.default_target_image_uri }} \

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -23,6 +23,7 @@ jobs:
     with:
       framework: vllm
       target: runtime
+      no_cache: true
       platforms: '["amd64", "arm64"]'
       cuda_versions: '["12.9", "13.0"]'
       extra_tags: |
@@ -45,6 +46,7 @@ jobs:
     with:
       framework: sglang
       target: runtime
+      no_cache: true
       platforms: '["amd64", "arm64"]'
       cuda_versions: '["12.9", "13.0"]'
       extra_tags: |
@@ -66,6 +68,7 @@ jobs:
     with:
       framework: trtllm
       target: runtime
+      no_cache: true
       platforms: '["amd64", "arm64"]'
       cuda_versions: '["13.1"]'
       extra_tags: |

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -30,7 +30,7 @@ jobs:
         ${{ github.ref_name == 'main' && 'main-vllm' || '' }}
         ${{ github.ref_name == 'main' && format('main-vllm-{0}', github.sha) || '' }}
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
-      build_timeout_minutes: ${{ github.ref_name == 'main' && 120 || 60 }}
+      build_timeout_minutes: 180
       cpu_only_test_markers: 'nightly and vllm and gpu_0'
       single_gpu_test_markers: 'nightly and vllm and gpu_1'
       single_gpu_test_timeout_minutes: 35
@@ -53,7 +53,7 @@ jobs:
         ${{ github.ref_name == 'main' && 'main-sglang' || '' }}
         ${{ github.ref_name == 'main' && format('main-sglang-{0}', github.sha) || '' }}
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
-      build_timeout_minutes: ${{ github.ref_name == 'main' && 120 || 60 }}
+      build_timeout_minutes: 180
       cpu_only_test_markers: 'nightly and sglang and gpu_0'
       single_gpu_test_markers: 'nightly and sglang and gpu_1'
       multi_gpu_test_markers: 'nightly and sglang and (gpu_2 or gpu_4)'
@@ -75,7 +75,7 @@ jobs:
         ${{ github.ref_name == 'main' && 'main-trtllm' || '' }}
         ${{ github.ref_name == 'main' && format('main-trtllm-{0}', github.sha) || '' }}
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
-      build_timeout_minutes: ${{ github.ref_name == 'main' && 120 || 60 }}
+      build_timeout_minutes: 180
       cpu_only_test_markers: 'nightly and trtllm and gpu_0'
       single_gpu_test_markers: 'nightly and trtllm and gpu_1'
       multi_gpu_test_markers: 'nightly and trtllm and (gpu_2 or gpu_4)'


### PR DESCRIPTION
Enable no_cache for all nightly CI pipelines so every build step runs from scratch, producing full logs and catching failures that cached layers might hide. Increase nightly build timeout to 180 minutes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflows with configurable Docker build caching options
  * Enabled no-cache mode for nightly builds to ensure fresh dependencies
  * Standardized build timeout settings across pipeline stages for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->