### PR TITLE
feat(frontend): local and k8s frontend perf test runner

### DIFF
--- a/benchmarks/frontend/README.md
+++ b/benchmarks/frontend/README.md
@@ -1,0 +1,283 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Frontend Performance Benchmark Suite
+
+A configurable sweep runner for measuring Dynamo frontend tokenizer performance.
+It drives [aiperf](https://github.com/AI-Infra-Bench/aiperf) load against a
+frontend/mocker (or frontend/vLLM) stack and collects throughput, latency, and
+observability data across a grid of parameters.
+
+The primary use case is **HuggingFace tokenizer vs. fastokens comparison** --
+sweeping across concurrency levels, input sequence lengths (ISL), and worker
+counts to quantify the tokenizer's impact on end-to-end performance.
+
+---
+
+## Architecture
+
+The codebase follows a three-layer design that separates pure logic from
+execution and infrastructure concerns:
+
+| Layer | Package | Responsibility |
+|-------|---------|----------------|
+| **Core** | `scripts/sweep_core/` | Pure data models, plan construction, artifact writing, reporting. No subprocess or kubectl calls. |
+| **Executors** | `scripts/sweep_executors/` | `SweepExecutor` protocol with two implementations -- `LocalExecutor` (delegates to `run_perf.sh`) and `K8sDgdExecutor` (DynamoGraphDeployment-based k8s runs). |
+| **K8s helpers** | `scripts/sweep_k8s/` | kubectl wrappers, DGD patching, template rendering, aiperf Job launching, and Prometheus metrics capture. |
+
+The entry point is `scripts/sweep_runner.py`, a thin CLI that wires the three
+layers together: it builds a `SweepPlan` from CLI arguments, selects an
+executor based on `--mode`, and feeds the plan to the orchestrator.
+
+**Data flow:**
+
+```
+CLI args --> SweepConfig --> SweepPlan (Cartesian grid of RunSpecs)
+                                |
+                          Orchestrator
+                                |
+                   LocalExecutor  or  K8sDgdExecutor
+                        |                   |
+                  run_perf.sh        DGD + aiperf Job
+                        |                   |
+                  artifacts/           artifacts/
+```
+
+---
+
+## Quick Start -- Local
+
+Local mode starts a mocker backend and frontend process on the current machine,
+runs aiperf against them, and tears everything down between runs.
+
+**Prerequisites:**
+
+- `dynamo.mocker` and `dynamo.frontend` installed (from the Dynamo repo)
+- `aiperf` installed and on `$PATH`
+- A HuggingFace model accessible locally (default: `Qwen/Qwen3-0.6B`)
+
+**Smoke test (2 runs, ~30 s each):**
+
+```bash
+cd benchmarks/frontend/scripts
+
+python3 sweep_runner.py \
+    --tokenizers hf,fastokens \
+    --concurrency 32 \
+    --isl 512 \
+    --benchmark-duration 30 \
+    --speedup-ratio 0
+```
+
+**Full local sweep:**
+
+```bash
+python3 sweep_runner.py \
+    --tokenizers hf,fastokens \
+    --concurrency 32,64,128 \
+    --isl 512,1024,2048
+```
+
+**Transport saturation sweep (high concurrency, vary workers):**
+
+```bash
+python3 sweep_runner.py \
+    --tokenizers hf \
+    --concurrency 4096 \
+    --num-requests 16384,32768 \
+    --workers 1,2,4,8 \
+    --speedup-ratio 0
+```
+
+Results are written to `artifacts/sweep_<timestamp>/`.
+
+---
+
+## Quick Start -- Kubernetes
+
+K8s mode deploys a DynamoGraphDeployment (DGD) into a Kubernetes namespace and
+launches aiperf as an in-cluster Job that targets the frontend service endpoint.
+
+### Prerequisites
+
+1. **Namespace** -- a dedicated namespace for the benchmark (default: `dynamo-bench`).
+2. **HuggingFace token secret** -- a Kubernetes Secret named `hf-token-secret`
+   containing your HF token, if the model requires authentication.
+3. **Model cache PVC** -- a PersistentVolumeClaim for caching model weights
+   (avoids repeated downloads across runs).
+4. **DGD deployed** -- either pre-deploy the DGD yourself, or use the
+   `--deploy --deploy-template` flags to let the sweep runner create it.
+5. **kubectl** configured with access to the target cluster and namespace.
+
+### Example: mocker backend
+
+```bash
+python3 sweep_runner.py \
+    --mode k8s \
+    --dgd-name dynamo-bench-mocker \
+    --tokenizers hf,fastokens \
+    --concurrency 50,100 \
+    --isl 512
+```
+
+### Example: template-based deployment
+
+When `--deploy-template` is provided, the runner renders the template with
+per-run variables (tokenizer, workers, model, etc.) and applies it via kubectl
+before each run group:
+
+```bash
+python3 sweep_runner.py \
+    --mode k8s \
+    --deploy \
+    --deploy-template dgd/templates/mocker.yaml \
+    --dgd-name dynamo-bench-mocker \
+    --image nvcr.io/.../image:tag \
+    --tokenizers hf,fastokens \
+    --concurrency 50,100 \
+    --isl 512
+```
+
+### How aiperf runs in-cluster
+
+The sweep runner creates a short-lived Kubernetes Job in the same namespace as
+the DGD. The Job pod runs `aiperf` against the frontend's in-cluster service
+DNS name (e.g., `dynamo-bench-mocker-frontend:8000`). Once the Job completes,
+artifacts are copied back to the local host via `kubectl cp`.
+
+### Reset strategy
+
+Between runs, the `--reset-strategy` flag controls how the deployed stack is
+recycled:
+
+| Strategy | Behavior |
+|----------|----------|
+| `none` | No resets; runs back-to-back on the same deployment. |
+| `frontend` | Restart only the frontend pod between runs. |
+| `graph` (default) | Redeploy the entire DGD graph between run groups. |
+
+---
+
+## CLI Reference
+
+All flags for `sweep_runner.py`:
+
+### Common options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--mode` | `local` | Execution mode: `local` or `k8s`. |
+| `--backend` | `mocker` | Engine backend: `mocker` (synthetic) or `vllm` (real inference). |
+| `--model` | `Qwen/Qwen3-0.6B` | HuggingFace model path. |
+| `--model-name` | same as `--model` | Served model name (for multi-model setups). |
+| `--tokenizers` | `hf,fastokens` | Comma-separated tokenizer backends. |
+| `--concurrency` | `50,100,200` | Comma-separated concurrency levels. |
+| `--isl` | `512,1024,2048` | Comma-separated input sequence lengths. |
+| `--osl` | `256` | Output sequence length. |
+| `--workers` | `2` | Comma-separated worker counts per model. |
+| `--num-models` | `1` | Number of model instances. |
+| `--speedup-ratio` | `1.0` | Mocker speedup (0 = infinite speed). |
+| `--benchmark-duration` | `60` | aiperf duration in seconds. |
+| `--num-requests` | none | Comma-separated request counts (overrides `--benchmark-duration`). |
+| `--rps` | none | Comma-separated target request rates (req/s). |
+| `--output-dir` | auto-timestamped | Output directory. |
+| `--cooldown` | `3` | Seconds between runs. |
+| `--max-consecutive-fails` | `2` | Abort sweep after N consecutive failures. |
+| `--isolation` | `fresh_per_run` | Isolation policy: `fresh_per_run` or `reuse_by_deploy_key`. |
+| `--no-report` | off | Skip per-run report generation. |
+
+### Execution control
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Print the sweep plan without executing any runs. |
+| `--emit-plan` | Print the sweep plan as JSON and exit (useful for Argo or MCP integration). |
+
+### K8s mode options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--namespace` | `dynamo-bench` | Kubernetes namespace. |
+| `--endpoint` | auto-derived | Frontend endpoint (`host:port`). |
+| `--dgd-name` | none | DynamoGraphDeployment name. |
+| `--image` | none | Container image for k8s deployment. |
+| `--deploy-template` | none | Path to a DGD YAML template (enables template-based deployment). |
+| `--deploy` | off | Deploy infrastructure before sweeping. |
+| `--reset-strategy` | `graph` | Per-run reset: `none`, `frontend`, or `graph`. |
+| `--frontend-port` | `8000` | Frontend HTTP port. |
+| `--worker-replicas` | `1` | Number of worker pod replicas. |
+| `--request-plane` | `tcp` | Request plane transport. |
+| `--event-plane` | `nats` | Event plane transport. |
+| `--router-mode` | `round-robin` | Frontend router mode. |
+| `--hf-token` | none | HuggingFace token for k8s. |
+| `--image-pull-secret` | none | Image pull secret name. |
+| `--export-level` | `summary` | aiperf export level. |
+
+---
+
+## Artifact Structure
+
+Each sweep produces a timestamped output directory:
+
+```
+artifacts/sweep_20260330_143000/
+    sweep_config.json        # Full SweepConfig used for this run
+    results.csv              # One row per run with key metrics
+    summary.md               # Markdown summary table
+
+    mocker_hf_w2_c50_isl512/
+        aiperf/              # aiperf JSON output
+        prometheus/          # Prometheus metric snapshots
+        report.md            # Per-run analysis report (unless --no-report)
+
+    mocker_fastokens_w2_c50_isl512/
+        aiperf/
+        prometheus/
+        report.md
+    ...
+```
+
+**results.csv columns:**
+
+`run_id`, `backend`, `tokenizer`, `concurrency`, `isl`, `osl`, `workers`,
+`speedup_ratio`, `status`, `req_per_sec`, `output_tok_per_sec`,
+`ttft_p50_ms`, `ttft_p99_ms`, `itl_p50_ms`, `itl_p99_ms`, `duration_sec`,
+`run_dir`
+
+---
+
+## DGD Templates
+
+The `dgd/templates/` directory contains DynamoGraphDeployment YAML templates
+for k8s mode. Template variables (e.g., `${DGD_NAME}`, `${IMAGE}`,
+`${DYN_TOKENIZER_BACKEND}`) are substituted by the sweep runner at deploy time.
+
+| Template | Backend | GPU required | Description |
+|----------|---------|-------------|-------------|
+| `mocker.yaml` | mocker | No | Synthetic backend for isolating frontend/tokenizer overhead. |
+| `vllm.yaml` | vLLM | Yes | Real inference backend for end-to-end benchmarking. |
+
+---
+
+## Analysis
+
+Post-sweep analysis scripts live in `scripts/analysis/`:
+
+| Script | Purpose |
+|--------|---------|
+| `create_report.py` | Generates a per-run observability report from aiperf JSON, Prometheus snapshots, NVTX traces, syscall profiles, and BPF data. |
+| `frontend_perf_analysis.py` | Produces scalability curves (TTFT/ITL/throughput vs. concurrency), ISL heatmaps, stage waterfall breakdowns, and regression detection. Supports single-run analysis, A/B comparison, and heatmap generation. |
+
+**Single-run report:**
+
+```bash
+python3 scripts/analysis/create_report.py analyze artifacts/sweep_*/mocker_hf_w2_c50_isl512/
+```
+
+**A/B comparison:**
+
+```bash
+python3 scripts/analysis/frontend_perf_analysis.py compare \
+    artifacts/sweep_*/mocker_hf_w2_c50_isl512/ \
+    artifacts/sweep_*/mocker_fastokens_w2_c50_isl512/
+```

--- a/benchmarks/frontend/README.md
+++ b/benchmarks/frontend/README.md
@@ -4,7 +4,7 @@
 # Frontend Performance Benchmark Suite
 
 A configurable sweep runner for measuring Dynamo frontend tokenizer performance.
-It drives [aiperf](https://github.com/AI-Infra-Bench/aiperf) load against a
+It drives [aiperf](https://github.com/ai-dynamo/aiperf) load against a
 frontend/mocker (or frontend/vLLM) stack and collects throughput, latency, and
 observability data across a grid of parameters.
 

--- a/benchmarks/frontend/README.md
+++ b/benchmarks/frontend/README.md
@@ -57,7 +57,7 @@ python3 sweep_runner.py \
     --concurrency 32 \
     --isl 512 \
     --benchmark-duration 30 \
-    --speedup-ratio 0
+    --speedup-ratio 1000000
 ```
 
 **Full local sweep:**
@@ -77,7 +77,7 @@ python3 sweep_runner.py \
     --concurrency 4096 \
     --num-requests 16384,32768 \
     --workers 1,2,4,8 \
-    --speedup-ratio 0
+    --speedup-ratio 1000000
 ```
 
 Results are written to `artifacts/sweep_<timestamp>/`.
@@ -161,7 +161,7 @@ All flags for `sweep_runner.py`:
 | `--osl` | `256` | Output sequence length. |
 | `--workers` | `2` | Comma-separated worker counts per model. |
 | `--num-models` | `1` | Number of model instances. |
-| `--speedup-ratio` | `1.0` | Mocker speedup (0 = infinite speed). |
+| `--speedup-ratio` | `1.0` | Mocker speedup divisor; use large values (e.g., 1000000) for near-instant mocker. |
 | `--benchmark-duration` | `60` | aiperf duration in seconds. |
 | `--num-requests` | none | Comma-separated request counts (overrides `--benchmark-duration`). |
 | `--rps` | none | Comma-separated target request rates (req/s). |

--- a/benchmarks/frontend/README.md
+++ b/benchmarks/frontend/README.md
@@ -3,21 +3,15 @@
 
 # Frontend Performance Benchmark Suite
 
-A configurable sweep runner for measuring Dynamo frontend tokenizer performance.
-It drives [aiperf](https://github.com/ai-dynamo/aiperf) load against a
-frontend/mocker (or frontend/vLLM) stack and collects throughput, latency, and
-observability data across a grid of parameters.
+A configurable sweep runner for measuring Dynamo frontend model serving performance.  It drives [aiperf](https://github.com/ai-dynamo/aiperf) load against a frontend/mocker (or frontend/vLLM) stack and collects throughput, latency, and observability data across a grid of parameters.
 
-The primary use case is **HuggingFace tokenizer vs. fastokens comparison** --
-sweeping across concurrency levels, input sequence lengths (ISL), and worker
-counts to quantify the tokenizer's impact on end-to-end performance.
+The primary use case is **HuggingFace tokenizer vs. fastokens comparison** -- sweeping across concurrency levels, input sequence lengths (ISL), and worker counts to quantify the tokenizer's impact on end-to-end performance.
 
 ---
 
 ## Architecture
 
-The codebase follows a three-layer design that separates pure logic from
-execution and infrastructure concerns:
+The codebase follows a three-layer design that separates pure logic from execution and infrastructure concerns.
 
 | Layer | Package | Responsibility |
 |-------|---------|----------------|
@@ -25,9 +19,7 @@ execution and infrastructure concerns:
 | **Executors** | `scripts/sweep_executors/` | `SweepExecutor` protocol with two implementations -- `LocalExecutor` (delegates to `run_perf.sh`) and `K8sDgdExecutor` (DynamoGraphDeployment-based k8s runs). |
 | **K8s helpers** | `scripts/sweep_k8s/` | kubectl wrappers, DGD patching, template rendering, aiperf Job launching, and Prometheus metrics capture. |
 
-The entry point is `scripts/sweep_runner.py`, a thin CLI that wires the three
-layers together: it builds a `SweepPlan` from CLI arguments, selects an
-executor based on `--mode`, and feeds the plan to the orchestrator.
+The entry point is `scripts/sweep_runner.py`, a thin CLI that wires the three layers together: it builds a `SweepPlan` from CLI arguments, selects an executor based on `--mode`, and feeds the plan to the orchestrator.
 
 **Data flow:**
 
@@ -47,8 +39,7 @@ CLI args --> SweepConfig --> SweepPlan (Cartesian grid of RunSpecs)
 
 ## Quick Start -- Local
 
-Local mode starts a mocker backend and frontend process on the current machine,
-runs aiperf against them, and tears everything down between runs.
+Local mode starts a mocker backend and frontend process on the current machine, runs aiperf against them, and tears everything down between runs.
 
 **Prerequisites:**
 
@@ -95,8 +86,7 @@ Results are written to `artifacts/sweep_<timestamp>/`.
 
 ## Quick Start -- Kubernetes
 
-K8s mode deploys a DynamoGraphDeployment (DGD) into a Kubernetes namespace and
-launches aiperf as an in-cluster Job that targets the frontend service endpoint.
+K8s mode deploys a DynamoGraphDeployment (DGD) into a Kubernetes namespace and launches aiperf as an in-cluster Job that targets the frontend service endpoint.
 
 ### Prerequisites
 
@@ -122,9 +112,7 @@ python3 sweep_runner.py \
 
 ### Example: template-based deployment
 
-When `--deploy-template` is provided, the runner renders the template with
-per-run variables (tokenizer, workers, model, etc.) and applies it via kubectl
-before each run group:
+When `--deploy-template` is provided, the runner renders the template with per-run variables (tokenizer, workers, model, etc.) and applies it via kubectl before each run group:
 
 ```bash
 python3 sweep_runner.py \
@@ -140,10 +128,7 @@ python3 sweep_runner.py \
 
 ### How aiperf runs in-cluster
 
-The sweep runner creates a short-lived Kubernetes Job in the same namespace as
-the DGD. The Job pod runs `aiperf` against the frontend's in-cluster service
-DNS name (e.g., `dynamo-bench-mocker-frontend:8000`). Once the Job completes,
-artifacts are copied back to the local host via `kubectl cp`.
+The sweep runner creates a short-lived Kubernetes Job in the same namespace as the DGD. The Job pod runs `aiperf` against the frontend's in-cluster service DNS name (e.g., `dynamo-bench-mocker-frontend:8000`). Once the Job completes, artifacts are copied back to the local host via `kubectl cp`.
 
 ### Reset strategy
 

--- a/benchmarks/frontend/dgd/templates/mocker.yaml
+++ b/benchmarks/frontend/dgd/templates/mocker.yaml
@@ -12,8 +12,9 @@
 #   ${MODEL_PATH}            - HF model ID
 #   ${MODEL_NAME}            - Served model name
 #   ${NUM_WORKERS}           - Mocker workers per pod
+#   ${FRONTEND_REPLICAS}     - Number of frontend pods (default: 1)
 #   ${WORKER_REPLICAS}       - Number of worker pods
-#   ${SPEEDUP_RATIO}         - Mocker speedup ratio (0 = infinite)
+#   ${SPEEDUP_RATIO}         - Mocker speedup ratio (use large value for near-instant)
 #
 # Usage:
 #   python3 sweep_runner.py --mode k8s --deploy-template dgd/templates/mocker.yaml \
@@ -28,7 +29,7 @@ spec:
   services:
     Frontend:
       componentType: frontend
-      replicas: 1
+      replicas: ${FRONTEND_REPLICAS}
       extraPodSpec:
 ${FRONTEND_IMAGE_PULL_SECRETS_BLOCK}
         mainContainer:

--- a/benchmarks/frontend/dgd/templates/mocker.yaml
+++ b/benchmarks/frontend/dgd/templates/mocker.yaml
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deploy template: Mocker backend (no GPUs required).
+#
+# Template variables (substituted by sweep_runner.py --deploy-template):
+#   ${DGD_NAME}              - DynamoGraphDeployment name
+#   ${IMAGE}                 - Container image
+#   ${DYN_TOKENIZER_BACKEND} - "default" (hf) or "fast"
+#   ${FRONTEND_PORT}         - Frontend HTTP port
+#   ${ROUTER_MODE}           - Frontend router mode
+#   ${MODEL_PATH}            - HF model ID
+#   ${MODEL_NAME}            - Served model name
+#   ${NUM_WORKERS}           - Mocker workers per pod
+#   ${WORKER_REPLICAS}       - Number of worker pods
+#   ${SPEEDUP_RATIO}         - Mocker speedup ratio (0 = infinite)
+#
+# Usage:
+#   python3 sweep_runner.py --mode k8s --deploy-template dgd/templates/mocker.yaml \
+#       --dgd-name dynamo-bench-mocker --image nvcr.io/.../image:tag \
+#       --tokenizers hf,fastokens --concurrency 50,100 --isl 512
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DGD_NAME}
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 -m dynamo.frontend --router-mode ${ROUTER_MODE} --http-port ${FRONTEND_PORT}
+          env:
+            - name: DYN_TOKENIZER_BACKEND
+              value: "${DYN_TOKENIZER_BACKEND}"
+            - name: DYN_PERF_DIAG
+              value: "1"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+
+    MockerWorker:
+      componentType: worker
+      replicas: ${WORKER_REPLICAS}
+      extraPodSpec:
+        mainContainer:
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              python3 -m dynamo.mocker \
+                --model-path "${MODEL_PATH}" \
+                --model-name "${MODEL_NAME}" \
+                --num-workers ${NUM_WORKERS} \
+                --speedup-ratio ${SPEEDUP_RATIO}
+          env:
+            - name: MODEL_PATH
+              value: "${MODEL_PATH}"
+            - name: MODEL_NAME
+              value: "${MODEL_NAME}"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN

--- a/benchmarks/frontend/dgd/templates/mocker.yaml
+++ b/benchmarks/frontend/dgd/templates/mocker.yaml
@@ -30,6 +30,7 @@ spec:
       componentType: frontend
       replicas: 1
       extraPodSpec:
+${FRONTEND_IMAGE_PULL_SECRETS_BLOCK}
         mainContainer:
           image: ${IMAGE}
           imagePullPolicy: IfNotPresent
@@ -46,13 +47,14 @@ spec:
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: hf-token-secret
+                  name: ${HF_TOKEN_SECRET_NAME}
                   key: HF_TOKEN
 
     MockerWorker:
       componentType: worker
       replicas: ${WORKER_REPLICAS}
       extraPodSpec:
+${WORKER_IMAGE_PULL_SECRETS_BLOCK}
         mainContainer:
           image: ${IMAGE}
           imagePullPolicy: IfNotPresent
@@ -74,5 +76,5 @@ spec:
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: hf-token-secret
+                  name: ${HF_TOKEN_SECRET_NAME}
                   key: HF_TOKEN

--- a/benchmarks/frontend/dgd/templates/vllm-gpt-oss-20b.yaml
+++ b/benchmarks/frontend/dgd/templates/vllm-gpt-oss-20b.yaml
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deploy template: vLLM backend for openai/gpt-oss-20b (TP=2, 2 GPUs per worker).
+#
+# Model: openai/gpt-oss-20b (20B params, BF16/FP8, 131K context)
+#   - Architecture: gpt_oss, 24 layers, 64 attn heads, 8 KV heads
+#   - TP options: 1, 2, 4, 8 (all divide heads/kv_heads evenly)
+#   - Weight size: ~13 GB (safetensors, excluding metal/ and original/)
+#   - Recommended: TP=2 on H100 for good prefill throughput
+#
+# Template variables (substituted by sweep_runner.py --deploy-template):
+#   ${DGD_NAME}              - DynamoGraphDeployment name
+#   ${IMAGE}                 - Container image
+#   ${DYN_TOKENIZER_BACKEND} - "default" (hf) or "fast"
+#   ${FRONTEND_PORT}         - Frontend HTTP port (default: 8000)
+#   ${ROUTER_MODE}           - Frontend router mode (default: round-robin)
+#   ${MODEL}                 - Model path (HF ID or local path on PVC)
+#   ${MODEL_NAME}            - Served model name (used by aiperf --model)
+#   ${FRONTEND_REPLICAS}     - Number of frontend pods (default: 1)
+#   ${WORKER_REPLICAS}       - Number of vLLM worker pods
+#
+# Prerequisites:
+#   - Model downloaded to model-cache PVC (excluding metal/ and original/):
+#       huggingface-cli download openai/gpt-oss-20b \
+#           --exclude "metal/*" --exclude "original/*" \
+#           --local-dir /model-store/hub/models--openai--gpt-oss-20b/snapshots/main
+#   - hf-token-secret in the target namespace
+#   - model-cache PVC (>= 100Gi) in the target namespace
+#   - GPU nodes with nvidia.com/gpu toleration
+#
+# Usage:
+#   python3 sweep_runner.py --mode k8s \
+#       --deploy-template dgd/templates/vllm-gpt-oss-20b.yaml \
+#       --dgd-name dynamo-bench-vllm \
+#       --model /model-store/hub/models--openai--gpt-oss-20b/snapshots/main \
+#       --image nvcr.io/.../vllm-runtime:tag \
+#       --tokenizers hf,fastokens --concurrency 20 --isl 8192
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DGD_NAME}
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: ${FRONTEND_REPLICAS}
+      extraPodSpec:
+${FRONTEND_IMAGE_PULL_SECRETS_BLOCK}
+        mainContainer:
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 -m dynamo.frontend --router-mode ${ROUTER_MODE} --http-port ${FRONTEND_PORT}
+          env:
+            - name: DYN_TOKENIZER_BACKEND
+              value: "${DYN_TOKENIZER_BACKEND}"
+            - name: DYN_PERF_DIAG
+              value: "1"
+            - name: HF_HOME
+              value: /model-store
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: ${HF_TOKEN_SECRET_NAME}
+                  key: HF_TOKEN
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-store
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache
+
+    VllmWorker:
+      componentType: worker
+      replicas: ${WORKER_REPLICAS}
+      extraPodSpec:
+${WORKER_IMAGE_PULL_SECRETS_BLOCK}
+        tolerations:
+          - effect: NoSchedule
+            key: nvidia.com/gpu
+            operator: Exists
+        mainContainer:
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - >-
+              python3 -m dynamo.vllm
+              --model ${MODEL}
+              --served-model-name ${MODEL_NAME}
+              --tensor-parallel-size 2
+              --max-model-len 65536
+              --max-num-batched-tokens 32768
+              --gpu-memory-utilization 0.90
+          env:
+            - name: HF_HOME
+              value: /model-store
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: ${HF_TOKEN_SECRET_NAME}
+                  key: HF_TOKEN
+          resources:
+            limits:
+              nvidia.com/gpu: "2"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-store
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache

--- a/benchmarks/frontend/dgd/templates/vllm.yaml
+++ b/benchmarks/frontend/dgd/templates/vllm.yaml
@@ -11,6 +11,7 @@
 #   ${ROUTER_MODE}           - Frontend router mode
 #   ${MODEL}                 - HF model ID
 #   ${MODEL_NAME}            - Served model name
+#   ${FRONTEND_REPLICAS}     - Number of frontend pods (default: 1)
 #   ${WORKER_REPLICAS}       - Number of vLLM worker pods
 #
 # Usage:
@@ -27,7 +28,7 @@ spec:
   services:
     Frontend:
       componentType: frontend
-      replicas: 1
+      replicas: ${FRONTEND_REPLICAS}
       extraPodSpec:
 ${FRONTEND_IMAGE_PULL_SECRETS_BLOCK}
         mainContainer:

--- a/benchmarks/frontend/dgd/templates/vllm.yaml
+++ b/benchmarks/frontend/dgd/templates/vllm.yaml
@@ -29,6 +29,7 @@ spec:
       componentType: frontend
       replicas: 1
       extraPodSpec:
+${FRONTEND_IMAGE_PULL_SECRETS_BLOCK}
         mainContainer:
           image: ${IMAGE}
           imagePullPolicy: IfNotPresent
@@ -45,13 +46,14 @@ spec:
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: hf-token-secret
+                  name: ${HF_TOKEN_SECRET_NAME}
                   key: HF_TOKEN
 
     VllmWorker:
       componentType: worker
       replicas: ${WORKER_REPLICAS}
       extraPodSpec:
+${WORKER_IMAGE_PULL_SECRETS_BLOCK}
         mainContainer:
           image: ${IMAGE}
           imagePullPolicy: IfNotPresent
@@ -64,7 +66,7 @@ spec:
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: hf-token-secret
+                  name: ${HF_TOKEN_SECRET_NAME}
                   key: HF_TOKEN
           resources:
             limits:

--- a/benchmarks/frontend/dgd/templates/vllm.yaml
+++ b/benchmarks/frontend/dgd/templates/vllm.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deploy template: vLLM backend (requires GPUs).
+#
+# Template variables (substituted by sweep_runner.py --deploy-template):
+#   ${DGD_NAME}              - DynamoGraphDeployment name
+#   ${IMAGE}                 - Container image
+#   ${DYN_TOKENIZER_BACKEND} - "default" (hf) or "fast"
+#   ${FRONTEND_PORT}         - Frontend HTTP port
+#   ${ROUTER_MODE}           - Frontend router mode
+#   ${MODEL}                 - HF model ID
+#   ${MODEL_NAME}            - Served model name
+#   ${WORKER_REPLICAS}       - Number of vLLM worker pods
+#
+# Usage:
+#   python3 sweep_runner.py --mode k8s --deploy-template dgd/templates/vllm.yaml \
+#       --dgd-name dynamo-bench-vllm --image nvcr.io/.../vllm-runtime:tag \
+#       --model meta-llama/Llama-3.1-8B-Instruct \
+#       --tokenizers hf --concurrency 128 --isl 1024
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DGD_NAME}
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 -m dynamo.frontend --router-mode ${ROUTER_MODE} --http-port ${FRONTEND_PORT}
+          env:
+            - name: DYN_TOKENIZER_BACKEND
+              value: "${DYN_TOKENIZER_BACKEND}"
+            - name: DYN_PERF_DIAG
+              value: "1"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+
+    VllmWorker:
+      componentType: worker
+      replicas: ${WORKER_REPLICAS}
+      extraPodSpec:
+        mainContainer:
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 -m dynamo.vllm --model ${MODEL} --tensor-parallel-size 1
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          resources:
+            limits:
+              nvidia.com/gpu: "1"

--- a/benchmarks/frontend/scripts/README.md
+++ b/benchmarks/frontend/scripts/README.md
@@ -11,11 +11,11 @@ source dynamo/bin/activate
 # Single run (mocker + frontend + aiperf + Prometheus)
 cd benchmarks/frontend/scripts
 ./run_perf.sh --model Qwen/Qwen3-0.6B --concurrency 32 --num-requests 640 \
-    --speedup-ratio 0 --skip-bpf --skip-nsys --skip-flamegraph --skip-perf
+    --speedup-ratio 1000000 --skip-bpf --skip-nsys --skip-flamegraph --skip-perf
 
 # Sweep (multiple config points)
 python3 sweep_runner.py --tokenizers hf --concurrency 32 --isl 512 \
-    --benchmark-duration 30 --speedup-ratio 0 \
+    --benchmark-duration 30 --speedup-ratio 1000000 \
     -- --skip-bpf --skip-nsys --skip-flamegraph --skip-perf
 ```
 
@@ -132,17 +132,17 @@ The main entry point for running performance sweeps. Iterates over a grid of con
 ```bash
 # Smoke test (1 run)
 python3 sweep_runner.py --tokenizers hf --concurrency 32 --isl 512 \
-    --benchmark-duration 30 --speedup-ratio 0 \
+    --benchmark-duration 30 --speedup-ratio 1000000 \
     -- --skip-bpf --skip-nsys --skip-flamegraph --skip-perf
 
 # Full tokenizer comparison
 python3 sweep_runner.py --tokenizers hf,fastokens \
     --concurrency 32,64 --isl 512,1024,2048 \
-    --benchmark-duration 60 --speedup-ratio 0
+    --benchmark-duration 60 --speedup-ratio 1000000
 
 # Transport saturation (vary workers and request count)
 python3 sweep_runner.py --tokenizers hf --concurrency 4096 \
-    --num-requests 16384,32768 --workers 1,2,4,8 --speedup-ratio 0
+    --num-requests 16384,32768 --workers 1,2,4,8 --speedup-ratio 1000000
 
 # Preview sweep plan without running
 python3 sweep_runner.py --dry-run --tokenizers hf,fastokens \
@@ -168,7 +168,7 @@ for m in 1 2 3 4; do
         --num-models $m \
         --rps 75 \
         --benchmark-duration 60 \
-        --speedup-ratio 0 \
+        --speedup-ratio 1000000 \
         --output-dir artifacts/sweep_models/m${m} \
         -- --skip-bpf
 done
@@ -195,7 +195,7 @@ python3 sweep_runner.py \
     --num-models 1 \
     --rps 75 \
     --benchmark-duration 60 \
-    --speedup-ratio 0 \
+    --speedup-ratio 1000000 \
     --output-dir artifacts/sweep_workers \
     -- --skip-bpf
 ```
@@ -214,7 +214,7 @@ python3 sweep_runner.py \
     --num-models 2 \
     --rps 50 \
     --benchmark-duration 60 \
-    --speedup-ratio 0 \
+    --speedup-ratio 1000000 \
     --output-dir artifacts/sweep_grid \
     -- --skip-bpf
 ```
@@ -237,15 +237,15 @@ python3 sweep_runner.py \
 ```bash
 # With perf stat + flamegraphs (no root needed)
 python3 sweep_runner.py --tokenizers hf --concurrency 64 --isl 1024 \
-    --benchmark-duration 60 --speedup-ratio 0
+    --benchmark-duration 60 --speedup-ratio 1000000
 
 # With everything including BPF (needs sudo)
 sudo -E python3 sweep_runner.py --tokenizers hf --concurrency 64 --isl 1024 \
-    --benchmark-duration 60 --speedup-ratio 0
+    --benchmark-duration 60 --speedup-ratio 1000000
 
 # nsys profiling (needs nsys in PATH)
 python3 sweep_runner.py --tokenizers hf --concurrency 64 --isl 1024 \
-    --benchmark-duration 60 --speedup-ratio 0 \
+    --benchmark-duration 60 --speedup-ratio 1000000 \
     -- --nsys-path /opt/nvidia/nsight-systems/bin/nsys
 ```
 
@@ -272,7 +272,7 @@ Profiler controls are passed through to run_perf.sh after `--`:
 | `--num-models` | `1` | Number of model instances (each gets `--workers` workers) |
 | `--rps` | - | Comma-separated target request rates (req/s) |
 | `--aiperf-targets` | `first` | `first`: model-1 only. `all`: run aiperf for each model |
-| `--speedup-ratio` | `1.0` | Mocker speedup (0 = infinite) |
+| `--speedup-ratio` | `1.0` | Mocker speedup divisor; use large values (e.g., 1000000) for near-instant mocker |
 | `--benchmark-duration` | `60` | aiperf run duration (seconds) |
 | `--num-requests` | - | Comma-separated request counts (overrides duration) |
 | `--output-dir` | auto | Output directory |
@@ -288,21 +288,21 @@ Low-level per-run harness. Normally called by sweep_runner.py, but can be used d
 ```bash
 # Minimal (no profilers)
 ./run_perf.sh --model Qwen/Qwen3-0.6B --concurrency 32 --num-requests 640 \
-    --speedup-ratio 0 --skip-bpf --skip-nsys --skip-flamegraph --skip-perf
+    --speedup-ratio 1000000 --skip-bpf --skip-nsys --skip-flamegraph --skip-perf
 
 # Full observability (needs sudo for BPF)
 sudo -E ./run_perf.sh --model Qwen/Qwen3-0.6B --concurrency 64 \
-    --benchmark-duration 60 --speedup-ratio 0
+    --benchmark-duration 60 --speedup-ratio 1000000
 
 # Multi-model with 2 workers each
 ./run_perf.sh --model Qwen/Qwen3-0.6B --num-models 2 --workers 2 \
-    --concurrency 32 --benchmark-duration 30 --speedup-ratio 0 \
+    --concurrency 32 --benchmark-duration 30 --speedup-ratio 1000000 \
     --skip-bpf --skip-nsys --skip-flamegraph --skip-perf
 
 # 4 models, 1 worker each, rate-limited to 75 rps
 ./run_perf.sh --model Qwen/Qwen3-0.6B --num-models 4 --workers 1 \
     --concurrency 512 --benchmark-duration 60 --request-rate 75 \
-    --speedup-ratio 0 --skip-bpf
+    --speedup-ratio 1000000 --skip-bpf
 ```
 
 ## Analyzing Results

--- a/benchmarks/frontend/scripts/run_perf.sh
+++ b/benchmarks/frontend/scripts/run_perf.sh
@@ -121,7 +121,7 @@ Service Options:
   --model PATH              Model path (default: nvidia/Llama-3.1-8B-Instruct-FP8)
   --model-name NAME         Served model name (default: same as --model)
   --workers N               Number of mocker workers (default: 2)
-  --speedup-ratio RATIO     Mocker speedup ratio (default: 1.0; 0 = infinite)
+  --speedup-ratio RATIO     Mocker speedup ratio (default: 1.0; use large value for near-instant)
   --data-parallel-size N    Mocker DP workers (default: 1)
   --request-plane PLANE     nats|http|tcp (default: tcp)
   --event-plane PLANE       nats|zmq (default: nats)

--- a/benchmarks/frontend/scripts/scaling-test.md
+++ b/benchmarks/frontend/scripts/scaling-test.md
@@ -1,0 +1,351 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Frontend Scaling Test: Finding the Saturation Point
+
+This guide walks through using the sweep runner to find the saturation point of
+a Dynamo frontend serving a real vLLM backend.  The saturation point is the
+request rate at which latency begins to degrade -- prefill requests start
+queuing instead of being served immediately, TTFT p99 spikes, and throughput
+plateaus.
+
+---
+
+## Overview
+
+The test sweeps increasing request rates (`--rps`) at a fixed input sequence
+length while keeping the backend warm (`--reset-strategy frontend`).  Each data
+point is a 60-second aiperf run at a controlled RPS.  The sweep stops
+automatically after consecutive failures (`--max-consecutive-fails`).
+
+**What you get:**
+
+- Per-RPS throughput (actual req/s vs target), TTFT p50/p99, ITL p50/p99
+- Prometheus pre/post metrics for pipeline stage breakdown
+- CSV + summary for easy comparison
+
+---
+
+## Prerequisites
+
+1. **K8s namespace** with:
+   - `hf-token-secret` (HuggingFace token)
+   - `nvcrimagepullsecret` (image pull credentials)
+   - `model-cache` PVC (RWX, large enough for model weights)
+   - Model weights downloaded to PVC (see "Model Download" below)
+
+2. **DGD deployed** with the target model and backend.
+
+3. **sweep_runner.py** accessible from a machine with `kubectl` access to the
+   cluster.
+
+---
+
+## Model Download (gpt-oss-20b example)
+
+Download the model to the PVC, excluding large non-inference directories:
+
+```bash
+# Create a download Job (adjust image and namespace)
+kubectl apply -n <namespace> -f - <<'EOF'
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download-gpt-oss-20b
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: Never
+      imagePullSecrets:
+        - name: nvcrimagepullsecret
+      containers:
+        - name: download
+          image: nvcr.io/nvidian/dynamo-dev/biswa:vllm-runtime-1a8bce12ea
+          command: ["python3", "-c"]
+          args:
+            - |
+              import os, subprocess, sys, pathlib
+              model = "openai/gpt-oss-20b"
+              os.environ["HF_HOME"] = "/model-store"
+              cmd = ["huggingface-cli", "download", model,
+                     "--exclude", "metal/*", "--exclude", "original/*",
+                     "--local-dir", "/model-store/hub/models--openai--gpt-oss-20b/snapshots/main"]
+              sys.exit(subprocess.run(cmd).returncode)
+          env:
+            - name: HF_HOME
+              value: /model-store
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-store
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+EOF
+
+# Monitor
+kubectl logs -n <namespace> -l job-name=model-download-gpt-oss-20b -f
+```
+
+---
+
+## Deploy the DGD
+
+Use the provided template for gpt-oss-20b with TP=2:
+
+```bash
+# Template path (relative to repo root)
+# benchmarks/frontend/dgd/templates/vllm-gpt-oss-20b.yaml
+#
+# Key settings in the template:
+#   - tensor-parallel-size 2 (2 GPUs per worker)
+#   - max-model-len 65536
+#   - gpu-memory-utilization 0.90
+#   - GPU toleration for scheduling
+
+# Deploy directly (adjust values as needed):
+kubectl apply -n <namespace> -f - <<'EOF'
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: gpt-oss-20b-bench
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        imagePullSecrets:
+          - name: nvcrimagepullsecret
+        mainContainer:
+          image: <your-image>
+          command: ["/bin/sh", "-c"]
+          args: ["python3 -m dynamo.frontend --router-mode round-robin --http-port 8000"]
+          env:
+            - name: DYN_TOKENIZER_BACKEND
+              value: "default"
+            - name: DYN_PERF_DIAG
+              value: "1"
+            - name: HF_HOME
+              value: /model-store
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-store
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache
+
+    VllmWorker:
+      componentType: worker
+      replicas: 4                    # <-- number of backend replicas
+      extraPodSpec:
+        imagePullSecrets:
+          - name: nvcrimagepullsecret
+        tolerations:
+          - effect: NoSchedule
+            key: nvidia.com/gpu
+            operator: Exists
+        mainContainer:
+          image: <your-image>
+          command: ["/bin/sh", "-c"]
+          args:
+            - >-
+              python3 -m dynamo.vllm
+              --model /model-store/hub/models--openai--gpt-oss-20b/snapshots/main
+              --served-model-name openai/gpt-oss-20b
+              --tensor-parallel-size 2
+              --max-model-len 65536
+              --gpu-memory-utilization 0.90
+          env:
+            - name: HF_HOME
+              value: /model-store
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          resources:
+            limits:
+              nvidia.com/gpu: "2"    # <-- 2 GPUs for TP=2
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-store
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache
+EOF
+
+# Wait for all pods to be ready
+kubectl get pods -n <namespace> -w
+```
+
+---
+
+## Run the Saturation Sweep
+
+### Baseline: HF tokenizer, RPS sweep
+
+```bash
+cd benchmarks/frontend/scripts
+
+python3 sweep_runner.py --mode k8s \
+    --dgd-name gpt-oss-20b-bench \
+    --namespace <namespace> \
+    --endpoint gpt-oss-20b-bench-frontend:8000 \
+    --model openai/gpt-oss-20b \
+    --backend vllm \
+    --image <your-image> \
+    --tokenizers hf \
+    --concurrency 200 \
+    --rps 10,20,30,40,50,60,70,80,90,100 \
+    --isl 6144 \
+    --osl 256 \
+    --benchmark-duration 60 \
+    --reset-strategy frontend \
+    --isolation reuse_by_deploy_key \
+    --worker-replicas 4 \
+    --max-consecutive-fails 2
+```
+
+**Flag explanations:**
+
+| Flag | Value | Purpose |
+|------|-------|---------|
+| `--rps 10,20,...,100` | Sweep dimension | Each run targets a fixed request rate. aiperf uses `--request-rate` to cap submission. |
+| `--concurrency 200` | High ceiling | Maximum in-flight requests. Set high so aiperf can sustain the target RPS without being limited by available connection slots. This is NOT a sweep dimension. |
+| `--isl 6144` | Fixed ISL | Holds input length constant to isolate throughput scaling. |
+| `--osl 256` | Fixed OSL | Consistent output length across all runs. |
+| `--benchmark-duration 60` | 60s per point | Long enough for vLLM scheduling to stabilize. |
+| `--reset-strategy frontend` | Frontend-only | Resets Prometheus counters between runs, but keeps vLLM workers alive with warm KV caches and CUDA graphs. Avoids the ~90s full DGD restart per point. |
+| `--isolation reuse_by_deploy_key` | Reuse deployment | Since tokenizer=hf is constant, no DGD restart between runs. Only a frontend pod restart for clean metrics. |
+| `--max-consecutive-fails 2` | Auto-stop | After 2 consecutive failures at a given RPS, remaining higher RPS values are skipped. |
+
+### Follow-up: FastTokens comparison
+
+Once you have the baseline, run the same sweep with fastokens to see if the
+saturation point shifts:
+
+```bash
+python3 sweep_runner.py --mode k8s \
+    --dgd-name gpt-oss-20b-bench \
+    --namespace <namespace> \
+    --endpoint gpt-oss-20b-bench-frontend:8000 \
+    --model openai/gpt-oss-20b \
+    --backend vllm \
+    --image <your-image> \
+    --tokenizers fastokens \
+    --concurrency 200 \
+    --rps 10,20,30,40,50,60,70,80,90,100 \
+    --isl 6144 \
+    --osl 256 \
+    --benchmark-duration 60 \
+    --reset-strategy frontend \
+    --isolation reuse_by_deploy_key \
+    --worker-replicas 4 \
+    --max-consecutive-fails 2
+```
+
+### Fine-grained sweep around the inflection
+
+If the baseline shows saturation between, say, RPS=40 and RPS=60:
+
+```bash
+python3 sweep_runner.py --mode k8s \
+    ... \
+    --rps 35,40,45,50,55,60 \
+    --reset-strategy frontend \
+    --isolation reuse_by_deploy_key
+```
+
+---
+
+## Reading the Results
+
+The sweep produces `results.csv` and `summary.md` in the output directory.
+
+### Identifying the saturation point
+
+Look for these signals in the CSV:
+
+| RPS | Actual Req/s | TTFT p50 | TTFT p99 | ITL p99 | Status |
+|----:|-----------:|--------:|--------:|-------:|--------|
+| 10 | 10.0 | 800ms | 1200ms | 30ms | ok |
+| 20 | 19.8 | 850ms | 1400ms | 32ms | ok |
+| 30 | 29.5 | 900ms | 2000ms | 35ms | ok |
+| 40 | 38.0 | 1200ms | 5000ms | 45ms | ok -- onset |
+| 50 | 42.0 | 3000ms | 15000ms | 80ms | ok -- saturated |
+| 60 | 41.5 | 8000ms | 30000ms | 120ms | ok -- overloaded |
+| 70 | -- | -- | -- | -- | fail |
+
+**Saturation indicators:**
+
+1. **Actual req/s < target RPS**: The system cannot sustain the requested rate.
+   At RPS=50, only 42 req/s are achieved.
+2. **TTFT p99 spike**: A sharp increase (e.g., 2x-5x) means prefill requests
+   are queuing behind each other.
+3. **ITL p99 degradation**: Decode throughput drops because the vLLM scheduler
+   is overloaded with concurrent prefills.
+4. **Errors/failures**: Timeouts, OOM, or vLLM rejecting requests.
+
+The **saturation point** in the example above is **RPS ~40** -- the last rate
+where actual throughput tracks the target and TTFT p99 is still reasonable.
+
+### Prometheus metrics
+
+Each run captures `frontend_metrics_pre.txt` and `frontend_metrics_post.txt`.
+Key metrics for saturation analysis:
+
+- `dynamo_frontend_stage_duration_seconds{stage="preprocess"}` -- tokenization time
+- `dynamo_frontend_stage_duration_seconds{stage="transport_roundtrip"}` -- backend latency
+- `dynamo_frontend_queued_requests` -- requests waiting in HTTP queue (should be 0 below saturation)
+- `dynamo_frontend_inflight_requests` -- concurrent in-flight requests
+- `dynamo_frontend_time_to_first_token_seconds` -- TTFT histogram buckets
+
+---
+
+## DGD Template Reference
+
+The `dgd/templates/vllm-gpt-oss-20b.yaml` template is pre-configured for
+gpt-oss-20b with TP=2.  To use it with `--deploy-template`:
+
+```bash
+python3 sweep_runner.py --mode k8s \
+    --deploy-template benchmarks/frontend/dgd/templates/vllm-gpt-oss-20b.yaml \
+    --dgd-name gpt-oss-20b-bench \
+    --model /model-store/hub/models--openai--gpt-oss-20b/snapshots/main \
+    --image <your-image> \
+    --worker-replicas 4 \
+    ...
+```
+
+The template substitutes these variables at deploy time:
+`${DGD_NAME}`, `${IMAGE}`, `${MODEL}`, `${MODEL_NAME}`,
+`${WORKER_REPLICAS}`, `${DYN_TOKENIZER_BACKEND}`, `${FRONTEND_PORT}`,
+`${ROUTER_MODE}`.
+
+---
+
+## Tuning Parameters
+
+| Parameter | Recommended Range | Notes |
+|-----------|-------------------|-------|
+| `--benchmark-duration` | 60-120s | Longer = more stable averages but slower sweep |
+| `--concurrency` | 2-4x max target RPS | Must be high enough that aiperf can reach the target rate |
+| `--rps` | Start at 10, double until failures | Geometric progression finds the order of magnitude fast |
+| `--worker-replicas` | 1-8 | More replicas = higher saturation point but more GPUs |
+| `--reset-strategy` | `frontend` for saturation tests | `graph` for clean-baseline TTFT measurements |
+| `--isolation` | `reuse_by_deploy_key` for same-tokenizer sweeps | Avoids unnecessary DGD restarts |
+| `--max-consecutive-fails` | 2-3 | Higher = more data points at the failure boundary |

--- a/benchmarks/frontend/scripts/sweep_core/__init__.py
+++ b/benchmarks/frontend/scripts/sweep_core/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""sweep_core -- pure-logic library for frontend performance sweeps."""
+
+from sweep_core.models import (
+    AiperfDimension,
+    DeployDimension,
+    DeployKey,
+    IsolationPolicy,
+    RunResult,
+    RunSpec,
+    SweepConfig,
+    SweepPlan,
+)
+
+__all__ = [
+    "AiperfDimension",
+    "DeployDimension",
+    "DeployKey",
+    "IsolationPolicy",
+    "RunResult",
+    "RunSpec",
+    "SweepConfig",
+    "SweepPlan",
+]

--- a/benchmarks/frontend/scripts/sweep_core/artifacts.py
+++ b/benchmarks/frontend/scripts/sweep_core/artifacts.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Artifact writers for sweep results.
+
+Produces CSV, markdown summary, and sweep_config.json -- the contract
+consumed by downstream analysis tools (analyze_sweep.py, sweep_data.py).
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import time
+from pathlib import Path
+from typing import List
+
+from sweep_core.models import RunResult, SweepConfig
+
+
+def write_csv(results: List[RunResult], csv_path: Path) -> None:
+    """Write incremental CSV results file (called after each run)."""
+    fieldnames = [
+        "run_id",
+        "backend",
+        "tokenizer",
+        "concurrency",
+        "isl",
+        "osl",
+        "workers",
+        "speedup_ratio",
+        "status",
+        "req_per_sec",
+        "output_tok_per_sec",
+        "ttft_p50_ms",
+        "ttft_p99_ms",
+        "itl_p50_ms",
+        "itl_p99_ms",
+        "duration_sec",
+        "run_dir",
+    ]
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for r in results:
+            spec = r.run_spec
+            row = {
+                "run_id": spec.run_id,
+                "backend": spec.deploy.backend,
+                "tokenizer": spec.deploy.tokenizer,
+                "concurrency": spec.aiperf.concurrency,
+                "isl": spec.aiperf.isl,
+                "osl": spec.aiperf.osl,
+                "workers": spec.deploy.workers,
+                "speedup_ratio": 0,  # filled by config
+                "status": r.status,
+                "req_per_sec": f"{r.req_per_sec:.2f}" if r.req_per_sec else "",
+                "output_tok_per_sec": f"{r.output_tok_per_sec:.1f}" if r.output_tok_per_sec else "",
+                "ttft_p50_ms": f"{r.ttft_p50_ms:.1f}" if r.ttft_p50_ms else "",
+                "ttft_p99_ms": f"{r.ttft_p99_ms:.1f}" if r.ttft_p99_ms else "",
+                "itl_p50_ms": f"{r.itl_p50_ms:.1f}" if r.itl_p50_ms else "",
+                "itl_p99_ms": f"{r.itl_p99_ms:.1f}" if r.itl_p99_ms else "",
+                "duration_sec": f"{r.duration_sec:.1f}" if r.duration_sec else "",
+                "run_dir": r.run_dir,
+            }
+            writer.writerow(row)
+
+
+def write_summary(results: List[RunResult], summary_path: Path) -> None:
+    """Write markdown summary table."""
+    lines = ["# Sweep Summary\n"]
+    lines.append(f"**Generated:** {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+    lines.append(
+        "| Run ID | Req/s | Tok/s | TTFT p50 | TTFT p99 | ITL p50 | Duration | Status |"
+    )
+    lines.append(
+        "|--------|------:|------:|---------:|---------:|--------:|---------:|--------|"
+    )
+
+    for r in results:
+        rps = f"{r.req_per_sec:.1f}" if r.req_per_sec else "-"
+        tps = f"{r.output_tok_per_sec:.0f}" if r.output_tok_per_sec else "-"
+        tp50 = f"{r.ttft_p50_ms:.1f}ms" if r.ttft_p50_ms else "-"
+        tp99 = f"{r.ttft_p99_ms:.1f}ms" if r.ttft_p99_ms else "-"
+        ip50 = f"{r.itl_p50_ms:.1f}ms" if r.itl_p50_ms else "-"
+        dur = f"{r.duration_sec:.0f}s" if r.duration_sec else "-"
+        lines.append(
+            f"| {r.run_spec.run_id} | {rps} | {tps} | {tp50} | {tp99} | {ip50} | {dur} | {r.status} |"
+        )
+
+    lines.append("")
+    ok = sum(1 for r in results if r.status == "ok")
+    fail = sum(1 for r in results if r.status == "fail")
+    skip = sum(1 for r in results if r.status == "skipped")
+    lines.append(f"**Totals:** {ok} passed, {fail} failed, {skip} skipped out of {len(results)}")
+
+    summary_path.write_text("\n".join(lines) + "\n")
+
+
+def write_sweep_config(config: SweepConfig, output_dir: Path) -> None:
+    """Write sweep_config.json for downstream consumers."""
+    config_path = output_dir / "sweep_config.json"
+    config_data = {
+        "timestamp": time.strftime("%Y%m%d_%H%M%S"),
+        "mode": config.mode,
+        "model": config.model,
+        "model_name": config.model_name,
+        "backends": ",".join(config.tokenizers),
+        "isl_list": ",".join(str(i) for i in config.isls),
+        "concurrency_list": ",".join(str(c) for c in config.concurrencies),
+        "benchmark_duration": config.benchmark_duration or "N/A",
+        "osl": config.osl,
+        "output_dir": config.output_dir,
+        "total_runs": len(config.tokenizers) * len(config.concurrencies) * len(config.isls),
+        "isolation_policy": config.isolation_policy,
+    }
+    config_path.write_text(json.dumps(config_data, indent=2) + "\n")
+
+
+def print_results_table(results: List[RunResult]) -> None:
+    """Print a compact results table to stdout."""
+    print(f"\n{'=' * 90}")
+    print(
+        f"  {'Run ID':<30} {'Req/s':>8} {'Tok/s':>8} {'TTFT p50':>10} {'TTFT p99':>10} {'Status':>8}"
+    )
+    print(f"  {'-' * 30} {'-' * 8} {'-' * 8} {'-' * 10} {'-' * 10} {'-' * 8}")
+    for r in results:
+        rps = f"{r.req_per_sec:.1f}" if r.req_per_sec else "N/A"
+        tps = f"{r.output_tok_per_sec:.0f}" if r.output_tok_per_sec else "N/A"
+        tp50 = f"{r.ttft_p50_ms:.1f}ms" if r.ttft_p50_ms else "N/A"
+        tp99 = f"{r.ttft_p99_ms:.1f}ms" if r.ttft_p99_ms else "N/A"
+        print(
+            f"  {r.run_spec.run_id:<30} {rps:>8} {tps:>8} {tp50:>10} {tp99:>10} {r.status:>8}"
+        )
+    print(f"{'=' * 90}")

--- a/benchmarks/frontend/scripts/sweep_core/artifacts.py
+++ b/benchmarks/frontend/scripts/sweep_core/artifacts.py
@@ -55,7 +55,9 @@ def write_csv(results: List[RunResult], csv_path: Path) -> None:
                 "speedup_ratio": 0,  # filled by config
                 "status": r.status,
                 "req_per_sec": f"{r.req_per_sec:.2f}" if r.req_per_sec else "",
-                "output_tok_per_sec": f"{r.output_tok_per_sec:.1f}" if r.output_tok_per_sec else "",
+                "output_tok_per_sec": f"{r.output_tok_per_sec:.1f}"
+                if r.output_tok_per_sec
+                else "",
                 "ttft_p50_ms": f"{r.ttft_p50_ms:.1f}" if r.ttft_p50_ms else "",
                 "ttft_p99_ms": f"{r.ttft_p99_ms:.1f}" if r.ttft_p99_ms else "",
                 "itl_p50_ms": f"{r.itl_p50_ms:.1f}" if r.itl_p50_ms else "",
@@ -92,7 +94,9 @@ def write_summary(results: List[RunResult], summary_path: Path) -> None:
     ok = sum(1 for r in results if r.status == "ok")
     fail = sum(1 for r in results if r.status == "fail")
     skip = sum(1 for r in results if r.status == "skipped")
-    lines.append(f"**Totals:** {ok} passed, {fail} failed, {skip} skipped out of {len(results)}")
+    lines.append(
+        f"**Totals:** {ok} passed, {fail} failed, {skip} skipped out of {len(results)}"
+    )
 
     summary_path.write_text("\n".join(lines) + "\n")
 
@@ -111,7 +115,9 @@ def write_sweep_config(config: SweepConfig, output_dir: Path) -> None:
         "benchmark_duration": config.benchmark_duration or "N/A",
         "osl": config.osl,
         "output_dir": config.output_dir,
-        "total_runs": len(config.tokenizers) * len(config.concurrencies) * len(config.isls),
+        "total_runs": len(config.tokenizers)
+        * len(config.concurrencies)
+        * len(config.isls),
         "isolation_policy": config.isolation_policy,
     }
     config_path.write_text(json.dumps(config_data, indent=2) + "\n")

--- a/benchmarks/frontend/scripts/sweep_core/artifacts.py
+++ b/benchmarks/frontend/scripts/sweep_core/artifacts.py
@@ -54,15 +54,23 @@ def write_csv(results: List[RunResult], csv_path: Path) -> None:
                 "workers": spec.deploy.workers,
                 "speedup_ratio": 0,  # filled by config
                 "status": r.status,
-                "req_per_sec": f"{r.req_per_sec:.2f}" if r.req_per_sec else "",
-                "output_tok_per_sec": f"{r.output_tok_per_sec:.1f}"
-                if r.output_tok_per_sec
+                "req_per_sec": f"{r.req_per_sec:.2f}"
+                if r.req_per_sec is not None
                 else "",
-                "ttft_p50_ms": f"{r.ttft_p50_ms:.1f}" if r.ttft_p50_ms else "",
-                "ttft_p99_ms": f"{r.ttft_p99_ms:.1f}" if r.ttft_p99_ms else "",
-                "itl_p50_ms": f"{r.itl_p50_ms:.1f}" if r.itl_p50_ms else "",
-                "itl_p99_ms": f"{r.itl_p99_ms:.1f}" if r.itl_p99_ms else "",
-                "duration_sec": f"{r.duration_sec:.1f}" if r.duration_sec else "",
+                "output_tok_per_sec": f"{r.output_tok_per_sec:.1f}"
+                if r.output_tok_per_sec is not None
+                else "",
+                "ttft_p50_ms": f"{r.ttft_p50_ms:.1f}"
+                if r.ttft_p50_ms is not None
+                else "",
+                "ttft_p99_ms": f"{r.ttft_p99_ms:.1f}"
+                if r.ttft_p99_ms is not None
+                else "",
+                "itl_p50_ms": f"{r.itl_p50_ms:.1f}" if r.itl_p50_ms is not None else "",
+                "itl_p99_ms": f"{r.itl_p99_ms:.1f}" if r.itl_p99_ms is not None else "",
+                "duration_sec": f"{r.duration_sec:.1f}"
+                if r.duration_sec is not None
+                else "",
                 "run_dir": r.run_dir,
             }
             writer.writerow(row)
@@ -80,12 +88,12 @@ def write_summary(results: List[RunResult], summary_path: Path) -> None:
     )
 
     for r in results:
-        rps = f"{r.req_per_sec:.1f}" if r.req_per_sec else "-"
-        tps = f"{r.output_tok_per_sec:.0f}" if r.output_tok_per_sec else "-"
-        tp50 = f"{r.ttft_p50_ms:.1f}ms" if r.ttft_p50_ms else "-"
-        tp99 = f"{r.ttft_p99_ms:.1f}ms" if r.ttft_p99_ms else "-"
-        ip50 = f"{r.itl_p50_ms:.1f}ms" if r.itl_p50_ms else "-"
-        dur = f"{r.duration_sec:.0f}s" if r.duration_sec else "-"
+        rps = f"{r.req_per_sec:.1f}" if r.req_per_sec is not None else "-"
+        tps = f"{r.output_tok_per_sec:.0f}" if r.output_tok_per_sec is not None else "-"
+        tp50 = f"{r.ttft_p50_ms:.1f}ms" if r.ttft_p50_ms is not None else "-"
+        tp99 = f"{r.ttft_p99_ms:.1f}ms" if r.ttft_p99_ms is not None else "-"
+        ip50 = f"{r.itl_p50_ms:.1f}ms" if r.itl_p50_ms is not None else "-"
+        dur = f"{r.duration_sec:.0f}s" if r.duration_sec is not None else "-"
         lines.append(
             f"| {r.run_spec.run_id} | {rps} | {tps} | {tp50} | {tp99} | {ip50} | {dur} | {r.status} |"
         )
@@ -101,7 +109,9 @@ def write_summary(results: List[RunResult], summary_path: Path) -> None:
     summary_path.write_text("\n".join(lines) + "\n")
 
 
-def write_sweep_config(config: SweepConfig, output_dir: Path) -> None:
+def write_sweep_config(
+    config: SweepConfig, output_dir: Path, total_runs: int = 0
+) -> None:
     """Write sweep_config.json for downstream consumers."""
     config_path = output_dir / "sweep_config.json"
     config_data = {
@@ -115,9 +125,7 @@ def write_sweep_config(config: SweepConfig, output_dir: Path) -> None:
         "benchmark_duration": config.benchmark_duration or "N/A",
         "osl": config.osl,
         "output_dir": config.output_dir,
-        "total_runs": len(config.tokenizers)
-        * len(config.concurrencies)
-        * len(config.isls),
+        "total_runs": total_runs,
         "isolation_policy": config.isolation_policy,
     }
     config_path.write_text(json.dumps(config_data, indent=2) + "\n")
@@ -131,10 +139,12 @@ def print_results_table(results: List[RunResult]) -> None:
     )
     print(f"  {'-' * 30} {'-' * 8} {'-' * 8} {'-' * 10} {'-' * 10} {'-' * 8}")
     for r in results:
-        rps = f"{r.req_per_sec:.1f}" if r.req_per_sec else "N/A"
-        tps = f"{r.output_tok_per_sec:.0f}" if r.output_tok_per_sec else "N/A"
-        tp50 = f"{r.ttft_p50_ms:.1f}ms" if r.ttft_p50_ms else "N/A"
-        tp99 = f"{r.ttft_p99_ms:.1f}ms" if r.ttft_p99_ms else "N/A"
+        rps = f"{r.req_per_sec:.1f}" if r.req_per_sec is not None else "N/A"
+        tps = (
+            f"{r.output_tok_per_sec:.0f}" if r.output_tok_per_sec is not None else "N/A"
+        )
+        tp50 = f"{r.ttft_p50_ms:.1f}ms" if r.ttft_p50_ms is not None else "N/A"
+        tp99 = f"{r.ttft_p99_ms:.1f}ms" if r.ttft_p99_ms is not None else "N/A"
         print(
             f"  {r.run_spec.run_id:<30} {rps:>8} {tps:>8} {tp50:>10} {tp99:>10} {r.status:>8}"
         )

--- a/benchmarks/frontend/scripts/sweep_core/artifacts.py
+++ b/benchmarks/frontend/scripts/sweep_core/artifacts.py
@@ -18,7 +18,7 @@ from typing import List
 from sweep_core.models import RunResult, SweepConfig
 
 
-def write_csv(results: List[RunResult], csv_path: Path) -> None:
+def write_csv(results: List[RunResult], csv_path: Path, config: SweepConfig) -> None:
     """Write incremental CSV results file (called after each run)."""
     fieldnames = [
         "run_id",
@@ -52,7 +52,7 @@ def write_csv(results: List[RunResult], csv_path: Path) -> None:
                 "isl": spec.aiperf.isl,
                 "osl": spec.aiperf.osl,
                 "workers": spec.deploy.workers,
-                "speedup_ratio": 0,  # filled by config
+                "speedup_ratio": config.speedup_ratio,
                 "status": r.status,
                 "req_per_sec": f"{r.req_per_sec:.2f}"
                 if r.req_per_sec is not None
@@ -119,11 +119,14 @@ def write_sweep_config(
         "mode": config.mode,
         "model": config.model,
         "model_name": config.model_name,
-        "backends": ",".join(config.tokenizers),
+        "backend": config.backend,
+        "backends": config.backend,
+        "tokenizers": ",".join(config.tokenizers),
         "isl_list": ",".join(str(i) for i in config.isls),
         "concurrency_list": ",".join(str(c) for c in config.concurrencies),
         "benchmark_duration": config.benchmark_duration or "N/A",
         "osl": config.osl,
+        "speedup_ratio": config.speedup_ratio,
         "output_dir": config.output_dir,
         "total_runs": total_runs,
         "isolation_policy": config.isolation_policy,

--- a/benchmarks/frontend/scripts/sweep_core/config.py
+++ b/benchmarks/frontend/scripts/sweep_core/config.py
@@ -54,7 +54,9 @@ def build_argument_parser() -> argparse.ArgumentParser:
 
     # Common options
     parser.add_argument("--model", default=DEFAULT_MODEL, help="HF model path")
-    parser.add_argument("--model-name", default="", help="Served model name (default: same as --model)")
+    parser.add_argument(
+        "--model-name", default="", help="Served model name (default: same as --model)"
+    )
     parser.add_argument(
         "--mode",
         choices=["local", "k8s"],
@@ -146,15 +148,11 @@ def build_argument_parser() -> argparse.ArgumentParser:
 
     # K8s-specific options
     k8s_group = parser.add_argument_group("K8s mode options")
-    k8s_group.add_argument(
-        "--namespace", default="dynamo-bench", help="K8s namespace"
-    )
+    k8s_group.add_argument("--namespace", default="dynamo-bench", help="K8s namespace")
     k8s_group.add_argument(
         "--endpoint", default=None, help="K8s frontend endpoint (host:port)"
     )
-    k8s_group.add_argument(
-        "--dgd-name", default="", help="DynamoGraphDeployment name"
-    )
+    k8s_group.add_argument("--dgd-name", default="", help="DynamoGraphDeployment name")
     k8s_group.add_argument(
         "--image", default="", help="Container image for k8s deployment"
     )
@@ -187,9 +185,7 @@ def build_argument_parser() -> argparse.ArgumentParser:
     k8s_group.add_argument(
         "--router-mode", default="round-robin", help="Frontend router mode"
     )
-    k8s_group.add_argument(
-        "--hf-token", default="", help="HuggingFace token for k8s"
-    )
+    k8s_group.add_argument("--hf-token", default="", help="HuggingFace token for k8s")
     k8s_group.add_argument(
         "--image-pull-secret", default="", help="Image pull secret name"
     )
@@ -253,7 +249,9 @@ def config_from_args(args: argparse.Namespace) -> SweepConfig:
     if args.endpoint:
         k8s_config.endpoint = args.endpoint
     elif k8s_config.dgd_name:
-        k8s_config.endpoint = f"{k8s_config.dgd_name}-frontend:{k8s_config.frontend_port}"
+        k8s_config.endpoint = (
+            f"{k8s_config.dgd_name}-frontend:{k8s_config.frontend_port}"
+        )
     else:
         k8s_config.endpoint = f"frontend:{k8s_config.frontend_port}"
 

--- a/benchmarks/frontend/scripts/sweep_core/config.py
+++ b/benchmarks/frontend/scripts/sweep_core/config.py
@@ -34,7 +34,7 @@ def build_argument_parser() -> argparse.ArgumentParser:
         epilog="""Examples:
   # Local smoke test
   python3 sweep_runner.py --tokenizers hf,fastokens --concurrency 32 --isl 512 \\
-      --benchmark-duration 30 --speedup-ratio 0
+      --benchmark-duration 30 --speedup-ratio 1000000
 
   # K8s sweep with DGD
   python3 sweep_runner.py --mode k8s --tokenizers hf,fastokens --concurrency 50,100 --isl 512
@@ -45,7 +45,7 @@ def build_argument_parser() -> argparse.ArgumentParser:
 
   # Transport saturation (high concurrency, vary workers)
   python3 sweep_runner.py --tokenizers hf --concurrency 4096 \\
-      --num-requests 16384,32768 --workers 1,2,4,8 --speedup-ratio 0
+      --num-requests 16384,32768 --workers 1,2,4,8 --speedup-ratio 1000000
 
   # Dry run
   python3 sweep_runner.py --dry-run --tokenizers hf,fastokens --concurrency 32,64 --isl 512,1024
@@ -177,6 +177,12 @@ def build_argument_parser() -> argparse.ArgumentParser:
         "--worker-replicas", type=int, default=1, help="Number of worker pod replicas"
     )
     k8s_group.add_argument(
+        "--frontend-replicas",
+        type=int,
+        default=1,
+        help="Number of frontend pod replicas",
+    )
+    k8s_group.add_argument(
         "--request-plane", default="tcp", help="Request plane transport"
     )
     k8s_group.add_argument(
@@ -234,6 +240,7 @@ def config_from_args(args: argparse.Namespace) -> SweepConfig:
         image=args.image,
         frontend_port=args.frontend_port,
         worker_replicas=args.worker_replicas,
+        frontend_replicas=args.frontend_replicas,
         deploy_template=args.deploy_template,
         reset_strategy=args.reset_strategy,
         request_plane=args.request_plane,

--- a/benchmarks/frontend/scripts/sweep_core/config.py
+++ b/benchmarks/frontend/scripts/sweep_core/config.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Typed SweepConfig construction from argparse Namespace.
+
+Centralizes the parsing of CLI arguments into the SweepConfig data model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+from typing import List, Optional
+
+from sweep_core.models import K8sConfig, SweepConfig
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = SCRIPT_DIR.parent.parent.parent
+
+DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
+DEFAULT_OSL = 256
+DEFAULT_SPEEDUP = 1.0
+DEFAULT_BENCHMARK_DURATION = 60
+DEFAULT_MAX_CONSECUTIVE_FAILS = 2
+DEFAULT_COOLDOWN = 3
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for sweep_runner.py."""
+    parser = argparse.ArgumentParser(
+        description="Frontend performance sweep runner",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Examples:
+  # Local smoke test
+  python3 sweep_runner.py --tokenizers hf,fastokens --concurrency 32 --isl 512 \\
+      --benchmark-duration 30 --speedup-ratio 0
+
+  # K8s sweep with DGD
+  python3 sweep_runner.py --mode k8s --tokenizers hf,fastokens --concurrency 50,100 --isl 512
+
+  # K8s with custom deploy template
+  python3 sweep_runner.py --mode k8s --deploy-template dgd/templates/vllm.yaml \\
+      --tokenizers hf --concurrency 128 --isl 1024
+
+  # Transport saturation (high concurrency, vary workers)
+  python3 sweep_runner.py --tokenizers hf --concurrency 4096 \\
+      --num-requests 16384,32768 --workers 1,2,4,8 --speedup-ratio 0
+
+  # Dry run
+  python3 sweep_runner.py --dry-run --tokenizers hf,fastokens --concurrency 32,64 --isl 512,1024
+""",
+    )
+
+    # Common options
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="HF model path")
+    parser.add_argument("--model-name", default="", help="Served model name (default: same as --model)")
+    parser.add_argument(
+        "--mode",
+        choices=["local", "k8s"],
+        default="local",
+        help="Execution mode: local (run_perf.sh) or k8s (DGD + aiperf)",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["mocker", "vllm"],
+        default="mocker",
+        help="Engine backend: mocker (synthetic) or vllm (real inference)",
+    )
+    parser.add_argument(
+        "--tokenizers",
+        default="hf,fastokens",
+        help="Comma-separated tokenizer backends (hf, fastokens)",
+    )
+    parser.add_argument(
+        "--concurrency", default="50,100,200", help="Comma-separated concurrency levels"
+    )
+    parser.add_argument(
+        "--isl", default="512,1024,2048", help="Comma-separated ISL values"
+    )
+    parser.add_argument(
+        "--osl", type=int, default=DEFAULT_OSL, help="Output sequence length"
+    )
+    parser.add_argument(
+        "--workers", default="2", help="Comma-separated worker counts per model"
+    )
+    parser.add_argument(
+        "--num-models",
+        type=int,
+        default=1,
+        help="Number of model instances",
+    )
+    parser.add_argument(
+        "--aiperf-targets",
+        choices=["first", "all"],
+        default="first",
+        help="'first': aiperf targets model-1 only. 'all': run aiperf for each model.",
+    )
+    parser.add_argument(
+        "--speedup-ratio",
+        type=float,
+        default=DEFAULT_SPEEDUP,
+        help="Mocker speedup (0=infinite)",
+    )
+    parser.add_argument(
+        "--benchmark-duration",
+        type=int,
+        default=DEFAULT_BENCHMARK_DURATION,
+        help="aiperf duration (seconds)",
+    )
+    parser.add_argument(
+        "--num-requests",
+        default=None,
+        help="Comma-separated request counts (overrides --benchmark-duration)",
+    )
+    parser.add_argument(
+        "--rps",
+        default=None,
+        help="Comma-separated target request rates (req/s)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory (default: auto timestamped)",
+    )
+    parser.add_argument(
+        "--max-consecutive-fails",
+        type=int,
+        default=DEFAULT_MAX_CONSECUTIVE_FAILS,
+    )
+    parser.add_argument(
+        "--cooldown", type=int, default=DEFAULT_COOLDOWN, help="Seconds between runs"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print plan without executing"
+    )
+    parser.add_argument(
+        "--no-report", action="store_true", help="Skip per-run report generation"
+    )
+    parser.add_argument(
+        "--isolation",
+        choices=["fresh_per_run", "reuse_by_deploy_key"],
+        default="fresh_per_run",
+        help="Isolation policy (default: fresh_per_run)",
+    )
+
+    # K8s-specific options
+    k8s_group = parser.add_argument_group("K8s mode options")
+    k8s_group.add_argument(
+        "--namespace", default="dynamo-bench", help="K8s namespace"
+    )
+    k8s_group.add_argument(
+        "--endpoint", default=None, help="K8s frontend endpoint (host:port)"
+    )
+    k8s_group.add_argument(
+        "--dgd-name", default="", help="DynamoGraphDeployment name"
+    )
+    k8s_group.add_argument(
+        "--image", default="", help="Container image for k8s deployment"
+    )
+    k8s_group.add_argument(
+        "--deploy-template",
+        default="",
+        help="Path to deploy.yaml template (enables template-based deployment)",
+    )
+    k8s_group.add_argument(
+        "--reset-strategy",
+        choices=["none", "frontend", "graph"],
+        default="graph",
+        help="K8s reset strategy per run (default: graph)",
+    )
+    k8s_group.add_argument(
+        "--deploy", action="store_true", help="Deploy infrastructure before sweeping"
+    )
+    k8s_group.add_argument(
+        "--frontend-port", type=int, default=8000, help="Frontend HTTP port"
+    )
+    k8s_group.add_argument(
+        "--worker-replicas", type=int, default=1, help="Number of worker pod replicas"
+    )
+    k8s_group.add_argument(
+        "--request-plane", default="tcp", help="Request plane transport"
+    )
+    k8s_group.add_argument(
+        "--event-plane", default="nats", help="Event plane transport"
+    )
+    k8s_group.add_argument(
+        "--router-mode", default="round-robin", help="Frontend router mode"
+    )
+    k8s_group.add_argument(
+        "--hf-token", default="", help="HuggingFace token for k8s"
+    )
+    k8s_group.add_argument(
+        "--image-pull-secret", default="", help="Image pull secret name"
+    )
+    k8s_group.add_argument(
+        "--export-level", default="summary", help="aiperf export level"
+    )
+
+    # Passthrough args for run_perf.sh
+    parser.add_argument(
+        "passthrough", nargs="*", help="Extra args passed to run_perf.sh (after --)"
+    )
+
+    return parser
+
+
+def config_from_args(args: argparse.Namespace) -> SweepConfig:
+    """Convert parsed argparse Namespace to SweepConfig."""
+    # Parse comma-separated lists
+    tokenizers = [t.strip() for t in args.tokenizers.split(",")]
+    concurrencies = [int(c) for c in args.concurrency.split(",")]
+    isls = [int(i) for i in args.isl.split(",")]
+    worker_counts = [int(w) for w in args.workers.split(",")]
+    num_requests_list: List[Optional[int]] = (
+        [int(n) for n in args.num_requests.split(",")] if args.num_requests else [None]
+    )
+    rps_list: List[Optional[int]] = (
+        [int(r) for r in args.rps.split(",")] if args.rps else [None]
+    )
+
+    # Output directory
+    if args.output_dir:
+        output_dir = args.output_dir
+    else:
+        ts = time.strftime("%Y%m%d_%H%M%S")
+        if args.mode == "k8s" and Path("/artifacts").is_dir():
+            # Inside a k8s pod with /artifacts PVC mounted
+            output_dir = f"/artifacts/sweep_{ts}"
+        else:
+            # Local or k8s-from-host: use repo artifacts directory
+            output_dir = str(REPO_ROOT / "artifacts" / f"sweep_{ts}")
+
+    # Build K8s config
+    k8s_config = K8sConfig(
+        namespace=args.namespace,
+        dgd_name=args.dgd_name,
+        image=args.image,
+        frontend_port=args.frontend_port,
+        worker_replicas=args.worker_replicas,
+        deploy_template=args.deploy_template,
+        reset_strategy=args.reset_strategy,
+        request_plane=args.request_plane,
+        event_plane=args.event_plane,
+        router_mode=args.router_mode,
+        deploy=args.deploy,
+        hf_token=args.hf_token,
+        image_pull_secret=args.image_pull_secret,
+        export_level=args.export_level,
+    )
+
+    # Compute k8s endpoint
+    if args.endpoint:
+        k8s_config.endpoint = args.endpoint
+    elif k8s_config.dgd_name:
+        k8s_config.endpoint = f"{k8s_config.dgd_name}-frontend:{k8s_config.frontend_port}"
+    else:
+        k8s_config.endpoint = f"frontend:{k8s_config.frontend_port}"
+
+    return SweepConfig(
+        model=args.model,
+        model_name=args.model_name or args.model,
+        mode=args.mode,
+        backend=args.backend,
+        tokenizers=tokenizers,
+        concurrencies=concurrencies,
+        isls=isls,
+        osl=args.osl,
+        worker_counts=worker_counts,
+        num_models=args.num_models,
+        aiperf_targets=args.aiperf_targets,
+        speedup_ratio=args.speedup_ratio,
+        benchmark_duration=args.benchmark_duration,
+        num_requests_list=num_requests_list,
+        rps_list=rps_list,
+        output_dir=output_dir,
+        max_consecutive_fails=args.max_consecutive_fails,
+        cooldown=args.cooldown,
+        dry_run=args.dry_run,
+        no_report=args.no_report,
+        isolation_policy=args.isolation,
+        passthrough_args=args.passthrough or [],
+        k8s=k8s_config,
+    )

--- a/benchmarks/frontend/scripts/sweep_core/failures.py
+++ b/benchmarks/frontend/scripts/sweep_core/failures.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Consecutive-failure skip policy for sweep runs."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+
+class FailureTracker:
+    """Track consecutive failures per (backend, concurrency, workers) tuple.
+
+    After max_consecutive_fails consecutive failures at a given key,
+    subsequent runs with the same key are skipped.
+    """
+
+    def __init__(self, max_consecutive_fails: int = 2):
+        self.max_consecutive_fails = max_consecutive_fails
+        self._counts: Dict[Tuple[str, int, int], int] = {}
+
+    def should_skip(self, backend: str, concurrency: int, workers: int) -> bool:
+        """Check if a run should be skipped due to prior consecutive failures."""
+        key = (backend, concurrency, workers)
+        return self._counts.get(key, 0) >= self.max_consecutive_fails
+
+    def record_success(self, backend: str, concurrency: int, workers: int) -> None:
+        """Record a successful run, resetting the failure count."""
+        key = (backend, concurrency, workers)
+        self._counts[key] = 0
+
+    def record_failure(self, backend: str, concurrency: int, workers: int) -> int:
+        """Record a failed run. Returns the new consecutive failure count."""
+        key = (backend, concurrency, workers)
+        self._counts[key] = self._counts.get(key, 0) + 1
+        return self._counts[key]
+
+    def get_count(self, backend: str, concurrency: int, workers: int) -> int:
+        """Get the current consecutive failure count for a key."""
+        key = (backend, concurrency, workers)
+        return self._counts.get(key, 0)

--- a/benchmarks/frontend/scripts/sweep_core/lifecycle.py
+++ b/benchmarks/frontend/scripts/sweep_core/lifecycle.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from sweep_core.models import DeployKey, IsolationPolicy, RunSpec
+from sweep_core.models import IsolationPolicy, RunSpec
 
 
 def needs_deploy_or_reset(

--- a/benchmarks/frontend/scripts/sweep_core/lifecycle.py
+++ b/benchmarks/frontend/scripts/sweep_core/lifecycle.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Lifecycle management -- deploy-dimension delta detection and reset strategy."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sweep_core.models import DeployKey, IsolationPolicy, RunSpec
+
+
+def needs_deploy_or_reset(
+    current: RunSpec,
+    previous: Optional[RunSpec],
+    isolation_policy: IsolationPolicy,
+) -> bool:
+    """Determine if the current run needs a deploy/reset before execution.
+
+    Args:
+        current: The run about to execute.
+        previous: The run that just completed (None for the first run).
+        isolation_policy: The sweep-level isolation policy.
+
+    Returns:
+        True if a deploy/reset is needed before this run.
+    """
+    if previous is None:
+        # First run always needs deployment
+        return True
+
+    if isolation_policy == "fresh_per_run":
+        # Every run gets its own deploy/reset cycle
+        return True
+
+    # reuse_by_deploy_key: only reset when the deploy key changes
+    return current.deploy_key != previous.deploy_key
+
+
+def deploy_key_changed(
+    current: RunSpec,
+    previous: Optional[RunSpec],
+) -> bool:
+    """Check if the deploy key has changed between consecutive runs."""
+    if previous is None:
+        return True
+    return current.deploy_key != previous.deploy_key

--- a/benchmarks/frontend/scripts/sweep_core/models.py
+++ b/benchmarks/frontend/scripts/sweep_core/models.py
@@ -216,6 +216,8 @@ class K8sConfig:
             "event_plane": self.event_plane,
             "router_mode": self.router_mode,
             "deploy": self.deploy,
+            "hf_token": "***" if self.hf_token else "",
+            "image_pull_secret": self.image_pull_secret,
             "export_level": self.export_level,
         }
 
@@ -276,7 +278,10 @@ class SweepConfig:
             "output_dir": self.output_dir,
             "max_consecutive_fails": self.max_consecutive_fails,
             "cooldown": self.cooldown,
+            "dry_run": self.dry_run,
+            "no_report": self.no_report,
             "isolation_policy": self.isolation_policy,
+            "passthrough_args": self.passthrough_args,
             "k8s": self.k8s.to_dict(),
         }
 

--- a/benchmarks/frontend/scripts/sweep_core/models.py
+++ b/benchmarks/frontend/scripts/sweep_core/models.py
@@ -192,6 +192,7 @@ class K8sConfig:
     image: str = ""
     frontend_port: int = 8000
     worker_replicas: int = 1
+    frontend_replicas: int = 1
     deploy_template: str = ""  # path to deploy.yaml template
     reset_strategy: str = "graph"  # none | frontend | graph
     request_plane: str = "tcp"
@@ -210,6 +211,7 @@ class K8sConfig:
             "image": self.image,
             "frontend_port": self.frontend_port,
             "worker_replicas": self.worker_replicas,
+            "frontend_replicas": self.frontend_replicas,
             "deploy_template": self.deploy_template,
             "reset_strategy": self.reset_strategy,
             "request_plane": self.request_plane,

--- a/benchmarks/frontend/scripts/sweep_core/models.py
+++ b/benchmarks/frontend/scripts/sweep_core/models.py
@@ -1,0 +1,323 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Data models for sweep_core.
+
+All data structures are plain dataclasses that serialize to/from JSON/dict.
+No subprocess, kubectl, or argparse imports allowed in this module.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+IsolationPolicy = Literal["fresh_per_run", "reuse_by_deploy_key"]
+
+
+@dataclass(frozen=True)
+class DeployKey:
+    """Hashable key identifying a unique deployment configuration."""
+
+    backend: str
+    tokenizer: str
+    workers: int
+    num_models: int
+    env_overrides: frozenset[tuple[str, str]] = field(default_factory=frozenset)
+
+    def to_dict(self) -> dict:
+        return {
+            "backend": self.backend,
+            "tokenizer": self.tokenizer,
+            "workers": self.workers,
+            "num_models": self.num_models,
+            "env_overrides": dict(self.env_overrides),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> DeployKey:
+        env = d.get("env_overrides", {})
+        return cls(
+            backend=d["backend"],
+            tokenizer=d["tokenizer"],
+            workers=d["workers"],
+            num_models=d["num_models"],
+            env_overrides=frozenset(env.items()) if isinstance(env, dict) else frozenset(env),
+        )
+
+
+@dataclass
+class DeployDimension:
+    """Configuration for a single deployment state."""
+
+    backend: str  # "mocker" or "vllm"
+    tokenizer: str  # "hf" or "fastokens"
+    workers: int = 2
+    num_models: int = 1
+    env_overrides: Dict[str, str] = field(default_factory=dict)
+
+    @property
+    def deploy_key(self) -> DeployKey:
+        return DeployKey(
+            backend=self.backend,
+            tokenizer=self.tokenizer,
+            workers=self.workers,
+            num_models=self.num_models,
+            env_overrides=frozenset(self.env_overrides.items()),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "backend": self.backend,
+            "tokenizer": self.tokenizer,
+            "workers": self.workers,
+            "num_models": self.num_models,
+            "env_overrides": self.env_overrides,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> DeployDimension:
+        return cls(
+            backend=d["backend"],
+            tokenizer=d["tokenizer"],
+            workers=d.get("workers", 2),
+            num_models=d.get("num_models", 1),
+            env_overrides=d.get("env_overrides", {}),
+        )
+
+
+@dataclass
+class AiperfDimension:
+    """Configuration for a single aiperf run."""
+
+    concurrency: int
+    isl: int
+    osl: int = 256
+    num_requests: Optional[int] = None
+    benchmark_duration: Optional[int] = None
+    request_rate: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "concurrency": self.concurrency,
+            "isl": self.isl,
+            "osl": self.osl,
+            "num_requests": self.num_requests,
+            "benchmark_duration": self.benchmark_duration,
+            "request_rate": self.request_rate,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> AiperfDimension:
+        return cls(
+            concurrency=d["concurrency"],
+            isl=d["isl"],
+            osl=d.get("osl", 256),
+            num_requests=d.get("num_requests"),
+            benchmark_duration=d.get("benchmark_duration"),
+            request_rate=d.get("request_rate"),
+        )
+
+
+@dataclass
+class RunSpec:
+    """One logical perf run -- the atomic unit of execution."""
+
+    deploy: DeployDimension
+    aiperf: AiperfDimension
+    deploy_key: DeployKey
+    run_id: str
+
+    def to_dict(self) -> dict:
+        return {
+            "deploy": self.deploy.to_dict(),
+            "aiperf": self.aiperf.to_dict(),
+            "deploy_key": self.deploy_key.to_dict(),
+            "run_id": self.run_id,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> RunSpec:
+        deploy = DeployDimension.from_dict(d["deploy"])
+        aiperf = AiperfDimension.from_dict(d["aiperf"])
+        deploy_key = DeployKey.from_dict(d["deploy_key"])
+        return cls(
+            deploy=deploy,
+            aiperf=aiperf,
+            deploy_key=deploy_key,
+            run_id=d["run_id"],
+        )
+
+
+@dataclass
+class RunResult:
+    """Result from a single sweep point."""
+
+    run_spec: RunSpec
+    status: str = "pending"  # ok, fail, skipped
+    req_per_sec: float = 0.0
+    output_tok_per_sec: float = 0.0
+    ttft_p50_ms: float = 0.0
+    ttft_p99_ms: float = 0.0
+    itl_p50_ms: float = 0.0
+    itl_p99_ms: float = 0.0
+    duration_sec: float = 0.0
+    run_dir: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "run_spec": self.run_spec.to_dict(),
+            "status": self.status,
+            "req_per_sec": self.req_per_sec,
+            "output_tok_per_sec": self.output_tok_per_sec,
+            "ttft_p50_ms": self.ttft_p50_ms,
+            "ttft_p99_ms": self.ttft_p99_ms,
+            "itl_p50_ms": self.itl_p50_ms,
+            "itl_p99_ms": self.itl_p99_ms,
+            "duration_sec": self.duration_sec,
+            "run_dir": self.run_dir,
+        }
+
+
+@dataclass
+class K8sConfig:
+    """K8s-specific configuration."""
+
+    namespace: str = "dynamo-bench"
+    endpoint: str = "frontend:8000"
+    dgd_name: str = ""
+    image: str = ""
+    frontend_port: int = 8000
+    worker_replicas: int = 1
+    deploy_template: str = ""  # path to deploy.yaml template
+    reset_strategy: str = "graph"  # none | frontend | graph
+    request_plane: str = "tcp"
+    event_plane: str = "nats"
+    router_mode: str = "round-robin"
+    deploy: bool = False
+    hf_token: str = ""
+    image_pull_secret: str = ""
+    export_level: str = "summary"
+
+    def to_dict(self) -> dict:
+        return {
+            "namespace": self.namespace,
+            "endpoint": self.endpoint,
+            "dgd_name": self.dgd_name,
+            "image": self.image,
+            "frontend_port": self.frontend_port,
+            "worker_replicas": self.worker_replicas,
+            "deploy_template": self.deploy_template,
+            "reset_strategy": self.reset_strategy,
+            "request_plane": self.request_plane,
+            "event_plane": self.event_plane,
+            "router_mode": self.router_mode,
+            "deploy": self.deploy,
+            "export_level": self.export_level,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> K8sConfig:
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class SweepConfig:
+    """Top-level configuration for a sweep."""
+
+    model: str = "Qwen/Qwen3-0.6B"
+    model_name: str = ""
+    mode: str = "local"  # "local" or "k8s"
+    backend: str = "mocker"
+    tokenizers: List[str] = field(default_factory=lambda: ["hf", "fastokens"])
+    concurrencies: List[int] = field(default_factory=lambda: [50, 100, 200])
+    isls: List[int] = field(default_factory=lambda: [512, 1024, 2048])
+    osl: int = 256
+    worker_counts: List[int] = field(default_factory=lambda: [2])
+    num_models: int = 1
+    aiperf_targets: str = "first"
+    speedup_ratio: float = 1.0
+    benchmark_duration: Optional[int] = 60
+    num_requests_list: List[Optional[int]] = field(default_factory=lambda: [None])
+    rps_list: List[Optional[int]] = field(default_factory=lambda: [None])
+    output_dir: str = ""
+    max_consecutive_fails: int = 2
+    cooldown: int = 3
+    dry_run: bool = False
+    no_report: bool = False
+    isolation_policy: IsolationPolicy = "fresh_per_run"
+    passthrough_args: List[str] = field(default_factory=list)
+    k8s: K8sConfig = field(default_factory=K8sConfig)
+
+    def __post_init__(self):
+        if not self.model_name:
+            self.model_name = self.model
+
+    def to_dict(self) -> dict:
+        return {
+            "model": self.model,
+            "model_name": self.model_name,
+            "mode": self.mode,
+            "backend": self.backend,
+            "tokenizers": self.tokenizers,
+            "concurrencies": self.concurrencies,
+            "isls": self.isls,
+            "osl": self.osl,
+            "worker_counts": self.worker_counts,
+            "num_models": self.num_models,
+            "aiperf_targets": self.aiperf_targets,
+            "speedup_ratio": self.speedup_ratio,
+            "benchmark_duration": self.benchmark_duration,
+            "num_requests_list": self.num_requests_list,
+            "rps_list": self.rps_list,
+            "output_dir": self.output_dir,
+            "max_consecutive_fails": self.max_consecutive_fails,
+            "cooldown": self.cooldown,
+            "isolation_policy": self.isolation_policy,
+            "k8s": self.k8s.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> SweepConfig:
+        k8s_data = d.pop("k8s", {})
+        config = cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
+        if k8s_data:
+            config.k8s = K8sConfig.from_dict(k8s_data)
+        return config
+
+
+@dataclass
+class SweepPlan:
+    """Serializable execution plan."""
+
+    config: SweepConfig
+    runs: List[RunSpec]
+    isolation_policy: IsolationPolicy
+    total_runs: int
+
+    def to_dict(self) -> dict:
+        return {
+            "config": self.config.to_dict(),
+            "runs": [r.to_dict() for r in self.runs],
+            "isolation_policy": self.isolation_policy,
+            "total_runs": self.total_runs,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> SweepPlan:
+        config = SweepConfig.from_dict(d["config"])
+        runs = [RunSpec.from_dict(r) for r in d["runs"]]
+        return cls(
+            config=config,
+            runs=runs,
+            isolation_policy=d["isolation_policy"],
+            total_runs=d["total_runs"],
+        )
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @classmethod
+    def from_json(cls, s: str) -> SweepPlan:
+        return cls.from_dict(json.loads(s))

--- a/benchmarks/frontend/scripts/sweep_core/models.py
+++ b/benchmarks/frontend/scripts/sweep_core/models.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 IsolationPolicy = Literal["fresh_per_run", "reuse_by_deploy_key"]
 
@@ -43,7 +43,9 @@ class DeployKey:
             tokenizer=d["tokenizer"],
             workers=d["workers"],
             num_models=d["num_models"],
-            env_overrides=frozenset(env.items()) if isinstance(env, dict) else frozenset(env),
+            env_overrides=frozenset(env.items())
+            if isinstance(env, dict)
+            else frozenset(env),
         )
 
 

--- a/benchmarks/frontend/scripts/sweep_core/naming.py
+++ b/benchmarks/frontend/scripts/sweep_core/naming.py
@@ -17,6 +17,6 @@ def build_run_id(deploy: DeployDimension, aiperf: AiperfDimension) -> str:
     base = f"{deploy.tokenizer}_c{aiperf.concurrency}_isl{aiperf.isl}_w{deploy.workers}"
     if deploy.num_models > 1:
         base += f"_m{deploy.num_models}"
-    if aiperf.request_rate:
+    if aiperf.request_rate is not None:
         base += f"_rps{aiperf.request_rate}"
     return base

--- a/benchmarks/frontend/scripts/sweep_core/naming.py
+++ b/benchmarks/frontend/scripts/sweep_core/naming.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run ID and directory naming conventions for sweep runs."""
+
+from __future__ import annotations
+
+from sweep_core.models import AiperfDimension, DeployDimension
+
+
+def build_run_id(deploy: DeployDimension, aiperf: AiperfDimension) -> str:
+    """Build a human-readable run ID from deploy + aiperf dimensions.
+
+    Format: {tokenizer}_c{concurrency}_isl{isl}_w{workers}[_m{models}][_rps{rate}]
+
+    This matches the naming convention from the original sweep_runner.py.
+    """
+    base = f"{deploy.tokenizer}_c{aiperf.concurrency}_isl{aiperf.isl}_w{deploy.workers}"
+    if deploy.num_models > 1:
+        base += f"_m{deploy.num_models}"
+    if aiperf.request_rate:
+        base += f"_rps{aiperf.request_rate}"
+    return base

--- a/benchmarks/frontend/scripts/sweep_core/orchestrator.py
+++ b/benchmarks/frontend/scripts/sweep_core/orchestrator.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Sequential plan runner -- iterates through a SweepPlan using a SweepExecutor.
+
+This module is interface-agnostic: it does not import argparse, subprocess,
+or kubectl. It is callable from CLI, MCP server, or test harness.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional
+
+from sweep_core.artifacts import print_results_table, write_csv, write_summary, write_sweep_config
+from sweep_core.failures import FailureTracker
+from sweep_core.lifecycle import needs_deploy_or_reset
+from sweep_core.models import RunResult, RunSpec, SweepPlan
+from sweep_core.reporting import generate_report
+
+if TYPE_CHECKING:
+    from sweep_executors.base import SweepExecutor
+
+
+def run(plan: SweepPlan, executor: "SweepExecutor") -> List[RunResult]:
+    """Execute a SweepPlan sequentially using the given executor.
+
+    Args:
+        plan: The sweep plan to execute.
+        executor: The executor that handles individual runs.
+
+    Returns:
+        List of RunResult objects, one per run.
+    """
+    config = plan.config
+    output_root = Path(config.output_dir)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    csv_path = output_root / "results.csv"
+    summary_path = output_root / "summary.md"
+
+    # Write sweep config
+    write_sweep_config(config, output_root)
+
+    # Prepare executor
+    executor.prepare(config)
+
+    failure_tracker = FailureTracker(config.max_consecutive_fails)
+    results: List[RunResult] = []
+    previous_run: Optional[RunSpec] = None
+
+    try:
+        for i, run_spec in enumerate(plan.runs, 1):
+            deploy = run_spec.deploy
+            aiperf = run_spec.aiperf
+            run_dir = output_root / run_spec.run_id
+
+            # Check skip policy
+            if failure_tracker.should_skip(deploy.backend, aiperf.concurrency, deploy.workers):
+                result = RunResult(
+                    run_spec=run_spec,
+                    status="skipped",
+                    run_dir=str(run_dir),
+                )
+                results.append(result)
+                print(
+                    f"\n  [{i}/{plan.total_runs}] SKIPPED {run_spec.run_id} "
+                    f"({config.max_consecutive_fails} consecutive failures)"
+                )
+                continue
+
+            print(f"\n{'=' * 60}")
+            print(f"  [{i}/{plan.total_runs}] {run_spec.run_id}")
+            print(f"{'=' * 60}")
+
+            # Deploy or reset if needed
+            if needs_deploy_or_reset(run_spec, previous_run, plan.isolation_policy):
+                prev_deploy = previous_run.deploy if previous_run else None
+                executor.apply_deploy(deploy, prev_deploy)
+
+            # Execute the run
+            result = executor.execute_run(run_spec, run_dir)
+            results.append(result)
+            previous_run = run_spec
+
+            # Update failure tracking
+            if result.status == "ok":
+                failure_tracker.record_success(deploy.backend, aiperf.concurrency, deploy.workers)
+                rps = f"{result.req_per_sec:.1f}" if result.req_per_sec else "N/A"
+                tp50 = f"{result.ttft_p50_ms:.1f}ms" if result.ttft_p50_ms else "N/A"
+                print(f"    OK: {rps} req/s, TTFT p50={tp50}")
+            else:
+                count = failure_tracker.record_failure(
+                    deploy.backend, aiperf.concurrency, deploy.workers
+                )
+                print(f"    FAIL (consecutive: {count}/{config.max_consecutive_fails})")
+
+            # Generate per-run report
+            if not config.no_report and result.status == "ok":
+                generate_report(run_dir)
+
+            # Write incremental CSV + summary
+            write_csv(results, csv_path)
+            write_summary(results, summary_path)
+
+            # Cooldown between runs
+            if i < plan.total_runs:
+                time.sleep(config.cooldown)
+
+    except KeyboardInterrupt:
+        print("\n\nInterrupted! Partial results saved.")
+    finally:
+        # Final write
+        write_csv(results, csv_path)
+        write_summary(results, summary_path)
+        # Cleanup executor
+        executor.cleanup()
+
+    # Print final table
+    print_results_table(results)
+    print(f"\nResults:  {csv_path}")
+    print(f"Summary:  {summary_path}")
+    print(f"Per-run:  {output_root}/<run_id>/report.md")
+
+    return results

--- a/benchmarks/frontend/scripts/sweep_core/orchestrator.py
+++ b/benchmarks/frontend/scripts/sweep_core/orchestrator.py
@@ -13,7 +13,12 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
-from sweep_core.artifacts import print_results_table, write_csv, write_summary, write_sweep_config
+from sweep_core.artifacts import (
+    print_results_table,
+    write_csv,
+    write_summary,
+    write_sweep_config,
+)
 from sweep_core.failures import FailureTracker
 from sweep_core.lifecycle import needs_deploy_or_reset
 from sweep_core.models import RunResult, RunSpec, SweepPlan
@@ -57,7 +62,9 @@ def run(plan: SweepPlan, executor: "SweepExecutor") -> List[RunResult]:
             run_dir = output_root / run_spec.run_id
 
             # Check skip policy
-            if failure_tracker.should_skip(deploy.backend, aiperf.concurrency, deploy.workers):
+            if failure_tracker.should_skip(
+                deploy.backend, aiperf.concurrency, deploy.workers
+            ):
                 result = RunResult(
                     run_spec=run_spec,
                     status="skipped",
@@ -86,7 +93,9 @@ def run(plan: SweepPlan, executor: "SweepExecutor") -> List[RunResult]:
 
             # Update failure tracking
             if result.status == "ok":
-                failure_tracker.record_success(deploy.backend, aiperf.concurrency, deploy.workers)
+                failure_tracker.record_success(
+                    deploy.backend, aiperf.concurrency, deploy.workers
+                )
                 rps = f"{result.req_per_sec:.1f}" if result.req_per_sec else "N/A"
                 tp50 = f"{result.ttft_p50_ms:.1f}ms" if result.ttft_p50_ms else "N/A"
                 print(f"    OK: {rps} req/s, TTFT p50={tp50}")

--- a/benchmarks/frontend/scripts/sweep_core/orchestrator.py
+++ b/benchmarks/frontend/scripts/sweep_core/orchestrator.py
@@ -46,16 +46,16 @@ def run(plan: SweepPlan, executor: "SweepExecutor") -> List[RunResult]:
     summary_path = output_root / "summary.md"
 
     # Write sweep config
-    write_sweep_config(config, output_root)
-
-    # Prepare executor
-    executor.prepare(config)
+    write_sweep_config(config, output_root, total_runs=plan.total_runs)
 
     failure_tracker = FailureTracker(config.max_consecutive_fails)
     results: List[RunResult] = []
     previous_run: Optional[RunSpec] = None
 
     try:
+        # Prepare executor inside try so cleanup() runs on prepare failure
+        executor.prepare(config)
+
         for i, run_spec in enumerate(plan.runs, 1):
             deploy = run_spec.deploy
             aiperf = run_spec.aiperf

--- a/benchmarks/frontend/scripts/sweep_core/orchestrator.py
+++ b/benchmarks/frontend/scripts/sweep_core/orchestrator.py
@@ -110,7 +110,7 @@ def run(plan: SweepPlan, executor: "SweepExecutor") -> List[RunResult]:
                 generate_report(run_dir)
 
             # Write incremental CSV + summary
-            write_csv(results, csv_path)
+            write_csv(results, csv_path, config)
             write_summary(results, summary_path)
 
             # Cooldown between runs
@@ -121,7 +121,7 @@ def run(plan: SweepPlan, executor: "SweepExecutor") -> List[RunResult]:
         print("\n\nInterrupted! Partial results saved.")
     finally:
         # Final write
-        write_csv(results, csv_path)
+        write_csv(results, csv_path, config)
         write_summary(results, summary_path)
         # Cleanup executor
         executor.cleanup()

--- a/benchmarks/frontend/scripts/sweep_core/planner.py
+++ b/benchmarks/frontend/scripts/sweep_core/planner.py
@@ -97,6 +97,8 @@ def print_plan(plan: SweepPlan) -> None:
     if config.mode == "k8s":
         print(f"  Namespace:      {config.k8s.namespace}")
         print(f"  Endpoint:       {config.k8s.endpoint}")
+        if config.k8s.frontend_replicas > 1:
+            print(f"  FE replicas:    {config.k8s.frontend_replicas}")
         if config.k8s.dgd_name:
             print(f"  DGD:            {config.k8s.dgd_name}")
         if config.k8s.deploy_template:

--- a/benchmarks/frontend/scripts/sweep_core/planner.py
+++ b/benchmarks/frontend/scripts/sweep_core/planner.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+SweepPlan builder -- constructs a serializable execution plan from SweepConfig.
+
+The planner builds the Cartesian product of deploy dimensions x aiperf dimensions,
+producing a flat list of RunSpec objects. The isolation policy determines how
+they are executed by the orchestrator.
+"""
+
+from __future__ import annotations
+
+from sweep_core.models import (
+    AiperfDimension,
+    DeployDimension,
+    RunSpec,
+    SweepConfig,
+    SweepPlan,
+)
+from sweep_core.naming import build_run_id
+
+
+def build_plan(config: SweepConfig) -> SweepPlan:
+    """Build a SweepPlan from a SweepConfig.
+
+    The plan contains a flat list of RunSpecs, one per (deploy, aiperf) combination.
+    The ordering is: tokenizers -> workers -> concurrencies -> ISLs -> num_requests -> rps
+
+    This matches the grid construction order from the original sweep_runner.py.
+    """
+    runs: list[RunSpec] = []
+
+    for tokenizer in config.tokenizers:
+        for workers in config.worker_counts:
+            for concurrency in config.concurrencies:
+                for isl in config.isls:
+                    for nr in config.num_requests_list:
+                        for rps in config.rps_list:
+                            deploy = DeployDimension(
+                                backend=config.backend,
+                                tokenizer=tokenizer,
+                                workers=workers,
+                                num_models=config.num_models,
+                            )
+
+                            aiperf = AiperfDimension(
+                                concurrency=concurrency,
+                                isl=isl,
+                                osl=config.osl,
+                                num_requests=nr,
+                                benchmark_duration=config.benchmark_duration if nr is None else None,
+                                request_rate=rps,
+                            )
+
+                            run_id = build_run_id(deploy, aiperf)
+
+                            runs.append(
+                                RunSpec(
+                                    deploy=deploy,
+                                    aiperf=aiperf,
+                                    deploy_key=deploy.deploy_key,
+                                    run_id=run_id,
+                                )
+                            )
+
+    return SweepPlan(
+        config=config,
+        runs=runs,
+        isolation_policy=config.isolation_policy,
+        total_runs=len(runs),
+    )
+
+
+def print_plan(plan: SweepPlan) -> None:
+    """Print a human-readable summary of the sweep plan."""
+    config = plan.config
+    print(f"Sweep plan: {plan.total_runs} runs")
+    print(f"  Model:          {config.model}")
+    print(f"  Mode:           {config.mode}")
+    print(f"  Backend:        {config.backend}")
+    print(f"  Tokenizers:     {config.tokenizers}")
+    print(f"  Concurrencies:  {config.concurrencies}")
+    print(f"  ISLs:           {config.isls}")
+    print(f"  Workers/model:  {config.worker_counts}")
+    print(f"  Models:         {config.num_models}")
+    print(f"  Isolation:      {plan.isolation_policy}")
+    print(f"  Benchmark dur:  {config.benchmark_duration}s")
+    nr_list = [n for n in config.num_requests_list if n is not None]
+    if nr_list:
+        print(f"  Num requests:   {nr_list}")
+    rps_list = [r for r in config.rps_list if r is not None]
+    if rps_list:
+        print(f"  Request rates:  {rps_list} req/s")
+    print(f"  Output:         {config.output_dir}")
+    if config.mode == "k8s":
+        print(f"  Namespace:      {config.k8s.namespace}")
+        print(f"  Endpoint:       {config.k8s.endpoint}")
+        if config.k8s.dgd_name:
+            print(f"  DGD:            {config.k8s.dgd_name}")
+        if config.k8s.deploy_template:
+            print(f"  Template:       {config.k8s.deploy_template}")
+        print(f"  Reset strategy: {config.k8s.reset_strategy}")
+    print()

--- a/benchmarks/frontend/scripts/sweep_core/planner.py
+++ b/benchmarks/frontend/scripts/sweep_core/planner.py
@@ -48,7 +48,9 @@ def build_plan(config: SweepConfig) -> SweepPlan:
                                 isl=isl,
                                 osl=config.osl,
                                 num_requests=nr,
-                                benchmark_duration=config.benchmark_duration if nr is None else None,
+                                benchmark_duration=config.benchmark_duration
+                                if nr is None
+                                else None,
                                 request_rate=rps,
                             )
 

--- a/benchmarks/frontend/scripts/sweep_core/reporting.py
+++ b/benchmarks/frontend/scripts/sweep_core/reporting.py
@@ -26,4 +26,3 @@ def generate_report(run_dir: Path) -> None:
         print(f"    Report generation failed: {e}")
     except Exception as e:
         print(f"    Report generation failed: {e}")
-        raise

--- a/benchmarks/frontend/scripts/sweep_core/reporting.py
+++ b/benchmarks/frontend/scripts/sweep_core/reporting.py
@@ -10,14 +10,20 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent.parent
 ANALYSIS_DIR = SCRIPT_DIR / "analysis"
 
+# Add analysis directory to sys.path once at import time
+if str(ANALYSIS_DIR) not in sys.path:
+    sys.path.insert(0, str(ANALYSIS_DIR))
+
 
 def generate_report(run_dir: Path) -> None:
     """Run create_report.py on a single run directory, saving report.md."""
     try:
-        sys.path.insert(0, str(ANALYSIS_DIR))
         from create_report import run_analysis
 
         report = run_analysis(run_dir)
         (run_dir / "report.md").write_text(report)
+    except (ImportError, OSError) as e:
+        print(f"    Report generation failed: {e}")
     except Exception as e:
         print(f"    Report generation failed: {e}")
+        raise

--- a/benchmarks/frontend/scripts/sweep_core/reporting.py
+++ b/benchmarks/frontend/scripts/sweep_core/reporting.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-run report generation -- wraps analysis/create_report.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+ANALYSIS_DIR = SCRIPT_DIR / "analysis"
+
+
+def generate_report(run_dir: Path) -> None:
+    """Run create_report.py on a single run directory, saving report.md."""
+    try:
+        sys.path.insert(0, str(ANALYSIS_DIR))
+        from create_report import run_analysis
+
+        report = run_analysis(run_dir)
+        (run_dir / "report.md").write_text(report)
+    except Exception as e:
+        print(f"    Report generation failed: {e}")

--- a/benchmarks/frontend/scripts/sweep_executors/__init__.py
+++ b/benchmarks/frontend/scripts/sweep_executors/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""sweep_executors -- how individual runs execute."""

--- a/benchmarks/frontend/scripts/sweep_executors/base.py
+++ b/benchmarks/frontend/scripts/sweep_executors/base.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+SweepExecutor protocol -- the run-level extensibility seam.
+
+Each executor implements this protocol. The orchestrator calls these methods
+without knowing whether runs execute locally, in k8s, or elsewhere.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Protocol, runtime_checkable
+
+from sweep_core.models import DeployDimension, RunResult, RunSpec, SweepConfig
+
+
+@runtime_checkable
+class SweepExecutor(Protocol):
+    """Protocol for sweep executors."""
+
+    def prepare(self, config: SweepConfig) -> None:
+        """One-time setup before the sweep begins (e.g., start infra)."""
+        ...
+
+    def apply_deploy(
+        self,
+        deploy: DeployDimension,
+        prev: Optional[DeployDimension],
+    ) -> None:
+        """Apply a deployment change (e.g., restart frontend, switch backend).
+
+        Args:
+            deploy: The deployment configuration to apply.
+            prev: The previous deployment configuration (None for first run).
+        """
+        ...
+
+    def execute_run(self, run_spec: RunSpec, run_dir: Path) -> RunResult:
+        """Execute a single run and return results.
+
+        Args:
+            run_spec: The run specification.
+            run_dir: Directory where artifacts should be written.
+
+        Returns:
+            RunResult with status and metrics.
+        """
+        ...
+
+    def cleanup(self) -> None:
+        """Cleanup after the sweep completes (e.g., stop infra)."""
+        ...

--- a/benchmarks/frontend/scripts/sweep_executors/k8s_dgd.py
+++ b/benchmarks/frontend/scripts/sweep_executors/k8s_dgd.py
@@ -75,9 +75,7 @@ class K8sDgdExecutor:
 
         if self._template_path:
             # Template-based deployment: render + apply
-            k8s_template.apply_rendered_template(
-                self._template_path, deploy, config
-            )
+            k8s_template.apply_rendered_template(self._template_path, deploy, config)
             print("  Waiting for deployment to be ready...")
             k8s_dgd.wait_model_ready(k8s.endpoint, config.model_name, max_wait=300)
             return
@@ -113,16 +111,20 @@ class K8sDgdExecutor:
         if strategy == "graph":
             if k8s.dgd_name:
                 k8s_dgd.dgd_restart_graph(
-                    k8s.dgd_name, k8s.namespace,
-                    k8s.endpoint, self._config.model_name,
+                    k8s.dgd_name,
+                    k8s.namespace,
+                    k8s.endpoint,
+                    self._config.model_name,
                 )
             else:
                 print("  WARNING: graph reset requires --dgd-name")
         elif strategy == "frontend":
             if k8s.dgd_name:
                 k8s_dgd.dgd_restart_frontend(
-                    k8s.dgd_name, k8s.namespace,
-                    k8s.endpoint, self._config.model_name,
+                    k8s.dgd_name,
+                    k8s.namespace,
+                    k8s.endpoint,
+                    self._config.model_name,
                 )
             else:
                 print("  WARNING: frontend reset requires --dgd-name")
@@ -130,12 +132,16 @@ class K8sDgdExecutor:
             # Just wait for readiness
             if k8s.dgd_name:
                 k8s_dgd.dgd_wait_all_ready(
-                    k8s.dgd_name, k8s.namespace,
-                    k8s.endpoint, self._config.model_name,
+                    k8s.dgd_name,
+                    k8s.namespace,
+                    k8s.endpoint,
+                    self._config.model_name,
                     max_wait=60,
                 )
             else:
-                k8s_dgd.wait_model_ready(k8s.endpoint, self._config.model_name, max_wait=60)
+                k8s_dgd.wait_model_ready(
+                    k8s.endpoint, self._config.model_name, max_wait=60
+                )
 
     def execute_run(self, run_spec: RunSpec, run_dir: Path) -> RunResult:
         """Execute a single k8s run: metrics capture + aiperf + post-metrics."""
@@ -149,9 +155,13 @@ class K8sDgdExecutor:
 
         # Capture pre-run metrics (use in-cluster endpoint + kubectl exec fallback)
         frontend_label = (
-            f"nvidia.com/dynamo-graph-deployment-name={k8s.dgd_name},"
-            f"nvidia.com/dynamo-component-type=frontend"
-        ) if k8s.dgd_name else None
+            (
+                f"nvidia.com/dynamo-graph-deployment-name={k8s.dgd_name},"
+                f"nvidia.com/dynamo-component-type=frontend"
+            )
+            if k8s.dgd_name
+            else None
+        )
         capture_metrics(
             self._incluster_endpoint,
             run_dir / "frontend_metrics_pre.txt",

--- a/benchmarks/frontend/scripts/sweep_executors/k8s_dgd.py
+++ b/benchmarks/frontend/scripts/sweep_executors/k8s_dgd.py
@@ -20,6 +20,7 @@ from sweep_core.models import DeployDimension, RunResult, RunSpec, SweepConfig
 from sweep_k8s import aiperf as k8s_aiperf
 from sweep_k8s import dgd as k8s_dgd
 from sweep_k8s import template as k8s_template
+from sweep_k8s.kubectl import apply_secret_literal
 from sweep_k8s.metrics import capture_metrics
 
 
@@ -36,6 +37,15 @@ class K8sDgdExecutor:
         self._config = config
         k8s = config.k8s
 
+        if k8s.deploy and not k8s.deploy_template:
+            raise ValueError(
+                "--deploy requires --deploy-template; otherwise pre-deploy the DGD and omit --deploy"
+            )
+        if k8s.deploy_template and not k8s.deploy:
+            raise ValueError(
+                "--deploy-template mutates cluster resources; pass --deploy to allow template application"
+            )
+
         if k8s.deploy_template:
             self._template_path = Path(k8s.deploy_template)
             if not self._template_path.exists():
@@ -43,6 +53,17 @@ class K8sDgdExecutor:
                     f"Deploy template not found: {self._template_path}"
                 )
             print(f"  Using deploy template: {self._template_path}")
+
+        if k8s.hf_token:
+            print(
+                f"  Updating HuggingFace token secret: {k8s_template.DEFAULT_HF_TOKEN_SECRET_NAME}"
+            )
+            apply_secret_literal(
+                k8s_template.DEFAULT_HF_TOKEN_SECRET_NAME,
+                k8s.namespace,
+                "HF_TOKEN",
+                k8s.hf_token,
+            )
 
         # Compute the in-cluster endpoint for aiperf Jobs.
         # The user-provided --endpoint may be port-forwarded (e.g. localhost:18000),
@@ -195,6 +216,8 @@ class K8sDgdExecutor:
             num_requests=aiperf.num_requests,
             request_rate=aiperf.request_rate,
             export_level=k8s.export_level,
+            image_pull_secret=k8s.image_pull_secret,
+            hf_token_secret_name=k8s_template.DEFAULT_HF_TOKEN_SECRET_NAME,
         )
 
         if success:

--- a/benchmarks/frontend/scripts/sweep_executors/k8s_dgd.py
+++ b/benchmarks/frontend/scripts/sweep_executors/k8s_dgd.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+K8sDgdExecutor -- DynamoGraphDeployment-based executor for k8s sweeps.
+
+Handles DGD backend switching, restart strategies, metrics capture,
+and aiperf invocation against a k8s-deployed frontend.
+
+When --deploy-template is provided, uses template rendering instead of
+DGD patching. This enables arbitrary backend deployments.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from sweep_core.models import DeployDimension, RunResult, RunSpec, SweepConfig
+from sweep_k8s import aiperf as k8s_aiperf
+from sweep_k8s import dgd as k8s_dgd
+from sweep_k8s import template as k8s_template
+from sweep_k8s.metrics import capture_metrics
+
+
+class K8sDgdExecutor:
+    """Executor for k8s sweeps using DynamoGraphDeployment."""
+
+    def __init__(self) -> None:
+        self._config: Optional[SweepConfig] = None
+        self._template_path: Optional[Path] = None
+        self._incluster_endpoint: str = ""  # in-cluster service DNS for aiperf Jobs
+
+    def prepare(self, config: SweepConfig) -> None:
+        """Store config and validate k8s setup."""
+        self._config = config
+        k8s = config.k8s
+
+        if k8s.deploy_template:
+            self._template_path = Path(k8s.deploy_template)
+            if not self._template_path.exists():
+                raise FileNotFoundError(
+                    f"Deploy template not found: {self._template_path}"
+                )
+            print(f"  Using deploy template: {self._template_path}")
+
+        # Compute the in-cluster endpoint for aiperf Jobs.
+        # The user-provided --endpoint may be port-forwarded (e.g. localhost:18000),
+        # but aiperf Jobs run inside the cluster and need the service DNS name.
+        if k8s.dgd_name:
+            self._incluster_endpoint = f"{k8s.dgd_name}-frontend:{k8s.frontend_port}"
+        else:
+            self._incluster_endpoint = k8s.endpoint
+        print(f"  In-cluster endpoint for aiperf: {self._incluster_endpoint}")
+
+        # Wait for model to be ready before starting sweep.
+        # Uses kubectl fallback for in-cluster endpoints not reachable from localhost.
+        print("--- Pre-flight: waiting for frontend ---")
+        k8s_dgd.wait_model_ready(
+            self._incluster_endpoint,
+            config.model_name,
+            max_wait=300,
+            namespace=k8s.namespace,
+        )
+
+    def apply_deploy(
+        self,
+        deploy: DeployDimension,
+        prev: Optional[DeployDimension],
+    ) -> None:
+        """Apply a deployment change -- template-based or DGD patching."""
+        assert self._config is not None
+        config = self._config
+        k8s = config.k8s
+
+        if self._template_path:
+            # Template-based deployment: render + apply
+            k8s_template.apply_rendered_template(
+                self._template_path, deploy, config
+            )
+            print("  Waiting for deployment to be ready...")
+            k8s_dgd.wait_model_ready(k8s.endpoint, config.model_name, max_wait=300)
+            return
+
+        # Legacy DGD patching
+        if not k8s.dgd_name:
+            print("  WARNING: no DGD name set for k8s mode; skipping deploy")
+            return
+
+        # Check if tokenizer changed from previous run
+        if prev is not None and deploy.tokenizer != prev.tokenizer:
+            # Tokenizer changed -- need to switch backend
+            k8s_dgd.dgd_switch_backend(
+                k8s.dgd_name,
+                k8s.namespace,
+                k8s.endpoint,
+                config.model_name,
+                deploy.tokenizer,
+            )
+            return
+
+        # First run or same tokenizer -- apply reset strategy
+        # (On first run the DGD is already deployed with the right backend;
+        #  we just reset to get a clean baseline for metrics.)
+        self._apply_reset_strategy()
+
+    def _apply_reset_strategy(self) -> None:
+        """Apply the configured reset strategy."""
+        assert self._config is not None
+        k8s = self._config.k8s
+        strategy = k8s.reset_strategy
+
+        if strategy == "graph":
+            if k8s.dgd_name:
+                k8s_dgd.dgd_restart_graph(
+                    k8s.dgd_name, k8s.namespace,
+                    k8s.endpoint, self._config.model_name,
+                )
+            else:
+                print("  WARNING: graph reset requires --dgd-name")
+        elif strategy == "frontend":
+            if k8s.dgd_name:
+                k8s_dgd.dgd_restart_frontend(
+                    k8s.dgd_name, k8s.namespace,
+                    k8s.endpoint, self._config.model_name,
+                )
+            else:
+                print("  WARNING: frontend reset requires --dgd-name")
+        elif strategy == "none":
+            # Just wait for readiness
+            if k8s.dgd_name:
+                k8s_dgd.dgd_wait_all_ready(
+                    k8s.dgd_name, k8s.namespace,
+                    k8s.endpoint, self._config.model_name,
+                    max_wait=60,
+                )
+            else:
+                k8s_dgd.wait_model_ready(k8s.endpoint, self._config.model_name, max_wait=60)
+
+    def execute_run(self, run_spec: RunSpec, run_dir: Path) -> RunResult:
+        """Execute a single k8s run: metrics capture + aiperf + post-metrics."""
+        assert self._config is not None
+        config = self._config
+        k8s = config.k8s
+        aiperf = run_spec.aiperf
+
+        result = RunResult(run_spec=run_spec, run_dir=str(run_dir))
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        # Capture pre-run metrics (use in-cluster endpoint + kubectl exec fallback)
+        frontend_label = (
+            f"nvidia.com/dynamo-graph-deployment-name={k8s.dgd_name},"
+            f"nvidia.com/dynamo-component-type=frontend"
+        ) if k8s.dgd_name else None
+        capture_metrics(
+            self._incluster_endpoint,
+            run_dir / "frontend_metrics_pre.txt",
+            namespace=k8s.namespace,
+            pod_label=frontend_label,
+        )
+
+        # Run aiperf as a k8s Job (uses in-cluster service endpoint)
+        success = k8s_aiperf.run_aiperf(
+            artifact_dir=run_dir / "aiperf",
+            endpoint=self._incluster_endpoint,
+            model_name=config.model_name,
+            concurrency=aiperf.concurrency,
+            isl=aiperf.isl,
+            namespace=k8s.namespace,
+            image=k8s.image,
+            run_id=run_spec.run_id,
+            osl=aiperf.osl,
+            benchmark_duration=aiperf.benchmark_duration,
+            num_requests=aiperf.num_requests,
+            request_rate=aiperf.request_rate,
+            export_level=k8s.export_level,
+        )
+
+        if success:
+            result.status = "ok"
+        else:
+            result.status = "fail"
+
+        # Capture post-run metrics
+        capture_metrics(
+            self._incluster_endpoint,
+            run_dir / "frontend_metrics_post.txt",
+            namespace=k8s.namespace,
+            pod_label=frontend_label,
+        )
+
+        # Parse aiperf results
+        _parse_k8s_aiperf_into_result(result, run_dir)
+
+        return result
+
+    def cleanup(self) -> None:
+        """No persistent state to clean up."""
+        pass
+
+
+def _parse_k8s_aiperf_into_result(result: RunResult, run_dir: Path) -> None:
+    """Parse aiperf results from k8s run directory."""
+    aiperf_json = run_dir / "aiperf" / "profile_export_aiperf.json"
+    if not aiperf_json.exists():
+        return
+
+    try:
+        data = json.loads(aiperf_json.read_text())
+        rt = data.get("request_throughput", {})
+        result.req_per_sec = rt.get("avg", 0) or 0
+        ot = data.get("output_token_throughput", {})
+        result.output_tok_per_sec = ot.get("avg", 0) or 0
+        ttft = data.get("time_to_first_token", data.get("ttft", {}))
+        if isinstance(ttft, dict):
+            result.ttft_p50_ms = ttft.get("p50", 0) or 0
+            result.ttft_p99_ms = ttft.get("p99", 0) or 0
+        itl = data.get("inter_token_latency", data.get("itl", {}))
+        if isinstance(itl, dict):
+            result.itl_p50_ms = itl.get("p50", 0) or 0
+            result.itl_p99_ms = itl.get("p99", 0) or 0
+        bd = data.get("benchmark_duration", 0)
+        result.duration_sec = bd.get("avg", 0) if isinstance(bd, dict) else (bd or 0)
+    except (json.JSONDecodeError, KeyError, TypeError):
+        pass

--- a/benchmarks/frontend/scripts/sweep_executors/k8s_dgd.py
+++ b/benchmarks/frontend/scripts/sweep_executors/k8s_dgd.py
@@ -54,14 +54,15 @@ class K8sDgdExecutor:
         print(f"  In-cluster endpoint for aiperf: {self._incluster_endpoint}")
 
         # Wait for model to be ready before starting sweep.
-        # Uses kubectl fallback for in-cluster endpoints not reachable from localhost.
-        print("--- Pre-flight: waiting for frontend ---")
-        k8s_dgd.wait_model_ready(
-            self._incluster_endpoint,
-            config.model_name,
-            max_wait=300,
-            namespace=k8s.namespace,
-        )
+        # Skip when using deploy templates -- the deployment hasn't been applied yet.
+        if not self._template_path:
+            print("--- Pre-flight: waiting for frontend ---")
+            k8s_dgd.wait_model_ready(
+                self._incluster_endpoint,
+                config.model_name,
+                max_wait=300,
+                namespace=k8s.namespace,
+            )
 
     def apply_deploy(
         self,
@@ -69,7 +70,8 @@ class K8sDgdExecutor:
         prev: Optional[DeployDimension],
     ) -> None:
         """Apply a deployment change -- template-based or DGD patching."""
-        assert self._config is not None
+        if self._config is None:
+            raise RuntimeError("prepare() must be called before apply_deploy()")
         config = self._config
         k8s = config.k8s
 
@@ -77,7 +79,12 @@ class K8sDgdExecutor:
             # Template-based deployment: render + apply
             k8s_template.apply_rendered_template(self._template_path, deploy, config)
             print("  Waiting for deployment to be ready...")
-            k8s_dgd.wait_model_ready(k8s.endpoint, config.model_name, max_wait=300)
+            k8s_dgd.wait_model_ready(
+                self._incluster_endpoint,
+                config.model_name,
+                namespace=k8s.namespace,
+                max_wait=300,
+            )
             return
 
         # Legacy DGD patching
@@ -104,7 +111,10 @@ class K8sDgdExecutor:
 
     def _apply_reset_strategy(self) -> None:
         """Apply the configured reset strategy."""
-        assert self._config is not None
+        if self._config is None:
+            raise RuntimeError(
+                "prepare() must be called before _apply_reset_strategy()"
+            )
         k8s = self._config.k8s
         strategy = k8s.reset_strategy
 
@@ -145,7 +155,8 @@ class K8sDgdExecutor:
 
     def execute_run(self, run_spec: RunSpec, run_dir: Path) -> RunResult:
         """Execute a single k8s run: metrics capture + aiperf + post-metrics."""
-        assert self._config is not None
+        if self._config is None:
+            raise RuntimeError("prepare() must be called before execute_run()")
         config = self._config
         k8s = config.k8s
         aiperf = run_spec.aiperf

--- a/benchmarks/frontend/scripts/sweep_executors/local.py
+++ b/benchmarks/frontend/scripts/sweep_executors/local.py
@@ -22,14 +22,6 @@ from sweep_core.models import DeployDimension, RunResult, RunSpec, SweepConfig
 
 SCRIPT_DIR = Path(__file__).resolve().parent.parent
 
-# Tokenizer name mapping: human-readable CLI names -> DYN_TOKENIZER values
-TOKENIZER_MAP = {
-    "fast": "fastokens",
-    "fastokens": "fastokens",
-    "hf": "default",
-    "default": "default",
-}
-
 
 class LocalExecutor:
     """Executor that delegates runs to run_perf.sh."""
@@ -56,7 +48,8 @@ class LocalExecutor:
 
     def execute_run(self, run_spec: RunSpec, run_dir: Path) -> RunResult:
         """Execute a single run via run_perf.sh."""
-        assert self._config is not None
+        if self._config is None:
+            raise RuntimeError("prepare() must be called before execute_run()")
         config = self._config
         deploy = run_spec.deploy
         aiperf = run_spec.aiperf
@@ -200,11 +193,8 @@ def _parse_aiperf_into_result(result: RunResult, run_dir: Path) -> None:
 
 def _port_free(port: int) -> bool:
     """Check if a port is free."""
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         return s.connect_ex(("127.0.0.1", port)) != 0
-    finally:
-        s.close()
 
 
 def _kill_port(port: int) -> None:

--- a/benchmarks/frontend/scripts/sweep_executors/local.py
+++ b/benchmarks/frontend/scripts/sweep_executors/local.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+LocalExecutor -- wraps run_perf.sh for local sweep execution.
+
+This executor delegates each run to run_perf.sh, which handles service
+lifecycle (mocker + frontend), observability captures, and aiperf load.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+from sweep_core.models import DeployDimension, RunResult, RunSpec, SweepConfig
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+
+# Tokenizer name mapping: human-readable CLI names -> DYN_TOKENIZER values
+TOKENIZER_MAP = {
+    "fast": "fastokens",
+    "fastokens": "fastokens",
+    "hf": "default",
+    "default": "default",
+}
+
+
+class LocalExecutor:
+    """Executor that delegates runs to run_perf.sh."""
+
+    def __init__(self) -> None:
+        self._config: Optional[SweepConfig] = None
+        self._frontend_port: int = 8000
+
+    def prepare(self, config: SweepConfig) -> None:
+        """Store config for use during runs."""
+        self._config = config
+        self._frontend_port = 8000  # local mode always uses 8000
+
+    def apply_deploy(
+        self,
+        deploy: DeployDimension,
+        prev: Optional[DeployDimension],
+    ) -> None:
+        """In local mode, run_perf.sh handles its own service lifecycle.
+
+        We just wait for the port to be free from the previous run.
+        """
+        _wait_port_free(self._frontend_port)
+
+    def execute_run(self, run_spec: RunSpec, run_dir: Path) -> RunResult:
+        """Execute a single run via run_perf.sh."""
+        assert self._config is not None
+        config = self._config
+        deploy = run_spec.deploy
+        aiperf = run_spec.aiperf
+
+        result = RunResult(run_spec=run_spec, run_dir=str(run_dir))
+
+        cmd = [
+            str(SCRIPT_DIR / "run_perf.sh"),
+            "--model",
+            config.model,
+            "--isl",
+            str(aiperf.isl),
+            "--osl",
+            str(aiperf.osl),
+            "--concurrency",
+            str(aiperf.concurrency),
+            "--workers",
+            str(deploy.workers),
+            "--speedup-ratio",
+            str(config.speedup_ratio),
+            "--num-models",
+            str(deploy.num_models),
+            "--aiperf-targets",
+            config.aiperf_targets,
+            "--output-dir",
+            str(run_dir),
+        ]
+
+        if aiperf.benchmark_duration:
+            cmd.extend(["--benchmark-duration", str(aiperf.benchmark_duration)])
+        if aiperf.num_requests:
+            cmd.extend(["--num-requests", str(aiperf.num_requests)])
+        if aiperf.request_rate:
+            cmd.extend(["--request-rate", str(aiperf.request_rate)])
+        if deploy.tokenizer in ("fast", "fastokens"):
+            cmd.append("--fast-tokens")
+
+        # TODO: when run_perf.sh gains --backend vllm support, pass it here
+        if deploy.backend == "vllm":
+            print("    WARNING: vllm backend not yet supported by run_perf.sh; using mocker")
+
+        # Passthrough args (e.g., --skip-bpf --skip-nsys)
+        cmd.extend(config.passthrough_args)
+
+        print(f"    cmd: {' '.join(cmd[:6])}...")
+
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                start_new_session=True,
+            )
+            stdout, _ = proc.communicate(timeout=600)
+
+            if proc.returncode == 0:
+                result.status = "ok"
+            else:
+                result.status = "fail"
+                print(f"    run_perf.sh failed (rc={proc.returncode})")
+                lines = (stdout or "").strip().split("\n")
+                for line in lines[-5:]:
+                    print(f"      {line}")
+
+        except subprocess.TimeoutExpired:
+            result.status = "fail"
+            print("    TIMEOUT after 600s")
+            try:
+                pgid = os.getpgid(proc.pid)
+                os.killpg(pgid, signal.SIGTERM)
+                time.sleep(2)
+                os.killpg(pgid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        except Exception as e:
+            result.status = "fail"
+            print(f"    ERROR: {e}")
+
+        # Parse aiperf results
+        _parse_aiperf_into_result(result, run_dir)
+
+        return result
+
+    def cleanup(self) -> None:
+        """No persistent state to clean up in local mode."""
+        pass
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _parse_aiperf_json(json_path: Path) -> dict:
+    """Parse aiperf profile_export_aiperf.json."""
+    if not json_path.exists():
+        return {}
+    try:
+        data = json.loads(json_path.read_text())
+        result = {}
+        rt = data.get("request_throughput", {})
+        result["req_per_sec"] = rt.get("avg", 0)
+        ot = data.get("output_token_throughput", {})
+        result["output_tok_per_sec"] = ot.get("avg", 0)
+        ttft = data.get("time_to_first_token", data.get("ttft", {}))
+        if isinstance(ttft, dict):
+            result["ttft_p50_ms"] = ttft.get("p50", 0) or 0
+            result["ttft_p99_ms"] = ttft.get("p99", 0) or 0
+        itl = data.get("inter_token_latency", data.get("itl", {}))
+        if isinstance(itl, dict):
+            result["itl_p50_ms"] = itl.get("p50", 0) or 0
+            result["itl_p99_ms"] = itl.get("p99", 0) or 0
+        bd = data.get("benchmark_duration", 0)
+        result["duration_sec"] = bd.get("avg", 0) if isinstance(bd, dict) else (bd or 0)
+        return result
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return {}
+
+
+def _parse_aiperf_into_result(result: RunResult, run_dir: Path) -> None:
+    """Parse aiperf results from the run directory into the RunResult."""
+    aiperf_json = run_dir / "aiperf" / "profile_export_aiperf.json"
+    if not aiperf_json.exists():
+        # Multi-model: results are in aiperf/<model-name>/
+        for candidate in sorted((run_dir / "aiperf").glob("*/profile_export_aiperf.json")):
+            aiperf_json = candidate
+            break
+    metrics = _parse_aiperf_json(aiperf_json)
+    if metrics:
+        result.req_per_sec = metrics.get("req_per_sec", 0)
+        result.output_tok_per_sec = metrics.get("output_tok_per_sec", 0)
+        result.ttft_p50_ms = metrics.get("ttft_p50_ms", 0)
+        result.ttft_p99_ms = metrics.get("ttft_p99_ms", 0)
+        result.itl_p50_ms = metrics.get("itl_p50_ms", 0)
+        result.itl_p99_ms = metrics.get("itl_p99_ms", 0)
+        result.duration_sec = metrics.get("duration_sec", 0)
+
+
+def _port_free(port: int) -> bool:
+    """Check if a port is free."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        return s.connect_ex(("127.0.0.1", port)) != 0
+    finally:
+        s.close()
+
+
+def _kill_port(port: int) -> None:
+    """Kill any process holding a port."""
+    subprocess.run(f"fuser -k -TERM {port}/tcp", shell=True, capture_output=True, timeout=5)
+    time.sleep(2)
+    subprocess.run(f"fuser -k -KILL {port}/tcp", shell=True, capture_output=True, timeout=5)
+
+
+def _wait_port_free(port: int, timeout: int = 30) -> None:
+    """Wait for a port to become free."""
+    for i in range(timeout):
+        if _port_free(port):
+            return
+        if i == 0:
+            print(f"  Waiting for port {port} to free...")
+        time.sleep(1)
+    print(f"  Forcing port {port} release...")
+    _kill_port(port)
+    time.sleep(2)

--- a/benchmarks/frontend/scripts/sweep_executors/local.py
+++ b/benchmarks/frontend/scripts/sweep_executors/local.py
@@ -96,7 +96,9 @@ class LocalExecutor:
 
         # TODO: when run_perf.sh gains --backend vllm support, pass it here
         if deploy.backend == "vllm":
-            print("    WARNING: vllm backend not yet supported by run_perf.sh; using mocker")
+            print(
+                "    WARNING: vllm backend not yet supported by run_perf.sh; using mocker"
+            )
 
         # Passthrough args (e.g., --skip-bpf --skip-nsys)
         cmd.extend(config.passthrough_args)
@@ -180,7 +182,9 @@ def _parse_aiperf_into_result(result: RunResult, run_dir: Path) -> None:
     aiperf_json = run_dir / "aiperf" / "profile_export_aiperf.json"
     if not aiperf_json.exists():
         # Multi-model: results are in aiperf/<model-name>/
-        for candidate in sorted((run_dir / "aiperf").glob("*/profile_export_aiperf.json")):
+        for candidate in sorted(
+            (run_dir / "aiperf").glob("*/profile_export_aiperf.json")
+        ):
             aiperf_json = candidate
             break
     metrics = _parse_aiperf_json(aiperf_json)
@@ -205,9 +209,13 @@ def _port_free(port: int) -> bool:
 
 def _kill_port(port: int) -> None:
     """Kill any process holding a port."""
-    subprocess.run(f"fuser -k -TERM {port}/tcp", shell=True, capture_output=True, timeout=5)
+    subprocess.run(
+        f"fuser -k -TERM {port}/tcp", shell=True, capture_output=True, timeout=5
+    )
     time.sleep(2)
-    subprocess.run(f"fuser -k -KILL {port}/tcp", shell=True, capture_output=True, timeout=5)
+    subprocess.run(
+        f"fuser -k -KILL {port}/tcp", shell=True, capture_output=True, timeout=5
+    )
 
 
 def _wait_port_free(port: int, timeout: int = 30) -> None:

--- a/benchmarks/frontend/scripts/sweep_k8s/__init__.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""sweep_k8s -- Kubernetes subprocess helpers for DGD-based sweeps."""

--- a/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
@@ -21,6 +21,8 @@ from typing import Optional
 
 from sweep_k8s.kubectl import run_kubectl
 
+DEFAULT_HF_TOKEN_SECRET_NAME = "hf-token-secret"
+
 
 def _build_aiperf_script(
     model_name: str,
@@ -118,12 +120,20 @@ def _build_job_yaml(
     job_name: str,
     namespace: str,
     script: str,
+    image_pull_secret: str = "",
+    hf_token_secret_name: str = DEFAULT_HF_TOKEN_SECRET_NAME,
 ) -> str:
     """Build the aiperf k8s Job YAML.
 
     Uses python:3.12-slim with pip-installed aiperf (same pattern as
     recipes/qwen3-235b-a22b-fp8/trtllm/agg/perf.yaml).
     """
+    image_pull_secret_block = ""
+    if image_pull_secret:
+        image_pull_secret_block = f"""
+      imagePullSecrets:
+        - name: {image_pull_secret}"""
+
     return f"""apiVersion: batch/v1
 kind: Job
 metadata:
@@ -143,8 +153,7 @@ spec:
         job-name: {job_name}
     spec:
       restartPolicy: Never
-      imagePullSecrets:
-        - name: nvcrimagepullsecret
+{image_pull_secret_block}
       securityContext:
         sysctls:
           - name: net.ipv4.ip_local_port_range
@@ -166,7 +175,7 @@ spec:
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: hf-token-secret
+                  name: {hf_token_secret_name}
                   key: HF_TOKEN
             - name: PYTHONUNBUFFERED
               value: "1"
@@ -376,6 +385,8 @@ def run_aiperf(
     warmup_duration: Optional[int] = None,
     warmup_count: Optional[int] = None,
     export_level: str = "summary",
+    image_pull_secret: str = "",
+    hf_token_secret_name: str = DEFAULT_HF_TOKEN_SECRET_NAME,
     timeout: int = 600,
 ) -> bool:
     """Run aiperf as a k8s Job inside the namespace.
@@ -400,6 +411,8 @@ def run_aiperf(
         warmup_duration: Optional warmup duration in seconds.
         warmup_count: Optional warmup request count.
         export_level: aiperf export level (summary, records, raw).
+        image_pull_secret: Optional image pull secret for the Job pod.
+        hf_token_secret_name: Secret name that stores HF_TOKEN.
         timeout: Job timeout in seconds.
 
     Returns:
@@ -430,6 +443,8 @@ def run_aiperf(
         job_name=job_name,
         namespace=namespace,
         script=script,
+        image_pull_secret=image_pull_secret,
+        hf_token_secret_name=hf_token_secret_name,
     )
 
     # Create the Job

--- a/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
@@ -241,8 +241,14 @@ def _print_job_logs(job_name: str, namespace: str, tail: int = 20) -> None:
 def _get_job_pod_name(job_name: str, namespace: str) -> Optional[str]:
     """Get the pod name for a Job."""
     result = run_kubectl(
-        ["get", "pods", "-l", f"job-name={job_name}",
-         "-o", "jsonpath={.items[0].metadata.name}"],
+        [
+            "get",
+            "pods",
+            "-l",
+            f"job-name={job_name}",
+            "-o",
+            "jsonpath={.items[0].metadata.name}",
+        ],
         namespace=namespace,
         check=False,
     )
@@ -292,7 +298,8 @@ spec:
         for _ in range(30):
             result = run_kubectl(
                 ["get", "pod", helper_name, "-o", "jsonpath={.status.phase}"],
-                namespace=namespace, check=False,
+                namespace=namespace,
+                check=False,
             )
             if result.stdout.strip() == "Running":
                 break
@@ -301,7 +308,8 @@ spec:
         # List what's on the PVC
         result = run_kubectl(
             ["exec", helper_name, "--", "ls", "-la", pvc_path],
-            namespace=namespace, check=False,
+            namespace=namespace,
+            check=False,
         )
         if result.stdout:
             print(f"  PVC artifacts ({pvc_path}):")
@@ -310,10 +318,16 @@ spec:
 
         # Copy artifacts locally
         subprocess.run(
-            ["kubectl", "cp",
-             f"{namespace}/{helper_name}:{pvc_path}/",
-             str(local_dir) + "/"],
-            capture_output=True, text=True, check=True, timeout=120,
+            [
+                "kubectl",
+                "cp",
+                f"{namespace}/{helper_name}:{pvc_path}/",
+                str(local_dir) + "/",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=120,
         )
         files = list(local_dir.glob("*"))
         print(f"  Copied {len(files)} artifact files to local")
@@ -326,7 +340,8 @@ spec:
         # Cleanup helper pod
         run_kubectl(
             ["delete", "pod", helper_name, "--ignore-not-found", "--grace-period=0"],
-            namespace=namespace, check=False,
+            namespace=namespace,
+            check=False,
         )
 
 

--- a/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
@@ -59,9 +59,8 @@ def _build_aiperf_script(
 
     return f"""set -e
 apt-get update -qq && apt-get install -y -qq curl jq git procps 2>/dev/null
-pip install --quiet git+https://github.com/ai-dynamo/aiperf.git@main
+pip install --quiet git+https://github.com/ai-dynamo/aiperf.git@54cd6dc820bff8bfebc875da104e59d745e14f75
 echo "aiperf installed"
-sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
 
 # Wait for model
 echo "Waiting for model '{model_name}' at http://{endpoint}/v1/models..."
@@ -146,12 +145,16 @@ spec:
       restartPolicy: Never
       imagePullSecrets:
         - name: nvcrimagepullsecret
+      securityContext:
+        sysctls:
+          - name: net.ipv4.ip_local_port_range
+            value: "1024 65000"
       containers:
         - name: aiperf
           image: python:3.12-slim
           imagePullPolicy: IfNotPresent
           securityContext:
-            privileged: true
+            allowPrivilegeEscalation: false
           command:
             - /bin/bash
             - -c
@@ -212,8 +215,8 @@ def _wait_for_job(
                     print(f"  aiperf Job FAILED (waited {waited}s)")
                     _print_job_logs(job_name, namespace)
                     return False
-        except Exception:
-            pass
+        except (json.JSONDecodeError, subprocess.SubprocessError, OSError) as e:
+            print(f"  Transient error polling job {job_name} in {namespace}: {e}")
 
         time.sleep(5)
         waited += 5
@@ -260,13 +263,17 @@ def _copy_artifacts_from_pvc(
     job_name: str,
     namespace: str,
     local_dir: Path,
-) -> None:
+) -> bool:
     """Copy aiperf artifacts from the model-cache PVC to the local filesystem.
 
     Spins up a temporary busybox pod that mounts the PVC, uses kubectl cp
     to extract the artifacts, then deletes the pod.
+
+    Returns True if artifacts were successfully copied and the expected
+    profile_export_aiperf.json exists, False otherwise.
     """
     local_dir.mkdir(parents=True, exist_ok=True)
+    artifacts_ok = False
     helper_name = f"copy-{job_name[-20:]}"
     pvc_path = f"/model-cache/perf/{job_name}"
 
@@ -334,6 +341,12 @@ spec:
         for f in sorted(files)[:5]:
             print(f"    {f.name} ({f.stat().st_size} bytes)")
 
+        expected = local_dir / "profile_export_aiperf.json"
+        if expected.exists() and expected.stat().st_size > 0:
+            artifacts_ok = True
+        else:
+            print(f"  WARNING: expected artifact missing or empty: {expected.name}")
+
     except Exception as e:
         print(f"  WARNING: artifact copy failed: {e}")
     finally:
@@ -343,6 +356,8 @@ spec:
             namespace=namespace,
             check=False,
         )
+
+    return artifacts_ok
 
 
 def run_aiperf(
@@ -432,7 +447,10 @@ def run_aiperf(
     success = _wait_for_job(job_name, namespace, timeout=timeout)
 
     # Copy artifacts from PVC regardless of success (partial results may exist)
-    _copy_artifacts_from_pvc(job_name, namespace, artifact_dir)
+    artifacts_ok = _copy_artifacts_from_pvc(job_name, namespace, artifact_dir)
+    if success and not artifacts_ok:
+        print("  Job succeeded but artifacts missing -- marking as failure")
+        success = False
 
     # Print logs on failure
     if not success:

--- a/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
@@ -1,0 +1,433 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+K8s aiperf Job launcher.
+
+Runs aiperf as a k8s Job inside the same namespace as the DGD, using the
+in-cluster service DNS endpoint. Uses python:3.12-slim with pip-installed
+aiperf (same pattern as recipes/qwen3-235b-a22b-fp8/trtllm/agg/perf.yaml).
+
+Artifacts are written inside the pod, then copied back to the local host
+via kubectl cp.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+from sweep_k8s.kubectl import run_kubectl
+
+
+def _build_aiperf_script(
+    model_name: str,
+    endpoint: str,
+    concurrency: int,
+    isl: int,
+    osl: int = 256,
+    benchmark_duration: Optional[int] = None,
+    num_requests: Optional[int] = None,
+    request_rate: Optional[int] = None,
+    warmup_duration: Optional[int] = None,
+    warmup_count: Optional[int] = None,
+    export_level: str = "summary",
+) -> str:
+    """Build the shell script that runs inside the Job container."""
+    # Build load-control args
+    load_args = ""
+    if benchmark_duration:
+        load_args += f" --benchmark-duration {benchmark_duration}"
+    if num_requests:
+        load_args += f" --request-count {num_requests}"
+    if request_rate:
+        load_args += f" --request-rate {request_rate}"
+    if not load_args.strip():
+        auto_count = max(concurrency * 20, 640)
+        load_args = f" --request-count {auto_count}"
+
+    # Warmup args
+    warmup_args = ""
+    if warmup_duration:
+        warmup_args = f" --warmup-duration {warmup_duration}"
+    elif warmup_count:
+        warmup_args = f" --warmup-request-count {warmup_count}"
+    else:
+        warmup_args = f" --warmup-request-count {concurrency}"
+
+    return f"""set -e
+apt-get update -qq && apt-get install -y -qq curl jq git procps 2>/dev/null
+pip install --quiet git+https://github.com/ai-dynamo/aiperf.git@main
+echo "aiperf installed"
+sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
+
+# Wait for model
+echo "Waiting for model '{model_name}' at http://{endpoint}/v1/models..."
+while ! curl -sf "http://{endpoint}/v1/models" 2>/dev/null | \\
+      jq -e --arg m "{model_name}" '.data[]? | select(.id == $m)' >/dev/null 2>&1; do
+    echo "  Model not ready, sleeping 5s..."
+    sleep 5
+done
+echo "Model ready!"
+
+# Write artifacts to PVC so they persist after pod completion
+ARTIFACT_DIR="${{ARTIFACT_PVC_DIR:-/model-cache/perf/${{JOB_NAME}}}}"
+mkdir -p "$ARTIFACT_DIR"
+echo "Running aiperf: c={concurrency} isl={isl} osl={osl}"
+echo "Artifact dir: $ARTIFACT_DIR"
+aiperf profile \\
+    --artifact-dir "$ARTIFACT_DIR" \\
+    --model "{model_name}" \\
+    --tokenizer "{model_name}" \\
+    --endpoint-type chat \\
+    --endpoint /v1/chat/completions \\
+    --streaming \\
+    --url "http://{endpoint}" \\
+    --synthetic-input-tokens-mean {isl} \\
+    --synthetic-input-tokens-stddev 0 \\
+    --output-tokens-mean {osl} \\
+    --output-tokens-stddev 0 \\
+    --extra-inputs "max_tokens:{osl}" \\
+    --extra-inputs "min_tokens:{osl}" \\
+    --extra-inputs "ignore_eos:true" \\
+    --extra-inputs "repetition_penalty:1.0" \\
+    --extra-inputs "temperature:0.0" \\
+    --concurrency {concurrency} \\
+    {load_args.strip()} \\
+    {warmup_args.strip()} \\
+    --num-dataset-entries 12800 \\
+    --random-seed 100 \\
+    --workers-max {concurrency} \\
+    --record-processors 32 \\
+    --export-level {export_level} \\
+    --ui simple
+
+echo "aiperf done. Artifacts:"
+ls -la "$ARTIFACT_DIR"/
+"""
+
+
+def _indent(text: str, spaces: int) -> str:
+    """Indent each line of text by N spaces."""
+    prefix = " " * spaces
+    return "\n".join(prefix + line for line in text.split("\n"))
+
+
+def _build_job_yaml(
+    job_name: str,
+    namespace: str,
+    script: str,
+) -> str:
+    """Build the aiperf k8s Job YAML.
+
+    Uses python:3.12-slim with pip-installed aiperf (same pattern as
+    recipes/qwen3-235b-a22b-fp8/trtllm/agg/perf.yaml).
+    """
+    return f"""apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {job_name}
+  namespace: {namespace}
+  labels:
+    app: sweep-aiperf
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: sweep-aiperf
+        job-name: {job_name}
+    spec:
+      restartPolicy: Never
+      imagePullSecrets:
+        - name: nvcrimagepullsecret
+      containers:
+        - name: aiperf
+          image: python:3.12-slim
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          command:
+            - /bin/bash
+            - -c
+            - |
+{_indent(script, 14)}
+          env:
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: AIPERF_HTTP_CONNECTION_LIMIT
+              value: "512"
+            - name: JOB_NAME
+              value: {job_name}
+            - name: ARTIFACT_PVC_DIR
+              value: /model-cache/perf/{job_name}
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-cache
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+"""
+
+
+def _wait_for_job(
+    job_name: str,
+    namespace: str,
+    timeout: int = 600,
+) -> bool:
+    """Poll for Job completion. Returns True if succeeded."""
+    waited = 0
+    while waited < timeout:
+        try:
+            result = run_kubectl(
+                ["get", "job", job_name, "-o", "json"],
+                namespace=namespace,
+                check=False,
+            )
+            if result.returncode != 0:
+                time.sleep(5)
+                waited += 5
+                continue
+
+            job_data = json.loads(result.stdout)
+            conditions = job_data.get("status", {}).get("conditions", [])
+            for cond in conditions:
+                if cond.get("type") == "Complete" and cond.get("status") == "True":
+                    print(f"  aiperf Job completed (waited {waited}s)")
+                    return True
+                if cond.get("type") == "Failed" and cond.get("status") == "True":
+                    print(f"  aiperf Job FAILED (waited {waited}s)")
+                    _print_job_logs(job_name, namespace)
+                    return False
+        except Exception:
+            pass
+
+        time.sleep(5)
+        waited += 5
+        if waited % 30 == 0:
+            print(f"  aiperf Job running ({waited}s / {timeout}s)...")
+
+    print(f"  aiperf Job timed out after {timeout}s")
+    _print_job_logs(job_name, namespace)
+    return False
+
+
+def _print_job_logs(job_name: str, namespace: str, tail: int = 20) -> None:
+    """Print last N lines of the Job pod logs."""
+    result = run_kubectl(
+        ["logs", f"job/{job_name}", f"--tail={tail}"],
+        namespace=namespace,
+        check=False,
+    )
+    if result.stdout:
+        print(f"  --- Last {tail} lines of aiperf logs ---")
+        for line in result.stdout.strip().split("\n"):
+            print(f"    {line}")
+
+
+def _get_job_pod_name(job_name: str, namespace: str) -> Optional[str]:
+    """Get the pod name for a Job."""
+    result = run_kubectl(
+        ["get", "pods", "-l", f"job-name={job_name}",
+         "-o", "jsonpath={.items[0].metadata.name}"],
+        namespace=namespace,
+        check=False,
+    )
+    name = result.stdout.strip()
+    return name if name else None
+
+
+def _copy_artifacts_from_pvc(
+    job_name: str,
+    namespace: str,
+    local_dir: Path,
+) -> None:
+    """Copy aiperf artifacts from the model-cache PVC to the local filesystem.
+
+    Spins up a temporary busybox pod that mounts the PVC, uses kubectl cp
+    to extract the artifacts, then deletes the pod.
+    """
+    local_dir.mkdir(parents=True, exist_ok=True)
+    helper_name = f"copy-{job_name[-20:]}"
+    pvc_path = f"/model-cache/perf/{job_name}"
+
+    try:
+        # Create a helper pod to access the PVC
+        helper_yaml = f"""apiVersion: v1
+kind: Pod
+metadata:
+  name: {helper_name}
+  namespace: {namespace}
+spec:
+  restartPolicy: Never
+  containers:
+    - name: copy
+      image: busybox:latest
+      command: ["sh", "-c", "echo ready && sleep 300"]
+      volumeMounts:
+        - name: model-cache
+          mountPath: /model-cache
+          readOnly: true
+  volumes:
+    - name: model-cache
+      persistentVolumeClaim:
+        claimName: model-cache
+"""
+        run_kubectl(["apply", "-f", "-"], namespace=namespace, input_data=helper_yaml)
+
+        # Wait for helper pod to be ready
+        for _ in range(30):
+            result = run_kubectl(
+                ["get", "pod", helper_name, "-o", "jsonpath={.status.phase}"],
+                namespace=namespace, check=False,
+            )
+            if result.stdout.strip() == "Running":
+                break
+            time.sleep(2)
+
+        # List what's on the PVC
+        result = run_kubectl(
+            ["exec", helper_name, "--", "ls", "-la", pvc_path],
+            namespace=namespace, check=False,
+        )
+        if result.stdout:
+            print(f"  PVC artifacts ({pvc_path}):")
+            for line in result.stdout.strip().split("\n")[:6]:
+                print(f"    {line}")
+
+        # Copy artifacts locally
+        subprocess.run(
+            ["kubectl", "cp",
+             f"{namespace}/{helper_name}:{pvc_path}/",
+             str(local_dir) + "/"],
+            capture_output=True, text=True, check=True, timeout=120,
+        )
+        files = list(local_dir.glob("*"))
+        print(f"  Copied {len(files)} artifact files to local")
+        for f in sorted(files)[:5]:
+            print(f"    {f.name} ({f.stat().st_size} bytes)")
+
+    except Exception as e:
+        print(f"  WARNING: artifact copy failed: {e}")
+    finally:
+        # Cleanup helper pod
+        run_kubectl(
+            ["delete", "pod", helper_name, "--ignore-not-found", "--grace-period=0"],
+            namespace=namespace, check=False,
+        )
+
+
+def run_aiperf(
+    artifact_dir: Path,
+    endpoint: str,
+    model_name: str,
+    concurrency: int,
+    isl: int,
+    namespace: str,
+    image: str,
+    run_id: str,
+    osl: int = 256,
+    benchmark_duration: Optional[int] = None,
+    num_requests: Optional[int] = None,
+    request_rate: Optional[int] = None,
+    warmup_duration: Optional[int] = None,
+    warmup_count: Optional[int] = None,
+    export_level: str = "summary",
+    timeout: int = 600,
+) -> bool:
+    """Run aiperf as a k8s Job inside the namespace.
+
+    Creates a Job with python:3.12-slim, installs aiperf via pip, runs the
+    benchmark against the in-cluster service endpoint, then copies artifacts
+    back to the local filesystem.
+
+    Args:
+        artifact_dir: Local directory for aiperf artifacts.
+        endpoint: In-cluster frontend endpoint (service:port).
+        model_name: Model name for aiperf --model.
+        concurrency: Concurrency level.
+        isl: Input sequence length.
+        namespace: K8s namespace.
+        image: Container image (unused -- uses python:3.12-slim).
+        run_id: Unique run identifier (used in Job name).
+        osl: Output sequence length.
+        benchmark_duration: Optional benchmark duration in seconds.
+        num_requests: Optional request count.
+        request_rate: Optional request rate limit.
+        warmup_duration: Optional warmup duration in seconds.
+        warmup_count: Optional warmup request count.
+        export_level: aiperf export level (summary, records, raw).
+        timeout: Job timeout in seconds.
+
+    Returns:
+        True if aiperf succeeded, False otherwise.
+    """
+    # Sanitize run_id for k8s naming (lowercase, no underscores, max 63 chars)
+    safe_id = run_id.lower().replace("_", "-")[:40]
+    ts = str(int(time.time()))[-6:]
+    job_name = f"aiperf-{safe_id}-{ts}"
+
+    print(f"  Creating aiperf Job: {job_name} (c={concurrency} isl={isl})")
+
+    script = _build_aiperf_script(
+        model_name=model_name,
+        endpoint=endpoint,
+        concurrency=concurrency,
+        isl=isl,
+        osl=osl,
+        benchmark_duration=benchmark_duration,
+        num_requests=num_requests,
+        request_rate=request_rate,
+        warmup_duration=warmup_duration,
+        warmup_count=warmup_count,
+        export_level=export_level,
+    )
+
+    job_yaml = _build_job_yaml(
+        job_name=job_name,
+        namespace=namespace,
+        script=script,
+    )
+
+    # Create the Job
+    try:
+        run_kubectl(
+            ["apply", "-f", "-"],
+            namespace=namespace,
+            input_data=job_yaml,
+        )
+    except Exception as e:
+        print(f"  ERROR: Failed to create aiperf Job: {e}")
+        return False
+
+    # Wait for completion
+    success = _wait_for_job(job_name, namespace, timeout=timeout)
+
+    # Copy artifacts from PVC regardless of success (partial results may exist)
+    _copy_artifacts_from_pvc(job_name, namespace, artifact_dir)
+
+    # Print logs on failure
+    if not success:
+        _print_job_logs(job_name, namespace, tail=30)
+
+    # Clean up the Job
+    run_kubectl(
+        ["delete", "job", job_name, "--ignore-not-found"],
+        namespace=namespace,
+        check=False,
+    )
+
+    return success

--- a/benchmarks/frontend/scripts/sweep_k8s/dgd.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/dgd.py
@@ -13,6 +13,8 @@ import json
 import random
 import subprocess
 import time
+import urllib.error
+import urllib.request
 
 from sweep_k8s.kubectl import (
     delete_pod,
@@ -58,8 +60,6 @@ def wait_model_ready(
     while True:
         # Try direct HTTP (works if endpoint is port-forwarded or localhost)
         try:
-            import urllib.request
-
             req = urllib.request.Request(
                 f"http://{endpoint}/v1/models",
                 headers={"Accept": "application/json"},
@@ -70,7 +70,7 @@ def wait_model_ready(
                 if any(m.get("id") == model_name for m in models):
                     print(f"  Model ready (waited {waited}s)")
                     return
-        except Exception:
+        except (urllib.error.URLError, json.JSONDecodeError, OSError, ValueError):
             pass
 
         # Fallback: kubectl-based check for in-cluster endpoints
@@ -93,12 +93,13 @@ def _check_model_via_kubectl(
     namespace: str,
 ) -> bool:
     """Check model readiness by running curl from inside the cluster."""
+    pod_name = f"model-check-{int(time.time())}-{random.randint(0, 9999)}"
     try:
         result = subprocess.run(
             [
                 "kubectl",
                 "run",
-                "model-check",
+                pod_name,
                 "--rm",
                 "-i",
                 "--restart=Never",
@@ -118,7 +119,7 @@ def _check_model_via_kubectl(
             data = json.loads(result.stdout)
             models = data.get("data", [])
             return any(m.get("id") == model_name for m in models)
-    except Exception:
+    except (subprocess.SubprocessError, json.JSONDecodeError, OSError):
         pass
     return False
 
@@ -132,14 +133,25 @@ def dgd_wait_all_ready(
 ) -> None:
     """Wait for all DGD worker pods to be Ready, then wait for model endpoint."""
     print("  Waiting for all worker pods to be Ready...")
-    try:
-        wait_pod(
-            dgd_label_selector(dgd_name, "worker"),
-            namespace,
-            timeout=max_wait,
-        )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        print("  WARNING: Timed out waiting for worker pods")
+    retries = 3
+    for attempt in range(retries):
+        try:
+            wait_pod(
+                dgd_label_selector(dgd_name, "worker"),
+                namespace,
+                timeout=max_wait,
+            )
+            break
+        except subprocess.TimeoutExpired:
+            raise
+        except subprocess.CalledProcessError as e:
+            if attempt < retries - 1:
+                print(f"  kubectl error (attempt {attempt + 1}/{retries}), retrying...")
+                time.sleep(5)
+            else:
+                raise RuntimeError(
+                    f"Worker pods not ready after {retries} retries: {e}"
+                ) from e
 
     wait_model_ready(endpoint, model_name, max_wait, namespace=namespace)
 
@@ -180,6 +192,13 @@ def dgd_switch_backend(
     except Exception:
         idx = None
 
+    # Capture the current frontend pod name BEFORE patching so we track
+    # the right pod for deletion (avoids racing with the operator).
+    old_pod = get_pod_name(
+        dgd_label_selector(dgd_name, "frontend"),
+        namespace,
+    )
+
     if idx is not None:
         patch_json(
             "dgd",
@@ -208,12 +227,6 @@ def dgd_switch_backend(
         )
 
     print("  DGD patched -- waiting for frontend pod replacement...")
-
-    # Wait for old pod to terminate
-    old_pod = get_pod_name(
-        dgd_label_selector(dgd_name, "frontend"),
-        namespace,
-    )
     if old_pod:
         print(f"  Waiting for old pod {old_pod} to terminate...")
         wait_for_pod_deletion(old_pod, namespace, timeout=120)

--- a/benchmarks/frontend/scripts/sweep_k8s/dgd.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/dgd.py
@@ -20,7 +20,6 @@ from sweep_k8s.kubectl import (
     get_pod_name,
     patch_json,
     patch_merge,
-    pod_exists,
     run_kubectl,
     wait_for_pod_deletion,
     wait_pod,
@@ -60,6 +59,7 @@ def wait_model_ready(
         # Try direct HTTP (works if endpoint is port-forwarded or localhost)
         try:
             import urllib.request
+
             req = urllib.request.Request(
                 f"http://{endpoint}/v1/models",
                 headers={"Accept": "application/json"},
@@ -95,11 +95,24 @@ def _check_model_via_kubectl(
     """Check model readiness by running curl from inside the cluster."""
     try:
         result = subprocess.run(
-            ["kubectl", "run", "model-check", "--rm", "-i", "--restart=Never",
-             "-n", namespace, "--quiet",
-             "--image=curlimages/curl:latest",
-             "--", "-sf", f"http://{endpoint}/v1/models"],
-            capture_output=True, text=True, timeout=20,
+            [
+                "kubectl",
+                "run",
+                "model-check",
+                "--rm",
+                "-i",
+                "--restart=Never",
+                "-n",
+                namespace,
+                "--quiet",
+                "--image=curlimages/curl:latest",
+                "--",
+                "-sf",
+                f"http://{endpoint}/v1/models",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
         )
         if result.returncode == 0 and result.stdout.strip():
             data = json.loads(result.stdout)
@@ -144,7 +157,9 @@ def dgd_switch_backend(
     recreates the frontend pod automatically.
     """
     mapped_backend = TOKENIZER_BACKEND_MAP.get(backend, backend)
-    print(f"\n--- Switching DGD tokenizer backend -> {mapped_backend} (dgd={dgd_name}) ---")
+    print(
+        f"\n--- Switching DGD tokenizer backend -> {mapped_backend} (dgd={dgd_name}) ---"
+    )
 
     # Find the index of DYN_TOKENIZER_BACKEND in the Frontend env array
     try:
@@ -170,18 +185,26 @@ def dgd_switch_backend(
             "dgd",
             dgd_name,
             namespace,
-            [{"op": "replace",
-              "path": f"/spec/services/Frontend/extraPodSpec/mainContainer/env/{idx}/value",
-              "value": mapped_backend}],
+            [
+                {
+                    "op": "replace",
+                    "path": f"/spec/services/Frontend/extraPodSpec/mainContainer/env/{idx}/value",
+                    "value": mapped_backend,
+                }
+            ],
         )
     else:
         patch_json(
             "dgd",
             dgd_name,
             namespace,
-            [{"op": "add",
-              "path": "/spec/services/Frontend/extraPodSpec/mainContainer/env/-",
-              "value": {"name": "DYN_TOKENIZER_BACKEND", "value": mapped_backend}}],
+            [
+                {
+                    "op": "add",
+                    "path": "/spec/services/Frontend/extraPodSpec/mainContainer/env/-",
+                    "value": {"name": "DYN_TOKENIZER_BACKEND", "value": mapped_backend},
+                }
+            ],
         )
 
     print("  DGD patched -- waiting for frontend pod replacement...")
@@ -287,7 +310,9 @@ def dgd_restart_graph(
                     print(f"  DGD restart completed (waited {waited}s)")
                     break
                 elif phase in ("Failed", "Superseded"):
-                    raise RuntimeError(f"DGD restart {restart_id} ended with phase={phase}")
+                    raise RuntimeError(
+                        f"DGD restart {restart_id} ended with phase={phase}"
+                    )
         except (KeyError, TypeError):
             pass
         except (subprocess.TimeoutExpired, subprocess.CalledProcessError) as e:

--- a/benchmarks/frontend/scripts/sweep_k8s/dgd.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/dgd.py
@@ -274,9 +274,10 @@ def dgd_restart_graph(
     )
 
     waited = 0
+    phase = "pending"
     while True:
         try:
-            state_json = get_json("dgd", dgd_name, namespace)
+            state_json = get_json("dgd", dgd_name, namespace, timeout=60)
             restart_status = state_json.get("status", {}).get("restart", {})
             observed = restart_status.get("observedID", "")
             phase = restart_status.get("phase", "")
@@ -289,11 +290,14 @@ def dgd_restart_graph(
                     raise RuntimeError(f"DGD restart {restart_id} ended with phase={phase}")
         except (KeyError, TypeError):
             pass
+        except (subprocess.TimeoutExpired, subprocess.CalledProcessError) as e:
+            # Transient kubectl timeout -- retry
+            print(f"  kubectl transient error, retrying... ({e.__class__.__name__})")
 
         time.sleep(5)
         waited += 5
         if waited >= 600:
             raise TimeoutError(f"Timed out waiting for DGD restart {restart_id}")
-        print(f"  Waiting for DGD restart ({waited}s / 600s)... phase={phase if 'phase' in dir() else 'pending'}")
+        print(f"  Waiting for DGD restart ({waited}s / 600s)... phase={phase}")
 
     dgd_wait_all_ready(dgd_name, namespace, endpoint, model_name)

--- a/benchmarks/frontend/scripts/sweep_k8s/dgd.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/dgd.py
@@ -292,6 +292,20 @@ def dgd_restart_graph(
     restart_id = f"bench-{time.strftime('%Y%m%d-%H%M%S')}-{random.randint(0, 9999)}"
     print(f"  Restarting full DGD deployment (id={restart_id})...")
 
+    # Discover service names from the DGD spec so the restart order is correct
+    # for any backend (mocker, vllm, trtllm, etc.)
+    try:
+        dgd_spec = get_json("dgd", dgd_name, namespace, timeout=60)
+        services = list(dgd_spec.get("spec", {}).get("services", {}).keys())
+        # Put workers before frontend: restart workers first, then frontend
+        frontend_names = [s for s in services if s.lower() == "frontend"]
+        worker_names = [s for s in services if s.lower() != "frontend"]
+        restart_order = worker_names + frontend_names
+    except Exception:
+        restart_order = ["Frontend"]
+
+    print(f"  Restart order: {restart_order}")
+
     patch_merge(
         "dgd",
         dgd_name,
@@ -302,7 +316,7 @@ def dgd_restart_graph(
                     "id": restart_id,
                     "strategy": {
                         "type": "Sequential",
-                        "order": ["MockerWorker", "Frontend"],
+                        "order": restart_order,
                     },
                 }
             }

--- a/benchmarks/frontend/scripts/sweep_k8s/dgd.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/dgd.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+DynamoGraphDeployment helpers -- backend switch, restart, readiness.
+
+Ported from sweep.sh functions: dgd_switch_backend, dgd_restart_frontend,
+dgd_restart_graph, dgd_wait_all_ready.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import subprocess
+import time
+
+from sweep_k8s.kubectl import (
+    delete_pod,
+    get_json,
+    get_pod_name,
+    patch_json,
+    patch_merge,
+    pod_exists,
+    run_kubectl,
+    wait_for_pod_deletion,
+    wait_pod,
+)
+
+# Tokenizer backend name mapping for DGD env vars
+TOKENIZER_BACKEND_MAP = {
+    "hf": "default",
+    "default": "default",
+    "fast": "fast",
+    "fastokens": "fast",
+}
+
+
+def dgd_label_selector(dgd_name: str, component_type: str) -> str:
+    """Build a label selector for DGD-managed pods."""
+    return (
+        f"nvidia.com/dynamo-graph-deployment-name={dgd_name},"
+        f"nvidia.com/dynamo-component-type={component_type}"
+    )
+
+
+def wait_model_ready(
+    endpoint: str,
+    model_name: str,
+    max_wait: int = 300,
+    namespace: str = "",
+) -> None:
+    """Wait for a model to be registered at the frontend /v1/models endpoint.
+
+    Tries direct HTTP first. If the endpoint is not reachable from localhost
+    (in-cluster DNS), falls back to kubectl run to check from inside the cluster.
+    """
+    print(f"  Waiting for model '{model_name}' at http://{endpoint}/v1/models...")
+    waited = 0
+    while True:
+        # Try direct HTTP (works if endpoint is port-forwarded or localhost)
+        try:
+            import urllib.request
+            req = urllib.request.Request(
+                f"http://{endpoint}/v1/models",
+                headers={"Accept": "application/json"},
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = json.loads(resp.read().decode())
+                models = data.get("data", [])
+                if any(m.get("id") == model_name for m in models):
+                    print(f"  Model ready (waited {waited}s)")
+                    return
+        except Exception:
+            pass
+
+        # Fallback: kubectl-based check for in-cluster endpoints
+        if namespace and _check_model_via_kubectl(endpoint, model_name, namespace):
+            print(f"  Model ready via kubectl (waited {waited}s)")
+            return
+
+        time.sleep(5)
+        waited += 5
+        if waited >= max_wait:
+            print(f"ERROR: Model not ready after {max_wait}s")
+            raise TimeoutError(f"Model '{model_name}' not ready after {max_wait}s")
+        if waited % 15 == 0:
+            print(f"  Still waiting ({waited}s / {max_wait}s)...")
+
+
+def _check_model_via_kubectl(
+    endpoint: str,
+    model_name: str,
+    namespace: str,
+) -> bool:
+    """Check model readiness by running curl from inside the cluster."""
+    try:
+        result = subprocess.run(
+            ["kubectl", "run", "model-check", "--rm", "-i", "--restart=Never",
+             "-n", namespace, "--quiet",
+             "--image=curlimages/curl:latest",
+             "--", "-sf", f"http://{endpoint}/v1/models"],
+            capture_output=True, text=True, timeout=20,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            data = json.loads(result.stdout)
+            models = data.get("data", [])
+            return any(m.get("id") == model_name for m in models)
+    except Exception:
+        pass
+    return False
+
+
+def dgd_wait_all_ready(
+    dgd_name: str,
+    namespace: str,
+    endpoint: str,
+    model_name: str,
+    max_wait: int = 300,
+) -> None:
+    """Wait for all DGD worker pods to be Ready, then wait for model endpoint."""
+    print("  Waiting for all worker pods to be Ready...")
+    try:
+        wait_pod(
+            dgd_label_selector(dgd_name, "worker"),
+            namespace,
+            timeout=max_wait,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        print("  WARNING: Timed out waiting for worker pods")
+
+    wait_model_ready(endpoint, model_name, max_wait, namespace=namespace)
+
+
+def dgd_switch_backend(
+    dgd_name: str,
+    namespace: str,
+    endpoint: str,
+    model_name: str,
+    backend: str,
+) -> None:
+    """Switch tokenizer backend on a DynamoGraphDeployment.
+
+    Patches the DGD spec to set DYN_TOKENIZER_BACKEND; the Grove operator
+    recreates the frontend pod automatically.
+    """
+    mapped_backend = TOKENIZER_BACKEND_MAP.get(backend, backend)
+    print(f"\n--- Switching DGD tokenizer backend -> {mapped_backend} (dgd={dgd_name}) ---")
+
+    # Find the index of DYN_TOKENIZER_BACKEND in the Frontend env array
+    try:
+        dgd_json = get_json("dgd", dgd_name, namespace)
+        env_list = (
+            dgd_json.get("spec", {})
+            .get("services", {})
+            .get("Frontend", {})
+            .get("extraPodSpec", {})
+            .get("mainContainer", {})
+            .get("env", [])
+        )
+        idx = None
+        for i, env_var in enumerate(env_list):
+            if env_var.get("name") == "DYN_TOKENIZER_BACKEND":
+                idx = i
+                break
+    except Exception:
+        idx = None
+
+    if idx is not None:
+        patch_json(
+            "dgd",
+            dgd_name,
+            namespace,
+            [{"op": "replace",
+              "path": f"/spec/services/Frontend/extraPodSpec/mainContainer/env/{idx}/value",
+              "value": mapped_backend}],
+        )
+    else:
+        patch_json(
+            "dgd",
+            dgd_name,
+            namespace,
+            [{"op": "add",
+              "path": "/spec/services/Frontend/extraPodSpec/mainContainer/env/-",
+              "value": {"name": "DYN_TOKENIZER_BACKEND", "value": mapped_backend}}],
+        )
+
+    print("  DGD patched -- waiting for frontend pod replacement...")
+
+    # Wait for old pod to terminate
+    old_pod = get_pod_name(
+        dgd_label_selector(dgd_name, "frontend"),
+        namespace,
+    )
+    if old_pod:
+        print(f"  Waiting for old pod {old_pod} to terminate...")
+        wait_for_pod_deletion(old_pod, namespace, timeout=120)
+
+    # Wait for new frontend pod to be Ready
+    print("  Waiting for new frontend pod to be Ready...")
+    wait_pod(
+        dgd_label_selector(dgd_name, "frontend"),
+        namespace,
+        timeout=300,
+    )
+
+    dgd_wait_all_ready(dgd_name, namespace, endpoint, model_name)
+
+
+def dgd_restart_frontend(
+    dgd_name: str,
+    namespace: str,
+    endpoint: str,
+    model_name: str,
+) -> None:
+    """Restart only the frontend component to reset metrics counters."""
+    print("  Restarting frontend pod to reset metrics counters...")
+
+    old_pod = get_pod_name(
+        dgd_label_selector(dgd_name, "frontend"),
+        namespace,
+    )
+
+    if old_pod:
+        delete_pod(old_pod, namespace, grace_period=5)
+        print(f"  Waiting for old pod {old_pod} to terminate...")
+        # Wait for delete
+        try:
+            run_kubectl(
+                ["wait", "pod", old_pod, "--for=delete", "--timeout=90s"],
+                namespace=namespace,
+                check=False,
+            )
+        except Exception:
+            pass
+
+    print("  Waiting for new frontend pod to be Ready...")
+    wait_pod(
+        dgd_label_selector(dgd_name, "frontend"),
+        namespace,
+        timeout=300,
+    )
+
+    dgd_wait_all_ready(dgd_name, namespace, endpoint, model_name)
+
+
+def dgd_restart_graph(
+    dgd_name: str,
+    namespace: str,
+    endpoint: str,
+    model_name: str,
+) -> None:
+    """Trigger a full DGD restart through spec.restart.
+
+    Every run starts from a clean graph deployment state.
+    """
+    restart_id = f"bench-{time.strftime('%Y%m%d-%H%M%S')}-{random.randint(0, 9999)}"
+    print(f"  Restarting full DGD deployment (id={restart_id})...")
+
+    patch_merge(
+        "dgd",
+        dgd_name,
+        namespace,
+        {
+            "spec": {
+                "restart": {
+                    "id": restart_id,
+                    "strategy": {
+                        "type": "Sequential",
+                        "order": ["MockerWorker", "Frontend"],
+                    },
+                }
+            }
+        },
+    )
+
+    waited = 0
+    while True:
+        try:
+            state_json = get_json("dgd", dgd_name, namespace)
+            restart_status = state_json.get("status", {}).get("restart", {})
+            observed = restart_status.get("observedID", "")
+            phase = restart_status.get("phase", "")
+
+            if observed == restart_id:
+                if phase == "Completed":
+                    print(f"  DGD restart completed (waited {waited}s)")
+                    break
+                elif phase in ("Failed", "Superseded"):
+                    raise RuntimeError(f"DGD restart {restart_id} ended with phase={phase}")
+        except (KeyError, TypeError):
+            pass
+
+        time.sleep(5)
+        waited += 5
+        if waited >= 600:
+            raise TimeoutError(f"Timed out waiting for DGD restart {restart_id}")
+        print(f"  Waiting for DGD restart ({waited}s / 600s)... phase={phase if 'phase' in dir() else 'pending'}")
+
+    dgd_wait_all_ready(dgd_name, namespace, endpoint, model_name)

--- a/benchmarks/frontend/scripts/sweep_k8s/kubectl.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/kubectl.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Safe kubectl subprocess helpers.
+
+All k8s interactions go through this module for consistent error handling
+and namespace scoping.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from typing import Any, Dict, List, Optional
+
+
+def run_kubectl(
+    args: List[str],
+    namespace: Optional[str] = None,
+    capture: bool = True,
+    check: bool = True,
+    timeout: int = 60,
+    input_data: Optional[str] = None,
+) -> subprocess.CompletedProcess:
+    """Run a kubectl command with namespace scoping and error handling.
+
+    Args:
+        args: kubectl arguments (e.g., ["get", "pods"]).
+        namespace: K8s namespace (prepended as -n <namespace>).
+        capture: Whether to capture stdout/stderr.
+        check: Whether to raise on non-zero exit.
+        timeout: Command timeout in seconds.
+        input_data: Optional stdin input.
+
+    Returns:
+        CompletedProcess result.
+    """
+    cmd = ["kubectl"]
+    if namespace:
+        cmd.extend(["-n", namespace])
+    cmd.extend(args)
+
+    result = subprocess.run(
+        cmd,
+        capture_output=capture,
+        text=True,
+        check=False,
+        timeout=timeout,
+        input=input_data,
+    )
+    if check and result.returncode != 0:
+        stderr = result.stderr.strip() if result.stderr else ""
+        print(f"  kubectl error (rc={result.returncode}): {' '.join(args[:4])}")
+        if stderr:
+            print(f"    {stderr}")
+        result.check_returncode()
+    return result
+
+
+def get_json(
+    resource: str,
+    name: str,
+    namespace: str,
+    timeout: int = 30,
+) -> Dict[str, Any]:
+    """Get a k8s resource as a parsed JSON dict."""
+    result = run_kubectl(
+        ["get", resource, name, "-o", "json"],
+        namespace=namespace,
+        timeout=timeout,
+    )
+    return json.loads(result.stdout)
+
+
+def patch_json(
+    resource: str,
+    name: str,
+    namespace: str,
+    patch: List[Dict[str, Any]],
+    timeout: int = 30,
+) -> None:
+    """Apply a JSON patch to a k8s resource."""
+    patch_str = json.dumps(patch)
+    run_kubectl(
+        ["patch", resource, name, "--type=json", f"-p={patch_str}"],
+        namespace=namespace,
+        timeout=timeout,
+    )
+
+
+def patch_merge(
+    resource: str,
+    name: str,
+    namespace: str,
+    patch: Dict[str, Any],
+    timeout: int = 30,
+) -> None:
+    """Apply a strategic merge patch to a k8s resource."""
+    patch_str = json.dumps(patch)
+    run_kubectl(
+        ["patch", resource, name, "--type=merge", f"-p={patch_str}"],
+        namespace=namespace,
+        timeout=timeout,
+    )
+
+
+def wait_pod(
+    label_selector: str,
+    namespace: str,
+    condition: str = "Ready",
+    timeout: int = 300,
+) -> None:
+    """Wait for pod(s) matching a label selector to reach a condition."""
+    run_kubectl(
+        ["wait", "pod", "-l", label_selector,
+         f"--for=condition={condition}", f"--timeout={timeout}s"],
+        namespace=namespace,
+        timeout=timeout + 10,
+    )
+
+
+def delete_pod(
+    name: str,
+    namespace: str,
+    grace_period: int = 5,
+) -> None:
+    """Delete a pod by name."""
+    run_kubectl(
+        ["delete", "pod", name, f"--grace-period={grace_period}"],
+        namespace=namespace,
+        check=False,
+    )
+
+
+def get_pod_name(
+    label_selector: str,
+    namespace: str,
+) -> Optional[str]:
+    """Get the name of the first pod matching a label selector."""
+    result = run_kubectl(
+        ["get", "pod", "-l", label_selector,
+         "-o", "jsonpath={.items[0].metadata.name}"],
+        namespace=namespace,
+        check=False,
+    )
+    name = result.stdout.strip()
+    return name if name else None
+
+
+def pod_exists(name: str, namespace: str) -> bool:
+    """Check if a pod exists."""
+    result = run_kubectl(
+        ["get", "pod", name],
+        namespace=namespace,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def apply_yaml(yaml_content: str, namespace: str) -> None:
+    """Apply YAML content via kubectl apply -f -."""
+    run_kubectl(
+        ["apply", "-f", "-"],
+        namespace=namespace,
+        input_data=yaml_content,
+    )
+
+
+def wait_for_pod_deletion(
+    name: str,
+    namespace: str,
+    timeout: int = 120,
+) -> None:
+    """Wait for a pod to be deleted."""
+    waited = 0
+    while pod_exists(name, namespace):
+        time.sleep(5)
+        waited += 5
+        if waited >= timeout:
+            print(f"  WARNING: pod {name} still present after {timeout}s")
+            break

--- a/benchmarks/frontend/scripts/sweep_k8s/kubectl.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/kubectl.py
@@ -113,8 +113,14 @@ def wait_pod(
 ) -> None:
     """Wait for pod(s) matching a label selector to reach a condition."""
     run_kubectl(
-        ["wait", "pod", "-l", label_selector,
-         f"--for=condition={condition}", f"--timeout={timeout}s"],
+        [
+            "wait",
+            "pod",
+            "-l",
+            label_selector,
+            f"--for=condition={condition}",
+            f"--timeout={timeout}s",
+        ],
         namespace=namespace,
         timeout=timeout + 10,
     )
@@ -139,8 +145,14 @@ def get_pod_name(
 ) -> Optional[str]:
     """Get the name of the first pod matching a label selector."""
     result = run_kubectl(
-        ["get", "pod", "-l", label_selector,
-         "-o", "jsonpath={.items[0].metadata.name}"],
+        [
+            "get",
+            "pod",
+            "-l",
+            label_selector,
+            "-o",
+            "jsonpath={.items[0].metadata.name}",
+        ],
         namespace=namespace,
         check=False,
     )

--- a/benchmarks/frontend/scripts/sweep_k8s/kubectl.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/kubectl.py
@@ -179,6 +179,19 @@ def apply_yaml(yaml_content: str, namespace: str) -> None:
     )
 
 
+def apply_secret_literal(name: str, namespace: str, key: str, value: str) -> None:
+    """Create or update an opaque Secret from a literal value."""
+    secret_yaml = f"""apiVersion: v1
+kind: Secret
+metadata:
+  name: {name}
+type: Opaque
+stringData:
+  {key}: {json.dumps(value)}
+"""
+    apply_yaml(secret_yaml, namespace)
+
+
 def wait_for_pod_deletion(
     name: str,
     namespace: str,

--- a/benchmarks/frontend/scripts/sweep_k8s/metrics.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/metrics.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Prometheus metrics capture for k8s sweeps.
+
+Captures pre/post frontend /metrics snapshots for delta analysis.
+Supports both direct HTTP (when endpoint is reachable) and kubectl-exec
+(when only in-cluster DNS is available).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+
+def capture_metrics(
+    endpoint: str,
+    dest: Path,
+    namespace: Optional[str] = None,
+    pod_label: Optional[str] = None,
+) -> None:
+    """Capture frontend /metrics to a file.
+
+    Tries direct HTTP first. If that fails and namespace + pod_label are
+    provided, falls back to kubectl exec curl from the frontend pod.
+
+    Args:
+        endpoint: Frontend endpoint (host:port) -- may be in-cluster DNS.
+        dest: Destination file path.
+        namespace: K8s namespace (for kubectl exec fallback).
+        pod_label: Pod label selector (for kubectl exec fallback).
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    # Try direct HTTP first (works if port-forwarded or on same network)
+    body = _try_http(endpoint)
+
+    # Fallback: kubectl exec into the frontend pod to curl metrics
+    if body is None and namespace and pod_label:
+        body = _try_kubectl_exec(endpoint, namespace, pod_label)
+
+    # Fallback 2: kubectl run a temporary pod to curl
+    if body is None and namespace:
+        body = _try_kubectl_run(endpoint, namespace)
+
+    if body and body.strip():
+        dest.write_text(body)
+        line_count = len(body.strip().split("\n"))
+        print(f"  Metrics captured -> {dest.name} ({line_count} lines)")
+    else:
+        msg = f"# metrics capture failed at {time.strftime('%Y-%m-%dT%H:%M:%S')}\n"
+        dest.write_text(msg)
+        print(f"  WARNING: could not capture metrics from {endpoint}")
+
+
+def _try_http(endpoint: str) -> Optional[str]:
+    """Try fetching metrics via direct HTTP."""
+    try:
+        req = urllib.request.Request(f"http://{endpoint}/metrics")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.read().decode()
+    except Exception:
+        return None
+
+
+def _try_kubectl_exec(
+    endpoint: str,
+    namespace: str,
+    pod_label: str,
+) -> Optional[str]:
+    """Fetch metrics by exec-ing curl inside a running pod."""
+    try:
+        # Get a pod name from the label selector
+        result = subprocess.run(
+            ["kubectl", "-n", namespace, "get", "pod", "-l", pod_label,
+             "-o", "jsonpath={.items[0].metadata.name}"],
+            capture_output=True, text=True, timeout=10,
+        )
+        pod_name = result.stdout.strip()
+        if not pod_name:
+            return None
+
+        # Exec curl inside the pod (curl may not be available; try wget too)
+        result = subprocess.run(
+            ["kubectl", "-n", namespace, "exec", pod_name, "--",
+             "sh", "-c",
+             f"curl -sf http://{endpoint}/metrics 2>/dev/null || "
+             f"wget -qO- http://{endpoint}/metrics 2>/dev/null || "
+             f"python3 -c \"import urllib.request; print(urllib.request.urlopen('http://{endpoint}/metrics').read().decode())\" 2>/dev/null"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout
+    except Exception:
+        pass
+    return None
+
+
+def _try_kubectl_run(endpoint: str, namespace: str) -> Optional[str]:
+    """Fetch metrics via a one-shot kubectl run --rm pod."""
+    try:
+        result = subprocess.run(
+            ["kubectl", "run", "metrics-fetch", "--rm", "-i", "--restart=Never",
+             "-n", namespace,
+             "--image=curlimages/curl:latest",
+             "--", "-sf", f"http://{endpoint}/metrics"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout
+    except Exception:
+        pass
+    return None

--- a/benchmarks/frontend/scripts/sweep_k8s/metrics.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/metrics.py
@@ -76,9 +76,20 @@ def _try_kubectl_exec(
     try:
         # Get a pod name from the label selector
         result = subprocess.run(
-            ["kubectl", "-n", namespace, "get", "pod", "-l", pod_label,
-             "-o", "jsonpath={.items[0].metadata.name}"],
-            capture_output=True, text=True, timeout=10,
+            [
+                "kubectl",
+                "-n",
+                namespace,
+                "get",
+                "pod",
+                "-l",
+                pod_label,
+                "-o",
+                "jsonpath={.items[0].metadata.name}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         pod_name = result.stdout.strip()
         if not pod_name:
@@ -86,12 +97,22 @@ def _try_kubectl_exec(
 
         # Exec curl inside the pod (curl may not be available; try wget too)
         result = subprocess.run(
-            ["kubectl", "-n", namespace, "exec", pod_name, "--",
-             "sh", "-c",
-             f"curl -sf http://{endpoint}/metrics 2>/dev/null || "
-             f"wget -qO- http://{endpoint}/metrics 2>/dev/null || "
-             f"python3 -c \"import urllib.request; print(urllib.request.urlopen('http://{endpoint}/metrics').read().decode())\" 2>/dev/null"],
-            capture_output=True, text=True, timeout=15,
+            [
+                "kubectl",
+                "-n",
+                namespace,
+                "exec",
+                pod_name,
+                "--",
+                "sh",
+                "-c",
+                f"curl -sf http://{endpoint}/metrics 2>/dev/null || "
+                f"wget -qO- http://{endpoint}/metrics 2>/dev/null || "
+                f"python3 -c \"import urllib.request; print(urllib.request.urlopen('http://{endpoint}/metrics').read().decode())\" 2>/dev/null",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout
@@ -104,11 +125,23 @@ def _try_kubectl_run(endpoint: str, namespace: str) -> Optional[str]:
     """Fetch metrics via a one-shot kubectl run --rm pod."""
     try:
         result = subprocess.run(
-            ["kubectl", "run", "metrics-fetch", "--rm", "-i", "--restart=Never",
-             "-n", namespace,
-             "--image=curlimages/curl:latest",
-             "--", "-sf", f"http://{endpoint}/metrics"],
-            capture_output=True, text=True, timeout=30,
+            [
+                "kubectl",
+                "run",
+                "metrics-fetch",
+                "--rm",
+                "-i",
+                "--restart=Never",
+                "-n",
+                namespace,
+                "--image=curlimages/curl:latest",
+                "--",
+                "-sf",
+                f"http://{endpoint}/metrics",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout

--- a/benchmarks/frontend/scripts/sweep_k8s/metrics.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/metrics.py
@@ -10,6 +10,7 @@ Supports both direct HTTP (when endpoint is reachable) and kubectl-exec
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 import time
 import urllib.request
@@ -96,6 +97,7 @@ def _try_kubectl_exec(
             return None
 
         # Exec curl inside the pod (curl may not be available; try wget too)
+        safe_endpoint = shlex.quote(endpoint)
         result = subprocess.run(
             [
                 "kubectl",
@@ -106,9 +108,9 @@ def _try_kubectl_exec(
                 "--",
                 "sh",
                 "-c",
-                f"curl -sf http://{endpoint}/metrics 2>/dev/null || "
-                f"wget -qO- http://{endpoint}/metrics 2>/dev/null || "
-                f"python3 -c \"import urllib.request; print(urllib.request.urlopen('http://{endpoint}/metrics').read().decode())\" 2>/dev/null",
+                f"curl -sf http://{safe_endpoint}/metrics 2>/dev/null || "
+                f"wget -qO- http://{safe_endpoint}/metrics 2>/dev/null || "
+                f'python3 -c "import urllib.request,sys; print(urllib.request.urlopen(sys.argv[1]).read().decode())" http://{safe_endpoint}/metrics 2>/dev/null',
             ],
             capture_output=True,
             text=True,

--- a/benchmarks/frontend/scripts/sweep_k8s/template.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/template.py
@@ -25,6 +25,23 @@ TOKENIZER_TEMPLATE_MAP = {
     "fastokens": "fast",
 }
 
+DEFAULT_HF_TOKEN_SECRET_NAME = "hf-token-secret"
+
+
+def _indent_block(text: str, spaces: int) -> str:
+    prefix = " " * spaces
+    return "\n".join(f"{prefix}{line}" if line else "" for line in text.splitlines())
+
+
+def _build_image_pull_secrets_block(image_pull_secret: str) -> str:
+    if not image_pull_secret:
+        return ""
+    return _indent_block(
+        f"""imagePullSecrets:
+  - name: {image_pull_secret}""",
+        8,
+    )
+
 
 def build_substitution_dict(
     deploy: DeployDimension,
@@ -36,6 +53,7 @@ def build_substitution_dict(
     dictionary suitable for string.Template substitution.
     """
     k8s = config.k8s
+    hf_token_secret_name = DEFAULT_HF_TOKEN_SECRET_NAME
     variables: Dict[str, str] = {
         # Deploy dimensions
         "DYN_TOKENIZER_BACKEND": TOKENIZER_TEMPLATE_MAP.get(
@@ -57,6 +75,13 @@ def build_substitution_dict(
         "REQUEST_PLANE": k8s.request_plane,
         "EVENT_PLANE": k8s.event_plane,
         "ROUTER_MODE": k8s.router_mode,
+        "HF_TOKEN_SECRET_NAME": hf_token_secret_name,
+        "FRONTEND_IMAGE_PULL_SECRETS_BLOCK": _build_image_pull_secrets_block(
+            k8s.image_pull_secret
+        ),
+        "WORKER_IMAGE_PULL_SECRETS_BLOCK": _build_image_pull_secrets_block(
+            k8s.image_pull_secret
+        ),
     }
 
     # Add any env_overrides from the deploy dimension

--- a/benchmarks/frontend/scripts/sweep_k8s/template.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/template.py
@@ -71,6 +71,7 @@ def build_substitution_dict(
         "DGD_NAME": k8s.dgd_name,
         "FRONTEND_PORT": str(k8s.frontend_port),
         "WORKER_REPLICAS": str(k8s.worker_replicas),
+        "FRONTEND_REPLICAS": str(k8s.frontend_replicas),
         "SPEEDUP_RATIO": str(config.speedup_ratio),
         "REQUEST_PLANE": k8s.request_plane,
         "EVENT_PLANE": k8s.event_plane,

--- a/benchmarks/frontend/scripts/sweep_k8s/template.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/template.py
@@ -17,7 +17,6 @@ from typing import Dict
 from sweep_core.models import DeployDimension, SweepConfig
 from sweep_k8s.kubectl import apply_yaml
 
-
 # Tokenizer backend mapping for template substitution
 TOKENIZER_TEMPLATE_MAP = {
     "hf": "default",

--- a/benchmarks/frontend/scripts/sweep_k8s/template.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/template.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Deploy YAML template rendering and application.
+
+Supports ${VARIABLE} placeholders using Python's string.Template.
+This enables arbitrary backend deployments (mocker, vLLM, TensorRT-LLM, etc.)
+without hardcoding DGD structures.
+"""
+
+from __future__ import annotations
+
+import string
+from pathlib import Path
+from typing import Dict
+
+from sweep_core.models import DeployDimension, SweepConfig
+from sweep_k8s.kubectl import apply_yaml
+
+
+# Tokenizer backend mapping for template substitution
+TOKENIZER_TEMPLATE_MAP = {
+    "hf": "default",
+    "default": "default",
+    "fast": "fast",
+    "fastokens": "fast",
+}
+
+
+def build_substitution_dict(
+    deploy: DeployDimension,
+    config: SweepConfig,
+) -> Dict[str, str]:
+    """Build a variable substitution dictionary for template rendering.
+
+    Combines deploy dimensions, sweep config, and k8s config into a flat
+    dictionary suitable for string.Template substitution.
+    """
+    k8s = config.k8s
+    variables: Dict[str, str] = {
+        # Deploy dimensions
+        "DYN_TOKENIZER_BACKEND": TOKENIZER_TEMPLATE_MAP.get(
+            deploy.tokenizer, deploy.tokenizer
+        ),
+        "NUM_WORKERS": str(deploy.workers),
+        # Model info
+        "MODEL": config.model,
+        "MODEL_NAME": config.model_name,
+        "MODEL_PATH": config.model,
+        # Image
+        "IMAGE": k8s.image,
+        # K8s config
+        "NAMESPACE": k8s.namespace,
+        "DGD_NAME": k8s.dgd_name,
+        "FRONTEND_PORT": str(k8s.frontend_port),
+        "WORKER_REPLICAS": str(k8s.worker_replicas),
+        "SPEEDUP_RATIO": str(config.speedup_ratio),
+        "REQUEST_PLANE": k8s.request_plane,
+        "EVENT_PLANE": k8s.event_plane,
+        "ROUTER_MODE": k8s.router_mode,
+    }
+
+    # Add any env_overrides from the deploy dimension
+    variables.update(deploy.env_overrides)
+
+    return variables
+
+
+def render_template(template_path: Path, variables: Dict[str, str]) -> str:
+    """Read a deploy YAML template and substitute ${VAR} placeholders.
+
+    Uses safe_substitute so missing variables are left as-is rather than
+    raising KeyError. This is important because DGD templates may contain
+    ${VARIABLE} references that are resolved by the k8s operator at runtime.
+    """
+    raw = template_path.read_text()
+    tmpl = string.Template(raw)
+    return tmpl.safe_substitute(variables)
+
+
+def apply_rendered_template(
+    template_path: Path,
+    deploy: DeployDimension,
+    config: SweepConfig,
+) -> None:
+    """Render a deploy template and apply it via kubectl."""
+    variables = build_substitution_dict(deploy, config)
+    rendered = render_template(template_path, variables)
+    print(f"  Applying rendered template: {template_path.name}")
+    apply_yaml(rendered, config.k8s.namespace)

--- a/benchmarks/frontend/scripts/sweep_runner.py
+++ b/benchmarks/frontend/scripts/sweep_runner.py
@@ -20,7 +20,7 @@ Sweep dimensions (all configurable):
 Usage:
     # Local smoke test (2 runs)
     python3 sweep_runner.py --tokenizers hf,fastokens --concurrency 32 --isl 512 \\
-        --benchmark-duration 30 --speedup-ratio 0
+        --benchmark-duration 30 --speedup-ratio 1000000
 
     # Full local sweep with mocker
     python3 sweep_runner.py --tokenizers hf,fastokens --concurrency 32,64 --isl 512,1024,2048
@@ -35,7 +35,7 @@ Usage:
 
     # Transport saturation sweep
     python3 sweep_runner.py --tokenizers hf --concurrency 4096 \\
-        --num-requests 16384,32768 --workers 1,2,4,8 --speedup-ratio 0
+        --num-requests 16384,32768 --workers 1,2,4,8 --speedup-ratio 1000000
 
     # Dry run
     python3 sweep_runner.py --dry-run --tokenizers hf,fastokens --concurrency 32,64 --isl 512,1024

--- a/benchmarks/frontend/scripts/sweep_runner.py
+++ b/benchmarks/frontend/scripts/sweep_runner.py
@@ -4,10 +4,12 @@
 """
 Frontend performance sweep runner.
 
-Standalone Python script that orchestrates performance sweeps by delegating
-each run to run_perf.sh.  Combines the sweep grid logic of sweep.sh with
-the saturation analysis of tasks/sweep.py, and the Prometheus/report
-integration of the analysis scripts.
+Thin CLI entry point that delegates to sweep_core (pure logic), sweep_executors
+(how runs execute), and sweep_k8s (k8s helpers).
+
+Supports two execution modes:
+  - local: delegates each run to run_perf.sh (mocker + frontend per run)
+  - k8s: DGD-based execution with aiperf against a k8s-deployed frontend
 
 Sweep dimensions (all configurable):
   - tokenizers (hf, fastokens)
@@ -15,644 +17,91 @@ Sweep dimensions (all configurable):
   - ISL values
   - worker counts
 
-Backends:
-  - mocker (default): fast synthetic backend, no real inference
-  - vllm: real vLLM inference server (produces TTFT/ITL metrics)
-
-Each (tokenizer, concurrency, ISL) point is a separate run_perf.sh invocation.
-Results are collected into CSV + summary.md + per-run reports.
-
 Usage:
-    # Smoke test (2 runs)
+    # Local smoke test (2 runs)
     python3 sweep_runner.py --tokenizers hf,fastokens --concurrency 32 --isl 512 \\
         --benchmark-duration 30 --speedup-ratio 0
 
-    # Full sweep with mocker
+    # Full local sweep with mocker
     python3 sweep_runner.py --tokenizers hf,fastokens --concurrency 32,64 --isl 512,1024,2048
 
-    # vLLM backend (real inference)
-    python3 sweep_runner.py --backend vllm --tokenizers hf --concurrency 128 --isl 1024
+    # K8s sweep with DGD
+    python3 sweep_runner.py --mode k8s --dgd-name dynamo-bench-mocker \\
+        --tokenizers hf,fastokens --concurrency 50,100 --isl 512
 
-    # Transport saturation sweep (tasks/sweep.py style)
+    # K8s with custom deploy template
+    python3 sweep_runner.py --mode k8s --deploy-template dgd/templates/vllm.yaml \\
+        --tokenizers hf --concurrency 128 --isl 1024
+
+    # Transport saturation sweep
     python3 sweep_runner.py --tokenizers hf --concurrency 4096 \\
         --num-requests 16384,32768 --workers 1,2,4,8 --speedup-ratio 0
 
     # Dry run
     python3 sweep_runner.py --dry-run --tokenizers hf,fastokens --concurrency 32,64 --isl 512,1024
+
+    # Emit plan as JSON (for Argo or MCP)
+    python3 sweep_runner.py --emit-plan --tokenizers hf --concurrency 50 --isl 512
 """
 
-import argparse
-import csv
-import json
-import os
-import signal
-import subprocess
 import sys
-import time
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
+# Ensure the scripts directory is on the path for package imports
 SCRIPT_DIR = Path(__file__).resolve().parent
-REPO_ROOT = SCRIPT_DIR.parent.parent.parent
-ANALYSIS_DIR = SCRIPT_DIR / "analysis"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
-# ── Defaults ─────────────────────────────────────────────────────────────────
-
-DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
-DEFAULT_OSL = 256
-DEFAULT_SPEEDUP = 1.0
-DEFAULT_BENCHMARK_DURATION = 60
-DEFAULT_MAX_CONSECUTIVE_FAILS = 2
-DEFAULT_COOLDOWN = 3
-
-TOKENIZER_MAP = {
-    "fast": "fastokens",
-    "fastokens": "fastokens",
-    "hf": "default",
-    "default": "default",
-}
-
-
-# ── Data ─────────────────────────────────────────────────────────────────────
-
-
-@dataclass
-class RunConfig:
-    """Configuration for a single sweep point."""
-
-    backend: str  # "mocker" or "vllm"
-    tokenizer: str  # "hf" or "fastokens"
-    concurrency: int
-    isl: int
-    osl: int
-    workers: int
-    num_models: int
-    aiperf_targets: str  # "first" or "all"
-    speedup_ratio: float
-    model: str
-    benchmark_duration: Optional[int]
-    num_requests: Optional[int]
-    request_rate: Optional[int]
-
-    @property
-    def run_id(self) -> str:
-        base = f"{self.tokenizer}_c{self.concurrency}_isl{self.isl}_w{self.workers}"
-        if self.num_models > 1:
-            base += f"_m{self.num_models}"
-        if self.request_rate:
-            base += f"_rps{self.request_rate}"
-        return base
-
-
-@dataclass
-class RunResult:
-    """Result from a single sweep point."""
-
-    config: RunConfig
-    status: str = "pending"  # ok, fail, skipped
-    req_per_sec: float = 0.0
-    output_tok_per_sec: float = 0.0
-    ttft_p50_ms: float = 0.0
-    ttft_p99_ms: float = 0.0
-    itl_p50_ms: float = 0.0
-    itl_p99_ms: float = 0.0
-    duration_sec: float = 0.0
-    run_dir: str = ""
-
-
-# ── Helpers ──────────────────────────────────────────────────────────────────
-
-
-def _kill_port(port: int):
-    """Kill any process holding a port (SIGTERM first, then SIGKILL)."""
-    subprocess.run(
-        f"fuser -k -TERM {port}/tcp", shell=True, capture_output=True, timeout=5
-    )
-    time.sleep(2)
-    subprocess.run(
-        f"fuser -k -KILL {port}/tcp", shell=True, capture_output=True, timeout=5
-    )
-
-
-def _port_free(port: int) -> bool:
-    import socket
-
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        return s.connect_ex(("127.0.0.1", port)) != 0
-    finally:
-        s.close()
-
-
-def _wait_port_free(port: int, timeout: int = 30):
-    """Wait for a port to become free."""
-    for i in range(timeout):
-        if _port_free(port):
-            return
-        if i == 0:
-            print(f"  Waiting for port {port} to free...")
-        time.sleep(1)
-    print(f"  Forcing port {port} release...")
-    _kill_port(port)
-    time.sleep(2)
-
-
-def _parse_aiperf_json(json_path: Path) -> dict:
-    """Parse aiperf profile_export_aiperf.json."""
-    if not json_path.exists():
-        return {}
-    try:
-        data = json.loads(json_path.read_text())
-        result = {}
-        # Request throughput
-        rt = data.get("request_throughput", {})
-        result["req_per_sec"] = rt.get("avg", 0)
-        # Output token throughput
-        ot = data.get("output_token_throughput", {})
-        result["output_tok_per_sec"] = ot.get("avg", 0)
-        # TTFT (aiperf exports in ms already)
-        ttft = data.get("time_to_first_token", data.get("ttft", {}))
-        if isinstance(ttft, dict):
-            result["ttft_p50_ms"] = ttft.get("p50", 0) or 0
-            result["ttft_p99_ms"] = ttft.get("p99", 0) or 0
-        # ITL
-        itl = data.get("inter_token_latency", data.get("itl", {}))
-        if isinstance(itl, dict):
-            result["itl_p50_ms"] = itl.get("p50", 0) or 0
-            result["itl_p99_ms"] = itl.get("p99", 0) or 0
-        # Duration (can be dict with .avg or raw float)
-        bd = data.get("benchmark_duration", 0)
-        result["duration_sec"] = bd.get("avg", 0) if isinstance(bd, dict) else (bd or 0)
-        return result
-    except (json.JSONDecodeError, KeyError, TypeError):
-        return {}
-
-
-def _run_single(
-    cfg: RunConfig,
-    run_dir: Path,
-    passthrough_args: list[str],
-) -> RunResult:
-    """Execute a single run_perf.sh invocation."""
-    result = RunResult(config=cfg, run_dir=str(run_dir))
-
-    cmd = [
-        str(SCRIPT_DIR / "run_perf.sh"),
-        "--model",
-        cfg.model,
-        "--isl",
-        str(cfg.isl),
-        "--osl",
-        str(cfg.osl),
-        "--concurrency",
-        str(cfg.concurrency),
-        "--workers",
-        str(cfg.workers),
-        "--speedup-ratio",
-        str(cfg.speedup_ratio),
-        "--num-models",
-        str(cfg.num_models),
-        "--aiperf-targets",
-        cfg.aiperf_targets,
-        "--output-dir",
-        str(run_dir),
-    ]
-    if cfg.benchmark_duration:
-        cmd.extend(["--benchmark-duration", str(cfg.benchmark_duration)])
-    if cfg.num_requests:
-        cmd.extend(["--num-requests", str(cfg.num_requests)])
-    if cfg.request_rate:
-        cmd.extend(["--request-rate", str(cfg.request_rate)])
-    if cfg.tokenizer in ("fast", "fastokens"):
-        cmd.append("--fast-tokens")
-    # TODO: when run_perf.sh gains --backend vllm support, pass it here
-    if cfg.backend == "vllm":
-        print(
-            "    WARNING: vllm backend not yet supported by run_perf.sh; using mocker"
-        )
-
-    cmd.extend(passthrough_args)
-
-    print(f"    cmd: {' '.join(cmd[:6])}...")
-
-    try:
-        proc = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            start_new_session=True,
-        )
-        stdout, _ = proc.communicate(timeout=600)
-
-        if proc.returncode == 0:
-            result.status = "ok"
-        else:
-            result.status = "fail"
-            print(f"    run_perf.sh failed (rc={proc.returncode})")
-            # Print last few lines of output for debugging
-            lines = (stdout or "").strip().split("\n")
-            for line in lines[-5:]:
-                print(f"      {line}")
-
-    except subprocess.TimeoutExpired:
-        result.status = "fail"
-        print("    TIMEOUT after 600s")
-        try:
-            pgid = os.getpgid(proc.pid)
-            os.killpg(pgid, signal.SIGTERM)
-            time.sleep(2)
-            os.killpg(pgid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass  # already exited
-    except Exception as e:
-        result.status = "fail"
-        print(f"    ERROR: {e}")
-
-    # Parse aiperf results -- check both flat and multi-model layouts
-    aiperf_json = run_dir / "aiperf" / "profile_export_aiperf.json"
-    if not aiperf_json.exists():
-        # Multi-model: results are in aiperf/<model-name>/
-        for candidate in sorted(
-            (run_dir / "aiperf").glob("*/profile_export_aiperf.json")
-        ):
-            aiperf_json = candidate
-            break  # Use the first model's results for the summary row
-    metrics = _parse_aiperf_json(aiperf_json)
-    if metrics:
-        result.req_per_sec = metrics.get("req_per_sec", 0)
-        result.output_tok_per_sec = metrics.get("output_tok_per_sec", 0)
-        result.ttft_p50_ms = metrics.get("ttft_p50_ms", 0)
-        result.ttft_p99_ms = metrics.get("ttft_p99_ms", 0)
-        result.itl_p50_ms = metrics.get("itl_p50_ms", 0)
-        result.itl_p99_ms = metrics.get("itl_p99_ms", 0)
-        result.duration_sec = metrics.get("duration_sec", 0)
-
-    return result
-
-
-def _generate_report(run_dir: Path):
-    """Run create_report.py on a single run directory."""
-    try:
-        sys.path.insert(0, str(ANALYSIS_DIR))
-        from create_report import run_analysis
-
-        report = run_analysis(run_dir)
-        (run_dir / "report.md").write_text(report)
-    except Exception as e:
-        print(f"    Report generation failed: {e}")
-
-
-# ── Output ───────────────────────────────────────────────────────────────────
-
-
-def _write_csv(results: list[RunResult], csv_path: Path):
-    """Write incremental CSV (called after each run)."""
-    fieldnames = [
-        "run_id",
-        "backend",
-        "tokenizer",
-        "concurrency",
-        "isl",
-        "osl",
-        "workers",
-        "speedup_ratio",
-        "status",
-        "req_per_sec",
-        "output_tok_per_sec",
-        "ttft_p50_ms",
-        "ttft_p99_ms",
-        "itl_p50_ms",
-        "itl_p99_ms",
-        "duration_sec",
-        "run_dir",
-    ]
-    with open(csv_path, "w", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
-        writer.writeheader()
-        for r in results:
-            row = {
-                "run_id": r.config.run_id,
-                "backend": r.config.backend,
-                "tokenizer": r.config.tokenizer,
-                "concurrency": r.config.concurrency,
-                "isl": r.config.isl,
-                "osl": r.config.osl,
-                "workers": r.config.workers,
-                "speedup_ratio": r.config.speedup_ratio,
-                "status": r.status,
-                "req_per_sec": f"{r.req_per_sec:.2f}" if r.req_per_sec else "",
-                "output_tok_per_sec": f"{r.output_tok_per_sec:.1f}"
-                if r.output_tok_per_sec
-                else "",
-                "ttft_p50_ms": f"{r.ttft_p50_ms:.1f}" if r.ttft_p50_ms else "",
-                "ttft_p99_ms": f"{r.ttft_p99_ms:.1f}" if r.ttft_p99_ms else "",
-                "itl_p50_ms": f"{r.itl_p50_ms:.1f}" if r.itl_p50_ms else "",
-                "itl_p99_ms": f"{r.itl_p99_ms:.1f}" if r.itl_p99_ms else "",
-                "duration_sec": f"{r.duration_sec:.1f}" if r.duration_sec else "",
-                "run_dir": r.run_dir,
-            }
-            writer.writerow(row)
-
-
-def _write_summary(results: list[RunResult], summary_path: Path):
-    """Write markdown summary table."""
-    lines = ["# Sweep Summary\n"]
-    lines.append(f"**Generated:** {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
-    lines.append(
-        "| Run ID | Req/s | Tok/s | TTFT p50 | TTFT p99 | ITL p50 | Duration | Status |"
-    )
-    lines.append(
-        "|--------|------:|------:|---------:|---------:|--------:|---------:|--------|"
-    )
-
-    for r in results:
-        rps = f"{r.req_per_sec:.1f}" if r.req_per_sec else "-"
-        tps = f"{r.output_tok_per_sec:.0f}" if r.output_tok_per_sec else "-"
-        tp50 = f"{r.ttft_p50_ms:.1f}ms" if r.ttft_p50_ms else "-"
-        tp99 = f"{r.ttft_p99_ms:.1f}ms" if r.ttft_p99_ms else "-"
-        ip50 = f"{r.itl_p50_ms:.1f}ms" if r.itl_p50_ms else "-"
-        dur = f"{r.duration_sec:.0f}s" if r.duration_sec else "-"
-        lines.append(
-            f"| {r.config.run_id} | {rps} | {tps} | {tp50} | {tp99} | {ip50} | {dur} | {r.status} |"
-        )
-
-    lines.append("")
-    ok = sum(1 for r in results if r.status == "ok")
-    fail = sum(1 for r in results if r.status == "fail")
-    skip = sum(1 for r in results if r.status == "skipped")
-    lines.append(
-        f"**Totals:** {ok} passed, {fail} failed, {skip} skipped out of {len(results)}"
-    )
-
-    summary_path.write_text("\n".join(lines) + "\n")
-
-
-def _print_results_table(results: list[RunResult]):
-    """Print a compact results table to stdout."""
-    print(f"\n{'='*90}")
-    print(
-        f"  {'Run ID':<30} {'Req/s':>8} {'Tok/s':>8} {'TTFT p50':>10} {'TTFT p99':>10} {'Status':>8}"
-    )
-    print(f"  {'-'*30} {'-'*8} {'-'*8} {'-'*10} {'-'*10} {'-'*8}")
-    for r in results:
-        rps = f"{r.req_per_sec:.1f}" if r.req_per_sec else "N/A"
-        tps = f"{r.output_tok_per_sec:.0f}" if r.output_tok_per_sec else "N/A"
-        tp50 = f"{r.ttft_p50_ms:.1f}ms" if r.ttft_p50_ms else "N/A"
-        tp99 = f"{r.ttft_p99_ms:.1f}ms" if r.ttft_p99_ms else "N/A"
-        print(
-            f"  {r.config.run_id:<30} {rps:>8} {tps:>8} {tp50:>10} {tp99:>10} {r.status:>8}"
-        )
-    print(f"{'='*90}")
-
-
-# ── Main ─────────────────────────────────────────────────────────────────────
+from sweep_core.config import build_argument_parser, config_from_args
+from sweep_core.orchestrator import run as run_sweep
+from sweep_core.planner import build_plan, print_plan
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Frontend performance sweep runner",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""Examples:
-  # Smoke test
-  python3 sweep_runner.py --tokenizers hf,fastokens --concurrency 32 --isl 512 \\
-      --benchmark-duration 30 --speedup-ratio 0
+    parser = build_argument_parser()
 
-  # Full tokenizer comparison
-  python3 sweep_runner.py --tokenizers hf,fastokens --concurrency 32,64 --isl 512,1024,2048
-
-  # vLLM backend (real inference)
-  python3 sweep_runner.py --backend vllm --tokenizers hf --concurrency 128 --isl 1024
-
-  # Transport saturation (high concurrency, vary workers)
-  python3 sweep_runner.py --tokenizers hf --concurrency 4096 \\
-      --num-requests 16384,32768 --workers 1,2,4,8 --speedup-ratio 0
-
-  # With profilers (needs sudo for BPF)
-  sudo -E python3 sweep_runner.py --tokenizers hf --concurrency 64 --isl 1024 \\
-      -- --with-nsys --with-perf --with-bpf
-""",
-    )
-
-    parser.add_argument("--model", default=DEFAULT_MODEL, help="HF model path")
+    # Add CLI-only flags that don't belong in SweepConfig
     parser.add_argument(
-        "--backend",
-        choices=["mocker", "vllm"],
-        default="mocker",
-        help="Engine backend: mocker (synthetic) or vllm (real inference)",
-    )
-    parser.add_argument(
-        "--tokenizers",
-        default="hf,fastokens",
-        help="Comma-separated tokenizer backends (hf, fastokens)",
-    )
-    parser.add_argument(
-        "--concurrency", default="50,100,200", help="Comma-separated concurrency levels"
-    )
-    parser.add_argument(
-        "--isl", default="512,1024,2048", help="Comma-separated ISL values"
-    )
-    parser.add_argument(
-        "--osl", type=int, default=DEFAULT_OSL, help="Output sequence length"
-    )
-    parser.add_argument(
-        "--workers", default="2", help="Comma-separated worker counts per model"
-    )
-    parser.add_argument(
-        "--num-models",
-        type=int,
-        default=1,
-        help="Number of model instances (each gets --workers workers, named model-1, model-2, ...)",
-    )
-    parser.add_argument(
-        "--aiperf-targets",
-        choices=["first", "all"],
-        default="first",
-        help="'first': aiperf targets model-1 only (default). 'all': run aiperf for each model.",
-    )
-    parser.add_argument(
-        "--speedup-ratio",
-        type=float,
-        default=DEFAULT_SPEEDUP,
-        help="Mocker speedup (0=infinite)",
-    )
-    parser.add_argument(
-        "--benchmark-duration",
-        type=int,
-        default=DEFAULT_BENCHMARK_DURATION,
-        help="aiperf duration (seconds)",
-    )
-    parser.add_argument(
-        "--num-requests",
-        default=None,
-        help="Comma-separated request counts (overrides --benchmark-duration)",
-    )
-    parser.add_argument(
-        "--rps",
-        default=None,
-        help="Comma-separated target request rates (req/s). Sweep dimension when multiple values given.",
-    )
-    parser.add_argument(
-        "--output-dir",
-        default=None,
-        help="Output directory (default: auto timestamped)",
-    )
-    parser.add_argument(
-        "--max-consecutive-fails", type=int, default=DEFAULT_MAX_CONSECUTIVE_FAILS
-    )
-    parser.add_argument(
-        "--cooldown", type=int, default=DEFAULT_COOLDOWN, help="Seconds between runs"
-    )
-    parser.add_argument(
-        "--dry-run", action="store_true", help="Print plan without executing"
-    )
-    parser.add_argument(
-        "--no-report", action="store_true", help="Skip per-run report generation"
-    )
-    parser.add_argument(
-        "passthrough", nargs="*", help="Extra args passed to run_perf.sh (after --)"
+        "--emit-plan",
+        action="store_true",
+        help="Print the sweep plan as JSON and exit (no execution)",
     )
 
     args = parser.parse_args()
 
-    # Parse lists
-    tokenizers = [t.strip() for t in args.tokenizers.split(",")]
-    concurrencies = [int(c) for c in args.concurrency.split(",")]
-    isls = [int(i) for i in args.isl.split(",")]
-    worker_counts = [int(w) for w in args.workers.split(",")]
-    num_requests_list = (
-        [int(n) for n in args.num_requests.split(",")] if args.num_requests else [None]
-    )
-    rps_list = [int(r) for r in args.rps.split(",")] if args.rps else [None]
+    # Build typed config from args
+    config = config_from_args(args)
 
-    # Build sweep grid
-    configs: list[RunConfig] = []
-    for tokenizer in tokenizers:
-        for workers in worker_counts:
-            for concurrency in concurrencies:
-                for isl in isls:
-                    for nr in num_requests_list:
-                        for rps in rps_list:
-                            configs.append(
-                                RunConfig(
-                                    backend=args.backend,
-                                    tokenizer=tokenizer,
-                                    concurrency=concurrency,
-                                    isl=isl,
-                                    osl=args.osl,
-                                    workers=workers,
-                                    num_models=args.num_models,
-                                    aiperf_targets=args.aiperf_targets,
-                                    speedup_ratio=args.speedup_ratio,
-                                    model=args.model,
-                                    benchmark_duration=args.benchmark_duration
-                                    if nr is None
-                                    else None,
-                                    num_requests=nr,
-                                    request_rate=rps,
-                                )
-                            )
+    # Build plan
+    plan = build_plan(config)
+    print_plan(plan)
 
-    # Output directory
-    if args.output_dir:
-        output_root = Path(args.output_dir)
-    else:
-        ts = time.strftime("%Y%m%d_%H%M%S")
-        output_root = REPO_ROOT / "artifacts" / f"sweep_{ts}"
-
-    total = len(configs)
-    print(f"Sweep plan: {total} runs")
-    print(f"  Model:          {args.model}")
-    print(f"  Backend:        {args.backend}")
-    print(f"  Tokenizers:     {tokenizers}")
-    print(f"  Concurrencies:  {concurrencies}")
-    print(f"  ISLs:           {isls}")
-    print(f"  Workers/model:  {worker_counts}")
-    print(f"  Models:         {args.num_models}")
-    print(f"  Benchmark dur:  {args.benchmark_duration}s")
-    if args.num_requests:
-        print(f"  Num requests:   {[int(n) for n in args.num_requests.split(',')]}")
-    if args.rps:
-        print(f"  Request rates:  {[int(r) for r in args.rps.split(',')]} req/s")
-    print(f"  Output:         {output_root}")
-    print()
-
-    if args.dry_run:
-        for i, cfg in enumerate(configs, 1):
-            print(f"  [{i}/{total}] {cfg.run_id}")
+    # Emit plan JSON mode
+    if args.emit_plan:
+        print(plan.to_json())
         return
 
-    output_root.mkdir(parents=True, exist_ok=True)
-    csv_path = output_root / "results.csv"
-    summary_path = output_root / "summary.md"
+    # Dry run mode
+    if config.dry_run:
+        for i, run_spec in enumerate(plan.runs, 1):
+            print(f"  [{i}/{plan.total_runs}] {run_spec.run_id}")
+        return
 
-    # Passthrough args for run_perf.sh (e.g., --skip-bpf --skip-nsys)
-    passthrough = args.passthrough or []
+    # Select executor based on mode
+    if config.mode == "local":
+        from sweep_executors.local import LocalExecutor
 
-    results: list[RunResult] = []
-    consecutive_fails: dict[tuple, int] = {}  # (backend, concurrency, workers) -> count
+        executor = LocalExecutor()
+    elif config.mode == "k8s":
+        from sweep_executors.k8s_dgd import K8sDgdExecutor
 
-    try:
-        for i, cfg in enumerate(configs, 1):
-            key = (cfg.backend, cfg.concurrency, cfg.workers)
-            run_dir = output_root / cfg.run_id
+        executor = K8sDgdExecutor()
+    else:
+        print(f"ERROR: Unknown mode '{config.mode}'. Use 'local' or 'k8s'.", file=sys.stderr)
+        sys.exit(1)
 
-            # Skip after consecutive failures
-            if consecutive_fails.get(key, 0) >= args.max_consecutive_fails:
-                result = RunResult(config=cfg, status="skipped", run_dir=str(run_dir))
-                results.append(result)
-                print(
-                    f"\n  [{i}/{total}] SKIPPED {cfg.run_id} ({args.max_consecutive_fails} consecutive failures)"
-                )
-                continue
-
-            print(f"\n{'='*60}")
-            print(f"  [{i}/{total}] {cfg.run_id}")
-            print(f"{'='*60}")
-
-            # Wait for port from previous run
-            _wait_port_free(8000)
-
-            # Run
-            result = _run_single(cfg, run_dir, passthrough)
-            results.append(result)
-
-            # Update consecutive failure tracking
-            if result.status == "ok":
-                consecutive_fails[key] = 0
-                rps = f"{result.req_per_sec:.1f}" if result.req_per_sec else "N/A"
-                tp50 = f"{result.ttft_p50_ms:.1f}ms" if result.ttft_p50_ms else "N/A"
-                print(f"    OK: {rps} req/s, TTFT p50={tp50}")
-            else:
-                consecutive_fails[key] = consecutive_fails.get(key, 0) + 1
-                print(
-                    f"    FAIL (consecutive: {consecutive_fails[key]}/{args.max_consecutive_fails})"
-                )
-
-            # Generate per-run report
-            if not args.no_report and result.status == "ok":
-                _generate_report(run_dir)
-
-            # Write incremental CSV + summary
-            _write_csv(results, csv_path)
-            _write_summary(results, summary_path)
-
-            # Cooldown
-            if i < total:
-                time.sleep(args.cooldown)
-
-    except KeyboardInterrupt:
-        print("\n\nInterrupted! Partial results saved.")
-    finally:
-        _write_csv(results, csv_path)
-        _write_summary(results, summary_path)
-
-    # Final output
-    _print_results_table(results)
-    print(f"\nResults:  {csv_path}")
-    print(f"Summary:  {summary_path}")
-    print(f"Per-run:  {output_root}/<run_id>/report.md")
+    # Run the sweep
+    run_sweep(plan, executor)
 
 
 if __name__ == "__main__":

--- a/benchmarks/frontend/scripts/sweep_runner.py
+++ b/benchmarks/frontend/scripts/sweep_runner.py
@@ -52,9 +52,9 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-from sweep_core.config import build_argument_parser, config_from_args
-from sweep_core.orchestrator import run as run_sweep
-from sweep_core.planner import build_plan, print_plan
+from sweep_core.config import build_argument_parser, config_from_args  # noqa: E402
+from sweep_core.orchestrator import run as run_sweep  # noqa: E402
+from sweep_core.planner import build_plan, print_plan  # noqa: E402
 
 
 def main():
@@ -97,7 +97,10 @@ def main():
 
         executor = K8sDgdExecutor()
     else:
-        print(f"ERROR: Unknown mode '{config.mode}'. Use 'local' or 'k8s'.", file=sys.stderr)
+        print(
+            f"ERROR: Unknown mode '{config.mode}'. Use 'local' or 'k8s'.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     # Run the sweep


### PR DESCRIPTION
#### Overview:

Perf sweep with local + k8s support:

Sample k8s perf sweep result for vllm backend isl=8k,32k and tokenizer=fast,hf for concurrency=20

```bash
python3 sweep_runner.py --mode k8s \
    --dgd-name dynamo-bench-vllm \
    --namespace dynamo-bench-2 \
    --endpoint dynamo-bench-vllm-frontend:8000 \
    --model openai/gpt-oss-20b \
    --backend vllm \
    --image nvcr.io/nvidian/dynamo-dev/biswa:vllm-runtime-1a8bce12ea \
    --tokenizers hf,fastokens \
    --concurrency 20 \
    --isl 8192,32768 \
    --benchmark-duration 30 \
    --reset-strategy graph 
```

<img width="759" height="302" alt="Screenshot 2026-03-31 at 12 01 27 AM" src="https://github.com/user-attachments/assets/6f508482-790b-435f-92f5-15c4e244d16a" />

#### Details:

Implement unified frontend perf harness -

Layer 1 - sweep_core/ (pure logic, no I/O):
  - models.py: DeployDimension, AiperfDimension, RunSpec, RunResult,
    SweepPlan, SweepConfig, K8sConfig with full JSON serialization
  - planner.py: builds SweepPlan (deploy x aiperf dimension cross-product)
  - orchestrator.py: sequential plan runner, interface-agnostic
  - config.py: typed SweepConfig from argparse with local + k8s options
  - artifacts.py: CSV, summary.md, sweep_config.json writers
  - failures.py: consecutive-failure skip policy
  - lifecycle.py: deploy-dimension delta detection + reset decisions
  - naming.py: run_id conventions matching existing artifact contract
  - reporting.py: per-run report generation wrapper

Layer 2 - sweep_executors/ (how runs execute):
  - base.py: SweepExecutor protocol (prepare/apply_deploy/execute_run/cleanup)
  - local.py: LocalExecutor wrapping run_perf.sh
  - k8s_dgd.py: K8sDgdExecutor with DGD patching, template-based deploy, in-cluster aiperf Jobs, kubectl-based metrics capture

Layer 2 - sweep_k8s/ (k8s subprocess helpers):
  - kubectl.py: safe kubectl helpers with error reporting
  - dgd.py: DGD backend switch, restart (frontend/graph), readiness polling with kubectl-based fallback for in-cluster DNS endpoints
  - template.py: deploy.yaml template rendering (string.Template substitution)
  - metrics.py: Prometheus pre/post /metrics capture via kubectl exec
  - aiperf.py: aiperf as k8s Job (python:3.12-slim), artifacts on PVC, copy-back via helper busybox pod

DGD deploy templates:
  - dgd/templates/mocker.yaml: mocker backend (no GPUs)
  - dgd/templates/vllm.yaml: vLLM backend (GPU resources)

sweep_runner.py refactored to thin CLI:
  - Builds SweepConfig from args, calls planner.build_plan(), selects executor by --mode, calls orchestrator.run()
  - New flags: --mode k8s, --deploy-template, --isolation, --reset-strategy, --emit-plan, --endpoint, --dgd-name
  - Backward compatible: local mode with same CLI args works unchanged

Validated:
  - Local: hf + fastokens sweeps with full artifact pipeline
  - K8s: DGD graph restart, backend switching, in-cluster aiperf Jobs,
    pre/post Prometheus metrics capture, PVC artifact copy

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: DIS-1572


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Kubernetes deployment templates for Mocker and vLLM backends
  * Introduced support for both local and Kubernetes-based sweep execution modes
  * Added sweep plan generation with configurable grid parameters
  * Improved sweep configuration via enhanced CLI with timestamped output directories

* **Refactor**
  * Reorganized sweep orchestration logic into modular components for maintainability
  * Streamlined sweep runner entry point with cleaner command-line interface
  * Enhanced execution framework with pluggable executor backends and consistent reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->