### PR TITLE
fix(operator): Add TTL to profiling job cleanup

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1364,6 +1364,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 			},
 		}
 
+		ttlSeconds := int32(600) // 10 minutes
 		job := &batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      jobName,
@@ -1375,7 +1376,8 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 				},
 			},
 			Spec: batchv1.JobSpec{
-				BackoffLimit: &backoffLimit,
+				BackoffLimit:            &backoffLimit,
+				TTLSecondsAfterFinished: &ttlSeconds,
 				Template: corev1.PodTemplateSpec{
 					Spec: podSpec,
 				},


### PR DESCRIPTION
Fixes #6395

Add ttlSecondsAfterFinished: 600 (10 minutes) to profiling Job specs
to automatically clean up completed profiling jobs. This prevents
profiling pods from lingering indefinitely and wasting Kubernetes
resources.

Profiling jobs are ephemeral workloads that should be cleaned up after
completion, reducing operational overhead in long-running clusters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Finished profiling jobs now automatically clean up after 10 minutes, reducing unnecessary cluster resource consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->