### PR TITLE
feat: session_control endpoint for subagent KV isolation

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -391,6 +391,78 @@ class BaseWorkerHandler(BaseGenerativeHandler):
             result = {"status": "error", "message": f"Unknown action: {action}"}
         yield result
 
+    async def open_session(self, body: dict) -> dict:
+        """Open a streaming session for subagent KV isolation.
+
+        Args:
+            body: Dict with "session_id", optional "timeout" (default 120),
+                  and optional "capacity_of_str_len" (default 65536).
+        """
+        from sglang.srt.managers.io_struct import OpenSessionReqInput
+
+        session_id = body.get("session_id")
+        if not session_id:
+            return {"status": "error", "message": "session_id required"}
+        timeout = body.get("timeout", 120)
+        capacity = body.get("capacity_of_str_len", 65536)
+        try:
+            obj = OpenSessionReqInput(
+                capacity_of_str_len=capacity,
+                session_id=session_id,
+                streaming=True,
+                timeout=float(timeout),
+            )
+            result = await self.engine.tokenizer_manager.open_session(obj, None)
+            if result is None:
+                return {
+                    "status": "ok",
+                    "session_id": session_id,
+                    "message": "Session already exists",
+                }
+            return {"status": "ok", "session_id": result}
+        except Exception as e:
+            logging.error(f"Failed to open session {session_id}: {e}")
+            return {"status": "error", "message": str(e)}
+
+    async def close_session(self, body: dict) -> dict:
+        """Close a streaming session and release its KV resources.
+
+        Args:
+            body: Dict with "session_id".
+        """
+        from sglang.srt.managers.io_struct import CloseSessionReqInput
+
+        session_id = body.get("session_id")
+        if not session_id:
+            return {"status": "error", "message": "session_id required"}
+        try:
+            obj = CloseSessionReqInput(session_id=session_id)
+            await self.engine.tokenizer_manager.close_session(obj, None)
+            return {"status": "ok", "session_id": session_id}
+        except Exception as e:
+            logging.error(f"Failed to close session {session_id}: {e}")
+            return {"status": "error", "message": str(e)}
+
+    async def session_control(self, request, context=None):
+        """Service mesh endpoint for session lifecycle operations.
+
+        Args:
+            request: Dict with "action" key ("open_session" or "close_session")
+                     and action-specific parameters.
+            context: Optional Dynamo context (unused but required by protocol).
+
+        Yields:
+            Single dict with operation result.
+        """
+        action = request.get("action")
+        if action == "open_session":
+            result = await self.open_session(request)
+        elif action == "close_session":
+            result = await self.close_session(request)
+        else:
+            result = {"status": "error", "message": f"Unknown action: {action}"}
+        yield result
+
     def register_engine_routes(self, runtime: DistributedRuntime) -> None:
         """Register all engine routes for this handler.
 
@@ -421,6 +493,7 @@ class BaseWorkerHandler(BaseGenerativeHandler):
         runtime.register_engine_route(
             "update_weight_version", self.update_weight_version
         )
+        runtime.register_engine_route("session_control", self.session_control)
 
     @abstractmethod
     async def generate(self, request: Dict[str, Any], context: Context):

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -113,6 +113,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         )
         priority = (request.get("routing") or {}).get("priority")
 
+        # Extract session_params from extra_args if present
+        extra_args = request.get("extra_args") or {}
+        session_params = extra_args.get("session_params")
+
         if self.serving_mode == DisaggregationMode.DECODE:
             # Check if bootstrap_info is pre-computed in the request (from frontend)
             bootstrap_info = request.get("bootstrap_info")
@@ -148,6 +152,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 external_trace_header=trace_header,
                 rid=trace_id,
                 data_parallel_rank=dp_rank,
+                session_params=session_params,
                 **self._priority_kwargs(priority),
             )
 
@@ -188,6 +193,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 external_trace_header=trace_header,
                 rid=trace_id,
                 data_parallel_rank=dp_rank,
+                session_params=session_params,
                 **self._priority_kwargs(priority),
             )
             if self.skip_tokenizer_init:

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -31,6 +31,7 @@ pub use dynamo_kv_router::selector;
 
 pub mod cache_control;
 pub mod config;
+pub mod session_control;
 mod jetstream;
 pub mod metrics;
 pub mod prefill_router;
@@ -45,6 +46,7 @@ pub mod worker_query;
 
 pub use cache_control::{CacheControlClient, spawn_pin_prefix};
 pub use config::{KvRouterConfig, RouterConfigOverride};
+pub use session_control::{SessionControlClient, spawn_close_session, spawn_open_session};
 pub use prefill_router::PrefillRouter;
 pub use push_router::{DirectRoutingRouter, KvPushRouter};
 

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -20,6 +20,7 @@ use crate::{
     kv_router::{
         CacheControlClient, KvRouter,
         cache_control::{PinState, create_cache_control_client, spawn_pin_prefix},
+        session_control::{SessionControlClient, create_session_control_client, spawn_open_session, spawn_close_session},
         metrics::RouterRequestMetrics,
         protocols::{TokensWithHashes, WorkerWithDpRank},
     },
@@ -35,6 +36,8 @@ pub struct KvPushRouter {
     pub chooser: Arc<KvRouter>,
     /// Lazily initialized on first PIN request. `None` when cache_control is disabled.
     cache_control_cell: Option<OnceCell<CacheControlClient>>,
+    /// Lazily initialized on first session request. `None` when cache_control is disabled.
+    session_control_cell: Option<OnceCell<SessionControlClient>>,
 }
 
 /// Result of worker selection containing instance ID, dp_rank, and overlap amount.
@@ -42,6 +45,13 @@ struct WorkerSelection {
     instance_id: u64,
     dp_rank: u32,
     overlap_amount: u32,
+}
+
+/// State captured at routing time for a deferred session close after generation completes.
+struct SessionCloseState {
+    session_id: String,
+    sc_client: SessionControlClient,
+    instance_id: u64,
 }
 
 /// Drop guard that manages the full lifecycle of a routed request:
@@ -67,6 +77,8 @@ struct RequestGuard {
     expected_output_tokens: Option<u32>,
     // PIN state: set when cache_control TTL is present and a cc_client exists
     pin_state: Option<PinState>,
+    // Session close state: set when session_control.action == Close
+    session_close_state: Option<SessionCloseState>,
 }
 
 impl RequestGuard {
@@ -152,6 +164,10 @@ impl RequestGuard {
                 pin.ttl_seconds,
             );
         }
+
+        if let Some(ref state) = self.session_close_state {
+            spawn_close_session(&state.sc_client, &state.session_id, state.instance_id, &self.context_id);
+        }
     }
 
     fn record_metrics(&mut self) {
@@ -205,10 +221,17 @@ impl KvPushRouter {
         } else {
             None
         };
+        let session_control_cell = if chooser.kv_router_config().router_enable_cache_control {
+            tracing::info!("Session control enabled for subagent isolation (lazy init)");
+            Some(OnceCell::new())
+        } else {
+            None
+        };
         KvPushRouter {
             inner,
             chooser,
             cache_control_cell,
+            session_control_cell,
         }
     }
 
@@ -475,6 +498,47 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         }
         .await;
 
+        // Handle session control: open session on selected worker before routing
+        let session_control = request.routing.as_ref().and_then(|r| r.session_control.clone());
+        if let Some(ref sc) = session_control {
+            use crate::protocols::openai::nvext::SessionAction;
+            if sc.action == SessionAction::Open {
+                if let Some(cell) = self.session_control_cell.as_ref() {
+                    let component = self.chooser.client().endpoint.component().clone();
+                    if let Ok(client) = cell
+                        .get_or_try_init(|| create_session_control_client(&component))
+                        .await
+                    {
+                        spawn_open_session(client, &sc.session_id, instance_id, sc.timeout, &context_id);
+                    } else {
+                        tracing::warn!("Failed to create session_control client for open");
+                    }
+                }
+            }
+        }
+
+        let session_close_state: Option<SessionCloseState> = async {
+            let sc = session_control.as_ref()?;
+            use crate::protocols::openai::nvext::SessionAction;
+            if sc.action != SessionAction::Close {
+                return None;
+            }
+            let cell = self.session_control_cell.as_ref()?;
+            let component = self.chooser.client().endpoint.component().clone();
+            let client = cell
+                .get_or_try_init(|| create_session_control_client(&component))
+                .await
+                .inspect_err(|e| tracing::warn!("Failed to create session_control client: {e}"))
+                .ok()?
+                .clone();
+            Some(SessionCloseState {
+                session_id: sc.session_id.clone(),
+                sc_client: client,
+                instance_id,
+            })
+        }
+        .await;
+
         let (mut backend_input, context) = request.into_parts();
         backend_input.routing_mut().dp_rank = Some(dp_rank);
         let updated_request = context.map(|_| backend_input);
@@ -517,6 +581,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 block_size,
                 expected_output_tokens,
                 pin_state,
+                session_close_state,
             };
 
             loop {

--- a/lib/llm/src/kv_router/session_control.rs
+++ b/lib/llm/src/kv_router/session_control.rs
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use dynamo_runtime::{
+    component::Component,
+    pipeline::{PushRouter, RouterMode, SingleIn},
+    protocols::annotated::Annotated,
+};
+use futures::StreamExt;
+
+/// A PushRouter client typed for session_control requests/responses.
+///
+/// Both request and response are untyped JSON. The worker's session_control
+/// endpoint dispatches open_session / close_session to SGLang's TokenizerManager.
+pub type SessionControlClient = PushRouter<serde_json::Value, Annotated<serde_json::Value>>;
+
+/// Create a session_control client from a component.
+///
+/// Connects to the "session_control" endpoint on the given component and returns
+/// a PushRouter client for sending session lifecycle operations to workers.
+pub(crate) async fn create_session_control_client(
+    component: &Component,
+) -> Result<SessionControlClient> {
+    let client = component.endpoint("session_control").client().await?;
+    SessionControlClient::from_client(client, RouterMode::KV).await
+}
+
+/// Fire-and-forget open_session to the worker that will serve this subagent.
+///
+/// Spawns a detached task that sends the open request and logs the outcome.
+pub fn spawn_open_session(
+    client: &SessionControlClient,
+    session_id: &str,
+    instance_id: u64,
+    timeout: u64,
+    context_id: &str,
+) {
+    let client = client.clone();
+    let session_id = session_id.to_owned();
+    let context_id = context_id.to_owned();
+
+    tokio::spawn(async move {
+        let request = serde_json::json!({
+            "action": "open_session",
+            "session_id": session_id,
+            "timeout": timeout,
+            "capacity_of_str_len": 65536,
+        });
+        match client.direct(SingleIn::new(request), instance_id).await {
+            Ok(mut stream) => {
+                if let Some(resp) = stream.next().await {
+                    tracing::info!(
+                        request_id = %context_id,
+                        worker_id = instance_id,
+                        %session_id,
+                        ?resp,
+                        "open_session response"
+                    );
+                }
+                while stream.next().await.is_some() {}
+            }
+            Err(e) => {
+                tracing::warn!(
+                    request_id = %context_id,
+                    worker_id = instance_id,
+                    %session_id,
+                    "Failed to open session: {e}"
+                );
+            }
+        }
+    });
+}
+
+/// Fire-and-forget close_session on the worker holding this subagent's KV.
+///
+/// Spawns a detached task that sends the close request and logs the outcome.
+pub fn spawn_close_session(
+    client: &SessionControlClient,
+    session_id: &str,
+    instance_id: u64,
+    context_id: &str,
+) {
+    let client = client.clone();
+    let session_id = session_id.to_owned();
+    let context_id = context_id.to_owned();
+
+    tokio::spawn(async move {
+        let request = serde_json::json!({
+            "action": "close_session",
+            "session_id": session_id,
+        });
+        match client.direct(SingleIn::new(request), instance_id).await {
+            Ok(mut stream) => {
+                if let Some(resp) = stream.next().await {
+                    tracing::info!(
+                        request_id = %context_id,
+                        worker_id = instance_id,
+                        %session_id,
+                        ?resp,
+                        "close_session response"
+                    );
+                }
+                while stream.next().await.is_some() {}
+            }
+            Err(e) => {
+                tracing::warn!(
+                    request_id = %context_id,
+                    worker_id = instance_id,
+                    %session_id,
+                    "Failed to close session: {e}"
+                );
+            }
+        }
+    });
+}

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -308,6 +308,7 @@ impl OpenAIPreprocessor {
                 lora_name,
                 cache_control_ttl: nvext.cache_control.as_ref().map(|cc| cc.ttl_seconds()),
                 allowed_worker_ids: None,
+                session_control: nvext.session_control.clone(),
             };
             builder.routing(Some(routing));
         } else if lora_name.is_some() || cache_control_ttl.is_some() {

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -248,7 +248,23 @@ impl OpenAIPreprocessor {
             .await
             .with_context(|| "Failed to gather multimodal data")?;
 
-        Ok((builder.build()?, annotations, prompt_injected_reasoning))
+        // Forward session_params into extra_args for backend handler
+        let session_params = request
+            .nvext()
+            .and_then(|ext| ext.session_params.clone());
+
+        let mut preprocessed = builder.build()?;
+
+        if let Some(sp) = session_params {
+            let extra = preprocessed
+                .extra_args
+                .get_or_insert_with(|| serde_json::json!({}));
+            if let serde_json::Value::Object(map) = extra {
+                map.insert("session_params".to_string(), sp);
+            }
+        }
+
+        Ok((preprocessed, annotations, prompt_injected_reasoning))
     }
 
     pub fn builder<

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -64,6 +64,10 @@ pub struct RoutingHints {
     /// When set, only workers in this set are considered during scoring.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_worker_ids: Option<HashSet<WorkerId>>,
+
+    /// Session control for subagent KV isolation. Forwarded from nvext.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_control: Option<crate::protocols::openai::nvext::SessionControl>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -181,6 +181,14 @@ pub struct NvExt {
     #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_control: Option<SessionControl>,
+
+    /// Session parameters for multi-turn streaming sessions.
+    /// Forwarded to SGLang's async_generate as session_params.
+    /// Fields: id (session ID), rid (request ID from previous turn),
+    /// offset, replace, drop_previous_output.
+    #[builder(default, setter(strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_params: Option<serde_json::Value>,
 }
 
 /// Hints from the agent/caller about request characteristics.
@@ -336,6 +344,7 @@ mod tests {
         assert_eq!(nv_ext.agent_hints, None);
         assert_eq!(nv_ext.cache_control, None);
         assert_eq!(nv_ext.session_control, None);
+        assert_eq!(nv_ext.session_params, None);
     }
 
     // Test CacheControl serde roundtrip and TTL parsing

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -174,6 +174,13 @@ pub struct NvExt {
     #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
+
+    /// Session lifecycle control for subagent KV isolation.
+    /// When present, the router opens or closes a streaming session on the
+    /// selected worker, keeping subagent KV in a dedicated SessionSlot.
+    #[builder(default, setter(strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_control: Option<SessionControl>,
 }
 
 /// Hints from the agent/caller about request characteristics.
@@ -253,6 +260,33 @@ impl CacheControl {
     }
 }
 
+/// Default session timeout in seconds.
+fn default_session_timeout() -> u64 {
+    120
+}
+
+/// Session lifecycle control for subagent KV isolation.
+/// Sessions hold KV cache in dedicated slots outside the radix tree,
+/// preventing pollution from short-lived subagent conversations.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct SessionControl {
+    /// Action to perform: open or close the session.
+    pub action: SessionAction,
+    /// Unique session identifier.
+    pub session_id: String,
+    /// Inactivity timeout in seconds (default 120). Session auto-closes after this.
+    #[serde(default = "default_session_timeout")]
+    pub timeout: u64,
+}
+
+/// Session lifecycle actions.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionAction {
+    Open,
+    Close,
+}
+
 impl Default for NvExt {
     fn default() -> Self {
         NvExt::builder().build().unwrap()
@@ -301,6 +335,7 @@ mod tests {
         assert_eq!(nv_ext.decode_worker_id, None);
         assert_eq!(nv_ext.agent_hints, None);
         assert_eq!(nv_ext.cache_control, None);
+        assert_eq!(nv_ext.session_control, None);
     }
 
     // Test CacheControl serde roundtrip and TTL parsing
@@ -405,6 +440,40 @@ mod tests {
         assert_eq!(nv_ext.prefill_worker_id, Some(100));
         assert_eq!(nv_ext.decode_worker_id, Some(200));
         assert!(nv_ext.validate().is_ok());
+    }
+
+    #[test]
+    fn test_session_control_serde() {
+        // Open action
+        let sc_json = r#"{"action": "open", "session_id": "sub-1", "timeout": 60}"#;
+        let sc: SessionControl = serde_json::from_str(sc_json).unwrap();
+        assert_eq!(sc.action, SessionAction::Open);
+        assert_eq!(sc.session_id, "sub-1");
+        assert_eq!(sc.timeout, 60);
+
+        // Close action
+        let sc_close = r#"{"action": "close", "session_id": "sub-1"}"#;
+        let sc: SessionControl = serde_json::from_str(sc_close).unwrap();
+        assert_eq!(sc.action, SessionAction::Close);
+        assert_eq!(sc.timeout, 120); // default
+
+        // NvExt with session_control
+        let nvext_json = r#"{"session_control": {"action": "open", "session_id": "sub-2", "timeout": 30}}"#;
+        let nvext: NvExt = serde_json::from_str(nvext_json).unwrap();
+        assert!(nvext.session_control.is_some());
+        let sc = nvext.session_control.unwrap();
+        assert_eq!(sc.action, SessionAction::Open);
+        assert_eq!(sc.session_id, "sub-2");
+
+        // Roundtrip
+        let original = SessionControl {
+            action: SessionAction::Close,
+            session_id: "test-session".to_string(),
+            timeout: 90,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let deser: SessionControl = serde_json::from_str(&json).unwrap();
+        assert_eq!(deser, original);
     }
 
     // Test apply_header_routing_overrides - worker header present, prefill header absent


### PR DESCRIPTION
## Motivation

Agentic orchestrators spawn short-lived subagents that accumulate KV cache, use it
for a few turns, then die. Under normal radix cache behavior, this ephemeral KV
pollutes the tree and competes with the lead agent's long-lived prefix for eviction.

SGLang's `SessionAwareCache` (#19171) solves this by holding session KV in dedicated
slots outside the radix tree -- invisible to eviction, no L2 pollution, deterministic
cleanup. This PR wires session lifecycle through Dynamo's router so orchestrators can
use it.

## Example

Orchestrator spawns a subagent and opens a session on the best worker:

\`\`\`
POST /v1/chat/completions
{
  "messages": [{"role": "user", "content": "Research topic X"}],
  "nvext": {
    "session_control": {"action": "open", "session_id": "sub-1", "timeout": 60}
  }
}
# Response includes worker_id -- client uses it for affinity
\`\`\`

Subsequent subagent turns pin to that worker and use the session:

\`\`\`
POST /v1/chat/completions
{
  "messages": [{"role": "user", "content": "Follow-up question"}],
  "nvext": {
    "backend_instance_id": 42,
    "session_params": {"id": "sub-1", "rid": "<rid from previous turn>"}
  }
}
\`\`\`

When the subagent finishes, close the session to free KV immediately:

\`\`\`
POST /v1/chat/completions
{
  "messages": [{"role": "user", "content": "Summarize findings"}],
  "nvext": {
    "backend_instance_id": 42,
    "session_control": {"action": "close", "session_id": "sub-1"}
  }
}
\`\`\`

## What changed

- **nvext**: `session_control` (open/close lifecycle) and `session_params` (per-request session usage)
- **Router**: `session_control.rs` fires open/close to workers via event plane, gated by `router_enable_cache_control`
- **Preprocessor**: `session_params` forwarded through `extra_args` to backend
- **Decode handler**: passes `session_params` to `engine.async_generate()`
- **Worker endpoint**: `session_control()` dispatches to SGLang's `tokenizer_manager.open_session()` / `close_session()`

Requires `--enable-streaming-session` on SGLang server and `--router-enable-cache-control` on router.