### PR TITLE
docs: remove "Best For" row from backend feature table

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Built in Rust for performance and Python for extensibility, Dynamo is fully open
 
 | | [SGLang](docs/backends/sglang/README.md) | [TensorRT-LLM](docs/backends/trtllm/README.md) | [vLLM](docs/backends/vllm/README.md) |
 |---|:----:|:----------:|:--:|
-| **Best For** | High-throughput serving | Maximum performance | Broadest feature coverage |
 | [**Disaggregated Serving**](docs/design-docs/disagg-serving.md) | ✅ | ✅ | ✅ |
 | [**KV-Aware Routing**](docs/components/router/README.md) | ✅ | ✅ | ✅ |
 | [**SLA-Based Planner**](docs/components/planner/planner-guide.md) | ✅ | ✅ | ✅ |


### PR DESCRIPTION
## Summary
- Removes the "Best For" row from the Backend Feature Support table in the README
- These subjective descriptions (e.g., "High-throughput serving", "Maximum performance") are editorial characterizations that don't belong in a feature matrix

## Test Plan
- [ ] Verify table renders correctly on GitHub


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the Backend Feature Support table in the README by removing the "Best For" comparison row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->