### PR TITLE
fix: fern failures

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -118,6 +118,12 @@ navigation:
             path: features/multimodal/encoder-disaggregation.md
           - page: Multimodal KV Routing
             path: features/multimodal/multimodal-kv-routing.md
+          - page: vLLM Multimodal
+            path: features/multimodal/multimodal-vllm.md
+          - page: SGLang Multimodal
+            path: features/multimodal/multimodal-sglang.md
+          - page: TensorRT-LLM Multimodal
+            path: features/multimodal/multimodal-trtllm.md
       - section: Diffusion (Preview)
         slug: diffusion
         path: features/diffusion/README.md

--- a/docs/kubernetes/tilt-dev-setup.md
+++ b/docs/kubernetes/tilt-dev-setup.md
@@ -58,7 +58,7 @@ EOF
 tilt up
 ```
 
-Tilt opens a terminal UI and a web dashboard at <http://localhost:10350>.
+Tilt opens a terminal UI and a web dashboard at [http://localhost:10350](http://localhost:10350).
 The dashboard shows resource status, build logs, and port-forwards.
 
 Press **Space** in the terminal to open the web UI. Press **Ctrl-C** to
@@ -246,7 +246,7 @@ REGISTRY=ghcr.io/myorg tilt up
 
 ## Tilt UI
 
-The web UI at <http://localhost:10350> shows:
+The web UI at [http://localhost:10350](http://localhost:10350) shows:
 
 - **Resource status** — green/red/pending for each resource
 - **Build logs** — compilation output and errors


### PR DESCRIPTION
#### Overview:



Fixes Fern broken links failures in main:

example: https://github.com/ai-dynamo/dynamo/actions/runs/23425911088/job/68140635701?pr=6749

```
Run fern docs broken-links
  fern docs broken-links
  shell: /usr/bin/bash -e {0}
[docs]: Unexpected character `/` (U+002F) before local name, expected a character that can start a name, such as a letter, `$`, or `_` (note: to create a link in MDX, use `[text](url)`)
                      ╭──────────────────────────────────╮
                      │                                  │
                      │        Upgrades available        │
                      │                                  │
                      │      Fern 4.23.0 → 4.43.0        │
                      │   (Run fern upgrade to update)   │
                      │                                  │
                      ╰──────────────────────────────────╯

Error: Process completed with exit code 1.
```


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new sidebar navigation pages for vLLM Multimodal, SGLang Multimodal, and TensorRT-LLM Multimodal features under the Multimodal section.
  * Improved link formatting in the Tilt development setup documentation for enhanced readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->