### PR TITLE
docs: add image-to-video support for vLLM-Omni in diffusion support matrix

### DIFF
--- a/docs/features/diffusion/README.md
+++ b/docs/features/diffusion/README.md
@@ -20,9 +20,6 @@ Dynamo supports serving diffusion models across multiple backends, enabling gene
 
 **Status:** ✅ Supported | ❌ Not supported
 
-> [!NOTE]
-> Image-to-video support for SGLang and TRT-LLM backends is planned and coming soon.
-
 ## Backend Documentation
 
 For deployment guides, configuration, and examples for each backend:

--- a/docs/features/diffusion/README.md
+++ b/docs/features/diffusion/README.md
@@ -16,12 +16,12 @@ Dynamo supports serving diffusion models across multiple backends, enabling gene
 | Text-to-Text | ✅ | ✅ | ❌ |
 | Text-to-Image | ✅ | ✅ | ❌ |
 | Text-to-Video | ✅ | ✅ | ✅ |
-| Image-to-Video | ❌ | ❌ | ❌ |
+| Image-to-Video | ✅ | ❌ | ❌ |
 
 **Status:** ✅ Supported | ❌ Not supported
 
 > [!NOTE]
-> Image-to-video support is planned and coming soon across all backends.
+> Image-to-video support for SGLang and TRT-LLM backends is planned and coming soon.
 
 ## Backend Documentation
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Update the diffusion support matrix to reflect that vLLM-Omni now supports image-to-video generation after #6530.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated diffusion feature support matrix to reflect Image-to-Video functionality now available for the vLLM-Omni backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->