### PR TITLE
chore: add vllm omni e2e tests

### DIFF
--- a/components/src/dynamo/vllm/omni/args.py
+++ b/components/src/dynamo/vllm/omni/args.py
@@ -258,6 +258,10 @@ def parse_omni_args() -> OmniConfig:
     args, unknown = parser.parse_known_args()
     config = OmniConfig.from_cli_args(args)
 
+    # Default endpoint to "generate" if not explicitly provided by user
+    if config.endpoint is None:
+        config.endpoint = "generate"
+
     vllm_args = vllm_parser.parse_args(unknown)
     config.model = vllm_args.model
 

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -21,7 +21,7 @@ from tests.serve.common import (
     run_serve_deployment,
 )
 from tests.utils.engine_process import EngineConfig
-from tests.utils.payloads import BasePayload
+from tests.utils.payloads import BasePayload, ChatPayload
 
 logger = logging.getLogger(__name__)
 
@@ -110,8 +110,64 @@ class VLLMOmniConfig(EngineConfig):
 
 
 vllm_omni_configs = {
-    # omni_text (Qwen2.5-Omni-7B): ~80GB GPU required, exceeds CI capacity (22GB).
-    # omni_image (Qwen/Qwen-Image): ~40GB GPU required, exceeds CI capacity (22GB).
+    "omni_text": VLLMOmniConfig(
+        name="omni_text",
+        directory=vllm_dir,
+        script_name="agg_omni.sh",
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.post_merge,
+            pytest.mark.timeout(1200),
+            pytest.mark.skip(
+                reason="Qwen2.5-Omni-7B requires ~80GB GPU memory, exceeds CI capacity (22GB)"
+            ),
+        ],
+        model="Qwen/Qwen2.5-Omni-7B",
+        request_payloads=[
+            ChatPayload(
+                body={
+                    "messages": [{"role": "user", "content": "Say hello"}],
+                    "max_tokens": 32,
+                    "temperature": 0.0,
+                },
+                repeat_count=1,
+                expected_response=["hello", "Hello"],
+                expected_log=[],
+            ),
+        ],
+    ),
+    "omni_image": VLLMOmniConfig(
+        name="omni_image",
+        directory=vllm_dir,
+        script_name="agg_omni_image.sh",
+        script_args=[
+            "--vae-use-slicing",
+            "--vae-use-tiling",
+            "--enforce-eager",
+        ],
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.post_merge,
+            pytest.mark.timeout(1200),
+            pytest.mark.skip(
+                reason="Qwen/Qwen-Image requires ~40GB GPU memory, exceeds CI capacity (22GB)"
+            ),
+        ],
+        model="Qwen/Qwen-Image",
+        request_payloads=[
+            ImageGenerationPayload(
+                body={
+                    "prompt": "A red apple on a table",
+                    "size": "512x512",
+                    "num_inference_steps": 20,
+                    "response_format": "url",
+                },
+                repeat_count=1,
+                expected_response=[],
+                expected_log=[],
+            ),
+        ],
+    ),
     "omni_i2v": VLLMOmniConfig(
         name="omni_i2v",
         directory=vllm_dir,

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -193,6 +193,11 @@ vllm_omni_configs = {
         name="omni_video",
         directory=vllm_dir,
         script_name="agg_omni_video.sh",
+        script_args=[
+            "--vae-use-slicing",
+            "--vae-use-tiling",
+            "--enforce-eager",
+        ],
         marks=[
             pytest.mark.gpu_1,
             pytest.mark.pre_merge,
@@ -203,11 +208,11 @@ vllm_omni_configs = {
             VideoGenerationPayload(
                 body={
                     "prompt": "Dog running on a beach",
-                    "size": "832x480",
+                    "size": "480x272",
                     "response_format": "url",
                     "nvext": {
-                        "num_inference_steps": 20,
-                        "num_frames": 30,
+                        "num_inference_steps": 10,
+                        "num_frames": 17,
                     },
                 },
                 repeat_count=1,

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -21,7 +21,6 @@ from tests.serve.common import (
     run_serve_deployment,
 )
 from tests.utils.engine_process import EngineConfig
-from tests.utils.payload_builder import chat_payload
 from tests.utils.payloads import BasePayload
 
 logger = logging.getLogger(__name__)
@@ -110,81 +109,82 @@ class VLLMOmniConfig(EngineConfig):
 
 
 vllm_omni_configs = {
-    "omni_text": VLLMOmniConfig(
-        name="omni_text",
-        directory=vllm_dir,
-        script_name="agg_omni.sh",
-        marks=[
-            pytest.mark.gpu_1,
-            pytest.mark.pre_merge,
-            pytest.mark.timeout(600),
-        ],
-        model="Qwen/Qwen2.5-Omni-7B",
-        request_payloads=[
-            chat_payload(
-                "Say hello",
-                repeat_count=1,
-                expected_response=["hello", "Hello"],
-                temperature=0.0,
-                max_tokens=32,
-            ),
-        ],
-    ),
-    "omni_image": VLLMOmniConfig(
-        name="omni_image",
-        directory=vllm_dir,
-        script_name="agg_omni_image.sh",
-        marks=[
-            pytest.mark.gpu_1,
-            pytest.mark.pre_merge,
-            pytest.mark.timeout(600),
-        ],
-        model="Qwen/Qwen-Image",
-        request_payloads=[
-            ImageGenerationPayload(
-                body={
-                    "prompt": "A red apple on a table",
-                    "size": "512x512",
-                    "num_inference_steps": 20,
-                    "response_format": "url",
-                },
-                repeat_count=1,
-                expected_response=[],
-                expected_log=[],
-            ),
-        ],
-    ),
-    "omni_i2v": VLLMOmniConfig(
-        name="omni_i2v",
-        directory=vllm_dir,
-        script_name="agg_omni_i2v.sh",
-        marks=[
-            pytest.mark.gpu_1,
-            pytest.mark.pre_merge,
-            pytest.mark.timeout(900),
-        ],
-        model="Wan-AI/Wan2.2-TI2V-5B-Diffusers",
-        request_payloads=[
-            I2VPayload(
-                body={
-                    "prompt": "Make it dance",
-                    "size": "832x480",
-                    "response_format": "url",
-                    "nvext": {
-                        "num_inference_steps": 20,
-                        "num_frames": 33,
-                        "guidance_scale": 1.0,
-                        "boundary_ratio": 0.875,
-                        "guidance_scale_2": 1.0,
-                        "seed": 42,
-                    },
-                },
-                repeat_count=1,
-                expected_response=[],
-                expected_log=[],
-            ),
-        ],
-    ),
+    # TODO: Enable once CI has faster model download/caching for large models.
+    # "omni_text": VLLMOmniConfig(
+    #     name="omni_text",
+    #     directory=vllm_dir,
+    #     script_name="agg_omni.sh",
+    #     marks=[
+    #         pytest.mark.gpu_1,
+    #         pytest.mark.pre_merge,
+    #         pytest.mark.timeout(1200),
+    #     ],
+    #     model="Qwen/Qwen2.5-Omni-7B",
+    #     request_payloads=[
+    #         chat_payload(
+    #             "Say hello",
+    #             repeat_count=1,
+    #             expected_response=["hello", "Hello"],
+    #             temperature=0.0,
+    #             max_tokens=32,
+    #         ),
+    #     ],
+    # ),
+    # "omni_image": VLLMOmniConfig(
+    #     name="omni_image",
+    #     directory=vllm_dir,
+    #     script_name="agg_omni_image.sh",
+    #     marks=[
+    #         pytest.mark.gpu_1,
+    #         pytest.mark.pre_merge,
+    #         pytest.mark.timeout(1200),
+    #     ],
+    #     model="Qwen/Qwen-Image",
+    #     request_payloads=[
+    #         ImageGenerationPayload(
+    #             body={
+    #                 "prompt": "A red apple on a table",
+    #                 "size": "512x512",
+    #                 "num_inference_steps": 20,
+    #                 "response_format": "url",
+    #             },
+    #             repeat_count=1,
+    #             expected_response=[],
+    #             expected_log=[],
+    #         ),
+    #     ],
+    # ),
+    # "omni_i2v": VLLMOmniConfig(
+    #     name="omni_i2v",
+    #     directory=vllm_dir,
+    #     script_name="agg_omni_i2v.sh",
+    #     marks=[
+    #         pytest.mark.gpu_1,
+    #         pytest.mark.pre_merge,
+    #         pytest.mark.timeout(1200),
+    #     ],
+    #     model="Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+    #     request_payloads=[
+    #         I2VPayload(
+    #             body={
+    #                 "prompt": "Make it dance",
+    #                 "size": "832x480",
+    #                 "response_format": "url",
+    #                 "nvext": {
+    #                     "num_inference_steps": 20,
+    #                     "num_frames": 33,
+    #                     "guidance_scale": 1.0,
+    #                     "boundary_ratio": 0.875,
+    #                     "guidance_scale_2": 1.0,
+    #                     "seed": 42,
+    #                 },
+    #             },
+    #             repeat_count=1,
+    #             expected_response=[],
+    #             expected_log=[],
+    #         ),
+    #     ],
+    # ),
     "omni_video": VLLMOmniConfig(
         name="omni_video",
         directory=vllm_dir,
@@ -192,7 +192,7 @@ vllm_omni_configs = {
         marks=[
             pytest.mark.gpu_1,
             pytest.mark.pre_merge,
-            pytest.mark.timeout(900),
+            pytest.mark.timeout(1200),
         ],
         model="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
         request_payloads=[

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -45,10 +45,11 @@ class ImageGenerationPayload(BasePayload):
         ), f"Missing 'data' in response. Keys: {list(result.keys())}"
         assert len(result["data"]) > 0, "Empty data in image response"
         entry = result["data"][0]
-        assert (
-            "b64_json" in entry or "url" in entry
-        ), f"Expected 'b64_json' or 'url' in data entry. Keys: {list(entry.keys())}"
-        return entry.get("url") or "b64_image_returned"
+        if "url" in entry:
+            assert entry["url"], "Image response url is empty"
+            return entry["url"]
+        assert entry.get("b64_json"), "Image response b64_json is empty"
+        return "b64_image_returned"
 
 
 @dataclass
@@ -70,17 +71,20 @@ class VideoGenerationPayload(BasePayload):
         ), f"Missing 'data' in response. Keys: {list(result.keys())}"
         assert len(result["data"]) > 0, "Empty data in video response"
         entry = result["data"][0]
-        assert (
-            "url" in entry or "b64_json" in entry
-        ), f"Expected 'url' or 'b64_json' in data entry. Keys: {list(entry.keys())}"
-        return entry.get("url") or "b64_video_returned"
+        if "url" in entry:
+            assert entry["url"], "Video response url is empty"
+            return entry["url"]
+        assert entry.get("b64_json"), "Video response b64_json is empty"
+        return "b64_video_returned"
 
     def validate(self, response: Any, content: str) -> None:
-        if self.expected_response:
-            for expected in self.expected_response:
-                if expected.lower() in content.lower():
-                    return
         assert content, "Video response content is empty"
+        if self.expected_response and not any(
+            expected.lower() in content.lower() for expected in self.expected_response
+        ):
+            raise AssertionError(
+                f"Expected at least one of {self.expected_response} in {content!r}"
+            )
 
 
 @dataclass

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+try:
+    from dynamo.vllm.omni.args import OmniConfig  # noqa: F401
+except ImportError:
+    pytest.skip("vLLM omni dependencies not available", allow_module_level=True)
+
+from tests.serve.common import (
+    WORKSPACE_DIR,
+    params_with_model_mark,
+    run_serve_deployment,
+)
+from tests.utils.engine_process import EngineConfig
+from tests.utils.payload_builder import chat_payload
+from tests.utils.payloads import BasePayload
+
+logger = logging.getLogger(__name__)
+
+vllm_dir = os.environ.get("VLLM_DIR") or os.path.join(
+    WORKSPACE_DIR, "examples/backends/vllm"
+)
+
+
+
+@dataclass
+class ImageGenerationPayload(BasePayload):
+    """Payload for /v1/images/generations endpoint."""
+
+    endpoint: str = "/v1/images/generations"
+    timeout: int = 300
+
+    def response_handler(self, response: Any) -> str:
+        response.raise_for_status()
+        result = response.json()
+        assert "data" in result, f"Missing 'data' in response. Keys: {list(result.keys())}"
+        assert len(result["data"]) > 0, "Empty data in image response"
+        entry = result["data"][0]
+        assert "b64_json" in entry or "url" in entry, (
+            f"Expected 'b64_json' or 'url' in data entry. Keys: {list(entry.keys())}"
+        )
+        return entry.get("url") or "b64_image_returned"
+
+
+@dataclass
+class VideoGenerationPayload(BasePayload):
+    """Payload for /v1/videos endpoint."""
+
+    endpoint: str = "/v1/videos"
+    timeout: int = 600
+
+    def response_handler(self, response: Any) -> str:
+        response.raise_for_status()
+        result = response.json()
+        assert result.get("status") == "completed", (
+            f"Video generation not completed. Status: {result.get('status')}, "
+            f"Error: {result.get('error', 'none')}"
+        )
+        assert "data" in result, f"Missing 'data' in response. Keys: {list(result.keys())}"
+        assert len(result["data"]) > 0, "Empty data in video response"
+        entry = result["data"][0]
+        assert "url" in entry or "b64_json" in entry, (
+            f"Expected 'url' or 'b64_json' in data entry. Keys: {list(entry.keys())}"
+        )
+        return entry.get("url") or "b64_video_returned"
+
+    def validate(self, response: Any, content: str) -> None:
+        if self.expected_response:
+            for expected in self.expected_response:
+                if expected.lower() in content.lower():
+                    return
+        assert content, "Video response content is empty"
+
+
+@dataclass
+class VLLMOmniConfig(EngineConfig):
+    """Configuration for vLLM-Omni test scenarios."""
+
+    stragglers: list[str] = field(default_factory=lambda: ["VLLM:EngineCore"])
+
+
+vllm_omni_configs = {
+    "omni_text": VLLMOmniConfig(
+        name="omni_text",
+        directory=vllm_dir,
+        script_name="agg_omni.sh",
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.pre_merge,
+            pytest.mark.timeout(600),
+        ],
+        model="Qwen/Qwen2.5-Omni-7B",
+        request_payloads=[
+            chat_payload(
+                "Say hello",
+                repeat_count=1,
+                expected_response=["hello", "Hello"],
+                temperature=0.0,
+                max_tokens=32,
+            ),
+        ],
+    ),
+    "omni_image": VLLMOmniConfig(
+        name="omni_image",
+        directory=vllm_dir,
+        script_name="agg_omni_image.sh",
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.pre_merge,
+            pytest.mark.timeout(600),
+        ],
+        model="Qwen/Qwen-Image",
+        request_payloads=[
+            ImageGenerationPayload(
+                body={
+                    "prompt": "A red apple on a table",
+                    "size": "512x512",
+                    "num_inference_steps": 20,
+                    "response_format": "url",
+                },
+                repeat_count=1,
+                expected_response=[],
+                expected_log=[],
+            ),
+        ],
+    ),
+    "omni_video": VLLMOmniConfig(
+        name="omni_video",
+        directory=vllm_dir,
+        script_name="agg_omni_video.sh",
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.pre_merge,
+            pytest.mark.timeout(900),
+        ],
+        model="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        request_payloads=[
+            VideoGenerationPayload(
+                body={
+                    "prompt": "Dog running on a beach",
+                    "size": "832x480",
+                    "response_format": "url",
+                    "nvext": {
+                        "num_inference_steps": 20,
+                        "num_frames": 30,
+                    },
+                },
+                repeat_count=1,
+                expected_response=[],
+                expected_log=[],
+            ),
+        ],
+    ),
+}
+
+
+@pytest.fixture(params=params_with_model_mark(vllm_omni_configs))
+def vllm_omni_config_test(request):
+    """Fixture that provides different vLLM-Omni test configurations."""
+    return vllm_omni_configs[request.param]
+
+
+@pytest.mark.vllm
+@pytest.mark.e2e
+def test_omni_serve_deployment(
+    vllm_omni_config_test,
+    request,
+    runtime_services_dynamic_ports,
+    dynamo_dynamic_ports,
+    predownload_models,
+):
+    """Test dynamo serve deployments with vLLM-Omni configurations."""
+    config = dataclasses.replace(
+        vllm_omni_config_test, frontend_port=dynamo_dynamic_ports.frontend_port
+    )
+    run_serve_deployment(config, request, ports=dynamo_dynamic_ports)

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -4,6 +4,7 @@
 import dataclasses
 import logging
 import os
+import tempfile
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -84,6 +85,24 @@ class VideoGenerationPayload(BasePayload):
 
 
 @dataclass
+class I2VPayload(VideoGenerationPayload):
+    """Payload for image-to-video via /v1/videos with input_reference."""
+
+    _image_path: str = ""
+
+    def __post_init__(self):
+        # Create a minimal test image for the input_reference
+        if not self._image_path:
+            from PIL import Image
+
+            fd, path = tempfile.mkstemp(suffix=".png")
+            os.close(fd)
+            Image.new("RGB", (64, 64), color="red").save(path)
+            self._image_path = path
+            self.body["input_reference"] = path
+
+
+@dataclass
 class VLLMOmniConfig(EngineConfig):
     """Configuration for vLLM-Omni test scenarios."""
 
@@ -128,6 +147,37 @@ vllm_omni_configs = {
                     "size": "512x512",
                     "num_inference_steps": 20,
                     "response_format": "url",
+                },
+                repeat_count=1,
+                expected_response=[],
+                expected_log=[],
+            ),
+        ],
+    ),
+    "omni_i2v": VLLMOmniConfig(
+        name="omni_i2v",
+        directory=vllm_dir,
+        script_name="agg_omni_i2v.sh",
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.pre_merge,
+            pytest.mark.timeout(900),
+        ],
+        model="Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+        request_payloads=[
+            I2VPayload(
+                body={
+                    "prompt": "Make it dance",
+                    "size": "832x480",
+                    "response_format": "url",
+                    "nvext": {
+                        "num_inference_steps": 20,
+                        "num_frames": 33,
+                        "guidance_scale": 1.0,
+                        "boundary_ratio": 0.875,
+                        "guidance_scale_2": 1.0,
+                        "seed": 42,
+                    },
                 },
                 repeat_count=1,
                 expected_response=[],

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -113,34 +113,43 @@ class VLLMOmniConfig(EngineConfig):
 
 
 vllm_omni_configs = {
-    # TODO: Enable once CI has faster model download/caching for large models.
+    # Qwen2.5-Omni-7B requires ~80GB GPU memory, exceeds CI GPU capacity.
     # "omni_text": VLLMOmniConfig(
     #     name="omni_text",
     #     directory=vllm_dir,
     #     script_name="agg_omni.sh",
     #     marks=[
     #         pytest.mark.gpu_1,
-    #         pytest.mark.pre_merge,
+    #         pytest.mark.post_merge,
     #         pytest.mark.timeout(1200),
     #     ],
     #     model="Qwen/Qwen2.5-Omni-7B",
     #     request_payloads=[
-    #         chat_payload(
-    #             "Say hello",
+    #         ChatPayload(
+    #             body={
+    #                 "messages": [{"role": "user", "content": "Say hello"}],
+    #                 "max_tokens": 32,
+    #                 "temperature": 0.0,
+    #             },
     #             repeat_count=1,
     #             expected_response=["hello", "Hello"],
-    #             temperature=0.0,
-    #             max_tokens=32,
+    #             expected_log=[],
     #         ),
     #     ],
     # ),
+    # Qwen/Qwen-Image requires ~56GB GPU memory, exceeds CI GPU capacity.
     # "omni_image": VLLMOmniConfig(
     #     name="omni_image",
     #     directory=vllm_dir,
     #     script_name="agg_omni_image.sh",
+    #     script_args=[
+    #         "--vae-use-slicing",
+    #         "--vae-use-tiling",
+    #         "--enforce-eager",
+    #     ],
     #     marks=[
     #         pytest.mark.gpu_1,
-    #         pytest.mark.pre_merge,
+    #         pytest.mark.post_merge,
     #         pytest.mark.timeout(1200),
     #     ],
     #     model="Qwen/Qwen-Image",
@@ -158,37 +167,43 @@ vllm_omni_configs = {
     #         ),
     #     ],
     # ),
-    # "omni_i2v": VLLMOmniConfig(
-    #     name="omni_i2v",
-    #     directory=vllm_dir,
-    #     script_name="agg_omni_i2v.sh",
-    #     marks=[
-    #         pytest.mark.gpu_1,
-    #         pytest.mark.pre_merge,
-    #         pytest.mark.timeout(1200),
-    #     ],
-    #     model="Wan-AI/Wan2.2-TI2V-5B-Diffusers",
-    #     request_payloads=[
-    #         I2VPayload(
-    #             body={
-    #                 "prompt": "Make it dance",
-    #                 "size": "832x480",
-    #                 "response_format": "url",
-    #                 "nvext": {
-    #                     "num_inference_steps": 20,
-    #                     "num_frames": 33,
-    #                     "guidance_scale": 1.0,
-    #                     "boundary_ratio": 0.875,
-    #                     "guidance_scale_2": 1.0,
-    #                     "seed": 42,
-    #                 },
-    #             },
-    #             repeat_count=1,
-    #             expected_response=[],
-    #             expected_log=[],
-    #         ),
-    #     ],
-    # ),
+    "omni_i2v": VLLMOmniConfig(
+        name="omni_i2v",
+        directory=vllm_dir,
+        script_name="agg_omni_i2v.sh",
+        script_args=[
+            "--vae-use-slicing",
+            "--vae-use-tiling",
+            "--enforce-eager",
+            "--enable-cpu-offload",
+        ],
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.pre_merge,
+            pytest.mark.timeout(1200),
+        ],
+        model="Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+        request_payloads=[
+            I2VPayload(
+                body={
+                    "prompt": "Make it dance",
+                    "size": "320x192",
+                    "response_format": "url",
+                    "nvext": {
+                        "num_inference_steps": 5,
+                        "num_frames": 9,
+                        "guidance_scale": 1.0,
+                        "boundary_ratio": 0.875,
+                        "guidance_scale_2": 1.0,
+                        "seed": 42,
+                    },
+                },
+                repeat_count=1,
+                expected_response=[],
+                expected_log=[],
+            ),
+        ],
+    ),
     "omni_video": VLLMOmniConfig(
         name="omni_video",
         directory=vllm_dir,

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -30,7 +30,6 @@ vllm_dir = os.environ.get("VLLM_DIR") or os.path.join(
 )
 
 
-
 @dataclass
 class ImageGenerationPayload(BasePayload):
     """Payload for /v1/images/generations endpoint."""
@@ -41,12 +40,14 @@ class ImageGenerationPayload(BasePayload):
     def response_handler(self, response: Any) -> str:
         response.raise_for_status()
         result = response.json()
-        assert "data" in result, f"Missing 'data' in response. Keys: {list(result.keys())}"
+        assert (
+            "data" in result
+        ), f"Missing 'data' in response. Keys: {list(result.keys())}"
         assert len(result["data"]) > 0, "Empty data in image response"
         entry = result["data"][0]
-        assert "b64_json" in entry or "url" in entry, (
-            f"Expected 'b64_json' or 'url' in data entry. Keys: {list(entry.keys())}"
-        )
+        assert (
+            "b64_json" in entry or "url" in entry
+        ), f"Expected 'b64_json' or 'url' in data entry. Keys: {list(entry.keys())}"
         return entry.get("url") or "b64_image_returned"
 
 
@@ -64,12 +65,14 @@ class VideoGenerationPayload(BasePayload):
             f"Video generation not completed. Status: {result.get('status')}, "
             f"Error: {result.get('error', 'none')}"
         )
-        assert "data" in result, f"Missing 'data' in response. Keys: {list(result.keys())}"
+        assert (
+            "data" in result
+        ), f"Missing 'data' in response. Keys: {list(result.keys())}"
         assert len(result["data"]) > 0, "Empty data in video response"
         entry = result["data"][0]
-        assert "url" in entry or "b64_json" in entry, (
-            f"Expected 'url' or 'b64_json' in data entry. Keys: {list(entry.keys())}"
-        )
+        assert (
+            "url" in entry or "b64_json" in entry
+        ), f"Expected 'url' or 'b64_json' in data entry. Keys: {list(entry.keys())}"
         return entry.get("url") or "b64_video_returned"
 
     def validate(self, response: Any, content: str) -> None:

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -91,18 +91,15 @@ class VideoGenerationPayload(BasePayload):
 class I2VPayload(VideoGenerationPayload):
     """Payload for image-to-video via /v1/videos with input_reference."""
 
-    _image_path: str = ""
+    _tmp_dir: Any = field(default=None, init=False, repr=False, compare=False)
 
     def __post_init__(self):
-        # Create a minimal test image for the input_reference
-        if not self._image_path:
-            from PIL import Image
+        from PIL import Image
 
-            fd, path = tempfile.mkstemp(suffix=".png")
-            os.close(fd)
-            Image.new("RGB", (64, 64), color="red").save(path)
-            self._image_path = path
-            self.body["input_reference"] = path
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        path = os.path.join(self._tmp_dir.name, "input.png")
+        Image.new("RGB", (64, 64), color="red").save(path)
+        self.body["input_reference"] = path
 
 
 @dataclass
@@ -113,60 +110,8 @@ class VLLMOmniConfig(EngineConfig):
 
 
 vllm_omni_configs = {
-    # Qwen2.5-Omni-7B requires ~80GB GPU memory, exceeds CI GPU capacity.
-    # "omni_text": VLLMOmniConfig(
-    #     name="omni_text",
-    #     directory=vllm_dir,
-    #     script_name="agg_omni.sh",
-    #     marks=[
-    #         pytest.mark.gpu_1,
-    #         pytest.mark.post_merge,
-    #         pytest.mark.timeout(1200),
-    #     ],
-    #     model="Qwen/Qwen2.5-Omni-7B",
-    #     request_payloads=[
-    #         ChatPayload(
-    #             body={
-    #                 "messages": [{"role": "user", "content": "Say hello"}],
-    #                 "max_tokens": 32,
-    #                 "temperature": 0.0,
-    #             },
-    #             repeat_count=1,
-    #             expected_response=["hello", "Hello"],
-    #             expected_log=[],
-    #         ),
-    #     ],
-    # ),
-    # Qwen/Qwen-Image requires ~56GB GPU memory, exceeds CI GPU capacity.
-    # "omni_image": VLLMOmniConfig(
-    #     name="omni_image",
-    #     directory=vllm_dir,
-    #     script_name="agg_omni_image.sh",
-    #     script_args=[
-    #         "--vae-use-slicing",
-    #         "--vae-use-tiling",
-    #         "--enforce-eager",
-    #     ],
-    #     marks=[
-    #         pytest.mark.gpu_1,
-    #         pytest.mark.post_merge,
-    #         pytest.mark.timeout(1200),
-    #     ],
-    #     model="Qwen/Qwen-Image",
-    #     request_payloads=[
-    #         ImageGenerationPayload(
-    #             body={
-    #                 "prompt": "A red apple on a table",
-    #                 "size": "512x512",
-    #                 "num_inference_steps": 20,
-    #                 "response_format": "url",
-    #             },
-    #             repeat_count=1,
-    #             expected_response=[],
-    #             expected_log=[],
-    #         ),
-    #     ],
-    # ),
+    # omni_text (Qwen2.5-Omni-7B): ~80GB GPU required, exceeds CI capacity (22GB).
+    # omni_image (Qwen/Qwen-Image): ~40GB GPU required, exceeds CI capacity (22GB).
     "omni_i2v": VLLMOmniConfig(
         name="omni_i2v",
         directory=vllm_dir,
@@ -204,8 +149,8 @@ vllm_omni_configs = {
             ),
         ],
     ),
-    "omni_video": VLLMOmniConfig(
-        name="omni_video",
+    "omni_t2v": VLLMOmniConfig(
+        name="omni_t2v",
         directory=vllm_dir,
         script_name="agg_omni_video.sh",
         script_args=[


### PR DESCRIPTION
#### Overview:

Add e2e serve tests for vLLM-Omni backend and fix the omni worker health endpoint registration.

#### Details:

- Add `tests/serve/test_vllm_omni.py` with two active e2e configs: `omni_video` (T2V, 1.3B) and `omni_i2v` (I2V, 5B)
- Fix omni worker health endpoint: default `endpoint` to `"generate"` in `parse_omni_args()` so `/health` reports `dyn://dynamo.backend.generate` (was `dyn://dynamo.backend.None`)
- Custom `ImageGenerationPayload`, `VideoGenerationPayload`, and `I2VPayload` classes for `/v1/images/generations` and `/v1/videos`
- Memory-optimized for CI GPUs (22GB): uses `--vae-use-slicing --vae-use-tiling --enforce-eager` with reduced resolution/frames
- All memory usage locally verified against 22GB limit (T2V: 16.8GB, I2V: 14.7GB)
- Gracefully skips on containers without `vllm-omni` installed
- Text and image configs commented out (Qwen2.5-Omni-7B needs ~80GB, Qwen-Image needs ~40GB)

**CI impact:** Adds ~2 min to single-GPU pre-merge test step (omni_video: ~56s, omni_i2v: ~60s estimated).

#### Where should the reviewer start?

- `components/src/dynamo/vllm/omni/args.py` — health endpoint fix
- `tests/serve/test_vllm_omni.py` — e2e tests

#### Related Issues:

- Relates to #6788