### PR TITLE
refactor(vllm): Use model arch instead of hard-coded model list for Qwen VL support

### DIFF
--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -13,12 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import os
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import torch
+from huggingface_hub import hf_hub_download
 from transformers import AutoModel
 from vllm import LLM
 from vllm.utils.system_utils import update_environment_variables
@@ -29,28 +32,23 @@ logger = logging.getLogger(__name__)
 # should be removed once there is proper way to extract vLLM encoder.
 VLLM_ENCODER = int(os.getenv("VLLM_ENCODER", 1))
 
+# HF architecture classes that use Qwen VL-style image processing
+# (grid_thw + pixel_values). Adding an entry here is sufficient to support
+# any model that shares the same vision pipeline.
+QWEN_VL_ARCHITECTURES = {
+    "Qwen2VLForConditionalGeneration",
+    "Qwen2_5_VLForConditionalGeneration",
+    "Qwen3VLForConditionalGeneration",
+    "Qwen3VLMoeForConditionalGeneration",
+    "Qwen3_5ForConditionalGeneration",
+    "Qwen3_5MoeForConditionalGeneration",
+}
+
 
 class SupportedModels:
-    """Supported multimodal model identifiers"""
-
-    # TODO: Replace this explicit model list with dynamic detection using
-    # HF config `architectures` field or vLLM's model registry, so any
-    # vLLM-supported VLM works without maintaining entries here.
+    """Non-Qwen multimodal model identifiers that need model-specific handling."""
 
     LLAVA_1_5_7B = "llava-hf/llava-1.5-7b-hf"
-    QWEN_2_VL_2B = "Qwen/Qwen2-VL-2B-Instruct"
-    QWEN_2_5_VL_3B = "Qwen/Qwen2.5-VL-3B-Instruct"
-    QWEN_2_5_VL_7B = "Qwen/Qwen2.5-VL-7B-Instruct"
-    QWEN_2_5_VL_32B = "Qwen/Qwen2.5-VL-32B-Instruct"
-    QWEN_3_VL_2B = "Qwen/Qwen3-VL-2B-Instruct"
-    QWEN_3_VL_30B_A3B = "Qwen/Qwen3-VL-30B-A3B-Instruct"
-    QWEN_3_VL_30B_A3B_FP8 = "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8"
-    QWEN_3_VL_8B = "Qwen/Qwen3-VL-8B-Instruct"
-    QWEN_3_VL_8B_FP8 = "Qwen/Qwen3-VL-8B-Instruct-FP8"
-    QWEN_3_VL_4B = "Qwen/Qwen3-VL-4B-Instruct"
-    QWEN_3_VL_4B_FP8 = "Qwen/Qwen3-VL-4B-Instruct-FP8"
-    QWEN_3_VL_32B = "Qwen/Qwen3-VL-32B-Instruct"
-    QWEN_3_VL_32B_FP8 = "Qwen/Qwen3-VL-32B-Instruct-FP8"
     LLAVA_NEXT_VIDEO_7B = "llava-hf/LLaVA-NeXT-Video-7B-hf"
 
 
@@ -123,27 +121,49 @@ def is_model_supported(model_name: str, supported_model: str) -> bool:
     return normalized_name == normalized_supported
 
 
-# List of all Qwen VL model variants for easy extension
-QWEN_VL_MODELS = [
-    SupportedModels.QWEN_2_VL_2B,
-    SupportedModels.QWEN_2_5_VL_3B,
-    SupportedModels.QWEN_2_5_VL_7B,
-    SupportedModels.QWEN_2_5_VL_32B,
-    SupportedModels.QWEN_3_VL_2B,
-    SupportedModels.QWEN_3_VL_30B_A3B,
-    SupportedModels.QWEN_3_VL_30B_A3B_FP8,
-    SupportedModels.QWEN_3_VL_8B,
-    SupportedModels.QWEN_3_VL_8B_FP8,
-    SupportedModels.QWEN_3_VL_4B,
-    SupportedModels.QWEN_3_VL_4B_FP8,
-    SupportedModels.QWEN_3_VL_32B,
-    SupportedModels.QWEN_3_VL_32B_FP8,
-]
+@lru_cache(maxsize=32)
+def _get_model_architectures(model_name: str) -> tuple[str, ...]:
+    """Get the architectures list from a model's config.json (cached).
+
+    Reads the raw JSON instead of using ``AutoConfig`` so that brand-new
+    model types work even before ``transformers`` adds native support.
+
+    Args:
+        model_name: HF model id, local path, or cache path.
+
+    Returns:
+        Tuple of architecture class names (empty if lookup fails).
+    """
+    normalized = normalize_model_name(model_name)
+    try:
+        # Local path
+        local_config = Path(normalized) / "config.json"
+        if local_config.is_file():
+            config_path = str(local_config)
+        else:
+            # Download (or resolve from HF cache) just the config file
+            config_path = hf_hub_download(normalized, "config.json")
+
+        with open(config_path) as f:
+            config = json.load(f)
+        return tuple(config.get("architectures", []))
+    except Exception:
+        logger.warning(
+            "Could not load config.json for model %s, "
+            "architecture-based detection unavailable",
+            normalized,
+        )
+        return ()
 
 
 def is_qwen_vl_model(model_name: str) -> bool:
     """
-    Check if a model is any Qwen VL variant.
+    Check if a model uses Qwen VL-style vision processing by inspecting
+    its HF config ``architectures`` field.
+
+    This replaces the previous explicit model-name list, so any Qwen VL
+    variant (including community finetunes and quantised checkpoints)
+    is recognised automatically.
 
     Args:
         model_name: The model name to check
@@ -152,7 +172,7 @@ def is_qwen_vl_model(model_name: str) -> bool:
         True if the model is a Qwen VL variant, False otherwise
     """
     return any(
-        is_model_supported(model_name, qwen_model) for qwen_model in QWEN_VL_MODELS
+        arch in QWEN_VL_ARCHITECTURES for arch in _get_model_architectures(model_name)
     )
 
 

--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -134,14 +134,14 @@ def _get_model_architectures(model_name: str) -> tuple[str, ...]:
     Returns:
         Tuple of architecture class names (empty if lookup fails).
     """
-    normalized = normalize_model_name(model_name)
     try:
-        # Local path
-        local_config = Path(normalized) / "config.json"
+        # Check the original model_name as a local directory first
+        local_config = Path(model_name) / "config.json"
         if local_config.is_file():
             config_path = str(local_config)
         else:
             # Download (or resolve from HF cache) just the config file
+            normalized = normalize_model_name(model_name)
             config_path = hf_hub_download(normalized, "config.json")
 
         with open(config_path) as f:
@@ -151,7 +151,7 @@ def _get_model_architectures(model_name: str) -> tuple[str, ...]:
         logger.warning(
             "Could not load config.json for model %s, "
             "architecture-based detection unavailable",
-            normalized,
+            model_name,
         )
         return ()
 

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py
@@ -1,13 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for DynamoMultimodalEmbeddingCacheConnector."""
+"""Unit tests for multimodal model utilities."""
 
+
+from unittest.mock import patch
 
 import pytest
 import torch
 
-from dynamo.vllm.multimodal_utils.model import construct_qwen_decode_mm_data
+from dynamo.vllm.multimodal_utils.model import (
+    construct_qwen_decode_mm_data,
+    is_qwen_vl_model,
+)
 
 pytestmark = [
     pytest.mark.pre_merge,
@@ -15,6 +20,51 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.multimodal,
 ]
+
+
+class TestIsQwenVlModel:
+    """Test architecture-based Qwen VL detection."""
+
+    @pytest.mark.parametrize(
+        "arch",
+        [
+            "Qwen2VLForConditionalGeneration",
+            "Qwen2_5_VLForConditionalGeneration",
+            "Qwen3VLForConditionalGeneration",
+            "Qwen3VLMoeForConditionalGeneration",
+            "Qwen3_5ForConditionalGeneration",
+            "Qwen3_5MoeForConditionalGeneration",
+        ],
+    )
+    def test_positive_qwen_vl_architectures(self, arch):
+        with patch(
+            "dynamo.vllm.multimodal_utils.model._get_model_architectures",
+            return_value=(arch,),
+        ):
+            assert is_qwen_vl_model("any/model") is True
+
+    @pytest.mark.parametrize(
+        "arch",
+        [
+            "Qwen3ForCausalLM",
+            "LlavaForConditionalGeneration",
+            "LlamaForCausalLM",
+            "MistralForCausalLM",
+        ],
+    )
+    def test_negative_non_qwen_vl_architectures(self, arch):
+        with patch(
+            "dynamo.vllm.multimodal_utils.model._get_model_architectures",
+            return_value=(arch,),
+        ):
+            assert is_qwen_vl_model("any/model") is False
+
+    def test_empty_architectures(self):
+        with patch(
+            "dynamo.vllm.multimodal_utils.model._get_model_architectures",
+            return_value=(),
+        ):
+            assert is_qwen_vl_model("any/model") is False
 
 
 class TestMultiModalUtils:


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Problems:
- Hard coded list is hard to maintain, and there are many variants of models
- Custom fine tunings and patches to model may not even match list, despite being functionally equivalent

This PR's solution:
- Use model architecture to check instead

TODO:
- is this change even needed? IIUC this is_qwen_vl check is to (1) check if model will work with vision encoder and (2) check if it has qwen specific fields related to image/patch sizes, mm_uuid computation, etc.
  - For (1) what if we were to always try to initialize Vision Encoder and just fail rather than fallback to AutoModel?
  - For (2) what if we just check for existence of necessary attributes/fields like `image_grid_thw`?

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
