### PR TITLE
feat: kvbm-registry hub abstraction

### DIFF
--- a/lib/kvbm-registry/src/core/hub.rs
+++ b/lib/kvbm-registry/src/core/hub.rs
@@ -1,0 +1,540 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Registry hub (server-side) implementation.
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use anyhow::Result;
+use tracing::{debug, warn};
+
+use super::codec::{OffloadStatus, QueryType, RegistryCodec, ResponseType};
+use super::hub_transport::{ClientId, HubMessage, HubTransport};
+use super::key::RegistryKey;
+use super::lease::{LeaseManager, LeaseStats};
+use super::metadata::RegistryMetadata;
+use super::storage::Storage;
+use super::value::RegistryValue;
+
+/// Statistics for the registry hub.
+#[derive(Debug, Clone, Default)]
+pub struct HubStats {
+    pub queries_received: u64,
+    pub registrations_received: u64,
+    pub entries_stored: u64,
+    pub lease_stats: LeaseStats,
+}
+
+/// Configuration for the registry hub.
+#[derive(Debug, Clone)]
+pub struct HubConfig {
+    /// Lease TTL for can_offload claims.
+    pub lease_ttl: Duration,
+    /// Interval for cleaning up expired leases.
+    pub lease_cleanup_interval: Duration,
+}
+
+impl Default for HubConfig {
+    fn default() -> Self {
+        Self {
+            lease_ttl: Duration::from_secs(30),
+            lease_cleanup_interval: Duration::from_secs(5),
+        }
+    }
+}
+
+/// Registry hub server.
+///
+/// Handles incoming queries and registrations from clients.
+/// Now includes lease-based claiming to prevent race conditions.
+pub struct RegistryHub<K, V, M, S, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    S: Storage<K, V>,
+    C: RegistryCodec<K, V, M>,
+{
+    storage: S,
+    codec: C,
+    lease_manager: Arc<LeaseManager<K>>,
+    queries_received: AtomicU64,
+    registrations_received: AtomicU64,
+    _phantom: PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M, S, C> RegistryHub<K, V, M, S, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    S: Storage<K, V>,
+    C: RegistryCodec<K, V, M>,
+{
+    /// Create a new registry hub with the given storage and codec.
+    pub fn new(storage: S, codec: C) -> Self {
+        Self::with_config(storage, codec, HubConfig::default())
+    }
+
+    /// Create a new registry hub with custom configuration.
+    pub fn with_config(storage: S, codec: C, config: HubConfig) -> Self {
+        Self {
+            storage,
+            codec,
+            lease_manager: Arc::new(LeaseManager::new(config.lease_ttl)),
+            queries_received: AtomicU64::new(0),
+            registrations_received: AtomicU64::new(0),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Get a reference to the lease manager.
+    pub fn lease_manager(&self) -> &Arc<LeaseManager<K>> {
+        &self.lease_manager
+    }
+
+    /// Get current statistics.
+    pub fn stats(&self) -> HubStats {
+        HubStats {
+            queries_received: self.queries_received.load(Ordering::Relaxed),
+            registrations_received: self.registrations_received.load(Ordering::Relaxed),
+            entries_stored: self.storage.len() as u64,
+            lease_stats: self.lease_manager.stats(),
+        }
+    }
+
+    /// Get the number of entries in storage.
+    pub fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    /// Check if storage is empty.
+    pub fn is_empty(&self) -> bool {
+        self.storage.is_empty()
+    }
+
+    /// Insert directly into storage (for testing/seeding).
+    pub fn storage_insert(&self, key: K, value: V) {
+        self.storage.insert(key, value);
+    }
+
+    /// Generate a client ID from ClientId bytes.
+    fn client_id_to_u64(client: &ClientId) -> u64 {
+        let bytes = client.as_bytes();
+        if bytes.len() >= 8 {
+            u64::from_le_bytes(bytes[0..8].try_into().unwrap_or([0; 8]))
+        } else {
+            // Hash short client IDs
+            let mut hash: u64 = 0;
+            for (i, &b) in bytes.iter().enumerate() {
+                hash ^= (b as u64) << ((i % 8) * 8);
+            }
+            hash
+        }
+    }
+
+    /// Process a single message.
+    async fn process_message<T: HubTransport>(
+        &self,
+        transport: &mut T,
+        message: HubMessage,
+    ) -> Result<()> {
+        match message {
+            HubMessage::Query { client, data } => {
+                self.queries_received.fetch_add(1, Ordering::Relaxed);
+
+                let client_id = Self::client_id_to_u64(&client);
+                let response = self.handle_query(&data, client_id);
+                transport.respond(&client, &response).await?;
+            }
+            HubMessage::Publish { data } => {
+                self.registrations_received.fetch_add(1, Ordering::Relaxed);
+                self.handle_registration(&data);
+            }
+        }
+        Ok(())
+    }
+
+    /// Handle a query message.
+    fn handle_query(&self, data: &[u8], client_id: u64) -> Vec<u8> {
+        let mut response_buf = Vec::new();
+
+        let Some(query) = self.codec.decode_query(data) else {
+            warn!("Failed to decode query");
+            return response_buf;
+        };
+
+        match query {
+            QueryType::CanOffload(keys) => {
+                let statuses: Vec<_> = keys
+                    .iter()
+                    .map(|k| {
+                        // Check if already stored
+                        if self.storage.contains(k) {
+                            return OffloadStatus::AlreadyStored;
+                        }
+
+                        // Try to acquire a lease
+                        match self.lease_manager.try_acquire(*k, client_id) {
+                            Some(_) => OffloadStatus::Granted,
+                            None => OffloadStatus::Leased,
+                        }
+                    })
+                    .collect();
+
+                debug!(
+                    num_keys = keys.len(),
+                    granted = statuses
+                        .iter()
+                        .filter(|s| **s == OffloadStatus::Granted)
+                        .count(),
+                    already_stored = statuses
+                        .iter()
+                        .filter(|s| **s == OffloadStatus::AlreadyStored)
+                        .count(),
+                    leased = statuses
+                        .iter()
+                        .filter(|s| **s == OffloadStatus::Leased)
+                        .count(),
+                    "Processed can_offload query"
+                );
+
+                if let Err(e) = self
+                    .codec
+                    .encode_response(&ResponseType::CanOffload(statuses), &mut response_buf)
+                {
+                    warn!("Failed to encode response: {}", e);
+                }
+            }
+            QueryType::Match(keys) => {
+                let entries: Vec<_> = keys
+                    .iter()
+                    .filter_map(|k| self.storage.get(k).map(|v| (*k, v, M::default())))
+                    .collect();
+
+                debug!(
+                    requested = keys.len(),
+                    matched = entries.len(),
+                    "Processed match query"
+                );
+
+                if let Err(e) = self
+                    .codec
+                    .encode_response(&ResponseType::Match(entries), &mut response_buf)
+                {
+                    warn!("Failed to encode response: {}", e);
+                }
+            }
+            QueryType::Remove(keys) => {
+                let mut removed_count = 0usize;
+                for key in &keys {
+                    if self.storage.remove(key).is_some() {
+                        removed_count += 1;
+                    }
+                }
+
+                debug!(
+                    requested = keys.len(),
+                    removed = removed_count,
+                    "Processed remove query"
+                );
+
+                if let Err(e) = self
+                    .codec
+                    .encode_response(&ResponseType::Remove(removed_count), &mut response_buf)
+                {
+                    warn!("Failed to encode response: {}", e);
+                }
+            }
+            QueryType::Touch(keys) => {
+                // Touch is used for LRU/LFU tracking - record access for each key
+                // that exists in storage. The storage/eviction policy handles the
+                // actual access tracking.
+                let mut touched_count = 0usize;
+                for key in &keys {
+                    if self.storage.contains(key) {
+                        // Note: The actual access tracking happens in the eviction policy.
+                        // For now, we just count how many keys exist.
+                        // TODO: Call storage.touch(key) when eviction policies support it
+                        touched_count += 1;
+                    }
+                }
+
+                debug!(
+                    requested = keys.len(),
+                    touched = touched_count,
+                    "Processed touch query (access notification)"
+                );
+
+                if let Err(e) = self
+                    .codec
+                    .encode_response(&ResponseType::Touch(touched_count), &mut response_buf)
+                {
+                    warn!("Failed to encode response: {}", e);
+                }
+            }
+        }
+
+        response_buf
+    }
+
+    /// Handle a registration message.
+    fn handle_registration(&self, data: &[u8]) {
+        let Some(entries) = self.codec.decode_register(data) else {
+            warn!("Failed to decode registration");
+            return;
+        };
+
+        let count = entries.len();
+        for (key, value, _metadata) in entries {
+            // Release any lease for this key
+            self.lease_manager.release(&key);
+            // Store the entry
+            self.storage.insert(key, value);
+        }
+
+        debug!(
+            registered = count,
+            total_entries = self.storage.len(),
+            "Processed registration"
+        );
+    }
+
+    /// Serve requests until an error occurs or shutdown.
+    ///
+    /// This is the main loop for the hub.
+    pub async fn serve<T: HubTransport>(&self, transport: &mut T) -> Result<()> {
+        tracing::info!(transport = transport.name(), "Registry hub starting");
+
+        loop {
+            match transport.recv().await {
+                Ok(message) => {
+                    if let Err(e) = self.process_message(transport, message).await {
+                        warn!(error = %e, "Error processing message");
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "Transport error, shutting down");
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    /// Process a single message (for testing or custom loops).
+    pub async fn process_one<T: HubTransport>(&self, transport: &mut T) -> Result<()> {
+        let message = transport.recv().await?;
+        self.process_message(transport, message).await
+    }
+}
+
+/// Create a simple hub with HashMap storage and binary codec.
+#[allow(clippy::type_complexity)]
+pub fn simple_hub<K, V, M>()
+-> RegistryHub<K, V, M, super::storage::HashMapStorage<K, V>, super::codec::BinaryCodec<K, V, M>>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+{
+    RegistryHub::new(
+        super::storage::HashMapStorage::new(),
+        super::codec::BinaryCodec::new(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::hub_transport::InProcessHubTransport;
+    use crate::core::{
+        BinaryCodec, HashMapStorage, NoMetadata,
+    };
+
+    #[tokio::test]
+    async fn test_hub_can_offload() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        storage.insert(1, 100);
+        storage.insert(2, 200);
+
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let hub = RegistryHub::new(storage, codec);
+
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        // Spawn hub to handle one request
+        let hub_task = tokio::spawn(async move {
+            hub.process_one(&mut transport).await.unwrap();
+            hub
+        });
+
+        // Client query
+        let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let mut query_buf = Vec::new();
+        client_codec
+            .encode_query(&QueryType::CanOffload(vec![1, 2, 3, 4]), &mut query_buf)
+            .unwrap();
+
+        let response = handle.request(&query_buf).await.unwrap();
+        let decoded: ResponseType<u64, u64, NoMetadata> =
+            client_codec.decode_response(&response).unwrap();
+
+        match decoded {
+            ResponseType::CanOffload(statuses) => {
+                assert_eq!(statuses.len(), 4);
+                assert_eq!(statuses[0], OffloadStatus::AlreadyStored); // 1 exists
+                assert_eq!(statuses[1], OffloadStatus::AlreadyStored); // 2 exists
+                assert_eq!(statuses[2], OffloadStatus::Granted); // 3 doesn't exist
+                assert_eq!(statuses[3], OffloadStatus::Granted); // 4 doesn't exist
+            }
+            _ => panic!("Wrong response type"),
+        }
+
+        let hub = hub_task.await.unwrap();
+        assert_eq!(hub.stats().queries_received, 1);
+    }
+
+    #[tokio::test]
+    async fn test_hub_lease_conflict() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let hub = RegistryHub::new(storage, codec);
+
+        // First client acquires lease for key 1
+        hub.lease_manager.try_acquire(1, 100);
+
+        // Create transport with different client ID
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        let hub_task = tokio::spawn(async move {
+            hub.process_one(&mut transport).await.unwrap();
+            hub
+        });
+
+        let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let mut query_buf = Vec::new();
+        client_codec
+            .encode_query(&QueryType::CanOffload(vec![1, 2]), &mut query_buf)
+            .unwrap();
+
+        let response = handle.request(&query_buf).await.unwrap();
+        let decoded: ResponseType<u64, u64, NoMetadata> =
+            client_codec.decode_response(&response).unwrap();
+
+        match decoded {
+            ResponseType::CanOffload(statuses) => {
+                assert_eq!(statuses.len(), 2);
+                // Key 1 should be Leased (held by client 100)
+                assert_eq!(statuses[0], OffloadStatus::Leased);
+                // Key 2 should be Granted (new lease for this client)
+                assert_eq!(statuses[1], OffloadStatus::Granted);
+            }
+            _ => panic!("Wrong response type"),
+        }
+
+        hub_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_hub_registration_releases_lease() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let hub = RegistryHub::new(storage, codec);
+
+        // Client acquires lease
+        hub.lease_manager.try_acquire(1, 100);
+        assert!(hub.lease_manager.is_leased(&1));
+
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        let hub_task = tokio::spawn(async move {
+            hub.process_one(&mut transport).await.unwrap();
+            hub
+        });
+
+        // Register the key
+        let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let mut reg_buf = Vec::new();
+        client_codec
+            .encode_register(&[(1, 100, NoMetadata)], &mut reg_buf)
+            .unwrap();
+
+        handle.publish(&reg_buf).unwrap();
+
+        let hub = hub_task.await.unwrap();
+
+        // Lease should be released and key stored
+        assert!(!hub.lease_manager.is_leased(&1));
+        assert!(hub.storage.contains(&1));
+    }
+
+    #[tokio::test]
+    async fn test_hub_match() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        storage.insert(1, 100);
+        storage.insert(2, 200);
+        storage.insert(3, 300);
+
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let hub = RegistryHub::new(storage, codec);
+
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        let hub_task = tokio::spawn(async move {
+            hub.process_one(&mut transport).await.unwrap();
+            hub
+        });
+
+        let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let mut query_buf = Vec::new();
+        client_codec
+            .encode_query(&QueryType::Match(vec![1, 2, 5]), &mut query_buf)
+            .unwrap();
+
+        let response = handle.request(&query_buf).await.unwrap();
+        let decoded: ResponseType<u64, u64, NoMetadata> =
+            client_codec.decode_response(&response).unwrap();
+
+        match decoded {
+            ResponseType::Match(entries) => {
+                assert_eq!(entries.len(), 2); // Only 1 and 2 exist
+                assert_eq!(entries[0], (1, 100, NoMetadata));
+                assert_eq!(entries[1], (2, 200, NoMetadata));
+            }
+            _ => panic!("Wrong response type"),
+        }
+
+        hub_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_hub_registration() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let hub = RegistryHub::new(storage, codec);
+
+        assert!(hub.is_empty());
+
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        let hub_task = tokio::spawn(async move {
+            hub.process_one(&mut transport).await.unwrap();
+            hub
+        });
+
+        let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let mut reg_buf = Vec::new();
+        client_codec
+            .encode_register(&[(1, 100, NoMetadata), (2, 200, NoMetadata)], &mut reg_buf)
+            .unwrap();
+
+        handle.publish(&reg_buf).unwrap();
+
+        let hub = hub_task.await.unwrap();
+        assert_eq!(hub.len(), 2);
+        assert_eq!(hub.stats().registrations_received, 1);
+    }
+}

--- a/lib/kvbm-registry/src/core/hub_transport.rs
+++ b/lib/kvbm-registry/src/core/hub_transport.rs
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Server-side transport traits and implementations.
+
+use std::collections::VecDeque;
+
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use parking_lot::Mutex;
+use tmq::{Context, Message, Multipart, pull, router};
+use tokio::sync::mpsc;
+
+/// Opaque client identifier for routing responses.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ClientId(Vec<u8>);
+
+impl ClientId {
+    pub fn new(id: Vec<u8>) -> Self {
+        Self(id)
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// Message received by the hub.
+#[derive(Debug)]
+pub enum HubMessage {
+    /// Query from a client (needs response).
+    Query { client: ClientId, data: Vec<u8> },
+    /// Published registration (fire-and-forget).
+    Publish { data: Vec<u8> },
+}
+
+/// Server-side transport for the registry hub.
+///
+/// Note: Not `Sync` because ZMQ sockets can't be shared across threads.
+/// The hub uses `&mut self` and is owned by a single serve task.
+#[async_trait]
+pub trait HubTransport: Send {
+    /// Receive the next message (query or publish).
+    async fn recv(&mut self) -> Result<HubMessage>;
+
+    /// Send a response to a specific client.
+    async fn respond(&mut self, client: &ClientId, data: &[u8]) -> Result<()>;
+
+    /// Get the transport name.
+    fn name(&self) -> &'static str;
+}
+
+/// In-process hub transport for testing.
+pub struct InProcessHubTransport {
+    query_rx: mpsc::UnboundedReceiver<(ClientId, Vec<u8>)>,
+    query_response_tx: mpsc::UnboundedSender<(ClientId, Vec<u8>)>,
+    publish_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+}
+
+/// Handle for clients to communicate with InProcessHubTransport.
+pub struct InProcessClientHandle {
+    query_tx: mpsc::UnboundedSender<(ClientId, Vec<u8>)>,
+    query_response_rx: Mutex<mpsc::UnboundedReceiver<(ClientId, Vec<u8>)>>,
+    publish_tx: mpsc::UnboundedSender<Vec<u8>>,
+    client_id: ClientId,
+}
+
+impl InProcessHubTransport {
+    /// Create a new in-process hub transport and client handle.
+    pub fn new() -> (Self, InProcessClientHandle) {
+        let (query_tx, query_rx) = mpsc::unbounded_channel();
+        let (response_tx, response_rx) = mpsc::unbounded_channel();
+        let (publish_tx, publish_rx) = mpsc::unbounded_channel();
+
+        let transport = Self {
+            query_rx,
+            query_response_tx: response_tx,
+            publish_rx,
+        };
+
+        let handle = InProcessClientHandle {
+            query_tx,
+            query_response_rx: Mutex::new(response_rx),
+            publish_tx,
+            client_id: ClientId::new(vec![0, 1, 2, 3]),
+        };
+
+        (transport, handle)
+    }
+}
+
+impl InProcessClientHandle {
+    /// Send a query and wait for response.
+    #[allow(clippy::await_holding_lock)] // Lock must be held to ensure exclusive receiver access
+    pub async fn request(&self, data: &[u8]) -> Result<Vec<u8>> {
+        self.query_tx
+            .send((self.client_id.clone(), data.to_vec()))
+            .map_err(|_| anyhow!("Hub disconnected"))?;
+
+        let mut rx = self.query_response_rx.lock();
+        match rx.recv().await {
+            Some((_, response)) => Ok(response),
+            None => Err(anyhow!("Hub disconnected")),
+        }
+    }
+
+    /// Publish a message (fire-and-forget).
+    pub fn publish(&self, data: &[u8]) -> Result<()> {
+        self.publish_tx
+            .send(data.to_vec())
+            .map_err(|_| anyhow!("Hub disconnected"))
+    }
+}
+
+#[async_trait]
+impl HubTransport for InProcessHubTransport {
+    async fn recv(&mut self) -> Result<HubMessage> {
+        tokio::select! {
+            Some((client, data)) = self.query_rx.recv() => {
+                Ok(HubMessage::Query { client, data })
+            }
+            Some(data) = self.publish_rx.recv() => {
+                Ok(HubMessage::Publish { data })
+            }
+            else => Err(anyhow!("All clients disconnected"))
+        }
+    }
+
+    async fn respond(&mut self, client: &ClientId, data: &[u8]) -> Result<()> {
+        self.query_response_tx
+            .send((client.clone(), data.to_vec()))
+            .map_err(|_| anyhow!("Client disconnected"))
+    }
+
+    fn name(&self) -> &'static str {
+        "in_process"
+    }
+}
+
+/// ZMQ-based hub transport.
+///
+/// Uses ROUTER for queries and PULL for registrations.
+pub struct ZmqHubTransport {
+    router: router::Router,
+    puller: pull::Pull,
+}
+
+/// Default high-water mark for ZMQ hub sockets.
+pub const DEFAULT_HUB_HWM: i32 = 10_000;
+
+/// Configuration for ZMQ hub transport.
+#[derive(Clone, Debug)]
+pub struct ZmqHubConfig {
+    pub query_bind_addr: String,
+    pub subscribe_bind_addr: String,
+    /// High-water mark for the ROUTER (query) socket.
+    pub router_hwm: i32,
+    /// High-water mark for the PULL (registration) socket.
+    pub pull_hwm: i32,
+}
+
+impl ZmqHubConfig {
+    pub fn new(query_addr: impl Into<String>, subscribe_addr: impl Into<String>) -> Self {
+        Self {
+            query_bind_addr: query_addr.into(),
+            subscribe_bind_addr: subscribe_addr.into(),
+            router_hwm: DEFAULT_HUB_HWM,
+            pull_hwm: DEFAULT_HUB_HWM,
+        }
+    }
+
+    pub fn default_ports(port_base: u16) -> Self {
+        Self {
+            query_bind_addr: format!("tcp://*:{}", port_base),
+            subscribe_bind_addr: format!("tcp://*:{}", port_base + 1),
+            router_hwm: DEFAULT_HUB_HWM,
+            pull_hwm: DEFAULT_HUB_HWM,
+        }
+    }
+
+    /// Set high-water marks for both sockets.
+    pub fn with_hwm(mut self, hwm: i32) -> Self {
+        self.router_hwm = hwm;
+        self.pull_hwm = hwm;
+        self
+    }
+}
+
+impl Default for ZmqHubConfig {
+    fn default() -> Self {
+        Self::default_ports(5555)
+    }
+}
+
+impl ZmqHubTransport {
+    /// Bind and start listening.
+    pub fn bind(config: ZmqHubConfig) -> Result<Self> {
+        let context = Context::new();
+
+        let router = router::router(&context)
+            .set_sndhwm(config.router_hwm)
+            .set_rcvhwm(config.router_hwm)
+            .bind(&config.query_bind_addr)
+            .map_err(|e| anyhow!("Failed to bind ROUTER to {}: {}", config.query_bind_addr, e))?;
+
+        let puller = pull::pull(&context)
+            .set_rcvhwm(config.pull_hwm)
+            .bind(&config.subscribe_bind_addr)
+            .map_err(|e| {
+                anyhow!(
+                    "Failed to bind PULL to {}: {}",
+                    config.subscribe_bind_addr,
+                    e
+                )
+            })?;
+
+        tracing::info!(
+            query_addr = %config.query_bind_addr,
+            pull_addr = %config.subscribe_bind_addr,
+            router_hwm = config.router_hwm,
+            pull_hwm = config.pull_hwm,
+            "ZMQ hub transport bound"
+        );
+
+        Ok(Self { router, puller })
+    }
+
+    /// Bind with default configuration.
+    pub fn bind_default() -> Result<Self> {
+        Self::bind(ZmqHubConfig::default())
+    }
+}
+
+#[async_trait]
+impl HubTransport for ZmqHubTransport {
+    async fn recv(&mut self) -> Result<HubMessage> {
+        tokio::select! {
+            result = self.router.next() => {
+                match result {
+                    Some(Ok(msg)) => {
+                        let frames: Vec<_> = msg.iter().collect();
+                        if frames.len() < 2 {
+                            return Err(anyhow!("Invalid ROUTER message: expected identity + data"));
+                        }
+                        let client = ClientId::new(frames[0].to_vec());
+                        let data = frames[frames.len() - 1].to_vec();
+                        Ok(HubMessage::Query { client, data })
+                    }
+                    Some(Err(e)) => Err(anyhow!("ROUTER receive error: {}", e)),
+                    None => Err(anyhow!("ROUTER socket closed")),
+                }
+            }
+            result = self.puller.next() => {
+                match result {
+                    Some(Ok(msg)) => {
+                        let frames: Vec<_> = msg.iter().collect();
+                        if frames.is_empty() {
+                            return Err(anyhow!("Empty PULL message"));
+                        }
+                        let data = frames[0].to_vec();
+                        Ok(HubMessage::Publish { data })
+                    }
+                    Some(Err(e)) => Err(anyhow!("PULL receive error: {}", e)),
+                    None => Err(anyhow!("PULL socket closed")),
+                }
+            }
+        }
+    }
+
+    async fn respond(&mut self, client: &ClientId, data: &[u8]) -> Result<()> {
+        let mut msg = VecDeque::new();
+        msg.push_back(Message::from(client.as_bytes().to_vec()));
+        msg.push_back(Message::from(data.to_vec()));
+
+        self.router
+            .send(Multipart(msg))
+            .await
+            .map_err(|e| anyhow!("Failed to send response: {}", e))
+    }
+
+    fn name(&self) -> &'static str {
+        "zmq"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_in_process_hub_transport() {
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        // Spawn hub handler
+        let hub_task = tokio::spawn(async move {
+            if let Ok(HubMessage::Query { client, data }) = transport.recv().await {
+                let mut response = data;
+                response.reverse();
+                transport.respond(&client, &response).await.unwrap();
+            }
+        });
+
+        // Client sends request
+        let response = handle.request(b"hello").await.unwrap();
+        assert_eq!(response, b"olleh");
+
+        hub_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_in_process_publish() {
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        // Spawn hub handler
+        let hub_task = tokio::spawn(async move {
+            if let Ok(HubMessage::Publish { data }) = transport.recv().await {
+                assert_eq!(data, b"registration");
+            }
+        });
+
+        // Client publishes
+        handle.publish(b"registration").unwrap();
+
+        hub_task.await.unwrap();
+    }
+}

--- a/lib/kvbm-registry/src/core/mod.rs
+++ b/lib/kvbm-registry/src/core/mod.rs
@@ -7,6 +7,8 @@ pub mod codec;
 pub mod error;
 pub mod events;
 pub mod eviction;
+pub mod hub;
+pub mod hub_transport;
 pub mod key;
 pub mod lease;
 pub mod metadata;
@@ -38,6 +40,10 @@ pub use value::{RegistryValue, StorageBackend, StorageLocation};
 
 // Transport
 pub use transport::{InProcessHub, InProcessTransport, RegistryTransport};
+
+// Hub (Server)
+pub use hub::{HubStats, RegistryHub};
+pub use hub_transport::{ClientId, HubMessage, HubTransport, InProcessClientHandle, InProcessHubTransport};
 
 // Event Bus
 pub use events::{


### PR DESCRIPTION
#### Overview:

Adds the server-side processing core:
- `RegistryHub<K,V,M,S>` dispatches queries against a `Storage` backend, updates metrics, fires lease heartbeats and eviction events
- `HubTransport` trait (`recv` / `respond`)
- `InProcessHubTransport` for single-process testing with zero serialization overhead
- `process_one()` helper drives the hub loop

**Part of chain:** R0 → R1 → R2 → R3 → R4 → R5 → **R6** → R7 → R8

#### Details:

- `src/core/hub.rs`: `RegistryHub<K,V,M,S>` with query dispatch, metrics update, event emission
- `src/core/hub_transport.rs`: `HubTransport` trait; `InProcessHubTransport`; `process_one()`

#### Where should the reviewer start?

Start with `src/core/hub.rs` for the query dispatch logic, then `src/core/hub_transport.rs` for the transport abstraction.

#### Related Issues:

- Relates to kvbm distributed registry chain (R6/8)