### PR TITLE
docs: add redirect for legacy planner URL

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -95,6 +95,8 @@ redirects:
     destination: "/dynamo/dev/user-guides/agents/:slug*"
   - source: "/dynamo/dev/user-guides/agentic-workloads"
     destination: "/dynamo/dev/user-guides/agents"
+  - source: "/dynamo/latest/planner/planner_intro.html"
+    destination: "/dynamo/components/planner"
 
 # GitHub repository link in navbar
 navbar-links:


### PR DESCRIPTION
## Summary
- Add redirect from `/dynamo/latest/planner/planner_intro.html` to `/dynamo/components/planner`

## Details
Fixes broken links from old documentation that referenced the legacy Planner page URL.

## Where Should the Reviewer Start?
`fern/docs.yml` - the redirect entry

## Test Plan
- [x] `fern check` passes
- [ ] CI passes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation URL mappings to improve site navigation and ensure previous documentation links redirect to their updated locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->