### PR TITLE
fix: remove cutlass-dsl stub that crashes TRT-LLM on CUDA 13.1

### DIFF
--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -280,7 +280,11 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
         --requirement /tmp/requirements.common.txt \
         --requirement /tmp/requirements.planner.txt \
         --requirement /tmp/requirements.benchmark.txt \
-        cupy-cuda13x
+        cupy-cuda13x && \
+    # nvidia-cutlass-dsl-libs-base==4.4.1 (transitive dep) ships a stub cute/experimental/__init__.py
+    # that unconditionally raises NotImplementedError, crashing TRT-LLM on import. cutlass-dsl==4.3.4
+    # (pinned by TRT-LLM) works without cute/experimental/. Remove the stub to fix the NotImplementedError.
+    rm -rf ${VIRTUAL_ENV}/lib/python${PYTHON_VERSION}/site-packages/nvidia_cutlass_dsl/python_packages/cutlass/cute/experimental/
 
 # Copy tests, deploy and components for CI with correct ownership
 # Pattern: COPY --chmod=775 <path>; chmod g+w <path> done later as root because COPY --chmod only affects <path>/*, not <path>


### PR DESCRIPTION
#### Overview:

- nvidia-cutlass-dsl-libs-base==4.4.1 (transitive dependency) ships a stub
  cute/experimental/__init__.py that unconditionally raises
  NotImplementedError("CuTe Experimental module is only supported on Cuda toolkit
  13.1 and above!")
  - TRT-LLM's cute_dsl_utils.py catches ImportError but not NotImplementedError, so
  the stub crashes the entire import chain at startup
  - nvidia-cutlass-dsl==4.3.4 (pinned by TRT-LLM) is a self-contained wheel that
  works without cute/experimental/ — the working TRT-LLM container has no libs-base
  and no cute/experimental/ directory
  - Changing the MOE backend from CUTLASS to DEEPGEMM does not help because DeepGEMM
   also uses cutlass-dsl internally, and the crash occurs at TRT-LLM module import
  time before any backend selection
  - Fix: delete the stub directory after package installation to match the working
  TRT-LLM container state


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue in the runtime Docker image build process that could cause runtime instability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->