### PR TITLE
feat: Nemo-rl support

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import hashlib
+import logging
 import os
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -22,6 +25,8 @@ from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers import ToolParser
 from vllm.utils.async_utils import AsyncMicrobatchTokenizer
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class PreprocessResult:
@@ -34,6 +39,29 @@ class PreprocessResult:
 
 _ASYNC_TOKENIZER_POOL: dict[int, AsyncMicrobatchTokenizer] = {}
 SKIP_REQUEST_VALIDATION = os.getenv("DYN_VLLM_SKIP_REQUEST_VALIDATION", "1") == "1"
+DEBUG_FRONTEND = os.getenv("DYN_FRONTEND_DEBUG", "0") == "1"
+DEBUG_FRONTEND_MAX_TEXT = int(os.getenv("DYN_FRONTEND_DEBUG_MAX_TEXT", "240"))
+
+
+def _debug_enabled() -> bool:
+    return DEBUG_FRONTEND
+
+
+def _short_text(value: Any, limit: int = DEBUG_FRONTEND_MAX_TEXT) -> str:
+    text = str(value)
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}...<trimmed:{len(text) - limit}>"
+
+
+def _hash_messages(messages: Sequence[Any]) -> str:
+    payload: list[Any] = []
+    for message in messages:
+        if hasattr(message, "model_dump"):
+            payload.append(message.model_dump(exclude_none=False))
+        else:
+            payload.append(message)
+    return hashlib.sha256(repr(payload).encode("utf-8", "ignore")).hexdigest()[:16]
 
 
 def _get_async_tokenizer(tokenizer: TokenizerLike) -> AsyncMicrobatchTokenizer:
@@ -103,6 +131,8 @@ def _prepare_request(
     else:
         request_for_sampling = ChatCompletionRequest.model_validate(request)
 
+    original_tools_count = len(request_for_sampling.tools or [])
+    original_messages_hash = _hash_messages(request_for_sampling.messages)
     tool_parser: ToolParser | None = None
     # With enable_auto_tool_choice the model may emit tool calls even when the
     # client did not supply an explicit `tools` list, so we activate the parser
@@ -152,6 +182,26 @@ def _prepare_request(
         ),
     )
 
+    if _debug_enabled():
+        logger.info(
+            "[DYN_DEBUG preprocess] request_summary messages=%d messages_hash=%s tool_choice=%r "
+            "tools_in=%d tools_exposed=%d tool_parser=%s auto_tool_choice=%s "
+            "reasoning_effort=%r add_generation_prompt=%r continue_final_message=%r "
+            "chat_template_kwargs_keys=%s tokenize_in_template=%s",
+            len(request_for_sampling.messages),
+            original_messages_hash,
+            request_for_sampling.tool_choice,
+            original_tools_count,
+            len(tool_dicts or []),
+            tool_parser.__class__.__name__ if tool_parser is not None else None,
+            enable_auto_tool_choice,
+            request_for_sampling.reasoning_effort,
+            request_for_sampling.add_generation_prompt,
+            request_for_sampling.continue_final_message,
+            sorted(chat_template_kwargs.keys()),
+            tokenize_in_template,
+        )
+
     return (
         request_for_sampling,
         tool_parser,
@@ -170,6 +220,7 @@ async def preprocess_chat_request(
     exclude_tools_when_tool_choice_none: bool = True,
     enable_auto_tool_choice: bool = False,
 ) -> PreprocessResult:
+    t0 = time.monotonic()
     (
         request_for_sampling,
         tool_parser,
@@ -184,7 +235,9 @@ async def preprocess_chat_request(
         enable_auto_tool_choice=enable_auto_tool_choice,
     )
 
+    t_prepare = time.monotonic()
     _, engine_prompt = await renderer.render_messages_async(messages, chat_params)
+    t_render = time.monotonic()
 
     if "prompt_token_ids" in engine_prompt:
         tokens = list(engine_prompt["prompt_token_ids"])
@@ -195,6 +248,25 @@ async def preprocess_chat_request(
             add_special_tokens=request_for_sampling.add_special_tokens,
         )
         tokens = list(encoded.input_ids)
+    t_tokenize = time.monotonic()
+
+    if _debug_enabled():
+        prompt_text = engine_prompt.get("prompt")
+        logger.info(
+            "[DYN_DEBUG preprocess] render_summary prepare_ms=%.1f render_ms=%.1f tokenize_ms=%.1f "
+            "prompt_tokens=%d has_prompt_text=%s prompt_text_hash=%s prompt_preview=%r",
+            (t_prepare - t0) * 1000,
+            (t_render - t_prepare) * 1000,
+            (t_tokenize - t_render) * 1000,
+            len(tokens),
+            isinstance(prompt_text, str),
+            (
+                hashlib.sha256(prompt_text.encode("utf-8", "ignore")).hexdigest()[:16]
+                if isinstance(prompt_text, str)
+                else None
+            ),
+            _short_text(prompt_text) if isinstance(prompt_text, str) else None,
+        )
 
     return PreprocessResult(
         request_for_sampling=request_for_sampling,
@@ -216,11 +288,13 @@ class StreamingPostProcessor:
         tool_parser: ToolParser | None,
         reasoning_parser_class: type[ReasoningParser] | None,
         chat_template_kwargs: dict[str, Any],
+        debug_request_id: str | None = None,
     ) -> None:
         self.tokenizer = tokenizer
         self.request_for_sampling = request_for_sampling
         self.sampling_params = sampling_params
         self.tool_parser = tool_parser
+        self.debug_request_id = debug_request_id
         self.reasoning_parser = (
             reasoning_parser_class(
                 tokenizer,
@@ -246,6 +320,18 @@ class StreamingPostProcessor:
         # this correctly, so we accumulate text here and fall back to the
         # non-streaming extract_tool_calls() once the buffer is complete.
         self._tool_text_buffer: str | None = None
+        self._debug_reasoning_started = False
+        self._debug_logged_fast_path = False
+
+    def _debug(self, message: str, *args: Any) -> None:
+        if not _debug_enabled():
+            return
+        prefix = (
+            f"[DYN_DEBUG stream rid={self.debug_request_id}] "
+            if self.debug_request_id
+            else "[DYN_DEBUG stream] "
+        )
+        logger.info(prefix + message, *args)
 
     @staticmethod
     def _merge_tool_call(
@@ -308,6 +394,14 @@ class StreamingPostProcessor:
         )
         existing = self.in_progress_tool_calls.get(index)
         self.in_progress_tool_calls[index] = self._merge_tool_call(existing, tool_delta)
+        merged = self.in_progress_tool_calls[index]
+        self._debug(
+            "tool_call_extracted index=%d id=%r name=%r args_len=%d",
+            index,
+            merged.id,
+            merged.function.name if merged.function else None,
+            len(merged.function.arguments or "") if merged.function else 0,
+        )
 
     def _extract_tool_calls_from_text(
         self, text: str, *, saved_reasoning: str | None = None
@@ -348,6 +442,13 @@ class StreamingPostProcessor:
             existing = self.in_progress_tool_calls.get(tool_delta.index)
             merged = self._merge_tool_call(existing, tool_delta)
             self.in_progress_tool_calls[tool_delta.index] = merged
+            self._debug(
+                "tool_call_stream index=%d id=%r name=%r args_len=%d",
+                merged.index,
+                merged.id,
+                merged.function.name if merged.function else None,
+                len(merged.function.arguments or "") if merged.function else 0,
+            )
 
     def _dump_in_progress_tool_calls(self) -> list[dict[str, Any]]:
         return [
@@ -384,6 +485,9 @@ class StreamingPostProcessor:
         delta_text = output.text or ""
         delta: dict[str, Any] = {}
         if self._fast_plain_text:
+            if not self._debug_logged_fast_path:
+                self._debug("fast_plain_text enabled")
+                self._debug_logged_fast_path = True
             if delta_text:
                 delta = {
                     "role": "assistant",
@@ -415,6 +519,12 @@ class StreamingPostProcessor:
             if buffer_complete:
                 buffered_text = self._tool_text_buffer
                 self._tool_text_buffer = None
+                self._debug(
+                    "tool_buffer_complete len=%d finish_reason=%r preview=%r",
+                    len(buffered_text),
+                    output.finish_reason,
+                    _short_text(buffered_text),
+                )
                 delta_message = self._extract_tool_calls_from_text(buffered_text)
             else:
                 # Still accumulating; emit nothing for this chunk.
@@ -440,6 +550,13 @@ class StreamingPostProcessor:
             if self.reasoning_parser.is_reasoning_end_streaming(
                 current_token_ids, delta_token_ids
             ):
+                self._debug(
+                    "reasoning_end delta_preview=%r reasoning_len=%d content_len=%d finish_reason=%r",
+                    _short_text(delta_text),
+                    len(delta_message.reasoning or "") if delta_message else 0,
+                    len(delta_message.content or "") if delta_message else 0,
+                    output.finish_reason,
+                )
                 self.reasoning_is_done = True
                 saved_reasoning = delta_message.reasoning if delta_message else None
                 post_content = (delta_message.content if delta_message else None) or ""
@@ -457,6 +574,12 @@ class StreamingPostProcessor:
                     # extraction (streaming parser can't handle the combined
                     # reasoning-end + tool-start in a single chunk).
                     self._tool_text_buffer = post_content
+                    self._debug(
+                        "tool_buffer_start len=%d finish_reason=%r preview=%r",
+                        len(post_content),
+                        output.finish_reason,
+                        _short_text(post_content),
+                    )
                     if output.finish_reason:
                         # If finish_reason is already set, this is the final
                         # chunk; parse buffered text now instead of waiting for
@@ -494,6 +617,13 @@ class StreamingPostProcessor:
                     current_token_ids=current_token_ids,
                     delta_token_ids=delta_token_ids,
                 )
+            elif delta_message and delta_message.reasoning and not self._debug_reasoning_started:
+                self._debug_reasoning_started = True
+                self._debug(
+                    "reasoning_start len=%d preview=%r",
+                    len(delta_message.reasoning or ""),
+                    _short_text(delta_message.reasoning or delta_text),
+                )
         else:
             if self._should_parse_tools():
                 no_prev_reasoning = (
@@ -526,6 +656,10 @@ class StreamingPostProcessor:
             delta = {"role": "assistant"}
             content = delta_message.content
             if self.in_progress_tool_calls and self._is_control_only_content(content):
+                self._debug(
+                    "control_only_content_suppressed preview=%r",
+                    _short_text(content),
+                )
                 content = None
             if content:
                 delta["content"] = content
@@ -543,4 +677,17 @@ class StreamingPostProcessor:
 
         self.previous_text = current_text
         self.previous_token_ids = current_token_ids
+        if choice is not None:
+            delta_out = choice.get("delta") or {}
+            self._debug(
+                "emit_choice finish_reason=%r has_content=%s content_len=%d has_reasoning=%s "
+                "reasoning_len=%d tool_calls=%d delta_tokens=%d",
+                choice.get("finish_reason"),
+                "content" in delta_out,
+                len(delta_out.get("content") or ""),
+                "reasoning_content" in delta_out,
+                len(delta_out.get("reasoning_content") or ""),
+                len(delta_out.get("tool_calls") or []),
+                len(delta_token_ids),
+            )
         return choice

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -14,7 +14,10 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from vllm.config import CacheConfig, LoadConfig, ModelConfig, VllmConfig
-from vllm.inputs import TokensPrompt
+try:
+    from vllm.inputs import TokensPrompt
+except ImportError:
+    from vllm.inputs.data import TokensPrompt
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.tasks import GENERATION_TASKS

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -6,6 +6,8 @@
 #
 
 import asyncio
+import hashlib
+import json
 import logging
 import os
 import time
@@ -43,6 +45,22 @@ from .prepost import StreamingPostProcessor, preprocess_chat_request
 from .utils import extract_mm_urls, random_uuid
 
 logger = logging.getLogger(__name__)
+DEBUG_FRONTEND = os.getenv("DYN_FRONTEND_DEBUG", "0") == "1"
+DEBUG_LONG_WAIT_MS = int(os.getenv("DYN_FRONTEND_DEBUG_LONG_WAIT_MS", "120000"))
+DEBUG_MAX_TEXT = int(os.getenv("DYN_FRONTEND_DEBUG_MAX_TEXT", "240"))
+
+
+def _short_text(value: Any, limit: int = DEBUG_MAX_TEXT) -> str:
+    text = str(value)
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}...<trimmed:{len(text) - limit}>"
+
+
+def _hash_request_messages(messages: list[dict[str, Any]]) -> str:
+    return hashlib.sha256(
+        json.dumps(messages, sort_keys=True, default=str).encode("utf-8", "ignore")
+    ).hexdigest()[:16]
 
 
 _FINISH_REASON_MAP: dict[str, FinishReason] = {
@@ -125,6 +143,7 @@ class VllmProcessor:
         self, request: dict[str, Any]
     ) -> AsyncGenerator[dict[str, Any], None]:
         request_id = random_uuid()
+        t0 = time.monotonic()
 
         # vLLM's Pydantic model requires image_url.detail to be 'auto'/'low'/'high'.
         # The Rust HTTP layer accepts None/missing, so normalize before validation.
@@ -143,6 +162,23 @@ class VllmProcessor:
                     if isinstance(img_url, dict) and img_url.get("detail") is None:
                         img_url["detail"] = "auto"
 
+        if DEBUG_FRONTEND:
+            logger.info(
+                "[DYN_DEBUG ingress rid=%s] model=%r messages=%d messages_hash=%s tools=%d "
+                "tool_choice=%r has_reasoning=%s max_tokens=%r max_completion_tokens=%r routing=%r last_role=%r",
+                request_id,
+                request.get("model"),
+                len(messages),
+                _hash_request_messages(messages),
+                len(request.get("tools") or []),
+                request.get("tool_choice"),
+                request.get("reasoning") is not None,
+                request.get("max_tokens"),
+                request.get("max_completion_tokens"),
+                request.get("routing"),
+                messages[-1].get("role") if messages and isinstance(messages[-1], dict) else None,
+            )
+
         pre = await preprocess_chat_request(
             request,
             tokenizer=self.tokenizer,
@@ -157,6 +193,7 @@ class VllmProcessor:
         chat_template_kwargs = pre.chat_template_kwargs
         engine_prompt = pre.engine_prompt
         tokens = pre.prompt_token_ids
+        t_pre = time.monotonic()
 
         if request_for_sampling.max_completion_tokens is not None:
             max_tokens = request_for_sampling.max_completion_tokens
@@ -294,7 +331,22 @@ class VllmProcessor:
             tool_parser=tool_parser,
             reasoning_parser_class=self.reasoning_parser_class,
             chat_template_kwargs=chat_template_kwargs,
+            debug_request_id=request_id,
         )
+
+        if DEBUG_FRONTEND:
+            logger.info(
+                "[DYN_DEBUG ingress rid=%s] preprocess_done pre_ms=%.1f prompt_tokens=%d tool_parser=%s "
+                "reasoning_parser=%s sampling_max_tokens=%r stop=%r stop_token_ids=%r",
+                request_id,
+                (t_pre - t0) * 1000,
+                len(tokens),
+                tool_parser.__class__.__name__ if tool_parser is not None else None,
+                self.reasoning_parser_class.__name__ if self.reasoning_parser_class is not None else None,
+                sampling_params.max_tokens,
+                sampling_params.stop,
+                sampling_params.stop_token_ids,
+            )
 
         async for item in self._generate_and_stream(
             request_id,
@@ -316,6 +368,15 @@ class VllmProcessor:
         post: StreamingPostProcessor,
     ) -> AsyncGenerator[dict[str, Any], None]:
         self.output_processor.add_request(vllm_preproc, None)
+        stream_start = time.monotonic()
+        first_chunk_time: float | None = None
+        first_token_time: float | None = None
+        total_new_tokens = 0
+        chunk_count = 0
+        emitted_choices = 0
+        last_raw_finish_reason = None
+        last_finish_reason = None
+        last_stop_reason = None
 
         try:
             if self.is_kv_router:
@@ -338,6 +399,9 @@ class VllmProcessor:
                 )
 
             async for dynamo_response in dynamo_stream:
+                now = time.monotonic()
+                if first_chunk_time is None:
+                    first_chunk_time = now
                 if self.is_kv_router:
                     engine_response = dynamo_response
                 elif hasattr(dynamo_response, "data"):
@@ -358,6 +422,13 @@ class VllmProcessor:
                 raw_finish_reason = engine_response.get("finish_reason")
                 finish_reason = map_finish_reason(raw_finish_reason)
                 stop_reason = engine_response.get("stop_reason")
+                chunk_count += 1
+                total_new_tokens += len(engine_response["token_ids"])
+                if engine_response["token_ids"] and first_token_time is None:
+                    first_token_time = now
+                last_raw_finish_reason = raw_finish_reason
+                last_finish_reason = finish_reason
+                last_stop_reason = stop_reason
 
                 vllm_response = EngineCoreOutput(
                     request_id=vllm_preproc.request_id,
@@ -382,6 +453,7 @@ class VllmProcessor:
                         choices.append(choice)
 
                 if choices:
+                    emitted_choices += len(choices)
                     dynamo_out = {
                         "id": request_id,
                         "choices": choices,
@@ -394,6 +466,35 @@ class VllmProcessor:
 
                     yield dynamo_out
         finally:
+            total_ms = (time.monotonic() - stream_start) * 1000
+            first_chunk_ms = (
+                (first_chunk_time - stream_start) * 1000
+                if first_chunk_time is not None
+                else None
+            )
+            first_token_ms = (
+                (first_token_time - stream_start) * 1000
+                if first_token_time is not None
+                else None
+            )
+            should_log_summary = DEBUG_FRONTEND or last_raw_finish_reason == "length" or total_ms >= DEBUG_LONG_WAIT_MS
+            if should_log_summary:
+                logger.info(
+                    "[DYN_PERF rid=%s] total_ms=%.1f first_chunk_ms=%s first_token_ms=%s "
+                    "chunks=%d emitted_choices=%d new_tokens=%d raw_finish_reason=%r finish_reason=%r "
+                    "stop_reason=%r model=%r",
+                    request_id,
+                    total_ms,
+                    f"{first_chunk_ms:.1f}" if first_chunk_ms is not None else None,
+                    f"{first_token_ms:.1f}" if first_token_ms is not None else None,
+                    chunk_count,
+                    emitted_choices,
+                    total_new_tokens,
+                    last_raw_finish_reason,
+                    last_finish_reason.name if last_finish_reason is not None else None,
+                    last_stop_reason,
+                    request.get("model"),
+                )
             if vllm_preproc.request_id in self.output_processor.request_states:
                 self.output_processor.abort_requests(
                     [vllm_preproc.request_id], internal=True

--- a/components/src/dynamo/planner/connectors/kubernetes.py
+++ b/components/src/dynamo/planner/connectors/kubernetes.py
@@ -21,6 +21,12 @@ from typing import Optional
 from dynamo.planner.config.defaults import SubComponentType, TargetReplica
 from dynamo.planner.connectors.base import PlannerConnector
 from dynamo.planner.connectors.kubernetes_api import KubernetesAPI
+from dynamo.planner.connectors.mdc import (
+    MdcEntry,
+    is_model_card,
+    select_entry,
+    worker_info_from_mdc,
+)
 from dynamo.planner.errors import (
     DeploymentModelNameMismatchError,
     DeploymentValidationError,
@@ -340,22 +346,18 @@ class KubernetesConnector(PlannerConnector):
                 return []
             raise
 
-    def _extract_mdc_entries(
-        self,
-    ) -> list[dict]:
+    def _extract_mdc_entries(self) -> list[MdcEntry]:
         """Extract MDC entries belonging to this DGD.
 
         CRs are named after the worker pod (e.g. ``<dgd>-0-<service>-<hash>``),
         so we filter by the DGD name prefix to avoid picking up entries from
-        other deployments sharing the namespace.
-
-        Returns a list of dicts, each containing:
-            namespace, component, endpoint, instance_id, card_json
+        other deployments sharing the namespace.  LoRA-adapter wrappers are
+        dropped via :func:`is_model_card`.
         """
         crs = self._list_worker_metadata_crs()
         dgd_prefix = f"{self.graph_deployment_name}-"
 
-        entries: list[dict] = []
+        entries: list[MdcEntry] = []
         for cr in crs:
             cr_name = cr.get("metadata", {}).get("name", "")
             if not cr_name.startswith(dgd_prefix):
@@ -368,125 +370,37 @@ class KubernetesConnector(PlannerConnector):
                 except json.JSONDecodeError:
                     continue
             model_cards = data.get("model_cards", {})
-            for _key, instance in model_cards.items():
-                if instance.get("type") != "Model":
+            for _key, wrapper in model_cards.items():
+                if not is_model_card(wrapper):
                     continue
-                entries.append(instance)
+                entries.append(
+                    MdcEntry(
+                        card_json=wrapper.get("card_json") or {},
+                        component=wrapper.get("component"),
+                        endpoint=wrapper.get("endpoint"),
+                        instance_id=wrapper.get("instance_id"),
+                    )
+                )
         return entries
 
-    def _mdc_entry_is_prefill(self, entry: dict) -> bool:
-        """Check if an MDC entry is a prefill worker.
+    def _resolve_dgd_service(
+        self, sub_component_type: SubComponentType, backend: str
+    ) -> tuple[Optional[str], str]:
+        """Return (dgd_service_name, component_name_for_filter).
 
-        model_type can be serialized as:
-        - An integer bitflag (ModelType::Prefill = 1 << 4 = 16)
-        - A dict with a "bits" key (serde bitflags format)
-        - A string like "Prefill" or "Chat|Completions"
+        Uses the DGD when available; otherwise falls back to backend defaults
+        so that stale/missing DGD state still lets us filter out LoRA cards
+        by their expected component name.
         """
-        card = entry.get("card_json", {})
-        model_type = card.get("model_type", 0)
-        if isinstance(model_type, str):
-            return "prefill" in model_type.lower()
-        if isinstance(model_type, dict):
-            model_type = model_type.get("bits", 0)
-        return bool(model_type & 0x10)
-
-    def _build_worker_info_from_mdc(
-        self,
-        entry: dict,
-        sub_component_type: SubComponentType,
-    ) -> WorkerInfo:
-        """Build a WorkerInfo from an MDC entry, applying the fallback chain.
-
-        Priority: MDC -> DGD container-arg parsing -> hard-coded defaults.
-        """
-        defaults = build_worker_info_from_defaults(
-            self._backend_hint or "vllm", sub_component_type
-        )
-
-        card = entry.get("card_json", {})
-        runtime_cfg = card.get("runtime_config", {})
-
-        # --- component / endpoint names from MDC wrapper ---
-        mdc_component = entry.get("component")
-        mdc_endpoint = entry.get("endpoint")
-
-        component_name = mdc_component or defaults.component_name
-        endpoint = mdc_endpoint or defaults.endpoint
-        if not mdc_component:
-            logger.info(
-                f"MDC missing 'component' for {sub_component_type.value}, "
-                f"falling back to default: {defaults.component_name}"
-            )
-        if not mdc_endpoint:
-            logger.info(
-                f"MDC missing 'endpoint' for {sub_component_type.value}, "
-                f"falling back to default: {defaults.endpoint}"
-            )
-
-        # --- model name ---
-        mdc_model = card.get("display_name")
-        model_name = mdc_model
-        if not model_name:
-            # Fallback: parse from DGD container args
-            try:
-                deployment = self.kube_api.get_graph_deployment(
-                    self.graph_deployment_name
-                )
-                service = get_service_from_sub_component_type_or_name(
-                    deployment, sub_component_type
-                )
-                model_name = service.get_model_name()
-                if model_name:
-                    logger.info(
-                        f"MDC missing model name for {sub_component_type.value}, "
-                        f"fell back to DGD container args: {model_name}"
-                    )
-            except PlannerError:
-                pass
-        if not model_name:
-            logger.warning(
-                f"Could not determine model name for {sub_component_type.value} "
-                f"from MDC or DGD container args"
-            )
-
-        # --- runtime config fields ---
-        total_kv_blocks = runtime_cfg.get("total_kv_blocks")
-        max_num_seqs = runtime_cfg.get("max_num_seqs")
-        max_num_batched_tokens = runtime_cfg.get("max_num_batched_tokens")
-        kv_cache_block_size = card.get("kv_cache_block_size")
-        context_length = card.get("context_length")
-
-        if total_kv_blocks is None:
-            logger.info(f"MDC missing total_kv_blocks for {sub_component_type.value}")
-        if max_num_seqs is None:
-            logger.info(f"MDC missing max_num_seqs for {sub_component_type.value}")
-
-        # --- k8s_name: resolve from DGD subComponentType ---
-        k8s_name = defaults.k8s_name
         try:
             deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
             service = get_service_from_sub_component_type_or_name(
                 deployment, sub_component_type
             )
-            k8s_name = service.name
+            return service.name, service.name
         except PlannerError:
-            logger.info(
-                f"Could not resolve k8s service name for {sub_component_type.value}, "
-                f"using default: {defaults.k8s_name}"
-            )
-
-        info = WorkerInfo(
-            k8s_name=k8s_name,
-            component_name=component_name,
-            endpoint=endpoint,
-            model_name=model_name,
-            total_kv_blocks=total_kv_blocks,
-            kv_cache_block_size=kv_cache_block_size,
-            max_num_seqs=max_num_seqs,
-            max_num_batched_tokens=max_num_batched_tokens,
-            context_length=context_length,
-        )
-        return info
+            defaults = build_worker_info_from_defaults(backend, sub_component_type)
+            return None, defaults.component_name or ""
 
     def get_worker_info(
         self,
@@ -499,74 +413,57 @@ class KubernetesConnector(PlannerConnector):
             sub_component_type: PREFILL or DECODE
             backend: Backend framework name (for default fallback)
         """
-        self._backend_hint = backend
         entries = self._extract_mdc_entries()
+        dgd_service_name, expected_component = self._resolve_dgd_service(
+            sub_component_type, backend
+        )
 
-        # Resolve the expected component name so we can scope card selection
-        # and avoid picking up LoRA-adapter cards that share the same CR but
-        # carry a different component/model identity.
-        expected_component: Optional[str] = None
-        try:
-            deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
-            service = get_service_from_sub_component_type_or_name(
-                deployment, sub_component_type
-            )
-            expected_component = service.name
-        except PlannerError:
-            expected_component = build_worker_info_from_defaults(
-                backend, sub_component_type
-            ).component_name
-
-        for entry in entries:
-            is_prefill = self._mdc_entry_is_prefill(entry)
-            if sub_component_type == SubComponentType.PREFILL and not is_prefill:
-                continue
-            if sub_component_type == SubComponentType.DECODE and is_prefill:
-                continue
-
-            entry_component = entry.get("component")
-            if (
-                entry_component
-                and expected_component
-                and entry_component != expected_component
-            ):
-                logger.debug(
-                    f"Skipping MDC entry with component={entry_component!r}, "
-                    f"expected {expected_component!r} for {sub_component_type.value}"
+        def _dgd_model_name() -> Optional[str]:
+            try:
+                deployment = self.kube_api.get_graph_deployment(
+                    self.graph_deployment_name
                 )
-                continue
+                service = get_service_from_sub_component_type_or_name(
+                    deployment, sub_component_type
+                )
+                return service.get_model_name()
+            except PlannerError:
+                return None
 
-            info = self._build_worker_info_from_mdc(entry, sub_component_type)
+        entry = select_entry(entries, sub_component_type, expected_component)
+        if entry is not None:
+            info = worker_info_from_mdc(
+                entry,
+                sub_component_type,
+                backend=backend,
+                model_name_fallback=_dgd_model_name,
+                k8s_name_override=dgd_service_name,
+            )
+            if not info.model_name:
+                logger.warning(
+                    f"Could not determine model name for {sub_component_type.value} "
+                    f"from MDC or DGD container args"
+                )
             logger.info(
                 f"Built {sub_component_type.value} WorkerInfo from MDC: "
                 f"{info.summary()}"
             )
             return info
 
-        # No MDC entry found -- fall back entirely to defaults + DGD arg parsing
+        # No MDC entry found -- fall back entirely to defaults + DGD arg parsing.
         logger.warning(
             f"No DynamoWorkerMetadata CR found for {sub_component_type.value}. "
             f"Workers may not be registered yet. Falling back to defaults."
         )
         info = build_worker_info_from_defaults(backend, sub_component_type)
-
-        # Try to enrich model_name from DGD container args
-        try:
-            deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
-            service = get_service_from_sub_component_type_or_name(
-                deployment, sub_component_type
-            )
-            info.k8s_name = service.name
-            arg_model = service.get_model_name()
-            if arg_model:
-                info.model_name = arg_model
-                logger.info(
-                    f"Enriched {sub_component_type.value} WorkerInfo model name "
-                    f"from DGD args: {arg_model}"
-                )
-        except PlannerError as e:
+        if dgd_service_name is not None:
+            info.k8s_name = dgd_service_name
+        arg_model = _dgd_model_name()
+        if arg_model:
+            info.model_name = arg_model
             logger.info(
-                f"Could not enrich WorkerInfo from DGD for {sub_component_type.value}: {e}"
+                f"Enriched {sub_component_type.value} WorkerInfo model name "
+                f"from DGD args: {arg_model}"
             )
 
         logger.info(

--- a/components/src/dynamo/planner/connectors/mdc.py
+++ b/components/src/dynamo/planner/connectors/mdc.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared ModelDeploymentCard (MDC) plumbing for planner connectors.
+
+Connectors that want to populate ``WorkerInfo`` from MDCs feed
+:class:`MdcEntry` records into :func:`worker_info_from_mdc`.  The transform
+is pure: it has no K8s or discovery dependency.  Each connector supplies
+its own :class:`MdcSource` implementation that fetches entries from
+whatever backing store it uses (Kubernetes CRDs, the dynamo discovery
+watch, etc.).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, Protocol
+
+from dynamo.planner.config.defaults import SubComponentType
+from dynamo.planner.monitoring.worker_info import (
+    WorkerInfo,
+    build_worker_info_from_defaults,
+)
+
+logger = logging.getLogger(__name__)
+
+# ModelType::Prefill bit in ModelDeploymentCard::model_type (bitflags: 1 << 4).
+_MODEL_TYPE_PREFILL_BIT = 0x10
+
+
+@dataclass
+class MdcEntry:
+    """Normalized MDC record consumed by :func:`worker_info_from_mdc`.
+
+    ``component`` / ``endpoint`` come from the CRD wrapper in K8s mode and
+    are typically ``None`` for discovery-sourced entries (where they fall
+    back to backend defaults).
+    """
+
+    card_json: dict = field(default_factory=dict)
+    component: Optional[str] = None
+    endpoint: Optional[str] = None
+    instance_id: Optional[str] = None
+
+
+class MdcSource(Protocol):
+    """Source of :class:`MdcEntry` records scoped to a sub-component type."""
+
+    def get_entries(self, sub_component_type: SubComponentType) -> list[MdcEntry]:
+        ...
+
+
+def is_model_card(wrapper: dict) -> bool:
+    """Filter that excludes LoRA-adapter cards from a CRD wrapper dict.
+
+    K8s CRDs store both Model and LoRA cards together; discovery-sourced
+    entries are already scoped to the ``Model`` variant, so this filter
+    only matters for the CRD path.
+    """
+    return wrapper.get("type") == "Model"
+
+
+def is_prefill_card(card_json: dict) -> bool:
+    """Whether a card_json belongs to a prefill worker.
+
+    ``model_type`` can be serialized three ways depending on the producer:
+    an integer bitflag, a serde-bitflags dict with a ``bits`` key, or a
+    human-readable string (e.g. ``"Prefill"`` / ``"Chat|Completions"``).
+    """
+    model_type: Any = card_json.get("model_type", 0)
+    if isinstance(model_type, str):
+        return "prefill" in model_type.lower()
+    if isinstance(model_type, dict):
+        model_type = model_type.get("bits", 0)
+    try:
+        return bool(int(model_type) & _MODEL_TYPE_PREFILL_BIT)
+    except (TypeError, ValueError):
+        return False
+
+
+def select_entry(
+    entries: list[MdcEntry],
+    sub_component_type: SubComponentType,
+    expected_component: Optional[str] = None,
+) -> Optional[MdcEntry]:
+    """Pick the first entry matching ``sub_component_type`` and (if given)
+    ``expected_component``.  Used to scope past LoRA-adapter cards and
+    stray entries from sibling deployments.
+    """
+    want_prefill = sub_component_type == SubComponentType.PREFILL
+    for entry in entries:
+        if is_prefill_card(entry.card_json) != want_prefill:
+            continue
+        if (
+            entry.component
+            and expected_component
+            and entry.component != expected_component
+        ):
+            continue
+        return entry
+    return None
+
+
+def worker_info_from_mdc(
+    entry: MdcEntry,
+    sub_component_type: SubComponentType,
+    backend: str,
+    model_name_fallback: Optional[Callable[[], Optional[str]]] = None,
+    k8s_name_override: Optional[str] = None,
+) -> WorkerInfo:
+    """Build a :class:`WorkerInfo` from a single :class:`MdcEntry`.
+
+    Pure function.  Connector-specific enrichment is injected via
+    ``model_name_fallback`` (called only when the card lacks a
+    ``display_name``) and ``k8s_name_override``.
+    """
+    defaults = build_worker_info_from_defaults(backend, sub_component_type)
+
+    card = entry.card_json or {}
+    runtime_cfg = card.get("runtime_config")
+    if not isinstance(runtime_cfg, dict):
+        runtime_cfg = {}
+
+    component_name = entry.component or defaults.component_name
+    endpoint = entry.endpoint or defaults.endpoint
+
+    model_name: Optional[str] = card.get("display_name")
+    if not model_name and model_name_fallback is not None:
+        try:
+            model_name = model_name_fallback()
+        except Exception as e:
+            logger.debug(f"Model name fallback raised: {e}")
+            model_name = None
+
+    k8s_name = k8s_name_override if k8s_name_override is not None else defaults.k8s_name
+
+    return WorkerInfo(
+        k8s_name=k8s_name,
+        component_name=component_name,
+        endpoint=endpoint,
+        model_name=model_name,
+        total_kv_blocks=runtime_cfg.get("total_kv_blocks"),
+        kv_cache_block_size=card.get("kv_cache_block_size"),
+        max_num_seqs=runtime_cfg.get("max_num_seqs"),
+        max_num_batched_tokens=runtime_cfg.get("max_num_batched_tokens"),
+        context_length=card.get("context_length"),
+    )

--- a/components/src/dynamo/planner/connectors/virtual.py
+++ b/components/src/dynamo/planner/connectors/virtual.py
@@ -1,16 +1,25 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 import os
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from dynamo._core import VirtualConnectorCoordinator
 from dynamo.planner.config.defaults import SubComponentType, TargetReplica
 from dynamo.planner.connectors.base import PlannerConnector
+from dynamo.planner.connectors.mdc import MdcEntry, select_entry, worker_info_from_mdc
 from dynamo.planner.errors import EmptyTargetReplicasError
+from dynamo.planner.monitoring.worker_info import (
+    WorkerInfo,
+    build_worker_info_from_defaults,
+)
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
+
+if TYPE_CHECKING:
+    from dynamo.llm import FpmEventSubscriber
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
@@ -23,6 +32,35 @@ SCALING_MAX_WAIT_TIME = int(
     os.environ.get("SCALING_MAX_WAIT_TIME", 1800)
 )  # Maximum wait time: 30 minutes (1800 seconds)
 SCALING_MAX_RETRIES = SCALING_MAX_WAIT_TIME // SCALING_CHECK_INTERVAL  # 180 retries
+
+
+def _mdc_entries_from_subscriber(
+    subscriber: Optional["FpmEventSubscriber"],
+) -> list[MdcEntry]:
+    """Read the discovery-captured card JSON snapshot from an FPM subscriber.
+
+    Returns an empty list if tracking has not been started yet or no cards
+    have been observed.  Discovery-sourced entries have no wrapper
+    component/endpoint (those come from the CRD in K8s mode); worker_info_from_mdc
+    falls back to backend defaults for those fields.
+    """
+    if subscriber is None:
+        return []
+    try:
+        cards = subscriber.get_model_cards()
+    except RuntimeError:
+        # start_tracking() not called yet.
+        return []
+
+    entries: list[MdcEntry] = []
+    for worker_id, card_str in cards.items():
+        try:
+            card_json = json.loads(card_str)
+        except json.JSONDecodeError:
+            logger.warning(f"Skipping malformed MDC card JSON for worker {worker_id}")
+            continue
+        entries.append(MdcEntry(card_json=card_json, instance_id=worker_id))
+    return entries
 
 
 class VirtualConnector(PlannerConnector):
@@ -52,6 +90,55 @@ class VirtualConnector(PlannerConnector):
         self.model_name = model_name.lower()  # normalize model name to lowercase (MDC)
 
         self.dynamo_namespace = dynamo_namespace
+
+        # MDC sources injected by NativePlannerBase after FPM subscribers exist.
+        self._prefill_mdc_sub: Optional["FpmEventSubscriber"] = None
+        self._decode_mdc_sub: Optional["FpmEventSubscriber"] = None
+
+    def set_mdc_subscribers(
+        self,
+        prefill: Optional["FpmEventSubscriber"] = None,
+        decode: Optional["FpmEventSubscriber"] = None,
+    ) -> None:
+        """Inject FPM subscribers used as the MDC source for get_worker_info.
+
+        VirtualConnector has no K8s CRDs to read, so it reads model cards
+        from the discovery watch maintained by the FPM subscribers.  Until
+        this is called, get_worker_info returns backend defaults only.
+        """
+        self._prefill_mdc_sub = prefill
+        self._decode_mdc_sub = decode
+
+    def get_worker_info(
+        self,
+        sub_component_type: SubComponentType,
+        backend: str = "vllm",
+    ) -> WorkerInfo:
+        """Populate WorkerInfo from discovery-sourced MDCs, with defaults fallback.
+
+        Called by ``resolve_worker_info`` (once, at init) and by the tick-loop
+        refresh (once cards are available in discovery).
+        """
+        subscriber = (
+            self._prefill_mdc_sub
+            if sub_component_type == SubComponentType.PREFILL
+            else self._decode_mdc_sub
+        )
+        entries = _mdc_entries_from_subscriber(subscriber)
+        entry = select_entry(entries, sub_component_type)
+        if entry is not None:
+            info = worker_info_from_mdc(
+                entry,
+                sub_component_type,
+                backend=backend,
+            )
+            if not info.model_name:
+                info.model_name = self.model_name
+            return info
+
+        info = build_worker_info_from_defaults(backend, sub_component_type)
+        info.model_name = self.model_name
+        return info
 
     async def _async_init(self):
         """Async initialization that must be called after __init__"""

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -24,7 +24,7 @@ import aiohttp.web
 from prometheus_client import start_http_server
 
 from dynamo.planner.config.backend_components import WORKER_COMPONENT_NAMES
-from dynamo.planner.config.defaults import TargetReplica
+from dynamo.planner.config.defaults import SubComponentType, TargetReplica
 from dynamo.planner.config.planner_config import PlannerConfig
 from dynamo.planner.connectors.global_planner import GlobalPlannerConnector
 from dynamo.planner.connectors.kubernetes import KubernetesConnector
@@ -259,6 +259,10 @@ class NativePlannerBase:
         )
         await self.connector.wait_for_deployment_ready(include_planner=False)
 
+        # Resolve WorkerInfo once from the connector.  For K8s this populates
+        # runtime_config fields from MDC CRDs; for Virtual it returns backend
+        # defaults (subscribers aren't attached yet) which is enough to
+        # construct the FPM endpoint.
         await self._init_worker_info()
 
         if self.runtime is not None:
@@ -266,6 +270,15 @@ class NativePlannerBase:
                 await self._init_fpm_subscriber("prefill")
             if self.require_decode:
                 await self._init_fpm_subscriber("decode")
+
+        # VirtualConnector reads MDC from the FPM subscriber's discovery watch;
+        # hand it the subscribers now that they exist.  The tick-loop refresh
+        # will backfill runtime_config fields once discovery sees the workers.
+        if isinstance(self.connector, VirtualConnector):
+            self.connector.set_mdc_subscribers(
+                prefill=self._prefill_fpm_sub,
+                decode=self._decode_fpm_sub,
+            )
 
         await self._bootstrap_regression()
 
@@ -333,35 +346,62 @@ class NativePlannerBase:
         pass
 
     # ------------------------------------------------------------------
-    # Discovery backfill
+    # Discovery refresh
     # ------------------------------------------------------------------
 
-    def _populate_worker_info_from_discovery(self) -> None:
-        """Fill missing WorkerInfo fields from model cards observed by FPM subscribers.
+    _MDC_REFRESH_FIELDS = (
+        "total_kv_blocks",
+        "kv_cache_block_size",
+        "max_num_seqs",
+        "max_num_batched_tokens",
+        "context_length",
+    )
 
-        The FPM subscriber extracts ``max_num_batched_tokens`` from each
-        worker's ``ModelDeploymentCard.runtime_config`` at discovery time
-        and resolves the **minimum** across all known workers so the
-        planner uses the most constrained capacity.
+    def _refresh_worker_info_from_connector(self) -> None:
+        """Re-query the connector for any sub-component whose WorkerInfo is
+        still missing runtime-config fields.
 
-        When the connector does not provide WorkerInfo fields like
-        max_num_batched_tokens (e.g. VirtualConnector), this method
-        backfills them from discovery.
-
-        If a value is successfully backfilled, the state machine's
-        capabilities are updated so that subsequent scaling decisions
-        see the new value.
+        This handles the cold-start path where workers haven't registered
+        their model cards yet when ``_init_worker_info`` first runs.  It is
+        a no-op for K8s mode once CRDs are present, and drives the
+        VirtualConnector's discovery-sourced population once cards arrive.
         """
+        if not hasattr(self.connector, "get_worker_info"):
+            return
+
+        targets: list[tuple[WorkerInfo, SubComponentType]] = []
+        if self.require_prefill:
+            targets.append((self.prefill_worker_info, SubComponentType.PREFILL))
+        if self.require_decode:
+            targets.append((self.decode_worker_info, SubComponentType.DECODE))
+
         changed = False
-        for subscriber, worker_info, label in [
-            (self._prefill_fpm_sub, self.prefill_worker_info, "prefill"),
-            (self._decode_fpm_sub, self.decode_worker_info, "decode"),
-        ]:
-            if subscriber is None:
+        for worker_info, sub_type in targets:
+            if worker_info.max_num_batched_tokens is not None:
                 continue
-            if worker_info.max_num_batched_tokens:
+            try:
+                fresh = self.connector.get_worker_info(sub_type, self.config.backend)
+            except Exception as e:
+                logger.debug(
+                    f"get_worker_info refresh for {sub_type.value} failed: {e}"
+                )
                 continue
-            changed |= self._backfill_from_subscriber(subscriber, worker_info, label)
+
+            updated = False
+            for field_name in self._MDC_REFRESH_FIELDS:
+                fresh_val = getattr(fresh, field_name)
+                if (
+                    fresh_val is not None
+                    and getattr(worker_info, field_name) != fresh_val
+                ):
+                    setattr(worker_info, field_name, fresh_val)
+                    updated = True
+            if updated:
+                changed = True
+                logger.info(
+                    f"Refreshed {sub_type.value} WorkerInfo from connector: "
+                    f"{worker_info.summary()}"
+                )
 
         if changed and self._state_machine is not None:
             self._state_machine.update_capabilities(
@@ -371,33 +411,6 @@ class NativePlannerBase:
                     self.decode_worker_info,
                 )
             )
-
-    def _backfill_from_subscriber(
-        self,
-        subscriber: FpmEventSubscriber,
-        worker_info: WorkerInfo,
-        label: str,
-    ) -> bool:
-        """Try to backfill max_num_batched_tokens from a subscriber.
-
-        The Rust subscriber resolves the minimum value across all known
-        workers, so the result is deterministic even for heterogeneous
-        registrations.
-
-        Returns True if a value was backfilled.
-        """
-        try:
-            val = subscriber.get_max_num_batched_tokens()
-        except RuntimeError:
-            return False
-
-        if val is not None and val > 0:
-            worker_info.max_num_batched_tokens = val
-            logger.info(
-                f"Populated {label} max_num_batched_tokens={val} from discovery"
-            )
-            return True
-        return False
 
     # ------------------------------------------------------------------
     # Data collection (runtime I/O)
@@ -747,7 +760,7 @@ class NativePlannerBase:
                     await asyncio.sleep(min(next_tick.at_s - now, poll_interval))
                     continue
 
-                self._populate_worker_info_from_discovery()
+                self._refresh_worker_info_from_connector()
 
                 tick_input = await self._gather_tick_input(next_tick)
                 effects = self.state_machine.on_tick(next_tick, tick_input)

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -333,6 +333,73 @@ class NativePlannerBase:
         pass
 
     # ------------------------------------------------------------------
+    # Discovery backfill
+    # ------------------------------------------------------------------
+
+    def _populate_worker_info_from_discovery(self) -> None:
+        """Fill missing WorkerInfo fields from model cards observed by FPM subscribers.
+
+        The FPM subscriber extracts ``max_num_batched_tokens`` from each
+        worker's ``ModelDeploymentCard.runtime_config`` at discovery time
+        and resolves the **minimum** across all known workers so the
+        planner uses the most constrained capacity.
+
+        When the connector does not provide WorkerInfo fields like
+        max_num_batched_tokens (e.g. VirtualConnector), this method
+        backfills them from discovery.
+
+        If a value is successfully backfilled, the state machine's
+        capabilities are updated so that subsequent scaling decisions
+        see the new value.
+        """
+        changed = False
+        for subscriber, worker_info, label in [
+            (self._prefill_fpm_sub, self.prefill_worker_info, "prefill"),
+            (self._decode_fpm_sub, self.decode_worker_info, "decode"),
+        ]:
+            if subscriber is None:
+                continue
+            if worker_info.max_num_batched_tokens:
+                continue
+            changed |= self._backfill_from_subscriber(subscriber, worker_info, label)
+
+        if changed and self._state_machine is not None:
+            self._state_machine.update_capabilities(
+                build_worker_capabilities(
+                    self.config,
+                    self.prefill_worker_info,
+                    self.decode_worker_info,
+                )
+            )
+
+    def _backfill_from_subscriber(
+        self,
+        subscriber: FpmEventSubscriber,
+        worker_info: WorkerInfo,
+        label: str,
+    ) -> bool:
+        """Try to backfill max_num_batched_tokens from a subscriber.
+
+        The Rust subscriber resolves the minimum value across all known
+        workers, so the result is deterministic even for heterogeneous
+        registrations.
+
+        Returns True if a value was backfilled.
+        """
+        try:
+            val = subscriber.get_max_num_batched_tokens()
+        except RuntimeError:
+            return False
+
+        if val is not None and val > 0:
+            worker_info.max_num_batched_tokens = val
+            logger.info(
+                f"Populated {label} max_num_batched_tokens={val} from discovery"
+            )
+            return True
+        return False
+
+    # ------------------------------------------------------------------
     # Data collection (runtime I/O)
     # ------------------------------------------------------------------
 
@@ -679,6 +746,8 @@ class NativePlannerBase:
                 if now < next_tick.at_s:
                     await asyncio.sleep(min(next_tick.at_s - now, poll_interval))
                     continue
+
+                self._populate_worker_info_from_discovery()
 
                 tick_input = await self._gather_tick_input(next_tick)
                 effects = self.state_machine.on_tick(next_tick, tick_input)

--- a/components/src/dynamo/planner/core/state_machine.py
+++ b/components/src/dynamo/planner/core/state_machine.py
@@ -63,6 +63,7 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
     ) -> None:
         self._config = config
         self._capabilities = capabilities or WorkerCapabilities()
+
         self._is_agg = config.mode == "agg"
         self._has_prefill = config.mode in ("disagg", "prefill")
         self._has_decode = config.mode in ("disagg", "decode", "agg")
@@ -120,6 +121,10 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+
+    def update_capabilities(self, capabilities: WorkerCapabilities) -> None:
+        """Replace the current worker capabilities."""
+        self._capabilities = capabilities
 
     def initial_tick(self, start_s: float) -> ScheduledTick:
         self._next_load_s = start_s + self._config.load_adjustment_interval

--- a/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
@@ -447,3 +447,125 @@ class TestAggRegressionModel:
             itl_sla=50.0,
         )
         assert thpt == 0.0
+
+
+# ── Discovery backfill tests ────────────────────────────────────────
+
+
+class TestPopulateWorkerInfoFromDiscovery:
+    """Tests for NativePlannerBase._populate_worker_info_from_discovery."""
+
+    def _make_planner(self):
+        """Build a minimal NativePlannerBase with no_operation=True."""
+        from unittest.mock import Mock, patch
+
+        from dynamo.planner.config.planner_config import PlannerConfig
+        from dynamo.planner.core.base import NativePlannerBase
+        from dynamo.planner.monitoring.worker_info import WorkerInfo
+
+        with patch("dynamo.planner.monitoring.planner_metrics.Gauge") as mock_gauge:
+            mock_gauge.return_value = Mock()
+            config = PlannerConfig.model_construct(
+                throughput_adjustment_interval=60,
+                prefill_engine_num_gpu=1,
+                decode_engine_num_gpu=1,
+                min_endpoint=1,
+                max_gpu_budget=-1,
+                ttft=500.0,
+                itl=50.0,
+                backend="vllm",
+                no_operation=True,
+                metric_pulling_prometheus_endpoint="http://localhost:9090",
+                metric_reporting_prometheus_port=0,
+                load_predictor="constant",
+                environment="kubernetes",
+                namespace="test-namespace",
+                mode="agg",
+                enable_load_scaling=True,
+                enable_throughput_scaling=True,
+                load_adjustment_interval=5,
+                max_num_fpm_samples=50,
+                fpm_sample_bucket_size=16,
+                load_scaling_down_sensitivity=80,
+                load_metric_samples=10,
+                load_min_observations=5,
+            )
+            planner = NativePlannerBase(None, config)
+        planner.prefill_worker_info = WorkerInfo()
+        planner.decode_worker_info = WorkerInfo()
+        return planner
+
+    def test_backfill_from_discovery(self):
+        """max_num_batched_tokens is populated from discovery (min across workers)."""
+        from unittest.mock import Mock
+
+        planner = self._make_planner()
+        assert planner.decode_worker_info.max_num_batched_tokens is None
+
+        mock_sub = Mock()
+        mock_sub.get_max_num_batched_tokens.return_value = 8192
+        planner._decode_fpm_sub = mock_sub
+
+        planner._populate_worker_info_from_discovery()
+        assert planner.decode_worker_info.max_num_batched_tokens == 8192
+
+    def test_noop_when_already_set(self):
+        """Does not overwrite an existing max_num_batched_tokens value."""
+        from unittest.mock import Mock
+
+        from dynamo.planner.monitoring.worker_info import WorkerInfo
+
+        planner = self._make_planner()
+        planner.decode_worker_info = WorkerInfo(max_num_batched_tokens=2048)
+
+        mock_sub = Mock()
+        mock_sub.get_max_num_batched_tokens.return_value = 8192
+        planner._decode_fpm_sub = mock_sub
+
+        planner._populate_worker_info_from_discovery()
+        assert planner.decode_worker_info.max_num_batched_tokens == 2048
+
+    def test_noop_when_no_subscriber(self):
+        """Gracefully does nothing when there is no FPM subscriber."""
+        planner = self._make_planner()
+        # Both subscribers are None by default
+        planner._populate_worker_info_from_discovery()
+        assert planner.prefill_worker_info.max_num_batched_tokens is None
+        assert planner.decode_worker_info.max_num_batched_tokens is None
+
+    def test_noop_when_no_value_reported(self):
+        """Does nothing when no worker has reported max_num_batched_tokens."""
+        from unittest.mock import Mock
+
+        planner = self._make_planner()
+
+        mock_sub = Mock()
+        mock_sub.get_max_num_batched_tokens.return_value = None
+        planner._decode_fpm_sub = mock_sub
+
+        planner._populate_worker_info_from_discovery()
+        assert planner.decode_worker_info.max_num_batched_tokens is None
+
+    def test_updates_state_machine_capabilities(self):
+        """State machine capabilities are updated via update_capabilities()."""
+        from unittest.mock import Mock
+
+        planner = self._make_planner()
+        # Force state machine creation
+        _ = planner.state_machine
+        assert planner._state_machine is not None
+        assert (
+            planner._state_machine._capabilities.decode is None
+            or planner._state_machine._capabilities.decode.max_num_batched_tokens
+            is None
+        )
+
+        mock_sub = Mock()
+        mock_sub.get_max_num_batched_tokens.return_value = 4096
+        planner._decode_fpm_sub = mock_sub
+
+        planner._populate_worker_info_from_discovery()
+        assert planner.decode_worker_info.max_num_batched_tokens == 4096
+        assert (
+            planner._state_machine._capabilities.decode.max_num_batched_tokens == 4096
+        )

--- a/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
@@ -449,13 +449,19 @@ class TestAggRegressionModel:
         assert thpt == 0.0
 
 
-# ── Discovery backfill tests ────────────────────────────────────────
+# ── Connector-driven refresh tests ──────────────────────────────────
 
 
-class TestPopulateWorkerInfoFromDiscovery:
-    """Tests for NativePlannerBase._populate_worker_info_from_discovery."""
+class TestRefreshWorkerInfoFromConnector:
+    """Tests for NativePlannerBase._refresh_worker_info_from_connector.
 
-    def _make_planner(self):
+    The tick-loop refresh delegates to the connector's ``get_worker_info``,
+    which is where each connector implements its own MDC source (K8s CRDs
+    for KubernetesConnector, discovery watch for VirtualConnector).  These
+    tests exercise the shared refresh plumbing with a mock connector.
+    """
+
+    def _make_planner(self, require_prefill=False, require_decode=True):
         """Build a minimal NativePlannerBase with no_operation=True."""
         from unittest.mock import Mock, patch
 
@@ -491,81 +497,121 @@ class TestPopulateWorkerInfoFromDiscovery:
                 load_min_observations=5,
             )
             planner = NativePlannerBase(None, config)
+        planner.require_prefill = require_prefill
+        planner.require_decode = require_decode
         planner.prefill_worker_info = WorkerInfo()
         planner.decode_worker_info = WorkerInfo()
         return planner
 
-    def test_backfill_from_discovery(self):
-        """max_num_batched_tokens is populated from discovery (min across workers)."""
+    def _install_mock_connector(self, planner, **fresh_info_kwargs):
+        """Replace planner.connector with a Mock returning a fresh WorkerInfo."""
         from unittest.mock import Mock
 
+        from dynamo.planner.monitoring.worker_info import WorkerInfo
+
+        fresh = WorkerInfo(**fresh_info_kwargs)
+        mock_connector = Mock()
+        mock_connector.get_worker_info.return_value = fresh
+        planner.connector = mock_connector
+        return mock_connector
+
+    def test_refresh_populates_missing_fields(self):
+        """Connector returns a populated WorkerInfo; missing fields backfill."""
         planner = self._make_planner()
         assert planner.decode_worker_info.max_num_batched_tokens is None
 
-        mock_sub = Mock()
-        mock_sub.get_max_num_batched_tokens.return_value = 8192
-        planner._decode_fpm_sub = mock_sub
+        self._install_mock_connector(
+            planner,
+            max_num_batched_tokens=8192,
+            total_kv_blocks=1024,
+            max_num_seqs=256,
+            kv_cache_block_size=16,
+            context_length=4096,
+        )
 
-        planner._populate_worker_info_from_discovery()
+        planner._refresh_worker_info_from_connector()
         assert planner.decode_worker_info.max_num_batched_tokens == 8192
+        assert planner.decode_worker_info.total_kv_blocks == 1024
+        assert planner.decode_worker_info.max_num_seqs == 256
+        assert planner.decode_worker_info.kv_cache_block_size == 16
+        assert planner.decode_worker_info.context_length == 4096
 
     def test_noop_when_already_set(self):
-        """Does not overwrite an existing max_num_batched_tokens value."""
-        from unittest.mock import Mock
-
+        """Does not re-query once max_num_batched_tokens is populated."""
         from dynamo.planner.monitoring.worker_info import WorkerInfo
 
         planner = self._make_planner()
         planner.decode_worker_info = WorkerInfo(max_num_batched_tokens=2048)
 
-        mock_sub = Mock()
-        mock_sub.get_max_num_batched_tokens.return_value = 8192
-        planner._decode_fpm_sub = mock_sub
+        mock_connector = self._install_mock_connector(
+            planner, max_num_batched_tokens=8192
+        )
 
-        planner._populate_worker_info_from_discovery()
+        planner._refresh_worker_info_from_connector()
         assert planner.decode_worker_info.max_num_batched_tokens == 2048
+        mock_connector.get_worker_info.assert_not_called()
 
-    def test_noop_when_no_subscriber(self):
-        """Gracefully does nothing when there is no FPM subscriber."""
+    def test_noop_when_connector_lacks_get_worker_info(self):
+        """Silently does nothing if the connector does not implement get_worker_info."""
         planner = self._make_planner()
-        # Both subscribers are None by default
-        planner._populate_worker_info_from_discovery()
-        assert planner.prefill_worker_info.max_num_batched_tokens is None
+
+        class _StubConnector:
+            pass
+
+        planner.connector = _StubConnector()
+        planner._refresh_worker_info_from_connector()
         assert planner.decode_worker_info.max_num_batched_tokens is None
 
-    def test_noop_when_no_value_reported(self):
-        """Does nothing when no worker has reported max_num_batched_tokens."""
+    def test_noop_when_connector_returns_none_fields(self):
+        """Fresh WorkerInfo with None everywhere does not overwrite anything."""
+        planner = self._make_planner()
+        self._install_mock_connector(planner)  # All Nones
+        planner._refresh_worker_info_from_connector()
+        assert planner.decode_worker_info.max_num_batched_tokens is None
+
+    def test_exception_does_not_propagate(self):
+        """If connector.get_worker_info throws, refresh is a no-op."""
         from unittest.mock import Mock
 
         planner = self._make_planner()
+        mock_connector = Mock()
+        mock_connector.get_worker_info.side_effect = RuntimeError("boom")
+        planner.connector = mock_connector
 
-        mock_sub = Mock()
-        mock_sub.get_max_num_batched_tokens.return_value = None
-        planner._decode_fpm_sub = mock_sub
-
-        planner._populate_worker_info_from_discovery()
+        planner._refresh_worker_info_from_connector()  # must not raise
         assert planner.decode_worker_info.max_num_batched_tokens is None
 
     def test_updates_state_machine_capabilities(self):
         """State machine capabilities are updated via update_capabilities()."""
-        from unittest.mock import Mock
-
         planner = self._make_planner()
-        # Force state machine creation
         _ = planner.state_machine
         assert planner._state_machine is not None
-        assert (
-            planner._state_machine._capabilities.decode is None
-            or planner._state_machine._capabilities.decode.max_num_batched_tokens
-            is None
-        )
 
-        mock_sub = Mock()
-        mock_sub.get_max_num_batched_tokens.return_value = 4096
-        planner._decode_fpm_sub = mock_sub
+        self._install_mock_connector(planner, max_num_batched_tokens=4096)
 
-        planner._populate_worker_info_from_discovery()
+        planner._refresh_worker_info_from_connector()
         assert planner.decode_worker_info.max_num_batched_tokens == 4096
         assert (
             planner._state_machine._capabilities.decode.max_num_batched_tokens == 4096
         )
+
+    def test_refresh_skips_unneeded_sub_component(self):
+        """Only sub-components with require_* True are refreshed."""
+        from unittest.mock import Mock
+
+        from dynamo.planner.monitoring.worker_info import WorkerInfo
+
+        planner = self._make_planner(require_prefill=False, require_decode=True)
+
+        def _side_effect(sub_type, backend):
+            # Should only be called for DECODE.
+            assert sub_type.value == "decode"
+            return WorkerInfo(max_num_batched_tokens=4096)
+
+        mock_connector = Mock()
+        mock_connector.get_worker_info.side_effect = _side_effect
+        planner.connector = mock_connector
+
+        planner._refresh_worker_info_from_connector()
+        assert planner.prefill_worker_info.max_num_batched_tokens is None
+        assert planner.decode_worker_info.max_num_batched_tokens == 4096

--- a/components/src/dynamo/planner/tests/unit/test_mdc.py
+++ b/components/src/dynamo/planner/tests/unit/test_mdc.py
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the shared MDC helpers.
+
+These cover the pure transform shared by KubernetesConnector and
+VirtualConnector (see PR #8042 review): parsing ``card_json`` /
+``runtime_config`` into ``WorkerInfo``, the prefill/decode heuristic,
+and the LoRA-card filter.
+"""
+
+import pytest
+
+from dynamo.planner.config.defaults import SubComponentType
+from dynamo.planner.connectors.mdc import (
+    MdcEntry,
+    is_model_card,
+    is_prefill_card,
+    select_entry,
+    worker_info_from_mdc,
+)
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+# ── is_model_card ──────────────────────────────────────────────────
+
+
+class TestIsModelCard:
+    def test_model_wrapper_accepted(self):
+        assert is_model_card({"type": "Model"})
+
+    def test_lora_wrapper_rejected(self):
+        assert not is_model_card({"type": "LoRA"})
+
+    def test_missing_type_rejected(self):
+        assert not is_model_card({})
+
+
+# ── is_prefill_card ────────────────────────────────────────────────
+
+
+class TestIsPrefillCard:
+    def test_int_prefill_bit_set(self):
+        # ModelType::Prefill = 1 << 4 = 16
+        assert is_prefill_card({"model_type": 16})
+
+    def test_int_prefill_bit_unset(self):
+        # Chat | Completions = 1 | 2 = 3
+        assert not is_prefill_card({"model_type": 3})
+
+    def test_int_prefill_combined_with_other_bits(self):
+        # Prefill | Chat = 16 | 1 = 17
+        assert is_prefill_card({"model_type": 17})
+
+    def test_bitflags_dict_with_prefill(self):
+        assert is_prefill_card({"model_type": {"bits": 16}})
+
+    def test_bitflags_dict_without_prefill(self):
+        assert not is_prefill_card({"model_type": {"bits": 2}})
+
+    def test_string_prefill(self):
+        assert is_prefill_card({"model_type": "Prefill"})
+
+    def test_string_prefill_combined(self):
+        assert is_prefill_card({"model_type": "Prefill|Chat"})
+
+    def test_string_no_prefill(self):
+        assert not is_prefill_card({"model_type": "Chat|Completions"})
+
+    def test_missing_model_type_defaults_to_decode(self):
+        assert not is_prefill_card({})
+
+    def test_unparseable_model_type_defaults_to_decode(self):
+        assert not is_prefill_card({"model_type": "not-a-thing"})
+        assert not is_prefill_card({"model_type": None})
+
+
+# ── worker_info_from_mdc ──────────────────────────────────────────
+
+
+def _card(**runtime_config_overrides) -> dict:
+    """Build a minimal realistic card_json payload."""
+    return {
+        "display_name": "meta-llama/Llama-3.1-8B",
+        "model_type": 2,  # Completions (not prefill)
+        "kv_cache_block_size": 16,
+        "context_length": 8192,
+        "runtime_config": {
+            "total_kv_blocks": 1024,
+            "max_num_seqs": 256,
+            "max_num_batched_tokens": 8192,
+            **runtime_config_overrides,
+        },
+    }
+
+
+class TestWorkerInfoFromMdc:
+    def test_happy_path_populates_all_fields(self):
+        entry = MdcEntry(
+            card_json=_card(),
+            component="backend",
+            endpoint="generate",
+        )
+        info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")
+        assert info.model_name == "meta-llama/Llama-3.1-8B"
+        assert info.component_name == "backend"
+        assert info.endpoint == "generate"
+        assert info.total_kv_blocks == 1024
+        assert info.max_num_seqs == 256
+        assert info.max_num_batched_tokens == 8192
+        assert info.kv_cache_block_size == 16
+        assert info.context_length == 8192
+
+    def test_missing_wrapper_fields_fall_back_to_defaults(self):
+        entry = MdcEntry(card_json=_card())
+        info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")
+        # From VllmComponentName
+        assert info.component_name == "backend"
+        assert info.endpoint == "generate"
+        assert info.k8s_name == "VllmDecodeWorker"
+
+    def test_prefill_defaults(self):
+        entry = MdcEntry(card_json=_card())
+        info = worker_info_from_mdc(entry, SubComponentType.PREFILL, backend="vllm")
+        assert info.component_name == "prefill"
+        assert info.k8s_name == "VllmPrefillWorker"
+
+    def test_model_name_fallback_invoked_when_card_missing(self):
+        card = _card()
+        del card["display_name"]
+        entry = MdcEntry(card_json=card)
+
+        info = worker_info_from_mdc(
+            entry,
+            SubComponentType.DECODE,
+            backend="vllm",
+            model_name_fallback=lambda: "from-dgd-args",
+        )
+        assert info.model_name == "from-dgd-args"
+
+    def test_model_name_fallback_not_invoked_when_card_has_it(self):
+        called = []
+        entry = MdcEntry(card_json=_card())
+
+        info = worker_info_from_mdc(
+            entry,
+            SubComponentType.DECODE,
+            backend="vllm",
+            model_name_fallback=lambda: (called.append(1), "other")[1],
+        )
+        assert info.model_name == "meta-llama/Llama-3.1-8B"
+        assert not called
+
+    def test_k8s_name_override(self):
+        entry = MdcEntry(card_json=_card())
+        info = worker_info_from_mdc(
+            entry,
+            SubComponentType.DECODE,
+            backend="vllm",
+            k8s_name_override="custom-decode-svc",
+        )
+        assert info.k8s_name == "custom-decode-svc"
+
+    def test_partial_runtime_config_populates_available_fields(self):
+        card = _card()
+        del card["runtime_config"]["max_num_seqs"]
+        entry = MdcEntry(card_json=card)
+        info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")
+        assert info.max_num_batched_tokens == 8192
+        assert info.max_num_seqs is None
+
+    def test_missing_runtime_config(self):
+        card = _card()
+        del card["runtime_config"]
+        entry = MdcEntry(card_json=card)
+        info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")
+        assert info.max_num_batched_tokens is None
+        assert info.total_kv_blocks is None
+        # Non-runtime_config fields still populate
+        assert info.kv_cache_block_size == 16
+        assert info.context_length == 8192
+
+    def test_non_dict_runtime_config_treated_as_missing(self):
+        card = _card()
+        card["runtime_config"] = "not-a-dict"
+        entry = MdcEntry(card_json=card)
+        info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")
+        assert info.max_num_batched_tokens is None
+        assert info.total_kv_blocks is None
+        assert info.max_num_seqs is None
+
+    def test_empty_card_json(self):
+        entry = MdcEntry(card_json={})
+        info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")
+        # Component/endpoint/k8s_name from defaults
+        assert info.component_name == "backend"
+        # Runtime fields all None
+        assert info.max_num_batched_tokens is None
+        assert info.model_name is None
+
+    def test_fallback_exception_produces_none_model_name(self):
+        card = _card()
+        del card["display_name"]
+        entry = MdcEntry(card_json=card)
+
+        def _raise():
+            raise RuntimeError("boom")
+
+        info = worker_info_from_mdc(
+            entry,
+            SubComponentType.DECODE,
+            backend="vllm",
+            model_name_fallback=_raise,
+        )
+        assert info.model_name is None
+
+
+# ── select_entry ───────────────────────────────────────────────────
+
+
+class TestSelectEntry:
+    def test_selects_prefill_entry(self):
+        entries = [
+            MdcEntry(card_json={**_card(), "model_type": 2}, component="backend"),
+            MdcEntry(card_json={**_card(), "model_type": 16}, component="prefill"),
+        ]
+        hit = select_entry(entries, SubComponentType.PREFILL)
+        assert hit is not None
+        assert hit.component == "prefill"
+
+    def test_selects_decode_entry(self):
+        entries = [
+            MdcEntry(card_json={**_card(), "model_type": 2}, component="backend"),
+            MdcEntry(card_json={**_card(), "model_type": 16}, component="prefill"),
+        ]
+        hit = select_entry(entries, SubComponentType.DECODE)
+        assert hit is not None
+        assert hit.component == "backend"
+
+    def test_component_filter_skips_mismatched(self):
+        # Simulates a LoRA wrapper that slipped past is_model_card but points
+        # at a different component — should be skipped when we know the
+        # expected component.
+        entries = [
+            MdcEntry(card_json={**_card(), "model_type": 2}, component="lora-adapter"),
+            MdcEntry(card_json={**_card(), "model_type": 2}, component="backend"),
+        ]
+        hit = select_entry(
+            entries, SubComponentType.DECODE, expected_component="backend"
+        )
+        assert hit is not None
+        assert hit.component == "backend"
+
+    def test_returns_none_when_no_match(self):
+        entries = [
+            MdcEntry(card_json={**_card(), "model_type": 2}, component="backend"),
+        ]
+        assert select_entry(entries, SubComponentType.PREFILL) is None

--- a/components/src/dynamo/vllm/envs.py
+++ b/components/src/dynamo/vllm/envs.py
@@ -47,7 +47,7 @@ def _resolve_port(env_var: str, default_port: int) -> int:
                 f"{env_var} must be an integer port number, got {env_value!r}."
             ) from exc
 
-    if not (REGISTERED_PORT_MIN <= port <= REGISTERED_PORT_MAX):
+    if not (REGISTERED_PORT_MIN <= port):
         raise ValueError(
             f"{env_var} port {port} is outside of the registered port range "
             f"({REGISTERED_PORT_MIN}-{REGISTERED_PORT_MAX})."

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1794,8 +1794,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             output_options.get("return_tokens_as_token_ids")
         )
 
-        print(f"[DEBUG] output_options={output_options}, return_tokens_as_token_ids={return_tokens_as_token_ids}", flush=True)
-
         async with self._abort_monitor(context, request_id):
             try:
                 async for tok in self.generate_tokens(

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1433,7 +1433,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
     @staticmethod
     def _extract_logprobs(
-        output, num_output_tokens_so_far: int, tokenizer=None
+        output, num_output_tokens_so_far: int, tokenizer=None,
+        return_tokens_as_token_ids: bool = False,
     ) -> tuple[list[float] | None, list[list[dict]] | None]:
         """
         Extract logprobs from vLLM CompletionOutput for new tokens.
@@ -1475,12 +1476,15 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             # Build top_logprobs list for this token position
             token_top_logprobs = []
             for tok_id, logprob_info in token_logprobs_dict.items():
-                token_str = getattr(logprob_info, "decoded_token", None)
-                if not token_str and tokenizer:
-                    try:
-                        token_str = tokenizer.decode([tok_id])
-                    except Exception:
-                        token_str = None
+                if return_tokens_as_token_ids:
+                    token_str = f"token_id:{tok_id}"
+                else:
+                    token_str = getattr(logprob_info, "decoded_token", None)
+                    if not token_str and tokenizer:
+                        try:
+                            token_str = tokenizer.decode([tok_id])
+                        except Exception:
+                            token_str = None
                 token_top_logprobs.append(
                     {
                         "rank": (
@@ -1542,6 +1546,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         embedding_sequence_length=None,
         trace_headers=None,
         priority=0,
+        return_tokens_as_token_ids=False,
     ):
         try:
             # Log LoRA usage for this generation (debug level to avoid log spam)
@@ -1585,7 +1590,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 # Extract logprobs for new tokens if available
                 tokenizer = getattr(self.engine_client, "tokenizer", None)
                 log_probs, top_logprobs = self._extract_logprobs(
-                    output, num_output_tokens_so_far, tokenizer=tokenizer
+                    output, num_output_tokens_so_far, tokenizer=tokenizer,
+                    return_tokens_as_token_ids=return_tokens_as_token_ids,
                 )
                 if log_probs is not None:
                     out["log_probs"] = log_probs
@@ -1783,6 +1789,13 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
         trace_headers = build_trace_headers(context)
 
+        output_options = request.get("output_options", {})
+        return_tokens_as_token_ids = bool(
+            output_options.get("return_tokens_as_token_ids")
+        )
+
+        print(f"[DEBUG] output_options={output_options}, return_tokens_as_token_ids={return_tokens_as_token_ids}", flush=True)
+
         async with self._abort_monitor(context, request_id):
             try:
                 async for tok in self.generate_tokens(
@@ -1794,6 +1807,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     embedding_sequence_length=embedding_sequence_length,
                     trace_headers=trace_headers,
                     priority=priority,
+                    return_tokens_as_token_ids=return_tokens_as_token_ids,
                 ):
                     if prefill_result is not None and "completion_usage" in tok:
                         tok["completion_usage"][

--- a/components/src/dynamo/vllm/multimodal_utils/protocol.py
+++ b/components/src/dynamo/vllm/multimodal_utils/protocol.py
@@ -22,7 +22,11 @@ import torch
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 from pydantic_core import core_schema
 from typing_extensions import NotRequired
-from vllm.inputs import MultiModalUUIDDict, TokensPrompt  # noqa: F401
+try:
+    from vllm.inputs import MultiModalUUIDDict, TokensPrompt  # noqa: F401
+except ImportError:
+    from vllm.inputs.data import TokensPrompt  # noqa: F401
+    from vllm.multimodal.inputs import MultiModalUUIDDict  # noqa: F401
 from vllm.logprobs import PromptLogprobs
 from vllm.outputs import CompletionOutput
 from vllm.sampling_params import SamplingParams

--- a/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
@@ -23,7 +23,11 @@ _chat_protocol = importlib.import_module(
     "vllm.entrypoints.openai.chat_completion.protocol"
 )
 _engine_protocol = importlib.import_module("vllm.entrypoints.openai.engine.protocol")
-_inputs_data = importlib.import_module("vllm.inputs")
+try:
+    _inputs_data = importlib.import_module("vllm.inputs")
+    _inputs_data.TokensPrompt  # verify the symbol is here
+except (ImportError, AttributeError):
+    _inputs_data = importlib.import_module("vllm.inputs.data")
 _reasoning = importlib.import_module("vllm.reasoning")
 _sampling_params = importlib.import_module("vllm.sampling_params")
 _tool_parsers = importlib.import_module("vllm.tool_parsers")

--- a/lib/bindings/python/rust/llm/fpm.rs
+++ b/lib/bindings/python/rust/llm/fpm.rs
@@ -310,11 +310,11 @@ pub(crate) struct FpmEventSubscriber {
     // (insert on Added, remove on Removed).  Used by get_recent_stats()
     // to filter out ghost entries without contending with Task 1's writes.
     known_workers: Arc<DashSet<String>>,
-    // max_num_batched_tokens per worker_id, extracted from the model
-    // deployment card's runtime_config on discovery Added events.
-    // Exposed via get_max_num_batched_tokens() so the planner can read
-    // the effective (minimum) value without a separate connector query.
-    worker_max_batched_tokens: Arc<DashMap<String, u64>>,
+    // Serialized ModelDeploymentCard per worker_id, captured on discovery
+    // Added events.  Exposed via get_model_cards() so connectors can
+    // construct WorkerInfo from the same MDC stream the liveness watch
+    // uses, without the subscriber having to interpret card fields itself.
+    worker_model_cards: Arc<DashMap<String, String>>,
 }
 
 #[pymethods]
@@ -337,7 +337,7 @@ impl FpmEventSubscriber {
             tracking_started: Arc::new(AtomicBool::new(false)),
             latest_stats: Arc::new(DashMap::new()),
             known_workers: Arc::new(DashSet::new()),
-            worker_max_batched_tokens: Arc::new(DashMap::new()),
+            worker_model_cards: Arc::new(DashMap::new()),
         })
     }
 
@@ -517,13 +517,13 @@ impl FpmEventSubscriber {
         // normal scale-down path.  Any ghost entries created by the race
         // condition (FPM arriving *after* the Removed event) are caught by the
         // known_workers filter in get_recent_stats().
-        let max_bt = self.worker_max_batched_tokens.clone();
+        let cards = self.worker_model_cards.clone();
         rt.spawn({
             let cancel = cancel.clone();
             let component = component.clone();
             let stats = stats.clone();
             let known = known.clone();
-            let max_bt = max_bt.clone();
+            let cards = cards.clone();
             async move {
                 let discovery = component.drt().discovery();
                 let query = DiscoveryQuery::ComponentModels {
@@ -553,15 +553,20 @@ impl FpmEventSubscriber {
                             match event {
                                 Some(Ok(DiscoveryEvent::Added(instance))) => {
                                     let wid = instance.instance_id().to_string();
-                                    // Extract max_num_batched_tokens from the model card's runtime_config.
-                                    if let DiscoveryInstance::Model { ref card_json, .. } = instance
-                                        && let Some(val) = card_json
-                                            .get("runtime_config")
-                                            .and_then(|rc| rc.get("max_num_batched_tokens"))
-                                            .and_then(|v| v.as_u64())
-                                        && val > 0
-                                    {
-                                        max_bt.insert(wid.clone(), val);
+                                    // Capture the full card JSON so connectors can build WorkerInfo
+                                    // from runtime_config / display_name / kv_cache_block_size / etc.
+                                    // without the subscriber having to know which fields matter.
+                                    if let DiscoveryInstance::Model { ref card_json, .. } = instance {
+                                        match serde_json::to_string(card_json) {
+                                            Ok(s) => {
+                                                cards.insert(wid.clone(), s);
+                                            }
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    "FPM tracker: failed to serialize card_json for {wid}: {e}"
+                                                );
+                                            }
+                                        }
                                     }
                                     known.insert(wid.clone());
                                     tracing::debug!("FPM tracker: worker {wid} added to known set");
@@ -569,7 +574,7 @@ impl FpmEventSubscriber {
                                 Some(Ok(DiscoveryEvent::Removed(id))) => {
                                     let removed_id = id.instance_id().to_string();
                                     known.remove(&removed_id);
-                                    max_bt.remove(&removed_id);
+                                    cards.remove(&removed_id);
 
                                     // Eagerly prune latest_stats for the common case
                                     // (worker removed cleanly before any late FPMs arrive).
@@ -627,29 +632,30 @@ impl FpmEventSubscriber {
         Ok(snapshot)
     }
 
-    /// Return the effective `max_num_batched_tokens` across all known workers.
+    /// Snapshot of model deployment cards keyed by worker id.
     ///
-    /// The value is the **minimum** observed across workers so the planner
-    /// uses the most constrained capacity, avoiding nondeterminism when
-    /// workers report different values during heterogeneous rollouts.
+    /// The snapshot is filtered against `known_workers` so entries for
+    /// already-removed workers are not returned.  Values are the raw
+    /// `ModelDeploymentCard` serialized as a JSON string; callers parse
+    /// whichever fields they need (e.g. `runtime_config`, `display_name`).
     ///
     /// Returns:
-    ///     The minimum `max_num_batched_tokens`, or `None` if no worker has reported one.
-    fn get_max_num_batched_tokens(&self) -> PyResult<Option<u64>> {
+    ///     dict mapping `worker_id: str` to `card_json: str`.
+    fn get_model_cards(&self) -> PyResult<HashMap<String, String>> {
         if !self.tracking_started.load(Ordering::SeqCst) {
             return Err(PyRuntimeError::new_err(
                 "start_tracking() has not been called",
             ));
         }
 
-        let min_val = self
-            .worker_max_batched_tokens
+        let snapshot = self
+            .worker_model_cards
             .iter()
             .filter(|entry| self.known_workers.contains(entry.key()))
-            .map(|entry| *entry.value())
-            .min();
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
 
-        Ok(min_val)
+        Ok(snapshot)
     }
 
     /// Shut down the subscriber (all background tasks).

--- a/lib/bindings/python/rust/llm/fpm.rs
+++ b/lib/bindings/python/rust/llm/fpm.rs
@@ -23,7 +23,7 @@ use super::*;
 use crate::Endpoint;
 use crate::to_pyerr;
 use dynamo_runtime::component::Component;
-use dynamo_runtime::discovery::{DiscoveryEvent, DiscoveryQuery};
+use dynamo_runtime::discovery::{DiscoveryEvent, DiscoveryInstance, DiscoveryQuery};
 use dynamo_runtime::traits::DistributedRuntimeProvider;
 use dynamo_runtime::transports::event_plane::EventSubscriber;
 
@@ -310,6 +310,11 @@ pub(crate) struct FpmEventSubscriber {
     // (insert on Added, remove on Removed).  Used by get_recent_stats()
     // to filter out ghost entries without contending with Task 1's writes.
     known_workers: Arc<DashSet<String>>,
+    // max_num_batched_tokens per worker_id, extracted from the model
+    // deployment card's runtime_config on discovery Added events.
+    // Exposed via get_max_num_batched_tokens() so the planner can read
+    // the effective (minimum) value without a separate connector query.
+    worker_max_batched_tokens: Arc<DashMap<String, u64>>,
 }
 
 #[pymethods]
@@ -332,6 +337,7 @@ impl FpmEventSubscriber {
             tracking_started: Arc::new(AtomicBool::new(false)),
             latest_stats: Arc::new(DashMap::new()),
             known_workers: Arc::new(DashSet::new()),
+            worker_max_batched_tokens: Arc::new(DashMap::new()),
         })
     }
 
@@ -511,11 +517,13 @@ impl FpmEventSubscriber {
         // normal scale-down path.  Any ghost entries created by the race
         // condition (FPM arriving *after* the Removed event) are caught by the
         // known_workers filter in get_recent_stats().
+        let max_bt = self.worker_max_batched_tokens.clone();
         rt.spawn({
             let cancel = cancel.clone();
             let component = component.clone();
             let stats = stats.clone();
             let known = known.clone();
+            let max_bt = max_bt.clone();
             async move {
                 let discovery = component.drt().discovery();
                 let query = DiscoveryQuery::ComponentModels {
@@ -545,12 +553,23 @@ impl FpmEventSubscriber {
                             match event {
                                 Some(Ok(DiscoveryEvent::Added(instance))) => {
                                     let wid = instance.instance_id().to_string();
+                                    // Extract max_num_batched_tokens from the model card's runtime_config.
+                                    if let DiscoveryInstance::Model { ref card_json, .. } = instance
+                                        && let Some(val) = card_json
+                                            .get("runtime_config")
+                                            .and_then(|rc| rc.get("max_num_batched_tokens"))
+                                            .and_then(|v| v.as_u64())
+                                        && val > 0
+                                    {
+                                        max_bt.insert(wid.clone(), val);
+                                    }
                                     known.insert(wid.clone());
                                     tracing::debug!("FPM tracker: worker {wid} added to known set");
                                 }
                                 Some(Ok(DiscoveryEvent::Removed(id))) => {
                                     let removed_id = id.instance_id().to_string();
                                     known.remove(&removed_id);
+                                    max_bt.remove(&removed_id);
 
                                     // Eagerly prune latest_stats for the common case
                                     // (worker removed cleanly before any late FPMs arrive).
@@ -606,6 +625,31 @@ impl FpmEventSubscriber {
             .collect();
 
         Ok(snapshot)
+    }
+
+    /// Return the effective `max_num_batched_tokens` across all known workers.
+    ///
+    /// The value is the **minimum** observed across workers so the planner
+    /// uses the most constrained capacity, avoiding nondeterminism when
+    /// workers report different values during heterogeneous rollouts.
+    ///
+    /// Returns:
+    ///     The minimum `max_num_batched_tokens`, or `None` if no worker has reported one.
+    fn get_max_num_batched_tokens(&self) -> PyResult<Option<u64>> {
+        if !self.tracking_started.load(Ordering::SeqCst) {
+            return Err(PyRuntimeError::new_err(
+                "start_tracking() has not been called",
+            ));
+        }
+
+        let min_val = self
+            .worker_max_batched_tokens
+            .iter()
+            .filter(|entry| self.known_workers.contains(entry.key()))
+            .map(|entry| *entry.value())
+            .min();
+
+        Ok(min_val)
     }
 
     /// Shut down the subscriber (all background tasks).

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -906,6 +906,21 @@ class FpmEventSubscriber:
         """
         ...
 
+    def get_max_num_batched_tokens(self) -> int | None:
+        """
+        Return the effective ``max_num_batched_tokens`` across all known workers.
+
+        The value is the **minimum** observed across workers so the planner
+        uses the most constrained capacity.
+
+        Raises RuntimeError if ``start_tracking()`` has not been called.
+
+        Returns:
+            The minimum ``max_num_batched_tokens``, or ``None`` if no worker
+            has reported one.
+        """
+        ...
+
     def shutdown(self) -> None:
         """Shut down the subscriber (all background tasks)."""
         ...

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -906,18 +906,20 @@ class FpmEventSubscriber:
         """
         ...
 
-    def get_max_num_batched_tokens(self) -> int | None:
+    def get_model_cards(self) -> dict[str, str]:
         """
-        Return the effective ``max_num_batched_tokens`` across all known workers.
+        Snapshot of model deployment cards keyed by worker id.
 
-        The value is the **minimum** observed across workers so the planner
-        uses the most constrained capacity.
+        The snapshot is filtered against the known-workers set so entries
+        for already-removed workers are not returned.  Values are the raw
+        ``ModelDeploymentCard`` serialized as a JSON string; callers parse
+        whichever fields they need (e.g. ``runtime_config``,
+        ``display_name``).
 
         Raises RuntimeError if ``start_tracking()`` has not been called.
 
         Returns:
-            The minimum ``max_num_batched_tokens``, or ``None`` if no worker
-            has reported one.
+            dict mapping ``worker_id`` to ``card_json`` (JSON string).
         """
         ...
 

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -447,6 +447,7 @@ impl ModelWatcher {
         if let Some(model) = self.manager.get_model(&model_name)
             && model.has_worker_set(&ws_key)
         {
+            self.resolve_card_local_files(&model_name, card);
             self.manager
                 .save_model_card(&mcid.to_path(), card.clone())?;
             tracing::debug!(
@@ -550,6 +551,26 @@ impl ModelWatcher {
             "Worker joined existing WorkerSet, skipping pipeline build"
         );
         Ok(false)
+    }
+
+    /// If an existing card for the same model has already-downloaded local files,
+    /// point this card's URL-backed files at the same local directory. This avoids
+    /// re-downloading config files for every worker that joins an existing WorkerSet.
+    fn resolve_card_local_files(
+        &self,
+        model_name: &str,
+        card: &mut ModelDeploymentCard,
+    ) {
+        let local_dir = self
+            .manager
+            .get_model_cards()
+            .iter()
+            .find(|c| c.name() == model_name)
+            .and_then(|c| c.local_file_dir().map(|p| p.to_path_buf()));
+
+        if let Some(dir) = local_dir {
+            card.update_dir(&dir);
+        }
     }
 
     /// Build a complete WorkerSet with all engines for this (model, namespace)

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -103,10 +103,6 @@ pub async fn run(
             let engine = Arc::new(StreamingEngineAdapter::new(engine));
             let manager = http_service.model_manager();
             let checksum = model.card().mdcsum();
-            manager.save_model_card(
-                &format!("__local_model_card_{}", model.display_name()),
-                model.card().clone(),
-            )?;
             manager.add_completions_model(model.display_name(), checksum, engine.clone())?;
             manager.add_chat_completions_model(model.display_name(), checksum, engine)?;
 
@@ -124,10 +120,6 @@ pub async fn run(
             let http_service = http_service_builder.build()?;
             let manager = http_service.model_manager();
             let checksum = model.card().mdcsum();
-            manager.save_model_card(
-                &format!("__local_model_card_{}", model.display_name()),
-                model.card().clone(),
-            )?;
 
             let tokenizer = model.card().tokenizer()?;
             let chat_pipeline = common::build_pipeline::<

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -103,6 +103,10 @@ pub async fn run(
             let engine = Arc::new(StreamingEngineAdapter::new(engine));
             let manager = http_service.model_manager();
             let checksum = model.card().mdcsum();
+            manager.save_model_card(
+                &format!("__local_model_card_{}", model.display_name()),
+                model.card().clone(),
+            )?;
             manager.add_completions_model(model.display_name(), checksum, engine.clone())?;
             manager.add_chat_completions_model(model.display_name(), checksum, engine)?;
 
@@ -120,6 +124,10 @@ pub async fn run(
             let http_service = http_service_builder.build()?;
             let manager = http_service.model_manager();
             let checksum = model.card().mdcsum();
+            manager.save_model_card(
+                &format!("__local_model_card_{}", model.display_name()),
+                model.card().clone(),
+            )?;
 
             let tokenizer = model.card().tokenizer()?;
             let chat_pipeline = common::build_pipeline::<

--- a/lib/llm/src/entrypoint/input/text.rs
+++ b/lib/llm/src/entrypoint/input/text.rs
@@ -115,6 +115,7 @@ async fn main_loop(
             nvext: None,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         };
 

--- a/lib/llm/src/entrypoint/input/text.rs
+++ b/lib/llm/src/entrypoint/input/text.rs
@@ -116,6 +116,7 @@ async fn main_loop(
             chat_template_args: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
             unsupported_fields: Default::default(),
         };
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2865,6 +2865,18 @@ mod tests {
         make_tokenize_state_with_path(model_name, TOKENIZE_MODEL_PATH)
     }
 
+    fn make_tokenize_state_without_card(model_name: &str) -> Arc<service_v2::State> {
+        let manager = Arc::new(ModelManager::new());
+        manager.add_prefill_model(model_name, "missing-card").unwrap();
+
+        let discovery = Arc::new(MockDiscovery::new(None, SharedMockRegistry::new()));
+        Arc::new(service_v2::State::new(
+            manager,
+            discovery,
+            CancellationToken::new(),
+        ))
+    }
+
     async fn response_json<T: serde::de::DeserializeOwned>(response: Response) -> T {
         let body = response.into_body();
         let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
@@ -4056,6 +4068,50 @@ mod tests {
         .unwrap();
         let body: DetokenizeResponse = response_json(response).await;
         assert_eq!(body.prompt, prompt);
+    }
+
+    #[tokio::test]
+    async fn test_tokenize_route_rejects_models_without_card_metadata() {
+        let state = make_tokenize_state_without_card("test-model");
+        let error = tokenize(
+            State(state),
+            Json(TokenizeRequest::Completion(TokenizeCompletionRequest {
+                model: Some("test-model".to_string()),
+                prompt: "hello".to_string(),
+                add_special_tokens: true,
+                return_token_strs: false,
+            })),
+        )
+        .await
+        .unwrap_err();
+
+        let response = error.into_response();
+        let body: ErrorMessage = response_json(response).await;
+        assert!(
+            body.message
+                .contains("Tokenizer metadata is not available for model 'test-model'")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_detokenize_route_rejects_models_without_card_metadata() {
+        let state = make_tokenize_state_without_card("test-model");
+        let error = detokenize(
+            State(state),
+            Json(DetokenizeRequest {
+                model: Some("test-model".to_string()),
+                tokens: vec![1, 2, 3],
+            }),
+        )
+        .await
+        .unwrap_err();
+
+        let response = error.into_response();
+        let body: ErrorMessage = response_json(response).await;
+        assert!(
+            body.message
+                .contains("Tokenizer metadata is not available for model 'test-model'")
+        );
     }
 
     #[tokio::test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -43,6 +43,8 @@ use super::{
     service_v2,
 };
 use crate::engines::ValidateRequest;
+use crate::model_card::ModelDeploymentCard;
+use crate::preprocessor::prompt::PromptFormatter;
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
 use crate::protocols::openai::nvext::apply_header_routing_overrides;
 use crate::protocols::openai::{
@@ -55,6 +57,10 @@ use crate::protocols::openai::{
     embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
     images::{NvCreateImageRequest, NvImagesResponse},
     responses::{NvCreateResponse, NvResponse, ResponseParams, chat_completion_to_response},
+    tokenization::{
+        DetokenizeRequest, DetokenizeResponse, TokenizeChatRequest, TokenizeCompletionRequest,
+        TokenizeRequest, TokenizeResponse,
+    },
     videos::{NvCreateVideoRequest, NvVideosResponse},
 };
 use crate::protocols::unified::UnifiedRequest;
@@ -324,6 +330,169 @@ pub async fn smart_json_error_middleware(request: Request<Body>, next: Next) -> 
         // Pass through if it is not a 422
         response
     }
+}
+
+fn bad_request<T: Into<String>>(message: T) -> ErrorResponse {
+    let code = StatusCode::BAD_REQUEST;
+    (
+        code,
+        Json(ErrorMessage {
+            message: message.into(),
+            error_type: map_error_code_to_error_type(code),
+            code: code.as_u16(),
+        }),
+    )
+}
+
+fn resolve_tokenizer_model_name(
+    state: &Arc<service_v2::State>,
+    requested_model: Option<&str>,
+) -> Result<String, ErrorResponse> {
+    if let Some(model) = requested_model {
+        if state.manager().has_model_any(model) {
+            return Ok(model.to_string());
+        }
+        return Err(ErrorMessage::model_not_found());
+    }
+
+    let served_models = state.manager().model_display_names();
+    if served_models.len() == 1 {
+        return Ok(served_models.into_iter().next().unwrap());
+    }
+
+    let card_models: HashSet<String> = state
+        .manager()
+        .get_model_cards()
+        .into_iter()
+        .map(|card| card.display_name)
+        .collect();
+    if card_models.len() == 1 {
+        return Ok(card_models.into_iter().next().unwrap());
+    }
+
+    Err(bad_request(
+        "Model must be specified when more than one model is served.",
+    ))
+}
+
+fn resolve_model_card(
+    state: &Arc<service_v2::State>,
+    requested_model: Option<&str>,
+) -> Result<(String, ModelDeploymentCard), ErrorResponse> {
+    let model = resolve_tokenizer_model_name(state, requested_model)?;
+    let card = state
+        .manager()
+        .get_model_cards()
+        .into_iter()
+        .find(|card| card.display_name == model)
+        .ok_or_else(|| {
+            ErrorMessage::internal_server_error(&format!(
+                "Tokenizer metadata is not available for model '{}'",
+                model
+            ))
+        })?;
+    Ok((model, card))
+}
+
+fn extract_assistant_content_text(
+    content: &dynamo_protocols::types::ChatCompletionRequestAssistantMessageContent,
+) -> String {
+    use dynamo_protocols::types::ChatCompletionRequestAssistantMessageContent as Content;
+    use dynamo_protocols::types::ChatCompletionRequestAssistantMessageContentPart as Part;
+
+    match content {
+        Content::Text(text) => text.clone(),
+        Content::Array(parts) => parts
+            .iter()
+            .filter_map(|part| match part {
+                Part::Text(text) => Some(text.text.clone()),
+                Part::Refusal(_) => None,
+            })
+            .collect::<Vec<_>>()
+            .join(""),
+    }
+}
+
+fn apply_continue_final_message(
+    rendered_prompt: String,
+    messages: &[dynamo_protocols::types::ChatCompletionRequestMessage],
+) -> Result<String, ErrorResponse> {
+    use dynamo_protocols::types::ChatCompletionRequestMessage as Message;
+
+    let Some(Message::Assistant(message)) = messages.last() else {
+        return Err(bad_request(
+            "Cannot set `continue_final_message` to True when the final message is not from the assistant.",
+        ));
+    };
+
+    let Some(content) = message.content.as_ref() else {
+        return Err(bad_request(
+            "Cannot set `continue_final_message` to True when the final assistant message has no content.",
+        ));
+    };
+
+    let final_message = extract_assistant_content_text(content);
+    let trimmed_final_message = final_message.trim();
+    if trimmed_final_message.is_empty() {
+        return Err(bad_request(
+            "Cannot set `continue_final_message` to True when the final assistant message content is empty.",
+        ));
+    }
+
+    // Use rfind to locate the last occurrence of the assistant content in the rendered prompt,
+    // then truncate everything after it (e.g. EOS tokens, generation prompts). This assumes the
+    // final assistant message text appears only once at the end of the rendered output.
+    let Some(final_msg_loc) = rendered_prompt.rfind(trimmed_final_message) else {
+        return Err(ErrorMessage::internal_server_error(
+            "Failed to trim rendered prompt for `continue_final_message`.",
+        ));
+    };
+
+    Ok(rendered_prompt[..final_msg_loc + trimmed_final_message.len()].to_string())
+}
+
+fn make_tokenize_chat_completion_request(
+    model: String,
+    request: &TokenizeChatRequest,
+) -> NvCreateChatCompletionRequest {
+    let inner = dynamo_protocols::types::CreateChatCompletionRequest {
+        model,
+        messages: request.messages.clone(),
+        tools: request.tools.clone(),
+        ..Default::default()
+    };
+
+    NvCreateChatCompletionRequest {
+        inner,
+        common: Default::default(),
+        nvext: None,
+        chat_template_args: Some(request.merged_chat_template_kwargs()),
+        media_io_kwargs: request.media_io_kwargs.clone(),
+        unsupported_fields: Default::default(),
+    }
+}
+
+fn render_tokenize_chat_prompt(
+    card: &ModelDeploymentCard,
+    model: String,
+    request: &TokenizeChatRequest,
+) -> Result<String, ErrorResponse> {
+    request.validate().map_err(bad_request)?;
+
+    let formatter =
+        PromptFormatter::from_mdc_with_chat_template(card, request.chat_template.as_deref())
+            .map_err(|err| ErrorMessage::from_anyhow(err, "Failed to build chat formatter"))?;
+    let wrapped_request = make_tokenize_chat_completion_request(model, request);
+    let mut prompt = match formatter {
+        PromptFormatter::OAI(formatter) => formatter.render(&wrapped_request),
+    }
+    .map_err(|err| ErrorMessage::from_anyhow(err, "Failed to render chat prompt"))?;
+
+    if request.continue_final_message {
+        prompt = apply_continue_final_message(prompt, &request.messages)?;
+    }
+
+    Ok(prompt)
 }
 
 /// Return the request ID for the current request.
@@ -1920,6 +2089,102 @@ struct ModelListing {
     max_output_tokens: Option<u64>,
 }
 
+async fn tokenize(
+    State(state): State<Arc<service_v2::State>>,
+    Json(request): Json<TokenizeRequest>,
+) -> Result<Response, ErrorResponse> {
+    check_ready(&state)?;
+
+    let (_, card) = resolve_model_card(&state, request.model())?;
+    let tokenizer = card
+        .tokenizer()
+        .map_err(|err| ErrorMessage::from_anyhow(err, "Failed to load tokenizer"))?;
+
+    let (tokens, token_strs) = match request {
+        TokenizeRequest::Completion(TokenizeCompletionRequest {
+            prompt,
+            add_special_tokens,
+            return_token_strs,
+            ..
+        }) => {
+            let encoding = tokenizer
+                .encode_with_special_tokens(&prompt, add_special_tokens)
+                .map_err(|err| ErrorMessage::from_anyhow(err, "Failed to tokenize prompt"))?;
+            let token_ids = encoding.token_ids().to_vec();
+            let token_strs = if return_token_strs {
+                Some(tokenizer.convert_ids_to_tokens(&token_ids).map_err(|err| {
+                    ErrorMessage::from_anyhow(err, "Failed to resolve token strings")
+                })?)
+            } else {
+                None
+            };
+            (token_ids, token_strs)
+        }
+        TokenizeRequest::Chat(request) => {
+            let model = request
+                .model
+                .clone()
+                .unwrap_or_else(|| card.display_name.clone());
+            let prompt = render_tokenize_chat_prompt(&card, model, &request)?;
+            let encoding = tokenizer
+                .encode_with_special_tokens(&prompt, request.add_special_tokens)
+                .map_err(|err| {
+                    ErrorMessage::from_anyhow(err, "Failed to tokenize rendered chat prompt")
+                })?;
+            let token_ids = encoding.token_ids().to_vec();
+            let token_strs = if request.return_token_strs {
+                Some(tokenizer.convert_ids_to_tokens(&token_ids).map_err(|err| {
+                    ErrorMessage::from_anyhow(err, "Failed to resolve token strings")
+                })?)
+            } else {
+                None
+            };
+            (token_ids, token_strs)
+        }
+    };
+
+    Ok(Json(TokenizeResponse {
+        count: tokens.len(),
+        max_model_len: card.context_length,
+        tokens,
+        token_strs,
+    })
+    .into_response())
+}
+
+async fn detokenize(
+    State(state): State<Arc<service_v2::State>>,
+    Json(request): Json<DetokenizeRequest>,
+) -> Result<Response, ErrorResponse> {
+    check_ready(&state)?;
+
+    let (_, card) = resolve_model_card(&state, request.model.as_deref())?;
+    let tokenizer = card
+        .tokenizer()
+        .map_err(|err| ErrorMessage::from_anyhow(err, "Failed to load tokenizer"))?;
+    let prompt = tokenizer
+        .decode(&request.tokens, false)
+        .map_err(|err| ErrorMessage::from_anyhow(err, "Failed to detokenize prompt"))?;
+
+    Ok(Json(DetokenizeResponse { prompt }).into_response())
+}
+
+pub fn tokenization_router(state: Arc<service_v2::State>) -> (Vec<RouteDoc>, Router) {
+    let tokenize_path = "/tokenize";
+    let detokenize_path = "/detokenize";
+    let docs = vec![
+        RouteDoc::new(axum::http::Method::POST, tokenize_path),
+        RouteDoc::new(axum::http::Method::POST, detokenize_path),
+    ];
+    let router = Router::new()
+        .route(tokenize_path, post(tokenize))
+        .route(detokenize_path, post(detokenize))
+        .layer(middleware::from_fn(smart_json_error_middleware))
+        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
+        .with_state(state);
+    (docs, router)
+}
+
 /// Create an Axum [`Router`] for the OpenAI API Completions endpoint
 /// If not path is provided, the default path is `/v1/completions`
 pub fn completions_router(
@@ -2538,19 +2803,112 @@ pub fn audios_router(
 mod tests {
 
     use super::*;
-    use crate::discovery::ModelManagerError;
+    use crate::discovery::{ModelManager, ModelManagerError};
     use crate::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
     use crate::protocols::openai::common_ext::CommonExt;
     use crate::protocols::openai::completions::NvCreateCompletionRequest;
     use crate::protocols::openai::responses::NvCreateResponse;
+    use crate::protocols::openai::tokenization::DetokenizeRequest;
+    use axum::extract::State;
     use dynamo_protocols::types::responses::{CreateResponse, Input, PromptConfig};
     use dynamo_protocols::types::{
+        ChatCompletionRequestAssistantMessage, ChatCompletionRequestAssistantMessageContent,
         ChatCompletionRequestMessage, ChatCompletionRequestUserMessage,
-        ChatCompletionRequestUserMessageContent, CreateChatCompletionRequest,
-        CreateCompletionRequest,
+        ChatCompletionRequestUserMessageContent, ChatCompletionTool, CreateChatCompletionRequest,
+        CreateCompletionRequest, FunctionObject,
     };
+    use dynamo_runtime::discovery::{MockDiscovery, SharedMockRegistry};
+    use std::collections::HashMap as StdHashMap;
+    use tokio_util::sync::CancellationToken;
 
     const BACKUP_ERROR_MESSAGE: &str = "Failed to generate completions";
+    const TOKENIZE_MODEL_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/data/sample-models/mock-llama-3.1-8b-instruct"
+    );
+    const DETOKENIZE_MODEL_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/data/sample-models/TinyLlama_v1.1"
+    );
+
+    fn make_tokenize_state_with_path(
+        model_name: &str,
+        model_path: &str,
+    ) -> (Arc<service_v2::State>, ModelDeploymentCard) {
+        let mut card = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
+        card.set_name(model_name);
+
+        let manager = Arc::new(ModelManager::new());
+        manager
+            .save_model_card(&format!("__test_model_card_{model_name}"), card.clone())
+            .unwrap();
+        manager
+            .add_prefill_model(model_name, card.mdcsum())
+            .unwrap();
+
+        let discovery = Arc::new(MockDiscovery::new(None, SharedMockRegistry::new()));
+        let state = Arc::new(service_v2::State::new(
+            manager,
+            discovery,
+            CancellationToken::new(),
+        ));
+        (state, card)
+    }
+
+    fn make_tokenize_state(model_name: &str) -> (Arc<service_v2::State>, ModelDeploymentCard) {
+        make_tokenize_state_with_path(model_name, TOKENIZE_MODEL_PATH)
+    }
+
+    async fn response_json<T: serde::de::DeserializeOwned>(response: Response) -> T {
+        let body = response.into_body();
+        let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    fn sample_chat_messages() -> Vec<ChatCompletionRequestMessage> {
+        vec![
+            ChatCompletionRequestMessage::User(ChatCompletionRequestUserMessage {
+                content: ChatCompletionRequestUserMessageContent::Text("Hi there!".to_string()),
+                name: None,
+            }),
+            ChatCompletionRequestMessage::Assistant(ChatCompletionRequestAssistantMessage {
+                content: Some(ChatCompletionRequestAssistantMessageContent::Text(
+                    "Nice to meet you!".to_string(),
+                )),
+                reasoning_content: None,
+                refusal: None,
+                name: None,
+                audio: None,
+                tool_calls: None,
+                function_call: None,
+            }),
+            ChatCompletionRequestMessage::User(ChatCompletionRequestUserMessage {
+                content: ChatCompletionRequestUserMessageContent::Text(
+                    "Can I ask a question?".to_string(),
+                ),
+                name: None,
+            }),
+        ]
+    }
+
+    fn sample_tools() -> Vec<ChatCompletionTool> {
+        vec![ChatCompletionTool {
+            r#type: dynamo_protocols::types::ChatCompletionToolType::Function,
+            function: FunctionObject {
+                name: "get_weather".to_string(),
+                description: None,
+                parameters: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string"
+                        }
+                    }
+                })),
+                strict: None,
+            },
+        }]
+    }
 
     fn http_error_from_engine(code: u16) -> Result<(), anyhow::Error> {
         Err(HttpError {
@@ -3460,6 +3818,350 @@ mod tests {
             extract_error_type_from_response(&response),
             ErrorType::NotImplemented
         );
+    }
+
+    #[test]
+    fn test_apply_continue_final_message_trims_rendered_prompt() {
+        let rendered_prompt = "USER: Hi\nASSISTANT: Sure.</s><|assistant|>".to_string();
+        let messages = vec![
+            ChatCompletionRequestMessage::User(ChatCompletionRequestUserMessage {
+                content: ChatCompletionRequestUserMessageContent::Text("Hi".to_string()),
+                name: None,
+            }),
+            ChatCompletionRequestMessage::Assistant(ChatCompletionRequestAssistantMessage {
+                content: Some(ChatCompletionRequestAssistantMessageContent::Text(
+                    "Sure.".to_string(),
+                )),
+                reasoning_content: None,
+                refusal: None,
+                name: None,
+                audio: None,
+                tool_calls: None,
+                function_call: None,
+            }),
+        ];
+
+        let trimmed = apply_continue_final_message(rendered_prompt, &messages).unwrap();
+        assert_eq!(trimmed, "USER: Hi\nASSISTANT: Sure.");
+    }
+
+    #[tokio::test]
+    async fn test_tokenize_completion_route_matches_tokenizer() {
+        let (state, card) = make_tokenize_state("test-model");
+        let tokenizer = card.tokenizer().unwrap();
+        let prompt = "This is a completion tokenize test.";
+
+        for add_special_tokens in [false, true] {
+            let response = tokenize(
+                State(state.clone()),
+                Json(TokenizeRequest::Completion(TokenizeCompletionRequest {
+                    model: Some("test-model".to_string()),
+                    prompt: prompt.to_string(),
+                    add_special_tokens,
+                    return_token_strs: false,
+                })),
+            )
+            .await
+            .unwrap();
+            let body: TokenizeResponse = response_json(response).await;
+            let expected = tokenizer
+                .encode_with_special_tokens(prompt, add_special_tokens)
+                .unwrap();
+
+            assert_eq!(body.tokens, expected.token_ids());
+            assert_eq!(body.count, expected.token_ids().len());
+            assert_eq!(body.max_model_len, card.context_length);
+            assert!(body.token_strs.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_tokenize_chat_route_matches_rendered_prompt() {
+        let (state, card) = make_tokenize_state("test-model");
+        let tokenizer = card.tokenizer().unwrap();
+        let messages = sample_chat_messages();
+
+        for add_generation_prompt in [false, true] {
+            for add_special_tokens in [false, true] {
+                let request = TokenizeChatRequest {
+                    model: Some("test-model".to_string()),
+                    messages: messages.clone(),
+                    add_generation_prompt,
+                    return_token_strs: false,
+                    continue_final_message: false,
+                    add_special_tokens,
+                    chat_template: None,
+                    chat_template_kwargs: None,
+                    media_io_kwargs: None,
+                    mm_processor_kwargs: None,
+                    tools: None,
+                };
+                let prompt =
+                    render_tokenize_chat_prompt(&card, "test-model".to_string(), &request).unwrap();
+                let expected = tokenizer
+                    .encode_with_special_tokens(&prompt, add_special_tokens)
+                    .unwrap();
+
+                let response = tokenize(
+                    State(state.clone()),
+                    Json(TokenizeRequest::Chat(TokenizeChatRequest {
+                        model: Some("test-model".to_string()),
+                        messages: messages.clone(),
+                        add_generation_prompt,
+                        return_token_strs: false,
+                        continue_final_message: false,
+                        add_special_tokens,
+                        chat_template: None,
+                        chat_template_kwargs: None,
+                        media_io_kwargs: None,
+                        mm_processor_kwargs: None,
+                        tools: None,
+                    })),
+                )
+                .await
+                .unwrap();
+                let body: TokenizeResponse = response_json(response).await;
+                assert_eq!(body.tokens, expected.token_ids());
+                assert_eq!(body.count, expected.token_ids().len());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_tokenize_chat_route_with_tools_and_continue_final_message() {
+        let (state, card) = make_tokenize_state("test-model");
+        let tokenizer = card.tokenizer().unwrap();
+        let mut messages = sample_chat_messages();
+        messages.push(ChatCompletionRequestMessage::Assistant(
+            ChatCompletionRequestAssistantMessage {
+                content: Some(ChatCompletionRequestAssistantMessageContent::Text(
+                    "Sure,".to_string(),
+                )),
+                reasoning_content: None,
+                refusal: None,
+                name: None,
+                audio: None,
+                tool_calls: None,
+                function_call: None,
+            },
+        ));
+        let tools = sample_tools();
+
+        let request = TokenizeChatRequest {
+            model: Some("test-model".to_string()),
+            messages: messages.clone(),
+            add_generation_prompt: false,
+            return_token_strs: false,
+            continue_final_message: true,
+            add_special_tokens: true,
+            chat_template: None,
+            chat_template_kwargs: None,
+            media_io_kwargs: None,
+            mm_processor_kwargs: None,
+            tools: Some(tools.clone()),
+        };
+        let prompt =
+            render_tokenize_chat_prompt(&card, "test-model".to_string(), &request).unwrap();
+        let expected = tokenizer.encode_with_special_tokens(&prompt, true).unwrap();
+
+        let response = tokenize(
+            State(state),
+            Json(TokenizeRequest::Chat(TokenizeChatRequest {
+                model: Some("test-model".to_string()),
+                messages: messages.clone(),
+                add_generation_prompt: false,
+                return_token_strs: false,
+                continue_final_message: true,
+                add_special_tokens: true,
+                chat_template: None,
+                chat_template_kwargs: None,
+                media_io_kwargs: None,
+                mm_processor_kwargs: None,
+                tools: Some(tools),
+            })),
+        )
+        .await
+        .unwrap();
+        let body: TokenizeResponse = response_json(response).await;
+        assert_eq!(body.tokens, expected.token_ids());
+    }
+
+    #[tokio::test]
+    async fn test_tokenize_route_returns_token_strings() {
+        let (state, card) = make_tokenize_state("test-model");
+        let tokenizer = card.tokenizer().unwrap();
+        let prompt = "Return token strings please.";
+
+        let response = tokenize(
+            State(state),
+            Json(TokenizeRequest::Completion(TokenizeCompletionRequest {
+                model: Some("test-model".to_string()),
+                prompt: prompt.to_string(),
+                add_special_tokens: true,
+                return_token_strs: true,
+            })),
+        )
+        .await
+        .unwrap();
+        let body: TokenizeResponse = response_json(response).await;
+        let expected = tokenizer.encode_with_special_tokens(prompt, true).unwrap();
+        let expected_token_strs = tokenizer
+            .convert_ids_to_tokens(expected.token_ids())
+            .unwrap();
+
+        assert_eq!(body.tokens, expected.token_ids());
+        assert_eq!(body.token_strs, Some(expected_token_strs));
+    }
+
+    #[tokio::test]
+    async fn test_tokenize_chat_rejects_incompatible_flags() {
+        let (state, _) = make_tokenize_state("test-model");
+        let messages = sample_chat_messages();
+
+        let error = tokenize(
+            State(state),
+            Json(TokenizeRequest::Chat(TokenizeChatRequest {
+                model: Some("test-model".to_string()),
+                messages,
+                add_generation_prompt: true,
+                return_token_strs: false,
+                continue_final_message: true,
+                add_special_tokens: false,
+                chat_template: None,
+                chat_template_kwargs: None,
+                media_io_kwargs: None,
+                mm_processor_kwargs: None,
+                tools: None,
+            })),
+        )
+        .await
+        .unwrap_err();
+        let response = error.into_response();
+        let body: ErrorMessage = response_json(response).await;
+        assert!(body.message.contains(
+            "Cannot set both `continue_final_message` and `add_generation_prompt` to True."
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_detokenize_route_round_trips_prompt() {
+        let (state, card) = make_tokenize_state_with_path("test-model", DETOKENIZE_MODEL_PATH);
+        let tokenizer = card.tokenizer().unwrap();
+        let prompt = "This is a detokenize test prompt.";
+        let tokens = tokenizer
+            .encode_with_special_tokens(prompt, false)
+            .unwrap()
+            .token_ids()
+            .to_vec();
+
+        let response = detokenize(
+            State(state),
+            Json(DetokenizeRequest {
+                model: Some("test-model".to_string()),
+                tokens,
+            }),
+        )
+        .await
+        .unwrap();
+        let body: DetokenizeResponse = response_json(response).await;
+        assert_eq!(body.prompt, prompt);
+    }
+
+    #[tokio::test]
+    async fn test_tokenize_route_defaults_model_when_only_one_is_served() {
+        let (state, card) = make_tokenize_state("test-model");
+        let tokenizer = card.tokenizer().unwrap();
+        let prompt = "Single served model default.";
+        let expected = tokenizer.encode_with_special_tokens(prompt, true).unwrap();
+
+        let response = tokenize(
+            State(state),
+            Json(TokenizeRequest::Completion(TokenizeCompletionRequest {
+                model: None,
+                prompt: prompt.to_string(),
+                add_special_tokens: true,
+                return_token_strs: false,
+            })),
+        )
+        .await
+        .unwrap();
+        let body: TokenizeResponse = response_json(response).await;
+        assert_eq!(body.tokens, expected.token_ids());
+    }
+
+    #[tokio::test]
+    async fn test_tokenize_chat_route_supports_request_chat_template_override() {
+        let (state, card) = make_tokenize_state("test-model");
+        let tokenizer = card.tokenizer().unwrap();
+        let messages = sample_chat_messages();
+        let custom_template = concat!(
+            "{% for message in messages %}",
+            "[[{{ message['role'] }}]] {{ message['content'] }}\n",
+            "{% endfor %}",
+            "{% if add_generation_prompt %}[[assistant]] {% endif %}"
+        );
+
+        let request = TokenizeChatRequest {
+            model: Some("test-model".to_string()),
+            messages: messages.clone(),
+            add_generation_prompt: true,
+            return_token_strs: false,
+            continue_final_message: false,
+            add_special_tokens: false,
+            chat_template: Some(custom_template.to_string()),
+            chat_template_kwargs: Some(StdHashMap::from([(
+                "unused_value".to_string(),
+                serde_json::Value::String("ignored".to_string()),
+            )])),
+            media_io_kwargs: None,
+            mm_processor_kwargs: Some(StdHashMap::from([(
+                "image".to_string(),
+                serde_json::json!({"size": "ignored"}),
+            )])),
+            tools: None,
+        };
+        let prompt =
+            render_tokenize_chat_prompt(&card, "test-model".to_string(), &request).unwrap();
+        let expected = tokenizer
+            .encode_with_special_tokens(&prompt, false)
+            .unwrap();
+
+        let response = tokenize(
+            State(state),
+            Json(TokenizeRequest::Chat(TokenizeChatRequest {
+                model: Some("test-model".to_string()),
+                messages,
+                add_generation_prompt: true,
+                return_token_strs: false,
+                continue_final_message: false,
+                add_special_tokens: false,
+                chat_template: Some(custom_template.to_string()),
+                chat_template_kwargs: Some(StdHashMap::from([(
+                    "unused_value".to_string(),
+                    serde_json::Value::String("ignored".to_string()),
+                )])),
+                media_io_kwargs: None,
+                mm_processor_kwargs: Some(StdHashMap::from([(
+                    "image".to_string(),
+                    serde_json::json!({"size": "ignored"}),
+                )])),
+                tools: None,
+            })),
+        )
+        .await
+        .unwrap();
+        let body: TokenizeResponse = response_json(response).await;
+        assert_eq!(body.tokens, expected.token_ids());
+    }
+
+    #[test]
+    fn test_tokenization_router_registers_root_paths() {
+        let (state, _) = make_tokenize_state("test-model");
+        let (docs, _) = tokenization_router(state);
+        let docs = docs.iter().map(|doc| doc.to_string()).collect::<Vec<_>>();
+
+        assert!(docs.contains(&"POST /tokenize".to_string()));
+        assert!(docs.contains(&"POST /detokenize".to_string()));
     }
 
     // ── streaming dispatch tests ──────────────────────────────────────

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2173,7 +2173,10 @@ async fn detokenize(
         .decode(&request.tokens, false)
         .map_err(|err| ErrorMessage::from_anyhow(err, "Failed to detokenize prompt"))?;
 
-    Ok(Json(DetokenizeResponse { prompt }).into_response())
+    Ok(Json(DetokenizeResponse {
+        prompt: prompt.into(),
+    })
+    .into_response())
 }
 
 pub fn tokenization_router(state: Arc<service_v2::State>) -> (Vec<RouteDoc>, Router) {

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -355,6 +355,12 @@ fn resolve_tokenizer_model_name(
         return Err(ErrorMessage::model_not_found());
     }
 
+    // Preserve this order: without an explicit model, prefer `model_display_names()` first because
+    // those names are known to the serving layer; only if that yields one choice do we fall back
+    // to `get_model_cards()`, whose card-only metadata may exist before a model is fully
+    // registered. This keeps tokenizer endpoints usable from cards alone, but card names may not
+    // map to serving-capable models, so explicit requests still gate on `has_model_any()` /
+    // `ErrorMessage::model_not_found()` and ambiguous fallback still returns `bad_request()`.
     let served_models = state.manager().model_display_names();
     if served_models.len() == 1 {
         return Ok(served_models.into_iter().next().unwrap());

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2867,7 +2867,9 @@ mod tests {
 
     fn make_tokenize_state_without_card(model_name: &str) -> Arc<service_v2::State> {
         let manager = Arc::new(ModelManager::new());
-        manager.add_prefill_model(model_name, "missing-card").unwrap();
+        manager
+            .add_prefill_model(model_name, "missing-card")
+            .unwrap();
 
         let discovery = Arc::new(MockDiscovery::new(None, SharedMockRegistry::new()));
         Arc::new(service_v2::State::new(

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2875,12 +2875,7 @@ mod tests {
                 content: Some(ChatCompletionRequestAssistantMessageContent::Text(
                     "Nice to meet you!".to_string(),
                 )),
-                reasoning_content: None,
-                refusal: None,
-                name: None,
-                audio: None,
-                tool_calls: None,
-                function_call: None,
+                ..Default::default()
             }),
             ChatCompletionRequestMessage::User(ChatCompletionRequestUserMessage {
                 content: ChatCompletionRequestUserMessageContent::Text(
@@ -3832,12 +3827,7 @@ mod tests {
                 content: Some(ChatCompletionRequestAssistantMessageContent::Text(
                     "Sure.".to_string(),
                 )),
-                reasoning_content: None,
-                refusal: None,
-                name: None,
-                audio: None,
-                tool_calls: None,
-                function_call: None,
+                ..Default::default()
             }),
         ];
 
@@ -3937,12 +3927,7 @@ mod tests {
                 content: Some(ChatCompletionRequestAssistantMessageContent::Text(
                     "Sure,".to_string(),
                 )),
-                reasoning_content: None,
-                refusal: None,
-                name: None,
-                audio: None,
-                tool_calls: None,
-                function_call: None,
+                ..Default::default()
             },
         ));
         let tools = sample_tools();

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -474,6 +474,7 @@ fn make_tokenize_chat_completion_request(
         nvext: None,
         chat_template_args: Some(request.merged_chat_template_kwargs()),
         media_io_kwargs: request.media_io_kwargs.clone(),
+        return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
     }
 }
@@ -3109,6 +3110,7 @@ mod tests {
             nvext: None,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_required_fields(&request);
@@ -3141,6 +3143,7 @@ mod tests {
             nvext: None,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_required_fields(&request);
@@ -3357,6 +3360,7 @@ mod tests {
             nvext: None,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         };
 
@@ -3387,6 +3391,7 @@ mod tests {
             nvext: None,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);
@@ -3416,6 +3421,7 @@ mod tests {
             nvext: None,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);
@@ -3445,6 +3451,7 @@ mod tests {
             nvext: None,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);
@@ -3476,6 +3483,7 @@ mod tests {
             nvext: None,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);
@@ -3505,6 +3513,7 @@ mod tests {
             nvext: None,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -44,6 +44,7 @@ use super::{
 };
 use crate::engines::ValidateRequest;
 use crate::model_card::ModelDeploymentCard;
+use crate::preprocessor::apply_required_prefix_token_ids_to_chat_request;
 use crate::preprocessor::prompt::PromptFormatter;
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
 use crate::protocols::openai::nvext::apply_header_routing_overrides;
@@ -475,9 +476,68 @@ fn make_tokenize_chat_completion_request(
         chat_template_args: Some(request.merged_chat_template_kwargs()),
         media_io_kwargs: request.media_io_kwargs.clone(),
         return_tokens_as_token_ids: None,
-        required_prefix_token_ids: None,
+        required_prefix_token_ids: request.required_prefix_token_ids.clone(),
         unsupported_fields: Default::default(),
     }
+}
+
+fn render_tokenize_chat_tokens(
+    card: &ModelDeploymentCard,
+    model: String,
+    request: &TokenizeChatRequest,
+) -> Result<Vec<u32>, ErrorResponse> {
+    request.validate().map_err(bad_request)?;
+
+    let formatter =
+        PromptFormatter::from_mdc_with_chat_template(card, request.chat_template.as_deref())
+            .map_err(|err| ErrorMessage::from_anyhow(err, "Failed to build chat formatter"))?;
+    let tokenizer = card
+        .tokenizer()
+        .map_err(|err| ErrorMessage::from_anyhow(err, "Failed to load tokenizer"))?;
+    let eos_token_ids = card
+        .model_info
+        .as_ref()
+        .ok_or_else(|| {
+            ErrorMessage::internal_server_error(
+                "Tokenizer metadata is missing model_info for prefix reuse.",
+            )
+        })?
+        .get_model_info()
+        .map_err(|err| ErrorMessage::from_anyhow(err, "Failed to load model info"))?
+        .eos_token_ids();
+
+    let wrapped_request = make_tokenize_chat_completion_request(model.clone(), request);
+    let mut prompt = match &formatter {
+        PromptFormatter::OAI(formatter) => formatter.render(&wrapped_request),
+    }
+    .map_err(|err| ErrorMessage::from_anyhow(err, "Failed to render chat prompt"))?;
+
+    if request.continue_final_message {
+        prompt = apply_continue_final_message(prompt, &request.messages)?;
+    }
+
+    let mut token_ids = tokenizer
+        .encode_with_special_tokens(&prompt, request.add_special_tokens)
+        .map_err(|err| {
+            ErrorMessage::from_anyhow(err, "Failed to tokenize rendered chat prompt")
+        })?
+        .token_ids()
+        .to_vec();
+
+    token_ids = match &formatter {
+        PromptFormatter::OAI(formatter) => apply_required_prefix_token_ids_to_chat_request(
+            formatter.as_ref(),
+            tokenizer.as_ref(),
+            &wrapped_request,
+            &token_ids,
+            eos_token_ids.as_slice(),
+            request.add_special_tokens,
+        )
+        .map_err(|err| ErrorMessage::from_anyhow(err, "Failed to apply tokenize prefix reuse"))?
+        .unwrap_or(token_ids),
+    };
+
+    Ok(token_ids)
 }
 
 fn render_tokenize_chat_prompt(
@@ -2133,13 +2193,7 @@ async fn tokenize(
                 .model
                 .clone()
                 .unwrap_or_else(|| card.display_name.clone());
-            let prompt = render_tokenize_chat_prompt(&card, model, &request)?;
-            let encoding = tokenizer
-                .encode_with_special_tokens(&prompt, request.add_special_tokens)
-                .map_err(|err| {
-                    ErrorMessage::from_anyhow(err, "Failed to tokenize rendered chat prompt")
-                })?;
-            let token_ids = encoding.token_ids().to_vec();
+            let token_ids = render_tokenize_chat_tokens(&card, model, &request)?;
             let token_strs = if request.return_token_strs {
                 Some(tokenizer.convert_ids_to_tokens(&token_ids).map_err(|err| {
                     ErrorMessage::from_anyhow(err, "Failed to resolve token strings")
@@ -3945,6 +3999,7 @@ mod tests {
                     media_io_kwargs: None,
                     mm_processor_kwargs: None,
                     tools: None,
+                    required_prefix_token_ids: None,
                 };
                 let prompt =
                     render_tokenize_chat_prompt(&card, "test-model".to_string(), &request).unwrap();
@@ -3966,6 +4021,7 @@ mod tests {
                         media_io_kwargs: None,
                         mm_processor_kwargs: None,
                         tools: None,
+                        required_prefix_token_ids: None,
                     })),
                 )
                 .await
@@ -4004,6 +4060,7 @@ mod tests {
             media_io_kwargs: None,
             mm_processor_kwargs: None,
             tools: Some(tools.clone()),
+            required_prefix_token_ids: None,
         };
         let prompt =
             render_tokenize_chat_prompt(&card, "test-model".to_string(), &request).unwrap();
@@ -4023,6 +4080,7 @@ mod tests {
                 media_io_kwargs: None,
                 mm_processor_kwargs: None,
                 tools: Some(tools),
+                required_prefix_token_ids: None,
             })),
         )
         .await
@@ -4077,6 +4135,7 @@ mod tests {
                 media_io_kwargs: None,
                 mm_processor_kwargs: None,
                 tools: None,
+                required_prefix_token_ids: None,
             })),
         )
         .await
@@ -4208,6 +4267,7 @@ mod tests {
                 serde_json::json!({"size": "ignored"}),
             )])),
             tools: None,
+            required_prefix_token_ids: None,
         };
         let prompt =
             render_tokenize_chat_prompt(&card, "test-model".to_string(), &request).unwrap();
@@ -4235,12 +4295,116 @@ mod tests {
                     serde_json::json!({"size": "ignored"}),
                 )])),
                 tools: None,
+                required_prefix_token_ids: None,
             })),
         )
         .await
         .unwrap();
         let body: TokenizeResponse = response_json(response).await;
         assert_eq!(body.tokens, expected.token_ids());
+    }
+
+    #[tokio::test]
+    async fn test_tokenize_chat_route_applies_required_prefix_token_ids() {
+        let (state, card) = make_tokenize_state("test-model");
+        let request = TokenizeChatRequest {
+            model: Some("test-model".to_string()),
+            messages: sample_chat_messages(),
+            add_generation_prompt: true,
+            return_token_strs: false,
+            continue_final_message: false,
+            add_special_tokens: true,
+            chat_template: None,
+            chat_template_kwargs: None,
+            media_io_kwargs: None,
+            mm_processor_kwargs: None,
+            tools: None,
+            required_prefix_token_ids: None,
+        };
+
+        let baseline_tokens =
+            render_tokenize_chat_tokens(&card, "test-model".to_string(), &request).unwrap();
+        let wrapped_request =
+            make_tokenize_chat_completion_request("test-model".to_string(), &request);
+        let prefix_wrapped_request = NvCreateChatCompletionRequest {
+            inner: dynamo_protocols::types::CreateChatCompletionRequest {
+                model: wrapped_request.inner.model.clone(),
+                messages: crate::preprocessor::messages_to_last_assistant(&wrapped_request),
+                tools: wrapped_request.inner.tools.clone(),
+                ..Default::default()
+            },
+            common: Default::default(),
+            nvext: None,
+            chat_template_args: wrapped_request.chat_template_args.clone(),
+            media_io_kwargs: wrapped_request.media_io_kwargs.clone(),
+            return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
+            unsupported_fields: Default::default(),
+        };
+        let formatter =
+            PromptFormatter::from_mdc_with_chat_template(&card, request.chat_template.as_deref())
+                .unwrap();
+        let tokenizer = card.tokenizer().unwrap();
+        let prefix_tokens = match &formatter {
+            PromptFormatter::OAI(formatter) => {
+                let prompt = formatter.render(&prefix_wrapped_request).unwrap();
+                tokenizer
+                    .encode_with_special_tokens(&prompt, request.add_special_tokens)
+                    .unwrap()
+                    .token_ids()
+                    .to_vec()
+            }
+        };
+
+        let eos_token_ids = card
+            .model_info
+            .as_ref()
+            .unwrap()
+            .get_model_info()
+            .unwrap()
+            .eos_token_ids();
+        let eos_token = eos_token_ids[0];
+        let replacement_token = if eos_token == 0 { 1 } else { 0 };
+        let mut required_prefix_token_ids = prefix_tokens.clone();
+        if let Some(last_non_eos) = required_prefix_token_ids
+            .iter_mut()
+            .rev()
+            .find(|token| **token != eos_token)
+        {
+            *last_non_eos = replacement_token;
+        } else {
+            panic!("expected at least one non-EOS token in prefix");
+        }
+
+        let expected_tokens = match &formatter {
+            PromptFormatter::OAI(formatter) => apply_required_prefix_token_ids_to_chat_request(
+                formatter.as_ref(),
+                tokenizer.as_ref(),
+                &NvCreateChatCompletionRequest {
+                    required_prefix_token_ids: Some(required_prefix_token_ids.clone()),
+                    ..wrapped_request.clone()
+                },
+                &baseline_tokens,
+                eos_token_ids.as_slice(),
+                request.add_special_tokens,
+            )
+            .unwrap()
+            .unwrap(),
+        };
+
+        let response = tokenize(
+            State(state),
+            Json(TokenizeRequest::Chat(TokenizeChatRequest {
+                required_prefix_token_ids: Some(required_prefix_token_ids),
+                ..request
+            })),
+        )
+        .await
+        .unwrap();
+        let body: TokenizeResponse = response_json(response).await;
+
+        assert_eq!(body.tokens, expected_tokens);
+        assert_ne!(body.tokens, baseline_tokens);
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -475,6 +475,7 @@ fn make_tokenize_chat_completion_request(
         chat_template_args: Some(request.merged_chat_template_kwargs()),
         media_io_kwargs: request.media_io_kwargs.clone(),
         return_tokens_as_token_ids: None,
+        required_prefix_token_ids: None,
         unsupported_fields: Default::default(),
     }
 }
@@ -3114,6 +3115,7 @@ mod tests {
             chat_template_args: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_required_fields(&request);
@@ -3147,6 +3149,7 @@ mod tests {
             chat_template_args: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_required_fields(&request);
@@ -3364,6 +3367,7 @@ mod tests {
             chat_template_args: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
             unsupported_fields: Default::default(),
         };
 
@@ -3395,6 +3399,7 @@ mod tests {
             chat_template_args: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);
@@ -3425,6 +3430,7 @@ mod tests {
             chat_template_args: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);
@@ -3455,6 +3461,7 @@ mod tests {
             chat_template_args: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);
@@ -3487,6 +3494,7 @@ mod tests {
             chat_template_args: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);
@@ -3517,6 +3525,7 @@ mod tests {
             chat_template_args: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);
@@ -3563,6 +3572,25 @@ mod tests {
             assert!(msg.contains("documents"));
             assert!(msg.contains("chat_template"));
         }
+    }
+
+    #[test]
+    fn test_chat_completions_required_prefix_token_ids_accepted() {
+        let json = r#"{
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "test-model",
+            "required_prefix_token_ids": [1, 2, 3]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json).unwrap();
+
+        assert_eq!(request.required_prefix_token_ids, Some(vec![1, 2, 3]));
+        assert!(!request
+            .unsupported_fields
+            .contains_key("required_prefix_token_ids"));
+
+        let result = validate_chat_completion_fields_generic(&request);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -532,6 +532,7 @@ impl HttpServiceConfigBuilder {
             } else {
                 super::openai::list_models_router(state.clone(), var(HTTP_SVC_MODELS_PATH_ENV).ok())
             },
+            super::openai::tokenization_router(state.clone()),
             super::health::health_check_router(state.clone(), var(HTTP_SVC_HEALTH_PATH_ENV).ok()),
             super::health::live_check_router(state.clone(), var(HTTP_SVC_LIVE_PATH_ENV).ok()),
             super::busy_threshold::busy_threshold_router(state.clone(), None),

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -597,6 +597,29 @@ impl ModelDeploymentCard {
         Ok(())
     }
 
+    /// Return the local directory that contains the model config files, if any
+    /// file has already been resolved to a local path.
+    pub(crate) fn local_file_dir(&self) -> Option<&Path> {
+        if let Some(TokenizerKind::HfTokenizerJson(cf) | TokenizerKind::TikTokenModel(cf)) =
+            &self.tokenizer
+        {
+            if let Some(dir) = cf.path().and_then(|p| p.parent()) {
+                return Some(dir);
+            }
+        }
+        if let Some(ModelInfoType::HfConfigJson(cf)) = &self.model_info {
+            if let Some(dir) = cf.path().and_then(|p| p.parent()) {
+                return Some(dir);
+            }
+        }
+        if let Some(PromptFormatterArtifact::HfTokenizerConfigJson(cf)) = &self.prompt_formatter {
+            if let Some(dir) = cf.path().and_then(|p| p.parent()) {
+                return Some(dir);
+            }
+        }
+        None
+    }
+
     /// Are all the files we need (tokenizer.json, etc) available locally?
     fn has_local_files(&self) -> bool {
         let has_model_info = self
@@ -633,7 +656,7 @@ impl ModelDeploymentCard {
     }
 
     /// Update the directory for files like tokenizer.json be in here.
-    fn update_dir(&mut self, dir: &Path) {
+    pub(crate) fn update_dir(&mut self, dir: &Path) {
         if let Some(model_info) = self.model_info.as_mut() {
             model_info.update_dir(dir);
         }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -108,20 +108,59 @@ fn replace_prefix_tokens(
     let template_cut_start = (0..template_prefix_token_ids.len())
         .rev()
         .find(|&pos| eos_token_ids.contains(&template_token_ids[pos]))
-        .with_context(|| {
-            format!(
-                "No EOS token ID found in the chat-templated messages. \
-template_prefix_len={}, template_len={}",
-                template_prefix_token_ids.len(),
-                template_token_ids.len()
-            )
-        })?;
+        .unwrap_or(template_prefix_token_ids.len());
 
     Ok([
         &model_prefix_token_ids[..model_cut_end],
         &template_token_ids[template_cut_start..],
     ]
     .concat())
+}
+
+pub(crate) fn apply_required_prefix_token_ids_to_chat_request(
+    formatter: &dyn OAIPromptFormatter,
+    tokenizer: &dyn crate::tokenizers::traits::Tokenizer,
+    request: &NvCreateChatCompletionRequest,
+    token_ids: &[u32],
+    eos_token_ids: &[u32],
+    add_special_tokens: bool,
+) -> Result<Option<Vec<u32>>> {
+    let Some(required_prefix_token_ids) = request.required_prefix_token_ids.as_ref() else {
+        return Ok(None);
+    };
+
+    let prefix_request = PrefixReuseChatRequest {
+        base: request,
+        messages: messages_to_last_assistant(request),
+    };
+    let template_prefix_prompt = formatter
+        .render(&prefix_request)
+        .with_context(|| "Failed to apply prompt template for prefix reuse")?;
+    let template_prefix_token_ids = tokenizer
+        .encode_with_special_tokens(&template_prefix_prompt, add_special_tokens)?
+        .token_ids()
+        .to_vec();
+
+    Ok(Some(replace_prefix_tokens(
+        required_prefix_token_ids,
+        &template_prefix_token_ids,
+        token_ids,
+        eos_token_ids,
+    )?))
+}
+
+pub(crate) fn messages_to_last_assistant(
+    request: &NvCreateChatCompletionRequest,
+) -> Vec<ChatCompletionRequestMessage> {
+    let messages = &request.inner.messages;
+    let last_assistant_idx = messages
+        .iter()
+        .rposition(|message| matches!(message, ChatCompletionRequestMessage::Assistant(_)));
+
+    match last_assistant_idx {
+        Some(idx) => messages[..=idx].to_vec(),
+        None => messages.clone(),
+    }
 }
 
 struct PrefixReuseChatRequest<'a> {
@@ -483,48 +522,19 @@ impl OpenAIPreprocessor {
         }
     }
 
-    fn messages_to_last_assistant(
-        request: &NvCreateChatCompletionRequest,
-    ) -> Vec<ChatCompletionRequestMessage> {
-        let messages = &request.inner.messages;
-        let last_assistant_idx = messages.iter().rposition(|message| {
-            matches!(message, ChatCompletionRequestMessage::Assistant(_))
-        });
-
-        match last_assistant_idx {
-            Some(idx) => messages[..=idx].to_vec(),
-            None => messages.clone(),
-        }
-    }
-
     fn maybe_apply_required_prefix_token_ids(
         &self,
         request: &NvCreateChatCompletionRequest,
         token_ids: &[u32],
     ) -> Result<Option<Vec<u32>>> {
-        let Some(required_prefix_token_ids) = request.required_prefix_token_ids.as_ref() else {
-            return Ok(None);
-        };
-
-        let prefix_request = PrefixReuseChatRequest {
-            base: request,
-            messages: Self::messages_to_last_assistant(request),
-        };
-        let template_prefix_prompt = self
-            .formatter
-            .render(&prefix_request)
-            .with_context(|| "Failed to apply prompt template for prefix reuse")?;
-        let template_prefix_token_ids = self
-            .encode_with_timing(&template_prefix_prompt, None)?
-            .token_ids()
-            .to_vec();
-
-        Ok(Some(replace_prefix_tokens(
-            required_prefix_token_ids,
-            &template_prefix_token_ids,
+        apply_required_prefix_token_ids_to_chat_request(
+            self.formatter.as_ref(),
+            self.tokenizer.as_ref(),
+            request,
             token_ids,
             self.model_info.eos_token_ids().as_slice(),
-        )?))
+            false,
+        )
     }
 
     /// Replace inline `data:` URLs with empty strings in message content parts.
@@ -1979,7 +1989,7 @@ mod tests {
         }))
         .unwrap();
 
-        let messages = OpenAIPreprocessor::messages_to_last_assistant(&request);
+        let messages = messages_to_last_assistant(&request);
 
         assert_eq!(messages.len(), 2);
         assert!(matches!(

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -77,6 +77,104 @@ use crate::protocols::common::llm_backend::EmbeddingsEngineOutput;
 pub const ANNOTATION_FORMATTED_PROMPT: &str = "formatted_prompt";
 pub const ANNOTATION_TOKEN_IDS: &str = "token_ids";
 pub const ANNOTATION_LLM_METRICS: &str = "llm_metrics";
+
+fn replace_prefix_tokens(
+    model_prefix_token_ids: &[u32],
+    template_prefix_token_ids: &[u32],
+    template_token_ids: &[u32],
+    eos_token_ids: &[u32],
+) -> Result<Vec<u32>> {
+    if model_prefix_token_ids.is_empty() {
+        return Ok(template_token_ids.to_vec());
+    }
+
+    anyhow::ensure!(
+        !eos_token_ids.is_empty(),
+        "Your tokenizer must have at least one EOS token ID!"
+    );
+
+    let mut model_cut_end = model_prefix_token_ids.len();
+    if model_prefix_token_ids
+        .last()
+        .is_some_and(|token| eos_token_ids.contains(token))
+    {
+        model_cut_end -= 1;
+    }
+
+    if template_token_ids.len() <= template_prefix_token_ids.len() {
+        return Ok(template_token_ids.to_vec());
+    }
+
+    let template_cut_start = (0..template_prefix_token_ids.len())
+        .rev()
+        .find(|&pos| eos_token_ids.contains(&template_token_ids[pos]))
+        .with_context(|| {
+            format!(
+                "No EOS token ID found in the chat-templated messages. \
+template_prefix_len={}, template_len={}",
+                template_prefix_token_ids.len(),
+                template_token_ids.len()
+            )
+        })?;
+
+    Ok([
+        &model_prefix_token_ids[..model_cut_end],
+        &template_token_ids[template_cut_start..],
+    ]
+    .concat())
+}
+
+struct PrefixReuseChatRequest<'a> {
+    base: &'a NvCreateChatCompletionRequest,
+    messages: Vec<ChatCompletionRequestMessage>,
+}
+
+impl OAIChatLikeRequest for PrefixReuseChatRequest<'_> {
+    fn model(&self) -> String {
+        self.base.inner.model.clone()
+    }
+
+    fn messages(&self) -> minijinja::value::Value {
+        let messages_json = serde_json::to_value(&self.messages).unwrap();
+        minijinja::value::Value::from_serialize(&messages_json)
+    }
+
+    fn typed_messages(&self) -> Option<&[ChatCompletionRequestMessage]> {
+        Some(self.messages.as_slice())
+    }
+
+    fn tools(&self) -> Option<minijinja::value::Value> {
+        <NvCreateChatCompletionRequest as OAIChatLikeRequest>::tools(self.base)
+    }
+
+    fn tool_choice(&self) -> Option<minijinja::value::Value> {
+        <NvCreateChatCompletionRequest as OAIChatLikeRequest>::tool_choice(self.base)
+    }
+
+    fn response_format(&self) -> Option<minijinja::value::Value> {
+        <NvCreateChatCompletionRequest as OAIChatLikeRequest>::response_format(self.base)
+    }
+
+    fn should_add_generation_prompt(&self) -> bool {
+        false
+    }
+
+    fn chat_template_args(&self) -> Option<&HashMap<String, serde_json::Value>> {
+        self.base.chat_template_args.as_ref()
+    }
+
+    fn extract_text(&self) -> Option<TextInput> {
+        Some(TextInput::Single(String::new()))
+    }
+
+    fn media_io_kwargs(&self) -> Option<&media::MediaDecoder> {
+        self.base.media_io_kwargs.as_ref()
+    }
+
+    fn mm_processor_kwargs(&self) -> Option<&serde_json::Value> {
+        self.base.inner.mm_processor_kwargs.as_ref()
+    }
+}
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LLMMetricAnnotation {
     pub input_tokens: usize,
@@ -383,6 +481,50 @@ impl OpenAIPreprocessor {
         } else {
             Ok(None)
         }
+    }
+
+    fn messages_to_last_assistant(
+        request: &NvCreateChatCompletionRequest,
+    ) -> Vec<ChatCompletionRequestMessage> {
+        let messages = &request.inner.messages;
+        let last_assistant_idx = messages.iter().rposition(|message| {
+            matches!(message, ChatCompletionRequestMessage::Assistant(_))
+        });
+
+        match last_assistant_idx {
+            Some(idx) => messages[..=idx].to_vec(),
+            None => messages.clone(),
+        }
+    }
+
+    fn maybe_apply_required_prefix_token_ids(
+        &self,
+        request: &NvCreateChatCompletionRequest,
+        token_ids: &[u32],
+    ) -> Result<Option<Vec<u32>>> {
+        let Some(required_prefix_token_ids) = request.required_prefix_token_ids.as_ref() else {
+            return Ok(None);
+        };
+
+        let prefix_request = PrefixReuseChatRequest {
+            base: request,
+            messages: Self::messages_to_last_assistant(request),
+        };
+        let template_prefix_prompt = self
+            .formatter
+            .render(&prefix_request)
+            .with_context(|| "Failed to apply prompt template for prefix reuse")?;
+        let template_prefix_token_ids = self
+            .encode_with_timing(&template_prefix_prompt, None)?
+            .token_ids()
+            .to_vec();
+
+        Ok(Some(replace_prefix_tokens(
+            required_prefix_token_ids,
+            &template_prefix_token_ids,
+            token_ids,
+            self.model_info.eos_token_ids().as_slice(),
+        )?))
     }
 
     /// Replace inline `data:` URLs with empty strings in message content parts.
@@ -1367,6 +1509,9 @@ impl
         let (mut common_request, annotations, prompt_injected_reasoning) = self
             .preprocess_request(&request, tracker.as_deref())
             .await?;
+        if let Some(token_ids) = self.maybe_apply_required_prefix_token_ids(&request, &common_request.token_ids)? {
+            common_request.token_ids = token_ids;
+        }
         tracing::trace!(request = ?common_request, prompt_injected_reasoning, "Pre-processed request");
 
         // Attach the timing tracker to the request so downstream components can record metrics
@@ -1653,6 +1798,7 @@ mod strip_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_is_reasoning_disabled_by_request() {
@@ -1806,5 +1952,39 @@ mod tests {
                 "FAILED: {desc}",
             );
         }
+    }
+
+    #[test]
+    fn test_replace_prefix_tokens_preserves_model_prefix_up_to_eos() {
+        let result = replace_prefix_tokens(
+            &[11, 12, 13, 40, 41, 220, 17, 2],
+            &[11, 12, 13, 40, 41, 1001, 2],
+            &[11, 12, 13, 40, 41, 1001, 2, 21, 22, 40, 41],
+            &[2],
+        )
+        .unwrap();
+
+        assert_eq!(result, vec![11, 12, 13, 40, 41, 220, 17, 2, 21, 22, 40, 41]);
+    }
+
+    #[test]
+    fn test_messages_to_last_assistant_includes_last_assistant_only() {
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "messages": [
+                {"role": "user", "content": "one"},
+                {"role": "assistant", "content": "two"},
+                {"role": "user", "content": "three"}
+            ]
+        }))
+        .unwrap();
+
+        let messages = OpenAIPreprocessor::messages_to_last_assistant(&request);
+
+        assert_eq!(messages.len(), 2);
+        assert!(matches!(
+            messages.last(),
+            Some(ChatCompletionRequestMessage::Assistant(_))
+        ));
     }
 }

--- a/lib/llm/src/preprocessor/prompt/template.rs
+++ b/lib/llm/src/preprocessor/prompt/template.rs
@@ -4,6 +4,7 @@
 use std::{collections::HashSet, sync::Arc};
 
 use anyhow::{Context, Ok, Result};
+use either::Either;
 use minijinja::Environment;
 
 use crate::model_card::{ModelDeploymentCard, PromptContextMixin, PromptFormatterArtifact};
@@ -19,11 +20,19 @@ use tokcfg::ChatTemplateValue;
 
 impl PromptFormatter {
     pub fn from_mdc(mdc: &ModelDeploymentCard) -> Result<PromptFormatter> {
+        Self::from_mdc_with_chat_template(mdc, None)
+    }
+
+    pub fn from_mdc_with_chat_template(
+        mdc: &ModelDeploymentCard,
+        chat_template_override: Option<&str>,
+    ) -> Result<PromptFormatter> {
         // Special handling for DeepSeek-V3.2(-Speciale) which doesn't provide Jinja chat_template
         let name_lower = mdc.display_name.to_lowercase();
         if name_lower.contains("deepseek")
             && name_lower.contains("v3.2")
             && !name_lower.contains("exp")
+            && chat_template_override.is_none()
         {
             tracing::info!("Detected DeepSeek V3.2 model (non-Exp), using native Rust formatter");
             return Ok(Self::OAI(Arc::new(
@@ -54,57 +63,64 @@ impl PromptFormatter {
                         crate::log_json_err(&file.display().to_string(), &contents, err)
                     })?;
 
+                if let Some(chat_template) = chat_template_override {
+                    config.chat_template =
+                        Some(ChatTemplateValue(Either::Left(chat_template.to_string())));
+                }
+
                 // Some HF model (i.e. meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8)
                 // stores the chat template in a separate file, we check if the file exists and
                 // put the chat template into config as normalization.
                 // This may also be a custom template provided via CLI flag.
-                match mdc.chat_template_file.as_ref() {
-                    Some(PromptFormatterArtifact::HfChatTemplateJinja {
-                        file: checked_file,
-                        ..
-                    }) => {
-                        let Some(path) = checked_file.path() else {
-                            anyhow::bail!(
-                                "HfChatTemplateJinja for {} is a URL, cannot load",
-                                mdc.display_name
-                            );
-                        };
-                        let chat_template = std::fs::read_to_string(path)
-                            .with_context(|| format!("fs:read_to_string '{}'", path.display()))?;
-                        config.chat_template = Some(ChatTemplateValue(either::Left(chat_template)));
-                    }
-                    Some(PromptFormatterArtifact::HfChatTemplateJson {
-                        file: checked_file,
-                        ..
-                    }) => {
-                        let Some(path) = checked_file.path() else {
-                            anyhow::bail!(
-                                "HfChatTemplateJson for {} is a URL, cannot load",
-                                mdc.display_name
-                            );
-                        };
-                        let raw = std::fs::read_to_string(path)
-                            .with_context(|| format!("fs:read_to_string '{}'", path.display()))?;
-                        let wrapper: serde_json::Value =
-                            serde_json::from_str(&raw).with_context(|| {
-                                format!("Failed to parse '{}' as JSON", path.display())
-                            })?;
-                        let field = wrapper.get("chat_template").ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "'{}' does not contain a 'chat_template' field",
-                                path.display()
-                            )
-                        })?;
-                        let value = serde_json::from_value::<ChatTemplateValue>(field.clone())
-                            .with_context(|| {
-                                format!(
-                                    "Failed to deserialize 'chat_template' in '{}'",
+                if chat_template_override.is_none() {
+                    match mdc.chat_template_file.as_ref() {
+                        Some(PromptFormatterArtifact::HfChatTemplateJinja {
+                            file: checked_file,
+                            ..
+                        }) => {
+                            let Some(path) = checked_file.path() else {
+                                anyhow::bail!(
+                                    "HfChatTemplateJinja for {} is a URL, cannot load",
+                                    mdc.display_name
+                                );
+                            };
+                            let chat_template = std::fs::read_to_string(path)
+                                .with_context(|| format!("fs:read_to_string '{}'", path.display()))?;
+                            config.chat_template = Some(ChatTemplateValue(either::Left(chat_template)));
+                        }
+                        Some(PromptFormatterArtifact::HfChatTemplateJson {
+                            file: checked_file,
+                            ..
+                        }) => {
+                            let Some(path) = checked_file.path() else {
+                                anyhow::bail!(
+                                    "HfChatTemplateJson for {} is a URL, cannot load",
+                                    mdc.display_name
+                                );
+                            };
+                            let raw = std::fs::read_to_string(path)
+                                .with_context(|| format!("fs:read_to_string '{}'", path.display()))?;
+                            let wrapper: serde_json::Value =
+                                serde_json::from_str(&raw).with_context(|| {
+                                    format!("Failed to parse '{}' as JSON", path.display())
+                                })?;
+                            let field = wrapper.get("chat_template").ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "'{}' does not contain a 'chat_template' field",
                                     path.display()
                                 )
                             })?;
-                        config.chat_template = Some(value);
+                            let value = serde_json::from_value::<ChatTemplateValue>(field.clone())
+                                .with_context(|| {
+                                    format!(
+                                        "Failed to deserialize 'chat_template' in '{}'",
+                                        path.display()
+                                    )
+                                })?;
+                            config.chat_template = Some(value);
+                        }
+                        _ => {}
                     }
-                    _ => {}
                 }
                 Self::from_parts(
                     config,

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -140,6 +140,7 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
                 None
             },
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         })
     }

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -141,6 +141,7 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
             },
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
             unsupported_fields: Default::default(),
         })
     }

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -514,6 +514,10 @@ pub struct OutputOptions {
     /// the tokenizer. This is useful for inspecting the behavior of prompt
     /// templates that are applied during the backend preprocessing.
     pub formatted_prompt: Option<bool>,
+
+    /// When true, logprob token fields are returned as "token_id:<id>"
+    /// instead of the decoded text.  vLLM-specific extension for NeMo-RL.
+    pub return_tokens_as_token_ids: Option<bool>,
 }
 
 // Struct for log probability information

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -91,6 +91,10 @@ pub(crate) trait OpenAIOutputOptionsProvider {
     fn get_skip_special_tokens(&self) -> Option<bool>;
 
     fn get_formatted_prompt(&self) -> Option<bool>;
+
+    fn get_return_tokens_as_token_ids(&self) -> Option<bool> {
+        None
+    }
 }
 
 impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvider for T {
@@ -204,12 +208,14 @@ impl<T: OpenAIOutputOptionsProvider> OutputOptionsProvider for T {
         let prompt_logprobs = self.get_prompt_logprobs();
         let skip_special_tokens = self.get_skip_special_tokens();
         let formatted_prompt = self.get_formatted_prompt();
+        let return_tokens_as_token_ids = self.get_return_tokens_as_token_ids();
 
         Ok(common::OutputOptions {
             logprobs,
             prompt_logprobs,
             skip_special_tokens,
             formatted_prompt,
+            return_tokens_as_token_ids,
         })
     }
 }

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -20,6 +20,7 @@ pub mod images;
 pub mod models;
 pub mod nvext;
 pub mod responses;
+pub mod tokenization;
 pub mod tools;
 pub mod validate;
 pub mod videos;

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -59,6 +59,12 @@ pub struct NvCreateChatCompletionRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub media_io_kwargs: Option<MediaDecoder>,
 
+    /// When true, logprob token fields are returned as "token_id:<id>" instead
+    /// of the decoded text.  This is a vLLM-specific extension used by NeMo-RL
+    /// to extract per-token IDs for RL training.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub return_tokens_as_token_ids: Option<bool>,
+
     /// Catch-all for unsupported fields - checked during validation
     #[serde(flatten, default, skip_serializing)]
     pub unsupported_fields: std::collections::HashMap<String, serde_json::Value>,
@@ -329,6 +335,10 @@ impl OpenAIOutputOptionsProvider for NvCreateChatCompletionRequest {
 
     fn get_formatted_prompt(&self) -> Option<bool> {
         None
+    }
+
+    fn get_return_tokens_as_token_ids(&self) -> Option<bool> {
+        self.return_tokens_as_token_ids
     }
 }
 

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -65,6 +65,11 @@ pub struct NvCreateChatCompletionRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub return_tokens_as_token_ids: Option<bool>,
 
+    /// Optional exact prior assistant token prefix to preserve across
+    /// multi-turn chat-template re-rendering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_prefix_token_ids: Option<Vec<u32>>,
+
     /// Catch-all for unsupported fields - checked during validation
     #[serde(flatten, default, skip_serializing)]
     pub unsupported_fields: std::collections::HashMap<String, serde_json::Value>,
@@ -435,5 +440,24 @@ mod tests {
 
             assert_eq!(output_options.skip_special_tokens, Some(skip_value));
         }
+    }
+
+    #[test]
+    fn test_required_prefix_token_ids_is_supported() {
+        let json_str = json!({
+            "model": "test-model",
+            "messages": [
+                {"role": "user", "content": "Hello"}
+            ],
+            "required_prefix_token_ids": [1, 2, 3]
+        });
+
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(json_str).expect("Failed to deserialize request");
+
+        assert_eq!(request.required_prefix_token_ids, Some(vec![1, 2, 3]));
+        assert!(!request
+            .unsupported_fields
+            .contains_key("required_prefix_token_ids"));
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -82,6 +82,7 @@ impl NvCreateChatCompletionRequest {
             enable_logprobs: self.inner.logprobs.unwrap_or(false)
                 || self.inner.top_logprobs.unwrap_or(0) > 0,
             enable_tracking,
+            return_tokens_as_token_ids: self.return_tokens_as_token_ids.unwrap_or(false),
             runtime_config: ModelRuntimeConfig::default(),
         };
 
@@ -100,6 +101,8 @@ pub struct DeltaGeneratorOptions {
     pub enable_logprobs: bool,
     /// Determines whether request tracking (timing, KV hit rate) should be enabled.
     pub enable_tracking: bool,
+    /// When true, logprob token fields use "token_id:<id>" format instead of decoded text.
+    pub return_tokens_as_token_ids: bool,
 
     pub runtime_config: ModelRuntimeConfig,
 }
@@ -210,16 +213,22 @@ impl DeltaGenerator {
             .map(|(_, lp)| lp as f32)
             .collect::<Vec<f32>>();
 
+        let return_as_ids = self.options.return_tokens_as_token_ids;
         let content = top_logprobs.map(|top_logprobs| {
             toks.iter()
                 .zip(tok_lps)
                 .zip(top_logprobs)
                 .map(|(((t, tid), lp), top_lps)| {
+                    let token_str = if return_as_ids {
+                        format!("token_id:{}", tid)
+                    } else {
+                        t.clone()
+                    };
                     let converted = convert_backend_top_logprobs(&top_lps, t, *tid, lp);
                     dynamo_protocols::types::ChatCompletionTokenLogprob {
-                        token: t.clone(),
+                        token: token_str.clone(),
                         logprob: lp,
-                        bytes: token_to_utf8_bytes(t),
+                        bytes: token_to_utf8_bytes(&token_str),
                         top_logprobs: converted,
                     }
                 })
@@ -525,6 +534,7 @@ mod tests {
             nvext: None,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         }
     }

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -535,6 +535,7 @@ mod tests {
             chat_template_args: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
             unsupported_fields: Default::default(),
         }
     }

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -100,6 +100,10 @@ struct ChoiceJailState {
     is_jailed: bool,
     /// Accumulated content for this choice while jailed
     accumulated_content: String,
+    /// Accumulated logprobs for this choice while jailed.
+    /// Logprobs from each jailed chunk are appended so the full token-level
+    /// log-probability information is preserved when the jail emits.
+    accumulated_logprobs: Option<ChatChoiceLogprobs>,
     /// Buffer for partial marker matches across chunks
     partial_match_buffer: String,
     /// Stream finish reason
@@ -145,6 +149,7 @@ impl ChoiceJailState {
             index,
             is_jailed: starts_jailed,
             accumulated_content: String::new(),
+            accumulated_logprobs: None,
             partial_match_buffer: String::new(),
             stream_finish_reason: None,
             emitted_tool_calls_count: 0,
@@ -152,16 +157,41 @@ impl ChoiceJailState {
         }
     }
 
-    /// Add content to this choice's accumulation
-    fn accumulate(&mut self, content: &str) {
+    /// Add content and logprobs to this choice's accumulation
+    fn accumulate(&mut self, content: &str, logprobs: Option<&ChatChoiceLogprobs>) {
         if self.is_jailed {
             self.accumulated_content.push_str(content);
+            // Accumulate logprobs so they are preserved across jailed chunks.
+            if let Some(lp) = logprobs {
+                let state_lps = self.accumulated_logprobs.get_or_insert(ChatChoiceLogprobs {
+                    content: None,
+                    refusal: None,
+                });
+                if let Some(content_lps) = &lp.content {
+                    state_lps
+                        .content
+                        .get_or_insert_with(Vec::new)
+                        .extend(content_lps.clone());
+                }
+                if let Some(refusal_lps) = &lp.refusal {
+                    state_lps
+                        .refusal
+                        .get_or_insert_with(Vec::new)
+                        .extend(refusal_lps.clone());
+                }
+            }
         }
+    }
+
+    /// Consume the accumulated logprobs, replacing them with `None`.
+    fn take_accumulated_logprobs(&mut self) -> Option<ChatChoiceLogprobs> {
+        self.accumulated_logprobs.take()
     }
 
     /// End jailing and return the accumulated content
     fn end_jail(&mut self) -> String {
         self.is_jailed = false;
+        self.accumulated_logprobs = None;
         std::mem::take(&mut self.accumulated_content)
     }
 
@@ -235,6 +265,8 @@ impl ChoiceJailState {
                             if jail_stream.should_start_jail(trailing_part) {
                                 self.is_jailed = true;
                                 self.accumulated_content = trailing_part.to_string();
+                                // No logprobs to seed here — they were already emitted with the tool call
+                                self.accumulated_logprobs = None;
                             } else {
                                 #[allow(deprecated)]
                                 let trailing_choice = create_choice_stream(
@@ -253,6 +285,8 @@ impl ChoiceJailState {
                         // Start jailing with the marker and suffix
                         self.is_jailed = true;
                         self.accumulated_content = full_content;
+                        // Seed accumulated logprobs with this chunk's logprobs
+                        self.accumulated_logprobs = choice.logprobs.clone();
                     }
 
                     self.partial_match_buffer.clear();
@@ -301,6 +335,8 @@ impl ChoiceJailState {
                         // Start jailing with the combined content
                         self.is_jailed = true;
                         self.accumulated_content = combined_content;
+                        // Seed accumulated logprobs with this chunk's logprobs
+                        self.accumulated_logprobs = choice.logprobs.clone();
                         self.partial_match_buffer.clear();
                     } else {
                         // No markers - emit everything
@@ -322,25 +358,31 @@ impl ChoiceJailState {
                 }
             }
         } else {
-            // Already jailed - accumulate and check for unjail
-            self.accumulate(content);
+            // Already jailed - accumulate content AND logprobs, then check for unjail
+            self.accumulate(content, choice.logprobs.as_ref());
 
             let (should_end, split_pos) =
                 jail_stream.should_end_jail(&self.accumulated_content).await;
 
             if should_end {
+                // Take accumulated logprobs before borrowing accumulated_content
+                let jail_logprobs = self.take_accumulated_logprobs();
+
                 // Split the content
                 let (jailed_part, trailing_part) = self.accumulated_content.split_at(split_pos);
+                let trailing_owned = trailing_part.to_string();
+                let jailed_owned = jailed_part.to_string();
 
-                // Create the unjailed choice
-                let unjailed_choice = jail_stream
+                // Create the unjailed choice, using accumulated logprobs
+                let mut unjailed_choice = jail_stream
                     .create_tool_call_choice(
                         choice.index,
-                        jailed_part,
+                        &jailed_owned,
                         choice,
                         self.emitted_tool_calls_count,
                     )
                     .await;
+                unjailed_choice.logprobs = jail_logprobs;
 
                 // Determine emission type based on whether tool calls were parsed
                 if unjailed_choice.delta.tool_calls.is_some() {
@@ -353,7 +395,6 @@ impl ChoiceJailState {
                 }
 
                 // End jailing before processing trailing content
-                let trailing_owned = trailing_part.to_string();
                 self.end_jail();
 
                 // Handle trailing content if any
@@ -393,7 +434,7 @@ impl ChoiceJailState {
                 None,
                 self.stream_finish_reason, // For the accumulated content, assign the original stream finish reason, otherwise it will get lost
                 None,
-                None,
+                self.accumulated_logprobs.clone(),
             );
 
             let mut final_choice = jail_stream
@@ -404,6 +445,8 @@ impl ChoiceJailState {
                     self.emitted_tool_calls_count,
                 )
                 .await;
+            // Attach the full accumulated logprobs to the final choice
+            final_choice.logprobs = self.take_accumulated_logprobs();
 
             // Preserve any pending reasoning content collected while jailed.
             if let Some(pending_reasoning) = self.pending_reasoning_content.take() {
@@ -928,7 +971,7 @@ impl JailedStream {
                         Some(tool_call_chunks),
                         None,
                         None,
-                        None,
+                        base_choice.logprobs.clone(),
                     );
                     return choice;
                 }
@@ -1411,6 +1454,158 @@ mod tests {
                 }
             })
             .collect()
+    }
+
+    /// Helper: build a single-choice stream chunk with text content and logprobs
+    #[allow(deprecated)]
+    fn text_chunk_with_logprobs(text: &str) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        let logprobs = ChatChoiceLogprobs {
+            content: Some(
+                text.chars()
+                    .enumerate()
+                    .map(|(i, c)| dynamo_protocols::types::ChatCompletionTokenLogprob {
+                        token: c.to_string(),
+                        logprob: -(i as f32 + 1.0) * 0.1,
+                        bytes: Some(c.to_string().into_bytes()),
+                        top_logprobs: vec![],
+                    })
+                    .collect(),
+            ),
+            refusal: None,
+        };
+
+        let choice = ChatChoiceStream {
+            index: 0,
+            delta: ChatCompletionStreamResponseDelta {
+                role: Some(Role::Assistant),
+                content: Some(dynamo_protocols::types::ChatCompletionMessageContent::Text(
+                    text.to_string(),
+                )),
+                tool_calls: None,
+                function_call: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: None,
+            stop_reason: None,
+            logprobs: Some(logprobs),
+        };
+
+        Annotated {
+            data: Some(NvCreateChatCompletionStreamResponse {
+                inner: CreateChatCompletionStreamResponse {
+                    id: "id-42".to_string(),
+                    object: "chat.completion.chunk".to_string(),
+                    created: 0,
+                    model: "test-model".to_string(),
+                    choices: vec![choice],
+                    usage: None,
+                    service_tier: None,
+                    system_fingerprint: None,
+                },
+                nvext: None,
+            }),
+            id: None,
+            event: None,
+            comment: None,
+            error: None,
+        }
+    }
+
+    /// Collect all logprobs from jailed stream output choices
+    fn collect_logprobs(
+        responses: &[Annotated<NvCreateChatCompletionStreamResponse>],
+    ) -> Vec<Option<ChatChoiceLogprobs>> {
+        responses
+            .iter()
+            .flat_map(|r| r.data.iter())
+            .flat_map(|d| d.inner.choices.iter())
+            .map(|c| c.logprobs.clone())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_tool_call_preserves_logprobs_single_chunk() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![text_chunk_with_logprobs(
+            "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}\n</tool_call>",
+        )];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+        assert_eq!(tool_calls.len(), 1, "Expected 1 tool call, got {:?}", tool_calls);
+        assert_eq!(tool_calls[0].0, "get_weather");
+
+        // Logprobs must be preserved even though the entire output is a tool call
+        let all_logprobs = collect_logprobs(&responses);
+        let has_some_logprobs = all_logprobs.iter().any(|lp| lp.is_some());
+        assert!(
+            has_some_logprobs,
+            "Logprobs should be preserved for tool call responses, got all None: {:?}",
+            all_logprobs
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tool_call_preserves_logprobs_multiple_chunks() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![
+            text_chunk_with_logprobs("<tool_call>\n{\"name\": \"get_weather\", \"arguments\""),
+            text_chunk_with_logprobs(": {\"location\": \"SF\"}}\n</tool_call>"),
+        ];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+        assert!(!tool_calls.is_empty(), "Expected tool calls, got none");
+
+        let all_logprobs = collect_logprobs(&responses);
+        let has_some_logprobs = all_logprobs.iter().any(|lp| lp.is_some());
+        assert!(
+            has_some_logprobs,
+            "Logprobs should be preserved for tool call responses across chunks, got all None",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tool_call_with_text_preserves_logprobs() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![text_chunk_with_logprobs(
+            "Let me check.\n<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}\n</tool_call>",
+        )];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+        assert_eq!(tool_calls.len(), 1);
+
+        let all_logprobs = collect_logprobs(&responses);
+        let has_some_logprobs = all_logprobs.iter().any(|lp| lp.is_some());
+        assert!(
+            has_some_logprobs,
+            "Logprobs should be preserved for mixed text+tool_call responses",
+        );
+
+        // Verify the logprobs content is non-empty
+        let logprob_entries: Vec<_> = all_logprobs
+            .iter()
+            .filter_map(|lp| lp.as_ref())
+            .filter_map(|lp| lp.content.as_ref())
+            .collect();
+        assert!(
+            logprob_entries.iter().any(|entries| !entries.is_empty()),
+            "Logprobs content should have entries",
+        );
     }
 
     #[tokio::test]

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -532,6 +532,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
             nvext: resp.nvext,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         })
     }

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -533,6 +533,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
             chat_template_args: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
             unsupported_fields: Default::default(),
         })
     }

--- a/lib/llm/src/protocols/openai/tokenization.rs
+++ b/lib/llm/src/protocols/openai/tokenization.rs
@@ -86,6 +86,7 @@ impl TokenizeChatRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum TokenizeRequest {
     Completion(TokenizeCompletionRequest),
     Chat(TokenizeChatRequest),

--- a/lib/llm/src/protocols/openai/tokenization.rs
+++ b/lib/llm/src/protocols/openai/tokenization.rs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::preprocessor::media::MediaDecoder;
+use crate::types::TokenIdType;
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_false() -> bool {
+    false
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TokenizeCompletionRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub prompt: String,
+    #[serde(default = "default_true")]
+    pub add_special_tokens: bool,
+    #[serde(default = "default_false")]
+    pub return_token_strs: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TokenizeChatRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub messages: Vec<dynamo_async_openai::types::ChatCompletionRequestMessage>,
+    #[serde(default = "default_true")]
+    pub add_generation_prompt: bool,
+    #[serde(default = "default_false")]
+    pub return_token_strs: bool,
+    #[serde(default = "default_false")]
+    pub continue_final_message: bool,
+    #[serde(default = "default_false")]
+    pub add_special_tokens: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_template: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "chat_template_args"
+    )]
+    pub chat_template_kwargs: Option<HashMap<String, serde_json::Value>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub media_io_kwargs: Option<MediaDecoder>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mm_processor_kwargs: Option<HashMap<String, serde_json::Value>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<dynamo_async_openai::types::ChatCompletionTool>>,
+}
+
+impl TokenizeChatRequest {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.continue_final_message && self.add_generation_prompt {
+            return Err(
+                "Cannot set both `continue_final_message` and `add_generation_prompt` to True."
+                    .to_string(),
+            );
+        }
+
+        Ok(())
+    }
+
+    pub fn merged_chat_template_kwargs(&self) -> HashMap<String, serde_json::Value> {
+        let mut kwargs = self.chat_template_kwargs.clone().unwrap_or_default();
+        kwargs.insert(
+            "add_generation_prompt".to_string(),
+            serde_json::Value::Bool(self.add_generation_prompt),
+        );
+        kwargs.insert(
+            "continue_final_message".to_string(),
+            serde_json::Value::Bool(self.continue_final_message),
+        );
+        kwargs
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TokenizeRequest {
+    Completion(TokenizeCompletionRequest),
+    Chat(TokenizeChatRequest),
+}
+
+impl TokenizeRequest {
+    pub fn model(&self) -> Option<&str> {
+        match self {
+            Self::Completion(request) => request.model.as_deref(),
+            Self::Chat(request) => request.model.as_deref(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TokenizeResponse {
+    pub count: usize,
+    pub max_model_len: u32,
+    pub tokens: Vec<TokenIdType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_strs: Option<Vec<String>>,
+}

--- a/lib/llm/src/protocols/openai/tokenization.rs
+++ b/lib/llm/src/protocols/openai/tokenization.rs
@@ -108,3 +108,16 @@ pub struct TokenizeResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_strs: Option<Vec<String>>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DetokenizeRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub tokens: Vec<TokenIdType>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DetokenizeResponse {
+    pub prompt: String,
+}

--- a/lib/llm/src/protocols/openai/tokenization.rs
+++ b/lib/llm/src/protocols/openai/tokenization.rs
@@ -33,7 +33,7 @@ pub struct TokenizeCompletionRequest {
 pub struct TokenizeChatRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
-    pub messages: Vec<dynamo_async_openai::types::ChatCompletionRequestMessage>,
+    pub messages: Vec<dynamo_protocols::types::ChatCompletionRequestMessage>,
     #[serde(default = "default_true")]
     pub add_generation_prompt: bool,
     #[serde(default = "default_false")]
@@ -55,7 +55,7 @@ pub struct TokenizeChatRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mm_processor_kwargs: Option<HashMap<String, serde_json::Value>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tools: Option<Vec<dynamo_async_openai::types::ChatCompletionTool>>,
+    pub tools: Option<Vec<dynamo_protocols::types::ChatCompletionTool>>,
 }
 
 impl TokenizeChatRequest {

--- a/lib/llm/src/protocols/openai/tokenization.rs
+++ b/lib/llm/src/protocols/openai/tokenization.rs
@@ -56,6 +56,8 @@ pub struct TokenizeChatRequest {
     pub mm_processor_kwargs: Option<HashMap<String, serde_json::Value>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<dynamo_protocols::types::ChatCompletionTool>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_prefix_token_ids: Option<Vec<TokenIdType>>,
 }
 
 impl TokenizeChatRequest {

--- a/lib/llm/src/protocols/unified.rs
+++ b/lib/llm/src/protocols/unified.rs
@@ -534,6 +534,7 @@ mod tests {
             nvext: None,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         };
 

--- a/lib/llm/src/protocols/unified.rs
+++ b/lib/llm/src/protocols/unified.rs
@@ -535,6 +535,7 @@ mod tests {
             chat_template_args: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            required_prefix_token_ids: None,
             unsupported_fields: Default::default(),
         };
 

--- a/lib/llm/src/tokenizers.rs
+++ b/lib/llm/src/tokenizers.rs
@@ -61,6 +61,14 @@ pub mod traits {
     pub trait Encoder: Send + Sync {
         fn encode(&self, input: &str) -> Result<Encoding>;
         fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>>;
+
+        fn encode_with_special_tokens(
+            &self,
+            input: &str,
+            _add_special_tokens: bool,
+        ) -> Result<Encoding> {
+            self.encode(input)
+        }
     }
 
     /// Result of decoding token IDs to text.
@@ -126,8 +134,12 @@ pub mod traits {
     }
 
     pub trait Tokenizer: Encoder + Decoder {
-        // fn get_vocab_size(&self) -> usize;
-        // fn make_unique_clone(&self) -> Box<dyn Tokenizer>;
+        fn convert_ids_to_tokens(&self, token_ids: &[TokenIdType]) -> Result<Vec<String>> {
+            token_ids
+                .iter()
+                .map(|id| self.decode(std::slice::from_ref(id), false))
+                .collect()
+        }
     }
 }
 
@@ -146,6 +158,18 @@ pub struct Tokenizer(Arc<dyn traits::Tokenizer>);
 impl Tokenizer {
     pub fn from_file(file_path: &str) -> Result<Tokenizer> {
         Ok(Tokenizer(create_tokenizer_from_file(file_path)?))
+    }
+
+    pub fn encode_with_special_tokens(
+        &self,
+        input: &str,
+        add_special_tokens: bool,
+    ) -> Result<Encoding> {
+        self.0.encode_with_special_tokens(input, add_special_tokens)
+    }
+
+    pub fn convert_ids_to_tokens(&self, token_ids: &[TokenIdType]) -> Result<Vec<String>> {
+        self.0.convert_ids_to_tokens(token_ids)
     }
 
     /// Create a stateful sequence object for decoding token_ids into text

--- a/lib/llm/src/tokenizers.rs
+++ b/lib/llm/src/tokenizers.rs
@@ -137,7 +137,10 @@ pub mod traits {
         fn convert_ids_to_tokens(&self, token_ids: &[TokenIdType]) -> Result<Vec<String>> {
             token_ids
                 .iter()
-                .map(|id| self.decode(std::slice::from_ref(id), false))
+                .map(|id| {
+                    self.decode(std::slice::from_ref(id), false)
+                        .map(Into::into)
+                })
                 .collect()
         }
     }

--- a/lib/llm/src/tokenizers/fastokens.rs
+++ b/lib/llm/src/tokenizers/fastokens.rs
@@ -39,15 +39,27 @@ impl FastTokenizer {
 
 impl Encoder for FastTokenizer {
     fn encode(&self, input: &str) -> Result<Encoding> {
+        self.encode_with_special_tokens(input, false)
+    }
+
+    fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>> {
+        inputs.par_iter().map(|input| self.encode(input)).collect()
+    }
+
+    fn encode_with_special_tokens(
+        &self,
+        input: &str,
+        add_special_tokens: bool,
+    ) -> Result<Encoding> {
+        if add_special_tokens {
+            return self.hf_decoder.encode_with_special_tokens(input, true);
+        }
+
         let ids = self
             .fast_encoder
             .encode(input)
             .map_err(|e| Error::msg(format!("Fastokens encode error: {e}")))?;
         Ok(Encoding::Sp(ids))
-    }
-
-    fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>> {
-        inputs.par_iter().map(|input| self.encode(input)).collect()
     }
 }
 
@@ -57,7 +69,11 @@ impl Decoder for FastTokenizer {
     }
 }
 
-impl Tokenizer for FastTokenizer {}
+impl Tokenizer for FastTokenizer {
+    fn convert_ids_to_tokens(&self, token_ids: &[TokenIdType]) -> Result<Vec<String>> {
+        self.hf_decoder.convert_ids_to_tokens(token_ids)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/lib/llm/src/tokenizers/hf.rs
+++ b/lib/llm/src/tokenizers/hf.rs
@@ -27,13 +27,7 @@ impl HuggingFaceTokenizer {
 
 impl Encoder for HuggingFaceTokenizer {
     fn encode(&self, input: &str) -> Result<Encoding> {
-        // This self.tokenizer is the library
-        let encoding = self
-            .tokenizer
-            .encode(input, false)
-            .map_err(|err| Error::msg(format!("Error tokenizing input: {err}")))?;
-
-        Ok(Encoding::Hf(Box::new(encoding)))
+        self.encode_with_special_tokens(input, false)
     }
 
     fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>> {
@@ -49,6 +43,20 @@ impl Encoder for HuggingFaceTokenizer {
 
         Ok(encodings)
     }
+
+    fn encode_with_special_tokens(
+        &self,
+        input: &str,
+        add_special_tokens: bool,
+    ) -> Result<Encoding> {
+        // This self.tokenizer is the library
+        let encoding = self
+            .tokenizer
+            .encode(input, add_special_tokens)
+            .map_err(|err| Error::msg(format!("Error tokenizing input: {err}")))?;
+
+        Ok(Encoding::Hf(Box::new(encoding)))
+    }
 }
 
 impl Decoder for HuggingFaceTokenizer {
@@ -63,7 +71,14 @@ impl Decoder for HuggingFaceTokenizer {
     }
 }
 
-impl Tokenizer for HuggingFaceTokenizer {}
+impl Tokenizer for HuggingFaceTokenizer {
+    fn convert_ids_to_tokens(&self, token_ids: &[TokenIdType]) -> Result<Vec<String>> {
+        Ok(token_ids
+            .iter()
+            .map(|&id| self.tokenizer.id_to_token(id).unwrap_or_default())
+            .collect())
+    }
+}
 
 impl From<HfTokenizer> for HuggingFaceTokenizer {
     fn from(tokenizer: HfTokenizer) -> Self {

--- a/lib/llm/src/tokenizers/tiktoken.rs
+++ b/lib/llm/src/tokenizers/tiktoken.rs
@@ -24,6 +24,8 @@ const KIMI_PATTERN: &str = r#"[\p{Han}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p
 pub struct TikTokenTokenizer {
     bpe: CoreBPE,
     special_token_ids: HashSet<u32>,
+    decoder_tokens: FxHashMap<u32, Vec<u8>>,
+    special_tokens_decoder: FxHashMap<u32, Vec<u8>>,
 }
 
 impl TikTokenTokenizer {
@@ -39,6 +41,14 @@ impl TikTokenTokenizer {
         special_tokens: FxHashMap<String, u32>,
     ) -> Result<Self> {
         let encoder = parse_tiktoken_file(path)?;
+        let decoder_tokens: FxHashMap<u32, Vec<u8>> = encoder
+            .iter()
+            .map(|(bytes, &id)| (id, bytes.clone()))
+            .collect();
+        let special_tokens_decoder: FxHashMap<u32, Vec<u8>> = special_tokens
+            .iter()
+            .map(|(token, &id)| (id, token.as_bytes().to_vec()))
+            .collect();
         let special_token_ids: HashSet<u32> = special_tokens.values().copied().collect();
 
         let bpe = CoreBPE::new(encoder, special_tokens, pattern)
@@ -47,6 +57,8 @@ impl TikTokenTokenizer {
         Ok(Self {
             bpe,
             special_token_ids,
+            decoder_tokens,
+            special_tokens_decoder,
         })
     }
 
@@ -62,9 +74,17 @@ impl TikTokenTokenizer {
 
         let pattern = detect_bpe_pattern(directory)?;
         let encoder = parse_tiktoken_file(path)?;
+        let decoder_tokens: FxHashMap<u32, Vec<u8>> = encoder
+            .iter()
+            .map(|(bytes, &id)| (id, bytes.clone()))
+            .collect();
         // Use max rank + 1 (not len) to avoid ID collisions with sparse/non-contiguous ranks
         let num_base_tokens = encoder.values().max().map_or(0, |&m| m + 1) as usize;
         let special_tokens = load_special_tokens(directory, num_base_tokens)?;
+        let special_tokens_decoder: FxHashMap<u32, Vec<u8>> = special_tokens
+            .iter()
+            .map(|(token, &id)| (id, token.as_bytes().to_vec()))
+            .collect();
         let special_token_ids: HashSet<u32> = special_tokens.values().copied().collect();
 
         let bpe = CoreBPE::new(encoder, special_tokens, pattern)
@@ -73,18 +93,32 @@ impl TikTokenTokenizer {
         Ok(Self {
             bpe,
             special_token_ids,
+            decoder_tokens,
+            special_tokens_decoder,
         })
     }
 }
 
 impl Encoder for TikTokenTokenizer {
     fn encode(&self, input: &str) -> Result<Encoding> {
-        let token_ids: Vec<u32> = self.bpe.encode_with_special_tokens(input);
-        Ok(Encoding::Sp(token_ids))
+        self.encode_with_special_tokens(input, true)
     }
 
     fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>> {
         inputs.par_iter().map(|input| self.encode(input)).collect()
+    }
+
+    fn encode_with_special_tokens(
+        &self,
+        input: &str,
+        add_special_tokens: bool,
+    ) -> Result<Encoding> {
+        let token_ids: Vec<u32> = if add_special_tokens {
+            self.bpe.encode_with_special_tokens(input)
+        } else {
+            self.bpe.encode_ordinary(input)
+        };
+        Ok(Encoding::Sp(token_ids))
     }
 }
 
@@ -119,7 +153,20 @@ impl Decoder for TikTokenTokenizer {
     }
 }
 
-impl Tokenizer for TikTokenTokenizer {}
+impl Tokenizer for TikTokenTokenizer {
+    fn convert_ids_to_tokens(&self, token_ids: &[TokenIdType]) -> Result<Vec<String>> {
+        Ok(token_ids
+            .iter()
+            .map(|id| {
+                self.decoder_tokens
+                    .get(id)
+                    .or_else(|| self.special_tokens_decoder.get(id))
+                    .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
+                    .unwrap_or_default()
+            })
+            .collect())
+    }
+}
 
 /// Parse a tiktoken model file (base64-encoded token + rank per line).
 fn parse_tiktoken_file(path: &str) -> Result<FxHashMap<Vec<u8>, u32>> {

--- a/lib/llm/tests/parallel_tool_call_integration.rs
+++ b/lib/llm/tests/parallel_tool_call_integration.rs
@@ -92,6 +92,7 @@ fn create_mock_chat_completion_request() -> NvCreateChatCompletionRequest {
         nvext: None,
         chat_template_args: None,
         media_io_kwargs: None,
+        return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
     }
 }

--- a/lib/llm/tests/parallel_tool_call_integration.rs
+++ b/lib/llm/tests/parallel_tool_call_integration.rs
@@ -94,6 +94,7 @@ fn create_mock_chat_completion_request() -> NvCreateChatCompletionRequest {
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
+        required_prefix_token_ids: None,
     }
 }
 

--- a/lib/llm/tests/preprocessor.rs
+++ b/lib/llm/tests/preprocessor.rs
@@ -260,6 +260,7 @@ impl Request {
             nvext: None,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         }
     }
@@ -650,6 +651,7 @@ mod context_length_validation {
             nvext: None,
             chat_template_args: None,
             media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
         }
     }

--- a/lib/llm/tests/preprocessor.rs
+++ b/lib/llm/tests/preprocessor.rs
@@ -262,6 +262,7 @@ impl Request {
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
+            required_prefix_token_ids: None,
         }
     }
 }
@@ -653,6 +654,7 @@ mod context_length_validation {
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
             unsupported_fields: Default::default(),
+            required_prefix_token_ids: None,
         }
     }
 

--- a/lib/llm/tests/test_common_ext.rs
+++ b/lib/llm/tests/test_common_ext.rs
@@ -69,6 +69,7 @@ fn test_sampling_parameters_include_stop_str_in_output_extraction() {
         nvext: None,
         chat_template_args: None,
         media_io_kwargs: None,
+        return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
     };
 
@@ -299,6 +300,7 @@ fn test_serialization_preserves_structure() {
         }),
         chat_template_args: None,
         media_io_kwargs: None,
+        return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
     };
 
@@ -351,6 +353,7 @@ fn test_sampling_parameters_extraction() {
         nvext: None,
         chat_template_args: None,
         media_io_kwargs: None,
+        return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
     };
 

--- a/lib/llm/tests/test_common_ext.rs
+++ b/lib/llm/tests/test_common_ext.rs
@@ -71,6 +71,7 @@ fn test_sampling_parameters_include_stop_str_in_output_extraction() {
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
+        required_prefix_token_ids: None,
     };
 
     let sampling = request.extract_sampling_options().unwrap();
@@ -302,6 +303,7 @@ fn test_serialization_preserves_structure() {
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
+        required_prefix_token_ids: None,
     };
 
     let json = serde_json::to_value(&request).unwrap();
@@ -355,6 +357,7 @@ fn test_sampling_parameters_extraction() {
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
+        required_prefix_token_ids: None,
     };
 
     let sampling_options = request.extract_sampling_options().unwrap();

--- a/lib/llm/tests/test_streaming_usage.rs
+++ b/lib/llm/tests/test_streaming_usage.rs
@@ -191,6 +191,7 @@ fn create_chat_request(
         nvext: None,
         chat_template_args: None,
         media_io_kwargs: None,
+        return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
     }
 }
@@ -521,6 +522,7 @@ fn create_nonstreaming_chat_request() -> NvCreateChatCompletionRequest {
         nvext: None,
         chat_template_args: None,
         media_io_kwargs: None,
+        return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
     }
 }

--- a/lib/llm/tests/test_streaming_usage.rs
+++ b/lib/llm/tests/test_streaming_usage.rs
@@ -193,6 +193,7 @@ fn create_chat_request(
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
+        required_prefix_token_ids: None,
     }
 }
 
@@ -524,6 +525,7 @@ fn create_nonstreaming_chat_request() -> NvCreateChatCompletionRequest {
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
+        required_prefix_token_ids: None,
     }
 }
 

--- a/lib/llm/tests/tool_choice.rs
+++ b/lib/llm/tests/tool_choice.rs
@@ -40,6 +40,7 @@ fn create_test_request() -> NvCreateChatCompletionRequest {
         nvext: None,
         chat_template_args: None,
         media_io_kwargs: None,
+        return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
     }
 }

--- a/lib/llm/tests/tool_choice.rs
+++ b/lib/llm/tests/tool_choice.rs
@@ -42,6 +42,7 @@ fn create_test_request() -> NvCreateChatCompletionRequest {
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
+        required_prefix_token_ids: None,
     }
 }
 

--- a/lib/llm/tests/tool_choice_finish_reasons.rs
+++ b/lib/llm/tests/tool_choice_finish_reasons.rs
@@ -33,6 +33,7 @@ fn create_test_request() -> NvCreateChatCompletionRequest {
         nvext: None,
         chat_template_args: None,
         media_io_kwargs: None,
+        return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
     }
 }

--- a/lib/llm/tests/tool_choice_finish_reasons.rs
+++ b/lib/llm/tests/tool_choice_finish_reasons.rs
@@ -35,6 +35,7 @@ fn create_test_request() -> NvCreateChatCompletionRequest {
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
         unsupported_fields: Default::default(),
+        required_prefix_token_ids: None,
     }
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ trtllm =[
 vllm = [
     "uvloop",
     "nixl[cu12]<=0.10.1",
-    "vllm[flashinfer,runai,otel]==0.19.0",
+    "vllm[flashinfer,runai,otel]>=0.18.0,<=0.19.0",
     # vllm-omni is installed separately in container builds (see
     # container/deps/vllm/install_vllm.sh). Do not add it to ai-dynamo[vllm]:
     # pip/uv dependency resolution for omni can override the vLLM torch stack.


### PR DESCRIPTION
Adds /tokenize and /detokenize endpoints, following the semantics of vllm. This is needed for RL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tokenization endpoints (`POST /tokenize`, `POST /detokenize`) for encoding prompts and chat messages to tokens and decoding tokens back to text
  * Added support for custom chat template overrides when rendering prompts
  * Added optional token string output in tokenization responses for human-readable token representation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->