### PR TITLE
fix: auto-inject tolerations into DGDR profiling jobs

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -929,10 +929,30 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 		}
 	}
 
-	// Enrich hardware from GPU discovery before marshalling the spec.
-	// This fills in gpuSku, vramMb, numGpusPerNode if the user didn't set them.
-	if err := r.enrichHardwareFromDiscovery(ctx, dgdr); err != nil {
+	// Enrich hardware from GPU discovery and collect node taints for toleration injection.
+	// enrichHardwareFromDiscovery may short-circuit when all hardware fields are set,
+	// so we fall back to DiscoverNodeTaints for taint-only discovery.
+	var discoveredTolerations []corev1.Toleration
+	gpuInfo, err := r.enrichHardwareFromDiscovery(ctx, dgdr)
+	if err != nil {
 		logger.Info("GPU discovery not available, proceeding without enrichment", "reason", err.Error())
+	}
+	if r.Config.Namespace.Restricted == "" {
+		if gpuInfo != nil && len(gpuInfo.NodeTaints) > 0 {
+			// Reuse taints already collected by DiscoverGPUs
+			discoveredTolerations = gpu.TaintsToTolerations(gpuInfo.NodeTaints)
+		} else {
+			// GPU discovery was skipped or failed; discover taints separately
+			taints, taintErr := gpu.DiscoverNodeTaints(ctx, r.APIReader)
+			if taintErr != nil {
+				logger.Info("Node taint discovery not available", "reason", taintErr.Error())
+			} else if len(taints) > 0 {
+				discoveredTolerations = gpu.TaintsToTolerations(taints)
+			}
+		}
+		if len(discoveredTolerations) > 0 {
+			logger.Info("Discovered node taints for profiling job tolerations", "count", len(discoveredTolerations))
+		}
 	}
 
 	// Use SyncResource to create/update the job
@@ -1140,6 +1160,14 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 			},
 		}
 
+		// Auto-inject tolerations from cluster node taints so the profiling
+		// pod can schedule on tainted nodes (e.g. DGXC clusters).
+		// Applied before user overrides so that spec.overrides.profilingJob
+		// tolerations take precedence.
+		if len(discoveredTolerations) > 0 {
+			podSpec.Tolerations = discoveredTolerations
+		}
+
 		job := &batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      jobName,
@@ -1193,19 +1221,20 @@ func marshalDGDRSpec(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (strin
 
 // enrichHardwareFromDiscovery fills in hardware fields that the user didn't set.
 // Called before marshalDGDRSpec(). Mutates dgdr.Spec.Hardware in-place (memory only, not persisted).
-func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
+// Returns the GPUInfo from discovery (nil when all hardware fields were already set).
+func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (*gpu.GPUInfo, error) {
 	if dgdr.Spec.Hardware == nil {
 		dgdr.Spec.Hardware = &nvidiacomv1beta1.HardwareSpec{}
 	}
 	hw := dgdr.Spec.Hardware
 
 	if hw.GPUSKU != "" && hw.VRAMMB != nil && hw.NumGPUsPerNode != nil {
-		return nil // all fields already set by user; TotalGPUs is filled below when discovery runs
+		return nil, nil // all fields already set by user; TotalGPUs is filled below when discovery runs
 	}
 
 	gpuInfo, err := gpu.DiscoverGPUs(ctx, r.APIReader)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	logger := log.FromContext(ctx)
@@ -1245,7 +1274,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 		}
 		hw.TotalGPUs = &total
 	}
-	return nil
+	return gpuInfo, nil
 }
 
 // extractModelCachePVCConfig reads model cache PVC settings from the typed v1beta1 spec.

--- a/deploy/operator/internal/controller/enrich_hardware_test.go
+++ b/deploy/operator/internal/controller/enrich_hardware_test.go
@@ -94,7 +94,7 @@ func TestEnrichHardwareFromDiscovery_UsesAICSystemIdentifier(t *testing.T) {
 			r := newFakeReconciler(gpuNode("gpu-node-1", tt.gfdProduct, 8, 141312))
 			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}
 
-			err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+			_, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
 			require.NoError(t, err)
 			require.NotNil(t, dgdr.Spec.Hardware)
 			assert.Equal(t, tt.expectedGPUSKU, string(dgdr.Spec.Hardware.GPUSKU),
@@ -109,7 +109,7 @@ func TestEnrichHardwareFromDiscovery_FallsBackToModelForUnknownGPU(t *testing.T)
 	r := newFakeReconciler(gpuNode("gpu-node-1", "Tesla-V100-SXM2-16GB", 8, 16384))
 	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}
 
-	err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+	_, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
 	require.NoError(t, err)
 	require.NotNil(t, dgdr.Spec.Hardware)
 	assert.Equal(t, "Tesla-V100-SXM2-16GB", string(dgdr.Spec.Hardware.GPUSKU),

--- a/deploy/operator/internal/gpu/discovery.go
+++ b/deploy/operator/internal/gpu/discovery.go
@@ -43,6 +43,7 @@ type GPUInfo struct {
 	Model         string                      // GPU product name (e.g., "H100-SXM5-80GB")
 	VRAMPerGPU    int                         // VRAM in MiB per GPU
 	System        nvidiacomv1beta1.GPUSKUType // AIC hardware system identifier (e.g., "h100_sxm", "h200_sxm"), empty if unknown
+	NodeTaints    []corev1.Taint              // Union of all taints found on cluster nodes
 }
 
 // DiscoverGPUs queries Kubernetes nodes to determine GPU configuration.
@@ -67,6 +68,9 @@ func DiscoverGPUs(ctx context.Context, k8sClient client.Reader) (*GPUInfo, error
 	}
 
 	logger.Info("Found cluster nodes", "count", len(nodeList.Items))
+
+	// Collect union of all node taints for toleration injection
+	allTaints := collectNodeTaints(nodeList)
 
 	// Track the best GPU configuration found
 	var bestGPUInfo *GPUInfo
@@ -107,6 +111,7 @@ func DiscoverGPUs(ctx context.Context, k8sClient client.Reader) (*GPUInfo, error
 	// Infer hardware system from GPU model
 	bestGPUInfo.System = InferHardwareSystem(bestGPUInfo.Model)
 	bestGPUInfo.NodesWithGPUs = nodesWithGPUs
+	bestGPUInfo.NodeTaints = allTaints
 
 	logger.Info("GPU discovery completed",
 		"gpusPerNode", bestGPUInfo.GPUsPerNode,
@@ -202,4 +207,59 @@ func InferHardwareSystem(gpuProduct string) nvidiacomv1beta1.GPUSKUType {
 	// Unknown GPU type, return empty value.
 	// User must specify gpuSku explicitly in spec.hardware.
 	return ""
+}
+
+// DiscoverNodeTaints lists all cluster nodes and returns the deduplicated union
+// of their taints. This is useful when GPU discovery is skipped (e.g. hardware
+// fields are already set) but toleration injection is still needed.
+func DiscoverNodeTaints(ctx context.Context, k8sClient client.Reader) ([]corev1.Taint, error) {
+	nodeList := &corev1.NodeList{}
+	if err := k8sClient.List(ctx, nodeList); err != nil {
+		return nil, fmt.Errorf("failed to list cluster nodes: %w", err)
+	}
+	return collectNodeTaints(nodeList), nil
+}
+
+// collectNodeTaints returns the deduplicated union of all taints across nodes.
+func collectNodeTaints(nodeList *corev1.NodeList) []corev1.Taint {
+	type taintKey struct {
+		Key    string
+		Value  string
+		Effect corev1.TaintEffect
+	}
+	seen := make(map[taintKey]struct{})
+	var result []corev1.Taint
+	for i := range nodeList.Items {
+		for _, t := range nodeList.Items[i].Spec.Taints {
+			k := taintKey{Key: t.Key, Value: t.Value, Effect: t.Effect}
+			if _, exists := seen[k]; !exists {
+				seen[k] = struct{}{}
+				result = append(result, corev1.Taint{
+					Key:    t.Key,
+					Value:  t.Value,
+					Effect: t.Effect,
+				})
+			}
+		}
+	}
+	return result
+}
+
+// TaintsToTolerations converts a slice of taints to matching tolerations.
+func TaintsToTolerations(taints []corev1.Taint) []corev1.Toleration {
+	tolerations := make([]corev1.Toleration, 0, len(taints))
+	for _, t := range taints {
+		tol := corev1.Toleration{
+			Key:    t.Key,
+			Effect: t.Effect,
+		}
+		if t.Value == "" {
+			tol.Operator = corev1.TolerationOpExists
+		} else {
+			tol.Operator = corev1.TolerationOpEqual
+			tol.Value = t.Value
+		}
+		tolerations = append(tolerations, tol)
+	}
+	return tolerations
 }

--- a/deploy/operator/internal/gpu/discovery_test.go
+++ b/deploy/operator/internal/gpu/discovery_test.go
@@ -375,3 +375,101 @@ func TestInferHardwareSystem_SpacesAndDashes(t *testing.T) {
 		assert.Equal(t, "h100_sxm", string(result), "Should normalize spaces/dashes: %s", variant)
 	}
 }
+
+func TestDiscoverGPUs_CollectsNodeTaints(t *testing.T) {
+	ctx := context.Background()
+
+	gpuNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-node-1",
+			Labels: map[string]string{
+				LabelGPUCount:   "8",
+				LabelGPUProduct: "H100-SXM5-80GB",
+				LabelGPUMemory:  "81920",
+			},
+		},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{
+				{Key: "nvidia.com/gpu", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "dedicated", Value: "user-workload", Effect: corev1.TaintEffectNoExecute},
+			},
+		},
+	}
+	cpuNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "cpu-node-1",
+			Labels: map[string]string{},
+		},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{
+				{Key: "team", Effect: corev1.TaintEffectNoSchedule},
+			},
+		},
+	}
+
+	k8sClient := newFakeClient(gpuNode, cpuNode)
+	gpuInfo, err := DiscoverGPUs(ctx, k8sClient)
+	require.NoError(t, err)
+	require.NotNil(t, gpuInfo)
+
+	// Should collect taints from both GPU and CPU nodes
+	assert.Len(t, gpuInfo.NodeTaints, 3)
+}
+
+func TestDiscoverNodeTaints(t *testing.T) {
+	ctx := context.Background()
+
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{
+				{Key: "nvidia.com/gpu", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "dedicated", Value: "user-workload", Effect: corev1.TaintEffectNoExecute},
+			},
+		},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-2"},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{
+				// Duplicate of node1's first taint
+				{Key: "nvidia.com/gpu", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "kubernetes.io/arch", Effect: corev1.TaintEffectNoSchedule},
+			},
+		},
+	}
+
+	k8sClient := newFakeClient(node1, node2)
+	taints, err := DiscoverNodeTaints(ctx, k8sClient)
+	require.NoError(t, err)
+
+	// Should deduplicate: nvidia.com/gpu appears once, not twice
+	assert.Len(t, taints, 3)
+}
+
+func TestTaintsToTolerations(t *testing.T) {
+	taints := []corev1.Taint{
+		{Key: "nvidia.com/gpu", Effect: corev1.TaintEffectNoSchedule},
+		{Key: "dedicated", Value: "user-workload", Effect: corev1.TaintEffectNoExecute},
+	}
+
+	tolerations := TaintsToTolerations(taints)
+	require.Len(t, tolerations, 2)
+
+	// Empty-value taint → Exists operator
+	assert.Equal(t, "nvidia.com/gpu", tolerations[0].Key)
+	assert.Equal(t, corev1.TolerationOpExists, tolerations[0].Operator)
+	assert.Equal(t, corev1.TaintEffectNoSchedule, tolerations[0].Effect)
+	assert.Empty(t, tolerations[0].Value)
+
+	// Valued taint → Equal operator
+	assert.Equal(t, "dedicated", tolerations[1].Key)
+	assert.Equal(t, corev1.TolerationOpEqual, tolerations[1].Operator)
+	assert.Equal(t, "user-workload", tolerations[1].Value)
+	assert.Equal(t, corev1.TaintEffectNoExecute, tolerations[1].Effect)
+}
+
+func TestTaintsToTolerations_Empty(t *testing.T) {
+	tolerations := TaintsToTolerations(nil)
+	assert.Empty(t, tolerations)
+}


### PR DESCRIPTION
## Summary
- DGDR profiling jobs on DGXC and other tainted clusters get stuck in `Pending` because the operator doesn't add tolerations to the profiling pod spec
- This fix discovers all node taints in the cluster and auto-injects matching tolerations into the profiling Job pod
- User-provided tolerations via `spec.overrides.profilingJob` still take precedence (applied after auto-discovered ones)

## Changes
- **`deploy/operator/internal/gpu/discovery.go`**: Added `NodeTaints` field to `GPUInfo`, `DiscoverNodeTaints()`, `collectNodeTaints()`, and `TaintsToTolerations()` helpers
- **`deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go`**: Call `DiscoverNodeTaints()` in `createProfilingJob()` and inject tolerations into the pod spec before user overrides
- **`deploy/operator/internal/gpu/discovery_test.go`**: Tests for taint collection, deduplication, and conversion

## Test plan
- [ ] Unit tests for `collectNodeTaints` deduplication
- [ ] Unit tests for `TaintsToTolerations` (empty-value → Exists, valued → Equal)
- [ ] Unit test for `DiscoverNodeTaints` end-to-end with fake client
- [ ] Verify profiling job gets tolerations on a DGXC cluster
- [ ] Verify user overrides via `spec.overrides.profilingJob.template.spec.tolerations` still replace auto-discovered tolerations



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profiling jobs now automatically include tolerations for cluster node taints, enabling proper pod scheduling on nodes with specific taint constraints.
  * GPU discovery now collects cluster node taint information for improved resource compatibility.

* **Tests**
  * Added test coverage for node taint discovery, deduplication, and taint-to-toleration conversion logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->