### PR TITLE
fix: broaden operator filter to cover missing generated file paths

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -103,8 +103,7 @@ operator:
   - 'deploy/operator/**'
   - 'deploy/operator/.*'
   - 'docs/kubernetes/api-reference.md'
-  - 'deploy/helm/charts/platform/*'
-  - 'deploy/helm/charts/platform/components/operator/**'
+  - 'deploy/helm/charts/platform/**'
   - 'components/src/dynamo/profiler/utils/dgdr_*'
 
 deploy:

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -103,11 +103,9 @@ operator:
   - 'deploy/operator/**'
   - 'deploy/operator/.*'
   - 'docs/kubernetes/api-reference.md'
-  - 'deploy/helm/charts/platform/components/operator/crds/**'
-  - 'deploy/helm/charts/platform/values.yaml'
-  - 'deploy/helm/charts/platform/README.md'
-  - 'deploy/helm/charts/platform/README.md.gotmpl'
-  - 'deploy/helm/charts/platform/components/operator/values.yaml'
+  - 'deploy/helm/charts/platform/*'
+  - 'deploy/helm/charts/platform/components/operator/**'
+  - 'components/src/dynamo/profiler/utils/dgdr_*'
 
 deploy:
   - '!**/*.md'


### PR DESCRIPTION
The operator CI filter was missing paths for helm Chart.yaml files and the pydantic generated output, causing make check to detect uncommitted changes. Replace specific helm file entries with glob patterns and add the dgdr pydantic output pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator CI build trigger configuration to broaden file pattern matching and include additional build-related files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->