### PR TITLE
chore: Bump GAIE dependency to v1.4.0

### DIFF
--- a/deploy/inference-gateway/epp/go.mod
+++ b/deploy/inference-gateway/epp/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	sigs.k8s.io/controller-runtime v0.22.4
-	sigs.k8s.io/gateway-api-inference-extension v1.2.1
+	sigs.k8s.io/gateway-api-inference-extension v1.4.0
 )
 
 require (

--- a/deploy/inference-gateway/scripts/install_gaie_crd_kgateway.sh
+++ b/deploy/inference-gateway/scripts/install_gaie_crd_kgateway.sh
@@ -29,7 +29,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/downloa
 
 
 # Install the Inference Extension CRDs
-IGW_LATEST_RELEASE=v1.2.1
+IGW_LATEST_RELEASE=v1.4.0
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${IGW_LATEST_RELEASE}/manifests.yaml
 
 

--- a/deploy/operator/go.mod
+++ b/deploy/operator/go.mod
@@ -25,7 +25,7 @@ require (
 	k8s.io/client-go v0.34.3
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/controller-runtime v0.22.4
-	sigs.k8s.io/gateway-api-inference-extension v1.2.0
+	sigs.k8s.io/gateway-api-inference-extension v1.4.0
 	sigs.k8s.io/lws v0.6.1
 	sigs.k8s.io/yaml v1.6.0
 	volcano.sh/apis v1.12.2


### PR DESCRIPTION
- Update deploy/inference-gateway/epp/go.mod: v1.2.1 → v1.4.0
- Update deploy/operator/go.mod: v1.2.0 → v1.4.0
- Update install_gaie_crd_kgateway.sh: v1.2.1 → v1.4.0

Fixes #7612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gateway API inference extension dependencies to v1.4.0 for inference gateway and operator configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->