### PR TITLE
docs: alphabetize engine sidebars and update latest to v1.0.1

### DIFF
--- a/fern/versions/dev.yml
+++ b/fern/versions/dev.yml
@@ -110,12 +110,12 @@ navigation:
           - page: FastVideo
             slug: fastvideo
             path: ../pages-dev/features/diffusion/fastvideo.md
-          - page: vLLM-Omni
-            path: ../pages-dev/backends/vllm/vllm-omni.md
           - page: SGLang Diffusion
             path: ../pages-dev/backends/sglang/sglang-diffusion.md
           - page: TRT-LLM Diffusion
             path: ../pages-dev/backends/trtllm/trtllm-video-diffusion.md
+          - page: vLLM-Omni
+            path: ../pages-dev/backends/vllm/vllm-omni.md
       - page: Tool Calling
         path: ../pages-dev/agents/tool-calling.md
       - page: LoRA Adapters
@@ -336,18 +336,6 @@ navigation:
       - page: NVIDIA Request Extensions (nvext)
         path: ../pages-dev/components/frontend/nvext.md
       # -- Backend detail pages --
-      - section: vLLM Details
-        contents:
-          - page: Reference Guide
-            path: ../pages-dev/backends/vllm/vllm-reference-guide.md
-          - page: Examples
-            path: ../pages-dev/backends/vllm/vllm-examples.md
-          - page: KV Cache Offloading
-            path: ../pages-dev/backends/vllm/vllm-kv-offloading.md
-          - page: Observability
-            path: ../pages-dev/backends/vllm/vllm-observability.md
-          - page: vLLM-Omni
-            path: ../pages-dev/backends/vllm/vllm-omni.md
       - section: TensorRT-LLM Details
         contents:
           - page: Building a Custom Container
@@ -366,6 +354,18 @@ navigation:
             path: ../pages-dev/backends/trtllm/trtllm-gemma3-sliding-window-attention.md
           - page: GPT-OSS
             path: ../pages-dev/backends/trtllm/trtllm-gpt-oss.md
+      - section: vLLM Details
+        contents:
+          - page: Reference Guide
+            path: ../pages-dev/backends/vllm/vllm-reference-guide.md
+          - page: Examples
+            path: ../pages-dev/backends/vllm/vllm-examples.md
+          - page: KV Cache Offloading
+            path: ../pages-dev/backends/vllm/vllm-kv-offloading.md
+          - page: Observability
+            path: ../pages-dev/backends/vllm/vllm-observability.md
+          - page: vLLM-Omni
+            path: ../pages-dev/backends/vllm/vllm-omni.md
       # -- Features (hidden sub-pages) --
       - section: Speculative Decoding
         path: ../pages-dev/features/speculative-decoding/README.md

--- a/fern/versions/latest.yml
+++ b/fern/versions/latest.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Navigation structure for v0.9.1 release
+# Navigation structure for v1.0.1 release
 # Also used as the "Latest" version (default)
 
 navigation:
@@ -21,187 +21,263 @@ navigation:
   - section: Getting Started
     contents:
       - page: Quickstart
-        path: ../pages-v0.9.1/getting-started/quickstart.md
+        path: ../pages-v1.0.1/getting-started/quickstart.md
+      - page: Introduction
+        path: ../pages-v1.0.1/getting-started/introduction.md
+      - page: Contribution Guide
+        path: ../pages-v1.0.1/contribution-guide.md
+  # ==================== Resources ====================
+  - section: Resources
+    contents:
       - page: Support Matrix
-        path: ../pages-v0.9.1/reference/support-matrix.md
+        path: ../pages-v1.0.1/reference/support-matrix.md
       - page: Feature Matrix
-        path: ../pages-v0.9.1/reference/feature-matrix.md
+        path: ../pages-v1.0.1/reference/feature-matrix.md
       - page: Release Artifacts
-        path: ../pages-v0.9.1/reference/release-artifacts.md
+        path: ../pages-v1.0.1/reference/release-artifacts.md
       - page: Examples
-        path: ../pages-v0.9.1/getting-started/examples.md
-
+        path: ../pages-v1.0.1/getting-started/examples.md
   # ==================== Kubernetes Deployment ====================
   - section: Kubernetes Deployment
     contents:
       - section: Deployment Guide
-        path: ../pages-v0.9.1/kubernetes/README.md
+        path: ../pages-v1.0.1/kubernetes/README.md
         contents:
           - page: Detailed Installation Guide
-            path: ../pages-v0.9.1/kubernetes/installation-guide.md
+            path: ../pages-v1.0.1/kubernetes/installation-guide.md
+          - page: Deploying Your First Model
+            path: ../pages-v1.0.1/kubernetes/dgdr.md
           - page: Dynamo Operator
-            path: ../pages-v0.9.1/kubernetes/dynamo-operator.md
+            path: ../pages-v1.0.1/kubernetes/dynamo-operator.md
           - page: Service Discovery
-            path: ../pages-v0.9.1/kubernetes/service-discovery.md
+            path: ../pages-v1.0.1/kubernetes/service-discovery.md
           - page: Webhooks
-            path: ../pages-v0.9.1/kubernetes/webhooks.md
+            path: ../pages-v1.0.1/kubernetes/webhooks.md
           - page: Minikube Setup
-            path: ../pages-v0.9.1/kubernetes/deployment/minikube.md
+            path: ../pages-v1.0.1/kubernetes/deployment/minikube.md
           - page: Managing Models with DynamoModel
-            path: ../pages-v0.9.1/kubernetes/deployment/dynamomodel-guide.md
+            path: ../pages-v1.0.1/kubernetes/deployment/dynamomodel-guide.md
           - page: Autoscaling
-            path: ../pages-v0.9.1/kubernetes/autoscaling.md
+            path: ../pages-v1.0.1/kubernetes/autoscaling.md
+          - page: Rolling Update
+            path: ../pages-v1.0.1/kubernetes/rolling-update.md
           - page: Inference Gateway (GAIE)
-            path: ../pages-v0.9.1/kubernetes/inference-gateway.md
+            path: ../pages-v1.0.1/kubernetes/inference-gateway.md
+          - page: Snapshot
+            path: ../pages-v1.0.1/kubernetes/snapshot.md
       - section: Observability (K8s)
         contents:
           - page: Metrics
-            path: ../pages-v0.9.1/kubernetes/observability/metrics.md
+            path: ../pages-v1.0.1/kubernetes/observability/metrics.md
           - page: Logging
-            path: ../pages-v0.9.1/kubernetes/observability/logging.md
+            path: ../pages-v1.0.1/kubernetes/observability/logging.md
           - page: Operator Metrics
-            path: ../pages-v0.9.1/kubernetes/observability/operator-metrics.md
+            path: ../pages-v1.0.1/kubernetes/observability/operator-metrics.md
       - section: Multinode
         contents:
           - page: Multinode Deployments
-            path: ../pages-v0.9.1/kubernetes/deployment/multinode-deployment.md
+            path: ../pages-v1.0.1/kubernetes/deployment/multinode-deployment.md
           - page: Grove
-            path: ../pages-v0.9.1/kubernetes/grove.md
-
+            path: ../pages-v1.0.1/kubernetes/grove.md
   # ==================== User Guides ====================
   - section: User Guides
     contents:
       - page: KV Cache Aware Routing
-        path: ../pages-v0.9.1/components/router/router-guide.md
+        path: ../pages-v1.0.1/components/router/router-guide.md
       - page: Disaggregated Serving
-        path: ../pages-v0.9.1/features/disaggregated-serving/README.md
+        path: ../pages-v1.0.1/features/disaggregated-serving/README.md
       - page: KV Cache Offloading
-        path: ../pages-v0.9.1/components/kvbm/kvbm-guide.md
+        path: ../pages-v1.0.1/components/kvbm/kvbm-guide.md
       - page: Dynamo Benchmarking
-        path: ../pages-v0.9.1/benchmarks/benchmarking.md
-      - section: Multimodality Support
-        path: ../pages-v0.9.1/features/multimodal/README.md
+        path: ../pages-v1.0.1/benchmarks/benchmarking.md
+      - section: Multimodal
+        path: ../pages-v1.0.1/features/multimodal/README.md
         contents:
-          - page: vLLM Multimodal
-            path: ../pages-v0.9.1/features/multimodal/multimodal-vllm.md
-          - page: TensorRT-LLM Multimodal
-            path: ../pages-v0.9.1/features/multimodal/multimodal-trtllm.md
-          - page: SGLang Multimodal
-            path: ../pages-v0.9.1/features/multimodal/multimodal-sglang.md
+          - page: Embedding Cache
+            path: ../pages-v1.0.1/features/multimodal/embedding-cache.md
+          - page: Encoder Disaggregation
+            path: ../pages-v1.0.1/features/multimodal/encoder-disaggregation.md
+          - page: Multimodal KV Routing
+            path: ../pages-v1.0.1/features/multimodal/multimodal-kv-routing.md
+      - section: Diffusion (Preview)
+        slug: diffusion
+        path: ../pages-v1.0.1/features/diffusion/README.md
+        contents:
+          - page: FastVideo
+            slug: fastvideo
+            path: ../pages-v1.0.1/features/diffusion/fastvideo.md
+          - page: SGLang Diffusion
+            path: ../pages-v1.0.1/backends/sglang/sglang-diffusion.md
+          - page: TRT-LLM Diffusion
+            path: ../pages-v1.0.1/backends/trtllm/trtllm-video-diffusion.md
+          - page: vLLM-Omni
+            path: ../pages-v1.0.1/backends/vllm/vllm-omni.md
       - page: Tool Calling
-        path: ../pages-v0.9.1/agents/tool-calling.md
+        path: ../pages-v1.0.1/agents/tool-calling.md
       - page: LoRA Adapters
-        path: ../pages-v0.9.1/features/lora/README.md
+        path: ../pages-v1.0.1/features/lora/README.md
+      - section: Agents
+        slug: agents
+        path: ../pages-v1.0.1/features/agentic_workloads.md
+        contents:
+          - page: SGLang for Agentic Workloads
+            path: ../pages-v1.0.1/backends/sglang/agents.md
       - section: Observability (Local)
-        path: ../pages-v0.9.1/observability/README.md
+        path: ../pages-v1.0.1/observability/README.md
         contents:
           - page: Prometheus + Grafana Setup
-            path: ../pages-v0.9.1/observability/prometheus-grafana.md
+            path: ../pages-v1.0.1/observability/prometheus-grafana.md
           - page: Metrics
-            path: ../pages-v0.9.1/observability/metrics.md
+            path: ../pages-v1.0.1/observability/metrics.md
           - page: Metrics Developer Guide
-            path: ../pages-v0.9.1/observability/metrics-developer-guide.md
+            path: ../pages-v1.0.1/observability/metrics-developer-guide.md
           - page: Health Checks
-            path: ../pages-v0.9.1/observability/health-checks.md
+            path: ../pages-v1.0.1/observability/health-checks.md
           - page: Tracing
-            path: ../pages-v0.9.1/observability/tracing.md
+            path: ../pages-v1.0.1/observability/tracing.md
           - page: Logging
-            path: ../pages-v0.9.1/observability/logging.md
+            path: ../pages-v1.0.1/observability/logging.md
       - section: Fault Tolerance
-        path: ../pages-v0.9.1/fault-tolerance/README.md
+        path: ../pages-v1.0.1/fault-tolerance/README.md
         contents:
           - page: Request Migration
-            path: ../pages-v0.9.1/fault-tolerance/request-migration.md
+            path: ../pages-v1.0.1/fault-tolerance/request-migration.md
           - page: Request Cancellation
-            path: ../pages-v0.9.1/fault-tolerance/request-cancellation.md
-          - page: Graceful Shutdown
-            path: ../pages-v0.9.1/fault-tolerance/graceful-shutdown.md
+            path: ../pages-v1.0.1/fault-tolerance/request-cancellation.md
           - page: Request Rejection
-            path: ../pages-v0.9.1/fault-tolerance/request-rejection.md
+            path: ../pages-v1.0.1/fault-tolerance/request-rejection.md
+          - page: Graceful Shutdown
+            path: ../pages-v1.0.1/fault-tolerance/graceful-shutdown.md
           - page: Testing
-            path: ../pages-v0.9.1/fault-tolerance/testing.md
-      - page: Writing Python Workers in Dynamo
-        path: ../pages-v0.9.1/development/backend-guide.md
-
+            path: ../pages-v1.0.1/fault-tolerance/testing.md
+      - page: Writing Python Workers
+        path: ../pages-v1.0.1/development/backend-guide.md
+  # ==================== Backends ====================
+  - section: Backends
+    contents:
+      - section: SGLang
+        path: ../pages-v1.0.1/backends/sglang/README.md
+        contents:
+          - page: Reference Guide
+            path: ../pages-v1.0.1/backends/sglang/sglang-reference-guide.md
+          - page: Chat Processor
+            path: ../pages-v1.0.1/backends/sglang/sglang-chat-processor.md
+          - page: Examples
+            path: ../pages-v1.0.1/backends/sglang/sglang-examples.md
+          - page: Disaggregation
+            path: ../pages-v1.0.1/backends/sglang/sglang-disaggregation.md
+          - page: Diffusion
+            path: ../pages-v1.0.1/backends/sglang/sglang-diffusion.md
+          - page: Observability
+            path: ../pages-v1.0.1/backends/sglang/sglang-observability.md
+          - page: Agentic Workloads
+            path: ../pages-v1.0.1/backends/sglang/agents.md
+      - section: TensorRT-LLM
+        path: ../pages-v1.0.1/backends/trtllm/README.md
+        contents:
+          - page: Reference Guide
+            path: ../pages-v1.0.1/backends/trtllm/trtllm-reference-guide.md
+          - page: Examples
+            path: ../pages-v1.0.1/backends/trtllm/trtllm-examples.md
+          - page: Prometheus Metrics
+            path: ../pages-v1.0.1/backends/trtllm/trtllm-prometheus.md
+          - page: Video Diffusion (Experimental)
+            path: ../pages-v1.0.1/backends/trtllm/trtllm-video-diffusion.md
+          - page: Known Issues and Mitigations
+            path: ../pages-v1.0.1/backends/trtllm/trtllm-known-issues.md
+      - page: vLLM
+        path: ../pages-v1.0.1/backends/vllm/README.md
   # ==================== Components ====================
   - section: Components
     contents:
-      - section: Backends
-        contents:
-          - page: vLLM
-            path: ../pages-v0.9.1/backends/vllm/README.md
-          - page: SGLang
-            path: ../pages-v0.9.1/backends/sglang/README.md
-          - page: TensorRT-LLM
-            path: ../pages-v0.9.1/backends/trtllm/README.md
       - section: Frontend
-        path: ../pages-v0.9.1/components/frontend/README.md
+        path: ../pages-v1.0.1/components/frontend/README.md
         contents:
           - page: Frontend Guide
-            path: ../pages-v0.9.1/components/frontend/frontend-guide.md
+            path: ../pages-v1.0.1/components/frontend/frontend-guide.md
       - section: Router
-        path: ../pages-v0.9.1/components/router/README.md
+        path: ../pages-v1.0.1/components/router/README.md
         contents:
           - page: Router Guide
-            path: ../pages-v0.9.1/components/router/router-guide.md
+            path: ../pages-v1.0.1/components/router/router-guide.md
           - page: Router Examples
-            path: ../pages-v0.9.1/components/router/router-examples.md
+            path: ../pages-v1.0.1/components/router/router-examples.md
+          - page: KV Event Replay — Dynamo vs vLLM
+            path: ../pages-v1.0.1/components/router/kv-event-replay-comparison.md
       - section: Planner
-        path: ../pages-v0.9.1/components/planner/README.md
+        path: ../pages-v1.0.1/components/planner/README.md
         contents:
           - page: Planner Guide
-            path: ../pages-v0.9.1/components/planner/planner-guide.md
+            path: ../pages-v1.0.1/components/planner/planner-guide.md
           - page: Planner Examples
-            path: ../pages-v0.9.1/components/planner/planner-examples.md
+            path: ../pages-v1.0.1/components/planner/planner-examples.md
       - section: Profiler
-        path: ../pages-v0.9.1/components/profiler/README.md
+        path: ../pages-v1.0.1/components/profiler/README.md
         contents:
           - page: Profiler Guide
-            path: ../pages-v0.9.1/components/profiler/profiler-guide.md
+            path: ../pages-v1.0.1/components/profiler/profiler-guide.md
           - page: Profiler Examples
-            path: ../pages-v0.9.1/components/profiler/profiler-examples.md
+            path: ../pages-v1.0.1/components/profiler/profiler-examples.md
       - section: KVBM
-        path: ../pages-v0.9.1/components/kvbm/README.md
+        path: ../pages-v1.0.1/components/kvbm/README.md
         contents:
           - page: KVBM Guide
-            path: ../pages-v0.9.1/components/kvbm/kvbm-guide.md
-
+            path: ../pages-v1.0.1/components/kvbm/kvbm-guide.md
   # ==================== Integrations ====================
   - section: Integrations
     contents:
       - page: LMCache
-        path: ../pages-v0.9.1/integrations/lmcache-integration.md
+        path: ../pages-v1.0.1/integrations/lmcache-integration.md
       - page: SGLang HiCache
-        path: ../pages-v0.9.1/integrations/sglang-hicache.md
+        path: ../pages-v1.0.1/integrations/sglang-hicache.md
       - page: FlexKV
-        path: ../pages-v0.9.1/integrations/flexkv-integration.md
+        path: ../pages-v1.0.1/integrations/flexkv-integration.md
       - page: KV Events for Custom Engines
-        path: ../pages-v0.9.1/integrations/kv-events-custom-engines.md
-
+        path: ../pages-v1.0.1/integrations/kv-events-custom-engines.md
   # ==================== Design Docs ====================
   - section: Design Docs
     contents:
       - page: Overall Architecture
-        path: ../pages-v0.9.1/design-docs/architecture.md
+        path: ../pages-v1.0.1/design-docs/architecture.md
       - page: Architecture Flow
-        path: ../pages-v0.9.1/design-docs/dynamo-flow.md
+        path: ../pages-v1.0.1/design-docs/dynamo-flow.md
       - page: Disaggregated Serving
-        path: ../pages-v0.9.1/design-docs/disagg-serving.md
+        path: ../pages-v1.0.1/design-docs/disagg-serving.md
       - page: Distributed Runtime
-        path: ../pages-v0.9.1/design-docs/distributed-runtime.md
-      - page: Discovery Plane
-        path: ../pages-v0.9.1/design-docs/discovery-plane.md
-      - page: Request Plane
-        path: ../pages-v0.9.1/design-docs/request-plane.md
-      - page: Event Plane
-        path: ../pages-v0.9.1/design-docs/event-plane.md
-      - page: Router Design
-        path: ../pages-v0.9.1/design-docs/router-design.md
-      - page: KVBM Design
-        path: ../pages-v0.9.1/design-docs/kvbm-design.md
-      - page: Planner Design
-        path: ../pages-v0.9.1/design-docs/planner-design.md
-
+        path: ../pages-v1.0.1/design-docs/distributed-runtime.md
+      - section: Communication Planes
+        contents:
+          - page: Discovery Plane
+            path: ../pages-v1.0.1/design-docs/discovery-plane.md
+          - page: Request Plane
+            path: ../pages-v1.0.1/design-docs/request-plane.md
+          - page: Event Plane
+            path: ../pages-v1.0.1/design-docs/event-plane.md
+      - section: Component Design
+        contents:
+          - page: Router Design
+            path: ../pages-v1.0.1/design-docs/router-design.md
+          - page: KVBM Design
+            path: ../pages-v1.0.1/design-docs/kvbm-design.md
+          - page: Planner Design
+            path: ../pages-v1.0.1/design-docs/planner-design.md
+  # ==================== Blog ====================
+  - section: Blog
+    collapsed: true
+    path: ../blogs/index.mdx
+    slug: blog
+    contents:
+      - page: "Full-Stack Optimizations for Agentic Inference"
+        path: ../blogs/agentic-inference/agentic-inference.md
+        slug: agentic-inference
+      - page: "Flash Indexer: Inter-Galactic KV Routing"
+        path: ../blogs/flash-indexer/flash-indexer.md
+        slug: flash-indexer
+  # ==================== Documentation ====================
+  - section: Documentation
+    contents:
+      - page: Dynamo Docs Guide
+        path: ../pages-v1.0.1/README.md
   # ==================== Hidden Pages ====================
   # Pages accessible via direct URL but not shown in main navigation.
   # Matches Sphinx hidden_toctree.rst -- pages linked from within content
@@ -211,128 +287,116 @@ navigation:
     contents:
       # -- Development --
       - page: Runtime Guide
-        path: ../pages-v0.9.1/development/runtime-guide.md
+        path: ../pages-v1.0.1/development/runtime-guide.md
       - page: Jail Stream
-        path: ../pages-v0.9.1/development/jail-stream.md
+        path: ../pages-v1.0.1/development/jail-stream.md
       # -- API Reference --
       - section: NIXL Connect API
-        path: ../pages-v0.9.1/api/nixl-connect/README.md
+        path: ../pages-v1.0.1/api/nixl-connect/README.md
         contents:
           - page: Connector
-            path: ../pages-v0.9.1/api/nixl-connect/connector.md
+            path: ../pages-v1.0.1/api/nixl-connect/connector.md
           - page: Device
-            path: ../pages-v0.9.1/api/nixl-connect/device.md
+            path: ../pages-v1.0.1/api/nixl-connect/device.md
           - page: Device Kind
-            path: ../pages-v0.9.1/api/nixl-connect/device-kind.md
+            path: ../pages-v1.0.1/api/nixl-connect/device-kind.md
           - page: Descriptor
-            path: ../pages-v0.9.1/api/nixl-connect/descriptor.md
+            path: ../pages-v1.0.1/api/nixl-connect/descriptor.md
           - page: Read Operation
-            path: ../pages-v0.9.1/api/nixl-connect/read-operation.md
+            path: ../pages-v1.0.1/api/nixl-connect/read-operation.md
           - page: Write Operation
-            path: ../pages-v0.9.1/api/nixl-connect/write-operation.md
+            path: ../pages-v1.0.1/api/nixl-connect/write-operation.md
           - page: Readable Operation
-            path: ../pages-v0.9.1/api/nixl-connect/readable-operation.md
+            path: ../pages-v1.0.1/api/nixl-connect/readable-operation.md
           - page: Writable Operation
-            path: ../pages-v0.9.1/api/nixl-connect/writable-operation.md
+            path: ../pages-v1.0.1/api/nixl-connect/writable-operation.md
           - page: Operation Status
-            path: ../pages-v0.9.1/api/nixl-connect/operation-status.md
+            path: ../pages-v1.0.1/api/nixl-connect/operation-status.md
           - page: RDMA Metadata
-            path: ../pages-v0.9.1/api/nixl-connect/rdma-metadata.md
+            path: ../pages-v1.0.1/api/nixl-connect/rdma-metadata.md
       # -- Kubernetes (hidden sub-pages) --
       - page: API Reference (K8s)
-        path: ../pages-v0.9.1/kubernetes/api-reference.md
+        path: ../pages-v1.0.1/kubernetes/api-reference.md
       - page: Creating Deployments
-        path: ../pages-v0.9.1/kubernetes/deployment/create-deployment.md
+        path: ../pages-v1.0.1/kubernetes/deployment/create-deployment.md
       - page: FluxCD
-        path: ../pages-v0.9.1/kubernetes/fluxcd.md
+        path: ../pages-v1.0.1/kubernetes/fluxcd.md
       - page: Model Caching with Fluid
-        path: ../pages-v0.9.1/kubernetes/model-caching-with-fluid.md
+        path: ../pages-v1.0.1/kubernetes/model-caching-with-fluid.md
       # -- Reference --
-      - page: CLI Reference
-        path: ../pages-v0.9.1/reference/cli.md
       - page: Glossary
-        path: ../pages-v0.9.1/reference/glossary.md
+        path: ../pages-v1.0.1/reference/glossary.md
       - page: Tuning Disaggregated Performance
-        path: ../pages-v0.9.1/performance/tuning.md
+        path: ../pages-v1.0.1/performance/tuning.md
+      # -- Frontend (hidden sub-pages) --
+      - page: NVIDIA Request Extensions (nvext)
+        path: ../pages-v1.0.1/components/frontend/nvext.md
       # -- Backend detail pages --
-      - section: vLLM Details
-        contents:
-          - page: DeepSeek-R1
-            path: ../pages-v0.9.1/backends/vllm/deepseek-r1.md
-          - page: GPT-OSS
-            path: ../pages-v0.9.1/backends/vllm/gpt-oss.md
-          - page: Multi-Node
-            path: ../pages-v0.9.1/backends/vllm/multi-node.md
-          - page: Prometheus
-            path: ../pages-v0.9.1/backends/vllm/prometheus.md
-          - page: Prompt Embeddings
-            path: ../pages-v0.9.1/backends/vllm/prompt-embeddings.md
-      - section: SGLang Details
-        contents:
-          - page: Expert Distribution (EPLB)
-            path: ../pages-v0.9.1/backends/sglang/expert-distribution-eplb.md
-          - page: GPT-OSS
-            path: ../pages-v0.9.1/backends/sglang/gpt-oss.md
-          - page: Diffusion LM
-            path: ../pages-v0.9.1/backends/sglang/diffusion-lm.md
-          - page: Profiling
-            path: ../pages-v0.9.1/backends/sglang/profiling.md
-          - page: Disaggregation
-            path: ../pages-v0.9.1/backends/sglang/sglang-disaggregation.md
-          - page: Prometheus
-            path: ../pages-v0.9.1/backends/sglang/prometheus.md
       - section: TensorRT-LLM Details
         contents:
-          - page: Multinode Examples
-            path: ../pages-v0.9.1/backends/trtllm/multinode/multinode-examples.md
-          - page: Llama4 + Eagle
-            path: ../pages-v0.9.1/backends/trtllm/llama4-plus-eagle.md
+          - page: Building a Custom Container
+            path: ../pages-v1.0.1/backends/trtllm/trtllm-building-custom-container.md
           - page: KV Cache Transfer
-            path: ../pages-v0.9.1/backends/trtllm/kv-cache-transfer.md
+            path: ../pages-v1.0.1/backends/trtllm/trtllm-kv-cache-transfer.md
+          - page: Logits Processing
+            path: ../pages-v1.0.1/backends/trtllm/trtllm-logits-processing.md
+          - page: DP Rank Routing
+            path: ../pages-v1.0.1/backends/trtllm/trtllm-dp-rank-routing.md
+          - page: Multinode Examples
+            path: ../pages-v1.0.1/backends/trtllm/multinode/trtllm-multinode-examples.md
+          - page: Llama4 + Eagle
+            path: ../pages-v1.0.1/backends/trtllm/trtllm-llama4-plus-eagle.md
           - page: Gemma3 Sliding Window
-            path: ../pages-v0.9.1/backends/trtllm/gemma3-sliding-window-attention.md
+            path: ../pages-v1.0.1/backends/trtllm/trtllm-gemma3-sliding-window-attention.md
           - page: GPT-OSS
-            path: ../pages-v0.9.1/backends/trtllm/gpt-oss.md
-          - page: Prometheus
-            path: ../pages-v0.9.1/backends/trtllm/prometheus.md
+            path: ../pages-v1.0.1/backends/trtllm/trtllm-gpt-oss.md
+      - section: vLLM Details
+        contents:
+          - page: Reference Guide
+            path: ../pages-v1.0.1/backends/vllm/vllm-reference-guide.md
+          - page: Examples
+            path: ../pages-v1.0.1/backends/vllm/vllm-examples.md
+          - page: KV Cache Offloading
+            path: ../pages-v1.0.1/backends/vllm/vllm-kv-offloading.md
+          - page: Observability
+            path: ../pages-v1.0.1/backends/vllm/vllm-observability.md
+          - page: vLLM-Omni
+            path: ../pages-v1.0.1/backends/vllm/vllm-omni.md
       # -- Features (hidden sub-pages) --
       - section: Speculative Decoding
-        path: ../pages-v0.9.1/features/speculative-decoding/README.md
+        path: ../pages-v1.0.1/features/speculative-decoding/README.md
         contents:
           - page: Speculative Decoding with vLLM
-            path: ../pages-v0.9.1/features/speculative-decoding/speculative-decoding-vllm.md
+            path: ../pages-v1.0.1/features/speculative-decoding/speculative-decoding-vllm.md
       # -- Benchmarks --
       - page: KV Router A/B Testing
-        path: ../pages-v0.9.1/benchmarks/kv-router-ab-testing.md
+        path: ../pages-v1.0.1/benchmarks/kv-router-ab-testing.md
       # -- Mocker --
       - page: Mocker
-        path: ../pages-v0.9.1/mocker/mocker.md
-      # -- Docs README --
-      - page: Building Documentation
-        path: ../pages-v0.9.1/README.md
+        path: ../pages-v1.0.1/mocker/mocker.md
       # -- Templates --
       - section: Templates
-        path: ../pages-v0.9.1/templates/README.md
+        path: ../pages-v1.0.1/templates/README.md
         contents:
           - page: Backend Guide
-            path: ../pages-v0.9.1/templates/backend-guide.md
+            path: ../pages-v1.0.1/templates/backend-guide.md
           - page: Backend README
-            path: ../pages-v0.9.1/templates/backend-readme.md
+            path: ../pages-v1.0.1/templates/backend-readme.md
           - page: Component Design
-            path: ../pages-v0.9.1/templates/component-design.md
+            path: ../pages-v1.0.1/templates/component-design.md
           - page: Component Examples
-            path: ../pages-v0.9.1/templates/component-examples.md
+            path: ../pages-v1.0.1/templates/component-examples.md
           - page: Component Guide
-            path: ../pages-v0.9.1/templates/component-guide.md
+            path: ../pages-v1.0.1/templates/component-guide.md
           - page: Component README
-            path: ../pages-v0.9.1/templates/component-readme.md
+            path: ../pages-v1.0.1/templates/component-readme.md
           - page: Feature Backend
-            path: ../pages-v0.9.1/templates/feature-backend.md
+            path: ../pages-v1.0.1/templates/feature-backend.md
           - page: Feature README
-            path: ../pages-v0.9.1/templates/feature-readme.md
+            path: ../pages-v1.0.1/templates/feature-readme.md
           - page: In-Code README
-            path: ../pages-v0.9.1/templates/incode-readme.md
+            path: ../pages-v1.0.1/templates/incode-readme.md
           - page: Infrastructure README
-            path: ../pages-v0.9.1/templates/infrastructure-readme.md
+            path: ../pages-v1.0.1/templates/infrastructure-readme.md
           - page: Integration README
-            path: ../pages-v0.9.1/templates/integration-readme.md
+            path: ../pages-v1.0.1/templates/integration-readme.md

--- a/fern/versions/v0.7.0.yml
+++ b/fern/versions/v0.7.0.yml
@@ -222,18 +222,6 @@ navigation:
                 path: ../pages-v0.7.0/api/nixl-connect/rdma-metadata.md
       - section: Backend Details
         contents:
-          - section: vLLM
-            contents:
-              - page: DeepSeek-R1
-                path: ../pages-v0.7.0/backends/vllm/deepseek-r1.md
-              - page: GPT-OSS
-                path: ../pages-v0.7.0/backends/vllm/gpt-oss.md
-              - page: Multi-Node
-                path: ../pages-v0.7.0/backends/vllm/multi-node.md
-              - page: Multimodal
-                path: ../pages-v0.7.0/backends/vllm/multimodal.md
-              - page: Prometheus
-                path: ../pages-v0.7.0/backends/vllm/prometheus.md
           - section: SGLang
             contents:
               - page: GPT-OSS
@@ -274,3 +262,15 @@ navigation:
                 path: ../pages-v0.7.0/backends/trtllm/multimodal-epd.md
               - page: Prometheus
                 path: ../pages-v0.7.0/backends/trtllm/prometheus.md
+          - section: vLLM
+            contents:
+              - page: DeepSeek-R1
+                path: ../pages-v0.7.0/backends/vllm/deepseek-r1.md
+              - page: GPT-OSS
+                path: ../pages-v0.7.0/backends/vllm/gpt-oss.md
+              - page: Multi-Node
+                path: ../pages-v0.7.0/backends/vllm/multi-node.md
+              - page: Multimodal
+                path: ../pages-v0.7.0/backends/vllm/multimodal.md
+              - page: Prometheus
+                path: ../pages-v0.7.0/backends/vllm/prometheus.md

--- a/fern/versions/v0.7.1.yml
+++ b/fern/versions/v0.7.1.yml
@@ -222,18 +222,6 @@ navigation:
                 path: ../pages-v0.7.1/api/nixl-connect/rdma-metadata.md
       - section: Backend Details
         contents:
-          - section: vLLM
-            contents:
-              - page: DeepSeek-R1
-                path: ../pages-v0.7.1/backends/vllm/deepseek-r1.md
-              - page: GPT-OSS
-                path: ../pages-v0.7.1/backends/vllm/gpt-oss.md
-              - page: Multi-Node
-                path: ../pages-v0.7.1/backends/vllm/multi-node.md
-              - page: Multimodal
-                path: ../pages-v0.7.1/backends/vllm/multimodal.md
-              - page: Prometheus
-                path: ../pages-v0.7.1/backends/vllm/prometheus.md
           - section: SGLang
             contents:
               - page: GPT-OSS
@@ -274,3 +262,15 @@ navigation:
                 path: ../pages-v0.7.1/backends/trtllm/multimodal-epd.md
               - page: Prometheus
                 path: ../pages-v0.7.1/backends/trtllm/prometheus.md
+          - section: vLLM
+            contents:
+              - page: DeepSeek-R1
+                path: ../pages-v0.7.1/backends/vllm/deepseek-r1.md
+              - page: GPT-OSS
+                path: ../pages-v0.7.1/backends/vllm/gpt-oss.md
+              - page: Multi-Node
+                path: ../pages-v0.7.1/backends/vllm/multi-node.md
+              - page: Multimodal
+                path: ../pages-v0.7.1/backends/vllm/multimodal.md
+              - page: Prometheus
+                path: ../pages-v0.7.1/backends/vllm/prometheus.md

--- a/fern/versions/v0.8.0.yml
+++ b/fern/versions/v0.8.0.yml
@@ -174,12 +174,12 @@ navigation:
             path: ../pages-v0.8.0/kubernetes/api-reference.md
       - section: Multimodal Details
         contents:
-          - page: vLLM
-            path: ../pages-v0.8.0/multimodal/vllm.md
           - page: SGLang
             path: ../pages-v0.8.0/multimodal/sglang.md
           - page: TensorRT-LLM
             path: ../pages-v0.8.0/multimodal/trtllm.md
+          - page: vLLM
+            path: ../pages-v0.8.0/multimodal/vllm.md
       - section: Router Details
         contents:
           - page: KV Cache Routing

--- a/fern/versions/v0.8.1.yml
+++ b/fern/versions/v0.8.1.yml
@@ -174,12 +174,12 @@ navigation:
             path: ../pages-v0.8.1/kubernetes/api-reference.md
       - section: Multimodal Details
         contents:
-          - page: vLLM
-            path: ../pages-v0.8.1/multimodal/vllm.md
           - page: SGLang
             path: ../pages-v0.8.1/multimodal/sglang.md
           - page: TensorRT-LLM
             path: ../pages-v0.8.1/multimodal/trtllm.md
+          - page: vLLM
+            path: ../pages-v0.8.1/multimodal/vllm.md
       - section: Router Details
         contents:
           - page: KV Cache Routing

--- a/fern/versions/v0.9.0.yml
+++ b/fern/versions/v0.9.0.yml
@@ -82,12 +82,12 @@ navigation:
       - section: Multimodality Support
         path: ../pages-v0.9.0/features/multimodal/README.md
         contents:
-          - page: vLLM Multimodal
-            path: ../pages-v0.9.0/features/multimodal/multimodal-vllm.md
-          - page: TensorRT-LLM Multimodal
-            path: ../pages-v0.9.0/features/multimodal/multimodal-trtllm.md
           - page: SGLang Multimodal
             path: ../pages-v0.9.0/features/multimodal/multimodal-sglang.md
+          - page: TensorRT-LLM Multimodal
+            path: ../pages-v0.9.0/features/multimodal/multimodal-trtllm.md
+          - page: vLLM Multimodal
+            path: ../pages-v0.9.0/features/multimodal/multimodal-vllm.md
       - page: Tool Calling
         path: ../pages-v0.9.0/agents/tool-calling.md
       - page: LoRA Adapters
@@ -128,12 +128,12 @@ navigation:
     contents:
       - section: Backends
         contents:
-          - page: vLLM
-            path: ../pages-v0.9.0/backends/vllm/README.md
           - page: SGLang
             path: ../pages-v0.9.0/backends/sglang/README.md
           - page: TensorRT-LLM
             path: ../pages-v0.9.0/backends/trtllm/README.md
+          - page: vLLM
+            path: ../pages-v0.9.0/backends/vllm/README.md
       - section: Frontend
         path: ../pages-v0.9.0/components/frontend/README.md
         contents:
@@ -255,18 +255,6 @@ navigation:
       - page: Tuning Disaggregated Performance
         path: ../pages-v0.9.0/performance/tuning.md
       # -- Backend detail pages --
-      - section: vLLM Details
-        contents:
-          - page: DeepSeek-R1
-            path: ../pages-v0.9.0/backends/vllm/deepseek-r1.md
-          - page: GPT-OSS
-            path: ../pages-v0.9.0/backends/vllm/gpt-oss.md
-          - page: Multi-Node
-            path: ../pages-v0.9.0/backends/vllm/multi-node.md
-          - page: Prometheus
-            path: ../pages-v0.9.0/backends/vllm/prometheus.md
-          - page: Prompt Embeddings
-            path: ../pages-v0.9.0/backends/vllm/prompt-embeddings.md
       - section: SGLang Details
         contents:
           - page: Expert Distribution (EPLB)
@@ -295,6 +283,18 @@ navigation:
             path: ../pages-v0.9.0/backends/trtllm/gpt-oss.md
           - page: Prometheus
             path: ../pages-v0.9.0/backends/trtllm/prometheus.md
+      - section: vLLM Details
+        contents:
+          - page: DeepSeek-R1
+            path: ../pages-v0.9.0/backends/vllm/deepseek-r1.md
+          - page: GPT-OSS
+            path: ../pages-v0.9.0/backends/vllm/gpt-oss.md
+          - page: Multi-Node
+            path: ../pages-v0.9.0/backends/vllm/multi-node.md
+          - page: Prometheus
+            path: ../pages-v0.9.0/backends/vllm/prometheus.md
+          - page: Prompt Embeddings
+            path: ../pages-v0.9.0/backends/vllm/prompt-embeddings.md
       # -- Features (hidden sub-pages) --
       - section: Speculative Decoding
         path: ../pages-v0.9.0/features/speculative-decoding/README.md

--- a/fern/versions/v0.9.1.yml
+++ b/fern/versions/v0.9.1.yml
@@ -82,12 +82,12 @@ navigation:
       - section: Multimodality Support
         path: ../pages-v0.9.1/features/multimodal/README.md
         contents:
-          - page: vLLM Multimodal
-            path: ../pages-v0.9.1/features/multimodal/multimodal-vllm.md
-          - page: TensorRT-LLM Multimodal
-            path: ../pages-v0.9.1/features/multimodal/multimodal-trtllm.md
           - page: SGLang Multimodal
             path: ../pages-v0.9.1/features/multimodal/multimodal-sglang.md
+          - page: TensorRT-LLM Multimodal
+            path: ../pages-v0.9.1/features/multimodal/multimodal-trtllm.md
+          - page: vLLM Multimodal
+            path: ../pages-v0.9.1/features/multimodal/multimodal-vllm.md
       - page: Tool Calling
         path: ../pages-v0.9.1/agents/tool-calling.md
       - page: LoRA Adapters
@@ -128,12 +128,12 @@ navigation:
     contents:
       - section: Backends
         contents:
-          - page: vLLM
-            path: ../pages-v0.9.1/backends/vllm/README.md
           - page: SGLang
             path: ../pages-v0.9.1/backends/sglang/README.md
           - page: TensorRT-LLM
             path: ../pages-v0.9.1/backends/trtllm/README.md
+          - page: vLLM
+            path: ../pages-v0.9.1/backends/vllm/README.md
       - section: Frontend
         path: ../pages-v0.9.1/components/frontend/README.md
         contents:
@@ -255,18 +255,6 @@ navigation:
       - page: Tuning Disaggregated Performance
         path: ../pages-v0.9.1/performance/tuning.md
       # -- Backend detail pages --
-      - section: vLLM Details
-        contents:
-          - page: DeepSeek-R1
-            path: ../pages-v0.9.1/backends/vllm/deepseek-r1.md
-          - page: GPT-OSS
-            path: ../pages-v0.9.1/backends/vllm/gpt-oss.md
-          - page: Multi-Node
-            path: ../pages-v0.9.1/backends/vllm/multi-node.md
-          - page: Prometheus
-            path: ../pages-v0.9.1/backends/vllm/prometheus.md
-          - page: Prompt Embeddings
-            path: ../pages-v0.9.1/backends/vllm/prompt-embeddings.md
       - section: SGLang Details
         contents:
           - page: Expert Distribution (EPLB)
@@ -295,6 +283,18 @@ navigation:
             path: ../pages-v0.9.1/backends/trtllm/gpt-oss.md
           - page: Prometheus
             path: ../pages-v0.9.1/backends/trtllm/prometheus.md
+      - section: vLLM Details
+        contents:
+          - page: DeepSeek-R1
+            path: ../pages-v0.9.1/backends/vllm/deepseek-r1.md
+          - page: GPT-OSS
+            path: ../pages-v0.9.1/backends/vllm/gpt-oss.md
+          - page: Multi-Node
+            path: ../pages-v0.9.1/backends/vllm/multi-node.md
+          - page: Prometheus
+            path: ../pages-v0.9.1/backends/vllm/prometheus.md
+          - page: Prompt Embeddings
+            path: ../pages-v0.9.1/backends/vllm/prompt-embeddings.md
       # -- Features (hidden sub-pages) --
       - section: Speculative Decoding
         path: ../pages-v0.9.1/features/speculative-decoding/README.md

--- a/fern/versions/v1.0.0.yml
+++ b/fern/versions/v1.0.0.yml
@@ -93,12 +93,6 @@ navigation:
       - section: Multimodal
         path: ../pages-v1.0.0/features/multimodal/README.md
         contents:
-          - page: vLLM Multimodal
-            path: ../pages-v1.0.0/features/multimodal/multimodal-vllm.md
-          - page: SGLang Multimodal
-            path: ../pages-v1.0.0/features/multimodal/multimodal-sglang.md
-          - page: TensorRT-LLM Multimodal
-            path: ../pages-v1.0.0/features/multimodal/multimodal-trtllm.md
           - page: Embedding Cache
             path: ../pages-v1.0.0/features/multimodal/embedding-cache.md
           - page: Encoder Disaggregation
@@ -112,12 +106,12 @@ navigation:
           - page: FastVideo
             slug: fastvideo
             path: ../pages-v1.0.0/features/diffusion/fastvideo.md
-          - page: vLLM-Omni
-            path: ../pages-v1.0.0/backends/vllm/vllm-omni.md
           - page: SGLang Diffusion
             path: ../pages-v1.0.0/backends/sglang/sglang-diffusion.md
           - page: TRT-LLM Diffusion
             path: ../pages-v1.0.0/backends/trtllm/trtllm-video-diffusion.md
+          - page: vLLM-Omni
+            path: ../pages-v1.0.0/backends/vllm/vllm-omni.md
       - page: Tool Calling
         path: ../pages-v1.0.0/agents/tool-calling.md
       - page: LoRA Adapters
@@ -346,18 +340,6 @@ navigation:
       - page: Global Planner Guide
         path: ../pages-v1.0.0/components/planner/global-planner.md
       # -- Backend detail pages --
-      - section: vLLM Details
-        contents:
-          - page: Reference Guide
-            path: ../pages-v1.0.0/backends/vllm/vllm-reference-guide.md
-          - page: Examples
-            path: ../pages-v1.0.0/backends/vllm/vllm-examples.md
-          - page: KV Cache Offloading
-            path: ../pages-v1.0.0/backends/vllm/vllm-kv-offloading.md
-          - page: Observability
-            path: ../pages-v1.0.0/backends/vllm/vllm-observability.md
-          - page: vLLM-Omni
-            path: ../pages-v1.0.0/backends/vllm/vllm-omni.md
       - section: TensorRT-LLM Details
         contents:
           - page: Building a Custom Container
@@ -376,6 +358,18 @@ navigation:
             path: ../pages-v1.0.0/backends/trtllm/trtllm-gemma3-sliding-window-attention.md
           - page: GPT-OSS
             path: ../pages-v1.0.0/backends/trtllm/trtllm-gpt-oss.md
+      - section: vLLM Details
+        contents:
+          - page: Reference Guide
+            path: ../pages-v1.0.0/backends/vllm/vllm-reference-guide.md
+          - page: Examples
+            path: ../pages-v1.0.0/backends/vllm/vllm-examples.md
+          - page: KV Cache Offloading
+            path: ../pages-v1.0.0/backends/vllm/vllm-kv-offloading.md
+          - page: Observability
+            path: ../pages-v1.0.0/backends/vllm/vllm-observability.md
+          - page: vLLM-Omni
+            path: ../pages-v1.0.0/backends/vllm/vllm-omni.md
       # -- Features (hidden sub-pages) --
       - section: Speculative Decoding
         path: ../pages-v1.0.0/features/speculative-decoding/README.md

--- a/fern/versions/v1.0.1.yml
+++ b/fern/versions/v1.0.1.yml
@@ -106,12 +106,12 @@ navigation:
           - page: FastVideo
             slug: fastvideo
             path: ../pages-v1.0.1/features/diffusion/fastvideo.md
-          - page: vLLM-Omni
-            path: ../pages-v1.0.1/backends/vllm/vllm-omni.md
           - page: SGLang Diffusion
             path: ../pages-v1.0.1/backends/sglang/sglang-diffusion.md
           - page: TRT-LLM Diffusion
             path: ../pages-v1.0.1/backends/trtllm/trtllm-video-diffusion.md
+          - page: vLLM-Omni
+            path: ../pages-v1.0.1/backends/vllm/vllm-omni.md
       - page: Tool Calling
         path: ../pages-v1.0.1/agents/tool-calling.md
       - page: LoRA Adapters
@@ -332,18 +332,6 @@ navigation:
       - page: NVIDIA Request Extensions (nvext)
         path: ../pages-v1.0.1/components/frontend/nvext.md
       # -- Backend detail pages --
-      - section: vLLM Details
-        contents:
-          - page: Reference Guide
-            path: ../pages-v1.0.1/backends/vllm/vllm-reference-guide.md
-          - page: Examples
-            path: ../pages-v1.0.1/backends/vllm/vllm-examples.md
-          - page: KV Cache Offloading
-            path: ../pages-v1.0.1/backends/vllm/vllm-kv-offloading.md
-          - page: Observability
-            path: ../pages-v1.0.1/backends/vllm/vllm-observability.md
-          - page: vLLM-Omni
-            path: ../pages-v1.0.1/backends/vllm/vllm-omni.md
       - section: TensorRT-LLM Details
         contents:
           - page: Building a Custom Container
@@ -362,6 +350,18 @@ navigation:
             path: ../pages-v1.0.1/backends/trtllm/trtllm-gemma3-sliding-window-attention.md
           - page: GPT-OSS
             path: ../pages-v1.0.1/backends/trtllm/trtllm-gpt-oss.md
+      - section: vLLM Details
+        contents:
+          - page: Reference Guide
+            path: ../pages-v1.0.1/backends/vllm/vllm-reference-guide.md
+          - page: Examples
+            path: ../pages-v1.0.1/backends/vllm/vllm-examples.md
+          - page: KV Cache Offloading
+            path: ../pages-v1.0.1/backends/vllm/vllm-kv-offloading.md
+          - page: Observability
+            path: ../pages-v1.0.1/backends/vllm/vllm-observability.md
+          - page: vLLM-Omni
+            path: ../pages-v1.0.1/backends/vllm/vllm-omni.md
       # -- Features (hidden sub-pages) --
       - section: Speculative Decoding
         path: ../pages-v1.0.1/features/speculative-decoding/README.md


### PR DESCRIPTION
## Summary
- Multimodal sidebar for v1.0.0 and v1.0.1 now shows only feature pages (Embedding Cache, Encoder Disaggregation, Multimodal KV Routing) — removes per-engine multimodal pages from sidebar
- Alphabetizes all engine listings (SGLang, TensorRT-LLM, vLLM) across all version YAMLs: Backends, Multimodal, Diffusion, and hidden Details sections
- Points `latest.yml` to v1.0.1 pages (was v0.9.1)

## Files Changed
All 10 version YAML files under `fern/versions/`:
- `v1.0.0.yml`, `v1.0.1.yml` — multimodal sidebar fix + diffusion + details alphabetized
- `dev.yml` — diffusion + details alphabetized
- `latest.yml` — replaced with v1.0.1 content
- `v0.9.1.yml`, `v0.9.0.yml` — multimodal + backends + details alphabetized
- `v0.8.1.yml`, `v0.8.0.yml` — multimodal details alphabetized
- `v0.7.1.yml`, `v0.7.0.yml` — backend details alphabetized

## Test Plan
- [ ] Verify multimodal sidebar on v1.0.0 shows only Embedding Cache, Encoder Disaggregation, Multimodal KV Routing
- [ ] Verify multimodal sidebar on v1.0.1 shows the same
- [ ] Verify latest version resolves to v1.0.1
- [ ] Verify engine ordering is SGLang, TensorRT-LLM, vLLM across all versions


Made with [Cursor](https://cursor.com)