### PR TITLE
feat: cosmetic improvement in Dev Container-- fix double banner, add workspace warnings, add gh

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -95,27 +95,21 @@ else
     echo "⚠️ SSH agent forwarding not configured - SSH_AUTH_SOCK is not set"
 fi
 
-echo -e "\n🔍 Running sanity check..."
-if show_and_run $WORKSPACE_DIR/deploy/sanity_check.py; then
-    SANITY_STATUS="✅ Sanity check passed"
-else
-    SANITY_STATUS="⚠️ Sanity check failed - review output above"
-fi
-
 cat <<EOF
 
 ========================================
-$SANITY_STATUS
 ✅ Pre-commit hooks configured
 
 Now build the project:
-  cargo build --locked --profile dev --features dynamo-llm/block-manager
-  cd lib/bindings/python && maturin develop --uv
+  cargo build --features dynamo-llm/block-manager
+  cd lib/bindings/python && maturin develop --uv && cd /workspace
+  uv pip install --no-deps -e /workspace
+
+Optional:
   uv pip install -e lib/gpu_memory_service  # GPU memory manager with C++ extension
-  DYNAMO_BIN_PATH=\$CARGO_TARGET_DIR/debug uv pip install -e .
+  cd lib/bindings/kvbm && maturin develop --uv  # For KVBM support
 
-Optional: cd lib/bindings/kvbm && maturin develop --uv  # For KVBM support
-
-If cargo build fails with a Cargo.lock error, try to update it with 'cargo update'
+Verify with:
+  /workspace/deploy/sanity_check.py
 ========================================
 EOF

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -102,14 +102,14 @@ cat <<EOF
 
 Now build the project:
   cargo build --features dynamo-llm/block-manager
-  cd lib/bindings/python && maturin develop --uv && cd /workspace
-  uv pip install --no-deps -e /workspace
+  cd lib/bindings/python && maturin develop --uv && cd $WORKSPACE_DIR
+  uv pip install --no-deps -e $WORKSPACE_DIR
 
 Optional:
   uv pip install -e lib/gpu_memory_service  # GPU memory manager with C++ extension
   cd lib/bindings/kvbm && maturin develop --uv  # For KVBM support
 
 Verify with:
-  /workspace/deploy/sanity_check.py
+  $WORKSPACE_DIR/deploy/sanity_check.py
 ========================================
 EOF

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -126,19 +126,20 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
      rm -rf /var/lib/apt/lists/*) && \
     (command -v awk >/dev/null 2>&1 && echo "awk available: $(command -v awk)" || echo "awk not available")
 
-# Add NVIDIA devtools repository and install development tools (nsight-systems).
-# Estimated layer size: ~500MB–1.5GB (nsight-systems is a full profiling suite)
+# Add external repos (NVIDIA devtools, GitHub CLI) and install in one pass.
 # Cache apt downloads; sharing=locked avoids apt/dpkg races with concurrent builds.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     wget -qO - "https://developer.download.nvidia.com/devtools/repos/ubuntu2404/${TARGETARCH}/nvidia.pub" \
         | gpg --dearmor -o /etc/apt/keyrings/nvidia-devtools.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/nvidia-devtools.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu2404/${TARGETARCH} /" \
         | tee /etc/apt/sources.list.d/nvidia-devtools.list && \
+    curl --retry 3 --retry-delay 5 -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=${TARGETARCH} signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt-get update && \
-    apt-get install -y --no-install-recommends nsight-systems-2025.5.1 && \
+    apt-get install -y --no-install-recommends nsight-systems-2025.5.1 gh && \
     rm -rf /var/lib/apt/lists/*
-
-# TODO: Add GitHub CLI (gh) for development. Estimated layer size: ~50MB
 
 # ======================================================================
 # TARGET: dev (root-based development)
@@ -362,11 +363,25 @@ RUN if command -v uv >/dev/null 2>&1; then \
 ARG DYNAMO_COMMIT_SHA
 ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
 
-# Setup dev launch banner (displayed on interactive shell entry)
+# Setup dev launch banner (guard prevents double-print when framework runtimes already added it)
 RUN --mount=type=bind,source=./container/launch_message/dev.txt,target=/opt/dynamo/launch_message.txt \
     sed '/^#\s/d' /opt/dynamo/launch_message.txt > /opt/dynamo/.launch_screen && \
     chmod 755 /opt/dynamo/.launch_screen && \
-    echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc
+    (grep -q 'launch_screen' /etc/bash.bashrc || echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc)
+
+# Warn on interactive entry if /workspace is not bind-mounted from the host
+RUN printf '%s\n' \
+    'if [ ! -f /workspace/Cargo.toml ]; then' \
+    '    echo ""' \
+    '    echo "  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"' \
+    '    echo "  !! WARNING: /workspace is not mounted from your host.         !!"' \
+    '    echo "  !! Use one of:                                                !!"' \
+    '    echo "  !!   ./container/run.sh --mount-workspace --image <img> -it   !!"' \
+    '    echo "  !!   docker run -v /path/to/dynamo:/workspace ...             !!"' \
+    '    echo "  !!   Dev Container (VS Code / Cursor)                         !!"' \
+    '    echo "  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"' \
+    '    echo ""' \
+    'fi' >> /etc/bash.bashrc
 
 {% if device == "xpu" %}
 SHELL ["bash", "-c"]


### PR DESCRIPTION
#### Overview:

- Cosmetic improvements: fix the double launch banner, add a missing-workspace warning, and clean up post-create build instructions.
- Add `gh` for better GitHub development inside Docker

#### Details:

**dev.Dockerfile:**
- Guard bash.bashrc banner append with `grep -q` to prevent double-print in framework images
- Add `/workspace` not-mounted warning on interactive shell entry
- Install GitHub CLI (`gh`) alongside nsight-systems in a single apt pass (resolves the existing TODO)

**post-create.sh:**
- Remove automatic sanity check (moved to a manual "Verify with" step)
- Simplify and correct build instructions (drop `--locked`, `--profile dev`, `DYNAMO_BIN_PATH`; add `--no-deps` for editable install)
- Separate required vs optional build steps more clearly

#### Where should the reviewer start?

`container/templates/dev.Dockerfile`

#### Related Issues:

/coderabbit profile chill