### PR TITLE
fix: race condition in multi modal PD worker

### DIFF
--- a/components/src/dynamo/vllm/multimodal_handlers/multimodal_pd_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/multimodal_pd_worker_handler.py
@@ -280,9 +280,13 @@ class MultimodalPDWorkerHandler(BaseWorkerHandler[dict, dict]):
                 logger.debug(
                     f"length of expanded prompt ids: {len(response.prompt_token_ids)}"
                 )
-                yield self._format_engine_output(response, num_output_tokens_so_far)
+                chunk = self._format_engine_output(response, num_output_tokens_so_far)
+
+                # Capture token count BEFORE yield — vLLM may mutate
+                # response.outputs[0].token_ids in-place while we're suspended.
                 if response.outputs:
                     num_output_tokens_so_far = len(response.outputs[0].token_ids)
+                yield chunk
         finally:
             if first_token:
                 if rng_ttft is not None:


### PR DESCRIPTION
#### Overview:

When we run vLLM bench with E/PD disaggregation, number of "Total generated tokens" is always less than expected. Debug showed that vLLM generates correct number of tokens but some of them are lost during transmission. The reason is race-condition in `MultimodalPDWorkerHandler`.

#### Details:

Here's what happens: `_format_engine_output` captures `token_ids[num_output_tokens_so_far:]` as a slice (new list), suspends the generator, control returns to the consumer. While suspended, vLLM's engine continues running and mutates `response.outputs[0].token_ids` in-place (appends the next token to the same list object). Generator resumes → `num_output_tokens_so_far = len(response.outputs[0].token_ids)` reads the already-mutated length.

The fix: capture `len(response.outputs[0].token_ids)` before the yield.

Note that `generate_tokens()` in `handlers.py` does this correctly — it captures `next_total_toks = len(output.token_ids)` before yielding. 	The `_generate_disagg` method doesn't have this bug also because it deserializes from JSON (`MyRequestOutput.model_validate_json()`), creating a fresh object each time rather than sharing a mutable list with the engine. 





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved token counting accuracy in multimodal generation operations to ensure reliable output tracking during streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->