### PR TITLE
fix: update patch_model_runner to actually adjust total_gpu_memory

### DIFF
--- a/lib/gpu_memory_service/integrations/sglang/patches.py
+++ b/lib/gpu_memory_service/integrations/sglang/patches.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 from contextlib import contextmanager
 from typing import Optional
@@ -146,9 +147,10 @@ def patch_torch_memory_saver() -> None:
 def patch_model_runner() -> None:
     """Patch SGLang's ModelRunner to fix memory accounting with pre-loaded weights.
 
-    When weights are pre-loaded via GMS (import-only mode), SGLang's min_per_gpu_memory
-    captured before loading is lower than device total. This causes under-reservation
-    of overhead memory in KV cache calculation.
+    SGLang 0.5.9 passes a startup free-memory snapshot as total_gpu_memory into
+    init_memory_pool(). In GMS read mode, imported weights can already occupy GPU
+    memory, so that snapshot is lower than physical device capacity and the KV cache
+    overhead term is under-reserved.
     """
     global _model_runner_patched
 
@@ -165,33 +167,57 @@ def patch_model_runner() -> None:
         return
 
     original_init_memory_pool = ModelRunner.init_memory_pool
+    memory_arg_name = next(
+        (
+            name
+            for name in inspect.signature(original_init_memory_pool).parameters
+            if name != "self"
+        ),
+        None,
+    )
 
     def patched_init_memory_pool(self, *args, **kwargs):
-        """Patch init_memory_pool to use device total for overhead calculation.
+        """Patch init_memory_pool for SGLang versions that use total_gpu_memory.
 
         SGLang's KV cache formula uses total_gpu_memory as the baseline:
         rest_memory = available - total*(1-mem_fraction).
-        When weights are pre-loaded by GMS, total_gpu_memory was captured before
-        model load and reflects a partially-occupied device, making the overhead
-        term too small and over-allocating KV cache. Fix: replace total_gpu_memory
-        with the physical device capacity so the overhead term is correctly sized.
+        Replace that baseline with physical device capacity when GMS imported
+        weights are already resident. Newer SGLang versions changed this API, so
+        only rewrite the old total_gpu_memory parameter shape.
         """
         from gpu_memory_service.integrations.sglang.memory_saver import (
             get_gms_memory_saver_impl,
         )
 
         impl = get_gms_memory_saver_impl()
-        if impl is not None and impl.get_imported_weights_bytes() > 0 and args:
+        if impl is not None and impl.get_imported_weights_bytes() > 0:
             total_memory_gib = torch.cuda.get_device_properties(
                 torch.cuda.current_device()
             ).total_memory / (1 << 30)
-            old_value = args[0]
-            args = (total_memory_gib,) + args[1:]
-            logger.info(
-                "[GMS] Adjusted total_gpu_memory: %.2f GiB -> %.2f GiB",
-                old_value,
-                total_memory_gib,
-            )
+            if memory_arg_name == "total_gpu_memory":
+                if args:
+                    old_value = args[0]
+                    args = (total_memory_gib,) + args[1:]
+                elif memory_arg_name in kwargs:
+                    old_value = kwargs[memory_arg_name]
+                    kwargs = dict(kwargs)
+                    kwargs[memory_arg_name] = total_memory_gib
+                else:
+                    old_value = None
+                logger.info(
+                    "[GMS] Adjusted total_gpu_memory: %s -> %.2f GiB",
+                    (
+                        f"{old_value:.2f} GiB"
+                        if isinstance(old_value, (int, float))
+                        else "<missing>"
+                    ),
+                    total_memory_gib,
+                )
+            elif memory_arg_name is not None:
+                logger.info(
+                    "[GMS] Leaving %s unchanged in patched init_memory_pool",
+                    memory_arg_name,
+                )
 
         return original_init_memory_pool(self, *args, **kwargs)
 

--- a/lib/gpu_memory_service/integrations/sglang/patches.py
+++ b/lib/gpu_memory_service/integrations/sglang/patches.py
@@ -167,24 +167,31 @@ def patch_model_runner() -> None:
     original_init_memory_pool = ModelRunner.init_memory_pool
 
     def patched_init_memory_pool(self, *args, **kwargs):
-        """Patched init_memory_pool that uses device total for overhead calculation."""
+        """Patch init_memory_pool to use device total for overhead calculation.
+
+        SGLang's KV cache formula uses total_gpu_memory as the baseline:
+        rest_memory = available - total*(1-mem_fraction).
+        When weights are pre-loaded by GMS, total_gpu_memory was captured before
+        model load and reflects a partially-occupied device, making the overhead
+        term too small and over-allocating KV cache. Fix: replace total_gpu_memory
+        with the physical device capacity so the overhead term is correctly sized.
+        """
         from gpu_memory_service.integrations.sglang.memory_saver import (
             get_gms_memory_saver_impl,
         )
 
         impl = get_gms_memory_saver_impl()
-        if impl is not None and impl.get_imported_weights_bytes() > 0:
-            total_memory = torch.cuda.get_device_properties(
+        if impl is not None and impl.get_imported_weights_bytes() > 0 and args:
+            total_memory_gib = torch.cuda.get_device_properties(
                 torch.cuda.current_device()
-            ).total_memory
-            if hasattr(self, "min_per_gpu_memory"):
-                old_value = self.min_per_gpu_memory
-                self.min_per_gpu_memory = total_memory
-                logger.info(
-                    "[GMS] Adjusted min_per_gpu_memory: %.2f GiB -> %.2f GiB",
-                    old_value / (1 << 30),
-                    total_memory / (1 << 30),
-                )
+            ).total_memory / (1 << 30)
+            old_value = args[0]
+            args = (total_memory_gib,) + args[1:]
+            logger.info(
+                "[GMS] Adjusted total_gpu_memory: %.2f GiB -> %.2f GiB",
+                old_value,
+                total_memory_gib,
+            )
 
         return original_init_memory_pool(self, *args, **kwargs)
 

--- a/tests/gms/common/test_gms_sglang_patches.py
+++ b/tests/gms/common/test_gms_sglang_patches.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from gpu_memory_service.integrations.sglang import patches as sglang_patches
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+]
+
+
+def test_patch_model_runner_rewrites_total_gpu_memory(monkeypatch):
+    fake_sglang = types.ModuleType("sglang")
+    fake_srt = types.ModuleType("sglang.srt")
+    fake_executor = types.ModuleType("sglang.srt.model_executor")
+    fake_model_runner = types.ModuleType("sglang.srt.model_executor.model_runner")
+
+    class FakeModelRunner:
+        def init_memory_pool(self, total_gpu_memory):
+            self.seen_total_gpu_memory = total_gpu_memory
+            return total_gpu_memory
+
+    fake_model_runner.ModelRunner = FakeModelRunner
+    fake_sglang.srt = fake_srt
+    fake_srt.model_executor = fake_executor
+    fake_executor.model_runner = fake_model_runner
+
+    fake_memory_saver = types.ModuleType(
+        "gpu_memory_service.integrations.sglang.memory_saver"
+    )
+
+    class FakeImpl:
+        def get_imported_weights_bytes(self):
+            return 8 << 30
+
+    fake_memory_saver.get_gms_memory_saver_impl = lambda: FakeImpl()
+
+    monkeypatch.setitem(sys.modules, "sglang", fake_sglang)
+    monkeypatch.setitem(sys.modules, "sglang.srt", fake_srt)
+    monkeypatch.setitem(sys.modules, "sglang.srt.model_executor", fake_executor)
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang.srt.model_executor.model_runner",
+        fake_model_runner,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "gpu_memory_service.integrations.sglang.memory_saver",
+        fake_memory_saver,
+    )
+    monkeypatch.setattr(sglang_patches, "_model_runner_patched", False)
+    monkeypatch.delattr(FakeModelRunner, "_gms_patched", raising=False)
+    monkeypatch.setattr(
+        sglang_patches.torch.cuda,
+        "current_device",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        sglang_patches.torch.cuda,
+        "get_device_properties",
+        lambda device: types.SimpleNamespace(total_memory=80 * (1 << 30)),
+    )
+
+    sglang_patches.patch_model_runner()
+
+    runner = FakeModelRunner()
+    assert runner.init_memory_pool(40.0) == pytest.approx(80.0)
+    assert runner.seen_total_gpu_memory == pytest.approx(80.0)

--- a/tests/gms/common/test_gms_sglang_patches.py
+++ b/tests/gms/common/test_gms_sglang_patches.py
@@ -7,12 +7,12 @@ import sys
 import types
 
 import pytest
-
 from gpu_memory_service.integrations.sglang import patches as sglang_patches
 
 pytestmark = [
     pytest.mark.pre_merge,
     pytest.mark.unit,
+    pytest.mark.gpu_0,
 ]
 
 


### PR DESCRIPTION
#### Overview:

In SGLang, `min_per_gpu_memory` is passed positionally as the first arg, and it becomes `total_gpu_memory` inside `init_memory_pool`. The patch replaces `args[0]` with the physical device capacity to serve as the baseline for the KV cache overhead calculation.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory overhead calculation to accurately account for physical device capacity when pre-loaded weights are present, enhancing stability in memory-constrained deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->