### PR TITLE
fix(trtllm): propagate max_seq_len from extra-engine-args to MDC registration

### DIFF
--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -199,7 +199,7 @@ async def init_llm_worker(
     if config.extra_engine_args != "":
         # TODO: Support extra engine args from json file as well.
         arg_map = update_llm_args_with_extra_options(arg_map, config.extra_engine_args)
-        
+
         # Propagate any overridden values back to config for MDC registration
         # This ensures context_length, max_batch_size, etc. reflect the actual engine limits
         if "max_seq_len" in arg_map:

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -225,6 +225,23 @@ async def init_llm_worker(
             logging.info(f"Applying engine arg overrides: {overrides}")
 
             deep_update(arg_map, overrides)
+
+            # Propagate any overridden values back to config for MDC registration
+            if "max_seq_len" in overrides:
+                config.max_seq_len = arg_map["max_seq_len"]
+                logging.info(
+                    f"Updated config.max_seq_len from override-engine-args: {config.max_seq_len}"
+                )
+            if "max_batch_size" in overrides:
+                config.max_batch_size = arg_map["max_batch_size"]
+                logging.info(
+                    f"Updated config.max_batch_size from override-engine-args: {config.max_batch_size}"
+                )
+            if "max_num_tokens" in overrides:
+                config.max_num_tokens = arg_map["max_num_tokens"]
+                logging.info(
+                    f"Updated config.max_num_tokens from override-engine-args: {config.max_num_tokens}"
+                )
         except json.JSONDecodeError as e:
             logging.error(f"Failed to parse override_engine_args as JSON: {e}")
             sys.exit(1)

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -199,6 +199,24 @@ async def init_llm_worker(
     if config.extra_engine_args != "":
         # TODO: Support extra engine args from json file as well.
         arg_map = update_llm_args_with_extra_options(arg_map, config.extra_engine_args)
+        
+        # Propagate any overridden values back to config for MDC registration
+        # This ensures context_length, max_batch_size, etc. reflect the actual engine limits
+        if "max_seq_len" in arg_map:
+            config.max_seq_len = arg_map["max_seq_len"]
+            logging.info(
+                f"Updated config.max_seq_len from extra-engine-args: {config.max_seq_len}"
+            )
+        if "max_batch_size" in arg_map:
+            config.max_batch_size = arg_map["max_batch_size"]
+            logging.info(
+                f"Updated config.max_batch_size from extra-engine-args: {config.max_batch_size}"
+            )
+        if "max_num_tokens" in arg_map:
+            config.max_num_tokens = arg_map["max_num_tokens"]
+            logging.info(
+                f"Updated config.max_num_tokens from extra-engine-args: {config.max_num_tokens}"
+            )
 
     # Apply override_engine_args if provided
     if config.override_engine_args != "":


### PR DESCRIPTION
When --extra-engine-args overrides max_seq_len (and other engine config fields), propagate these values back to config so they are correctly reflected in the ModelDeploymentCard (MDC) registration.

This ensures:
- context_length in MDC matches the engine's actual max_seq_len limit
- Prompt length validation correctly rejects over-length requests (HTTP 400)
- Instead of allowing them through and crashing in the engine (HTTP 500)

Also propagates max_batch_size and max_num_tokens for consistency.

Fixes #6987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration override handling to ensure engine limits are correctly propagated when custom configuration options are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->