### PR TITLE
fix(trtllm): populate disagg_request_id for PYTHON transceiver

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -27,6 +27,7 @@ import torch
 from tensorrt_llm.executor.result import GenerationResult
 from tensorrt_llm.executor.utils import RequestError
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
+from tensorrt_llm.llmapi.disagg_utils import get_global_disagg_request_id
 from tensorrt_llm.llmapi.llm import SamplingParams
 from tensorrt_llm.sampling_params import GuidedDecodingParams
 from tensorrt_llm.scheduling_params import SchedulingParams
@@ -83,6 +84,7 @@ class RequestHandlerConfig:
     disable_request_abort: bool = True
     additional_metrics: Optional["AdditionalMetricsCollector"] = None
     max_seq_len: Optional[int] = None
+    disagg_machine_id: int = 0  # 10-bit machine_id for snowflake disagg_request_id
 
 
 class HandlerBase(BaseGenerativeHandler):
@@ -114,6 +116,7 @@ class HandlerBase(BaseGenerativeHandler):
         self.disable_request_abort = config.disable_request_abort
         self.additional_metrics = config.additional_metrics
         self.max_seq_len = config.max_seq_len
+        self.disagg_machine_id = config.disagg_machine_id
 
     def check_error(self, result: dict) -> bool:
         """
@@ -465,7 +468,18 @@ class HandlerBase(BaseGenerativeHandler):
                 disaggregated_params = ep_disaggregated_params
             else:
                 disaggregated_params = LlmDisaggregatedParams(
-                    request_type="context_only"
+                    request_type="context_only",
+                    disagg_request_id=get_global_disagg_request_id(
+                        self.disagg_machine_id
+                    ),
+                )
+
+            # Ensure disagg_request_id is set even when using
+            # ep_disaggregated_params, so the PYTHON transceiver can track
+            # requests across prefill/decode workers.
+            if disaggregated_params.disagg_request_id is None:
+                disaggregated_params.disagg_request_id = get_global_disagg_request_id(
+                    self.disagg_machine_id
                 )
 
         # AGGREGATED (prefill_and_decode) mode with encoder disaggregation:

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -440,3 +440,80 @@ class TestMultimodalGuard:
         assert result["prompt"] == "describe image"
         assert result["prompt_token_ids"] == [1, 2, 3]
         assert result["multi_modal_data"] is None
+
+
+class TestDisaggRequestId:
+    """Tests for disagg_request_id population in _setup_disaggregated_params_for_mode."""
+
+    def _make_prefill_handler(self, machine_id: int = 42) -> HandlerBase:
+        config = MagicMock()
+        config.shutdown_event = None
+        config.disagg_machine_id = machine_id
+        handler = _ConcreteHandler(config)
+        handler.disaggregation_mode = DisaggregationMode.PREFILL
+        return handler
+
+    def test_disagg_request_id_populated_in_prefill_mode(self):
+        """When mode is PREFILL and no ep_disaggregated_params, disagg_request_id is set."""
+        handler = self._make_prefill_handler()
+        disagg_params, _, _ = handler._setup_disaggregated_params_for_mode(
+            request={}, ep_disaggregated_params=None
+        )
+        assert disagg_params is not None
+        assert disagg_params.disagg_request_id is not None
+        assert isinstance(disagg_params.disagg_request_id, int)
+
+    def test_disagg_request_id_unique_across_calls(self):
+        """Multiple calls should produce different IDs."""
+        handler = self._make_prefill_handler()
+        ids = set()
+        for _ in range(10):
+            params, _, _ = handler._setup_disaggregated_params_for_mode(
+                request={}, ep_disaggregated_params=None
+            )
+            ids.add(params.disagg_request_id)
+        assert len(ids) == 10, f"Expected 10 unique IDs, got {len(ids)}"
+
+    def test_disagg_request_id_set_on_ep_params_with_none(self):
+        """When ep_disaggregated_params has disagg_request_id=None, it gets populated."""
+        handler = self._make_prefill_handler()
+        ep_params = MagicMock()
+        ep_params.disagg_request_id = None
+        # Make bool(ep_params) truthy so the if-branch is taken
+        ep_params.__bool__ = lambda self: True
+
+        params, _, _ = handler._setup_disaggregated_params_for_mode(
+            request={}, ep_disaggregated_params=ep_params
+        )
+        assert params.disagg_request_id is not None
+        assert isinstance(params.disagg_request_id, int)
+
+    def test_disagg_request_id_not_overwritten_when_set(self):
+        """When ep_disaggregated_params already has a disagg_request_id, keep it."""
+        handler = self._make_prefill_handler()
+        existing_id = 12345678
+        ep_params = MagicMock()
+        ep_params.disagg_request_id = existing_id
+        ep_params.__bool__ = lambda self: True
+
+        params, _, _ = handler._setup_disaggregated_params_for_mode(
+            request={}, ep_disaggregated_params=ep_params
+        )
+        assert params.disagg_request_id == existing_id
+
+    def test_machine_id_from_config(self):
+        """disagg_machine_id is taken from the handler config."""
+        handler = self._make_prefill_handler(machine_id=123)
+        assert handler.disagg_machine_id == 123
+
+    def test_different_machine_ids_produce_different_id_ranges(self):
+        """Handlers with different machine_ids produce non-overlapping snowflake IDs."""
+        handler_a = self._make_prefill_handler(machine_id=1)
+        handler_b = self._make_prefill_handler(machine_id=2)
+        params_a, _, _ = handler_a._setup_disaggregated_params_for_mode(
+            request={}, ep_disaggregated_params=None
+        )
+        params_b, _, _ = handler_b._setup_disaggregated_params_for_mode(
+            request={}, ep_disaggregated_params=None
+        )
+        assert params_a.disagg_request_id != params_b.disagg_request_id

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -479,6 +479,7 @@ async def init_llm_worker(
             disable_request_abort=config.disable_request_abort,
             additional_metrics=additional_metrics,
             max_seq_len=config.max_seq_len,
+            disagg_machine_id=int(endpoint.connection_id()) % 1021,
         )
 
         # Register the model with runtime config


### PR DESCRIPTION
## Summary

- Fix response shuffling and crashes in disaggregated serving when using the PYTHON cache transceiver (`transceiver_runtime=PYTHON`) with NIXL
- Populate `disagg_request_id` on `DisaggregatedParams` in the prefill path using TRT-LLM's `get_global_disagg_request_id()` snowflake ID generator

## Problem

When dynamo creates `DisaggregatedParams(request_type="context_only")` in the prefill worker, it never sets `disagg_request_id`. TRT-LLM's Python transceiver uses `get_unique_rid()` which prefers `disagg_request_id` over `request_id`. When `disagg_request_id` is `None`:

1. **AssertionError crash (rc9)**: `transfer.py:140` asserts `params.disagg_request_id is not None` — **100% failure rate**, every single request crashes
2. **Response shuffling (older TRT-LLM)**: All concurrent requests map to the same dictionary key (`None`) in the transceiver's session tracking

TRT-LLM's native serving path (`openai_disagg_service.py`) calls `get_global_disagg_request_id()` to generate unique IDs, but dynamo bypasses that path.

### Proof: HEAD crashes without this fix

Built from dynamo HEAD (`f849e1a69`) + TRT-LLM 1.3.0rc9, deployed 1P1D disagg with `transceiver_runtime: PYTHON` on GB200. Every request fails:

```
File "tensorrt_llm/_torch/disaggregation/native/transfer.py", line 140, in __init__
    assert params.disagg_request_id is not None
AssertionError
```

Image: `nvcr.io/goirlvsxnepa/llm_nim/dynamo-trtllm:head-no-fix` (local only, not pushed)

## Fix

Call `get_global_disagg_request_id(self.disagg_machine_id)` when creating `DisaggregatedParams` in the prefill path. This generates a snowflake ID (timestamp + machine_id + counter) that is globally unique and persists across the prefill→decode handoff via the `params_dict` transport.

**Machine ID derivation**: `endpoint.connection_id() % 1021` — uses the worker's etcd lease ID (dynamo's per-worker unique identifier) mod the largest prime < 1024. This matches the 10-bit machine_id space used by TRT-LLM's snowflake generator ([ref](https://github.com/NVIDIA/TensorRT-LLM/blob/d0c8c5b0b66d3ea194e7027d0abc3a483f8351a4/tensorrt_llm/llmapi/disagg_utils.py#L84-L85)) and provides per-worker uniqueness even when multiple workers run on the same host.

Also ensures `disagg_request_id` is set when using `ep_disaggregated_params` from the encode worker (EPD flow) if it comes in as `None`.

## Test Plan

- [x] 6 unit tests added to `test_trtllm_handler_base.py`:
  - ID populated in prefill mode
  - IDs unique across calls
  - ID set on ep_params with None
  - Existing non-None ID preserved
  - Machine ID taken from config
  - Different machine IDs produce different snowflake IDs
- [x] E2E validated on GB200 1P1D disagg serving with `transceiver_runtime: PYTHON`
  - Image pulled fresh from nvcr.io (TRT-LLM 1.3.0rc9, digest `sha256:65cda0da...`)
  - Model: Qwen3-Coder-30B-A3B + EAGLE3
  - 5 concurrent keyword requests (ALPHA/BRAVO/CHARLIE/DELTA/ECHO): zero response shuffling
  - Nodes: gb-nvl-053-compute[07,09], Job 693513
- [x] Proved HEAD without fix crashes 100% (`head-no-fix` image, same setup)
- [x] Linters pass (black, ruff, isort)
- [ ] CI

## Related

- Companion TRT-LLM fix for gen-side timeout: [NVIDIA/TensorRT-LLM#12471](https://github.com/NVIDIA/TensorRT-LLM/pull/12471)
- tool_choice=none fix: [ai-dynamo/dynamo#7391](https://github.com/ai-dynamo/dynamo/pull/7391)

Signed-off-by: Yifan Jiang <19356972+yifjiang@users.noreply.github.com>