### PR TITLE
docs: fix navbar Documentation link to point to Getting Started

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -113,7 +113,7 @@ logo:
   dark: ../docs/assets/NVIDIA_dark.svg
   light: ../docs/assets/NVIDIA_light.svg
   height: 20
-  href: /
+  href: /dynamo/getting-started
   right-text: Documentation
 
 favicon: ../docs/assets/NVIDIA_symbol.svg


### PR DESCRIPTION
## Summary

- Change the navbar logo `href` from `/` to `/dynamo/getting-started` so clicking "Documentation" lands on the Getting Started page instead of the site root

## Test Plan

- [ ] PR preview shows navbar "Documentation" link goes to `/dynamo/getting-started`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation**
  * Updated the logo link in the navbar to direct to the Getting Started guide instead of the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->