### PR TITLE
docs: add fork contributor guidance to PR workflow guidelines

### DIFF
--- a/.ai/pr-workflow-guidelines.md
+++ b/.ai/pr-workflow-guidelines.md
@@ -39,18 +39,33 @@ produces a clean, linear history where every commit is the PR author's.
 git merge main
 
 # GOOD -- clean diff showing only your work
+# Use "origin" if you cloned ai-dynamo/dynamo directly
 git fetch origin && git rebase origin/main
+
+# Use "upstream" if you cloned your fork (origin = your fork)
+git fetch upstream && git rebase upstream/main
 ```
 
 ### Guidance
 
+> **Fork contributors:** The examples below use `origin` to mean
+> `ai-dynamo/dynamo`. If you cloned your fork, replace `origin` with
+> `upstream` in fetch/rebase commands. See the
+> [Contribution Guide](https://docs.nvidia.com/dynamo/latest/contribution-guide.html)
+> for fork setup (`git remote add upstream`).
+
 - **Rebase when you are more than ~25 commits behind main.**
 - **Prefer `rebase` over `merge`** for linear history. Force-push after
-  rebasing (`git push --force-with-lease`).
+  rebasing (`git push --force-with-lease origin your-branch`).
 - **Before requesting review**, check your distance from main:
   ```bash
+  # Direct clone:
   git fetch origin
   git rev-list --count HEAD..origin/main
+
+  # Fork:
+  git fetch upstream
+  git rev-list --count HEAD..upstream/main
   ```
   More than 25? Rebase first.
 - **If CI is slow**, check your base commit age before debugging other causes.

--- a/.ai/pr-workflow-guidelines.md
+++ b/.ai/pr-workflow-guidelines.md
@@ -51,7 +51,7 @@ git fetch upstream && git rebase upstream/main
 > **Fork contributors:** The examples below use `origin` to mean
 > `ai-dynamo/dynamo`. If you cloned your fork, replace `origin` with
 > `upstream` in fetch/rebase commands. See the
-> [Contribution Guide](https://docs.nvidia.com/dynamo/latest/contribution-guide.html)
+> [Contribution Guide](https://docs.dynamo.nvidia.com/dynamo/dev/getting-started/contribution-guide)
 > for fork setup (`git remote add upstream`).
 
 - **Rebase when you are more than ~25 commits behind main.**


### PR DESCRIPTION
The rebase and distance-check commands assumed origin pointed to ai-dynamo/dynamo, which is incorrect for fork contributors. Add upstream variants and a callout explaining the distinction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced PR workflow guidelines with improved fork and clone instructions
  * Added explicit guidance for fork contributors
  * Clarified force-push and workflow processes with updated command examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->