### PR TITLE
ci: add generate-attributions action to post-merge build workflow

### DIFF
--- a/.github/actions/generate-attributions/action.yml
+++ b/.github/actions/generate-attributions/action.yml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Generate Attributions'
+description: 'Generate ATTRIBUTIONS-*.md from lock files and registry license APIs'
+
+inputs:
+  image:
+    description: 'Container image for pip freeze extraction (Python attributions)'
+    required: false
+    default: ''
+  ecosystem:
+    description: 'Ecosystem to generate (rust, python, go, all)'
+    required: false
+    default: 'all'
+  artifact_name:
+    description: 'Name for the uploaded artifact'
+    required: false
+    default: 'attributions'
+  retention_days:
+    description: 'Artifact retention in days'
+    required: false
+    default: '90'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      with:
+        python-version: '3.12'
+
+    - name: Install dynamo-attributions
+      shell: bash
+      run: pip install ./tools/attributions/
+
+    - name: Restore license cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      with:
+        path: ~/.dynamo_license_cache.json
+        key: license-cache-${{ hashFiles('Cargo.lock', 'deploy/operator/go.mod') }}
+        restore-keys: license-cache-
+
+    - name: Extract pip freeze from container
+      if: inputs.image != ''
+      shell: bash
+      run: |
+        source ./.github/scripts/retry_docker.sh
+        retry_pull ${{ inputs.image }}
+        docker run --rm --entrypoint /bin/sh ${{ inputs.image }} \
+          -c "pip freeze 2>/dev/null" > /tmp/pip-freeze.txt
+        echo "Extracted $(wc -l < /tmp/pip-freeze.txt) Python packages"
+
+    - name: Generate attributions
+      shell: bash
+      run: |
+        mkdir -p ./attributions-output
+        ARGS="--branch ${{ github.sha }} --ecosystem ${{ inputs.ecosystem }}"
+        ARGS+=" --output-dir ./attributions-output"
+        ARGS+=" --github-token ${{ github.token }}"
+        if [ -f /tmp/pip-freeze.txt ]; then
+          ARGS+=" --pip-freeze-file /tmp/pip-freeze.txt"
+        fi
+        dynamo-attributions ${ARGS}
+
+    - name: Upload attributions
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ./attributions-output/ATTRIBUTIONS-*.md
+        retention-days: ${{ inputs.retention_days }}

--- a/.github/actions/generate-attributions/action.yml
+++ b/.github/actions/generate-attributions/action.yml
@@ -32,7 +32,7 @@ runs:
 
     - name: Install dynamo-attributions
       shell: bash
-      run: pip install ./tools/attributions/
+      run: pip install ./container/compliance/generate-attributions-md/
 
     - name: Restore license cache
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
@@ -41,15 +41,12 @@ runs:
         key: license-cache-${{ hashFiles('Cargo.lock', 'deploy/operator/go.mod') }}
         restore-keys: license-cache-
 
-    - name: Extract pip freeze from container
+    - name: Pull container image
       if: inputs.image != ''
       shell: bash
       run: |
         source ./.github/scripts/retry_docker.sh
         retry_pull ${{ inputs.image }}
-        docker run --rm --entrypoint /bin/sh ${{ inputs.image }} \
-          -c "pip freeze 2>/dev/null" > /tmp/pip-freeze.txt
-        echo "Extracted $(wc -l < /tmp/pip-freeze.txt) Python packages"
 
     - name: Generate attributions
       shell: bash
@@ -58,8 +55,8 @@ runs:
         ARGS="--branch ${{ github.sha }} --ecosystem ${{ inputs.ecosystem }}"
         ARGS+=" --output-dir ./attributions-output"
         ARGS+=" --github-token ${{ github.token }}"
-        if [ -f /tmp/pip-freeze.txt ]; then
-          ARGS+=" --pip-freeze-file /tmp/pip-freeze.txt"
+        if [ -n "${{ inputs.image }}" ]; then
+          ARGS+=" --image ${{ inputs.image }}"
         fi
         dynamo-attributions ${ARGS}
 

--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -548,6 +548,41 @@ jobs:
 
 
   # ============================================================================
+  # ATTRIBUTIONS
+  # ============================================================================
+  attributions:
+    if: inputs.build_image && inputs.push_image
+    needs: [build]
+    name: Attributions cuda${{ inputs.cuda_version }}-${{ inputs.platform }}
+    runs-on: ${{ inputs.platform == 'amd64' && 'prod-builder-amd-v1' || 'prod-tester-arm-v1' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+      - name: Docker Login
+        uses: ./.github/actions/docker-login
+        with:
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+          azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+      - name: Calculate image URI
+        id: images
+        shell: bash
+        run: |
+          CUDA_VERSION_RAW=${{ inputs.cuda_version }}
+          CUDA_VERSION=${CUDA_VERSION_RAW%%.*}
+          echo "cuda_major=${CUDA_VERSION}" >> $GITHUB_OUTPUT
+          RUNTIME_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${{ needs.build.outputs.target_tag_plain }}-cuda${CUDA_VERSION}-${{ inputs.platform }}
+          echo "runtime_image=${RUNTIME_IMAGE}" >> $GITHUB_OUTPUT
+      - name: Generate attributions
+        uses: ./.github/actions/generate-attributions
+        with:
+          image: ${{ steps.images.outputs.runtime_image }}
+          artifact_name: attributions-${{ inputs.framework }}-${{ inputs.target }}${{ inputs.make_efa && '-efa' || '' }}-cuda${{ steps.images.outputs.cuda_major }}-${{ inputs.platform }}
+
+
+  # ============================================================================
   # COPY TO ACR
   # ============================================================================
   copy-to-acr:


### PR DESCRIPTION
## Summary

Adds a `generate-attributions` composite action and wires it into the post-merge build workflow to automatically generate ATTRIBUTIONS-*.md files after container builds.

- Runs in parallel with the existing `compliance` scan job -- zero additional pipeline wall time
- Uses `--image` flag to extract Python packages via v1's `python_helper.py` (importlib.metadata inside the container)
- Caches license lookups via `actions/cache` keyed on lock file hashes

## When It Triggers

Post-merge container builds only:

```
push to main/release/* -> post-merge-ci.yml
  -> build-test-distribute-flavor-matrix.yml
    -> build-test-distribute-flavor.yml
      -> build (existing)
      -> compliance (existing, parallel)
      -> attributions (NEW, parallel)   <-- this job
      -> test (existing, parallel)
```

Condition: `inputs.build_image && inputs.push_image` (same gate as compliance).
Does NOT run on PRs.

## Overhead Analysis

**Warm cache (normal case):** ~10 seconds total

| Step | Time |
|------|------|
| Setup Python + pip install | ~3s |
| Restore actions/cache | ~1s |
| docker run python_helper.py | ~3s |
| Generate Rust + Go (all cached) | ~2s |
| Render + upload artifacts | ~1s |

**Cold cache (first run or after Cargo.lock changes):** ~15 min, dominated by crates.io 1 req/sec rate limit for 767 Rust crates. Happens once, then cache persists. Partial cache hits via `restore-keys` mean only new/changed packages need fresh lookups.

**Net impact on pipeline wall time: zero.** The job runs in parallel with GPU test jobs that take 10-30 minutes.

## Release Branch Consideration

The post-merge CI runs on both `main` and `release/*` branches. When a release branch diverges (cherry-picks, version bumps), the attributions job generates files from that branch's lock files and container image -- so release attributions accurately reflect the release, not tip-of-tree.

The `release.yml` workflow itself does not regenerate attributions (it only tags and copies images). The attributions are generated during the post-merge build that produces the release candidate images.

## Dependencies

Requires #7402 (attributions tool at `container/compliance/generate-attributions-md/`) to be merged first.

## Files Changed

- `NEW` `.github/actions/generate-attributions/action.yml` -- composite action (SHA-pinned actions matching repo conventions)
- `EDIT` `.github/workflows/build-test-distribute-flavor.yml` -- adds `attributions` job after `compliance`

## Test Plan

- [ ] PR #7402 merged first
- [ ] YAML lint passes (check yaml pre-commit hook)
- [ ] Post-merge build triggers attributions job alongside compliance
- [ ] Artifacts appear in workflow run with ATTRIBUTIONS-*.md files
- [ ] Second run with same lock files uses cache (visible in Restore license cache step)
- [ ] Release branch build generates attributions from release branch lock files

## Artifact vs Committed Files

The CI job uploads generated ATTRIBUTIONS-*.md as **workflow artifacts** (downloadable from the Actions run page, retained 90 days). It does **not** auto-commit them back to the branch.

The ATTRIBUTIONS files that ship in containers come from whatever is already committed in the repo (`COPY ATTRIBUTION* LICENSE /workspace/` in the Dockerfiles). The CI artifacts serve as an audit trail to verify the committed files are accurate and up-to-date.

**Release workflow:** Before a release, someone runs the tool locally (~7s with warm cache), commits the updated files, and the release branch build picks them up. The CI artifacts on the release branch build confirm the committed files match what the tool would generate.