### PR TITLE
fix: fix deploy-test namespace collisions on rerun

### DIFF
--- a/.github/actions/dynamo-deploy-test/action.yml
+++ b/.github/actions/dynamo-deploy-test/action.yml
@@ -64,10 +64,11 @@ runs:
           echo "Namespace $NAMESPACE exists, will reuse it"
         else
           echo "exists=false" >> $GITHUB_OUTPUT
-          # Use check_run_id (unique per job+retry) to keep namespace under k8s 63-char label limit
-          SELF_NS="${NAMESPACE}-${{ job.check_run_id }}"
-          SELF_NS="${SELF_NS:0:36}"
-          SELF_NS="${SELF_NS%-}"
+          # Use last 7 digits of check_run_id (unique per job+retry).
+          # Leading digits are shared across matrix jobs so truncating from the
+          # front caused namespace collisions; the trailing digits differ.
+          CRI="${{ job.check_run_id }}"
+          SELF_NS="${NAMESPACE}-${CRI: -7}"
           echo "ns=${SELF_NS}" >> $GITHUB_OUTPUT
           echo "Namespace $NAMESPACE not found, will self-bootstrap as ${SELF_NS}"
         fi

--- a/.github/actions/teardown-deploy-namespace/action.yml
+++ b/.github/actions/teardown-deploy-namespace/action.yml
@@ -57,5 +57,5 @@ runs:
         NAMESPACE: ${{ inputs.namespace }}
       run: |
         echo "::group::Delete namespace $NAMESPACE"
-        kubectl delete namespace $NAMESPACE --timeout=120s
+        kubectl delete namespace $NAMESPACE --ignore-not-found --timeout=120s
         echo "::endgroup::"


### PR DESCRIPTION
## Summary
- Fix namespace collisions when multiple deploy-test matrix jobs self-bootstrap on rerun: use last 7 digits of `check_run_id` instead of truncating from the front, since leading digits are shared across all matrix jobs
- Add `--ignore-not-found` to namespace teardown so cleanup doesn't fail when a namespace was already deleted by a prior run

## Root cause
All deploy-test jobs in a workflow run get nearly-identical `check_run_id`s (e.g. `67771440077`, `67771440153`, `67771440241`). The old code appended the full ID then truncated to 36 chars from the front, keeping only `6777144` — identical for all jobs. This caused a race where the first job to `kubectl create namespace` succeeded and the rest failed with `AlreadyExists`.

Observed in: https://github.com/ai-dynamo/dynamo/actions/runs/23298215961/job/67771440153?pr=7480

## Test plan
- [ ] Verify deploy-test jobs on a PR CI run no longer collide on namespace names
- [ ] Verify cleanup job succeeds even if namespace was already deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted deployment testing namespace naming strategy to use fixed trailing-suffix truncation for improved identifier consistency
  * Enhanced namespace cleanup operations to gracefully handle scenarios where target Kubernetes namespaces do not exist, preventing step failures while maintaining timeout configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->