### PR TITLE
fix: unique compliance artifact names for build variants

### DIFF
--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -510,7 +510,7 @@ jobs:
   compliance:
     if: inputs.build_image && inputs.push_image
     needs: [build]
-    name: Compliance ${{ inputs.framework }}-cuda${{ inputs.cuda_version }}-${{ inputs.platform }}
+    name: Compliance cuda${{ inputs.cuda_version }}-${{ inputs.platform }}
     runs-on: ${{ inputs.platform == 'amd64' && 'prod-builder-amd-v1' || 'prod-tester-arm-v1' }}
     steps:
       - name: Checkout repository
@@ -536,7 +536,7 @@ jobs:
         uses: ./.github/actions/compliance-scan
         with:
           image: ${{ steps.images.outputs.runtime_image }}
-          artifact_name: compliance-${{ inputs.framework }}-cuda${{ steps.images.outputs.cuda_major }}-${{ inputs.platform }}
+          artifact_name: compliance-${{ inputs.framework }}-${{ inputs.target }}${{ inputs.make_efa && '-efa' || '' }}-cuda${{ steps.images.outputs.cuda_major }}-${{ inputs.platform }}
           framework: ${{ inputs.framework }}
           cuda_version: ${{ inputs.cuda_version }}
 


### PR DESCRIPTION
Include target and EFA suffix in compliance artifact names to avoid 409 Conflict errors when multiple build variants (runtime/dev/EFA) run in the same workflow. Also align compliance job name pattern with other jobs in the workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and distribution workflow configurations to improve artifact naming conventions and streamline job naming for better clarity in CI/CD processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->