### PR TITLE
fix(frontend): carry forward real stream metadata in JailedStream finalization

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -513,6 +513,10 @@ impl JailedStream {
             let mut last_annotated_id: Option<String> = None;
             let mut last_annotated_event: Option<String> = None;
             let mut last_annotated_comment: Option<Vec<String>> = None;
+            // Track stream response metadata so finalization chunks carry real values
+            let mut last_stream_id = String::new();
+            let mut last_stream_model = String::new();
+            let mut last_stream_created: u32 = 0;
 
             // Pin the stream for iteration (stack pinning is more efficient)
             tokio::pin!(stream);
@@ -521,6 +525,10 @@ impl JailedStream {
             // Process each item in the stream
             while let Some(response) = stream.next().await {
                 if let Some(chat_response) = response.data.as_ref() {
+                    last_stream_id.clone_from(&chat_response.id);
+                    last_stream_model.clone_from(&chat_response.model);
+                    last_stream_created = chat_response.created;
+
                     let mut all_emissions = Vec::new();
 
                     if chat_response.choices.is_empty() {
@@ -666,12 +674,12 @@ impl JailedStream {
 
             if !final_emissions.is_empty() {
                 tracing::debug!("Stream ended while jailed, releasing accumulated content");
-                // Create a dummy response for finalization
+                // Create a finalization response carrying forward real stream metadata
                 let dummy_response = NvCreateChatCompletionStreamResponse {
-                    id: "stream-end".to_string(),
+                    id: last_stream_id,
                     object: "chat.completion.chunk".to_string(),
-                    created: 0,
-                    model: "unknown".to_string(),
+                    created: last_stream_created,
+                    model: last_stream_model,
                     choices: Vec::new(),
                     usage: None,
                     service_tier: None,

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -1315,10 +1315,23 @@ mod tests {
             "Comment should be preserved when stream ends while jailed"
         );
 
+        // Verify inner response metadata carries forward real stream values (not placeholders)
+        let inner = accumulated_chunk.data.as_ref().unwrap();
+        assert_eq!(
+            inner.id, "test-id",
+            "Inner response id should carry forward from real stream chunks, not be 'stream-end'"
+        );
+        assert_eq!(
+            inner.model, "test-model",
+            "Inner response model should carry forward from real stream chunks, not be 'unknown'"
+        );
+        assert_eq!(
+            inner.created, 1234567890,
+            "Inner response created should carry forward from real stream chunks, not be 0"
+        );
+
         // Verify accumulated content is returned
-        let content = &accumulated_chunk.data.as_ref().unwrap().choices[0]
-            .delta
-            .content;
+        let content = &inner.choices[0].delta.content;
         assert!(content.is_some(), "Should have accumulated content");
         let content = content.as_ref().unwrap();
         assert!(


### PR DESCRIPTION
## Summary

Fixes #7602 — Non-streaming responses with tool calls (Harmony parser) return corrupted metadata: `"id": "stream-end"`, `"model": "unknown"`, `"created": 0`.

**Root cause**: `JailedStream` generates a dummy finalization chunk with hardcoded placeholder values. When `DeltaAggregator` combines streaming chunks into a non-streaming response, this dummy chunk (being last) overwrites the real metadata.

**Fix**: Track `id`, `model`, and `created` from real stream chunks and use them in the finalization response instead of placeholders.

## Changes

- `lib/llm/src/protocols/openai/chat_completions/jail.rs` — 3 tracking variables to carry forward real metadata
- `lib/llm/tests/test_jail.rs` — Added assertions to verify inner response fields are preserved

## Test plan

- [x] `cargo test -p dynamo-llm` — all tests pass
- [x] `cargo test --test test_jail` — metadata preservation test passes
- [x] **E2E integration test**: Built `vllm-runtime:vvagias-jail-fix` container, ran GPT-OSS-20B with Harmony tool-call parser, verified non-streaming + tool calls returns real `id`/`model`/`created` values instead of placeholders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Streaming chat responses now preserve actual stream metadata (identifiers, model information, and timestamps) when streams complete, ensuring consistency instead of using previously hardcoded placeholder values.
* Stream finalization now maintains real metadata from observed responses rather than inserting default/unknown values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->