### PR TITLE
fix: ci(operator): expand changed-files filter to include helm chart outputs

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -103,6 +103,11 @@ operator:
   - 'deploy/operator/**'
   - 'deploy/operator/.*'
   - 'docs/kubernetes/api-reference.md'
+  - 'deploy/helm/charts/platform/components/operator/crds/**'
+  - 'deploy/helm/charts/platform/values.yaml'
+  - 'deploy/helm/charts/platform/README.md'
+  - 'deploy/helm/charts/platform/README.md.gotmpl'
+  - 'deploy/helm/charts/platform/components/operator/values.yaml'
 
 deploy:
   - '!**/*.md'

--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
@@ -131,7 +131,7 @@ spec:
                         WorkersImage specifies the container image to use for DynamoGraphDeployment worker components.
                         This image is used for both temporary DGDs created during online profiling and the final DGD.
                         If omitted, the image from the base config file (e.g., disagg.yaml) is used.
-                        Example: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0-test-drift"
+                        Example: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0"
                       type: string
                   type: object
                 enableGpuDiscovery:

--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
@@ -131,7 +131,7 @@ spec:
                         WorkersImage specifies the container image to use for DynamoGraphDeployment worker components.
                         This image is used for both temporary DGDs created during online profiling and the final DGD.
                         If omitted, the image from the base config file (e.g., disagg.yaml) is used.
-                        Example: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0"
+                        Example: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0-test-drift"
                       type: string
                   type: object
                 enableGpuDiscovery:


### PR DESCRIPTION
## Summary
- Expands the operator filter in `.github/filters.yaml` to include helm chart paths that `make check` generates into
- Previously, PRs editing helm CRDs or chart values/templates directly would skip the operator codegen check, allowing drift to reach post-merge CI (e.g. [this failure](https://github.com/ai-dynamo/dynamo/actions/runs/23106466664/job/67116422403))

### New paths added to operator filter
| Path | Reason |
|---|---|
| `deploy/helm/charts/platform/components/operator/crds/**` | CRD copies generated by `make manifests` |
| `deploy/helm/charts/platform/values.yaml` | Input to `generate-helm-docs` |
| `deploy/helm/charts/platform/README.md` | Output of `generate-helm-docs` |
| `deploy/helm/charts/platform/README.md.gotmpl` | Template for `generate-helm-docs` |
| `deploy/helm/charts/platform/components/operator/values.yaml` | Operator subchart values |

## Test plan
- [x] Verify the `changed-files` action correctly detects operator changes when only helm chart files are modified
  - pushed a commit with a drift and it was caught: https://github.com/ai-dynamo/dynamo/actions/runs/23118467050/job/67148146476?pr=7407#step:10:236
- [x] Confirm the Operator job triggers and `make check` runs on PRs that touch these new paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration filter configuration to include Helm chart deployment artifacts and configuration files for operator-related changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->