### PR TITLE
chore: bump copy to acr timeout to 20 min for dev images

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -104,6 +104,7 @@ jobs:
       cuda_versions: '["12.9", "13.0"]'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       build_timeout_minutes: 60
+      copy_timeout_minutes: 20
       run_cpu_only_tests: false
       run_single_gpu_tests: false
       run_multi_gpu_tests: false
@@ -119,6 +120,7 @@ jobs:
       cuda_versions: '["12.9", "13.0"]'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       build_timeout_minutes: 60
+      copy_timeout_minutes: 20
       run_cpu_only_tests: false
       run_single_gpu_tests: false
       run_multi_gpu_tests: false
@@ -134,6 +136,7 @@ jobs:
       cuda_versions: '["13.1"]'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       build_timeout_minutes: 60
+      copy_timeout_minutes: 20
       run_cpu_only_tests: false
       run_single_gpu_tests: false
       run_multi_gpu_tests: false


### PR DESCRIPTION
#### Overview:

should fix https://github.com/ai-dynamo/dynamo/actions/runs/23204957955/job/67438342602#step:4:232
#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended copy timeout duration in CI/CD pipelines across multiple build configurations to improve build reliability and reduce timeout-related failures during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->