### PR TITLE
feat: NIXL Telemetry to be deployed with docker compose

### DIFF
--- a/deploy/observability/prometheus.yml
+++ b/deploy/observability/prometheus.yml
@@ -48,6 +48,14 @@ scrape_configs:
     static_configs:
       - targets: ['host.docker.internal:8081']
 
+  # NIXL Prometheus metrics (requires env on the worker: NIXL_TELEMETRY_ENABLE=y,
+  # NIXL_TELEMETRY_EXPORTER=prometheus, NIXL_TELEMETRY_PROMETHEUS_PORT=19090).
+  # Compose Prometheus reaches the host via host.docker.internal (see docker-observability.yml).
+  - job_name: 'dynamo-nixl'
+    scrape_interval: 1s
+    static_configs:
+      - targets: ['host.docker.internal:19090']
+
 
   # KVBM leader related metrics
   - job_name: 'kvbm-metrics'


### PR DESCRIPTION
#### Overview:

NIXL telemetry was limited to k8s deployment, This change fixes it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded observability capabilities by integrating an additional metrics collection source into the monitoring configuration to capture system performance data at optimized collection intervals.
  * Enables improved real-time visibility into system health and performance metrics through enhanced distributed monitoring infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->