### PR TITLE
fix(sglang): use incremental_streaming_output instead of deprecated stream_output

### DIFF
--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -369,10 +369,9 @@ async def parse_args(args: list[str]) -> Config:
         server_args = ServerArgs.from_cli_args(parsed_args)
 
     # Dynamo's streaming handlers expect disjoint output_ids from SGLang (only new
-    # tokens since last output), not cumulative tokens. When stream_output=True,
-    # SGLang sends disjoint segments which Dynamo passes through directly.
-    # Force stream_output=True for optimal streaming performance.
-    server_args.stream_output = True
+    # tokens since last output), not cumulative tokens.
+    # sglang renamed stream_output -> incremental_streaming_output in PR #20614.
+    server_args.incremental_streaming_output = True
 
     if dynamo_config.use_sglang_tokenizer:
         warnings.warn(

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -371,7 +371,10 @@ async def parse_args(args: list[str]) -> Config:
     # Dynamo's streaming handlers expect disjoint output_ids from SGLang (only new
     # tokens since last output), not cumulative tokens.
     # sglang renamed stream_output -> incremental_streaming_output in PR #20614.
-    server_args.incremental_streaming_output = True
+    if hasattr(ServerArgs, "incremental_streaming_output"):
+        server_args.incremental_streaming_output = True
+    else:
+        server_args.stream_output = True
 
     if dynamo_config.use_sglang_tokenizer:
         warnings.warn(


### PR DESCRIPTION
#### Overview:

use incremental_streaming_output instead of deprecated stream_output
#### Details:

sglang renamed `stream_output` to `incremental_streaming_output` in sglang/sglang#20614. The old attribute assignment silently became a no-op, causing cumulative output_ids to be sent instead of disjoint deltas. This led to triangular-sum inflation of completion_tokens (~10x).

Before the fix:
```
============ Serving Benchmark Result ============
Successful requests:                     8         
Benchmark duration (s):                  22.07     
Total input tokens:                      8000      
Total generated tokens:                  84160     
Request throughput (req/s):              0.36      
Output token throughput (tok/s):         3813.62   
Total Token throughput (tok/s):          4176.14   
---------------Time to First Token----------------
Mean TTFT (ms):                          780.26    
Median TTFT (ms):                        775.64    
P99 TTFT (ms):                           817.16    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.97      
Median TPOT (ms):                        0.97      
P99 TPOT (ms):                           1.01      
---------------Inter-token Latency----------------
Mean ITL (ms):                           512.30    
Median ITL (ms):                         487.04    
P99 ITL (ms):                            1111.95   
----------------End-to-end Latency----------------
Mean E2EL (ms):                          11026.20  
Median E2EL (ms):                        11024.14  
P99 E2EL (ms):                           11437.12  
==================================================
```
After the fix:
```
============ Serving Benchmark Result ============
Successful requests:                     8         
Benchmark duration (s):                  20.50     
Total input tokens:                      7302      
Total generated tokens:                  7093      
Request throughput (req/s):              0.39      
Output token throughput (tok/s):         346.04    
Total Token throughput (tok/s):          702.28    
---------------Time to First Token----------------
Mean TTFT (ms):                          984.03    
Median TTFT (ms):                        771.13    
P99 TTFT (ms):                           1556.39   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.02     
Median TPOT (ms):                        9.80      
P99 TPOT (ms):                           10.84     
---------------Inter-token Latency----------------
Mean ITL (ms):                           10.00     
Median ITL (ms):                         9.75      
P99 ITL (ms):                            10.33     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          9839.03   
Median E2EL (ms):                        9963.85   
P99 E2EL (ms):                           10276.21  
==================================================

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated streaming configuration for SGLang server compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->