### PR TITLE
fix: Request Rejection busy signal passage

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -502,8 +502,18 @@ impl ModelWatcher {
             // monitor (1-to-1) since each monitor is scoped to this WorkerSet's Client/namespace.
             // The monitor tracks Prometheus metrics (active_decode_blocks, active_prefill_tokens,
             // worker TTFT/ITL cleanup). The thresholds control busy detection behavior only.
+            //
+            // IMPORTANT: When KV routing is active, the monitor must use the KvRouter's Client
+            // so that busy-state updates (via update_free_instances) are visible to the
+            // PushRouter, which also uses the KvRouter's Client (see common.rs:258-263).
+            // Using a different Client instance would cause the PushRouter to never see
+            // busy workers, since each Client::new() creates independent ArcSwap state.
+            let monitor_client = kv_chooser
+                .as_ref()
+                .map(|chooser| chooser.client().clone())
+                .unwrap_or_else(|| client.clone());
             let worker_monitor = Some(KvWorkerMonitor::new(
-                client.clone(),
+                monitor_client,
                 self.router_config.load_threshold_config.clone(),
             ));
 

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -681,7 +681,7 @@ def _test_router_overload_503(
                     )
 
                 # Wait briefly to ensure requests are in-flight
-                await asyncio.sleep(0.2)
+                await asyncio.sleep(0.8)
 
                 # Now send one more request that should get 503
                 logger.info("Sending additional request that should receive 503...")
@@ -691,10 +691,10 @@ def _test_router_overload_503(
                         if status_code == 503:
                             body = await response.json()
                             logger.info(f"Got expected 503 response: {body}")
-                            assert "Service temporarily unavailable" in body.get(
-                                "error", ""
-                            ) or "All workers are busy" in body.get(
-                                "error", ""
+                            error_msg = body.get("message", "")
+                            assert (
+                                "Service temporarily unavailable" in error_msg
+                                or "All workers are busy" in error_msg
                             ), f"Expected service overload error message, got: {body}"
                             return True
                         else:

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -762,7 +762,6 @@ def test_mocker_two_kv_router(
         )
 
 
-@pytest.mark.skip(reason="Flaky, temporarily disabled")
 @pytest.mark.parametrize(
     "durable_kv_events", [False], ids=["nondurable"], indirect=True
 )  # Use NATS Core (local indexer)


### PR DESCRIPTION
#### Overview:

PushRouter need to use the same Client as the KvRouter / monitor, otherwise, any rejection decision won't be visible to the PushRouter that actually performs rejections.

#### Details:

* Request Rejection
    * Fix PushRouter Client instance
* Test case
    * Fix 503 error message parsing - returned JSON object changed from "error" to "message"
    * Increase wait to ensure verification request is sent while busy requests are in-flight.

Test:
```
$ pytest router/test_router_e2e_with_mockers.py::test_mocker_kv_router_overload_503 -v -s
...
[PYTHON3] 2026-03-24T23:16:02.384443Z  INFO dynamo_llm::discovery::watcher: added model model_name="Qwen/Qwen3-0.6B" namespace="test-namespace-qwkokcubca"
[PYTHON3] 2026-03-24T23:16:04.134526Z  INFO dynamo_kv_router::scheduling::selector: Selected worker: worker_type=decode, worker_id=1823849144036495877 dp_rank=0, logit: 66.750
[PYTHON3] 2026-03-24T23:16:04.177432Z  INFO dynamo_kv_router::scheduling::selector: Selected worker: worker_type=decode, worker_id=1823849144036495877 dp_rank=0, logit: 33.750
[TEST] 2026-03-24T23:16:04 INFO tests.router.helper: Completed all requests: 1 successful, 0 failed
[TEST] 2026-03-24T23:16:04 INFO tests.router.helper: All 1 requests completed successfully
[TEST] 2026-03-24T23:16:04 INFO tests.router.common: Sending 50 concurrent requests to exhaust resources...
[PYTHON3] 2026-03-24T23:16:04.225091Z  INFO dynamo_kv_router::scheduling::selector: Selected worker: worker_type=decode, worker_id=1823849144036495877 dp_rank=0, logit: 66.750
...
[PYTHON3] 2026-03-24T23:16:04.226857Z  INFO dynamo_kv_router::scheduling::selector: Selected worker: worker_type=decode, worker_id=1823849144036495877 dp_rank=0, logit: 1410.000
[PYTHON3] 2026-03-24T23:16:04.226850Z  WARN http-request:kv_router.route_request: dynamo_runtime::pipeline::network::egress::push_router: Rejecting request: all workers are busy instance_id=1823849144036495877 total_workers=1 method=POST uri=/v1/chat/completions version=HTTP/1.1 request_id=18fc543b-4df9-4e6f-9662-a11f6e745783 worker_id=1823849144036495877 dp_rank=0 overlap_blocks=0 phase=Aggregated
[PYTHON3] 2026-03-24T23:16:04.226913Z  INFO dynamo_kv_router::scheduling::selector: Selected worker: worker_type=decode, worker_id=1823849144036495877 dp_rank=0, logit: 1478.000
[TEST] 2026-03-24T23:16:04 INFO tests.router.common: Request 20 got status 503
[TEST] 2026-03-24T23:16:04 INFO tests.router.common: Request 48 got status 503
[TEST] 2026-03-24T23:16:04 INFO tests.router.common: Request 22 got status 503
[TEST] 2026-03-24T23:16:04 INFO tests.router.common: Request 8 got status 503
[PYTHON3] 2026-03-24T23:16:04.226904Z  WARN http-request:kv_router.route_request: dynamo_runtime::pipeline::network::egress::push_router: Rejecting request: all workers are busy instance_id=1823849144036495877 total_workers=1 method=POST uri=/v1/chat/completions version=HTTP/1.1 request_id=6768b036-41b1-4dc7-87ed-b6022b003e10 worker_id=1823849144036495877 dp_rank=0 overlap_blocks=0 phase=Aggregated
...
[TEST] 2026-03-24T23:16:05 INFO tests.router.common: Sending additional request that should receive 503...
...
[TEST] 2026-03-24T23:16:05 INFO tests.router.common: Got expected 503 response: {'message': 'Service temporarily unavailable: All workers are busy, please retry later', 'type': 'Service Unavailable', 'code': 503}
...
[TEST] 2026-03-24T23:16:05 INFO tests.router.common: Successfully verified 503 response when all workers are busy
...
...=== 1 passed in 12.58s ===...
```

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes DIS-1620


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed KV router monitoring to properly use the KV router's client for busy-state detection when KV routing is active, instead of defaulting to the primary client.

* **Tests**
  * Re-enabled KV router overload handling test suite.
  * Improved test timing to reliably establish request state.
  * Enhanced error message validation for service unavailability responses during overload conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->