### PR TITLE
feat(gms): add NIXL GDS backend for GPU Direct Storage restore

### DIFF
--- a/lib/gpu_memory_service/cli/storage_runner.py
+++ b/lib/gpu_memory_service/cli/storage_runner.py
@@ -97,18 +97,21 @@ def _run_load(args) -> None:
     _configure_logging(args.verbose)
     socket_path = _resolve_socket(args.device, args.socket_path)
 
+    use_gds = getattr(args, "gds", False)
     logger.info(
-        "Loading GMS state: device=%s, socket=%s, input_dir=%s, clear_existing=%s",
+        "Loading GMS state: device=%s, socket=%s, input_dir=%s, clear_existing=%s, gds=%s",
         args.device,
         socket_path,
         args.input_dir,
         not args.no_clear,
+        use_gds,
     )
 
     client = GMSStorageClient(
         socket_path=socket_path,
         device=args.device,
         timeout_ms=args.timeout_ms,
+        use_gds=use_gds,
     )
 
     id_map = client.load_to_gms(
@@ -239,6 +242,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Do not clear existing GMS allocations before loading. "
             "Default behaviour clears the server to produce an exact replica."
+        ),
+    )
+    load_p.add_argument(
+        "--gds",
+        action="store_true",
+        default=False,
+        help=(
+            "Use NIXL GDS backend for direct file-to-GPU transfers. "
+            "Requires NIXL Python bindings and GDS-capable storage."
         ),
     )
     load_p.add_argument(

--- a/lib/gpu_memory_service/client/_gms_storage_gds.py
+++ b/lib/gpu_memory_service/client/_gms_storage_gds.py
@@ -21,6 +21,8 @@ try:
     _NIXL_AVAILABLE = True
 except ImportError:
     _NIXL_AVAILABLE = False
+    nixl_agent = None  # type: ignore[assignment]
+    nixl_agent_config = None  # type: ignore[assignment]
 
 
 class NixlGDSStorageBackend:
@@ -76,33 +78,48 @@ class NixlGDSStorageBackend:
             # Register all files and VAs, then post transfers concurrently
             for rel_path, entries in groups.items():
                 abs_path = os.path.join(input_dir, rel_path)
-                fd = os.open(abs_path, os.O_RDONLY)
+                fd = None
+                file_reg = None
+                vram_reg = None
+                handle = None
+                try:
+                    fd = os.open(abs_path, os.O_RDONLY)
 
-                # FILE descriptors: (offset, length, fd, meta)
-                file_descs = [
-                    (entry.tensor_offset, entry.aligned_size, fd, "")
-                    for entry in entries
-                ]
-                file_reg = self._agent.register_memory(file_descs, "FILE")
+                    # FILE descriptors: (offset, length, fd, meta)
+                    file_descs = [
+                        (entry.tensor_offset, entry.aligned_size, fd, "")
+                        for entry in entries
+                    ]
+                    file_reg = self._agent.register_memory(file_descs, "FILE")
 
-                # VRAM descriptors: (addr, length, device_id, meta)
-                vram_descs = [
-                    (va_map[entry.allocation_id], entry.aligned_size, self._device, "")
-                    for entry in entries
-                ]
-                vram_reg = self._agent.register_memory(vram_descs, "VRAM")
+                    # VRAM descriptors: (addr, length, device_id, meta)
+                    vram_descs = [
+                        (
+                            va_map[entry.allocation_id],
+                            entry.aligned_size,
+                            self._device,
+                            "",
+                        )
+                        for entry in entries
+                    ]
+                    vram_reg = self._agent.register_memory(vram_descs, "VRAM")
 
-                # Post transfer: FILE → VRAM
-                vram_xfer = vram_reg.trim()
-                file_xfer = file_reg.trim()
-                handle = self._agent.initialize_xfer(
-                    "READ", vram_xfer, file_xfer, self._agent_name
-                )
-                state = self._agent.transfer(handle)
-                if state == "ERR":
-                    raise RuntimeError(f"GDS transfer failed to start for {rel_path}")
+                    # Post transfer: FILE -> VRAM
+                    vram_xfer = vram_reg.trim()
+                    file_xfer = file_reg.trim()
+                    handle = self._agent.initialize_xfer(
+                        "READ", vram_xfer, file_xfer, self._agent_name
+                    )
+                    state = self._agent.transfer(handle)
+                    if state == "ERR":
+                        raise RuntimeError(
+                            f"GDS transfer failed to start for {rel_path}"
+                        )
 
-                pending.append((handle, file_reg, vram_reg, fd))
+                    pending.append((handle, file_reg, vram_reg, fd))
+                except Exception:
+                    self._release_transfer_resources(handle, file_reg, vram_reg, fd)
+                    raise
 
             # Wait for all transfers to complete
             for handle, file_reg, vram_reg, fd in pending:
@@ -123,23 +140,36 @@ class NixlGDSStorageBackend:
 
         finally:
             for handle, file_reg, vram_reg, fd in pending:
-                try:
-                    self._agent.release_xfer_handle(handle)
-                except Exception:
-                    pass
-                try:
-                    self._agent.deregister_memory(vram_reg)
-                except Exception:
-                    pass
-                try:
-                    self._agent.deregister_memory(file_reg)
-                except Exception:
-                    pass
-                try:
-                    os.close(fd)
-                except OSError:
-                    pass
+                self._release_transfer_resources(handle, file_reg, vram_reg, fd)
 
     def close(self) -> None:
         """Release NIXL agent resources."""
         self._agent = None
+
+    def _release_transfer_resources(
+        self,
+        handle: object,
+        file_reg: object,
+        vram_reg: object,
+        fd: int | None,
+    ) -> None:
+        if handle is not None:
+            try:
+                self._agent.release_xfer_handle(handle)
+            except Exception:
+                pass
+        if vram_reg is not None:
+            try:
+                self._agent.deregister_memory(vram_reg)
+            except Exception:
+                pass
+        if file_reg is not None:
+            try:
+                self._agent.deregister_memory(file_reg)
+            except Exception:
+                pass
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass

--- a/lib/gpu_memory_service/client/_gms_storage_gds.py
+++ b/lib/gpu_memory_service/client/_gms_storage_gds.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NIXL GDS storage backend for direct file-to-GPU transfers."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import TYPE_CHECKING, Dict, List, Tuple
+
+if TYPE_CHECKING:
+    from gpu_memory_service.client._gms_storage_model import AllocationEntry
+
+logger = logging.getLogger(__name__)
+
+try:
+    from nixl._api import nixl_agent, nixl_agent_config
+
+    _NIXL_AVAILABLE = True
+except ImportError:
+    _NIXL_AVAILABLE = False
+
+
+class NixlGDSStorageBackend:
+    """NIXL-based GDS backend: reads shard files directly into GPU VAs.
+
+    Uses NVIDIA NIXL library with the GDS backend to perform
+    GPUDirect Storage transfers, bypassing CPU memory entirely.
+    """
+
+    def __init__(self, device: int) -> None:
+        if not _NIXL_AVAILABLE:
+            raise RuntimeError(
+                "NIXL Python bindings are required for GDS support. "
+                "Install with: pip install nixl"
+            )
+        self._device = device
+        self._agent_name = f"gms_gds_{device}_{os.getpid()}"
+        self._agent = nixl_agent(
+            self._agent_name,
+            nixl_agent_config(backends=[]),
+        )
+        self._agent.create_backend("GDS_MT")
+        logger.info("NIXL GDS_MT backend initialized for device %d", device)
+
+    def restore_shards(
+        self,
+        input_dir: str,
+        groups: Dict[str, List[AllocationEntry]],
+        va_map: Dict[str, int],
+    ) -> None:
+        """Read shard files directly into pre-allocated GPU VAs using GDS.
+
+        Each GMS VA (from create_mapping) is registered individually with cuFile
+        for proper GDS without compat mode.  All shard transfers are posted
+        concurrently and then awaited — GDS_MT handles internal parallelism.
+
+        Note: ensure CUFILE_ENV_PATH_JSON points to a cufile.json with
+        max_device_pinned_mem_size_kb large enough for the total model size.
+
+        Args:
+            input_dir: Base directory containing shard files.
+            groups: Mapping of relative shard path to sorted allocation entries.
+            va_map: Mapping of allocation_id to GPU virtual address.
+        """
+        pending: List[Tuple] = []  # (handle, file_reg, vram_reg, fd)
+        total_bytes = sum(
+            entry.aligned_size for entries in groups.values() for entry in entries
+        )
+
+        try:
+            t0 = time.monotonic()
+
+            # Register all files and VAs, then post transfers concurrently
+            for rel_path, entries in groups.items():
+                abs_path = os.path.join(input_dir, rel_path)
+                fd = os.open(abs_path, os.O_RDONLY)
+
+                # FILE descriptors: (offset, length, fd, meta)
+                file_descs = [
+                    (entry.tensor_offset, entry.aligned_size, fd, "")
+                    for entry in entries
+                ]
+                file_reg = self._agent.register_memory(file_descs, "FILE")
+
+                # VRAM descriptors: (addr, length, device_id, meta)
+                vram_descs = [
+                    (va_map[entry.allocation_id], entry.aligned_size, self._device, "")
+                    for entry in entries
+                ]
+                vram_reg = self._agent.register_memory(vram_descs, "VRAM")
+
+                # Post transfer: FILE → VRAM
+                vram_xfer = vram_reg.trim()
+                file_xfer = file_reg.trim()
+                handle = self._agent.initialize_xfer(
+                    "READ", vram_xfer, file_xfer, self._agent_name
+                )
+                state = self._agent.transfer(handle)
+                if state == "ERR":
+                    raise RuntimeError(f"GDS transfer failed to start for {rel_path}")
+
+                pending.append((handle, file_reg, vram_reg, fd))
+
+            # Wait for all transfers to complete
+            for handle, file_reg, vram_reg, fd in pending:
+                state = self._agent.check_xfer_state(handle)
+                while state == "PROC":
+                    state = self._agent.check_xfer_state(handle)
+                if state == "ERR":
+                    raise RuntimeError("GDS transfer failed")
+
+            elapsed = time.monotonic() - t0
+            throughput = total_bytes / elapsed / (1024**3) if elapsed > 0 else 0
+            logger.info(
+                "GDS transfers complete: %.2f GiB in %.3fs (%.2f GiB/s)",
+                total_bytes / (1024**3),
+                elapsed,
+                throughput,
+            )
+
+        finally:
+            for handle, file_reg, vram_reg, fd in pending:
+                try:
+                    self._agent.release_xfer_handle(handle)
+                except Exception:
+                    pass
+                try:
+                    self._agent.deregister_memory(vram_reg)
+                except Exception:
+                    pass
+                try:
+                    self._agent.deregister_memory(file_reg)
+                except Exception:
+                    pass
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+
+    def close(self) -> None:
+        """Release NIXL agent resources."""
+        self._agent = None

--- a/lib/gpu_memory_service/client/gms_storage_client.py
+++ b/lib/gpu_memory_service/client/gms_storage_client.py
@@ -53,15 +53,23 @@ logger = logging.getLogger(__name__)
 
 try:
     from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
-    from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
     from gpu_memory_service.common.types import RequestedLockType
 
-    _GMS_IMPORTS_AVAILABLE = True
+    _GMS_CORE_IMPORTS_AVAILABLE = True
 except ImportError:
-    _GMS_IMPORTS_AVAILABLE = False
+    _GMS_CORE_IMPORTS_AVAILABLE = False
     GMSClientMemoryManager = None  # type: ignore[assignment,misc]
-    _tensor_from_pointer = None  # type: ignore[assignment]
     RequestedLockType = None  # type: ignore[assignment]
+
+try:
+    from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
+
+    _GMS_TENSOR_IMPORTS_AVAILABLE = True
+except ImportError:
+    _GMS_TENSOR_IMPORTS_AVAILABLE = False
+    _tensor_from_pointer = None  # type: ignore[assignment]
+
+_GMS_IMPORTS_AVAILABLE = _GMS_CORE_IMPORTS_AVAILABLE and _GMS_TENSOR_IMPORTS_AVAILABLE
 
 try:
     import torch
@@ -511,16 +519,19 @@ class GMSStorageClient:
         max_workers: int = 4,
         clear_existing: bool = True,
     ) -> Dict[str, str]:
-        if not _GMS_IMPORTS_AVAILABLE:
-            raise RuntimeError(
-                "GMS client imports unavailable (missing cuda-python or torch)"
-            )
+        if not _GMS_CORE_IMPORTS_AVAILABLE:
+            raise RuntimeError("GMS client imports unavailable (missing cuda-python)")
 
         if self._use_gds:
             return self._load_to_gms_gds(
                 input_dir,
                 max_workers=max_workers,
                 clear_existing=clear_existing,
+            )
+
+        if not _GMS_IMPORTS_AVAILABLE:
+            raise RuntimeError(
+                "GMS client imports unavailable (missing cuda-python or torch)"
             )
 
         manifest, saved_metadata = _load_manifest_and_metadata(input_dir)

--- a/lib/gpu_memory_service/client/gms_storage_client.py
+++ b/lib/gpu_memory_service/client/gms_storage_client.py
@@ -144,11 +144,13 @@ class GMSStorageClient:
         *,
         timeout_ms: Optional[int] = None,
         shard_size_bytes: int = 4 * 1024**3,
+        use_gds: bool = False,
     ) -> None:
         self.output_dir = output_dir
         self.device = device
         self._timeout_ms = timeout_ms
         self._shard_size = shard_size_bytes
+        self._use_gds = use_gds
 
         if socket_path is None:
             from gpu_memory_service.common.utils import get_socket_path
@@ -514,6 +516,13 @@ class GMSStorageClient:
                 "GMS client imports unavailable (missing cuda-python or torch)"
             )
 
+        if self._use_gds:
+            return self._load_to_gms_gds(
+                input_dir,
+                max_workers=max_workers,
+                clear_existing=clear_existing,
+            )
+
         manifest, saved_metadata = _load_manifest_and_metadata(input_dir)
         groups = _group_entries_by_shard(manifest.allocations)
         worker_count = max(1, min(max_workers, len(groups) or 1))
@@ -548,6 +557,61 @@ class GMSStorageClient:
 
         logger.info(
             "load_to_gms complete: %d allocations, %d metadata keys",
+            len(id_map),
+            len(saved_metadata),
+        )
+        return id_map
+
+    def _load_to_gms_gds(
+        self,
+        input_dir: str,
+        *,
+        max_workers: int = 4,
+        clear_existing: bool = True,
+    ) -> Dict[str, str]:
+        """GDS restore path: read shard files directly into GPU VAs via NIXL."""
+        from gpu_memory_service.client._gms_storage_gds import NixlGDSStorageBackend
+
+        manifest, saved_metadata = _load_manifest_and_metadata(input_dir)
+        groups = _group_entries_by_shard(manifest.allocations)
+
+        gds_backend = NixlGDSStorageBackend(device=self.device)
+        try:
+            with GMSClientMemoryManager(self._socket_path, device=self.device) as mm:
+                mm.connect(RequestedLockType.RW, timeout_ms=self._timeout_ms)
+                if clear_existing:
+                    cleared = mm.clear_all_handles()
+                    if cleared:
+                        logger.info("Cleared %d pre-existing allocations", cleared)
+
+                # Phase A: allocate all VAs upfront (needed for NIXL VRAM registration)
+                id_map: Dict[str, str] = {}
+                va_map: Dict[str, int] = {}
+                for entry in manifest.allocations:
+                    old_id = entry.allocation_id
+                    va = mm.create_mapping(size=entry.size, tag=entry.tag)
+                    id_map[old_id] = mm.get_allocation_id(va)
+                    va_map[old_id] = va
+                logger.info(
+                    "Phase A complete: allocated %d GMS VAs",
+                    len(va_map),
+                )
+
+                # Phase B: GDS transfer — file → GPU directly
+                gds_backend.restore_shards(input_dir, groups, va_map)
+                logger.info(
+                    "Phase B complete: GDS-restored %d allocations to GMS memory",
+                    len(manifest.allocations),
+                )
+
+                self._restore_metadata(mm, saved_metadata, id_map)
+                if not mm.commit():
+                    raise RuntimeError("GMS commit failed after GDS restore")
+        finally:
+            gds_backend.close()
+
+        logger.info(
+            "load_to_gms (GDS) complete: %d allocations, %d metadata keys",
             len(id_map),
             len(saved_metadata),
         )

--- a/lib/gpu_memory_service/tests/e2e/bench_gds_restore.py
+++ b/lib/gpu_memory_service/tests/e2e/bench_gds_restore.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark: GDS vs O_DIRECT restore throughput (standalone, no GMS server needed).
+
+Creates synthetic shard files on disk and benchmarks reading them into GPU memory
+using (a) NIXL GDS (direct file→GPU) and (b) O_DIRECT + H2D copy baseline.
+
+Usage:
+    python bench_gds_restore.py --data-dir /mnt/weka/gds_bench --total-gib 135 --device 0
+"""
+
+import argparse
+import logging
+import os
+import time
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def create_shard_files(data_dir: str, total_bytes: int, shard_size: int) -> list[str]:
+    """Create synthetic shard files filled with a pattern."""
+    shards_dir = os.path.join(data_dir, "shards")
+    os.makedirs(shards_dir, exist_ok=True)
+
+    paths = []
+    remaining = total_bytes
+    shard_idx = 0
+    while remaining > 0:
+        size = min(shard_size, remaining)
+        path = os.path.join(shards_dir, f"shard_{shard_idx:04d}.bin")
+        if os.path.exists(path) and os.path.getsize(path) == size:
+            logger.info("Shard %s already exists (%d bytes), skipping", path, size)
+        else:
+            logger.info("Creating shard %s (%d bytes)...", path, size)
+            # Write in 256MB chunks to avoid huge memory alloc
+            chunk_size = 256 * 1024 * 1024
+            with open(path, "wb") as f:
+                written = 0
+                while written < size:
+                    n = min(chunk_size, size - written)
+                    f.write(b"\xba" * n)
+                    written += n
+        paths.append(path)
+        remaining -= size
+        shard_idx += 1
+
+    logger.info(
+        "Created %d shard files (%.2f GiB total)", len(paths), total_bytes / (1024**3)
+    )
+    return paths
+
+
+def bench_gds(shard_paths: list[str], device: int) -> float:
+    """Benchmark: read shards into GPU memory using NIXL GDS."""
+    import torch
+    from nixl._api import nixl_agent, nixl_agent_config
+
+    agent_name = f"bench_gds_{device}"
+    agent = nixl_agent(agent_name, nixl_agent_config(backends=[]))
+    agent.create_backend("GDS_MT")
+
+    # Pre-allocate GPU buffer for all shards
+    total_bytes = sum(os.path.getsize(p) for p in shard_paths)
+    gpu_buf = torch.empty(total_bytes, dtype=torch.uint8, device=f"cuda:{device}")
+    gpu_ptr = gpu_buf.data_ptr()
+
+    # Register VRAM
+    vram_reg = agent.register_memory([(gpu_ptr, total_bytes, device, "bench")], "VRAM")
+
+    # Warm up: small read
+    warmup_size = min(4096, total_bytes)
+    fd = os.open(shard_paths[0], os.O_RDONLY)
+    file_reg = agent.register_memory([(0, warmup_size, fd, "")], "FILE")
+    vram_xfer = agent.get_xfer_descs([(gpu_ptr, warmup_size, device)], "VRAM")
+    file_xfer = file_reg.trim()
+    h = agent.initialize_xfer("READ", vram_xfer, file_xfer, agent_name)
+    s = agent.transfer(h)
+    while s == "PROC":
+        s = agent.check_xfer_state(h)
+    agent.release_xfer_handle(h)
+    agent.deregister_memory(file_reg)
+    os.close(fd)
+
+    torch.cuda.synchronize(device)
+
+    # Benchmark
+    offset = 0
+    pending = []
+
+    t0 = time.monotonic()
+
+    for path in shard_paths:
+        size = os.path.getsize(path)
+        fd = os.open(path, os.O_RDONLY)
+        file_reg = agent.register_memory([(0, size, fd, "")], "FILE")
+        vram_xfer = agent.get_xfer_descs([(gpu_ptr + offset, size, device)], "VRAM")
+        file_xfer = file_reg.trim()
+
+        h = agent.initialize_xfer("READ", vram_xfer, file_xfer, agent_name)
+        state = agent.transfer(h)
+        if state == "ERR":
+            raise RuntimeError(f"GDS transfer failed for {path}")
+        pending.append((h, file_reg, fd))
+        offset += size
+
+    # Wait for all
+    for h, file_reg, fd in pending:
+        state = agent.check_xfer_state(h)
+        while state == "PROC":
+            state = agent.check_xfer_state(h)
+        if state == "ERR":
+            raise RuntimeError("GDS transfer error during wait")
+
+    torch.cuda.synchronize(device)
+    elapsed = time.monotonic() - t0
+
+    # Cleanup
+    for h, file_reg, fd in pending:
+        agent.release_xfer_handle(h)
+        agent.deregister_memory(file_reg)
+        os.close(fd)
+    agent.deregister_memory(vram_reg)
+
+    del gpu_buf
+    return elapsed
+
+
+def bench_odirect(shard_paths: list[str], device: int) -> float:
+    """Benchmark: read shards into GPU via O_DIRECT + H2D copy (baseline)."""
+    import torch
+
+    # Warm up
+    torch.cuda.synchronize(device)
+
+    t0 = time.monotonic()
+
+    # Read each shard with O_DIRECT into pinned memory, then copy to GPU
+    for path in shard_paths:
+        size = os.path.getsize(path)
+        pinned = torch.empty(size, dtype=torch.uint8, pin_memory=True)
+        arr = pinned.numpy()
+
+        fd = os.open(path, os.O_RDONLY | os.O_DIRECT)
+        done = 0
+        mv = memoryview(arr)
+        while done < size:
+            n = os.readv(fd, [mv[done:]])
+            if n == 0:
+                raise RuntimeError(f"Short read: {done}/{size}")
+            done += n
+        mv.release()
+        os.close(fd)
+
+        pinned.to(f"cuda:{device}", non_blocking=True)
+
+    torch.cuda.synchronize(device)
+    elapsed = time.monotonic() - t0
+
+    return elapsed
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark GDS vs O_DIRECT restore")
+    parser.add_argument(
+        "--data-dir",
+        required=True,
+        help="Directory for shard files (e.g. /mnt/weka/gds_bench)",
+    )
+    parser.add_argument(
+        "--total-gib",
+        type=float,
+        default=135.0,
+        help="Total data size in GiB (default: 135 for Qwen-72B BF16)",
+    )
+    parser.add_argument(
+        "--shard-gib",
+        type=float,
+        default=4.0,
+        help="Shard file size in GiB (default: 4)",
+    )
+    parser.add_argument(
+        "--device", type=int, default=0, help="CUDA device index (default: 0)"
+    )
+    parser.add_argument(
+        "--skip-create",
+        action="store_true",
+        help="Skip shard creation (reuse existing)",
+    )
+    parser.add_argument(
+        "--skip-baseline", action="store_true", help="Skip O_DIRECT baseline"
+    )
+    parser.add_argument("--skip-gds", action="store_true", help="Skip GDS benchmark")
+    args = parser.parse_args()
+
+    total_bytes = int(args.total_gib * 1024**3)
+    shard_size = int(args.shard_gib * 1024**3)
+
+    logger.info("=== GDS Restore Benchmark ===")
+    logger.info(
+        "Total: %.2f GiB, Shard size: %.2f GiB, Device: cuda:%d",
+        args.total_gib,
+        args.shard_gib,
+        args.device,
+    )
+
+    # Create shard files
+    if not args.skip_create:
+        shard_paths = create_shard_files(args.data_dir, total_bytes, shard_size)
+    else:
+        shards_dir = os.path.join(args.data_dir, "shards")
+        shard_paths = sorted(
+            os.path.join(shards_dir, f)
+            for f in os.listdir(shards_dir)
+            if f.startswith("shard_") and f.endswith(".bin")
+        )
+        actual = sum(os.path.getsize(p) for p in shard_paths)
+        logger.info(
+            "Reusing %d existing shards (%.2f GiB)",
+            len(shard_paths),
+            actual / (1024**3),
+        )
+
+    total_gib = sum(os.path.getsize(p) for p in shard_paths) / (1024**3)
+
+    # Drop page cache before each benchmark
+    def drop_cache():
+        try:
+            with open("/proc/sys/vm/drop_caches", "w") as f:
+                f.write("3\n")
+            logger.info("Page cache dropped")
+        except PermissionError:
+            logger.warning("Cannot drop page cache (not root?)")
+
+    # GDS benchmark
+    if not args.skip_gds:
+        drop_cache()
+        logger.info("--- GDS benchmark ---")
+        gds_time = bench_gds(shard_paths, args.device)
+        logger.info(
+            "GDS:      %.2f GiB in %.3fs = %.2f GiB/s",
+            total_gib,
+            gds_time,
+            total_gib / gds_time,
+        )
+    else:
+        gds_time = None
+
+    # O_DIRECT baseline
+    if not args.skip_baseline:
+        drop_cache()
+        logger.info("--- O_DIRECT + H2D baseline ---")
+        baseline_time = bench_odirect(shard_paths, args.device)
+        logger.info(
+            "O_DIRECT: %.2f GiB in %.3fs = %.2f GiB/s",
+            total_gib,
+            baseline_time,
+            total_gib / baseline_time,
+        )
+    else:
+        baseline_time = None
+
+    # Summary
+    logger.info("=== Summary ===")
+    logger.info("Data size: %.2f GiB (%d shards)", total_gib, len(shard_paths))
+    if gds_time is not None:
+        logger.info("GDS:      %.3fs  (%.2f GiB/s)", gds_time, total_gib / gds_time)
+    if baseline_time is not None:
+        logger.info(
+            "O_DIRECT: %.3fs  (%.2f GiB/s)", baseline_time, total_gib / baseline_time
+        )
+    if gds_time and baseline_time:
+        logger.info("Speedup:  %.2fx", baseline_time / gds_time)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/gpu_memory_service/tests/test_gms_storage_client.py
+++ b/lib/gpu_memory_service/tests/test_gms_storage_client.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, List
 from unittest.mock import MagicMock, patch
 
 import pytest
+from gpu_memory_service.client import _gms_storage_gds as _gds_module
 
 # ---------------------------------------------------------------------------
 # Availability guards
@@ -1295,19 +1296,31 @@ class TestGMSStorageClientLoadMock:
         mock_mm: MagicMock,
         *,
         clear_existing: bool = True,
+        core_imports_available: bool = True,
+        full_imports_available: bool = True,
+        use_gds: bool = False,
         tensor_from_pointer: Any = None,
         tensor_from_pointer_side_effect: Any = None,
         read_shard_to_queue: Any = None,
     ) -> Dict[str, str]:
-        client = GMSStorageClient(tmpdir, socket_path="/tmp/fake.sock", device=0)
+        client = GMSStorageClient(
+            tmpdir,
+            socket_path="/tmp/fake.sock",
+            device=0,
+            use_gds=use_gds,
+        )
         patches = [
             patch(
                 "gpu_memory_service.client.gms_storage_client.GMSClientMemoryManager",
                 return_value=mock_mm,
             ),
             patch(
+                "gpu_memory_service.client.gms_storage_client._GMS_CORE_IMPORTS_AVAILABLE",
+                core_imports_available,
+            ),
+            patch(
                 "gpu_memory_service.client.gms_storage_client._GMS_IMPORTS_AVAILABLE",
-                True,
+                full_imports_available,
             ),
             patch(
                 "gpu_memory_service.client.gms_storage_client._tensor_from_pointer",
@@ -1558,6 +1571,116 @@ class TestGMSStorageClientLoadMock:
                     mock_mm,
                     read_shard_to_queue=_failing_read,
                 )
+
+    def test_load_to_gms_gds_does_not_require_torch_pipeline_imports(self):
+        """The GDS path should run with only the core GMS client imports present."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._build_dump_dir(tmpdir, num_allocs=2)
+            mock_mm, _ = self._build_mock_rw_mm(None)
+            gds_backend = MagicMock()
+
+            with (
+                patch(
+                    "gpu_memory_service.client.gms_storage_client.GMSClientMemoryManager",
+                    return_value=mock_mm,
+                ),
+                patch(
+                    "gpu_memory_service.client._gms_storage_gds.NixlGDSStorageBackend",
+                    return_value=gds_backend,
+                ),
+            ):
+                id_map = self._run_load_to_gms(
+                    tmpdir,
+                    mock_mm,
+                    core_imports_available=True,
+                    full_imports_available=False,
+                    use_gds=True,
+                )
+
+        assert id_map == {"orig-0": "new-0", "orig-1": "new-1"}
+        gds_backend.restore_shards.assert_called_once()
+        (
+            restore_input_dir,
+            restore_groups,
+            restore_va_map,
+        ) = gds_backend.restore_shards.call_args.args
+        assert restore_input_dir == tmpdir
+        assert set(restore_groups) == {"tensors/orig-0.pt", "tensors/orig-1.pt"}
+        assert restore_va_map == {"orig-0": 0x1000_0000, "orig-1": 0x1100_0000}
+        gds_backend.close.assert_called_once()
+        mock_mm.metadata_put.assert_any_call("key0", "new-0", 0, b"v0")
+        mock_mm.metadata_put.assert_any_call("key1", "new-1", 8, b"v1")
+        mock_mm.commit.assert_called_once()
+
+    def test_load_to_gms_gds_closes_backend_on_restore_failure(self):
+        """The GDS backend must still be closed when shard restore fails."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._build_dump_dir(tmpdir, num_allocs=1)
+            mock_mm, _ = self._build_mock_rw_mm(None)
+            gds_backend = MagicMock()
+            gds_backend.restore_shards.side_effect = RuntimeError("gds failed")
+
+            with (
+                patch(
+                    "gpu_memory_service.client.gms_storage_client.GMSClientMemoryManager",
+                    return_value=mock_mm,
+                ),
+                patch(
+                    "gpu_memory_service.client._gms_storage_gds.NixlGDSStorageBackend",
+                    return_value=gds_backend,
+                ),
+            ):
+                with pytest.raises(RuntimeError, match="gds failed"):
+                    self._run_load_to_gms(
+                        tmpdir,
+                        mock_mm,
+                        core_imports_available=True,
+                        use_gds=True,
+                    )
+
+        gds_backend.close.assert_called_once()
+        mock_mm.commit.assert_not_called()
+
+
+class TestNixlGDSStorageBackend:
+    def test_restore_shards_cleans_up_partial_registration_failure(self):
+        """Per-shard setup failures should release the file registration and fd."""
+        agent = MagicMock()
+        file_reg = MagicMock()
+        agent.register_memory.side_effect = [file_reg, RuntimeError("vram boom")]
+
+        with (
+            patch.object(_gds_module, "_NIXL_AVAILABLE", True),
+            patch.object(_gds_module, "nixl_agent", return_value=agent),
+            patch.object(_gds_module, "nixl_agent_config", return_value=MagicMock()),
+        ):
+            backend = _gds_module.NixlGDSStorageBackend(device=0)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shards_dir = os.path.join(tmpdir, "shards")
+            os.makedirs(shards_dir)
+            shard_path = os.path.join(shards_dir, "shard_0000.bin")
+            with open(shard_path, "wb") as f:
+                f.write(b"x" * 64)
+
+            entry = _make_entry(
+                alloc_id="alloc-1",
+                size=64,
+                aligned_size=64,
+                tensor_file="shards/shard_0000.bin",
+            )
+
+            with patch.object(_gds_module.os, "close", wraps=os.close) as close_mock:
+                with pytest.raises(RuntimeError, match="vram boom"):
+                    backend.restore_shards(
+                        tmpdir,
+                        {"shards/shard_0000.bin": [entry]},
+                        {"alloc-1": 0x1234},
+                    )
+
+        agent.deregister_memory.assert_called_once_with(file_reg)
+        agent.release_xfer_handle.assert_not_called()
+        close_mock.assert_called_once()
 
     def test_drain_restore_pipeline_cancels_and_finalizes_after_disk_error(self):
         """Disk errors should still cancel the pipeline and run final cleanup."""


### PR DESCRIPTION
   Add NixlGDSStorageBackend, a swappable storage backend that uses NVIDIA
    NIXL's GDS_MT (multi-threaded GPUDirect Storage) to read shard files
    directly into GPU memory, bypassing CPU entirely.

    - New file `client/_gms_storage_gds.py`: NixlGDSStorageBackend class
      - Uses NIXL GDS_MT backend for direct file→VRAM transfers via cuFile
      - Per-shard VRAM registration to avoid cuFile buffer size limits
      - Pipelined: transfer() returns immediately so VRAM registration for
        shard N+1 overlaps with in-flight I/O for shard N

    - Modified `client/gms_storage_client.py`:
      - Added `use_gds` parameter to GMSStorageClient
      - Added `_load_to_gms_gds()` method — GDS-specific restore path
      - Existing O_DIRECT pipeline completely unchanged when use_gds=False

    - Modified `cli/storage_runner.py`:
      - Added `--gds` flag to `load` subcommand

    - New file `tests/e2e/bench_gds_restore.py`:
      - Standalone GDS vs O_DIRECT throughput benchmark (no GMS server needed)

    Dataset: 135 GiB (Qwen-72B BF16 equivalent), 34 × 4 GiB shards

    | Method                              | Time   | Throughput  | % of SoL |
    |-------------------------------------|--------|-------------|----------|
    | GDS (NIXL GDS_MT, pipelined)        | 3.86s  | 34.99 GiB/s | 92%      |
    | GDS (compat mode, large buf)        | 7.72s  | 17.49 GiB/s | 46%      |
    | O_DIRECT + H2D copy (baseline)      | 70.46s | 1.92 GiB/s  | 5%       |
    | Speed-of-light (gdsio, 32 threads)  | 3.57s  | 37.84 GiB/s | 100%     |

    Speed-of-light is limited by a single 400G NDR NIC per GPU
    (RoundRobinMaxMin RDMA load balancing policy, 8 NICs / 8 GPUs).

    - Must use GDS_MT (multi-threaded), not GDS (single-threaded hangs
      on concurrent transfers, 18x slower on single transfers)
    - cuFile max_device_pinned_mem_size_kb must cover total model size;
      default 128 GiB is insufficient for 135+ GiB models — override
      via CUFILE_ENV_PATH_JSON
    - Per-shard VRAM registration avoids compat mode fallback (error 5016
      for buffers exceeding the pinned memory limit)
    - Pipelining registration with I/O recovers 0.77s of VRAM registration
      overhead, improving from 66% to 92% of speed-of-light