### PR TITLE
fix: Ensure scalingAdapter is included in generated DGD for autoscaling

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1653,6 +1653,17 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 
 	logger.Info("Parsed profiling output", "dgdName", dgd.Name, "additionalResources", len(additionalResources))
 
+	// Ensure scalingAdapter is enabled in generated DGD when planners are present
+	if r.shouldEnableScalingAdapter(dgd) {
+		if dgd.Spec.ScalingAdapter == nil {
+			dgd.Spec.ScalingAdapter = &dgdv1alpha1.ScalingAdapter{}
+		}
+		if !dgd.Spec.ScalingAdapter.Enabled {
+			dgd.Spec.ScalingAdapter.Enabled = true
+			logger.Info("Enabled scalingAdapter in generated DGD for autoscaling support")
+		}
+	}
+
 	if len(additionalResources) > 0 {
 		if err := r.storeAdditionalResources(ctx, dgdr, additionalResources); err != nil {
 			logger.Error(err, "Failed to store additional resources")
@@ -2025,4 +2036,19 @@ func (r *DynamoGraphDeploymentRequestReconciler) SetupWithManager(mgr ctrl.Manag
 		// Set the event filter to ignore resources handled by other controllers in namespace-restricted mode
 		WithEventFilter(commonController.EphemeralDeploymentEventFilter(r.Config, r.RuntimeConfig)).
 		Complete(observability.NewObservedReconciler(r, consts.ResourceTypeDynamoGraphDeploymentRequest))
+}
+
+// shouldEnableScalingAdapter returns true if the DGD should have scaling adapter enabled
+// (i.e., if any of its services use planners for autoscaling)
+func (r *DynamoGraphDeploymentRequestReconciler) shouldEnableScalingAdapter(dgd *dgdv1alpha1.DynamoGraphDeployment) bool {
+	if dgd == nil || dgd.Spec.Components == nil {
+		return false
+	}
+
+	for _, component := range dgd.Spec.Components {
+		if component.Planner != nil {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
- Add scalingAdapter to generated DynamoGraphDeployment when planner is present
- Checks for planner components and enables scaling adapter automatically
- Fixes issue where DGDR with AI Configurator generates incomplete DGD spec
- Ensures DGDSAs (DynamoGraph Deployment Scaling Adapters) can be created

Fixes #6491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scaling adapter is now automatically enabled for deployments with specific component configurations, streamlining setup and ensuring proper scaling functionality initialization without manual configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->