### PR TITLE
fix(replay): resolve planner_profile_data directory

### DIFF
--- a/docs/mocker/mocker.md
+++ b/docs/mocker/mocker.md
@@ -200,6 +200,15 @@ python -m dynamo.mocker \
 
 The AIC model automatically uses `--model-path` and `--engine-type` to select the appropriate performance data. Available systems include `h200_sxm`, `h100_sxm`, etc. (see AIC SDK documentation for the full list).
 
+When using `python -m dynamo.replay`, there are no dedicated AIC flags. Pass the equivalent fields directly via `--extra-engine-args`:
+
+```bash
+python -m dynamo.replay /path/to/trace.jsonl \
+    --extra-engine-args '{"aic_backend":"vllm","aic_system":"h200_sxm","aic_model_path":"nvidia/Llama-3.1-8B-Instruct-FP8","aic_tp_size":1}'
+```
+
+The `aic_backend` field enables the AIC perf model and should match `engine_type` (`"vllm"` or `"sglang"`). The `aic_model_path` field is the equivalent of `--model-path` in `dynamo.mocker`.
+
 Example `--reasoning` configuration:
 
 ```bash

--- a/lib/bindings/python/src/dynamo/replay/main.py
+++ b/lib/bindings/python/src/dynamo/replay/main.py
@@ -4,13 +4,16 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 from collections.abc import Sequence
+from pathlib import Path
 
 os.environ.setdefault("DYNAMO_SKIP_PYTHON_LOG_INIT", "1")
 
 from dynamo.llm import KvRouterConfig, MockEngineArgs
+from dynamo.mocker.args import resolve_planner_profile_data
 from dynamo.replay import run_synthetic_trace_replay, run_trace_replay
 from dynamo.replay.reporting import format_report_table, write_report_json
 
@@ -56,11 +59,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             "synthetic replay requires --input-tokens, --output-tokens, and --request-count"
         )
 
-    extra_engine_args = (
-        MockEngineArgs.from_json(args.extra_engine_args)
-        if args.extra_engine_args is not None
-        else None
-    )
+    # Resolve planner_profile_data directory -> NPZ before passing to Rust.
+    # Rust only accepts NPZ files; resolve_planner_profile_data handles conversion.
+    profile_data_result = None
+    if args.extra_engine_args is not None:
+        raw = json.loads(args.extra_engine_args)
+        if "planner_profile_data" in raw:
+            profile_data_result = resolve_planner_profile_data(
+                Path(raw["planner_profile_data"])
+            )
+            if profile_data_result.npz_path is not None:
+                raw["planner_profile_data"] = str(profile_data_result.npz_path)
+            else:
+                del raw["planner_profile_data"]
+            extra_engine_args = MockEngineArgs.from_json(json.dumps(raw))
+        else:
+            extra_engine_args = MockEngineArgs.from_json(args.extra_engine_args)
+    else:
+        extra_engine_args = None
     router_config = (
         KvRouterConfig.from_json(args.router_config)
         if args.router_config is not None


### PR DESCRIPTION
#### Overview:

Fix the following error when using the `planner_profile_data` directory with replay:
```
ERROR dynamo_mocker::common::protocols: Failed to load performance model from "tests/planner/profiling_results/H200_TP1P_TP1D": Failed to create NPZ reader for: "tests/planner/profiling_results/H200_TP1P_TP1D". Falling back to polynomial model.
```
#### Details:

Mirror the conversion that `dynamo.mocker` already does: parse
`planner_profile_data` out of the extra-engine-args JSON, call
`resolve_planner_profile_data` to convert a profiler results directory
to an NPZ file, then re-serialize before constructing `MockEngineArgs`.

Also add `dynamo.replay` AIC usage to the AIC Performance Model section in `mocker.md`

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced handling of planner profile data in engine arguments with automatic directory-to-NPZ conversion when specified via `--extra-engine-args`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->