### PR TITLE
feat(sglang): relay forward pass metrics to event plane

### DIFF
--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -408,6 +408,15 @@ async def parse_args(args: list[str]) -> Config:
         f"Derived use_kv_events={use_kv_events} from kv_events_config={server_args.kv_events_config}"
     )
 
+    # Set forward pass metrics port from dynamo env var if configured
+    fpm_port_str = os.environ.get("DYN_FORWARDPASS_METRIC_PORT")
+    if fpm_port_str and not getattr(server_args, "forward_pass_metrics_port", None):
+        server_args.forward_pass_metrics_port = int(fpm_port_str)
+        logging.info(
+            f"Set forward_pass_metrics_port={server_args.forward_pass_metrics_port} "
+            f"from DYN_FORWARDPASS_METRIC_PORT"
+        )
+
     # Auto-detect diffusion worker mode if dllm_algorithm
     diffusion_worker = server_args.dllm_algorithm is not None
 

--- a/components/src/dynamo/sglang/init_diffusion.py
+++ b/components/src/dynamo/sglang/init_diffusion.py
@@ -17,7 +17,11 @@ from dynamo.sglang.health_check import (
     SglangHealthCheckPayload,
     VideoGenerationHealthCheckPayload,
 )
-from dynamo.sglang.publisher import handle_non_leader_node, setup_sgl_metrics
+from dynamo.sglang.publisher import (
+    handle_non_leader_node,
+    set_forward_pass_metrics_worker_id,
+    setup_sgl_metrics,
+)
 from dynamo.sglang.register import (
     register_image_diffusion_model,
     register_model_with_readiness_gate,
@@ -51,11 +55,12 @@ async def init_llm_diffusion(
     if server_args.node_rank >= 1:
         os.environ["SGLANG_BLOCK_NONZERO_RANK_CHILDREN"] = "0"
 
-    engine = sgl.Engine(server_args=server_args)
-
     generate_endpoint = runtime.endpoint(
         f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
     )
+    set_forward_pass_metrics_worker_id(server_args, generate_endpoint)
+
+    engine = sgl.Engine(server_args=server_args)
 
     shutdown_endpoints[:] = [generate_endpoint]
 

--- a/components/src/dynamo/sglang/init_embedding.py
+++ b/components/src/dynamo/sglang/init_embedding.py
@@ -11,7 +11,10 @@ from dynamo.llm import ModelInput, ModelType
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
 from dynamo.sglang.health_check import SglangHealthCheckPayload
-from dynamo.sglang.publisher import setup_sgl_metrics
+from dynamo.sglang.publisher import (
+    set_forward_pass_metrics_worker_id,
+    setup_sgl_metrics,
+)
 from dynamo.sglang.register import register_model_with_readiness_gate
 from dynamo.sglang.request_handlers import EmbeddingWorkerHandler
 
@@ -26,11 +29,12 @@ async def init_embedding(
     """Initialize embedding worker component"""
     server_args, dynamo_args = config.server_args, config.dynamo_args
 
-    engine = sgl.Engine(server_args=server_args)
-
     generate_endpoint = runtime.endpoint(
         f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
     )
+    set_forward_pass_metrics_worker_id(server_args, generate_endpoint)
+
+    engine = sgl.Engine(server_args=server_args)
 
     shutdown_endpoints[:] = [generate_endpoint]
 

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -19,7 +19,11 @@ from dynamo.sglang.health_check import (
     SglangHealthCheckPayload,
     SglangPrefillHealthCheckPayload,
 )
-from dynamo.sglang.publisher import handle_non_leader_node, setup_sgl_metrics
+from dynamo.sglang.publisher import (
+    handle_non_leader_node,
+    set_forward_pass_metrics_worker_id,
+    setup_sgl_metrics,
+)
 from dynamo.sglang.register import register_model_with_readiness_gate
 from dynamo.sglang.request_handlers import DecodeWorkerHandler, PrefillWorkerHandler
 
@@ -70,18 +74,25 @@ async def init_decode(
     if server_args.node_rank >= 1:
         os.environ["SGLANG_BLOCK_NONZERO_RANK_CHILDREN"] = "0"
 
+    generate_endpoint = runtime.endpoint(
+        f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
+    )
+    set_forward_pass_metrics_worker_id(server_args, generate_endpoint)
+
     # Use pre-created engine if provided (snapshot mode)
     if snapshot_engine is not None:
         engine = snapshot_engine
         load_time = 0.0
+        if getattr(server_args, "forward_pass_metrics_port", None) is not None:
+            logging.warning(
+                "Forward pass metrics enabled with snapshot engine: "
+                "worker_id may remain empty because the engine was created before "
+                "the endpoint instance existed."
+            )
     else:
         start_time = time.time()
         engine = sgl.Engine(server_args=server_args)
         load_time = time.time() - start_time
-
-    generate_endpoint = runtime.endpoint(
-        f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
-    )
 
     shutdown_endpoints[:] = [generate_endpoint]
 
@@ -165,15 +176,22 @@ async def init_prefill(
     if server_args.node_rank >= 1:
         os.environ["SGLANG_BLOCK_NONZERO_RANK_CHILDREN"] = "0"
 
-    # Use pre-created engine if provided (snapshot mode)
-    if snapshot_engine is not None:
-        engine = snapshot_engine
-    else:
-        engine = sgl.Engine(server_args=server_args)
-
     generate_endpoint = runtime.endpoint(
         f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
     )
+    set_forward_pass_metrics_worker_id(server_args, generate_endpoint)
+
+    # Use pre-created engine if provided (snapshot mode)
+    if snapshot_engine is not None:
+        engine = snapshot_engine
+        if getattr(server_args, "forward_pass_metrics_port", None) is not None:
+            logging.warning(
+                "Forward pass metrics enabled with snapshot engine: "
+                "worker_id may remain empty because the engine was created before "
+                "the endpoint instance existed."
+            )
+    else:
+        engine = sgl.Engine(server_args=server_args)
 
     shutdown_endpoints[:] = [generate_endpoint]
 

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -25,6 +25,34 @@ from dynamo.runtime import Endpoint
 from dynamo.sglang.args import Config
 
 
+def get_local_dp_rank_range(server_args) -> range:
+    """Return the global DP ranks hosted by this local worker."""
+    dp_size = getattr(server_args, "dp_size", 1) or 1
+    enable_dp_attention = getattr(server_args, "enable_dp_attention", False)
+    nnodes = getattr(server_args, "nnodes", 1) or 1
+    node_rank = getattr(server_args, "node_rank", 0) or 0
+
+    if enable_dp_attention and dp_size > 1:
+        local_dp_size = dp_size // nnodes if nnodes > 0 else dp_size
+        start_dp_rank = node_rank * local_dp_size
+        end_dp_rank = start_dp_rank + local_dp_size
+    else:
+        start_dp_rank = 0
+        end_dp_rank = 1
+
+    return range(start_dp_rank, end_dp_rank)
+
+
+def set_forward_pass_metrics_worker_id(server_args, generate_endpoint: Endpoint) -> None:
+    """Inject the endpoint instance identity into SGLang before engine init."""
+    if getattr(server_args, "forward_pass_metrics_port", None) is None:
+        return
+
+    server_args.forward_pass_metrics_worker_id = str(
+        generate_endpoint.connection_id()
+    )
+
+
 def format_zmq_endpoint(endpoint_template: str, ip_address: str) -> str:
     """Format ZMQ endpoint by replacing wildcard with IP address.
 
@@ -222,30 +250,15 @@ class DynamoSglangPublisher:
             local_ip = get_local_ip_auto()
 
             # Determine DP attention configuration
-            dp_size = getattr(self.server_args, "dp_size", 1) or 1
-            enable_dp_attention = getattr(
-                self.server_args, "enable_dp_attention", False
-            )
-            nnodes = getattr(self.server_args, "nnodes", 1) or 1
-            node_rank = getattr(self.server_args, "node_rank", 0) or 0
-
-            if enable_dp_attention and dp_size > 1:
-                # Calculate which DP ranks are local to this node
-                # DP ranks are distributed evenly across nodes
-                local_dp_size = dp_size // nnodes if nnodes > 0 else dp_size
-                start_dp_rank = node_rank * local_dp_size
-                end_dp_rank = start_dp_rank + local_dp_size
-
+            dp_ranks = get_local_dp_rank_range(self.server_args)
+            if len(dp_ranks) > 1:
                 logging.info(
-                    f"DP attention mode: node_rank={node_rank}, dp_size={dp_size}, "
-                    f"nnodes={nnodes}. Subscribing to local DP ranks [{start_dp_rank}, {end_dp_rank})"
+                    "DP attention mode: subscribing to local DP ranks [%d, %d)",
+                    dp_ranks.start,
+                    dp_ranks.stop,
                 )
-            else:
-                # Standard mode: single subscriber for rank 0
-                start_dp_rank = 0
-                end_dp_rank = 1
 
-            for dp_rank in range(start_dp_rank, end_dp_rank):
+            for dp_rank in dp_ranks:
                 # Use SGLang's offset_endpoint_port to ensure alignment with publishers
                 # This is the same function SGLang schedulers use to determine their bind ports
                 zmq_ep = ZmqEventPublisher.offset_endpoint_port(base_ep, dp_rank)
@@ -299,23 +312,8 @@ class DynamoSglangPublisher:
                 "Forward pass metrics will not be relayed to the event plane."
             )
             return []
-        dp_size = getattr(self.server_args, "dp_size", 1) or 1
-        enable_dp_attention = getattr(
-            self.server_args, "enable_dp_attention", False
-        )
-        nnodes = getattr(self.server_args, "nnodes", 1) or 1
-        node_rank = getattr(self.server_args, "node_rank", 0) or 0
-
-        if enable_dp_attention and dp_size > 1:
-            local_dp_size = dp_size // nnodes if nnodes > 0 else dp_size
-            start_dp_rank = node_rank * local_dp_size
-            end_dp_rank = start_dp_rank + local_dp_size
-        else:
-            start_dp_rank = 0
-            end_dp_rank = 1
-
         relays = []
-        for dp_rank in range(start_dp_rank, end_dp_rank):
+        for dp_rank in get_local_dp_rank_range(self.server_args):
             zmq_ep = f"tcp://127.0.0.1:{base_port + dp_rank}"
             relay = FpmEventRelay(
                 endpoint=self.generate_endpoint,

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -287,10 +287,8 @@ class DynamoSglangPublisher:
         Returns:
             List of FpmEventRelay instances, or empty list if not enabled.
         """
-        import os
-
-        fpm_port_str = os.environ.get("DYN_FORWARDPASS_METRIC_PORT")
-        if not fpm_port_str:
+        base_port = getattr(self.server_args, "forward_pass_metrics_port", None)
+        if base_port is None:
             return []
 
         try:
@@ -301,8 +299,6 @@ class DynamoSglangPublisher:
                 "Forward pass metrics will not be relayed to the event plane."
             )
             return []
-
-        base_port = int(fpm_port_str)
         dp_size = getattr(self.server_args, "dp_size", 1) or 1
         enable_dp_attention = getattr(
             self.server_args, "enable_dp_attention", False

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -89,6 +89,7 @@ class DynamoSglangPublisher:
 
         self._running = True
         self.kv_publishers: List[KvEventPublisher] = []
+        self.fpm_relays: list = []
 
         # ZMQ setup for receiving scheduler metrics (leader node only)
         # Non-leader nodes don't receive scheduler metrics via this socket - they only
@@ -175,6 +176,13 @@ class DynamoSglangPublisher:
                 publisher.shutdown()
             except Exception as e:
                 logging.warning(f"Failed to shutdown kv publisher: {e}")
+
+        # Shutdown FPM relays
+        for relay in self.fpm_relays:
+            try:
+                relay.shutdown()
+            except Exception as e:
+                logging.warning(f"Failed to shutdown FPM relay: {e}")
 
         logging.info("DynamoSglangPublisher cleanup complete")
 
@@ -268,6 +276,62 @@ class DynamoSglangPublisher:
         self.kv_publisher = self.kv_publishers[0] if self.kv_publishers else None
 
         return self.kv_publishers
+
+    def init_fpm_relay(self) -> list:
+        """Set up forward pass metrics relays for the event plane.
+
+        Creates one FpmEventRelay per local DP rank. Each relay subscribes
+        to the ZMQ PUB from sglang's _FpmPublisherThread (in the scheduler
+        process) and re-publishes to the Dynamo event plane.
+
+        Returns:
+            List of FpmEventRelay instances, or empty list if not enabled.
+        """
+        import os
+
+        fpm_port_str = os.environ.get("DYN_FORWARDPASS_METRIC_PORT")
+        if not fpm_port_str:
+            return []
+
+        try:
+            from dynamo.llm import FpmEventRelay
+        except ImportError:
+            logging.warning(
+                "FpmEventRelay not available (Rust bindings not built with FPM support). "
+                "Forward pass metrics will not be relayed to the event plane."
+            )
+            return []
+
+        base_port = int(fpm_port_str)
+        dp_size = getattr(self.server_args, "dp_size", 1) or 1
+        enable_dp_attention = getattr(
+            self.server_args, "enable_dp_attention", False
+        )
+        nnodes = getattr(self.server_args, "nnodes", 1) or 1
+        node_rank = getattr(self.server_args, "node_rank", 0) or 0
+
+        if enable_dp_attention and dp_size > 1:
+            local_dp_size = dp_size // nnodes if nnodes > 0 else dp_size
+            start_dp_rank = node_rank * local_dp_size
+            end_dp_rank = start_dp_rank + local_dp_size
+        else:
+            start_dp_rank = 0
+            end_dp_rank = 1
+
+        relays = []
+        for dp_rank in range(start_dp_rank, end_dp_rank):
+            zmq_ep = f"tcp://127.0.0.1:{base_port + dp_rank}"
+            relay = FpmEventRelay(
+                endpoint=self.generate_endpoint,
+                zmq_endpoint=zmq_ep,
+            )
+            relays.append(relay)
+            logging.info(
+                f"FPM relay for dp_rank={dp_rank} subscribing to {zmq_ep}"
+            )
+
+        self.fpm_relays = relays
+        return relays
 
 
 def setup_prometheus_registry(
@@ -372,6 +436,7 @@ async def setup_sgl_metrics(
 
     publisher.init_engine_metrics_publish()
     publisher.init_kv_event_publish()
+    publisher.init_fpm_relay()
 
     task = asyncio.create_task(publisher.run())
     logging.info("SGLang metrics loop started")

--- a/components/src/dynamo/sglang/tests/test_sglang_publisher.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_publisher.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from dynamo.sglang.publisher import (
+    get_local_dp_rank_range,
+    set_forward_pass_metrics_worker_id,
+)
+
+
+def test_get_local_dp_rank_range_defaults_to_rank_zero():
+    server_args = SimpleNamespace(
+        dp_size=1,
+        enable_dp_attention=False,
+        nnodes=1,
+        node_rank=0,
+    )
+
+    assert list(get_local_dp_rank_range(server_args)) == [0]
+
+
+def test_get_local_dp_rank_range_respects_multinode_dp_attention():
+    server_args = SimpleNamespace(
+        dp_size=8,
+        enable_dp_attention=True,
+        nnodes=2,
+        node_rank=1,
+    )
+
+    assert list(get_local_dp_rank_range(server_args)) == [4, 5, 6, 7]
+
+
+def test_set_forward_pass_metrics_worker_id_uses_endpoint_identity():
+    server_args = SimpleNamespace(forward_pass_metrics_port=20380)
+    endpoint = SimpleNamespace(connection_id=lambda: "endpoint-9")
+
+    set_forward_pass_metrics_worker_id(server_args, endpoint)
+
+    assert server_args.forward_pass_metrics_worker_id == "endpoint-9"
+
+
+def test_set_forward_pass_metrics_worker_id_is_noop_when_disabled():
+    server_args = SimpleNamespace(forward_pass_metrics_port=None)
+    endpoint = SimpleNamespace(connection_id=lambda: "endpoint-9")
+
+    set_forward_pass_metrics_worker_id(server_args, endpoint)
+
+    assert not hasattr(server_args, "forward_pass_metrics_worker_id")

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -143,6 +143,18 @@ async def test_namespace_flag_drives_default_endpoint_namespace(mock_sglang_cli)
 
 
 @pytest.mark.asyncio
+async def test_forward_pass_metrics_port_reads_from_env(
+    monkeypatch, mock_sglang_cli
+):
+    """Dynamo should pass the configured FPM port through to SGLang."""
+    monkeypatch.setenv("DYN_FORWARDPASS_METRIC_PORT", "21380")
+    mock_sglang_cli("--model", "Qwen/Qwen3-0.6B")
+
+    config = await parse_args(sys.argv[1:])
+    assert config.server_args.forward_pass_metrics_port == 21380
+
+
+@pytest.mark.asyncio
 async def test_obsolete_dyn_endpoint_types_flag_is_supported(mock_sglang_cli):
     """Obsolete --dyn-endpoint-types alias should map to endpoint_types."""
     mock_sglang_cli(

--- a/docs/backends/sglang/README.md
+++ b/docs/backends/sglang/README.md
@@ -23,11 +23,11 @@ uv venv --python 3.12 --seed
 uv pip install "ai-dynamo[sglang]"
 ```
 
-This installs Dynamo with the compatible SGLang version.
+This installs the latest stable release of Dynamo with the compatible SGLang version.
 
 ### Install for Development
 
-<Accordion title="Development installation">
+<Accordion title="Development installation in a virtual environment (recommended)">
 Requires Rust and the CUDA toolkit (`nvcc`).
 
 ```bash
@@ -40,30 +40,55 @@ cd $DYNAMO_HOME
 uv pip install -e .
 # install sglang
 git clone https://github.com/sgl-project/sglang.git
+# you can optionally checkout any sglang branch
 cd sglang && uv pip install -e "python"
 ```
 
-This is the ideal way for agents to also develop. You can provide the path to both repos and the virtual environment and have it rerun these commands as it makes changes
+This is the ideal way for agents to develop. You can provide the path to both repos and the virtual environment and have it rerun these commands as it makes changes
 </Accordion>
 
 ### Docker
 
-<Accordion title="Build and run container">
-```bash
-cd $DYNAMO_ROOT
-python container/render.py --framework sglang --output-short-filename
-docker build -f container/rendered.Dockerfile -t dynamo:latest-sglang .
-```
+<Accordion title="Development installation inside SGLang container">
+
+Pull and launch the SGLang runtime image:
 
 ```bash
-docker run \
-    --gpus all -it --rm \
+docker run --gpus all -it --rm \
     --network host --shm-size=10G \
     --ulimit memlock=-1 --ulimit stack=67108864 \
     --ulimit nofile=65536:65536 \
-    --cap-add CAP_SYS_PTRACE --ipc host \
-    dynamo:latest-sglang
+    --ipc host \
+    lmsysorg/sglang:v{sglang_version}
 ```
+
+Inside the container, install build dependencies and Rust:
+
+```bash
+apt-get update -qq && apt-get install -y -qq \
+    build-essential libclang-dev curl git > /dev/null 2>&1
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source "$HOME/.cargo/env"
+
+pip install maturin[patchelf]
+```
+
+Clone and build Dynamo:
+
+```bash
+cd /sgl-workspace/
+git clone https://github.com/ai-dynamo/dynamo.git
+cd dynamo
+
+cd lib/bindings/python/
+maturin build -o /tmp
+pip install /tmp/ai_dynamo_runtime*.whl
+
+cd /sgl-workspace/dynamo/
+pip install -e .
+```
+
 </Accordion>
 
 ## Feature Support Matrix


### PR DESCRIPTION
## Summary

- Extend `DynamoSglangPublisher` with `init_fpm_relay()` to subscribe to sglang's ForwardPassMetrics ZMQ PUB and relay to the event plane
- Map `DYN_FORWARDPASS_METRIC_PORT` env var to sglang's `server_args.forward_pass_metrics_port` in `args.py`
- Uses the same `FpmEventRelay` Rust binding as the vLLM integration (#7250)
- Handles DP attention topology (one relay per local DP rank)

## Motivation

Companion to sgl-project/sglang#20569 which adds per-iteration ForwardPassMetrics emission from sglang's scheduler. This PR wires the Dynamo side to receive those metrics and forward them to the event plane for consumption by the planner.

## Architecture

```
sglang scheduler (SchedulerMetricsMixin):
  _emit_forward_pass_metrics() -> _FpmPublisherThread -> ZMQ PUB (localhost)

Dynamo parent (DynamoSglangPublisher):
  init_fpm_relay() -> FpmEventRelay (ZMQ SUB) -> Event Plane (NATS)

Consumer (planner):
  FpmEventSubscriber -> decode() -> ForwardPassMetrics
```

## Changes

- `args.py`: Map `DYN_FORWARDPASS_METRIC_PORT` env var to `server_args.forward_pass_metrics_port` before engine creation
- `publisher.py`: Add `init_fpm_relay()` method reading port from `server_args`, cleanup in `cleanup()`, call from `setup_sgl_metrics()`

## Test plan

- [x] Wire compatibility verified: sglang-encoded ForwardPassMetrics decoded by Dynamo's decoder
- [x] Live server test: sglang with `--forward-pass-metrics-port 20380` emits prefill/decode metrics per iteration
- [ ] Full stack test with event plane consumer (requires NATS/etcd)