### PR TITLE
chore: increase vcluster and dynamo operator setup timeout

### DIFF
--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -131,7 +131,7 @@ runs:
         kubectl wait --for=condition=ready pod \
           -l app=vcluster,release=${VCLUSTER_NAME} \
           -n ${NAMESPACE} \
-          --timeout=300s
+          --timeout=900s
         echo "::endgroup::"
 
     - name: Connect to vCluster
@@ -194,7 +194,7 @@ runs:
       run: |
         echo "::group::Wait for operator rollout inside vCluster"
         kubectl --kubeconfig=${{ github.workspace }}/.kubeconfig-vcluster \
-          rollout status deployment -n default --watch --timeout=600s
+          rollout status deployment -n default --watch --timeout=900s
         echo "::endgroup::"
 
     - name: Debug deployment failure


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased Kubernetes operation timeouts to enhance deployment stability and reduce timeout-related failures during setup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->