### PR TITLE
fix: prevent DYN_SYSTEM_PORT collisions in TRT-LLM EPD launch scripts

### DIFF
--- a/examples/backends/trtllm/launch/disagg_e_pd.sh
+++ b/examples/backends/trtllm/launch/disagg_e_pd.sh
@@ -27,6 +27,10 @@ export MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
 # Extra arguments forwarded to the PD worker (e.g. --multimodal-embedding-cache-capacity-gb 10)
 EXTRA_PD_ARGS=("$@")
 
+# Prevent port collisions: the test framework exports DYN_SYSTEM_PORT which all
+# child processes would inherit. Unset it so only workers that need it set their own.
+unset DYN_SYSTEM_PORT
+
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 print_launch_banner --multimodal "Launching Multimodal E/PD" "$MODEL_PATH" "$HTTP_PORT"
 
@@ -34,7 +38,8 @@ print_launch_banner --multimodal "Launching Multimodal E/PD" "$MODEL_PATH" "$HTT
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
 python3 -m dynamo.frontend &
 
-# run encode worker (vision encoder on GPU 0)
+# run encode worker (vision encoder on GPU 0) with metrics on port 8081
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 CUDA_VISIBLE_DEVICES=$ENCODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
@@ -44,7 +49,8 @@ CUDA_VISIBLE_DEVICES=$ENCODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --max-file-size-mb "$MAX_FILE_SIZE_MB" \
   --disaggregation-mode encode &
 
-# run PD worker 1 (GPU 0)
+# run PD worker 1 (GPU 0) with metrics on port 8082
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \

--- a/examples/backends/trtllm/launch/epd_multimodal_image_and_embeddings.sh
+++ b/examples/backends/trtllm/launch/epd_multimodal_image_and_embeddings.sh
@@ -23,6 +23,10 @@ export MODALITY=${MODALITY:-"multimodal"}
 export ALLOWED_LOCAL_MEDIA_PATH=${ALLOWED_LOCAL_MEDIA_PATH:-"/tmp"}
 export MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
 
+# Prevent port collisions: the test framework exports DYN_SYSTEM_PORT which all
+# child processes would inherit. Unset it so only workers that need it set their own.
+unset DYN_SYSTEM_PORT
+
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 print_launch_banner --multimodal "Launching Multimodal E/P/D" "$MODEL_PATH" "$HTTP_PORT"
 
@@ -30,7 +34,8 @@ print_launch_banner --multimodal "Launching Multimodal E/P/D" "$MODEL_PATH" "$HT
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
 python3 -m dynamo.frontend &
 
-# run encode worker
+# run encode worker with metrics on port 8081
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 CUDA_VISIBLE_DEVICES=$ENCODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
@@ -40,7 +45,8 @@ CUDA_VISIBLE_DEVICES=$ENCODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --max-file-size-mb "$MAX_FILE_SIZE_MB" \
   --disaggregation-mode encode &
 
-# run prefill worker
+# run prefill worker with metrics on port 8082
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 CUDA_VISIBLE_DEVICES=$PREFILL_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
@@ -49,7 +55,8 @@ CUDA_VISIBLE_DEVICES=$PREFILL_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --disaggregation-mode prefill \
   --encode-endpoint "$ENCODE_ENDPOINT" &
 
-# run decode worker
+# run decode worker with metrics on port 8083
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT3:-8083} \
 CUDA_VISIBLE_DEVICES=$DECODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \


### PR DESCRIPTION
### Overview

  - Add unset `DYN_SYSTEM_PORT` to epd_multimodal_image_and_embeddings.sh and disagg_e_pd.sh so inherited test-framework ports don't collide across child processes
  - Assign per-worker ports via numbered variants (`DYN_SYSTEM_PORT1/2/3`)

### Problem

  When the test framework exports DYN_SYSTEM_PORT, all child processes (frontend, encode worker, prefill worker, decode
  worker) inherit the same port and collide:
```
ERROR dynamo_runtime::system_status_server: Failed to bind to address 0.0.0.0:8099: Address already in use (os error 98)
ERROR dynamo_runtime::distributed: System status server startup failed: Failed to bind to address: Address already in use (os error 98)
```
  Example CI run: https://github.com/ai-dynamo/dynamo/actions/runs/23068370239/job/67013279083?pr=6953

### Fix

Matches the pattern from SGLang PR #7046 (multimodal_epd.sh, disagg_same_gpu.sh):
  1. unset DYN_SYSTEM_PORT after env setup, before launching processes
  2. Workers set their port inline: DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081}

### Test plan
  - test_deployment[epd_multimodal-2] passes (was FAILED)
  - test_deployment[e_pd_multimodal-2] still passes (nightly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example launch scripts with improved port management to prevent collisions in distributed worker execution.
  * Enhanced multimodal backend example with dedicated per-worker port configuration for encode, prefill, and decode workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->