### PR TITLE
fix: change sglang unit tests from gpu_1 to gpu_0

### DIFF
--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -29,7 +29,7 @@ JINJA_TEMPLATE_PATH = str(
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
 # Create SGLang-specific CLI args fixture

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -29,7 +29,8 @@ JINJA_TEMPLATE_PATH = str(
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
-    pytest.mark.gpu_0,
+    pytest.mark.gpu_1,  # needs sglang installed (GPU node) but uses no GPU
+    pytest.mark.max_vram_gib(0),
     pytest.mark.pre_merge,
 ]
 # Create SGLang-specific CLI args fixture


### PR DESCRIPTION
#### Overview:

SGLang unit tests were incorrectly marked `gpu_1`, inflating GPU test counts. They're pure arg-parsing/config tests that don't need a GPU.

#### Details:

- Changed `gpu_1` to `gpu_0` in `test_sglang_unit.py` pytestmark (16 tests)

#### Where should the reviewer start?

`components/src/dynamo/sglang/tests/test_sglang_unit.py` line 32

#### Related Issues:

Relates to DIS-1528

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test markers for GPU resource allocation in unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->