### PR TITLE
Fix SGLang network helper imports

### DIFF
--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import ipaddress
 import json
 import logging
 from typing import TYPE_CHECKING, List, Optional, Tuple
@@ -10,7 +11,7 @@ import sglang as sgl
 import zmq
 import zmq.asyncio
 from sglang.srt.disaggregation.kv_events import ZmqEventPublisher
-from sglang.srt.utils import get_local_ip_auto, get_zmq_socket, maybe_wrap_ipv6_address
+from sglang.srt.utils.network import get_local_ip_auto, get_zmq_socket
 
 if TYPE_CHECKING:
     from prometheus_client import CollectorRegistry
@@ -29,7 +30,6 @@ def format_zmq_endpoint(endpoint_template: str, ip_address: str) -> str:
     """Format ZMQ endpoint by replacing wildcard with IP address.
 
     Properly handles IPv6 addresses by wrapping them in square brackets.
-    Uses SGLang's maybe_wrap_ipv6_address for consistent formatting.
 
     Args:
         endpoint_template: ZMQ endpoint template with wildcard (e.g., "tcp://*:5557")
@@ -44,8 +44,11 @@ def format_zmq_endpoint(endpoint_template: str, ip_address: str) -> str:
         >>> format_zmq_endpoint("tcp://*:5557", "2a02:6b8:c46:2b4:0:74c1:75b0:0")
         'tcp://[2a02:6b8:c46:2b4:0:74c1:75b0:0]:5557'
     """
-    # Use SGLang's utility to wrap IPv6 addresses in brackets
-    formatted_ip = maybe_wrap_ipv6_address(ip_address)
+    try:
+        ipaddress.IPv6Address(ip_address)
+        formatted_ip = f"[{ip_address}]"
+    except ValueError:
+        formatted_ip = ip_address
     return endpoint_template.replace("*", formatted_ip)
 
 

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -8,7 +8,7 @@ from typing import Any, List, Optional
 
 import sglang as sgl
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils import get_local_ip_auto
+from sglang.srt.utils.network import get_local_ip_auto
 
 from dynamo._core import Endpoint
 from dynamo.common.utils.output_modalities import get_output_modalities

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -20,7 +20,7 @@ from typing import (
 )
 
 import sglang as sgl
-from sglang.srt.utils import get_local_ip_auto
+from sglang.srt.utils.network import get_local_ip_auto
 
 from dynamo._core import Context
 from dynamo.common.utils.input_params import InputParamManager


### PR DESCRIPTION
## Summary
Sglang changed the module org in https://github.com/sgl-project/sglang/pull/20646
- import get_local_ip_auto from sglang.srt.utils.network instead of sglang.srt.utils
- import get_zmq_socket from sglang.srt.utils.network in the SGLang publisher
- replace the broken maybe_wrap_ipv6_address dependency with a small local IPv6 formatter in publisher.py

## Validation
- python3 -m py_compile components/src/dynamo/sglang/publisher.py components/src/dynamo/sglang/request_handlers/handler_base.py components/src/dynamo/sglang/register.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal network utility imports across modules for improved code organization.
  * Optimized IPv6 address handling in network endpoint formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->