### PR TITLE
fix: remove omni dependency from dynamo.vllm path

### DIFF
--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -34,7 +34,6 @@ from dynamo.llm import (
 )
 from dynamo.runtime import Endpoint
 from dynamo.runtime.logging import configure_dynamo_logging
-from dynamo.vllm.omni.args import OmniConfig
 from dynamo.vllm.worker_factory import WorkerFactory
 
 from . import envs
@@ -184,7 +183,7 @@ async def worker() -> None:
 
 
 def setup_metrics_collection(
-    config: Config | OmniConfig, generate_endpoint: Endpoint, logger: logging.Logger
+    config: Config, generate_endpoint: Endpoint, logger: logging.Logger
 ) -> None:
     """Set up metrics collection for vLLM and LMCache metrics.
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -6,6 +6,7 @@
 import json
 import re
 import socket
+import sys
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
@@ -558,3 +559,40 @@ class TestEnsureSideChannelHost:
         ):
             with pytest.raises(RuntimeError, match="Unable to determine"):
                 ensure_side_channel_host()
+
+
+# --- vllm_omni optional dependency tests ---
+
+
+class TestVllmOmniOptionalDependency:
+    def test_dynamo_vllm_main_importable_without_vllm_omni(self):
+        """dynamo.vllm.main must import cleanly even when vllm_omni is absent.
+
+        Setting sys.modules["vllm_omni"] = None blocks ALL imports from the
+        vllm_omni package — Python always resolves the top-level package first,
+        so a None sentinel at the root raises ImportError for any submodule import.
+        """
+        # Save and evict any already-cached vllm_omni and dynamo.vllm.omni modules
+        saved = {
+            k: sys.modules.pop(k)
+            for k in list(sys.modules)
+            if k == "vllm_omni"
+            or k.startswith("vllm_omni.")
+            or k == "dynamo.vllm.main"
+            or k.startswith("dynamo.vllm.omni")
+        }
+        # Explicitly block the top-level vllm_omni package regardless of prior imports
+        sys.modules["vllm_omni"] = None  # type: ignore[assignment]
+
+        try:
+            import dynamo.vllm.main  # noqa: F401
+        except ImportError as e:
+            pytest.fail(f"dynamo.vllm.main has a hard dependency on vllm_omni: {e}")
+        finally:
+            sys.modules.pop("vllm_omni", None)
+            # Remove any modules imported during this test
+            for mod in list(sys.modules):
+                if mod == "dynamo.vllm.main" or mod.startswith("dynamo.vllm.omni"):
+                    sys.modules.pop(mod, None)
+            # Restore original state
+            sys.modules.update(saved)


### PR DESCRIPTION
#### Overview:

`dynamo.vllm` (the standard vLLM worker) had an accidental hard dependency on `vllm_omni`, causing `python -m dynamo.vllm` to crash with `ModuleNotFoundError: No module named 'vllm_omni'` in any environment where `vllm-omni` is not installed.

#### Details:

**Root cause:** `dynamo/vllm/main.py` imported `OmniConfig` from `dynamo.vllm.omni.args` at module level. Importing any symbol from the `dynamo.vllm.omni` package causes Python to execute `dynamo/vllm/omni/__init__.py` first, which eagerly imports `BaseOmniHandler` → `base_handler.py` → `from vllm_omni.entrypoints import AsyncOmni` (hard import).

**Fix:**
- Remove `from dynamo.vllm.omni.args import OmniConfig` from `main.py` — the only usage was a type annotation on `setup_metrics_collection(config: Config | OmniConfig, ...)`. Since `omni/main.py` is the only caller that passes an `OmniConfig`, and Python does not enforce types at runtime, the annotation is changed to `Config`. Duck typing handles the rest.
- Add a unit test that verifies `dynamo.vllm.main` is importable when `vllm_omni` is blocked from `sys.modules`.

The dependency is correctly preserved in `dynamo.vllm.omni` — `python -m dynamo.vllm.omni` still requires `vllm_omni` to be installed.

#### Where should the reviewer start?

- `components/src/dynamo/vllm/main.py` — line removed (`OmniConfig` import) and annotation simplified
- `components/src/dynamo/vllm/tests/test_vllm_unit.py` — `TestVllmOmniOptionalDependency` class at the bottom

#### Related Issues:

- Fixes [DIS-1630](https://linear.app/nvidia/issue/DIS-1630/dynamo-tot-requires-vllm-omni-as-a-hard-dependency)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for optional vLLM dependency handling to ensure the system gracefully functions when the optional package is unavailable.

* **Refactor**
  * Simplified internal type constraints to improve consistency and reduce dependency coupling in metrics collection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->