### PR TITLE
fix: eliminate port-collision flake in Rust HTTP service tests

### DIFF
--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -312,7 +312,9 @@ impl HttpService {
 
         if self.enable_tls {
             if listener.is_some() {
-                tracing::warn!("Pre-bound listener ignored when TLS is enabled; the server will bind its own socket");
+                tracing::warn!(
+                    "Pre-bound listener ignored when TLS is enabled; the server will bind its own socket"
+                );
             }
 
             let cert_path = self

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -268,7 +268,10 @@ impl HttpService {
     }
 
     /// Like [`spawn`](Self::spawn), but uses a pre-bound TCP listener instead
-    /// of binding a new one. This eliminates port-collision races in tests.
+    /// of binding a new one in non-TLS mode.
+    ///
+    /// When TLS is enabled, the provided listener is ignored and the service
+    /// binds its own TLS socket.
     pub fn spawn_with_listener(
         &self,
         cancel_token: CancellationToken,
@@ -283,7 +286,10 @@ impl HttpService {
     }
 
     /// Like [`run`](Self::run), but uses a pre-bound TCP listener instead of
-    /// binding a new one. This eliminates port-collision races in tests.
+    /// binding a new one in non-TLS mode.
+    ///
+    /// When TLS is enabled, the provided listener is ignored and the service
+    /// binds its own TLS socket.
     pub async fn run_with_listener(
         &self,
         cancel_token: CancellationToken,

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -267,7 +267,36 @@ impl HttpService {
         tokio::spawn(async move { this.run(cancel_token).await })
     }
 
+    /// Like [`spawn`](Self::spawn), but uses a pre-bound TCP listener instead
+    /// of binding a new one. This eliminates port-collision races in tests.
+    pub fn spawn_with_listener(
+        &self,
+        cancel_token: CancellationToken,
+        listener: tokio::net::TcpListener,
+    ) -> JoinHandle<Result<()>> {
+        let this = self.clone();
+        tokio::spawn(async move { this.run_with_listener(cancel_token, listener).await })
+    }
+
     pub async fn run(&self, cancel_token: CancellationToken) -> Result<()> {
+        self.run_inner(cancel_token, None).await
+    }
+
+    /// Like [`run`](Self::run), but uses a pre-bound TCP listener instead of
+    /// binding a new one. This eliminates port-collision races in tests.
+    pub async fn run_with_listener(
+        &self,
+        cancel_token: CancellationToken,
+        listener: tokio::net::TcpListener,
+    ) -> Result<()> {
+        self.run_inner(cancel_token, Some(listener)).await
+    }
+
+    async fn run_inner(
+        &self,
+        cancel_token: CancellationToken,
+        listener: Option<tokio::net::TcpListener>,
+    ) -> Result<()> {
         let address = format!("{}:{}", self.host, self.port);
         let protocol = if self.enable_tls { "HTTPS" } else { "HTTP" };
         tracing::info!(protocol, address, "Starting HTTP(S) service");
@@ -282,6 +311,10 @@ impl HttpService {
             .map_err(|e| anyhow::anyhow!("Invalid address '{}': {}", address, e))?;
 
         if self.enable_tls {
+            if listener.is_some() {
+                tracing::warn!("Pre-bound listener ignored when TLS is enabled; the server will bind its own socket");
+            }
+
             let cert_path = self
                 .tls_cert_path
                 .as_ref()
@@ -319,27 +352,30 @@ impl HttpService {
                 }
             }
         } else {
-            let listener = tokio::net::TcpListener::bind(addr).await.map_err(|e| {
-                tracing::error!(
-                    protocol = %protocol,
-                    address = %address,
-                    error = %e,
-                    "Failed to bind server to address"
-                );
-                match e.kind() {
-                    std::io::ErrorKind::AddrInUse => anyhow::anyhow!(
-                        "Failed to start {} server: port {} already in use. Use --http-port to specify a different port.",
-                        protocol,
-                        self.port
-                    ),
-                    _ => anyhow::anyhow!(
-                        "Failed to start {} server on {}: {}",
-                        protocol,
-                        address,
-                        e
-                    ),
-                }
-            })?;
+            let listener = match listener {
+                Some(l) => l,
+                None => tokio::net::TcpListener::bind(addr).await.map_err(|e| {
+                    tracing::error!(
+                        protocol = %protocol,
+                        address = %address,
+                        error = %e,
+                        "Failed to bind server to address"
+                    );
+                    match e.kind() {
+                        std::io::ErrorKind::AddrInUse => anyhow::anyhow!(
+                            "Failed to start {} server: port {} already in use. Use --http-port to specify a different port.",
+                            protocol,
+                            self.port
+                        ),
+                        _ => anyhow::anyhow!(
+                            "Failed to start {} server on {}: {}",
+                            protocol,
+                            address,
+                            e
+                        ),
+                    }
+                })?,
+            };
 
             axum::serve(listener, router)
                 .with_graceful_shutdown(async move {

--- a/lib/llm/tests/common/ports.rs
+++ b/lib/llm/tests/common/ports.rs
@@ -1,8 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Get a random available port for testing (prefer to hardcoding port numbers to avoid collisions)
-pub async fn get_random_port() -> u16 {
+/// Bind to a random available port and return both the listener and port.
+///
+/// Callers that pass the listener to `HttpService::run_with_listener` (or
+/// `spawn_with_listener`) avoid the TOCTOU race where the port is freed and
+/// then re-assigned to a different test before the service binds.
+pub async fn bind_random_port() -> (tokio::net::TcpListener, u16) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("failed to bind ephemeral port");
@@ -10,6 +14,17 @@ pub async fn get_random_port() -> u16 {
         .local_addr()
         .expect("failed to read local_addr")
         .port();
-    drop(listener);
+    (listener, port)
+}
+
+/// Get a random available port for testing.
+///
+/// **Prefer [`bind_random_port`] when possible** — it keeps the socket open
+/// until the service binds, eliminating port-collision races.  This helper
+/// is still useful for services (e.g. gRPC) that do not yet accept a
+/// pre-bound listener.
+#[allow(dead_code)]
+pub async fn get_random_port() -> u16 {
+    let (_listener, port) = bind_random_port().await;
     port
 }

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -285,7 +285,8 @@ async fn test_http_service() {
 
     let token = CancellationToken::new();
     let cancel_token = token.clone();
-    let task = tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
+    let task =
+        tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
 
     // Wait for the service to be ready before proceeding
     wait_for_service_ready(port).await;

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -45,7 +45,7 @@ use tokio_util::codec::FramedRead;
 
 #[path = "common/ports.rs"]
 mod ports;
-use ports::get_random_port;
+use ports::bind_random_port;
 
 struct CounterEngine {}
 
@@ -273,7 +273,7 @@ fn inc_counter(
 #[allow(deprecated)]
 #[tokio::test]
 async fn test_http_service() {
-    let port = get_random_port().await;
+    let (listener, port) = bind_random_port().await;
     let service = HttpService::builder()
         .port(port)
         .enable_chat_endpoints(true)
@@ -285,7 +285,7 @@ async fn test_http_service() {
 
     let token = CancellationToken::new();
     let cancel_token = token.clone();
-    let task = tokio::spawn(async move { service.run(token.clone()).await });
+    let task = tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
 
     // Wait for the service to be ready before proceeding
     wait_for_service_ready(port).await;
@@ -581,8 +581,14 @@ async fn wait_for_service_ready(port: u16) {
     }
 }
 
-async fn service_with_engines() -> (HttpService, Arc<CounterEngine>, Arc<AlwaysFailEngine>, u16) {
-    let port = get_random_port().await;
+async fn service_with_engines() -> (
+    HttpService,
+    Arc<CounterEngine>,
+    Arc<AlwaysFailEngine>,
+    tokio::net::TcpListener,
+    u16,
+) {
+    let (listener, port) = bind_random_port().await;
     let service = HttpService::builder()
         .enable_chat_endpoints(true)
         .enable_cmpl_endpoints(true)
@@ -606,7 +612,7 @@ async fn service_with_engines() -> (HttpService, Arc<CounterEngine>, Arc<AlwaysF
         .add_completions_model("bar", card.mdcsum(), failure.clone())
         .unwrap();
 
-    (service, counter, failure, port)
+    (service, counter, failure, listener, port)
 }
 
 fn pure_openai_client(port: u16) -> PureOpenAIClient {
@@ -635,14 +641,14 @@ fn generic_byot_client(port: u16) -> GenericBYOTClient {
 
 #[tokio::test]
 async fn test_pure_openai_client() {
-    let (service, _counter, _failure, port) = service_with_engines().await;
+    let (service, _counter, _failure, listener, port) = service_with_engines().await;
     let pure_openai_client = pure_openai_client(port);
 
     let token = CancellationToken::new();
     let cancel_token = token.clone();
 
     // Start the service
-    let task = tokio::spawn(async move { service.run(token).await });
+    let task = tokio::spawn(async move { service.run_with_listener(token, listener).await });
 
     // Wait for service to be ready
     wait_for_service_ready(port).await;
@@ -747,14 +753,14 @@ async fn test_pure_openai_client() {
 
 #[tokio::test]
 async fn test_nv_custom_client() {
-    let (service, _counter, _failure, port) = service_with_engines().await;
+    let (service, _counter, _failure, listener, port) = service_with_engines().await;
     let nv_custom_client = nv_custom_client(port);
 
     let token = CancellationToken::new();
     let cancel_token = token.clone();
 
     // Start the service
-    let task = tokio::spawn(async move { service.run(token).await });
+    let task = tokio::spawn(async move { service.run_with_listener(token, listener).await });
 
     // Wait for service to be ready
     wait_for_service_ready(port).await;
@@ -886,14 +892,14 @@ async fn test_nv_custom_client() {
 
 #[tokio::test]
 async fn test_generic_byot_client() {
-    let (service, _counter, _failure, port) = service_with_engines().await;
+    let (service, _counter, _failure, listener, port) = service_with_engines().await;
     let generic_byot_client = generic_byot_client(port);
 
     let token = CancellationToken::new();
     let cancel_token = token.clone();
 
     // Start the service
-    let task = tokio::spawn(async move { service.run(token).await });
+    let task = tokio::spawn(async move { service.run_with_listener(token, listener).await });
 
     // Wait for service to be ready
     wait_for_service_ready(port).await;
@@ -981,7 +987,7 @@ async fn test_generic_byot_client() {
 
 #[tokio::test]
 async fn test_client_disconnect_cancellation_unary() {
-    let port = get_random_port().await;
+    let (listener, port) = bind_random_port().await;
     let service = HttpService::builder()
         .enable_chat_endpoints(true)
         .enable_cmpl_endpoints(true)
@@ -995,7 +1001,7 @@ async fn test_client_disconnect_cancellation_unary() {
     let cancel_token = token.clone();
 
     // Start the service
-    let task = tokio::spawn(async move { service.run(token).await });
+    let task = tokio::spawn(async move { service.run_with_listener(token, listener).await });
 
     // Wait for service to be ready
     wait_for_service_ready(port).await;
@@ -1073,7 +1079,7 @@ async fn test_client_disconnect_cancellation_unary() {
 async fn test_client_disconnect_cancellation_streaming() {
     dynamo_runtime::logging::init();
 
-    let port = get_random_port().await;
+    let (listener, port) = bind_random_port().await;
     let service = HttpService::builder()
         .enable_chat_endpoints(true)
         .enable_cmpl_endpoints(true)
@@ -1087,7 +1093,7 @@ async fn test_client_disconnect_cancellation_streaming() {
     let cancel_token = token.clone();
 
     // Start the service
-    let task = tokio::spawn(async move { service.run(token).await });
+    let task = tokio::spawn(async move { service.run_with_listener(token, listener).await });
 
     // Wait for service to be ready
     wait_for_service_ready(port).await;
@@ -1176,7 +1182,7 @@ async fn test_request_id_annotation() {
     // TODO(ryan): make better fixtures, this is too much to test sometime so simple
     dynamo_runtime::logging::init();
 
-    let port = get_random_port().await;
+    let (listener, port) = bind_random_port().await;
     let service = HttpService::builder()
         .enable_chat_endpoints(true)
         .enable_cmpl_endpoints(true)
@@ -1190,7 +1196,7 @@ async fn test_request_id_annotation() {
     let cancel_token = token.clone();
 
     // Start the service
-    let task = tokio::spawn(async move { service.run(token).await });
+    let task = tokio::spawn(async move { service.run_with_listener(token, listener).await });
 
     // Wait for service to be ready
     wait_for_service_ready(port).await;

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -203,7 +203,8 @@ async fn test_metrics_with_mock_model() {
         // Start the HTTP service
         let token = CancellationToken::new();
         let cancel_token = token.clone();
-        let task = tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
+        let task =
+            tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
 
         // Add mock model engine
         let card = ModelDeploymentCard::with_name_only("mockmodel");

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -24,7 +24,7 @@ use std::{sync::Arc, time::Duration};
 
 #[path = "common/ports.rs"]
 mod ports;
-use ports::get_random_port;
+use ports::bind_random_port;
 
 // Mock engine for testing metrics
 struct MockModelEngine {}
@@ -65,10 +65,10 @@ impl
 async fn test_metrics_prefix_default() {
     // Test default prefix when no env var is set
     temp_env::async_with_vars([(METRICS_PREFIX_ENV, None::<&str>)], async {
-        let port = get_random_port().await;
+        let (listener, port) = bind_random_port().await;
         let service = HttpService::builder().port(port).build().unwrap();
         let token = CancellationToken::new();
-        let handle = service.spawn(token.clone()).await;
+        let handle = service.spawn_with_listener(token.clone(), listener);
         wait_for_metrics_ready(port).await;
 
         // Populate labeled metrics
@@ -104,10 +104,10 @@ async fn test_metrics_prefix_default() {
 async fn test_metrics_prefix_custom() {
     // Test custom prefix override via environment variable
     temp_env::async_with_vars([(METRICS_PREFIX_ENV, Some("custom_prefix"))], async {
-        let port = get_random_port().await;
+        let (listener, port) = bind_random_port().await;
         let service = HttpService::builder().port(port).build().unwrap();
         let token = CancellationToken::new();
-        let handle = service.spawn(token.clone()).await;
+        let handle = service.spawn_with_listener(token.clone(), listener);
         wait_for_metrics_ready(port).await;
 
         // Populate labeled metrics
@@ -139,10 +139,10 @@ async fn test_metrics_prefix_custom() {
 async fn test_metrics_prefix_sanitized() {
     // Test that invalid prefix characters are sanitized
     temp_env::async_with_vars([(METRICS_PREFIX_ENV, Some("nv-llm/http service"))], async {
-        let port = get_random_port().await;
+        let (listener, port) = bind_random_port().await;
         let service = HttpService::builder().port(port).build().unwrap();
         let token = CancellationToken::new();
-        let handle = service.spawn(token.clone()).await;
+        let handle = service.spawn_with_listener(token.clone(), listener);
         wait_for_metrics_ready(port).await;
 
         let state = service.state_clone();
@@ -190,7 +190,7 @@ async fn test_metrics_with_mock_model() {
     // Test metrics collection with a mock model serving requests
     // Ensure we use the default prefix
     temp_env::async_with_vars([(METRICS_PREFIX_ENV, None::<&str>)], async {
-        let port = get_random_port().await;
+        let (listener, port) = bind_random_port().await;
         let service = HttpService::builder()
             .port(port)
             .enable_chat_endpoints(true)
@@ -203,7 +203,7 @@ async fn test_metrics_with_mock_model() {
         // Start the HTTP service
         let token = CancellationToken::new();
         let cancel_token = token.clone();
-        let task = tokio::spawn(async move { service.run(token.clone()).await });
+        let task = tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
 
         // Add mock model engine
         let card = ModelDeploymentCard::with_name_only("mockmodel");
@@ -305,7 +305,7 @@ mod integration_tests {
     #[ignore = "Requires etcd and distributed runtime"]
     async fn test_metrics_with_mdc_registration() {
         // Integration test for metrics collection with full MDC registration (like real model servers)
-        let port = get_random_port().await;
+        let (listener, port) = bind_random_port().await;
 
         // Create distributed runtime (required for MDC registration)
         let runtime = dynamo_runtime::Runtime::from_settings().unwrap();
@@ -407,8 +407,7 @@ mod integration_tests {
         // Start the HTTP service
         let token = CancellationToken::new();
         let cancel_token = token.clone();
-        let service_for_task = service.clone();
-        let task = tokio::spawn(async move { service_for_task.run(token.clone()).await });
+        let task = service.spawn_with_listener(token.clone(), listener);
 
         // Wait for service to be ready
         wait_for_metrics_ready(port).await;


### PR DESCRIPTION
## Summary

Fixes a flaky `test_generic_byot_client` failure in the `rust-tests` CI job caused by a TOCTOU (time-of-check-time-of-use) port collision race.

## Root Cause

The test helper `get_random_port()` binds to port `0` to obtain a random ephemeral port, then **drops the listener** before returning the port number. Between when the listener is dropped and when the test's `HttpService` actually binds to that port, another parallel test can receive the same port from the OS.

From the [failing CI run](https://github.com/ai-dynamo/dynamo/actions/runs/23172908962/job/67328686606):

```
Starting HTTP(S) service protocol="HTTP" address="0.0.0.0:42379"
...
Starting HTTP(S) service protocol="HTTP" address="0.0.0.0:42379"
ERROR Failed to bind server to address protocol=HTTP address=0.0.0.0:42379 error=Address already in use (os error 98)
```

Two tests both got port `42379`. The second bind failed silently (the service started on a fallback port), but the test client was still pointing at the original port — hitting a different test's server that didn't have the expected model registered, resulting in `404 Not Found`.

## Fix Decision

Several approaches were considered:

| Approach | Pros | Cons |
|----------|------|------|
| **`#[serial]`** on all HTTP tests | Simple | Slow — serializes all tests unnecessarily |
| **Retry with new port** in `get_random_port()` | No prod changes | Only shrinks the race window, doesn't eliminate it |
| **Pass pre-bound `TcpListener`** to service | Eliminates race entirely | Touches production code |

We chose **option 3** because it completely eliminates the race with a small, additive, backward-compatible change to `HttpService`. The new methods are also useful beyond tests — any caller that needs deterministic port binding can use them.

## Changes

- **`lib/llm/src/http/service/service_v2.rs`**: Extracted `run()` body into private `run_inner(cancel_token, listener: Option<TcpListener>)`. Added public `run_with_listener()` and `spawn_with_listener()` methods. Existing `run()`/`spawn()` signatures unchanged — zero impact on production callers.
- **`lib/llm/tests/common/ports.rs`**: Added `bind_random_port() -> (TcpListener, u16)` that keeps the socket open. Retained `get_random_port()` (delegates to `bind_random_port`) for callers that can't pass a listener (e.g. gRPC/kserve tests).
- **`lib/llm/tests/http-service.rs`**: All 7 tests updated to use `bind_random_port()` + `run_with_listener()`.
- **`lib/llm/tests/http_metrics.rs`**: All 5 tests updated to use `bind_random_port()` + `spawn_with_listener()`/`run_with_listener()`.

## Test plan

- [x] `cargo test -p dynamo-llm --test http-service` — 7/7 passed on gpu dev box
- [x] `cargo test -p dynamo-llm --test http_metrics` — 4/4 passed on gpu dev box
- [x] `cargo test -p dynamo-llm --test kserve_service -- --list` — compiles, unaffected
- [x] No compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * HTTP service now supports initialization with a pre-bound TCP listener via new public APIs, reducing port collision risks in concurrent testing scenarios.

* **Tests**
  * Updated test infrastructure to utilize listener-based service initialization for improved stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->