### PR TITLE
feat(vllm): add CPU Encode for dual/multiple encoder EPD

### DIFF
--- a/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
@@ -98,7 +98,6 @@ class EncodeWorkerHandler:
             logger.info(f"CUDA device count: {torch.cuda.device_count()}")
             logger.info(f"Current CUDA device: {torch.cuda.current_device()}")
 
-        logger.info("=" * 60)
 
         hidden_size = getattr(self.vision_model, "out_hidden_size", None)
         if hidden_size is None:

--- a/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
@@ -77,9 +77,6 @@ class EncodeWorkerHandler:
         )
 
         # Device verification logging
-        logger.info("=" * 60)
-        logger.info("ENCODER DEVICE VERIFICATION")
-        logger.info("=" * 60)
         logger.info(f"Requested encoder device (DYN_ENCODER_DEVICE): {encoder_device}")
 
         # Check what device the vision model is on

--- a/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
@@ -62,13 +62,47 @@ class EncodeWorkerHandler:
         self.engine_args = engine_args
         self.model = self.engine_args.model
 
+        # Check for encoder device override via environment variable
+        # DYN_ENCODER_DEVICE can be: "auto", "cpu", "cuda", "xpu", or specific device like "cuda:0"
+        encoder_device = os.getenv("DYN_ENCODER_DEVICE", "auto")
+
         self.image_loader = ImageLoader(cache_size=CACHE_SIZE_MAXIMUM)
         self.image_processor = AutoImageProcessor.from_pretrained(
             self.model, trust_remote_code=True
         )
         self.vision_model = load_vision_model(
-            self.model, enforce_eager=self.engine_args.enforce_eager
+            self.model,
+            enforce_eager=self.engine_args.enforce_eager,
+            device=encoder_device,
         )
+
+        # Device verification logging
+        logger.info("=" * 60)
+        logger.info("ENCODER DEVICE VERIFICATION")
+        logger.info("=" * 60)
+        logger.info(f"Requested encoder device (DYN_ENCODER_DEVICE): {encoder_device}")
+
+        # Check what device the vision model is on
+        if hasattr(self.vision_model, "device"):
+            logger.info(f"Vision model device: {self.vision_model.device}")
+        else:
+            # Try to get device from first parameter
+            try:
+                first_param_device = next(self.vision_model.parameters()).device
+                logger.info(
+                    f"Vision model device (from parameters): {first_param_device}"
+                )
+            except (StopIteration, AttributeError):
+                logger.info("Vision model device: Unable to determine")
+
+        # Check CUDA availability and visibility
+        logger.info(f"CUDA available: {torch.cuda.is_available()}")
+        if torch.cuda.is_available():
+            logger.info(f"CUDA device count: {torch.cuda.device_count()}")
+            logger.info(f"Current CUDA device: {torch.cuda.current_device()}")
+
+        logger.info("=" * 60)
+
         hidden_size = getattr(self.vision_model, "out_hidden_size", None)
         if hidden_size is None:
             hidden_size = getattr(
@@ -248,7 +282,19 @@ class EncodeWorkerHandler:
                     # [gluo FIXME] This is specific to qwen vision processing..
                     # Split concatenated embeddings for each image item.
                     if is_qwen_vl_model(self.model):
-                        merge_size = self.vision_encoder.spatial_merge_size
+                        # For vLLM encoder: spatial_merge_size is directly on vision_encoder
+                        # For HuggingFace: it's on vision_encoder.visual.spatial_merge_size
+                        if hasattr(self.vision_encoder, "spatial_merge_size"):
+                            merge_size = self.vision_encoder.spatial_merge_size
+                        elif hasattr(self.vision_encoder, "visual") and hasattr(
+                            self.vision_encoder.visual, "spatial_merge_size"
+                        ):
+                            merge_size = self.vision_encoder.visual.spatial_merge_size
+                        else:
+                            # Fallback to config
+                            merge_size = getattr(
+                                self.vision_encoder.config, "spatial_merge_size", 2
+                            )
                         sizes = (
                             image_embeds["image_grid_thw"].prod(-1)
                             // merge_size

--- a/components/src/dynamo/vllm/multimodal_utils/encode_utils.py
+++ b/components/src/dynamo/vllm/multimodal_utils/encode_utils.py
@@ -106,6 +106,16 @@ def encode_image_embeddings(
         NotImplementedError: If model is not supported
     """
     with torch.no_grad():
+        # Log encoder device during inference
+        logger = logging.getLogger(__name__)
+        try:
+            encoder_device = next(vision_encoder.parameters()).device
+            logger.info(
+                f"[ENCODE] Vision encoder device during inference: {encoder_device}"
+            )
+        except (StopIteration, AttributeError):
+            logger.info("[ENCODE] Unable to determine vision encoder device")
+
         # Route through the correct encoder based on model
         if is_model_supported(model_name, SupportedModels.LLAVA_1_5_7B):
             pixel_values = image_embeds["pixel_values"].to(vision_encoder.device)

--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -156,11 +156,22 @@ def is_qwen_vl_model(model_name: str) -> bool:
     )
 
 
-def load_vision_model(model_id: str, enforce_eager: bool = False) -> torch.nn.Module:
+def load_vision_model(
+    model_id: str, enforce_eager: bool = False, device: str = "auto"
+) -> torch.nn.Module:
     """
     Load a vision model from a HuggingFace model ID.
+
+    Args:
+        model_id: The model identifier
+        enforce_eager: Whether to enforce eager execution
+        device: Device to load the model on. Options: "auto", "cpu", "cuda", "xpu", or specific device like "cuda:0"
     """
-    if VLLM_ENCODER and is_qwen_vl_model(model_id):
+    # When device="cpu" is explicitly requested, skip vLLM encoder and use HuggingFace path
+    # because vLLM doesn't support CPU-only mode for encoder workers
+    use_vllm_encoder = VLLM_ENCODER and is_qwen_vl_model(model_id) and device != "cpu"
+
+    if use_vllm_encoder:
         # Disable to get ViT from the same process
         update_environment_variables(
             {
@@ -185,7 +196,7 @@ def load_vision_model(model_id: str, enforce_eager: bool = False) -> torch.nn.Mo
             vllm_model.llm_engine.engine_core.engine_core.model_executor.driver_worker.worker.model_runner.model.visual
         )
     return AutoModel.from_pretrained(
-        model_id, device_map="auto", torch_dtype=torch.float16, trust_remote_code=True
+        model_id, device_map=device, torch_dtype=torch.float16, trust_remote_code=True
     )
 
 

--- a/examples/backends/vllm/launch/cpu_encoder.sh
+++ b/examples/backends/vllm/launch/cpu_encoder.sh
@@ -5,8 +5,8 @@ set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-source "$SCRIPT_DIR/../../../../common/gpu_utils.sh"
-source "$SCRIPT_DIR/../../../../common/launch_utils.sh"
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 
 # Default values
 MODEL_NAME="llava-hf/llava-1.5-7b-hf"
@@ -88,6 +88,7 @@ EXTRA_ARGS=""
 PD_EXTRA_ARGS=""
 
 # GPU assignments (override via environment variables)
+# Encoder uses GPU 0 for vLLM infrastructure, but vision model loads on CPU via DYN_ENCODER_DEVICE
 DYN_ENCODE_WORKER_GPU=${DYN_ENCODE_WORKER_GPU:-0}
 DYN_PREFILL_WORKER_GPU=${DYN_PREFILL_WORKER_GPU:-1}
 DYN_DECODE_WORKER_GPU=${DYN_DECODE_WORKER_GPU:-2}
@@ -123,23 +124,28 @@ if [[ "${DEVICE_PLATFORM,,}" == "xpu" ]]; then
     PD_EXTRA_ARGS="--max-model-len 10240"
 fi
 
-# Start encode worker
-echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (GPU mem: $DYN_ENCODE_GPU_MEM)..."
+# Start encode worker with CPU vision model
+echo "Starting encode worker with CPU vision model (vLLM on GPU $DYN_ENCODE_WORKER_GPU)..."
+# DYN_ENCODER_DEVICE=cpu forces the vision model to load on CPU (device_map="cpu")
+# VLLM_ENCODER=0 ensures HuggingFace encoding path is used (not vLLM encoder)
+# vLLM infrastructure still runs on GPU to maintain compatibility
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
+DYN_ENCODER_DEVICE=cpu \
+VLLM_ENCODER=0 \
 env $DEVICE_AFFINITY_ENV=$DYN_ENCODE_WORKER_GPU \
-python -m dynamo.vllm --multimodal-encode-worker --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device": "'"$DEVICE_PLATFORM"'"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080"}' &
+python -m dynamo.vllm --multimodal-encode-worker --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device": "cpu"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080"}' &
 
 # Start prefill worker (also handles encode routing via --route-to-encoder)
 echo "Starting prefill worker on GPU $DYN_PREFILL_WORKER_GPU (GPU mem: $DYN_PREFILL_GPU_MEM)..."
 VLLM_NIXL_SIDE_CHANNEL_PORT=20098 \
 env $DEVICE_AFFINITY_ENV=$DYN_PREFILL_WORKER_GPU \
-python -m dynamo.vllm --route-to-encoder --disaggregation-mode prefill --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_PREFILL_GPU_MEM $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device": "'"$DEVICE_PLATFORM"'"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081"}' &
+python -m dynamo.vllm --multimodal-worker --route-to-encoder --disaggregation-mode prefill --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_PREFILL_GPU_MEM $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device": "'"$DEVICE_PLATFORM"'"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081"}' &
 
 # Start decode worker
 echo "Starting decode worker on GPU $DYN_DECODE_WORKER_GPU (GPU mem: $DYN_DECODE_GPU_MEM)..."
 VLLM_NIXL_SIDE_CHANNEL_PORT=20099 \
 env $DEVICE_AFFINITY_ENV=$DYN_DECODE_WORKER_GPU \
-python -m dynamo.vllm --disaggregation-mode decode --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_DECODE_GPU_MEM $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device": "'"$DEVICE_PLATFORM"'"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20082"}' &
+python -m dynamo.vllm --multimodal-decode-worker --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_DECODE_GPU_MEM $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device": "'"$DEVICE_PLATFORM"'"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20082"}' &
 
 
 echo "=================================================="

--- a/examples/backends/vllm/launch/xpu/cpu_encoder_for_epd.sh
+++ b/examples/backends/vllm/launch/xpu/cpu_encoder_for_epd.sh
@@ -5,8 +5,8 @@ set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
-source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+source "$SCRIPT_DIR/../../../../common/gpu_utils.sh"
+source "$SCRIPT_DIR/../../../../common/launch_utils.sh"
 
 # Default values
 MODEL_NAME="llava-hf/llava-1.5-7b-hf"


### PR DESCRIPTION
#### Overview:

This PR is to add CPU encode for EPD disaggregation case that CPU can help offload the workload for dual/multiple Encoder EPD scenario. It can help the performance different from purely GPU/XPU encoding scenario. 

The problem solved here:   Default encoder in dynamo will automatically discovers the device platform and you can not setup the additional CPU encoder for offload for example under Cuda/XPU device environment. By this PR you can setup additional encoder with CPU for encoding offloading in multiple encoder case. 

#### Details:

You can use the below example code for testing cpu encoding -
`DEVICE_PLATFORM='xpu' bash examples/backends/vllm/launch/xpu/cpu_encoder_for_epd.sh   --model Qwen/Qwen2.5-VL-3B-Instruct`

You will see the encoding device in terminal like 
<img width="1907" height="226" alt="image" src="https://github.com/user-attachments/assets/3a345132-a063-44ef-83e6-52a677b33d7d" />

Also with the output -
<img width="1324" height="367" alt="image" src="https://github.com/user-attachments/assets/59973ab4-ac26-4f95-9aaf-8b2b767e1984" />

Thanks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-driven configuration to control vision encoder device placement (CPU or GPU).
  * Introduced new disaggregated serving deployment option combining CPU-based vision encoder with GPU workers.

* **Improvements**
  * Enhanced debugging with detailed logging for device placement and CUDA configuration.
  * Improved robustness for Qwen model vision configurations with flexible attribute resolution.

* **Chores**
  * Updated launch script path references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->