### PR TITLE
fix: Upgrade futures-util to 0.3.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ derive-getters = { version = "0.5" }
 either = { version = "1.13", features = ["serde"] }
 etcd-client = { version = "0.17.0", features = ["tls"] }
 futures = { version = "0.3" }
+futures-util = { version = "0.3.32" }
 hf-hub = { version = "0.4.2", default-features = false, features = [
     "tokio",
     "rustls-tls",

--- a/lib/bench/Cargo.toml
+++ b/lib/bench/Cargo.toml
@@ -33,7 +33,7 @@ harness = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive"] }
-futures-util = "0.3"
+futures-util = { workspace = true }
 indicatif = "0.18"
 rand = { workspace = true }
 reqwest = { workspace = true }

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -64,7 +64,7 @@ chrono = { workspace = true }
 derive_builder = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
-futures-util = "0.3.31"
+futures-util = { workspace = true }
 hf-hub = { workspace = true }
 humantime = { workspace = true }                           # input/batch
 rand = { workspace = true }


### PR DESCRIPTION
We are already using that since #6305 so no Cargo.lock changes, but we're using it as a side effect of a different package so it's not pinned. This PR pins it.

Closes: #7328
