### PR TITLE
fix: use check_run_id for retry namespace to avoid label overflow

### DIFF
--- a/.github/actions/dynamo-deploy-test/action.yml
+++ b/.github/actions/dynamo-deploy-test/action.yml
@@ -58,6 +58,8 @@ runs:
           echo "exists=false" >> $GITHUB_OUTPUT
           # Use check_run_id (unique per job+retry) to keep namespace under k8s 63-char label limit
           SELF_NS="${NAMESPACE}-${{ job.check_run_id }}"
+          SELF_NS="${SELF_NS:0:36}"
+          SELF_NS="${SELF_NS%-}"
           echo "ns=${SELF_NS}" >> $GITHUB_OUTPUT
           echo "Namespace $NAMESPACE not found, will self-bootstrap as ${SELF_NS}"
         fi

--- a/.github/actions/dynamo-deploy-test/action.yml
+++ b/.github/actions/dynamo-deploy-test/action.yml
@@ -56,15 +56,10 @@ runs:
           echo "Namespace $NAMESPACE exists, will reuse it"
         else
           echo "exists=false" >> $GITHUB_OUTPUT
-          # Generate a unique namespace for this framework+profile to avoid collisions on parallel reruns
-          # Replace underscores with hyphens for k8s naming compliance
-          PROFILE_SANITIZED="${PROFILE//_/-}"
-          SELF_NS="${NAMESPACE}-${FRAMEWORK}-${PROFILE_SANITIZED}"
-          #TODO: Improve this truncation logic. The operator creates k8s labels as "{namespace}-{deployment_name} which restricts max length to 44 chars
-          # (largest deployment name is "vllm-disagg-router" (18 chars)).
-          SELF_NS="${SELF_NS:0:44}"
-          # Remove trailing dash from truncation
-          SELF_NS="${SELF_NS%-}"
+          # Use job check_run_id for per-job uniqueness on retries.
+          # Avoids appending framework+profile which made namespace too long
+          # for operator labels ("{k8s_namespace}-{dgd_name}" max 63 chars).
+          SELF_NS="${NAMESPACE}-${{ job.check_run_id }}"
           echo "ns=${SELF_NS}" >> $GITHUB_OUTPUT
           echo "Namespace $NAMESPACE not found, will self-bootstrap as ${SELF_NS}"
         fi

--- a/.github/actions/dynamo-deploy-test/action.yml
+++ b/.github/actions/dynamo-deploy-test/action.yml
@@ -56,9 +56,7 @@ runs:
           echo "Namespace $NAMESPACE exists, will reuse it"
         else
           echo "exists=false" >> $GITHUB_OUTPUT
-          # Use job check_run_id for per-job uniqueness on retries.
-          # Avoids appending framework+profile which made namespace too long
-          # for operator labels ("{k8s_namespace}-{dgd_name}" max 63 chars).
+          # Use check_run_id (unique per job+retry) to keep namespace under k8s 63-char label limit
           SELF_NS="${NAMESPACE}-${{ job.check_run_id }}"
           echo "ns=${SELF_NS}" >> $GITHUB_OUTPUT
           echo "Namespace $NAMESPACE not found, will self-bootstrap as ${SELF_NS}"


### PR DESCRIPTION
## Summary
- Deploy tests fail on retry because the self-bootstrap namespace (built by appending `framework+profile` and truncating to 44 chars) produces dynamo namespace labels exceeding the 63-char K8s label value limit https://github.com/ai-dynamo/dynamo/actions/runs/22986641389/job/66855752590?pr=7170
- The operator's `ComputeDynamoNamespace()` builds labels as `{k8s_namespace}-{dgd_name}`, and longer DGD names like `vllm-v1-disagg-router` (21 chars) push the total over 63
- Replace the framework+profile suffix with `job.check_run_id` which is already unique per job and retry attempt, keeping the namespace short

## Test plan
- [ ] Retry a deploy test workflow for the `vllm/disagg_router` profile and verify the namespace label no longer exceeds 63 chars
- [ ] Verify parallel retry jobs get distinct namespaces (each has a unique `check_run_id`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated namespace construction logic for GitHub Actions test deployments to use unique job identifiers, removing framework and profile-based namespace parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->