### PR TITLE
feat(vllm): add TTS audio generation endpoint via vLLM Omni

### DIFF
--- a/components/src/dynamo/common/protocols/__init__.py
+++ b/components/src/dynamo/common/protocols/__init__.py
@@ -5,8 +5,13 @@
 
 This module provides protocol types for various modalities:
 - video_protocol: NvCreateVideoRequest, NvVideosResponse for video generation
+- audio_protocol: NvCreateAudioSpeechRequest, NvAudiosResponse for audio generation
 """
 
+from dynamo.common.protocols.audio_protocol import (
+    NvAudiosResponse,
+    NvCreateAudioSpeechRequest,
+)
 from dynamo.common.protocols.video_protocol import (
     NvCreateVideoRequest,
     NvVideosResponse,
@@ -14,6 +19,8 @@ from dynamo.common.protocols.video_protocol import (
 )
 
 __all__ = [
+    "NvAudiosResponse",
+    "NvCreateAudioSpeechRequest",
     "NvCreateVideoRequest",
     "NvVideosResponse",
     "VideoData",

--- a/components/src/dynamo/common/protocols/audio_protocol.py
+++ b/components/src/dynamo/common/protocols/audio_protocol.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Protocol types for audio speech generation.
+
+These types match the Rust protocol types in lib/llm/src/protocols/openai/audios.rs
+to ensure compatibility with the Dynamo HTTP frontend.
+"""
+# TODO: Replace these Pydantic models with Python bindings to the Rust protocol types once PyO3 bindings are available.
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class AudioNvExt(BaseModel):
+    """NVIDIA extensions for audio speech generation requests.
+
+    Matches Rust NvExt in lib/llm/src/protocols/openai/audios/nvext.rs.
+    """
+
+    annotations: Optional[list[str]] = None
+    """Annotations for SSE stream events."""
+
+    task_type: Optional[str] = None
+    """Task type (e.g. 'tts', 'voice_clone')."""
+
+    language: Optional[str] = None
+    """Language code (e.g. 'en', 'zh')."""
+
+    instructions: Optional[str] = None
+    """Additional instructions for speech generation."""
+
+    ref_audio: Optional[str] = None
+    """Base64-encoded reference audio for voice cloning."""
+
+    ref_text: Optional[str] = None
+    """Reference text corresponding to ref_audio."""
+
+    max_new_tokens: Optional[int] = None
+    """Maximum number of tokens to generate."""
+
+    seed: Optional[int] = None
+    """Random seed for reproducibility."""
+
+
+class NvCreateAudioSpeechRequest(BaseModel):
+    """Request for audio speech generation (/v1/audio/speech endpoint).
+
+    Matches Rust NvCreateAudioSpeechRequest in lib/llm/src/protocols/openai/audios.rs.
+    """
+
+    # Required fields
+    input: str
+    """The text to generate audio for."""
+
+    model: str
+    """The model to use for audio generation."""
+
+    voice: str
+    """The voice to use for generation."""
+
+    # Optional fields
+    response_format: Optional[str] = None
+    """Audio format: mp3, wav, opus, aac, flac, pcm."""
+
+    speed: Optional[float] = None
+    """Playback speed (0.25 to 4.0, default 1.0)."""
+
+    nvext: Optional[AudioNvExt] = None
+    """NVIDIA extensions."""
+
+
+class NvAudiosResponse(BaseModel):
+    """Response structure for audio speech generation.
+
+    Matches Rust NvAudiosResponse in lib/llm/src/protocols/openai/audios.rs.
+    Internal transport uses base64-encoded audio. The HTTP handler decodes
+    this to return raw binary audio to clients.
+    """
+
+    audio_b64: str
+    """Base64-encoded audio bytes."""
+
+    content_type: str
+    """MIME content type (e.g. 'audio/mpeg', 'audio/wav')."""
+
+    model: str
+    """Model used for generation."""
+
+    created: int
+    """Unix timestamp of creation."""

--- a/components/src/dynamo/common/utils/output_modalities.py
+++ b/components/src/dynamo/common/utils/output_modalities.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import BaseModel
 
+from dynamo.common.protocols.audio_protocol import NvCreateAudioSpeechRequest
 from dynamo.common.protocols.image_protocol import NvCreateImageRequest
 from dynamo.common.protocols.video_protocol import NvCreateVideoRequest
 from dynamo.llm import ModelType
@@ -91,8 +92,7 @@ def parse_request_type(
         return NvCreateVideoRequest(**raw_request), RequestType.VIDEO_GENERATION
 
     if modality is OutputModality.AUDIO:
-        # Audio protocol types are not yet defined; pass through the raw dict.
-        return raw_request, RequestType.AUDIO_GENERATION
+        return NvCreateAudioSpeechRequest(**raw_request), RequestType.AUDIO_GENERATION
 
     # Text Modality
     return raw_request, RequestType.CHAT_COMPLETION

--- a/components/src/dynamo/vllm/omni/omni_handler.py
+++ b/components/src/dynamo/vllm/omni/omni_handler.py
@@ -17,6 +17,10 @@ from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
 
 from dynamo._core import Context
 from dynamo.common.multimodal import ImageLoader
+from dynamo.common.protocols.audio_protocol import (
+    NvAudiosResponse,
+    NvCreateAudioSpeechRequest,
+)
 from dynamo.common.protocols.image_protocol import (
     ImageData,
     NvCreateImageRequest,
@@ -42,6 +46,62 @@ logger = logging.getLogger(__name__)
 DEFAULT_VIDEO_FPS = 16
 
 
+def _single_item_to_bytes(item) -> bytes | None:
+    """Convert a single audio tensor / ndarray / bytes to raw PCM bytes."""
+    if isinstance(item, bytes):
+        return item
+    if hasattr(item, "numpy"):
+        # torch Tensor
+        return item.cpu().float().numpy().tobytes()
+    if hasattr(item, "tobytes"):
+        # numpy array
+        return item.tobytes()
+    return None
+
+
+def _audio_val_to_bytes(audio_val) -> bytes | None:
+    """Convert multimodal_output["audio"] to raw PCM bytes.
+
+    The value can be:
+    - A single tensor or ndarray (one waveform)
+    - A list of tensors/ndarrays (accumulated chunks)
+    - Raw bytes
+    """
+    if isinstance(audio_val, bytes):
+        return audio_val
+
+    # Single tensor / ndarray
+    if hasattr(audio_val, "numpy") or hasattr(audio_val, "tobytes"):
+        return _single_item_to_bytes(audio_val)
+
+    # List — could be a list of chunks (tensors/ndarrays) or a flat list of floats
+    if isinstance(audio_val, list) and audio_val:
+        first = audio_val[0]
+        if hasattr(first, "numpy") or hasattr(first, "tobytes"):
+            # List of tensors / ndarrays — concatenate
+            parts = [_single_item_to_bytes(item) for item in audio_val]
+            return b"".join(p for p in parts if p)
+        # Flat list of numbers
+        import numpy as np
+
+        try:
+            arr = np.array(audio_val, dtype=np.float32)
+            return arr.tobytes()
+        except ValueError:
+            # Inhomogeneous — try concatenating sub-arrays
+            parts = []
+            for sub in audio_val:
+                if hasattr(sub, "tobytes"):
+                    parts.append(sub.tobytes())
+                elif hasattr(sub, "numpy"):
+                    parts.append(sub.cpu().float().numpy().tobytes())
+                else:
+                    parts.append(np.array(sub, dtype=np.float32).tobytes())
+            return b"".join(parts)
+
+    return None
+
+
 @dataclass
 class EngineInputs:
     """Parsed engine inputs ready for AsyncOmni.generate().
@@ -61,6 +121,7 @@ class EngineInputs:
     request_type: RequestType = RequestType.CHAT_COMPLETION
     fps: int = 0
     response_format: str | None = None
+    audio_response_format: str | None = None
 
 
 class OmniHandler(BaseOmniHandler):
@@ -164,6 +225,10 @@ class OmniHandler(BaseOmniHandler):
 
         previous_text = ""
 
+        # For audio requests, keep the latest PCM output (vLLM returns
+        # cumulative audio — each iteration contains the full waveform so far).
+        audio_pcm: bytes | None = None
+
         async with self._abort_monitor(context, request_id):
             try:
                 async for stage_output in self.engine_client.generate(
@@ -206,17 +271,36 @@ class OmniHandler(BaseOmniHandler):
                         if chunk:
                             yield chunk
 
+                    elif inputs.request_type == RequestType.AUDIO_GENERATION:
+                        pcm = self._extract_audio_bytes(stage_output)
+                        if pcm:
+                            audio_pcm = pcm
+
             except GeneratorExit:
                 logger.info(f"Request {request_id} aborted due to shutdown")
                 raise
             except Exception as e:
                 logger.error(f"Error during generation for request {request_id}: {e}")
                 yield self._error_chunk(request_id, str(e))
+                return
+
+        # After the generator finishes, emit the complete audio response.
+        if audio_pcm:
+            chunk = self._format_audio_chunk(
+                audio_pcm,
+                request_id,
+                response_format=inputs.audio_response_format,
+            )
+            if chunk:
+                yield chunk
 
     def build_engine_inputs(
         self,
         parsed_request: Union[
-            NvCreateImageRequest, NvCreateVideoRequest, Dict[str, Any]
+            NvCreateImageRequest,
+            NvCreateVideoRequest,
+            NvCreateAudioSpeechRequest,
+            Dict[str, Any],
         ],
         request_type: RequestType,
         image: PIL.Image.Image | None = None,
@@ -241,9 +325,8 @@ class OmniHandler(BaseOmniHandler):
         elif request_type == RequestType.VIDEO_GENERATION:
             assert isinstance(parsed_request, NvCreateVideoRequest)
             return self._engine_inputs_from_video(parsed_request, image=image)
-
         elif request_type == RequestType.AUDIO_GENERATION:
-            raise NotImplementedError("Audio generation is not yet supported")
+            return self._engine_inputs_from_audio(parsed_request)
 
         raise ValueError(f"Unknown request type: {request_type}")
 
@@ -373,6 +456,125 @@ class OmniHandler(BaseOmniHandler):
             request_type=RequestType.VIDEO_GENERATION,
             fps=fps,
         )
+
+    def _engine_inputs_from_audio(
+        self, req: NvCreateAudioSpeechRequest
+    ) -> EngineInputs:
+        """Build engine inputs from an NvCreateAudioSpeechRequest.
+
+        Mirrors the logic in vllm-omni's ``serving_speech.py``: the prompt
+        is a dict with **dummy** ``prompt_token_ids`` whose length matches
+        what the model's ``preprocess()`` will produce, plus an
+        ``additional_information`` dict with all TTS parameters wrapped in
+        lists.
+        """
+        nvext = req.nvext
+
+        # --- task type ---
+        task_type = nvext.task_type if nvext and nvext.task_type else None
+        if task_type is None:
+            if nvext and nvext.ref_audio:
+                task_type = "Base"
+            else:
+                task_type = "CustomVoice"
+
+        # --- additional_information (all values must be lists) ---
+        additional_info: Dict[str, Any] = {
+            "task_type": [task_type],
+            "text": [req.input],
+        }
+
+        if req.voice:
+            additional_info["speaker"] = [req.voice]
+
+        language = nvext.language if nvext and nvext.language else "auto"
+        additional_info["language"] = [language]
+
+        instruct = nvext.instructions if nvext and nvext.instructions else ""
+        additional_info["instruct"] = [instruct]
+
+        if nvext:
+            if nvext.ref_audio is not None:
+                additional_info["ref_audio"] = [nvext.ref_audio]
+            if nvext.ref_text is not None:
+                additional_info["ref_text"] = [nvext.ref_text]
+
+        max_new_tokens = (
+            nvext.max_new_tokens if nvext and nvext.max_new_tokens else 2048
+        )
+        additional_info["max_new_tokens"] = [max_new_tokens]
+
+        # --- estimate prompt length ---
+        # The TTS model replaces prompt token IDs with computed embeddings
+        # in preprocess().  The token IDs themselves are unused, but their
+        # *count* must match the embedding length the model will produce,
+        # otherwise the sampler's penalty kernel indexes out of bounds.
+        ph_len = self._estimate_tts_prompt_len(additional_info, task_type)
+
+        # Build prompt dict the same way serving_speech.py does.
+        prompt: Dict[str, Any] = {
+            "prompt_token_ids": [1] * ph_len,
+            "additional_information": additional_info,
+        }
+
+        if req.speed is not None:
+            additional_info["speed"] = [req.speed]
+
+        sp_kwargs: Dict[str, Any] = {}
+        if nvext:
+            if nvext.seed is not None:
+                sp_kwargs["seed"] = nvext.seed
+
+        sampling_params_list = (
+            [OmniDiffusionSamplingParams(**sp_kwargs)] if sp_kwargs else None
+        )
+
+        return EngineInputs(
+            prompt=prompt,
+            sampling_params_list=sampling_params_list,
+            request_type=RequestType.AUDIO_GENERATION,
+            audio_response_format=req.response_format,
+        )
+
+    def _estimate_tts_prompt_len(
+        self, additional_info: Dict[str, Any], task_type: str
+    ) -> int:
+        """Estimate the prompt embedding length for a TTS request.
+
+        Calls the model's ``estimate_prompt_len_from_additional_information``
+        with a tokenizer so that the dummy ``prompt_token_ids`` length
+        matches what ``preprocess()`` will produce.  A mismatch causes the
+        sampler to index out of bounds or generates garbage audio.
+        """
+        try:
+            from vllm_omni.model_executor.models.qwen3_tts.qwen3_tts_talker import (
+                Qwen3TTSTalkerForConditionalGeneration,
+            )
+
+            # Lazy-load the TTS tokenizer (cached on first call).
+            if not hasattr(self, "_tts_tokenizer"):
+                from transformers import AutoTokenizer
+
+                self._tts_tokenizer = AutoTokenizer.from_pretrained(
+                    self.config.model, trust_remote_code=True
+                )
+
+            return Qwen3TTSTalkerForConditionalGeneration.estimate_prompt_len_from_additional_information(
+                additional_information=additional_info,
+                task_type=task_type,
+                tokenize_prompt=lambda t: self._tts_tokenizer(t, padding=False)[
+                    "input_ids"
+                ],
+                codec_language_id=None,
+                spk_is_dialect=None,
+            )
+        except Exception as exc:
+            logger.warning(
+                "TTS prompt length estimation failed: %s; using heuristic", exc
+            )
+            # Heuristic: ~4 chars/token + template overhead.
+            text = (additional_info.get("text") or [""])[0]
+            return max(2, len(text) // 4 + 12)
 
     async def _prepare_image_output(
         self, images: list, request_id: str, response_format: str | None = None
@@ -548,6 +750,93 @@ class OmniHandler(BaseOmniHandler):
                 error=str(e),
             )
             return error_response.model_dump()
+
+    @staticmethod
+    def _extract_audio_bytes(stage_output) -> bytes | None:
+        """Extract raw audio bytes from a vllm-omni stage output.
+
+        vllm-omni stores TTS audio in ``multimodal_output["audio"]``,
+        accessible either directly on the stage output or on its nested
+        ``request_output``.
+        """
+        mm = getattr(stage_output, "multimodal_output", None)
+        if not mm:
+            ro = getattr(stage_output, "request_output", None)
+            mm = getattr(ro, "multimodal_output", None) if ro else None
+        if not mm or "audio" not in mm:
+            return None
+
+        audio_val = mm["audio"]
+        return _audio_val_to_bytes(audio_val)
+
+    def _format_audio_chunk(
+        self,
+        pcm_bytes: bytes,
+        request_id: str,
+        response_format: str | None = None,
+        sample_rate: int = 24000,
+    ) -> Dict[str, Any] | None:
+        """Encode accumulated PCM float32 data as an NvAudiosResponse.
+
+        The raw PCM is wrapped in a WAV container (float32, mono) so
+        that clients receive a playable file.
+
+        Args:
+            pcm_bytes: Raw float32 PCM bytes from the engine.
+            request_id: Unique request identifier.
+            response_format: Requested audio format (wav, pcm, etc.).
+            sample_rate: Sample rate of the audio (default 24000 for Qwen3-TTS).
+
+        Returns:
+            ``NvAudiosResponse.model_dump()`` dict, or ``None`` if empty.
+        """
+        if not pcm_bytes:
+            return None
+
+        fmt = response_format or "wav"
+
+        if fmt == "pcm":
+            # Raw PCM: send as-is
+            encoded = pcm_bytes
+            content_type = "audio/pcm"
+        else:
+            # Wrap in WAV container (IEEE float32, mono)
+            encoded = self._pcm_to_wav(pcm_bytes, sample_rate)
+            content_type = "audio/wav"
+
+        audio_b64 = base64.b64encode(encoded).decode("utf-8")
+
+        response = NvAudiosResponse(
+            audio_b64=audio_b64,
+            content_type=content_type,
+            model=self.config.served_model_name or self.config.model,
+            created=int(time.time()),
+        )
+        return response.model_dump()
+
+    @staticmethod
+    def _pcm_to_wav(pcm_bytes: bytes, sample_rate: int) -> bytes:
+        """Wrap raw float32 PCM in a WAV header."""
+        import struct
+
+        n = len(pcm_bytes)
+        header = struct.pack(
+            "<4sI4s4sIHHIIHH4sI",
+            b"RIFF",
+            36 + n,  # file size - 8
+            b"WAVE",
+            b"fmt ",
+            16,  # fmt chunk size
+            3,  # format tag: IEEE float
+            1,  # channels: mono
+            sample_rate,
+            sample_rate * 4,  # byte rate
+            4,  # block align
+            32,  # bits per sample
+            b"data",
+            n,  # data size
+        )
+        return header + pcm_bytes
 
     def _format_text_chunk(
         self,

--- a/components/src/dynamo/vllm/tests/omni/test_omni_handler.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_handler.py
@@ -8,6 +8,10 @@ import pytest
 try:
     from PIL import Image
 
+    from dynamo.common.protocols.audio_protocol import (
+        AudioNvExt,
+        NvCreateAudioSpeechRequest,
+    )
     from dynamo.common.protocols.image_protocol import NvCreateImageRequest
     from dynamo.common.protocols.video_protocol import NvCreateVideoRequest, VideoNvExt
     from dynamo.common.utils.output_modalities import RequestType
@@ -118,11 +122,44 @@ class TestBuildEngineInputs:
         assert inputs.prompt["prompt"] == "a drone"
         assert inputs.fps > 0
 
-    def test_audio_not_implemented(self):
-        """Audio generation raises NotImplementedError."""
+    def test_audio_generation(self):
+        """Audio request parses input text and sets request type."""
         handler = _make_handler()
-        with pytest.raises(NotImplementedError):
-            handler.build_engine_inputs({}, RequestType.AUDIO_GENERATION)
+        req = NvCreateAudioSpeechRequest(
+            input="Hello world", model="test-tts", voice="vivian"
+        )
+        inputs = handler.build_engine_inputs(req, RequestType.AUDIO_GENERATION)
+        assert inputs.request_type == RequestType.AUDIO_GENERATION
+        assert inputs.prompt["additional_information"]["text"] == ["Hello world"]
+
+    def test_audio_generation_with_nvext(self):
+        """Audio request with nvext forwards seed and max_new_tokens."""
+        handler = _make_handler()
+        req = NvCreateAudioSpeechRequest(
+            input="Test",
+            model="test-tts",
+            voice="vivian",
+            speed=1.5,
+            nvext=AudioNvExt(seed=42, max_new_tokens=1024),
+        )
+        inputs = handler.build_engine_inputs(req, RequestType.AUDIO_GENERATION)
+        assert inputs.request_type == RequestType.AUDIO_GENERATION
+        assert inputs.audio_response_format is None
+        assert inputs.sampling_params_list is not None
+        assert inputs.prompt["additional_information"]["speed"] == [1.5]
+        assert inputs.prompt["additional_information"]["max_new_tokens"] == [1024]
+
+    def test_audio_generation_response_format(self):
+        """Audio request preserves response_format in audio_response_format."""
+        handler = _make_handler()
+        req = NvCreateAudioSpeechRequest(
+            input="Test",
+            model="test-tts",
+            voice="vivian",
+            response_format="wav",
+        )
+        inputs = handler.build_engine_inputs(req, RequestType.AUDIO_GENERATION)
+        assert inputs.audio_response_format == "wav"
 
 
 class TestFormatTextChunk:
@@ -249,6 +286,54 @@ class TestFormatVideoChunk:
             chunk = await handler._format_video_chunk([MagicMock()], "req-1", fps=16)
         assert chunk["status"] == "failed"
         assert "boom" in chunk["error"]
+
+
+class TestFormatAudioChunk:
+    def test_empty_bytes_returns_none(self):
+        """Empty audio bytes returns None."""
+        handler = _make_handler()
+        result = handler._format_audio_chunk(b"", "req-1")
+        assert result is None
+
+    def test_default_wav_mime(self):
+        """Default format returns audio/wav MIME type (PCM wrapped in WAV)."""
+        handler = _make_handler()
+        chunk = handler._format_audio_chunk(b"\xff\xfb\x90\x00", "req-1")
+        assert chunk is not None
+        assert chunk["content_type"] == "audio/wav"
+        assert chunk["model"] == "test-model"
+        assert "audio_b64" in chunk
+
+    def test_wav_mime(self):
+        """WAV format returns audio/wav MIME type."""
+        handler = _make_handler()
+        chunk = handler._format_audio_chunk(
+            b"RIFF\x00\x00\x00\x00WAVE", "req-1", response_format="wav"
+        )
+        assert chunk["content_type"] == "audio/wav"
+
+    def test_opus_falls_back_to_wav(self):
+        """Non-PCM formats are wrapped in WAV container."""
+        handler = _make_handler()
+        chunk = handler._format_audio_chunk(b"\x00", "req-1", response_format="opus")
+        assert chunk["content_type"] == "audio/wav"
+
+    def test_base64_encoding(self):
+        """Audio bytes are WAV-wrapped and correctly base64-encoded."""
+        import base64
+
+        handler = _make_handler()
+        audio_data = b"test audio data"
+        chunk = handler._format_audio_chunk(audio_data, "req-1")
+        decoded = base64.b64decode(chunk["audio_b64"])
+        assert decoded[:4] == b"RIFF"
+        assert audio_data in decoded
+
+    def test_unknown_format_defaults_to_wav(self):
+        """Unknown response_format falls back to WAV wrapping."""
+        handler = _make_handler()
+        chunk = handler._format_audio_chunk(b"\x00", "req-1", response_format="unknown")
+        assert chunk["content_type"] == "audio/wav"
 
 
 class TestI2VEngineInputs:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -61,7 +61,7 @@ vllm:
     vllm_ref: v0.16.0
   flashinf_ref: v0.6.6
   lmcache_ref: 0.4.2
-  vllm_omni_ref: "v0.16.0"
+  vllm_omni_ref: "v0.17.0rc1"
   max_jobs: "10"
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -27,7 +27,7 @@ DEEPGEMM_REF=""
 CUDA_VERSION="12.9"
 FLASHINF_REF="v0.6.6"
 LMCACHE_REF="0.4.2"
-VLLM_OMNI_REF="v0.16.0"
+VLLM_OMNI_REF="v0.17.0rc1"
 
 while [[ $# -gt 0 ]]; do
     case $1 in

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -293,6 +293,7 @@ fn register_model<'p>(
     let is_tensor_based = model_type.inner.supports_tensor();
     let is_images = model_type.inner.supports_images();
     let is_videos = model_type.inner.supports_videos();
+    let is_audios = model_type.inner.supports_audios();
 
     let model_type_obj = model_type.inner;
 
@@ -341,9 +342,9 @@ fn register_model<'p>(
         .or_else(|| Some(source_path.clone()));
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        // For TensorBased, Images, and Videos models, skip HuggingFace downloads and register directly
+        // For TensorBased, Images, Videos, and Audios models, skip HuggingFace downloads and register directly
         // These model types handle model loading internally, no tokenizer extraction needed
-        if is_tensor_based || is_images || is_videos {
+        if is_tensor_based || is_images || is_videos || is_audios {
             let model_name = model_name.unwrap_or_else(|| source_path.clone());
             let mut card = llm_rs::model_card::ModelDeploymentCard::with_name_only(&model_name);
             card.model_type = model_type_obj;

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -19,6 +19,7 @@ use crate::protocols::openai::ParsingOptions;
 use crate::types::{
     generic::tensor::TensorStreamingEngine,
     openai::{
+        audios::OpenAIAudiosStreamingEngine,
         chat_completions::OpenAIChatCompletionsStreamingEngine,
         completions::OpenAICompletionsStreamingEngine, embeddings::OpenAIEmbeddingsStreamingEngine,
         images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
@@ -152,6 +153,13 @@ impl Model {
             .any(|entry| entry.value().has_videos_engine())
     }
 
+    /// Check if any WorkerSet has an audios engine.
+    pub fn has_audios_engine(&self) -> bool {
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_audios_engine())
+    }
+
     /// Whether this model should be visible in /v1/models.
     pub fn is_displayable(&self) -> bool {
         let has_serving_engine = |ws: &WorkerSet| {
@@ -159,6 +167,7 @@ impl Model {
                 || ws.has_completions_engine()
                 || ws.has_embeddings_engine()
                 || ws.has_images_engine()
+                || ws.has_audios_engine()
                 || ws.has_tensor_engine()
                 || ws.has_videos_engine()
         };
@@ -237,6 +246,11 @@ impl Model {
 
     pub fn get_videos_engine(&self) -> Result<OpenAIVideosStreamingEngine, ModelManagerError> {
         self.select_worker_set_with(|ws| ws.videos_engine.clone())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(self.name.clone()))
+    }
+
+    pub fn get_audios_engine(&self) -> Result<OpenAIAudiosStreamingEngine, ModelManagerError> {
+        self.select_worker_set_with(|ws| ws.audios_engine.clone())
             .ok_or_else(|| ModelManagerError::ModelNotFound(self.name.clone()))
     }
 

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -24,6 +24,7 @@ use crate::{
     types::{
         generic::tensor::TensorStreamingEngine,
         openai::{
+            audios::OpenAIAudiosStreamingEngine,
             chat_completions::OpenAIChatCompletionsStreamingEngine,
             completions::OpenAICompletionsStreamingEngine,
             embeddings::OpenAIEmbeddingsStreamingEngine, images::OpenAIImagesStreamingEngine,
@@ -247,6 +248,14 @@ impl ModelManager {
             .collect()
     }
 
+    pub fn list_audios_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_audios_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     pub fn list_prefill_models(&self) -> Vec<String> {
         self.models
             .iter()
@@ -313,6 +322,16 @@ impl ModelManager {
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_videos_engine()
+    }
+
+    pub fn get_audios_engine(
+        &self,
+        model: &str,
+    ) -> Result<OpenAIAudiosStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_audios_engine()
     }
 
     // -- Combined engine + parsing options (atomically from one WorkerSet) --
@@ -481,6 +500,27 @@ impl ModelManager {
         Ok(())
     }
 
+    pub fn add_audios_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: OpenAIAudiosStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_audios_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_audios_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            ModelDeploymentCard::default(),
+        );
+        ws.audios_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws))?;
+        Ok(())
+    }
+
     pub fn add_prefill_model(
         &self,
         model: &str,
@@ -548,6 +588,13 @@ impl ModelManager {
 
     pub fn remove_videos_model(&self, model: &str) -> Result<(), ModelManagerError> {
         let namespace = format!("__local_videos_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_audios_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_audios_{}", model);
         self.remove_worker_set(model, &namespace)
             .map(|_| ())
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -101,6 +101,8 @@ fn is_model_type_list_empty(manager: &ModelManager, model_type: ModelType) -> bo
         manager.list_images_models().is_empty()
     } else if model_type == ModelType::Videos {
         manager.list_videos_models().is_empty()
+    } else if model_type == ModelType::Audios {
+        manager.list_audios_models().is_empty()
     } else if model_type == ModelType::TensorBased {
         manager.list_tensor_models().is_empty()
     } else if model_type == ModelType::Prefill {
@@ -646,7 +648,16 @@ impl ModelWatcher {
                 worker_set.videos_engine = Some(Arc::new(videos_router));
             }
 
-            // TODO: add audio models support
+            if card.model_type.supports_audios() {
+                let audios_router = PushRouter::<
+                    crate::protocols::openai::audios::NvCreateAudioSpeechRequest,
+                    Annotated<crate::protocols::openai::audios::NvAudiosResponse>,
+                >::from_client_with_threshold(
+                    client.clone(), self.router_config.router_mode, None, None
+                )
+                .await?;
+                worker_set.audios_engine = Some(Arc::new(audios_router));
+            }
         } else if card.model_input == ModelInput::Text && card.model_type.supports_chat() {
             // Case: Text + Chat (pure text-to-text, no diffusion)
             let push_router = PushRouter::<

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -16,6 +16,7 @@ use crate::{
     types::{
         generic::tensor::TensorStreamingEngine,
         openai::{
+            audios::OpenAIAudiosStreamingEngine,
             chat_completions::OpenAIChatCompletionsStreamingEngine,
             completions::OpenAICompletionsStreamingEngine,
             embeddings::OpenAIEmbeddingsStreamingEngine, images::OpenAIImagesStreamingEngine,
@@ -41,6 +42,7 @@ pub struct WorkerSet {
     pub(crate) embeddings_engine: Option<OpenAIEmbeddingsStreamingEngine>,
     pub(crate) images_engine: Option<OpenAIImagesStreamingEngine>,
     pub(crate) videos_engine: Option<OpenAIVideosStreamingEngine>,
+    pub(crate) audios_engine: Option<OpenAIAudiosStreamingEngine>,
     pub(crate) tensor_engine: Option<TensorStreamingEngine>,
 
     /// KV router for this set's workers (if KV mode)
@@ -65,6 +67,7 @@ impl WorkerSet {
             embeddings_engine: None,
             images_engine: None,
             videos_engine: None,
+            audios_engine: None,
             tensor_engine: None,
             kv_router: None,
             worker_monitor: None,
@@ -104,6 +107,10 @@ impl WorkerSet {
         self.videos_engine.is_some()
     }
 
+    pub fn has_audios_engine(&self) -> bool {
+        self.audios_engine.is_some()
+    }
+
     pub fn has_tensor_engine(&self) -> bool {
         self.tensor_engine.is_some()
     }
@@ -119,6 +126,7 @@ impl WorkerSet {
             && !self.has_embeddings_engine()
             && !self.has_images_engine()
             && !self.has_videos_engine()
+            && !self.has_audios_engine()
             && !self.has_tensor_engine()
     }
 

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -304,6 +304,9 @@ pub enum Endpoint {
     /// OAI Videos
     Videos,
 
+    /// OAI Audios
+    Audios,
+
     /// OAI Responses
     Responses,
 
@@ -1026,6 +1029,7 @@ impl std::fmt::Display for Endpoint {
             Endpoint::Embeddings => write!(f, "embeddings"),
             Endpoint::Images => write!(f, "images"),
             Endpoint::Videos => write!(f, "videos"),
+            Endpoint::Audios => write!(f, "audios"),
             Endpoint::Responses => write!(f, "responses"),
             Endpoint::AnthropicMessages => write!(f, "anthropic_messages"),
             Endpoint::Tensor => write!(f, "tensor"),
@@ -1041,6 +1045,7 @@ impl Endpoint {
             Endpoint::Embeddings => "embeddings",
             Endpoint::Images => "images",
             Endpoint::Videos => "videos",
+            Endpoint::Audios => "audios",
             Endpoint::Responses => "responses",
             Endpoint::AnthropicMessages => "anthropic_messages",
             Endpoint::Tensor => "tensor",

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -46,6 +46,7 @@ use crate::engines::ValidateRequest;
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
 use crate::protocols::openai::nvext::apply_header_routing_overrides;
 use crate::protocols::openai::{
+    audios::{NvAudiosResponse, NvCreateAudioSpeechRequest},
     chat_completions::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,
         NvCreateChatCompletionStreamResponse,
@@ -2199,6 +2200,101 @@ pub fn videos_router(
         .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .with_state(state);
     (vec![doc, stream_doc], router)
+}
+
+async fn audios(
+    State(state): State<Arc<service_v2::State>>,
+    headers: HeaderMap,
+    Json(request): Json<NvCreateAudioSpeechRequest>,
+) -> Result<Response, ErrorResponse> {
+    // return a 503 if the service is not ready
+    check_ready(&state)?;
+
+    let request_id = get_or_create_request_id(None, &headers);
+    let request = Context::with_id(request, request_id);
+    let request_id = request.id().to_string();
+
+    // Audio generation is non-streaming to the client
+    let streaming = false;
+
+    let model = request.model.clone();
+
+    // Create http_queue_guard early - tracks time waiting to be processed
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+
+    // Get the audio generation engine
+    let engine = state
+        .manager()
+        .get_audios_engine(&model)
+        .map_err(|_| ErrorMessage::model_not_found())?;
+
+    // this will increment the inflight gauge for the model
+    let mut inflight =
+        state
+            .metrics_clone()
+            .create_inflight_guard(&model, Endpoint::Audios, streaming);
+
+    let mut response_collector = state.metrics_clone().create_response_collector(&model);
+
+    // issue the generate call on the engine
+    let stream = engine
+        .generate(request)
+        .await
+        .map_err(|e| ErrorMessage::from_anyhow(e, "Failed to generate audio"))?;
+
+    // Process stream to collect metrics and drop http_queue_guard on first token
+    let mut http_queue_guard = Some(http_queue_guard);
+    let stream = stream.inspect(move |response| {
+        process_response_and_observe_metrics(
+            response,
+            &mut response_collector,
+            &mut http_queue_guard,
+        );
+    });
+
+    // Audio is returned as a single response (non-streaming)
+    // Fold the internal stream into a single response
+    let response = NvAudiosResponse::from_annotated_stream(stream)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to fold audios stream for {}: {:?}", request_id, e);
+            ErrorMessage::internal_server_error("Failed to fold audios stream")
+        })?;
+
+    inflight.mark_ok();
+
+    // Decode base64 and return raw binary audio (matching OpenAI convention)
+    let audio_bytes = base64::prelude::BASE64_STANDARD
+        .decode(&response.audio_b64)
+        .map_err(|e| {
+            tracing::error!("Failed to decode audio base64 for {}: {:?}", request_id, e);
+            ErrorMessage::internal_server_error("Failed to decode audio response")
+        })?;
+
+    axum::http::Response::builder()
+        .status(axum::http::StatusCode::OK)
+        .header(axum::http::header::CONTENT_TYPE, &response.content_type)
+        .body(Body::from(audio_bytes))
+        .map(|r| r.into_response())
+        .map_err(|e| {
+            ErrorMessage::internal_server_error(&format!("Failed to build audio response: {e}"))
+        })
+}
+
+/// Create an Axum [`Router`] for the OpenAI API Audio Speech endpoint
+/// If no path is provided, the default path is `/v1/audio/speech`
+pub fn audios_router(
+    state: Arc<service_v2::State>,
+    path: Option<String>,
+) -> (Vec<RouteDoc>, Router) {
+    let path = path.unwrap_or("/v1/audio/speech".to_string());
+    let doc = RouteDoc::new(axum::http::Method::POST, &path);
+    let router = Router::new()
+        .route(&path, post(audios))
+        .layer(middleware::from_fn(smart_json_error_middleware))
+        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
+        .with_state(state);
+    (vec![doc], router)
 }
 
 #[cfg(test)]

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -56,6 +56,7 @@ struct StateFlags {
     embeddings_endpoints_enabled: AtomicBool,
     images_endpoints_enabled: AtomicBool,
     videos_endpoints_enabled: AtomicBool,
+    audios_endpoints_enabled: AtomicBool,
     responses_endpoints_enabled: AtomicBool,
     anthropic_endpoints_enabled: AtomicBool,
 }
@@ -68,8 +69,7 @@ impl StateFlags {
             EndpointType::Embedding => self.embeddings_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Images => self.images_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Videos => self.videos_endpoints_enabled.load(Ordering::Relaxed),
-            // TODO: add audios_endpoints_enabled flag
-            EndpointType::Audios => false,
+            EndpointType::Audios => self.audios_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Responses => self.responses_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::AnthropicMessages => {
                 self.anthropic_endpoints_enabled.load(Ordering::Relaxed)
@@ -94,8 +94,9 @@ impl StateFlags {
             EndpointType::Videos => self
                 .videos_endpoints_enabled
                 .store(enabled, Ordering::Relaxed),
-            // TODO: add audios_endpoints_enabled flag
-            EndpointType::Audios => {}
+            EndpointType::Audios => self
+                .audios_endpoints_enabled
+                .store(enabled, Ordering::Relaxed),
             EndpointType::Responses => self
                 .responses_endpoints_enabled
                 .store(enabled, Ordering::Relaxed),
@@ -122,6 +123,7 @@ impl State {
                 embeddings_endpoints_enabled: AtomicBool::new(false),
                 images_endpoints_enabled: AtomicBool::new(false),
                 videos_endpoints_enabled: AtomicBool::new(false),
+                audios_endpoints_enabled: AtomicBool::new(false),
                 responses_endpoints_enabled: AtomicBool::new(false),
                 anthropic_endpoints_enabled: AtomicBool::new(false),
             },
@@ -587,6 +589,7 @@ impl HttpServiceConfigBuilder {
             super::openai::embeddings_router(state.clone(), var(HTTP_SVC_EMB_PATH_ENV).ok());
         let (images_docs, images_route) = super::openai::images_router(state.clone(), None);
         let (videos_docs, videos_route) = super::openai::videos_router(state.clone(), None);
+        let (audios_docs, audios_route) = super::openai::audios_router(state.clone(), None);
         let (responses_docs, responses_route) = super::openai::responses_router(
             state.clone(),
             request_template.clone(),
@@ -598,6 +601,7 @@ impl HttpServiceConfigBuilder {
         endpoint_routes.insert(EndpointType::Embedding, (embed_docs, embed_route));
         endpoint_routes.insert(EndpointType::Images, (images_docs, images_route));
         endpoint_routes.insert(EndpointType::Videos, (videos_docs, videos_route));
+        endpoint_routes.insert(EndpointType::Audios, (audios_docs, audios_route));
         endpoint_routes.insert(EndpointType::Responses, (responses_docs, responses_route));
 
         if env_is_truthy(env_llm::DYN_ENABLE_ANTHROPIC_API) {

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -11,6 +11,7 @@ use super::{
 use crate::protocols::openai::common_ext::CommonExtProvider;
 use crate::types::TokenIdType;
 
+pub mod audios;
 pub mod chat_completions;
 pub mod common_ext;
 pub mod completions;

--- a/lib/llm/src/protocols/openai/audios.rs
+++ b/lib/llm/src/protocols/openai/audios.rs
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_runtime::protocols::annotated::AnnotationsProvider;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+mod aggregator;
+mod nvext;
+
+pub use aggregator::DeltaAggregator;
+pub use nvext::{NvExt, NvExtProvider};
+
+/// Request for audio speech generation (/v1/audio/speech endpoint)
+///
+/// Follows the OpenAI TTS API convention.
+#[derive(Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreateAudioSpeechRequest {
+    /// The text to generate audio for
+    pub input: String,
+
+    /// The model to use for audio generation
+    pub model: String,
+
+    /// The voice to use for generation
+    pub voice: String,
+
+    /// The audio format to return: mp3, wav, opus, aac, flac, pcm
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<String>,
+
+    /// Playback speed (0.25 to 4.0, default 1.0)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speed: Option<f32>,
+
+    /// NVIDIA extensions
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nvext: Option<NvExt>,
+}
+
+/// Response structure for audio speech generation.
+///
+/// Internal transport uses base64-encoded audio. The HTTP handler decodes
+/// this to return raw binary audio to clients (matching OpenAI convention).
+#[derive(Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvAudiosResponse {
+    /// Base64-encoded audio bytes
+    pub audio_b64: String,
+
+    /// MIME content type (e.g. "audio/mpeg", "audio/wav")
+    pub content_type: String,
+
+    /// Model used for generation
+    pub model: String,
+
+    /// Unix timestamp of creation
+    pub created: i64,
+}
+
+impl NvAudiosResponse {
+    pub fn empty() -> Self {
+        Self {
+            audio_b64: String::new(),
+            content_type: "audio/mpeg".to_string(),
+            model: String::new(),
+            created: 0,
+        }
+    }
+}
+
+/// Implements `NvExtProvider` for `NvCreateAudioSpeechRequest`,
+/// providing access to NVIDIA-specific extensions.
+impl NvExtProvider for NvCreateAudioSpeechRequest {
+    /// Returns a reference to the optional `NvExt` extension, if available.
+    fn nvext(&self) -> Option<&NvExt> {
+        self.nvext.as_ref()
+    }
+}
+
+/// Implements `AnnotationsProvider` for `NvCreateAudioSpeechRequest`,
+/// enabling retrieval and management of request annotations.
+impl AnnotationsProvider for NvCreateAudioSpeechRequest {
+    /// Retrieves the list of annotations from `NvExt`, if present.
+    fn annotations(&self) -> Option<Vec<String>> {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.clone())
+    }
+
+    /// Checks whether a specific annotation exists in the request.
+    fn has_annotation(&self, annotation: &str) -> bool {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.as_ref())
+            .map(|annotations| annotations.contains(&annotation.to_string()))
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request_serialization_roundtrip() {
+        let req = NvCreateAudioSpeechRequest {
+            input: "Hello world".to_string(),
+            model: "tts-model".to_string(),
+            voice: "vivian".to_string(),
+            response_format: Some("wav".to_string()),
+            speed: Some(1.5),
+            nvext: Some(NvExt {
+                seed: Some(42),
+                language: Some("en".to_string()),
+                ..Default::default()
+            }),
+        };
+
+        let json = serde_json::to_string(&req).unwrap();
+        let deserialized: NvCreateAudioSpeechRequest = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.input, "Hello world");
+        assert_eq!(deserialized.model, "tts-model");
+        assert_eq!(deserialized.voice, "vivian");
+        assert_eq!(deserialized.response_format.as_deref(), Some("wav"));
+        assert_eq!(deserialized.speed, Some(1.5));
+        assert_eq!(deserialized.nvext.as_ref().unwrap().seed, Some(42));
+        assert_eq!(
+            deserialized.nvext.as_ref().unwrap().language.as_deref(),
+            Some("en")
+        );
+    }
+
+    #[test]
+    fn test_request_minimal_deserialization() {
+        let json = r#"{"input":"Hi","model":"tts","voice":"alloy"}"#;
+        let req: NvCreateAudioSpeechRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.input, "Hi");
+        assert_eq!(req.model, "tts");
+        assert_eq!(req.voice, "alloy");
+        assert!(req.response_format.is_none());
+        assert!(req.speed.is_none());
+        assert!(req.nvext.is_none());
+    }
+
+    #[test]
+    fn test_response_serialization_roundtrip() {
+        let resp = NvAudiosResponse {
+            audio_b64: "dGVzdA==".to_string(),
+            content_type: "audio/wav".to_string(),
+            model: "tts-model".to_string(),
+            created: 1234567890,
+        };
+
+        let json = serde_json::to_string(&resp).unwrap();
+        let deserialized: NvAudiosResponse = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.audio_b64, "dGVzdA==");
+        assert_eq!(deserialized.content_type, "audio/wav");
+        assert_eq!(deserialized.model, "tts-model");
+        assert_eq!(deserialized.created, 1234567890);
+    }
+
+    #[test]
+    fn test_empty_response() {
+        let resp = NvAudiosResponse::empty();
+        assert!(resp.audio_b64.is_empty());
+        assert_eq!(resp.content_type, "audio/mpeg");
+        assert!(resp.model.is_empty());
+        assert_eq!(resp.created, 0);
+    }
+
+    #[test]
+    fn test_annotations_provider() {
+        let req = NvCreateAudioSpeechRequest {
+            input: "test".to_string(),
+            model: "m".to_string(),
+            voice: "v".to_string(),
+            response_format: None,
+            speed: None,
+            nvext: Some(NvExt {
+                annotations: Some(vec!["request_id".to_string()]),
+                ..Default::default()
+            }),
+        };
+
+        assert!(req.has_annotation("request_id"));
+        assert!(!req.has_annotation("other"));
+        assert_eq!(req.annotations().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_annotations_provider_no_nvext() {
+        let req = NvCreateAudioSpeechRequest {
+            input: "test".to_string(),
+            model: "m".to_string(),
+            voice: "v".to_string(),
+            response_format: None,
+            speed: None,
+            nvext: None,
+        };
+
+        assert!(!req.has_annotation("request_id"));
+        assert!(req.annotations().is_none());
+    }
+
+    #[test]
+    fn test_nvext_builder() {
+        let nvext = NvExt::builder()
+            .seed(42_i64)
+            .language("zh".to_string())
+            .add_annotation("test_ann")
+            .build()
+            .unwrap();
+
+        assert_eq!(nvext.seed, Some(42));
+        assert_eq!(nvext.language.as_deref(), Some("zh"));
+        assert_eq!(nvext.annotations.as_ref().unwrap(), &["test_ann"]);
+    }
+
+    #[test]
+    fn test_nvext_default() {
+        let nvext = NvExt::default();
+        assert!(nvext.seed.is_none());
+        assert!(nvext.language.is_none());
+        assert!(nvext.annotations.is_none());
+        assert!(nvext.task_type.is_none());
+        assert!(nvext.instructions.is_none());
+        assert!(nvext.ref_audio.is_none());
+        assert!(nvext.ref_text.is_none());
+        assert!(nvext.max_new_tokens.is_none());
+    }
+}

--- a/lib/llm/src/protocols/openai/audios/aggregator.rs
+++ b/lib/llm/src/protocols/openai/audios/aggregator.rs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::{Stream, StreamExt};
+
+use crate::types::Annotated;
+
+use super::NvAudiosResponse;
+
+/// Aggregator for combining audio response deltas into a final response.
+#[derive(Debug)]
+pub struct DeltaAggregator {
+    response: Option<NvAudiosResponse>,
+    error: Option<String>,
+}
+
+impl Default for DeltaAggregator {
+    /// Provides a default implementation for `DeltaAggregator` by calling [`DeltaAggregator::new`].
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeltaAggregator {
+    pub fn new() -> Self {
+        DeltaAggregator {
+            response: None,
+            error: None,
+        }
+    }
+
+    /// Aggregates a stream of annotated audio responses into a final response.
+    pub async fn apply(
+        stream: impl Stream<Item = Annotated<NvAudiosResponse>>,
+    ) -> Result<NvAudiosResponse, String> {
+        let aggregator = stream
+            .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
+                // Attempt to unwrap the delta, capturing any errors.
+                let delta = match delta.ok() {
+                    Ok(delta) => delta,
+                    Err(error) => {
+                        aggregator.error = Some(error);
+                        return aggregator;
+                    }
+                };
+
+                if aggregator.error.is_none()
+                    && let Some(response) = delta.data
+                {
+                    // For audio, we expect a single complete response
+                    match &mut aggregator.response {
+                        Some(existing) => {
+                            // If we get multiple responses, keep the latest one
+                            *existing = response;
+                        }
+                        None => {
+                            aggregator.response = Some(response);
+                        }
+                    }
+                }
+                aggregator
+            })
+            .await;
+
+        // Return early if an error was encountered.
+        if let Some(error) = aggregator.error {
+            return Err(error);
+        }
+
+        // Return the aggregated response or an empty response if none was found.
+        Ok(aggregator.response.unwrap_or_else(NvAudiosResponse::empty))
+    }
+}
+
+impl NvAudiosResponse {
+    /// Aggregates an annotated stream of audio responses into a final response.
+    pub async fn from_annotated_stream(
+        stream: impl Stream<Item = Annotated<NvAudiosResponse>>,
+    ) -> Result<NvAudiosResponse, String> {
+        DeltaAggregator::apply(stream).await
+    }
+}

--- a/lib/llm/src/protocols/openai/audios/nvext.rs
+++ b/lib/llm/src/protocols/openai/audios/nvext.rs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use validator::{Validate, ValidationError};
+
+pub trait NvExtProvider {
+    fn nvext(&self) -> Option<&NvExt>;
+}
+
+/// NVIDIA extensions to the OpenAI Audio Speech API
+#[derive(ToSchema, Serialize, Deserialize, Builder, Validate, Debug, Clone)]
+#[validate(schema(function = "validate_nv_ext"))]
+pub struct NvExt {
+    /// Annotations
+    /// User requests triggers which result in the request issue back out-of-band information in the SSE
+    /// stream using the `event:` field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub annotations: Option<Vec<String>>,
+
+    /// Task type (e.g. "tts", "voice_clone")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub task_type: Option<String>,
+
+    /// Language code (e.g. "en", "zh")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub language: Option<String>,
+
+    /// Additional instructions for speech generation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub instructions: Option<String>,
+
+    /// Base64-encoded reference audio for voice cloning
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub ref_audio: Option<String>,
+
+    /// Reference text corresponding to ref_audio
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub ref_text: Option<String>,
+
+    /// Maximum number of tokens to generate
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub max_new_tokens: Option<u32>,
+
+    /// The seed for the random number generator.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub seed: Option<i64>,
+}
+
+impl Default for NvExt {
+    fn default() -> Self {
+        NvExt::builder().build().unwrap()
+    }
+}
+
+impl NvExt {
+    pub fn builder() -> NvExtBuilder {
+        NvExtBuilder::default()
+    }
+}
+
+fn validate_nv_ext(_nv_ext: &NvExt) -> Result<(), ValidationError> {
+    Ok(())
+}
+
+impl NvExtBuilder {
+    pub fn add_annotation(&mut self, annotation: impl Into<String>) -> &mut Self {
+        self.annotations
+            .get_or_insert_with(|| Some(vec![]))
+            .as_mut()
+            .expect("annotations should always be Some(Vec)")
+            .push(annotation.into());
+        self
+    }
+}

--- a/lib/llm/src/types.rs
+++ b/lib/llm/src/types.rs
@@ -96,6 +96,16 @@ pub mod openai {
         pub type OpenAIVideosStreamingEngine =
             ServerStreamingEngine<NvCreateVideoRequest, Annotated<NvVideosResponse>>;
     }
+
+    pub mod audios {
+        use super::*;
+
+        pub use protocols::openai::audios::{NvAudiosResponse, NvCreateAudioSpeechRequest};
+
+        /// A [`ServerStreamingEngine`] implementation for the OpenAI Audio Speech API
+        pub type OpenAIAudiosStreamingEngine =
+            ServerStreamingEngine<NvCreateAudioSpeechRequest, Annotated<NvAudiosResponse>>;
+    }
 }
 
 pub mod generic {

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -222,6 +222,7 @@ fn compute_index(endpoint: &Endpoint, request_type: &RequestType, status: &Statu
         Endpoint::Tensor => todo!(),
         Endpoint::Images => todo!(),
         Endpoint::Videos => todo!(),
+        Endpoint::Audios => todo!(),
     };
 
     let request_type = match request_type {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ vllm = [
     # vllm-omni 0.16.0 is now on PyPI; install only future rc builds from source in container builds
     # (see container/deps/vllm/install_vllm.sh). pip install ai-dynamo[vllm] will
     # not include vllm-omni — install it separately from source if needed.
-    "vllm-omni==0.16.0",
+    "vllm-omni @ git+https://github.com/vllm-project/vllm-omni@v0.17.0rc1",
     "blake3>=1.0.0,<2.0.0",
 ]
 


### PR DESCRIPTION
DEP: https://github.com/ai-dynamo/enhancements/pull/78

## Overview:

Add a Text-to-Speech (TTS) audio generation endpoint (`POST /v1/audio/speech`) to Dynamo, powered by vLLM Omni. The endpoint accepts text input and returns a complete WAV or PCM audio file, following the same architectural patterns already established by the image and video generation modalities. This proposal covers the first working version (V1) that delivers complete audio responses, while laying the groundwork for future streaming and additional codecs.

## Example

**Worker**

```
python3 -m dynamo.vllm.omni \
    --model Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
    --discovery-backend file \
    --enforce-eager \
    --trust-remote-code \
    --output-modalities audio
```

**Request**

```
curl -X POST http://localhost:8091/v1/audio/speech \                                                                           
    -H "Content-Type: application/json" \
    -d '{
        "model": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
        "input": "Hello, this is a test of text to speech.",
        "voice": "aiden"
    }'  --output speech.wav
```

**Output:** [speech.wav](https://github.com/user-attachments/files/26304242/speech.wav)

## Details

```
                        RUST                              PYTHON
                  ──────────────                    ────────────────

  Client ──POST──> Axum Router
                   /v1/audio/speech
                        |
                   HTTP Handler
                        |
                   NvCreateAudioSpeechRequest
                        |
                   ModelManager -> WorkerSet
                   -> audios_engine
                        |
                   engine.generate()  ────────────>  OmniHandler.generate()
                                                           |
                                                      Parse request type
                                                      -> AudioGeneration
                                                           |
                                                      Build TTS model inputs
                                                      (model-specific prompt
                                                       construction)
                                                           |
                                                      vLLM engine generates
                                                      audio (cumulative PCM)
                                                           |
                                                      Extract & format audio
                                                      -> WAV or PCM + base64
                                                           |
                   <──── NvAudiosResponse ────────  yield NvAudiosResponse
                   (stream, base64 audio)
                        |
                   Aggregator
                   -> fold stream (take latest)
                        |
                   base64 decode -> raw bytes
                   Set Content-Type header
                        |
  Client <──200──  raw binary audio (WAV/PCM)
```

## Where should the reviewer start?

Most of the files follow images and videos setup. Audio/vllm specific logic is in this file: `components/src/dynamo/vllm/omni/omni_handler.py`

## Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: https://github.com/ai-dynamo/dynamo/issues/7664

## To fix/improve (self review)

* Move `instructions` out of nvnext to main API to match [OpenAI definition](https://developers.openai.com/api/reference/resources/audio/subresources/speech/methods/create).
* Omni handler logic, specially, prompt length estimation is coupled to Qwen-TTS.