### PR TITLE
feat(helm): add extraEnv support to operator deployment

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -79,6 +79,9 @@ spec:
         {{- with .Values.env }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with .Values.extraEnv }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         imagePullPolicy: {{ .Values.controllerManager.manager.image.pullPolicy | quote }}

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -24,6 +24,10 @@ upgradeCRD: true
 # Environment variables to pass to operator Deployment.
 env: []
 
+# Extra environment variables to add to the operator Deployment.
+# Useful for injecting additional configuration like proxy settings without modifying templates directly.
+extraEnv: []
+
 # Namespace restriction configuration for the operator
 # If enabled: true and targetNamespace is empty, the operator will be restricted to the release namespace
 # If enabled: true and targetNamespace is set, the operator will be restricted to the specified namespace


### PR DESCRIPTION
Add extraEnv field to Helm chart values to allow users to inject additional environment variables into the operator pod without modifying deployment templates directly. Useful for proxy configuration and other runtime environment customization.

Fixes #7066

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional environment variables in operator deployments through new configuration parameters, enabling greater customization of the operator runtime environment without modifying core deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->