### PR TITLE
chore: fix bindings typo in comments

### DIFF
--- a/lib/bindings/kvbm/src/block_manager.rs
+++ b/lib/bindings/kvbm/src/block_manager.rs
@@ -21,7 +21,7 @@ mod distributed;
 
 pub mod vllm;
 
-/// Add bingings from this crate to the provided module
+/// Add bindings from this crate to the provided module
 pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<BlockManager>()?;
     m.add_class::<distributed::KvbmWorker>()?;

--- a/lib/bindings/kvbm/src/block_manager/vllm.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm.rs
@@ -56,7 +56,7 @@ fn _vllm_integration(m: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }
 
-/// Add bingings from this crate to the provided module
+/// Add bindings from this crate to the provided module
 pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pymodule!(_vllm_integration))?;
     Ok(())

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -23,7 +23,7 @@ pub use dynamo_runtime::{
 
 use super::context::{Context, callable_accepts_kwarg};
 
-/// Add bingings from this crate to the provided module
+/// Add bindings from this crate to the provided module
 pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PythonAsyncEngine>()?;
     Ok(())


### PR DESCRIPTION
**Overview:**
Fix a typo in Rust bindings comment within the Python integration module.

⸻

**Details:**
	•	Corrected a misspelled word in a comment:
	•	bingings → bindings
	•	No functional or behavioral changes.
	•	Purely improves code readability and correctness.

⸻

**Where should the reviewer start?**
	•	lib/bindings/python/rust/engine.rs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation comments for improved clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->