### PR TITLE
feat(kv-router): Python-first semantic KV cache provider interface

### DIFF
--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -65,6 +65,9 @@ class KvRouterConfigBase(ConfigBase):
     use_remote_indexer: bool = False
     serve_indexer: bool = False
 
+    # Python-only field — NOT in _KV_ROUTER_FIELDS, so it does not flow to Rust.
+    semantic_kv_provider: Optional[str]
+
     def kv_router_kwargs(self) -> dict:
         """Return a dict suitable for ``KvRouterConfig(**kwargs)``."""
         return {f: getattr(self, f) for f in _KV_ROUTER_FIELDS}
@@ -298,4 +301,17 @@ class KvRouterArgGroup(ArgGroup):
                 "component via the request plane instead of maintaining a local radix tree."
             ),
             dest="use_remote_indexer",
+        )
+        add_argument(
+            g,
+            flag_name="--semantic-kv-provider",
+            env_var="DYN_SEMANTIC_KV_PROVIDER",
+            default=None,
+            help=(
+                "[EXPERIMENTAL] KV Router: Semantic KV cache provider name. When set, the router "
+                "augments exact block-hash matching with semantic similarity-based donor discovery. "
+                "Built-in: 'simple' (Jaccard reference impl). Custom providers must satisfy the "
+                "dynamo.llm.SemanticKvCacheProvider protocol."
+            ),
+            arg_type=str,
         )

--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -19,12 +19,14 @@ from typing import Optional
 import uvloop
 
 from dynamo.llm import AicPerfConfig, KvRouter, KvRouterConfig
+from dynamo.llm.semantic_kv import SemanticKvCacheProvider
 from dynamo.router.args import (
     DynamoRouterConfig,
     build_aic_perf_config,
     build_kv_router_config,
 )
 from dynamo.router.args import parse_args as parse_router_args
+from dynamo.router.semantic import create_semantic_provider
 from dynamo.runtime import Client, DistributedRuntime, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -42,12 +44,14 @@ class StandaloneRouterHandler:
         block_size: int,
         kv_router_config: KvRouterConfig,
         aic_perf_config: Optional[AicPerfConfig],
+        semantic_provider: Optional[SemanticKvCacheProvider] = None,
     ):
         self.runtime = runtime
         self.worker_endpoint_path = worker_endpoint_path
         self.block_size = block_size
         self.kv_router_config = kv_router_config
         self.aic_perf_config = aic_perf_config
+        self.semantic_provider = semantic_provider
         self.kv_router: Optional[KvRouter] = None
         self.worker_client: Optional[Client] = None
 
@@ -115,6 +119,34 @@ class StandaloneRouterHandler:
             "extra_args": request.get("extra_args"),
         }
 
+        # Semantic pre-routing: if a semantic provider is configured and
+        # prompt_text is available, try to find a donor before routing.
+        token_ids = request["token_ids"]
+        prompt_text = request.get("prompt_text")
+
+        if self.semantic_provider is not None and prompt_text is not None:
+            try:
+                match = await self.semantic_provider.find_semantic_match(
+                    token_ids, prompt_text
+                )
+                if match is not None:
+                    # Pass donor hint to the router via extra_args so the
+                    # backend can use the donor's KV blocks.
+                    extra = dict(request.get("extra_args") or {})
+                    extra["semantic_donor"] = {
+                        "donor_id": match.donor_id,
+                        "donor_token_ids": list(match.donor_token_ids),
+                        "similarity": match.similarity,
+                    }
+                    preprocessed_request["extra_args"] = extra
+                    logger.debug(
+                        "Semantic match: donor=%s sim=%.3f",
+                        match.donor_id,
+                        match.similarity,
+                    )
+            except Exception:
+                logger.warning("Semantic pre-routing failed", exc_info=True)
+
         async for worker_output in await self.kv_router.generate_from_request(
             preprocessed_request  # type: ignore[arg-type]
         ):
@@ -136,6 +168,17 @@ class StandaloneRouterHandler:
             }
             yield llm_engine_output
 
+        # Post-routing: register this request as a donor for future lookups
+        if self.semantic_provider is not None and prompt_text is not None:
+            request_id = request.get("request_id", "")
+            if request_id:
+                try:
+                    await self.semantic_provider.register_donor(
+                        request_id, token_ids, prompt_text
+                    )
+                except Exception:
+                    logger.warning("Semantic donor registration failed", exc_info=True)
+
     async def best_worker_id(self, token_ids, router_config_override=None):
         """
         Get the best worker ID for a given set of tokens without actually routing.
@@ -148,7 +191,7 @@ class StandaloneRouterHandler:
             logger.error("KvRouter not initialized - cannot get best worker")
             raise RuntimeError("Router not initialized")
 
-        (worker_id, _dp_rank, _overlap_blocks) = await self.kv_router.best_worker(
+        worker_id, _dp_rank, _overlap_blocks = await self.kv_router.best_worker(
             token_ids, router_config_override
         )
 
@@ -187,6 +230,11 @@ async def worker(runtime: DistributedRuntime):
     kv_router_config = build_kv_router_config(config)
     aic_perf_config = build_aic_perf_config(config)
 
+    # Load optional semantic KV cache provider
+    semantic_provider = create_semantic_provider(
+        getattr(config, "semantic_kv_provider", None)
+    )
+
     # Create handler
     handler = StandaloneRouterHandler(
         runtime,
@@ -194,6 +242,7 @@ async def worker(runtime: DistributedRuntime):
         config.router_block_size,
         kv_router_config,
         aic_perf_config,
+        semantic_provider=semantic_provider,
     )
     await handler.initialize()
 

--- a/components/src/dynamo/router/semantic.py
+++ b/components/src/dynamo/router/semantic.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Semantic KV cache integration for the standalone router.
+
+Provides helper functions to create and wire a SemanticKvCacheProvider
+into the StandaloneRouterHandler's request flow.
+
+Usage in router __main__.py::
+
+    from dynamo.router.semantic import create_semantic_provider
+
+    provider = create_semantic_provider(config.semantic_kv_provider)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from dynamo.llm.semantic_kv import SemanticKvCacheProvider
+
+logger = logging.getLogger(__name__)
+
+# Registry of built-in provider names → factory functions.
+_BUILTIN_PROVIDERS = {}
+
+
+def _register_builtin(name: str):
+    """Decorator to register a built-in provider factory."""
+
+    def decorator(fn):
+        _BUILTIN_PROVIDERS[name] = fn
+        return fn
+
+    return decorator
+
+
+@_register_builtin("simple")
+def _create_simple_provider(
+    min_similarity: float = 0.6,
+    max_donors: int = 10_000,
+) -> SemanticKvCacheProvider:
+    """Create the SimpleSemanticProvider reference implementation."""
+    from dynamo.llm.semantic_kv_simple import SimpleSemanticProvider
+
+    return SimpleSemanticProvider(
+        min_similarity=min_similarity,
+        max_donors=max_donors,
+    )
+
+
+def create_semantic_provider(
+    provider_name: Optional[str],
+) -> Optional[SemanticKvCacheProvider]:
+    """Create a semantic KV cache provider by name.
+
+    Args:
+        provider_name: Name of the provider to create. Built-in options:
+            - ``"simple"`` — Jaccard similarity reference implementation.
+            - ``None`` — Disable semantic KV cache (default).
+
+    Returns:
+        A provider instance, or ``None`` if semantic KV is disabled.
+
+    Raises:
+        ValueError: If the provider name is not recognized.
+    """
+    if not provider_name:
+        return None
+
+    factory = _BUILTIN_PROVIDERS.get(provider_name)
+    if factory is not None:
+        provider = factory()
+        logger.info("Semantic KV cache enabled: provider=%s", provider_name)
+        return provider
+
+    raise ValueError(
+        f"Unknown semantic KV provider: {provider_name!r}. "
+        f"Available: {', '.join(sorted(_BUILTIN_PROVIDERS))} "
+        f"or implement SemanticKvCacheProvider protocol."
+    )

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -43,6 +43,8 @@ from dynamo._core import run_mocker_trace_replay as _run_mocker_trace_replay
 from dynamo._core import unregister_model as unregister_model
 
 from .exceptions import HttpError
+from .semantic_kv import SemanticKvCacheProvider as SemanticKvCacheProvider
+from .semantic_kv import SemanticMatch as SemanticMatch
 
 # Backward-compatible aliases
 fetch_llm = fetch_model

--- a/lib/bindings/python/src/dynamo/llm/semantic_kv.py
+++ b/lib/bindings/python/src/dynamo/llm/semantic_kv.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Semantic KV cache lookup interface for Dynamo.
+
+When RadixTree exact-prefix matching misses (e.g., same document but different
+instruction), a semantic provider finds cached prompts with similar content.
+The router then queries the RadixTree with the donor's tokens to locate the
+worker holding the reusable KV blocks.
+
+This module defines the provider-agnostic interface. Implementations may use
+embeddings, learned routers, or any other similarity signal.
+
+Example usage with the standalone router::
+
+    from dynamo.llm import SemanticKvCacheProvider, SemanticMatch
+
+    class MyProvider:
+        async def find_semantic_match(self, token_ids, prompt_text=None):
+            # Your similarity search logic here
+            return SemanticMatch(donor_token_ids=[...], similarity=0.95, donor_id="req-123")
+
+        async def register_donor(self, donor_id, token_ids, prompt_text=None):
+            # Store embedding for future lookups
+            pass
+
+        def on_eviction(self, donor_id):
+            pass
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Protocol, Sequence, runtime_checkable
+
+__all__ = ["SemanticMatch", "SemanticKvCacheProvider"]
+
+
+@dataclass(frozen=True)
+class SemanticMatch:
+    """Result from a semantic KV cache lookup.
+
+    Returned by :meth:`SemanticKvCacheProvider.find_semantic_match` when a
+    similar cached prompt is found.
+
+    Attributes:
+        donor_token_ids: Token IDs of the matched donor prompt. The router
+            uses these to query the RadixTree for overlap scores.
+        similarity: Similarity score between query and donor (0.0–1.0).
+            Interpretation depends on the provider (cosine, Jaccard, etc.).
+        donor_id: Opaque identifier for the donor request. Used for
+            eviction callbacks and debugging.
+        metadata: Optional provider-specific metadata (e.g., embedding model,
+            match latency, donor age). Not used by the router.
+    """
+
+    donor_token_ids: Sequence[int]
+    similarity: float
+    donor_id: str
+    metadata: Optional[Mapping[str, Any]] = field(default=None)
+
+    def __post_init__(self) -> None:
+        if not (0.0 <= self.similarity <= 1.0):
+            raise ValueError(f"similarity must be in [0.0, 1.0], got {self.similarity}")
+
+
+@runtime_checkable
+class SemanticKvCacheProvider(Protocol):
+    """Provider for semantic KV cache lookup.
+
+    When the RadixTree exact-prefix match returns low overlap for a request,
+    the router calls :meth:`find_semantic_match` to search for cached prompts
+    with semantically similar content. If a match is found, the router queries
+    the RadixTree with the donor's ``token_ids`` to get overlap scores and
+    route the request to the worker holding those KV blocks.
+
+    After each request completes prefill, the router calls
+    :meth:`register_donor` so the provider can index the request for future
+    lookups.
+
+    Implementations are external to Dynamo — this interface is intentionally
+    provider-agnostic. No assumptions about embedding models, vector stores,
+    or similarity metrics.
+
+    Thread safety: all methods may be called concurrently from multiple
+    asyncio tasks. Implementations must handle their own synchronization.
+    """
+
+    async def find_semantic_match(
+        self,
+        token_ids: Sequence[int],
+        prompt_text: Optional[str] = None,
+    ) -> Optional[SemanticMatch]:
+        """Find a semantically similar cached prompt.
+
+        Args:
+            token_ids: Token IDs of the current request.
+            prompt_text: Optional decoded prompt text. Passing text avoids
+                the provider needing to decode tokens, but is not required.
+
+        Returns:
+            A :class:`SemanticMatch` if a similar donor is found, or ``None``
+            if no match exceeds the provider's similarity threshold.
+
+        Note:
+            Should complete quickly (< 10ms) to avoid adding latency to the
+            request critical path. Providers with expensive lookups should
+            use background indexing and return cached results.
+        """
+        ...
+
+    async def register_donor(
+        self,
+        donor_id: str,
+        token_ids: Sequence[int],
+        prompt_text: Optional[str] = None,
+    ) -> None:
+        """Register a completed request as a potential donor.
+
+        Called after a request completes prefill. The provider stores whatever
+        representation it needs (embedding, token hashes, etc.) for future
+        :meth:`find_semantic_match` lookups.
+
+        Args:
+            donor_id: Unique identifier for this request (e.g., request UUID).
+            token_ids: The request's token IDs.
+            prompt_text: Optional decoded prompt text.
+        """
+        ...
+
+    def on_eviction(self, donor_id: str) -> None:
+        """Notify the provider that a donor's KV blocks were evicted.
+
+        Called when the RadixTree evicts blocks for a previously registered
+        donor. The provider should remove or invalidate the entry so it is
+        no longer returned by :meth:`find_semantic_match`.
+
+        This method is synchronous because eviction notifications are
+        fire-and-forget — the router does not wait for the provider to
+        finish cleanup.
+
+        Args:
+            donor_id: Identifier previously passed to :meth:`register_donor`.
+        """
+        ...

--- a/lib/bindings/python/src/dynamo/llm/semantic_kv_simple.py
+++ b/lib/bindings/python/src/dynamo/llm/semantic_kv_simple.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Simple reference implementation of SemanticKvCacheProvider.
+
+Uses Jaccard similarity over sentence-segmented word trigrams (shingles)
+for fast approximate matching. No GPU, no embedding model — just stdlib.
+Note that this implementation should never be used in a production setting...
+Jaccard similarity on shingles is a very rough heuristic and does not capture semantic meaning well.
+It is also O(N) over donors, which can be slow for large counts.
+
+So... just here as an example... Demonstrates the interface contract and serves as a
+starting point for testing and prototyping. For production, I would use an
+embedding-based provider with a vector index.
+
+Concurrency: uses ``threading.Lock`` for safe access from multiple asyncio
+tasks or threads. The O(N) donor scan is bounded by a time budget to avoid
+blocking the event loop.
+
+Usage::
+
+    from dynamo.llm.semantic_kv_simple import SimpleSemanticProvider
+
+    provider = SimpleSemanticProvider(min_similarity=0.6)
+    await provider.register_donor("req-1", [1, 2, 3], "The quick brown fox...")
+    match = await provider.find_semantic_match([1, 2, 4], "The quick brown dog...")
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import FrozenSet, Optional, Sequence, Set
+
+from .semantic_kv import SemanticMatch
+
+logger = logging.getLogger(__name__)
+
+# Cap shingle count per donor to prevent memory blowup from very long prompts.
+_MAX_SHINGLES_PER_DONOR = 2_000
+
+# Maximum characters of prompt text to process (longer text is truncated).
+_MAX_TEXT_CHARS = 50_000
+
+# Time budget for the O(N) donor scan (seconds).
+_SEARCH_BUDGET_SECS = 0.005
+
+
+@dataclass
+class _DonorEntry:
+    """Internal donor record."""
+
+    donor_id: str
+    token_ids: list[int]
+    shingles: FrozenSet[str]
+
+
+class SimpleSemanticProvider:
+    """Reference SemanticKvCacheProvider using Jaccard similarity.
+
+    Stores donors in an OrderedDict with sentence-segmented word trigrams.
+    Matching is O(N) scan over donors with a time budget. Suitable for
+    small donor counts (< 10K).
+
+    Args:
+        min_similarity: Minimum Jaccard similarity (0.0–1.0) for a match.
+        max_donors: Maximum number of donors to keep (LRU eviction).
+
+    Raises:
+        ValueError: If min_similarity is not in [0.0, 1.0] or max_donors < 1.
+    """
+
+    def __init__(
+        self,
+        min_similarity: float = 0.6,
+        max_donors: int = 10_000,
+    ) -> None:
+        if not (0.0 <= min_similarity <= 1.0):
+            raise ValueError(
+                f"min_similarity must be in [0.0, 1.0], got {min_similarity}"
+            )
+        if max_donors < 1:
+            raise ValueError(f"max_donors must be >= 1, got {max_donors}")
+
+        self._min_similarity = min_similarity
+        self._max_donors = max_donors
+        self._donors: OrderedDict[str, _DonorEntry] = OrderedDict()
+        self._lock = threading.Lock()
+
+    async def find_semantic_match(
+        self,
+        token_ids: Sequence[int],
+        prompt_text: Optional[str] = None,
+    ) -> Optional[SemanticMatch]:
+        """Find the most similar donor by Jaccard similarity over shingles."""
+        if not prompt_text:
+            return None
+
+        query_shingles = self._text_to_shingles(prompt_text)
+        if not query_shingles:
+            return None
+
+        best_entry: Optional[_DonorEntry] = None
+        best_sim = 0.0
+        deadline = time.monotonic() + _SEARCH_BUDGET_SECS
+
+        with self._lock:
+            if not self._donors:
+                return None
+
+            for entry in self._donors.values():
+                sim = self._jaccard(query_shingles, entry.shingles)
+                if sim > best_sim and sim >= self._min_similarity:
+                    best_entry = entry
+                    best_sim = sim
+                if time.monotonic() > deadline:
+                    logger.debug(
+                        "Semantic search hit time budget; returning best so far"
+                    )
+                    break
+
+        if best_entry is None:
+            return None
+
+        return SemanticMatch(
+            donor_token_ids=list(best_entry.token_ids),
+            similarity=best_sim,
+            donor_id=best_entry.donor_id,
+            metadata={"method": "jaccard_shingles"},
+        )
+
+    async def register_donor(
+        self,
+        donor_id: str,
+        token_ids: Sequence[int],
+        prompt_text: Optional[str] = None,
+    ) -> None:
+        """Register a donor with sentence-segmented word trigrams."""
+        if not prompt_text:
+            return
+
+        shingles = self._text_to_shingles(prompt_text)
+        if not shingles:
+            return
+
+        with self._lock:
+            # Remove existing entry if re-registering (OrderedDict handles order)
+            if donor_id in self._donors:
+                del self._donors[donor_id]
+
+            # Evict oldest if at capacity
+            while len(self._donors) >= self._max_donors:
+                self._donors.popitem(last=False)
+
+            self._donors[donor_id] = _DonorEntry(
+                donor_id=donor_id,
+                token_ids=list(token_ids),
+                shingles=shingles,
+            )
+
+    def on_eviction(self, donor_id: str) -> None:
+        """Remove an evicted donor."""
+        with self._lock:
+            self._donors.pop(donor_id, None)
+
+    @property
+    def donor_count(self) -> int:
+        """Number of registered donors."""
+        return len(self._donors)
+
+    @staticmethod
+    def _text_to_shingles(text: str) -> FrozenSet[str]:
+        """Convert text to a set of normalized 3-word shingles.
+
+        Splits on sentence boundaries, normalizes whitespace and case,
+        then creates 3-word shingles for robust partial matching.
+        Caps output to ``_MAX_SHINGLES_PER_DONOR`` to bound memory.
+        """
+        # Truncate to prevent excessive processing
+        text = text[:_MAX_TEXT_CHARS]
+
+        # Normalize: collapse whitespace, lowercase
+        normalized = " ".join(text.lower().split())
+
+        # Split into sentences (simple heuristic)
+        for sep in (".", "!", "?", "\n"):
+            normalized = normalized.replace(sep, "|")
+
+        sentences = [s.strip() for s in normalized.split("|") if len(s.strip()) > 10]
+
+        # Create 3-word shingles from each sentence
+        shingles: Set[str] = set()
+        for sentence in sentences:
+            words = sentence.split()
+            for i in range(len(words) - 2):
+                shingles.add(" ".join(words[i : i + 3]))
+                if len(shingles) >= _MAX_SHINGLES_PER_DONOR:
+                    return frozenset(shingles)
+
+        return frozenset(shingles)
+
+    @staticmethod
+    def _jaccard(a: FrozenSet[str], b: FrozenSet[str]) -> float:
+        """Jaccard similarity between two sets."""
+        if not a or not b:
+            return 0.0
+        intersection = len(a & b)
+        union = len(a | b)
+        return intersection / union if union > 0 else 0.0

--- a/lib/bindings/python/tests/test_semantic_kv.py
+++ b/lib/bindings/python/tests/test_semantic_kv.py
@@ -1,0 +1,380 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the semantic KV cache provider interface and reference implementation.
+
+Run: pytest lib/bindings/python/tests/test_semantic_kv.py -v
+"""
+
+import os
+import sys
+import types
+
+import pytest
+
+# ── Bootstrap: import semantic_kv modules without compiled _core ──────
+# dynamo.llm.__init__ unconditionally imports from dynamo._core (compiled
+# Rust bindings). We create a minimal stub package so our pure-Python
+# modules can be imported for testing without _core.
+_src_dir = os.path.join(os.path.dirname(__file__), "..", "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+# Stub out dynamo.llm as a minimal package (skip __init__.py)
+_llm_pkg = types.ModuleType("dynamo.llm")
+_llm_pkg.__path__ = [os.path.join(_src_dir, "dynamo", "llm")]
+_llm_pkg.__package__ = "dynamo.llm"
+sys.modules.setdefault("dynamo", types.ModuleType("dynamo"))
+sys.modules["dynamo.llm"] = _llm_pkg
+
+# Now normal imports work
+from dynamo.llm.semantic_kv import SemanticKvCacheProvider, SemanticMatch  # noqa: E402
+from dynamo.llm.semantic_kv_simple import SimpleSemanticProvider  # noqa: E402
+
+pytestmark = pytest.mark.pre_merge
+
+
+# ── Protocol compliance ─────────────────────────────────────────────
+
+
+class TestProtocolCompliance:
+    """Verify the Protocol contract is correctly defined."""
+
+    def test_simple_provider_implements_protocol(self):
+        """SimpleSemanticProvider must satisfy the runtime-checkable Protocol."""
+        provider = SimpleSemanticProvider()
+        assert isinstance(provider, SemanticKvCacheProvider)
+
+    def test_minimal_implementation_satisfies_protocol(self):
+        """A bare-bones class with the right signatures should satisfy the Protocol."""
+
+        class MinimalProvider:
+            async def find_semantic_match(self, token_ids, prompt_text=None):
+                return None
+
+            async def register_donor(self, donor_id, token_ids, prompt_text=None):
+                pass
+
+            def on_eviction(self, donor_id):
+                pass
+
+        assert isinstance(MinimalProvider(), SemanticKvCacheProvider)
+
+    def test_incomplete_implementation_fails_protocol(self):
+        """A class missing methods should NOT satisfy the Protocol."""
+
+        class IncompleteProvider:
+            async def find_semantic_match(self, token_ids, prompt_text=None):
+                return None
+
+            # Missing register_donor and on_eviction
+
+        assert not isinstance(IncompleteProvider(), SemanticKvCacheProvider)
+
+
+# ── SemanticMatch dataclass ──────────────────────────────────────────
+
+
+class TestSemanticMatch:
+    """Verify SemanticMatch is immutable and well-formed."""
+
+    def test_creation(self):
+        match = SemanticMatch(
+            donor_token_ids=[1, 2, 3],
+            similarity=0.95,
+            donor_id="req-123",
+        )
+        assert match.donor_token_ids == [1, 2, 3]
+        assert match.similarity == 0.95
+        assert match.donor_id == "req-123"
+        assert match.metadata is None
+
+    def test_with_metadata(self):
+        match = SemanticMatch(
+            donor_token_ids=[1],
+            similarity=0.8,
+            donor_id="req-456",
+            metadata={"model": "minilm", "latency_ms": 2.3},
+        )
+        assert match.metadata["model"] == "minilm"
+
+    def test_frozen(self):
+        match = SemanticMatch(donor_token_ids=[1], similarity=0.9, donor_id="x")
+        with pytest.raises(AttributeError):
+            match.similarity = 0.5  # type: ignore[misc]
+
+
+# ── SimpleSemanticProvider unit tests ────────────────────────────────
+
+
+class TestSimpleSemanticProvider:
+    """Test the reference implementation."""
+
+    @pytest.fixture
+    def provider(self):
+        return SimpleSemanticProvider(min_similarity=0.5)
+
+    @pytest.mark.asyncio
+    async def test_empty_store_returns_none(self, provider):
+        """No donors registered → always None."""
+        result = await provider.find_semantic_match(
+            [1, 2, 3], "The quick brown fox jumps over the lazy dog."
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_prompt_text_returns_none(self, provider):
+        """Without prompt text, matching is impossible."""
+        await provider.register_donor("d1", [1, 2, 3], "Some text here for testing.")
+        result = await provider.find_semantic_match([1, 2, 3])
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_register_and_match_similar(self, provider):
+        """Register a donor, query with similar text → match."""
+        document = (
+            "Quantum computing uses qubits to perform calculations. "
+            "Unlike classical bits, qubits can exist in superposition states. "
+            "This enables quantum computers to solve certain problems exponentially faster."
+        )
+        await provider.register_donor("donor-1", [10, 20, 30], document)
+
+        # Same document, different question appended
+        query = (
+            "Quantum computing uses qubits to perform calculations. "
+            "Unlike classical bits, qubits can exist in superposition states. "
+            "This enables quantum computers to solve certain problems exponentially faster. "
+            "What are the main advantages of quantum computing?"
+        )
+        result = await provider.find_semantic_match([10, 20, 99], query)
+
+        assert result is not None
+        assert result.donor_id == "donor-1"
+        assert result.donor_token_ids == [10, 20, 30]
+        assert result.similarity > 0.5
+
+    @pytest.mark.asyncio
+    async def test_unrelated_text_no_match(self, provider):
+        """Completely different text → no match."""
+        await provider.register_donor(
+            "donor-1",
+            [1, 2, 3],
+            "Quantum computing uses qubits to perform calculations. "
+            "This enables solving problems exponentially faster than classical computers.",
+        )
+
+        result = await provider.find_semantic_match(
+            [99, 98, 97],
+            "The recipe calls for two cups of flour and one tablespoon of baking powder. "
+            "Mix the dry ingredients together before adding the wet ingredients slowly.",
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_eviction_removes_donor(self, provider):
+        """Evicted donor should no longer be findable."""
+        text = (
+            "Neural networks consist of layers of interconnected nodes. "
+            "Each node applies a nonlinear activation function to its weighted inputs."
+        )
+        await provider.register_donor("donor-1", [1, 2, 3], text)
+
+        # Verify it's findable
+        result = await provider.find_semantic_match([1, 2, 4], text)
+        assert result is not None
+
+        # Evict and verify it's gone
+        provider.on_eviction("donor-1")
+        result = await provider.find_semantic_match([1, 2, 4], text)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_multiple_donors_best_match(self, provider):
+        """With multiple donors, the most similar one should be returned."""
+        await provider.register_donor(
+            "cooking",
+            [1, 2, 3],
+            "The recipe requires flour, sugar, and butter to make a delicious cake. "
+            "Mix the dry ingredients first, then add wet ingredients gradually. "
+            "Bake at 350 degrees for 30 minutes until golden brown on top. "
+            "Let the cake cool completely before applying the frosting layer.",
+        )
+        await provider.register_donor(
+            "physics",
+            [4, 5, 6],
+            "Quantum entanglement allows particles to be correlated across vast distances. "
+            "Measuring one particle instantly determines the state of its entangled partner. "
+            "This phenomenon was famously described by Einstein as spooky action at a distance. "
+            "Modern experiments have confirmed entanglement over thousands of kilometers.",
+        )
+
+        result = await provider.find_semantic_match(
+            [10, 11, 12],
+            "Quantum entanglement allows particles to be correlated across vast distances. "
+            "This phenomenon was famously described by Einstein as spooky action at a distance. "
+            "Modern experiments have confirmed entanglement over thousands of kilometers. "
+            "What are the practical applications of quantum entanglement in computing?",
+        )
+
+        assert result is not None
+        # Should match physics donor, not cooking
+        assert result.donor_id == "physics"
+
+    @pytest.mark.asyncio
+    async def test_min_similarity_threshold(self):
+        """Matches below the threshold should be filtered out."""
+        provider = SimpleSemanticProvider(min_similarity=0.99)
+        await provider.register_donor(
+            "d1",
+            [1, 2, 3],
+            "Some moderately long text about artificial intelligence and machine learning.",
+        )
+
+        result = await provider.find_semantic_match(
+            [4, 5, 6],
+            "Some different moderately long text about deep learning and neural networks.",
+        )
+        # With 0.99 threshold, partial overlap should be rejected
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_max_donors_eviction(self):
+        """Exceeding max_donors should evict the oldest entry."""
+        provider = SimpleSemanticProvider(min_similarity=0.3, max_donors=3)
+
+        for i in range(5):
+            await provider.register_donor(
+                f"donor-{i}",
+                [i],
+                f"Document number {i} has unique content about topic {i} specifically. "
+                f"It discusses topic {i} in great detail with many examples and references.",
+            )
+
+        assert provider.donor_count == 3
+        # Oldest donors (0, 1) should have been evicted
+        assert "donor-0" not in provider._donors
+        assert "donor-1" not in provider._donors
+        # Newest donors should remain
+        assert "donor-4" in provider._donors
+
+    @pytest.mark.asyncio
+    async def test_donor_count_property(self, provider):
+        """donor_count should track registered donors."""
+        assert provider.donor_count == 0
+        await provider.register_donor("d1", [1], "Some text for testing the count.")
+        assert provider.donor_count == 1
+        await provider.register_donor("d2", [2], "More text for testing the count.")
+        assert provider.donor_count == 2
+        provider.on_eviction("d1")
+        assert provider.donor_count == 1
+
+    @pytest.mark.asyncio
+    async def test_register_without_text_is_noop(self, provider):
+        """Registering without prompt_text should be silently ignored."""
+        await provider.register_donor("d1", [1, 2, 3])
+        assert provider.donor_count == 0
+
+    @pytest.mark.asyncio
+    async def test_evict_nonexistent_is_safe(self, provider):
+        """Evicting a non-existent donor should not raise."""
+        provider.on_eviction("nonexistent")  # Should not raise
+
+
+# ── Integration test: SemanticMatch → RadixTree handoff ──────────────
+
+
+class TestRadixTreeIntegration:
+    """Test that semantic matches can be used with RadixTree overlap scoring.
+
+    This verifies the core handoff: semantic provider returns donor_token_ids,
+    which are then used to query the RadixTree for overlap scores.
+    """
+
+    @pytest.mark.asyncio
+    async def test_semantic_to_radixtree_handoff(self):
+        """Full flow: register donor → semantic match → RadixTree lookup."""
+        try:
+            from dynamo.llm import RadixTree, compute_block_hash_for_seq
+        except ImportError:
+            pytest.skip("dynamo._core not available (requires compiled bindings)")
+
+        provider = SimpleSemanticProvider(min_similarity=0.3)
+
+        # Simulate a donor request with specific token IDs
+        donor_tokens = list(range(64))  # 64 tokens = 2 blocks of 32
+        donor_text = (
+            "Quantum computing leverages quantum mechanical phenomena. "
+            "Superposition allows qubits to represent multiple states simultaneously. "
+            "Entanglement enables correlated measurements across distances."
+        )
+
+        # 1. Register the donor
+        await provider.register_donor("donor-1", donor_tokens, donor_text)
+
+        # 2. Store the donor's KV blocks in a RadixTree
+        tree = RadixTree()
+        block_hashes = compute_block_hash_for_seq(donor_tokens, 32)
+
+        import json
+
+        # Store block 0
+        event_0 = json.dumps(
+            {
+                "event_id": 1,
+                "data": {
+                    "stored": {
+                        "parent_hash": None,
+                        "blocks": [
+                            {
+                                "block_hash": block_hashes[0],
+                                "tokens_hash": block_hashes[0],
+                            }
+                        ],
+                    }
+                },
+            }
+        ).encode()
+        tree.apply_event(0, event_0)  # worker_id=0
+
+        # Store block 1
+        event_1 = json.dumps(
+            {
+                "event_id": 2,
+                "data": {
+                    "stored": {
+                        "parent_hash": block_hashes[0],
+                        "blocks": [
+                            {
+                                "block_hash": block_hashes[1],
+                                "tokens_hash": block_hashes[1],
+                            }
+                        ],
+                    }
+                },
+            }
+        ).encode()
+        tree.apply_event(0, event_1)
+
+        # 3. Simulate a new request with the same document but different question
+        query_text = (
+            "Quantum computing leverages quantum mechanical phenomena. "
+            "Superposition allows qubits to represent multiple states simultaneously. "
+            "Entanglement enables correlated measurements across distances. "
+            "How does quantum error correction work?"
+        )
+
+        match = await provider.find_semantic_match([50, 51, 52], query_text)
+        assert match is not None
+        assert match.donor_id == "donor-1"
+
+        # 4. Use the donor's token IDs to query the RadixTree
+        donor_block_hashes = compute_block_hash_for_seq(match.donor_token_ids, 32)
+        overlap = tree.find_matches(donor_block_hashes)
+        scores = overlap.scores
+
+        # Worker 0 should have a non-zero score (it has the donor's KV blocks)
+        assert len(scores) > 0, "RadixTree should find overlap for donor tokens"
+        assert any(
+            score > 0 for score in scores.values()
+        ), "At least one worker should have overlapping KV blocks"

--- a/lib/bindings/python/tests/test_semantic_kv_e2e.sh
+++ b/lib/bindings/python/tests/test_semantic_kv_e2e.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# End-to-end smoke test for the semantic KV cache interface.
+# Requires compiled dynamo bindings (run in CI or Linux environment).
+#
+# Usage: bash lib/bindings/python/tests/test_semantic_kv_e2e.sh
+#
+# Validates:
+# 1. Protocol imports work through the real dynamo.llm package
+# 2. RadixTree integration test passes (semantic → RadixTree handoff)
+# 3. SimpleSemanticProvider works with real RadixTree overlap scoring
+
+set -euo pipefail
+
+echo "=== Semantic KV Cache E2E Smoke Test ==="
+
+# 1. Verify imports through real dynamo package
+python3 -c "
+from dynamo.llm import SemanticKvCacheProvider, SemanticMatch
+from dynamo.llm.semantic_kv_simple import SimpleSemanticProvider
+
+provider = SimpleSemanticProvider()
+assert isinstance(provider, SemanticKvCacheProvider), 'Protocol check failed'
+print('OK: Protocol imports and compliance check passed')
+"
+
+# 2. Run full test suite including RadixTree integration
+python3 -m pytest lib/bindings/python/tests/test_semantic_kv.py -v \
+    --noconftest --override-ini="addopts=" --override-ini="filterwarnings="
+
+# 3. Standalone integration: register donor → semantic match → RadixTree lookup
+python3 -c "
+import asyncio
+import json
+from dynamo.llm import RadixTree, compute_block_hash_for_seq
+from dynamo.llm.semantic_kv_simple import SimpleSemanticProvider
+from dynamo.llm.semantic_kv import SemanticMatch
+
+async def main():
+    provider = SimpleSemanticProvider(min_similarity=0.3)
+
+    # Register a donor
+    donor_tokens = list(range(128))
+    donor_text = (
+        'Quantum computing leverages quantum mechanical phenomena like superposition. '
+        'Qubits can represent multiple states simultaneously unlike classical bits. '
+        'Entanglement enables correlated measurements across vast distances instantly. '
+        'Error correction is essential for practical quantum computation at scale.'
+    )
+    await provider.register_donor('donor-1', donor_tokens, donor_text)
+
+    # Store donor KV blocks in RadixTree
+    tree = RadixTree()
+    block_hashes = compute_block_hash_for_seq(donor_tokens, 32)
+    parent = None
+    for i, bh in enumerate(block_hashes):
+        event = json.dumps({
+            'event_id': i + 1,
+            'data': {'stored': {'parent_hash': parent, 'blocks': [{'block_hash': bh, 'tokens_hash': bh}]}},
+        }).encode()
+        tree.apply_event(0, event)
+        parent = bh
+
+    # Query with similar text (same document, different question)
+    query_text = (
+        'Quantum computing leverages quantum mechanical phenomena like superposition. '
+        'Qubits can represent multiple states simultaneously unlike classical bits. '
+        'Entanglement enables correlated measurements across vast distances instantly. '
+        'How does quantum error correction improve computation reliability?'
+    )
+    match = await provider.find_semantic_match([200, 201, 202], query_text)
+    assert match is not None, 'Semantic match should find the donor'
+    assert match.donor_id == 'donor-1'
+    print(f'Semantic match: donor={match.donor_id}, sim={match.similarity:.3f}')
+
+    # Use donor tokens to query RadixTree
+    donor_hashes = compute_block_hash_for_seq(match.donor_token_ids, 32)
+    overlap = tree.find_matches(donor_hashes)
+    scores = overlap.scores
+    assert len(scores) > 0, 'RadixTree should find overlap'
+    print(f'RadixTree overlap: {dict(scores)}')
+    print('OK: Full semantic → RadixTree handoff works end-to-end')
+
+asyncio.run(main())
+"
+
+echo ""
+echo "=== ALL E2E TESTS PASSED ==="


### PR DESCRIPTION
## Summary

Whole point of this is to start to define the interface for semantic KV cache lookup which will help provider further speeds to prefill.

Defines a minimal, provider-agnostic `SemanticKvCacheProvider` Protocol that lets any implementation (embeddings, learned routers, etc.) plug into Dynamo's KV routing. When RadixTree exact-prefix matching misses (e.g., same document, different instruction), the semantic provider finds cached prompts with similar content. The router then queries the RadixTree with the donor's tokens to locate the worker holding reusable KV blocks.


There is a lot more to do in this space. We have proven this up to the router level (we have our own "semantic router") with our own implementation of a provider that we use. 

### Files

| File | Purpose |
|------|---------|
| `lib/bindings/python/src/dynamo/llm/semantic_kv.py` | `SemanticKvCacheProvider` Protocol + `SemanticMatch` dataclass |
| `lib/bindings/python/src/dynamo/llm/semantic_kv_simple.py` | Reference impl (Jaccard similarity, thread-safe, time-bounded) |
| `lib/bindings/python/tests/test_semantic_kv.py` | 17 unit tests + RadixTree integration test |
| `lib/bindings/python/tests/test_semantic_kv_e2e.sh` | E2E smoke test script |
| `components/src/dynamo/router/semantic.py` | Provider factory with registry |
| `components/src/dynamo/router/__main__.py` | Semantic pre-routing + donor registration |
| `components/src/dynamo/common/configuration/groups/kv_router_args.py` | `--semantic-kv-provider` CLI arg |
| `lib/bindings/python/src/dynamo/llm/__init__.py` | Exports |

### Interface

```python
@runtime_checkable
class SemanticKvCacheProvider(Protocol):
    async def find_semantic_match(self, token_ids, prompt_text=None) -> Optional[SemanticMatch]: ...
    async def register_donor(self, donor_id, token_ids, prompt_text=None) -> None: ...
    def on_eviction(self, donor_id) -> None: ...
```

### Validation
- E2E validated on EKS with SemBlend (https://github.com/WorldFlowAI/semblend) - 3.4x speedup at 8K context
