### PR TITLE
fix(ci): use correct dynamo-epp repository in frontend build workflow

### DIFF
--- a/.github/workflows/build-frontend-image.yaml
+++ b/.github/workflows/build-frontend-image.yaml
@@ -106,7 +106,7 @@ jobs:
         timeout-minutes: 20
         run: |
           set -x
-          EPP_REPOSITORY="${{ env.IMAGE_REGISTRY }}/dynamo-epp"
+          EPP_REPOSITORY="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}/dynamo-epp"
           EPP_IMAGE_REPO="${{ env.ECR_HOSTNAME }}/${EPP_REPOSITORY}"
           EPP_IMAGE_TAG="${{ github.sha }}"
           EPP_IMAGE_REF="${EPP_REPOSITORY}:${EPP_IMAGE_TAG}"

--- a/.github/workflows/build-frontend-image.yaml
+++ b/.github/workflows/build-frontend-image.yaml
@@ -106,15 +106,16 @@ jobs:
         timeout-minutes: 20
         run: |
           set -x
-          EPP_IMAGE_REPO="${{ env.ECR_HOSTNAME }}/${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}"
+          EPP_REPOSITORY="${{ env.IMAGE_REGISTRY }}/dynamo-epp"
+          EPP_IMAGE_REPO="${{ env.ECR_HOSTNAME }}/${EPP_REPOSITORY}"
           EPP_IMAGE_TAG="${{ github.sha }}"
-          EPP_IMAGE_REF="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:${EPP_IMAGE_TAG}"
+          EPP_IMAGE_REF="${EPP_REPOSITORY}:${EPP_IMAGE_TAG}"
           echo "epp_image_ref=${EPP_IMAGE_REF}" >> $GITHUB_OUTPUT
 
           CACHE_ARGS=""
-          CACHE_ARGS+="--cache-from type=registry,ref=${ECR_HOSTNAME}/${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:cache "
+          CACHE_ARGS+="--cache-from type=registry,ref=${ECR_HOSTNAME}/${EPP_REPOSITORY}:cache "
           if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-            CACHE_ARGS+="--cache-to type=registry,ref=${ECR_HOSTNAME}/${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:cache,mode=max "
+            CACHE_ARGS+="--cache-to type=registry,ref=${ECR_HOSTNAME}/${EPP_REPOSITORY}:cache,mode=max "
           fi
 
           make -C deploy/inference-gateway/epp image-multiarch-push \


### PR DESCRIPTION
#### Overview:

Fixes a bug introduced in #7467 where the EPP image was being pushed to the wrong registry path.

#### Details:

When the two build jobs were consolidated into one in #7467, the `Build EPP Image` step inherited the job-level env var `IMAGE_REPOSITORY: dynamo` (intended for the frontend image). This caused the EPP image to be pushed to `ai-dynamo/dynamo:<sha>` instead of `ai-dynamo/dynamo/dynamo-epp:<sha>`, colliding with the frontend image.

Fix introduces a local `EPP_REPOSITORY` variable (`ai-dynamo/dynamo/dynamo-epp`) scoped to the EPP build step, used for the image ref, repo path, and cache args.

#### Where should the reviewer start?

`.github/workflows/build-frontend-image.yaml` — the `Build EPP Image` step (~line 103).

#### Related Issues:

- Relates to #7467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration for improved Docker image repository management and caching strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->