### PR TITLE
fix(install): derive VLLM_VER from VLLM_REF when --vllm-ref is passed

### DIFF
--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -37,6 +37,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --vllm-ref)
             VLLM_REF="$2"
+            VLLM_VER="${VLLM_REF#v}"
             shift 2
             ;;
         --max-jobs)


### PR DESCRIPTION
When --vllm-ref is passed via CLI, VLLM_VER should be derived from VLLM_REF to ensure consistent version handling across the script. This fixes issues where --vllm-ref updates were not reflected in GitHub release wheel URLs, PyPI install strings, and hotfix version checks.

Fixes #7420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected version string handling when using custom vllm references to prevent installation mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->