### PR TITLE
docs: remove blog section from sidebar navigation

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -269,19 +269,6 @@ navigation:
           - page: Planner Design
             path: design-docs/planner-design.md
 
-  # ==================== Blog ====================
-  - section: Blog
-    hidden: true
-    path: blogs/index.mdx
-    slug: blog
-    contents:
-      - page: "Full-Stack Optimizations for Agentic Inference"
-        path: blogs/agentic-inference/agentic-inference.md
-        slug: agentic-inference
-      - page: "Flash Indexer: Inter-Galactic KV Routing"
-        path: blogs/flash-indexer/flash-indexer.md
-        slug: flash-indexer
-
   # ==================== Documentation ====================
   - section: Documentation
     contents:
@@ -295,6 +282,17 @@ navigation:
   - section: Additional Resources
     hidden: true
     contents:
+      # -- Blog --
+      - section: Blog
+        path: blogs/index.mdx
+        slug: blog
+        contents:
+          - page: "Full-Stack Optimizations for Agentic Inference"
+            path: blogs/agentic-inference/agentic-inference.md
+            slug: agentic-inference
+          - page: "Flash Indexer: Inter-Galactic KV Routing"
+            path: blogs/flash-indexer/flash-indexer.md
+            slug: flash-indexer
       # -- Development --
       - page: Runtime Guide
         path: development/runtime-guide.md


### PR DESCRIPTION
## Summary
- Moved blog entries from a top-level hidden sidebar section into the existing Hidden Pages section
- The navbar Blog dropdown is preserved so blog pages remain accessible via direct URL
- No content changes — only navigation restructuring

## Test plan
- [x] `fern check` passes with 0 errors
- [x] Preview verified: blog removed from sidebar, navbar dropdown still works

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Reorganized documentation navigation: Blog section has been moved from main navigation to a hidden resources area. Blog content remains available through the updated documentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->