### PR TITLE
fix(kv-router): recover initial standalone-indexer ZMQ gaps

### DIFF
--- a/lib/kv-router/src/standalone_indexer/listener.rs
+++ b/lib/kv-router/src/standalone_indexer/listener.rs
@@ -31,6 +31,14 @@ fn calculate_backoff_ms(consecutive_errors: u32) -> u64 {
 
 const WATERMARK_UNSET: u64 = u64::MAX;
 
+fn gap_start(prev: u64, seq: u64) -> Option<u64> {
+    if prev == WATERMARK_UNSET {
+        return (seq > 0).then_some(0);
+    }
+
+    (seq > prev + 1).then_some(prev + 1)
+}
+
 #[expect(clippy::too_many_arguments)]
 async fn replay_gap(
     replay_socket: &mut DealerSocket,
@@ -323,8 +331,7 @@ async fn zmq_recv_loop(
                 let seq = u64::from_be_bytes(seq_bytes[..8].try_into().expect("length checked above"));
 
                 let prev = watermark.load(Ordering::Acquire);
-                if prev != WATERMARK_UNSET && seq > prev + 1 {
-                    let gap_start = prev + 1;
+                if let Some(gap_start) = gap_start(prev, seq) {
                     tracing::warn!(
                         worker_id,
                         dp_rank,
@@ -389,6 +396,23 @@ async fn zmq_recv_loop(
 #[cfg(test)]
 mod tests {
     use zeromq::{PubSocket, Socket, SocketRecv, SocketSend, SubSocket};
+
+    use super::{WATERMARK_UNSET, gap_start};
+
+    #[test]
+    fn gap_start_handles_unset_watermark() {
+        assert_eq!(gap_start(WATERMARK_UNSET, 0), None);
+        assert_eq!(gap_start(WATERMARK_UNSET, 1), Some(0));
+        assert_eq!(gap_start(WATERMARK_UNSET, 12), Some(0));
+    }
+
+    #[test]
+    fn gap_start_handles_established_watermark() {
+        assert_eq!(gap_start(0, 0), None);
+        assert_eq!(gap_start(0, 1), None);
+        assert_eq!(gap_start(11, 12), None);
+        assert_eq!(gap_start(11, 16), Some(12));
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn zmq_buffers_messages_during_brief_delay() {

--- a/lib/kv-router/src/standalone_indexer/listener.rs
+++ b/lib/kv-router/src/standalone_indexer/listener.rs
@@ -397,23 +397,6 @@ async fn zmq_recv_loop(
 mod tests {
     use zeromq::{PubSocket, Socket, SocketRecv, SocketSend, SubSocket};
 
-    use super::{WATERMARK_UNSET, gap_start};
-
-    #[test]
-    fn gap_start_handles_unset_watermark() {
-        assert_eq!(gap_start(WATERMARK_UNSET, 0), None);
-        assert_eq!(gap_start(WATERMARK_UNSET, 1), Some(0));
-        assert_eq!(gap_start(WATERMARK_UNSET, 12), Some(0));
-    }
-
-    #[test]
-    fn gap_start_handles_established_watermark() {
-        assert_eq!(gap_start(0, 0), None);
-        assert_eq!(gap_start(0, 1), None);
-        assert_eq!(gap_start(11, 12), None);
-        assert_eq!(gap_start(11, 16), Some(12));
-    }
-
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn zmq_buffers_messages_during_brief_delay() {
         let mut pub_socket = PubSocket::new();

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -226,15 +226,17 @@ impl ZmqKvEventSink {
                         let zmq_msg = zeromq::ZmqMessage::try_from(frames)
                             .expect("Failed to create ZMQ multipart message");
 
-                        if let Err(e) = pub_socket.send(zmq_msg).await {
-                            tracing::warn!("Failed to send ZMQ KV event: {e}");
-                        }
-
                         if router_socket.is_some() {
                             if ring_buffer.len() >= REPLAY_BUFFER_CAPACITY {
                                 ring_buffer.pop_front();
                             }
                             ring_buffer.push_back((seq_num, payload));
+                        }
+
+                        // Record the batch for replay before live publish so listeners
+                        // can recover even if the PUB send is missed or fails.
+                        if let Err(e) = pub_socket.send(zmq_msg).await {
+                            tracing::warn!("Failed to send ZMQ KV event: {e}");
                         }
 
                         seq_num += 1;


### PR DESCRIPTION
Recover missed standalone-indexer ZMQ events when the first observed sequence number is greater than zero. This closes the cold-start replay blind spot where initial batches could be lost before the listener established a watermark.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added unit tests for gap handling logic under various states.

* **Refactor**
  * Improved internal gap detection and handling in the indexer listener.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->