### PR TITLE
fix(docs): escape angle brackets in tilt-dev-setup to fix MDX parse error

### DIFF
--- a/docs/kubernetes/tilt-dev-setup.md
+++ b/docs/kubernetes/tilt-dev-setup.md
@@ -127,7 +127,7 @@ The operator image needs to be pullable by your cluster's nodes. The registry is
 1. **`REGISTRY` env var** — `REGISTRY=docker.io/myuser tilt up`
 2. **`registry` in `tilt-settings.yaml`**
 
-The image is pushed as `<registry>/controller:tilt-dev`.
+The image is pushed as `{registry}/controller:tilt-dev`.
 
 <Warning>
 If no registry is configured, the image is only available locally. This works


### PR DESCRIPTION
## Summary

- Replace `<registry>` with `{registry}` in `tilt-dev-setup.md` to prevent MDX from interpreting it as a JSX tag
- The `/` after `<registry>` was causing Fern to fail with: "Unexpected character `/` before local name"

## Context

This blocks all docs PRs (including #6370) because the Fern broken links check fails during preview generation.

## Test Plan

- [ ] Fern broken links check passes
- [ ] Fern docs preview generates successfully

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated syntax examples in the Kubernetes development setup guide for improved clarity and consistency with string interpolation conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->