### PR TITLE
fix: unskip multimodal_disagg_qwen EPD test

### DIFF
--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -386,7 +386,7 @@ vllm_configs = {
         marks=[
             pytest.mark.gpu_1,
             pytest.mark.max_vram_gib(19.4),  # observed peak 17.6 GiB (+10% safety)
-            pytest.mark.post_merge,
+            pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-VL-2B-Instruct",
         script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct", "--single-gpu"],

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -387,7 +387,6 @@ vllm_configs = {
             pytest.mark.gpu_1,
             pytest.mark.max_vram_gib(19.4),  # observed peak 17.6 GiB (+10% safety)
             pytest.mark.post_merge,
-            pytest.mark.skip(reason="DYN-2265"),
         ],
         model="Qwen/Qwen3-VL-2B-Instruct",
         script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct", "--single-gpu"],


### PR DESCRIPTION
#### Overview:
- Unskip `multimodal_disagg_qwen` and promote from `post_merge` → `pre_merge`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted test execution configuration for multimodal model inference validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->