### PR TITLE
fix: fix sglang multinode deployment with LWS

### DIFF
--- a/deploy/operator/internal/dynamo/backend_sglang.go
+++ b/deploy/operator/internal/dynamo/backend_sglang.go
@@ -87,8 +87,10 @@ func (b *SGLangBackend) getMultinodeFlags(numberOfNodes int32, role Role, servic
 	return flags, needsShell
 }
 
+// Match a string representing a shell variable, such as $ABC
 var shellVarRe = regexp.MustCompile(`^\$([A-Za-z_][A-Za-z0-9_]*)$`)
 
+// convertIfShellVar convert shell variable $ABC to $(ABC)
 func convertIfShellVar(s string) string {
 	if strings.HasPrefix(s, "$(") && strings.HasSuffix(s, ")") {
 		return s

--- a/deploy/operator/internal/dynamo/backend_sglang.go
+++ b/deploy/operator/internal/dynamo/backend_sglang.go
@@ -87,19 +87,15 @@ func (b *SGLangBackend) getMultinodeFlags(numberOfNodes int32, role Role, servic
 	return flags, needsShell
 }
 
-func convertIfShellVar(s string) string {
-	re := regexp.MustCompile(`^\$([A-Za-z_][A-Za-z0-9_]*)$`)
+var shellVarRe = regexp.MustCompile(`^\$([A-Za-z_][A-Za-z0-9_]*)$`)
 
+func convertIfShellVar(s string) string {
 	if strings.HasPrefix(s, "$(") && strings.HasSuffix(s, ")") {
 		return s
 	}
 
-	if re.MatchString(s) {
-		match := re.FindStringSubmatch(s)
-		if len(match) > 1 {
-			name := re.FindStringSubmatch(s)[1]
-			return "$(" + name + ")"
-		}
+	if match := shellVarRe.FindStringSubmatch(s); len(match) > 1 {
+		return "$(" + match[1] + ")"
 	}
 
 	return s

--- a/deploy/operator/internal/dynamo/backend_sglang.go
+++ b/deploy/operator/internal/dynamo/backend_sglang.go
@@ -3,6 +3,7 @@ package dynamo
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -68,7 +69,7 @@ func (b *SGLangBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int
 
 // getMultinodeFlags returns the multinode flags and whether shell interpretation is needed
 func (b *SGLangBackend) getMultinodeFlags(numberOfNodes int32, role Role, serviceName string, multinodeDeployer MultinodeDeployer) (string, bool) {
-	distInitAddr := fmt.Sprintf("%s:%s", multinodeDeployer.GetLeaderHostname(serviceName), SglangPort)
+	leaderHostname := multinodeDeployer.GetLeaderHostname(serviceName)
 
 	var nodeRank string
 	var needsShell bool
@@ -76,10 +77,30 @@ func (b *SGLangBackend) getMultinodeFlags(numberOfNodes int32, role Role, servic
 	if role == RoleLeader {
 		nodeRank = "0"
 		needsShell = false
+		leaderHostname = convertIfShellVar(leaderHostname)
 	} else {
 		nodeRank, needsShell = multinodeDeployer.GetNodeRank()
 	}
+	distInitAddr := fmt.Sprintf("%s:%s", leaderHostname, SglangPort)
 
 	flags := fmt.Sprintf("--dist-init-addr %s --nnodes %d --node-rank %s", distInitAddr, numberOfNodes, nodeRank)
 	return flags, needsShell
+}
+
+func convertIfShellVar(s string) string {
+	re := regexp.MustCompile(`^\$([A-Za-z_][A-Za-z0-9_]*)$`)
+
+	if strings.HasPrefix(s, "$(") && strings.HasSuffix(s, ")") {
+		return s
+	}
+
+	if re.MatchString(s) {
+		match := re.FindStringSubmatch(s)
+		if len(match) > 1 {
+			name := re.FindStringSubmatch(s)[1]
+			return "$(" + name + ")"
+		}
+	}
+
+	return s
 }

--- a/deploy/operator/internal/dynamo/backend_sglang_test.go
+++ b/deploy/operator/internal/dynamo/backend_sglang_test.go
@@ -273,7 +273,7 @@ func TestSGLangBackend_ShellCommandInjection(t *testing.T) {
 			multinodeDeployer: &LWSMultinodeDeployer{},
 			initialCommand:    []string{"sh", "-c"},
 			initialArgs:       []string{"python -m dynamo.sglang"},
-			expectedArgs:      []string{"python -m dynamo.sglang --dist-init-addr $LWS_LEADER_ADDRESS:29500 --nnodes 2 --node-rank 0"},
+			expectedArgs:      []string{"python -m dynamo.sglang --dist-init-addr $(LWS_LEADER_ADDRESS):29500 --nnodes 2 --node-rank 0"},
 			description:       "LWS shell commands should use LWS variables",
 		},
 		{
@@ -611,7 +611,6 @@ func TestSGLangBackend_UpdateContainer_UseAsCompilationCache(t *testing.T) {
 					t.Errorf("Expected no environment variable changes, but env count changed from %d to %d", originalEnvCount, len(container.Env))
 				}
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
…t be used in leader container args

#### Overview:

fix sglang multinode deployment with LWS when shell syntax cannot be used in leader container args

#### Details:

replace `$LWS_LEADER_ADDRESS` with `$(LWS_LEADER_ADDRESS)` in leader container args for sglang  LWS multinode deployment

resolve leader startup error
`[W318 09:34:46.763761558 socket.cpp:767] [c10d] The IPv6 network addresses of ($lws_leader_address, 29500) cannot be retrieved (gai error: -2 - Name or service not known).`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell-variable handling for multinode setups: leader hostnames are now normalized into a consistent shell-friendly form, ensuring reliable distributed initialization and address substitution.

* **Tests**
  * Updated test expectations to match the new shell-variable format for leader address substitution and applied minor formatting adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->