### PR TITLE
fix: filter Removed events by namespace in ModelWatcher (fixes #4801)

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -262,6 +262,17 @@ impl ModelWatcher {
                         }
                     };
 
+                    // Filter by namespace — mirror the Added-event guard so we never
+                    // attempt to remove a model card that was skipped during registration.
+                    if !namespace_filter.matches(&model_card_instance_id.namespace) {
+                        tracing::debug!(
+                            model_namespace = model_card_instance_id.namespace,
+                            namespace_filter = ?namespace_filter,
+                            "Skipping removal event due to namespace filter"
+                        );
+                        continue;
+                    }
+
                     match self
                         .handle_delete(model_card_instance_id, &namespace_filter)
                         .await


### PR DESCRIPTION
## Problem

When multiple Dynamo deployments with different namespaces share the same discovery backend (etcd/NATS), `ModelWatcher` emits spurious `Missing ModelDeploymentCard` errors on `Removed` events from foreign namespaces.

`Added` events are already correctly filtered by `namespace_filter` (line ~202), but `Removed` events were passed directly to `handle_delete`, which then fails because the model card was never registered (it was skipped during the `Added` phase).

Fixes #4801

## Solution

Added the same `namespace_filter.matches()` guard to the `Removed` event branch in `ModelWatcher::watch()`, mirroring the existing `Added`-event check. When a removal event arrives from a namespace that doesn't match the filter, it is now silently skipped with a debug-level log message.

## Testing

Manual review of code logic. The change is a single guard clause that mirrors the existing `Added`-event filtering pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where model deletions were being incorrectly processed when namespace filtering was configured, ensuring that only models matching the namespace filter are processed for removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->