### PR TITLE
fix: sglang disagg_same_gpu test - set prefill model_load_time metric…

### DIFF
--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -168,8 +168,11 @@ async def init_prefill(
     # Use pre-created engine if provided (snapshot mode)
     if snapshot_engine is not None:
         engine = snapshot_engine
+        load_time = 0.0
     else:
+        start_time = time.time()
         engine = sgl.Engine(server_args=server_args)
+        load_time = time.time() - start_time
 
     generate_endpoint = runtime.endpoint(
         f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
@@ -180,6 +183,8 @@ async def init_prefill(
     publisher, metrics_task, metrics_labels = await setup_sgl_metrics(
         engine, config, generate_endpoint
     )
+
+    publisher.component_gauges.set_model_load_time(load_time)
 
     if server_args.node_rank >= 1:
         await handle_non_leader_node(engine, publisher, metrics_task)

--- a/examples/backends/sglang/launch/disagg_same_gpu.sh
+++ b/examples/backends/sglang/launch/disagg_same_gpu.sh
@@ -59,12 +59,9 @@ python3 -m dynamo.sglang \
   --max-running-requests "$MAX_RUNNING_REQUESTS" \
   --enable-metrics &
 
-# Wait for prefill worker to initialize before starting decode worker
-# This prevents both workers from competing for GPU memory simultaneously, which can cause OOM.
-# The prefill worker needs time to:
-# 1. Load model weights and allocate its memory fraction
-# 2. Initialize KV cache with --delete-ckpt-after-loading to free checkpoint memory
-# 3. Register with NATS service discovery so decode worker can find it
+# Wait for prefill worker to initialize before starting decode worker.
+# Both workers share one GPU with --delete-ckpt-after-loading; without this
+# sleep they compete for GPU memory during model loading and the scheduler OOMs.
 echo "Waiting for prefill worker to initialize..."
 sleep 5
 

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -95,26 +95,24 @@ sglang_configs = {
         marks=[
             pytest.mark.gpu_1,
             pytest.mark.pre_merge,
-            pytest.mark.skip(reason="unstable"),
         ],
         model="Qwen/Qwen3-0.6B",
+        delayed_start=30,
         env={},
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
-            # Validate dynamo_component_* and sglang:* metrics from prefill worker
-            # (DefaultPort.SYSTEM1)
+            # Disagg workers expose fewer sglang:* metrics (~14 vs ~25 for aggregated)
+            # because each only runs half the scheduler pipeline.
             metric_payload_default(
                 min_num_requests=6,
-                backend="sglang",
+                backend="sglang_disagg",
                 port=DefaultPort.SYSTEM1.value,
             ),
-            # Validate dynamo_component_* and sglang:* metrics from decode worker
-            # (DefaultPort.SYSTEM2)
             metric_payload_default(
                 min_num_requests=6,
-                backend="sglang",
+                backend="sglang_disagg",
                 port=DefaultPort.SYSTEM2.value,
             ),
         ],

--- a/tests/utils/engine_process.py
+++ b/tests/utils/engine_process.py
@@ -16,6 +16,7 @@ from tests.utils.payloads import BasePayload, check_health_generate, check_model
 
 logger = logging.getLogger(__name__)
 
+
 FRONTEND_PORT = (
     DefaultPort.FRONTEND.value
 )  # Do NOT use this in tests! Use allocate_port() instead.
@@ -169,6 +170,27 @@ class EngineProcess(ManagedProcess):
         if extra_env:
             env.update(extra_env)
 
+        health_urls = [
+            (
+                f"http://localhost:{config.frontend_port}/v1/models",
+                check_models_api,
+            ),
+            (
+                f"http://localhost:{config.frontend_port}/health",
+                check_health_generate,
+            ),
+        ]
+
+        # For disagg deployments (delayed_start > 0), also health-check each
+        # worker's system port so we wait for ALL workers to be ready, not just
+        # the first one to register with the frontend.
+        delayed = config.delayed_start
+        if delayed > 0:
+            for key, val in sorted(env.items()):
+                if key.startswith("DYN_SYSTEM_PORT") and val.isdigit():
+                    health_urls.append((f"http://localhost:{val}/health", None))
+            delayed = 0
+
         return cls(
             command=command,
             env=env,
@@ -176,17 +198,8 @@ class EngineProcess(ManagedProcess):
             display_output=True,
             working_dir=config.directory,
             health_check_ports=[],
-            health_check_urls=[
-                (
-                    f"http://localhost:{config.frontend_port}/v1/models",
-                    check_models_api,
-                ),
-                (
-                    f"http://localhost:{config.frontend_port}/health",
-                    check_health_generate,
-                ),
-            ],
-            delayed_start=config.delayed_start,
+            health_check_urls=health_urls,
+            delayed_start=delayed,
             # Must stay False: command[0] is "bash", so True would kill every
             # bash process system-wide.  Stale cleanup relies on stragglers list
             # and process-group termination in __exit__ instead.

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -1152,6 +1152,29 @@ class SGLangMetricsPayload(MetricsPayload):
 
 
 @dataclass
+class SGLangDisaggMetricsPayload(SGLangMetricsPayload):
+    """Metrics validation for SGLang disaggregated workers.
+
+    Disagg workers (prefill/decode) expose fewer sglang:* metrics than
+    aggregated workers because each only runs half the scheduler pipeline.
+    Observed: ~14 unique sglang:* metrics vs ~25 for aggregated.
+    """
+
+    def _get_backend_specific_checks(self) -> list[MetricCheck]:
+        checks = super()._get_backend_specific_checks()
+        for check in checks:
+            if check.name == "sglang:*":
+                check.validator = lambda value: len(set(value)) >= 10
+                check.error_msg = lambda name, value: (
+                    f"Expected at least 10 unique sglang:* metrics, but found only {len(set(value))}"
+                )
+                check.success_msg = lambda name, value: (
+                    f"SUCCESS: Found {len(set(value))} unique sglang:* metrics (minimum required: 10)"
+                )
+        return checks
+
+
+@dataclass
 class TRTLLMMetricsPayload(MetricsPayload):
     """Metrics validation for TensorRT-LLM backend"""
 


### PR DESCRIPTION
#### Overview:

Fixes sglang disagg_same_gpu test (was skipped as "unstable"). Root causes: missing prefill metric, no health check for decode worker, and disagg workers expose fewer sglang metrics.

#### Details:

- Added `set_model_load_time` to `init_prefill()` (was only in `init_decode`)
- Health-check all worker system ports before sending requests (replaces sleep)
- Added `SGLangDisaggMetricsPayload` with lower sglang:* threshold for disagg workers

#### Where should the reviewer start?

`tests/utils/engine_process.py`

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added model load time metric tracking for improved performance diagnostics.

* **Improvements**
  * Enhanced stability for disaggregated GPU configurations.
  * Improved health check handling for distributed deployments with automatic worker endpoint detection.
  * Refined GPU memory management startup sequence documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->