### PR TITLE
fix: Add metadata section with canonical host

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -100,6 +100,9 @@ layout:
   tabs-placement: header
   hide-feedback: true
 
+metadata:
+  canonical-host: "docs.nvidia.com/dynamo"
+
 experimental:
   mdx-components:
     - ./components


### PR DESCRIPTION
Effort to have docs.nvidia.com/dynamo to have a higher google search ranking than docs.dynamo.nvidia.com


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation configuration to specify the canonical host for the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->