### PR TITLE
fix: add missing redirects for unversioned and dev docs URLs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -32,8 +32,20 @@ products:
 redirects:
   - source: "/dynamo/index.html"
     destination: "/dynamo/"
+  - source: "/dynamo/dev/index.html"
+    destination: "/dynamo/dev/"
   - source: "/dynamo/latest/index.html"
     destination: "/dynamo/"
+  # Unversioned root redirects → dev (fixes broken links from docs.nvidia.com/dynamo)
+  # See: https://github.com/ai-dynamo/dynamo/issues/7297
+  - source: "/dynamo/resources/support-matrix"
+    destination: "/dynamo/dev/resources/support-matrix"
+  - source: "/dynamo/resources/feature-matrix"
+    destination: "/dynamo/dev/resources/feature-matrix"
+  - source: "/dynamo/resources/release-artifacts"
+    destination: "/dynamo/dev/resources/release-artifacts"
+  - source: "/dynamo/resources/examples"
+    destination: "/dynamo/dev/resources/examples"
   # Version-scoped getting-started → resources redirects
   # Only for versions where these pages moved (dev, v1.0.0, latest).
   # Older versions (v0.9.x and below) still have pages under getting-started.


### PR DESCRIPTION
## Summary
- Add `/dynamo/dev/index.html` → `/dynamo/dev/` redirect (parity with existing root and latest redirects)
- Add unversioned `/dynamo/resources/*` → `/dynamo/dev/resources/*` redirects to fix 404s from the root docs URL

## Details

When users visit `https://docs.nvidia.com/dynamo` (no version slug), sidebar links to Support Matrix, Feature Matrix, Release Artifacts, and Examples resolve without a version prefix (e.g., `/dynamo/resources/support-matrix`), which 404s. The versioned URLs (`/dynamo/latest`, `/dynamo/dev`) work correctly. The new redirects catch these unversioned paths and forward to the `dev` version.

## Where Should the Reviewer Start?

`fern/docs.yml` — the `redirects` block, lines 32–48.

## Related Issues
Fixes #7297

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation URL redirects to ensure previously published links continue to work while resources are consolidated under a new structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->