### PR TITLE
fix: relax CodeRabbit asyncio rules due to discrepancy between runtime and dev containers

### DIFF
--- a/.ai/pytest-guidelines.md
+++ b/.ai/pytest-guidelines.md
@@ -304,31 +304,6 @@ def test_vllm_aggregated(start_serve_deployment):
     ...
 ```
 
-## Async Tests
-
-`asyncio_mode = "auto"` is configured in `pyproject.toml`, so all `async def test_*`
-functions are collected automatically.
-
-**Always flag** `@pytest.mark.asyncio` -- this is a **required change, not a style
-suggestion**. The marker is never needed in this repo. Remove it.
-
-```python
-# BAD -- redundant marker; asyncio_mode = "auto" handles this
-@pytest.mark.asyncio
-@pytest.mark.pre_merge
-@pytest.mark.gpu_0
-@pytest.mark.unit
-async def test_async_endpoint():
-    await asyncio.sleep(0.01)
-
-# GOOD -- no marker needed, pytest collects it automatically
-@pytest.mark.pre_merge
-@pytest.mark.gpu_0
-@pytest.mark.unit
-async def test_async_endpoint():
-    await asyncio.sleep(0.01)
-```
-
 ## Hermetic Testing
 
 Tests must be isolated. Every test must run in any order, on any machine, and


### PR DESCRIPTION
#### Overview:

Remove the incorrect "Async Tests" guideline from `.ai/pytest-guidelines.md` that
instructed reviewers to always flag and remove `@pytest.mark.asyncio`. The marker
is actually required because CI runtime containers don't include `pyproject.toml`,
so pytest-asyncio defaults to strict mode.

#### Details:

- Rather than reversing the guidance, the section is removed entirely to avoid
  over-prescribing async test conventions.

#### Where should the reviewer start?

`.ai/pytest-guidelines.md` -- the only file changed (25 lines removed).

#### Related Issues:

Relates to #7367

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation and error handling for worker initialization scenarios.
  * Added error messaging for unsupported multimodal encoding configurations.

* **Chores**
  * Refactored worker initialization logic for improved maintainability and type safety.
  * Enhanced internal type definitions and validation pathways for worker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->