### PR TITLE
docs: update quickstart container images to 1.0.0

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -20,13 +20,13 @@ Containers have all dependencies pre-installed. No setup required.
 
 ```bash
 # SGLang
-docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.8.1
+docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.0
 
 # TensorRT-LLM
-docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1
+docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0
 
 # vLLM
-docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.1
+docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0
 ```
 
 <Tip>


### PR DESCRIPTION
## Summary
- Updates quickstart container image tags from `0.8.1` → `1.0.0` for sglang, tensorrtllm, and vllm runtimes.

## Other non-1.0.0 container references in the repo

Full scan of hardcoded old version tags still present elsewhere (not changed in this PR):

### Docs
| File | Current Tag | Occurrences |
|------|-------------|-------------|
| `docs/components/router/router-examples.md` | `:0.6.0` | 2 |
| `docs/components/profiler/profiler-guide.md` | `:0.9.0` | 2 |
| `docs/components/profiler/README.md` | `:0.9.0` | 1 |
| `docs/features/disaggregated-serving/README.md` | `:0.8.0` | 5 |
| `docs/benchmarks/kv-router-ab-testing.md` | `:0.9.0` | 5 |
| `docs/backends/trtllm/multinode/trtllm-multinode-examples.md` | `:0.9.0` | 1 |
| `docs/kubernetes/api-reference.md` | `:0.9.0` | 2 (example comments) |
| `fern/components/profiler/profiler_guide.md` | `:0.9.0` | 3 |

### Examples
| File | Current Tag | Occurrences |
|------|-------------|-------------|
| `examples/basics/kubernetes/shared_frontend/shared_frontend.yaml` | `:0.5.0` | 5 |
| `examples/deployments/GKE/README.md` | `:0.6.0` | 2 |

### Recipes
| File | Current Tag | Occurrences |
|------|-------------|-------------|
| `recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml` | `:0.8.0` | 3 |
| `recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml` | `:0.8.0` | 3 |
| `recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml` | `:0.8.0` | 3 |
| `recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml` | `:0.8.0` | 3 |
| `recipes/llama-3-70b/vllm/disagg-single-node/deploy.yaml` | `:0.8.0` | 3 |
| `recipes/llama-3-70b/vllm/disagg-multi-node/deploy.yaml` | `:0.8.0` | 3 |
| `recipes/llama-3-70b/vllm/agg/deploy.yaml` | `:0.8.0` | 2 |
| `recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml` | `:0.8.0` | 3 |
| `recipes/qwen3-32b/vllm/agg-round-robin/deploy.yaml` | `:0.8.0` | 2 |
| `recipes/qwen3-32b-fp8/trtllm/disagg/deploy.yaml` | `:0.8.0` | 3 |
| `recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml` | `:0.8.0` | 2 |
| `recipes/qwen3-235b-a22b-fp8/trtllm/disagg/deploy.yaml` | `:0.8.0` | 3 |
| `recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml` | `:0.8.0` | 2 |
| `recipes/gpt-oss-120b/trtllm/disagg/deploy.yaml` | `:0.7.0` | 3 |
| `recipes/gpt-oss-120b/trtllm/agg/deploy.yaml` | `:0.8.0` | 2 |

### Operator/deploy
| File | Current Tag | Occurrences |
|------|-------------|-------------|
| `deploy/operator/api/v1alpha1/dynamographdeploymentrequest_types.go` | `:0.9.0` | 2 (comments) |
| `deploy/operator/config/samples/nvidia.com_v1beta1_dynamographdeploymentrequest.yaml` | `:0.9.0` | 1 |
| `deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml` | `:0.9.0` | 2 |
| `deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml` | `:0.9.0` | 2 |

### Tests
| File | Current Tag | Occurrences |
|------|-------------|-------------|
| `tests/utils/managed_deployment.py` | `:0.4.1` | 1 |
| `tests/profiler/configs/9a_thorough_dsr1_sglang_overrides.yaml` | `:0.8.0` | 1 |

### Intentional placeholders (not changed)
Files using `:my-tag`, `:<tag>`, `:<version>`, `:latest`, or `$DYNAMO_VERSION` are user-replaceable placeholders — left as-is.

## Test plan
- [ ] Verify quickstart image tags render correctly in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated container image tags to version 1.0.0 for SGLang, TensorRT-LLM, and vLLM runtimes in the quickstart guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->