### PR TITLE
fix: downgrade noisy tool parser INFO logs to DEBUG

### DIFF
--- a/lib/parsers/src/tool_calling/tools.rs
+++ b/lib/parsers/src/tool_calling/tools.rs
@@ -16,9 +16,9 @@ pub async fn try_tool_call_parse_aggregate(
     Option<String>,
 )> {
     if parser_str.is_none() {
-        tracing::info!("No tool parser provided. Trying parsing with default parser.");
+        tracing::debug!("No tool parser provided. Trying parsing with default parser.");
     } else {
-        tracing::info!("Using tool parser: {:?}", parser_str);
+        tracing::debug!("Using tool parser: {:?}", parser_str);
     }
     let (parsed, content) = detect_and_parse_tool_call(message, parser_str, tools).await?;
     if parsed.is_empty() {


### PR DESCRIPTION
## Summary

- Downgrade two `tracing::info!` calls to `tracing::debug!` in `try_tool_call_parse_aggregate` (`lib/parsers/src/tool_calling/tools.rs`)
- This function is called per streaming chunk (and up to 3x per chunk on tool calls), so with token-at-a-time streaming the parser selection message fires on every generated token — the parser choice is a static config, logging it per-token adds no value
- These logs dominate frontend log output in production; messages remain available via `RUST_LOG=debug`

Continuation of #6622 which was closed before this half of the fix landed (the KV router scheduler log was separately fixed in the refactor to `lib/kv-router/src/scheduling/selector.rs`).

Closes #6621