### PR TITLE
fix(kv-router): stop charging decode for old prompts

### DIFF
--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -1190,4 +1190,32 @@ mod tests {
             } if request_id == "req-123"
         ));
     }
+
+    #[test]
+    fn test_active_sequence_add_request_serialization_preserves_track_prefill_tokens() {
+        let event = ActiveSequenceEvent {
+            request_id: "req-123".to_string(),
+            worker: WorkerWithDpRank::new(7, 0),
+            data: ActiveSequenceEventData::AddRequest {
+                token_sequence: Some(vec![11, 22]),
+                isl: 128,
+                overlap: 1,
+                track_prefill_tokens: false,
+                expected_output_tokens: Some(32),
+            },
+            router_id: 9,
+            lora_name: None,
+        };
+
+        let serialized = serde_json::to_string(&event).unwrap();
+        let deserialized: ActiveSequenceEvent = serde_json::from_str(&serialized).unwrap();
+
+        match deserialized.data {
+            ActiveSequenceEventData::AddRequest {
+                track_prefill_tokens,
+                ..
+            } => assert!(!track_prefill_tokens),
+            _ => panic!("expected add request event"),
+        }
+    }
 }

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -400,6 +400,22 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             });
         }
 
+        if self.replica_sync {
+            let event = ActiveSequenceEvent {
+                request_id: request_id.clone(),
+                worker,
+                data: ActiveSequenceEventData::AddRequest {
+                    token_sequence: token_sequence.clone(),
+                    isl,
+                    overlap,
+                    track_prefill_tokens,
+                    expected_output_tokens,
+                },
+                router_id: self.router_id,
+                lora_name: lora_name.clone(),
+            };
+            self.publisher.publish_event(&event).await?;
+        }
         self.request_to_worker.insert(request_id.clone(), worker);
 
         if let Some(lora) = lora_name {


### PR DESCRIPTION
Preserve the decode-side behavior that ignores prompt-side prefill load after handoff.

This resolves the rebase onto the current router structure without reintroducing outdated hard-coded prefill tracking in replay paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test to verify serialization and deserialization of request tracking properties.

* **Chores**
  * Improved replica synchronization behavior for request handling to ensure consistency across system instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->