### PR TITLE
docs: revert #7371

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -269,6 +269,19 @@ navigation:
           - page: Planner Design
             path: design-docs/planner-design.md
 
+  # ==================== Blog ====================
+  - section: Blog
+    hidden: true
+    path: blogs/index.mdx
+    slug: blog
+    contents:
+      - page: "Full-Stack Optimizations for Agentic Inference"
+        path: blogs/agentic-inference/agentic-inference.md
+        slug: agentic-inference
+      - page: "Flash Indexer: Inter-Galactic KV Routing"
+        path: blogs/flash-indexer/flash-indexer.md
+        slug: flash-indexer
+
   # ==================== Documentation ====================
   - section: Documentation
     contents:
@@ -282,17 +295,6 @@ navigation:
   - section: Additional Resources
     hidden: true
     contents:
-      # -- Blog --
-      - section: Blog
-        path: blogs/index.mdx
-        slug: blog
-        contents:
-          - page: "Full-Stack Optimizations for Agentic Inference"
-            path: blogs/agentic-inference/agentic-inference.md
-            slug: agentic-inference
-          - page: "Flash Indexer: Inter-Galactic KV Routing"
-            path: blogs/flash-indexer/flash-indexer.md
-            slug: flash-indexer
       # -- Development --
       - page: Runtime Guide
         path: development/runtime-guide.md


### PR DESCRIPTION
## Summary
- Reverts #7371 which broke the blog landing page by nesting blog entries inside the Hidden Pages section
- Restores the Blog as a top-level `hidden: true` section so the landing page URL works correctly

## Test plan
- [ ] Verify blog landing page loads at `/dynamo/dev/blog`
- [ ] Verify blog posts accessible from navbar dropdown
- [ ] Verify blog does not appear in sidebar

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized documentation structure to improve content categorization.
  * Created a dedicated Blog section within Design Docs, with blog entries relocated from Additional Resources for enhanced navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->