### PR TITLE
chore: Sync ReasoningEffort with upstream

### DIFF
--- a/lib/async-openai/src/types/chat.rs
+++ b/lib/async-openai/src/types/chat.rs
@@ -823,13 +823,16 @@ pub enum ServiceTierResponse {
     Priority,
 }
 
-#[derive(ToSchema, Clone, Serialize, Debug, Deserialize, PartialEq)]
+#[derive(ToSchema, Clone, Serialize, Debug, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum ReasoningEffort {
+    None,
     Minimal,
     Low,
+    #[default]
     Medium,
     High,
+    Xhigh,
 }
 
 /// Output types that you would like the model to generate for this request.
@@ -924,10 +927,9 @@ pub struct CreateChatCompletionRequest {
     /// Constrains effort on reasoning for
     /// [reasoning models](https://platform.openai.com/docs/guides/reasoning).
     ///
-    /// Currently supported values are `low`, `medium`, and `high`. Reducing
+    /// Supported values are model-dependent and can include `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`.
     ///
-    /// reasoning effort can result in faster responses and fewer tokens
-    /// used on reasoning in a response.
+    /// Lower effort favors speed and lower token usage, while higher effort favors more complete reasoning.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<ReasoningEffort>,
 

--- a/lib/async-openai/src/types/responses/response.rs
+++ b/lib/async-openai/src/types/responses/response.rs
@@ -844,9 +844,8 @@ pub struct Billing {
 pub struct Reasoning {
     /// Constrains effort on reasoning for
     /// [reasoning models](https://platform.openai.com/docs/guides/reasoning).
-    /// Currently supported values are `minimal`, `low`, `medium`, and `high`. Reducing
-    /// reasoning effort can result in faster responses and fewer tokens used
-    /// on reasoning in a response.
+    /// Supported values are model-dependent and can include `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`.
+    /// Lower effort favors speed and lower token usage, while higher effort favors more complete reasoning.
     ///
     /// Note: The `gpt-5-pro` model defaults to (and only supports) `high` reasoning effort.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Sync the in-repo `ReasoningEffort` values with upstream [aysnc-openai](https://github.com/64bit/async-openai/blob/04845660b0f931f58d73eb7590d05028d0f15ec7/async-openai/src/types/shared/reasoning_effort.rs#L5).

#### Details:

<!-- Describe the changes made in this PR. -->
- Adds `none` and `xhigh` values,  makes `medium` the "default value".
- Rewords comments to directly take from https://developers.openai.com/api/docs/guides/reasoning#get-started-with-reasoning

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->
Main change is in lib/async-openai/src/types/chat.rs. I don't think any additional tests need to be added since this is only updates to the allowed list of enum values.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

~- closes GitHub issue: #xxx~
N/A. This is chore/upstream sync, let me know if you would prefer me to file a issues first. I also did not find any existing PRs for this or workflows for syncing this repo with async-openai.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new reasoning effort options to support expanded model capabilities.

* **Documentation**
  * Updated reasoning effort documentation to reflect model-dependent values, including newly supported options and updated parameter descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->