### PR TITLE
feat(gms): add GMS storage client for save/restore of GPU model weights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ package-lock.json
 # macOS
 .DS_Store
 **/.DS_Store
+result

--- a/lib/gpu_memory_service/cli/storage_runner.py
+++ b/lib/gpu_memory_service/cli/storage_runner.py
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GMS Storage Client CLI.
+
+Provides two subcommands for saving and loading GPU Memory Service state:
+
+* ``save`` – connect to a running GMS server in RO mode and write every
+              allocation plus all metadata to a sharded binary directory.
+* ``load`` – connect to a running GMS server in RW mode, read tensor data
+              from a saved directory, and commit the state so readers can
+              acquire the RO lock.
+
+Usage examples::
+
+    # Save GMS state to disk
+    gms-storage-client save --output-dir /mnt/nvme/save --device 0
+
+    # Load a previous save back into a fresh GMS server
+    gms-storage-client load --input-dir /mnt/nvme/save --device 0
+"""
+
+import argparse
+import logging
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _configure_logging(verbose: bool) -> None:
+    if verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+        logging.getLogger("gpu_memory_service").setLevel(logging.DEBUG)
+
+
+def _resolve_socket(device: int, socket_path) -> str:
+    if socket_path is not None:
+        return socket_path
+    from gpu_memory_service.common.utils import get_socket_path
+
+    return get_socket_path(device)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand implementations
+# ---------------------------------------------------------------------------
+
+
+def _run_save(args) -> None:
+    """Execute the save subcommand."""
+    from gpu_memory_service.client.gms_storage_client import GMSStorageClient
+
+    _configure_logging(args.verbose)
+    socket_path = _resolve_socket(args.device, args.socket_path)
+
+    logger.info(
+        "Saving GMS state: device=%s, socket=%s, output_dir=%s, save_workers=%s",
+        args.device,
+        socket_path,
+        args.output_dir,
+        args.save_workers,
+    )
+
+    client = GMSStorageClient(
+        args.output_dir,
+        socket_path=socket_path,
+        device=args.device,
+        timeout_ms=args.timeout_ms,
+        shard_size_bytes=args.shard_size_bytes,
+    )
+
+    manifest = client.save(max_workers=args.save_workers)
+    shard_count = len({a.tensor_file for a in manifest.allocations})
+
+    logger.info(
+        "Save complete: %s allocations written to %s (%s shards)",
+        len(manifest.allocations),
+        args.output_dir,
+        shard_count,
+    )
+    logger.info("Layout hash: %s", manifest.layout_hash)
+
+
+def _run_load(args) -> None:
+    """Execute the load subcommand."""
+    from gpu_memory_service.client.gms_storage_client import GMSStorageClient
+
+    _configure_logging(args.verbose)
+    socket_path = _resolve_socket(args.device, args.socket_path)
+
+    logger.info(
+        "Loading GMS state: device=%s, socket=%s, input_dir=%s, clear_existing=%s",
+        args.device,
+        socket_path,
+        args.input_dir,
+        not args.no_clear,
+    )
+
+    client = GMSStorageClient(
+        socket_path=socket_path,
+        device=args.device,
+        timeout_ms=args.timeout_ms,
+    )
+
+    id_map = client.load_to_gms(
+        args.input_dir,
+        max_workers=args.workers,
+        clear_existing=not args.no_clear,
+    )
+
+    logger.info("Load complete: %s allocations committed to GMS", len(id_map))
+    for old_id, new_id in id_map.items():
+        logger.info("  %s → %s", old_id, new_id)
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+_SHARD_SIZE_DEFAULT = 4 * 1024**3  # 4 GiB
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gms-storage-client",
+        description="Save and load GPU Memory Service state to/from disk.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="subcommand")
+
+    # -- save ---------------------------------------------------------------
+    save_p = subparsers.add_parser(
+        "save",
+        help="Save GMS state to a sharded binary directory.",
+        description=(
+            "Connect to a running GMS server in RO mode and export every "
+            "allocation plus all metadata to a compact sharded binary format."
+        ),
+    )
+    save_p.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory to write into (created if absent).",
+    )
+    save_p.add_argument(
+        "--device",
+        type=int,
+        default=0,
+        help="CUDA device index (default: 0).",
+    )
+    save_p.add_argument(
+        "--socket-path",
+        type=str,
+        default=None,
+        help="GMS Unix socket path. Default uses GPU UUID-based path.",
+    )
+    save_p.add_argument(
+        "--timeout-ms",
+        type=int,
+        default=None,
+        help="Timeout in milliseconds for acquiring the RO lock.",
+    )
+    save_p.add_argument(
+        "--shard-size-bytes",
+        type=int,
+        default=_SHARD_SIZE_DEFAULT,
+        help=(
+            f"Soft upper bound per shard file in bytes "
+            f"(default: {_SHARD_SIZE_DEFAULT // 1024**3} GiB).  "
+            "Decrease to increase parallelism on save/load; increase to "
+            "reduce file count."
+        ),
+    )
+    save_p.add_argument(
+        "--save-workers",
+        type=int,
+        default=4,
+        help="Thread pool size for parallel shard writes (default: 4).",
+    )
+    save_p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging.",
+    )
+
+    # -- load ---------------------------------------------------------------
+    load_p = subparsers.add_parser(
+        "load",
+        help="Load a saved GMS state back into a running GMS server.",
+        description=(
+            "Connect to a running GMS server in RW mode, read tensor data "
+            "from a saved directory (reading each shard file sequentially), "
+            "and commit the state so readers can acquire the RO lock."
+        ),
+    )
+    load_p.add_argument(
+        "--input-dir",
+        required=True,
+        help="Directory previously created by the save subcommand.",
+    )
+    load_p.add_argument(
+        "--device",
+        type=int,
+        default=0,
+        help="CUDA device index (default: 0).",
+    )
+    load_p.add_argument(
+        "--socket-path",
+        type=str,
+        default=None,
+        help="GMS Unix socket path. Default uses GPU UUID-based path.",
+    )
+    load_p.add_argument(
+        "--timeout-ms",
+        type=int,
+        default=None,
+        help="Timeout in milliseconds for acquiring the RW lock.",
+    )
+    load_p.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        help="Thread pool size for parallel shard reads (default: 4).",
+    )
+    load_p.add_argument(
+        "--no-clear",
+        action="store_true",
+        default=False,
+        help=(
+            "Do not clear existing GMS allocations before loading. "
+            "Default behaviour clears the server to produce an exact replica."
+        ),
+    )
+    load_p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging.",
+    )
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Entry point for the GMS Storage Client CLI."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.subcommand is None:
+        parser.print_help()
+        sys.exit(1)
+
+    if args.subcommand == "save":
+        _run_save(args)
+    elif args.subcommand == "load":
+        _run_load(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/gpu_memory_service/client/__init__.py
+++ b/lib/gpu_memory_service/client/__init__.py
@@ -12,6 +12,7 @@ GPU Memory Service:
 For PyTorch integration (MemPool, tensor utilities), see gpu_memory_service.client.torch.
 """
 
+from gpu_memory_service.client.gms_storage_client import GMSStorageClient, SaveManifest
 from gpu_memory_service.client.memory_manager import (
     GMSClientMemoryManager,
     StaleMemoryLayoutError,
@@ -22,4 +23,6 @@ __all__ = [
     "GMSClientMemoryManager",
     "StaleMemoryLayoutError",
     "GMSRPCClient",
+    "GMSStorageClient",
+    "SaveManifest",
 ]

--- a/lib/gpu_memory_service/client/gms_storage_client.py
+++ b/lib/gpu_memory_service/client/gms_storage_client.py
@@ -1,0 +1,1232 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GMS storage client: save GMS state to disk and load it back.
+
+Exports GMS state (all allocations + metadata) to a compact sharded format for
+offline analysis, backup, or migration, then loads it back into a fresh GMS
+server.
+
+File format::
+
+    save_dir/
+    ├── manifest.json        # version, timestamp, layout_hash, device, allocations[]
+    ├── gms_metadata.json    # {key: {allocation_id, offset_bytes, value (base64)}}
+    └── shards/
+        ├── shard_0000.bin   # allocations packed contiguously (raw bytes, no headers)
+        ├── shard_0001.bin   # next batch
+        └── ...
+
+Each allocation's ``AllocationEntry`` records which shard file it lives in
+(``tensor_file``) and its byte offset within that file (``tensor_offset``).
+Shards are written sequentially during save and **read sequentially** during
+load — no ``seek()`` calls are issued within a shard file.  Parallelism
+across shard files is provided via ``ThreadPoolExecutor``.  During restore,
+GMS VAs are pre-allocated serially (Phase A) then filled in parallel using
+per-thread CUDA streams (Phase B).
+
+Sizing: with the default 4 GiB shard limit, a 100 GB model with 100k tensors
+produces roughly 25 shard files rather than 100 000 individual files.
+
+Usage::
+
+    # Save running GMS → disk
+    client = GMSStorageClient("/tmp/save_dir", socket_path="/tmp/gms.sock", device=0)
+    manifest = client.save()
+
+    # Load disk → fresh GMS server (RW → commit)
+    id_map = client.load_to_gms("/tmp/save_dir")
+    # id_map: {old_allocation_id: new_allocation_id, ...}
+
+    # Load tensor data only (no GMS write-back)
+    tensors, metadata = GMSStorageClient.load_tensors("/tmp/save_dir", device=0)
+"""
+
+from __future__ import annotations
+
+import base64
+import errno
+import json
+import logging
+import os
+import queue
+import threading
+import time
+from collections import defaultdict
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# GMS imports (module-level so they are patchable in tests)
+# ---------------------------------------------------------------------------
+
+try:
+    from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
+    from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
+    from gpu_memory_service.common.types import RequestedLockType
+
+    _GMS_IMPORTS_AVAILABLE = True
+except ImportError:
+    _GMS_IMPORTS_AVAILABLE = False
+    GMSClientMemoryManager = None  # type: ignore[assignment,misc]
+    _tensor_from_pointer = None  # type: ignore[assignment]
+    RequestedLockType = None  # type: ignore[assignment]
+
+# ---------------------------------------------------------------------------
+# Lazy PyTorch import (allows unit tests to run without CUDA)
+# ---------------------------------------------------------------------------
+
+try:
+    import torch
+
+    _TORCH_AVAILABLE = True
+except ImportError:
+    _TORCH_AVAILABLE = False
+    torch = None  # type: ignore[assignment]
+
+# ---------------------------------------------------------------------------
+# Lazy GMS imports (allow tests to mock them)
+# ---------------------------------------------------------------------------
+
+_CURRENT_VERSION = "1.0"
+_WORK_QUEUE_DEPTH_MULTIPLIER = 2
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AllocationEntry:
+    """Immutable record of one dumped allocation.
+
+    ``tensor_file`` is a path relative to the dump directory pointing to the
+    shard file that contains this allocation's bytes.  ``tensor_offset`` is
+    the byte offset within that shard file where the data starts.
+
+    Older dumps (version 1.0 before sharding) may not have ``tensor_offset``
+    in their JSON; ``SaveManifest.from_dict`` defaults it to ``0``.
+    """
+
+    allocation_id: str
+    size: int
+    aligned_size: int
+    tag: str
+    tensor_file: str  # relative path inside dump_dir (e.g. "shards/shard_0000.bin")
+    tensor_offset: int = 0  # byte offset within tensor_file
+
+
+@dataclass
+class SaveManifest:
+    """Manifest for a GMS dump directory."""
+
+    version: str
+    timestamp: float
+    layout_hash: str
+    device: int
+    allocations: List[AllocationEntry] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "timestamp": self.timestamp,
+            "layout_hash": self.layout_hash,
+            "device": self.device,
+            "allocations": [asdict(a) for a in self.allocations],
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "SaveManifest":
+        version = d["version"]
+        if version != _CURRENT_VERSION:
+            raise ValueError(
+                f"Unsupported manifest version {version!r} "
+                f"(expected {_CURRENT_VERSION!r})"
+            )
+        # Construct AllocationEntry explicitly so we can default tensor_offset=0
+        # for manifests written before the sharding feature was added.
+        allocations = [
+            AllocationEntry(
+                allocation_id=a["allocation_id"],
+                size=a["size"],
+                aligned_size=a["aligned_size"],
+                tag=a["tag"],
+                tensor_file=a["tensor_file"],
+                tensor_offset=a.get("tensor_offset", 0),
+            )
+            for a in d.get("allocations", [])
+        ]
+        return cls(
+            version=d["version"],
+            timestamp=d["timestamp"],
+            layout_hash=d["layout_hash"],
+            device=d["device"],
+            allocations=allocations,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Shard writer
+# ---------------------------------------------------------------------------
+
+
+class _ShardWriter:
+    """Packs allocation bytes sequentially into large binary shard files.
+
+    Each allocation is appended back-to-back with no inter-allocation padding
+    (``aligned_size`` is already aligned to CUDA VMM granularity).  This
+    layout enables restore to read each shard **front-to-back with zero
+    seeking**: entries sorted by ``tensor_offset`` are contiguous in the file,
+    so sequential ``f.read(aligned_size)`` calls naturally advance the file
+    pointer to the next entry.
+
+    Shard files are named ``shard_{n:04d}.bin`` inside *shards_dir* and are
+    referenced with paths like ``shards/shard_0000.bin`` relative to the dump
+    root.
+
+    A new shard is started whenever the next write would cause the current
+    shard to exceed *shard_size_bytes*, **unless** the current shard is still
+    empty (in which case an oversized allocation is written as the sole entry
+    in that shard).
+
+    Args:
+        shards_dir: Absolute path to the directory that will hold shard files.
+            Created automatically if absent.
+        shard_size_bytes: Soft upper bound per shard (default 4 GiB).
+    """
+
+    def __init__(self, shards_dir: str, shard_size_bytes: int = 4 * 1024**3) -> None:
+        self._shards_dir = shards_dir
+        self._shard_size = shard_size_bytes
+        self._shard_idx = -1
+        self._current_offset = 0
+        self._current_file: Optional[Any] = None
+        self._current_rel_path: str = ""
+        os.makedirs(shards_dir, exist_ok=True)
+
+    def _roll_shard(self) -> None:
+        """Close the current shard (if open) and open the next one."""
+        if self._current_file is not None:
+            self._current_file.close()
+        self._shard_idx += 1
+        filename = f"shard_{self._shard_idx:04d}.bin"  # noqa: E231
+        abs_path = os.path.join(self._shards_dir, filename)
+        self._current_file = open(abs_path, "wb")
+        self._current_rel_path = os.path.join("shards", filename)
+        self._current_offset = 0
+
+    def write(self, tensor: "torch.Tensor") -> Tuple[str, int]:
+        """Append *tensor* bytes to the current shard.
+
+        Rolls to the next shard if the current one would overflow
+        *shard_size_bytes* (but never leaves an empty shard: an oversized
+        single allocation always starts its own shard).
+
+        Args:
+            tensor: Any dtype tensor (GPU or CPU).  Moved to CPU and written
+                as a contiguous raw byte stream.
+
+        Returns:
+            ``(rel_path, byte_offset)`` where *rel_path* is the path of the
+            shard file relative to the dump root directory and *byte_offset*
+            is the byte offset at which this allocation's data starts within
+            that file.
+        """
+        cpu = tensor.cpu() if hasattr(tensor, "is_cuda") and tensor.is_cuda else tensor
+        if hasattr(cpu, "is_contiguous") and not cpu.is_contiguous():
+            cpu = cpu.contiguous()
+        arr = cpu.numpy()
+        size = arr.nbytes
+
+        # Roll to next shard if this write would overflow the current one
+        # (but always write at least one allocation per shard)
+        if self._current_file is None or (
+            self._current_offset > 0 and self._current_offset + size > self._shard_size
+        ):
+            self._roll_shard()
+
+        offset = self._current_offset
+        arr.tofile(self._current_file)
+        self._current_offset += size
+
+        return self._current_rel_path, offset
+
+    def close(self) -> None:
+        """Flush and close the current shard file."""
+        if self._current_file is not None:
+            self._current_file.close()
+            self._current_file = None
+
+    def __enter__(self) -> "_ShardWriter":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+
+# ---------------------------------------------------------------------------
+# Sequential shard reader
+# ---------------------------------------------------------------------------
+
+
+def _read_shard_sequential(
+    abs_path: str,
+    sorted_entries: List[AllocationEntry],
+    device: int,
+    pin_memory: bool = False,
+) -> Dict[str, "torch.Tensor"]:
+    """Read one shard file **front-to-back without seeking**.
+
+    ``sorted_entries`` must be sorted by ``tensor_offset`` in ascending order.
+    Because :class:`_ShardWriter` writes allocations contiguously with no gaps,
+    reading them in offset order is equivalent to a pure sequential scan: each
+    ``f.read(aligned_size)`` call advances the file pointer exactly to the
+    start of the next entry.
+
+    Legacy single-allocation ``*.pt`` files (written before the sharding
+    feature) are handled transparently via ``torch.load``.
+
+    Args:
+        abs_path: Absolute path to the shard (or legacy ``.pt``) file.
+        sorted_entries: Entries belonging to this file, sorted by
+            ``tensor_offset`` ascending.
+        device: CUDA device index.  Pass ``-1`` to keep tensors on CPU
+            (used by :func:`load_to_gms` to avoid holding two GPU copies of
+            the model simultaneously).
+
+    Returns:
+        ``{allocation_id: tensor}`` dict for all entries in this shard.
+    """
+    result: Dict[str, "torch.Tensor"] = {}
+    device_str = f"cuda:{device}" if device >= 0 else "cpu"  # noqa: E231
+
+    if abs_path.endswith(".pt"):
+        # Legacy format: one .pt file contains exactly one allocation.
+        assert len(sorted_entries) == 1, (
+            f"Expected exactly 1 entry for legacy .pt file, got "
+            f"{len(sorted_entries)}: {abs_path}"
+        )
+        entry = sorted_entries[0]
+        t = torch.load(abs_path, weights_only=True, map_location=device_str)
+        result[entry.allocation_id] = t
+        return result
+
+    # Binary shard: read the whole file at once, then zero-copy slice per
+    # allocation.  This amortises mmap/TLB overhead across all allocations in
+    # the shard (N mmaps + N copies → 1 numpy alloc + 0 copies).
+
+    # Try O_DIRECT to bypass page cache (Linux only).
+    # Falls back to buffered reads if the filesystem rejects O_DIRECT.
+    _O_DIRECT = getattr(os, "O_DIRECT", None)
+    if _O_DIRECT is not None:
+        fd: Optional[int] = None
+        done = 0
+        try:
+            total_size = sum(e.aligned_size for e in sorted_entries)
+            # When pin_memory=True, allocate CUDA-pinned host memory so that
+            # Phase B dst.copy_(src, non_blocking=True) is a true async DMA
+            # transfer rather than a staged (synchronous) copy.
+            # For large allocations both torch pinned and np.empty use mmap
+            # internally, giving page-aligned buffers that satisfy O_DIRECT.
+            if pin_memory and torch.cuda.is_available():
+                shard_t = torch.empty(total_size, dtype=torch.uint8, pin_memory=True)
+                arr = shard_t.numpy()
+            else:
+                shard_t = None
+                arr = np.empty(total_size, dtype=np.uint8)
+            fd = os.open(abs_path, os.O_RDONLY | _O_DIRECT)
+            try:
+                # readv caps at ~2 GiB per call on Linux; loop until full.
+                mv = memoryview(arr)
+                try:
+                    while done < total_size:
+                        n = os.readv(fd, [mv[done:]])
+                        if n == 0:
+                            raise RuntimeError(
+                                f"Unexpected EOF in O_DIRECT read from {abs_path}: "
+                                f"got {done} of {total_size} bytes"
+                            )
+                        done += n
+                finally:
+                    mv.release()
+            finally:
+                os.close(fd)
+            # Zero-copy: each tensor is a slice of the shared shard buffer.
+            # Slices of a pinned tensor are also pinned (same physical pages).
+            offset = 0
+            for entry in sorted_entries:
+                size = entry.aligned_size
+                if shard_t is not None:
+                    t = shard_t[offset : offset + size]
+                else:
+                    t = torch.from_numpy(arr[offset : offset + size])
+                if device >= 0:
+                    t = t.to(device_str)
+                result[entry.allocation_id] = t
+                offset += size
+            return result
+        except OSError as exc:
+            # Fall back to buffered reads if:
+            #   - os.open() itself failed (fd is None): filesystem rejects O_DIRECT
+            #   - os.readv() returned EINVAL: buffer or length not block-aligned
+            #     (happens for small allocations where np.empty uses malloc)
+            # Any other errno after a successful open is a real I/O failure.
+            _ODIRECT_FALLBACK_ERRNOS = {errno.EINVAL, errno.EOPNOTSUPP}
+            if fd is not None and exc.errno not in _ODIRECT_FALLBACK_ERRNOS:
+                raise
+            result.clear()
+            if fd is None:
+                logger.debug(
+                    "O_DIRECT unsupported on %s (errno %s); using buffered reads",
+                    abs_path,
+                    exc.errno,
+                )
+            else:
+                logger.debug(
+                    "O_DIRECT read on %s hit EINVAL after %d/%d bytes; using buffered reads",
+                    abs_path,
+                    done,
+                    total_size,
+                )
+
+    # Buffered fallback: reads sequentially from the start of the file.
+    # Entries must start at offset 0 and be contiguous (no gaps); this is
+    # guaranteed by _group_entries_by_shard + _ShardWriter's layout.
+    assert not sorted_entries or sorted_entries[0].tensor_offset == 0, (
+        f"Buffered shard read requires entries starting at offset 0, "
+        f"got {sorted_entries[0].tensor_offset} in {abs_path}"
+    )
+    with open(abs_path, "rb") as f:
+        for entry in sorted_entries:
+            raw = f.read(entry.aligned_size)
+            if len(raw) != entry.aligned_size:
+                raise RuntimeError(
+                    f"Short read from {abs_path} at offset {entry.tensor_offset}: "
+                    f"expected {entry.aligned_size} bytes, got {len(raw)}"
+                )
+            arr = np.frombuffer(raw, dtype=np.uint8).copy()
+            t = torch.from_numpy(arr)
+            if device >= 0:
+                t = t.to(device_str)
+            result[entry.allocation_id] = t
+
+    return result
+
+
+def _decode_metadata(
+    raw_meta: Dict[str, Any],
+) -> Dict[str, Dict[str, Any]]:
+    """Decode a raw metadata dict (as loaded from JSON) into Python types.
+
+    Base64-encoded ``value`` fields are decoded to ``bytes``.
+    """
+    return {
+        key: {
+            "allocation_id": entry["allocation_id"],
+            "offset_bytes": int(entry["offset_bytes"]),
+            "value": base64.b64decode(entry["value"]),
+        }
+        for key, entry in raw_meta.items()
+    }
+
+
+def _group_entries_by_shard(
+    allocations: List[AllocationEntry],
+) -> Dict[str, List[AllocationEntry]]:
+    """Group allocation entries by shard file and sort each group by offset.
+
+    The resulting per-shard lists are sorted by ``tensor_offset`` ascending,
+    which is the order required for sequential (seek-free) reads.
+    """
+    groups: Dict[str, List[AllocationEntry]] = defaultdict(list)
+    for entry in allocations:
+        groups[entry.tensor_file].append(entry)
+    for entries_in_shard in groups.values():
+        entries_in_shard.sort(key=lambda e: e.tensor_offset)
+    return dict(groups)
+
+
+def _plan_shard_layout(
+    allocations_info: List[Dict[str, Any]],
+    shard_size_bytes: int,
+) -> List[Tuple[int, int]]:
+    """Compute ``(shard_idx, byte_offset)`` for each allocation in order.
+
+    Mirrors the roll logic of :class:`_ShardWriter` so that parallel save
+    produces an identical on-disk layout to the serial writer.
+    """
+    result: List[Tuple[int, int]] = []
+    shard_idx = -1
+    current_offset = 0
+    started = False
+    for alloc in allocations_info:
+        size = int(alloc["aligned_size"])
+        if not started or (
+            current_offset > 0 and current_offset + size > shard_size_bytes
+        ):
+            shard_idx += 1
+            current_offset = 0
+            started = True
+        result.append((shard_idx, current_offset))
+        current_offset += size
+    return result
+
+
+def _read_shard_to_queue(
+    abs_path: str,
+    sorted_entries: List[AllocationEntry],
+    work_q: "queue.Queue[Optional[Tuple[AllocationEntry, 'torch.Tensor']]]",
+    *,
+    pin_memory: bool,
+    cancel_event: Optional[threading.Event] = None,
+) -> int:
+    """Read one shard and enqueue its allocations in file order.
+
+    Returns the number of items enqueued.  Raises ``concurrent.futures.CancelledError``
+    if *cancel_event* is set before all items are enqueued, so callers can
+    distinguish cancellation from a genuinely empty shard.
+    """
+    from concurrent.futures import CancelledError
+
+    shard_result = _read_shard_sequential(
+        abs_path,
+        sorted_entries,
+        -1,
+        pin_memory=pin_memory,
+    )
+    for entry in sorted_entries:
+        while True:
+            if cancel_event is not None and cancel_event.is_set():
+                raise CancelledError(f"shard read cancelled: {abs_path}")
+            try:
+                work_q.put(
+                    (entry, shard_result[entry.allocation_id]),
+                    timeout=0.1,
+                )
+                break
+            except queue.Full:
+                if cancel_event is not None and cancel_event.is_set():
+                    raise CancelledError(f"shard read cancelled: {abs_path}")
+    return len(sorted_entries)
+
+
+def _load_manifest_and_metadata(
+    input_dir: str,
+) -> Tuple[SaveManifest, Dict[str, Dict[str, Any]]]:
+    """Load manifest.json and gms_metadata.json from a save directory."""
+    manifest_path = os.path.join(input_dir, "manifest.json")
+    with open(manifest_path, encoding="utf-8") as f:
+        manifest = SaveManifest.from_dict(json.load(f))
+
+    metadata_path = os.path.join(input_dir, "gms_metadata.json")
+    raw_meta: Dict[str, Any] = {}
+    if os.path.exists(metadata_path):
+        with open(metadata_path, encoding="utf-8") as f:
+            raw_meta = json.load(f)
+
+    return manifest, _decode_metadata(raw_meta)
+
+
+@dataclass
+class _RestorePipelineContext:
+    """Mutable state shared across disk, copy, and Phase A restore stages."""
+
+    worker_count: int
+    use_streams: bool
+    device: int
+    work_q: "queue.Queue[Optional[Tuple[AllocationEntry, 'torch.Tensor']]]"
+    va_events: Dict[str, threading.Event]
+    streams: List["torch.cuda.Stream"]
+    cancel_event: threading.Event = field(default_factory=threading.Event)
+    vas: Dict[str, int] = field(default_factory=dict)
+    staged_srcs: List["torch.Tensor"] = field(default_factory=list)
+    copy_errors: List[BaseException] = field(default_factory=list)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    @classmethod
+    def build(
+        cls,
+        allocations: List[AllocationEntry],
+        worker_count: int,
+        *,
+        device: int,
+        use_streams: bool,
+    ) -> "_RestorePipelineContext":
+        streams = (
+            [torch.cuda.Stream(device=device) for _ in range(worker_count)]
+            if use_streams
+            else []
+        )
+        return cls(
+            worker_count=worker_count,
+            use_streams=use_streams,
+            device=device,
+            work_q=queue.Queue(maxsize=worker_count * _WORK_QUEUE_DEPTH_MULTIPLIER),
+            va_events={entry.allocation_id: threading.Event() for entry in allocations},
+            streams=streams,
+        )
+
+
+@dataclass
+class _RestorePipelineResources:
+    """Live restore pipeline resources that must be torn down together."""
+
+    ctx: _RestorePipelineContext
+    disk_pool: ThreadPoolExecutor
+    disk_futures: Dict[Future[int], str]
+    copy_threads: List[threading.Thread]
+    active: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+class GMSStorageClient:
+    """Dump and restore GMS state to/from disk.
+
+    Can be used for dump-only, restore-only, or both:
+
+    * **Dump**: pass ``output_dir``; call :meth:`save`.
+    * **Restore**: ``output_dir`` may be ``None``; call :meth:`load_to_gms`
+      with the dump directory path.
+    * **Both**: pass ``output_dir`` and use the same instance for both.
+
+    The dump format packs all allocations into a small number of large binary
+    shard files (default 4 GiB each).  For a 100 GB model with 100k tensors
+    this produces ~25 shard files instead of 100 000 individual files.
+    Restore reads each shard **sequentially** (no seeking); shard files are
+    processed in parallel via a thread pool.
+
+    Args:
+        output_dir: Directory in which to create the dump (created if absent).
+            Pass ``None`` when using this client for restore only.
+        socket_path: Unix socket path for the GMS server.  If ``None``, the
+            default UUID-based path for *device* is used.
+        device: CUDA device index.
+        timeout_ms: Timeout in milliseconds for lock acquisition.
+        shard_size_bytes: Soft upper bound per shard file (default 4 GiB).
+            Decrease for faster parallel restore on systems with many I/O
+            lanes; increase to reduce file count.
+    """
+
+    def __init__(
+        self,
+        output_dir: Optional[str] = None,
+        socket_path: Optional[str] = None,
+        device: int = 0,
+        *,
+        timeout_ms: Optional[int] = None,
+        shard_size_bytes: int = 4 * 1024**3,
+    ) -> None:
+        self.output_dir = output_dir
+        self.device = device
+        self._timeout_ms = timeout_ms
+        self._shard_size = shard_size_bytes
+
+        # Resolve socket path lazily to avoid importing pynvml in tests
+        if socket_path is None:
+            from gpu_memory_service.common.utils import get_socket_path
+
+            socket_path = get_socket_path(device)
+        self._socket_path = socket_path
+
+    # ------------------------------------------------------------------
+    # Public: dump
+    # ------------------------------------------------------------------
+
+    def save(self, max_workers: int = 4) -> SaveManifest:
+        """Connect to GMS in RO mode and save all allocations + metadata to disk.
+
+        Allocation bytes are packed into shard files under *shards_dir*
+        (default: ``{output_dir}/shards/``).  Metadata is written to
+        ``{output_dir}/gms_metadata.json`` and a manifest to
+        ``{output_dir}/manifest.json``.
+
+        Save is performed in two phases to maximise throughput:
+
+        * **Phase A (serial)**: import every GMS allocation VA via RPC.  The
+          RPC socket is not thread-safe so all imports run on the calling
+          thread, but they are fast (no data movement).
+        * **Phase B (parallel)**: write each shard file concurrently.  Each
+          worker thread reads its assigned allocations from GPU to CPU and
+          streams the bytes to its shard file, so D2H copies and disk writes
+          for different shards overlap in time.
+
+        Args:
+            max_workers: Thread pool size for parallel shard writes (default 4).
+
+        Returns:
+            :class:`SaveManifest` describing the saved state.
+
+        Raises:
+            ConnectionError: If GMS server is not running at *socket_path*.
+            RuntimeError: If GMS has no committed weights.
+            ValueError: If *output_dir* was not provided at construction time.
+        """
+        if not _GMS_IMPORTS_AVAILABLE:
+            raise RuntimeError(
+                "GMS client imports unavailable (missing cuda-python or torch)"
+            )
+        if self.output_dir is None:
+            raise ValueError(
+                "output_dir must be set to call save(); pass it to GMSStorageClient()"
+            )
+
+        os.makedirs(self.output_dir, exist_ok=True)
+        shards_dir = os.path.join(self.output_dir, "shards")
+        os.makedirs(shards_dir, exist_ok=True)
+        # Remove stale shard outputs from prior saves to the same directory.
+        # Manifest/metadata are rewritten below, but old shard_NNNN.bin files
+        # would otherwise be left behind and can confuse downstream tooling.
+        for name in os.listdir(shards_dir):
+            if name.startswith("shard_") and name.endswith(".bin"):
+                os.unlink(os.path.join(shards_dir, name))
+
+        with GMSClientMemoryManager(
+            self._socket_path,
+            device=self.device,
+        ) as mm:
+            mm.connect(RequestedLockType.RO, timeout_ms=self._timeout_ms)
+            if not mm.committed:
+                raise RuntimeError(
+                    "GMS server has no committed weights; nothing to dump"
+                )
+
+            layout_hash = mm.get_memory_layout_hash()
+            allocations_info = mm.list_handles()
+
+            # Compute shard layout upfront (mirrors _ShardWriter roll logic).
+            layout = _plan_shard_layout(allocations_info, self._shard_size)
+
+            # Phase A: import all VAs serially — the RPC socket is not
+            # thread-safe so concurrent calls would corrupt the stream.
+            va_list: List[int] = []
+            for alloc in allocations_info:
+                va_list.append(mm.create_mapping(allocation_id=alloc["allocation_id"]))
+            logger.info("Phase A complete: imported %d allocation VAs", len(va_list))
+
+            # Group by shard: shard_idx → [(alloc_list_index, byte_offset)]
+            shard_groups: Dict[int, List[Tuple[int, int]]] = defaultdict(list)
+            for i, (shard_idx, byte_offset) in enumerate(layout):
+                shard_groups[shard_idx].append((i, byte_offset))
+
+            entries: List[Optional[AllocationEntry]] = [None] * len(allocations_info)
+
+            def _write_shard(
+                shard_idx: int, alloc_pairs: List[Tuple[int, int]]
+            ) -> None:
+                filename = f"shard_{shard_idx:04d}.bin"  # noqa: E231
+                abs_path = os.path.join(shards_dir, filename)
+                tensor_file = os.path.join("shards", filename)
+                with open(abs_path, "wb") as f:
+                    for i, byte_offset in alloc_pairs:
+                        alloc = allocations_info[i]
+                        alloc_id = alloc["allocation_id"]
+                        aligned_size = int(alloc["aligned_size"])
+                        tensor = _tensor_from_pointer(
+                            va_list[i], [aligned_size], [1], torch.uint8, self.device
+                        )
+                        tensor.cpu().numpy().tofile(f)
+                        # Each shard worker owns a disjoint subset of indices
+                        # (guaranteed by _plan_shard_layout), so concurrent writes
+                        # never target the same slot — no locking required.
+                        entries[i] = AllocationEntry(
+                            allocation_id=alloc_id,
+                            size=int(alloc["size"]),
+                            aligned_size=aligned_size,
+                            tag=str(alloc.get("tag", "default")),
+                            tensor_file=tensor_file,
+                            tensor_offset=byte_offset,
+                        )
+                        logger.debug(
+                            "Dumped allocation %s (%d bytes) → %s@%d",
+                            alloc_id,
+                            aligned_size,
+                            tensor_file,
+                            byte_offset,
+                        )
+
+            # Phase B: write shards in parallel.
+            with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                save_futures = {
+                    pool.submit(_write_shard, shard_idx, alloc_pairs): shard_idx
+                    for shard_idx, alloc_pairs in shard_groups.items()
+                }
+                for fut in as_completed(save_futures):
+                    fut.result()  # propagate any worker exceptions
+
+            logger.info("Phase B complete: wrote %d shards", len(shard_groups))
+
+            # entries list is fully populated — all slots must be set.
+            assert all(e is not None for e in entries), (
+                f"BUG: {sum(1 for e in entries if e is None)} allocation(s) were not "
+                "written despite all shard futures completing without error"
+            )
+            final_entries: List[AllocationEntry] = [e for e in entries if e is not None]
+
+            metadata = self._save_metadata(mm)
+
+        # Write metadata file
+        metadata_path = os.path.join(self.output_dir, "gms_metadata.json")
+        with open(metadata_path, "w", encoding="utf-8") as f:
+            json.dump(metadata, f, indent=2)
+        logger.info("Wrote metadata to %s (%d keys)", metadata_path, len(metadata))
+
+        manifest = SaveManifest(
+            version=_CURRENT_VERSION,
+            timestamp=time.time(),
+            layout_hash=layout_hash,
+            device=self.device,
+            allocations=final_entries,
+        )
+
+        manifest_path = os.path.join(self.output_dir, "manifest.json")
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest.to_dict(), f, indent=2)
+        logger.info(
+            "Wrote manifest to %s (%d allocations)", manifest_path, len(final_entries)
+        )
+
+        return manifest
+
+    def _run_restore_copy_worker(
+        self,
+        ctx: _RestorePipelineContext,
+        stream_idx: int,
+    ) -> None:
+        """Copy staged CPU tensors into ready GMS VAs until sentinel shutdown."""
+        while True:
+            try:
+                item = ctx.work_q.get(timeout=0.1)
+            except queue.Empty:
+                if ctx.cancel_event.is_set():
+                    return
+                continue
+            if item is None:
+                return
+
+            entry, src = item
+            try:
+                while not ctx.va_events[entry.allocation_id].wait(timeout=0.1):
+                    if ctx.cancel_event.is_set():
+                        return
+                dst = _tensor_from_pointer(
+                    ctx.vas[entry.allocation_id],
+                    [entry.aligned_size],
+                    [1],
+                    torch.uint8,
+                    self.device,
+                )
+                if ctx.streams:
+                    with torch.cuda.stream(ctx.streams[stream_idx]):
+                        # non_blocking=True only when src is pinned; unpinned
+                        # buffers use a synchronous copy so no staging is needed.
+                        # IMPORTANT: if this ever changes to non_blocking=True
+                        # unconditionally, staged_srcs must also append unpinned src.
+                        dst.copy_(src, non_blocking=src.is_pinned())
+                else:
+                    dst.copy_(src)
+                # Only stage pinned src tensors: unpinned copies are synchronous
+                # (non_blocking=False above) so the DMA is already complete.
+                if ctx.use_streams and src.is_pinned():
+                    with ctx.lock:
+                        ctx.staged_srcs.append(src)
+            except Exception as exc:  # noqa: BLE001
+                with ctx.lock:
+                    ctx.copy_errors.append(exc)
+
+    def _start_restore_copy_threads(
+        self,
+        ctx: _RestorePipelineContext,
+    ) -> List[threading.Thread]:
+        """Start daemon copy threads that drain the restore work queue."""
+        threads = [
+            threading.Thread(
+                target=self._run_restore_copy_worker,
+                args=(ctx, i),
+                daemon=True,
+            )
+            for i in range(ctx.worker_count)
+        ]
+        for thread in threads:
+            thread.start()
+        return threads
+
+    def _prepare_restore_pipeline(
+        self,
+        manifest: SaveManifest,
+        groups: Dict[str, List[AllocationEntry]],
+        worker_count: int,
+        input_dir: str,
+    ) -> _RestorePipelineResources:
+        """Start restore workers and shard readers for the current manifest."""
+        ctx = _RestorePipelineContext.build(
+            manifest.allocations,
+            worker_count,
+            device=self.device,
+            use_streams=_TORCH_AVAILABLE and torch.cuda.is_available(),
+        )
+        copy_threads = self._start_restore_copy_threads(ctx)
+        disk_pool = ThreadPoolExecutor(max_workers=worker_count)
+        disk_futures = {
+            disk_pool.submit(
+                _read_shard_to_queue,
+                os.path.join(input_dir, rel_path),
+                sorted_entries,
+                ctx.work_q,
+                pin_memory=ctx.use_streams,
+                cancel_event=ctx.cancel_event,
+            ): rel_path
+            for rel_path, sorted_entries in groups.items()
+        }
+        return _RestorePipelineResources(
+            ctx=ctx,
+            disk_pool=disk_pool,
+            disk_futures=disk_futures,
+            copy_threads=copy_threads,
+        )
+
+    def _allocate_restore_mappings(
+        self,
+        mm: Any,
+        manifest: SaveManifest,
+        ctx: _RestorePipelineContext,
+    ) -> Dict[str, str]:
+        """Allocate destination GMS mappings and publish them to copy workers."""
+        id_map: Dict[str, str] = {}
+        for entry in manifest.allocations:
+            old_id = entry.allocation_id
+            va = mm.create_mapping(size=entry.size, tag=entry.tag)
+            new_id = mm.get_allocation_id(va)
+            id_map[old_id] = new_id
+            ctx.vas[old_id] = va
+            ctx.va_events[old_id].set()
+
+        logger.info(
+            "Phase A complete: allocated %d GMS VAs; waiting for disk/copy pipeline",
+            len(ctx.vas),
+        )
+        return id_map
+
+    def _await_disk_reads(
+        self,
+        disk_futures: Dict[Future[int], str],
+    ) -> None:
+        """Re-raise shard read failures with shard-path context.
+
+        ``CancelledError`` from ``_read_shard_to_queue`` is silently ignored —
+        it indicates the pipeline was cancelled, not a true I/O error.
+        """
+        from concurrent.futures import CancelledError
+
+        for future in as_completed(disk_futures):
+            rel_path = disk_futures[future]
+            try:
+                future.result()
+            except CancelledError:
+                pass  # pipeline was cancelled; not a real I/O failure
+            except Exception as exc:
+                raise RuntimeError(f"Failed to load shard {rel_path}: {exc}") from exc
+
+    def _stop_restore_copy_threads(
+        self,
+        ctx: _RestorePipelineContext,
+        threads: List[threading.Thread],
+        *,
+        drain_queue: bool = False,
+    ) -> None:
+        """Signal copy workers to exit and wait for thread completion."""
+        if drain_queue:
+            self._drain_restore_queue(ctx)
+        for _ in threads:
+            while True:
+                try:
+                    ctx.work_q.put(None, timeout=0.1)
+                    break
+                except queue.Full:
+                    if drain_queue:
+                        self._drain_restore_queue(ctx)
+        for thread in threads:
+            thread.join()
+
+    def _drain_restore_queue(self, ctx: _RestorePipelineContext) -> None:
+        """Drop queued work items to free capacity during cancellation."""
+        while True:
+            try:
+                ctx.work_q.get_nowait()
+            except queue.Empty:
+                return
+
+    def _cancel_restore_pipeline(
+        self,
+        ctx: _RestorePipelineContext,
+    ) -> None:
+        """Release queue and event waiters so pipeline shutdown cannot deadlock."""
+        ctx.cancel_event.set()
+        for event in ctx.va_events.values():
+            event.set()
+        self._drain_restore_queue(ctx)
+
+    def _finalize_restore_pipeline(
+        self,
+        ctx: _RestorePipelineContext,
+    ) -> None:
+        """Synchronize async copies and surface worker failures."""
+        if ctx.use_streams:
+            torch.cuda.synchronize(device=self.device)
+            ctx.staged_srcs.clear()
+        if ctx.copy_errors:
+            raise RuntimeError(
+                f"Failed to copy restored data to GMS: {ctx.copy_errors[0]}"
+            )
+
+    def _drain_restore_pipeline(
+        self,
+        resources: _RestorePipelineResources,
+    ) -> None:
+        """Wait for disk reads and copy workers, then finalize async copies.
+
+        ``_finalize_restore_pipeline`` (which calls ``cuda.synchronize`` and
+        clears ``staged_srcs``) runs in the ``finally`` block so that in-flight
+        async H2D DMAs are always waited on — even when a disk read raises.
+
+        Note: ``_cancel_restore_pipeline`` is intentionally *not* called here.
+        Phase A (``_allocate_restore_mappings``) always runs to completion
+        before this function is invoked, so all ``va_events`` are already set
+        and copy threads cannot be stuck waiting on them.  Cancellation is only
+        needed in ``_shutdown_restore_pipeline`` (Phase A failure path).
+        """
+        try:
+            self._await_disk_reads(resources.disk_futures)
+        finally:
+            resources.disk_pool.shutdown(wait=True)
+            self._stop_restore_copy_threads(resources.ctx, resources.copy_threads)
+            resources.active = False
+            # Always synchronize and release staged source tensors so that
+            # in-flight async DMA is complete before this frame unwinds.
+            self._finalize_restore_pipeline(resources.ctx)
+
+    def _shutdown_restore_pipeline(
+        self,
+        resources: _RestorePipelineResources,
+    ) -> None:
+        """Best-effort cleanup for partially started restore pipelines.
+
+        Called on Phase A (VA allocation) failure.  Copy threads may have
+        already issued async DMAs for allocations that were enqueued before
+        the error; synchronize before returning so those DMAs finish before
+        the pinned source buffers are released.
+        """
+        if not resources.active:
+            return
+        self._cancel_restore_pipeline(resources.ctx)
+        resources.disk_pool.shutdown(wait=True, cancel_futures=True)
+        self._stop_restore_copy_threads(
+            resources.ctx,
+            resources.copy_threads,
+            drain_queue=True,
+        )
+        resources.active = False
+        # Synchronize any in-flight async DMAs and release staged src tensors.
+        self._finalize_restore_pipeline(resources.ctx)
+
+    # ------------------------------------------------------------------
+    # Public: load_to_gms
+    # ------------------------------------------------------------------
+
+    def load_to_gms(
+        self,
+        input_dir: str,
+        *,
+        max_workers: int = 4,
+        clear_existing: bool = True,
+    ) -> Dict[str, str]:
+        """Load a saved GMS state back into a running GMS server.
+
+        Connects in **RW mode**, allocates GMS memory for each saved
+        allocation, loads the tensor bytes from disk and copies them into GMS
+        memory, restores all metadata (remapping old → new allocation IDs),
+        then commits.
+
+        Restore is orchestrated in two overlapping phases:
+
+        * **Phase A (serial)**: allocate all destination GMS VAs.
+        * **Phase B (parallel)**: stream shard data from disk and copy it into
+          those VAs using worker threads and per-thread CUDA streams.
+
+        Args:
+            input_dir: Directory previously created by :meth:`save`.
+            max_workers: Thread pool size for parallel shard reads/copies.
+            clear_existing: If ``True`` (default) call ``clear_all()`` on the
+                server before restoring, so the result is an exact replica of
+                the dump.  Set to ``False`` to add allocations on top of any
+                existing state (advanced use).
+
+        Returns:
+            Mapping of ``{old_allocation_id: new_allocation_id}`` — the IDs
+            assigned by GMS during restore.  Use this if callers cache the
+            old allocation IDs and need to look up the new ones.
+
+        Raises:
+            ConnectionError: If GMS server is not running at *socket_path*.
+            RuntimeError: If GMS imports are unavailable or restore fails.
+        """
+        if not _GMS_IMPORTS_AVAILABLE:
+            raise RuntimeError(
+                "GMS client imports unavailable (missing cuda-python or torch)"
+            )
+
+        manifest, saved_metadata = _load_manifest_and_metadata(input_dir)
+
+        groups = _group_entries_by_shard(manifest.allocations)
+        worker_count = max(1, min(max_workers, len(groups) or 1))
+
+        with GMSClientMemoryManager(
+            self._socket_path,
+            device=self.device,
+        ) as mm:
+            mm.connect(RequestedLockType.RW, timeout_ms=self._timeout_ms)
+            if clear_existing:
+                cleared = mm.clear_all_handles()
+                if cleared:
+                    logger.info("Cleared %d pre-existing allocations", cleared)
+
+            resources = self._prepare_restore_pipeline(
+                manifest,
+                groups,
+                worker_count,
+                input_dir,
+            )
+            try:
+                id_map = self._allocate_restore_mappings(
+                    mm,
+                    manifest,
+                    resources.ctx,
+                )
+                self._drain_restore_pipeline(resources)
+            except Exception:
+                self._shutdown_restore_pipeline(resources)
+                raise
+
+            logger.info(
+                "Phase B complete: streamed %d allocations to GMS memory",
+                len(manifest.allocations),
+            )
+
+            self._restore_metadata(mm, saved_metadata, id_map)
+            ok = mm.commit()
+            if not ok:
+                raise RuntimeError("GMS commit failed after restore")
+
+        logger.info(
+            "load_to_gms complete: %d allocations, %d metadata keys",
+            len(id_map),
+            len(saved_metadata),
+        )
+        return id_map
+
+    def _restore_metadata(
+        self,
+        mm: Any,
+        saved_metadata: Dict[str, Dict[str, Any]],
+        id_map: Dict[str, str],
+    ) -> None:
+        """Write saved metadata back to GMS, remapping old → new allocation IDs."""
+        for key, meta in saved_metadata.items():
+            old_alloc_id = meta["allocation_id"]
+            new_alloc_id = id_map.get(old_alloc_id, old_alloc_id)
+            ok = mm.metadata_put(key, new_alloc_id, meta["offset_bytes"], meta["value"])
+            if not ok:
+                raise RuntimeError(f"Failed to write metadata key={key!r}")
+            logger.debug("Restored metadata key=%s → alloc=%s", key, new_alloc_id)
+        logger.info("Restored %d metadata keys; committing", len(saved_metadata))
+
+    # ------------------------------------------------------------------
+    # Public: load_tensors  (disk-only, no GMS write-back)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def load_tensors(
+        input_dir: str,
+        device: int = 0,
+        *,
+        max_workers: int = 4,
+    ) -> Tuple[Dict[str, "torch.Tensor"], Dict[str, Dict[str, Any]]]:
+        """Load tensors and metadata from a dump directory into GPU memory.
+
+        This is a **disk-only** operation — it does NOT connect to GMS.
+        Use :meth:`load_to_gms` to write data back into a running GMS server.
+
+        Shard files are read in parallel (``max_workers`` threads), each thread
+        reading its shard **front-to-back without seeking**.
+
+        Args:
+            input_dir: Directory created by :meth:`save`.
+            device: CUDA device index to restore tensors onto.
+            max_workers: Thread pool size for parallel shard reads.
+
+        Returns:
+            ``(tensors, metadata)`` where *tensors* maps allocation ID →
+            ``torch.Tensor`` (uint8, on device) and *metadata* maps metadata
+            key → ``{allocation_id, offset_bytes, value}`` (value as bytes).
+        """
+        if not _TORCH_AVAILABLE:
+            raise RuntimeError("PyTorch is required for load_tensors()")
+        manifest, metadata = _load_manifest_and_metadata(input_dir)
+        groups = _group_entries_by_shard(manifest.allocations)
+
+        # One thread per shard; each thread reads its shard sequentially
+        tensors: Dict[str, "torch.Tensor"] = {}
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {
+                pool.submit(
+                    _read_shard_sequential,
+                    os.path.join(input_dir, rel_path),
+                    sorted_entries,
+                    device,
+                ): rel_path
+                for rel_path, sorted_entries in groups.items()
+            }
+            for future in as_completed(futures):
+                rel_path = futures[future]
+                try:
+                    shard_tensors = future.result()
+                    tensors.update(shard_tensors)
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Failed to load shard {rel_path}: {exc}"
+                    ) from exc
+
+        logger.info("Loaded %d allocations from %s", len(tensors), input_dir)
+        return tensors, metadata
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _save_metadata(self, mm: Any) -> Dict[str, Any]:
+        """Read all metadata entries from GMS and return a JSON-serialisable dict.
+
+        Values (bytes) are base64-encoded so the result is JSON-safe.
+        """
+        result: Dict[str, Any] = {}
+        for key in mm.metadata_list():
+            got = mm.metadata_get(key)
+            if got is None:
+                logger.warning("Metadata key disappeared during dump: %s", key)
+                continue
+            allocation_id, offset_bytes, value = got
+            result[key] = {
+                "allocation_id": str(allocation_id),
+                "offset_bytes": int(offset_bytes),
+                "value": base64.b64encode(value).decode("ascii"),
+            }
+        return result

--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -51,6 +51,7 @@ from gpu_memory_service.client.cuda_vmm_utils import (
 from gpu_memory_service.client.rpc import GMSRPCClient
 from gpu_memory_service.common.cuda_vmm_utils import (
     align_to_granularity,
+    ensure_cuda_initialized,
     get_allocation_granularity,
 )
 from gpu_memory_service.common.types import GrantedLockType, RequestedLockType
@@ -145,6 +146,10 @@ class GMSClientMemoryManager:
         self._va_preserved = False
         self._last_memory_layout_hash: str = ""
 
+        # Ensure the CUDA driver is initialized before any driver API calls.
+        ensure_cuda_initialized()
+
+        # Set the current CUDA device for subsequent operations.
         set_current_device(self.device)
         self.granularity = get_allocation_granularity(device)
 
@@ -169,6 +174,10 @@ class GMSClientMemoryManager:
     @property
     def total_bytes(self) -> int:
         return sum(m.aligned_size for m in self._mappings.values())
+
+    @property
+    def committed(self) -> bool:
+        return self._client is not None and self._client.committed
 
     # ==================== Tier 1: Connection ====================
 
@@ -254,6 +263,12 @@ class GMSClientMemoryManager:
 
     def list_handles(self, tag: Optional[str] = None) -> List[Dict]:
         return self._client_rpc.list_allocations(tag)
+
+    def get_allocation_id(self, va: int) -> str:
+        mapping = self._mappings.get(va)
+        if mapping is None:
+            raise KeyError(f"Unknown VA 0x{va:x}")
+        return mapping.allocation_id
 
     # ==================== Tier 1: Metadata ====================
 
@@ -456,8 +471,8 @@ class GMSClientMemoryManager:
         # Stale layout check
         current_hash = self.get_memory_layout_hash()
         if (
-            self._last_memory_layout_hash
-            and current_hash != self._last_memory_layout_hash
+            self._last_memory_layout_hash  # noqa: W503
+            and current_hash != self._last_memory_layout_hash  # noqa: W503
         ):
             raise StaleMemoryLayoutError(
                 f"Layout changed: {self._last_memory_layout_hash[:16]}... -> {current_hash[:16]}..."
@@ -576,9 +591,9 @@ class GMSClientMemoryManager:
                 logger.warning("Error freeing VA 0x%x during close: %s", va, e)
 
         if (
-            free
-            and self._client is not None
-            and self._granted_lock_type == GrantedLockType.RW
+            free  # noqa: W503
+            and self._client is not None  # noqa: W503
+            and self._granted_lock_type == GrantedLockType.RW  # noqa: W503
         ):
             try:
                 self.clear_all_handles()

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -51,8 +51,21 @@ def register_gms_loader(load_format: str = "gms") -> None:
 
         def __init__(self, load_config):
             super().__init__(load_config)
+            default_extra = getattr(load_config, "model_loader_extra_config", {}) or {}
+            # Strip GMS-only flags before delegating to vLLM's auto loader.
+            # The default loader rejects unknown keys such as gms_read_only.
+            _GMS_ONLY_KEYS = {"gms_read_only"}
+            default_extra = {
+                key: value
+                for key, value in default_extra.items()
+                if key not in _GMS_ONLY_KEYS
+            }
             self.default_loader = DefaultModelLoader(
-                replace(load_config, load_format="auto")
+                replace(
+                    load_config,
+                    load_format="auto",
+                    model_loader_extra_config=default_extra,
+                )
             )
 
         def download_model(self, model_config) -> None:

--- a/lib/gpu_memory_service/pyproject.toml
+++ b/lib/gpu_memory_service/pyproject.toml
@@ -36,9 +36,16 @@ keywords = ["llm", "genai", "inference", "nvidia", "gpu", "memory", "dynamo"]
 
 [project.scripts]
 gpu-memory-service = "gpu_memory_service.cli.runner:main"
+gms-storage-client = "gpu_memory_service.cli.storage_runner:main"
 
 [project.optional-dependencies]
 test = [
     "pytest>=8.3.4",
     "pytest-asyncio",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "e2e: end-to-end tests that require a real GPU, CUDA environment, and vLLM installed",
 ]

--- a/lib/gpu_memory_service/tests/e2e/__init__.py
+++ b/lib/gpu_memory_service/tests/e2e/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/lib/gpu_memory_service/tests/e2e/bench_gms_restore.py
+++ b/lib/gpu_memory_service/tests/e2e/bench_gms_restore.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Benchmark GMS restore with varying worker counts.
+
+Saves GMS state once (if not already saved), then loops over worker counts
+for restore-only, reporting per-phase timings.
+
+Usage
+-----
+    # Save + benchmark (first run or if save dir is missing):
+    python bench_gms_restore.py \\
+        --save-dir /ramdisk/gms_bench_save_72b \\
+        --model Qwen/Qwen2.5-72B-Instruct \\
+        --workers 16 32 64
+
+    # Restore-only benchmark (save dir already populated):
+    python bench_gms_restore.py \\
+        --save-dir /ramdisk/gms_bench_save_72b \\
+        --restore-only \\
+        --workers 16 32 64
+
+Phase timing is extracted from log timestamps in the subprocess output:
+    Disk+A (disk+alloc):  "Loading GMS state" → "Phase A complete"  (overlapped)
+    Phase B (GPU copy):   "Phase A complete"  → "Phase B complete"
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import ctypes.util
+import json
+import logging
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s %(message)s",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
+
+_TIMESTAMP_RE = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})")
+
+# ---------------------------------------------------------------------------
+# Process helpers (shared with e2e test)
+# ---------------------------------------------------------------------------
+
+
+class ManagedProcess:
+    def __init__(self, cmd: list[str], log_path: Path, env: Optional[dict] = None):
+        self._log_fh = log_path.open("w")
+        self._proc = subprocess.Popen(
+            cmd,
+            stdout=self._log_fh,
+            stderr=subprocess.STDOUT,
+            env=env or os.environ.copy(),
+            preexec_fn=os.setsid,
+        )
+        logger.info("Started pid=%d: %s", self._proc.pid, " ".join(cmd))
+
+    @property
+    def pid(self) -> int:
+        return self._proc.pid
+
+    def is_running(self) -> bool:
+        return self._proc.poll() is None
+
+    def terminate(self, name: str = "") -> None:
+        if not self.is_running():
+            return
+        try:
+            os.killpg(os.getpgid(self._proc.pid), signal.SIGTERM)
+            try:
+                self._proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                os.killpg(os.getpgid(self._proc.pid), signal.SIGKILL)
+                self._proc.wait(timeout=5)
+        except ProcessLookupError:
+            pass
+        self._log_fh.close()
+        logger.info("Stopped %s", name or f"pid={self._proc.pid}")
+
+    def tail(self, n: int = 20) -> str:
+        try:
+            lines = Path(self._log_fh.name).read_text().splitlines()
+            return "\n".join(lines[-n:])
+        except OSError:
+            return "(unavailable)"
+
+
+def _python() -> str:
+    return sys.executable
+
+
+def _gms_server_cmd(device: int = 0) -> list[str]:
+    return [_python(), "-m", "gpu_memory_service", "--device", str(device)]
+
+
+def _vllm_serve_cmd(model: str, port: int) -> list[str]:
+    return [
+        _python(),
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+        "--model",
+        model,
+        "--load-format",
+        "gms",
+        "--worker-cls",
+        "gpu_memory_service.integrations.vllm.worker.GMSWorker",
+        "--port",
+        str(port),
+        "--max-model-len",
+        "512",
+        "--disable-log-stats",
+    ]
+
+
+def _device_env(device: int) -> dict:
+    """Return an env dict with CUDA_VISIBLE_DEVICES set to *device*."""
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = str(device)
+    return env
+
+
+def _gms_save_cmd(output_dir: Path, device: int = 0) -> list[str]:
+    return [
+        _python(),
+        "-m",
+        "gpu_memory_service.cli.storage_runner",
+        "save",
+        "--output-dir",
+        str(output_dir),
+        "--device",
+        str(device),
+        "--verbose",
+    ]
+
+
+def _wait_for_http(url: str, timeout: int) -> bool:
+    import urllib.request
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=5) as r:
+                if r.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(3)
+    return False
+
+
+def _wait_gpu_free(exclude_pids: set[int], timeout: int = 120) -> bool:
+    if shutil.which("nvidia-smi") is None:
+        logger.warning("nvidia-smi not found; skipping GPU idle wait")
+        return True
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        r = subprocess.run(
+            ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if r.returncode != 0:
+            logger.warning(
+                "nvidia-smi exited with %d; skipping GPU idle wait", r.returncode
+            )
+            return True
+        pids = {
+            int(p.strip()) for p in r.stdout.strip().split("\n") if p.strip().isdigit()
+        }
+        if not (pids - exclude_pids):
+            return True
+        time.sleep(3)
+    return False
+
+
+def _gms_socket_path(device: int = 0) -> Path:
+    from gpu_memory_service.common.utils import get_socket_path
+
+    return Path(get_socket_path(device))
+
+
+# ---------------------------------------------------------------------------
+# Phase timing extraction from log output
+# ---------------------------------------------------------------------------
+
+_MARKERS = {
+    "disk_start": re.compile(r"Loading GMS state:"),
+    "phaseA_end": re.compile(r"Phase A complete"),
+    "phaseB_end": re.compile(r"Phase B complete"),
+}
+
+
+def _ts(line: str) -> Optional[datetime]:
+    m = _TIMESTAMP_RE.match(line)
+    if not m:
+        return None
+    return datetime.strptime(m.group(1), "%Y-%m-%d %H:%M:%S,%f")
+
+
+def parse_phase_times(log_text: str) -> dict[str, float]:
+    """Return {diskA_s, phaseB_s, total_s} from subprocess log text.
+
+    Disk reads and Phase A (GMS VA allocation) run concurrently in the new
+    pipeline, so only the combined duration (disk_start → Phase A complete)
+    is measurable from logs.
+    """
+    times: dict[str, datetime] = {}
+    for line in log_text.splitlines():
+        for key, pat in _MARKERS.items():
+            if key not in times and pat.search(line):
+                ts = _ts(line)
+                if ts:
+                    times[key] = ts
+    result: dict[str, float] = {}
+    if "disk_start" in times and "phaseA_end" in times:
+        result["diskA_s"] = (times["phaseA_end"] - times["disk_start"]).total_seconds()
+    if "phaseA_end" in times and "phaseB_end" in times:
+        result["phaseB_s"] = (times["phaseB_end"] - times["phaseA_end"]).total_seconds()
+    if "disk_start" in times and "phaseB_end" in times:
+        result["total_s"] = (times["phaseB_end"] - times["disk_start"]).total_seconds()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Save phase
+# ---------------------------------------------------------------------------
+
+
+def run_save(
+    save_dir: Path,
+    model: str,
+    device: int = 0,
+    vllm_port: int = 18_700,
+    startup_timeout: int = 1800,
+    log_dir: Optional[Path] = None,
+) -> None:
+    """Load model via vLLM → GMS, save GMS state to disk, tear down."""
+    if log_dir is None:
+        log_dir = save_dir.parent / "gms_bench_logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    gms: Optional[ManagedProcess] = None
+    vllm: Optional[ManagedProcess] = None
+    try:
+        logger.info("=== Save phase: starting GMS + vLLM ===")
+        gms = ManagedProcess(_gms_server_cmd(device), log_dir / "gms_save.log")
+        time.sleep(2)
+        assert gms.is_running(), f"GMS exited.\n{gms.tail()}"
+
+        vllm = ManagedProcess(
+            _vllm_serve_cmd(model, vllm_port),
+            log_dir / "vllm_save.log",
+            env=_device_env(device),
+        )
+        assert _wait_for_http(
+            f"http://localhost:{vllm_port}/health", startup_timeout
+        ), f"vLLM did not become healthy.\nvLLM:\n{vllm.tail()}\nGMS:\n{gms.tail()}"
+        logger.info("vLLM healthy; saving GMS state → %s", save_dir)
+
+        subprocess.run(_gms_save_cmd(save_dir, device), check=True)
+
+        manifest = json.loads((save_dir / "manifest.json").read_text())
+        n = len(manifest.get("allocations", []))
+        total_gib = sum(a["aligned_size"] for a in manifest["allocations"]) / 1024**3
+        logger.info("Saved %d allocations (%.2f GiB) → %s", n, total_gib, save_dir)
+
+    finally:
+        if vllm:
+            vllm.terminate("vLLM")
+        if gms:
+            gms.terminate("GMS")
+        _wait_gpu_free(exclude_pids={os.getpid()}, timeout=120)
+        sock = _gms_socket_path(device)
+        if sock.exists():
+            sock.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Restore benchmark
+# ---------------------------------------------------------------------------
+
+
+def _gms_load_cmd(input_dir: Path, device: int = 0, workers: int = 16) -> list[str]:
+    return [
+        _python(),
+        "-m",
+        "gpu_memory_service.cli.storage_runner",
+        "load",
+        "--input-dir",
+        str(input_dir),
+        "--device",
+        str(device),
+        "--workers",
+        str(workers),
+        "--verbose",
+    ]
+
+
+def _fadvise_dontneed(path: Path) -> None:
+    """Tell the kernel to evict *path* from the page cache (POSIX_FADV_DONTNEED).
+
+    Works inside an unprivileged container — no SYS_ADMIN capability required.
+    Falls back silently if the libc call is unavailable.
+    """
+    _libc_name = ctypes.util.find_library("c")
+    if not _libc_name:
+        return
+    _libc = ctypes.CDLL(_libc_name, use_errno=True)
+    POSIX_FADV_DONTNEED = 4  # Linux constant
+    try:
+        fd = os.open(str(path), os.O_RDONLY)
+        try:
+            _libc.posix_fadvise(
+                fd, ctypes.c_int64(0), ctypes.c_int64(0), POSIX_FADV_DONTNEED
+            )
+        finally:
+            os.close(fd)
+    except OSError:
+        pass
+
+
+def _evict_save_dir(save_dir: Path) -> None:
+    """Evict all shard files and JSON metadata in *save_dir* from page cache."""
+    evicted = 0
+    for p in save_dir.rglob("*"):
+        if p.is_file():
+            _fadvise_dontneed(p)
+            evicted += 1
+    logger.info("fadvise(DONTNEED) called on %d files in %s", evicted, save_dir)
+
+
+def bench_restore(
+    save_dir: Path,
+    workers: int,
+    device: int = 0,
+    log_dir: Optional[Path] = None,
+    drop_cache: bool = False,
+) -> dict:
+    """Start fresh GMS, run restore with *workers*, return timing dict."""
+    if log_dir is None:
+        log_dir = save_dir.parent / "gms_bench_logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = json.loads((save_dir / "manifest.json").read_text())
+    total_bytes = sum(a["aligned_size"] for a in manifest["allocations"])
+    total_gib = total_bytes / 1024**3
+
+    if drop_cache:
+        _evict_save_dir(save_dir)
+
+    gms: Optional[ManagedProcess] = None
+    log_path = log_dir / f"gms_restore_w{workers}.log"
+    restore_log_path = log_dir / f"restore_w{workers}.log"
+
+    try:
+        gms = ManagedProcess(_gms_server_cmd(device), log_path)
+        time.sleep(2)
+        assert gms.is_running(), f"GMS exited.\n{gms.tail()}"
+
+        cmd = _gms_load_cmd(save_dir, device, workers)
+        wall_t0 = time.monotonic()
+        with open(restore_log_path, "w") as log_f:
+            subprocess.run(
+                cmd,
+                check=True,
+                capture_output=False,
+                stdout=log_f,
+                stderr=subprocess.STDOUT,
+            )
+        wall_elapsed = time.monotonic() - wall_t0
+
+        log_text = restore_log_path.read_text()
+        times = parse_phase_times(log_text)
+        times["wall_s"] = wall_elapsed
+        times["total_gib"] = total_gib
+        if "phaseB_s" in times and times["phaseB_s"] > 0:
+            times["phaseB_gib_s"] = total_gib / times["phaseB_s"]
+        if "total_s" in times and times["total_s"] > 0:
+            times["total_gib_s"] = total_gib / times["total_s"]
+
+        logger.info(
+            "workers=%3d  diskA=%.2fs  phaseB=%.2fs  total=%.2fs  "
+            "B_throughput=%.2f GiB/s",
+            workers,
+            times.get("diskA_s", float("nan")),
+            times.get("phaseB_s", float("nan")),
+            times.get("total_s", float("nan")),
+            times.get("phaseB_gib_s", float("nan")),
+        )
+        return {"workers": workers, **times}
+
+    finally:
+        if gms:
+            gms.terminate("GMS")
+        _wait_gpu_free(exclude_pids={os.getpid()}, timeout=60)
+        sock = _gms_socket_path(device)
+        if sock.exists():
+            sock.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark GMS restore phases")
+    parser.add_argument(
+        "--save-dir",
+        default="/ramdisk/gms_bench_save_72b",
+        help="Persistent directory for saved GMS state",
+    )
+    parser.add_argument(
+        "--model",
+        default="Qwen/Qwen2.5-72B-Instruct",
+        help="HuggingFace model id (used only if save needed)",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        nargs="+",
+        default=[16, 32, 64],
+        help="Worker counts to benchmark",
+    )
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--vllm-port", type=int, default=18_700)
+    parser.add_argument(
+        "--restore-only",
+        action="store_true",
+        help="Skip save phase even if save-dir is missing",
+    )
+    parser.add_argument(
+        "--drop-cache",
+        action="store_true",
+        help="Call fadvise(DONTNEED) on shard files before each run "
+        "to evict them from the page cache (cold-read measurement)",
+    )
+    args = parser.parse_args()
+
+    save_dir = Path(args.save_dir)
+
+    # Save phase (if needed)
+    if not (save_dir / "manifest.json").exists():
+        if args.restore_only:
+            sys.exit(f"Save dir {save_dir} missing but --restore-only set.")
+        logger.info("No save data found; running save phase first.")
+        run_save(save_dir, args.model, args.device, args.vllm_port)
+    else:
+        manifest = json.loads((save_dir / "manifest.json").read_text())
+        total_gib = sum(a["aligned_size"] for a in manifest["allocations"]) / 1024**3
+        logger.info(
+            "Using existing save at %s (%.2f GiB, %d allocs)",
+            save_dir,
+            total_gib,
+            len(manifest["allocations"]),
+        )
+
+    # Restore benchmark
+    logger.info(
+        "=== Starting restore benchmark: workers=%s drop_cache=%s ===",
+        args.workers,
+        args.drop_cache,
+    )
+    results = []
+    for w in args.workers:
+        logger.info("--- workers=%d ---", w)
+        r = bench_restore(save_dir, w, args.device, drop_cache=args.drop_cache)
+        results.append(r)
+
+    # Summary table
+    print()
+    print(
+        f"{'workers':>8}  {'diskA_s':>8}  {'phaseB_s':>9}  "
+        f"{'total_s':>8}  {'B_GiB/s':>8}  {'tot_GiB/s':>10}"
+    )
+    print("-" * 68)
+    for r in results:
+        print(
+            f"{r['workers']:>8}  "
+            f"{r.get('diskA_s', float('nan')):>8.2f}  "
+            f"{r.get('phaseB_s', float('nan')):>9.2f}  "
+            f"{r.get('total_s', float('nan')):>8.2f}  "
+            f"{r.get('phaseB_gib_s', float('nan')):>8.2f}  "
+            f"{r.get('total_gib_s', float('nan')):>10.2f}"
+        )
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/gpu_memory_service/tests/e2e/conftest.py
+++ b/lib/gpu_memory_service/tests/e2e/conftest.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--model",
+        default="facebook/opt-125m",
+        help="HuggingFace model id or local path to use for the E2E test "
+        "(default: facebook/opt-125m).",
+    )
+    parser.addoption(
+        "--vllm-port",
+        type=int,
+        default=18_700,
+        help="TCP port for the vLLM OpenAI-compatible server (default: 18700).",
+    )
+    parser.addoption(
+        "--vllm-startup-timeout",
+        type=int,
+        default=300,
+        help="Seconds to wait for vLLM to become healthy (default: 300).",
+    )
+    parser.addoption(
+        "--restore-workers",
+        type=int,
+        default=4,
+        help="Number of parallel worker threads for restoring GMS state from "
+        "disk (default: 4).  Passed as --workers to gms-storage-client load.",
+    )

--- a/lib/gpu_memory_service/tests/e2e/multi_ssd_bench.py
+++ b/lib/gpu_memory_service/tests/e2e/multi_ssd_bench.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Multi-SSD GMS restore benchmark with exclusive per-SSD thread affinity.
+
+The ThreadPoolExecutor submits ONE task per NVMe (not one per shard).
+Each task reads ALL shards on its assigned drive sequentially — so concurrent
+reads to the same SSD are structurally impossible.
+
+Shard distribution (round-robin by sorted shard index):
+    shard_N  →  /mnt/nvme{2 + N % 8}/gms_shards/shard_NNNN.bin
+
+Restore phases
+--------------
+  Disk  : 8 threads, one per NVMe, each reads its shards front-to-back.
+  Phase A: serial GMS VA allocation (cuMemCreate × N allocs).
+  Phase B: parallel CPU→GPU copy (one CUDA stream per worker thread).
+
+Usage
+-----
+    # First run: save Qwen2.5-72B to nvme2, distribute, then benchmark.
+    .venv/bin/python multi_ssd_bench.py
+
+    # Subsequent runs (shards already distributed):
+    .venv/bin/python multi_ssd_bench.py --skip-distribute
+
+    # Keep page cache warm (removes cold-read penalty for debugging):
+    .venv/bin/python multi_ssd_bench.py --skip-distribute --no-drop-cache
+"""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import ctypes.util
+import json
+import logging
+import os
+import queue
+import shutil
+import sys
+import threading
+import time
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s %(message)s",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
+
+_WORK_QUEUE_DEPTH_MULTIPLIER = 2
+
+# Cache the libc handle once at import time — ctypes.util.find_library +
+# CDLL are non-trivial and would otherwise run once per shard file.
+_libc_name = ctypes.util.find_library("c")
+_libc: Optional[ctypes.CDLL] = (
+    ctypes.CDLL(_libc_name, use_errno=True) if _libc_name else None
+)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+NVME_DIRS: List[Path] = [Path(f"/mnt/nvme{i}") for i in range(2, 10)]  # nvme2..nvme9
+SHARD_SUBDIR = "gms_shards"  # per-NVMe subdir that holds copied shard files
+
+# ---------------------------------------------------------------------------
+# Shared process helpers (imported from adjacent bench script)
+# ---------------------------------------------------------------------------
+
+sys.path.insert(0, str(Path(__file__).parent))
+from bench_gms_restore import (  # noqa: E402
+    ManagedProcess,
+    _gms_server_cmd,
+    _gms_socket_path,
+    _wait_gpu_free,
+    run_save,
+)
+
+# ---------------------------------------------------------------------------
+# GMS / PyTorch imports
+# ---------------------------------------------------------------------------
+
+try:
+    from gpu_memory_service.client.gms_storage_client import (
+        AllocationEntry,
+        SaveManifest,
+        _decode_metadata,
+        _group_entries_by_shard,
+        _read_shard_sequential,
+    )
+    from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
+    from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
+    from gpu_memory_service.common.types import RequestedLockType
+
+    _GMS_OK = True
+except ImportError as _e:
+    logger.error("GMS imports unavailable: %s", _e)
+    _GMS_OK = False
+
+try:
+    import torch
+
+    _TORCH_OK = True
+except ImportError:
+    _TORCH_OK = False
+
+
+# ---------------------------------------------------------------------------
+# Shard distribution: copy shards round-robin to /mnt/nvme{2..9}/gms_shards/
+# ---------------------------------------------------------------------------
+
+
+def distribute_shards(save_dir: Path, nvme_dirs: List[Path]) -> None:
+    """Copy shard files round-robin to per-NVMe directories.
+
+    shard_N  →  nvme_dirs[N % len(nvme_dirs)] / SHARD_SUBDIR / shard_NNNN.bin
+
+    Uses hard links when source and destination are on the same filesystem
+    (instant, no data copy).  Falls back to shutil.copy2() across devices.
+    Already-present destination files are skipped.
+    Copies run in parallel (one thread per NVMe) to saturate source bandwidth.
+    """
+    shard_files = sorted((save_dir / "shards").glob("shard_*.bin"))
+    if not shard_files:
+        raise FileNotFoundError(f"No shard files found in {save_dir / 'shards'}")
+
+    n = len(nvme_dirs)
+    logger.info(
+        "Distributing %d shards across %d NVMes (~%d shards/NVMe) …",
+        len(shard_files),
+        n,
+        (len(shard_files) + n - 1) // n,
+    )
+
+    for d in nvme_dirs:
+        (d / SHARD_SUBDIR).mkdir(parents=True, exist_ok=True)
+
+    def _copy_one(idx: int, src: Path) -> None:
+        dest = nvme_dirs[idx % n] / SHARD_SUBDIR / src.name
+        if dest.exists():
+            dest.unlink()
+        # Hard-link if same filesystem (instant); copy otherwise.
+        try:
+            os.link(src, dest)
+            logger.debug("  shard_%04d refreshed via hard link → %s", idx, dest.parent)
+        except OSError:  # EXDEV — different device
+            logger.info("  copying shard_%04d → %s", idx, dest.parent)
+            shutil.copy2(src, dest)
+
+    with ThreadPoolExecutor(max_workers=n) as pool:
+        futs = {pool.submit(_copy_one, i, f): i for i, f in enumerate(shard_files)}
+        for fut in as_completed(futs):
+            fut.result()  # re-raise any errors
+
+    # Flush dirty pages to disk so O_DIRECT reads in the benchmark see clean
+    # data; without this, competing write-back tanks read throughput.
+    os.sync()
+    logger.info("Shard distribution complete.")
+
+
+# ---------------------------------------------------------------------------
+# Build per-NVMe shard groups (mirrors distribute_shards assignment)
+# ---------------------------------------------------------------------------
+
+
+def _build_nvme_groups(
+    manifest: SaveManifest,
+    nvme_dirs: List[Path],
+) -> Dict[Path, List[Tuple[str, List[AllocationEntry]]]]:
+    """Map each NVMe to the list of (abs_path, sorted_entries) it owns.
+
+    Assignment rule is identical to distribute_shards: shard at sorted
+    index N belongs to nvme_dirs[N % len(nvme_dirs)].
+
+    IMPORTANT: both distribute_shards and this function sort shard filenames
+    lexicographically (``sorted(glob(...))`` vs ``sorted(by_shard.keys())``).
+    The round-robin index N must be consistent between the two — if the sort
+    order here ever diverges from distribute_shards, shards will be read from
+    the wrong NVMe.
+
+    Returns:
+        { nvme_dir: [(abs_shard_path, sorted_entries), …] }
+        One entry per shard file assigned to that NVMe.
+    """
+    by_shard = _group_entries_by_shard(manifest.allocations)
+    sorted_rel_paths = sorted(by_shard.keys())  # "shards/shard_NNNN.bin" in order
+
+    result: Dict[Path, List[Tuple[str, List[AllocationEntry]]]] = defaultdict(list)
+    for idx, rel_path in enumerate(sorted_rel_paths):
+        nvme = nvme_dirs[idx % len(nvme_dirs)]
+        shard_name = Path(rel_path).name  # "shard_NNNN.bin"
+        abs_path = str(nvme / SHARD_SUBDIR / shard_name)
+        result[nvme].append((abs_path, by_shard[rel_path]))
+
+    return dict(result)
+
+
+# ---------------------------------------------------------------------------
+# Page-cache eviction
+# ---------------------------------------------------------------------------
+
+
+def _fadvise_dontneed(path: str) -> None:
+    """Evict a single file from the page cache (POSIX_FADV_DONTNEED)."""
+    if _libc is None:
+        return
+    POSIX_FADV_DONTNEED = 4
+    try:
+        fd = os.open(path, os.O_RDONLY)
+        try:
+            _libc.posix_fadvise(
+                fd, ctypes.c_int64(0), ctypes.c_int64(0), POSIX_FADV_DONTNEED
+            )
+        finally:
+            os.close(fd)
+    except OSError:
+        pass
+
+
+def drop_shard_caches(
+    nvme_groups: Dict[Path, List[Tuple[str, List[AllocationEntry]]]],
+) -> None:
+    """Call fadvise(DONTNEED) on every shard file assigned to each NVMe."""
+    evicted = 0
+    for shard_list in nvme_groups.values():
+        for abs_path, _ in shard_list:
+            _fadvise_dontneed(abs_path)
+            evicted += 1
+    logger.info("Page-cache evicted for %d shard files", evicted)
+
+
+# ---------------------------------------------------------------------------
+# Disk-read worker: one thread owns one NVMe, reads all its shards in order
+# ---------------------------------------------------------------------------
+
+
+def _read_and_enqueue(
+    shard_list: List[Tuple[str, List[AllocationEntry]]],
+    nvme_label: str,
+    work_q: "queue.Queue",
+    entry_by_id: Dict[str, "AllocationEntry"],
+    cancel_event: Optional[threading.Event] = None,
+) -> int:
+    """Read shards for one NVMe, putting per-allocation items on work_q after each shard.
+
+    Reads each shard as one large O_DIRECT read (fast sequential I/O), then
+    immediately enqueues all allocations.  Copy threads see data after each
+    shard completes (~shard_size / NVMe_speed, e.g. 0.3 s for 1 GiB shards).
+
+    NOTE: shard_size_bytes < ~1.2 GiB is required for the copy tail to reach zero
+    and combined time to approach disk_time (speed-of-light ≈ 5.45 s total).
+
+    Uses timed put() + cancel_event checks so that a Phase A exception that
+    calls _cancel_pipeline() is guaranteed to unblock this function; without
+    this, a full queue would cause this function to block forever.
+    """
+    n = 0
+    for abs_path, sorted_entries in shard_list:
+        logger.debug(
+            "%s  reading %s (%d allocs)", nvme_label, abs_path, len(sorted_entries)
+        )
+        shard_result = _read_shard_sequential(abs_path, sorted_entries, device=-1)
+        for alloc_id, src in shard_result.items():
+            while True:
+                if cancel_event is not None and cancel_event.is_set():
+                    logger.debug("%s  cancelled mid-enqueue", nvme_label)
+                    return n
+                try:
+                    work_q.put((entry_by_id[alloc_id], src), timeout=0.1)
+                    break
+                except queue.Full:
+                    pass
+            n += 1
+    logger.info("%s  done — %d allocations enqueued", nvme_label, n)
+    return n
+
+
+# ---------------------------------------------------------------------------
+# Full restore with per-NVMe thread affinity
+# ---------------------------------------------------------------------------
+
+
+def restore_multissd(
+    save_dir: Path,
+    nvme_dirs: List[Path],
+    device: int = 0,
+    drop_cache: bool = True,
+    log_dir: Optional[Path] = None,
+) -> dict:
+    """Run a full GMS restore with one exclusive reader thread per NVMe.
+
+    Returns a dict with timing breakdown and throughput numbers.
+    """
+    if not _GMS_OK:
+        raise RuntimeError("GMS imports not available — check venv installation")
+
+    if log_dir is None:
+        log_dir = save_dir.parent / "gms_bench_logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # Load manifest + metadata
+    manifest = SaveManifest.from_dict(
+        json.loads((save_dir / "manifest.json").read_text())
+    )
+    total_gib = sum(e.aligned_size for e in manifest.allocations) / 1024**3
+    raw_meta: dict = {}
+    meta_path = save_dir / "gms_metadata.json"
+    if meta_path.exists():
+        raw_meta = json.loads(meta_path.read_text())
+
+    # Build per-NVMe shard groups (same assignment as distribute_shards)
+    nvme_groups = _build_nvme_groups(manifest, nvme_dirs)
+    n_threads = len(nvme_groups)
+
+    logger.info(
+        "Multi-SSD restore: %.2f GiB  |  %d shards  |  %d NVMes  |  1 thread/NVMe",
+        total_gib,
+        sum(len(v) for v in nvme_groups.values()),
+        n_threads,
+    )
+    for nvme, shard_list in sorted(nvme_groups.items()):
+        logger.info(
+            "  %s  ←  %d shards  (%.2f GiB)",
+            nvme,
+            len(shard_list),
+            sum(
+                sum(e.aligned_size for e in entries) / 1024**3
+                for _, entries in shard_list
+            ),
+        )
+
+    if drop_cache:
+        drop_shard_caches(nvme_groups)
+
+    sock = _gms_socket_path(device)
+    gms: Optional[ManagedProcess] = None
+
+    disk_s = phaseA_s = combined_s = float("nan")
+
+    try:
+        # Start a fresh GMS server
+        gms = ManagedProcess(_gms_server_cmd(device), log_dir / "gms_multissd.log")
+        time.sleep(2)
+        assert gms.is_running(), f"GMS server exited immediately.\n{gms.tail()}"
+
+        # ── Pipelined Disk + Phase A + B (one RW lock session) ──
+        # Phase A (serial cuMemCreate, ~0.6 s) and disk reads start simultaneously.
+        # Phase A runs in the main thread; disk reads run in the thread pool.
+        # Copy threads wait for each allocation's VA via _va_events before copying.
+        # This hides Phase A entirely under the ~5 s disk phase.
+        with GMSClientMemoryManager(str(sock), device=device) as mm:
+            mm.connect(RequestedLockType.RW)
+            cleared = mm.clear_all_handles()
+            if cleared:
+                logger.info("Cleared %d pre-existing allocations", cleared)
+
+            # Setup for pipelined disk + registration + copy
+            import queue as _queue
+            import threading as _threading
+
+            _libcudart = ctypes.CDLL("libcudart.so", use_errno=True)
+            _libcudart.cudaHostRegister.restype = ctypes.c_int
+            _libcudart.cudaHostUnregister.restype = ctypes.c_int
+
+            streams = (
+                [torch.cuda.Stream(device=device) for _ in range(n_threads)]
+                if _TORCH_OK and torch.cuda.is_available()
+                else []
+            )
+
+            entry_by_id = {e.allocation_id: e for e in manifest.allocations}
+            _work_q: _queue.Queue = _queue.Queue(
+                maxsize=max(1, n_threads * _WORK_QUEUE_DEPTH_MULTIPLIER)
+            )
+            _state_lock = _threading.Lock()
+            _cancel_event = _threading.Event()
+            _registered: list = []
+            _srcs: list = []  # keep src tensors alive until after CUDA sync
+            _copy_exc: list = []
+            id_map: Dict[str, str] = {}
+            vas: Dict[str, int] = {}
+
+            # One event per allocation: set by Phase A after VA is ready
+            _va_events: Dict[str, _threading.Event] = {
+                e.allocation_id: _threading.Event() for e in manifest.allocations
+            }
+
+            def _register_and_copy(stream_idx: int) -> None:
+                while True:
+                    try:
+                        item = _work_q.get(timeout=0.1)
+                    except _queue.Empty:
+                        if _cancel_event.is_set():
+                            return
+                        continue
+                    if item is None:
+                        return
+                    entry, src = item
+                    try:
+                        # Wait until Phase A has allocated the VA for this allocation
+                        while not _va_events[entry.allocation_id].wait(timeout=0.1):
+                            if _cancel_event.is_set():
+                                return
+                        if streams and not src.is_pinned():
+                            ptr = ctypes.c_void_p(src.data_ptr())
+                            ret = _libcudart.cudaHostRegister(
+                                ptr, ctypes.c_size_t(src.nbytes), ctypes.c_uint(0)
+                            )
+                            if ret == 0:
+                                with _state_lock:
+                                    _registered.append(ptr)
+                        dst = _tensor_from_pointer(
+                            vas[entry.allocation_id],
+                            [entry.aligned_size],
+                            [1],
+                            torch.uint8,
+                            device,
+                        )
+                        if streams:
+                            with torch.cuda.stream(streams[stream_idx]):
+                                dst.copy_(src, non_blocking=True)
+                        else:
+                            dst.copy_(src)
+                        # Keep src alive until torch.cuda.synchronize() below;
+                        # async DMA may still be reading it after copy_ returns.
+                        with _state_lock:
+                            _srcs.append(src)
+                    except Exception as exc:  # noqa: BLE001
+                        with _state_lock:
+                            _copy_exc.append(exc)
+
+            def _drain_queue() -> None:
+                while True:
+                    try:
+                        _work_q.get_nowait()
+                    except _queue.Empty:
+                        break
+
+            def _cancel_pipeline() -> None:
+                _cancel_event.set()
+                for event in _va_events.values():
+                    event.set()
+                _drain_queue()
+
+            def _stop_copy_threads(*, drain_queue: bool = False) -> None:
+                if drain_queue:
+                    _drain_queue()
+                for _ in range(n_threads):
+                    while True:
+                        try:
+                            _work_q.put(None, timeout=0.1)
+                            break
+                        except _queue.Full:
+                            if drain_queue:
+                                _drain_queue()
+                for t in copy_threads:
+                    t.join()
+
+            # Start copy threads before disk and Phase A
+            copy_threads = [
+                _threading.Thread(target=_register_and_copy, args=(i,), daemon=True)
+                for i in range(n_threads)
+            ]
+            for t in copy_threads:
+                t.start()
+
+            # Start disk and Phase A simultaneously
+            t_combined = time.monotonic()
+
+            # Launch disk pool in background (non-blocking submit)
+            disk_pool = ThreadPoolExecutor(max_workers=n_threads)
+            disk_futs = {
+                disk_pool.submit(
+                    _read_and_enqueue,
+                    shard_list,
+                    str(nvme),
+                    _work_q,
+                    entry_by_id,
+                    _cancel_event,
+                ): nvme
+                for nvme, shard_list in nvme_groups.items()
+            }
+
+            # Phase A: serial cuMemCreate — runs concurrently with disk reads above
+            t_a = time.monotonic()
+            try:
+                for entry in manifest.allocations:
+                    va = mm.create_mapping(size=entry.size, tag=entry.tag)
+                    new_id = mm.get_allocation_id(va)
+                    id_map[entry.allocation_id] = new_id
+                    vas[entry.allocation_id] = va
+                    # Signal copy threads that VA for this allocation is ready
+                    _va_events[entry.allocation_id].set()
+            except Exception:
+                _cancel_pipeline()
+                disk_pool.shutdown(wait=True, cancel_futures=True)
+                _stop_copy_threads(drain_queue=True)
+                raise
+            phaseA_s = time.monotonic() - t_a
+            logger.info(
+                "Phase A complete: %.3fs  (%d GMS VAs allocated)", phaseA_s, len(vas)
+            )
+
+            # Wait for all disk reads to finish
+            try:
+                for fut in as_completed(disk_futs):
+                    fut.result()  # propagate any read exceptions
+            finally:
+                disk_pool.shutdown(wait=True)
+            disk_s = time.monotonic() - t_combined
+            logger.info(
+                "Disk reads complete: %.2fs  (%.2f GiB/s)", disk_s, total_gib / disk_s
+            )
+
+            # Signal copy threads and wait for all DMAs to be enqueued
+            _stop_copy_threads()
+
+            try:
+                if streams:
+                    torch.cuda.synchronize(device=device)
+                combined_s = time.monotonic() - t_combined
+            finally:
+                for ptr in _registered:
+                    _libcudart.cudaHostUnregister(ptr)
+                _srcs.clear()
+
+            if _copy_exc:
+                raise _copy_exc[0]
+            logger.info(
+                "Disk+B combined: %.2fs  (%.2f GiB/s  effective)",
+                combined_s,
+                total_gib / combined_s if combined_s > 0 else float("nan"),
+            )
+
+            # Restore metadata and commit
+            saved_metadata = _decode_metadata(raw_meta)
+            for key, meta in saved_metadata.items():
+                old_id = meta["allocation_id"]
+                new_id = id_map.get(old_id, old_id)
+                mm.metadata_put(key, new_id, meta["offset_bytes"], meta["value"])
+            ok = mm.commit()
+            if not ok:
+                raise RuntimeError("GMS commit failed after restore")
+
+    finally:
+        if gms:
+            gms.terminate("GMS")
+        _wait_gpu_free(exclude_pids={os.getpid()}, timeout=60)
+        if sock.exists():
+            sock.unlink()
+
+    total_s = combined_s  # Phase A overlaps with disk; combined_s already covers both
+    return {
+        "n_nvmes": n_threads,
+        "total_gib": total_gib,
+        "disk_s": disk_s,
+        "phaseA_s": phaseA_s,
+        "combined_s": combined_s,
+        "total_s": total_s,
+        "disk_gib_s": total_gib / disk_s if disk_s > 0 else float("nan"),
+        "combined_gib_s": total_gib / combined_s if combined_s > 0 else float("nan"),
+        "total_gib_s": total_gib / total_s if total_s > 0 else float("nan"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Multi-SSD GMS restore benchmark (exclusive per-SSD thread affinity)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--source-dir",
+        default="/mnt/nvme2/gms_bench_save_72b",
+        help="Directory for the initial (single-SSD) GMS save "
+        "(default: /mnt/nvme2/gms_bench_save_72b)",
+    )
+    parser.add_argument(
+        "--model",
+        default="Qwen/Qwen2.5-72B-Instruct",
+        help="HuggingFace model for the save phase (used only if save is missing)",
+    )
+    parser.add_argument("--device", type=int, default=0, help="CUDA device index")
+    parser.add_argument(
+        "--skip-distribute",
+        action="store_true",
+        help="Skip copying shards to per-NVMe dirs (assume already done)",
+    )
+    parser.add_argument(
+        "--no-drop-cache",
+        action="store_true",
+        help="Do NOT evict page cache before measuring (warm-cache run)",
+    )
+    args = parser.parse_args()
+
+    source_dir = Path(args.source_dir)
+
+    # 1. Save phase (if save data is missing)
+    if not (source_dir / "manifest.json").exists():
+        logger.info(
+            "=== Save phase: loading model and saving GMS state → %s ===", source_dir
+        )
+        run_save(source_dir, args.model, args.device)
+    else:
+        manifest = json.loads((source_dir / "manifest.json").read_text())
+        total_gib = sum(a["aligned_size"] for a in manifest["allocations"]) / 1024**3
+        logger.info(
+            "Existing save found at %s  (%.2f GiB, %d allocs, %d shards)",
+            source_dir,
+            total_gib,
+            len(manifest["allocations"]),
+            len({a["tensor_file"] for a in manifest["allocations"]}),
+        )
+
+    # 2. Distribute shards across NVMes
+    if not args.skip_distribute:
+        distribute_shards(source_dir, NVME_DIRS)
+    else:
+        logger.info("--skip-distribute: using shards already on NVMes")
+
+    # 3. Benchmark restore
+    logger.info(
+        "=== Multi-SSD restore benchmark: %d NVMes, 1 thread/NVMe, drop_cache=%s ===",
+        len(NVME_DIRS),
+        not args.no_drop_cache,
+    )
+    result = restore_multissd(
+        source_dir,
+        NVME_DIRS,
+        device=args.device,
+        drop_cache=not args.no_drop_cache,
+    )
+
+    # Results
+    W = 60
+    print()
+    print("─" * W)
+    print(
+        f"  Multi-SSD GMS restore  ({result['n_nvmes']} NVMes, 1 exclusive thread/NVMe)"
+    )
+    print("─" * W)
+    print(f"  Data     : {result['total_gib']:.2f} GiB")
+    print(f"  Phase A  : {result['phaseA_s']:.3f}s  (overlapped with disk reads)")
+    print(
+        f"  Disk+B   : {result['combined_s']:.2f}s"
+        f"   →  {result['combined_gib_s']:.2f} GiB/s  (disk+PhaseA+copy overlapped)"
+    )
+    print(
+        f"    disk   : {result['disk_s']:.2f}s"
+        f"   →  {result['disk_gib_s']:.2f} GiB/s  (aggregate across all NVMes)"
+    )
+    print(
+        f"  Total    : {result['total_s']:.2f}s   →  {result['total_gib_s']:.2f} GiB/s"
+    )
+    print("─" * W)
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/gpu_memory_service/tests/e2e/reshard.py
+++ b/lib/gpu_memory_service/tests/e2e/reshard.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Repack an existing GMS save directory with a different shard size.
+
+Reads all allocations from the source shards and rewrites them into new shard
+files capped at *--shard-size-bytes*.  The allocation IDs, sizes, and tags are
+preserved; only tensor_file and tensor_offset change.
+
+Usage
+-----
+    .venv/bin/python reshard.py \
+        --source /mnt/nvme2/gms_bench_save_72b \
+        --dest   /mnt/nvme2/gms_bench_save_1gib \
+        --shard-size-bytes 1073741824
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import shutil
+import sys
+import time
+from dataclasses import replace
+from pathlib import Path
+
+logging.basicConfig(format="%(asctime)s %(levelname)s %(message)s", level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+
+def reshard(source_dir: Path, dest_dir: Path, shard_size_bytes: int) -> None:
+    from gpu_memory_service.client.gms_storage_client import (
+        SaveManifest,
+        _group_entries_by_shard,
+        _read_shard_sequential,
+        _ShardWriter,
+    )
+
+    manifest = SaveManifest.from_dict(
+        json.loads((source_dir / "manifest.json").read_text())
+    )
+    total_gib = sum(e.aligned_size for e in manifest.allocations) / 1024**3
+    logger.info(
+        "Source: %s  (%.2f GiB, %d allocs, %d shards)",
+        source_dir,
+        total_gib,
+        len(manifest.allocations),
+        len({e.tensor_file for e in manifest.allocations}),
+    )
+    logger.info(
+        "Dest:   %s  (shard_size=%.2f GiB)",
+        dest_dir,
+        shard_size_bytes / 1024**3,
+    )
+
+    if dest_dir.exists() and any(dest_dir.iterdir()):
+        raise FileExistsError(
+            f"Destination directory {dest_dir} must not already contain files"
+        )
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    shards_dir = dest_dir / "shards"
+    shards_dir.mkdir(parents=True, exist_ok=True)
+
+    # Read source shards in order; write to new shards
+    groups = _group_entries_by_shard(manifest.allocations)
+
+    new_by_id: dict = {}  # allocation_id → new AllocationEntry
+    t0 = time.monotonic()
+    bytes_written = 0
+
+    with _ShardWriter(str(shards_dir), shard_size_bytes=shard_size_bytes) as writer:
+        for rel_path, sorted_entries in sorted(groups.items()):
+            abs_path = str(source_dir / rel_path)
+            logger.info(
+                "  reading %s  (%d allocs, %.2f GiB)",
+                rel_path,
+                len(sorted_entries),
+                sum(e.aligned_size for e in sorted_entries) / 1024**3,
+            )
+            tensors = _read_shard_sequential(abs_path, sorted_entries, device=-1)
+            for entry in sorted_entries:
+                src = tensors[entry.allocation_id]
+                new_rel, new_off = writer.write(src)
+                new_by_id[entry.allocation_id] = replace(
+                    entry, tensor_file=new_rel, tensor_offset=new_off
+                )
+                bytes_written += entry.aligned_size
+
+    elapsed = time.monotonic() - t0
+    gib_written = bytes_written / 1024**3
+    logger.info(
+        "Resharding done: %.2f GiB in %.1fs  (%.2f GiB/s)",
+        gib_written,
+        elapsed,
+        gib_written / elapsed if elapsed > 0 else 0,
+    )
+
+    # Write new manifest preserving original allocation order
+    new_allocs = [new_by_id[e.allocation_id] for e in manifest.allocations]
+    new_manifest = SaveManifest(
+        version=manifest.version,
+        timestamp=manifest.timestamp,
+        layout_hash=manifest.layout_hash,
+        device=manifest.device,
+        allocations=new_allocs,
+    )
+    (dest_dir / "manifest.json").write_text(
+        json.dumps(new_manifest.to_dict(), indent=2)
+    )
+    n_new_shards = len({e.tensor_file for e in new_allocs})
+    logger.info(
+        "Wrote manifest: %d allocs across %d shards", len(new_allocs), n_new_shards
+    )
+
+    # Copy metadata
+    meta_src = source_dir / "gms_metadata.json"
+    if meta_src.exists():
+        shutil.copy2(meta_src, dest_dir / "gms_metadata.json")
+
+    logger.info("Done → %s", dest_dir)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source", required=True, type=Path, help="Source save directory"
+    )
+    parser.add_argument(
+        "--dest", required=True, type=Path, help="Destination directory"
+    )
+    parser.add_argument(
+        "--shard-size-bytes",
+        type=int,
+        default=1 * 1024**3,
+        help="Soft shard size limit in bytes (default: 1 GiB)",
+    )
+    args = parser.parse_args()
+    reshard(args.source, args.dest, args.shard_size_bytes)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/gpu_memory_service/tests/e2e/test_gms_vllm_serialize.py
+++ b/lib/gpu_memory_service/tests/e2e/test_gms_vllm_serialize.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""In-process E2E test: GMS serialize/deserialize with a vLLM engine.
+
+This variant avoids subprocesses and `nvidia-smi` polling entirely:
+
+1. Start a GMS server in a background thread.
+2. Instantiate an in-process vLLM `LLM` with `load_format="gms"`.
+3. Verify generation works and the loader logged GMS write mode.
+4. Save GMS state to disk via `GMSStorageClient.save()`.
+5. Tear down the engine and GMS server, then start a fresh GMS server.
+6. Restore the saved state via `GMSStorageClient.load_to_gms()`.
+7. Instantiate a second in-process vLLM `LLM` in read-only GMS mode.
+8. Verify generation works and the loader logged GMS read mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import logging
+import shutil
+import threading
+from pathlib import Path
+from typing import Generator, Optional
+
+import pytest
+
+torch = pytest.importorskip("torch")
+vllm = pytest.importorskip("vllm")
+uvloop = pytest.importorskip("uvloop")
+
+from gpu_memory_service.client.gms_storage_client import GMSStorageClient  # noqa: E402
+from gpu_memory_service.common.utils import get_socket_path  # noqa: E402
+from gpu_memory_service.integrations.vllm import (  # noqa: E402, F401
+    worker as _gms_vllm_worker,
+)
+from gpu_memory_service.server import GMSRPCServer  # noqa: E402
+from vllm import LLM, SamplingParams  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+def _run_server(
+    socket_path: str,
+    ready_event: threading.Event,
+    stop_event: threading.Event,
+) -> None:
+    async def _serve() -> None:
+        server = GMSRPCServer(socket_path, device=0)
+        await server.start()
+        ready_event.set()
+        try:
+            while not stop_event.is_set():
+                await asyncio.sleep(0.05)
+        finally:
+            await server.stop()
+
+    uvloop.install()
+    asyncio.run(_serve())
+
+
+class ThreadedGMSServer:
+    """Thread wrapper for an in-process GMS server."""
+
+    def __init__(self, device: int = 0) -> None:
+        self.device = device
+        self.socket_path = str(get_socket_path(device))
+        self._ready = threading.Event()
+        self._stop = threading.Event()
+        self._started = False
+        self._thread = threading.Thread(
+            target=_run_server,
+            args=(self.socket_path, self._ready, self._stop),
+            daemon=True,
+        )
+
+    def start(self) -> None:
+        sock = Path(self.socket_path)
+        if sock.exists():
+            sock.unlink()
+        self._thread.start()
+        self._started = True
+        assert self._ready.wait(timeout=10), "GMS server did not start in time"
+
+    def stop(self) -> None:
+        if not self._started:
+            return
+        self._stop.set()
+        self._thread.join(timeout=10)
+        if self._thread.is_alive():
+            logger.warning("GMS server thread did not stop within 10 s")
+        sock = Path(self.socket_path)
+        if sock.exists():
+            sock.unlink()
+
+
+def _reset_gms_allocator_singleton() -> None:
+    """Clear the process-global GMS allocator state between vLLM engine lifecycles."""
+    from gpu_memory_service.client.torch import allocator as gms_allocator
+
+    manager = gms_allocator.get_gms_client_memory_manager()
+    if manager is not None:
+        manager.close()
+
+    gms_allocator._manager = None
+    gms_allocator._mem_pool = None
+    gms_allocator._tag = "weights"
+
+
+def _destroy_llm(llm: Optional[LLM]) -> None:
+    """Best-effort cleanup for an in-process vLLM engine."""
+    from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
+
+    if llm is not None:
+        try:
+            sleep = getattr(llm, "sleep", None)
+            if callable(sleep):
+                sleep()
+        except Exception:
+            pass
+
+        del llm
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+    cleanup_dist_env_and_memory()
+
+    _reset_gms_allocator_singleton()
+
+
+def _build_llm(model: str, *, read_only: bool) -> LLM:
+    extra = {"gms_read_only": True} if read_only else {}
+    return LLM(
+        model=model,
+        load_format="gms",
+        worker_cls="gpu_memory_service.integrations.vllm.worker.GMSWorker",
+        enforce_eager=True,
+        max_model_len=512,
+        trust_remote_code=False,
+        disable_log_stats=True,
+        gpu_memory_utilization=0.1,
+        kv_cache_memory_bytes=256 * 1024 * 1024,
+        model_loader_extra_config=extra,
+    )
+
+
+def _generate_text(llm: LLM, prompt: str = "The capital of France is") -> str:
+    outputs = llm.generate(
+        prompt,
+        SamplingParams(max_tokens=10, temperature=0.0),
+        use_tqdm=False,
+    )
+    return outputs[0].outputs[0].text
+
+
+@pytest.fixture(scope="module")
+def tmp_save_dir(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[Path, None, None]:
+    d = tmp_path_factory.mktemp("gms_save")
+    yield d
+    if d.exists():
+        shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.mark.e2e
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+class TestGMSSerializeDeserialize:
+    """Serialize GMS state to disk, restore it, and confirm vLLM reuses weights."""
+
+    def test_full_lifecycle(
+        self,
+        request: pytest.FixtureRequest,
+        tmp_save_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        model: str = request.config.getoption("--model")
+        restore_workers: int = request.config.getoption("--restore-workers")
+
+        monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+
+        gms1 = ThreadedGMSServer(device=0)
+        gms2 = ThreadedGMSServer(device=0)
+        llm1: Optional[LLM] = None
+        llm2: Optional[LLM] = None
+
+        caplog.set_level(logging.INFO)
+
+        try:
+            logger.info(
+                "=== Phase 1: start threaded GMS + in-process vLLM (RW mode) ==="
+            )
+            gms1.start()
+
+            caplog.clear()
+            llm1 = _build_llm(model, read_only=False)
+            generated_text = _generate_text(llm1)
+            assert generated_text, "Phase 1 baseline generation returned empty text."
+            assert "Write mode" in caplog.text or "write mode" in caplog.text, (
+                "Expected vLLM to publish weights in GMS write mode.\n"
+                f"Captured logs:\n{caplog.text}"
+            )
+
+            logger.info("=== Phase 2: save GMS state to disk ===")
+            client = GMSStorageClient(
+                str(tmp_save_dir),
+                socket_path=gms1.socket_path,
+                device=0,
+            )
+            manifest = client.save()
+            assert manifest.allocations, "Save produced 0 allocations."
+
+            logger.info("=== Phase 3: tear down engine and GMS ===")
+            _destroy_llm(llm1)
+            llm1 = None
+            gms1.stop()
+
+            logger.info("=== Phase 4: start fresh threaded GMS + restore ===")
+            gms2.start()
+            restore_client = GMSStorageClient(
+                socket_path=gms2.socket_path,
+                device=0,
+            )
+            id_map = restore_client.load_to_gms(
+                str(tmp_save_dir),
+                max_workers=restore_workers,
+            )
+            assert len(id_map) == len(manifest.allocations)
+
+            logger.info("=== Phase 5: in-process vLLM attaches in RO mode ===")
+            caplog.clear()
+            llm2 = _build_llm(model, read_only=True)
+            restored_text = _generate_text(llm2)
+            assert restored_text, "Generation after GMS restore returned empty text."
+            assert "Read mode" in caplog.text or "read mode" in caplog.text, (
+                "Expected vLLM to import weights in GMS read mode.\n"
+                f"Captured logs:\n{caplog.text}"
+            )
+        finally:
+            _destroy_llm(llm2)
+            _destroy_llm(llm1)
+            gms2.stop()
+            gms1.stop()

--- a/lib/gpu_memory_service/tests/test_gms_storage_client.py
+++ b/lib/gpu_memory_service/tests/test_gms_storage_client.py
@@ -1,0 +1,1557 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for client.gms_storage_client (GMSStorageClient).
+
+Test classes:
+- TestAllocationEntry        – dataclass creation and asdict roundtrip (no GPU)
+- TestSaveManifest           – to_dict/from_dict/JSON roundtrip (no GPU)
+- TestShardWriter            – _ShardWriter write behaviour (no GPU)
+- TestTorchSerializationRoundtrip – torch.save/.load roundtrip (no GPU + optional CUDA)
+- TestLoadFromPrebuiltSave        – load_tensors() against hand-crafted save dir (no GPU)
+- TestGMSStorageClientInit        – __init__ attribute checks (no GPU)
+- TestGMSStorageClientSaveMock    – mocked GMSClientMemoryManager (no GPU)
+- TestGMSStorageIntegration       – real GMS server in background thread (GPU required)
+- TestGMSStorageClientLoadMock    – mocked load_to_gms (no GPU)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import errno
+import json
+import os
+import tempfile
+import threading
+import time
+from contextlib import ExitStack
+from dataclasses import asdict
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Availability guards
+# ---------------------------------------------------------------------------
+
+try:
+    import torch
+
+    _TORCH_AVAILABLE = True
+except ImportError:
+    _TORCH_AVAILABLE = False
+
+try:
+    import uvloop  # noqa: F401
+
+    _UVLOOP_AVAILABLE = True
+except ImportError:
+    _UVLOOP_AVAILABLE = False
+
+_CUDA_AVAILABLE = _TORCH_AVAILABLE and torch.cuda.is_available()
+
+# ---------------------------------------------------------------------------
+# Module under test
+# ---------------------------------------------------------------------------
+
+from gpu_memory_service.client.gms_storage_client import (  # noqa: E402
+    _CURRENT_VERSION,
+    AllocationEntry,
+    GMSStorageClient,
+    SaveManifest,
+    _read_shard_sequential,
+    _RestorePipelineContext,
+    _ShardWriter,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(
+    alloc_id: str = "alloc-1",
+    size: int = 1024,
+    aligned_size: int = 2097152,
+    tag: str = "default",
+    tensor_file: str = "shards/shard_0000.bin",
+    tensor_offset: int = 0,
+) -> AllocationEntry:
+    return AllocationEntry(
+        allocation_id=alloc_id,
+        size=size,
+        aligned_size=aligned_size,
+        tag=tag,
+        tensor_file=tensor_file,
+        tensor_offset=tensor_offset,
+    )
+
+
+def _make_manifest(allocations=None) -> SaveManifest:
+    return SaveManifest(
+        version=_CURRENT_VERSION,
+        timestamp=1_700_000_000.0,
+        layout_hash="deadbeef",
+        device=0,
+        allocations=allocations or [],
+    )
+
+
+# ===========================================================================
+# TestAllocationEntry
+# ===========================================================================
+
+
+class TestAllocationEntry:
+    def test_creation(self):
+        e = _make_entry()
+        assert e.allocation_id == "alloc-1"
+        assert e.size == 1024
+        assert e.aligned_size == 2097152
+        assert e.tag == "default"
+        assert e.tensor_file == "shards/shard_0000.bin"
+        assert e.tensor_offset == 0
+
+    def test_creation_with_offset(self):
+        e = _make_entry(tensor_file="shards/shard_0000.bin", tensor_offset=4096)
+        assert e.tensor_file == "shards/shard_0000.bin"
+        assert e.tensor_offset == 4096
+
+    def test_frozen(self):
+        e = _make_entry()
+        with pytest.raises((AttributeError, TypeError)):
+            e.size = 9999  # type: ignore[misc]
+
+    def test_asdict_roundtrip(self):
+        e = _make_entry()
+        d = asdict(e)
+        assert d == {
+            "allocation_id": "alloc-1",
+            "size": 1024,
+            "aligned_size": 2097152,
+            "tag": "default",
+            "tensor_file": "shards/shard_0000.bin",
+            "tensor_offset": 0,
+        }
+        e2 = AllocationEntry(**d)
+        assert e2 == e
+
+    def test_different_ids_not_equal(self):
+        e1 = _make_entry("a-1")
+        e2 = _make_entry("a-2")
+        assert e1 != e2
+
+
+# ===========================================================================
+# TestSaveManifest
+# ===========================================================================
+
+
+class TestSaveManifest:
+    def test_to_dict(self):
+        m = _make_manifest()
+        d = m.to_dict()
+        assert d["version"] == _CURRENT_VERSION
+        assert d["timestamp"] == 1_700_000_000.0
+        assert d["layout_hash"] == "deadbeef"
+        assert d["device"] == 0
+        assert d["allocations"] == []
+
+    def test_from_dict_roundtrip(self):
+        entry = _make_entry(tensor_file="shards/shard_0000.bin", tensor_offset=128)
+        m = _make_manifest([entry])
+        d = m.to_dict()
+        m2 = SaveManifest.from_dict(d)
+        assert m2.version == m.version
+        assert m2.timestamp == m.timestamp
+        assert m2.layout_hash == m.layout_hash
+        assert m2.device == m.device
+        assert len(m2.allocations) == 1
+        a = m2.allocations[0]
+        assert a.allocation_id == entry.allocation_id
+        assert a.size == entry.size
+        assert a.aligned_size == entry.aligned_size
+        assert a.tag == entry.tag
+        assert a.tensor_file == entry.tensor_file
+        assert a.tensor_offset == 128
+
+    def test_from_dict_backward_compat_no_tensor_offset(self):
+        """Old manifests without tensor_offset load with tensor_offset=0."""
+        entry = _make_entry()
+        m = _make_manifest([entry])
+        d = m.to_dict()
+        # Simulate an old manifest that doesn't have tensor_offset
+        for a in d["allocations"]:
+            a.pop("tensor_offset", None)
+        m2 = SaveManifest.from_dict(d)
+        assert m2.allocations[0].tensor_offset == 0
+
+    def test_json_file_roundtrip(self):
+        entry = _make_entry()
+        m = _make_manifest([entry])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.json")
+            with open(path, "w") as f:
+                json.dump(m.to_dict(), f)
+            with open(path) as f:
+                m2 = SaveManifest.from_dict(json.load(f))
+        assert m2.layout_hash == m.layout_hash
+        assert len(m2.allocations) == 1
+
+    def test_empty_allocations_roundtrip(self):
+        m = _make_manifest()
+        m2 = SaveManifest.from_dict(m.to_dict())
+        assert m2.allocations == []
+
+    def test_multiple_allocations(self):
+        entries = [_make_entry(f"a-{i}", size=i * 100) for i in range(5)]
+        m = _make_manifest(entries)
+        m2 = SaveManifest.from_dict(m.to_dict())
+        assert len(m2.allocations) == 5
+        for orig, restored in zip(entries, m2.allocations):
+            assert orig.allocation_id == restored.allocation_id
+            assert orig.size == restored.size
+
+
+# ===========================================================================
+# TestShardWriter  (no GPU required)
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="PyTorch not available")
+class TestShardWriter:
+    """Tests for _ShardWriter: sequential write, shard rolling, file contents."""
+
+    def test_single_shard_sequential_offsets(self):
+        """Two allocations fit in one shard; offsets are contiguous."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shards_dir = os.path.join(tmpdir, "shards")
+            with _ShardWriter(shards_dir, shard_size_bytes=1024 * 1024) as writer:
+                t1 = torch.full((64,), 0xAA, dtype=torch.uint8)
+                t2 = torch.full((128,), 0xBB, dtype=torch.uint8)
+                path1, off1 = writer.write(t1)
+                path2, off2 = writer.write(t2)
+
+            # Assertions must be inside the tempdir context (dir is deleted on exit)
+            assert path1 == path2, "Both allocations should land in the same shard"
+            assert off1 == 0
+            assert off2 == 64  # t1 is 64 bytes
+
+            shard_path = os.path.join(tmpdir, path1)
+            with open(shard_path, "rb") as f:
+                data = f.read()
+            assert len(data) == 64 + 128
+            assert all(b == 0xAA for b in data[:64])
+            assert all(b == 0xBB for b in data[64:])
+
+    def test_shard_rolling(self):
+        """When a shard is full, writer starts a new shard."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shards_dir = os.path.join(tmpdir, "shards")
+            # shard_size=100 bytes; two 64-byte writes → two shards
+            # (after first write: 64 bytes; 64+64=128 > 100 → roll)
+            with _ShardWriter(shards_dir, shard_size_bytes=100) as writer:
+                t1 = torch.full((64,), 1, dtype=torch.uint8)
+                t2 = torch.full((64,), 2, dtype=torch.uint8)
+                path1, off1 = writer.write(t1)
+                path2, off2 = writer.write(t2)
+
+            # File existence assertions must be inside the tempdir context
+            assert path1 != path2, "Overflow must produce a new shard"
+            assert off1 == 0
+            assert off2 == 0  # second shard starts at offset 0
+            assert path1 == os.path.join("shards", "shard_0000.bin")
+            assert path2 == os.path.join("shards", "shard_0001.bin")
+            assert os.path.exists(os.path.join(tmpdir, path1))
+            assert os.path.exists(os.path.join(tmpdir, path2))
+
+    def test_oversized_allocation_gets_own_shard(self):
+        """An allocation larger than shard_size still writes (sole entry in shard)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shards_dir = os.path.join(tmpdir, "shards")
+            with _ShardWriter(shards_dir, shard_size_bytes=16) as writer:
+                big = torch.full((256,), 0xCC, dtype=torch.uint8)
+                path, off = writer.write(big)
+
+            # File access must be inside the tempdir context
+            assert off == 0
+            shard_path = os.path.join(tmpdir, path)
+            assert os.path.getsize(shard_path) == 256
+
+    def test_four_allocs_two_shards(self):
+        """Four 64-byte allocations with 100-byte shard → 2 shards, 2 per shard."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shards_dir = os.path.join(tmpdir, "shards")
+            paths_offsets = []
+            with _ShardWriter(shards_dir, shard_size_bytes=130) as writer:
+                for i in range(4):
+                    t = torch.full((64,), i, dtype=torch.uint8)
+                    paths_offsets.append(writer.write(t))
+
+        shard_paths = {p for p, _ in paths_offsets}
+        assert len(shard_paths) == 2, f"Expected 2 shards, got {shard_paths}"
+
+        # First two land in shard 0 (0 bytes, 64 bytes); second two in shard 1
+        assert paths_offsets[0] == (os.path.join("shards", "shard_0000.bin"), 0)
+        assert paths_offsets[1] == (os.path.join("shards", "shard_0000.bin"), 64)
+        assert paths_offsets[2] == (os.path.join("shards", "shard_0001.bin"), 0)
+        assert paths_offsets[3] == (os.path.join("shards", "shard_0001.bin"), 64)
+
+    def test_shard_rel_path_starts_with_shards(self):
+        """All returned relative paths start with 'shards/'."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shards_dir = os.path.join(tmpdir, "shards")
+            with _ShardWriter(shards_dir) as writer:
+                path, _ = writer.write(torch.zeros(32, dtype=torch.uint8))
+        assert path.startswith("shards/")
+
+    @pytest.mark.skipif(not _CUDA_AVAILABLE, reason="CUDA required")
+    def test_sequential_read_matches_write(self):
+        """Data written to a shard can be read back in order via _read_shard_sequential."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shards_dir = os.path.join(tmpdir, "shards")
+            entries: List[AllocationEntry] = []
+            originals: Dict[str, torch.Tensor] = {}
+
+            with _ShardWriter(shards_dir, shard_size_bytes=512) as writer:
+                for i in range(3):
+                    data = torch.full((64,), i + 1, dtype=torch.uint8)
+                    originals[f"a{i}"] = data
+                    rel_path, offset = writer.write(data)
+                    entries.append(
+                        AllocationEntry(
+                            allocation_id=f"a{i}",
+                            size=64,
+                            aligned_size=64,
+                            tag="t",
+                            tensor_file=rel_path,
+                            tensor_offset=offset,
+                        )
+                    )
+
+            # All three in the same shard (3 × 64 = 192 < 512)
+            assert len({e.tensor_file for e in entries}) == 1
+
+            entries.sort(key=lambda e: e.tensor_offset)
+            abs_path = os.path.join(tmpdir, entries[0].tensor_file)
+            result = _read_shard_sequential(abs_path, entries, device=0)
+
+            assert set(result.keys()) == {"a0", "a1", "a2"}
+            for aid, expected in originals.items():
+                assert torch.equal(result[aid].cpu(), expected), f"Mismatch for {aid}"
+
+
+# ===========================================================================
+# TestTorchSerializationRoundtrip
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="PyTorch not available")
+class TestTorchSerializationRoundtrip:
+    def test_uint8_tensor_cpu(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "t.pt")
+            data = torch.arange(256, dtype=torch.uint8)
+            torch.save(data, path)
+            loaded = torch.load(path, weights_only=True)
+        assert torch.equal(data, loaded)
+
+    def test_float_as_bytes(self):
+        """Simulate how float tensors are stored: as a uint8 view."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "t.pt")
+            src = torch.randn(32, dtype=torch.float32)
+            # View as uint8 (how dump works)
+            raw = src.view(torch.uint8)
+            torch.save(raw, path)
+            loaded_raw = torch.load(path, weights_only=True)
+            restored = loaded_raw.view(torch.float32)
+        assert torch.equal(src, restored)
+
+    def test_large_tensor(self):
+        """Round-trip a 16 MiB tensor."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "t.pt")
+            data = torch.randint(0, 256, (16 * 1024 * 1024,), dtype=torch.uint8)
+            torch.save(data, path)
+            loaded = torch.load(path, weights_only=True)
+        assert torch.equal(data, loaded)
+
+    @pytest.mark.skipif(not _CUDA_AVAILABLE, reason="CUDA not available")
+    def test_gpu_tensor_roundtrip(self):
+        """GPU tensor → CPU save → GPU restore."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "t.pt")
+            gpu_tensor = torch.randint(
+                0, 256, (1024,), dtype=torch.uint8, device="cuda"
+            )
+            torch.save(gpu_tensor.cpu(), path)
+            loaded = torch.load(path, weights_only=True, map_location="cuda")
+        assert torch.equal(gpu_tensor, loaded)
+
+
+# ===========================================================================
+# TestRestoreFromPrebuiltDump
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="PyTorch not available")
+class TestLoadFromPrebuiltSave:
+    """Build a dump directory by hand and verify load_tensors() reads it correctly."""
+
+    @staticmethod
+    def _build_dump_dir(tmpdir: str) -> Dict[str, Any]:
+        """Create a minimal dump directory with two allocations and metadata.
+
+        Uses the legacy .pt format (one file per allocation) to verify
+        backward compatibility with the new sequential-read code path.
+        """
+        tensors_dir = os.path.join(tmpdir, "tensors")
+        os.makedirs(tensors_dir)
+
+        # Allocation A: 16 bytes
+        data_a = torch.arange(16, dtype=torch.uint8)
+        path_a = os.path.join(tensors_dir, "alloc-a.pt")
+        torch.save(data_a, path_a)
+
+        # Allocation B: 32 bytes
+        data_b = torch.arange(32, dtype=torch.uint8)
+        path_b = os.path.join(tensors_dir, "alloc-b.pt")
+        torch.save(data_b, path_b)
+
+        # Metadata
+        meta_value_a = b"tensor_meta_a"
+        meta_value_b = b"tensor_meta_b"
+        metadata = {
+            "key_a": {
+                "allocation_id": "alloc-a",
+                "offset_bytes": 0,
+                "value": base64.b64encode(meta_value_a).decode("ascii"),
+            },
+            "key_b": {
+                "allocation_id": "alloc-b",
+                "offset_bytes": 8,
+                "value": base64.b64encode(meta_value_b).decode("ascii"),
+            },
+        }
+        with open(os.path.join(tmpdir, "gms_metadata.json"), "w") as f:
+            json.dump(metadata, f)
+
+        # Manifest — legacy format: no tensor_offset field
+        entries = [
+            AllocationEntry("alloc-a", 16, 16, "default", "tensors/alloc-a.pt"),
+            AllocationEntry("alloc-b", 32, 32, "default", "tensors/alloc-b.pt"),
+        ]
+        manifest = SaveManifest(
+            version=_CURRENT_VERSION,
+            timestamp=time.time(),
+            layout_hash="cafebabe",
+            device=0,
+            allocations=entries,
+        )
+        with open(os.path.join(tmpdir, "manifest.json"), "w") as f:
+            json.dump(manifest.to_dict(), f)
+
+        return {
+            "data_a": data_a,
+            "data_b": data_b,
+            "meta_a": meta_value_a,
+            "meta_b": meta_value_b,
+        }
+
+    def test_loads_all_allocations(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._build_dump_dir(tmpdir)
+            tensors, _ = GMSStorageClient.load_tensors(tmpdir, max_workers=2)
+        assert "alloc-a" in tensors
+        assert "alloc-b" in tensors
+
+    def test_tensor_values_match(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            expected = self._build_dump_dir(tmpdir)
+            tensors, _ = GMSStorageClient.load_tensors(tmpdir, max_workers=2)
+        assert torch.equal(tensors["alloc-a"].cpu(), expected["data_a"])
+        assert torch.equal(tensors["alloc-b"].cpu(), expected["data_b"])
+
+    def test_metadata_roundtrip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            expected = self._build_dump_dir(tmpdir)
+            _, metadata = GMSStorageClient.load_tensors(tmpdir, max_workers=2)
+        assert metadata["key_a"]["allocation_id"] == "alloc-a"
+        assert metadata["key_a"]["offset_bytes"] == 0
+        assert metadata["key_a"]["value"] == expected["meta_a"]
+        assert metadata["key_b"]["allocation_id"] == "alloc-b"
+        assert metadata["key_b"]["offset_bytes"] == 8
+        assert metadata["key_b"]["value"] == expected["meta_b"]
+
+    def test_parallel_restore(self):
+        """load_tensors with max_workers > number of allocations."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._build_dump_dir(tmpdir)
+            tensors, _ = GMSStorageClient.load_tensors(tmpdir, max_workers=8)
+        assert len(tensors) == 2
+
+    def test_missing_metadata_file_ok(self):
+        """load_tensors still works when gms_metadata.json is absent."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._build_dump_dir(tmpdir)
+            os.unlink(os.path.join(tmpdir, "gms_metadata.json"))
+            tensors, metadata = GMSStorageClient.load_tensors(tmpdir, max_workers=1)
+        assert len(metadata) == 0
+        assert len(tensors) == 2
+
+    @pytest.mark.skipif(not hasattr(os, "O_DIRECT"), reason="O_DIRECT not available")
+    def test_odirect_read_errors_are_not_silently_masked(self):
+        """O_DIRECT open failures may fall back, but read failures must surface."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "shards.bin")
+            with open(path, "wb") as f:
+                f.write(b"\x00" * 64)
+            entry = AllocationEntry(
+                allocation_id="alloc-1",
+                size=64,
+                aligned_size=64,
+                tag="default",
+                tensor_file="shards.bin",
+                tensor_offset=0,
+            )
+
+            with (
+                patch(
+                    "gpu_memory_service.client.gms_storage_client.os.open",
+                    return_value=123,
+                ),
+                patch(
+                    "gpu_memory_service.client.gms_storage_client.os.readv",
+                    side_effect=OSError("read failure"),
+                ),
+                patch("gpu_memory_service.client.gms_storage_client.os.close"),
+            ):
+                with pytest.raises(OSError, match="read failure"):
+                    _read_shard_sequential(path, [entry], device=-1)
+
+    @pytest.mark.skipif(not hasattr(os, "O_DIRECT"), reason="O_DIRECT not available")
+    def test_odirect_pin_memory_path_requests_pinned_buffer(self):
+        """pin_memory=True should allocate the shard buffer via torch.empty."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "shards.bin")
+            payload = bytes(range(64))
+            with open(path, "wb") as f:
+                f.write(payload)
+            entry = AllocationEntry(
+                allocation_id="alloc-1",
+                size=64,
+                aligned_size=64,
+                tag="default",
+                tensor_file="shards.bin",
+                tensor_offset=0,
+            )
+            fake_shard = torch.empty(64, dtype=torch.uint8)
+
+            with (
+                patch(
+                    "gpu_memory_service.client.gms_storage_client.torch.cuda.is_available",
+                    return_value=True,
+                ),
+                patch(
+                    "gpu_memory_service.client.gms_storage_client.torch.empty",
+                    return_value=fake_shard,
+                ) as empty_mock,
+                patch(
+                    "gpu_memory_service.client.gms_storage_client.os.open",
+                    side_effect=OSError(errno.EINVAL, "odirect unsupported"),
+                ),
+            ):
+                tensors = _read_shard_sequential(
+                    path,
+                    [entry],
+                    device=-1,
+                    pin_memory=True,
+                )
+
+        empty_mock.assert_called_once_with(64, dtype=torch.uint8, pin_memory=True)
+        assert torch.equal(
+            tensors["alloc-1"], torch.tensor(list(payload), dtype=torch.uint8)
+        )
+
+
+# ===========================================================================
+# TestGMSStorageClientInit
+# ===========================================================================
+
+
+class TestGMSStorageClientInit:
+    def test_basic_init(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            client = GMSStorageClient(tmpdir, socket_path="/tmp/fake.sock", device=0)
+        assert client.output_dir == tmpdir
+        assert client.device == 0
+
+    def test_output_dir_attr(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = os.path.join(tmpdir, "my_dump")
+            client = GMSStorageClient(subdir, socket_path="/tmp/fake.sock", device=2)
+        assert client.output_dir == subdir
+        assert client.device == 2
+
+    def test_restore_only_no_output_dir(self):
+        """GMSStorageClient can be created without output_dir for restore-only use."""
+        client = GMSStorageClient(socket_path="/tmp/fake.sock", device=0)
+        assert client.output_dir is None
+
+    def test_dump_without_output_dir_raises(self):
+        """dump() raises ValueError when output_dir is None."""
+        client = GMSStorageClient(socket_path="/tmp/fake.sock", device=0)
+        with patch(
+            "gpu_memory_service.client.gms_storage_client._GMS_IMPORTS_AVAILABLE", True
+        ):
+            with pytest.raises(ValueError, match="output_dir"):
+                client.save()
+
+    def test_custom_shard_size(self):
+        """shard_size_bytes parameter is stored."""
+        client = GMSStorageClient(
+            socket_path="/tmp/fake.sock", shard_size_bytes=128 * 1024 * 1024
+        )
+        assert client._shard_size == 128 * 1024 * 1024
+
+
+# ===========================================================================
+# TestGMSStorageClientDumpMock
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="PyTorch not available")
+class TestGMSStorageClientSaveMock:
+    """Primary correctness tests: full serialisation pipeline without GPU.
+
+    Mocks GMSClientMemoryManager and _tensor_from_pointer so tests run
+    entirely in CPU memory.
+    """
+
+    # -- helpers -----------------------------------------------------------
+
+    @staticmethod
+    def _make_cpu_tensor(size: int, fill: int = 42) -> "torch.Tensor":
+        return torch.full((size,), fill, dtype=torch.uint8)
+
+    @staticmethod
+    def _build_mock_mm(allocations: List[Dict], metadata: Dict[str, Any]):
+        """Return a MagicMock that mimics GMSClientMemoryManager API."""
+        mm = MagicMock()
+        mm.__enter__ = MagicMock(return_value=mm)
+        mm.__exit__ = MagicMock(return_value=False)
+        mm.committed = True
+        mm.get_memory_layout_hash.return_value = "hash-abc"
+        mm.list_handles.return_value = allocations
+        mm.create_mapping.side_effect = (
+            lambda allocation_id=None, size=0, tag="default": 0xDEAD_BEEF
+        )  # noqa: E501
+
+        def _metadata_list():
+            return list(metadata.keys())
+
+        def _metadata_get(key):
+            entry = metadata.get(key)
+            if entry is None:
+                return None
+            return (entry["allocation_id"], entry["offset_bytes"], entry["value"])
+
+        mm.metadata_list.side_effect = lambda: _metadata_list()
+        mm.metadata_get.side_effect = _metadata_get
+        mm.get_allocation_id = MagicMock(return_value="allocated-id")
+        return mm
+
+    def _run_dump(
+        self,
+        tmpdir: str,
+        allocations: List[Dict],
+        metadata: Dict[str, Any],
+        cpu_tensors: Dict[str, torch.Tensor],
+        shard_size_bytes: int = 4 * 1024**3,
+    ) -> SaveManifest:
+        """Patch GMSClientMemoryManager and _tensor_from_pointer, then call dump()."""
+        mock_mm = self._build_mock_mm(allocations, metadata)
+
+        # Track call order to map create_mapping call → allocation id
+        call_counter = [0]
+
+        def fake_tensor_from_pointer(va, shape, stride, dtype, device):
+            idx = call_counter[0]
+            call_counter[0] += 1
+            if idx >= len(allocations):
+                raise IndexError(
+                    f"Call index {idx} out of range for {len(allocations)} allocations"
+                )
+            alloc_id = allocations[idx]["allocation_id"]
+            return cpu_tensors[alloc_id]
+
+        client = GMSStorageClient(
+            tmpdir,
+            socket_path="/tmp/fake.sock",
+            device=0,
+            shard_size_bytes=shard_size_bytes,
+        )
+
+        with (
+            patch(
+                "gpu_memory_service.client.gms_storage_client.GMSClientMemoryManager",
+                return_value=mock_mm,
+            ),
+            patch(
+                "gpu_memory_service.client.gms_storage_client._tensor_from_pointer",
+                side_effect=fake_tensor_from_pointer,
+            ),
+            patch(
+                "gpu_memory_service.client.gms_storage_client._GMS_IMPORTS_AVAILABLE",
+                True,
+            ),
+        ):
+            manifest = client.save()
+
+        return manifest
+
+    # -- tests -------------------------------------------------------------
+
+    def test_creates_expected_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            allocations = [
+                {"allocation_id": "a1", "size": 16, "aligned_size": 16, "tag": "t1"},
+            ]
+            cpu_tensors = {"a1": self._make_cpu_tensor(16, fill=1)}
+            manifest = self._run_dump(tmpdir, allocations, {}, cpu_tensors)
+
+            assert os.path.exists(os.path.join(tmpdir, "manifest.json"))
+            assert os.path.exists(os.path.join(tmpdir, "gms_metadata.json"))
+            tensor_file = os.path.join(tmpdir, manifest.allocations[0].tensor_file)
+            assert os.path.exists(tensor_file)
+
+    def test_save_removes_stale_shard_files_from_previous_run(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shards_dir = os.path.join(tmpdir, "shards")
+            os.makedirs(shards_dir, exist_ok=True)
+            stale_path = os.path.join(shards_dir, "shard_9999.bin")
+            with open(stale_path, "wb") as f:
+                f.write(b"stale")
+
+            allocations = [
+                {"allocation_id": "a1", "size": 16, "aligned_size": 16, "tag": "t1"},
+            ]
+            cpu_tensors = {"a1": self._make_cpu_tensor(16, fill=1)}
+
+            manifest = self._run_dump(tmpdir, allocations, {}, cpu_tensors)
+
+        assert not os.path.exists(stale_path)
+        assert {entry.tensor_file for entry in manifest.allocations} == {
+            os.path.join("shards", "shard_0000.bin")
+        }
+
+    def test_uses_shard_format(self):
+        """dump() packs allocations into shards/shard_*.bin files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            allocations = [
+                {"allocation_id": "a1", "size": 16, "aligned_size": 16, "tag": "t1"},
+                {"allocation_id": "a2", "size": 32, "aligned_size": 32, "tag": "t2"},
+            ]
+            cpu_tensors = {
+                "a1": self._make_cpu_tensor(16, fill=1),
+                "a2": self._make_cpu_tensor(32, fill=2),
+            }
+            manifest = self._run_dump(tmpdir, allocations, {}, cpu_tensors)
+
+        # Both allocations in shard files
+        for entry in manifest.allocations:
+            assert entry.tensor_file.startswith(
+                "shards/"
+            ), f"Expected shards/ prefix, got {entry.tensor_file!r}"
+
+        # With default 4 GiB shard size, both fit in one shard
+        shard_files = {a.tensor_file for a in manifest.allocations}
+        assert len(shard_files) == 1
+
+        # Offsets are sequential: first is 0, second is 16 (size of first)
+        sorted_entries = sorted(manifest.allocations, key=lambda e: e.tensor_offset)
+        assert sorted_entries[0].tensor_offset == 0
+        assert sorted_entries[1].tensor_offset == 16
+
+    def test_shard_rolling_with_small_shard_size(self):
+        """Small shard_size causes allocations to roll into multiple shards."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            allocations = [
+                {
+                    "allocation_id": f"a{i}",
+                    "size": 64,
+                    "aligned_size": 64,
+                    "tag": f"t{i}",
+                }
+                for i in range(4)
+            ]
+            cpu_tensors = {f"a{i}": self._make_cpu_tensor(64, fill=i) for i in range(4)}
+            # shard_size=100: first alloc writes 64 bytes; second alloc would
+            # make 64+64=128 > 100, so it rolls to a new shard.  Each alloc
+            # of 64 bytes triggers a roll → 4 shards for 4 allocations.
+            manifest = self._run_dump(
+                tmpdir, allocations, {}, cpu_tensors, shard_size_bytes=100
+            )
+
+        shard_files = {a.tensor_file for a in manifest.allocations}
+        assert (
+            len(shard_files) == 4
+        ), f"Expected 4 shards (one per 64-byte alloc with 100-byte limit), got {shard_files}"
+
+    def test_manifest_content(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            allocations = [
+                {
+                    "allocation_id": "a1",
+                    "size": 16,
+                    "aligned_size": 32,
+                    "tag": "weights",
+                },
+                {
+                    "allocation_id": "a2",
+                    "size": 8,
+                    "aligned_size": 16,
+                    "tag": "kvcache",
+                },
+            ]
+            cpu_tensors = {
+                "a1": self._make_cpu_tensor(32, fill=1),
+                "a2": self._make_cpu_tensor(16, fill=2),
+            }
+            manifest = self._run_dump(tmpdir, allocations, {}, cpu_tensors)
+
+        assert manifest.version == _CURRENT_VERSION
+        assert manifest.layout_hash == "hash-abc"
+        assert manifest.device == 0
+        assert len(manifest.allocations) == 2
+        ids = {a.allocation_id for a in manifest.allocations}
+        assert ids == {"a1", "a2"}
+
+    def test_metadata_content(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            allocations = [
+                {"allocation_id": "a1", "size": 16, "aligned_size": 16, "tag": "t"},
+            ]
+            cpu_tensors = {"a1": self._make_cpu_tensor(16)}
+            raw_meta = {
+                "key1": {
+                    "allocation_id": "a1",
+                    "offset_bytes": 0,
+                    "value": b"hello_meta",
+                }
+            }
+            self._run_dump(tmpdir, allocations, raw_meta, cpu_tensors)
+
+            with open(os.path.join(tmpdir, "gms_metadata.json")) as f:
+                saved = json.load(f)
+
+        assert "key1" in saved
+        assert saved["key1"]["allocation_id"] == "a1"
+        assert saved["key1"]["offset_bytes"] == 0
+        decoded = base64.b64decode(saved["key1"]["value"])
+        assert decoded == b"hello_meta"
+
+    def test_full_dump_load_tensors_roundtrip(self):
+        """Dump then load_tensors: tensor data must be bit-exact."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_a = torch.arange(64, dtype=torch.uint8)
+            data_b = torch.full((32,), 0xFF, dtype=torch.uint8)
+            allocations = [
+                {"allocation_id": "a1", "size": 64, "aligned_size": 64, "tag": "w"},
+                {"allocation_id": "a2", "size": 32, "aligned_size": 32, "tag": "k"},
+            ]
+            cpu_tensors = {"a1": data_a, "a2": data_b}
+            raw_meta = {
+                "m1": {"allocation_id": "a1", "offset_bytes": 0, "value": b"meta1"},
+            }
+            self._run_dump(tmpdir, allocations, raw_meta, cpu_tensors)
+            tensors, metadata = GMSStorageClient.load_tensors(tmpdir, max_workers=2)
+
+        assert torch.equal(tensors["a1"].cpu(), data_a)
+        assert torch.equal(tensors["a2"].cpu(), data_b)
+        assert metadata["m1"]["value"] == b"meta1"
+        assert metadata["m1"]["allocation_id"] == "a1"
+
+    def test_empty_allocations(self):
+        """Dump with no allocations produces valid (empty) manifest."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = self._run_dump(tmpdir, [], {}, {})
+        assert manifest.allocations == []
+
+    def test_uncommitted_raises(self):
+        """dump() raises RuntimeError when GMS has no committed weights."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mm = self._build_mock_mm([], {})
+            mm.committed = False
+            client = GMSStorageClient(tmpdir, socket_path="/tmp/fake.sock")
+            with (
+                patch(
+                    "gpu_memory_service.client.gms_storage_client.GMSClientMemoryManager",
+                    return_value=mm,
+                ),
+                patch(
+                    "gpu_memory_service.client.gms_storage_client._GMS_IMPORTS_AVAILABLE",
+                    True,
+                ),
+            ):
+                with pytest.raises(RuntimeError, match="committed"):
+                    client.save()
+
+
+# ===========================================================================
+# TestGMSDumpIntegration  (GPU required)
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _CUDA_AVAILABLE, reason="CUDA not available")
+@pytest.mark.skipif(not _UVLOOP_AVAILABLE, reason="uvloop not available")
+class TestGMSStorageIntegration:
+    """Full integration test: real GMS server → dump → restore → verify."""
+
+    @staticmethod
+    def _run_server(
+        socket_path: str, ready_event: threading.Event, stop_event: threading.Event
+    ):
+        """Start a GMS server in a background thread."""
+        import uvloop  # noqa: F811
+        from gpu_memory_service.server import GMSRPCServer
+
+        async def _serve():
+            server = GMSRPCServer(socket_path, device=0)
+            await server.start()
+            ready_event.set()
+            # Poll until stop is requested
+            while not stop_event.is_set():
+                await asyncio.sleep(0.05)
+            await server.stop()
+
+        uvloop.install()
+        asyncio.run(_serve())
+
+    def test_write_dump_restore_verify(self):
+        import tempfile
+
+        from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
+        from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
+        from gpu_memory_service.common.types import RequestedLockType
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            socket_path = os.path.join(tmpdir, "gms.sock")
+            dump_dir = os.path.join(tmpdir, "dump")
+
+            ready = threading.Event()
+            stop = threading.Event()
+            srv_thread = threading.Thread(
+                target=self._run_server,
+                args=(socket_path, ready, stop),
+                daemon=True,
+            )
+            srv_thread.start()
+            assert ready.wait(timeout=10), "GMS server did not start in time"
+
+            try:
+                # Write two allocations
+                with GMSClientMemoryManager(socket_path, device=0) as mm:
+                    mm.connect(RequestedLockType.RW)
+                    va1 = mm.create_mapping(size=2097152, tag="layer0")
+                    t1 = _tensor_from_pointer(va1, [2097152], [1], torch.uint8, 0)
+                    t1.fill_(0xAB)
+
+                    va2 = mm.create_mapping(size=4194304, tag="layer1")
+                    t2 = _tensor_from_pointer(va2, [4194304], [1], torch.uint8, 0)
+                    t2.fill_(0xCD)
+
+                    mm.metadata_put("t1_meta", mm.get_allocation_id(va1), 0, b"meta1")
+                    mm.commit()
+
+                # Dump
+                client = GMSStorageClient(dump_dir, socket_path=socket_path, device=0)
+                manifest = client.save()
+
+                assert len(manifest.allocations) == 2
+                assert manifest.layout_hash != ""
+
+                # Verify shard format
+                for entry in manifest.allocations:
+                    assert entry.tensor_file.startswith("shards/")
+
+                # load_tensors: disk-only, returns standalone GPU tensors
+                tensors, metadata = GMSStorageClient.load_tensors(dump_dir, device=0)
+
+                assert len(tensors) == 2
+                for tensor in tensors.values():
+                    assert tensor.dtype == torch.uint8
+                    assert tensor.is_cuda
+
+                # Check metadata round-tripped
+                assert "t1_meta" in metadata
+                assert metadata["t1_meta"]["value"] == b"meta1"
+
+            finally:
+                stop.set()
+                srv_thread.join(timeout=5)
+
+    def test_dump_load_to_gms_roundtrip(self):
+        """Full cycle: write → commit → dump → fresh server → load_to_gms → verify."""
+        from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
+        from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
+        from gpu_memory_service.common.types import RequestedLockType
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            socket_path = os.path.join(tmpdir, "gms.sock")
+            dump_dir = os.path.join(tmpdir, "dump")
+
+            ready = threading.Event()
+            stop = threading.Event()
+            srv_thread = threading.Thread(
+                target=self._run_server,
+                args=(socket_path, ready, stop),
+                daemon=True,
+            )
+            srv_thread.start()
+            assert ready.wait(timeout=10), "GMS server did not start in time"
+
+            try:
+                # Write and commit initial data
+                with GMSClientMemoryManager(socket_path, device=0) as mm:
+                    mm.connect(RequestedLockType.RW)
+                    va1 = mm.create_mapping(size=2097152, tag="layerA")
+                    t1 = _tensor_from_pointer(va1, [2097152], [1], torch.uint8, 0)
+                    t1.fill_(0x11)
+
+                    va2 = mm.create_mapping(size=2097152, tag="layerB")
+                    t2 = _tensor_from_pointer(va2, [2097152], [1], torch.uint8, 0)
+                    t2.fill_(0x22)
+
+                    mm.metadata_put("mA", mm.get_allocation_id(va1), 0, b"meta_a")
+                    mm.metadata_put("mB", mm.get_allocation_id(va2), 4, b"meta_b")
+                    mm.commit()
+
+                # Dump
+                dump_client = GMSStorageClient(
+                    dump_dir, socket_path=socket_path, device=0
+                )
+                manifest = dump_client.save()
+                assert len(manifest.allocations) == 2
+
+                # Simulate fresh start: clear GMS by acquiring RW and clearing
+                with GMSClientMemoryManager(socket_path, device=0) as mm:
+                    mm.connect(RequestedLockType.RW)
+                    mm.clear_all_handles()
+                    mm.commit()
+
+                # load_to_gms: writes data back
+                id_map = dump_client.load_to_gms(dump_dir, max_workers=2)
+
+                assert len(id_map) == 2
+                # All old IDs must be mapped to new IDs
+                for old_id in [e.allocation_id for e in manifest.allocations]:
+                    assert old_id in id_map
+
+                # Verify data via RO reader
+                with GMSClientMemoryManager(socket_path, device=0) as mm:
+                    mm.connect(RequestedLockType.RO)
+                    allocs = mm.list_handles()
+                    assert len(allocs) == 2
+
+                    # Check tags preserved
+                    tags = {a["allocation_id"]: a.get("tag") for a in allocs}
+                    new_ids = list(id_map.values())
+                    assert tags[new_ids[0]] in ("layerA", "layerB")
+                    assert tags[new_ids[1]] in ("layerA", "layerB")
+
+                    # Check tensor values
+                    for alloc in allocs:
+                        va = mm.create_mapping(allocation_id=alloc["allocation_id"])
+                        t = _tensor_from_pointer(
+                            va, [alloc["aligned_size"]], [1], torch.uint8, 0
+                        )
+                        fill = 0x11 if alloc.get("tag") == "layerA" else 0x22
+                        assert (
+                            t[0].item() == fill
+                        ), f"Wrong fill for {alloc['allocation_id']}"
+
+                    # Check metadata keys survived and have bytes values
+                    assert set(mm.metadata_list()) == {"mA", "mB"}
+                    got_a = mm.metadata_get("mA")
+                    assert got_a is not None
+                    assert got_a[2] == b"meta_a"
+                    got_b = mm.metadata_get("mB")
+                    assert got_b is not None
+                    assert got_b[2] == b"meta_b"
+
+            finally:
+                stop.set()
+                srv_thread.join(timeout=5)
+
+    def test_true_restart_roundtrip(self):
+        """The primary workflow test: start → write → dump → RESTART → restore → verify.
+
+        The server thread is fully stopped between dump and restore so the
+        socket file is deleted and a brand-new server process starts with
+        EMPTY state (committed=False).  This is the exact production scenario.
+        """
+        from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
+        from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
+        from gpu_memory_service.common.types import RequestedLockType
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            socket_path = os.path.join(tmpdir, "gms.sock")
+            dump_dir = os.path.join(tmpdir, "dump")
+
+            # ---- Phase 1: start server --------------------------------
+            ready1 = threading.Event()
+            stop1 = threading.Event()
+            srv1 = threading.Thread(
+                target=self._run_server,
+                args=(socket_path, ready1, stop1),
+                daemon=True,
+            )
+            srv1.start()
+            assert ready1.wait(timeout=10), "Server 1 did not start"
+
+            # ---- Phase 2: write and commit ----------------------------
+            with GMSClientMemoryManager(socket_path, device=0) as mm:
+                mm.connect(RequestedLockType.RW)
+                va1 = mm.create_mapping(size=2097152, tag="layer0")
+                t1 = _tensor_from_pointer(va1, [2097152], [1], torch.uint8, 0)
+                t1.fill_(0xAA)
+
+                va2 = mm.create_mapping(size=2097152, tag="layer1")
+                t2 = _tensor_from_pointer(va2, [2097152], [1], torch.uint8, 0)
+                t2.fill_(0xBB)
+
+                mm.metadata_put("w0", mm.get_allocation_id(va1), 0, b"weight_meta_0")
+                mm.metadata_put("w1", mm.get_allocation_id(va2), 0, b"weight_meta_1")
+                mm.commit()
+
+            # ---- Phase 3: dump ----------------------------------------
+            dump_client = GMSStorageClient(dump_dir, socket_path=socket_path, device=0)
+            manifest = dump_client.save()
+            assert len(manifest.allocations) == 2
+            # Verify shard format was used
+            for entry in manifest.allocations:
+                assert entry.tensor_file.startswith("shards/")
+
+            # ---- Phase 4: RESTART server (stop old, start new) --------
+            stop1.set()
+            srv1.join(timeout=10)
+            assert not srv1.is_alive(), "Server 1 did not stop"
+            # Socket file must be gone after stop()
+            assert not os.path.exists(socket_path), "Socket file was not cleaned up"
+
+            ready2 = threading.Event()
+            stop2 = threading.Event()
+            srv2 = threading.Thread(
+                target=self._run_server,
+                args=(socket_path, ready2, stop2),
+                daemon=True,
+            )
+            srv2.start()
+            assert ready2.wait(timeout=10), "Server 2 did not start"
+
+            try:
+                # ---- Phase 5: restore into fresh server ---------------
+                restore_client = GMSStorageClient(socket_path=socket_path, device=0)
+                id_map = restore_client.load_to_gms(dump_dir, max_workers=2)
+
+                assert len(id_map) == 2, f"Expected 2 remapped IDs, got {id_map}"
+
+                # ---- Phase 6: verify via RO reader --------------------
+                with GMSClientMemoryManager(socket_path, device=0) as mm:
+                    mm.connect(RequestedLockType.RO)
+                    allocs = mm.list_handles()
+                    assert len(allocs) == 2
+
+                    tag_to_alloc = {a.get("tag"): a for a in allocs}
+                    assert "layer0" in tag_to_alloc
+                    assert "layer1" in tag_to_alloc
+
+                    # Verify tensor values
+                    for tag, fill in (("layer0", 0xAA), ("layer1", 0xBB)):
+                        a = tag_to_alloc[tag]
+                        va = mm.create_mapping(allocation_id=a["allocation_id"])
+                        t = _tensor_from_pointer(
+                            va, [a["aligned_size"]], [1], torch.uint8, 0
+                        )
+                        assert (
+                            t[0].item() == fill
+                        ), f"{tag}: expected 0x{fill:02X}, got 0x{t[0].item():02X}"
+
+                    # Verify metadata
+                    assert set(mm.metadata_list()) == {"w0", "w1"}
+                    assert mm.metadata_get("w0")[2] == b"weight_meta_0"
+                    assert mm.metadata_get("w1")[2] == b"weight_meta_1"
+
+            finally:
+                stop2.set()
+                srv2.join(timeout=5)
+
+
+# ===========================================================================
+# TestGMSStorageClientRestoreMock  (no GPU)
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="PyTorch not available")
+class TestGMSStorageClientLoadMock:
+    """Tests for load_to_gms() using mocked GMSClientMemoryManager.
+
+    No GPU required.  Verifies: allocation IDs remapped correctly, tensor data
+    copied into GMS memory, metadata written with new IDs, commit called.
+    """
+
+    @staticmethod
+    def _build_dump_dir(tmpdir: str, num_allocs: int = 2) -> Dict[str, Any]:
+        """Create a minimal dump directory using legacy .pt format."""
+        tensors_dir = os.path.join(tmpdir, "tensors")
+        os.makedirs(tensors_dir)
+
+        alloc_ids = [f"orig-{i}" for i in range(num_allocs)]
+        entries = []
+        cpu_data: Dict[str, torch.Tensor] = {}
+        for i, aid in enumerate(alloc_ids):
+            data = torch.full((64,), i + 1, dtype=torch.uint8)
+            cpu_data[aid] = data
+            path = os.path.join(tensors_dir, f"{aid}.pt")
+            torch.save(data, path)
+            entries.append(AllocationEntry(aid, 64, 64, f"tag{i}", f"tensors/{aid}.pt"))
+
+        meta_raw = {
+            "key0": {
+                "allocation_id": alloc_ids[0],
+                "offset_bytes": 0,
+                "value": base64.b64encode(b"v0").decode(),
+            },
+        }
+        if num_allocs > 1:
+            meta_raw["key1"] = {
+                "allocation_id": alloc_ids[1],
+                "offset_bytes": 8,
+                "value": base64.b64encode(b"v1").decode(),
+            }
+
+        with open(os.path.join(tmpdir, "gms_metadata.json"), "w") as f:
+            json.dump(meta_raw, f)
+
+        manifest = SaveManifest(
+            version=_CURRENT_VERSION,
+            timestamp=time.time(),
+            layout_hash="abc",
+            device=0,
+            allocations=entries,
+        )
+        with open(os.path.join(tmpdir, "manifest.json"), "w") as f:
+            json.dump(manifest.to_dict(), f)
+
+        return {"alloc_ids": alloc_ids, "cpu_data": cpu_data}
+
+    @staticmethod
+    def _build_mock_rw_mm(_alloc_ids_iter):
+        """Mock that simulates allocate_and_map, _mappings, metadata_put, commit."""
+
+        mm = MagicMock()
+        mm.__enter__ = MagicMock(return_value=mm)
+        mm.__exit__ = MagicMock(return_value=False)
+
+        # Each call to allocate_and_map returns a fake VA; new allocation IDs
+        # are stored in mm._mappings keyed by that VA.
+        call_count = [0]
+        va_base = 0x1000_0000
+
+        new_ids = [f"new-{i}" for i in range(10)]  # pool of new IDs
+
+        def _alloc_and_map(size, tag="default"):
+            idx = call_count[0]
+            call_count[0] += 1
+            va = va_base + idx * 0x100_0000
+
+            # Build a LocalMapping-like namedtuple
+            mapping = MagicMock()
+            mapping.allocation_id = new_ids[idx]
+            mapping.aligned_size = size
+            mm._mappings[va] = mapping
+
+            return va
+
+        mm._mappings = {}
+        mm.create_mapping = MagicMock(side_effect=_alloc_and_map)
+        mm.get_allocation_id = MagicMock(
+            side_effect=lambda va: mm._mappings[va].allocation_id
+        )
+        mm.clear_all_handles = MagicMock(return_value=0)
+        mm.metadata_put = MagicMock(return_value=True)
+        mm.commit = MagicMock(return_value=True)
+
+        return mm, new_ids
+
+    def _run_load_to_gms(
+        self,
+        tmpdir: str,
+        mock_mm: MagicMock,
+        *,
+        clear_existing: bool = True,
+        tensor_from_pointer: Any = None,
+        tensor_from_pointer_side_effect: Any = None,
+        read_shard_to_queue: Any = None,
+    ) -> Dict[str, str]:
+        client = GMSStorageClient(tmpdir, socket_path="/tmp/fake.sock", device=0)
+        patches = [
+            patch(
+                "gpu_memory_service.client.gms_storage_client.GMSClientMemoryManager",
+                return_value=mock_mm,
+            ),
+            patch(
+                "gpu_memory_service.client.gms_storage_client._GMS_IMPORTS_AVAILABLE",
+                True,
+            ),
+            patch(
+                "gpu_memory_service.client.gms_storage_client._tensor_from_pointer",
+                return_value=tensor_from_pointer or torch.zeros(64, dtype=torch.uint8),
+                side_effect=tensor_from_pointer_side_effect,
+            ),
+        ]
+        if read_shard_to_queue is not None:
+            patches.append(
+                patch(
+                    "gpu_memory_service.client.gms_storage_client._read_shard_to_queue",
+                    side_effect=read_shard_to_queue,
+                )
+            )
+
+        with ExitStack() as stack:
+            for active_patch in patches:
+                stack.enter_context(active_patch)
+            return client.load_to_gms(tmpdir, clear_existing=clear_existing)
+
+    def test_id_map_returned(self):
+        """load_to_gms returns a dict mapping old → new allocation IDs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            info = self._build_dump_dir(tmpdir, num_allocs=2)
+            mock_mm, new_ids = self._build_mock_rw_mm(None)
+            id_map = self._run_load_to_gms(tmpdir, mock_mm)
+
+        assert len(id_map) == 2
+        for old_id in info["alloc_ids"]:
+            assert old_id in id_map
+            assert id_map[old_id].startswith("new-")
+
+    def test_metadata_remapped(self):
+        """Metadata allocation IDs are translated to new IDs before metadata_put."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._build_dump_dir(tmpdir, num_allocs=2)
+            mock_mm, new_ids = self._build_mock_rw_mm(None)
+            self._run_load_to_gms(tmpdir, mock_mm)
+
+        # metadata_put should have been called with the NEW alloc IDs
+        calls = mock_mm.metadata_put.call_args_list
+        put_keys = {c.args[0] for c in calls}
+        assert "key0" in put_keys
+        assert "key1" in put_keys
+
+        # The allocation_id argument must be from the new ID pool, not the old
+        for c in calls:
+            _key, alloc_id_arg, _offset, _value = c.args
+            assert alloc_id_arg.startswith(
+                "new-"
+            ), f"Expected remapped new ID, got {alloc_id_arg!r}"
+
+    def test_commit_called(self):
+        """commit() is called exactly once after all allocations are restored."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._build_dump_dir(tmpdir, num_allocs=1)
+            mock_mm, _ = self._build_mock_rw_mm(None)
+            self._run_load_to_gms(tmpdir, mock_mm)
+
+        mock_mm.commit.assert_called_once()
+
+    def test_clear_existing_default(self):
+        """clear_all_handles() is called by default (clear_existing=True)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._build_dump_dir(tmpdir, num_allocs=1)
+            mock_mm, _ = self._build_mock_rw_mm(None)
+            self._run_load_to_gms(tmpdir, mock_mm, clear_existing=True)
+
+        mock_mm.clear_all_handles.assert_called_once()
+
+    def test_no_clear_skips_clear_all(self):
+        """clear_all_handles() is NOT called when clear_existing=False."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._build_dump_dir(tmpdir, num_allocs=1)
+            mock_mm, _ = self._build_mock_rw_mm(None)
+            self._run_load_to_gms(tmpdir, mock_mm, clear_existing=False)
+
+        mock_mm.clear_all_handles.assert_not_called()
+
+    def test_tensor_data_copied(self):
+        """The tensor data loaded from disk is copied into the GMS memory view."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            info = self._build_dump_dir(tmpdir, num_allocs=1)
+            mock_mm, _ = self._build_mock_rw_mm(None)
+
+            # Capture what gets written into dst_tensor via copy_()
+            copied = {}
+
+            dst_mock = MagicMock(spec=torch.Tensor)
+            dst_mock.copy_ = MagicMock(
+                side_effect=lambda src, **_kw: copied.update({"src": src})
+            )
+            self._run_load_to_gms(tmpdir, mock_mm, tensor_from_pointer=dst_mock)
+
+        dst_mock.copy_.assert_called_once()
+        src_tensor = copied["src"]
+        expected = info["cpu_data"][info["alloc_ids"][0]]
+        assert torch.equal(src_tensor.cpu(), expected)
+
+    def test_load_to_gms_pipelines_phase_a_with_disk_reads(self):
+        """Phase A allocation starts before the disk workers finish reading."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._build_dump_dir(tmpdir, num_allocs=1)
+            mock_mm, _ = self._build_mock_rw_mm(None)
+            mapping_called = threading.Event()
+
+            original_create_mapping = mock_mm.create_mapping.side_effect
+
+            def _create_mapping(*args, **kwargs):
+                mapping_called.set()
+                return original_create_mapping(*args, **kwargs)
+
+            mock_mm.create_mapping.side_effect = _create_mapping
+
+            def _blocking_read(
+                abs_path,
+                sorted_entries,
+                work_q,
+                *,
+                pin_memory,
+                cancel_event=None,
+            ):
+                del abs_path, sorted_entries, work_q, pin_memory, cancel_event
+                assert mapping_called.wait(timeout=1), (
+                    "load_to_gms waited for disk staging to finish before starting "
+                    "Phase A allocation"
+                )
+                return 0
+
+            self._run_load_to_gms(
+                tmpdir,
+                mock_mm,
+                read_shard_to_queue=_blocking_read,
+            )
+
+    def test_allocation_failure_shuts_down_restore_pipeline(self):
+        """Allocation failures must tear down the started restore pipeline."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._build_dump_dir(tmpdir, num_allocs=1)
+            mock_mm, _ = self._build_mock_rw_mm(None)
+            client = GMSStorageClient(tmpdir, socket_path="/tmp/fake.sock", device=0)
+            resources = MagicMock()
+            resources.ctx = MagicMock()
+
+            with (
+                patch(
+                    "gpu_memory_service.client.gms_storage_client.GMSClientMemoryManager",
+                    return_value=mock_mm,
+                ),
+                patch(
+                    "gpu_memory_service.client.gms_storage_client._GMS_IMPORTS_AVAILABLE",
+                    True,
+                ),
+                patch.object(
+                    client,
+                    "_prepare_restore_pipeline",
+                    return_value=resources,
+                ) as prepare_pipeline,
+                patch.object(
+                    client,
+                    "_allocate_restore_mappings",
+                    side_effect=RuntimeError("phase a failed"),
+                ),
+                patch.object(client, "_shutdown_restore_pipeline") as shutdown_pipeline,
+            ):
+                with pytest.raises(RuntimeError, match="phase a failed"):
+                    client.load_to_gms(tmpdir)
+
+        prepare_pipeline.assert_called_once()
+        shutdown_pipeline.assert_called_once_with(resources)
+
+    def test_copy_worker_error_surfaces_after_pipeline_sync(self):
+        """Copy worker failures should propagate as a restore error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._build_dump_dir(tmpdir, num_allocs=1)
+            mock_mm, _ = self._build_mock_rw_mm(None)
+
+            with pytest.raises(RuntimeError, match="copy failed"):
+                self._run_load_to_gms(
+                    tmpdir,
+                    mock_mm,
+                    tensor_from_pointer_side_effect=RuntimeError("copy failed"),
+                )
+
+    def test_finalize_restore_pipeline_syncs_before_raising_copy_error(self):
+        """Async copies must be synchronized even when a worker reported failure."""
+        client = GMSStorageClient(socket_path="/tmp/fake.sock", device=0)
+        ctx = _RestorePipelineContext.build(
+            [_make_entry()],
+            worker_count=1,
+            device=0,
+            use_streams=False,
+        )
+        ctx.use_streams = True
+        ctx.staged_srcs.append(torch.zeros(1, dtype=torch.uint8))
+        ctx.copy_errors.append(RuntimeError("copy failed"))
+
+        with patch(
+            "gpu_memory_service.client.gms_storage_client.torch.cuda.synchronize"
+        ) as sync_mock:
+            with pytest.raises(RuntimeError, match="copy failed"):
+                client._finalize_restore_pipeline(ctx)
+
+        sync_mock.assert_called_once_with(device=0)
+        assert ctx.staged_srcs == []
+
+    def test_cancel_restore_pipeline_releases_waiters_and_drains_queue(self):
+        """Cancellation should unblock waiters before shutdown joins threads."""
+        client = GMSStorageClient(socket_path="/tmp/fake.sock", device=0)
+        ctx = _RestorePipelineContext.build(
+            [_make_entry()],
+            worker_count=1,
+            device=0,
+            use_streams=False,
+        )
+        ctx.work_q.put((_make_entry(), torch.zeros(1, dtype=torch.uint8)))
+
+        client._cancel_restore_pipeline(ctx)
+
+        assert ctx.cancel_event.is_set()
+        assert ctx.va_events["alloc-1"].is_set()
+        assert ctx.work_q.empty()
+
+    def test_disk_read_failure_propagates_and_cancels_pipeline(self):
+        """A disk-read error must propagate and set cancel_event so copy threads exit."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._build_dump_dir(tmpdir, num_allocs=1)
+            mock_mm, _ = self._build_mock_rw_mm(None)
+
+            def _failing_read(
+                abs_path,
+                sorted_entries,
+                work_q,
+                *,
+                pin_memory,
+                cancel_event=None,
+            ):
+                del abs_path, sorted_entries, work_q, pin_memory, cancel_event
+                raise OSError("simulated disk read failure")
+
+            with pytest.raises(
+                (RuntimeError, OSError), match="simulated disk read failure"
+            ):
+                self._run_load_to_gms(
+                    tmpdir,
+                    mock_mm,
+                    read_shard_to_queue=_failing_read,
+                )

--- a/lib/gpu_memory_service/tests/test_reshard.py
+++ b/lib/gpu_memory_service/tests/test_reshard.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+from gpu_memory_service.client.gms_storage_client import (
+    _CURRENT_VERSION,
+    AllocationEntry,
+    SaveManifest,
+    _group_entries_by_shard,
+    _read_shard_sequential,
+    _ShardWriter,
+)
+from gpu_memory_service.tests.e2e.reshard import reshard
+
+
+def _build_source_save(source_dir: Path) -> None:
+    shards_dir = source_dir / "shards"
+    shards_dir.mkdir(parents=True)
+
+    allocations = []
+    with _ShardWriter(str(shards_dir), shard_size_bytes=1024) as writer:
+        for idx, fill in enumerate((1, 2)):
+            data = torch.full((64,), fill, dtype=torch.uint8)
+            rel_path, offset = writer.write(data)
+            allocations.append(
+                AllocationEntry(
+                    allocation_id=f"alloc-{idx}",
+                    size=64,
+                    aligned_size=64,
+                    tag=f"tag-{idx}",
+                    tensor_file=rel_path,
+                    tensor_offset=offset,
+                )
+            )
+
+    manifest = SaveManifest(
+        version=_CURRENT_VERSION,
+        timestamp=1.0,
+        layout_hash="hash",
+        device=0,
+        allocations=allocations,
+    )
+    (source_dir / "manifest.json").write_text(json.dumps(manifest.to_dict()))
+    (source_dir / "gms_metadata.json").write_text(
+        json.dumps(
+            {
+                "key0": {
+                    "allocation_id": "alloc-0",
+                    "offset_bytes": 0,
+                    "value": "djA=",
+                }
+            }
+        )
+    )
+
+
+def test_reshard_rewrites_manifest_and_metadata(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    dest_dir = tmp_path / "dest"
+    _build_source_save(source_dir)
+
+    reshard(source_dir, dest_dir, shard_size_bytes=64)
+
+    manifest = SaveManifest.from_dict(
+        json.loads((dest_dir / "manifest.json").read_text())
+    )
+    assert len(manifest.allocations) == 2
+    assert {entry.tensor_file for entry in manifest.allocations} == {
+        "shards/shard_0000.bin",
+        "shards/shard_0001.bin",
+    }
+    assert (dest_dir / "gms_metadata.json").exists()
+
+    # Verify actual tensor bytes are preserved correctly.
+    groups = _group_entries_by_shard(manifest.allocations)
+    tensors: dict = {}
+    for rel_path, sorted_entries in groups.items():
+        abs_path = str(dest_dir / rel_path)
+        tensors.update(_read_shard_sequential(abs_path, sorted_entries, device=-1))
+
+    alloc_by_tag = {e.tag: e for e in manifest.allocations}
+    assert tensors[alloc_by_tag["tag-0"].allocation_id].tolist() == [1] * 64
+    assert tensors[alloc_by_tag["tag-1"].allocation_id].tolist() == [2] * 64
+
+
+def test_reshard_rejects_non_empty_destination(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    dest_dir = tmp_path / "dest"
+    _build_source_save(source_dir)
+    dest_dir.mkdir()
+    (dest_dir / "stale.bin").write_bytes(b"stale")
+
+    with pytest.raises(FileExistsError, match="must not already contain files"):
+        reshard(source_dir, dest_dir, shard_size_bytes=64)

--- a/lib/gpu_memory_service/uv.lock
+++ b/lib/gpu_memory_service/uv.lock
@@ -1,0 +1,288 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "gpu-memory-service"
+version = "0.9.0"
+source = { editable = "." }
+dependencies = [
+    { name = "msgspec" },
+    { name = "uvloop" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "msgspec", specifier = ">=0.18.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", marker = "extra == 'test'" },
+    { name = "uvloop", specifier = ">=0.21.0" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "msgspec"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/9c/bfbd12955a49180cbd234c5d29ec6f74fe641698f0cd9df154a854fc8a15/msgspec-0.20.0.tar.gz", hash = "sha256:692349e588fde322875f8d3025ac01689fead5901e7fb18d6870a44519d62a29", size = 317862, upload-time = "2025-11-24T03:56:28.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/5e/151883ba2047cca9db8ed2f86186b054ad200bc231352df15b0c1dd75b1f/msgspec-0.20.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:23a6ec2a3b5038c233b04740a545856a068bc5cb8db184ff493a58e08c994fbf", size = 195191, upload-time = "2025-11-24T03:55:08.549Z" },
+    { url = "https://files.pythonhosted.org/packages/50/88/a795647672f547c983eff0823b82aaa35db922c767e1b3693e2dcf96678d/msgspec-0.20.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cde2c41ed3eaaef6146365cb0d69580078a19f974c6cb8165cc5dcd5734f573e", size = 188513, upload-time = "2025-11-24T03:55:10.008Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/91/eb0abb0e0de142066cebfe546dc9140c5972ea824aa6ff507ad0b6a126ac/msgspec-0.20.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5da0daa782f95d364f0d95962faed01e218732aa1aa6cad56b25a5d2092e75a4", size = 216370, upload-time = "2025-11-24T03:55:11.566Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2a/48e41d9ef0a24b1c6e67cbd94a676799e0561bfbc163be1aaaff5ca853f5/msgspec-0.20.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9369d5266144bef91be2940a3821e03e51a93c9080fde3ef72728c3f0a3a8bb7", size = 222653, upload-time = "2025-11-24T03:55:13.159Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c9/14b825df203d980f82a623450d5f39e7f7a09e6e256c52b498ea8f29d923/msgspec-0.20.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:90fb865b306ca92c03964a5f3d0cd9eb1adda14f7e5ac7943efd159719ea9f10", size = 222337, upload-time = "2025-11-24T03:55:14.777Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d7/39a5c3ddd294f587d6fb8efccc8361b6aa5089974015054071e665c9d24b/msgspec-0.20.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e8112cd48b67dfc0cfa49fc812b6ce7eb37499e1d95b9575061683f3428975d3", size = 225565, upload-time = "2025-11-24T03:55:16.4Z" },
+    { url = "https://files.pythonhosted.org/packages/98/bd/5db3c14d675ee12842afb9b70c94c64f2c873f31198c46cbfcd7dffafab0/msgspec-0.20.0-cp310-cp310-win_amd64.whl", hash = "sha256:666b966d503df5dc27287675f525a56b6e66a2b8e8ccd2877b0c01328f19ae6c", size = 188412, upload-time = "2025-11-24T03:55:17.747Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c7/06cc218bc0c86f0c6c6f34f7eeea6cfb8b835070e8031e3b0ef00f6c7c69/msgspec-0.20.0-cp310-cp310-win_arm64.whl", hash = "sha256:099e3e85cd5b238f2669621be65f0728169b8c7cb7ab07f6137b02dc7feea781", size = 173951, upload-time = "2025-11-24T03:55:19.335Z" },
+    { url = "https://files.pythonhosted.org/packages/03/59/fdcb3af72f750a8de2bcf39d62ada70b5eb17b06d7f63860e0a679cb656b/msgspec-0.20.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:09e0efbf1ac641fedb1d5496c59507c2f0dc62a052189ee62c763e0aae217520", size = 193345, upload-time = "2025-11-24T03:55:20.613Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/15/3c225610da9f02505d37d69a77f4a2e7daae2a125f99d638df211ba84e59/msgspec-0.20.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:23ee3787142e48f5ee746b2909ce1b76e2949fbe0f97f9f6e70879f06c218b54", size = 186867, upload-time = "2025-11-24T03:55:22.4Z" },
+    { url = "https://files.pythonhosted.org/packages/81/36/13ab0c547e283bf172f45491edfdea0e2cecb26ae61e3a7b1ae6058b326d/msgspec-0.20.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:81f4ac6f0363407ac0465eff5c7d4d18f26870e00674f8fcb336d898a1e36854", size = 215351, upload-time = "2025-11-24T03:55:23.958Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/96/5c095b940de3aa6b43a71ec76275ac3537b21bd45c7499b5a17a429110fa/msgspec-0.20.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb4d873f24ae18cd1334f4e37a178ed46c9d186437733351267e0a269bdf7e53", size = 219896, upload-time = "2025-11-24T03:55:25.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7a/81a7b5f01af300761087b114dafa20fb97aed7184d33aab64d48874eb187/msgspec-0.20.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b92b8334427b8393b520c24ff53b70f326f79acf5f74adb94fd361bcff8a1d4e", size = 220389, upload-time = "2025-11-24T03:55:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c0/3d0cce27db9a9912421273d49eab79ce01ecd2fed1a2f1b74af9b445f33c/msgspec-0.20.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:562c44b047c05cc0384e006fae7a5e715740215c799429e0d7e3e5adf324285a", size = 223348, upload-time = "2025-11-24T03:55:28.311Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5e/406b7d578926b68790e390d83a1165a9bfc2d95612a1a9c1c4d5c72ea815/msgspec-0.20.0-cp311-cp311-win_amd64.whl", hash = "sha256:d1dcc93a3ce3d3195985bfff18a48274d0b5ffbc96fa1c5b89da6f0d9af81b29", size = 188713, upload-time = "2025-11-24T03:55:29.553Z" },
+    { url = "https://files.pythonhosted.org/packages/47/87/14fe2316624ceedf76a9e94d714d194cbcb699720b210ff189f89ca4efd7/msgspec-0.20.0-cp311-cp311-win_arm64.whl", hash = "sha256:aa387aa330d2e4bd69995f66ea8fdc87099ddeedf6fdb232993c6a67711e7520", size = 174229, upload-time = "2025-11-24T03:55:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/6f/1e25eee957e58e3afb2a44b94fa95e06cebc4c236193ed0de3012fff1e19/msgspec-0.20.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2aba22e2e302e9231e85edc24f27ba1f524d43c223ef5765bd8624c7df9ec0a5", size = 196391, upload-time = "2025-11-24T03:55:32.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ee/af51d090ada641d4b264992a486435ba3ef5b5634bc27e6eb002f71cef7d/msgspec-0.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:716284f898ab2547fedd72a93bb940375de9fbfe77538f05779632dc34afdfde", size = 188644, upload-time = "2025-11-24T03:55:33.934Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d6/9709ee093b7742362c2934bfb1bbe791a1e09bed3ea5d8a18ce552fbfd73/msgspec-0.20.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:558ed73315efa51b1538fa8f1d3b22c8c5ff6d9a2a62eff87d25829b94fc5054", size = 218852, upload-time = "2025-11-24T03:55:35.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a2/488517a43ccf5a4b6b6eca6dd4ede0bd82b043d1539dd6bb908a19f8efd3/msgspec-0.20.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:509ac1362a1d53aa66798c9b9fd76872d7faa30fcf89b2fba3bcbfd559d56eb0", size = 224937, upload-time = "2025-11-24T03:55:36.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/49b832808aa23b85d4f090d1d2e48a4e3834871415031ed7c5fe48723156/msgspec-0.20.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1353c2c93423602e7dea1aa4c92f3391fdfc25ff40e0bacf81d34dbc68adb870", size = 222858, upload-time = "2025-11-24T03:55:38.187Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/56/1dc2fa53685dca9c3f243a6cbecd34e856858354e455b77f47ebd76cf5bf/msgspec-0.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:cb33b5eb5adb3c33d749684471c6a165468395d7aa02d8867c15103b81e1da3e", size = 227248, upload-time = "2025-11-24T03:55:39.496Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/51/aba940212c23b32eedce752896205912c2668472ed5b205fc33da28a6509/msgspec-0.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:fb1d934e435dd3a2b8cf4bbf47a8757100b4a1cfdc2afdf227541199885cdacb", size = 190024, upload-time = "2025-11-24T03:55:40.829Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/3b9f259d94f183daa9764fef33fdc7010f7ecffc29af977044fa47440a83/msgspec-0.20.0-cp312-cp312-win_arm64.whl", hash = "sha256:00648b1e19cf01b2be45444ba9dc961bd4c056ffb15706651e64e5d6ec6197b7", size = 175390, upload-time = "2025-11-24T03:55:42.05Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/d1/b902d38b6e5ba3bdddbec469bba388d647f960aeed7b5b3623a8debe8a76/msgspec-0.20.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9c1ff8db03be7598b50dd4b4a478d6fe93faae3bd54f4f17aa004d0e46c14c46", size = 196463, upload-time = "2025-11-24T03:55:43.405Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b6/eff0305961a1d9447ec2b02f8c73c8946f22564d302a504185b730c9a761/msgspec-0.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f6532369ece217fd37c5ebcfd7e981f2615628c21121b7b2df9d3adcf2fd69b8", size = 188650, upload-time = "2025-11-24T03:55:44.761Z" },
+    { url = "https://files.pythonhosted.org/packages/99/93/f2ec1ae1de51d3fdee998a1ede6b2c089453a2ee82b5c1b361ed9095064a/msgspec-0.20.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9a1697da2f85a751ac3cc6a97fceb8e937fc670947183fb2268edaf4016d1ee", size = 218834, upload-time = "2025-11-24T03:55:46.441Z" },
+    { url = "https://files.pythonhosted.org/packages/28/83/36557b04cfdc317ed8a525c4993b23e43a8fbcddaddd78619112ca07138c/msgspec-0.20.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7fac7e9c92eddcd24c19d9e5f6249760941485dff97802461ae7c995a2450111", size = 224917, upload-time = "2025-11-24T03:55:48.06Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/56/362037a1ed5be0b88aced59272442c4b40065c659700f4b195a7f4d0ac88/msgspec-0.20.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f953a66f2a3eb8d5ea64768445e2bb301d97609db052628c3e1bcb7d87192a9f", size = 222821, upload-time = "2025-11-24T03:55:49.388Z" },
+    { url = "https://files.pythonhosted.org/packages/92/75/fa2370ec341cedf663731ab7042e177b3742645c5dd4f64dc96bd9f18a6b/msgspec-0.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:247af0313ae64a066d3aea7ba98840f6681ccbf5c90ba9c7d17f3e39dbba679c", size = 227227, upload-time = "2025-11-24T03:55:51.125Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/25/5e8080fe0117f799b1b68008dc29a65862077296b92550632de015128579/msgspec-0.20.0-cp313-cp313-win_amd64.whl", hash = "sha256:67d5e4dfad52832017018d30a462604c80561aa62a9d548fc2bd4e430b66a352", size = 189966, upload-time = "2025-11-24T03:55:52.458Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b6/63363422153937d40e1cb349c5081338401f8529a5a4e216865decd981bf/msgspec-0.20.0-cp313-cp313-win_arm64.whl", hash = "sha256:91a52578226708b63a9a13de287b1ec3ed1123e4a088b198143860c087770458", size = 175378, upload-time = "2025-11-24T03:55:53.721Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/18/62dc13ab0260c7d741dda8dc7f481495b93ac9168cd887dda5929880eef8/msgspec-0.20.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:eead16538db1b3f7ec6e3ed1f6f7c5dec67e90f76e76b610e1ffb5671815633a", size = 196407, upload-time = "2025-11-24T03:55:55.001Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1d/b9949e4ad6953e9f9a142c7997b2f7390c81e03e93570c7c33caf65d27e1/msgspec-0.20.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:703c3bb47bf47801627fb1438f106adbfa2998fe586696d1324586a375fca238", size = 188889, upload-time = "2025-11-24T03:55:56.311Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/19/f8bb2dc0f1bfe46cc7d2b6b61c5e9b5a46c62298e8f4d03bbe499c926180/msgspec-0.20.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6cdb227dc585fb109305cee0fd304c2896f02af93ecf50a9c84ee54ee67dbb42", size = 219691, upload-time = "2025-11-24T03:55:57.908Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8e/6b17e43f6eb9369d9858ee32c97959fcd515628a1df376af96c11606cf70/msgspec-0.20.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27d35044dd8818ac1bd0fedb2feb4fbdff4e3508dd7c5d14316a12a2d96a0de0", size = 224918, upload-time = "2025-11-24T03:55:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/db/0e833a177db1a4484797adba7f429d4242585980b90882cc38709e1b62df/msgspec-0.20.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b4296393a29ee42dd25947981c65506fd4ad39beaf816f614146fa0c5a6c91ae", size = 223436, upload-time = "2025-11-24T03:56:00.716Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/30/d2ee787f4c918fd2b123441d49a7707ae9015e0e8e1ab51aa7967a97b90e/msgspec-0.20.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:205fbdadd0d8d861d71c8f3399fe1a82a2caf4467bc8ff9a626df34c12176980", size = 227190, upload-time = "2025-11-24T03:56:02.371Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/37/9c4b58ff11d890d788e700b827db2366f4d11b3313bf136780da7017278b/msgspec-0.20.0-cp314-cp314-win_amd64.whl", hash = "sha256:7dfebc94fe7d3feec6bc6c9df4f7e9eccc1160bb5b811fbf3e3a56899e398a6b", size = 193950, upload-time = "2025-11-24T03:56:03.668Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/4e/cab707bf2fa57408e2934e5197fc3560079db34a1e3cd2675ff2e47e07de/msgspec-0.20.0-cp314-cp314-win_arm64.whl", hash = "sha256:2ad6ae36e4a602b24b4bf4eaf8ab5a441fec03e1f1b5931beca8ebda68f53fc0", size = 179018, upload-time = "2025-11-24T03:56:05.038Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/06/3da3fc9aaa55618a8f43eb9052453cfe01f82930bca3af8cea63a89f3a11/msgspec-0.20.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f84703e0e6ef025663dd1de828ca028774797b8155e070e795c548f76dde65d5", size = 200389, upload-time = "2025-11-24T03:56:06.375Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3b/cc4270a5ceab40dfe1d1745856951b0a24fd16ac8539a66ed3004a60c91e/msgspec-0.20.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7c83fc24dd09cf1275934ff300e3951b3adc5573f0657a643515cc16c7dee131", size = 193198, upload-time = "2025-11-24T03:56:07.742Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ae/4c7905ac53830c8e3c06fdd60e3cdcfedc0bbc993872d1549b84ea21a1bd/msgspec-0.20.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f13ccb1c335a124e80c4562573b9b90f01ea9521a1a87f7576c2e281d547f56", size = 225973, upload-time = "2025-11-24T03:56:09.18Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/da/032abac1de4d0678d99eaeadb1323bd9d247f4711c012404ba77ed6f15ca/msgspec-0.20.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17c2b5ca19f19306fc83c96d85e606d2cc107e0caeea85066b5389f664e04846", size = 229509, upload-time = "2025-11-24T03:56:10.898Z" },
+    { url = "https://files.pythonhosted.org/packages/69/52/fdc7bdb7057a166f309e0b44929e584319e625aaba4771b60912a9321ccd/msgspec-0.20.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d931709355edabf66c2dd1a756b2d658593e79882bc81aae5964969d5a291b63", size = 230434, upload-time = "2025-11-24T03:56:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/fe/1dfd5f512b26b53043884e4f34710c73e294e7cc54278c3fe28380e42c37/msgspec-0.20.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:565f915d2e540e8a0c93a01ff67f50aebe1f7e22798c6a25873f9fda8d1325f8", size = 231758, upload-time = "2025-11-24T03:56:13.765Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f6/9ba7121b8e0c4e0beee49575d1dbc804e2e72467692f0428cf39ceba1ea5/msgspec-0.20.0-cp314-cp314t-win_amd64.whl", hash = "sha256:726f3e6c3c323f283f6021ebb6c8ccf58d7cd7baa67b93d73bfbe9a15c34ab8d", size = 206540, upload-time = "2025-11-24T03:56:15.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/3e/c5187de84bb2c2ca334ab163fcacf19a23ebb1d876c837f81a1b324a15bf/msgspec-0.20.0-cp314-cp314t-win_arm64.whl", hash = "sha256:93f23528edc51d9f686808a361728e903d6f2be55c901d6f5c92e44c6d546bfc", size = 183011, upload-time = "2025-11-24T03:56:16.442Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/14/ecceb239b65adaaf7fde510aa8bd534075695d1e5f8dadfa32b5723d9cfb/uvloop-0.22.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c", size = 1343335, upload-time = "2025-10-16T22:16:11.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ae/6f6f9af7f590b319c94532b9567409ba11f4fa71af1148cab1bf48a07048/uvloop-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7cd375a12b71d33d46af85a3343b35d98e8116134ba404bd657b3b1d15988792", size = 742903, upload-time = "2025-10-16T22:16:12.979Z" },
+    { url = "https://files.pythonhosted.org/packages/09/bd/3667151ad0702282a1f4d5d29288fce8a13c8b6858bf0978c219cd52b231/uvloop-0.22.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac33ed96229b7790eb729702751c0e93ac5bc3bcf52ae9eccbff30da09194b86", size = 3648499, upload-time = "2025-10-16T22:16:14.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/f6/21657bb3beb5f8c57ce8be3b83f653dd7933c2fd00545ed1b092d464799a/uvloop-0.22.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:481c990a7abe2c6f4fc3d98781cc9426ebd7f03a9aaa7eb03d3bfc68ac2a46bd", size = 3700133, upload-time = "2025-10-16T22:16:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/09/e0/604f61d004ded805f24974c87ddd8374ef675644f476f01f1df90e4cdf72/uvloop-0.22.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a592b043a47ad17911add5fbd087c76716d7c9ccc1d64ec9249ceafd735f03c2", size = 3512681, upload-time = "2025-10-16T22:16:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ce/8491fd370b0230deb5eac69c7aae35b3be527e25a911c0acdffb922dc1cd/uvloop-0.22.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1489cf791aa7b6e8c8be1c5a080bae3a672791fcb4e9e12249b05862a2ca9cec", size = 3615261, upload-time = "2025-10-16T22:16:19.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9", size = 1352420, upload-time = "2025-10-16T22:16:21.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/73/c4e271b3bce59724e291465cc936c37758886a4868787da0278b3b56b905/uvloop-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b7f102bf3cb1995cfeaee9321105e8f5da76fdb104cdad8986f85461a1b7b77", size = 748677, upload-time = "2025-10-16T22:16:22.558Z" },
+    { url = "https://files.pythonhosted.org/packages/86/94/9fb7fad2f824d25f8ecac0d70b94d0d48107ad5ece03769a9c543444f78a/uvloop-0.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53c85520781d84a4b8b230e24a5af5b0778efdb39142b424990ff1ef7c48ba21", size = 3753819, upload-time = "2025-10-16T22:16:23.903Z" },
+    { url = "https://files.pythonhosted.org/packages/74/4f/256aca690709e9b008b7108bc85fba619a2bc37c6d80743d18abad16ee09/uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56a2d1fae65fd82197cb8c53c367310b3eabe1bbb9fb5a04d28e3e3520e4f702", size = 3804529, upload-time = "2025-10-16T22:16:25.246Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/03c05ae4737e871923d21a76fe28b6aad57f5c03b6e6bfcfa5ad616013e4/uvloop-0.22.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:40631b049d5972c6755b06d0bfe8233b1bd9a8a6392d9d1c45c10b6f9e9b2733", size = 3621267, upload-time = "2025-10-16T22:16:26.819Z" },
+    { url = "https://files.pythonhosted.org/packages/75/be/f8e590fe61d18b4a92070905497aec4c0e64ae1761498cad09023f3f4b3e/uvloop-0.22.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:535cc37b3a04f6cd2c1ef65fa1d370c9a35b6695df735fcff5427323f2cd5473", size = 3723105, upload-time = "2025-10-16T22:16:28.252Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]


### PR DESCRIPTION
Implements a local-filesystem serializer for GPU Memory Service that saves and restores model weights to/from NVMe storage with minimal CPU overhead.

# GMS Storage Client — Implementation Summary

## What was built

An initial local-filesystem serializer for the GPU Memory Service (GMS),
enabling save and restore of GPU model weights to/from NVMe storage with
low CPU overhead and an overlapped disk/GPU restore pipeline.

### Core components

**`lib/gpu_memory_service/client/gms_storage_client.py`**

- `GMSStorageClient.save()` — snapshots all live GMS allocations to a shard
  layout on disk, writing a `manifest.json` index alongside raw `shard_*.bin`
  binary files. Stale shard files from previous saves are removed automatically.

- `GMSStorageClient.load_to_gms()` — three-phase overlapped pipeline:
  - **Phase A** (serial): calls `cuMemCreate` + `cuMemMap` for each allocation
    VA in manifest order; runs concurrently with disk reads.
  - **Disk reads** (parallel, worker pool): each worker owns one NVMe thread,
    reads shards sequentially with O_DIRECT to bypass page cache, and enqueues
    raw tensors to a shared work queue.
  - **Phase B** (CUDA streams): copy workers drain the work queue, issuing
    `cuMemcpyHtoD` via pinned CUDA streams; runs concurrently with ongoing
    disk reads.

  All three phases overlap: disk I/O, GMS VA allocation, and GPU H2D copies
  proceed simultaneously, keeping every resource saturated.

- `SaveManifest` / `AllocationEntry` dataclasses — typed, versioned on-disk
  index with forward-compatibility version check.

**`lib/gpu_memory_service/integrations/vllm/model_loader.py`**

- `GMSModelLoader` registered as `load_format="gms"` with vLLM's loader
  registry. Strips GMS-only keys such as `gms_read_only` before delegating
  to `DefaultModelLoader`.
- RW mode: allocates model tensors inside the GMS memory pool, loads weights
  from disk, commits for cross-process sharing.
- RO mode: creates model on `meta` device, materializes tensors from GMS
  metadata (zero disk I/O, zero copies).

**`lib/gpu_memory_service/tests/e2e/test_gms_vllm_serialize.py`**

Full in-process E2E lifecycle test:
1. Start GMS server in background thread.
2. Load vLLM `LLM` in RW mode (publishes weights to GMS).
3. Save GMS state to disk via `GMSStorageClient.save()`.
4. Tear down engine and GMS server; start fresh GMS server.
5. Restore saved state via `GMSStorageClient.load_to_gms()`.
6. Load second vLLM `LLM` in RO mode (imports from GMS, zero disk I/O).
7. Verify generation output is non-empty in both phases.

**`lib/gpu_memory_service/tests/e2e/multi_ssd_bench.py`**

Standalone benchmark that distributes shards across multiple NVMes and
measures aggregate restore throughput with configurable workers-per-NVMe.

---

## Benchmark note (B200, 8× NVMe)

Hardware: NVIDIA B200, 8× NVMe SSDs
Dataset: Qwen2.5-72B-Instruct weights, 135.48 GiB, 328 allocations, 41 shards

```
────────────────────────────────────────────────────────────
  Multi-SSD GMS restore  (8 NVMes, 1 exclusive thread/NVMe)
────────────────────────────────────────────────────────────
  Data     : 135.48 GiB
  Phase A  : 5.271s  (overlapped with disk reads)
  Disk+B   : 5.40s   →  25.09 GiB/s  (disk+PhaseA+copy overlapped)
    disk   : 5.30s   →  25.56 GiB/s  (aggregate across all NVMes)
  Total    : 5.40s   →  25.09 GiB/s
────────────────────────────────────────────────────────────
```

In one measured run on a B200 host with 8 NVMe drives, restore throughput
reached **25.09 GiB/s aggregate**. In that run, Phase A and GPU copies were
fully hidden behind disk I/O, so the restore path behaved as effectively
disk-bandwidth-limited.

For comparison, an earlier buffered cold-cache baseline on the same setup
was about 4.3 GiB/s, so this configuration showed an approximately **6x
improvement** in that environment.

---

## Key design decisions

| Decision | Rationale |
|---|---|
| O_DIRECT reads | Bypasses page cache; cold-read throughput ~3.2 GiB/s/NVMe vs ~0.6 GiB/s buffered |
| 1 thread/NVMe | Saturates NVMe queue depth; more threads add latency without throughput gain |
| Phase A serial | `cuMemCreate` is not thread-safe for sequential VA placement; serialized = deterministic layout |
| Phase A + disk overlap | Phase A is CPU-bound (~5s for 328 allocs); hiding it behind disk reads is free |
| CUDA streams for Phase B | Multiple concurrent H2D streams saturate PCIe bandwidth |
| `cancel_event` + timed queue put | Clean cancellation on disk-read failure without deadlock |
| Versioned manifest | Forward-compatibility: `load_to_gms` rejects unknown manifest versions with a clear error |

---

## Validation

Validated with:

- `lib/gpu_memory_service/tests/test_gms_storage_client.py`
- `lib/gpu_memory_service/tests/e2e/test_gms_vllm_serialize.py -m e2e -s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `gms-storage-client` command-line tool for saving and restoring GPU memory state to and from disk
  * Support for parallel save/load operations with configurable worker counts for improved performance
  * Efficient disk-based persistence with automatic sharding for large memory allocations

* **Tests**
  * Added end-to-end tests for GPU memory serialization and deserialization workflows
  * Added benchmarking utilities for measuring restore performance across multiple worker configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->