### PR TITLE
fix: remove bare pytest_asyncio import breaking pre-commit

### DIFF
--- a/tests/fault_tolerance/gpu_memory_service/test_failover_lock.py
+++ b/tests/fault_tolerance/gpu_memory_service/test_failover_lock.py
@@ -14,7 +14,6 @@ import signal
 import time
 
 import pytest
-import pytest_asyncio  # noqa: F401 — ensures the plugin is available
 from gpu_memory_service.failover_lock.flock import FlockFailoverLock
 
 

--- a/tests/fault_tolerance/gpu_memory_service/test_failover_lock.py
+++ b/tests/fault_tolerance/gpu_memory_service/test_failover_lock.py
@@ -16,6 +16,13 @@ import time
 import pytest
 from gpu_memory_service.failover_lock.flock import FlockFailoverLock
 
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.fault_tolerance,
+]
+
 
 @pytest.fixture
 def lock_path(tmp_path):

--- a/tests/report_pytest_markers.py
+++ b/tests/report_pytest_markers.py
@@ -112,6 +112,8 @@ STUB_MODULES = [
     "gpu_memory_service",
     "gpu_memory_service.common",
     "gpu_memory_service.common.utils",
+    "gpu_memory_service.failover_lock",
+    "gpu_memory_service.failover_lock.flock",
     "prometheus_client",
     "prometheus_client.parser",
     "sklearn",


### PR DESCRIPTION
## Summary

- Remove `import pytest_asyncio` from `test_failover_lock.py` that breaks the `pytest-marker-report` pre-commit hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an unused test dependency import. No impact on test execution or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->