### PR TITLE
feat(planner): add aggregated worker name to TrtllmComponentName

### DIFF
--- a/components/src/dynamo/planner/defaults.py
+++ b/components/src/dynamo/planner/defaults.py
@@ -130,6 +130,8 @@ class TrtllmComponentName(ComponentName):
     decode_worker_k8s_name = "TRTLLMDecodeWorker"
     decode_worker_component_name = "tensorrt_llm"
     decode_worker_endpoint = "generate"
+    # Aggregated deployment uses a single unified worker
+    aggregated_worker_k8s_name = "TRTLLMWorker"
 
 
 class MockerComponentName(ComponentName):


### PR DESCRIPTION
Add aggregated_worker_k8s_name field to TrtllmComponentName to define the service name for aggregated TRTLLM deployments. This enables removing hardcoded strings from test code and provides a single source of truth for all TRTLLM deployment names.

- disaggregated: TRTLLMPrefillWorker, TRTLLMDecodeWorker
- aggregated: TRTLLMWorker

Consistent with vLLM and SGLang component naming patterns.

Fixes #5116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration for worker deployment naming to support aggregated deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->