### PR TITLE
fix: preserve user-provided --runner flag in update_engine_config_with_dynamo

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -238,8 +238,6 @@ def update_engine_config_with_dynamo(
         ensure_side_channel_host()
 
     defaults = {
-        # vLLM 0.13+ renamed 'task' to 'runner'
-        "runner": "generate",
         # As of vLLM >=0.10.0 the engine unconditionally calls
         # `sampling_params.update_from_tokenizer(...)`, so we can no longer
         # skip tokenizer initialisation.  Setting this to **False** avoids
@@ -248,6 +246,18 @@ def update_engine_config_with_dynamo(
         "enable_log_requests": False,
         "disable_log_stats": False,
     }
+
+    # vLLM 0.13+ renamed 'task' to 'runner'.  Only default to "generate"
+    # when the user did NOT explicitly set --runner (vLLM's default is "auto").
+    # This preserves user-provided values like --runner pooling for embedding
+    # models.
+    if hasattr(engine_config, "runner"):
+        if getattr(engine_config, "runner", "auto") == "auto":
+            defaults["runner"] = "generate"
+        else:
+            logger.debug(
+                f"Preserving user-provided runner: {engine_config.runner}"
+            )
 
     kv_cfg = create_kv_events_config(dynamo_config, engine_config)
     defaults["kv_events_config"] = kv_cfg

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -252,7 +252,7 @@ def update_engine_config_with_dynamo(
     # This preserves user-provided values like --runner pooling for embedding
     # models.
     if hasattr(engine_config, "runner"):
-        if getattr(engine_config, "runner", "auto") == "auto":
+        if engine_config.runner == "auto":
             defaults["runner"] = "generate"
         else:
             logger.debug(

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -735,6 +735,7 @@ def _make_dynamo_config(**overrides):
         "disaggregation_mode": DisaggregationMode.AGGREGATED,
         "use_kv_events": False,
         "enable_local_indexer": True,
+        "benchmark_mode": None,
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -22,6 +22,7 @@ from dynamo.vllm.args import (
     ensure_side_channel_host,
     get_host_ip,
     parse_args,
+    update_engine_config_with_dynamo,
 )
 from dynamo.vllm.constants import DisaggregationMode
 from dynamo.vllm.tests.conftest import make_cli_args_fixture
@@ -723,3 +724,85 @@ class TestBenchmarkGrid:
         total_kv = 100 * 16
         for ctx_len, bs in points:
             assert ctx_len <= total_kv
+
+
+# --- update_engine_config_with_dynamo: --runner preservation tests ---
+
+
+def _make_dynamo_config(**overrides):
+    """Build a minimal fake DynamoConfig for update_engine_config_with_dynamo tests."""
+    defaults = {
+        "disaggregation_mode": DisaggregationMode.AGGREGATED,
+        "use_kv_events": False,
+        "enable_local_indexer": True,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_engine_config_with_runner(runner="auto", **overrides):
+    """Build a fake engine config with runner and other fields used by defaults loop."""
+    defaults = {
+        "runner": runner,
+        "enable_prefix_caching": True,
+        "block_size": 16,
+        "skip_tokenizer_init": True,
+        "enable_log_requests": True,
+        "disable_log_stats": True,
+        "kv_events_config": None,
+        "kv_transfer_config": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestRunnerPreservation:
+    """Tests for GitHub issue #7670: --runner must not be unconditionally overridden."""
+
+    def test_runner_defaults_to_generate_when_auto(self):
+        """When user does not pass --runner (vLLM default is 'auto'),
+        Dynamo should set it to 'generate'."""
+        dynamo_cfg = _make_dynamo_config()
+        engine_cfg = _make_engine_config_with_runner(runner="auto")
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert engine_cfg.runner == "generate"
+
+    def test_runner_pooling_preserved(self):
+        """When user passes --runner pooling (for embedding models),
+        Dynamo must NOT overwrite it."""
+        dynamo_cfg = _make_dynamo_config()
+        engine_cfg = _make_engine_config_with_runner(runner="pooling")
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert engine_cfg.runner == "pooling"
+
+    def test_runner_generate_explicit_preserved(self):
+        """When user explicitly passes --runner generate, it should still be 'generate'."""
+        dynamo_cfg = _make_dynamo_config()
+        engine_cfg = _make_engine_config_with_runner(runner="generate")
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert engine_cfg.runner == "generate"
+
+    def test_runner_draft_preserved(self):
+        """When user passes --runner draft, Dynamo must NOT overwrite it."""
+        dynamo_cfg = _make_dynamo_config()
+        engine_cfg = _make_engine_config_with_runner(runner="draft")
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert engine_cfg.runner == "draft"
+
+    def test_no_runner_attr_skipped_gracefully(self):
+        """If engine_config lacks a 'runner' attr (older vLLM), no error is raised."""
+        dynamo_cfg = _make_dynamo_config()
+        engine_cfg = _make_engine_config_with_runner()
+        del engine_cfg.runner  # simulate older vLLM without runner
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert not hasattr(engine_cfg, "runner")


### PR DESCRIPTION
## Summary

- `update_engine_config_with_dynamo()` unconditionally set `engine_args.runner = "generate"`, overwriting any user-provided `--runner` CLI argument
- This broke embedding models (e.g. `google/embeddinggemma-300m`) that require `--runner pooling`
- Now only defaults to `"generate"` when the user didn't explicitly set `--runner` (i.e. vLLM's default `"auto"` is still in place)

## Root cause

The `defaults` dict in `update_engine_config_with_dynamo()` hardcoded `"runner": "generate"` and the subsequent loop applied all defaults unconditionally via `setattr`, with no check for whether the user had already set the value.

## Fix

Moved the `runner` default out of the unconditional `defaults` dict. Before adding it, we check if `engine_config.runner` is still `"auto"` (vLLM's default when the user doesn't specify `--runner`). If the user explicitly provided a value like `pooling` or `draft`, it is preserved.

## Changelog

- `components/src/dynamo/vllm/args.py`: Check `engine_config.runner` before defaulting to `"generate"`
- `components/src/dynamo/vllm/tests/test_vllm_unit.py`: Added `TestRunnerPreservation` class with 5 test cases covering auto→generate default, pooling/generate/draft preservation, and graceful handling when the `runner` attr is absent (older vLLM)

## Test plan

- [ ] `TestRunnerPreservation::test_runner_defaults_to_generate_when_auto` — default behavior unchanged
- [ ] `TestRunnerPreservation::test_runner_pooling_preserved` — embedding model case from #7670
- [ ] `TestRunnerPreservation::test_runner_generate_explicit_preserved` — explicit generate still works
- [ ] `TestRunnerPreservation::test_runner_draft_preserved` — draft runner preserved
- [ ] `TestRunnerPreservation::test_no_runner_attr_skipped_gracefully` — backward compat with older vLLM
- [ ] Deploy an embedding model with `--runner pooling` and verify it starts without the `ValidationError`

Fixes #7670

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runner configuration is no longer unconditionally overwritten; user-specified values are now preserved, with defaults applied only when auto-configured.

* **Tests**
  * Added test coverage for runner configuration preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->