### PR TITLE
fix: inherit tool_call_parser and reasoning_parser in LoRA model registration

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -40,6 +40,7 @@ from dynamo.common.utils.time_section import time_and_log_code_section
 from dynamo.llm import (
     KvEventPublisher,
     ModelInput,
+    ModelRuntimeConfig,
     ModelType,
     lora_name_to_id,
     register_model,
@@ -776,6 +777,14 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                                 "lora_id": lora_id,
                             }
 
+                            runtime_config = ModelRuntimeConfig()
+                            runtime_config.tool_call_parser = (
+                                self.config.dyn_tool_call_parser
+                            )
+                            runtime_config.reasoning_parser = (
+                                self.config.dyn_reasoning_parser
+                            )
+
                             # Publish with format: v1/mdc/dynamo/backend/generate/{instance_id}/{lora_slug}
                             await register_model(
                                 model_input=ModelInput.Tokens,
@@ -783,6 +792,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                                 endpoint=self.generate_endpoint,
                                 model_path=self.config.model,
                                 kv_cache_block_size=self.config.engine_args.block_size,
+                                runtime_config=runtime_config,
                                 user_data=user_data,
                                 lora_name=lora_name,
                                 base_model_path=self.config.model,


### PR DESCRIPTION
Fixes #7558

## Summary

- LoRA adapter MDCs now include `tool_call_parser` and `reasoning_parser` from the base model config
- Fixes tool call parsing not working for LoRA model requests

## Problem

When a LoRA adapter is registered via `register_model()` in `handlers.py:load_lora`, no `runtime_config` is passed. The published MDC has `tool_call_parser: None`, causing the frontend to skip tool parsing for LoRA requests — even though the worker is configured with `--dyn-tool-call-parser hermes`.

## Fix

Build a `ModelRuntimeConfig` inheriting parsers from the base model config before calling `register_model()` for LoRA adapters:

```python
runtime_config = ModelRuntimeConfig()
runtime_config.tool_call_parser = self.config.dyn_tool_call_parser
runtime_config.reasoning_parser = self.config.dyn_reasoning_parser

await register_model(
    ...
    runtime_config=runtime_config,
    ...
)
```

## Files Changed

- `components/src/dynamo/vllm/handlers.py` — add `ModelRuntimeConfig` import; construct and pass `runtime_config` in `load_lora` method

## Test Plan

- [x] Built patched image from latest main (1.0)
- [x] Deployed to production cluster with Qwen3-30B-A3B MoE + LoRA adapters
- [x] Verified tool call request to LoRA model returns structured `tool_calls` with `finish_reason: "tool_calls"`
- [x] Verified base model tool calling still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LoRA model loading to ensure proper application of runtime configuration for tool and reasoning parsers, enhancing consistency and reliability across model operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->