### PR TITLE
fix: Don't double-count duplicate store events in the tree size.

### DIFF
--- a/lib/kv-router/src/indexer/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree.rs
@@ -397,6 +397,12 @@ impl ConcurrentRadixTree {
             current = child;
         }
 
+        // Insert worker into the last child (not yet handled since there is
+        // no subsequent iteration to pick it up).
+        if needs_worker_insert && current.write().workers.insert(worker) {
+            num_blocks_added += 1;
+        }
+
         match self.tree_sizes.get(&worker) {
             Some(size) => {
                 size.fetch_add(num_blocks_added, Ordering::Relaxed);
@@ -405,10 +411,6 @@ impl ConcurrentRadixTree {
                 self.tree_sizes
                     .insert(worker, AtomicUsize::new(num_blocks_added));
             }
-        }
-
-        if needs_worker_insert {
-            current.write().workers.insert(worker);
         }
 
         Ok(())

--- a/lib/kv-router/src/indexer/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree.rs
@@ -345,7 +345,7 @@ impl ConcurrentRadixTree {
 
         let mut needs_worker_insert = false;
 
-        let num_blocks_added = op.blocks.len();
+        let mut num_blocks_added = 0;
 
         for block_data in op.blocks {
             let child = {
@@ -354,8 +354,8 @@ impl ConcurrentRadixTree {
                 // Insert worker into this node if it was the child from the
                 // previous iteration (skip for the initial parent, which is
                 // not one of the blocks being stored).
-                if needs_worker_insert {
-                    parent_guard.workers.insert(worker);
+                if needs_worker_insert && parent_guard.workers.insert(worker) {
+                    num_blocks_added += 1;
                 }
                 needs_worker_insert = true;
 

--- a/lib/kv-router/src/indexer/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree.rs
@@ -347,6 +347,11 @@ impl ConcurrentRadixTree {
 
         let mut num_blocks_added = 0;
 
+        // In each iteration, we lock the parent block and insert the worker into it from
+        // the previous iteration. This avoids locking a block twice.
+        //
+        // Track tree size from worker_lookup insertions so it matches the single-threaded
+        // radix tree's `lookup.len()` semantics and naturally includes the tail block.
         for block_data in op.blocks {
             let child = {
                 let mut parent_guard = current.write();
@@ -354,8 +359,8 @@ impl ConcurrentRadixTree {
                 // Insert worker into this node if it was the child from the
                 // previous iteration (skip for the initial parent, which is
                 // not one of the blocks being stored).
-                if needs_worker_insert && parent_guard.workers.insert(worker) {
-                    num_blocks_added += 1;
+                if needs_worker_insert {
+                    parent_guard.workers.insert(worker);
                 }
                 needs_worker_insert = true;
 
@@ -392,15 +397,20 @@ impl ConcurrentRadixTree {
             };
 
             // Update lookup
-            worker_lookup.insert(block_data.block_hash, child.clone());
+            if worker_lookup
+                .insert(block_data.block_hash, child.clone())
+                .is_none()
+            {
+                num_blocks_added += 1;
+            }
 
             current = child;
         }
 
         // Insert worker into the last child (not yet handled since there is
         // no subsequent iteration to pick it up).
-        if needs_worker_insert && current.write().workers.insert(worker) {
-            num_blocks_added += 1;
+        if needs_worker_insert {
+            current.write().workers.insert(worker);
         }
 
         match self.tree_sizes.get(&worker) {

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -273,6 +273,41 @@ mod interface_tests {
     }
 
     #[tokio::test]
+    async fn test_concurrent_duplicate_store_does_not_inflate_tree_size() {
+        let index = make_indexer("concurrent");
+        let sequence = vec![LocalBlockHash(1), LocalBlockHash(2), LocalBlockHash(3)];
+        let worker = WorkerWithDpRank::new(0, 0);
+        let event = make_store_event(0, &[1, 2, 3]);
+
+        index.apply_event(event.clone()).await;
+        flush_and_settle(index.as_ref()).await;
+
+        let initial_snapshot = snapshot_tree(index.as_ref()).await;
+        let initial_scores = index.find_matches(sequence.clone()).await.unwrap();
+        assert_eq!(
+            initial_scores.tree_sizes.get(&worker),
+            Some(&3),
+            "initial store should count all three blocks"
+        );
+
+        index.apply_event(event).await;
+        flush_and_settle(index.as_ref()).await;
+
+        let duplicate_snapshot = snapshot_tree(index.as_ref()).await;
+        let duplicate_scores = index.find_matches(sequence).await.unwrap();
+
+        assert_eq!(
+            initial_snapshot, duplicate_snapshot,
+            "replaying the same store event should not change the tree structure"
+        );
+        assert_eq!(
+            duplicate_scores.tree_sizes.get(&worker),
+            Some(&3),
+            "replaying the same store event should not increase the per-worker tree size"
+        );
+    }
+
+    #[tokio::test]
     #[apply(indexer_template)]
     async fn test_partial_match(variant: &str) {
         let index = make_indexer(variant);


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker insertion tracking accuracy in concurrent operations to count newly inserted workers rather than processed blocks, enhancing system reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->