### PR TITLE
test(mocker): relax flaky online max-in-flight checks

### DIFF
--- a/lib/mocker/src/replay/online/tests.rs
+++ b/lib/mocker/src/replay/online/tests.rs
@@ -361,7 +361,7 @@ fn test_online_concurrency_replay_respects_max_in_flight() {
     .unwrap();
 
     assert_eq!(report.request_counts.completed_requests, 4);
-    assert_eq!(stats.max_in_flight_seen, 2);
+    assert!(stats.max_in_flight_seen <= 2);
 }
 
 #[test]
@@ -431,7 +431,7 @@ fn test_online_concurrency_replay_kv_router_respects_max_in_flight() {
             .unwrap();
 
     assert_eq!(report.request_counts.completed_requests, 4);
-    assert_eq!(stats.max_in_flight_seen, 2);
+    assert!(stats.max_in_flight_seen <= 2);
 }
 
 #[test]


### PR DESCRIPTION
Relax the two online replay max-in-flight assertions so they verify the cap is respected without depending on a specific Tokio scheduling interleaving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of concurrency-related test assertions to reduce test flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->