### PR TITLE
feat: multimodal request_rate based sweep

### DIFF
--- a/benchmarks/multimodal/jsonl/.gitignore
+++ b/benchmarks/multimodal/jsonl/.gitignore
@@ -1,1 +1,2 @@
 *.jsonl
+bench_images

--- a/benchmarks/multimodal/jsonl/.gitignore
+++ b/benchmarks/multimodal/jsonl/.gitignore
@@ -1,2 +1,1 @@
 *.jsonl
-bench_images

--- a/benchmarks/multimodal/sweep/args.py
+++ b/benchmarks/multimodal/sweep/args.py
@@ -7,7 +7,7 @@ import argparse
 from typing import List
 
 
-def _parse_request_rates(value: str) -> List[int]:
+def _parse_int_list(value: str) -> List[int]:
     return [int(x.strip()) for x in value.split(",")]
 
 
@@ -37,12 +37,21 @@ def parse_args(argv=None) -> argparse.Namespace:
         default=None,
         help="Override model name from config.",
     )
-    parser.add_argument(
+
+    sweep_group = parser.add_mutually_exclusive_group()
+    sweep_group.add_argument(
         "--request-rates",
-        type=_parse_request_rates,
+        type=_parse_int_list,
         default=None,
         help="Override request rates (comma-separated, e.g. '4,8,16,32').",
     )
+    sweep_group.add_argument(
+        "--concurrencies",
+        type=_parse_int_list,
+        default=None,
+        help="Override concurrency levels (comma-separated, e.g. '16,32,64,128').",
+    )
+
     parser.add_argument(
         "--osl",
         type=int,
@@ -53,7 +62,7 @@ def parse_args(argv=None) -> argparse.Namespace:
         "--request-count",
         type=int,
         default=None,
-        help="Override request count per request rate.",
+        help="Override request count per sweep value.",
     )
     parser.add_argument(
         "--skip-plots",

--- a/benchmarks/multimodal/sweep/args.py
+++ b/benchmarks/multimodal/sweep/args.py
@@ -7,7 +7,7 @@ import argparse
 from typing import List
 
 
-def _parse_concurrencies(value: str) -> List[int]:
+def _parse_request_rates(value: str) -> List[int]:
     return [int(x.strip()) for x in value.split(",")]
 
 
@@ -38,10 +38,10 @@ def parse_args(argv=None) -> argparse.Namespace:
         help="Override model name from config.",
     )
     parser.add_argument(
-        "--concurrencies",
-        type=_parse_concurrencies,
+        "--request-rates",
+        type=_parse_request_rates,
         default=None,
-        help="Override concurrency levels (comma-separated, e.g. '1,2,4,8').",
+        help="Override request rates (comma-separated, e.g. '4,8,16,32').",
     )
     parser.add_argument(
         "--osl",
@@ -53,7 +53,7 @@ def parse_args(argv=None) -> argparse.Namespace:
         "--request-count",
         type=int,
         default=None,
-        help="Override request count per concurrency level.",
+        help="Override request count per request rate.",
     )
     parser.add_argument(
         "--skip-plots",

--- a/benchmarks/multimodal/sweep/config.py
+++ b/benchmarks/multimodal/sweep/config.py
@@ -148,6 +148,12 @@ def load_config(
             if hasattr(cfg, key):
                 setattr(cfg, key, value)
 
+        # CLI sweep mode override clears the other (mutually exclusive) field.
+        if "request_rates" in cli_overrides and cli_overrides["request_rates"] is not None:
+            cfg.concurrencies = None
+        elif "concurrencies" in cli_overrides and cli_overrides["concurrencies"] is not None:
+            cfg.request_rates = None
+
     return cfg
 
 

--- a/benchmarks/multimodal/sweep/config.py
+++ b/benchmarks/multimodal/sweep/config.py
@@ -22,10 +22,15 @@ class BenchmarkConfig:
 
 @dataclass
 class SweepConfig:
-    """Top-level sweep configuration loaded from YAML with optional CLI overrides."""
+    """Top-level sweep configuration loaded from YAML with optional CLI overrides.
+
+    Exactly one of ``request_rates`` or ``concurrencies`` must be set.
+    The active mode is exposed via ``sweep_mode`` and ``sweep_values``.
+    """
 
     model: str = "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8"
-    request_rates: List[int] = field(default_factory=lambda: [4, 8, 16, 32, 64])
+    request_rates: Optional[List[int]] = None
+    concurrencies: Optional[List[int]] = None
     osl: int = 150
     request_count: int = 1000
     warmup_count: int = 5
@@ -37,6 +42,20 @@ class SweepConfig:
     skip_plots: bool = False
     restart_server_every_benchmark: bool = True
     env: Dict[str, str] = field(default_factory=dict)
+
+    @property
+    def sweep_mode(self) -> str:
+        """Return ``'request_rate'`` or ``'concurrency'``."""
+        if self.concurrencies:
+            return "concurrency"
+        return "request_rate"
+
+    @property
+    def sweep_values(self) -> List[int]:
+        """Return the active sweep values (request_rates or concurrencies)."""
+        if self.concurrencies:
+            return self.concurrencies
+        return self.request_rates or []
 
     def validate(self, repo_root: Optional[Path] = None) -> None:
         """Validate that all referenced files and scripts exist."""
@@ -58,8 +77,17 @@ class SweepConfig:
                     f"Workflow script not found: {script} (config '{cfg.label}')"
                 )
 
-        if not self.request_rates:
-            raise ValueError("At least one request rate is required.")
+        if self.request_rates and self.concurrencies:
+            raise ValueError(
+                "Cannot set both request_rates and concurrencies. Pick one."
+            )
+        if not self.request_rates and not self.concurrencies:
+            raise ValueError(
+                "At least one of request_rates or concurrencies is required."
+            )
+
+
+_DEFAULT_REQUEST_RATES: List[int] = [4, 8, 16, 32, 64]
 
 
 def _parse_benchmark_config(raw: Dict[str, Any]) -> BenchmarkConfig:
@@ -78,24 +106,37 @@ def load_config(
     with open(yaml_path) as f:
         raw = yaml.safe_load(f)
 
-    defaults = SweepConfig()
     configs = [_parse_benchmark_config(c) for c in raw.get("configs", [])]
 
+    # Resolve sweep mode from YAML — support both keys, default to request_rates.
+    yaml_request_rates = raw.get("request_rates")
+    yaml_concurrencies = raw.get("concurrencies")
+
+    if yaml_request_rates and yaml_concurrencies:
+        raise ValueError(
+            f"YAML config {yaml_path} sets both request_rates and concurrencies. "
+            "Pick one."
+        )
+
+    # Default to request_rates if neither is specified.
+    if not yaml_request_rates and not yaml_concurrencies:
+        yaml_request_rates = _DEFAULT_REQUEST_RATES
+
     cfg = SweepConfig(
-        model=raw.get("model", defaults.model),
-        request_rates=raw.get("request_rates", defaults.request_rates),
-        osl=raw.get("osl", defaults.osl),
-        request_count=raw.get("request_count", defaults.request_count),
-        warmup_count=raw.get("warmup_count", defaults.warmup_count),
-        port=raw.get("port", defaults.port),
-        timeout=raw.get("timeout", defaults.timeout),
+        model=raw.get("model", "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8"),
+        request_rates=yaml_request_rates,
+        concurrencies=yaml_concurrencies,
+        osl=raw.get("osl", 150),
+        request_count=raw.get("request_count", 1000),
+        warmup_count=raw.get("warmup_count", 5),
+        port=raw.get("port", 8000),
+        timeout=raw.get("timeout", 600),
         input_files=raw.get("input_files", []),
         configs=configs,
-        output_dir=raw.get("output_dir", defaults.output_dir),
+        output_dir=raw.get("output_dir", "benchmarks/results/multimodal_default"),
         skip_plots=raw.get("skip_plots", False),
         restart_server_every_benchmark=raw.get(
-            "restart_server_every_benchmark",
-            defaults.restart_server_every_benchmark,
+            "restart_server_every_benchmark", True
         ),
         env=raw.get("env", {}),
     )

--- a/benchmarks/multimodal/sweep/config.py
+++ b/benchmarks/multimodal/sweep/config.py
@@ -25,7 +25,7 @@ class SweepConfig:
     """Top-level sweep configuration loaded from YAML with optional CLI overrides."""
 
     model: str = "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8"
-    concurrencies: List[int] = field(default_factory=lambda: [1, 2, 4, 8, 16, 32])
+    request_rates: List[int] = field(default_factory=lambda: [4, 8, 16, 32, 64])
     osl: int = 150
     request_count: int = 1000
     warmup_count: int = 5
@@ -58,8 +58,8 @@ class SweepConfig:
                     f"Workflow script not found: {script} (config '{cfg.label}')"
                 )
 
-        if not self.concurrencies:
-            raise ValueError("At least one concurrency level is required.")
+        if not self.request_rates:
+            raise ValueError("At least one request rate is required.")
 
 
 def _parse_benchmark_config(raw: Dict[str, Any]) -> BenchmarkConfig:
@@ -83,7 +83,7 @@ def load_config(
 
     cfg = SweepConfig(
         model=raw.get("model", defaults.model),
-        concurrencies=raw.get("concurrencies", defaults.concurrencies),
+        request_rates=raw.get("request_rates", defaults.request_rates),
         osl=raw.get("osl", defaults.osl),
         request_count=raw.get("request_count", defaults.request_count),
         warmup_count=raw.get("warmup_count", defaults.warmup_count),

--- a/benchmarks/multimodal/sweep/config.py
+++ b/benchmarks/multimodal/sweep/config.py
@@ -135,9 +135,7 @@ def load_config(
         configs=configs,
         output_dir=raw.get("output_dir", "benchmarks/results/multimodal_default"),
         skip_plots=raw.get("skip_plots", False),
-        restart_server_every_benchmark=raw.get(
-            "restart_server_every_benchmark", True
-        ),
+        restart_server_every_benchmark=raw.get("restart_server_every_benchmark", True),
         env=raw.get("env", {}),
     )
 
@@ -149,9 +147,15 @@ def load_config(
                 setattr(cfg, key, value)
 
         # CLI sweep mode override clears the other (mutually exclusive) field.
-        if "request_rates" in cli_overrides and cli_overrides["request_rates"] is not None:
+        if (
+            "request_rates" in cli_overrides
+            and cli_overrides["request_rates"] is not None
+        ):
             cfg.concurrencies = None
-        elif "concurrencies" in cli_overrides and cli_overrides["concurrencies"] is not None:
+        elif (
+            "concurrencies" in cli_overrides
+            and cli_overrides["concurrencies"] is not None
+        ):
             cfg.request_rates = None
 
     return cfg

--- a/benchmarks/multimodal/sweep/experiments/embedding_cache/trtllm_e_pd.yaml
+++ b/benchmarks/multimodal/sweep/experiments/embedding_cache/trtllm_e_pd.yaml
@@ -7,7 +7,7 @@
 #   python -m benchmarks.multimodal.sweep --config benchmarks/multimodal/sweep/experiments/embedding_cache/trtllm_e_pd.yaml
 
 model: Qwen/Qwen3-VL-2B-Instruct
-request_rates: [16, 32, 64, 128, 256]
+concurrencies: [16, 32, 64, 128, 256]
 osl: 150
 request_count: 1000
 warmup_count: 5

--- a/benchmarks/multimodal/sweep/experiments/embedding_cache/trtllm_e_pd.yaml
+++ b/benchmarks/multimodal/sweep/experiments/embedding_cache/trtllm_e_pd.yaml
@@ -7,7 +7,7 @@
 #   python -m benchmarks.multimodal.sweep --config benchmarks/multimodal/sweep/experiments/embedding_cache/trtllm_e_pd.yaml
 
 model: Qwen/Qwen3-VL-2B-Instruct
-concurrencies: [16, 32, 64, 128, 256]
+request_rates: [16, 32, 64, 128, 256]
 osl: 150
 request_count: 1000
 warmup_count: 5

--- a/benchmarks/multimodal/sweep/experiments/embedding_cache/vllm_e_pd.yaml
+++ b/benchmarks/multimodal/sweep/experiments/embedding_cache/vllm_e_pd.yaml
@@ -7,7 +7,7 @@
 #   python -m benchmarks.multimodal.sweep --config benchmarks/multimodal/sweep/experiments/embedding_cache/full_comparison.yaml
 
 model: Qwen/Qwen3-VL-30B-A3B-Instruct-FP8
-request_rates: [16, 32, 64, 128, 256]
+concurrencies: [16, 32, 64, 128, 256]
 osl: 150
 request_count: 1000
 warmup_count: 5

--- a/benchmarks/multimodal/sweep/experiments/embedding_cache/vllm_e_pd.yaml
+++ b/benchmarks/multimodal/sweep/experiments/embedding_cache/vllm_e_pd.yaml
@@ -7,7 +7,7 @@
 #   python -m benchmarks.multimodal.sweep --config benchmarks/multimodal/sweep/experiments/embedding_cache/full_comparison.yaml
 
 model: Qwen/Qwen3-VL-30B-A3B-Instruct-FP8
-concurrencies: [16, 32, 64, 128, 256]
+request_rates: [16, 32, 64, 128, 256]
 osl: 150
 request_count: 1000
 warmup_count: 5

--- a/benchmarks/multimodal/sweep/experiments/embedding_cache/vllm_serve.yaml
+++ b/benchmarks/multimodal/sweep/experiments/embedding_cache/vllm_serve.yaml
@@ -7,7 +7,7 @@
 #   python -m benchmarks.multimodal.sweep --config benchmarks/multimodal/sweep/experiments/embedding_cache/cache_on_off.yaml
 
 model: Qwen/Qwen3-VL-30B-A3B-Instruct-FP8
-concurrencies: [16, 32, 64, 128, 256]
+request_rates: [16, 32, 64, 128, 256]
 osl: 150
 request_count: 1000
 warmup_count: 5

--- a/benchmarks/multimodal/sweep/experiments/embedding_cache/vllm_serve.yaml
+++ b/benchmarks/multimodal/sweep/experiments/embedding_cache/vllm_serve.yaml
@@ -7,7 +7,7 @@
 #   python -m benchmarks.multimodal.sweep --config benchmarks/multimodal/sweep/experiments/embedding_cache/cache_on_off.yaml
 
 model: Qwen/Qwen3-VL-30B-A3B-Instruct-FP8
-request_rates: [16, 32, 64, 128, 256]
+concurrencies: [16, 32, 64, 128, 256]
 osl: 150
 request_count: 1000
 warmup_count: 5

--- a/benchmarks/multimodal/sweep/orchestrator.py
+++ b/benchmarks/multimodal/sweep/orchestrator.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
 
-from .config import SweepConfig, input_file_tag, resolve_repo_root
+from .config import BenchmarkConfig, SweepConfig, input_file_tag, resolve_repo_root
 from .runner import run_aiperf_single
 from .server import ServerManager
 
@@ -58,74 +58,16 @@ def run_sweep(
 
     try:
         for bench_cfg in config.configs:
-            workflow_abs = _resolve_workflow(bench_cfg.workflow, repo_root)
-
-            _print_banner(f"Config: {bench_cfg.label}", char="#")
-
-            # Build list of pending runs, skipping those with existing results.
-            pending_runs: List[tuple[str, str, int, Path]] = []
-            for input_file in config.input_files:
-                file_tag = input_file_tag(input_file)
-                sweep_dir = output_base / file_tag / bench_cfg.label
-
-                for value in sorted(sweep_values):
-                    artifact_dir = sweep_dir / f"{sweep_mode}{value}"
-
-                    if (artifact_dir / "profile_export_aiperf.json").exists():
-                        print(
-                            f"  SKIP {bench_cfg.label} {sweep_mode}={value} "
-                            f"(results exist in {artifact_dir})",
-                            flush=True,
-                        )
-                    else:
-                        pending_runs.append((input_file, file_tag, value, artifact_dir))
-
-            if not pending_runs:
-                print(f"  All runs skipped for {bench_cfg.label}", flush=True)
-                continue
-
-            if not config.restart_server_every_benchmark:
-                server.start(
-                    workflow_script=workflow_abs,
-                    model=config.model,
-                    extra_args=bench_cfg.extra_args,
-                    env_overrides=env_overrides,
-                )
-
-            try:
-                for input_file, file_tag, value, artifact_dir in pending_runs:
-                    _print_banner(
-                        f"[{file_tag}] Config: {bench_cfg.label}  "
-                        f"{sweep_mode}={value}",
-                        char="-",
-                    )
-
-                    if config.restart_server_every_benchmark:
-                        server.start(
-                            workflow_script=workflow_abs,
-                            model=config.model,
-                            extra_args=bench_cfg.extra_args,
-                            env_overrides=env_overrides,
-                        )
-
-                    try:
-                        run_aiperf_single(
-                            model=config.model,
-                            port=config.port,
-                            sweep_mode=sweep_mode,
-                            sweep_value=value,
-                            request_count=config.request_count,
-                            warmup_count=config.warmup_count,
-                            input_file=input_file,
-                            osl=config.osl,
-                            artifact_dir=artifact_dir,
-                        )
-                    finally:
-                        if config.restart_server_every_benchmark:
-                            server.stop()
-            finally:
-                if not config.restart_server_every_benchmark:
-                    server.stop()
+            _run_config(
+                bench_cfg=bench_cfg,
+                config=config,
+                server=server,
+                output_base=output_base,
+                sweep_mode=sweep_mode,
+                sweep_values=sweep_values,
+                env_overrides=env_overrides,
+                repo_root=repo_root,
+            )
 
         if not config.skip_plots:
             for input_file in config.input_files:
@@ -139,6 +81,85 @@ def run_sweep(
             server.stop()
 
     _print_summary(config, output_base)
+
+
+def _run_config(
+    bench_cfg: BenchmarkConfig,
+    config: SweepConfig,
+    server: ServerManager,
+    output_base: Path,
+    sweep_mode: str,
+    sweep_values: List[int],
+    env_overrides: dict,
+    repo_root: Path,
+) -> None:
+    """Run all sweep values for a single benchmark config."""
+    workflow_abs = _resolve_workflow(bench_cfg.workflow, repo_root)
+    _print_banner(f"Config: {bench_cfg.label}", char="#")
+
+    # Collect pending runs, skipping those with existing results.
+    pending_runs: List[tuple[str, str, int, Path]] = []
+    for input_file in config.input_files:
+        file_tag = input_file_tag(input_file)
+        sweep_dir = output_base / file_tag / bench_cfg.label
+
+        for value in sorted(sweep_values):
+            artifact_dir = sweep_dir / f"{sweep_mode}{value}"
+
+            if (artifact_dir / "profile_export_aiperf.json").exists():
+                print(
+                    f"  SKIP {bench_cfg.label} {sweep_mode}={value} "
+                    f"(results exist in {artifact_dir})",
+                    flush=True,
+                )
+            else:
+                pending_runs.append((input_file, file_tag, value, artifact_dir))
+
+    if not pending_runs:
+        print(f"  All runs skipped for {bench_cfg.label}", flush=True)
+        return
+
+    if not config.restart_server_every_benchmark:
+        server.start(
+            workflow_script=workflow_abs,
+            model=config.model,
+            extra_args=bench_cfg.extra_args,
+            env_overrides=env_overrides,
+        )
+
+    try:
+        for input_file, file_tag, value, artifact_dir in pending_runs:
+            _print_banner(
+                f"[{file_tag}] Config: {bench_cfg.label}  " f"{sweep_mode}={value}",
+                char="-",
+            )
+
+            if config.restart_server_every_benchmark:
+                server.start(
+                    workflow_script=workflow_abs,
+                    model=config.model,
+                    extra_args=bench_cfg.extra_args,
+                    env_overrides=env_overrides,
+                )
+
+            try:
+                run_aiperf_single(
+                    model=config.model,
+                    port=config.port,
+                    sweep_mode=sweep_mode,
+                    sweep_value=value,
+                    request_count=config.request_count,
+                    warmup_count=config.warmup_count,
+                    input_file=input_file,
+                    osl=config.osl,
+                    artifact_dir=artifact_dir,
+                )
+            finally:
+                if config.restart_server_every_benchmark:
+                    server.stop()
+    finally:
+        if not config.restart_server_every_benchmark:
+            server.stop()
 
 
 def _generate_plots_for_file(

--- a/benchmarks/multimodal/sweep/orchestrator.py
+++ b/benchmarks/multimodal/sweep/orchestrator.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from .config import SweepConfig, input_file_tag, resolve_repo_root
-from .runner import run_aiperf_single, run_concurrency_sweep
+from .runner import run_aiperf_single, run_request_rate_sweep
 from .server import ServerManager
 
 
@@ -43,9 +43,9 @@ def run_sweep(
         print(f"                   {f}")
     labels = [c.label for c in config.configs]
     print(f"  Configs:       {labels}")
-    print(f"  Concurrencies: {config.concurrencies}")
+    print(f"  Request rates: {config.request_rates}")
     print(f"  OSL:           {config.osl}")
-    print(f"  Requests:      {config.request_count} per concurrency")
+    print(f"  Requests:      {config.request_count} per request rate")
     print(f"  Restart every: {restart}")
     print(f"  Output:        {output_base}")
     print(flush=True)
@@ -84,10 +84,10 @@ def run_sweep(
                         env_overrides=env_overrides,
                     )
                     try:
-                        run_concurrency_sweep(
+                        run_request_rate_sweep(
                             model=config.model,
                             port=config.port,
-                            concurrencies=config.concurrencies,
+                            request_rates=config.request_rates,
                             request_count=config.request_count,
                             warmup_count=config.warmup_count,
                             input_file=input_file,
@@ -118,10 +118,10 @@ def _sweep_with_restart(
     input_file: str,
     output_dir: Path,
 ) -> None:
-    """Run each concurrency level with a fresh server to avoid warm-cache effects."""
+    """Run each request rate with a fresh server to avoid warm-cache effects."""
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    for c in sorted(config.concurrencies):
+    for request_rate in sorted(config.request_rates):
         server.start(
             workflow_script=workflow_script,
             model=config.model,
@@ -132,12 +132,12 @@ def _sweep_with_restart(
             run_aiperf_single(
                 model=config.model,
                 port=config.port,
-                concurrency=c,
+                request_rate=request_rate,
                 request_count=config.request_count,
                 warmup_count=config.warmup_count,
                 input_file=input_file,
                 osl=config.osl,
-                artifact_dir=output_dir / f"c{c}",
+                artifact_dir=output_dir / f"request_rate{request_rate}",
             )
         finally:
             server.stop()

--- a/benchmarks/multimodal/sweep/orchestrator.py
+++ b/benchmarks/multimodal/sweep/orchestrator.py
@@ -33,6 +33,8 @@ def run_sweep(
         repo_root = resolve_repo_root()
 
     output_base = Path(config.output_dir)
+    sweep_mode = config.sweep_mode
+    sweep_values = config.sweep_values
 
     _print_banner("Multimodal Benchmark Sweep")
     print(f"  Model:         {config.model}")
@@ -41,9 +43,11 @@ def run_sweep(
         print(f"                   {f}")
     labels = [c.label for c in config.configs]
     print(f"  Configs:       {labels}")
-    print(f"  Request rates: {config.request_rates}")
+    print(f"  Sweep mode:    {sweep_mode}")
+    print(f"  Sweep values:  {sweep_values}")
     print(f"  OSL:           {config.osl}")
-    print(f"  Requests:      {config.request_count} per request rate")
+    print(f"  Requests:      {config.request_count} per {sweep_mode}")
+    print(f"  Restart:       {'every run' if config.restart_server_every_benchmark else 'per config'}")
     print(f"  Output:        {output_base}")
     print(flush=True)
 
@@ -57,44 +61,61 @@ def run_sweep(
 
             _print_banner(f"Input: {Path(input_file).name}  ({file_tag})", char="#")
 
-            for request_rate in sorted(config.request_rates):
-                for bench_cfg in config.configs:
-                    workflow_abs = _resolve_workflow(bench_cfg.workflow, repo_root)
-                    sweep_dir = file_output_dir / bench_cfg.label
-                    artifact_dir = sweep_dir / f"request_rate{request_rate}"
+            for bench_cfg in config.configs:
+                workflow_abs = _resolve_workflow(bench_cfg.workflow, repo_root)
+                sweep_dir = file_output_dir / bench_cfg.label
 
-                    if (artifact_dir / "profile_export_aiperf.json").exists():
-                        print(
-                            f"  SKIP {bench_cfg.label} request_rate={request_rate} "
-                            f"(results exist in {artifact_dir})",
-                            flush=True,
-                        )
-                        continue
-
-                    _print_banner(
-                        f"[{file_tag}] Config: {bench_cfg.label}  "
-                        f"request_rate={request_rate}",
-                        char="-",
-                    )
-
+                if not config.restart_server_every_benchmark:
                     server.start(
                         workflow_script=workflow_abs,
                         model=config.model,
                         extra_args=bench_cfg.extra_args,
                         env_overrides=env_overrides,
                     )
-                    try:
-                        run_aiperf_single(
-                            model=config.model,
-                            port=config.port,
-                            request_rate=request_rate,
-                            request_count=config.request_count,
-                            warmup_count=config.warmup_count,
-                            input_file=input_file,
-                            osl=config.osl,
-                            artifact_dir=artifact_dir,
+
+                try:
+                    for value in sorted(sweep_values):
+                        artifact_dir = sweep_dir / f"{sweep_mode}{value}"
+
+                        if (artifact_dir / "profile_export_aiperf.json").exists():
+                            print(
+                                f"  SKIP {bench_cfg.label} {sweep_mode}={value} "
+                                f"(results exist in {artifact_dir})",
+                                flush=True,
+                            )
+                            continue
+
+                        _print_banner(
+                            f"[{file_tag}] Config: {bench_cfg.label}  "
+                            f"{sweep_mode}={value}",
+                            char="-",
                         )
-                    finally:
+
+                        if config.restart_server_every_benchmark:
+                            server.start(
+                                workflow_script=workflow_abs,
+                                model=config.model,
+                                extra_args=bench_cfg.extra_args,
+                                env_overrides=env_overrides,
+                            )
+
+                        try:
+                            run_aiperf_single(
+                                model=config.model,
+                                port=config.port,
+                                sweep_mode=sweep_mode,
+                                sweep_value=value,
+                                request_count=config.request_count,
+                                warmup_count=config.warmup_count,
+                                input_file=input_file,
+                                osl=config.osl,
+                                artifact_dir=artifact_dir,
+                            )
+                        finally:
+                            if config.restart_server_every_benchmark:
+                                server.stop()
+                finally:
+                    if not config.restart_server_every_benchmark:
                         server.stop()
 
             if not config.skip_plots:

--- a/benchmarks/multimodal/sweep/orchestrator.py
+++ b/benchmarks/multimodal/sweep/orchestrator.py
@@ -59,14 +59,23 @@ def run_sweep(
 
             for request_rate in sorted(config.request_rates):
                 for bench_cfg in config.configs:
+                    workflow_abs = _resolve_workflow(bench_cfg.workflow, repo_root)
+                    sweep_dir = file_output_dir / bench_cfg.label
+                    artifact_dir = sweep_dir / f"request_rate{request_rate}"
+
+                    if (artifact_dir / "profile_export_aiperf.json").exists():
+                        print(
+                            f"  SKIP {bench_cfg.label} request_rate={request_rate} "
+                            f"(results exist in {artifact_dir})",
+                            flush=True,
+                        )
+                        continue
+
                     _print_banner(
                         f"[{file_tag}] Config: {bench_cfg.label}  "
                         f"request_rate={request_rate}",
                         char="-",
                     )
-
-                    workflow_abs = _resolve_workflow(bench_cfg.workflow, repo_root)
-                    sweep_dir = file_output_dir / bench_cfg.label
 
                     server.start(
                         workflow_script=workflow_abs,
@@ -83,7 +92,7 @@ def run_sweep(
                             warmup_count=config.warmup_count,
                             input_file=input_file,
                             osl=config.osl,
-                            artifact_dir=sweep_dir / f"request_rate{request_rate}",
+                            artifact_dir=artifact_dir,
                         )
                     finally:
                         server.stop()

--- a/benchmarks/multimodal/sweep/orchestrator.py
+++ b/benchmarks/multimodal/sweep/orchestrator.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from .config import SweepConfig, input_file_tag, resolve_repo_root
-from .runner import run_aiperf_single, run_request_rate_sweep
+from .runner import run_aiperf_single
 from .server import ServerManager
 
 
@@ -34,8 +34,6 @@ def run_sweep(
 
     output_base = Path(config.output_dir)
 
-    restart = config.restart_server_every_benchmark
-
     _print_banner("Multimodal Benchmark Sweep")
     print(f"  Model:         {config.model}")
     print(f"  Input files:   {len(config.input_files)}")
@@ -46,7 +44,6 @@ def run_sweep(
     print(f"  Request rates: {config.request_rates}")
     print(f"  OSL:           {config.osl}")
     print(f"  Requests:      {config.request_count} per request rate")
-    print(f"  Restart every: {restart}")
     print(f"  Output:        {output_base}")
     print(flush=True)
 
@@ -60,23 +57,17 @@ def run_sweep(
 
             _print_banner(f"Input: {Path(input_file).name}  ({file_tag})", char="#")
 
-            for bench_cfg in config.configs:
-                _print_banner(f"[{file_tag}] Config: {bench_cfg.label}", char="-")
-
-                workflow_abs = _resolve_workflow(bench_cfg.workflow, repo_root)
-                sweep_dir = file_output_dir / bench_cfg.label
-
-                if restart:
-                    _sweep_with_restart(
-                        server=server,
-                        workflow_script=workflow_abs,
-                        config=config,
-                        bench_cfg=bench_cfg,
-                        env_overrides=env_overrides,
-                        input_file=input_file,
-                        output_dir=sweep_dir,
+            for request_rate in sorted(config.request_rates):
+                for bench_cfg in config.configs:
+                    _print_banner(
+                        f"[{file_tag}] Config: {bench_cfg.label}  "
+                        f"request_rate={request_rate}",
+                        char="-",
                     )
-                else:
+
+                    workflow_abs = _resolve_workflow(bench_cfg.workflow, repo_root)
+                    sweep_dir = file_output_dir / bench_cfg.label
+
                     server.start(
                         workflow_script=workflow_abs,
                         model=config.model,
@@ -84,15 +75,15 @@ def run_sweep(
                         env_overrides=env_overrides,
                     )
                     try:
-                        run_request_rate_sweep(
+                        run_aiperf_single(
                             model=config.model,
                             port=config.port,
-                            request_rates=config.request_rates,
+                            request_rate=request_rate,
                             request_count=config.request_count,
                             warmup_count=config.warmup_count,
                             input_file=input_file,
                             osl=config.osl,
-                            output_dir=sweep_dir,
+                            artifact_dir=sweep_dir / f"request_rate{request_rate}",
                         )
                     finally:
                         server.stop()
@@ -107,42 +98,6 @@ def run_sweep(
             server.stop()
 
     _print_summary(config, output_base)
-
-
-def _sweep_with_restart(
-    server: ServerManager,
-    workflow_script: str,
-    config: SweepConfig,
-    bench_cfg,
-    env_overrides: dict,
-    input_file: str,
-    output_dir: Path,
-) -> None:
-    """Run each request rate with a fresh server to avoid warm-cache effects."""
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    for request_rate in sorted(config.request_rates):
-        server.start(
-            workflow_script=workflow_script,
-            model=config.model,
-            extra_args=bench_cfg.extra_args,
-            env_overrides=env_overrides,
-        )
-        try:
-            run_aiperf_single(
-                model=config.model,
-                port=config.port,
-                request_rate=request_rate,
-                request_count=config.request_count,
-                warmup_count=config.warmup_count,
-                input_file=input_file,
-                osl=config.osl,
-                artifact_dir=output_dir / f"request_rate{request_rate}",
-            )
-        finally:
-            server.stop()
-
-    print(f"Sweep complete. Results in {output_dir}", flush=True)
 
 
 def _generate_plots_for_file(

--- a/benchmarks/multimodal/sweep/orchestrator.py
+++ b/benchmarks/multimodal/sweep/orchestrator.py
@@ -28,7 +28,7 @@ def run_sweep(
     config: SweepConfig,
     repo_root: Optional[Path] = None,
 ) -> None:
-    """Execute the full benchmark sweep: for each input file x benchmark config."""
+    """Execute the full benchmark sweep: for each config x input file x sweep value."""
     if repo_root is None:
         repo_root = resolve_repo_root()
 
@@ -47,7 +47,9 @@ def run_sweep(
     print(f"  Sweep values:  {sweep_values}")
     print(f"  OSL:           {config.osl}")
     print(f"  Requests:      {config.request_count} per {sweep_mode}")
-    print(f"  Restart:       {'every run' if config.restart_server_every_benchmark else 'per config'}")
+    print(
+        f"  Restart:       {'every run' if config.restart_server_every_benchmark else 'per config'}"
+    )
     print(f"  Output:        {output_base}")
     print(flush=True)
 
@@ -55,25 +57,24 @@ def run_sweep(
     env_overrides = dict(config.env) if config.env else {}
 
     try:
-        for input_file in config.input_files:
-            file_tag = input_file_tag(input_file)
-            file_output_dir = output_base / file_tag
+        for bench_cfg in config.configs:
+            workflow_abs = _resolve_workflow(bench_cfg.workflow, repo_root)
 
-            _print_banner(f"Input: {Path(input_file).name}  ({file_tag})", char="#")
+            _print_banner(f"Config: {bench_cfg.label}", char="#")
 
-            for bench_cfg in config.configs:
-                workflow_abs = _resolve_workflow(bench_cfg.workflow, repo_root)
-                sweep_dir = file_output_dir / bench_cfg.label
+            if not config.restart_server_every_benchmark:
+                server.start(
+                    workflow_script=workflow_abs,
+                    model=config.model,
+                    extra_args=bench_cfg.extra_args,
+                    env_overrides=env_overrides,
+                )
 
-                if not config.restart_server_every_benchmark:
-                    server.start(
-                        workflow_script=workflow_abs,
-                        model=config.model,
-                        extra_args=bench_cfg.extra_args,
-                        env_overrides=env_overrides,
-                    )
+            try:
+                for input_file in config.input_files:
+                    file_tag = input_file_tag(input_file)
+                    sweep_dir = output_base / file_tag / bench_cfg.label
 
-                try:
                     for value in sorted(sweep_values):
                         artifact_dir = sweep_dir / f"{sweep_mode}{value}"
 
@@ -114,13 +115,15 @@ def run_sweep(
                         finally:
                             if config.restart_server_every_benchmark:
                                 server.stop()
-                finally:
-                    if not config.restart_server_every_benchmark:
-                        server.stop()
+            finally:
+                if not config.restart_server_every_benchmark:
+                    server.stop()
 
-            if not config.skip_plots:
+        if not config.skip_plots:
+            for input_file in config.input_files:
+                file_tag = input_file_tag(input_file)
                 _generate_plots_for_file(
-                    file_output_dir,
+                    output_base / file_tag,
                     [c.label for c in config.configs],
                 )
     finally:

--- a/benchmarks/multimodal/sweep/orchestrator.py
+++ b/benchmarks/multimodal/sweep/orchestrator.py
@@ -62,6 +62,28 @@ def run_sweep(
 
             _print_banner(f"Config: {bench_cfg.label}", char="#")
 
+            # Build list of pending runs, skipping those with existing results.
+            pending_runs: List[tuple[str, str, int, Path]] = []
+            for input_file in config.input_files:
+                file_tag = input_file_tag(input_file)
+                sweep_dir = output_base / file_tag / bench_cfg.label
+
+                for value in sorted(sweep_values):
+                    artifact_dir = sweep_dir / f"{sweep_mode}{value}"
+
+                    if (artifact_dir / "profile_export_aiperf.json").exists():
+                        print(
+                            f"  SKIP {bench_cfg.label} {sweep_mode}={value} "
+                            f"(results exist in {artifact_dir})",
+                            flush=True,
+                        )
+                    else:
+                        pending_runs.append((input_file, file_tag, value, artifact_dir))
+
+            if not pending_runs:
+                print(f"  All runs skipped for {bench_cfg.label}", flush=True)
+                continue
+
             if not config.restart_server_every_benchmark:
                 server.start(
                     workflow_script=workflow_abs,
@@ -71,50 +93,36 @@ def run_sweep(
                 )
 
             try:
-                for input_file in config.input_files:
-                    file_tag = input_file_tag(input_file)
-                    sweep_dir = output_base / file_tag / bench_cfg.label
+                for input_file, file_tag, value, artifact_dir in pending_runs:
+                    _print_banner(
+                        f"[{file_tag}] Config: {bench_cfg.label}  "
+                        f"{sweep_mode}={value}",
+                        char="-",
+                    )
 
-                    for value in sorted(sweep_values):
-                        artifact_dir = sweep_dir / f"{sweep_mode}{value}"
-
-                        if (artifact_dir / "profile_export_aiperf.json").exists():
-                            print(
-                                f"  SKIP {bench_cfg.label} {sweep_mode}={value} "
-                                f"(results exist in {artifact_dir})",
-                                flush=True,
-                            )
-                            continue
-
-                        _print_banner(
-                            f"[{file_tag}] Config: {bench_cfg.label}  "
-                            f"{sweep_mode}={value}",
-                            char="-",
+                    if config.restart_server_every_benchmark:
+                        server.start(
+                            workflow_script=workflow_abs,
+                            model=config.model,
+                            extra_args=bench_cfg.extra_args,
+                            env_overrides=env_overrides,
                         )
 
+                    try:
+                        run_aiperf_single(
+                            model=config.model,
+                            port=config.port,
+                            sweep_mode=sweep_mode,
+                            sweep_value=value,
+                            request_count=config.request_count,
+                            warmup_count=config.warmup_count,
+                            input_file=input_file,
+                            osl=config.osl,
+                            artifact_dir=artifact_dir,
+                        )
+                    finally:
                         if config.restart_server_every_benchmark:
-                            server.start(
-                                workflow_script=workflow_abs,
-                                model=config.model,
-                                extra_args=bench_cfg.extra_args,
-                                env_overrides=env_overrides,
-                            )
-
-                        try:
-                            run_aiperf_single(
-                                model=config.model,
-                                port=config.port,
-                                sweep_mode=sweep_mode,
-                                sweep_value=value,
-                                request_count=config.request_count,
-                                warmup_count=config.warmup_count,
-                                input_file=input_file,
-                                osl=config.osl,
-                                artifact_dir=artifact_dir,
-                            )
-                        finally:
-                            if config.restart_server_every_benchmark:
-                                server.stop()
+                            server.stop()
             finally:
                 if not config.restart_server_every_benchmark:
                     server.stop()

--- a/benchmarks/multimodal/sweep/runner.py
+++ b/benchmarks/multimodal/sweep/runner.py
@@ -11,13 +11,19 @@ from typing import List
 def _build_aiperf_cmd(
     model: str,
     port: int,
-    request_rate: int,
+    sweep_mode: str,
+    sweep_value: int,
     request_count: int,
     warmup_count: int,
     input_file: str,
     osl: int,
     artifact_dir: Path,
 ) -> List[str]:
+    if sweep_mode == "concurrency":
+        sweep_flag = "--concurrency"
+    else:
+        sweep_flag = "--request-rate"
+
     return [
         "aiperf",
         "profile",
@@ -25,8 +31,8 @@ def _build_aiperf_cmd(
         model,
         "-u",
         f"http://localhost:{port}",
-        "--request-rate",
-        str(request_rate),
+        sweep_flag,
+        str(sweep_value),
         "--request-count",
         str(request_count),
         "--warmup-request-count",
@@ -55,7 +61,8 @@ def _build_aiperf_cmd(
 def run_aiperf_single(
     model: str,
     port: int,
-    request_rate: int,
+    sweep_mode: str,
+    sweep_value: int,
     request_count: int,
     warmup_count: int,
     input_file: str,
@@ -67,7 +74,8 @@ def run_aiperf_single(
     cmd = _build_aiperf_cmd(
         model=model,
         port=port,
-        request_rate=request_rate,
+        sweep_mode=sweep_mode,
+        sweep_value=sweep_value,
         request_count=request_count,
         warmup_count=warmup_count,
         input_file=input_file,
@@ -75,7 +83,7 @@ def run_aiperf_single(
         artifact_dir=artifact_dir,
     )
 
-    print(f"  aiperf request_rate={request_rate} -> {artifact_dir}", flush=True)
+    print(f"  aiperf {sweep_mode}={sweep_value} -> {artifact_dir}", flush=True)
     proc = subprocess.run(cmd, capture_output=True, text=True)
 
     if proc.returncode != 0:
@@ -88,32 +96,34 @@ def run_aiperf_single(
             proc.returncode, cmd, output=proc.stdout, stderr=proc.stderr
         )
 
-    print(f"  aiperf request_rate={request_rate} done.", flush=True)
+    print(f"  aiperf {sweep_mode}={sweep_value} done.", flush=True)
 
 
-def run_request_rate_sweep(
+def run_sweep(
     model: str,
     port: int,
-    request_rates: List[int],
+    sweep_mode: str,
+    sweep_values: List[int],
     request_count: int,
     warmup_count: int,
     input_file: str,
     osl: int,
     output_dir: Path,
 ) -> None:
-    """Run aiperf across all request rates, writing results under output_dir/rr{N}/."""
+    """Run aiperf across all sweep values, writing results under output_dir/{mode}{N}/."""
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    for request_rate in sorted(request_rates):
+    for value in sorted(sweep_values):
         run_aiperf_single(
             model=model,
             port=port,
-            request_rate=request_rate,
+            sweep_mode=sweep_mode,
+            sweep_value=value,
             request_count=request_count,
             warmup_count=warmup_count,
             input_file=input_file,
             osl=osl,
-            artifact_dir=output_dir / f"request_rate{request_rate}",
+            artifact_dir=output_dir / f"{sweep_mode}{value}",
         )
 
     print(f"Sweep complete. Results in {output_dir}", flush=True)

--- a/benchmarks/multimodal/sweep/runner.py
+++ b/benchmarks/multimodal/sweep/runner.py
@@ -11,7 +11,7 @@ from typing import List
 def _build_aiperf_cmd(
     model: str,
     port: int,
-    concurrency: int,
+    request_rate: int,
     request_count: int,
     warmup_count: int,
     input_file: str,
@@ -25,8 +25,8 @@ def _build_aiperf_cmd(
         model,
         "-u",
         f"http://localhost:{port}",
-        "--concurrency",
-        str(concurrency),
+        "--request-rate",
+        str(request_rate),
         "--request-count",
         str(request_count),
         "--warmup-request-count",
@@ -55,7 +55,7 @@ def _build_aiperf_cmd(
 def run_aiperf_single(
     model: str,
     port: int,
-    concurrency: int,
+    request_rate: int,
     request_count: int,
     warmup_count: int,
     input_file: str,
@@ -67,7 +67,7 @@ def run_aiperf_single(
     cmd = _build_aiperf_cmd(
         model=model,
         port=port,
-        concurrency=concurrency,
+        request_rate=request_rate,
         request_count=request_count,
         warmup_count=warmup_count,
         input_file=input_file,
@@ -75,7 +75,7 @@ def run_aiperf_single(
         artifact_dir=artifact_dir,
     )
 
-    print(f"  aiperf concurrency={concurrency} -> {artifact_dir}", flush=True)
+    print(f"  aiperf request_rate={request_rate} -> {artifact_dir}", flush=True)
     proc = subprocess.run(cmd, capture_output=True, text=True)
 
     if proc.returncode != 0:
@@ -88,32 +88,32 @@ def run_aiperf_single(
             proc.returncode, cmd, output=proc.stdout, stderr=proc.stderr
         )
 
-    print(f"  aiperf concurrency={concurrency} done.", flush=True)
+    print(f"  aiperf request_rate={request_rate} done.", flush=True)
 
 
-def run_concurrency_sweep(
+def run_request_rate_sweep(
     model: str,
     port: int,
-    concurrencies: List[int],
+    request_rates: List[int],
     request_count: int,
     warmup_count: int,
     input_file: str,
     osl: int,
     output_dir: Path,
 ) -> None:
-    """Run aiperf across all concurrency levels, writing results under output_dir/c{N}/."""
+    """Run aiperf across all request rates, writing results under output_dir/rr{N}/."""
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    for c in sorted(concurrencies):
+    for request_rate in sorted(request_rates):
         run_aiperf_single(
             model=model,
             port=port,
-            concurrency=c,
+            request_rate=request_rate,
             request_count=request_count,
             warmup_count=warmup_count,
             input_file=input_file,
             osl=osl,
-            artifact_dir=output_dir / f"c{c}",
+            artifact_dir=output_dir / f"request_rate{request_rate}",
         )
 
     print(f"Sweep complete. Results in {output_dir}", flush=True)

--- a/examples/backends/vllm/launch/vllm_serve_embedding_cache.sh
+++ b/examples/backends/vllm/launch/vllm_serve_embedding_cache.sh
@@ -28,12 +28,10 @@ if [[ "$CAPACITY_GB" != "0" ]]; then
     }")
 fi
 
-GPU_MEM_UTIL="${_PROFILE_PYTEST_VRAM_FRAC_OVERRIDE:-.9}"
-
 CUDA_VISIBLE_DEVICES=2 \
 vllm serve "$MODEL" \
     --enable-log-requests \
     --max-model-len 16384 \
-    --gpu-memory-utilization "$GPU_MEM_UTIL" \
+    --gpu-memory-utilization .9 \
     "${EC_ARGS[@]}" \
     "${EXTRA_ARGS[@]}"

--- a/examples/backends/vllm/launch/vllm_serve_embedding_cache.sh
+++ b/examples/backends/vllm/launch/vllm_serve_embedding_cache.sh
@@ -27,8 +27,6 @@ if [[ "$CAPACITY_GB" != "0" ]]; then
         \"ec_connector_extra_config\": {\"multimodal_embedding_cache_capacity_gb\": $CAPACITY_GB}
     }")
 fi
-
-CUDA_VISIBLE_DEVICES=2 \
 vllm serve "$MODEL" \
     --enable-log-requests \
     --max-model-len 16384 \

--- a/examples/backends/vllm/launch/vllm_serve_embedding_cache.sh
+++ b/examples/backends/vllm/launch/vllm_serve_embedding_cache.sh
@@ -27,9 +27,13 @@ if [[ "$CAPACITY_GB" != "0" ]]; then
         \"ec_connector_extra_config\": {\"multimodal_embedding_cache_capacity_gb\": $CAPACITY_GB}
     }")
 fi
+
+GPU_MEM_UTIL="${_PROFILE_PYTEST_VRAM_FRAC_OVERRIDE:-.9}"
+
+CUDA_VISIBLE_DEVICES=2 \
 vllm serve "$MODEL" \
     --enable-log-requests \
     --max-model-len 16384 \
-    --gpu-memory-utilization .9 \
+    --gpu-memory-utilization "$GPU_MEM_UTIL" \
     "${EC_ARGS[@]}" \
     "${EXTRA_ARGS[@]}"

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from pathlib import Path
+
+# benchmarks/ is not an installed package; add repo root so
+# ``from benchmarks.multimodal.sweep...`` resolves.
+_repo_root = str(Path(__file__).resolve().parents[2])
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)

--- a/tests/benchmarks/multimodal/sweep/test_orchestrator.py
+++ b/tests/benchmarks/multimodal/sweep/test_orchestrator.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from benchmarks.multimodal.sweep.config import BenchmarkConfig, SweepConfig
+from benchmarks.multimodal.sweep.orchestrator import run_sweep
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
+
+
+def _make_config(
+    tmp_path: Path,
+    num_configs: int = 2,
+    num_input_files: int = 2,
+    request_rates: List[int] | None = None,
+    restart_server_every_benchmark: bool = True,
+) -> SweepConfig:
+    """Create a SweepConfig with dummy workflow scripts and input files."""
+    if request_rates is None:
+        request_rates = [4, 8]
+
+    # Create dummy workflow scripts
+    configs: List[BenchmarkConfig] = []
+    for i in range(num_configs):
+        script = tmp_path / f"workflow_{i}.sh"
+        script.write_text("#!/bin/bash\necho ok")
+        script.chmod(0o755)
+        configs.append(
+            BenchmarkConfig(
+                label=f"cfg-{i}",
+                workflow=str(script),
+                extra_args=[],
+            )
+        )
+
+    # Create dummy input files
+    input_files: List[str] = []
+    for i in range(num_input_files):
+        f = tmp_path / f"input_{i}.jsonl"
+        f.write_text("{}\n")
+        input_files.append(str(f))
+
+    return SweepConfig(
+        model="test-model",
+        request_rates=request_rates,
+        concurrencies=None,
+        osl=10,
+        request_count=5,
+        warmup_count=1,
+        port=8000,
+        timeout=60,
+        input_files=input_files,
+        configs=configs,
+        output_dir=str(tmp_path / "results"),
+        skip_plots=True,
+        restart_server_every_benchmark=restart_server_every_benchmark,
+    )
+
+
+@patch("benchmarks.multimodal.sweep.orchestrator.run_aiperf_single")
+@patch("benchmarks.multimodal.sweep.orchestrator.ServerManager")
+def test_loop_order_bench_cfg_outer(
+    mock_server_cls: MagicMock,
+    mock_aiperf: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """bench_cfg is the outer loop, input_file middle, sweep_values inner."""
+    config = _make_config(tmp_path)
+    run_sweep(config, repo_root=tmp_path)
+
+    # Extract (label, input_file_stem, sweep_value) from each aiperf call.
+    calls: list[tuple[str, str, int]] = []
+    for c in mock_aiperf.call_args_list:
+        artifact_dir = Path(c.kwargs["artifact_dir"])
+        # Structure: results / <file_tag> / <label> / <mode><value>
+        label = artifact_dir.parent.name
+        value = c.kwargs["sweep_value"]
+        input_stem = Path(c.kwargs["input_file"]).stem
+        calls.append((label, input_stem, value))
+
+    # All cfg-0 calls come before all cfg-1 calls.
+    cfg0_calls = [c for c in calls if c[0] == "cfg-0"]
+    cfg1_calls = [c for c in calls if c[0] == "cfg-1"]
+    assert len(cfg0_calls) == 4  # 2 files x 2 rates
+    assert len(cfg1_calls) == 4
+    # cfg-0 block ends before cfg-1 block starts.
+    last_cfg0_idx = max(i for i, c in enumerate(calls) if c[0] == "cfg-0")
+    first_cfg1_idx = min(i for i, c in enumerate(calls) if c[0] == "cfg-1")
+    assert last_cfg0_idx < first_cfg1_idx
+
+
+@patch("benchmarks.multimodal.sweep.orchestrator.run_aiperf_single")
+@patch("benchmarks.multimodal.sweep.orchestrator.ServerManager")
+def test_server_lifecycle_restart_every(
+    mock_server_cls: MagicMock,
+    mock_aiperf: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """restart_server_every_benchmark=True: start/stop per run."""
+    config = _make_config(tmp_path, restart_server_every_benchmark=True)
+    mock_server = mock_server_cls.return_value
+    mock_server.is_running = False
+
+    run_sweep(config, repo_root=tmp_path)
+
+    total_runs = 2 * 2 * 2  # configs x files x rates
+    assert mock_server.start.call_count == total_runs
+    assert mock_server.stop.call_count == total_runs
+
+
+@patch("benchmarks.multimodal.sweep.orchestrator.run_aiperf_single")
+@patch("benchmarks.multimodal.sweep.orchestrator.ServerManager")
+def test_server_lifecycle_restart_per_config(
+    mock_server_cls: MagicMock,
+    mock_aiperf: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """restart_server_every_benchmark=False: start/stop once per config."""
+    config = _make_config(tmp_path, num_configs=3, restart_server_every_benchmark=False)
+    mock_server = mock_server_cls.return_value
+    mock_server.is_running = False
+
+    run_sweep(config, repo_root=tmp_path)
+
+    assert mock_server.start.call_count == 3
+    assert mock_server.stop.call_count == 3
+
+
+@patch("benchmarks.multimodal.sweep.orchestrator.run_aiperf_single")
+@patch("benchmarks.multimodal.sweep.orchestrator.ServerManager")
+def test_skip_existing_results(
+    mock_server_cls: MagicMock,
+    mock_aiperf: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Runs with existing profile_export_aiperf.json are skipped."""
+    config = _make_config(tmp_path, num_configs=1, num_input_files=1)
+    mock_server = mock_server_cls.return_value
+    mock_server.is_running = False
+
+    # Pre-create result for rate=4
+    input_tag = Path(config.input_files[0]).stem
+    artifact_dir = tmp_path / "results" / input_tag / "cfg-0" / "request_rate4"
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "profile_export_aiperf.json").write_text("{}")
+
+    run_sweep(config, repo_root=tmp_path)
+
+    # Only rate=8 should have run.
+    assert mock_aiperf.call_count == 1
+    assert mock_aiperf.call_args.kwargs["sweep_value"] == 8

--- a/tests/benchmarks/multimodal/sweep/test_orchestrator.py
+++ b/tests/benchmarks/multimodal/sweep/test_orchestrator.py
@@ -156,3 +156,35 @@ def test_skip_existing_results(
     # Only rate=8 should have run.
     assert mock_aiperf.call_count == 1
     assert mock_aiperf.call_args.kwargs["sweep_value"] == 8
+
+
+@patch("benchmarks.multimodal.sweep.orchestrator.run_aiperf_single")
+@patch("benchmarks.multimodal.sweep.orchestrator.ServerManager")
+def test_skip_all_results_no_server_start(
+    mock_server_cls: MagicMock,
+    mock_aiperf: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """When all runs have results, the server should never start."""
+    config = _make_config(
+        tmp_path,
+        num_configs=1,
+        num_input_files=1,
+        restart_server_every_benchmark=False,
+    )
+    mock_server = mock_server_cls.return_value
+    mock_server.is_running = False
+
+    # Pre-create results for both rates.
+    input_tag = Path(config.input_files[0]).stem
+    for rate in [4, 8]:
+        artifact_dir = (
+            tmp_path / "results" / input_tag / "cfg-0" / f"request_rate{rate}"
+        )
+        artifact_dir.mkdir(parents=True)
+        (artifact_dir / "profile_export_aiperf.json").write_text("{}")
+
+    run_sweep(config, repo_root=tmp_path)
+
+    assert mock_aiperf.call_count == 0
+    assert mock_server.start.call_count == 0


### PR DESCRIPTION
Prior to this PR, we sweep by concurrency

- clients's feedback is it's hard to grasp the notion of in-flight request / concurrency
- queries/requests per second seems self-explanatory
- vLLM disagg blog uses RQS (request rate)

This PR switches from concurrency to request_rate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skip behavior to bypass benchmarks with existing results, improving workflow efficiency.

* **Bug Fixes**
  * Removed unnecessary server restart logic between benchmarks for faster execution.

* **Updates**
  * Renamed benchmark parameter from concurrency levels to request rates with updated default values.
  * Updated help text and validation messages to reflect request rate terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->