### PR TITLE
docs: remove duplicate title from introduction frontmatter

### DIFF
--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -1,7 +1,6 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: Introduction to Dynamo
 sidebar-title: Introduction
 ---
 


### PR DESCRIPTION
## Summary

- Remove `title: Introduction to Dynamo` from `docs/getting-started/introduction.md` frontmatter — the H1 heading already provides the page title, so the frontmatter `title` caused it to render twice on the docs site
- Keep `sidebar-title: Introduction` for the nav label

Note: The 4 `getting-started → resources` redirects were already removed from main's `fern/docs.yml`. The companion PR #7360 (against `docs-website`) removes them from the live site and fixes v0.9.1 stale version links.

## Test Plan

- [ ] Verify Introduction page on dev docs does not show duplicate title


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated metadata formatting in the getting started guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->