### PR TITLE
feat: kvbm-registry foundation types

### DIFF
--- a/lib/kvbm-registry/src/core/error.rs
+++ b/lib/kvbm-registry/src/core/error.rs
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Error types for the distributed registry.
+
+use std::fmt;
+
+/// Errors that can occur during registry operations.
+#[derive(Debug)]
+pub enum RegistryError {
+    /// Failed to encode a message.
+    EncodeError { context: &'static str },
+
+    /// Failed to decode a message.
+    DecodeError {
+        context: &'static str,
+        expected: String,
+        got: String,
+    },
+
+    /// Protocol version mismatch.
+    VersionMismatch { expected: u8, got: u8 },
+
+    /// Invalid message type.
+    InvalidMessageType { got: u8 },
+
+    /// Message too short.
+    MessageTooShort { expected: usize, got: usize },
+
+    /// Transport error.
+    TransportError { message: String },
+
+    /// Hub disconnected.
+    Disconnected,
+
+    /// Request timed out.
+    Timeout { duration_ms: u64 },
+
+    /// Lease conflict - key is leased by another client.
+    LeaseConflict { key_debug: String },
+
+    /// Storage error.
+    StorageError { message: String },
+}
+
+impl fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EncodeError { context } => {
+                write!(f, "encode error: {}", context)
+            }
+            Self::DecodeError {
+                context,
+                expected,
+                got,
+            } => {
+                write!(
+                    f,
+                    "decode error in {}: expected {}, got {}",
+                    context, expected, got
+                )
+            }
+            Self::VersionMismatch { expected, got } => {
+                write!(
+                    f,
+                    "protocol version mismatch: expected {}, got {}",
+                    expected, got
+                )
+            }
+            Self::InvalidMessageType { got } => {
+                write!(f, "invalid message type: {}", got)
+            }
+            Self::MessageTooShort { expected, got } => {
+                write!(
+                    f,
+                    "message too short: expected {} bytes, got {}",
+                    expected, got
+                )
+            }
+            Self::TransportError { message } => {
+                write!(f, "transport error: {}", message)
+            }
+            Self::Disconnected => {
+                write!(f, "hub disconnected")
+            }
+            Self::Timeout { duration_ms } => {
+                write!(f, "request timed out after {}ms", duration_ms)
+            }
+            Self::LeaseConflict { key_debug } => {
+                write!(f, "lease conflict for key: {}", key_debug)
+            }
+            Self::StorageError { message } => {
+                write!(f, "storage error: {}", message)
+            }
+        }
+    }
+}
+
+impl std::error::Error for RegistryError {}
+
+/// Result type for registry operations.
+pub type RegistryResult<T> = Result<T, RegistryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display() {
+        let err = RegistryError::DecodeError {
+            context: "register message",
+            expected: "4 bytes for count".to_string(),
+            got: "2 bytes".to_string(),
+        };
+        assert!(err.to_string().contains("register message"));
+        assert!(err.to_string().contains("4 bytes"));
+    }
+
+    #[test]
+    fn test_version_mismatch() {
+        let err = RegistryError::VersionMismatch {
+            expected: 1,
+            got: 2,
+        };
+        assert!(err.to_string().contains("version mismatch"));
+    }
+}

--- a/lib/kvbm-registry/src/core/key.rs
+++ b/lib/kvbm-registry/src/core/key.rs
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Registry key types and traits.
+
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use super::storage::PositionalStorageKey;
+
+/// Trait for registry keys.
+pub trait RegistryKey: Copy + Hash + Eq + Debug + Send + Sync + 'static {
+    fn to_bytes(&self) -> Vec<u8>;
+    fn from_bytes(bytes: &[u8]) -> Option<Self>;
+}
+
+impl RegistryKey for u64 {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        bytes.try_into().ok().map(u64::from_le_bytes)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Key128(pub u128);
+
+impl RegistryKey for Key128 {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_le_bytes().to_vec()
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 16 {
+            return None;
+        }
+        Some(Self(u128::from_le_bytes(bytes[0..16].try_into().ok()?)))
+    }
+}
+
+/// Key combining worker identifier and sequence hash.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct CompositeKey {
+    pub worker_id: u64,
+    pub sequence_hash: u64,
+}
+
+impl RegistryKey for CompositeKey {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(16);
+        buf.extend_from_slice(&self.worker_id.to_le_bytes());
+        buf.extend_from_slice(&self.sequence_hash.to_le_bytes());
+        buf
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 16 {
+            return None;
+        }
+        Some(Self {
+            worker_id: u64::from_le_bytes(bytes[0..8].try_into().ok()?),
+            sequence_hash: u64::from_le_bytes(bytes[8..16].try_into().ok()?),
+        })
+    }
+}
+
+/// Key with worker id, sequence hash, and position in sequence.
+///
+/// **Identity**: Only `worker_id` and `sequence_hash` determine equality and
+/// hashing. The `sequence_hash` is a Merkle chain hash that uniquely encodes
+/// the entire prefix, so position is redundant for identification. It is kept
+/// as metadata (for ordering and wire-format compat) but excluded from
+/// `Hash`/`Eq` so that registry lookups match regardless of how the caller
+/// enumerates positions within different array slices.
+#[derive(Clone, Copy, Debug)]
+pub struct PositionalKey {
+    pub worker_id: u64,
+    pub sequence_hash: u64,
+    pub position: u32,
+}
+
+impl PartialEq for PositionalKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.worker_id == other.worker_id && self.sequence_hash == other.sequence_hash
+    }
+}
+
+impl Eq for PositionalKey {}
+
+impl std::hash::Hash for PositionalKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.worker_id.hash(state);
+        self.sequence_hash.hash(state);
+    }
+}
+
+impl PartialOrd for PositionalKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PositionalKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.worker_id
+            .cmp(&other.worker_id)
+            .then(self.sequence_hash.cmp(&other.sequence_hash))
+            .then(self.position.cmp(&other.position))
+    }
+}
+
+impl RegistryKey for PositionalKey {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(20);
+        buf.extend_from_slice(&self.worker_id.to_le_bytes());
+        buf.extend_from_slice(&self.sequence_hash.to_le_bytes());
+        buf.extend_from_slice(&self.position.to_le_bytes());
+        buf
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 20 {
+            return None;
+        }
+        Some(Self {
+            worker_id: u64::from_le_bytes(bytes[0..8].try_into().ok()?),
+            sequence_hash: u64::from_le_bytes(bytes[8..16].try_into().ok()?),
+            position: u32::from_le_bytes(bytes[16..20].try_into().ok()?),
+        })
+    }
+}
+
+impl PositionalStorageKey for PositionalKey {
+    fn position(&self) -> u64 {
+        self.position as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_u64_roundtrip() {
+        let key: u64 = 0x123456789ABCDEF0;
+        let bytes = key.to_bytes();
+        assert_eq!(u64::from_bytes(&bytes), Some(key));
+    }
+
+    #[test]
+    fn test_key128_roundtrip() {
+        let key = Key128(0x123456789ABCDEF0_FEDCBA9876543210);
+        let bytes = key.to_bytes();
+        assert_eq!(Key128::from_bytes(&bytes), Some(key));
+    }
+
+    #[test]
+    fn test_composite_key_roundtrip() {
+        let key = CompositeKey {
+            worker_id: 123,
+            sequence_hash: 456,
+        };
+        let bytes = key.to_bytes();
+        assert_eq!(CompositeKey::from_bytes(&bytes), Some(key));
+    }
+
+    #[test]
+    fn test_positional_key_roundtrip() {
+        let key = PositionalKey {
+            worker_id: 123,
+            sequence_hash: 456,
+            position: 789,
+        };
+        let bytes = key.to_bytes();
+        assert_eq!(PositionalKey::from_bytes(&bytes), Some(key));
+    }
+}

--- a/lib/kvbm-registry/src/core/metadata.rs
+++ b/lib/kvbm-registry/src/core/metadata.rs
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Registry metadata types and traits.
+
+use std::fmt::Debug;
+
+pub trait RegistryMetadata: Clone + Debug + Default + Send + Sync + 'static {
+    fn to_bytes(&self) -> Vec<u8>;
+    fn from_bytes(bytes: &[u8]) -> Option<Self>;
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct NoMetadata;
+
+impl PartialEq for NoMetadata {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for NoMetadata {}
+
+impl RegistryMetadata for NoMetadata {
+    fn to_bytes(&self) -> Vec<u8> {
+        Vec::new()
+    }
+
+    fn from_bytes(_bytes: &[u8]) -> Option<Self> {
+        Some(Self)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TimestampMetadata {
+    pub created_at: u64,
+    pub ttl_secs: Option<u32>,
+}
+
+impl RegistryMetadata for TimestampMetadata {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(12);
+        buf.extend_from_slice(&self.created_at.to_le_bytes());
+        buf.extend_from_slice(&self.ttl_secs.unwrap_or(0).to_le_bytes());
+        buf
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 12 {
+            return None;
+        }
+        let created_at = u64::from_le_bytes(bytes[0..8].try_into().ok()?);
+        let ttl_raw = u32::from_le_bytes(bytes[8..12].try_into().ok()?);
+        Some(Self {
+            created_at,
+            ttl_secs: if ttl_raw == 0 { None } else { Some(ttl_raw) },
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PositionMetadata {
+    pub position: u32,
+    pub parent_hash: Option<u64>,
+    pub sequence_length: Option<u32>,
+    pub created_at: u64,
+}
+
+impl RegistryMetadata for PositionMetadata {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(24);
+        buf.extend_from_slice(&self.position.to_le_bytes());
+        buf.extend_from_slice(&self.parent_hash.unwrap_or(0).to_le_bytes());
+        buf.extend_from_slice(&self.sequence_length.unwrap_or(0).to_le_bytes());
+        buf.extend_from_slice(&self.created_at.to_le_bytes());
+        buf
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 24 {
+            return None;
+        }
+        let position = u32::from_le_bytes(bytes[0..4].try_into().ok()?);
+        let parent_raw = u64::from_le_bytes(bytes[4..12].try_into().ok()?);
+        let seq_len_raw = u32::from_le_bytes(bytes[12..16].try_into().ok()?);
+        let created_at = u64::from_le_bytes(bytes[16..24].try_into().ok()?);
+
+        Some(Self {
+            position,
+            parent_hash: if parent_raw == 0 {
+                None
+            } else {
+                Some(parent_raw)
+            },
+            sequence_length: if seq_len_raw == 0 {
+                None
+            } else {
+                Some(seq_len_raw)
+            },
+            created_at,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_metadata_roundtrip() {
+        let meta = NoMetadata;
+        let bytes = meta.to_bytes();
+        assert!(bytes.is_empty());
+        assert!(NoMetadata::from_bytes(&bytes).is_some());
+    }
+
+    #[test]
+    fn test_timestamp_metadata_roundtrip() {
+        let meta = TimestampMetadata {
+            created_at: 1234567890,
+            ttl_secs: Some(3600),
+        };
+        let bytes = meta.to_bytes();
+        let decoded = TimestampMetadata::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.created_at, meta.created_at);
+        assert_eq!(decoded.ttl_secs, meta.ttl_secs);
+    }
+
+    #[test]
+    fn test_position_metadata_roundtrip() {
+        let meta = PositionMetadata {
+            position: 5,
+            parent_hash: Some(0xDEADBEEF),
+            sequence_length: Some(10),
+            created_at: 9999999999,
+        };
+        let bytes = meta.to_bytes();
+        let decoded = PositionMetadata::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.position, meta.position);
+        assert_eq!(decoded.parent_hash, meta.parent_hash);
+        assert_eq!(decoded.sequence_length, meta.sequence_length);
+        assert_eq!(decoded.created_at, meta.created_at);
+    }
+}

--- a/lib/kvbm-registry/src/core/mod.rs
+++ b/lib/kvbm-registry/src/core/mod.rs
@@ -2,3 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Core traits and types for the pluggable registry architecture.
+
+pub mod error;
+pub mod key;
+pub mod metadata;
+pub mod storage;
+pub mod transport;
+pub mod value;
+
+// Error types
+pub use error::{RegistryError, RegistryResult};
+
+// Storage
+pub use storage::{FlatStorage, HashMapStorage, PositionalStorageKey, RadixStorage, Storage};
+
+// Key, Value, Metadata
+pub use key::{CompositeKey, Key128, PositionalKey, RegistryKey};
+pub use metadata::{NoMetadata, PositionMetadata, RegistryMetadata, TimestampMetadata};
+pub use value::{RegistryValue, StorageBackend, StorageLocation};
+
+// Transport
+pub use transport::{InProcessHub, InProcessTransport, RegistryTransport};

--- a/lib/kvbm-registry/src/core/storage.rs
+++ b/lib/kvbm-registry/src/core/storage.rs
@@ -1,0 +1,546 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Storage trait and implementations.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use dashmap::DashMap;
+use parking_lot::RwLock;
+
+/// Storage for key-value pairs.
+pub trait Storage<K, V>: Send + Sync {
+    fn insert(&self, key: K, value: V);
+    fn get(&self, key: &K) -> Option<V>;
+    fn contains(&self, key: &K) -> bool;
+    fn remove(&self, key: &K) -> Option<V>;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    fn clear(&self);
+
+    /// Insert a batch of entries. Default implementation inserts one at a time.
+    /// Override for batch-optimized locking (e.g., PositionalEviction).
+    fn insert_batch(&self, entries: Vec<(K, V)>) {
+        for (key, value) in entries {
+            self.insert(key, value);
+        }
+    }
+}
+
+/// HashMap-based storage.
+pub struct HashMapStorage<K, V> {
+    map: RwLock<HashMap<K, V>>,
+}
+
+impl<K, V> HashMapStorage<K, V>
+where
+    K: Eq + Hash,
+{
+    pub fn new() -> Self {
+        Self {
+            map: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            map: RwLock::new(HashMap::with_capacity(capacity)),
+        }
+    }
+}
+
+impl<K, V> Default for HashMapStorage<K, V>
+where
+    K: Eq + Hash,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> Storage<K, V> for HashMapStorage<K, V>
+where
+    K: Eq + Hash + Clone + Send + Sync,
+    V: Clone + Send + Sync,
+{
+    fn insert(&self, key: K, value: V) {
+        self.map.write().insert(key, value);
+    }
+
+    fn get(&self, key: &K) -> Option<V> {
+        self.map.read().get(key).cloned()
+    }
+
+    fn contains(&self, key: &K) -> bool {
+        self.map.read().contains_key(key)
+    }
+
+    fn remove(&self, key: &K) -> Option<V> {
+        self.map.write().remove(key)
+    }
+
+    fn len(&self) -> usize {
+        self.map.read().len()
+    }
+
+    fn clear(&self) {
+        self.map.write().clear();
+    }
+}
+
+/// Flat DashMap-based storage — no position sharding.
+///
+/// Unlike `RadixStorage`, which partitions entries by position into nested
+/// DashMaps, `FlatStorage` uses a single `DashMap` for all entries. This
+/// avoids the position-sharding bug where batched offloads register blocks
+/// at incorrect positions, making them invisible on lookup.
+///
+/// Use `FlatStorage` when position-based partitioning is not needed or when
+/// the keys' `position()` values may not be stable across insert/lookup.
+pub struct FlatStorage<K, V> {
+    map: DashMap<K, V>,
+    len_counter: AtomicUsize,
+}
+
+impl<K, V> FlatStorage<K, V>
+where
+    K: Eq + Hash + Clone + Send + Sync,
+{
+    pub fn new() -> Self {
+        Self {
+            map: DashMap::new(),
+            len_counter: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            map: DashMap::with_capacity(capacity),
+            len_counter: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl<K, V> Default for FlatStorage<K, V>
+where
+    K: Eq + Hash + Clone + Send + Sync,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> Storage<K, V> for FlatStorage<K, V>
+where
+    K: Eq + Hash + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    fn insert(&self, key: K, value: V) {
+        let old = self.map.insert(key, value);
+        if old.is_none() {
+            self.len_counter.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn get(&self, key: &K) -> Option<V> {
+        self.map.get(key).map(|v| v.clone())
+    }
+
+    fn contains(&self, key: &K) -> bool {
+        self.map.contains_key(key)
+    }
+
+    fn remove(&self, key: &K) -> Option<V> {
+        let removed = self.map.remove(key).map(|(_, v)| v);
+        if removed.is_some() {
+            self.len_counter.fetch_sub(1, Ordering::Relaxed);
+        }
+        removed
+    }
+
+    fn len(&self) -> usize {
+        self.len_counter.load(Ordering::Relaxed)
+    }
+
+    fn clear(&self) {
+        self.map.clear();
+        self.len_counter.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Trait for keys that have an extractable position for radix organization.
+pub trait PositionalStorageKey: Eq + Hash + Clone + Send + Sync {
+    /// Extract the position/prefix used for first-level partitioning.
+    fn position(&self) -> u64;
+}
+
+/// Radix-style storage using a two-level DashMap for concurrent access.
+///
+/// Organizes entries by position first, then by full key within each position.
+/// This provides:
+/// - Efficient prefix/position-based lookups
+/// - High concurrency via sharded DashMap structure
+/// - Natural grouping for positional data (e.g., sequence positions)
+///
+/// # Example
+/// ```text
+/// #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+/// struct MyKey { position: u64, hash: u64 }
+///
+/// impl PositionalStorageKey for MyKey {
+///     fn position(&self) -> u64 { self.position }
+/// }
+///
+/// let storage: RadixStorage<MyKey, String> = RadixStorage::new();
+/// storage.insert(MyKey { position: 0, hash: 123 }, "value".to_string());
+/// ```
+pub struct RadixStorage<K, V> {
+    /// Two-level map: position -> (key -> value)
+    map: DashMap<u64, DashMap<K, V>>,
+    /// O(1) length counter, maintained atomically on insert/remove/clear.
+    len_counter: AtomicUsize,
+}
+
+impl<K, V> RadixStorage<K, V>
+where
+    K: PositionalStorageKey,
+{
+    pub fn new() -> Self {
+        Self {
+            map: DashMap::new(),
+            len_counter: AtomicUsize::new(0),
+        }
+    }
+
+    /// Get the sub-map for a specific position.
+    pub fn position(
+        &self,
+        position: u64,
+    ) -> Option<dashmap::mapref::one::Ref<'_, u64, DashMap<K, V>>> {
+        self.map.get(&position)
+    }
+
+    /// Get or create the sub-map for a key's position.
+    pub fn prefix(&self, key: &K) -> dashmap::mapref::one::RefMut<'_, u64, DashMap<K, V>> {
+        self.map.entry(key.position()).or_default()
+    }
+
+    /// Iterate over all positions that have entries.
+    pub fn positions(&self) -> Vec<u64> {
+        self.map.iter().map(|entry| *entry.key()).collect()
+    }
+
+    /// Get the count of entries at a specific position.
+    pub fn position_len(&self, position: u64) -> usize {
+        self.map.get(&position).map(|m| m.len()).unwrap_or(0)
+    }
+}
+
+impl<K, V> Default for RadixStorage<K, V>
+where
+    K: PositionalStorageKey,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> Storage<K, V> for RadixStorage<K, V>
+where
+    K: PositionalStorageKey + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    fn insert(&self, key: K, value: V) {
+        let position = key.position();
+        let sub_map = self.map.entry(position).or_default();
+        let old = sub_map.insert(key, value);
+        if old.is_none() {
+            // Key was new — increment counter
+            self.len_counter.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn get(&self, key: &K) -> Option<V> {
+        let position = key.position();
+        self.map.get(&position)?.get(key).map(|v| v.clone())
+    }
+
+    fn contains(&self, key: &K) -> bool {
+        let position = key.position();
+        self.map
+            .get(&position)
+            .map(|m| m.contains_key(key))
+            .unwrap_or(false)
+    }
+
+    fn remove(&self, key: &K) -> Option<V> {
+        let position = key.position();
+        let inner = self.map.get(&position)?;
+        let removed = inner.remove(key).map(|(_, v)| v);
+
+        if removed.is_some() {
+            self.len_counter.fetch_sub(1, Ordering::Relaxed);
+        }
+
+        // Clean up empty position maps
+        if inner.is_empty() {
+            drop(inner);
+            self.map.remove(&position);
+        }
+
+        removed
+    }
+
+    fn len(&self) -> usize {
+        self.len_counter.load(Ordering::Relaxed)
+    }
+
+    fn clear(&self) {
+        self.map.clear();
+        self.len_counter.store(0, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hashmap_storage() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+
+        storage.insert(1, 100);
+        storage.insert(2, 200);
+
+        assert_eq!(storage.get(&1), Some(100));
+        assert_eq!(storage.get(&3), None);
+        assert!(storage.contains(&1));
+        assert!(!storage.contains(&3));
+        assert_eq!(storage.len(), 2);
+
+        storage.remove(&1);
+        assert_eq!(storage.len(), 1);
+        assert!(!storage.contains(&1));
+
+        storage.clear();
+        assert!(storage.is_empty());
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+    struct TestPositionalKey {
+        position: u64,
+        hash: u64,
+    }
+
+    impl PositionalStorageKey for TestPositionalKey {
+        fn position(&self) -> u64 {
+            self.position
+        }
+    }
+
+    #[test]
+    fn test_radix_storage_basic() {
+        let storage: RadixStorage<TestPositionalKey, u64> = RadixStorage::new();
+
+        let key1 = TestPositionalKey {
+            position: 0,
+            hash: 100,
+        };
+        let key2 = TestPositionalKey {
+            position: 0,
+            hash: 200,
+        };
+        let key3 = TestPositionalKey {
+            position: 1,
+            hash: 100,
+        };
+
+        storage.insert(key1, 1);
+        storage.insert(key2, 2);
+        storage.insert(key3, 3);
+
+        assert_eq!(storage.get(&key1), Some(1));
+        assert_eq!(storage.get(&key2), Some(2));
+        assert_eq!(storage.get(&key3), Some(3));
+        assert_eq!(storage.len(), 3);
+    }
+
+    #[test]
+    fn test_radix_storage_position_grouping() {
+        let storage: RadixStorage<TestPositionalKey, u64> = RadixStorage::new();
+
+        // Insert keys at different positions
+        for pos in 0..3 {
+            for hash in 0..5 {
+                storage.insert(
+                    TestPositionalKey {
+                        position: pos,
+                        hash,
+                    },
+                    pos * 10 + hash,
+                );
+            }
+        }
+
+        assert_eq!(storage.len(), 15);
+        assert_eq!(storage.position_len(0), 5);
+        assert_eq!(storage.position_len(1), 5);
+        assert_eq!(storage.position_len(2), 5);
+        assert_eq!(storage.position_len(99), 0);
+
+        let mut positions = storage.positions();
+        positions.sort();
+        assert_eq!(positions, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_radix_storage_remove() {
+        let storage: RadixStorage<TestPositionalKey, u64> = RadixStorage::new();
+
+        let key1 = TestPositionalKey {
+            position: 0,
+            hash: 100,
+        };
+        let key2 = TestPositionalKey {
+            position: 0,
+            hash: 200,
+        };
+
+        storage.insert(key1, 1);
+        storage.insert(key2, 2);
+
+        assert_eq!(storage.remove(&key1), Some(1));
+        assert_eq!(storage.len(), 1);
+        assert!(!storage.contains(&key1));
+        assert!(storage.contains(&key2));
+
+        // Remove last key at position 0, should clean up the position map
+        assert_eq!(storage.remove(&key2), Some(2));
+        assert_eq!(storage.len(), 0);
+        assert!(storage.position(0).is_none());
+    }
+
+    #[test]
+    fn test_radix_storage_clear() {
+        let storage: RadixStorage<TestPositionalKey, u64> = RadixStorage::new();
+
+        for pos in 0..10 {
+            storage.insert(
+                TestPositionalKey {
+                    position: pos,
+                    hash: 0,
+                },
+                pos,
+            );
+        }
+
+        assert_eq!(storage.len(), 10);
+        storage.clear();
+        assert!(storage.is_empty());
+        assert!(storage.positions().is_empty());
+    }
+
+    #[test]
+    fn test_radix_storage_overwrite_preserves_len() {
+        let storage: RadixStorage<TestPositionalKey, u64> = RadixStorage::new();
+
+        let key = TestPositionalKey {
+            position: 0,
+            hash: 100,
+        };
+
+        storage.insert(key, 1);
+        assert_eq!(storage.len(), 1);
+
+        // Overwrite same key — len should stay 1
+        storage.insert(key, 2);
+        assert_eq!(storage.len(), 1);
+        assert_eq!(storage.get(&key), Some(2));
+    }
+
+    #[test]
+    fn test_insert_batch_default() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+
+        let entries = vec![(1, 100), (2, 200), (3, 300)];
+        storage.insert_batch(entries);
+
+        assert_eq!(storage.len(), 3);
+        assert_eq!(storage.get(&1), Some(100));
+        assert_eq!(storage.get(&2), Some(200));
+        assert_eq!(storage.get(&3), Some(300));
+    }
+
+    // FlatStorage tests
+
+    #[test]
+    fn test_flat_storage_basic() {
+        let storage: FlatStorage<u64, u64> = FlatStorage::new();
+
+        storage.insert(1, 100);
+        storage.insert(2, 200);
+
+        assert_eq!(storage.get(&1), Some(100));
+        assert_eq!(storage.get(&3), None);
+        assert!(storage.contains(&1));
+        assert!(!storage.contains(&3));
+        assert_eq!(storage.len(), 2);
+
+        storage.remove(&1);
+        assert_eq!(storage.len(), 1);
+        assert!(!storage.contains(&1));
+
+        storage.clear();
+        assert!(storage.is_empty());
+    }
+
+    #[test]
+    fn test_flat_storage_overwrite_preserves_len() {
+        let storage: FlatStorage<u64, u64> = FlatStorage::new();
+
+        storage.insert(1, 100);
+        assert_eq!(storage.len(), 1);
+
+        storage.insert(1, 200);
+        assert_eq!(storage.len(), 1);
+        assert_eq!(storage.get(&1), Some(200));
+    }
+
+    #[test]
+    fn test_flat_storage_with_capacity() {
+        let storage: FlatStorage<u64, u64> = FlatStorage::with_capacity(100);
+
+        for i in 0..50 {
+            storage.insert(i, i * 10);
+        }
+        assert_eq!(storage.len(), 50);
+        assert_eq!(storage.get(&25), Some(250));
+    }
+
+    #[test]
+    fn test_flat_storage_with_positional_keys() {
+        // FlatStorage should work with PositionalStorageKey types
+        // but ignores position — all lookups are by full key equality
+        let storage: FlatStorage<TestPositionalKey, u64> = FlatStorage::new();
+
+        let key1 = TestPositionalKey {
+            position: 0,
+            hash: 100,
+        };
+        let key2 = TestPositionalKey {
+            position: 5,
+            hash: 100,
+        };
+        // Same hash, different position — should be distinct entries
+        storage.insert(key1, 1);
+        storage.insert(key2, 2);
+
+        assert_eq!(storage.len(), 2);
+        assert_eq!(storage.get(&key1), Some(1));
+        assert_eq!(storage.get(&key2), Some(2));
+    }
+}

--- a/lib/kvbm-registry/src/core/transport.rs
+++ b/lib/kvbm-registry/src/core/transport.rs
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transport trait and implementations.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+
+#[async_trait]
+pub trait RegistryTransport: Send + Sync {
+    async fn request(&self, data: &[u8]) -> Result<Vec<u8>>;
+    async fn publish(&self, data: &[u8]) -> Result<()>;
+    fn name(&self) -> &'static str;
+}
+
+/// Handler function type for in-process transport.
+type RequestHandler = Arc<dyn Fn(&[u8]) -> Vec<u8> + Send + Sync>;
+
+/// In-process transport for testing.
+pub struct InProcessTransport {
+    handler: RequestHandler,
+    publish_tx: mpsc::UnboundedSender<Vec<u8>>,
+}
+
+impl InProcessTransport {
+    pub fn new<F>(handler: F) -> (Self, mpsc::UnboundedReceiver<Vec<u8>>)
+    where
+        F: Fn(&[u8]) -> Vec<u8> + Send + Sync + 'static,
+    {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (
+            Self {
+                handler: Arc::new(handler),
+                publish_tx: tx,
+            },
+            rx,
+        )
+    }
+
+    pub fn pair() -> (Self, InProcessHub) {
+        let hub = InProcessHub::new();
+        let hub_clone = hub.clone();
+        let (transport, rx) = Self::new(move |data| hub_clone.handle(data));
+
+        let hub_for_publish = hub.clone();
+        tokio::spawn(async move {
+            let mut rx = rx;
+            while let Some(data) = rx.recv().await {
+                hub_for_publish.handle(&data);
+            }
+        });
+
+        (transport, hub)
+    }
+}
+
+#[async_trait]
+impl RegistryTransport for InProcessTransport {
+    async fn request(&self, data: &[u8]) -> Result<Vec<u8>> {
+        Ok((self.handler)(data))
+    }
+
+    async fn publish(&self, data: &[u8]) -> Result<()> {
+        self.publish_tx.send(data.to_vec())?;
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "in_process"
+    }
+}
+
+/// Handler option type for in-process hub.
+type HubHandler = Option<Box<dyn Fn(&[u8]) -> Vec<u8> + Send + Sync>>;
+
+/// In-process hub for testing.
+#[derive(Clone)]
+pub struct InProcessHub {
+    request_handler: Arc<Mutex<HubHandler>>,
+}
+
+impl InProcessHub {
+    pub fn new() -> Self {
+        Self {
+            request_handler: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub fn set_handler<F>(&self, handler: F)
+    where
+        F: Fn(&[u8]) -> Vec<u8> + Send + Sync + 'static,
+    {
+        *self.request_handler.lock() = Some(Box::new(handler));
+    }
+
+    pub fn handle(&self, data: &[u8]) -> Vec<u8> {
+        if let Some(handler) = self.request_handler.lock().as_ref() {
+            handler(data)
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+impl Default for InProcessHub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_in_process_transport() {
+        let (transport, _rx) = InProcessTransport::new(|data| {
+            let mut response = data.to_vec();
+            response.reverse();
+            response
+        });
+
+        let result = transport.request(b"hello").await.unwrap();
+        assert_eq!(result, b"olleh");
+    }
+
+    #[tokio::test]
+    async fn test_in_process_publish() {
+        let (transport, mut rx) = InProcessTransport::new(|_| Vec::new());
+
+        transport.publish(b"test message").await.unwrap();
+
+        let received = rx.recv().await.unwrap();
+        assert_eq!(received, b"test message");
+    }
+}

--- a/lib/kvbm-registry/src/core/value.rs
+++ b/lib/kvbm-registry/src/core/value.rs
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Registry value types and traits.
+
+use std::fmt::Debug;
+
+pub trait RegistryValue: Clone + Debug + Send + Sync + 'static {
+    fn to_bytes(&self) -> Vec<u8>;
+    fn from_bytes(bytes: &[u8]) -> Option<Self>;
+}
+
+impl RegistryValue for u64 {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        bytes.try_into().ok().map(u64::from_le_bytes)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum StorageBackend {
+    Object = 0,
+    Disk = 1,
+}
+
+impl TryFrom<u8> for StorageBackend {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Object),
+            1 => Ok(Self::Disk),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct StorageLocation {
+    pub backend: StorageBackend,
+    pub path: String,
+    pub size_bytes: u64,
+}
+
+impl RegistryValue for StorageLocation {
+    fn to_bytes(&self) -> Vec<u8> {
+        let path_bytes = self.path.as_bytes();
+        let mut buf = Vec::with_capacity(1 + 2 + path_bytes.len() + 8);
+        buf.push(self.backend as u8);
+        buf.extend_from_slice(&(path_bytes.len() as u16).to_le_bytes());
+        buf.extend_from_slice(path_bytes);
+        buf.extend_from_slice(&self.size_bytes.to_le_bytes());
+        buf
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 11 {
+            return None;
+        }
+        let backend = StorageBackend::try_from(bytes[0]).ok()?;
+        let path_len = u16::from_le_bytes(bytes[1..3].try_into().ok()?) as usize;
+        if bytes.len() < 3 + path_len + 8 {
+            return None;
+        }
+        let path = String::from_utf8(bytes[3..3 + path_len].to_vec()).ok()?;
+        let size_bytes = u64::from_le_bytes(bytes[3 + path_len..3 + path_len + 8].try_into().ok()?);
+        Some(Self {
+            backend,
+            path,
+            size_bytes,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_u64_roundtrip() {
+        let val: u64 = 0x123456789ABCDEF0;
+        let bytes = val.to_bytes();
+        assert_eq!(u64::from_bytes(&bytes), Some(val));
+    }
+
+    #[test]
+    fn test_storage_location_roundtrip() {
+        let loc = StorageLocation {
+            backend: StorageBackend::Object,
+            path: "bucket/key/object.bin".to_string(),
+            size_bytes: 1024 * 1024,
+        };
+        let bytes = loc.to_bytes();
+        let decoded = StorageLocation::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.backend, loc.backend);
+        assert_eq!(decoded.path, loc.path);
+        assert_eq!(decoded.size_bytes, loc.size_bytes);
+    }
+}


### PR DESCRIPTION
#### Overview:

Adds the core data model for `kvbm-registry`:
- `Storage<K,V>` trait + `HashMapStorage<K,V>` (DashMap-backed)
- `InProcessTransport` and `InProcessHub` for single-process use
- `BlockId`, `NodeId`, `OffloadStatus`, `RegistryError` types

All types are `Send + Sync + Clone`; key/value are fully generic.

**Part of chain:** R0 → **R1** → R2 → R3 → R4 → R5 → R6 → R7 → R8

#### Details:

- `src/core/storage.rs`: `Storage<K,V>` trait, `HashMapStorage`, `EvictingStorage` stub
- `src/core/transport.rs`: `InProcessTransport`, `InProcessHub` with `set_handler` callback
- `src/core/value.rs`: `BlockId`, `NodeId`, `OffloadStatus`, `RegistryError`
- `src/core/key.rs`, `error.rs`, `metadata.rs`: supporting types

#### Where should the reviewer start?

Start with `src/core/storage.rs` (the `Storage` trait) and `src/core/value.rs` (the key types).

#### Related Issues:

- Relates to kvbm distributed registry chain (R1/8)