### PR TITLE
ci: Remove output of command execution for vcluster connections

### DIFF
--- a/.github/actions/connect-vcluster/action.yml
+++ b/.github/actions/connect-vcluster/action.yml
@@ -37,7 +37,6 @@ runs:
         NAMESPACE: ${{ inputs.vcluster_namespace }}
       run: |
         echo "::group::Port-forward and generate vCluster kubeconfig"
-        set -x
         kubectl port-forward -n ${NAMESPACE} svc/${VCLUSTER_NAME} 8443:443 &
         sleep 5
 
@@ -50,6 +49,5 @@ runs:
         kubectl --kubeconfig=${{ github.workspace }}/.kubeconfig-vcluster get ns
 
         KUBECONFIG_B64=$(base64 -w 0 < ${{ github.workspace }}/.kubeconfig-vcluster)
-        echo "::add-mask::$KUBECONFIG_B64"
         echo "kubeconfig_base64=${KUBECONFIG_B64}" >> $GITHUB_OUTPUT
         echo "::endgroup::"

--- a/.github/actions/connect-vcluster/action.yml
+++ b/.github/actions/connect-vcluster/action.yml
@@ -49,6 +49,7 @@ runs:
         echo "Verifying vCluster connectivity..."
         kubectl --kubeconfig=${{ github.workspace }}/.kubeconfig-vcluster get ns
 
-        KUBECONFIG_B64=::add-mask::$(base64 -w 0 < ${{ github.workspace }}/.kubeconfig-vcluster)
-        echo "kubeconfig_base64=::add-mask::${KUBECONFIG_B64}" >> $GITHUB_OUTPUT
+        KUBECONFIG_B64=$(base64 -w 0 < ${{ github.workspace }}/.kubeconfig-vcluster)
+        echo "::add-mask::$KUBECONFIG_B64"
+        echo "kubeconfig_base64=${KUBECONFIG_B64}" >> $GITHUB_OUTPUT
         echo "::endgroup::"

--- a/.github/actions/connect-vcluster/action.yml
+++ b/.github/actions/connect-vcluster/action.yml
@@ -49,6 +49,6 @@ runs:
         echo "Verifying vCluster connectivity..."
         kubectl --kubeconfig=${{ github.workspace }}/.kubeconfig-vcluster get ns
 
-        KUBECONFIG_B64=$(base64 -w 0 < ${{ github.workspace }}/.kubeconfig-vcluster)
-        echo "kubeconfig_base64=${KUBECONFIG_B64}" >> $GITHUB_OUTPUT
+        KUBECONFIG_B64=::add-mask::$(base64 -w 0 < ${{ github.workspace }}/.kubeconfig-vcluster)
+        echo "kubeconfig_base64=::add-mask::${KUBECONFIG_B64}" >> $GITHUB_OUTPUT
         echo "::endgroup::"

--- a/.github/actions/dynamo-deploy-test/action.yml
+++ b/.github/actions/dynamo-deploy-test/action.yml
@@ -52,6 +52,7 @@ runs:
       env:
         NAMESPACE: ${{ inputs.namespace }}
       run: |
+        set +x
         echo "${{ inputs.kubeconfig_base64 }}" | base64 -d > ${{ github.workspace }}/.kubeconfig
         chmod 600 ${{ github.workspace }}/.kubeconfig
         echo "KUBECONFIG=${{ github.workspace }}/.kubeconfig" >> $GITHUB_ENV

--- a/.github/actions/dynamo-deploy-test/action.yml
+++ b/.github/actions/dynamo-deploy-test/action.yml
@@ -52,7 +52,7 @@ runs:
       env:
         NAMESPACE: ${{ inputs.namespace }}
       run: |
-        echo "${{ inputs.kubeconfig_base64 }}" | base64 -d > ${{ github.workspace }}/.kubeconfig
+        echo "::add-mask::${{ inputs.kubeconfig_base64 }}" | base64 -d > ${{ github.workspace }}/.kubeconfig
         chmod 600 ${{ github.workspace }}/.kubeconfig
         echo "KUBECONFIG=${{ github.workspace }}/.kubeconfig" >> $GITHUB_ENV
 

--- a/.github/actions/dynamo-deploy-test/action.yml
+++ b/.github/actions/dynamo-deploy-test/action.yml
@@ -52,7 +52,7 @@ runs:
       env:
         NAMESPACE: ${{ inputs.namespace }}
       run: |
-        echo "::add-mask::${{ inputs.kubeconfig_base64 }}" | base64 -d > ${{ github.workspace }}/.kubeconfig
+        echo "${{ inputs.kubeconfig_base64 }}" | base64 -d > ${{ github.workspace }}/.kubeconfig
         chmod 600 ${{ github.workspace }}/.kubeconfig
         echo "KUBECONFIG=${{ github.workspace }}/.kubeconfig" >> $GITHUB_ENV
 


### PR DESCRIPTION
#### Overview:

Remove output of command execution for vcluster connections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Masked sensitive kubeconfig credentials in GitHub Actions logs to prevent accidental exposure during workflow execution across multiple deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->