### PR TITLE
docs: add agentic inference post to blog landing page

### DIFF
--- a/docs/blogs/index.mdx
+++ b/docs/blogs/index.mdx
@@ -7,6 +7,14 @@ Technical deep dives, announcements, and updates from the Dynamo team.
 
 <CardGroup cols={2}>
   <Card
+    title="Full-Stack Optimizations for Agentic Inference"
+    icon="regular microchip"
+    href="/dynamo/dev/blog/agentic-inference"
+  >
+    How Dynamo optimizes for agentic workloads at three layers: the frontend API,
+    the router, and KV cache management.
+  </Card>
+  <Card
     title="Flash Indexer: Inter-Galactic KV Routing"
     icon="regular bolt"
     href="/dynamo/dev/blog/flash-indexer"


### PR DESCRIPTION
## Summary
- The blog landing page (`docs/blogs/index.mdx`) only listed the Flash Indexer post
- Add a Card for the "Full-Stack Optimizations for Agentic Inference" blog post so both posts are discoverable from the blog index

## Test Plan
- [ ] Verify Fern docs preview renders both cards in the CardGroup
- [ ] Confirm both card links resolve to the correct blog posts

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Featured a new blog post on "Full-Stack Optimizations for Agentic Inference" in the blog section. The new entry includes relevant metadata, descriptive content, and navigation links to help users discover and engage with information about optimizing agentic inference across full-stack architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->