### PR TITLE
fix: add default max_completion_tokens fallback for Chat Completions API (fixes #7476)

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1062,6 +1062,10 @@ async fn chat_completions(
     let streaming = request.inner.stream.unwrap_or(false);
 
     // Apply template values first to resolve the model before creating metrics guards
+    // Default max_completion_tokens to avoid backend-specific low defaults (e.g. TRT-LLM's 32).
+    // The Responses API already has this fallback; adding parity for Chat Completions.
+    const DEFAULT_MAX_COMPLETION_TOKENS: u32 = 4096;
+
     if let Some(template) = template {
         if request.inner.model.is_empty() {
             request.inner.model = template.model.clone();
@@ -1072,6 +1076,14 @@ async fn chat_completions(
         if request.inner.max_completion_tokens.unwrap_or(0) == 0 {
             request.inner.max_completion_tokens = Some(template.max_completion_tokens);
         }
+    }
+
+    // When no template is configured and the client omitted both max_completion_tokens
+    // and the deprecated max_tokens, apply a sensible default so backends like TRT-LLM
+    // don't silently cap output at their internal default (32 tokens).
+    #[allow(deprecated)]
+    if request.inner.max_completion_tokens.is_none() && request.inner.max_tokens.is_none() {
+        request.inner.max_completion_tokens = Some(DEFAULT_MAX_COMPLETION_TOKENS);
     }
 
     // Capture the resolved model after template application for metrics and engine lookup


### PR DESCRIPTION
## Problem

When a client sends a `/v1/chat/completions` request **without** specifying `max_completion_tokens` (or the deprecated `max_tokens`), and no `RequestTemplate` is configured, the TRT-LLM backend defaults to generating at most **32 tokens** — its internal `SamplingParams` default.

This is particularly destructive for **reasoning models** (e.g. models using `--dyn-reasoning-parser`), where the reasoning chain-of-thought consumes the entire 32-token budget, leaving **zero tokens for the actual response content** — resulting in `"content": null` and `"finish_reason": "length"`.

The Responses API (`/v1/responses`) already handles this correctly with a `DEFAULT_MAX_OUTPUT_TOKENS = 4096` fallback (line ~1429). The Chat Completions API was missing the equivalent logic.

## Solution

Added a `DEFAULT_MAX_COMPLETION_TOKENS = 4096` fallback to the `chat_completions` handler in `lib/llm/src/http/service/openai.rs`. After template application, if neither `max_completion_tokens` nor the deprecated `max_tokens` is set, the handler now applies the default — matching the Responses API behavior.

The check respects the deprecated `max_tokens` field: if a client explicitly sets `max_tokens`, the fallback is not applied, preserving backward compatibility.

## Testing

- Manual review of code logic
- The fix mirrors the existing pattern in the Responses API handler (same file, `create_response` function) which has been in production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API consistency: Chat Completions now applies a default token limit when clients don't specify their own, ensuring predictable request handling and alignment with the Responses API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->