### PR TITLE
feat: Make SLAs optional with dynamic default presets

### DIFF
--- a/components/src/dynamo/profiler/profile_sla.py
+++ b/components/src/dynamo/profiler/profile_sla.py
@@ -90,17 +90,28 @@ def _extract_profiler_params(dgdr: DynamoGraphDeploymentRequestSpec) -> tuple:
     isl = dgdr.workload.isl
     osl = dgdr.workload.osl
     request_latency = dgdr.sla.e2eLatency
+
+    # Determine SLA mode
     if request_latency is not None:
+        # e2eLatency mode — both targets equal the e2e value
         target_ttft = request_latency
         target_tpot = request_latency
+    elif dgdr.sla.optimizationType is not None:
+        # optimizationType mode — use sentinel values so downstream picking
+        # uses optimization-type-specific logic instead of SLA filtering
+        target_ttft = float("inf")
+        target_tpot = float("inf")
     else:
+        # Explicit ttft+itl mode
         target_ttft = dgdr.sla.ttft
         target_tpot = dgdr.sla.itl
+
     search_strategy = SearchStrategy(dgdr.searchStrategy)
     picking_mode = determine_picking_mode(dgdr)
     logger.info(
         "Profiler config: model=%s, backend=%s, system=%s, total_gpus=%s, "
-        "isl=%d, osl=%d, ttft=%.1f, itl=%.1f, e2e_latency=%s, strategy=%s, picking=%s",
+        "isl=%d, osl=%d, ttft=%s, itl=%s, e2e_latency=%s, "
+        "optimization_type=%s, strategy=%s, picking=%s",
         model,
         backend,
         system,
@@ -110,6 +121,7 @@ def _extract_profiler_params(dgdr: DynamoGraphDeploymentRequestSpec) -> tuple:
         target_ttft,
         target_tpot,
         request_latency,
+        dgdr.sla.optimizationType,
         search_strategy.value,
         picking_mode,
     )
@@ -431,7 +443,8 @@ async def run_profile(
             phase=ops.current_phase,
         )
         final_config = assemble_final_config(
-            dgdr, ops, dgd_config, best_prefill_config, best_decode_config
+            dgdr, ops, dgd_config, best_prefill_config, best_decode_config,
+            best_latencies=pick_result.get("best_latencies") if not ops.dry_run else None,
         )
 
         # --- Apply DGD overrides (user-supplied partial DGD) ---

--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -120,9 +120,9 @@ def _run_naive_fallback(
     """Handle the AIC-unsupported path via naive config generation.
 
     When ``optimizationType`` is active the GPU count is computed from model
-    weight and VRAM (1.5× rule) via :func:`resolve_optimization_type_config`.
-    The parallelization strategy (TP/TEP/DEP) is logged but full MoE support
-    in the AIC naive generator requires Task 2B in the aiconfigurator repo.
+    weight and VRAM (1.5× rule) via :func:`resolve_optimization_type_config`,
+    and the appropriate parallelization strategy (TP/TEP/DEP) and serving
+    mode (agg/disagg) are passed to the AIC naive generator.
     """
     if backend == "auto":
         backend = _DEFAULT_NAIVE_BACKEND
@@ -143,8 +143,7 @@ def _run_naive_fallback(
             effective_gpus = opt_config.num_gpus
             logger.info(
                 "optimizationType=%s: naive fallback using %d GPUs "
-                "(target parallelization: %s). "
-                "Note: full TEP/DEP support in naive requires AIC Task 2B.",
+                "(target parallelization: %s).",
                 dgdr.sla.optimizationType.value,
                 effective_gpus,
                 opt_config.prefill_mapping.label(),
@@ -156,11 +155,21 @@ def _run_naive_fallback(
                 total_gpus,
             )
 
+    # Determine serving mode: prefer disagg when we have enough GPUs
+    opt_type_value = None
+    naive_mode = "agg"
+    if dgdr.sla and dgdr.sla.optimizationType is not None:
+        opt_type_value = dgdr.sla.optimizationType.value
+        if effective_gpus >= 2:
+            naive_mode = "disagg"
+
     generator_params = build_naive_generator_params(
         model_name=model,
         total_gpus=effective_gpus,
         system_name=system,
         backend_name=backend,
+        mode=naive_mode,
+        optimization_type=opt_type_value,
     )
 
     k8s_overrides = _build_k8s_overrides(dgdr, backend)

--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -414,7 +414,20 @@ def _run_optimization_type_sim(
     )
 
     # Restrict parallelization to the resolved mapping
+    # Convert from ParallelizationMapping (tp/tep/dep) to AIC worker config lists
     mapping = opt_config.prefill_mapping
+    if mapping.tp is not None:
+        aic_tp = mapping.tp
+        aic_dp, aic_moe_tp, aic_moe_ep = 1, 1, 1
+    elif mapping.tep is not None:
+        aic_tp, aic_dp = 1, 1
+        aic_moe_tp, aic_moe_ep = mapping.tep, 1
+    elif mapping.dep is not None:
+        aic_tp, aic_moe_tp = 1, 1
+        aic_dp, aic_moe_ep = mapping.dep, mapping.dep
+    else:
+        aic_tp, aic_dp, aic_moe_tp, aic_moe_ep = 1, 1, 1, 1
+
     for _key, tc in task_configs.items():
         if not hasattr(tc, "config") or tc.config is None:
             continue
@@ -427,14 +440,14 @@ def _run_optimization_type_sim(
             if worker_cfg is None:
                 continue
             worker_cfg.num_gpu_per_worker = [opt_config.num_gpus]
-            worker_cfg.tp_list = [mapping.tp]
-            worker_cfg.dp_list = [mapping.dp]
+            worker_cfg.tp_list = [aic_tp]
+            worker_cfg.dp_list = [aic_dp]
             if hasattr(worker_cfg, "moe_tp_list"):
-                worker_cfg.moe_tp_list = [mapping.moe_tp]
+                worker_cfg.moe_tp_list = [aic_moe_tp]
             if hasattr(worker_cfg, "moe_ep_list"):
-                worker_cfg.moe_ep_list = [mapping.moe_ep]
+                worker_cfg.moe_ep_list = [aic_moe_ep]
             if hasattr(worker_cfg, "pp_list"):
-                worker_cfg.pp_list = [mapping.pp]
+                worker_cfg.pp_list = [1]
 
     logger.info(
         "Running optimization-type simulation: type=%s, parallelization=%s, "

--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -25,7 +25,14 @@ from aiconfigurator.generator.module_bridge import task_config_to_generator_conf
 from aiconfigurator.generator.naive import build_naive_generator_params
 from aiconfigurator.sdk.task import TaskConfig, TaskRunner
 
-from dynamo.profiler.utils.dgdr_v1beta1_types import DynamoGraphDeploymentRequestSpec
+from dynamo.profiler.utils.dgdr_v1beta1_types import (
+    DynamoGraphDeploymentRequestSpec,
+    OptimizationType,
+)
+from dynamo.profiler.utils.optimization_type import (
+    OptimizationTypeConfig,
+    resolve_optimization_type_config,
+)
 from dynamo.profiler.utils.profile_common import (
     derive_backend_image,
     needs_profile_data,
@@ -110,7 +117,13 @@ def _run_naive_fallback(
     system: str,
     backend: str,
 ) -> dict:
-    """Handle the AIC-unsupported path via naive config generation."""
+    """Handle the AIC-unsupported path via naive config generation.
+
+    When ``optimizationType`` is active the GPU count is computed from model
+    weight and VRAM (1.5× rule) via :func:`resolve_optimization_type_config`.
+    The parallelization strategy (TP/TEP/DEP) is logged but full MoE support
+    in the AIC naive generator requires Task 2B in the aiconfigurator repo.
+    """
     if backend == "auto":
         backend = _DEFAULT_NAIVE_BACKEND
         logger.info("Auto backend resolved to '%s' for naive fallback.", backend)
@@ -118,9 +131,34 @@ def _run_naive_fallback(
         "AIC does not support this combo — falling back to naive config generation."
     )
 
+    # When optimizationType is active, use VRAM-based GPU count instead of
+    # totalGpus so the naive config fits the model properly.
+    effective_gpus = total_gpus
+    if dgdr.sla and dgdr.sla.optimizationType is not None:
+        from dynamo.profiler.utils.model_info import get_model_info
+
+        try:
+            model_info = get_model_info(model)
+            opt_config = resolve_optimization_type_config(dgdr, model_info)
+            effective_gpus = opt_config.num_gpus
+            logger.info(
+                "optimizationType=%s: naive fallback using %d GPUs "
+                "(target parallelization: %s). "
+                "Note: full TEP/DEP support in naive requires AIC Task 2B.",
+                dgdr.sla.optimizationType.value,
+                effective_gpus,
+                opt_config.prefill_mapping.label(),
+            )
+        except Exception:
+            logger.warning(
+                "Could not resolve optimization type config for naive fallback; "
+                "using totalGpus=%d.",
+                total_gpus,
+            )
+
     generator_params = build_naive_generator_params(
         model_name=model,
-        total_gpus=total_gpus,
+        total_gpus=effective_gpus,
         system_name=system,
         backend_name=backend,
     )
@@ -296,6 +334,151 @@ def _run_default_sim(
     }
 
 
+def _pick_by_optimization_type(
+    results_df: pd.DataFrame,
+    optimization_type: OptimizationType,
+) -> pd.DataFrame:
+    """Pick the best row from simulation results based on optimization type.
+
+    For **throughput**: sort by ``tokens/s/gpu`` descending (highest concurrency).
+    For **latency**: sort by ``tpot`` ascending (lowest latency).
+
+    Returns a single-row DataFrame (or empty if input is empty).
+    """
+    if results_df is None or results_df.empty:
+        return pd.DataFrame()
+
+    if optimization_type == OptimizationType.Throughput:
+        # Prefer highest throughput per GPU
+        sort_col = "tokens/s/gpu" if "tokens/s/gpu" in results_df.columns else "tpot"
+        ascending = sort_col == "tpot"
+    else:
+        # Prefer lowest latency
+        sort_col = "tpot" if "tpot" in results_df.columns else "tokens/s/gpu"
+        ascending = sort_col != "tokens/s/gpu"
+
+    sorted_df = results_df.sort_values(sort_col, ascending=ascending)
+    return sorted_df.head(1).reset_index(drop=True)
+
+
+def _run_optimization_type_sim(
+    dgdr: DynamoGraphDeploymentRequestSpec,
+    opt_config: OptimizationTypeConfig,
+    model: str,
+    system: str,
+    backend: str,
+    total_gpus: int,
+    isl: int,
+    osl: int,
+) -> dict:
+    """Run AIC simulation restricted to the target parallelization for optimizationType.
+
+    This is similar to ``_run_default_sim`` but:
+    1. Restricts the AIC task config parallelization lists to only the resolved
+       mapping (e.g. TEP=8 → tp_list=[1], moe_ep_list=[8]).
+    2. Picks by optimization type (throughput → highest tps/gpu, latency → lowest tpot)
+       instead of SLA-based picking.
+    """
+    if backend == "auto":
+        backend = _DEFAULT_NAIVE_BACKEND
+        logger.info(
+            "Auto backend resolved to '%s' for optimization-type simulation.", backend
+        )
+
+    opt_type = dgdr.sla.optimizationType
+
+    # Use very permissive SLA targets — the picking is done by optimization type,
+    # not by SLA filtering
+    target_ttft = float("inf")
+    target_tpot = float("inf")
+
+    task_configs = build_default_task_configs(
+        model_path=model,
+        total_gpus=total_gpus,
+        system=system,
+        backend=backend,
+        isl=isl,
+        osl=osl,
+        ttft=target_ttft,
+        tpot=target_tpot,
+        request_latency=None,
+    )
+
+    # Restrict parallelization to the resolved mapping
+    mapping = opt_config.prefill_mapping
+    for _key, tc in task_configs.items():
+        if not hasattr(tc, "config") or tc.config is None:
+            continue
+        for worker_cfg_attr in (
+            "prefill_worker_config",
+            "decode_worker_config",
+            "agg_worker_config",
+        ):
+            worker_cfg = getattr(tc.config, worker_cfg_attr, None)
+            if worker_cfg is None:
+                continue
+            worker_cfg.num_gpu_per_worker = [opt_config.num_gpus]
+            worker_cfg.tp_list = [mapping.tp]
+            worker_cfg.dp_list = [mapping.dp]
+            if hasattr(worker_cfg, "moe_tp_list"):
+                worker_cfg.moe_tp_list = [mapping.moe_tp]
+            if hasattr(worker_cfg, "moe_ep_list"):
+                worker_cfg.moe_ep_list = [mapping.moe_ep]
+            if hasattr(worker_cfg, "pp_list"):
+                worker_cfg.pp_list = [mapping.pp]
+
+    logger.info(
+        "Running optimization-type simulation: type=%s, parallelization=%s, "
+        "num_gpus=%d",
+        opt_type.value,
+        mapping.label(),
+        opt_config.num_gpus,
+    )
+
+    chosen, best_configs, _, _, best_latencies_map = _execute_task_configs(
+        task_configs,
+        mode="default",
+        top_n=5,
+    )
+
+    # Merge all experiment results and pick by optimization type
+    all_dfs = [df for df in best_configs.values() if df is not None and not df.empty]
+    merged_df = pd.concat(all_dfs, ignore_index=True) if all_dfs else pd.DataFrame()
+    best_config_df = _pick_by_optimization_type(merged_df, opt_type)
+
+    best_latencies = {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0}
+    if not best_config_df.empty:
+        row = best_config_df.iloc[0]
+        best_latencies["ttft"] = float(row.get("ttft", 0.0))
+        best_latencies["tpot"] = float(row.get("tpot", 0.0))
+        best_latencies["request_latency"] = float(row.get("request_latency", 0.0))
+
+    # Determine the chosen experiment for DGD generation
+    if not best_config_df.empty:
+        # Prefer disagg when available
+        disagg_keys = [k for k in best_configs if "disagg" in k and not best_configs[k].empty]
+        chosen = disagg_keys[0] if disagg_keys else chosen
+
+    dgd_config = _generate_dgd_from_pick(dgdr, best_config_df, chosen, task_configs)
+
+    resolved_backend = backend
+    if (
+        backend == "auto"
+        and not best_config_df.empty
+        and "backend" in best_config_df.columns
+    ):
+        resolved_backend = best_config_df.iloc[0]["backend"]
+
+    return {
+        "best_config_df": best_config_df,
+        "best_latencies": best_latencies,
+        "dgd_config": dgd_config,
+        "chosen_exp": chosen,
+        "task_configs": task_configs,
+        "resolved_backend": resolved_backend,
+    }
+
+
 def run_rapid(
     dgdr: DynamoGraphDeploymentRequestSpec,
     picking_mode: str,
@@ -315,6 +498,24 @@ def run_rapid(
     """
     if not aic_supported:
         return _run_naive_fallback(dgdr, model, total_gpus, system, backend)
+
+    # optimizationType mode — restricted enumeration + optimization-type picking
+    if dgdr.sla and dgdr.sla.optimizationType is not None:
+        from dynamo.profiler.utils.model_info import get_model_info
+
+        model_info = get_model_info(model)
+        opt_config = resolve_optimization_type_config(dgdr, model_info)
+        return _run_optimization_type_sim(
+            dgdr,
+            opt_config,
+            model,
+            system,
+            backend,
+            total_gpus,
+            isl,
+            osl,
+        )
+
     if picking_mode == "autoscale":
         return _run_autoscale_sim(
             dgdr,

--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -457,11 +457,19 @@ def _run_optimization_type_sim(
         opt_config.num_gpus,
     )
 
-    chosen, best_configs, _, _, best_latencies_map = _execute_task_configs(
-        task_configs,
-        mode="default",
-        top_n=5,
-    )
+    try:
+        chosen, best_configs, _, _, best_latencies_map = _execute_task_configs(
+            task_configs,
+            mode="default",
+            top_n=5,
+        )
+    except (SystemExit, Exception) as exc:
+        logger.warning(
+            "AIC simulation failed for optimization-type mode (%s); "
+            "falling back to naive config generation.",
+            exc,
+        )
+        return _run_naive_fallback(dgdr, model, total_gpus, system, backend)
 
     # Merge all experiment results and pick by optimization type
     all_dfs = [df for df in best_configs.values() if df is not None and not df.empty]

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
@@ -15,6 +15,11 @@ from unittest.mock import patch
 import pytest
 import yaml
 
+try:
+    import pandas as pd
+except ImportError:
+    pd = None  # type: ignore[assignment]
+
 pytestmark = [
     pytest.mark.pre_merge,
     pytest.mark.gpu_0,
@@ -32,6 +37,7 @@ try:
         _write_final_output,
     )
     from dynamo.profiler.utils.config_modifiers.parallelization_mapping import (
+        ParallelizationMapping,
         PickedParallelConfig,
     )
     from dynamo.profiler.utils.defaults import SearchStrategy
@@ -44,12 +50,22 @@ try:
         FeaturesSpec,
         HardwareSpec,
         MockerSpec,
+        OptimizationType,
         SLASpec,
         WorkloadSpec,
     )
     from dynamo.profiler.utils.dgdr_validate import (
         valid_dgdr_spec,
         validate_dgdr_dynamo_features,
+    )
+    from dynamo.profiler.utils.model_info import (
+        ModelInfo,
+        calculate_min_gpus_for_model,
+        get_default_parallelization_for_architecture,
+    )
+    from dynamo.profiler.utils.optimization_type import (
+        OptimizationTypeConfig,
+        resolve_optimization_type_config,
     )
     from dynamo.profiler.utils.profile_common import ProfilerOperationalConfig
 except ImportError as e:
@@ -239,10 +255,13 @@ class TestValidDgdrSpec:
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0
     def test_none_sla_gets_default(self):
-        """None sla is populated with a default SLASpec."""
+        """None sla defaults to optimizationType=throughput."""
         dgdr = _make_dgdr(sla=None)
         valid_dgdr_spec(dgdr)
         assert dgdr.sla is not None
+        assert dgdr.sla.optimizationType == OptimizationType.Throughput
+        assert dgdr.sla.ttft is None
+        assert dgdr.sla.itl is None
 
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0
@@ -546,178 +565,597 @@ class TestAssembleFinalConfig:
                 PickedParallelConfig(tp=1),
             )
 
-        mock_mocker.assert_called_once()
-        mock_planner.assert_called_once()
-        assert mock_planner.call_args.args[1] is mocker_base
-        assert result == [planner_cm, profile_cm, mocker_base]
+        assert result is mocker_cfg
+
+
+# ---------------------------------------------------------------------------
+# optimizationType – SLASpec validation
+# ---------------------------------------------------------------------------
+
+
+class TestOptimizationTypeSlaValidation:
+    """Validate SLASpec pydantic model_validator and dgdr_validate for
+    the ``optimizationType`` field."""
 
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0
-    def test_mocker_only_no_planner_returns_mocker_config(self, tmp_path):
-        """Mocker-only (no planner): generate_mocker_config is called,
-        add_planner_to_config is not, profile data is still attached."""
-        dgdr = _make_dgdr(features=FeaturesSpec(mocker=MockerSpec(enabled=True)))
-        ops = _make_ops(tmp_path)
-        os.makedirs(ops.output_dir, exist_ok=True)
-        dgd_config = {"kind": "DGD"}
-        mocker_base = {"kind": "MockerDGD", "spec": {"services": {}}}
-        profile_cm = {"kind": "ConfigMap", "metadata": {"name": "profile-cm"}}
+    def test_optimization_type_clears_ttft_itl(self):
+        """When optimizationType is set, ttft and itl are cleared by the
+        model validator (pydantic defaults would otherwise populate them)."""
+        sla = SLASpec(optimizationType=OptimizationType.Throughput)
+        assert sla.ttft is None
+        assert sla.itl is None
+        assert sla.optimizationType == OptimizationType.Throughput
 
-        with (
-            patch(
-                f"{_DGD_GEN}.generate_mocker_config",
-                return_value=mocker_base,
-            ) as mock_mocker,
-            patch(
-                f"{_DGD_GEN}.add_planner_to_config",
-            ) as mock_planner,
-            patch(
-                f"{_DGD_GEN}.add_profile_data_to_config",
-                return_value=profile_cm,
-            ) as mock_profile,
-        ):
-            result = assemble_final_config(
-                dgdr,
-                ops,
-                dgd_config,
-                PickedParallelConfig(tp=1),
-                PickedParallelConfig(tp=1),
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_optimization_type_with_explicit_ttft_raises(self):
+        """Cannot combine optimizationType with explicitly-set ttft/itl."""
+        with pytest.raises(ValueError, match="exactly one"):
+            SLASpec(
+                optimizationType=OptimizationType.Throughput,
+                ttft=2000.0,
+                itl=30.0,
             )
 
-        mock_mocker.assert_called_once()
-        mock_planner.assert_not_called()
-        mock_profile.assert_called_once()
-        assert result == [profile_cm, mocker_base]
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_optimization_type_with_e2e_raises(self):
+        """Cannot combine optimizationType with e2eLatency."""
+        with pytest.raises(ValueError, match="exactly one"):
+            SLASpec(
+                optimizationType=OptimizationType.Latency,
+                e2eLatency=5000.0,
+            )
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_optimization_type_latency_variant(self):
+        """Latency variant also works."""
+        sla = SLASpec(optimizationType=OptimizationType.Latency)
+        assert sla.optimizationType == OptimizationType.Latency
+        assert sla.ttft is None
+        assert sla.itl is None
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_dgdr_validate_optimization_type_passes(self):
+        """valid_dgdr_spec accepts optimizationType SLA without error."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Throughput),
+        )
+        valid_dgdr_spec(dgdr)
+        assert dgdr.sla.optimizationType == OptimizationType.Throughput
+        assert dgdr.sla.ttft is None
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_none_sla_defaults_to_optimization_type_throughput(self):
+        """When sla is None, defaults to optimizationType=throughput."""
+        dgdr = _make_dgdr(sla=None)
+        valid_dgdr_spec(dgdr)
+        assert dgdr.sla.optimizationType == OptimizationType.Throughput
 
 
 # ---------------------------------------------------------------------------
-# add_profile_data_to_config — mocker_enabled guard (DYN-2409)
+# _extract_profiler_params – optimizationType
 # ---------------------------------------------------------------------------
 
 
-class TestAddProfileDataMockerGuard:
-    """Verify --planner-profile-data is only injected for mocker workers."""
+class TestExtractProfilerParamsOptimizationType:
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_optimization_type_throughput_sets_inf_targets(self):
+        """optimizationType=throughput produces inf for target_ttft/tpot."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Throughput),
+        )
+        _, _, _, _, _, _, req_lat, ttft, tpot, _, _ = _extract_profiler_params(dgdr)
+        assert req_lat is None
+        assert ttft == float("inf")
+        assert tpot == float("inf")
 
-    @staticmethod
-    def _sglang_dgd():
-        """Minimal DGD with sglang-style 'prefill' and 'decode' workers."""
-        return {
-            "spec": {
-                "services": {
-                    "Planner": {
-                        "extraPodSpec": {
-                            "mainContainer": {"args": ["--config", "{}"]},
-                        }
-                    },
-                    "prefill": {
-                        "extraPodSpec": {
-                            "mainContainer": {
-                                "args": [
-                                    "-m",
-                                    "dynamo.sglang",
-                                    "--model-path",
-                                    "Qwen/Qwen3-32B",
-                                    "--disaggregation-mode",
-                                    "prefill",
-                                ]
-                            }
-                        }
-                    },
-                    "decode": {
-                        "extraPodSpec": {
-                            "mainContainer": {
-                                "args": [
-                                    "-m",
-                                    "dynamo.sglang",
-                                    "--model-path",
-                                    "Qwen/Qwen3-32B",
-                                    "--disaggregation-mode",
-                                    "decode",
-                                ]
-                            }
-                        }
-                    },
-                }
-            }
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_optimization_type_latency_sets_inf_targets(self):
+        """optimizationType=latency also produces inf for target_ttft/tpot."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Latency),
+        )
+        _, _, _, _, _, _, req_lat, ttft, tpot, _, _ = _extract_profiler_params(dgdr)
+        assert req_lat is None
+        assert ttft == float("inf")
+        assert tpot == float("inf")
+
+
+# ---------------------------------------------------------------------------
+# model_info helpers – calculate_min_gpus_for_model
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateMinGpusForModel:
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_small_model_single_gpu(self):
+        """Model that fits in one GPU with overhead → 1 GPU."""
+        # 40 GB model, 80 GB VRAM → 1.5 * 40 = 60 < 80 → 1 GPU
+        assert calculate_min_gpus_for_model(40_000, 80_000) == 1
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_model_needs_two_gpus(self):
+        """Model that needs 2 GPUs."""
+        # 100 GB model, 80 GB VRAM → 1.5 * 100 = 150 → 150/80 ≈ 1.875 → next pow2 = 2
+        assert calculate_min_gpus_for_model(100_000, 80_000) == 2
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_model_needs_four_gpus(self):
+        """Model that needs 4 GPUs."""
+        # 200 GB model, 80 GB VRAM → 1.5 * 200 = 300 → 300/80 = 3.75 → next pow2 = 4
+        assert calculate_min_gpus_for_model(200_000, 80_000) == 4
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_model_needs_eight_gpus(self):
+        """Model that needs 8 GPUs."""
+        # 400 GB model, 80 GB VRAM → 1.5 * 400 = 600 → 600/80 = 7.5 → next pow2 = 8
+        assert calculate_min_gpus_for_model(400_000, 80_000) == 8
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_zero_vram_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            calculate_min_gpus_for_model(100_000, 0)
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_zero_model_size_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            calculate_min_gpus_for_model(0, 80_000)
+
+
+# ---------------------------------------------------------------------------
+# model_info helpers – get_default_parallelization_for_architecture
+# ---------------------------------------------------------------------------
+
+
+class TestGetDefaultParallelizationForArchitecture:
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_dense_model_returns_tp(self):
+        """Dense (non-MoE) model returns TP mapping."""
+        prefill, decode = get_default_parallelization_for_architecture(
+            "LlamaForCausalLM", is_moe=False, num_gpus=4
+        )
+        assert prefill == {"tp": 4}
+        assert decode == {"tp": 4}
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_mla_moe_throughput_returns_dep(self):
+        """MLA+MoE + throughput returns DEP."""
+        prefill, decode = get_default_parallelization_for_architecture(
+            "DeepseekV3ForCausalLM",
+            is_moe=True,
+            num_gpus=8,
+            optimization_type="throughput",
+        )
+        assert prefill == {"dep": 8}
+        assert decode == {"dep": 8}
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_mla_moe_latency_returns_tep(self):
+        """MLA+MoE + latency returns TEP (not DEP)."""
+        prefill, decode = get_default_parallelization_for_architecture(
+            "DeepseekV3ForCausalLM",
+            is_moe=True,
+            num_gpus=8,
+            optimization_type="latency",
+        )
+        assert prefill == {"tep": 8}
+        assert decode == {"tep": 8}
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_gqa_moe_throughput_returns_tep(self):
+        """GQA+MoE (Qwen3MoE) + throughput returns TEP (not DEP)."""
+        prefill, decode = get_default_parallelization_for_architecture(
+            "Qwen3MoeForCausalLM",
+            is_moe=True,
+            num_gpus=8,
+            optimization_type="throughput",
+        )
+        assert prefill == {"tep": 8}
+        assert decode == {"tep": 8}
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_gqa_moe_latency_returns_tep(self):
+        """GQA+MoE + latency returns TEP."""
+        prefill, decode = get_default_parallelization_for_architecture(
+            "Qwen3MoeForCausalLM",
+            is_moe=True,
+            num_gpus=8,
+            optimization_type="latency",
+        )
+        assert prefill == {"tep": 8}
+        assert decode == {"tep": 8}
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_moe_with_none_optimization_type_returns_tep(self):
+        """MoE model with no optimization_type (SLA path) defaults to TEP."""
+        prefill, decode = get_default_parallelization_for_architecture(
+            "DeepseekV3ForCausalLM",
+            is_moe=True,
+            num_gpus=8,
+            optimization_type=None,
+        )
+        assert prefill == {"tep": 8}
+        assert decode == {"tep": 8}
+
+
+# ---------------------------------------------------------------------------
+# resolve_optimization_type_config
+# ---------------------------------------------------------------------------
+
+
+def _make_model_info(**overrides) -> ModelInfo:
+    """Build a ModelInfo with sensible dense-model defaults."""
+    base = dict(
+        model_size=40_000.0,  # 40 GB
+        architecture="LlamaForCausalLM",
+        is_moe=False,
+    )
+    base.update(overrides)
+    return ModelInfo(**base)
+
+
+class TestResolveOptimizationTypeConfig:
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_dense_throughput(self):
+        """Dense model + throughput → TP, use_max_concurrency=True."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Throughput),
+            hardware=HardwareSpec(
+                gpuSku="h200_sxm", totalGpus=8, numGpusPerNode=8, vramMb=80_000,
+            ),
+        )
+        mi = _make_model_info(model_size=40_000.0)
+
+        cfg = resolve_optimization_type_config(dgdr, mi)
+
+        assert cfg.prefill_mapping == ParallelizationMapping(tp=1)
+        assert cfg.decode_mapping == ParallelizationMapping(tp=1)
+        assert cfg.num_gpus == 1
+        assert cfg.use_max_concurrency is True
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_dense_latency(self):
+        """Dense model + latency → TP, use_max_concurrency=False."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Latency),
+            hardware=HardwareSpec(
+                gpuSku="h200_sxm", totalGpus=8, numGpusPerNode=8, vramMb=80_000,
+            ),
+        )
+        mi = _make_model_info(model_size=40_000.0)
+
+        cfg = resolve_optimization_type_config(dgdr, mi)
+
+        assert cfg.prefill_mapping == ParallelizationMapping(tp=1)
+        assert cfg.use_max_concurrency is False
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_mla_moe_throughput_uses_dep(self):
+        """MLA+MoE + throughput → DEP mapping."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Throughput),
+            hardware=HardwareSpec(
+                gpuSku="h200_sxm", totalGpus=8, numGpusPerNode=8, vramMb=80_000,
+            ),
+        )
+        mi = _make_model_info(
+            model_size=400_000.0,
+            architecture="DeepseekV3ForCausalLM",
+            is_moe=True,
+        )
+
+        cfg = resolve_optimization_type_config(dgdr, mi)
+
+        assert cfg.prefill_mapping == ParallelizationMapping(dep=cfg.num_gpus)
+        assert cfg.decode_mapping == ParallelizationMapping(dep=cfg.num_gpus)
+        assert cfg.use_max_concurrency is True
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_mla_moe_latency_uses_tep(self):
+        """MLA+MoE + latency → TEP mapping."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Latency),
+            hardware=HardwareSpec(
+                gpuSku="h200_sxm", totalGpus=8, numGpusPerNode=8, vramMb=80_000,
+            ),
+        )
+        mi = _make_model_info(
+            model_size=400_000.0,
+            architecture="DeepseekV3ForCausalLM",
+            is_moe=True,
+        )
+
+        cfg = resolve_optimization_type_config(dgdr, mi)
+
+        assert cfg.prefill_mapping == ParallelizationMapping(tep=cfg.num_gpus)
+        assert cfg.decode_mapping == ParallelizationMapping(tep=cfg.num_gpus)
+        assert cfg.use_max_concurrency is False
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_num_gpus_from_vram_and_model_weight(self):
+        """GPU count computed from VRAM and model weight using 1.5× rule."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Throughput),
+            hardware=HardwareSpec(
+                gpuSku="h200_sxm", totalGpus=8, numGpusPerNode=8,
+                vramMb=80_000,
+            ),
+        )
+        # 200 GB model, 80 GB VRAM → 1.5 * 200 = 300 → 300/80 = 3.75 → pow2=4
+        mi = _make_model_info(model_size=200_000.0)
+
+        cfg = resolve_optimization_type_config(dgdr, mi)
+
+        assert cfg.num_gpus == 4
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_num_gpus_clamped_to_total(self):
+        """GPU count is clamped to totalGpus when model is very large."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Throughput),
+            hardware=HardwareSpec(
+                gpuSku="h200_sxm", totalGpus=4, numGpusPerNode=4,
+                vramMb=80_000,
+            ),
+        )
+        # Needs 8 GPUs but only 4 available
+        mi = _make_model_info(model_size=400_000.0)
+
+        cfg = resolve_optimization_type_config(dgdr, mi)
+
+        assert cfg.num_gpus == 4
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_missing_vram_falls_back_to_total_gpus(self):
+        """When vramMb is not set, falls back to totalGpus."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Throughput),
+            hardware=HardwareSpec(
+                gpuSku="h200_sxm", totalGpus=8, numGpusPerNode=8,
+                vramMb=None,
+            ),
+        )
+        mi = _make_model_info(model_size=200_000.0)
+
+        cfg = resolve_optimization_type_config(dgdr, mi)
+
+        assert cfg.num_gpus == 8
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_no_optimization_type_raises(self):
+        """resolve_optimization_type_config raises when optimizationType not set."""
+        dgdr = _make_dgdr(sla=SLASpec(ttft=2000.0, itl=30.0))
+        mi = _make_model_info()
+
+        with pytest.raises(ValueError, match="optimizationType"):
+            resolve_optimization_type_config(dgdr, mi)
+
+
+# ---------------------------------------------------------------------------
+# Task 3A: _pick_by_optimization_type
+# ---------------------------------------------------------------------------
+
+
+class TestPickByOptimizationType:
+    """Tests for the optimization-type picking logic in rapid.py."""
+
+    @pytest.fixture(autouse=True)
+    def _import_pick(self):
+        from dynamo.profiler.rapid import _pick_by_optimization_type
+
+        self.pick = _pick_by_optimization_type
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_throughput_picks_highest_tokens_per_gpu(self):
+        """throughput optimization picks row with highest tokens/s/gpu."""
+        df = pd.DataFrame(
+            [
+                {"tpot": 10.0, "tokens/s/gpu": 100.0, "ttft": 5.0},
+                {"tpot": 20.0, "tokens/s/gpu": 200.0, "ttft": 8.0},
+                {"tpot": 15.0, "tokens/s/gpu": 50.0, "ttft": 3.0},
+            ]
+        )
+        result = self.pick(df, OptimizationType.Throughput)
+        assert len(result) == 1
+        assert result.iloc[0]["tokens/s/gpu"] == 200.0
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_latency_picks_lowest_tpot(self):
+        """latency optimization picks row with lowest tpot."""
+        df = pd.DataFrame(
+            [
+                {"tpot": 10.0, "tokens/s/gpu": 100.0, "ttft": 5.0},
+                {"tpot": 20.0, "tokens/s/gpu": 200.0, "ttft": 8.0},
+                {"tpot": 5.0, "tokens/s/gpu": 50.0, "ttft": 3.0},
+            ]
+        )
+        result = self.pick(df, OptimizationType.Latency)
+        assert len(result) == 1
+        assert result.iloc[0]["tpot"] == 5.0
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_empty_df_returns_empty(self):
+        """Empty input returns empty DataFrame."""
+        result = self.pick(pd.DataFrame(), OptimizationType.Throughput)
+        assert result.empty
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_none_df_returns_empty(self):
+        """None input returns empty DataFrame."""
+        result = self.pick(None, OptimizationType.Latency)
+        assert result.empty
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_throughput_falls_back_to_tpot_when_no_tokens_col(self):
+        """When tokens/s/gpu column is missing, throughput falls back to tpot."""
+        df = pd.DataFrame(
+            [
+                {"tpot": 10.0, "ttft": 5.0},
+                {"tpot": 20.0, "ttft": 8.0},
+            ]
+        )
+        result = self.pick(df, OptimizationType.Throughput)
+        assert len(result) == 1
+        # Falls back to tpot ascending → picks lowest tpot
+        assert result.iloc[0]["tpot"] == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Task 4: _build_planner_config with optimizationType + best_latencies
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPlannerConfigOptimizationType:
+    """Tests for planner TTFT/ITL population from profiling estimates."""
+
+    @pytest.fixture(autouse=True)
+    def _import_build(self):
+        from dynamo.profiler.utils.dgd_generation import _build_planner_config
+
+        self.build = _build_planner_config
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_optimization_type_with_estimates_uses_them(self):
+        """When profiling estimates are available, planner gets estimated TTFT/ITL."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Throughput),
+            features=FeaturesSpec(planner=_make_planner()),
+        )
+        best_latencies = {"ttft": 150.0, "tpot": 12.0, "request_latency": 500.0}
+
+        cfg = self.build(dgdr, None, None, best_latencies=best_latencies)
+
+        assert cfg.ttft == 150.0
+        assert cfg.itl == 12.0
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_optimization_type_naive_fallback_uses_defaults(self):
+        """When best_latencies are zero (naive fallback), planner uses 2000/30 defaults."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Throughput),
+            features=FeaturesSpec(planner=_make_planner()),
+        )
+        best_latencies = {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0}
+
+        cfg = self.build(dgdr, None, None, best_latencies=best_latencies)
+
+        assert cfg.ttft == 2000.0
+        assert cfg.itl == 30.0
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_optimization_type_no_latencies_uses_defaults(self):
+        """When best_latencies is None, planner uses 2000/30 defaults."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Latency),
+            features=FeaturesSpec(planner=_make_planner()),
+        )
+
+        cfg = self.build(dgdr, None, None, best_latencies=None)
+
+        assert cfg.ttft == 2000.0
+        assert cfg.itl == 30.0
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_explicit_sla_does_not_override_planner_ttft(self):
+        """When explicit ttft/itl SLA is used, planner keeps its own defaults."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(ttft=500.0, itl=20.0),
+            features=FeaturesSpec(planner=_make_planner()),
+        )
+        best_latencies = {"ttft": 150.0, "tpot": 12.0, "request_latency": 500.0}
+
+        cfg = self.build(dgdr, None, None, best_latencies=best_latencies)
+
+        # Should NOT use the best_latencies — explicit SLA mode, not optimizationType
+        # Planner uses its own SLAPlannerDefaults (ttft=500, itl=50)
+        assert cfg.ttft != 150.0
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_gpu_counts_passed_through(self):
+        """Prefill/decode GPU counts are set on planner config."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Throughput),
+            features=FeaturesSpec(planner=_make_planner()),
+        )
+        prefill = PickedParallelConfig(tp=4)
+        decode = PickedParallelConfig(tp=2)
+
+        cfg = self.build(dgdr, prefill, decode, best_latencies=None)
+
+        assert cfg.prefill_engine_num_gpu == prefill.num_gpus
+        assert cfg.decode_engine_num_gpu == decode.num_gpus
+
+
+# ---------------------------------------------------------------------------
+# Task 4: assemble_final_config threading best_latencies
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleFinalConfigOptimizationType:
+    """Verify best_latencies reaches the planner config via assemble_final_config."""
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_assemble_threads_best_latencies_to_planner(self, tmp_path):
+        """assemble_final_config passes best_latencies through to _build_planner_config."""
+        dgdr = _make_dgdr(
+            sla=SLASpec(optimizationType=OptimizationType.Throughput),
+            features=FeaturesSpec(planner=_make_planner()),
+        )
+        ops = _make_ops(tmp_path)
+        dgd_config = {
+            "metadata": {"name": "test"},
+            "spec": {"services": {}},
         }
+        best_latencies = {"ttft": 250.0, "tpot": 18.0, "request_latency": 600.0}
 
-    @pytest.mark.pre_merge
-    @pytest.mark.gpu_0
-    def test_mocker_disabled_no_planner_profile_data_in_workers(self, tmp_path):
-        """When mocker is disabled, workers must NOT receive --planner-profile-data."""
-        dgd = self._sglang_dgd()
-        with patch(f"{_DGD_GEN}._load_profiling_data", return_value={"prefill": {}}):
-            add_profile_data_to_config(dgd, str(tmp_path), mocker_enabled=False)
-
-        for name in ("prefill", "decode"):
-            args = dgd["spec"]["services"][name]["extraPodSpec"]["mainContainer"][
-                "args"
-            ]
-            assert (
-                "--planner-profile-data" not in args
-            ), f"sglang worker '{name}' should not have --planner-profile-data"
-
-    @pytest.mark.pre_merge
-    @pytest.mark.gpu_0
-    def test_mocker_enabled_injects_planner_profile_data(self, tmp_path):
-        """When mocker is enabled, mocker workers MUST receive --planner-profile-data."""
-        dgd = self._sglang_dgd()
-        with patch(f"{_DGD_GEN}._load_profiling_data", return_value={"prefill": {}}):
-            add_profile_data_to_config(dgd, str(tmp_path), mocker_enabled=True)
-
-        for name in ("prefill", "decode"):
-            args = dgd["spec"]["services"][name]["extraPodSpec"]["mainContainer"][
-                "args"
-            ]
-            assert (
-                "--planner-profile-data" in args
-            ), f"mocker worker '{name}' should have --planner-profile-data"
-
-
-# ---------------------------------------------------------------------------
-# Regression tests: naive fallback resolved_backend propagation (bug fix)
-# ---------------------------------------------------------------------------
-
-
-class TestNaiveFallbackResolvedBackend:
-    """Regression tests for the 'auto' backend KeyError bug.
-
-    When backend='auto', _run_naive_fallback resolves it to a concrete
-    backend (e.g. 'vllm') and must expose that in the result dict so
-    run_profile() can pass the concrete name to run_interpolation().
-    """
-
-    @pytest.mark.pre_merge
-    @pytest.mark.gpu_0
-    @pytest.mark.parallel
-    def test_naive_fallback_resolved_backend_auto(self):
-        """_run_naive_fallback sets 'resolved_backend' to the concrete backend
-        when the input backend is 'auto'."""
-        try:
-            from unittest.mock import patch
-
-            from dynamo.profiler.rapid import _run_naive_fallback
-        except ImportError as e:
-            pytest.skip(f"Missing dependency: {e}")
-
-        dgdr = _make_dgdr(backend="auto")
-
-        with (
-            patch(
-                "dynamo.profiler.rapid.build_naive_generator_params",
-                return_value={},
-            ),
-            patch(
-                "dynamo.profiler.rapid.generate_backend_artifacts",
-                return_value={},
-            ),
-        ):
-            result = _run_naive_fallback(
-                dgdr,
-                model="Qwen/Qwen3-32B",
-                total_gpus=8,
-                system="h200_sxm",
-                backend="auto",
+        with patch(
+            "dynamo.profiler.utils.dgd_generation.DgdPlannerServiceConfig"
+        ) as mock_svc:
+            mock_svc.return_value.extraPodSpec.mainContainer = None
+            mock_svc.return_value.model_dump.return_value = {
+                "extraPodSpec": {"mainContainer": {"args": []}},
+            }
+            result = assemble_final_config(
+                dgdr, ops, dgd_config,
+                best_latencies=best_latencies,
             )
 
         # The resolved backend must be a concrete name, not 'auto'

--- a/components/src/dynamo/profiler/thorough.py
+++ b/components/src/dynamo/profiler/thorough.py
@@ -26,7 +26,7 @@ from aiconfigurator.sdk.task import TaskConfig
 
 from deploy.utils.dynamo_deployment import DynamoDeploymentClient
 from dynamo.planner.config.defaults import SubComponentType
-from dynamo.profiler.rapid import _generate_dgd_from_pick
+from dynamo.profiler.rapid import _generate_dgd_from_pick, _pick_by_optimization_type
 from dynamo.profiler.utils.aic_dataframe import (
     build_decode_row,
     build_disagg_df_from_static,
@@ -44,6 +44,10 @@ from dynamo.profiler.utils.dgdr_v1beta1_types import (
     DynamoGraphDeploymentRequestSpec,
     ModelCacheSpec,
     ProfilingPhase,
+)
+from dynamo.profiler.utils.optimization_type import (
+    OptimizationTypeConfig,
+    resolve_optimization_type_config,
 )
 from dynamo.profiler.utils.profile_common import (
     ProfilerOperationalConfig,
@@ -292,7 +296,27 @@ def _pick_thorough_best_config(
     total_gpus: int,
     dgdr: DynamoGraphDeploymentRequestSpec,
 ) -> dict:
-    """Dispatch to pick_autoscale / pick_load_match / pick_default, return result dict."""
+    """Dispatch to pick_autoscale / pick_load_match / pick_default, return result dict.
+
+    When ``optimizationType`` is active, uses optimization-type picking
+    (highest throughput or lowest latency) instead of SLA-based picking.
+    """
+    # optimizationType mode — pick by throughput/latency heuristic
+    if dgdr.sla and dgdr.sla.optimizationType is not None:
+        disagg_df = build_disagg_df_from_static(prefill_df, decode_df)
+        best_config_df = _pick_by_optimization_type(
+            disagg_df, dgdr.sla.optimizationType
+        )
+        best_latencies = {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0}
+        if not best_config_df.empty:
+            row = best_config_df.iloc[0]
+            best_latencies["ttft"] = float(row.get("ttft", 0.0))
+            best_latencies["tpot"] = float(row.get("tpot", 0.0))
+            best_latencies["request_latency"] = float(
+                row.get("request_latency", 0.0)
+            )
+        return {"best_config_df": best_config_df, "best_latencies": best_latencies}
+
     if picking_mode == "autoscale":
         return pick_autoscale(prefill_df, decode_df, target_ttft, target_tpot)
     elif picking_mode == "load_match":
@@ -366,6 +390,42 @@ async def run_thorough(
         len(prefill_candidates),
         len(decode_candidates),
     )
+
+    # --- optimizationType: filter to target parallelization -----------------
+    if dgdr.sla and dgdr.sla.optimizationType is not None:
+        from dynamo.profiler.utils.model_info import get_model_info
+
+        model_info = get_model_info(model)
+        opt_config = resolve_optimization_type_config(dgdr, model_info)
+        target_mapping = opt_config.prefill_mapping
+
+        def _candidate_matches(c, mapping) -> bool:
+            return (
+                c.tp == mapping.tp
+                and c.pp == mapping.pp
+                and c.dp == mapping.dp
+                and getattr(c, "moe_tp", 0) == mapping.moe_tp
+                and getattr(c, "moe_ep", 0) == mapping.moe_ep
+            )
+
+        prefill_before = len(prefill_candidates)
+        decode_before = len(decode_candidates)
+        prefill_candidates = [
+            c for c in prefill_candidates if _candidate_matches(c, target_mapping)
+        ]
+        decode_candidates = [
+            c for c in decode_candidates if _candidate_matches(c, target_mapping)
+        ]
+        logger.info(
+            "optimizationType=%s: filtered candidates to %s — "
+            "prefill %d→%d, decode %d→%d",
+            dgdr.sla.optimizationType.value,
+            target_mapping.label(),
+            prefill_before,
+            len(prefill_candidates),
+            decode_before,
+            len(decode_candidates),
+        )
 
     if dgdr.overrides and dgdr.overrides.dgd:
         for candidate in prefill_candidates:

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -64,6 +64,7 @@ def assemble_final_config(
     dgd_config: dict | None,
     best_prefill_config=None,
     best_decode_config=None,
+    best_latencies: dict | None = None,
 ) -> Any:
     """Apply Dynamo features to the picked DGD config via composable layers.
 
@@ -103,6 +104,7 @@ def assemble_final_config(
             base,
             best_prefill_mapping=best_prefill_config,
             best_decode_mapping=best_decode_config,
+            best_latencies=best_latencies,
         )
         config_maps.append(planner_cm)
 
@@ -161,6 +163,7 @@ def add_planner_to_config(
     config_dict: dict,
     best_prefill_mapping=None,
     best_decode_mapping=None,
+    best_latencies: dict | None = None,
 ) -> dict:
     """Add a Planner service and its planner-config ConfigMap to *config_dict*.
 
@@ -173,11 +176,14 @@ def add_planner_to_config(
         config_dict: The base DGD config (real or mocker) — mutated in place.
         best_prefill_mapping: Picked prefill parallel config.
         best_decode_mapping: Picked decode parallel config.
+        best_latencies: Profiling latency estimates (ttft, tpot, request_latency).
 
     Returns:
         The ``planner_config_cm`` ConfigMap dict.
     """
-    planner_cfg = _build_planner_config(dgdr, best_prefill_mapping, best_decode_mapping)
+    planner_cfg = _build_planner_config(
+        dgdr, best_prefill_mapping, best_decode_mapping, best_latencies
+    )
     planner_cfg.profile_results_dir = PROFILE_DATA_MOUNT
 
     planner_service = DgdPlannerServiceConfig()
@@ -343,8 +349,16 @@ def _build_planner_config(
     dgdr,
     best_prefill_mapping,
     best_decode_mapping,
+    best_latencies: dict | None = None,
 ) -> PlannerConfig:
-    """Build a PlannerConfig from the DGDR spec and picked parallel configs."""
+    """Build a PlannerConfig from the DGDR spec and picked parallel configs.
+
+    When ``dgdr.sla.optimizationType`` is active the planner still needs
+    concrete TTFT / ITL targets for autoscaling decisions.  This function
+    populates them from the profiling estimates (``best_latencies``) when
+    available, or falls back to conservative defaults (2 000 ms / 30 ms)
+    for the naive-fallback path where no simulation data exists.
+    """
     if dgdr.features and dgdr.features.planner:
         planner_cfg = dgdr.features.planner.model_copy(deep=True)
     else:
@@ -355,6 +369,26 @@ def _build_planner_config(
 
     if best_decode_mapping is not None:
         planner_cfg.decode_engine_num_gpu = best_decode_mapping.num_gpus
+
+    # --- optimizationType: populate planner TTFT / ITL from estimates ------
+    if dgdr.sla and dgdr.sla.optimizationType is not None:
+        if best_latencies and best_latencies.get("ttft", 0) > 0:
+            planner_cfg.ttft = best_latencies["ttft"]
+            planner_cfg.itl = best_latencies["tpot"]
+            logger.info(
+                "Planner TTFT/ITL set from profiling estimates: "
+                "ttft=%.1f ms, itl=%.1f ms",
+                planner_cfg.ttft,
+                planner_cfg.itl,
+            )
+        else:
+            # Naive fallback: no simulation estimates available
+            planner_cfg.ttft = 2000.0
+            planner_cfg.itl = 30.0
+            logger.warning(
+                "No estimated TTFT/ITL available (AIC unsupported, naive fallback). "
+                "Using defaults: ttft=2000ms, itl=30ms"
+            )
 
     return planner_cfg
 

--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -96,11 +96,19 @@ class WorkloadSpec(BaseModel):
 class SLASpec(BaseModel):
     """Service-level agreement targets.
 
-    Provide one of:
+    Provide exactly one of:
 
     - ``ttft`` + ``itl``: explicit latency targets (default: 2000 ms / 30 ms)
-    - ``e2eLatency``: end-to-end latency target (mutually exclusive with ttft/itl)"""
+    - ``e2eLatency``: end-to-end latency target
+    - ``optimizationType``: high-level objective without explicit numeric targets
 
+    When the entire ``sla`` field is omitted from the DGDR spec, the profiler
+    defaults to ``optimizationType=throughput``."""
+
+    optimizationType: Optional[OptimizationType] = Field(
+        default=None,
+        description="OptimizationType controls the profiling optimization strategy. Use when explicit SLA targets (ttft+itl or e2eLatency) are not known.",
+    )
     ttft: Optional[float] = Field(
         default=2000,
         description="TTFT is the Time To First Token target in milliseconds.",
@@ -115,19 +123,31 @@ class SLASpec(BaseModel):
 
     @model_validator(mode="after")
     def _validate_sla_options(self) -> "SLASpec":
-        """Ensure e2eLatency and ttft/itl are not both provided."""
+        """Ensure at most one SLA mode is active.
+
+        When ``optimizationType`` is set, ``ttft`` and ``itl`` are cleared
+        because they are not meaningful in that mode (pydantic defaults would
+        otherwise leave them populated).
+        """
         has_e2e = self.e2eLatency is not None
+        has_opt = self.optimizationType is not None
         ttft_itl_touched = (
             "ttft" in self.model_fields_set or "itl" in self.model_fields_set
         )
-        has_ttft_itl = (
-            self.ttft is not None or self.itl is not None
-        ) and ttft_itl_touched
-        if has_e2e and has_ttft_itl:
+        has_ttft_itl = (self.ttft is not None and self.itl is not None) and (
+            ttft_itl_touched or (not has_e2e and not has_opt)
+        )
+        options_count = sum([has_ttft_itl, has_e2e, has_opt])
+        if options_count > 1:
             raise ValueError(
-                "SLA must specify either (ttft and itl) or e2eLatency, not both."
+                "SLA must specify exactly one of: (ttft and itl), e2eLatency, "
+                "or optimizationType \u2014 not multiple."
             )
-        if (self.ttft is not None) != (self.itl is not None):
+        if has_opt:
+            # optimizationType mode \u2014 clear pydantic-defaulted ttft/itl
+            self.ttft = None
+            self.itl = None
+        elif (self.ttft is not None) != (self.itl is not None):
             raise ValueError("ttft and itl must both be provided together.")
         return self
 

--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -52,6 +52,11 @@ class ProfilingPhase(str, Enum):
     Done = "Done"
 
 
+class OptimizationType(str, Enum):
+    Latency = "latency"
+    Throughput = "throughput"
+
+
 class SearchStrategy(str, Enum):
     Rapid = "rapid"
     Thorough = "thorough"

--- a/components/src/dynamo/profiler/utils/dgdr_validate.py
+++ b/components/src/dynamo/profiler/utils/dgdr_validate.py
@@ -31,6 +31,7 @@ from dynamo.planner.config.planner_config import PlannerPreDeploymentSweepMode
 from dynamo.profiler.utils.defaults import SearchStrategy
 from dynamo.profiler.utils.dgdr_v1beta1_types import (
     DynamoGraphDeploymentRequestSpec,
+    OptimizationType,
     SLASpec,
     WorkloadSpec,
 )
@@ -50,7 +51,10 @@ def valid_dgdr_spec(
     - ``dgdr.hardware.gpuSku`` (str, non-empty)
     - ``dgdr.hardware.numGpusPerNode`` (int > 0)
     - ``dgdr.workload.isl``, ``dgdr.workload.osl`` (int)
-    - ``dgdr.sla.ttft``, ``dgdr.sla.itl`` (float) **or** ``dgdr.sla.e2eLatency`` (float)
+    - One of:
+      - ``dgdr.sla.ttft`` and ``dgdr.sla.itl`` (float)
+      - ``dgdr.sla.e2eLatency`` (float)
+      - ``dgdr.sla.optimizationType`` (OptimizationType)
 
     without additional ``None`` guards.
 
@@ -88,7 +92,7 @@ def _validate_required_fields(dgdr: DynamoGraphDeploymentRequestSpec) -> None:
     if dgdr.workload is None:
         dgdr.workload = WorkloadSpec()
     if dgdr.sla is None:
-        dgdr.sla = SLASpec()
+        dgdr.sla = SLASpec(optimizationType=OptimizationType.Throughput)
 
 
 def _validate_workload(workload: WorkloadSpec) -> None:
@@ -100,7 +104,13 @@ def _validate_workload(workload: WorkloadSpec) -> None:
 
 
 def _validate_sla(sla: SLASpec) -> None:
-    """Validate SLA targets and normalise e2eLatency mode."""
+    """Validate SLA targets and normalise mode.
+
+    Exactly one SLA mode must be active:
+    - ``optimizationType``: high-level objective (throughput/latency)
+    - ``e2eLatency``: single end-to-end latency target
+    - ``ttft`` + ``itl``: explicit per-phase latency targets
+    """
     for name, val in [
         ("ttft", sla.ttft),
         ("itl", sla.itl),
@@ -109,7 +119,14 @@ def _validate_sla(sla: SLASpec) -> None:
         if val is not None and val <= 0:
             raise ValueError(f"SLA '{name}' must be positive (got {val}).")
 
+    has_opt = sla.optimizationType is not None
     has_e2e = sla.e2eLatency is not None
+
+    # optimizationType mode — ttft/itl already cleared by model validator
+    if has_opt:
+        sla.ttft = None
+        sla.itl = None
+        return
 
     # When e2eLatency is provided it takes precedence — null out the per-token defaults
     if has_e2e:
@@ -120,7 +137,8 @@ def _validate_sla(sla: SLASpec) -> None:
     has_ttft_itl = sla.ttft is not None and sla.itl is not None
     if not has_ttft_itl:
         raise ValueError(
-            "Either both 'ttft' and 'itl', or 'e2eLatency', must be provided in the SLA spec."
+            "Either both 'ttft' and 'itl', 'e2eLatency', or "
+            "'optimizationType' must be provided in the SLA spec."
         )
 
 

--- a/components/src/dynamo/profiler/utils/model_info.py
+++ b/components/src/dynamo/profiler/utils/model_info.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 from pathlib import Path
 from typing import Optional, Union
 
@@ -38,6 +39,93 @@ MOE_ARCHITECTURES = {
 MOE_ADDITIONAL_TP_ARCHITECTURES = {
     "Qwen3MoeForCausalLM",  # GQA + MoE
 }
+# MoE architectures with Multi-Latent Attention (MLA)
+MLA_MOE_ARCHITECTURES = {
+    "DeepseekV3ForCausalLM",
+    "DeepseekV32ForCausalLM",
+}
+
+# Minimum GPU memory overhead factor: VRAM must exceed model weight by this
+# multiplier to leave room for KV cache, activations, etc.  Mirrors the 1.5×
+# rule used in AIC's ``_calculate_min_tp``.
+_VRAM_OVERHEAD_FACTOR = 1.5
+
+
+def calculate_min_gpus_for_model(
+    model_size_mb: float,
+    vram_per_gpu_mb: float,
+) -> int:
+    """Return the minimum number of GPUs needed to fit a model.
+
+    Uses the 1.5× rule: the combined VRAM of the returned GPU count must be at
+    least ``_VRAM_OVERHEAD_FACTOR`` × ``model_size_mb``.
+
+    The result is always a power of two (1, 2, 4, 8 …) so that it maps cleanly
+    to TP / TEP / DEP sizes.
+    """
+    if vram_per_gpu_mb <= 0:
+        raise ValueError(f"vram_per_gpu_mb must be positive, got {vram_per_gpu_mb}")
+    if model_size_mb <= 0:
+        raise ValueError(f"model_size_mb must be positive, got {model_size_mb}")
+
+    required_vram = model_size_mb * _VRAM_OVERHEAD_FACTOR
+    raw_gpus = required_vram / vram_per_gpu_mb
+    # Round up to the next power of two
+    if raw_gpus <= 1:
+        return 1
+    return int(2 ** math.ceil(math.log2(raw_gpus)))
+
+
+def get_default_parallelization_for_architecture(
+    architecture: str,
+    is_moe: bool,
+    num_gpus: int,
+    optimization_type: str | None = None,
+) -> tuple:
+    """Return ``(prefill_mapping, decode_mapping)`` for naive / optimization-type routes.
+
+    The mapping rules are identical for aggregated and disaggregated serving.
+    In aggregated mode the caller uses both mappings identically (single
+    engine); in disaggregated mode they map to separate prefill/decode workers.
+
+    Rules:
+        * **Dense** (``is_moe=False``): TP
+        * **MLA + MoE + throughput** (DeepSeek-V3 family): DEP
+        * **All other sparse** (MLA + MoE + latency, GQA + MoE either): TEP
+
+    Parameters
+    ----------
+    architecture:
+        HuggingFace model architecture class name.
+    is_moe:
+        Whether the model is a Mixture-of-Experts model.
+    num_gpus:
+        Number of GPUs to distribute across.
+    optimization_type:
+        ``"throughput"`` or ``"latency"`` (or *None* for the default/SLA path
+        which falls back to TEP for MoE models).
+
+    Returns
+    -------
+    tuple[dict, dict]
+        ``(prefill_mapping, decode_mapping)`` where each mapping is a dict
+        with exactly one key from ``{"tp", "tep", "dep"}``.
+    """
+    if not is_moe:
+        m = {"tp": num_gpus}
+        return m, m
+
+    # MLA + MoE + throughput → DEP (maximises concurrent KV-cache utilisation)
+    if (
+        architecture in MLA_MOE_ARCHITECTURES
+        and optimization_type == "throughput"
+    ):
+        m = {"dep": num_gpus}
+        return m, m
+
+    # All other sparse (MLA+MoE+latency, GQA+MoE either) → TEP
+    m = {"tep": num_gpus}
+    return m, m
 
 
 def get_local_model_weight_size(

--- a/components/src/dynamo/profiler/utils/optimization_type.py
+++ b/components/src/dynamo/profiler/utils/optimization_type.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for determining parallelization from ``optimizationType``."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from dynamo.profiler.utils.config_modifiers.parallelization_mapping import (
+    ParallelizationMapping,
+)
+from dynamo.profiler.utils.dgdr_v1beta1_types import (
+    DynamoGraphDeploymentRequestSpec,
+    OptimizationType,
+)
+from dynamo.profiler.utils.model_info import (
+    ModelInfo,
+    calculate_min_gpus_for_model,
+    get_default_parallelization_for_architecture,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class OptimizationTypeConfig:
+    """Resolved parallelization and concurrency strategy for optimization-type mode.
+
+    Attributes
+    ----------
+    prefill_mapping:
+        Parallelization mapping for the prefill engine.
+    decode_mapping:
+        Parallelization mapping for the decode engine.
+    num_gpus:
+        Number of GPUs per engine (always a power of two).
+    use_max_concurrency:
+        ``True`` for throughput optimisation (highest concurrency / full KV
+        cache); ``False`` for latency optimisation (single-stream).
+    """
+
+    prefill_mapping: ParallelizationMapping
+    decode_mapping: ParallelizationMapping
+    num_gpus: int
+    use_max_concurrency: bool
+
+
+def _mapping_dict_to_parallelization(mapping: dict) -> ParallelizationMapping:
+    """Convert a ``{"tp": N}`` / ``{"tep": N}`` / ``{"dep": N}`` dict to a
+    :class:`ParallelizationMapping` instance."""
+    return ParallelizationMapping(**mapping)
+
+
+def resolve_optimization_type_config(
+    dgdr: DynamoGraphDeploymentRequestSpec,
+    model_info: ModelInfo,
+) -> OptimizationTypeConfig:
+    """Determine parallelization and concurrency for ``optimizationType`` mode.
+
+    Parameters
+    ----------
+    dgdr:
+        The validated DGDR spec.  Must have ``dgdr.sla.optimizationType`` set.
+    model_info:
+        Pre-fetched model architecture information.
+
+    Returns
+    -------
+    OptimizationTypeConfig
+        The resolved config with parallelization mappings, GPU count, and
+        concurrency strategy.
+
+    Raises
+    ------
+    ValueError
+        If ``dgdr.sla.optimizationType`` is not set.
+    """
+    if dgdr.sla is None or dgdr.sla.optimizationType is None:
+        raise ValueError(
+            "resolve_optimization_type_config requires sla.optimizationType to be set"
+        )
+
+    opt_type: OptimizationType = dgdr.sla.optimizationType
+
+    # --- Determine number of GPUs -------------------------------------------
+    vram_mb = dgdr.hardware.vramMb
+    if vram_mb is not None and vram_mb > 0:
+        num_gpus = calculate_min_gpus_for_model(model_info.model_size, vram_mb)
+    else:
+        # VRAM not available — fall back to total GPUs (single-node assumption)
+        logger.warning(
+            "vramMb not set in hardware spec; falling back to totalGpus=%s",
+            dgdr.hardware.totalGpus,
+        )
+        num_gpus = dgdr.hardware.totalGpus or 1
+
+    # Clamp to available GPUs
+    total_gpus = dgdr.hardware.totalGpus or num_gpus
+    if num_gpus > total_gpus:
+        logger.warning(
+            "Computed num_gpus=%d exceeds totalGpus=%d; clamping.",
+            num_gpus,
+            total_gpus,
+        )
+        num_gpus = total_gpus
+
+    # --- Determine parallelization strategy ---------------------------------
+    prefill_dict, decode_dict = get_default_parallelization_for_architecture(
+        architecture=model_info.architecture,
+        is_moe=model_info.is_moe,
+        num_gpus=num_gpus,
+        optimization_type=opt_type.value,  # "throughput" or "latency"
+    )
+
+    prefill_mapping = _mapping_dict_to_parallelization(prefill_dict)
+    decode_mapping = _mapping_dict_to_parallelization(decode_dict)
+
+    # --- Concurrency strategy -----------------------------------------------
+    use_max_concurrency = opt_type == OptimizationType.Throughput
+
+    logger.info(
+        "Resolved optimizationType=%s: num_gpus=%d, prefill=%s, decode=%s, "
+        "use_max_concurrency=%s",
+        opt_type.value,
+        num_gpus,
+        prefill_mapping.label(),
+        decode_mapping.label(),
+        use_max_concurrency,
+    )
+
+    return OptimizationTypeConfig(
+        prefill_mapping=prefill_mapping,
+        decode_mapping=decode_mapping,
+        num_gpus=num_gpus,
+        use_max_concurrency=use_max_concurrency,
+    )

--- a/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
@@ -165,6 +165,15 @@ const (
 	ProfilingReasonJobCreationFailed = "JobCreationFailed"
 )
 
+// OptimizationType specifies the profiling optimization strategy.
+// +kubebuilder:validation:Enum=latency;throughput
+type OptimizationType string
+
+const (
+	OptimizationTypeLatency    OptimizationType = "latency"
+	OptimizationTypeThroughput OptimizationType = "throughput"
+)
+
 // SearchStrategy controls the profiling search depth.
 // +kubebuilder:validation:Enum=rapid;thorough
 type SearchStrategy string
@@ -223,6 +232,12 @@ type WorkloadSpec struct {
 
 // SLASpec defines the service-level agreement targets for profiling optimization.
 type SLASpec struct {
+	// OptimizationType controls the profiling optimization strategy.
+	// Use when explicit SLA targets (ttft+itl or e2eLatency) are not known.
+	// Valid values: "latency", "throughput".
+	// +optional
+	OptimizationType OptimizationType `json:"optimizationType,omitempty"`
+
 	// TTFT is the Time To First Token target in milliseconds.
 	// +optional
 	// +python-default=2000

--- a/deploy/operator/config/samples/nvidia.com_v1beta1_dynamographdeploymentrequest.yaml
+++ b/deploy/operator/config/samples/nvidia.com_v1beta1_dynamographdeploymentrequest.yaml
@@ -31,17 +31,12 @@ spec:
   # "rapid" for fast sweep; "thorough" for deeper exploration
   searchStrategy: thorough
 
-  # Hardware describes the hardware resources available for profiling and deployment.
-  # In cluster-scoped mode the operator auto-discovers GPU info from cluster nodes
-  # (via GPU Feature Discovery labels), so these fields are optional.
-  # In namespace-restricted mode, auto-discovery is intentionally disabled because
-  # the operator lacks permission to list cluster nodes. Validation will reject the
-  # DGDR before any profiling runs, so you must explicitly set numGpusPerNode,
-  # gpuSku, and vramMb.
+  # Hardware describes the hardware resources available for profiling and deployment
+  # Note: Operator auto-discovers GPU info from cluster nodes when available
   hardware:
-    numGpusPerNode: 8       # GPUs per node (required in namespace-restricted mode)
-    gpuSku: h200_sxm        # Hardware system (required in namespace-restricted mode)
-    # vramMb: 141557        # GPU VRAM in MiB (required in namespace-restricted mode)
+    numGpusPerNode: 8       # GPUs per node (optional - auto-discovered if not specified)
+    gpuSku: h200_sxm        # Hardware system (optional - auto-detected if not specified)
+    # vramMb: 141557        # GPU VRAM in MiB (optional - auto-discovered)
 
   # Workload defines the expected workload characteristics
   workload:

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1171,6 +1171,15 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 		logger.Info("GPU discovery not available, proceeding without enrichment", "reason", err.Error())
 	}
 
+	// Apply SLA defaults if the user omitted TTFT/ITL targets.
+	// This mutates the in-memory spec only — the persisted spec is not modified,
+	// so users still see their original (possibly empty) SLA in the API.
+	applySLADefaults(&dgdr.Spec)
+	logger.Info("SLA targets for profiling",
+		"ttft", *dgdr.Spec.SLA.TTFT,
+		"itl", *dgdr.Spec.SLA.ITL,
+		"defaultsApplied", dgdr.Spec.SLA != nil)
+
 	// Use SyncResource to create/update the job
 	modified, job, err := commonController.SyncResource(ctx, r, dgdr, func(ctx context.Context) (*batchv1.Job, bool, error) {
 		jobName := getProfilingJobName(dgdr)

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1176,9 +1176,10 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 	// so users still see their original (possibly empty) SLA in the API.
 	applySLADefaults(&dgdr.Spec)
 	logger.Info("SLA targets for profiling",
-		"ttft", *dgdr.Spec.SLA.TTFT,
-		"itl", *dgdr.Spec.SLA.ITL,
-		"defaultsApplied", dgdr.Spec.SLA != nil)
+		"optimizationType", dgdr.Spec.SLA.OptimizationType,
+		"ttft", dgdr.Spec.SLA.TTFT,
+		"itl", dgdr.Spec.SLA.ITL,
+		"e2eLatency", dgdr.Spec.SLA.E2ELatency)
 
 	// Use SyncResource to create/update the job
 	modified, job, err := commonController.SyncResource(ctx, r, dgdr, func(ctx context.Context) (*batchv1.Job, bool, error) {

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
@@ -853,6 +853,27 @@ var _ = Describe("DGDR Validation", func() {
 			err := reconciler.validateSpec(ctx, dgdr)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("Should pass validation without SLA targets (defaults will be applied later)", func() {
+			ctx := context.Background()
+			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model:   "test-model",
+					Backend: "vllm",
+					Image:   "test-profiler:latest",
+					Hardware: &nvidiacomv1beta1.HardwareSpec{
+						NumGPUsPerNode: ptr.To[int32](8),
+						GPUSKU:         "H100-SXM5-80GB",
+						VRAMMB:         ptr.To(81920.0),
+						TotalGPUs:      ptr.To[int32](128),
+					},
+				},
+			}
+
+			// Validation should pass without SLA - defaults are injected at profiling time
+			err := reconciler.validateSpec(ctx, dgdr)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 })
 

--- a/deploy/operator/internal/controller/sla_defaults.go
+++ b/deploy/operator/internal/controller/sla_defaults.go
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+)
+
+// applySLADefaults ensures that the SLA section of the DGDR spec has
+// a valid SLA mode when the user has not provided explicit targets.
+//
+// When SLA is nil or empty (no fields set), the operator defaults to
+// optimizationType=throughput. This lets users deploy models with zero
+// SLA configuration and get a throughput-optimized deployment.
+//
+// When the user provides explicit TTFT, ITL, e2eLatency, or
+// optimizationType, their values are preserved unchanged.
+//
+// The defaults are applied in-memory before the spec is marshalled to JSON
+// and passed to the profiler — the persisted spec on the API server is not modified.
+func applySLADefaults(spec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec) {
+	if spec.SLA == nil {
+		spec.SLA = &nvidiacomv1beta1.SLASpec{
+			OptimizationType: nvidiacomv1beta1.OptimizationTypeThroughput,
+		}
+		return
+	}
+
+	// If the user explicitly set any SLA field, respect it as-is.
+	if spec.SLA.OptimizationType != "" || spec.SLA.E2ELatency != nil ||
+		spec.SLA.TTFT != nil || spec.SLA.ITL != nil {
+		return
+	}
+
+	// Empty SLA struct (all fields nil/zero) — default to throughput.
+	spec.SLA.OptimizationType = nvidiacomv1beta1.OptimizationTypeThroughput
+}

--- a/deploy/operator/internal/controller/sla_defaults_test.go
+++ b/deploy/operator/internal/controller/sla_defaults_test.go
@@ -1,0 +1,156 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"testing"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"k8s.io/utils/ptr"
+)
+
+func TestApplySLADefaults(t *testing.T) {
+	tests := []struct {
+		name                     string
+		spec                     nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec
+		expectedOptimizationType nvidiacomv1beta1.OptimizationType
+		expectedTTFT             *float64
+		expectedITL              *float64
+	}{
+		{
+			name: "nil SLA defaults to optimizationType=throughput",
+			spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+				Model: "test-model",
+			},
+			expectedOptimizationType: nvidiacomv1beta1.OptimizationTypeThroughput,
+			expectedTTFT:             nil,
+			expectedITL:              nil,
+		},
+		{
+			name: "empty SLA struct defaults to optimizationType=throughput",
+			spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+				Model: "test-model",
+				SLA:   &nvidiacomv1beta1.SLASpec{},
+			},
+			expectedOptimizationType: nvidiacomv1beta1.OptimizationTypeThroughput,
+			expectedTTFT:             nil,
+			expectedITL:              nil,
+		},
+		{
+			name: "user-provided TTFT+ITL preserved, no optimizationType injected",
+			spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+				Model: "test-model",
+				SLA: &nvidiacomv1beta1.SLASpec{
+					TTFT: ptr.To(500.0),
+					ITL:  ptr.To(10.0),
+				},
+			},
+			expectedOptimizationType: "",
+			expectedTTFT:             ptr.To(500.0),
+			expectedITL:              ptr.To(10.0),
+		},
+		{
+			name: "user-provided TTFT only preserved, no defaults injected",
+			spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+				Model: "test-model",
+				SLA: &nvidiacomv1beta1.SLASpec{
+					TTFT: ptr.To(500.0),
+				},
+			},
+			expectedOptimizationType: "",
+			expectedTTFT:             ptr.To(500.0),
+			expectedITL:              nil,
+		},
+		{
+			name: "user-provided ITL only preserved, no defaults injected",
+			spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+				Model: "test-model",
+				SLA: &nvidiacomv1beta1.SLASpec{
+					ITL: ptr.To(10.0),
+				},
+			},
+			expectedOptimizationType: "",
+			expectedTTFT:             nil,
+			expectedITL:              ptr.To(10.0),
+		},
+		{
+			name: "optimizationType=latency preserved as-is",
+			spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+				Model: "test-model",
+				SLA: &nvidiacomv1beta1.SLASpec{
+					OptimizationType: nvidiacomv1beta1.OptimizationTypeLatency,
+				},
+			},
+			expectedOptimizationType: nvidiacomv1beta1.OptimizationTypeLatency,
+			expectedTTFT:             nil,
+			expectedITL:              nil,
+		},
+		{
+			name: "e2eLatency preserved, no optimizationType injected",
+			spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+				Model: "test-model",
+				SLA: &nvidiacomv1beta1.SLASpec{
+					E2ELatency: ptr.To(5000.0),
+				},
+			},
+			expectedOptimizationType: "",
+			expectedTTFT:             nil,
+			expectedITL:              nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := tt.spec // copy
+			applySLADefaults(&spec)
+
+			if spec.SLA == nil {
+				t.Fatal("applySLADefaults() SLA is nil after defaults applied")
+			}
+
+			if spec.SLA.OptimizationType != tt.expectedOptimizationType {
+				t.Errorf("applySLADefaults() OptimizationType = %q, want %q",
+					spec.SLA.OptimizationType, tt.expectedOptimizationType)
+			}
+
+			if tt.expectedTTFT == nil {
+				if spec.SLA.TTFT != nil {
+					t.Errorf("applySLADefaults() TTFT = %v, want nil", *spec.SLA.TTFT)
+				}
+			} else {
+				if spec.SLA.TTFT == nil {
+					t.Errorf("applySLADefaults() TTFT is nil, want %v", *tt.expectedTTFT)
+				} else if *spec.SLA.TTFT != *tt.expectedTTFT {
+					t.Errorf("applySLADefaults() TTFT = %v, want %v", *spec.SLA.TTFT, *tt.expectedTTFT)
+				}
+			}
+
+			if tt.expectedITL == nil {
+				if spec.SLA.ITL != nil {
+					t.Errorf("applySLADefaults() ITL = %v, want nil", *spec.SLA.ITL)
+				}
+			} else {
+				if spec.SLA.ITL == nil {
+					t.Errorf("applySLADefaults() ITL is nil, want %v", *tt.expectedITL)
+				} else if *spec.SLA.ITL != *tt.expectedITL {
+					t.Errorf("applySLADefaults() ITL = %v, want %v", *spec.SLA.ITL, *tt.expectedITL)
+				}
+			}
+		})
+	}
+}

--- a/docs/pages/components/profiler/README.md
+++ b/docs/pages/components/profiler/README.md
@@ -1,0 +1,118 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Profiler
+---
+
+The Dynamo Profiler is an automated performance analysis tool that measures model inference characteristics to optimize deployment configurations. It determines optimal tensor parallelism (TP) settings for prefill and decode phases, generates performance interpolation data, and enables SLA-driven autoscaling through the Planner.
+
+## Feature Matrix
+
+| Feature | SGLang | TensorRT-LLM | vLLM |
+|---------|--------|--------------|------|
+| Dense Model Profiling | ✅ | ✅ | ✅ |
+| MoE Model Profiling | ✅ | 🚧 | 🚧 |
+| AI Configurator (Offline) | ❌ | ✅ | ❌ |
+| Online Profiling (AIPerf) | ✅ | ✅ | ✅ |
+| Interactive WebUI | ✅ | ✅ | ✅ |
+| Runtime Profiling Endpoints | ✅ | ❌ | ❌ |
+
+## Quick Start
+
+### Prerequisites
+
+- Dynamo platform installed (see [Installation Guide](../../kubernetes/installation-guide.md))
+- Kubernetes cluster with GPU nodes (for DGDR-based profiling)
+- kube-prometheus-stack installed (required for SLA planner)
+
+### Using DynamoGraphDeploymentRequest (Recommended)
+
+The recommended way to profile models is through DGDRs, which automate the entire profiling and deployment workflow.
+
+**Simplest form** — omit SLA to default to throughput optimization:
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeploymentRequest
+metadata:
+  name: my-model-profiling
+spec:
+  model: "Qwen/Qwen3-0.6B"
+  backend: vllm
+  image: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0"
+  autoApply: true
+```
+
+**With explicit SLA targets:**
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeploymentRequest
+metadata:
+  name: my-model-profiling
+spec:
+  model: "Qwen/Qwen3-0.6B"
+  backend: vllm
+  image: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0"
+
+  workload:
+    isl: 3000      # Average input sequence length
+    osl: 150       # Average output sequence length
+
+  sla:
+    ttft: 200.0    # Target Time To First Token (ms)
+    itl: 20.0      # Target Inter-Token Latency (ms)
+
+  autoApply: true
+```
+
+```bash
+kubectl apply -f my-profiling-dgdr.yaml -n $NAMESPACE
+```
+
+### Using AI Configurator (Fast Offline Profiling)
+
+AI Configurator enables rapid offline profiling (~30 seconds) and supports all backends (vLLM, SGLang, TensorRT-LLM). Since `searchStrategy: rapid` is the default, AIC is used automatically unless you explicitly set `searchStrategy: thorough`.
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `sla.optimizationType` | `throughput` (when sla omitted) | Optimization strategy: `throughput` or `latency` |
+| `sla.ttft` | - | Target Time To First Token (milliseconds) |
+| `sla.itl` | - | Target Inter-Token Latency (milliseconds) |
+| `sla.e2eLatency` | - | Target end-to-end request latency (milliseconds) |
+| `workload.isl` | 4000 | Average input sequence length (tokens) |
+| `workload.osl` | 1000 | Average output sequence length (tokens) |
+| `hardware.numGpusPerNode` | auto | Number of GPUs per node |
+| `hardware.gpuSku` | auto | GPU SKU identifier |
+
+## Profiling Methods
+
+| Method | Duration | Accuracy | GPU Required | Backends |
+|--------|----------|----------|--------------|----------|
+| Online (AIPerf) | 2-4 hours | Highest | Yes | All |
+| Offline (AI Configurator) | 20-30 seconds | Estimated | No | TensorRT-LLM |
+
+## Output
+
+The profiler generates:
+
+1. **Optimal Configuration**: Recommended TP sizes for prefill and decode engines
+2. **Performance Data**: Interpolation models for the SLA Planner
+3. **Generated DGD**: Complete deployment manifest with optimized settings
+
+Example recommendations:
+```text
+Suggested prefill TP:4 (TTFT 48.37 ms, throughput 15505.23 tokens/s/GPU)
+Suggested decode TP:4 (ITL 4.83 ms, throughput 51.22 tokens/s/GPU)
+```
+
+## Next Steps
+
+| Document | Description |
+|----------|-------------|
+| [Profiler Guide](profiler-guide.md) | Configuration, methods, and troubleshooting |
+| [Profiler Examples](profiler-examples.md) | Complete DGDR YAMLs, WebUI, script examples |
+| [SLA Planner Guide](../planner/planner-guide.md) | End-to-end deployment workflow |
+| [SLA Planner Architecture](../planner/planner-guide.md) | How the Planner uses profiling data |

--- a/docs/pages/components/profiler/profiler-guide.md
+++ b/docs/pages/components/profiler/profiler-guide.md
@@ -1,0 +1,700 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Profiler Guide
+---
+
+## Overview
+
+The Dynamo Profiler analyzes model inference performance and generates optimized deployment configurations (DynamoGraphDeployments). Given a model, hardware, and SLA targets, it determines the best parallelization strategy, selects optimal prefill and decode engine configurations, and produces a ready-to-deploy DGD YAML.
+
+The profiler accepts a `DynamoGraphDeploymentRequestSpec` (DGDR) as input and uses [AI Configurator (AIC)](https://github.com/ai-dynamo/aiconfigurator) for performance simulation, candidate enumeration, and configuration picking. When the planner is enabled, the profiler additionally generates engine interpolation curves used for runtime autoscaling.
+
+## Workflow
+
+- **What** model you want to deploy (`model`)
+- **How** it should perform (optional SLA: `sla.optimizationType`, `sla.ttft`+`sla.itl`, or `sla.e2eLatency` — defaults to throughput optimization if omitted)
+- **Where** it should run (optional GPU preferences via `hardware`)
+- **Which** backend to use (`backend`: auto, vllm, sglang, or trtllm)
+- **Which** image to use (`image`)
+
+The profiler follows this pipeline:
+
+```mermaid
+flowchart TD
+    Input["DGDR Spec"] --> Validate["Validate + Gate Checks"]
+    Validate --> Strategy{searchStrategy?}
+
+    Strategy -->|rapid| AICCheck{"AIC supports\nmodel/hw/backend?"}
+    Strategy -->|thorough| Enumerate["Enumerate candidates\nvia AIC"]
+
+    AICCheck -->|yes| Simulate["AIC Simulation\n+ Picking"]
+    AICCheck -->|no| Naive["Naive Config\nGeneration"]
+
+    Enumerate --> Deploy["Deploy + Benchmark\neach candidate"]
+    Deploy --> Pick["AIC Picking"]
+
+    Simulate --> DGDGen["DGD Generation"]
+    Pick --> DGDGen
+    Naive --> DGDGen
+
+    DGDGen --> PlannerCheck{"Planner\nenabled?"}
+    PlannerCheck -->|yes| Interpolation["Interpolation\nCurves"]
+    PlannerCheck -->|no| MockerCheck
+
+    Interpolation --> AddPlanner["Add Planner\nService + ConfigMaps"]
+    AddPlanner --> MockerCheck{"Mocker\nenabled?"}
+
+    MockerCheck -->|yes| Mocker["Output Mocker DGD"]
+    MockerCheck -->|no| RealDGD["Output Real DGD"]
+
+    Mocker --> Final["final_config.yaml"]
+    RealDGD --> Final
+```
+
+### Stage-by-stage walkthrough
+
+1. **Validation**: The DGDR spec is validated — required fields checked (`image`, `hardware.gpuSku`, `hardware.numGpusPerNode`), and gate checks applied (see [Gate Checks](#gate-checks-and-constraints)). SLA is optional — if the `sla` section is omitted or empty, the controller defaults to `optimizationType: throughput` before passing the spec to the profiler.
+
+2. **Search Strategy**: The profiler branches based on `searchStrategy`:
+   - **Rapid**: Uses AIC simulation to estimate performance across parallelization configs. No GPUs needed, completes in ~30 seconds.
+   - **Thorough**: Enumerates candidate parallelization configs via AIC, deploys each on real GPUs, benchmarks with AIPerf, then picks the best. Takes 2-4 hours, disagg mode only.
+
+3. **Picking**: The profiler selects the best configuration using one of three modes, determined automatically from the DGDR spec (see [Picking Modes](#picking-modes)).
+
+4. **DGD Generation**: The picked configuration is rendered into a complete DGD YAML via AIC's generator pipeline, including correct parallelization, replica counts, container image, and PVC mounts.
+
+5. **Interpolation** (planner only): When the planner is enabled, the profiler generates detailed performance interpolation curves — TTFT vs ISL for prefill, ITL vs KV-cache utilization for decode. These are saved into ConfigMaps for the planner to use at runtime.
+
+6. **Final Assembly**: The planner service is added to the DGD if enabled. If mocker is enabled, the mocker DGD is used instead of real workers. The result is written to `final_config.yaml`.
+
+## Search Strategies
+
+### Rapid
+
+Uses AIC's performance simulation to estimate optimal configurations without deploying real engines. Completes in ~30 seconds.
+
+```yaml
+searchStrategy: rapid
+```
+
+- Supports all backends: vLLM, SGLang, TensorRT-LLM
+- If the model/hardware/backend combination is not supported by AIC, falls back to a naive config (memory-fit TP calculation)
+- No GPU resources consumed during profiling
+
+### Thorough
+
+Enumerates candidate parallelization configs, deploys each as a real K8s workload, and benchmarks with AIPerf.
+
+```yaml
+searchStrategy: thorough
+```
+
+- Only disaggregated mode is supported
+- Does not support `auto` backend — specify `vllm`, `sglang`, or `trtllm`
+- Takes 2-4 hours depending on the number of candidates
+- Provides highest accuracy since measurements come from real hardware
+
+## Picking Modes
+
+The profiler automatically selects a picking mode based on the DGDR spec:
+
+### Autoscale
+
+Triggered when the **planner is enabled** (scaling enabled in `features.planner`). Picks prefill and decode engines independently, each with 1 replica. The planner handles scaling at runtime.
+
+### Load Match
+
+Triggered when a **target load** is specified (`workload.requestRate` or `workload.concurrency`). Finds the configuration that serves the target load with the minimum number of GPUs under SLA.
+
+```yaml
+workload:
+  requestRate: 5.0   # target 5 req/s
+```
+
+### Default
+
+Triggered when there is **no planner and no target load**. Maximizes throughput for the available GPU budget under SLA.
+
+## Planner Integration
+
+When the planner is enabled, the profiler generates engine interpolation data needed for throughput-based autoscaling. The `pre_deployment_sweeping_mode` field controls how this data is produced:
+
+```yaml
+features:
+  planner:
+    pre_deployment_sweeping_mode: rapid   # rapid | thorough | none
+    enable_throughput_scaling: true
+```
+
+- **rapid**: Uses AIC simulation to generate interpolation curves (~30s, no GPUs)
+- **thorough**: Deploys the selected engine config on real GPUs and sweeps across ISL/concurrency ranges (2-4h)
+- **none**: Skips interpolation. Only valid when using load-based scaling without throughput-based scaling.
+
+The profiler saves two ConfigMaps into the generated DGD:
+- **planner-config-XXXX**: Serialized `PlannerConfig` JSON (with `profile_results_dir` pointing to the profiling data mount)
+- **planner-profile-data-XXXX**: Prefill and decode interpolation data (JSON)
+
+See the [Planner Guide](../planner/planner-guide.md) for the full `PlannerConfig` reference.
+
+## Mocker
+
+When `features.mocker.enabled: true`, the profiler outputs a mocker DGD that simulates engine behavior without real GPUs. This is useful for testing planner behavior and validating configurations at scale.
+
+Mocker requires pre-deployment sweeping to generate simulated performance profiles — `pre_deployment_sweeping_mode` cannot be `none` when mocker is enabled.
+
+## Gate Checks and Constraints
+
+The profiler enforces these rules at startup:
+
+| Condition | Behavior |
+|-----------|----------|
+| `searchStrategy: thorough` + `backend: auto` | Rejected. Specify a concrete backend. |
+| AIC unsupported + `enable_throughput_scaling: true` | Rejected. Throughput planner requires AIC support. |
+| AIC unsupported + `pre_deployment_sweeping_mode: rapid` | Falls back to `none` with a warning. |
+| `e2eLatency` provided without `ttft: null, itl: null` | Rejected by SLA validator. When using `e2eLatency`, explicitly null out `ttft` and `itl`. |
+| SLA unachievable | Warning logged, SLA updated to best achievable value. |
+| Load-match needs more GPUs than available | Warning logged. |
+
+## Support Matrix
+
+| Backend | Dense Models | MoE Models |
+|---------|-------------|------------|
+| vLLM | ✅ | 🚧 |
+| SGLang | ✅ | ✅ |
+| TensorRT-LLM | ✅ | 🚧 |
+
+The profiler sweeps over the following parallelization mappings for prefill and decode:
+
+| Model Architecture | Prefill Parallelization Mapping | Decode Parallelization Mapping |
+|---------|-------------|------------|
+| MLA+MoE (DeepseekV3ForCausalLM, DeepseekV32ForCausalLM) | TEP, DEP | TEP, DEP |
+| GQA+MoE (Qwen3MoeForCausalLM) | TP, TEP, DEP | TP, TEP, DEP |
+| Other Models | TP | TP |
+
+> [!NOTE]
+> Exact model x parallelization mapping support is dependent on the backend. The profiler does not guarantee that the recommended P/D engine configuration is supported and bug-free by the backend.
+
+## Deployment
+
+### Kubernetes Deployment (DGDR)
+
+The recommended deployment method is through DGDRs. Sample configurations are provided in `components/src/dynamo/profiler/deploy/`:
+
+| Sample | Description |
+|--------|-------------|
+| `profile_sla_dgdr.yaml` | Standard online profiling with AIPerf |
+| `profile_sla_aic_dgdr.yaml` | Fast offline profiling with AI Configurator |
+| `profile_sla_moe_dgdr.yaml` | MoE model profiling (SGLang) |
+
+#### Container Images
+
+Each DGDR requires a container image for profiling and deployment:
+
+- **`image`** (Optional): Container image for the profiling job. Must contain the profiler code and dependencies.
+
+```yaml
+spec:
+  image: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0"
+```
+
+#### Quick Start: Deploy with DGDR
+
+**Step 1: Create Your DGDR**
+
+Use a sample configuration or create your own:
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeploymentRequest
+metadata:
+  name: my-model-profiling
+spec:
+  model: "Qwen/Qwen3-0.6B"
+  backend: vllm
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.0.0"
+```
+
+**Step 2: Apply the DGDR**
+
+```bash
+export NAMESPACE=your-namespace
+kubectl apply -f my-profiling-dgdr.yaml -n $NAMESPACE
+```
+
+**Step 3: Monitor Progress**
+
+```bash
+# View status
+kubectl get dgdr -n $NAMESPACE
+
+# Detailed status
+kubectl describe dgdr my-model-profiling -n $NAMESPACE
+
+# Watch profiling job logs
+kubectl logs -f job/profile-my-model-profiling -n $NAMESPACE
+```
+
+**DGDR Status Phases:**
+- `Pending`: Initial state, preparing to profile
+- `Profiling`: Running profiling job (20-30 seconds for AIC, 2-4 hours for online)
+- `Ready`: Profiling complete, generated DGD spec available in status
+- `Deploying`: Generating and applying DGD configuration
+- `Deployed`: DGD successfully deployed and running
+- `Failed`: Error occurred (check events for details)
+
+**Step 4: Access Your Deployment**
+
+```bash
+# Find the frontend service
+kubectl get svc -n $NAMESPACE | grep frontend
+
+# Port-forward to access locally
+kubectl port-forward svc/<deployment>-frontend 8000:8000 -n $NAMESPACE
+
+# Test the endpoint
+curl http://localhost:8000/v1/models
+```
+
+> [!NOTE]
+> DGDRs are **immutable**. To update SLAs or configuration, delete the existing DGDR and create a new one.
+
+## Profiling Method
+
+The profiler follows a 5-step process:
+
+1. **Hardware Setup**: Uses defaults or user-specified hardware configuration. Optionally, cluster-scoped operators can enable automatic GPU discovery to detect specifications from cluster nodes.
+2. **Identify Sweep Ranges**: Automatically determine minimum and maximum number of GPUs per engine. Minimum is determined by the model size and GPU VRAM. Maximum is set to one node for dense models and 4 nodes for MoE models.
+3. **Parallelization Mapping Sweep**: Test performance of engines with different parallelization mappings using the input ISL and OSL.
+   - For dense models, test different TP sizes for both prefill and decode.
+   - For MoE models (SGLang), evaluate both TEP and DEP as candidates for prefill and decode.
+   - **Prefill**:
+     - TP/TEP: Measure TTFT with batch size = 1 (assuming ISL is long enough to saturate compute) without KV reuse.
+     - DEP: Attention uses data parallelism. Send a single burst with total concurrency `attention_dp_size × attn_dp_num_req_ratio` (defaults to 4) and compute the reported TTFT as `time_to_first_token.max / attn_dp_num_req_ratio` from the AIPerf summary of that burst.
+   ![Prefill Performance](../../../assets/img/h100-prefill-performance.png)
+   - **Decode**: Measure the ITL under different numbers of in-flight requests, from 1 to the maximum the KV cache can hold. To measure ITL without being affected by piggy-backed prefill requests, the script enables KV-reuse and warms up the engine by issuing the same prompts before measuring.
+   ![Decode Performance](../../../assets/img/h100-decode-performance.png)
+4. **Recommendation**: Select optimal parallelization mapping for prefill and decode that achieves the highest per-GPU throughput while adhering to the SLA on TTFT and ITL.
+5. **In-Depth Profiling on the Recommended P/D Engine**: Interpolate TTFT with ISL and ITL with active KV cache and decode context length for more accurate performance estimation.
+![ITL Interpolation](../../../assets/img/pd-interpolation.png)
+   - **Prefill**: Measures TTFT and throughput per GPU across different input lengths with batch size=1.
+   - **Decode**: Measures ITL and throughput per GPU under various KV cache loads and decode context lengths.
+
+### AIPerf on Real Engines
+
+Profiles your model by creating real test deployments in Kubernetes and measuring their performance.
+
+- **Duration**: 2-4 hours
+- **Accuracy**: Highest (real measurements)
+- **GPU Requirements**: Full access to test different parallelization mappings
+- **Backends**: vLLM, SGLang, TensorRT-LLM
+
+AIPerf-based profiling is the default behavior. Use `searchStrategy: thorough` for comprehensive real-engine profiling:
+
+```yaml
+spec:
+  searchStrategy: thorough  # Deep exploration with real engine profiling
+```
+
+### AI Configurator Simulation
+
+Uses performance simulation to rapidly estimate optimal configurations without running real deployments.
+
+- **Duration**: 20-30 seconds
+- **Accuracy**: Estimated (may have errors for unusual configurations)
+- **GPU Requirements**: None
+- **Backends**: TensorRT-LLM only (vLLM/SGLang coming soon)
+
+AI Configurator is used by default with `searchStrategy: rapid`:
+
+```yaml
+spec:
+  searchStrategy: rapid  # Fast profiling with AI Configurator simulation (default)
+```
+
+> [!NOTE]
+> `aicBackendVersion` specifies the TensorRT-LLM version that AI Configurator simulates. See the [AI Configurator supported features](https://github.com/ai-dynamo/aiconfigurator#supported-features) for available versions.
+
+**Currently supports:**
+- **Backends**: TensorRT-LLM (versions 0.20.0, 1.0.0rc3, 1.0.0rc6)
+- **Systems**: H100 SXM, H200 SXM, B200 SXM, GB200 SXM, A100 SXM
+- **Models**: Wide range including GPT, Llama, Mixtral, DeepSeek, Qwen, and more
+
+See [AI Configurator documentation](https://github.com/ai-dynamo/aiconfigurator#supported-features) for the full list.
+
+### Automatic GPU Discovery
+
+The operator automatically discovers GPU resources from cluster nodes, providing hardware info (GPU model, VRAM, GPUs per node) and automatic profiling search space calculation.
+
+**Requirements:**
+- **Cluster-scoped operators**: Have node read permissions by default
+- **Namespace-scoped operators**: GPU discovery is enabled by default when installing via Helm — the chart provisions the required ClusterRole/ClusterRoleBinding automatically
+
+**For namespace-scoped operators**, GPU discovery is controlled by a Helm value:
+
+```bash
+# GPU discovery enabled (default) — Helm provisions read-only node access automatically
+helm install dynamo-platform ... --set dynamo-operator.gpuDiscovery.enabled=true
+
+# GPU discovery disabled — you must provide hardware config manually in each DGDR
+helm install dynamo-platform ... --set dynamo-operator.gpuDiscovery.enabled=false
+```
+
+If GPU discovery is disabled, provide hardware config manually in the DGDR:
+
+```yaml
+spec:
+  hardware:
+    numGpusPerNode: 8
+    gpuSku: "H100-SXM5-80GB"
+    vramMb: 81920
+```
+
+If GPU discovery is disabled and no manual hardware config is provided, the DGDR will be rejected at admission time.
+
+## Configuration
+
+### DGDR Configuration Structure
+
+All profiler configuration is provided through the v1beta1 DGDR spec fields:
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeploymentRequest
+metadata:
+  name: my-deployment
+spec:
+  model: "Qwen/Qwen3-0.6B"
+  backend: vllm
+  image: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0"
+
+  searchStrategy: rapid  # or thorough
+  autoApply: true
+
+  workload: { ... }
+  sla: { ... }
+  hardware: { ... }
+  features: { ... }
+  overrides: { ... }
+```
+
+### SLA Configuration (Optional)
+
+The profiler supports three mutually exclusive SLA modes. If the entire `sla:` section is omitted, the profiler defaults to `optimizationType: throughput`.
+
+#### Mode 1: Optimization Type (Recommended for new users)
+
+When you don't know your exact latency requirements, specify an optimization strategy:
+
+```yaml
+sla:
+  optimizationType: throughput   # or "latency"
+```
+
+- **throughput**: Maximize tokens per second per GPU (highest concurrency, full KV cache)
+- **latency**: Minimize per-token latency (single-stream, lowest concurrency)
+- The profiler automatically determines the parallelization strategy (TP/TEP/DEP) and GPU count based on the model architecture and available VRAM
+- When the planner is enabled, TTFT/ITL targets are estimated from profiling results
+
+#### Mode 2: Explicit TTFT + ITL
+
+Specify exact latency targets for each phase:
+
+```yaml
+sla:
+  ttft: 200.0    # Target Time To First Token (milliseconds)
+  itl: 20.0      # Target Inter-Token Latency (milliseconds)
+```
+
+- **TTFT**: First token latency target (lower = more GPUs needed, affects prefill engine)
+- **ITL**: Token generation latency target (lower = more GPUs needed, affects decode engine)
+- **Trade-offs**: Tighter SLAs require more GPU resources
+
+#### Mode 3: End-to-End Latency
+
+Specify a single request-level latency target:
+
+```yaml
+sla:
+  e2eLatency: 5000.0   # Target end-to-end request latency (milliseconds)
+```
+
+#### Workload Configuration
+
+```yaml
+workload:
+  isl: 3000      # Average input sequence length (tokens)
+  osl: 150       # Average output sequence length (tokens)
+```
+
+- **ISL/OSL**: Based on your expected traffic patterns
+
+### Hardware Configuration (Optional)
+
+```yaml
+hardware:
+  gpuSku: h200_sxm            # GPU SKU identifier (auto-detected)
+  vramMb: 81920               # VRAM per GPU in MiB
+  totalGpus: 16               # Total GPUs available in the cluster
+  numGpusPerNode: 8           # GPUs per node (for multi-node MoE)
+```
+
+- **numGpusPerNode**: Determine the upper bound of GPUs per node for dense models and configure Grove for multi-node MoE engines
+- **gpuSku**: GPU SKU identifier, auto-detected by the controller
+
+> [!TIP]
+> If you don't specify hardware constraints, the controller auto-detects based on your model size and available cluster resources.
+
+### Search Strategy (Optional)
+
+Controls the profiling search depth:
+
+```yaml
+spec:
+  searchStrategy: rapid   # "rapid" (default) for fast sweep; "thorough" for deeper exploration
+```
+
+- **rapid**: Performs a fast sweep over parallelization mappings (default)
+- **thorough**: Explores more configurations for potentially better results
+
+### Planner Configuration (Optional)
+
+Pass arguments to the SLA planner via the features section:
+
+```yaml
+features:
+  planner:
+    planner_min_endpoint: 2                    # Minimum endpoints to maintain
+    planner_adjustment_interval: 60            # Adjustment interval (seconds)
+    planner_load_predictor: linear             # Load prediction method
+```
+
+> [!NOTE]
+> Planner arguments use `planner_` prefix. See [SLA Planner documentation](../planner/planner-guide.md) for full list.
+
+### Model Cache PVC (Advanced)
+
+For large models, use a pre-populated PVC containing model weights instead of downloading from HuggingFace:
+
+```yaml
+modelCache:
+  pvcName: "model-cache"
+  pvcModelPath: "hub/models--deepseek-ai--DeepSeek-R1"
+  pvcMountPath: "/opt/model-cache"
+```
+
+Requirements:
+- The PVC must exist in the same namespace as the DGDR
+- The model weights must be accessible at `{mountPath}/{pvcPath}`
+
+### Engine Configuration (Auto-configured)
+
+The controller automatically handles model and backend configuration from high-level fields:
+
+```yaml
+# You specify:
+spec:
+  model: "Qwen/Qwen3-0.6B"
+  backend: vllm
+
+# Controller auto-injects into the profiling job
+```
+
+You should **not** manually set model or backend in profiling config overrides.
+
+### Using Existing DGD Configs
+
+Provide a base DGD config via the overrides section:
+
+```yaml
+overrides:
+  dgd:
+    apiVersion: nvidia.com/v1alpha1
+    kind: DynamoGraphDeployment
+    metadata:
+      name: my-dgd
+    spec:
+      # ... your base DGD spec
+```
+
+The profiler uses the DGD config as a **base template**, then optimizes it based on your SLA targets.
+
+## Integration
+
+### With SLA Planner
+
+The Profiler generates interpolation data that the SLA Planner uses for autoscaling decisions.
+
+**Prefill Interpolation** (`selected_prefill_interpolation/raw_data.npz`):
+- `prefill_isl`: 1D array of input sequence lengths tested
+- `prefill_ttft`: 1D array of TTFTs (ms) at each ISL
+- `prefill_thpt_per_gpu`: 1D array of throughput (tokens/s/GPU) at each ISL
+
+**Decode Interpolation** (`selected_decode_interpolation/raw_data.npz`):
+- `max_kv_tokens`: Total KV tokens capacity in decode engine
+- `x_kv_usage`: 1D array of active KV usage percentages [0, 1]
+- `y_context_length`: 1D array of average context lengths tested
+- `z_itl`: 1D array of ITLs (ms) at each (KV usage, context length) point
+- `z_thpt_per_gpu`: 1D array of throughput (tokens/s/GPU) at each point
+
+### With Dynamo Operator
+
+When using DGDR, the Dynamo Operator:
+
+1. Creates profiling jobs automatically
+2. Stores profiling data in ConfigMaps (`planner-profile-data`)
+3. Generates optimized DGD configurations
+4. Deploys the DGD with SLA Planner integration
+
+The generated DGD is tracked via labels:
+```yaml
+metadata:
+  labels:
+    dgdr.nvidia.com/name: my-deployment
+    dgdr.nvidia.com/namespace: your-namespace
+```
+
+### With Observability
+
+Monitor profiling jobs:
+
+```bash
+kubectl logs -f job/profile-<dgdr-name> -n $NAMESPACE
+kubectl describe dgdr <name> -n $NAMESPACE
+```
+
+## Advanced Topics
+
+### Manual Deployment Control
+
+Disable auto-deployment to review the generated DGD before applying:
+
+```yaml
+spec:
+  autoApply: false
+```
+
+Then manually extract and apply:
+
+```bash
+# Extract generated DGD from DGDR status
+kubectl get dgdr my-deployment -n $NAMESPACE -o jsonpath='{.status.profilingResults.selectedConfig}' | kubectl apply -f -
+
+# Or save to file for review
+kubectl get dgdr my-deployment -n $NAMESPACE -o jsonpath='{.status.profilingResults.selectedConfig}' > my-dgd.yaml
+```
+
+### Mocker Deployment
+
+Deploy a mocker deployment that simulates engines without GPUs:
+
+```yaml
+spec:
+  model: <model-name>
+  backend: trtllm
+  features:
+    mocker:
+      enabled: true    # Deploy mocker instead of real backend
+  autoApply: true
+```
+
+Profiling still runs against the real backend to collect performance data. The mocker uses this data to simulate realistic timing behavior. Useful for large-scale experiments, testing Planner behavior, and validating configurations.
+
+### Accessing Profiling Artifacts
+
+By default, profiling data is stored in ConfigMaps. For detailed artifacts (plots, logs, raw data), attach a PVC via overrides:
+
+```yaml
+overrides:
+  profilingJob:
+    template:
+      spec:
+        volumes:
+        - name: profiling-output
+          persistentVolumeClaim:
+            claimName: "dynamo-pvc"
+```
+
+**ConfigMaps (always created):**
+- `dgdr-output-<name>`: Generated DGD configuration
+- `planner-profile-data`: Profiling data for Planner (JSON)
+
+**PVC artifacts (optional):**
+- Performance plots (PNGs)
+- DGD configurations for each profiled deployment
+- AIPerf profiling artifacts
+- Raw profiling data (`.npz` files)
+- Profiler logs
+
+Access PVC results:
+```bash
+kubectl apply -f deploy/utils/manifests/pvc-access-pod.yaml -n $NAMESPACE
+kubectl wait --for=condition=Ready pod/pvc-access-pod -n $NAMESPACE --timeout=60s
+kubectl cp $NAMESPACE/pvc-access-pod:/data ./profiling-results
+kubectl delete pod pvc-access-pod -n $NAMESPACE
+```
+
+### Output Performance Plots
+
+The profiler generates plots to visualize performance data:
+
+**Parallelization Mapping Sweep Plots:**
+- `prefill_performance.png`: TTFT vs Parallelization Mapping size
+- `decode_performance.png`: ITL vs Parallelization Mapping size and in-flight requests
+
+**In-Depth Profiling Plots:**
+- `selected_prefill_interpolation/prefill_ttft_interpolation.png`: TTFT vs ISL
+- `selected_prefill_interpolation/prefill_throughput_interpolation.png`: Throughput vs ISL
+- `selected_decode_interpolation/decode_itl_interplation.png`: ITL vs KV usage and context length
+- `selected_decode_interpolation/decode_throughput_interpolation.png`: Throughput vs KV usage and context length
+
+## Runtime Profiling (SGLang)
+
+SGLang workers expose profiling endpoints for runtime performance analysis:
+
+```bash
+# Start profiling
+curl -X POST http://localhost:9090/engine/start_profile \
+  -H "Content-Type: application/json" \
+  -d '{"output_dir": "/tmp/profiler_output"}'
+
+# Run inference requests...
+
+# Stop profiling
+curl -X POST http://localhost:9090/engine/stop_profile
+```
+
+View traces using Chrome's `chrome://tracing`, [Perfetto UI](https://ui.perfetto.dev/), or TensorBoard.
+
+## Troubleshooting
+
+### SLA Cannot Be Met
+
+The profiler logs a warning and updates the SLA to the best achievable value. To improve results:
+- Relax SLA targets (increase TTFT/ITL)
+- Add more GPU resources
+- Try a different backend
+- Use a smaller or quantized model
+
+### Profiling Takes Too Long
+
+- Use `searchStrategy: rapid` for ~30s profiling
+- Reduce interpolation granularity
+- Reduce the GPU search space via hardware constraints
+
+### Out of Memory During Profiling
+
+- Reduce `max_batch_size` in engine config
+- Skip larger TP configurations by constraining hardware
+- Use a quantized model variant
+
+### Image Pull Errors
+
+Ensure image pull secrets are configured in your namespace for the container registry.
+
+## See Also
+
+- [Profiler README](README.md) — Quick overview and feature matrix
+- [Profiler Examples](profiler-examples.md) — Complete DGDR YAML examples
+- [Planner Guide](../planner/planner-guide.md) — PlannerConfig reference and scaling modes
+- [DGDR API Reference](../../kubernetes/api-reference.md) — Full DGDR specification


### PR DESCRIPTION
## feat: Make SLAs optional with dynamic default presets (`optimizationType`)

Closes #6134

Adds a new `optimizationType` field (`throughput` | `latency`) to the DGDR SLA spec, allowing users to specify an optimization objective instead of explicit TTFT/ITL targets. When no SLA is provided at all, the system defaults to `optimizationType=throughput`.

### Motivation

Previously, omitting SLA targets caused the operator to inject static defaults (TTFT=2000ms, ITL=30ms), which don't generalize across model sizes and hardware. With this change, users can simply say "optimize for throughput" and the profiler automatically selects the right parallelization strategy (TP for dense, TEP for MoE, DEP for MLA+MoE like DeepSeek-V3) and picks the best configuration from profiling results without SLA filtering.

### Flow Diagram

```mermaid
flowchart TD
    subgraph USER ["1. User Input (DGDR)"]
        A["User submits DGDR<br/>spec.sla.optimizationType = throughput"]
    end

    subgraph GO_OP ["2. Go Operator (sla_defaults.go)"]
        B{"sla field<br/>provided?"}
        B -- "Yes + has any field set<br/>(optimizationType, ttft,<br/>itl, or e2eLatency)" --> C["Preserve user values as-is"]
        B -- "No (nil) or empty struct<br/>(all fields unset)" --> D["Default to<br/>optimizationType = throughput"]
    end

    subgraph VALIDATE ["3. Python Validation (dgdr_validate.py)"]
        E{"Which SLA mode?"}
        E -- optimizationType set --> F["Clear ttft/itl from spec<br/>Mode: optimization-type"]
        E -- ttft+itl set --> G["Use explicit values<br/>Mode: explicit SLA"]
        E -- e2eLatency set --> H["Clear ttft/itl<br/>Mode: e2e latency"]
        E -- nothing set --> I["Default to<br/>optimizationType=throughput"]
    end

    subgraph PARALLELIZATION ["4. Resolve Parallelization (optimization_type.py)"]
        J["resolve_optimization_type_config()"]
        J --> K{"Model<br/>architecture?"}
        K -- Dense --> L["TP = num_gpus<br/>(e.g. TP=4)"]
        K -- "MLA + MoE +<br/>throughput<br/>(DeepSeek-V3)" --> M["DEP = num_gpus<br/>(e.g. DEP=8)"]
        K -- "Other MoE<br/>(Qwen3Moe,<br/>MLA+latency)" --> N["TEP = num_gpus<br/>(e.g. TEP=8)"]

        O["GPU count:<br/>model_weight × 1.5 / VRAM<br/>→ round to power of 2"]
        J --> O
    end

    subgraph AIC_SIM ["5. AIC Simulation (_run_optimization_type_sim)"]
        P["build_default_task_configs()<br/>Creates experiment configs:<br/>agg, disagg_1, disagg_2, ..."]
        P --> Q["Restrict parallelization to resolved mapping<br/>e.g. tp_list=[1], moe_ep_list=[8]"]
        Q --> R["_execute_task_configs()<br/>AIC Performance Simulator"]
        R --> R1["For each config, AIC simulates:<br/>• GPU memory usage<br/>• Prefill/decode compute<br/>• Batching effects<br/>• Network overhead"]
        R1 --> R2["Output: DataFrame per experiment<br/>Columns: tp, dp, moe_ep, tpot,<br/>ttft, tokens/s/gpu, ..."]
    end

    subgraph PICKING ["6. Optimization-Type Picking"]
        S{"optimizationType?"}
        S -- throughput --> T["Sort by tokens/s/gpu DESC<br/>Pick HIGHEST throughput"]
        S -- latency --> U["Sort by tpot ASC<br/>Pick LOWEST latency"]
        T --> V["best_config_df = top 1 row"]
        U --> V
    end

    subgraph OUTPUT ["7. Output Generation"]
        V --> W["_generate_dgd_from_pick()<br/>AIC generator → DGD YAML"]
        V --> X["Extract best_latencies:<br/>ttft, tpot, request_latency"]
        W --> Y["DGD YAML (K8s deployment spec)"]
        X --> Z["_build_planner_config()<br/>Sets planner ttft/itl from estimates"]
        Z --> AA["PlannerConfig JSON (ConfigMap)"]
        Y --> BB["assemble_final_config()"]
        AA --> BB
        BB --> CC["Final Output:<br/>PlannerConfig ConfigMap + DGD YAML"]
    end

    A --> B
    C --> E
    D --> E
    F --> J
    I --> J
    L --> P
    M --> P
    N --> P
    R2 --> S

    style USER fill:#e1f5fe,stroke:#0288d1
    style GO_OP fill:#fff3e0,stroke:#f57c00
    style VALIDATE fill:#f3e5f5,stroke:#7b1fa2
    style PARALLELIZATION fill:#e8f5e9,stroke:#388e3c
    style AIC_SIM fill:#fce4ec,stroke:#c62828
    style PICKING fill:#fff9c4,stroke:#f9a825
    style OUTPUT fill:#e0f2f1,stroke:#00796b
```

### Changes

#### Go Operator (`deploy/operator/`)
- Added `OptimizationType` field to `SLASpec` CRD type
- New `applySLADefaults()` in controller: nil/empty SLA → `optimizationType=throughput` (no more static 2000/30 injection)
- 7 unit tests covering all SLA defaulting scenarios

#### Python Profiler (`components/src/dynamo/profiler/`)
- `dgdr_v1beta1_types.py`: `OptimizationType` enum, `SLASpec` TTFT/ITL defaults changed to `None`
- `dgdr_validate.py`: Empty SLA → `optimizationType=throughput`
- `optimization_type.py` (new): `OptimizationTypeConfig` + `resolve_optimization_type_config()` — determines TP/TEP/DEP, concurrency, and min GPU count from model architecture + VRAM
- `model_info.py` (new): MoE/MLA architecture detection, `calculate_min_gpus_for_model()`, default parallelization helpers
- `rapid.py`: New `_pick_by_optimization_type()`, `_run_optimization_type_sim()`, updated naive fallback with VRAM-based GPU count
- `thorough.py`: Filters enumerated candidates to target parallelization when `optimizationType` is active
- `dgd_generation.py`: `_build_planner_config()` populates TTFT/ITL from profiling estimates (2000/30 as operational defaults for naive fallback)
- `profile_sla.py`: `_extract_profiler_params()` uses `float("inf")` sentinels for optimization-type mode

#### Documentation
- Updated `docs/pages/components/profiler/profiler-guide.md` and `README.md`

#### Tests
- `tests/profiler/test_helpers_profile_sla.py`: Comprehensive profiler unit tests
- `deploy/operator/internal/controller/sla_defaults_test.go`: 7 Go tests

### Usage

**Simplest form** (empty SLA → throughput optimization):

```yaml
apiVersion: dynamo.nvidia.com/v1beta1
kind: DynamoGraphDeploymentRequest
metadata:
  name: my-deployment
spec:
  model: meta-llama/Llama-3.1-70B
  # No SLA block — defaults to optimizationType: throughput
```

**Explicit optimization type:**

```yaml
spec:
  model: meta-llama/Llama-3.1-70B
  sla:
    optimizationType: latency
```

**Traditional explicit targets** (still supported):

```yaml
spec:
  model: meta-llama/Llama-3.1-70B
  sla:
    ttft: 2000
    itl: 30
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `optimizationType` SLA mode allowing users to specify "latency" or "throughput" optimization strategy as an alternative to explicit SLA targets.
  * Enabled automatic GPU hardware discovery for deployment requests with optional VRAM-based GPU configuration calculation.
  * Enhanced profiler optimization selection to automatically choose configuration based on specified optimization type.

* **Documentation**
  * Added comprehensive Profiler guide and quick-start documentation with example workflows and configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->