### PR TITLE
fix(docs): restore comm-stack diagram outer zone dimensions

### DIFF
--- a/docs/assets/img/disagg-comm-stack.svg
+++ b/docs/assets/img/disagg-comm-stack.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" width="800" height="600" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 620" width="800" height="620" role="img" aria-labelledby="title desc">
   <title id="title">disagg-comm-stack</title>
   <desc id="desc">Architecture diagram showing disagg-comm-stack</desc>
 
@@ -29,13 +29,13 @@
             markerWidth="5" markerHeight="5" orient="auto">
       <path d="M0,0.5 L6,3 L0,5.5 Z" fill="var(--connector)"/>
     </marker>
-    <marker id="arrow-var--connector" viewBox="0 0 6 6" refX="5" refY="3"
-            markerWidth="5" markerHeight="5" orient="auto">
-      <path d="M0,0.5 L6,3 L0,5.5 Z" fill="var(--connector)"/>
-    </marker>
     <marker id="arrow-pill-kv" viewBox="0 0 6 6" refX="5" refY="3"
             markerWidth="5" markerHeight="5" orient="auto">
       <path d="M0,0.5 L6,3 L0,5.5 Z" fill="var(--pill-kv)"/>
+    </marker>
+    <marker id="arrow-var--connector" viewBox="0 0 6 6" refX="5" refY="3"
+            markerWidth="5" markerHeight="5" orient="auto">
+      <path d="M0,0.5 L6,3 L0,5.5 Z" fill="var(--connector)"/>
     </marker>
     <marker id="arrow-dark" viewBox="0 0 6 6" refX="5" refY="3"
             markerWidth="5" markerHeight="5" orient="auto">
@@ -175,7 +175,7 @@
     .connector-kv { fill: none; stroke: var(--pill-kv); stroke-width: 2.0; }
     .connector-dashed { fill: none; stroke: var(--connector); stroke-width: 2.0; stroke-dasharray: 6 4; }
   </style>
-  <rect x="20" y="20" width="760" height="560" rx="14" fill="var(--surface-zone)" stroke="var(--border-zone)" stroke-width="1.0" stroke-dasharray="6 3" filter="url(#blue-glow)"/>
+  <rect x="20" y="20" width="760" height="580" rx="14" fill="var(--surface-zone)" stroke="var(--border-zone)" stroke-width="1.0" stroke-dasharray="6 3" filter="url(#blue-glow)"/>
   <text x="400.0" y="46.5" class="zone-label" style="fill:var(--zone-label);text-anchor:middle;">Dynamo Disaggregated Serving</text>
 
   <rect x="40" y="320" width="720" height="270" rx="14" fill="var(--surface-zone)" stroke="var(--border-zone)" stroke-width="1.0" stroke-dasharray="6 3" filter="url(#blue-glow)"/>


### PR DESCRIPTION
## Summary
- Reverts incorrect dimension changes from #7638 that broke the outer zone rendering
- Restores canvas to 800x620 and outer-zone to 760x580

## Test Plan
- Visual inspection of rendered diagram

Made with [Cursor](https://cursor.com)