### PR TITLE
bug: reproduce error in aws

### DIFF
--- a/recipes/qwen3-vl-30b-fp8/embedding_cache/agg-vllm-serve/results/fetch-results.sh
+++ b/recipes/qwen3-vl-30b-fp8/embedding_cache/agg-vllm-serve/results/fetch-results.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Fetch aiperf results from the benchmark pod to local results directory.
+# Usage: bash fetch-results.sh
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-qiwa}"
+POD="agg-vllm-serve-1gpu-benchmark"
+REMOTE_BASE="/perf-cache-tmp/artifacts/fp8/gb200-1gpu/agg-vllm-serve"
+LOCAL_BASE="$(cd "$(dirname "$0")" && pwd)/gb200-1gpu"
+DATASETS=(
+  "1000req_1img_800pool_400word_base64"
+  "1000req_1img_800pool_400word_http"
+  "1000req_2img_1600pool_400word_base64"
+  "1000req_2img_1600pool_400word_http"
+  "1000req_4img_3200pool_400word_base64"
+  "1000req_4img_3200pool_400word_http"
+)
+CONCURRENCIES=(c4 c8 c16 c32 c64 c128)
+
+for mode in cache_on cache_off; do
+  for ds in "${DATASETS[@]}"; do
+    for conc in "${CONCURRENCIES[@]}"; do
+      local_dir="${LOCAL_BASE}/${ds}/${mode}/${conc}"
+      remote_dir="${REMOTE_BASE}/${mode}/${ds}/${conc}"
+      mkdir -p "${local_dir}"
+      echo "Fetching ${mode}/${ds}/${conc}..."
+      for ext in json csv; do
+        kubectl -n "${NAMESPACE}" cp \
+          "${POD}:${remote_dir}/profile_export_aiperf.${ext}" \
+          "${local_dir}/profile_export_aiperf.${ext}" 2>/dev/null || true
+      done
+      if [ ! -f "${local_dir}/profile_export_aiperf.json" ]; then
+        echo "  Not ready yet: ${mode}/${ds}/${conc}"
+      fi
+    done
+  done
+done
+
+echo "Done. Results in ${LOCAL_BASE}"

--- a/recipes/qwen3-vl-30b-fp8/embedding_cache/agg/deploy.yaml
+++ b/recipes/qwen3-vl-30b-fp8/embedding_cache/agg/deploy.yaml
@@ -12,6 +12,8 @@ apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: qwen3-vl-agg-gb200-v2
+  annotations:
+    grove.io/auto-mnnvl: "disabled"
 spec:
   pvcs:
     - create: false

--- a/recipes/qwen3-vl-30b-fp8/embedding_cache/agg/deploy.yaml
+++ b/recipes/qwen3-vl-30b-fp8/embedding_cache/agg/deploy.yaml
@@ -11,13 +11,11 @@
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
-  name: qwen3-vl-agg-gb200
+  name: qwen3-vl-agg-gb200-v2
 spec:
   pvcs:
     - create: false
-      name: model-cache
-    - create: false
-      name: compilation-cache
+      name: model-cache-tmp
   services:
     Frontend:
       componentType: frontend

--- a/recipes/qwen3-vl-30b-fp8/embedding_cache/agg/deploy.yaml
+++ b/recipes/qwen3-vl-30b-fp8/embedding_cache/agg/deploy.yaml
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated deployment using DynamoGraphDeployment CRD.
+# Single worker type (no separate encode worker) with embedding cache.
+#
+# Toggle embedding cache:
+#   cache ON:  DYN_MULTIMODAL_EMBEDDING_CACHE_GB = "10" (or any non-zero value)
+#   cache OFF: DYN_MULTIMODAL_EMBEDDING_CACHE_GB = "0"
+#
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: qwen3-vl-agg-gb200
+spec:
+  pvcs:
+    - create: false
+      name: model-cache
+    - create: false
+      name: compilation-cache
+  services:
+    Frontend:
+      componentType: frontend
+      envs:
+        - name: HF_HOME
+          value: /home/dynamo/.cache/huggingface
+        - name: DYN_REQUEST_PLANE
+          value: tcp
+      extraPodSpec:
+        tolerations:
+          - key: "dedicated"
+            value: "user-workload"
+            effect: "NoSchedule"
+            operator: "Equal"
+          - key: "dedicated"
+            value: "user-workload"
+            effect: "NoExecute"
+            operator: "Equal"
+        nodeSelector:
+          workload: qiwa-agg-benchmark
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          fsGroup: 0
+        imagePullSecrets:
+          - name: nvcrimagepullsecret
+        mainContainer:
+          image: nvcr.io/nvstaging/ai-dynamo/vllm-runtime:1.0.0rc8-arm64
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace
+      replicas: 1
+      resources:
+        requests:
+          cpu: "1"
+        limits:
+          cpu: "1"
+      subComponentType: null
+
+    VllmWorker:
+      componentType: worker
+      extraPodSpec:
+        tolerations:
+          - key: "dedicated"
+            value: "user-workload"
+            effect: "NoSchedule"
+            operator: "Equal"
+          - key: "dedicated"
+            value: "user-workload"
+            effect: "NoExecute"
+            operator: "Equal"
+          - key: "nvidia.com/gpu"
+            operator: "Exists"
+            effect: "NoSchedule"
+        nodeSelector:
+          workload: qiwa-agg-benchmark
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          fsGroup: 0
+        imagePullSecrets:
+          - name: nvcrimagepullsecret
+        mainContainer:
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - |
+              set -euo pipefail
+
+              SITE_PACKAGES="$(python3 -c 'import pathlib, vllm; print(pathlib.Path(vllm.__file__).resolve().parent.parent)')"
+              cd "${SITE_PACKAGES}"
+              curl -sL https://github.com/vllm-project/vllm/pull/34182.diff | patch -p1
+              curl -sL https://github.com/vllm-project/vllm/pull/34783.diff | python3 -c "
+              import sys
+              chunks = sys.stdin.read().split('diff --git ')
+              filtered = [c for c in chunks if c.startswith('a/vllm/')]
+              print(''.join('diff --git ' + c for c in filtered))
+              " | patch -p1
+              cd /workspace
+
+              python3 -m dynamo.vllm \
+                --model Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 \
+                --enable-multimodal \
+                --tensor-parallel-size 1 \
+                --gpu-memory-utilization 0.85 \
+                --max-model-len 16384 \
+                --disable-log-requests \
+                --enable-prefix-caching \
+                --multimodal-embedding-cache-capacity-gb "${DYN_MULTIMODAL_EMBEDDING_CACHE_GB}"
+          image: nvcr.io/nvstaging/ai-dynamo/vllm-runtime:1.0.0rc8-arm64
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+            - name: DYN_REQUEST_PLANE
+              value: tcp
+            - name: DYN_VLLM_EMBEDDING_TRANSFER_MODE
+              value: nixl-write
+            - name: DYN_MULTIMODAL_EMBEDDING_CACHE_GB
+              value: "10"
+          workingDir: /workspace
+      replicas: 4
+      resources:
+        limits:
+          gpu: "1"
+        requests:
+          gpu: "1"
+      subComponentType: null
+      volumeMounts:
+        - name: model-cache-tmp
+          mountPoint: /home/dynamo/.cache/huggingface
+

--- a/recipes/qwen3-vl-30b-fp8/embedding_cache/agg/generate-datasets-job.yaml
+++ b/recipes/qwen3-vl-30b-fp8/embedding_cache/agg/generate-datasets-job.yaml
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: qwen3-vl-30b-fp8-generate-datasets
+spec:
+  backoffLimit: 1
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: generate-datasets
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        workload: qiwa-agg-benchmark
+      tolerations:
+        - key: "dedicated"
+          value: "user-workload"
+          effect: "NoSchedule"
+        - key: "dedicated"
+          value: "user-workload"
+          effect: "NoExecute"
+      imagePullSecrets:
+        - name: nvcrimagepullsecret
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+      containers:
+        - name: generate-datasets
+          image: nvcr.io/nvstaging/ai-dynamo/vllm-runtime:1.0.0rc8-arm64
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -lc
+            - |
+              set -euo pipefail
+
+              GENERATOR_MAIN="/workspace/benchmarks/multimodal/jsonl/main.py"
+              OUTPUT_DIR="/perf-cache/datasets"
+
+              if [[ ! -f "${GENERATOR_MAIN}" ]]; then
+                echo "Generator not found at ${GENERATOR_MAIN}"
+                exit 1
+              fi
+
+              mkdir -p "${OUTPUT_DIR}"
+
+              for POOL_SIZE in 200; do  # 500 800
+                for IMAGE_MODE in base64 http; do
+                  OUTPUT_FILE="${OUTPUT_DIR}/1000req_3img_${POOL_SIZE}pool_400word_${IMAGE_MODE}.jsonl"
+                  echo "Generating ${OUTPUT_FILE} (images-pool=${POOL_SIZE}, image-mode=${IMAGE_MODE})"
+                  python3 "${GENERATOR_MAIN}" \
+                    -n 1000 \
+                    --images-per-request 3 \
+                    --images-pool "${POOL_SIZE}" \
+                    --user-text-tokens 400 \
+                    --image-mode "${IMAGE_MODE}" \
+                    --image-dir /perf-cache/images \
+                    -o "${OUTPUT_FILE}"
+                done
+              done
+
+              echo "Dataset generation complete in ${OUTPUT_DIR}"
+          volumeMounts:
+            - name: perf-cache
+              mountPath: /perf-cache
+      volumes:
+        - name: perf-cache
+          persistentVolumeClaim:
+            claimName: perf-cache

--- a/recipes/qwen3-vl-30b-fp8/embedding_cache/agg/perf.yaml
+++ b/recipes/qwen3-vl-30b-fp8/embedding_cache/agg/perf.yaml
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Runs cache_on vs cache_off interleaved per dataset/concurrency for realtime comparison.
+# For each (dataset, concurrency): run cache_on, then cache_off, back-to-back.
+#
+# Uses DynamoGraphDeployment CRD patching for cache toggling.
+# Requires: ServiceAccount with permissions to patch the CRD and delete worker pods.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: benchmark-agg-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: benchmark-agg-role
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["nvidia.com"]
+    resources: ["dynamographdeployments"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: benchmark-agg-binding
+subjects:
+  - kind: ServiceAccount
+    name: benchmark-agg-sa
+roleRef:
+  kind: Role
+  name: benchmark-agg-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: qwen3-vl-agg-benchmark
+  labels:
+    app: benchmark
+spec:
+  serviceAccountName: benchmark-agg-sa
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0
+  nodeSelector:
+    workload: qiwa-agg-benchmark
+  tolerations:
+    - key: "dedicated"
+      value: "user-workload"
+      effect: "NoSchedule"
+    - key: "dedicated"
+      value: "user-workload"
+      effect: "NoExecute"
+  containers:
+    - name: benchmark
+      image: nvcr.io/nvstaging/ai-dynamo/vllm-runtime:1.0.0rc8-arm64
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/bash
+        - -lc
+        - |
+          set -euo pipefail
+
+          apt update && apt install -y curl jq
+          pip install aiperf
+          curl -LO "https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubectl" \
+            && chmod +x kubectl && mv kubectl /opt/dynamo/venv/bin/
+
+          wait_for_model() {
+            echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models..."
+            until curl -s "http://${FRONTEND}:8000/v1/models" \
+              | jq -e --arg model "${MODEL_NAME}" '.data[]? | select(.id == $model)' >/dev/null 2>&1; do
+              echo "[$(date '+%H:%M:%S')] Model not ready, retrying in 5s..."
+              sleep 5
+            done
+            echo "Model '${MODEL_NAME}' is ready."
+          }
+
+          wait_for_pod_ready() {
+            local label=$1
+            echo "Waiting for pod with label ${label} to be ready..."
+            until kubectl get pod -l "${label}" -o jsonpath='{.items[0].status.containerStatuses[0].ready}' 2>/dev/null | grep -q true; do
+              sleep 5
+            done
+            echo "Pod ${label} is ready."
+          }
+
+          restart_workers() {
+            echo "Restarting worker pods..."
+            kubectl delete pod \
+              -l nvidia.com/dynamo-component=${WORKER_COMPONENT} \
+              -l nvidia.com/dynamo-graph-deployment-name=${GRAPH_DEPLOYMENT} \
+              --wait=true
+            wait_for_pod_ready "nvidia.com/dynamo-component=${WORKER_COMPONENT}"
+            wait_for_model
+          }
+
+          set_cache_gb() {
+            local gb=$1
+            echo "Patching DynamoGraphDeployment: DYN_MULTIMODAL_EMBEDDING_CACHE_GB=${gb}"
+            kubectl patch dynamographdeployment/${GRAPH_DEPLOYMENT} --type=json \
+              -p "[{\"op\":\"replace\",\"path\":\"/spec/services/VllmWorker/extraPodSpec/mainContainer/env/${CACHE_ENV_INDEX}/value\",\"value\":\"${gb}\"}]"
+            sleep 10
+            wait_for_pod_ready "nvidia.com/dynamo-component=${WORKER_COMPONENT}"
+            wait_for_model
+          }
+
+          run_one() {
+            local mode=$1 ds=$2 conc=$3
+            RUN_DIR="${ARTIFACT_BASE_DIR}/${mode}/${ds}/c${conc}"
+            mkdir -p "${RUN_DIR}"
+
+            echo "=== Running: ${mode} ${ds} concurrency=${conc} ==="
+            aiperf profile \
+              --model "${MODEL_NAME}" \
+              --input-file "${DATASET_DIR}/${ds}.jsonl" \
+              --custom-dataset-type single_turn \
+              --url "http://${FRONTEND}:8000" \
+              --streaming \
+              --ui-type none \
+              --request-count "${REQUEST_COUNT}" \
+              --concurrency "${conc}" \
+              --warmup-request-count "${WARMUP_REQUEST_COUNT}" \
+              --artifact-dir "${RUN_DIR}" \
+              --extra-inputs "max_tokens:${MAX_TOKENS}" \
+              --extra-inputs "min_tokens:${MAX_TOKENS}" \
+              --extra-inputs "ignore_eos:true"
+
+            echo "Done: ${RUN_DIR}"
+          }
+
+          DATASETS=(
+            "1000req_3img_200pool_400word_base64"
+            "1000req_3img_200pool_400word_http"
+            # "1000req_1img_500pool_400word_base64"
+            # "1000req_1img_800pool_400word_base64"
+          )
+          CONCURRENCIES=(4 8 16 32 64 128)
+
+          # Wait for datasets
+          for ds in "${DATASETS[@]}"; do
+            until [ -f "${DATASET_DIR}/${ds}.jsonl" ]; do
+              echo "Waiting for ${ds}.jsonl ..."
+              sleep 15
+            done
+          done
+
+          wait_for_model
+
+          for ds in "${DATASETS[@]}"; do
+            for conc in "${CONCURRENCIES[@]}"; do
+              # cache_on: set cache, restart, run
+              set_cache_gb "${CACHE_GB}"
+              restart_workers
+              run_one cache_on "${ds}" "${conc}"
+
+              # cache_off: set cache=0, restart, run
+              set_cache_gb 0
+              restart_workers
+              run_one cache_off "${ds}" "${conc}"
+            done
+          done
+
+          # Restore cache setting
+          set_cache_gb "${CACHE_GB}"
+
+          echo "All runs complete. Artifacts in ${ARTIFACT_BASE_DIR}"
+          sleep 3600
+      env:
+        - name: MODEL_NAME
+          value: Qwen/Qwen3-VL-30B-A3B-Instruct-FP8
+        - name: FRONTEND
+          value: qwen3-vl-agg-gb200-frontend
+        - name: GRAPH_DEPLOYMENT
+          value: qwen3-vl-agg-gb200
+        - name: WORKER_COMPONENT
+          value: VllmWorker
+        - name: CACHE_ENV_INDEX
+          value: "3"  # index of DYN_MULTIMODAL_EMBEDDING_CACHE_GB in deploy.yaml worker env array
+        - name: CACHE_GB
+          value: "10"
+        - name: MAX_TOKENS
+          value: "150"
+        - name: REQUEST_COUNT
+          value: "1000"
+        - name: WARMUP_REQUEST_COUNT
+          value: "3"
+        - name: DATASET_DIR
+          value: /perf-cache/datasets
+        - name: ARTIFACT_BASE_DIR
+          value: /perf-cache/artifacts/fp8/gb200-4gpu/agg
+      resources:
+        requests:
+          cpu: "8"
+          memory: 16Gi
+        limits:
+          cpu: "16"
+          memory: 32Gi
+      volumeMounts:
+        - name: perf-cache
+          mountPath: /perf-cache
+  volumes:
+    - name: perf-cache
+      persistentVolumeClaim:
+        claimName: perf-cache
+  restartPolicy: Never


### PR DESCRIPTION
This PR tries to allocate 4 replicas (4GPUs on the same GB200 nvl4 node)

> kubectl -n qiwa apply -f recipes/qwen3-vl-30b-fp8/embedding_cache/agg/deploy.yaml

dynamographdeployment.nvidia.com/qwen3-vl-agg-gb200-v2 created

1 replica running; another 3 pending

<img width="1773" height="188" alt="Screenshot 2026-03-12 at 2 23 44 PM" src="https://github.com/user-attachments/assets/e78cf412-3cc1-4299-afb7-e130960385a2" />


I tried to disable `auto-mnnvl`. Doesn't seem to help 

```
metadata:
  name: qwen3-vl-agg-gb200-v2
  annotations:
    grove.io/auto-mnnvl: "disabled"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Qwen3-VL-30B-FP8 model deployed with multimodal embedding cache capabilities for improved inference performance.
  * Dynamic embedding cache configuration enables optimized resource utilization.

* **Infrastructure**
  * Added comprehensive performance benchmarking suite to validate model performance across multiple datasets and concurrency levels.
  * Configured automated dataset generation for performance testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->