### PR TITLE
fix: #6291 add reset_prefix_cache route to frontend HTTP service

### DIFF
--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -31,6 +31,7 @@ pub mod health;
 pub mod metrics;
 pub mod openapi_docs;
 pub mod realtime;
+pub mod reset_prefix_cache;
 pub mod service_v2;
 
 pub use axum;

--- a/lib/llm/src/http/service/reset_prefix_cache.rs
+++ b/lib/llm/src/http/service/reset_prefix_cache.rs
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP endpoint for flushing the KV prefix cache across all workers.
+//!
+//! Operators occasionally need to drop the reused KV prefix cache on every
+//! worker (for example after swapping weights or between benchmark runs). Each
+//! worker already exposes a `clear_kv_blocks` control endpoint; this route fans
+//! that control out from the frontend so a single request reaches every
+//! discovered worker group.
+//!
+//! ## Endpoint
+//!
+//! ### POST /reset_prefix_cache
+//!
+//! Broadcasts the `clear_kv_blocks` control to every registered worker instance
+//! and reports, per instance, whether the flush succeeded.
+//!
+//! ```json
+//! // Response
+//! {
+//!   "cleared_workers": [
+//!     {"name": "dynamo/backend-instance-123", "endpoint": "dynamo/backend/clear_kv_blocks", "status": "Successfully cleared kv blocks for instance", "response": "{}"}
+//!   ],
+//!   "failed_workers": []
+//! }
+//! ```
+//!
+//! This route is part of the frontend admin API and is only registered when the
+//! admin API is enabled (see `DYN_DISABLE_FRONTEND_ADMIN_API`) and a
+//! [`DistributedRuntime`] is available to issue worker RPCs.
+
+use super::{RouteDoc, service_v2};
+use axum::{Json, Router, extract::State, http::Method, response::IntoResponse, routing::post};
+use serde_json::json;
+use std::sync::Arc;
+
+use dynamo_runtime::{
+    DistributedRuntime, discovery::DiscoveryInstance, discovery::DiscoveryQuery,
+    pipeline::PushRouter, protocols::annotated::Annotated, stream::StreamExt,
+};
+
+/// Worker-side control endpoint that flushes the KV block / prefix cache.
+pub const CLEAR_KV_ENDPOINT: &str = "clear_kv_blocks";
+
+/// Combined router state: the HTTP service state (for discovery) plus the
+/// distributed runtime used to issue RPCs to workers.
+#[derive(Clone)]
+struct ResetPrefixCacheState {
+    service: Arc<service_v2::State>,
+    drt: Option<Arc<DistributedRuntime>>,
+}
+
+/// Build the `/reset_prefix_cache` admin route.
+///
+/// `drt` is the runtime used to reach worker components; when `None` the route
+/// still registers but returns a clear "runtime not available" message so the
+/// endpoint's absence is never silently a 404.
+pub fn reset_prefix_cache_router(
+    service: Arc<service_v2::State>,
+    drt: Option<Arc<DistributedRuntime>>,
+    path: Option<String>,
+) -> (Vec<RouteDoc>, Router) {
+    let path = path.unwrap_or_else(|| "/reset_prefix_cache".to_string());
+
+    let docs: Vec<RouteDoc> = vec![RouteDoc::new(Method::POST, &path)];
+
+    let router = Router::new()
+        .route(&path, post(reset_prefix_cache_handler))
+        .with_state(ResetPrefixCacheState { service, drt });
+
+    (docs, router)
+}
+
+async fn reset_prefix_cache_handler(
+    State(state): State<ResetPrefixCacheState>,
+) -> impl IntoResponse {
+    let Some(drt) = state.drt.as_ref() else {
+        return Json(json!({
+            "message": "Distributed runtime not available"
+        }));
+    };
+
+    // Discover all registered clear_kv_blocks endpoint instances.
+    let all_instances = match state
+        .service
+        .discovery()
+        .list(DiscoveryQuery::AllEndpoints)
+        .await
+    {
+        Ok(instances) => instances,
+        Err(e) => {
+            return Json(json!({
+                "message": format!("Failed to list endpoints: {e}")
+            }));
+        }
+    };
+
+    // Collect the unique namespace/component pairs that expose clear_kv_blocks.
+    let mut worker_groups: Vec<(String, String)> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for instance in &all_instances {
+        if let DiscoveryInstance::Endpoint(inst) = instance
+            && inst.endpoint == CLEAR_KV_ENDPOINT
+        {
+            let key = (inst.namespace.clone(), inst.component.clone());
+            if seen.insert(key.clone()) {
+                worker_groups.push(key);
+            }
+        }
+    }
+
+    if worker_groups.is_empty() {
+        return Json(json!({
+            "message": "No active worker groups found"
+        }));
+    }
+
+    let mut cleared_workers = Vec::new();
+    let mut failed_workers = Vec::new();
+
+    for (namespace, component) in &worker_groups {
+        tracing::debug!("Processing worker group: {}/{}", namespace, component);
+
+        let endpoint_label = format!("{namespace}/{component}/{CLEAR_KV_ENDPOINT}");
+
+        let component_obj = match drt
+            .namespace(namespace)
+            .and_then(|ns| ns.component(component))
+        {
+            Ok(comp) => comp,
+            Err(e) => {
+                failed_workers.push(json!({
+                    "name": format!("{namespace}/{component}"),
+                    "endpoint": endpoint_label,
+                    "status": "Failed to resolve worker component",
+                    "error": e.to_string(),
+                }));
+                continue;
+            }
+        };
+
+        let endpoint = component_obj.endpoint(CLEAR_KV_ENDPOINT);
+
+        let client = match endpoint.client().await {
+            Ok(c) => c,
+            Err(e) => {
+                failed_workers.push(json!({
+                    "name": format!("{namespace}/{component}"),
+                    "endpoint": endpoint_label,
+                    "status": "Failed to get client",
+                    "error": e.to_string(),
+                }));
+                continue;
+            }
+        };
+
+        let router = match PushRouter::<(), Annotated<serde_json::Value>>::from_client(
+            client,
+            Default::default(),
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                failed_workers.push(json!({
+                    "name": format!("{namespace}/{component}"),
+                    "endpoint": endpoint_label,
+                    "status": "Failed to create router",
+                    "error": e.to_string(),
+                }));
+                continue;
+            }
+        };
+
+        let discovery_key = DiscoveryQuery::Endpoint {
+            namespace: namespace.clone(),
+            component: component.clone(),
+            endpoint: CLEAR_KV_ENDPOINT.to_string(),
+        };
+
+        let discovery_instances = match state.service.discovery().list(discovery_key).await {
+            Ok(instances) => instances,
+            Err(e) => {
+                failed_workers.push(json!({
+                    "name": format!("{namespace}/{component}"),
+                    "endpoint": endpoint_label,
+                    "status": "Failed to get instances for worker group",
+                    "error": e.to_string(),
+                }));
+                continue;
+            }
+        };
+
+        let instances_filtered: Vec<dynamo_runtime::component::Instance> = discovery_instances
+            .into_iter()
+            .filter_map(|di| match di {
+                DiscoveryInstance::Endpoint(instance) => Some(instance),
+                _ => None,
+            })
+            .collect();
+
+        if instances_filtered.is_empty() {
+            failed_workers.push(json!({
+                "name": format!("{namespace}/{component}"),
+                "endpoint": endpoint_label,
+                "status": "No instances found for clear_kv_blocks endpoint",
+            }));
+            continue;
+        }
+
+        for instance in &instances_filtered {
+            let instance_name = format!("{namespace}/{component}-instance-{}", instance.id());
+            match router.direct(().into(), instance.id()).await {
+                Ok(mut stream) => match stream.next().await {
+                    Some(response) => {
+                        let response_str = response
+                            .data
+                            .as_ref()
+                            .map(|d| d.to_string())
+                            .unwrap_or_default();
+                        cleared_workers.push(json!({
+                            "name": instance_name,
+                            "endpoint": endpoint_label,
+                            "status": "Successfully cleared kv blocks for instance",
+                            "response": response_str,
+                        }));
+                    }
+                    None => {
+                        failed_workers.push(json!({
+                            "name": instance_name,
+                            "endpoint": endpoint_label,
+                            "status": "No response from instance",
+                        }));
+                    }
+                },
+                Err(e) => {
+                    failed_workers.push(json!({
+                        "name": instance_name,
+                        "endpoint": endpoint_label,
+                        "status": "Failed to send request for instance",
+                        "error": e.to_string(),
+                    }));
+                }
+            }
+        }
+    }
+
+    Json(json!({
+        "cleared_workers": cleared_workers,
+        "failed_workers": failed_workers
+    }))
+}

--- a/lib/llm/src/http/service/reset_prefix_cache.rs
+++ b/lib/llm/src/http/service/reset_prefix_cache.rs
@@ -1,39 +1,56 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! HTTP endpoint for flushing the KV prefix cache across all workers.
+//! HTTP endpoint for flushing the KV prefix cache across workers.
 //!
-//! Operators occasionally need to drop the reused KV prefix cache on every
-//! worker (for example after swapping weights or between benchmark runs). Each
-//! worker already exposes a `clear_kv_blocks` control endpoint; this route fans
-//! that control out from the frontend so a single request reaches every
-//! discovered worker group.
+//! Operators occasionally need to drop the reused KV prefix cache on workers
+//! (for example after swapping weights or between benchmark runs). Each worker
+//! already exposes a `clear_kv_blocks` control endpoint; this route fans that
+//! control out from the frontend so a single request reaches every discovered
+//! worker instance.
 //!
 //! ## Endpoint
 //!
 //! ### POST /reset_prefix_cache
 //!
-//! Broadcasts the `clear_kv_blocks` control to every registered worker instance
-//! and reports, per instance, whether the flush succeeded.
+//! Broadcasts the `clear_kv_blocks` control to registered worker instances and
+//! reports, per instance, whether the flush succeeded.
+//!
+//! An optional JSON body scopes the flush to a single namespace:
 //!
 //! ```json
+//! // Request (optional) — omit the body to flush every discovered namespace
+//! {"namespace": "my-namespace"}
+//!
 //! // Response
 //! {
 //!   "cleared_workers": [
-//!     {"name": "dynamo/backend-instance-123", "endpoint": "dynamo/backend/clear_kv_blocks", "status": "Successfully cleared kv blocks for instance", "response": "{}"}
+//!     {"name": "dynamo/backend-instance-123", "endpoint": "dynamo/backend/clear_kv_blocks", "status": "Successfully cleared kv blocks for instance"}
 //!   ],
 //!   "failed_workers": []
 //! }
 //! ```
 //!
+//! In a shared discovery backend (one etcd serving several namespaces) an
+//! unscoped request flushes every namespace it can see; pass `namespace` to
+//! restrict the blast radius to a single tenant.
+//!
 //! This route is part of the frontend admin API and is only registered when the
-//! admin API is enabled (see `DYN_DISABLE_FRONTEND_ADMIN_API`) and a
-//! [`DistributedRuntime`] is available to issue worker RPCs.
+//! admin API is enabled (see `DYN_DISABLE_FRONTEND_ADMIN_API`).
 
 use super::{RouteDoc, service_v2};
-use axum::{Json, Router, extract::State, http::Method, response::IntoResponse, routing::post};
+use axum::{
+    Json, Router,
+    extract::State,
+    http::{Method, StatusCode},
+    response::IntoResponse,
+    routing::post,
+};
+use serde::Deserialize;
 use serde_json::json;
+use std::collections::HashMap;
 use std::sync::Arc;
+use tokio::sync::Mutex;
 
 use dynamo_runtime::{
     DistributedRuntime, discovery::DiscoveryInstance, discovery::DiscoveryQuery,
@@ -43,19 +60,39 @@ use dynamo_runtime::{
 /// Worker-side control endpoint that flushes the KV block / prefix cache.
 pub const CLEAR_KV_ENDPOINT: &str = "clear_kv_blocks";
 
-/// Combined router state: the HTTP service state (for discovery) plus the
-/// distributed runtime used to issue RPCs to workers.
+type ClearKvRouter = PushRouter<(), Annotated<serde_json::Value>>;
+
+/// Cache of PushRouters keyed by `(namespace, component)`.
+///
+/// Building a router calls `endpoint.client()`, which spawns a background
+/// monitor task bound to the runtime's cancellation token. Without caching, a
+/// fresh task would leak on every request; memoizing bounds the tasks to the
+/// number of worker groups.
+type RouterCache = Arc<Mutex<HashMap<(String, String), Arc<ClearKvRouter>>>>;
+
+/// Combined router state: the HTTP service state (for discovery), the
+/// distributed runtime used to issue RPCs to workers, and a cache of per-group
+/// routers.
 #[derive(Clone)]
 struct ResetPrefixCacheState {
     service: Arc<service_v2::State>,
     drt: Option<Arc<DistributedRuntime>>,
+    router_cache: RouterCache,
+}
+
+/// Optional request body used to scope the flush.
+#[derive(Debug, Default, Deserialize)]
+struct ResetPrefixCacheRequest {
+    /// When set, only worker groups in this namespace are flushed.
+    #[serde(default)]
+    namespace: Option<String>,
 }
 
 /// Build the `/reset_prefix_cache` admin route.
 ///
 /// `drt` is the runtime used to reach worker components; when `None` the route
-/// still registers but returns a clear "runtime not available" message so the
-/// endpoint's absence is never silently a 404.
+/// still registers but returns `503 Service Unavailable` so the endpoint's
+/// absence is never silently a `404`.
 pub fn reset_prefix_cache_router(
     service: Arc<service_v2::State>,
     drt: Option<Arc<DistributedRuntime>>,
@@ -65,20 +102,60 @@ pub fn reset_prefix_cache_router(
 
     let docs: Vec<RouteDoc> = vec![RouteDoc::new(Method::POST, &path)];
 
+    let state = ResetPrefixCacheState {
+        service,
+        drt,
+        router_cache: Arc::new(Mutex::new(HashMap::new())),
+    };
+
     let router = Router::new()
         .route(&path, post(reset_prefix_cache_handler))
-        .with_state(ResetPrefixCacheState { service, drt });
+        .with_state(state);
 
     (docs, router)
 }
 
+/// Return a cached PushRouter for `(namespace, component)`, creating and caching
+/// one on first use so the underlying client monitor task is not re-spawned per
+/// request.
+async fn get_or_create_router(
+    state: &ResetPrefixCacheState,
+    drt: &DistributedRuntime,
+    namespace: &str,
+    component: &str,
+) -> anyhow::Result<Arc<ClearKvRouter>> {
+    let key = (namespace.to_string(), component.to_string());
+
+    {
+        let cache = state.router_cache.lock().await;
+        if let Some(router) = cache.get(&key) {
+            return Ok(router.clone());
+        }
+    }
+
+    let component_obj = drt.namespace(namespace)?.component(component)?;
+    let endpoint = component_obj.endpoint(CLEAR_KV_ENDPOINT);
+    let client = endpoint.client().await?;
+    let router = Arc::new(ClearKvRouter::from_client(client, Default::default()).await?);
+
+    let mut cache = state.router_cache.lock().await;
+    // Another request may have inserted while we built ours; prefer the existing
+    // entry so callers share a single router (and monitor task) per group.
+    let router = cache.entry(key).or_insert(router).clone();
+    Ok(router)
+}
+
 async fn reset_prefix_cache_handler(
     State(state): State<ResetPrefixCacheState>,
+    body: Option<Json<ResetPrefixCacheRequest>>,
 ) -> impl IntoResponse {
-    let Some(drt) = state.drt.as_ref() else {
-        return Json(json!({
-            "message": "Distributed runtime not available"
-        }));
+    let filter = body.map(|Json(b)| b).unwrap_or_default();
+
+    let Some(drt) = state.drt.clone() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "message": "Distributed runtime not available" })),
+        );
     };
 
     // Discover all registered clear_kv_blocks endpoint instances.
@@ -90,19 +167,26 @@ async fn reset_prefix_cache_handler(
     {
         Ok(instances) => instances,
         Err(e) => {
-            return Json(json!({
-                "message": format!("Failed to list endpoints: {e}")
-            }));
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "message": format!("Failed to list endpoints: {e}") })),
+            );
         }
     };
 
-    // Collect the unique namespace/component pairs that expose clear_kv_blocks.
+    // Collect the unique namespace/component pairs that expose clear_kv_blocks,
+    // honoring the optional namespace filter.
     let mut worker_groups: Vec<(String, String)> = Vec::new();
     let mut seen = std::collections::HashSet::new();
     for instance in &all_instances {
         if let DiscoveryInstance::Endpoint(inst) = instance
             && inst.endpoint == CLEAR_KV_ENDPOINT
         {
+            if let Some(ns) = filter.namespace.as_deref()
+                && inst.namespace != ns
+            {
+                continue;
+            }
             let key = (inst.namespace.clone(), inst.component.clone());
             if seen.insert(key.clone()) {
                 worker_groups.push(key);
@@ -111,9 +195,11 @@ async fn reset_prefix_cache_handler(
     }
 
     if worker_groups.is_empty() {
-        return Json(json!({
-            "message": "No active worker groups found"
-        }));
+        let message = match filter.namespace.as_deref() {
+            Some(ns) => format!("No active worker groups found in namespace '{ns}'"),
+            None => "No active worker groups found".to_string(),
+        };
+        return (StatusCode::NOT_FOUND, Json(json!({ "message": message })));
     }
 
     let mut cleared_workers = Vec::new();
@@ -124,49 +210,13 @@ async fn reset_prefix_cache_handler(
 
         let endpoint_label = format!("{namespace}/{component}/{CLEAR_KV_ENDPOINT}");
 
-        let component_obj = match drt
-            .namespace(namespace)
-            .and_then(|ns| ns.component(component))
-        {
-            Ok(comp) => comp,
+        let router = match get_or_create_router(&state, &drt, namespace, component).await {
+            Ok(router) => router,
             Err(e) => {
                 failed_workers.push(json!({
                     "name": format!("{namespace}/{component}"),
                     "endpoint": endpoint_label,
-                    "status": "Failed to resolve worker component",
-                    "error": e.to_string(),
-                }));
-                continue;
-            }
-        };
-
-        let endpoint = component_obj.endpoint(CLEAR_KV_ENDPOINT);
-
-        let client = match endpoint.client().await {
-            Ok(c) => c,
-            Err(e) => {
-                failed_workers.push(json!({
-                    "name": format!("{namespace}/{component}"),
-                    "endpoint": endpoint_label,
-                    "status": "Failed to get client",
-                    "error": e.to_string(),
-                }));
-                continue;
-            }
-        };
-
-        let router = match PushRouter::<(), Annotated<serde_json::Value>>::from_client(
-            client,
-            Default::default(),
-        )
-        .await
-        {
-            Ok(r) => r,
-            Err(e) => {
-                failed_workers.push(json!({
-                    "name": format!("{namespace}/{component}"),
-                    "endpoint": endpoint_label,
-                    "status": "Failed to create router",
+                    "status": "Failed to connect to worker group",
                     "error": e.to_string(),
                 }));
                 continue;
@@ -213,6 +263,20 @@ async fn reset_prefix_cache_handler(
             let instance_name = format!("{namespace}/{component}-instance-{}", instance.id());
             match router.direct(().into(), instance.id()).await {
                 Ok(mut stream) => match stream.next().await {
+                    Some(response) if response.is_error() => {
+                        let error = response
+                            .error
+                            .as_ref()
+                            .map(|e| e.to_string())
+                            .or_else(|| response.comment.as_ref().map(|c| c.join(", ")))
+                            .unwrap_or_else(|| "worker reported an error".to_string());
+                        failed_workers.push(json!({
+                            "name": instance_name,
+                            "endpoint": endpoint_label,
+                            "status": "Worker reported an error clearing kv blocks",
+                            "error": error,
+                        }));
+                    }
                     Some(response) => {
                         let response_str = response
                             .data
@@ -246,8 +310,20 @@ async fn reset_prefix_cache_handler(
         }
     }
 
-    Json(json!({
-        "cleared_workers": cleared_workers,
-        "failed_workers": failed_workers
-    }))
+    // Report an error status when nothing could be cleared but failures occurred;
+    // otherwise 200 with the per-instance breakdown (which may include partial
+    // failures in `failed_workers`).
+    let status = if cleared_workers.is_empty() && !failed_workers.is_empty() {
+        StatusCode::INTERNAL_SERVER_ERROR
+    } else {
+        StatusCode::OK
+    };
+
+    (
+        status,
+        Json(json!({
+            "cleared_workers": cleared_workers,
+            "failed_workers": failed_workers,
+        })),
+    )
 }

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -1187,6 +1187,11 @@ impl HttpServiceConfigBuilder {
                 state.clone(),
                 None,
             ));
+            system_routes.push(super::reset_prefix_cache::reset_prefix_cache_router(
+                state.clone(),
+                config.runtime.clone(),
+                None,
+            ));
         } else {
             tracing::info!(
                 env = env_llm::DYN_DISABLE_FRONTEND_ADMIN_API,

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -1613,9 +1613,10 @@ async fn test_classify_and_pooling_validation_errors_are_metered() {
 ///
 /// The admin API is enabled by default, so the route is mounted. Without a
 /// `DistributedRuntime` wired into the service the handler cannot reach workers,
-/// but it must still respond `200 OK` with a clear "runtime not available"
-/// message rather than a `404` — proving the route is wired up rather than
-/// silently missing (the original bug in #6291 was a `404` on this control).
+/// so it responds `503 Service Unavailable` with a clear message — proving the
+/// route is wired up rather than silently missing (the original bug in #6291 was
+/// a `404` on this control) while still signalling the failure via the status
+/// code rather than masking it behind a `200`.
 #[tokio::test]
 async fn test_reset_prefix_cache_route_is_registered() {
     let (listener, port) = bind_random_port().await;
@@ -1638,12 +1639,12 @@ async fn test_reset_prefix_cache_route_is_registered() {
 
     assert_eq!(
         status,
-        StatusCode::OK,
-        "POST /reset_prefix_cache should be routed under the admin API (on by default); got {status}, body: {text}"
+        StatusCode::SERVICE_UNAVAILABLE,
+        "without a runtime, POST /reset_prefix_cache should be routed (admin API on by default) and return 503 rather than 404; got {status}, body: {text}"
     );
     assert!(
         text.contains("Distributed runtime not available"),
-        "without a runtime the handler should report it clearly instead of 404ing; got: {text}"
+        "without a runtime the handler should report it clearly; got: {text}"
     );
 
     cancel_token.cancel();

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -1608,3 +1608,44 @@ async fn test_classify_and_pooling_validation_errors_are_metered() {
     cancel_token.cancel();
     task.await.unwrap().unwrap();
 }
+
+/// The `/reset_prefix_cache` admin route must be registered and reachable.
+///
+/// The admin API is enabled by default, so the route is mounted. Without a
+/// `DistributedRuntime` wired into the service the handler cannot reach workers,
+/// but it must still respond `200 OK` with a clear "runtime not available"
+/// message rather than a `404` — proving the route is wired up rather than
+/// silently missing (the original bug in #6291 was a `404` on this control).
+#[tokio::test]
+async fn test_reset_prefix_cache_route_is_registered() {
+    let (listener, port) = bind_random_port().await;
+    let service = HttpService::builder().port(port).build().unwrap();
+
+    let token = CancellationToken::new();
+    let cancel_token = token.clone();
+    let task =
+        tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
+    wait_for_service_ready(port).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("http://localhost:{port}/reset_prefix_cache"))
+        .send()
+        .await
+        .expect("POST /reset_prefix_cache");
+
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "POST /reset_prefix_cache should be routed under the admin API (on by default); got {status}, body: {text}"
+    );
+    assert!(
+        text.contains("Distributed runtime not available"),
+        "without a runtime the handler should report it clearly instead of 404ing; got: {text}"
+    );
+
+    cancel_token.cancel();
+    task.await.unwrap().unwrap();
+}


### PR DESCRIPTION
## Description
Adds the missing POST /reset_prefix_cache endpoint to the frontend HTTP service to resolve issue #6291.

## Changes
- Export clear_kv_blocks module in service.rs
- Register clear_kv_blocks router with /reset_prefix_cache path in service_v2.rs
- Maps POST /reset_prefix_cache to existing clear_kv_blocks handler

## Fixes
Fixes #6291

## Testing
The endpoint now responds at POST /reset_prefix_cache and correctly routes to the clear_kv_blocks handler to trigger KV cache reset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new HTTP endpoint (`/reset_prefix_cache`) to manage cached data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->