### PR TITLE
docs(recipes): add experimental WIP note to Kimi-K2.5 recipe

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -42,7 +42,7 @@ These recipes demonstrate aggregated or disaggregated serving:
 | **[DeepSeek-R1](deepseek-r1/sglang/disagg-16gpu/)** | SGLang | Disagg WideEP | 32x H200 | ✅ | ❌ | TP=16, multi-node. Use `model-download-sglang.yaml` | ❌ |
 | **[DeepSeek-R1](deepseek-r1/trtllm/disagg/wide_ep/gb200/)** | TensorRT-LLM | Disagg WideEP (GB200) | 36x GB200 | ✅ | ✅ | Multi-node: 8 decode + 1 prefill nodes | ❌ |
 | **[DeepSeek-R1](deepseek-r1/)** | vLLM | Disagg DEP16 | 32x H200 | ✅ | ❌ | Multi-node, data-expert parallel | ❌ |
-| **[Kimi-K2.5](kimi-k2.5/)** | TensorRT-LLM | Aggregated | 8x B200 | ✅ | ❌ | MoE model, TP8×EP8, reasoning + tool calling | ❌ |
+| **[Kimi-K2.5](kimi-k2.5/)** 🚧 | TensorRT-LLM | Aggregated | 8x B200 | ✅ | ❌ | Experimental — MoE model, TP8×EP8, reasoning + tool calling | ❌ |
 
 **Legend:**
 - **Deployment**: ✅ = Complete `deploy.yaml` manifest available

--- a/recipes/kimi-k2.5/README.md
+++ b/recipes/kimi-k2.5/README.md
@@ -1,5 +1,11 @@
 # Kimi-K2.5 Recipes
 
+> 🚧 **Work-in-Progress — Experimental Recipe**
+>
+> The TensorRT-LLM Python package used for Dynamo's TRT-LLM integration does not yet include
+> native Kimi K2.5 support. This recipe is an **experimental** effort to bring
+> Kimi K2.5 to Dynamo ahead of upstream availability. It needs to patch the container image on top of released dynamo image.
+
 Deployment recipe for **Kimi-K2.5** using TensorRT-LLM with Dynamo's KV-aware routing.
 
 ## Available Configurations


### PR DESCRIPTION
#### Overview:

The TensorRT-LLM Python package (tensorrt-llm==1.3.0rc5.post1) does not yet have native Kimi K2.5 support. 
Add a visible note to the recipe README and mark the entry in the recipes index as experimental.


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked Kimi-K2.5 recipe as experimental with status badge.
  * Added work-in-progress notice highlighting experimental status and TensorRT-LLM support limitations.
  * Documented image patching requirements for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->