### PR TITLE
docs: add local-dev tag to devcontainer build command

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -146,9 +146,9 @@ Build the appropriate framework image (e.g., `dynamo:latest-vllm-local-dev`) fro
 # Single command approach (recommended)
 export FRAMEWORK=vllm         # Note: any of vllm, sglang, trtllm can be used
 python container/render.py --framework=${FRAMEWORK} --target=local-dev --output-short-filename
-docker build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -f container/rendered.Dockerfile .
+docker build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -t dynamo:latest-${FRAMEWORK}-local-dev -f container/rendered.Dockerfile .
 
-# Now you've created both dynamo:latest-vllm and dynamo:latest-vllm-local-dev
+# Now you've created dynamo:latest-vllm-local-dev
 ```
 
 The local-dev image will give you local user permissions matching your host user and includes extra developer utilities (debugging tools, text editors, system monitors, etc.).

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -417,9 +417,9 @@ If you see errors like "container is not running" or "An error occurred setting 
    docker images | grep dynamo
 
    # If missing, build the dev image first, then build local-dev
-   export FRAMEWORK=VLLM  # Replace with VLLM, SGLANG, or TRTLLM
+   export FRAMEWORK=vllm  # Replace with vllm, sglang, or trtllm
    python container/render.py --framework=${FRAMEWORK} --target=local-dev --output-short-filename
-   docker build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -f container/rendered.Dockerfile .
+   docker build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -t dynamo:latest-${FRAMEWORK}-local-dev -f container/rendered.Dockerfile .
    ```
 
 2. **Container startup failure:**


### PR DESCRIPTION
#### Overview:

The devcontainer build instructions don't reflect the changes made to the dynamo container build procedure (i.e. the switch to use `render.py` + `docker build` rather than `build.sh`). 

The user should specify the `-local-dev` tag explicitly (currently the image is untagged); also changed comment since `docker build` no longer creates both `dynamo:latest-{framework}` and `dynamo:latest-{framework}-local-dev`. 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Related to https://github.com/ai-dynamo/dynamo/pull/5633