### PR TITLE
chore: disable CodeRabbit poem generation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,8 +9,7 @@ reviews:
   profile: "chill"
   request_changes_workflow: false
   high_level_summary: true
-  # John likes the poems, no messing
-  poem: true
+  poem: false
   review_status: false
   collapse_walkthrough: false
   auto_review:


### PR DESCRIPTION
## Summary
- Disables the poem generation feature in CodeRabbit PR reviews

## Details
Sets `poem: false` in `.coderabbit.yaml` to turn off the whimsical poem that CodeRabbit includes at the end of PR review summaries.

## Where should the reviewer start?
`.coderabbit.yaml`

## Test Plan
- [ ] CI passes
- [ ] Next PR reviewed by CodeRabbit should not include a poem

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeRabbit configuration to disable poetry-based automated reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->