### PR TITLE
fix(recipes): revert untested/blocked recipes to pre-1.0.0 image tags

### DIFF
--- a/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
@@ -21,7 +21,7 @@ spec:
           mountPoint: /opt/model
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.8.0
     decode:
       componentType: worker
       subComponentType: decode
@@ -38,7 +38,7 @@ spec:
         size: 80Gi
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.8.0
           workingDir: /sgl-workspace/dynamo
           command:
             - python3
@@ -85,7 +85,7 @@ spec:
         size: 80Gi
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.8.0
           workingDir: /sgl-workspace/dynamo
           command:
             - python3

--- a/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
+++ b/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
@@ -126,7 +126,7 @@ spec:
         tolerations: []
         affinity: {}
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
           args:
           - |
             python3 -m dynamo.frontend --http-port 8000
@@ -158,7 +158,7 @@ spec:
         tolerations: []
         affinity: {}
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
           workingDir: /workspace/components/backends/trtllm
           # NOTE: If your PVCs (Persistent Volume Claims) are really slow,
           #       you might need to increase 'failureThreshold' below to allow more time for startup
@@ -216,7 +216,7 @@ spec:
         tolerations: []
         affinity: {}
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
           workingDir: /workspace/components/backends/trtllm
           # NOTE: If your PVCs (Persistent Volume Claims) are really slow,
           #       you might need to increase 'failureThreshold' below to allow more time for startup

--- a/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
+++ b/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
@@ -26,7 +26,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.0
     decode:
       componentType: worker
       subComponentType: decode
@@ -52,7 +52,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 600
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.0
           workingDir: /workspace/dynamo
           env:
             - name: VLLM_USE_DEEP_GEMM
@@ -124,7 +124,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 600
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.0
           workingDir: /workspace/dynamo
           env:
             - name: VLLM_USE_DEEP_GEMM

--- a/recipes/llama-3-70b/vllm/agg/gaie/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/agg/gaie/deploy.yaml
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/frontend:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/frontend:my-tag
       eppConfig:
         # This config uses the same disagg-profile-handler as disaggregated deployments.
         # The handler's graceful degradation feature makes this possible:
@@ -60,7 +60,7 @@ spec:
       sharedMemory:
         size: 20Gi
       frontendSidecar:
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
         args:
           - -m
           - dynamo.frontend
@@ -83,7 +83,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:

--- a/recipes/llama-3-70b/vllm/disagg-single-node/gaie/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-single-node/gaie/deploy.yaml
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/epp-image:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/epp-image:my-tag
       eppConfig:
         config:
           plugins:
@@ -68,7 +68,7 @@ spec:
       sharedMemory:
         size: 80Gi
       frontendSidecar:
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
         args:
           - -m
           - dynamo.frontend
@@ -101,7 +101,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
       replicas: 2
       resources:
@@ -119,7 +119,7 @@ spec:
       sharedMemory:
         size: 80Gi
       frontendSidecar:
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
         args:
           - -m
           - dynamo.frontend
@@ -152,7 +152,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml
@@ -53,7 +53,7 @@ spec:
                     - qwen3-235b-a22b-agg-frontend
               topologyKey: kubernetes.io/hostname
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
           args:
             - python3 -m dynamo.frontend --router-mode kv --http-port 8000
           command:
@@ -94,7 +94,7 @@ spec:
               --max-num-tokens 8192 \
               --max-seq-len 8192 \
               --extra-engine-args "${ENGINE_ARGS}"
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
           workingDir: /workspace/components/backends/trtllm
           volumeMounts:
             - name: agg-config


### PR DESCRIPTION
## Summary

- Reverts 6 recipes that were bulk-updated to `1.0.0` container images but **could not be validated** with live chat completions inference testing
- Only recipes that passed end-to-end deployment + inference testing should carry `1.0.0` tags; these did not

## Recipes reverted

| Recipe | Reverted To | Reason |
|--------|------------|--------|
| qwen3-235b-a22b-fp8/trtllm/agg | `0.8.0` | BLOCKED — DeepGEMM MoE CuTe stub raises `NotImplementedError` (fix in PR #7372, retest with 1.0.1) |
| deepseek-r1/trtllm/disagg/wide_ep/gb200 | `0.8.0` | BLOCKED — WIDEEP MoE `RuntimeError: 400` during EP32 decode init on GB200 |
| deepseek-r1/sglang/disagg-16gpu | `0.8.0` | NOT TESTED — requires 32 GPUs, not yet validated |
| deepseek-r1/vllm/disagg | `0.8.0` | NOT TESTED — requires 32 GPUs, not yet validated |
| llama-3-70b/vllm/agg/gaie | `my-tag` | BLOCKED — requires gateway-api + kgateway infra (not installed) |
| llama-3-70b/vllm/disagg-single-node/gaie | `my-tag` | BLOCKED — requires gateway-api + kgateway infra (not installed) |

## Context

PR #7375 updated all recipes to 1.0.0, but several were merged without passing inference testing. This PR reverts those specific recipes to their original `runtime-1.0.0` release tags. The 11 recipes that passed QA remain on 1.0.0. Kimi recipes (4 variants) are excluded — Biswa is handling those separately via PR #7381.

## Test plan

- [ ] Verify reverted recipes match their `runtime-1.0.0` tag versions
- [ ] No functional testing needed — these are reverts to known-good tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image tags across multiple deployment configurations for DeepSeek-r1, Llama-3-70b, and Qwen3-235b-a22b-fp8 recipes.
  * Modified image versions for sglang-runtime, tensorrtllm-runtime, vllm-runtime, and frontend containers in Kubernetes deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->