### PR TITLE
feat: Add support for PD disaggregated serving with vLLM and LMCache on XPU

### DIFF
--- a/examples/backends/vllm/launch/disagg_lmcache_xpu.sh
+++ b/examples/backends/vllm/launch/disagg_lmcache_xpu.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+MODEL="Qwen/Qwen3-0.6B"
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+# XPU-specific environment
+export VLLM_TARGET_DEVICE=xpu
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+
+print_launch_banner "Launching Disaggregated Serving + LMCache on XPU (2 XPUs)" "$MODEL" "$HTTP_PORT"
+
+# run ingress with KV router
+# dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
+python -m dynamo.frontend --router-mode kv &
+
+# run decode worker on XPU 0, without enabling LMCache
+ZE_AFFINITY_MASK=0 python3 -m dynamo.vllm \
+    --model "$MODEL" \
+    --block-size 64 &
+
+# wait for decode worker to initialize
+sleep 20
+
+# run prefill worker on XPU 1 with LMCache
+VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
+ZE_AFFINITY_MASK=1 \
+  python3 -m dynamo.vllm \
+    --model "$MODEL" \
+    --block-size 64 \
+    --disaggregation-mode prefill \
+    --kv-transfer-config '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"xpu"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}' \
+    --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}' &
+
+# Exit on first worker failure; kill 0 in the EXIT trap tears down the rest
+wait_any_exit

--- a/examples/backends/vllm/launch/xpu/disagg_lmcache_xpu.sh
+++ b/examples/backends/vllm/launch/xpu/disagg_lmcache_xpu.sh
@@ -7,7 +7,7 @@ trap 'echo Cleaning up...; kill 0' EXIT
 MODEL="Qwen/Qwen3-0.6B"
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+source "$SCRIPT_DIR/../../../../common/launch_utils.sh"
 
 # XPU-specific environment
 export VLLM_TARGET_DEVICE=xpu

--- a/examples/backends/vllm/launch/xpu/disagg_xpu.sh
+++ b/examples/backends/vllm/launch/xpu/disagg_xpu.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+# Common configuration
+MODEL="Qwen/Qwen3-0.6B"
+BLOCK_SIZE=64
+NIXL_BUFFER_DEVICE=xpu
+VLLM_NIXL_BACKEND=UCX
+
+# UCX configuration for Intel XPU (Level Zero copy)
+export UCX_MEMTYPE_CACHE=0
+# export UCX_TLS=shm,ze_copy
+# Adjust UCX_NET_DEVICES to match your InfiniBand/RDMA devices, or remove if not using RDMA
+# export UCX_NET_DEVICES=mlx5_0:1,mlx5_1:1
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../../common/launch_utils.sh"
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+print_launch_banner "Launching Disaggregated Serving (2 XPUs)" "$MODEL" "$HTTP_PORT"
+
+KV_TRANSFER_CONFIG="{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"${NIXL_BUFFER_DEVICE}\",\"kv_connector_extra_config\":{\"backends\":[\"${VLLM_NIXL_BACKEND}\"]}}"
+
+# run ingress
+python -m dynamo.frontend &
+
+# decode worker on XPU 0
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
+ZE_AFFINITY_MASK=0 python3 -m dynamo.vllm \
+    --model "$MODEL" \
+    --block-size $BLOCK_SIZE \
+    --disaggregation-mode decode \
+    --kv-transfer-config "$KV_TRANSFER_CONFIG" &
+
+# prefill worker on XPU 1
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
+VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
+ZE_AFFINITY_MASK=1 python3 -m dynamo.vllm \
+    --model "$MODEL" \
+    --block-size $BLOCK_SIZE \
+    --disaggregation-mode prefill \
+    --kv-transfer-config "$KV_TRANSFER_CONFIG" \
+    --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}' &
+
+# Exit on first worker failure; kill 0 in the EXIT trap tears down the rest
+wait_any_exit


### PR DESCRIPTION
#### Overview:

Add XPU launch script examples for prefill-decode disaggregated serving with vLLM, enabling Intel GPU users to run distributed inference with KV cache transfer via NIXL.

#### Details:

This PR adds two new launch scripts adapted from the existing CUDA disaggregated serving examples for Intel XPU hardware:

- `disagg_xpu.sh` — Basic 1P1D (1 prefill, 1 decode) disaggregated serving using NixlConnector for KV cache transfer between 2 XPUs. Adapted from disagg.sh.
- `disagg_lmcache_xpu.sh` — 1P1D disaggregated serving combining LMCache (for CPU-side KV cache reuse) with NIXL (for XPU-to-XPU KV transfer) using PdConnector. Adapted from disagg_lmcache.sh.

Key XPU-specific adaptations:
- `CUDA_VISIBLE_DEVICES` → `ZE_AFFINITY_MASK` for Intel GPU device selection
- `--block-size 64` required for XPU vLLM backend
- `"kv_buffer_device":"xpu"` in NIXL transfer config
- `VLLM_TARGET_DEVICE=xpu` and `VLLM_WORKER_MULTIPROC_METHOD=spawn` environment variables


#### Where should the reviewer start?

- `examples/backends/vllm/launch/disagg_xpu.sh` — simpler script, compare against `disagg.sh` for CUDA→XPU mapping
- `examples/backends/vllm/launch/disagg_lmcache_xpu.sh` — more complex PdConnector config, compare against `disagg_lmcache.sh`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added launcher script example for vLLM backend with disaggregated LMCache configuration on XPU hardware, supporting distributed KV cache operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->