### PR TITLE
docs: cherry-pick docs updates to release/1.0.0 (#7330, #7336, #7350, #7352)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ Containers have all dependencies pre-installed. No setup required.
 
 ```bash
 # SGLang
-docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.8.1
+docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.0
 
 # TensorRT-LLM
-docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1
+docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0
 
 # vLLM
-docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.1
+docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0
 ```
 
 > **Tip:** To run frontend and worker in the same container, either run processes in background with `&` (see below), or open a second terminal and use `docker exec -it <container_id> bash`.

--- a/docs/assets/img/intro-foundations.svg
+++ b/docs/assets/img/intro-foundations.svg
@@ -1,29 +1,65 @@
-<svg width="500" height="500" viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg">
-  <rect width="100%" height="100%" fill="transparent"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="0 0 500 500">
+  <defs>
+    <filter id="shadow" x="-10%" y="-10%" width="130%" height="130%">
+      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#0A0F25" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+  <style type="text/css"><![CDATA[
+    .fill-N1 { fill: #0A0F25; }
+    .fill-N7 { fill: transparent; }
+    .fill-B1 { fill: #0D32B2; }
+    .fill-B5 { fill: #EDF0FD; }
+    .stroke-B1 { stroke: #0D32B2; }
+    .fill-white { fill: #FFFFFF; }
 
-  <circle cx="250" cy="155" r="110" fill="#1a1a1a" stroke="#505050" stroke-width="1" />
-  <circle cx="150" cy="330" r="110" fill="#1a1a1a" stroke="#505050" stroke-width="1" />
-  <circle cx="350" cy="330" r="110" fill="#1a1a1a" stroke="#505050" stroke-width="1" />
+    .label {
+      font-family: "NVIDIA Sans", "Inter", "Segoe UI", Arial, sans-serif;
+      font-size: 18px;
+      font-weight: 700;
+      text-anchor: middle;
+    }
+    .sublabel {
+      font-family: "NVIDIA Sans", "Inter", "Segoe UI", Arial, sans-serif;
+      font-size: 14px;
+      font-weight: 700;
+      text-anchor: middle;
+    }
+    .center-label {
+      font-family: "NVIDIA Sans", "Inter", "Segoe UI", Arial, sans-serif;
+      font-size: 20px;
+      font-weight: 700;
+      text-anchor: middle;
+    }
 
-  <circle cx="250" cy="275" r="90" fill="#2d5a10" stroke="#76b900" stroke-width="2" />
+    @media (prefers-color-scheme: dark) {
+      .fill-N1 { fill: #F2F2F2; }
+      .fill-N7 { fill: transparent; }
+      .fill-B1 { fill: #4A6FF3; }
+      .fill-B5 { fill: #252535; }
+      .stroke-B1 { stroke: #6B9FFF; }
+      .fill-white { fill: #F2F2F2; }
+    }
+  ]]></style>
 
-  <style>
-    .label { font-family: Arial, Helvetica, sans-serif; font-size: 20px; font-weight: 700; text-anchor: middle; fill: #e0e0e0; }
-    .sublabel { font-family: Arial, Helvetica, sans-serif; font-size: 14px; font-weight: 400; text-anchor: middle; fill: #909090; }
-    .center-label { font-family: Arial, Helvetica, sans-serif; font-size: 20px; font-weight: 700; text-anchor: middle; fill: #f0f0f0; }
-  </style>
+  <rect width="100%" height="100%" class="fill-N7"/>
 
-  <text x="250" y="120" class="label">Scheduling</text>
-  <text x="250" y="140" class="sublabel">(Dynamo)</text>
+  <circle cx="250" cy="155" r="110" class="fill-B5 stroke-B1" style="stroke-width:1" filter="url(#shadow)" />
+  <circle cx="150" cy="330" r="110" class="fill-B5 stroke-B1" style="stroke-width:1" filter="url(#shadow)" />
+  <circle cx="350" cy="330" r="110" class="fill-B5 stroke-B1" style="stroke-width:1" filter="url(#shadow)" />
 
-  <text x="115" y="330" class="label">Memory</text>
-  <text x="115" y="352" class="label">Management</text>
-  <text x="115" y="375" class="sublabel">(KVBM)</text>
+  <circle cx="250" cy="275" r="90" class="fill-B1 stroke-B1" style="stroke-width:1" filter="url(#shadow)" />
 
-  <text x="385" y="330" class="label">Data</text>
-  <text x="385" y="352" class="label">Transfer</text>
-  <text x="385" y="375" class="sublabel">(NIXL)</text>
+  <text x="250" y="118" class="label fill-N1">Scheduling</text>
+  <text x="250" y="138" class="sublabel fill-N1">(Dynamo)</text>
 
-  <text x="250" y="268" class="center-label">Disaggregated</text>
-  <text x="250" y="292" class="center-label">Serving</text>
+  <text x="115" y="325" class="label fill-N1">Memory</text>
+  <text x="115" y="347" class="label fill-N1">Management</text>
+  <text x="115" y="370" class="sublabel fill-N1">(KVBM)</text>
+
+  <text x="385" y="325" class="label fill-N1">Data</text>
+  <text x="385" y="347" class="label fill-N1">Transfer</text>
+  <text x="385" y="370" class="sublabel fill-N1">(NIXL)</text>
+
+  <text x="250" y="268" class="center-label fill-white">Disaggregated</text>
+  <text x="250" y="292" class="center-label fill-white">Serving</text>
 </svg>

--- a/docs/assets/img/intro-perf.svg
+++ b/docs/assets/img/intro-perf.svg
@@ -1,31 +1,72 @@
-<svg width="650" height="440" viewBox="0 0 650 440" xmlns="http://www.w3.org/2000/svg">
-  <rect width="100%" height="100%" fill="transparent"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="650" height="440" viewBox="0 0 650 440">
+  <defs>
+    <filter id="shadow" x="-10%" y="-10%" width="130%" height="130%">
+      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#0A0F25" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+  <style type="text/css"><![CDATA[
+    .fill-N1 { fill: #0A0F25; }
+    .fill-N7 { fill: transparent; }
+    .fill-B1 { fill: #0D32B2; }
+    .fill-B5 { fill: #EDF0FD; }
+    .stroke-B1 { stroke: #0D32B2; }
 
-  <ellipse cx="325" cy="230" rx="200" ry="135" fill="none" stroke="#76b900" stroke-width="2" />
+    .box-text {
+      font-family: "NVIDIA Sans", "Inter", "Segoe UI", Arial, sans-serif;
+      font-size: 18px;
+      font-weight: 700;
+      text-anchor: middle;
+    }
+    .benefit {
+      font-family: "NVIDIA Sans", "Inter", "Segoe UI", Arial, sans-serif;
+      font-size: 16px;
+      font-weight: 700;
+    }
+    .benefit-center {
+      font-family: "NVIDIA Sans", "Inter", "Segoe UI", Arial, sans-serif;
+      font-size: 16px;
+      font-weight: 700;
+      text-anchor: middle;
+    }
+    .summary {
+      font-family: "NVIDIA Sans", "Inter", "Segoe UI", Arial, sans-serif;
+      font-size: 14px;
+      font-weight: 700;
+      text-anchor: middle;
+    }
 
-  <rect x="220" y="30" width="210" height="80" rx="12" fill="#1e3a08" stroke="#76b900" stroke-width="2"/>
-  <text x="325" y="65" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700" text-anchor="middle" fill="#f0f0f0">Disaggregated</text>
-  <text x="325" y="87" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700" text-anchor="middle" fill="#f0f0f0">Serving</text>
+    @media (prefers-color-scheme: dark) {
+      .fill-N1 { fill: #F2F2F2; }
+      .fill-N7 { fill: transparent; }
+      .fill-B1 { fill: #6B9FFF; }
+      .fill-B5 { fill: #252535; }
+      .stroke-B1 { stroke: #6B9FFF; }
+    }
+  ]]></style>
 
-  <rect x="35" y="230" width="210" height="80" rx="12" fill="#251a3a" stroke="#8a60c0" stroke-width="2"/>
-  <text x="140" y="265" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700" text-anchor="middle" fill="#f0f0f0">KV Cache</text>
-  <text x="140" y="287" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700" text-anchor="middle" fill="#f0f0f0">Aware Routing</text>
+  <rect width="100%" height="100%" class="fill-N7"/>
 
-  <rect x="405" y="230" width="210" height="80" rx="12" fill="#1a2a30" stroke="#50b0a0" stroke-width="2"/>
-  <text x="510" y="265" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700" text-anchor="middle" fill="#f0f0f0">KV Cache</text>
-  <text x="510" y="287" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700" text-anchor="middle" fill="#f0f0f0">Offloading</text>
+  <ellipse cx="325" cy="230" rx="200" ry="135" fill="none" class="stroke-B1" style="stroke-width:1" />
 
-  <!-- Left label: near left edge -->
-  <text x="45" y="155" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#d4b040">Improved latency</text>
-  <text x="45" y="173" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#d4b040">and throughput</text>
+  <rect x="220" y="30" width="210" height="80" rx="6" class="fill-B5 stroke-B1" style="stroke-width:1" filter="url(#shadow)"/>
+  <text x="325" y="65" class="box-text fill-N1">Disaggregated</text>
+  <text x="325" y="87" class="box-text fill-N1">Serving</text>
 
-  <!-- Right label: near right edge -->
-  <text x="510" y="155" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#d4b040">Better TCO</text>
-  <text x="510" y="173" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#d4b040">Faster TTFT</text>
+  <rect x="35" y="230" width="210" height="80" rx="6" class="fill-B5 stroke-B1" style="stroke-width:1" filter="url(#shadow)"/>
+  <text x="140" y="265" class="box-text fill-N1">KV Cache</text>
+  <text x="140" y="287" class="box-text fill-N1">Aware Routing</text>
 
-  <!-- Bottom label: between Routing and Offloading -->
-  <text x="325" y="345" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" text-anchor="middle" fill="#d4b040">Higher KV cache hit rate</text>
+  <rect x="405" y="230" width="210" height="80" rx="6" class="fill-B5 stroke-B1" style="stroke-width:1" filter="url(#shadow)"/>
+  <text x="510" y="265" class="box-text fill-N1">KV Cache</text>
+  <text x="510" y="287" class="box-text fill-N1">Offloading</text>
 
-  <!-- Composition summary -->
-  <text x="325" y="420" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600" text-anchor="middle" fill="#76b900">All Three Composed: Max Throughput | Lowest Latency | Best TCO</text>
+  <text x="30" y="145" class="benefit fill-N1">Improved latency</text>
+  <text x="30" y="163" class="benefit fill-N1">and throughput</text>
+
+  <text x="510" y="145" class="benefit fill-N1">Better TCO</text>
+  <text x="510" y="163" class="benefit fill-N1">Faster TTFT</text>
+
+  <text x="325" y="345" class="benefit-center fill-N1">Higher KV cache hit rate</text>
+
+  <text x="325" y="420" class="summary fill-N1">All Three Composed: Max Throughput | Lowest Latency | Best TCO</text>
 </svg>

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -85,7 +85,7 @@ The full list of supported ecosystem components:
 
 ## Performance
 
-Dynamo achieves state-of-the-art LLM performance by composing three core techniques: Disaggregated Serving, KV Cache Aware Routing, and KV Cache Offloading. These techniques are underpinned by NIXL, a low-latency data transfer layer that enables seamless KV cache movement between nodes.
+Dynamo achieves state-of-the-art LLM performance by composing three core techniques: Disaggregated Serving, KV Cache-Aware Routing, and KV Cache Offloading. These techniques are underpinned by NIXL, a low-latency data transfer layer that enables seamless KV cache movement between nodes.
 
 - [KV cache-aware routing](../design-docs/router-design.md) Smartly routes requests based on worker load and existing cache hits. By reusing precomputed KV pairs, it bypasses the prefill compute, starting the decode phase immediately. [Baseten](https://www.baseten.co/blog/how-baseten-achieved-2x-faster-inference-with-nvidia-dynamo/#how-baseten-uses-nvidia-dynamo) applied Dynamo KV cache-aware routing and saw 2x faster TTFT and 1.6x throughput on Qwen3 Coder 480B A35B.
 
@@ -153,7 +153,7 @@ Dynamo provides built-in metrics, distributed tracing, and logging for monitorin
 Explore the following resources to go deeper:
 
 - [Recipes](https://github.com/ai-dynamo/dynamo/tree/main/recipes) -- Compose disaggregated serving, routing, and offloading
-- [KV Cache Aware Routing](../components/router/router-guide.md) -- Configure smart request routing
+- [KV Cache-Aware Routing](../components/router/router-guide.md) -- Configure smart request routing
 - [KV Cache Offloading](../components/kvbm/kvbm-guide.md) -- Set up multi-tier memory management
 - [Planner](../components/planner/planner-guide.md) -- Configure SLA-based autoscaling
 - [Kubernetes Deployment](../kubernetes/README.md) -- Deploy at scale with Grove

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -1,13 +1,13 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: Introduction
+title: Introduction to Dynamo
 sidebar-title: Introduction
 ---
 
-# Introduction
+# Introduction to Dynamo
 
-Dynamo is NVIDIA's high-throughput, low-latency inference framework, designed to serve generative AI workloads in distributed environments. This page gives an overview of Dynamo's design principles, performance benefits, and production-grade features.
+Dynamo is an open-source, high-throughput, low-latency inference framework, designed to serve generative AI workloads in distributed environments. This page gives an overview of Dynamo's design principles, performance benefits, and production-grade features.
 
 > [!TIP]
 > Looking to get started right away? See the [Quickstart](quickstart.md) to install and run Dynamo in minutes.
@@ -53,12 +53,12 @@ The Dynamo ecosystem includes these additional modular components, and will cont
 | :--- | :--- | :--- |
 | **Scheduling** | Dynamo | Inference serving for GenAI workloads |
 | **Routing** | Router | Smart routing leveraging KV cache hit rate and KV cache load. More algorithms will be added (e.g., agentic routing) |
-| **Data Transfer** | NIXL | Point-to-point data transfer between GPUs and tiered storage (G1: GPU, G2: CPU, G3: SSD, G4: remote) |
+| **Data Transfer** | [NIXL](https://github.com/ai-dynamo/nixl) | Point-to-point data transfer between GPUs and tiered storage (G1: GPU, G2: CPU, G3: SSD, G4: remote) |
 | **Memory** | KVBM (KV Block Manager) | Manage KV cache across memory tiers (G1-G4) with customizable eviction policy |
 | **Scaling / Cloud** | Planner | Automatically tune performance in real time for prefill and decode given SLA constraints (TTFT and TPOT) |
-| | Grove | Enables gang scheduling and topology awareness required for Kubernetes multi-node disaggregated serving |
+| | [Grove](https://github.com/ai-dynamo/grove) | Enables gang scheduling and topology awareness required for Kubernetes multi-node disaggregated serving |
 | | [Model Express](https://github.com/ai-dynamo/model-express) | Load model weights fast by caching and transferring them via NIXL to other GPUs. Will also be leveraged for fault tolerance |
-| **Perf** | AIConfigurator | Estimate performance for aggregated vs. disaggregated serving based on model, ISL/OSL, HW, etc. Formerly known as LLMPet |
+| **Perf** | [AIConfigurator](https://github.com/ai-dynamo/aiconfigurator) | Estimate performance for aggregated vs. disaggregated serving based on model, ISL/OSL, HW, etc. Formerly known as LLMPet |
 | | [AIPerf](https://github.com/ai-dynamo/aiperf) | Re-architected GenAI-Perf written in Python for maximum extensibility; supports distributed benchmarking |
 | | AITune | Given a model or pipeline, searches for best backend to deploy with (e.g., TensorRT, Torch.compile, etc.) (coming soon) |
 | | Flex Tensor | Stream weights to GPUs from host memory to run very large language models in GPUs with limited memory capacity (coming soon) |
@@ -94,11 +94,11 @@ Dynamo achieves state-of-the-art LLM performance by composing three core techniq
 - [Disaggregated serving](../design-docs/disagg-serving.md) In the Design Principles section, we introduced the concept of disaggregated serving. Its performance has been showcased by [InferenceX](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs). DeepSeek V3 can be served with ~7x throughput/GPU, with disaggregated serving and large-scale expert parallelism.
 Furthermore, when these three techniques are composed together, they yield compounding benefits as shown in the following diagram.
 
-![Performance composability of disaggregated serving, KV cache aware routing, and KV cache offloading](../assets/img/intro-perf.svg)
+![Performance composability of disaggregated serving, KV cache-aware routing, and KV cache offloading](../assets/img/intro-perf.svg)
 
-- **Disaggregated serving + KV cache aware routing** -- KV cache aware routing load balances for both compute (on prefill) and memory (on decode), optimizing latency and throughput simultaneously.
-- **Disaggregated serving + KV cache offloading** -- KV cache offloading results in faster TTFT, and the number of prefill workers can be reduced to reduce TCO.
-- **KV cache aware routing + KV cache offloading** -- Offloading increases the total addressable cache size, increasing the KV cache hit rate, which in turn accelerates the TTFT.
+- **Disaggregated Serving + KV Cache-Aware Routing** -- KV cache-aware routing load balances for both compute (on prefill) and memory (on decode), optimizing latency and throughput simultaneously.
+- **Disaggregated Serving + KV Cache Offloading** -- KV cache offloading results in faster TTFT, and the number of prefill workers can be reduced to reduce TCO.
+- **KV Cache-Aware Routing + KV Cache Offloading** -- Offloading increases the total addressable cache size, increasing the KV cache hit rate, which in turn accelerates the TTFT.
 
 > [!TIP]
 > Ready to try these techniques? See [Dynamo recipes](https://github.com/ai-dynamo/dynamo/tree/main/recipes) for step-by-step deployment examples that compose disaggregated serving, routing, and offloading.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -147,10 +147,10 @@ navigation:
             path: fault-tolerance/request-migration.md
           - page: Request Cancellation
             path: fault-tolerance/request-cancellation.md
-          - page: Graceful Shutdown
-            path: fault-tolerance/graceful-shutdown.md
           - page: Request Rejection
             path: fault-tolerance/request-rejection.md
+          - page: Graceful Shutdown
+            path: fault-tolerance/graceful-shutdown.md
           - page: Testing
             path: fault-tolerance/testing.md
       - page: Writing Python Workers

--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -10,34 +10,26 @@ This document provides a comprehensive inventory of all Dynamo release artifacts
 
 Release history in this document begins at v0.6.0.
 
-## Current Release: Dynamo v0.9.0
+## Current Release: Dynamo v1.0.0
 
-- **GitHub Release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0)
-- **Docs:** [v0.9.0](https://docs.dynamo.nvidia.com/dynamo)
+- **GitHub Release:** [v1.0.0](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.0)
+- **Docs:** [v1.0.0](https://docs.dynamo.nvidia.com/dynamo)
 - **NGC Collection:** [ai-dynamo](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)
-
-### Patch Release: v0.9.0.post1 (Feb 2026)
-
-**v0.9.0.post1** is a Helm-chart-only patch release on NGC (no GitHub release). It fixes the `dynamo-platform` Helm chart which incorrectly set the operator image tag to `0.7.1` instead of `0.9.0`. Only the `dynamo-platform` chart was patched; all other artifacts remain at v0.9.0.
-
-| Artifact | Version | Change | Link |
-|----------|---------|--------|------|
-| `dynamo-platform` | `0.9.0-post1` | Fixed operator image tag (`0.7.1` -> `0.9.0`) | [NGC](https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-0.9.0-post1.tgz) |
-
-**Workaround for v0.9.0 chart:** If using the original v0.9.0 Helm chart, add this flag:
-`--set dynamo-operator.controllerManager.manager.image.tag=0.9.0`
 
 ### Container Images
 
 | Image:Tag | Description | Backend | CUDA | Arch | NGC | Notes |
 |-----------|-------------|---------|------|------|-----|-------|
-| `vllm-runtime:0.9.0` | Runtime container for vLLM backend | vLLM `v0.14.1` | `v12.9` | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime?version=0.9.0) | |
-| `vllm-runtime:0.9.0-cuda13` | Runtime container for vLLM backend (CUDA 13) | vLLM `v0.14.1` | `v13.0` | AMD64/ARM64* | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime?version=0.9.0-cuda13) | Experimental |
-| `sglang-runtime:0.9.0` | Runtime container for SGLang backend | SGLang `v0.5.8` | `v12.9` | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/sglang-runtime?version=0.9.0) | |
-| `sglang-runtime:0.9.0-cuda13` | Runtime container for SGLang backend (CUDA 13) | SGLang `v0.5.8` | `v13.0` | AMD64/ARM64* | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/sglang-runtime?version=0.9.0-cuda13) | Experimental |
-| `tensorrtllm-runtime:0.9.0` | Runtime container for TensorRT-LLM backend | TRT-LLM `v1.3.0rc1` | `v13.0` | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/tensorrtllm-runtime?version=0.9.0) | |
-| `dynamo-frontend:0.9.0` | API gateway with Endpoint Prediction Protocol (EPP) | — | — | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/dynamo-frontend?version=0.9.0) | |
-| `kubernetes-operator:0.9.0` | Kubernetes operator for Dynamo deployments | — | — | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/kubernetes-operator?version=0.9.0) | |
+| `vllm-runtime:1.0.0` | Runtime container for vLLM backend | vLLM `v0.16.0` | `v12.9` | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime?version=1.0.0) | |
+| `vllm-runtime:1.0.0-cuda13` | Runtime container for vLLM backend (CUDA 13) | vLLM `v0.16.0` | `v13.0` | AMD64/ARM64* | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime?version=1.0.0-cuda13) | |
+| `vllm-runtime:1.0.0-efa-amd64` | Runtime container for vLLM with AWS EFA | vLLM `v0.16.0` | `v12.9` | AMD64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime?version=1.0.0-efa-amd64) | Experimental |
+| `sglang-runtime:1.0.0` | Runtime container for SGLang backend | SGLang `v0.5.9` | `v12.9` | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/sglang-runtime?version=1.0.0) | |
+| `sglang-runtime:1.0.0-cuda13` | Runtime container for SGLang backend (CUDA 13) | SGLang `v0.5.9` | `v13.0` | AMD64/ARM64* | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/sglang-runtime?version=1.0.0-cuda13) | |
+| `tensorrtllm-runtime:1.0.0` | Runtime container for TensorRT-LLM backend | TRT-LLM `v1.3.0rc5.post1` | `v13.1` | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/tensorrtllm-runtime?version=1.0.0) | |
+| `tensorrtllm-runtime:1.0.0-efa-amd64` | Runtime container for TensorRT-LLM with AWS EFA | TRT-LLM `v1.3.0rc5.post1` | `v13.1` | AMD64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/tensorrtllm-runtime?version=1.0.0-efa-amd64) | Experimental |
+| `dynamo-frontend:1.0.0` | API gateway with Endpoint Prediction Protocol (EPP) | — | — | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/dynamo-frontend?version=1.0.0) | |
+| `kubernetes-operator:1.0.0` | Kubernetes operator for Dynamo deployments | — | — | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/kubernetes-operator?version=1.0.0) | |
+| `snapshot-agent:1.0.0` | Snapshot agent for fast GPU worker recovery via CRIU | — | — | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/snapshot-agent?version=1.0.0) | Preview |
 
 \* Multimodal inference on CUDA 13 images: works on AMD64 for all backends; works on ARM64 only for TensorRT-LLM (`vllm-runtime:*-cuda13` and `sglang-runtime:*-cuda13` do not support multimodality on ARM64).
 
@@ -47,30 +39,32 @@ We recommend using the TensorRT-LLM NGC container instead of the `ai-dynamo[trtl
 
 | Package | Description | Python | Platform | PyPI |
 |---------|-------------|--------|----------|------|
-| `ai-dynamo==0.9.0` | Main package with backend integrations (vLLM, SGLang, TRT-LLM) | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/ai-dynamo/0.9.0/) |
-| `ai-dynamo-runtime==0.9.0` | Core Python bindings for Dynamo runtime | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/ai-dynamo-runtime/0.9.0/) |
-| `kvbm==0.9.0` | KV Block Manager for disaggregated KV cache | `3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/kvbm/0.9.0/) |
+| `ai-dynamo==1.0.0` | Main package with backend integrations (vLLM, SGLang, TRT-LLM) | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/ai-dynamo/1.0.0/) |
+| `ai-dynamo-runtime==1.0.0` | Core Python bindings for Dynamo runtime | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/ai-dynamo-runtime/1.0.0/) |
+| `kvbm==1.0.0` | KV Block Manager for disaggregated KV cache | `3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/kvbm/1.0.0/) |
 
 ### Helm Charts
 
 | Chart | Description | NGC |
 |-------|-------------|-----|
-| `dynamo-crds-0.9.0` | Custom Resource Definitions for Dynamo Kubernetes resources | [link](https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-crds-0.9.0.tgz) |
-| `dynamo-platform-0.9.0-post1` | Platform services (etcd, NATS) for Dynamo cluster | [link](https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-0.9.0-post1.tgz) |
+| `dynamo-platform-1.0.0` | Platform services (etcd, NATS) and Dynamo Operator for Dynamo cluster | [link](https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-1.0.0.tgz) |
+| `snapshot-1.0.0` | Snapshot DaemonSet for fast GPU worker recovery | [link](https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/snapshot-1.0.0.tgz) |
 
-> **Note:** The `dynamo-graph` Helm chart is deprecated as of v0.9.0. Use the Kubernetes operator for deployment graph management.
+> **Note:** The `dynamo-crds` Helm chart is deprecated as of v1.0.0; CRDs are now managed by the Dynamo Operator. The `dynamo-graph` Helm chart is deprecated as of v0.9.0.
 
 ### Rust Crates
 
 | Crate | Description | MSRV (Rust) | crates.io |
 |-------|-------------|-------------|-----------|
-| `dynamo-runtime@0.9.0` | Core distributed runtime library | `v1.82` | [link](https://crates.io/crates/dynamo-runtime/0.9.0) |
-| `dynamo-llm@0.9.0` | LLM inference engine | `v1.82` | [link](https://crates.io/crates/dynamo-llm/0.9.0) |
-| `dynamo-async-openai@0.9.0` | Async OpenAI-compatible API client | `v1.82` | [link](https://crates.io/crates/dynamo-async-openai/0.9.0) |
-| `dynamo-parsers@0.9.0` | Protocol parsers (SSE, JSON streaming) | `v1.82` | [link](https://crates.io/crates/dynamo-parsers/0.9.0) |
-| `dynamo-memory@0.9.0` | Memory management utilities | `v1.82` | [link](https://crates.io/crates/dynamo-memory/0.9.0) |
-| `dynamo-config@0.9.0` | Configuration management | `v1.82` | [link](https://crates.io/crates/dynamo-config/0.9.0) |
-| `dynamo-tokens@0.9.0` | Tokenizer bindings for LLM inference | `v1.82` | [link](https://crates.io/crates/dynamo-tokens/0.9.0) |
+| `dynamo-runtime@1.0.0` | Core distributed runtime library | `v1.82` | [link](https://crates.io/crates/dynamo-runtime/1.0.0) |
+| `dynamo-llm@1.0.0` | LLM inference engine | `v1.82` | [link](https://crates.io/crates/dynamo-llm/1.0.0) |
+| `dynamo-async-openai@1.0.0` | Async OpenAI-compatible API client | `v1.82` | [link](https://crates.io/crates/dynamo-async-openai/1.0.0) |
+| `dynamo-parsers@1.0.0` | Protocol parsers (SSE, JSON streaming) | `v1.82` | [link](https://crates.io/crates/dynamo-parsers/1.0.0) |
+| `dynamo-memory@1.0.0` | Memory management utilities | `v1.82` | [link](https://crates.io/crates/dynamo-memory/1.0.0) |
+| `dynamo-config@1.0.0` | Configuration management | `v1.82` | [link](https://crates.io/crates/dynamo-config/1.0.0) |
+| `dynamo-tokens@1.0.0` | Tokenizer bindings for LLM inference | `v1.82` | [link](https://crates.io/crates/dynamo-tokens/1.0.0) |
+| `dynamo-mocker@1.0.0` | Inference engine simulator for benchmarking | `v1.82` | [link](https://crates.io/crates/dynamo-mocker/1.0.0) |
+| `dynamo-kv-router@1.0.0` | KV-aware request routing library | `v1.82` | [link](https://crates.io/crates/dynamo-kv-router/1.0.0) |
 
 ## Quick Install Commands
 
@@ -80,17 +74,22 @@ We recommend using the TensorRT-LLM NGC container instead of the `ai-dynamo[trtl
 
 ```bash
 # Runtime containers
-docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0
-docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.9.0
-docker pull nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.9.0
+docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0
+docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.0
+docker pull nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0
 
-# CUDA 13 variants (experimental)
-docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0-cuda13
-docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.9.0-cuda13
+# CUDA 13 variants
+docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0-cuda13
+docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.0-cuda13
+
+# EFA variants (AWS, AMD64 only, experimental)
+docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0-efa-amd64
+docker pull nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0-efa-amd64
 
 # Infrastructure containers
-docker pull nvcr.io/nvidia/ai-dynamo/dynamo-frontend:0.9.0
-docker pull nvcr.io/nvidia/ai-dynamo/kubernetes-operator:0.9.0
+docker pull nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.0.0
+docker pull nvcr.io/nvidia/ai-dynamo/kubernetes-operator:1.0.0
+docker pull nvcr.io/nvidia/ai-dynamo/snapshot-agent:1.0.0
 ```
 
 ### Python Wheels (PyPI)
@@ -99,16 +98,16 @@ docker pull nvcr.io/nvidia/ai-dynamo/kubernetes-operator:0.9.0
 
 ```bash
 # Install Dynamo with a specific backend (Recommended)
-uv pip install "ai-dynamo[vllm]==0.9.0"
-uv pip install "ai-dynamo[sglang]==0.9.0"
+uv pip install "ai-dynamo[vllm]==1.0.0"
+uv pip install "ai-dynamo[sglang]==1.0.0"
 # TensorRT-LLM requires the NVIDIA PyPI index and pip
-pip install --pre --extra-index-url https://pypi.nvidia.com "ai-dynamo[trtllm]==0.9.0"
+pip install --pre --extra-index-url https://pypi.nvidia.com "ai-dynamo[trtllm]==1.0.0"
 
 # Install Dynamo core only
-uv pip install ai-dynamo==0.9.0
+uv pip install ai-dynamo==1.0.0
 
 # Install standalone KVBM (Python 3.12 only)
-uv pip install kvbm==0.9.0
+uv pip install kvbm==1.0.0
 ```
 
 ### Helm Charts (NGC)
@@ -116,8 +115,8 @@ uv pip install kvbm==0.9.0
 > For Kubernetes deployment instructions, see the [Kubernetes Installation Guide](../kubernetes/installation-guide.md).
 
 ```bash
-helm install dynamo-crds oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-crds --version 0.9.0
-helm install dynamo-platform oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform --version 0.9.0-post1
+helm install dynamo-platform oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform --version 1.0.0
+helm install snapshot oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/snapshot --version 1.0.0
 ```
 
 ### Rust Crates (crates.io)
@@ -125,13 +124,15 @@ helm install dynamo-platform oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/d
 > For API documentation, see each crate on [docs.rs](https://docs.rs/). To build Dynamo from source, see [Building from Source](https://github.com/ai-dynamo/dynamo#building-from-source).
 
 ```bash
-cargo add dynamo-runtime@0.9.0
-cargo add dynamo-llm@0.9.0
-cargo add dynamo-async-openai@0.9.0
-cargo add dynamo-parsers@0.9.0
-cargo add dynamo-memory@0.9.0
-cargo add dynamo-config@0.9.0
-cargo add dynamo-tokens@0.9.0
+cargo add dynamo-runtime@1.0.0
+cargo add dynamo-llm@1.0.0
+cargo add dynamo-async-openai@1.0.0
+cargo add dynamo-parsers@1.0.0
+cargo add dynamo-memory@1.0.0
+cargo add dynamo-config@1.0.0
+cargo add dynamo-tokens@1.0.0
+cargo add dynamo-mocker@1.0.0
+cargo add dynamo-kv-router@1.0.0
 ```
 
 **CUDA and Driver Requirements:** For detailed CUDA toolkit versions and minimum driver requirements for each container image, see the [Support Matrix](support-matrix.md#cuda-and-driver-requirements).
@@ -139,6 +140,7 @@ cargo add dynamo-tokens@0.9.0
 ## Known Issues
 
 For a complete list of known issues, refer to the release notes for each version:
+- [v1.0.0 Release Notes](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.0)
 - [v0.9.0 Release Notes](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0)
 - [v0.8.1 Release Notes](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.1)
 
@@ -155,10 +157,13 @@ For a complete list of known issues, refer to the release notes for each version
 
 ## Release History
 
+- **v1.0.0**: First major release. SGLang `v0.5.9`, TRT-LLM `v1.3.0rc5.post1` (CUDA 13.1), vLLM `v0.16.0`, NIXL `v0.10.1`. New `snapshot-agent` container and `snapshot` Helm chart (Preview). New EFA container variants for vLLM and TRT-LLM (Experimental, AMD64 only). New `dynamo-mocker` and `dynamo-kv-router` Rust crates. Deprecated `dynamo-crds` Helm chart (CRDs now managed by the Operator). `v1alpha1` CRDs deprecated.
+- **v0.9.1**: Updated TRT-LLM to `v1.3.0rc3`. All other backend versions unchanged from v0.9.0.
 - **v0.9.0.post1**: Fixed `dynamo-platform` Helm chart operator image tag (Helm chart only, NGC)
 - **v0.9.0**: Updated vLLM to `v0.14.1`, SGLang to `v0.5.8`, TRT-LLM to `v1.3.0rc1`, NIXL to `v0.9.0`. New `dynamo-tokens` Rust crate. Deprecated `dynamo-graph` Helm chart.
 - **v0.8.1.post1/.post2/.post3 Patches**: Experimental patch releases updating TRT-LLM only (PyPI wheels and TRT-LLM container). No other artifacts changed.
 - **Standalone Frontend Container**: `dynamo-frontend` added in v0.8.0
+- **EFA Runtimes**: Experimental AWS EFA variants for vLLM and TRT-LLM (AMD64 only) in v1.0.0
 - **CUDA 13 Runtimes**: Experimental CUDA 13 runtime for SGLang and vLLM in v0.8.0
 - **New Rust Crates**: `dynamo-memory` and `dynamo-config` added in v0.8.0
 
@@ -166,13 +171,15 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Version | Release Date | GitHub | Docs |
 |---------|--------------|--------|------|
-| `v0.9.0` | Feb 11, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0) | [Docs](https://docs.dynamo.nvidia.com/dynamo) |
-| `v0.8.1` | Jan 23, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.1) | [Docs](https://docs.nvidia.com/dynamo/archive/0.8.1/index.html) |
-| `v0.8.0` | Jan 15, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.0) | [Docs](https://docs.nvidia.com/dynamo/archive/0.8.0/index.html) |
-| `v0.7.1` | Dec 15, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.1) | [Docs](https://docs.nvidia.com/dynamo/archive/0.7.1/index.html) |
-| `v0.7.0` | Nov 26, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.0) | [Docs](https://docs.nvidia.com/dynamo/archive/0.7.0/index.html) |
-| `v0.6.1` | Nov 6, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.1) | [Docs](https://docs.nvidia.com/dynamo/archive/0.6.1/index.html) |
-| `v0.6.0` | Oct 28, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.0) | [Docs](https://docs.nvidia.com/dynamo/archive/0.6.0/index.html) |
+| `v1.0.0` | Mar 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.0) | [Docs](https://docs.dynamo.nvidia.com/dynamo) |
+| `v0.9.1` | Mar 4, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.1) | [Docs](https://docs.dynamo.nvidia.com/dynamo) |
+| `v0.9.0` | Feb 11, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0) | [Docs](https://docs.dynamo.nvidia.com/dynamo/v-0-9-0/) |
+| `v0.8.1` | Jan 23, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.1) | [Docs](https://docs.nvidia.com/dynamo/v-0-8-1/) |
+| `v0.8.0` | Jan 15, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.0) | [Docs](https://docs.nvidia.com/dynamo/v-0-8-0/) |
+| `v0.7.1` | Dec 15, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.1) | [Docs](https://docs.nvidia.com/dynamo/v-0-7-1/) |
+| `v0.7.0` | Nov 26, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.0) | [Docs](https://docs.nvidia.com/dynamo/v-0-7-0/) |
+| `v0.6.1` | Nov 6, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.1) | — |
+| `v0.6.0` | Oct 28, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.0) | — |
 
 ### Container Images
 
@@ -185,6 +192,11 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Image:Tag | vLLM | Arch | CUDA | Notes |
 |-----------|------|------|------|-------|
+| `vllm-runtime:1.0.0` | `v0.16.0` | AMD64/ARM64 | `v12.9` | |
+| `vllm-runtime:1.0.0-cuda13` | `v0.16.0` | AMD64/ARM64* | `v13.0` | |
+| `vllm-runtime:1.0.0-efa-amd64` | `v0.16.0` | AMD64 | `v12.9` | Experimental |
+| `vllm-runtime:0.9.1` | `v0.14.1` | AMD64/ARM64 | `v12.9` | |
+| `vllm-runtime:0.9.1-cuda13` | `v0.14.1` | AMD64/ARM64* | `v13.0` | Experimental |
 | `vllm-runtime:0.9.0` | `v0.14.1` | AMD64/ARM64 | `v12.9` | |
 | `vllm-runtime:0.9.0-cuda13` | `v0.14.1` | AMD64/ARM64* | `v13.0` | Experimental |
 | `vllm-runtime:0.8.1` | `v0.12.0` | AMD64/ARM64 | `v12.9` | |
@@ -202,6 +214,10 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Image:Tag | SGLang | Arch | CUDA | Notes |
 |-----------|--------|------|------|-------|
+| `sglang-runtime:1.0.0` | `v0.5.9` | AMD64/ARM64 | `v12.9` | |
+| `sglang-runtime:1.0.0-cuda13` | `v0.5.9` | AMD64/ARM64* | `v13.0` | |
+| `sglang-runtime:0.9.1` | `v0.5.8` | AMD64/ARM64 | `v12.9` | |
+| `sglang-runtime:0.9.1-cuda13` | `v0.5.8` | AMD64/ARM64* | `v13.0` | Experimental |
 | `sglang-runtime:0.9.0` | `v0.5.8` | AMD64/ARM64 | `v12.9` | |
 | `sglang-runtime:0.9.0-cuda13` | `v0.5.8` | AMD64/ARM64* | `v13.0` | Experimental |
 | `sglang-runtime:0.8.1` | `v0.5.6.post2` | AMD64/ARM64 | `v12.9` | |
@@ -219,6 +235,9 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Image:Tag | TRT-LLM | Arch | CUDA | Notes |
 |-----------|---------|------|------|-------|
+| `tensorrtllm-runtime:1.0.0` | `v1.3.0rc5.post1` | AMD64/ARM64 | `v13.1` | |
+| `tensorrtllm-runtime:1.0.0-efa-amd64` | `v1.3.0rc5.post1` | AMD64 | `v13.1` | Experimental |
+| `tensorrtllm-runtime:0.9.1` | `v1.3.0rc3` | AMD64/ARM64 | `v13.0` | |
 | `tensorrtllm-runtime:0.9.0` | `v1.3.0rc1` | AMD64/ARM64 | `v13.0` | |
 | `tensorrtllm-runtime:0.8.1.post3` | `v1.2.0rc6.post3` | AMD64/ARM64 | `v13.0` | Patch |
 | `tensorrtllm-runtime:0.8.1.post1` | `v1.2.0rc6.post2` | AMD64/ARM64 | `v13.0` | Patch |
@@ -237,6 +256,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Image:Tag | Arch | Notes |
 |-----------|------|-------|
+| `dynamo-frontend:1.0.0` | AMD64/ARM64 | |
+| `dynamo-frontend:0.9.1` | AMD64/ARM64 | |
 | `dynamo-frontend:0.9.0` | AMD64/ARM64 | |
 | `dynamo-frontend:0.8.1` | AMD64/ARM64 | |
 | `dynamo-frontend:0.8.0` | AMD64/ARM64 | Initial |
@@ -245,6 +266,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Image:Tag | Arch | Notes |
 |-----------|------|-------|
+| `kubernetes-operator:1.0.0` | AMD64/ARM64 | |
+| `kubernetes-operator:0.9.1` | AMD64/ARM64 | |
 | `kubernetes-operator:0.9.0` | AMD64/ARM64 | |
 | `kubernetes-operator:0.8.1` | AMD64/ARM64 | |
 | `kubernetes-operator:0.8.0` | AMD64/ARM64 | |
@@ -253,6 +276,12 @@ For a complete list of known issues, refer to the release notes for each version
 | `kubernetes-operator:0.7.0` | AMD64/ARM64 | |
 | `kubernetes-operator:0.6.1` | AMD64/ARM64 | |
 | `kubernetes-operator:0.6.0` | AMD64/ARM64 | |
+
+#### snapshot-agent
+
+| Image:Tag | Arch | Notes |
+|-----------|------|-------|
+| `snapshot-agent:1.0.0` | AMD64/ARM64 | Preview |
 
 ### Python Wheels
 
@@ -264,6 +293,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Package | Python | Platform | Notes |
 |---------|--------|----------|-------|
+| `ai-dynamo==1.0.0` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
+| `ai-dynamo==0.9.1` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
 | `ai-dynamo==0.9.0` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
 | `ai-dynamo==0.8.1.post3` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | TRT-LLM `v1.2.0rc6.post3` |
 | `ai-dynamo==0.8.1.post1` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | TRT-LLM `v1.2.0rc6.post2` |
@@ -278,6 +309,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Package | Python | Platform | Notes |
 |---------|--------|----------|-------|
+| `ai-dynamo-runtime==1.0.0` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
+| `ai-dynamo-runtime==0.9.1` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
 | `ai-dynamo-runtime==0.9.0` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
 | `ai-dynamo-runtime==0.8.1.post3` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | TRT-LLM `v1.2.0rc6.post3` |
 | `ai-dynamo-runtime==0.8.1.post1` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | TRT-LLM `v1.2.0rc6.post2` |
@@ -292,6 +325,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Package | Python | Platform | Notes |
 |---------|--------|----------|-------|
+| `kvbm==1.0.0` | `3.12` | Linux (glibc `v2.28+`) | |
+| `kvbm==0.9.1` | `3.12` | Linux (glibc `v2.28+`) | |
 | `kvbm==0.9.0` | `3.12` | Linux (glibc `v2.28+`) | |
 | `kvbm==0.8.1` | `3.12` | Linux (glibc `v2.28+`) | |
 | `kvbm==0.8.0` | `3.12` | Linux (glibc `v2.28+`) | |
@@ -304,10 +339,13 @@ For a complete list of known issues, refer to the release notes for each version
 >
 > Direct download: `https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/{chart}-{version}.tgz`
 
-#### dynamo-crds (Helm chart)
+#### dynamo-crds (Helm chart) -- Deprecated
+
+> **Note:** The `dynamo-crds` Helm chart is deprecated as of v1.0.0. CRDs are now managed by the Dynamo Operator.
 
 | Chart | Notes |
 |-------|-------|
+| `dynamo-crds-0.9.1` | Last release |
 | `dynamo-crds-0.9.0` | |
 | `dynamo-crds-0.8.1` | |
 | `dynamo-crds-0.8.0` | |
@@ -320,6 +358,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Chart | Notes |
 |-------|-------|
+| `dynamo-platform-1.0.0` | |
+| `dynamo-platform-0.9.1` | |
 | `dynamo-platform-0.9.0-post1` | Helm fix: operator image tag |
 | `dynamo-platform-0.9.0` | |
 | `dynamo-platform-0.8.1` | |
@@ -328,6 +368,12 @@ For a complete list of known issues, refer to the release notes for each version
 | `dynamo-platform-0.7.0` | |
 | `dynamo-platform-0.6.1` | |
 | `dynamo-platform-0.6.0` | |
+
+#### snapshot (Helm chart)
+
+| Chart | Notes |
+|-------|-------|
+| `snapshot-1.0.0` | Preview |
 
 #### dynamo-graph (Helm chart) -- Deprecated
 
@@ -352,6 +398,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-runtime@1.0.0` | `v1.82` | |
+| `dynamo-runtime@0.9.1` | `v1.82` | |
 | `dynamo-runtime@0.9.0` | `v1.82` | |
 | `dynamo-runtime@0.8.1` | `v1.82` | |
 | `dynamo-runtime@0.8.0` | `v1.82` | |
@@ -364,6 +412,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-llm@1.0.0` | `v1.82` | |
+| `dynamo-llm@0.9.1` | `v1.82` | |
 | `dynamo-llm@0.9.0` | `v1.82` | |
 | `dynamo-llm@0.8.1` | `v1.82` | |
 | `dynamo-llm@0.8.0` | `v1.82` | |
@@ -376,6 +426,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-async-openai@1.0.0` | `v1.82` | |
+| `dynamo-async-openai@0.9.1` | `v1.82` | |
 | `dynamo-async-openai@0.9.0` | `v1.82` | |
 | `dynamo-async-openai@0.8.1` | `v1.82` | |
 | `dynamo-async-openai@0.8.0` | `v1.82` | |
@@ -388,6 +440,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-parsers@1.0.0` | `v1.82` | |
+| `dynamo-parsers@0.9.1` | `v1.82` | |
 | `dynamo-parsers@0.9.0` | `v1.82` | |
 | `dynamo-parsers@0.8.1` | `v1.82` | |
 | `dynamo-parsers@0.8.0` | `v1.82` | |
@@ -400,6 +454,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-memory@1.0.0` | `v1.82` | |
+| `dynamo-memory@0.9.1` | `v1.82` | |
 | `dynamo-memory@0.9.0` | `v1.82` | |
 | `dynamo-memory@0.8.1` | `v1.82` | |
 | `dynamo-memory@0.8.0` | `v1.82` | Initial |
@@ -408,6 +464,8 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-config@1.0.0` | `v1.82` | |
+| `dynamo-config@0.9.1` | `v1.82` | |
 | `dynamo-config@0.9.0` | `v1.82` | |
 | `dynamo-config@0.8.1` | `v1.82` | |
 | `dynamo-config@0.8.0` | `v1.82` | Initial |
@@ -416,4 +474,18 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Crate | MSRV (Rust) | Notes |
 |-------|-------------|-------|
+| `dynamo-tokens@1.0.0` | `v1.82` | |
+| `dynamo-tokens@0.9.1` | `v1.82` | |
 | `dynamo-tokens@0.9.0` | `v1.82` | Initial |
+
+#### dynamo-mocker (crate)
+
+| Crate | MSRV (Rust) | Notes |
+|-------|-------------|-------|
+| `dynamo-mocker@1.0.0` | `v1.82` | Initial |
+
+#### dynamo-kv-router (crate)
+
+| Crate | MSRV (Rust) | Notes |
+|-------|-------------|-------|
+| `dynamo-kv-router@1.0.0` | `v1.82` | Initial |

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -9,7 +9,7 @@ subtitle: Hardware, software, and build compatibility for Dynamo
 
 ## At a Glance
 
-**Latest stable release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0) -- SGLang `0.5.8` | TensorRT-LLM `1.3.0rc1` | vLLM `0.14.1` | NIXL `0.9.0`
+**Latest stable release:** [v1.0.0](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.0) -- SGLang `0.5.9` | TensorRT-LLM `1.3.0rc5.post1` | vLLM `0.16.0` | NIXL `0.10.1`
 
 | Requirement | Supported |
 | :--- | :--- |
@@ -28,7 +28,7 @@ The following table shows the backend framework versions included with each Dyna
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
 | **main (ToT)** | `0.5.9` | `1.3.0rc5.post1` | `0.16.0` | `0.10.1` |
-| **v1.0.0** *(in progress)* | `0.5.9` | `1.3.0rc5.post1` | `0.16.0` | `0.10.1` |
+| **v1.0.0** | `0.5.9` | `1.3.0rc5.post1` | `0.16.0` | `0.10.1` |
 | **v0.9.1** | `0.5.8` | `1.3.0rc3` | `0.14.1` | `0.9.0` |
 | **v0.9.0** | `0.5.8` | `1.3.0rc1` | `0.14.1` | `0.9.0` |
 | **v0.8.1.post3** | `0.5.6.post2` | `1.2.0rc6.post3` | `0.12.0` | `0.8.0` |
@@ -59,7 +59,7 @@ Dynamo container images include CUDA toolkit libraries. The host machine must ha
 
 | Dynamo Version | Backend | CUDA Toolkit | Min Driver | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-| **1.0.0** *(in progress)* | **SGLang** | 12.9 | 575.xx+ | |
+| **1.0.0** | **SGLang** | 12.9 | 575.xx+ | |
 | | | 13.0 | 580.xx+ | |
 | | **TensorRT-LLM** | 13.1 | 580.xx+ | |
 | | **vLLM** | 12.9 | 575.xx+ | |
@@ -168,13 +168,18 @@ For version-specific artifact details, installation commands, and release histor
   - [SGLang Runtime](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/sglang-runtime)
   - [SGLang Runtime (CUDA 13)](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/sglang-runtime-cu13)
   - [TensorRT-LLM Runtime](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/tensorrtllm-runtime)
+  - [TensorRT-LLM Runtime (EFA)](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/tensorrtllm-runtime) *(New in v1.0.0, Experimental, AMD64 only)*
   - [vLLM Runtime](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime)
   - [vLLM Runtime (CUDA 13)](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime-cu13)
+  - [vLLM Runtime (EFA)](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime) *(New in v1.0.0, Experimental, AMD64 only)*
   - [Kubernetes Operator](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/kubernetes-operator)
+  - [Snapshot Agent](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/snapshot-agent) *(New in v1.0.0, Preview)*
 
 - **Helm Charts**: [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo) hosts the helm charts supporting Kubernetes deployments of Dynamo:
-  - [Dynamo Platform](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/helm-charts/dynamo-platform) (includes CRDs)
-  - [Dynamo Graph](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/helm-charts/dynamo-graph)
+  - [Dynamo Platform](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/helm-charts/dynamo-platform) (now includes CRDs)
+  - [Snapshot](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/helm-charts/snapshot) *(New in v1.0.0, Preview)*
+  - [Dynamo CRDs](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/helm-charts/dynamo-crds) *(Deprecated in v1.0.0, CRDs managed by Operator)*
+  - [Dynamo Graph](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/helm-charts/dynamo-graph) *(Deprecated in v0.9.0)*
 
 - **Rust Crates**:
   - [dynamo-runtime](https://crates.io/crates/dynamo-runtime/)
@@ -183,5 +188,8 @@ For version-specific artifact details, installation commands, and release histor
   - [dynamo-parsers](https://crates.io/crates/dynamo-parsers/)
   - [dynamo-config](https://crates.io/crates/dynamo-config/) *(New in v0.8.0)*
   - [dynamo-memory](https://crates.io/crates/dynamo-memory/) *(New in v0.8.0)*
+  - [dynamo-tokens](https://crates.io/crates/dynamo-tokens/) *(New in v0.9.0)*
+  - [dynamo-mocker](https://crates.io/crates/dynamo-mocker/) *(New in v1.0.0)*
+  - [dynamo-kv-router](https://crates.io/crates/dynamo-kv-router/) *(New in v1.0.0)*
 
 Once you've confirmed that your platform and architecture are compatible, you can install **Dynamo** by following the [Local Quick Start](https://github.com/ai-dynamo/dynamo/blob/main/README.md#local-quick-start) in the README.


### PR DESCRIPTION
## Summary
- Cherry-pick of 4 docs PRs from main to release/1.0.0

## Cherry-Picked PRs
- #7330 — docs: update introduction page with links and formatting
- #7336 — docs: fix fault tolerance sidebar page order
- #7350 — docs: update support matrix, release artifacts, and README for v1.0.0
- #7352 — docs: modernize introduction page SVG figures

## Test Plan
- [ ] CI passes
- [ ] Fern docs preview renders correctly on release branch

Made with [Cursor](https://cursor.com)