### PR TITLE
fix: Support local filesystem paths in model download/discovery

### DIFF
--- a/docs/fern/pages/developer-guide/additional-resources/tensorrt-llm-details/multinode-examples.md
+++ b/docs/fern/pages/developer-guide/additional-resources/tensorrt-llm-details/multinode-examples.md
@@ -20,7 +20,7 @@ The main TRT-LLM recipe entrypoints are:
 - [Qwen3-235B-A22B-FP8 aggregated, Hopper](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/deploy.yaml)
 - [Qwen3-235B-A22B-FP8 aggregated, Blackwell](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/agg/blackwell/deploy.yaml)
 - [Qwen3-235B-A22B-FP8 disaggregated, Hopper](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/deploy.yaml)
-- [Qwen3-235B-A22B-FP8 disaggregated, Blackwell](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy.yaml)
+- [Qwen3-235B-A22B-FP8 disaggregated, Blackwell](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy-generic.yaml)
 - [Qwen3-32B-FP8 aggregated](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml)
 - [Qwen3-32B-FP8 disaggregated](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b-fp8/trtllm/disagg/deploy.yaml)
 - [GPT-OSS-120B aggregated](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml)

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -81,6 +81,14 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
     let name = name.as_ref();
     let model_name = name.display().to_string();
 
+    // If the name is an absolute filesystem path that exists, return it directly
+    // without attempting any HuggingFace download. This supports models loaded
+    // from local storage (e.g., FSx Lustre, NFS, or other shared filesystems).
+    if name.is_absolute() && name.exists() {
+        tracing::info!("Using local model path: {model_name}");
+        return Ok(name.to_path_buf());
+    }
+
     // In offline mode, check cache first and return immediately if found
     if is_offline_mode() {
         if let Some(cached_path) = get_cached_model_path(&model_name, ignore_weights) {

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -84,7 +84,7 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
     // If the name is an absolute filesystem path that exists, return it directly
     // without attempting any HuggingFace download. This supports models loaded
     // from local storage (e.g., FSx Lustre, NFS, or other shared filesystems).
-    if name.is_absolute() && name.exists() {
+    if name.is_absolute() && name.try_exists().unwrap_or(false) {
         tracing::info!("Using local model path: {model_name}");
         return Ok(name.to_path_buf());
     }

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -81,12 +81,27 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
     let name = name.as_ref();
     let model_name = name.display().to_string();
 
-    // If the name is an absolute filesystem path that exists, return it directly
-    // without attempting any HuggingFace download. This supports models loaded
-    // from local storage (e.g., FSx Lustre, NFS, or other shared filesystems).
-    if name.is_absolute() && name.try_exists().unwrap_or(false) {
-        tracing::info!("Using local model path: {model_name}");
-        return Ok(name.to_path_buf());
+    // If the name is an absolute filesystem path, treat it as a local model
+    // directory and return it without attempting any HuggingFace download.
+    // This supports models loaded from local storage (e.g., FSx Lustre, NFS,
+    // or other shared filesystems). Surface IO errors from `try_exists()`
+    // (such as permission-denied on a parent directory of a shared
+    // filesystem) instead of swallowing them, and require the path to be a
+    // directory because downstream `update_dir()` assumes a directory.
+    if name.is_absolute() {
+        match name.try_exists() {
+            Ok(true) if name.is_dir() => {
+                tracing::info!("Using local model path: {model_name}");
+                return Ok(name.to_path_buf());
+            }
+            Ok(true) => {
+                anyhow::bail!("Local model path must be a directory: {model_name}");
+            }
+            Ok(false) => {}
+            Err(e) => {
+                anyhow::bail!("Cannot access local model path '{model_name}': {e}");
+            }
+        }
     }
 
     // In offline mode, check cache first and return immediately if found

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -136,6 +136,14 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
     let name = name.as_ref();
     let model_name = name.display().to_string();
 
+    // If the name is an absolute filesystem path that exists, return it directly
+    // without attempting any HuggingFace download. This supports models loaded
+    // from local storage (e.g., FSx Lustre, NFS, or other shared filesystems).
+    if name.is_absolute() && name.exists() {
+        tracing::info!("Using local model path: {model_name}");
+        return Ok(name.to_path_buf());
+    }
+
     // Cache-first in all modes: if the snapshot is already on disk with the files we
     // need, return it without touching the network.
     if let Some(cached_path) = get_cached_model_path(&model_name, ignore_weights) {

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -139,7 +139,7 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
     // If the name is an absolute filesystem path that exists, return it directly
     // without attempting any HuggingFace download. This supports models loaded
     // from local storage (e.g., FSx Lustre, NFS, or other shared filesystems).
-    if name.is_absolute() && name.exists() {
+    if name.is_absolute() && name.try_exists().unwrap_or(false) {
         tracing::info!("Using local model path: {model_name}");
         return Ok(name.to_path_buf());
     }

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -136,12 +136,27 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
     let name = name.as_ref();
     let model_name = name.display().to_string();
 
-    // If the name is an absolute filesystem path that exists, return it directly
-    // without attempting any HuggingFace download. This supports models loaded
-    // from local storage (e.g., FSx Lustre, NFS, or other shared filesystems).
-    if name.is_absolute() && name.try_exists().unwrap_or(false) {
-        tracing::info!("Using local model path: {model_name}");
-        return Ok(name.to_path_buf());
+    // If the name is an absolute filesystem path, treat it as a local model
+    // directory and return it without attempting any HuggingFace download.
+    // This supports models loaded from local storage (e.g., FSx Lustre, NFS,
+    // or other shared filesystems). Surface IO errors from `try_exists()`
+    // (such as permission-denied on a parent directory of a shared
+    // filesystem) instead of swallowing them, and require the path to be a
+    // directory because downstream `update_dir()` assumes a directory.
+    if name.is_absolute() {
+        match name.try_exists() {
+            Ok(true) if name.is_dir() => {
+                tracing::info!("Using local model path: {model_name}");
+                return Ok(name.to_path_buf());
+            }
+            Ok(true) => {
+                anyhow::bail!("Local model path must be a directory: {model_name}");
+            }
+            Ok(false) => {}
+            Err(e) => {
+                anyhow::bail!("Cannot access local model path '{model_name}': {e}");
+            }
+        }
     }
 
     // Cache-first in all modes: if the snapshot is already on disk with the files we


### PR DESCRIPTION
## Summary
- When a worker uses `--model-path /shared/path/to/model`, the frontend's model discovery calls `from_hf()` which passes the local path to the HuggingFace provider, causing a validation error
- This PR adds an early check: if the path is absolute and exists on the filesystem, return it directly without HF download

## Problem
```
HFValidationError: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/shared/nvrx-demo/nemotron-phase1-merged'
```

## Fix
In `lib/llm/src/hub.rs::from_hf()`:
```rust
if name.is_absolute() && name.exists() {
    tracing::info!("Using local model path: {model_name}");
    return Ok(name.to_path_buf());
}
```

## Test plan
- [x] Verified that local FSx path models load correctly on TRT-LLM worker
- [ ] Verify frontend model discovery works with local paths
- [ ] Verify HF-hosted models still work (no regression)

Related issue: #7389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of absolute filesystem paths to be used directly without attempting unnecessary downloads or cache lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->