### PR TITLE
 fix: increase `/dev/shm` for CI pytest containers to fix NIXL UCX segfault

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -154,7 +154,7 @@ runs:
 
         docker run ${GPU_FLAGS} --rm -w /workspace \
           --cpus=${NUM_CPUS} \
-          --shm-size=100m \
+          --shm-size=200m \
           --network host \
           "${DOCKER_ENV_FLAGS[@]}" \
           --name ${{ env.CONTAINER_ID }}_pytest \
@@ -191,10 +191,12 @@ runs:
         set +e  # Don't exit on test failures
 
         # /dev/shm sizing: NIXL uses UCX which allocates shared memory segments in /dev/shm
-        # via shm_open(). Docker's default is 64MB, which is insufficient and causes segfaults.
+        # via shm_open(). Each NIXL agent with num_threads=8 creates 9 UCX workers, each needing
+        # ~4.8MB of shm. Disaggregated tests use up to 3 agents (encode+prefill+decode) = ~130MB.
+        # Docker's default is 64MB, which is insufficient and causes segfaults.
         # Do NOT use --ipc=host here — it overrides --shm-size with the host's /dev/shm
         # (64MB in K8s pods by default), silently ignoring the size we set.
-        DOCKER_OPTS="--shm-size=100m --ulimit memlock=-1 --ulimit stack=67108864"
+        DOCKER_OPTS="--shm-size=200m --ulimit memlock=-1 --ulimit stack=67108864"
 
         # Determine docker runtime flags and pytest command based on dry_run mode
         if [[ "${{ inputs.dry_run }}" == "true" ]]; then

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -190,9 +190,11 @@ runs:
         # Run pytest with detailed output and JUnit XML
         set +e  # Don't exit on test failures
 
-        # Define common docker flags for stability (Shared memory & limits)
-        # --ipc=host is critical for parallel pytest workers to communicate fast
-        DOCKER_OPTS="--ipc=host --ulimit memlock=-1 --ulimit stack=67108864"
+        # /dev/shm sizing: NIXL uses UCX which allocates shared memory segments in /dev/shm
+        # via shm_open(). Docker's default is 64MB, which is insufficient and causes segfaults.
+        # Do NOT use --ipc=host here — it overrides --shm-size with the host's /dev/shm
+        # (64MB in K8s pods by default), silently ignoring the size we set.
+        DOCKER_OPTS="--shm-size=100m --ulimit memlock=-1 --ulimit stack=67108864"
 
         # Determine docker runtime flags and pytest command based on dry_run mode
         if [[ "${{ inputs.dry_run }}" == "true" ]]; then
@@ -250,7 +252,6 @@ runs:
         fi
 
         docker run ${GPU_FLAGS} ${DOCKER_OPTS} --rm -w /workspace \
-          --shm-size=100m \
           --network host \
           "${DOCKER_ENV_FLAGS[@]}" \
           --name ${{ env.CONTAINER_ID }}_pytest \

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -154,6 +154,7 @@ runs:
 
         docker run ${GPU_FLAGS} --rm -w /workspace \
           --cpus=${NUM_CPUS} \
+          --shm-size=100m \
           --network host \
           "${DOCKER_ENV_FLAGS[@]}" \
           --name ${{ env.CONTAINER_ID }}_pytest \
@@ -249,6 +250,7 @@ runs:
         fi
 
         docker run ${GPU_FLAGS} ${DOCKER_OPTS} --rm -w /workspace \
+          --shm-size=100m \
           --network host \
           "${DOCKER_ENV_FLAGS[@]}" \
           --name ${{ env.CONTAINER_ID }}_pytest \

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -168,9 +168,9 @@ sglang_configs = {
         ],
     ),
     # NOTE: Pack all workers on 1 GPU for lower CI resource requirements
-    "multimodal_epd_qwen": SGLangConfig(
+    "multimodal_e_pd_qwen": SGLangConfig(
         # E/P/D architecture: Encode, Prefill, Decode workers all on GPU 0
-        name="multimodal_epd_qwen",
+        name="multimodal_e_pd_qwen",
         directory=sglang_dir,
         script_name="multimodal_epd.sh",
         marks=[pytest.mark.gpu_1, pytest.mark.pre_merge],
@@ -182,8 +182,6 @@ sglang_configs = {
             "DYN_WORKER_GPU": "0",
             "DYN_ENCODE_GPU_MEM": "0.1",
             "DYN_WORKER_GPU_MEM": "0.4",
-            # FIXME: NIXL Agent Initialization (shared memory interface) causes segfault
-            "UCX_TLS": "^mm",
         },
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
@@ -220,10 +218,7 @@ sglang_configs = {
         model="Qwen/Qwen3-VL-2B-Instruct",
         script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct", "--single-gpu"],
         timeout=360,
-        env={
-            # FIXME: NIXL Agent Initialization (shared memory interface) causes segfault
-            "UCX_TLS": "^mm",
-        },
+        env={},
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
             chat_payload(

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -299,8 +299,8 @@ vllm_configs = {
         ],
     ),
     # NOTE: Pack all workers on 1 GPU for lower CI resource requirements
-    "multimodal_disagg_qwen3vl_2b_e_pd": VLLMConfig(
-        name="multimodal_disagg_qwen3vl_2b_e_pd",
+    "multimodal_e_pd_qwen": VLLMConfig(
+        name="multimodal_e_pd_qwen",
         directory=vllm_dir,
         script_name="disagg_multimodal_e_pd.sh",
         marks=[
@@ -311,6 +311,9 @@ vllm_configs = {
         ],
         model="Qwen/Qwen3-VL-2B-Instruct",
         script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct", "--single-gpu"],
+        env={
+            "DYN_VLLM_EMBEDDING_TRANSFER_MODE": "nixl-write",
+        },
         request_payloads=[
             chat_payload(
                 [
@@ -376,8 +379,8 @@ vllm_configs = {
     # so _PROFILE_PYTEST_VRAM_FRAC_OVERRIDE has no effect. Regardless of GPU_MEM
     # fractions (0.1/0.4/0.4), the 3 workers combined consistently use ~17.6 GiB
     # total on this GPU.
-    "multimodal_disagg_qwen3vl_2b_epd": VLLMConfig(
-        name="multimodal_disagg_qwen3vl_2b_epd",
+    "multimodal_disagg_qwen": VLLMConfig(
+        name="multimodal_disagg_qwen",
         directory=vllm_dir,
         script_name="disagg_multimodal_epd.sh",
         marks=[
@@ -685,8 +688,8 @@ vllm_configs = {
         ],
     ),
     # TODO: Enable this test case when we have 4 GPUs runners.
-    # "multimodal_disagg": VLLMConfig(
-    #     name="multimodal_disagg",
+    # "multimodal_disagg_qwen": VLLMConfig(
+    #     name="multimodal_disagg_qwen",
     #     directory=os.path.join(WORKSPACE_DIR, "examples/multimodal"),
     #     script_name="disagg.sh",
     #     marks=[pytest.mark.gpu_4, pytest.mark.vllm],

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -688,8 +688,8 @@ vllm_configs = {
         ],
     ),
     # TODO: Enable this test case when we have 4 GPUs runners.
-    # "multimodal_disagg_qwen": VLLMConfig(
-    #     name="multimodal_disagg_qwen",
+    # "multimodal_disagg": VLLMConfig(
+    #     name="multimodal_disagg",
     #     directory=os.path.join(WORKSPACE_DIR, "examples/multimodal"),
     #     script_name="disagg.sh",
     #     marks=[pytest.mark.gpu_4, pytest.mark.vllm],


### PR DESCRIPTION
#### Overview:

- Increase `--shm-size` from Docker's default 64MB to 100MB in the pytest action's docker run commands. UCX's shared memory (mm) transport needs ~87MB when two NIXL agents each create 9 UCX workers (18 mm interfaces total). The 64MB default caused a segfault in `ucs_mpool_grow` during NIXL agent initialization.
- Remove `UCX_TLS=^mm` workaround from SGLang multimodal tests.
- Switch vLLM `multimodal_e_pd_qwen` test from local file transfer to NIXL WRITE

**Unrelated Changes:**
- Unify multimodal test naming across SGLang and vLLM (`multimodal_e_pd_qwen`, `multimodal_disagg_qwen`).

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
Relevant Context: https://github.com/ai-dynamo/dynamo/pull/7153#issuecomment-4080015026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker configuration for pytest execution to improve resource allocation.

* **Tests**
  * Refined multimodal test configurations and environment settings for SGLang and vLLM test scenarios.
  * Adjusted environment variable overrides in test configurations for improved test consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->