### PR TITLE
fix: skip unlink in weka cluster for now 

### DIFF
--- a/lib/llm/src/block_manager/storage/nixl.rs
+++ b/lib/llm/src/block_manager/storage/nixl.rs
@@ -387,7 +387,8 @@ impl NixlRegisterableStorage for DiskStorage {
         }
 
         handle_nixl_register(self, agent, opt_args)?;
-        self.unlink()?;
+        // self.unlink()?;
+        tracing::warn!("Unlinking disk storage after NIXL registration is currently disabled to avoid GDS registration failures.");
         Ok(())
     }
 }


### PR DESCRIPTION
#### Overview:

skip the unlink in weka cluster for now, since it will cause GDS failure.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
