### PR TITLE
fix: use list+watch to reduce API server load 

### DIFF
--- a/components/src/dynamo/global_planner/__main__.py
+++ b/components/src/dynamo/global_planner/__main__.py
@@ -142,23 +142,23 @@ async def main(runtime: DistributedRuntime, args):
     logger.info("GlobalPlanner is ready and waiting for scale requests")
     logger.info("=" * 60)
 
-    # Periodic liveness check for DGD watch thread (list+watch always runs)
-    DGD_WATCH_LIVENESS_INTERVAL_SEC = 60
+    if args.max_total_gpus >= 0:
+        DGD_WATCH_LIVENESS_INTERVAL_SEC = 60
 
-    async def watch_liveness_loop():
-        while True:
-            await asyncio.sleep(DGD_WATCH_LIVENESS_INTERVAL_SEC)
-            if not handler.is_dgd_watch_healthy():
-                logger.critical(
-                    "DGD watch thread is not running; DGD cache may be stale. "
-                    "Scaling decisions may use outdated data."
-                )
+        async def watch_liveness_loop():
+            while True:
+                await asyncio.sleep(DGD_WATCH_LIVENESS_INTERVAL_SEC)
+                if not handler.is_dgd_watch_healthy():
+                    logger.critical(
+                        "DGD watch thread is not running; DGD cache may be stale. "
+                        "Scaling decisions may use outdated data."
+                    )
 
-    asyncio.create_task(watch_liveness_loop())
-    logger.info(
-        "DGD watch liveness check started (interval %ds)",
-        DGD_WATCH_LIVENESS_INTERVAL_SEC,
-    )
+        asyncio.create_task(watch_liveness_loop())
+        logger.info(
+            "DGD watch liveness check started (interval %ds)",
+            DGD_WATCH_LIVENESS_INTERVAL_SEC,
+        )
 
     # Keep running forever (process scale requests as they come)
     await asyncio.Event().wait()

--- a/components/src/dynamo/global_planner/__main__.py
+++ b/components/src/dynamo/global_planner/__main__.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel
 
 from dynamo.global_planner.argparse_config import create_global_planner_parser
 from dynamo.global_planner.scale_handler import ScaleRequestHandler
-from dynamo.runtime import DistributedRuntime, dynamo_worker
+from dynamo.runtime import DistributedRuntime, dynamo_endpoint, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
 
 configure_dynamo_logging()
@@ -33,6 +33,17 @@ class HealthCheckRequest(BaseModel):
     """Request type for health check endpoint"""
 
     text: str = "ping"
+
+
+class HealthCheckResponse(BaseModel):
+    """Response type for health check endpoint"""
+
+    status: str
+    component: str
+    namespace: str
+    managed_namespaces: object
+    dgd_watch: dict
+    message: str = ""
 
 
 @dynamo_worker()
@@ -99,10 +110,11 @@ async def main(runtime: DistributedRuntime, args):
     # Serve scale_request endpoint
     logger.info("Serving endpoints...")
     scale_endpoint = runtime.endpoint(f"{namespace}.GlobalPlanner.scale_request")
-    await scale_endpoint.serve_endpoint(handler.scale_request)
+    asyncio.ensure_future(scale_endpoint.serve_endpoint(handler.scale_request))
     logger.info("  ✓ scale_request - Receives scaling requests from Planners")
 
     # Serve health check endpoint (includes DGD watch health)
+    @dynamo_endpoint(HealthCheckRequest, HealthCheckResponse)
     async def health_check(request: HealthCheckRequest):
         """Health check endpoint for monitoring"""
         payload = {
@@ -123,7 +135,7 @@ async def main(runtime: DistributedRuntime, args):
         yield payload
 
     health_endpoint = runtime.endpoint(f"{namespace}.GlobalPlanner.health")
-    await health_endpoint.serve_endpoint(health_check)
+    asyncio.ensure_future(health_endpoint.serve_endpoint(health_check))
     logger.info("  ✓ health - Health check endpoint")
 
     logger.info("=" * 60)

--- a/components/src/dynamo/global_planner/__main__.py
+++ b/components/src/dynamo/global_planner/__main__.py
@@ -102,15 +102,25 @@ async def main(runtime: DistributedRuntime, args):
     await scale_endpoint.serve_endpoint(handler.scale_request)
     logger.info("  ✓ scale_request - Receives scaling requests from Planners")
 
-    # Serve health check endpoint
+    # Serve health check endpoint (includes DGD watch health)
     async def health_check(request: HealthCheckRequest):
         """Health check endpoint for monitoring"""
-        yield {
+        payload = {
             "status": "healthy",
             "component": "GlobalPlanner",
             "namespace": namespace,
             "managed_namespaces": args.managed_namespaces or "all",
         }
+        dgd_watch_status = handler.get_dgd_watch_health_status()
+        payload["dgd_watch"] = dgd_watch_status
+        if dgd_watch_status.get("dgd_watch_enabled") and not dgd_watch_status.get(
+            "dgd_watch_alive", True
+        ):
+            payload["status"] = "degraded"
+            payload[
+                "message"
+            ] = "DGD watch thread not running; GPU budget cache may be stale"
+        yield payload
 
     health_endpoint = runtime.endpoint(f"{namespace}.GlobalPlanner.health")
     await health_endpoint.serve_endpoint(health_check)
@@ -119,6 +129,24 @@ async def main(runtime: DistributedRuntime, args):
     logger.info("=" * 60)
     logger.info("GlobalPlanner is ready and waiting for scale requests")
     logger.info("=" * 60)
+
+    # Periodic liveness check for DGD watch thread (list+watch always runs)
+    DGD_WATCH_LIVENESS_INTERVAL_SEC = 60
+
+    async def watch_liveness_loop():
+        while True:
+            await asyncio.sleep(DGD_WATCH_LIVENESS_INTERVAL_SEC)
+            if not handler.is_dgd_watch_healthy():
+                logger.critical(
+                    "DGD watch thread is not running; DGD cache may be stale. "
+                    "Scaling decisions may use outdated data."
+                )
+
+    asyncio.create_task(watch_liveness_loop())
+    logger.info(
+        "DGD watch liveness check started (interval %ds)",
+        DGD_WATCH_LIVENESS_INTERVAL_SEC,
+    )
 
     # Keep running forever (process scale requests as they come)
     await asyncio.Event().wait()

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -12,7 +12,6 @@ from typing import Optional
 from kubernetes import client
 
 from dynamo.planner import KubernetesConnector
-from dynamo.planner.config.defaults import SubComponentType
 from dynamo.planner.connectors.kubernetes_api import KubernetesAPI
 from dynamo.planner.connectors.protocol import ScaleRequest, ScaleResponse, ScaleStatus
 from dynamo.runtime import DistributedRuntime, dynamo_endpoint
@@ -65,8 +64,8 @@ class ScaleRequestHandler:
         self.no_operation = no_operation
         self.max_total_gpus = max_total_gpus
         self.connectors: dict[str, KubernetesConnector] = {}  # Cache per DGD
-        # Protects connectors dict (main + watch thread); held briefly.
-        self._connectors_lock = threading.Lock()
+        self._dgd_cache: dict[str, dict] = {}  # DGD objects maintained by watch thread
+        self._dgd_cache_lock = threading.Lock()
         # Serializes budget-check + scale-execution so concurrent requests from
         # different pools cannot both pass against the same pre-scale state.
         self._scale_lock = asyncio.Lock()
@@ -88,19 +87,18 @@ class ScaleRequestHandler:
                 "scale requests will be logged but not executed"
             )
 
-        # Always run list+watch to reduce API server pressure (single stream vs many get/list).
-        # The cache is also used for GPU budget checks (multi-replica safe).
-        self._populate_k8s_connectors()
-        self._dgd_watch_thread = threading.Thread(
-            target=self._run_dgd_watch, daemon=True, name="global-planner-dgd-watch"
-        )
-        self._dgd_watch_thread.start()
-        logger.info("DGD list+watch started (reduces API server load)")
-
         if self.max_total_gpus >= 0:
             logger.info(
                 f"GPU budget enforcement ENABLED: max {self.max_total_gpus} total GPUs"
             )
+            self._populate_k8s_connectors()
+            self._dgd_watch_thread = threading.Thread(
+                target=self._run_dgd_watch,
+                daemon=True,
+                name="global-planner-dgd-watch",
+            )
+            self._dgd_watch_thread.start()
+            logger.info("DGD list+watch started for GPU budget cache")
         else:
             logger.info("GPU budget enforcement DISABLED (unlimited)")
 
@@ -148,22 +146,21 @@ class ScaleRequestHandler:
                 if managed_names is not None and name not in managed_names:
                     continue
                 key = f"{self.k8s_namespace}/{name}"
-                with self._connectors_lock:
-                    self.connectors[key] = {
-                        "dgd": dgd,
-                        "connector": KubernetesConnector(
-                            dynamo_namespace="discovered",
-                            k8s_namespace=self.k8s_namespace,
-                            parent_dgd_name=name,
-                        ),
-                    }
+                if key not in self.connectors:
+                    self.connectors[key] = KubernetesConnector(
+                        dynamo_namespace="discovered",
+                        k8s_namespace=self.k8s_namespace,
+                        parent_dgd_name=name,
+                    )
+                with self._dgd_cache_lock:
+                    self._dgd_cache[key] = dgd
                 discovered.append(name)
             logger.info(f"Discovered {len(discovered)} existing DGDs: {discovered}")
         except Exception as e:
             logger.warning(f"Failed to discover existing DGDs: {e}")
 
     def _run_dgd_watch(self) -> None:
-        """Background thread: list+watch DGDs and keep connectors[].dgd updated."""
+        """Background thread: list+watch DGDs and keep _dgd_cache updated."""
         _BACKOFF_BASE_SEC = 5
         _BACKOFF_MAX_SEC = 60
         _ERROR_LOG_THRESHOLD = (
@@ -183,17 +180,11 @@ class ScaleRequestHandler:
                             continue
                         key = f"{self.k8s_namespace}/{name}"
                         logger.debug(f"DGD watch event: {event_type} {key}")
-                        with self._connectors_lock:
+                        with self._dgd_cache_lock:
                             if event_type == "DELETED":
-                                self.connectors.pop(key, None)
+                                self._dgd_cache.pop(key, None)
                             else:
-                                if key not in self.connectors:
-                                    self.connectors[key] = {
-                                        "dgd": dgd,
-                                        "connector": None,
-                                    }
-                                else:
-                                    self.connectors[key]["dgd"] = dgd
+                                self._dgd_cache[key] = dgd
                     # watch_graph_deployments exhausted without error → reset counter
                     consecutive_failures = 0
                 except client.ApiException as e:
@@ -252,7 +243,7 @@ class ScaleRequestHandler:
             )
 
     def is_dgd_watch_healthy(self) -> bool:
-        """Return True if the DGD watch thread is running. List+watch is always started."""
+        """Return True if the DGD watch thread is alive."""
         if self._dgd_watch_thread is None:
             return False
         if self._dgd_watch_exited_unexpectedly:
@@ -260,43 +251,21 @@ class ScaleRequestHandler:
         return self._dgd_watch_thread.is_alive()
 
     def get_dgd_watch_health_status(self) -> dict:
-        """Return health status for the DGD watch thread (for health endpoint).
-        List+watch is always enabled to reduce API server load.
-        """
+        """Return health status for the DGD watch thread (for health endpoint)."""
+        enabled = self.max_total_gpus >= 0
         return {
-            "dgd_watch_enabled": True,
+            "dgd_watch_enabled": enabled,
             "dgd_watch_alive": self.is_dgd_watch_healthy(),
             "dgd_watch_exited_unexpectedly": self._dgd_watch_exited_unexpectedly,
-            "gpu_budget_enabled": self.max_total_gpus >= 0,
+            "gpu_budget_enabled": enabled,
         }
-
-    def _update_cache_after_scale(
-        self, connector_key: str, target_replicas: list
-    ) -> None:
-        """Update cached DGD with new replica counts after a successful scale (no API call)."""
-        with self._connectors_lock:
-            entry = self.connectors.get(connector_key)
-            deployment = entry.get("dgd") if entry else None
-            if not deployment:
-                return
-            services = deployment.setdefault("spec", {}).setdefault("services", {})
-            for target in target_replicas:
-                sub_type = (
-                    target.sub_component_type.value
-                    if isinstance(target.sub_component_type, SubComponentType)
-                    else target.sub_component_type
-                )
-                for svc_spec in services.values():
-                    if svc_spec.get("subComponentType") == sub_type:
-                        svc_spec["replicas"] = target.desired_replicas
-                        break
 
     def _calculate_total_gpus_after_request(self, request: ScaleRequest) -> int:
         """Calculate total GPUs across all managed DGDs if this request is granted.
 
-        Uses the list+watch DGD cache when GPU budget is enabled so every replica
-        has the same full view (multi-replica safe). For the requesting DGD, uses
-        the desired replica counts from the request; for others, current spec.
+        Uses the list+watch DGD cache when GPU budget is enabled to avoid
+        per-request API calls. For the requesting DGD, uses the desired replica
+        counts from the request; for others, current spec.
 
         NOTE: GPU count is read from spec.services[].resources.limits.gpu only.
         GPUs specified via resources.requests.gpu or extraPodSpec resource
@@ -306,30 +275,18 @@ class ScaleRequestHandler:
         requesting_key = f"{request.k8s_namespace}/{request.graph_deployment_name}"
         deployments: list = []
 
-        # Always use list+watch cache when GPU budget is on: no per-request get per DGD.
         if self.max_total_gpus >= 0:
-            with self._connectors_lock:
-                deployments = [
-                    (k, e.get("dgd"))
-                    for k, e in self.connectors.items()
-                    if e.get("dgd")
-                ]
-                need_get = requesting_key not in self.connectors or not self.connectors[
-                    requesting_key
-                ].get("dgd")
+            with self._dgd_cache_lock:
+                deployments = list(self._dgd_cache.items())
+                need_get = requesting_key not in self._dgd_cache
             if need_get:
                 try:
                     kube_api = KubernetesAPI(self.k8s_namespace)
                     deployment = kube_api.get_graph_deployment(
                         request.graph_deployment_name
                     )
-                    with self._connectors_lock:
-                        if requesting_key not in self.connectors:
-                            self.connectors[requesting_key] = {
-                                "dgd": None,
-                                "connector": None,
-                            }
-                        self.connectors[requesting_key]["dgd"] = deployment
+                    with self._dgd_cache_lock:
+                        self._dgd_cache[requesting_key] = deployment
                     deployments.append((requesting_key, deployment))
                 except Exception as e:
                     logger.warning(
@@ -413,23 +370,14 @@ class ScaleRequestHandler:
 
             # Get or create connector for this DGD
             connector_key = f"{request.k8s_namespace}/{request.graph_deployment_name}"
-            with self._connectors_lock:
-                entry = self.connectors.get(connector_key)
-                connector = entry.get("connector") if entry else None
+            connector = self.connectors.get(connector_key)
             if connector is None:
                 connector = KubernetesConnector(
                     dynamo_namespace=request.caller_namespace,
                     k8s_namespace=request.k8s_namespace,
                     parent_dgd_name=request.graph_deployment_name,
                 )
-                with self._connectors_lock:
-                    if connector_key not in self.connectors:
-                        self.connectors[connector_key] = {
-                            "dgd": None,
-                            "connector": connector,
-                        }
-                    else:
-                        self.connectors[connector_key]["connector"] = connector
+                self.connectors[connector_key] = connector
                 logger.debug(f"Created new connector for {connector_key}")
             else:
                 logger.debug(f"Reusing cached connector for {connector_key}")
@@ -464,11 +412,7 @@ class ScaleRequestHandler:
                     request.target_replicas, blocking=request.blocking
                 )
 
-            # Optimistic cache update so next budget calculation sees new replicas immediately.
-            self._update_cache_after_scale(connector_key, request.target_replicas)
-
-            # Verify and report: read DGD from API for server-authoritative current_replicas
-            # and refresh cache with actual state (watch may deliver MODIFIED later).
+            # Read DGD from API for current_replicas and refresh cache.
             deployment = connector.kube_api.get_graph_deployment(
                 connector.parent_dgd_name
             )
@@ -479,13 +423,8 @@ class ScaleRequestHandler:
                 sub_type = service_spec.get("subComponentType", "")
                 if sub_type:
                     current_replicas[sub_type] = service_spec.get("replicas", 0)
-            with self._connectors_lock:
-                if connector_key not in self.connectors:
-                    self.connectors[connector_key] = {
-                        "dgd": None,
-                        "connector": connector,
-                    }
-                self.connectors[connector_key]["dgd"] = deployment
+            with self._dgd_cache_lock:
+                self._dgd_cache[connector_key] = deployment
 
             logger.info(
                 f"Successfully scaled {request.graph_deployment_name}: {current_replicas}"

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -5,8 +5,11 @@
 
 import asyncio
 import logging
+import threading
+import time
 
 from dynamo.planner import KubernetesConnector
+from dynamo.planner.config.defaults import SubComponentType
 from dynamo.planner.connectors.kubernetes_api import KubernetesAPI
 from dynamo.planner.connectors.protocol import ScaleRequest, ScaleResponse, ScaleStatus
 from dynamo.runtime import DistributedRuntime, dynamo_endpoint
@@ -59,6 +62,8 @@ class ScaleRequestHandler:
         self.no_operation = no_operation
         self.max_total_gpus = max_total_gpus
         self.connectors: dict[str, KubernetesConnector] = {}  # Cache per DGD
+        # Protects connectors dict (main + watch thread); held briefly.
+        self._connectors_lock = threading.Lock()
         # Serializes budget-check + scale-execution so concurrent requests from
         # different pools cannot both pass against the same pre-scale state.
         self._scale_lock = asyncio.Lock()
@@ -81,6 +86,11 @@ class ScaleRequestHandler:
                 f"GPU budget enforcement ENABLED: max {self.max_total_gpus} total GPUs"
             )
             self._populate_k8s_connectors()
+            _watch_thread = threading.Thread(
+                target=self._run_dgd_watch, daemon=True, name="global-planner-dgd-watch"
+            )
+            _watch_thread.start()
+            logger.info("DGD list+watch started for GPU budget (multi-replica safe)")
         else:
             logger.info("GPU budget enforcement DISABLED (unlimited)")
 
@@ -109,15 +119,12 @@ class ScaleRequestHandler:
                 )
         return names
 
-    def _populate_k8s_connectors(self):
-        """Pre-populate connectors for DGDs managed by this GlobalPlanner.
+    def _populate_k8s_connectors(self) -> None:
+        """Populate connectors from a single list call.
 
-        This ensures the GPU budget calculation accounts for DGDs that already
-        exist at startup, even if they haven't sent a scale request yet.
-
-        In explicit mode (--managed-namespaces set), only DGDs whose names
-        match the managed Dynamo namespaces are discovered.
-        In implicit mode, all DGDs in the k8s namespace are discovered.
+        Ensures GPU budget and connectors have data before watch events.
+        In explicit mode only managed DGDs are included; in implicit mode all
+        DGDs in the k8s namespace are discovered.
         """
         try:
             kube_api = KubernetesAPI(self.k8s_namespace)
@@ -128,27 +135,75 @@ class ScaleRequestHandler:
                 name = dgd.get("metadata", {}).get("name", "")
                 if not name:
                     continue
-                # In explicit mode, skip DGDs not in the managed set
                 if managed_names is not None and name not in managed_names:
                     continue
-                connector_key = f"{self.k8s_namespace}/{name}"
-                if connector_key not in self.connectors:
-                    connector = KubernetesConnector(
-                        dynamo_namespace="discovered",
-                        k8s_namespace=self.k8s_namespace,
-                        parent_dgd_name=name,
-                    )
-                    self.connectors[connector_key] = connector
+                key = f"{self.k8s_namespace}/{name}"
+                with self._connectors_lock:
+                    self.connectors[key] = {
+                        "dgd": dgd,
+                        "connector": KubernetesConnector(
+                            dynamo_namespace="discovered",
+                            k8s_namespace=self.k8s_namespace,
+                            parent_dgd_name=name,
+                        ),
+                    }
                 discovered.append(name)
             logger.info(f"Discovered {len(discovered)} existing DGDs: {discovered}")
         except Exception as e:
             logger.warning(f"Failed to discover existing DGDs: {e}")
 
+    def _run_dgd_watch(self) -> None:
+        """Background thread: list+watch DGDs and keep connectors[].dgd updated."""
+        kube_api = KubernetesAPI(self.k8s_namespace)
+        managed_names = self._managed_dgd_names()
+        while True:
+            try:
+                for event_type, dgd in kube_api.watch_graph_deployments():
+                    name = dgd.get("metadata", {}).get("name", "")
+                    if not name:
+                        continue
+                    if managed_names is not None and name not in managed_names:
+                        continue
+                    key = f"{self.k8s_namespace}/{name}"
+                    with self._connectors_lock:
+                        if event_type == "DELETED":
+                            self.connectors.pop(key, None)
+                        else:
+                            if key not in self.connectors:
+                                self.connectors[key] = {"dgd": dgd, "connector": None}
+                            else:
+                                self.connectors[key]["dgd"] = dgd
+            except Exception as e:
+                logger.warning(f"DGD watch error (will restart): {e}")
+                time.sleep(5)
+
+    def _update_cache_after_scale(
+        self, connector_key: str, target_replicas: list
+    ) -> None:
+        """Update cached DGD with new replica counts after a successful scale (no API call)."""
+        with self._connectors_lock:
+            entry = self.connectors.get(connector_key)
+            deployment = entry.get("dgd") if entry else None
+            if not deployment:
+                return
+            services = deployment.setdefault("spec", {}).setdefault("services", {})
+            for target in target_replicas:
+                sub_type = (
+                    target.sub_component_type.value
+                    if isinstance(target.sub_component_type, SubComponentType)
+                    else target.sub_component_type
+                )
+                for svc_spec in services.values():
+                    if svc_spec.get("subComponentType") == sub_type:
+                        svc_spec["replicas"] = target.desired_replicas
+                        break
+
     def _calculate_total_gpus_after_request(self, request: ScaleRequest) -> int:
         """Calculate total GPUs across all managed DGDs if this request is granted.
 
-        For the requesting DGD, uses the desired replica counts from the request.
-        For all other known DGDs, uses their current replica counts.
+        Uses the list+watch DGD cache when GPU budget is enabled so every replica
+        has the same full view (multi-replica safe). For the requesting DGD, uses
+        the desired replica counts from the request; for others, current spec.
 
         NOTE: GPU count is read from spec.services[].resources.limits.gpu only.
         GPUs specified via resources.requests.gpu or extraPodSpec resource
@@ -156,16 +211,33 @@ class ScaleRequestHandler:
         """
         total_gpus = 0
         requesting_key = f"{request.k8s_namespace}/{request.graph_deployment_name}"
+        deployments: list = []
 
-        for key, connector in self.connectors.items():
-            try:
-                deployment = connector.kube_api.get_graph_deployment(
-                    connector.parent_dgd_name
-                )
-            except Exception as e:
-                logger.warning(f"Failed to read DGD for {key}: {e}")
+        # Always use list+watch cache when GPU budget is on: no per-request get per DGD.
+        if self.max_total_gpus >= 0:
+            with self._connectors_lock:
+                deployments = [
+                    (k, e.get("dgd")) for k, e in self.connectors.items() if e.get("dgd")
+                ]
+                need_get = requesting_key not in self.connectors or not self.connectors[
+                    requesting_key
+                ].get("dgd")
+            if need_get:
+                try:
+                    kube_api = KubernetesAPI(self.k8s_namespace)
+                    deployment = kube_api.get_graph_deployment(
+                        request.graph_deployment_name
+                    )
+                    with self._connectors_lock:
+                        if requesting_key not in self.connectors:
+                            self.connectors[requesting_key] = {"dgd": None, "connector": None}
+                        self.connectors[requesting_key]["dgd"] = deployment
+                    deployments.append((requesting_key, deployment))
+                except Exception as e:
+                    logger.warning(f"Failed to read requesting DGD for {requesting_key}: {e}")
+        for key, deployment in deployments:
+            if not deployment:
                 continue
-
             services = deployment.get("spec", {}).get("services", {})
 
             for svc_spec in services.values():
@@ -241,16 +313,22 @@ class ScaleRequestHandler:
 
             # Get or create connector for this DGD
             connector_key = f"{request.k8s_namespace}/{request.graph_deployment_name}"
-            if connector_key not in self.connectors:
+            with self._connectors_lock:
+                entry = self.connectors.get(connector_key)
+                connector = entry.get("connector") if entry else None
+            if connector is None:
                 connector = KubernetesConnector(
                     dynamo_namespace=request.caller_namespace,
                     k8s_namespace=request.k8s_namespace,
                     parent_dgd_name=request.graph_deployment_name,
                 )
-                self.connectors[connector_key] = connector
+                with self._connectors_lock:
+                    if connector_key not in self.connectors:
+                        self.connectors[connector_key] = {"dgd": None, "connector": connector}
+                    else:
+                        self.connectors[connector_key]["connector"] = connector
                 logger.debug(f"Created new connector for {connector_key}")
             else:
-                connector = self.connectors[connector_key]
                 logger.debug(f"Reusing cached connector for {connector_key}")
 
             # Lock ensures the budget check and scale execution are atomic
@@ -283,15 +361,25 @@ class ScaleRequestHandler:
                     request.target_replicas, blocking=request.blocking
                 )
 
-            # Get current replica counts
-            current_replicas = {}
+            # Optimistic cache update so next budget calculation sees new replicas immediately.
+            self._update_cache_after_scale(connector_key, request.target_replicas)
+
+            # Verify and report: read DGD from API for server-authoritative current_replicas
+            # and refresh cache with actual state (watch may deliver MODIFIED later).
             deployment = connector.kube_api.get_graph_deployment(
                 connector.parent_dgd_name
             )
-            for service_name, service_spec in deployment["spec"]["services"].items():
+            current_replicas = {}
+            for service_name, service_spec in deployment.get("spec", {}).get(
+                "services", {}
+            ).items():
                 sub_type = service_spec.get("subComponentType", "")
                 if sub_type:
                     current_replicas[sub_type] = service_spec.get("replicas", 0)
+            with self._connectors_lock:
+                if connector_key not in self.connectors:
+                    self.connectors[connector_key] = {"dgd": None, "connector": connector}
+                self.connectors[connector_key]["dgd"] = deployment
 
             logger.info(
                 f"Successfully scaled {request.graph_deployment_name}: {current_replicas}"

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -182,6 +182,7 @@ class ScaleRequestHandler:
                         if managed_names is not None and name not in managed_names:
                             continue
                         key = f"{self.k8s_namespace}/{name}"
+                        logger.debug(f"DGD watch event: {event_type} {key}")
                         with self._connectors_lock:
                             if event_type == "DELETED":
                                 self.connectors.pop(key, None)

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -9,6 +9,8 @@ import threading
 import time
 from typing import Optional
 
+from kubernetes import client
+
 from dynamo.planner import KubernetesConnector
 from dynamo.planner.config.defaults import SubComponentType
 from dynamo.planner.connectors.kubernetes_api import KubernetesAPI
@@ -162,9 +164,15 @@ class ScaleRequestHandler:
 
     def _run_dgd_watch(self) -> None:
         """Background thread: list+watch DGDs and keep connectors[].dgd updated."""
+        _BACKOFF_BASE_SEC = 5
+        _BACKOFF_MAX_SEC = 60
+        _ERROR_LOG_THRESHOLD = (
+            3  # escalate to ERROR after this many consecutive failures
+        )
         try:
             kube_api = KubernetesAPI(self.k8s_namespace)
             managed_names = self._managed_dgd_names()
+            consecutive_failures = 0
             while True:
                 try:
                     for event_type, dgd in kube_api.watch_graph_deployments():
@@ -185,9 +193,55 @@ class ScaleRequestHandler:
                                     }
                                 else:
                                     self.connectors[key]["dgd"] = dgd
+                    # watch_graph_deployments exhausted without error → reset counter
+                    consecutive_failures = 0
+                except client.ApiException as e:
+                    consecutive_failures += 1
+                    backoff = min(
+                        _BACKOFF_BASE_SEC * (2 ** (consecutive_failures - 1)),
+                        _BACKOFF_MAX_SEC,
+                    )
+                    if e.status == 403:
+                        # RBAC misconfiguration: backing off but flagging loudly.
+                        logger.error(
+                            f"DGD watch RBAC error (403 Forbidden, attempt {consecutive_failures}, "
+                            f"retry in {backoff}s). Check planner ClusterRole/Role for 'watch' verb "
+                            f"on dynamographdeployments: {e}"
+                        )
+                    elif e.status == 410:
+                        # Normal expiry: re-list will happen on next iteration.
+                        consecutive_failures = 0
+                        backoff = 0
+                        logger.debug(
+                            "DGD watch resource version expired (410), restarting immediately"
+                        )
+                    else:
+                        log_fn = (
+                            logger.error
+                            if consecutive_failures > _ERROR_LOG_THRESHOLD
+                            else logger.warning
+                        )
+                        log_fn(
+                            f"DGD watch ApiException (status={e.status}, attempt {consecutive_failures}, "
+                            f"retry in {backoff}s): {e}"
+                        )
+                    if backoff:
+                        time.sleep(backoff)
                 except Exception as e:
-                    logger.warning(f"DGD watch error (will restart): {e}")
-                    time.sleep(5)
+                    consecutive_failures += 1
+                    backoff = min(
+                        _BACKOFF_BASE_SEC * (2 ** (consecutive_failures - 1)),
+                        _BACKOFF_MAX_SEC,
+                    )
+                    log_fn = (
+                        logger.error
+                        if consecutive_failures > _ERROR_LOG_THRESHOLD
+                        else logger.warning
+                    )
+                    log_fn(
+                        f"DGD watch error (attempt {consecutive_failures}, retry in {backoff}s): {e}"
+                    )
+                    time.sleep(backoff)
         except BaseException:
             self._dgd_watch_exited_unexpectedly = True
             logger.critical(
@@ -418,7 +472,7 @@ class ScaleRequestHandler:
                 connector.parent_dgd_name
             )
             current_replicas = {}
-            for service_name, service_spec in (
+            for _service_name, service_spec in (
                 deployment.get("spec", {}).get("services", {}).items()
             ):
                 sub_type = service_spec.get("subComponentType", "")

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -195,7 +195,6 @@ class ScaleRequestHandler:
                 "scaling decisions may use outdated data.",
                 exc_info=True,
             )
-            raise
 
     def is_dgd_watch_healthy(self) -> bool:
         """Return True if the DGD watch thread is running. List+watch is always started."""

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 import threading
 import time
+from typing import Optional
 
 from dynamo.planner import KubernetesConnector
 from dynamo.planner.config.defaults import SubComponentType
@@ -67,6 +68,10 @@ class ScaleRequestHandler:
         # Serializes budget-check + scale-execution so concurrent requests from
         # different pools cannot both pass against the same pre-scale state.
         self._scale_lock = asyncio.Lock()
+        # DGD watch thread (when GPU budget enabled); health checked by main loop.
+        self._dgd_watch_thread: Optional[threading.Thread] = None
+        # Set when _run_dgd_watch exits unexpectedly; GPU budget cache may be stale.
+        self._dgd_watch_exited_unexpectedly: bool = False
 
         if self.managed_namespaces:
             logger.info(
@@ -81,16 +86,19 @@ class ScaleRequestHandler:
                 "scale requests will be logged but not executed"
             )
 
+        # Always run list+watch to reduce API server pressure (single stream vs many get/list).
+        # The cache is also used for GPU budget checks (multi-replica safe).
+        self._populate_k8s_connectors()
+        self._dgd_watch_thread = threading.Thread(
+            target=self._run_dgd_watch, daemon=True, name="global-planner-dgd-watch"
+        )
+        self._dgd_watch_thread.start()
+        logger.info("DGD list+watch started (reduces API server load)")
+
         if self.max_total_gpus >= 0:
             logger.info(
                 f"GPU budget enforcement ENABLED: max {self.max_total_gpus} total GPUs"
             )
-            self._populate_k8s_connectors()
-            _watch_thread = threading.Thread(
-                target=self._run_dgd_watch, daemon=True, name="global-planner-dgd-watch"
-            )
-            _watch_thread.start()
-            logger.info("DGD list+watch started for GPU budget (multi-replica safe)")
         else:
             logger.info("GPU budget enforcement DISABLED (unlimited)")
 
@@ -154,28 +162,59 @@ class ScaleRequestHandler:
 
     def _run_dgd_watch(self) -> None:
         """Background thread: list+watch DGDs and keep connectors[].dgd updated."""
-        kube_api = KubernetesAPI(self.k8s_namespace)
-        managed_names = self._managed_dgd_names()
-        while True:
-            try:
-                for event_type, dgd in kube_api.watch_graph_deployments():
-                    name = dgd.get("metadata", {}).get("name", "")
-                    if not name:
-                        continue
-                    if managed_names is not None and name not in managed_names:
-                        continue
-                    key = f"{self.k8s_namespace}/{name}"
-                    with self._connectors_lock:
-                        if event_type == "DELETED":
-                            self.connectors.pop(key, None)
-                        else:
-                            if key not in self.connectors:
-                                self.connectors[key] = {"dgd": dgd, "connector": None}
+        try:
+            kube_api = KubernetesAPI(self.k8s_namespace)
+            managed_names = self._managed_dgd_names()
+            while True:
+                try:
+                    for event_type, dgd in kube_api.watch_graph_deployments():
+                        name = dgd.get("metadata", {}).get("name", "")
+                        if not name:
+                            continue
+                        if managed_names is not None and name not in managed_names:
+                            continue
+                        key = f"{self.k8s_namespace}/{name}"
+                        with self._connectors_lock:
+                            if event_type == "DELETED":
+                                self.connectors.pop(key, None)
                             else:
-                                self.connectors[key]["dgd"] = dgd
-            except Exception as e:
-                logger.warning(f"DGD watch error (will restart): {e}")
-                time.sleep(5)
+                                if key not in self.connectors:
+                                    self.connectors[key] = {
+                                        "dgd": dgd,
+                                        "connector": None,
+                                    }
+                                else:
+                                    self.connectors[key]["dgd"] = dgd
+                except Exception as e:
+                    logger.warning(f"DGD watch error (will restart): {e}")
+                    time.sleep(5)
+        except BaseException:
+            self._dgd_watch_exited_unexpectedly = True
+            logger.critical(
+                "DGD watch thread exited unexpectedly. GPU budget cache is stale; "
+                "scaling decisions may use outdated data.",
+                exc_info=True,
+            )
+            raise
+
+    def is_dgd_watch_healthy(self) -> bool:
+        """Return True if the DGD watch thread is running. List+watch is always started."""
+        if self._dgd_watch_thread is None:
+            return False
+        if self._dgd_watch_exited_unexpectedly:
+            return False
+        return self._dgd_watch_thread.is_alive()
+
+    def get_dgd_watch_health_status(self) -> dict:
+        """Return health status for the DGD watch thread (for health endpoint).
+        List+watch is always enabled to reduce API server load.
+        """
+        return {
+            "dgd_watch_enabled": True,
+            "dgd_watch_alive": self.is_dgd_watch_healthy(),
+            "dgd_watch_exited_unexpectedly": self._dgd_watch_exited_unexpectedly,
+            "gpu_budget_enabled": self.max_total_gpus >= 0,
+        }
 
     def _update_cache_after_scale(
         self, connector_key: str, target_replicas: list
@@ -217,7 +256,9 @@ class ScaleRequestHandler:
         if self.max_total_gpus >= 0:
             with self._connectors_lock:
                 deployments = [
-                    (k, e.get("dgd")) for k, e in self.connectors.items() if e.get("dgd")
+                    (k, e.get("dgd"))
+                    for k, e in self.connectors.items()
+                    if e.get("dgd")
                 ]
                 need_get = requesting_key not in self.connectors or not self.connectors[
                     requesting_key
@@ -230,11 +271,16 @@ class ScaleRequestHandler:
                     )
                     with self._connectors_lock:
                         if requesting_key not in self.connectors:
-                            self.connectors[requesting_key] = {"dgd": None, "connector": None}
+                            self.connectors[requesting_key] = {
+                                "dgd": None,
+                                "connector": None,
+                            }
                         self.connectors[requesting_key]["dgd"] = deployment
                     deployments.append((requesting_key, deployment))
                 except Exception as e:
-                    logger.warning(f"Failed to read requesting DGD for {requesting_key}: {e}")
+                    logger.warning(
+                        f"Failed to read requesting DGD for {requesting_key}: {e}"
+                    )
         for key, deployment in deployments:
             if not deployment:
                 continue
@@ -324,7 +370,10 @@ class ScaleRequestHandler:
                 )
                 with self._connectors_lock:
                     if connector_key not in self.connectors:
-                        self.connectors[connector_key] = {"dgd": None, "connector": connector}
+                        self.connectors[connector_key] = {
+                            "dgd": None,
+                            "connector": connector,
+                        }
                     else:
                         self.connectors[connector_key]["connector"] = connector
                 logger.debug(f"Created new connector for {connector_key}")
@@ -370,15 +419,18 @@ class ScaleRequestHandler:
                 connector.parent_dgd_name
             )
             current_replicas = {}
-            for service_name, service_spec in deployment.get("spec", {}).get(
-                "services", {}
-            ).items():
+            for service_name, service_spec in (
+                deployment.get("spec", {}).get("services", {}).items()
+            ):
                 sub_type = service_spec.get("subComponentType", "")
                 if sub_type:
                     current_replicas[sub_type] = service_spec.get("replicas", 0)
             with self._connectors_lock:
                 if connector_key not in self.connectors:
-                    self.connectors[connector_key] = {"dgd": None, "connector": connector}
+                    self.connectors[connector_key] = {
+                        "dgd": None,
+                        "connector": connector,
+                    }
                 self.connectors[connector_key]["dgd"] = deployment
 
             logger.info(

--- a/components/src/dynamo/planner/connectors/kubernetes_api.py
+++ b/components/src/dynamo/planner/connectors/kubernetes_api.py
@@ -15,10 +15,11 @@
 
 import asyncio
 import logging
-from typing import Optional
+from typing import Iterator, Optional
 
 from kubernetes import client, config
 from kubernetes.config.config_exception import ConfigException
+from kubernetes.watch import Watch
 
 from dynamo.planner.errors import DynamoGraphDeploymentNotFoundError
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -67,6 +68,30 @@ class KubernetesAPI:
             plural="dynamographdeployments",
         )
         return result.get("items", [])
+
+    def watch_graph_deployments(self) -> Iterator[tuple[str, dict]]:
+        """Watch DynamoGraphDeployments via Kubernetes List+Watch.
+
+        Yields (event_type, deployment) where event_type is 'ADDED', 'MODIFIED',
+        or 'DELETED', and deployment is the DynamoGraphDeployment object (for
+        DELETED, object may have only metadata). Follows K8s controller best
+        practice for consistent view across replicas.
+        """
+        w = Watch()
+        try:
+            for event in w.stream(
+                self.custom_api.list_namespaced_custom_object,
+                group="nvidia.com",
+                version="v1alpha1",
+                namespace=self.current_namespace,
+                plural="dynamographdeployments",
+            ):
+                yield event["type"], event.get("object", {})
+        except client.ApiException as e:
+            if e.status == 410:
+                # Resource version too old; caller should re-list and restart watch
+                logger.warning("DGD watch expired (410), restart required")
+            raise
 
     def get_graph_deployment(self, graph_deployment_name: str) -> dict:
         """

--- a/components/src/dynamo/planner/tests/unit/test_kube.py
+++ b/components/src/dynamo/planner/tests/unit/test_kube.py
@@ -68,6 +68,59 @@ def test_kubernetes_api_init_without_namespace(mock_custom_api, mock_config):
     assert api.current_namespace == "default"
 
 
+def test_watch_graph_deployments_yields_events(k8s_api_with_namespace, mock_custom_api):
+    """Test watch_graph_deployments yields (event_type, deployment) for each watch event."""
+    events = [
+        {"type": "ADDED", "object": {"metadata": {"name": "dgd-a"}, "spec": {}}},
+        {"type": "MODIFIED", "object": {"metadata": {"name": "dgd-a"}, "spec": {"replicas": 2}}},
+        {"type": "DELETED", "object": {"metadata": {"name": "dgd-a"}}},
+    ]
+
+    with patch("dynamo.planner.kube.Watch") as mock_watch_cls:
+        mock_watch = MagicMock()
+        mock_watch_cls.return_value = mock_watch
+        mock_watch.stream.return_value = iter(events)
+
+        out = list(k8s_api_with_namespace.watch_graph_deployments())
+
+    assert len(out) == 3
+    assert out[0] == ("ADDED", {"metadata": {"name": "dgd-a"}, "spec": {}})
+    assert out[1] == ("MODIFIED", {"metadata": {"name": "dgd-a"}, "spec": {"replicas": 2}})
+    assert out[2] == ("DELETED", {"metadata": {"name": "dgd-a"}})
+    mock_watch.stream.assert_called_once()
+    call_kw = mock_watch.stream.call_args[1]
+    assert call_kw["group"] == "nvidia.com"
+    assert call_kw["version"] == "v1alpha1"
+    assert call_kw["namespace"] == "test-namespace"
+    assert call_kw["plural"] == "dynamographdeployments"
+
+
+def test_watch_graph_deployments_reraises_410(k8s_api_with_namespace, mock_custom_api):
+    """Test watch_graph_deployments logs and re-raises ApiException on 410 Gone."""
+    with patch("dynamo.planner.kube.Watch") as mock_watch_cls:
+        mock_watch = MagicMock()
+        mock_watch_cls.return_value = mock_watch
+        mock_watch.stream.side_effect = client.ApiException(status=410)
+
+        with pytest.raises(client.ApiException) as exc_info:
+            list(k8s_api_with_namespace.watch_graph_deployments())
+
+        assert exc_info.value.status == 410
+
+
+def test_watch_graph_deployments_reraises_other_api_errors(k8s_api_with_namespace, mock_custom_api):
+    """Test watch_graph_deployments re-raises non-410 ApiException."""
+    with patch("dynamo.planner.kube.Watch") as mock_watch_cls:
+        mock_watch = MagicMock()
+        mock_watch_cls.return_value = mock_watch
+        mock_watch.stream.side_effect = client.ApiException(status=500)
+
+        with pytest.raises(client.ApiException) as exc_info:
+            list(k8s_api_with_namespace.watch_graph_deployments())
+
+        assert exc_info.value.status == 500
+
+
 def test_get_graph_deployment_from_name(k8s_api, mock_custom_api):
     """Test _get_graph_deployment_from_name method"""
     mock_deployment = {"metadata": {"name": "test-deployment"}}

--- a/components/src/dynamo/planner/tests/unit/test_kube.py
+++ b/components/src/dynamo/planner/tests/unit/test_kube.py
@@ -79,7 +79,7 @@ def test_watch_graph_deployments_yields_events(k8s_api_with_namespace, mock_cust
         {"type": "DELETED", "object": {"metadata": {"name": "dgd-a"}}},
     ]
 
-    with patch("dynamo.planner.kube.Watch") as mock_watch_cls:
+    with patch("dynamo.planner.connectors.kubernetes_api.Watch") as mock_watch_cls:
         mock_watch = MagicMock()
         mock_watch_cls.return_value = mock_watch
         mock_watch.stream.return_value = iter(events)
@@ -103,7 +103,7 @@ def test_watch_graph_deployments_yields_events(k8s_api_with_namespace, mock_cust
 
 def test_watch_graph_deployments_reraises_410(k8s_api_with_namespace, mock_custom_api):
     """Test watch_graph_deployments logs and re-raises ApiException on 410 Gone."""
-    with patch("dynamo.planner.kube.Watch") as mock_watch_cls:
+    with patch("dynamo.planner.connectors.kubernetes_api.Watch") as mock_watch_cls:
         mock_watch = MagicMock()
         mock_watch_cls.return_value = mock_watch
         mock_watch.stream.side_effect = client.ApiException(status=410)
@@ -118,7 +118,7 @@ def test_watch_graph_deployments_reraises_other_api_errors(
     k8s_api_with_namespace, mock_custom_api
 ):
     """Test watch_graph_deployments re-raises non-410 ApiException."""
-    with patch("dynamo.planner.kube.Watch") as mock_watch_cls:
+    with patch("dynamo.planner.connectors.kubernetes_api.Watch") as mock_watch_cls:
         mock_watch = MagicMock()
         mock_watch_cls.return_value = mock_watch
         mock_watch.stream.side_effect = client.ApiException(status=500)

--- a/components/src/dynamo/planner/tests/unit/test_kube.py
+++ b/components/src/dynamo/planner/tests/unit/test_kube.py
@@ -72,7 +72,10 @@ def test_watch_graph_deployments_yields_events(k8s_api_with_namespace, mock_cust
     """Test watch_graph_deployments yields (event_type, deployment) for each watch event."""
     events = [
         {"type": "ADDED", "object": {"metadata": {"name": "dgd-a"}, "spec": {}}},
-        {"type": "MODIFIED", "object": {"metadata": {"name": "dgd-a"}, "spec": {"replicas": 2}}},
+        {
+            "type": "MODIFIED",
+            "object": {"metadata": {"name": "dgd-a"}, "spec": {"replicas": 2}},
+        },
         {"type": "DELETED", "object": {"metadata": {"name": "dgd-a"}}},
     ]
 
@@ -85,7 +88,10 @@ def test_watch_graph_deployments_yields_events(k8s_api_with_namespace, mock_cust
 
     assert len(out) == 3
     assert out[0] == ("ADDED", {"metadata": {"name": "dgd-a"}, "spec": {}})
-    assert out[1] == ("MODIFIED", {"metadata": {"name": "dgd-a"}, "spec": {"replicas": 2}})
+    assert out[1] == (
+        "MODIFIED",
+        {"metadata": {"name": "dgd-a"}, "spec": {"replicas": 2}},
+    )
     assert out[2] == ("DELETED", {"metadata": {"name": "dgd-a"}})
     mock_watch.stream.assert_called_once()
     call_kw = mock_watch.stream.call_args[1]
@@ -108,7 +114,9 @@ def test_watch_graph_deployments_reraises_410(k8s_api_with_namespace, mock_custo
         assert exc_info.value.status == 410
 
 
-def test_watch_graph_deployments_reraises_other_api_errors(k8s_api_with_namespace, mock_custom_api):
+def test_watch_graph_deployments_reraises_other_api_errors(
+    k8s_api_with_namespace, mock_custom_api
+):
     """Test watch_graph_deployments re-raises non-410 ApiException."""
     with patch("dynamo.planner.kube.Watch") as mock_watch_cls:
         mock_watch = MagicMock()

--- a/deploy/helm/charts/platform/components/operator/templates/planner.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/planner.yaml
@@ -38,7 +38,7 @@ metadata:
 rules:
 - apiGroups: ["nvidia.com"]
   resources: ["dynamocomponentdeployments", "dynamographdeployments"]
-  verbs: ["get", "list", "create", "update", "patch"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
 - apiGroups: ["nvidia.com"]
   resources: ["dynamographdeploymentscalingadapters/scale"]
   verbs: ["patch"]
@@ -76,7 +76,7 @@ metadata:
 rules:
 - apiGroups: ["nvidia.com"]
   resources: ["dynamocomponentdeployments", "dynamographdeployments"]
-  verbs: ["get", "list", "create", "update", "patch"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
 - apiGroups: ["nvidia.com"]
   resources: ["dynamographdeploymentscalingadapters/scale"]
   verbs: ["patch"]


### PR DESCRIPTION
…planner bug

#### Overview:
Multiple GlobalPlanner replicas could see different DGD (DynamoGraphDeployment) state when handling scale requests. Each replica was doing its own get on the API server for every known DGD to compute total GPUs for budget checks. That led to API server pressure: Every scale request triggered N get calls (one per DGD) for GPU budget calculation.

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:
1. List+Watch for DGDs (multi-replica safe)

2. RBAC Planner Role/ClusterRole is updated so the planner can watch dynamographdeployments


<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #7416 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time monitoring of deployment changes with automatic synchronization.

* **Improvements**
  * Implemented deployment state caching to reduce API calls and improve performance.
  * Enhanced thread-safe concurrent access for deployment state management.

* **Tests**
  * Added tests for deployment watching and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->