### PR TITLE
ci: Give kubeapi time to register pod

### DIFF
--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -128,6 +128,8 @@ runs:
         NAMESPACE: ${{ steps.resolve-names.outputs.namespace }}
       run: |
         echo "::group::Wait for vCluster pod"
+        # Give the API server a moment to register the new pod
+        sleep 20
         kubectl wait --for=condition=ready pod \
           -l app=vcluster,release=${VCLUSTER_NAME} \
           -n ${NAMESPACE} \


### PR DESCRIPTION
#### Overview:

Workflow error saying resource doesn't exist: https://github.com/ai-dynamo/dynamo/actions/runs/23324240987/job/67842153849

This should give the Kubernetes API server time to register the resource.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of the operator setup process by enhancing initialization timing to ensure readiness checks complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->