### PR TITLE
docs: use a different assets folder for each version

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -172,24 +172,13 @@ jobs:
           rm -rf docs-checkout/fern/pages-dev
           mkdir -p docs-checkout/fern/pages-dev
           rsync -a \
-            --exclude='assets' \
             --exclude='blogs' \
-            --exclude='diagrams' \
             --exclude='index.yml' \
             source-checkout/docs/ docs-checkout/fern/pages-dev/
 
           # Sync index.yml as versions/dev.yml and transform paths for docs-website layout
           echo "Syncing index.yml to docs-website branch as versions/dev.yml..."
           cp source-checkout/docs/index.yml docs-checkout/fern/versions/dev.yml
-
-          # Sync assets/ directory
-          echo "Syncing assets/ to docs-website branch..."
-          rm -rf docs-checkout/fern/assets
-          cp -r source-checkout/docs/assets docs-checkout/fern/assets
-
-          # Symlink assets into pages-dev/ so relative image paths in markdown resolve correctly
-          # (e.g. ../../assets/img/foo.png from pages-dev/observability/metrics.md)
-          ln -sfn ../assets docs-checkout/fern/pages-dev/assets
 
           # Sync fern.config.json
           echo "Syncing fern.config.json to docs-website branch..."


### PR DESCRIPTION
#### Overview:

We're running into issues where new changes to images are conflicting with old images from previous versions. So we should move to having a different assets folder for each version. Per fern support, there shouldn't be any issues on the fern side



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation synchronization workflow configuration to remove assets directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->