### PR TITLE
fix: add missing pytest-asyncio dep and markers for test_failover_lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,7 @@ repos:
       pass_filenames: false
       additional_dependencies:
         - pytest
+        - pytest-asyncio
         - tomli
         - pydantic
         - filelock

--- a/tests/fault_tolerance/gpu_memory_service/test_failover_lock.py
+++ b/tests/fault_tolerance/gpu_memory_service/test_failover_lock.py
@@ -17,6 +17,13 @@ import pytest
 import pytest_asyncio  # noqa: F401 — ensures the plugin is available
 from gpu_memory_service.failover_lock.flock import FlockFailoverLock
 
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.fault_tolerance,
+]
+
 
 @pytest.fixture
 def lock_path(tmp_path):

--- a/tests/report_pytest_markers.py
+++ b/tests/report_pytest_markers.py
@@ -112,6 +112,8 @@ STUB_MODULES = [
     "gpu_memory_service",
     "gpu_memory_service.common",
     "gpu_memory_service.common.utils",
+    "gpu_memory_service.failover_lock",
+    "gpu_memory_service.failover_lock.flock",
     "prometheus_client",
     "prometheus_client.parser",
     "sklearn",


### PR DESCRIPTION
#### Overview:

Fixes the pytest-marker-report pre-commit hook failure caused by a missing pytest-asyncio dependency and uncollectable failover_lock test modules. Also adds required pytest markers to the new test file.

#### Details:

- Add `pytest-asyncio` to `.pre-commit-config.yaml` additional_dependencies for the marker-report hook so its isolated environment can collect async test files
- Add `pytestmark` block to `test_failover_lock.py` with `pre_merge`, `unit`, `gpu_0`, and `fault_tolerance` markers
- Add `gpu_memory_service.failover_lock` and `gpu_memory_service.failover_lock.flock` to the stub modules list in `report_pytest_markers.py` so the marker scanner can import and collect the test file

#### Where should the reviewer start?

`.pre-commit-config.yaml` for the dependency fix, then `tests/fault_tolerance/gpu_memory_service/test_failover_lock.py` for the marker additions.

#### Related Issues:

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit hook dependencies to enhance development testing infrastructure.
  * Improved test organization through additional marker support for better test categorization and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->