### PR TITLE
fix: update vllm script to install otel packages

### DIFF
--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -172,19 +172,19 @@ if [ "$DEVICE" = "cuda" ]; then
     #           does not prevent uv from resolving the cu12 variant)
     echo "Installing vLLM $VLLM_VER (torch backend: $TORCH_BACKEND)..."
     if [[ "$CUDA_VERSION_MAJOR" == "12" ]]; then
-        if uv pip install "vllm[flashinfer,runai]==${VLLM_VER}" ${EXTRA_PIP_ARGS} --torch-backend=${TORCH_BACKEND} 2>&1; then
+        if uv pip install "vllm[flashinfer,runai,otel]==${VLLM_VER}" ${EXTRA_PIP_ARGS} --torch-backend=${TORCH_BACKEND} 2>&1; then
             echo "✓ vLLM ${VLLM_VER} installed from PyPI"
         else
             echo "⚠ PyPI install failed, installing from GitHub release..."
             uv pip install ${EXTRA_PIP_ARGS} \
-                "${VLLM_GITHUB_URL}[flashinfer,runai]" \
+                "${VLLM_GITHUB_URL}[flashinfer,runai,otel]" \
                 --torch-backend=${TORCH_BACKEND}
             echo "✓ vLLM ${VLLM_VER} installed from GitHub"
         fi
     else
         echo "Installing vLLM from GitHub release (cu130 wheel not available on PyPI)..."
         uv pip install ${EXTRA_PIP_ARGS} \
-            "${VLLM_GITHUB_URL}[flashinfer,runai]" \
+            "${VLLM_GITHUB_URL}[flashinfer,runai,otel]" \
             --torch-backend=${TORCH_BACKEND}
         echo "✓ vLLM ${VLLM_VER} installed from GitHub"
     fi


### PR DESCRIPTION
#### Overview:

Update vllm install script to include the otel extra.

#### Details:

container build use the install_vllm.sh to install vllm related packages. Update it to include the otel extra to match pyproject.toml

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vLLM installation configuration to include additional observability support dependencies for CUDA environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->