### PR TITLE
fix: multimodal ImageLoader errors

### DIFF
--- a/components/src/dynamo/common/multimodal/http_client.py
+++ b/components/src/dynamo/common/multimodal/http_client.py
@@ -14,11 +14,16 @@
 # limitations under the License.
 
 import logging
+import os
 from typing import Optional
 
 import httpx
 
 logger = logging.getLogger(__name__)
+
+# All HTTP tuning lives here — single source of truth
+MAX_CONNECTIONS: int = int(os.environ.get("DYN_MM_HTTP_MAX_CONNECTIONS", "100"))
+MAX_KEEPALIVE: int = int(os.environ.get("DYN_MM_HTTP_MAX_KEEPALIVE", "20"))
 
 # Global HTTP client instance
 _global_http_client: Optional[httpx.AsyncClient] = None
@@ -40,8 +45,16 @@ def get_http_client(timeout: float = 60.0) -> httpx.AsyncClient:
         _global_http_client = httpx.AsyncClient(
             timeout=timeout,
             follow_redirects=True,
-            limits=httpx.Limits(max_keepalive_connections=20, max_connections=100),
+            limits=httpx.Limits(
+                max_keepalive_connections=MAX_KEEPALIVE,
+                max_connections=MAX_CONNECTIONS,
+            ),
         )
-        logger.info(f"Shared HTTP client initialized with timeout={timeout}s")
+        logger.info(
+            f"Shared HTTP client initialized: "
+            f"max_connections={MAX_CONNECTIONS}, "
+            f"max_keepalive={MAX_KEEPALIVE}, "
+            f"timeout={timeout}s"
+        )
 
     return _global_http_client

--- a/components/src/dynamo/common/multimodal/http_client.py
+++ b/components/src/dynamo/common/multimodal/http_client.py
@@ -14,16 +14,11 @@
 # limitations under the License.
 
 import logging
-import os
 from typing import Optional
 
 import httpx
 
 logger = logging.getLogger(__name__)
-
-# All HTTP tuning lives here — single source of truth
-MAX_CONNECTIONS: int = int(os.environ.get("DYN_MM_HTTP_MAX_CONNECTIONS", "100"))
-MAX_KEEPALIVE: int = int(os.environ.get("DYN_MM_HTTP_MAX_KEEPALIVE", "20"))
 
 # Global HTTP client instance
 _global_http_client: Optional[httpx.AsyncClient] = None
@@ -45,16 +40,8 @@ def get_http_client(timeout: float = 60.0) -> httpx.AsyncClient:
         _global_http_client = httpx.AsyncClient(
             timeout=timeout,
             follow_redirects=True,
-            limits=httpx.Limits(
-                max_keepalive_connections=MAX_KEEPALIVE,
-                max_connections=MAX_CONNECTIONS,
-            ),
+            limits=httpx.Limits(max_keepalive_connections=20, max_connections=100),
         )
-        logger.info(
-            f"Shared HTTP client initialized: "
-            f"max_connections={MAX_CONNECTIONS}, "
-            f"max_keepalive={MAX_KEEPALIVE}, "
-            f"timeout={timeout}s"
-        )
+        logger.info(f"Shared HTTP client initialized with timeout={timeout}s")
 
     return _global_http_client

--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -98,6 +98,8 @@ class ImageLoader:
                 image_data = BytesIO(response.content)
 
             with _nvtx.annotate("mm:img:pil_open_convert", color="lime"):
+                # PIL is sync, so offload to a thread to avoid blocking the event loop
+                # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
                 image = await asyncio.to_thread(
                     Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
                 )
@@ -169,7 +171,7 @@ class ImageLoader:
                         raise ValueError("Data URL must be base64 encoded")
 
                     try:
-                        image_bytes = base64.b64decode(data)
+                        image_bytes = base64.b64decode(data, validate=True)
                     except binascii.Error as e:
                         raise ValueError(f"Invalid base64 encoding: {e}")
                     image_data = BytesIO(image_bytes)

--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -30,9 +30,23 @@ from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.media_nixl import read_decoded_media_via_nixl
 from dynamo.common.utils.runtime import run_async
 
-from .http_client import get_http_client
+from .http_client import MAX_CONNECTIONS, get_http_client
 
 logger = logging.getLogger(__name__)
+
+# Process-global semaphore, lazily initialized on first use.
+# Caps concurrent HTTP fetches to the connection pool size.
+_fetch_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_fetch_semaphore() -> asyncio.Semaphore:
+    """Return a process-global semaphore to throttle concurrent HTTP fetches."""
+    global _fetch_semaphore
+    if _fetch_semaphore is None:
+        _fetch_semaphore = asyncio.Semaphore(MAX_CONNECTIONS)
+        logger.info(f"Image fetch semaphore initialized: concurrency={MAX_CONNECTIONS}")
+    return _fetch_semaphore
+
 
 # Constants for multimodal data variants
 URL_VARIANT_KEY: Final = "Url"
@@ -107,7 +121,8 @@ class ImageLoader:
                 with _nvtx.annotate("mm:img:http_fetch", color="lime"):
                     http_client = get_http_client(self._http_timeout)
 
-                    response = await http_client.get(image_url)
+                    async with _get_fetch_semaphore():
+                        response = await http_client.get(image_url)
                     response.raise_for_status()
 
                     if not response.content:

--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -64,7 +64,7 @@ class ImageLoader:
         self._http_timeout = http_timeout
         self._image_cache: dict[str, Image.Image] = {}
         self._cache_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=cache_size)
-        self._cache_lock = asyncio.Lock()
+        self._inflight: dict[str, asyncio.Task[Image.Image]] = {}
         self._enable_frontend_decoding = enable_frontend_decoding
         # Lazy-init NIXL connector only when frontend decoding is enabled
         self._nixl_connector = None
@@ -74,84 +74,37 @@ class ImageLoader:
                 self._nixl_connector.initialize
             )  # Synchronously wait for async init
 
-    @_nvtx.annotate("mm:img:load_image", color="lime")
-    async def load_image(self, image_url: str) -> Image.Image:
-        parsed_url = urlparse(image_url)
+    def _cache_put(self, key: str, image: Image.Image) -> None:
+        """Insert into cache if not already present. Sync — no awaits."""
+        if key not in self._image_cache:
+            if self._cache_queue.full():
+                oldest = self._cache_queue.get_nowait()
+                del self._image_cache[oldest]
+            self._image_cache[key] = image
+            self._cache_queue.put_nowait(key)
 
-        # For HTTP(S) URLs, check cache first
-        if parsed_url.scheme in ("http", "https"):
-            image_url_lower = image_url.lower()
-            async with self._cache_lock:
-                if image_url_lower in self._image_cache:
-                    logger.debug(f"Image found in cache for URL: {image_url}")
-                    return self._image_cache[image_url_lower]
+    async def _fetch_and_process(self, image_url: str, parsed_url: Any) -> Image.Image:
+        """Fetch image via HTTP(S), decode with PIL, return RGB Image.
 
+        All exception normalization happens here so shared callers
+        see identical error types.
+        """
         try:
-            if parsed_url.scheme == "data":
-                with _nvtx.annotate("mm:img:base64_decode", color="lime"):
-                    # Parse data URL format: data:[<media type>][;base64],<data>
-                    if not parsed_url.path.startswith("image/"):
-                        raise ValueError("Data URL must be an image type")
-
-                    # Split the path into media type and data
-                    media_type, data = parsed_url.path.split(",", 1)
-                    if ";base64" not in media_type:
-                        raise ValueError("Data URL must be base64 encoded")
-
-                    try:
-                        image_bytes = base64.b64decode(data)
-                        image_data = BytesIO(image_bytes)
-                    except binascii.Error as e:
-                        raise ValueError(f"Invalid base64 encoding: {e}")
-            elif parsed_url.scheme in ("http", "https"):
-                with _nvtx.annotate("mm:img:http_fetch", color="lime"):
-                    http_client = get_http_client(self._http_timeout)
-
-                    response = await http_client.get(image_url)
-                    response.raise_for_status()
-
-                    if not response.content:
-                        raise ValueError("Empty response content from image URL")
-
-                    image_data = BytesIO(response.content)
-            elif parsed_url.scheme in ("", "file"):
-                # Local file path (plain path or file:// URI)
-                path = image_url if parsed_url.scheme == "" else parsed_url.path
-
-                def _read_local_file(p: str) -> bytes:
-                    with open(p, "rb") as f:
-                        return f.read()
-
-                image_bytes = await asyncio.to_thread(_read_local_file, path)
-                image_data = BytesIO(image_bytes)
-            else:
-                raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
+            with _nvtx.annotate("mm:img:http_fetch", color="lime"):
+                http_client = get_http_client(self._http_timeout)
+                response = await http_client.get(image_url)
+                response.raise_for_status()
+                if not response.content:
+                    raise ValueError("Empty response content from image URL")
+                image_data = BytesIO(response.content)
 
             with _nvtx.annotate("mm:img:pil_open_convert", color="lime"):
-                # PIL is sync, so offload to a thread to avoid blocking the event loop
-                # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
                 image = await asyncio.to_thread(
                     Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
                 )
-
-                # Validate image format and convert to RGB
                 if image.format not in ("JPEG", "PNG", "WEBP"):
                     raise ValueError(f"Unsupported image format: {image.format}")
-
-                image_converted = image.convert("RGB")
-
-            # Cache HTTP(S) URLs
-            if parsed_url.scheme in ("http", "https"):
-                image_url_lower = image_url.lower()
-                async with self._cache_lock:
-                    if image_url_lower not in self._image_cache:
-                        if self._cache_queue.full():
-                            oldest_image_url = await self._cache_queue.get()
-                            del self._image_cache[oldest_image_url]
-                        self._image_cache[image_url_lower] = image_converted
-                        await self._cache_queue.put(image_url_lower)
-
-            return image_converted
+                return image.convert("RGB")
 
         except httpx.HTTPStatusError as e:
             logger.error(f"HTTP {e.response.status_code} loading image: '{image_url}'")
@@ -165,6 +118,83 @@ class ImageLoader:
         except httpx.HTTPError as e:
             logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")
             raise
+        except Exception as e:
+            logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")
+            raise ValueError(f"Failed to load image: '{image_url}': {e}")
+
+    async def _fetch_and_cache(
+        self, key: str, image_url: str, parsed_url: Any
+    ) -> Image.Image:
+        """Shared task: fetch, cache, then remove from _inflight."""
+        try:
+            image = await self._fetch_and_process(image_url, parsed_url)
+            self._cache_put(key, image)
+            return image
+        finally:
+            self._inflight.pop(key, None)
+
+    @_nvtx.annotate("mm:img:load_image", color="lime")
+    async def load_image(self, image_url: str) -> Image.Image:
+        parsed_url = urlparse(image_url)
+
+        if parsed_url.scheme in ("http", "https"):
+            key = image_url.lower()
+
+            # Check cache (sync — no await, no interleaving possible)
+            if key in self._image_cache:
+                logger.debug(f"Image found in cache for URL: {image_url}")
+                return self._image_cache[key]
+
+            # Join existing in-flight task, or start a new one
+            if key not in self._inflight:
+                task = asyncio.create_task(
+                    self._fetch_and_cache(key, image_url, parsed_url)
+                )
+                # Suppress "exception was never retrieved" if all waiters cancel
+                task.add_done_callback(
+                    lambda t: t.exception() if not t.cancelled() else None
+                )
+                self._inflight[key] = task
+
+            # shield so cancelling THIS caller doesn't cancel the shared task
+            return await asyncio.shield(self._inflight[key])
+
+        try:
+            if parsed_url.scheme == "data":
+                with _nvtx.annotate("mm:img:base64_decode", color="lime"):
+                    if not parsed_url.path.startswith("image/"):
+                        raise ValueError("Data URL must be an image type")
+
+                    media_type, data = parsed_url.path.split(",", 1)
+                    if ";base64" not in media_type:
+                        raise ValueError("Data URL must be base64 encoded")
+
+                    try:
+                        image_bytes = base64.b64decode(data)
+                    except binascii.Error as e:
+                        raise ValueError(f"Invalid base64 encoding: {e}")
+                    image_data = BytesIO(image_bytes)
+
+            elif parsed_url.scheme in ("", "file"):
+                path = image_url if parsed_url.scheme == "" else parsed_url.path
+
+                def _read_local_file(p: str) -> bytes:
+                    with open(p, "rb") as f:
+                        return f.read()
+
+                image_bytes = await asyncio.to_thread(_read_local_file, path)
+                image_data = BytesIO(image_bytes)
+            else:
+                raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
+
+            with _nvtx.annotate("mm:img:pil_open_convert", color="lime"):
+                image = await asyncio.to_thread(
+                    Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
+                )
+                if image.format not in ("JPEG", "PNG", "WEBP"):
+                    raise ValueError(f"Unsupported image format: {image.format}")
+                return image.convert("RGB")
+
         except Exception as e:
             logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")
             raise ValueError(f"Failed to load image: '{image_url}': {e}")

--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -30,25 +30,9 @@ from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.media_nixl import read_decoded_media_via_nixl
 from dynamo.common.utils.runtime import run_async
 
-from .http_client import MAX_CONNECTIONS, get_http_client
+from .http_client import get_http_client
 
 logger = logging.getLogger(__name__)
-
-# Process-global semaphore, lazily initialized on first use.
-# Defaults to MAX_CONNECTIONS so we never exceed the connection pool.
-_fetch_semaphore: asyncio.Semaphore | None = None
-
-
-def _get_fetch_semaphore() -> asyncio.Semaphore:
-    """Return a process-global semaphore to throttle concurrent HTTP fetches."""
-    global _fetch_semaphore
-    if _fetch_semaphore is None:
-        _fetch_semaphore = asyncio.Semaphore(MAX_CONNECTIONS)
-        logger.info(
-            f"Image fetch semaphore initialized: concurrency={MAX_CONNECTIONS}"
-        )
-    return _fetch_semaphore
-
 
 # Constants for multimodal data variants
 URL_VARIANT_KEY: Final = "Url"
@@ -80,6 +64,7 @@ class ImageLoader:
         self._http_timeout = http_timeout
         self._image_cache: dict[str, Image.Image] = {}
         self._cache_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=cache_size)
+        self._cache_lock = asyncio.Lock()
         self._enable_frontend_decoding = enable_frontend_decoding
         # Lazy-init NIXL connector only when frontend decoding is enabled
         self._nixl_connector = None
@@ -96,9 +81,10 @@ class ImageLoader:
         # For HTTP(S) URLs, check cache first
         if parsed_url.scheme in ("http", "https"):
             image_url_lower = image_url.lower()
-            if image_url_lower in self._image_cache:
-                logger.debug(f"Image found in cache for URL: {image_url}")
-                return self._image_cache[image_url_lower]
+            async with self._cache_lock:
+                if image_url_lower in self._image_cache:
+                    logger.debug(f"Image found in cache for URL: {image_url}")
+                    return self._image_cache[image_url_lower]
 
         try:
             if parsed_url.scheme == "data":
@@ -121,8 +107,7 @@ class ImageLoader:
                 with _nvtx.annotate("mm:img:http_fetch", color="lime"):
                     http_client = get_http_client(self._http_timeout)
 
-                    async with _get_fetch_semaphore():
-                        response = await http_client.get(image_url)
+                    response = await http_client.get(image_url)
                     response.raise_for_status()
 
                     if not response.content:
@@ -158,22 +143,31 @@ class ImageLoader:
             # Cache HTTP(S) URLs
             if parsed_url.scheme in ("http", "https"):
                 image_url_lower = image_url.lower()
-                # Cache the image for future use, and evict the oldest image if the cache is full
-                if self._cache_queue.full():
-                    oldest_image_url = await self._cache_queue.get()
-                    del self._image_cache[oldest_image_url]
-
-                self._image_cache[image_url_lower] = image_converted
-                await self._cache_queue.put(image_url_lower)
+                async with self._cache_lock:
+                    if image_url_lower not in self._image_cache:
+                        if self._cache_queue.full():
+                            oldest_image_url = await self._cache_queue.get()
+                            del self._image_cache[oldest_image_url]
+                        self._image_cache[image_url_lower] = image_converted
+                        await self._cache_queue.put(image_url_lower)
 
             return image_converted
 
+        except httpx.HTTPStatusError as e:
+            logger.error(f"HTTP {e.response.status_code} loading image: '{image_url}'")
+            raise
+        except httpx.TimeoutException as e:
+            logger.error(
+                f"{type(e).__name__} loading image: '{image_url}' "
+                f"(timeout={self._http_timeout}s)"
+            )
+            raise ValueError(f"Timeout loading image: '{image_url}'")
         except httpx.HTTPError as e:
-            logger.error(f"HTTP error loading image: {e}")
+            logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")
             raise
         except Exception as e:
-            logger.error(f"Error loading image: {e}")
-            raise ValueError(f"Failed to load image: {e}")
+            logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")
+            raise ValueError(f"Failed to load image: '{image_url}': {e}")
 
     async def load_image_batch(
         self,

--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -30,23 +30,9 @@ from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.media_nixl import read_decoded_media_via_nixl
 from dynamo.common.utils.runtime import run_async
 
-from .http_client import MAX_CONNECTIONS, get_http_client
+from .http_client import get_http_client
 
 logger = logging.getLogger(__name__)
-
-# Process-global semaphore, lazily initialized on first use.
-# Caps concurrent HTTP fetches to the connection pool size.
-_fetch_semaphore: asyncio.Semaphore | None = None
-
-
-def _get_fetch_semaphore() -> asyncio.Semaphore:
-    """Return a process-global semaphore to throttle concurrent HTTP fetches."""
-    global _fetch_semaphore
-    if _fetch_semaphore is None:
-        _fetch_semaphore = asyncio.Semaphore(MAX_CONNECTIONS)
-        logger.info(f"Image fetch semaphore initialized: concurrency={MAX_CONNECTIONS}")
-    return _fetch_semaphore
-
 
 # Constants for multimodal data variants
 URL_VARIANT_KEY: Final = "Url"
@@ -121,8 +107,7 @@ class ImageLoader:
                 with _nvtx.annotate("mm:img:http_fetch", color="lime"):
                     http_client = get_http_client(self._http_timeout)
 
-                    async with _get_fetch_semaphore():
-                        response = await http_client.get(image_url)
+                    response = await http_client.get(image_url)
                     response.raise_for_status()
 
                     if not response.content:

--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -30,9 +30,24 @@ from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.media_nixl import read_decoded_media_via_nixl
 from dynamo.common.utils.runtime import run_async
 
-from .http_client import get_http_client
+from .http_client import MAX_CONNECTIONS, get_http_client
 
 logger = logging.getLogger(__name__)
+
+# Process-global semaphore, lazily initialized on first use.
+# Defaults to MAX_CONNECTIONS so we never exceed the connection pool.
+_fetch_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_fetch_semaphore() -> asyncio.Semaphore:
+    """Return a process-global semaphore to throttle concurrent HTTP fetches."""
+    global _fetch_semaphore
+    if _fetch_semaphore is None:
+        _fetch_semaphore = asyncio.Semaphore(MAX_CONNECTIONS)
+        logger.info(
+            f"Image fetch semaphore initialized: concurrency={MAX_CONNECTIONS}"
+        )
+    return _fetch_semaphore
 
 
 # Constants for multimodal data variants
@@ -106,7 +121,8 @@ class ImageLoader:
                 with _nvtx.annotate("mm:img:http_fetch", color="lime"):
                     http_client = get_http_client(self._http_timeout)
 
-                    response = await http_client.get(image_url)
+                    async with _get_fetch_semaphore():
+                        response = await http_client.get(image_url)
                     response.raise_for_status()
 
                     if not response.content:

--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -118,13 +118,13 @@ class ImageLoader:
                 f"{type(e).__name__} loading image: '{image_url}' "
                 f"(timeout={self._http_timeout}s)"
             )
-            raise ValueError(f"Timeout loading image: '{image_url}'")
+            raise ValueError(f"Timeout loading image: '{image_url}'") from e
         except httpx.HTTPError as e:
             logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")
             raise
         except Exception as e:
             logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")
-            raise ValueError(f"Failed to load image: '{image_url}': {e}")
+            raise ValueError(f"Failed to load image: '{image_url}': {e}") from e
 
     async def _fetch_and_cache(
         self, key: str, image_url: str, parsed_url: Any
@@ -176,7 +176,7 @@ class ImageLoader:
                     try:
                         image_bytes = base64.b64decode(data, validate=True)
                     except binascii.Error as e:
-                        raise ValueError(f"Invalid base64 encoding: {e}")
+                        raise ValueError(f"Invalid base64 encoding: {e}") from e
                     image_data = BytesIO(image_bytes)
 
             elif parsed_url.scheme in ("", "file"):
@@ -195,7 +195,7 @@ class ImageLoader:
 
         except Exception as e:
             logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")
-            raise ValueError(f"Failed to load image: '{image_url}': {e}")
+            raise ValueError(f"Failed to load image: '{image_url}': {e}") from e
 
     async def load_image_batch(
         self,

--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -18,6 +18,7 @@ import base64
 import binascii
 import logging
 import os
+from collections import OrderedDict
 from io import BytesIO
 from typing import Any, Dict, Final, List
 from urllib.parse import urlparse
@@ -62,8 +63,8 @@ class ImageLoader:
                 network transport. Defaults to False.
         """
         self._http_timeout = http_timeout
-        self._image_cache: dict[str, Image.Image] = {}
-        self._cache_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=cache_size)
+        self._cache_size = cache_size
+        self._image_cache: OrderedDict[str, Image.Image] = OrderedDict()
         self._inflight: dict[str, asyncio.Task[Image.Image]] = {}
         self._enable_frontend_decoding = enable_frontend_decoding
         # Lazy-init NIXL connector only when frontend decoding is enabled
@@ -77,11 +78,9 @@ class ImageLoader:
     def _cache_put(self, key: str, image: Image.Image) -> None:
         """Insert into cache if not already present. Sync — no awaits."""
         if key not in self._image_cache:
-            if self._cache_queue.full():
-                oldest = self._cache_queue.get_nowait()
-                del self._image_cache[oldest]
+            if len(self._image_cache) >= self._cache_size:
+                self._image_cache.popitem(last=False)
             self._image_cache[key] = image
-            self._cache_queue.put_nowait(key)
 
     async def _fetch_and_process(self, image_url: str, parsed_url: Any) -> Image.Image:
         """Fetch image via HTTP(S), decode with PIL, return RGB Image.

--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -76,15 +76,19 @@ class ImageLoader:
             )  # Synchronously wait for async init
 
     @staticmethod
+    def _open_image_sync(image_data: BytesIO) -> Image.Image:
+        """Open, validate, and decode an image from raw bytes. Runs in a thread."""
+        image = Image.open(image_data, formats=["JPEG", "PNG", "WEBP"])
+        if image.format not in ("JPEG", "PNG", "WEBP"):
+            raise ValueError(f"Unsupported image format: {image.format}")
+        # Image.open() is lazy — convert() forces the actual pixel decode
+        return image.convert("RGB")
+
+    @staticmethod
     async def _open_image(image_data: BytesIO) -> Image.Image:
         """Open and validate an image from raw bytes, converting to RGB."""
         with _nvtx.annotate("mm:img:pil_open_convert", color="lime"):
-            image = await asyncio.to_thread(
-                Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
-            )
-            if image.format not in ("JPEG", "PNG", "WEBP"):
-                raise ValueError(f"Unsupported image format: {image.format}")
-            return image.convert("RGB")
+            return await asyncio.to_thread(ImageLoader._open_image_sync, image_data)
 
     def _cache_put(self, key: str, image: Image.Image) -> None:
         """Insert into cache if not already present. Sync — no awaits."""
@@ -93,7 +97,7 @@ class ImageLoader:
                 self._image_cache.popitem(last=False)
             self._image_cache[key] = image
 
-    async def _fetch_and_process(self, image_url: str, parsed_url: Any) -> Image.Image:
+    async def _fetch_and_process(self, image_url: str) -> Image.Image:
         """Fetch image via HTTP(S), decode with PIL, return RGB Image.
 
         All exception normalization happens here so shared callers
@@ -126,12 +130,10 @@ class ImageLoader:
             logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")
             raise ValueError(f"Failed to load image: '{image_url}': {e}") from e
 
-    async def _fetch_and_cache(
-        self, key: str, image_url: str, parsed_url: Any
-    ) -> Image.Image:
+    async def _fetch_and_cache(self, key: str, image_url: str) -> Image.Image:
         """Shared task: fetch, cache, then remove from _inflight."""
         try:
-            image = await self._fetch_and_process(image_url, parsed_url)
+            image = await self._fetch_and_process(image_url)
             self._cache_put(key, image)
             return image
         finally:
@@ -147,13 +149,12 @@ class ImageLoader:
             # Check cache (sync — no await, no interleaving possible)
             if key in self._image_cache:
                 logger.debug(f"Image found in cache for URL: {image_url}")
+                self._image_cache.move_to_end(key)
                 return self._image_cache[key]
 
             # Join existing in-flight task, or start a new one
             if key not in self._inflight:
-                task = asyncio.create_task(
-                    self._fetch_and_cache(key, image_url, parsed_url)
-                )
+                task = asyncio.create_task(self._fetch_and_cache(key, image_url))
                 # Suppress "exception was never retrieved" if all waiters cancel
                 task.add_done_callback(
                     lambda t: t.exception() if not t.cancelled() else None

--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -75,6 +75,17 @@ class ImageLoader:
                 self._nixl_connector.initialize
             )  # Synchronously wait for async init
 
+    @staticmethod
+    async def _open_image(image_data: BytesIO) -> Image.Image:
+        """Open and validate an image from raw bytes, converting to RGB."""
+        with _nvtx.annotate("mm:img:pil_open_convert", color="lime"):
+            image = await asyncio.to_thread(
+                Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
+            )
+            if image.format not in ("JPEG", "PNG", "WEBP"):
+                raise ValueError(f"Unsupported image format: {image.format}")
+            return image.convert("RGB")
+
     def _cache_put(self, key: str, image: Image.Image) -> None:
         """Insert into cache if not already present. Sync — no awaits."""
         if key not in self._image_cache:
@@ -97,15 +108,7 @@ class ImageLoader:
                     raise ValueError("Empty response content from image URL")
                 image_data = BytesIO(response.content)
 
-            with _nvtx.annotate("mm:img:pil_open_convert", color="lime"):
-                # PIL is sync, so offload to a thread to avoid blocking the event loop
-                # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
-                image = await asyncio.to_thread(
-                    Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
-                )
-                if image.format not in ("JPEG", "PNG", "WEBP"):
-                    raise ValueError(f"Unsupported image format: {image.format}")
-                return image.convert("RGB")
+            return await self._open_image(image_data)
 
         except httpx.HTTPStatusError as e:
             logger.error(f"HTTP {e.response.status_code} loading image: '{image_url}'")
@@ -188,13 +191,7 @@ class ImageLoader:
             else:
                 raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
 
-            with _nvtx.annotate("mm:img:pil_open_convert", color="lime"):
-                image = await asyncio.to_thread(
-                    Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
-                )
-                if image.format not in ("JPEG", "PNG", "WEBP"):
-                    raise ValueError(f"Unsupported image format: {image.format}")
-                return image.convert("RGB")
+            return await self._open_image(image_data)
 
         except Exception as e:
             logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")

--- a/components/src/dynamo/common/tests/multimodal/test_image_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_image_loader.py
@@ -1,0 +1,222 @@
+"""Tests for ImageLoader in-flight dedup, cancellation, and error contract."""
+
+import asyncio
+from io import BytesIO
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from PIL import Image
+
+from dynamo.common.multimodal.image_loader import ImageLoader
+
+
+def _make_png_bytes() -> bytes:
+    """Create a minimal valid PNG in memory."""
+    img = Image.new("RGB", (2, 2), color="red")
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+PNG_BYTES = _make_png_bytes()
+
+
+def _mock_http_client(
+    content: bytes = PNG_BYTES,
+    status_code: int = 200,
+    delay: float = 0.0,
+    side_effect: Exception | None = None,
+) -> AsyncMock:
+    """Return a mock httpx.AsyncClient whose .get() returns a fake response."""
+
+    async def _get(url: str) -> Any:
+        if delay > 0:
+            await asyncio.sleep(delay)
+        if side_effect is not None:
+            raise side_effect
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = status_code
+        resp.content = content
+        resp.raise_for_status = MagicMock()
+        if status_code >= 400:
+            resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "error", request=MagicMock(), response=resp
+            )
+        return resp
+
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=_get)
+    return client
+
+
+@pytest.fixture()
+def loader() -> ImageLoader:
+    return ImageLoader.__new__(ImageLoader)
+
+
+@pytest.fixture(autouse=True)
+def _init_loader(loader: ImageLoader) -> None:
+    loader._http_timeout = 30.0
+    loader._image_cache = {}
+    loader._cache_queue = asyncio.Queue(maxsize=4)
+    loader._inflight = {}
+    loader._enable_frontend_decoding = False
+    loader._nixl_connector = None
+
+
+# --- Concurrent same-URL dedup ---
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_url_deduplicates(loader: ImageLoader) -> None:
+    """Two concurrent load_image calls for the same URL should issue only one HTTP fetch."""
+    mock_client = _mock_http_client(delay=0.05)
+    with patch(
+        "dynamo.common.multimodal.image_loader.get_http_client",
+        return_value=mock_client,
+    ):
+        results = await asyncio.gather(
+            loader.load_image("https://example.com/img.png"),
+            loader.load_image("https://example.com/img.png"),
+        )
+
+    assert len(results) == 2
+    assert results[0].size == results[1].size
+    # Only one HTTP GET should have been issued
+    assert mock_client.get.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_different_urls_fetch_independently(
+    loader: ImageLoader,
+) -> None:
+    """Different URLs should each get their own fetch."""
+    mock_client = _mock_http_client()
+    with patch(
+        "dynamo.common.multimodal.image_loader.get_http_client",
+        return_value=mock_client,
+    ):
+        await asyncio.gather(
+            loader.load_image("https://example.com/a.png"),
+            loader.load_image("https://example.com/b.png"),
+        )
+
+    assert mock_client.get.call_count == 2
+
+
+# --- Waiter cancellation isolation ---
+
+
+@pytest.mark.asyncio
+async def test_waiter_cancellation_does_not_cancel_shared_task(
+    loader: ImageLoader,
+) -> None:
+    """Cancelling one waiter should not prevent the other from getting the image."""
+    mock_client = _mock_http_client(delay=0.1)
+    with patch(
+        "dynamo.common.multimodal.image_loader.get_http_client",
+        return_value=mock_client,
+    ):
+        task_a = asyncio.create_task(loader.load_image("https://example.com/img.png"))
+        task_b = asyncio.create_task(loader.load_image("https://example.com/img.png"))
+        await asyncio.sleep(0.01)
+        task_a.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task_a
+
+        result_b = await task_b
+        assert isinstance(result_b, Image.Image)
+
+
+# --- Retry after failure ---
+
+
+@pytest.mark.asyncio
+async def test_retry_after_failure(loader: ImageLoader) -> None:
+    """After a fetch failure, the next caller should start a fresh fetch."""
+    fail_client = _mock_http_client(side_effect=httpx.TimeoutException("timeout"))
+    ok_client = _mock_http_client()
+
+    with patch(
+        "dynamo.common.multimodal.image_loader.get_http_client",
+        return_value=fail_client,
+    ):
+        with pytest.raises(ValueError, match="Timeout"):
+            await loader.load_image("https://example.com/img.png")
+
+    # _inflight should be cleared after failure
+    assert "https://example.com/img.png" not in loader._inflight
+
+    with patch(
+        "dynamo.common.multimodal.image_loader.get_http_client",
+        return_value=ok_client,
+    ):
+        result = await loader.load_image("https://example.com/img.png")
+        assert isinstance(result, Image.Image)
+
+
+# --- Error contract preserved for non-HTTP ---
+
+
+@pytest.mark.asyncio
+async def test_file_not_found_normalized(loader: ImageLoader) -> None:
+    """file:// path that doesn't exist should raise ValueError, not FileNotFoundError."""
+    with pytest.raises(ValueError, match="Failed to load image"):
+        await loader.load_image("file:///nonexistent/path/img.png")
+
+
+@pytest.mark.asyncio
+async def test_data_url_invalid_base64_normalized(loader: ImageLoader) -> None:
+    """Malformed base64 data URL should raise ValueError."""
+    with pytest.raises(ValueError, match="Invalid base64"):
+        await loader.load_image("data:image/png;base64,NOT_VALID!!!")
+
+
+@pytest.mark.asyncio
+async def test_data_url_non_image_rejected(loader: ImageLoader) -> None:
+    """data: URL with non-image media type should raise ValueError."""
+    with pytest.raises(ValueError, match="Data URL must be an image type"):
+        await loader.load_image("data:text/plain;base64,aGVsbG8=")
+
+
+# --- HTTP error contract ---
+
+
+@pytest.mark.asyncio
+async def test_http_timeout_raises_valueerror(loader: ImageLoader) -> None:
+    """HTTP timeout should be normalized to ValueError."""
+    mock_client = _mock_http_client(side_effect=httpx.TimeoutException("timed out"))
+    with patch(
+        "dynamo.common.multimodal.image_loader.get_http_client",
+        return_value=mock_client,
+    ):
+        with pytest.raises(ValueError, match="Timeout loading image"):
+            await loader.load_image("https://example.com/img.png")
+
+
+@pytest.mark.asyncio
+async def test_http_status_error_propagated(loader: ImageLoader) -> None:
+    """HTTP 4xx/5xx should propagate as HTTPStatusError."""
+    mock_client = _mock_http_client(status_code=404)
+    with patch(
+        "dynamo.common.multimodal.image_loader.get_http_client",
+        return_value=mock_client,
+    ):
+        with pytest.raises(httpx.HTTPStatusError):
+            await loader.load_image("https://example.com/img.png")
+
+
+# --- Cache behavior ---
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_fetch(loader: ImageLoader) -> None:
+    """A cached image should be returned without making an HTTP request."""
+    img = Image.new("RGB", (2, 2))
+    loader._image_cache["https://example.com/img.png"] = img
+
+    result = await loader.load_image("https://example.com/img.png")
+    assert result is img

--- a/components/src/dynamo/common/tests/multimodal/test_image_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_image_loader.py
@@ -1,6 +1,7 @@
 """Tests for ImageLoader in-flight dedup, cancellation, and error contract."""
 
 import asyncio
+from collections import OrderedDict
 from io import BytesIO
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -59,8 +60,8 @@ def loader() -> ImageLoader:
 @pytest.fixture(autouse=True)
 def _init_loader(loader: ImageLoader) -> None:
     loader._http_timeout = 30.0
-    loader._image_cache = {}
-    loader._cache_queue = asyncio.Queue(maxsize=4)
+    loader._cache_size = 4
+    loader._image_cache = OrderedDict()
     loader._inflight = {}
     loader._enable_frontend_decoding = False
     loader._nixl_connector = None

--- a/components/src/dynamo/common/tests/multimodal/test_image_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_image_loader.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for ImageLoader in-flight dedup, cancellation, and error contract."""
 
 import asyncio
@@ -12,7 +27,12 @@ from PIL import Image
 
 from dynamo.common.multimodal.image_loader import ImageLoader
 
-pytestmark = [pytest.mark.asyncio, pytest.mark.gpu_0]
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
 
 
 def _make_png_bytes() -> bytes:

--- a/components/src/dynamo/common/tests/multimodal/test_image_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_image_loader.py
@@ -12,6 +12,8 @@ from PIL import Image
 
 from dynamo.common.multimodal.image_loader import ImageLoader
 
+pytestmark = [pytest.mark.asyncio, pytest.mark.gpu_0]
+
 
 def _make_png_bytes() -> bytes:
     """Create a minimal valid PNG in memory."""
@@ -70,7 +72,6 @@ def _init_loader(loader: ImageLoader) -> None:
 # --- Concurrent same-URL dedup ---
 
 
-@pytest.mark.asyncio
 async def test_concurrent_same_url_deduplicates(loader: ImageLoader) -> None:
     """Two concurrent load_image calls for the same URL should issue only one HTTP fetch."""
     mock_client = _mock_http_client(delay=0.05)
@@ -89,7 +90,6 @@ async def test_concurrent_same_url_deduplicates(loader: ImageLoader) -> None:
     assert mock_client.get.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_concurrent_different_urls_fetch_independently(
     loader: ImageLoader,
 ) -> None:
@@ -110,7 +110,6 @@ async def test_concurrent_different_urls_fetch_independently(
 # --- Waiter cancellation isolation ---
 
 
-@pytest.mark.asyncio
 async def test_waiter_cancellation_does_not_cancel_shared_task(
     loader: ImageLoader,
 ) -> None:
@@ -135,7 +134,6 @@ async def test_waiter_cancellation_does_not_cancel_shared_task(
 # --- Retry after failure ---
 
 
-@pytest.mark.asyncio
 async def test_retry_after_failure(loader: ImageLoader) -> None:
     """After a fetch failure, the next caller should start a fresh fetch."""
     fail_client = _mock_http_client(side_effect=httpx.TimeoutException("timeout"))
@@ -162,21 +160,18 @@ async def test_retry_after_failure(loader: ImageLoader) -> None:
 # --- Error contract preserved for non-HTTP ---
 
 
-@pytest.mark.asyncio
 async def test_file_not_found_normalized(loader: ImageLoader) -> None:
     """file:// path that doesn't exist should raise ValueError, not FileNotFoundError."""
     with pytest.raises(ValueError, match="Failed to load image"):
         await loader.load_image("file:///nonexistent/path/img.png")
 
 
-@pytest.mark.asyncio
 async def test_data_url_invalid_base64_normalized(loader: ImageLoader) -> None:
     """Malformed base64 data URL should raise ValueError."""
     with pytest.raises(ValueError, match="Invalid base64"):
         await loader.load_image("data:image/png;base64,NOT_VALID!!!")
 
 
-@pytest.mark.asyncio
 async def test_data_url_non_image_rejected(loader: ImageLoader) -> None:
     """data: URL with non-image media type should raise ValueError."""
     with pytest.raises(ValueError, match="Data URL must be an image type"):
@@ -186,7 +181,6 @@ async def test_data_url_non_image_rejected(loader: ImageLoader) -> None:
 # --- HTTP error contract ---
 
 
-@pytest.mark.asyncio
 async def test_http_timeout_raises_valueerror(loader: ImageLoader) -> None:
     """HTTP timeout should be normalized to ValueError."""
     mock_client = _mock_http_client(side_effect=httpx.TimeoutException("timed out"))
@@ -198,7 +192,6 @@ async def test_http_timeout_raises_valueerror(loader: ImageLoader) -> None:
             await loader.load_image("https://example.com/img.png")
 
 
-@pytest.mark.asyncio
 async def test_http_status_error_propagated(loader: ImageLoader) -> None:
     """HTTP 4xx/5xx should propagate as HTTPStatusError."""
     mock_client = _mock_http_client(status_code=404)
@@ -213,7 +206,6 @@ async def test_http_status_error_propagated(loader: ImageLoader) -> None:
 # --- Cache behavior ---
 
 
-@pytest.mark.asyncio
 async def test_cache_hit_skips_fetch(loader: ImageLoader) -> None:
     """A cached image should be returned without making an HTTP request."""
     img = Image.new("RGB", (2, 2))

--- a/components/src/dynamo/common/tests/multimodal/test_image_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_image_loader.py
@@ -16,7 +16,6 @@
 """Tests for ImageLoader in-flight dedup, cancellation, and error contract."""
 
 import asyncio
-from collections import OrderedDict
 from io import BytesIO
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -52,7 +51,14 @@ def _mock_http_client(
     delay: float = 0.0,
     side_effect: Exception | None = None,
 ) -> AsyncMock:
-    """Return a mock httpx.AsyncClient whose .get() returns a fake response."""
+    """Return a mock httpx.AsyncClient whose .get() returns a fake response.
+
+    Args:
+        content: Raw bytes returned as the HTTP response body.
+        status_code: HTTP status code; >=400 triggers raise_for_status().
+        delay: Seconds to sleep before responding (simulates network latency).
+        side_effect: If set, .get() raises this exception instead of returning.
+    """
 
     async def _get(url: str) -> Any:
         if delay > 0:
@@ -74,19 +80,9 @@ def _mock_http_client(
     return client
 
 
-@pytest.fixture()
-def loader() -> ImageLoader:
-    return ImageLoader.__new__(ImageLoader)
-
-
 @pytest.fixture(autouse=True)
-def _init_loader(loader: ImageLoader) -> None:
-    loader._http_timeout = 30.0
-    loader._cache_size = 4
-    loader._image_cache = OrderedDict()
-    loader._inflight = {}
-    loader._enable_frontend_decoding = False
-    loader._nixl_connector = None
+def loader() -> ImageLoader:
+    return ImageLoader(cache_size=4, http_timeout=30.0)
 
 
 # --- Concurrent same-URL dedup ---
@@ -233,3 +229,30 @@ async def test_cache_hit_skips_fetch(loader: ImageLoader) -> None:
 
     result = await loader.load_image("https://example.com/img.png")
     assert result is img
+
+
+async def test_cache_is_lru_not_fifo(loader: ImageLoader) -> None:
+    """Accessing a cached entry should protect it from eviction (LRU, not FIFO)."""
+    loader._cache_size = 3
+    mock_client = _mock_http_client()
+
+    with patch(
+        "dynamo.common.multimodal.image_loader.get_http_client",
+        return_value=mock_client,
+    ):
+        # Fill cache: a, b, c (oldest → newest)
+        await loader.load_image("https://example.com/a.png")
+        await loader.load_image("https://example.com/b.png")
+        await loader.load_image("https://example.com/c.png")
+        assert len(loader._image_cache) == 3
+
+        # Touch "a" so it becomes most-recently-used
+        await loader.load_image("https://example.com/a.png")
+
+        # Insert "d" — should evict "b" (least recently used), not "a"
+        await loader.load_image("https://example.com/d.png")
+
+    assert "https://example.com/a.png" in loader._image_cache
+    assert "https://example.com/b.png" not in loader._image_cache
+    assert "https://example.com/c.png" in loader._image_cache
+    assert "https://example.com/d.png" in loader._image_cache


### PR DESCRIPTION
  ## Why

  The `ImageLoader` LRU cache has an async race condition that causes `KeyError` crashes under concurrent
  multimodal requests.

  When multiple coroutines load the same image URL simultaneously, they all miss the cache (the HTTP fetch
  `await` yields control between cache-check and cache-insert). Each coroutine independently inserts the URL
  into the eviction queue via `asyncio.Queue.put()`, creating **duplicate entries** — but the dict only has one
  copy. On later evictions, the second `del self._image_cache[url]` raises `KeyError` because the first eviction
   already removed it.

  This is an async TOCTOU (time-of-check-time-of-use) bug: the GIL protects individual dict/queue operations,
  but `await` points between the cache miss and the cache insert allow coroutine interleaving. High image reuse
  (common in multimodal workloads) makes duplicate concurrent loads frequent.

  Reproduced with 200 requests × 12 images × 91.7% reuse at concurrency 32: **39 `KeyError` failures, zero HTTP
  errors**. After fix: **0 errors**.

  ## What Changed

  - Replace `dict` + `asyncio.Queue` cache with `OrderedDict` LRU; deduplicate concurrent HTTP fetches via
  `_inflight` task map + `asyncio.shield` so cancelling one caller doesn't cancel the shared fetch
  - Fix `base64.b64decode` to use `validate=True` so invalid base64 is rejected early; extract duplicated PIL
  open+convert block into `_open_image()` helper
  - Add comprehensive unit tests (10 cases: dedup, cancellation isolation, retry-after-failure, error contracts,
   cache hits)

## Test Plan

Before vs after:

with duplicate images, 12 images per request --

```
  ┌─────────────────────┬──────────────────────────────────┬──────────────────────────────┐
  │                     │ Before                           │ After (cache lock, 1000 req) │
  ├─────────────────────┼──────────────────────────────────┼──────────────────────────────┤
  │ Request count       │ 156/200 (22% failure)            │ 1,000/1,000                  │
  ├─────────────────────┼──────────────────────────────────┼──────────────────────────────┤
  │ KeyError            │ 39                               │ 0                            │
  ├─────────────────────┼──────────────────────────────────┼──────────────────────────────┤
  │ Image loader errors │ 39                               │ 0                            │
  ├─────────────────────┼──────────────────────────────────┼──────────────────────────────┤
```

with unique 10008 unique images, 834 requests, 12 images per request --

```
  ┌─────────────────────┬─────-─────────────┬─────────────────────────┐
  │       Metric        │ 1000-pool (dedup) │  10k unique (no reuse)  │
  ├─────────────────────┼─────-─────────────┼─────────────────────────┤
  │ Requests            │ 1000 / 0 errors   │ 833 / 1 error (SSE 502) │
  ├─────────────────────┼──────-────────────┼─────────────────────────┤
  │ Request throughput  │ 4.82 req/s        │ 3.60 req/s              │
  ├─────────────────────┼───────-───────────┼─────────────────────────┤
```

```
#!/bin/bash
set -e
LOGDIR=/workspace/logs/image-loader-concurrency-fix/repro-logs
JSONL_DIR=/workspace/benchmarks/multimodal/jsonl
INPUT_FILE=$JSONL_DIR/200req_12img_200pool_400word_http.jsonl

echo "=== Step 0: Generate JSONL input file ==="
if [ ! -f "$INPUT_FILE" ]; then
  cd $JSONL_DIR && python main.py \
    -n 200 \
    --images-per-request 12 \
    --images-pool 200 \
    --user-text-tokens 400 \
    --image-mode http
  cd /workspace
fi

echo "=== Cleanup: kill previous server processes ==="
pkill -9 -f "dynamo.frontend" 2>/dev/null || true
pkill -9 -f "dynamo.vllm" 2>/dev/null || true
sleep 3
# Wait until port 8000 is free
echo "Waiting for port 8000 to be free..."
for i in $(seq 1 30); do
  curl -sf http://localhost:8000/v1/models >/dev/null 2>&1 || break
  sleep 1
done
echo "Port 8000 is free"

echo "=== Step 1: Launch aggregated multimodal server (background) ==="
MAX_MODEL_LEN=16384 setsid bash examples/backends/vllm/launch/agg_multimodal.sh \
  --model Qwen/Qwen3-VL-2B-Instruct \
  > $LOGDIR/server.log 2>&1 &
SERVER_PID=$!

echo "Waiting for model to be loaded (polling localhost:8000/v1/models)..."
sleep 5
for i in $(seq 1 600); do
  MODEL_COUNT=$(curl -sf http://localhost:8000/v1/models 2>/dev/null \
    | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('data',[])))" 2>/dev/null \
    || echo "0")
  if [ "$MODEL_COUNT" -gt 0 ] 2>/dev/null; then
    echo "Model ready after ${i}s"
    break
  fi
  if [ $i -eq 600 ]; then
    echo "ERROR: Model not ready after 600s" | tee $LOGDIR/error.log
    kill $SERVER_PID 2>/dev/null || true
    exit 1
  fi
  sleep 1
done

echo "=== Step 2: Run aiperf at concurrency 32 ==="
aiperf profile \
  -m Qwen/Qwen3-VL-2B-Instruct \
  -u http://localhost:8000 \
  --concurrency 32 \
  --request-count 1000 \
  --input-file $INPUT_FILE \
  --custom-dataset-type single_turn \
  --streaming \
  --extra-inputs "max_tokens:1" \
  --extra-inputs "min_tokens:1" \
  --artifact-dir $LOGDIR/artifacts \
  2>&1 | tee $LOGDIR/aiperf.log

echo "=== Step 3: Save server logs ==="
kill $SERVER_PID 2>/dev/null || true
wait $SERVER_PID 2>/dev/null || true

echo "=== Done ==="
echo "Check $LOGDIR/server.log for errors"
echo "Check $LOGDIR/aiperf.log for benchmark results"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized image caching with improved performance and memory efficiency
  * Enhanced concurrent image loading to eliminate redundant fetches for the same resource
  * Strengthened error handling and consistency across image source types

* **Tests**
  * Added comprehensive test suite for image loading functionality with concurrent and edge-case scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->