### PR TITLE
feat: kvbm-registry velo TCP and UDS transports with sweep benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,18 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1397,6 +1408,29 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix 1.1.4",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "crunchy"
@@ -1837,6 +1871,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -3962,6 +4005,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kvbm-bench"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "clap 4.6.0",
+ "comfy-table",
+ "csv",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+]
+
+[[package]]
 name = "kvbm-common"
 version = "0.1.0"
 dependencies = [
@@ -4035,6 +4091,31 @@ dependencies = [
  "uuid",
  "validator",
  "velo-events",
+]
+
+[[package]]
+name = "kvbm-registry"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode 2.0.1",
+ "bytes",
+ "clap 4.6.0",
+ "dashmap 5.5.3",
+ "futures-util",
+ "kvbm-bench",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tmq",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "velo-transports",
 ]
 
 [[package]]
@@ -4150,6 +4231,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "local-ip-address"
@@ -5870,7 +5957,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -5890,7 +5977,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -9096,7 +9183,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/lib/kvbm-bench/src/sweep.rs
+++ b/lib/kvbm-bench/src/sweep.rs
@@ -150,8 +150,20 @@ configs:
 "#;
         let runner = SweepRunner::<TestParams>::from_yaml_str(yaml).unwrap();
         assert_eq!(runner.len(), 2);
-        assert_eq!(runner.points[0], TestParams { threads: 4, clients: 8 });
-        assert_eq!(runner.points[1], TestParams { threads: 2, clients: 16 });
+        assert_eq!(
+            runner.points[0],
+            TestParams {
+                threads: 4,
+                clients: 8
+            }
+        );
+        assert_eq!(
+            runner.points[1],
+            TestParams {
+                threads: 2,
+                clients: 16
+            }
+        );
     }
 
     #[test]
@@ -173,6 +185,12 @@ clients: 8
 "#;
         let runner = SweepRunner::<TestParams>::from_yaml_str(yaml).unwrap();
         assert_eq!(runner.len(), 1);
-        assert_eq!(runner.points[0], TestParams { threads: 4, clients: 8 });
+        assert_eq!(
+            runner.points[0],
+            TestParams {
+                threads: 4,
+                clients: 8
+            }
+        );
     }
 }

--- a/lib/kvbm-bench/src/sysinfo.rs
+++ b/lib/kvbm-bench/src/sysinfo.rs
@@ -27,7 +27,11 @@ pub fn collect() -> SystemInfo {
         .unwrap_or_default()
         .lines()
         .find(|l| l.starts_with("PRETTY_NAME="))
-        .map(|l| l.trim_start_matches("PRETTY_NAME=").trim_matches('"').to_string())
+        .map(|l| {
+            l.trim_start_matches("PRETTY_NAME=")
+                .trim_matches('"')
+                .to_string()
+        })
         .unwrap_or_else(|| "Unknown".to_string());
 
     let kernel = std::fs::read_to_string("/proc/version")
@@ -46,7 +50,10 @@ pub fn collect() -> SystemInfo {
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|| "Unknown".to_string());
 
-    let cpu_threads = cpuinfo.lines().filter(|l| l.starts_with("processor")).count();
+    let cpu_threads = cpuinfo
+        .lines()
+        .filter(|l| l.starts_with("processor"))
+        .count();
 
     let meminfo = std::fs::read_to_string("/proc/meminfo").unwrap_or_default();
     let memory_total_kb: u64 = meminfo
@@ -57,7 +64,14 @@ pub fn collect() -> SystemInfo {
         .unwrap_or(0);
     let memory_total_gb = memory_total_kb as f64 / (1024.0 * 1024.0);
 
-    SystemInfo { hostname, os, kernel, cpu_model, cpu_threads, memory_total_gb }
+    SystemInfo {
+        hostname,
+        os,
+        kernel,
+        cpu_model,
+        cpu_threads,
+        memory_total_gb,
+    }
 }
 
 impl std::fmt::Display for SystemInfo {
@@ -89,12 +103,23 @@ pub fn rss_snapshot() -> RssSnapshot {
     let mut peak_rss_kb = 0u64;
     for line in status.lines() {
         if line.starts_with("VmRSS:") {
-            rss_kb = line.split_whitespace().nth(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+            rss_kb = line
+                .split_whitespace()
+                .nth(1)
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
         } else if line.starts_with("VmPeak:") {
-            peak_rss_kb = line.split_whitespace().nth(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+            peak_rss_kb = line
+                .split_whitespace()
+                .nth(1)
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
         }
     }
-    RssSnapshot { rss_kb, peak_rss_kb }
+    RssSnapshot {
+        rss_kb,
+        peak_rss_kb,
+    }
 }
 
 /// CPU time snapshot from /proc/self/stat.

--- a/lib/kvbm-bench/src/table.rs
+++ b/lib/kvbm-bench/src/table.rs
@@ -27,7 +27,8 @@ impl BenchTable {
 
     /// Add a row of cells to the table.
     pub fn add_row(&mut self, cells: &[String]) {
-        self.table.add_row(cells.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+        self.table
+            .add_row(cells.iter().map(|s| s.to_string()).collect::<Vec<_>>());
         self.rows.push(cells.to_vec());
     }
 

--- a/lib/kvbm-registry/bin/bench.rs
+++ b/lib/kvbm-registry/bin/bench.rs
@@ -16,9 +16,9 @@ use anyhow::Result;
 use clap::Parser;
 use kvbm_bench::{BenchTable, LatencyStats, OutputFormat, SweepRunner};
 use kvbm_registry::{
-    BinaryCodec, HashMapStorage, InProcessHub, NoMetadata, RegistryCodec,
-    Storage, UdsClientTransport, UdsHubTransport, VeloClientTransport, VeloHubTransport,
-    hub, OffloadStatus, QueryType, ResponseType,
+    BinaryCodec, HashMapStorage, InProcessHub, NoMetadata, OffloadStatus, QueryType, RegistryCodec,
+    ResponseType, Storage, UdsClientTransport, UdsHubTransport, VeloClientTransport,
+    VeloHubTransport, hub,
 };
 use serde::{Deserialize, Serialize};
 use tokio::task::JoinSet;
@@ -234,7 +234,9 @@ async fn run_single(params: RegistryBenchParams, warmup_secs: u64) -> Result<Reg
                 let hub_obj = Arc::new(InProcessHub::new());
 
                 // Pre-populate a DashMap for the handler (avoids needing Arc<Storage>)
-                let store: Arc<dashmap::DashMap<u64, u64>> = Arc::new(dashmap::DashMap::with_capacity(params.storage_size as usize));
+                let store: Arc<dashmap::DashMap<u64, u64>> = Arc::new(
+                    dashmap::DashMap::with_capacity(params.storage_size as usize),
+                );
                 for i in 0..params.storage_size {
                     store.insert(i, i * 100);
                 }
@@ -247,27 +249,43 @@ async fn run_single(params: RegistryBenchParams, warmup_secs: u64) -> Result<Reg
                             let mut buf = Vec::new();
                             match query {
                                 QueryType::CanOffload(keys) => {
-                                    let statuses: Vec<_> = keys.iter().map(|k| {
-                                        if store2.contains_key(k) {
-                                            OffloadStatus::AlreadyStored
-                                        } else {
-                                            OffloadStatus::Granted
-                                        }
-                                    }).collect();
-                                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf).ok();
+                                    let statuses: Vec<_> = keys
+                                        .iter()
+                                        .map(|k| {
+                                            if store2.contains_key(k) {
+                                                OffloadStatus::AlreadyStored
+                                            } else {
+                                                OffloadStatus::Granted
+                                            }
+                                        })
+                                        .collect();
+                                    codec
+                                        .encode_response(
+                                            &ResponseType::CanOffload(statuses),
+                                            &mut buf,
+                                        )
+                                        .ok();
                                 }
                                 QueryType::Match(keys) => {
-                                    let entries: Vec<_> = keys.iter()
+                                    let entries: Vec<_> = keys
+                                        .iter()
                                         .filter_map(|k| store2.get(k).map(|v| (*k, *v, NoMetadata)))
                                         .collect();
-                                    codec.encode_response(&ResponseType::Match(entries), &mut buf).ok();
+                                    codec
+                                        .encode_response(&ResponseType::Match(entries), &mut buf)
+                                        .ok();
                                 }
                                 QueryType::Remove(keys) => {
-                                    let count = keys.iter().filter(|k| store2.contains_key(k)).count();
-                                    codec.encode_response(&ResponseType::Remove(count), &mut buf).ok();
+                                    let count =
+                                        keys.iter().filter(|k| store2.contains_key(k)).count();
+                                    codec
+                                        .encode_response(&ResponseType::Remove(count), &mut buf)
+                                        .ok();
                                 }
                                 QueryType::Touch(keys) => {
-                                    codec.encode_response(&ResponseType::Touch(keys.len()), &mut buf).ok();
+                                    codec
+                                        .encode_response(&ResponseType::Touch(keys.len()), &mut buf)
+                                        .ok();
                                 }
                             }
                             buf
@@ -304,15 +322,23 @@ async fn run_single(params: RegistryBenchParams, warmup_secs: u64) -> Result<Reg
             let keys = query_keys.clone();
             warmup_set.spawn(async move {
                 let codec = BinaryCodec::<u64, u64, NoMetadata>::new();
+                let mut warmup_idx = 0u64;
                 while !stop.load(Ordering::Relaxed) {
+                    if warmup_idx & 255 == 0 {
+                        tokio::task::yield_now().await;
+                    }
+                    warmup_idx += 1;
                     let mut buf = Vec::new();
-                    codec.encode_query(&QueryType::CanOffload(keys.clone()), &mut buf).ok();
+                    codec
+                        .encode_query(&QueryType::CanOffload(keys.clone()), &mut buf)
+                        .ok();
                     client.request(&buf).await.ok();
                 }
             });
         }
-        tokio::time::sleep(Duration::from_secs(warmup_secs)).await;
-        warmup_set.abort_all();
+        // Wait for warmup tasks to exit cleanly (they exit at top of loop after
+        // stop_warmup fires). Do NOT abort_all() — cancelling a task mid-request
+        // leaves the shared transport stream in a corrupted state for measurement.
         while warmup_set.join_next().await.is_some() {}
     }
 
@@ -345,6 +371,12 @@ async fn run_single(params: RegistryBenchParams, warmup_secs: u64) -> Result<Reg
             let mut op_idx = 0u64;
 
             while !stop.load(Ordering::Relaxed) {
+                // Yield every 256 ops so timer/control tasks can run.
+                // Necessary for InProcess mode which is pure-CPU with no I/O yields.
+                if op_idx & 255 == 0 {
+                    tokio::task::yield_now().await;
+                }
+
                 let do_query = match mode {
                     BenchMode::Query => true,
                     BenchMode::Register => false,
@@ -355,16 +387,17 @@ async fn run_single(params: RegistryBenchParams, warmup_secs: u64) -> Result<Reg
                 if do_query {
                     let t0 = Instant::now();
                     let mut buf = Vec::new();
-                    codec.encode_query(&QueryType::CanOffload(keys.clone()), &mut buf).ok();
+                    codec
+                        .encode_query(&QueryType::CanOffload(keys.clone()), &mut buf)
+                        .ok();
                     match client.request(&buf).await {
                         Ok(_) => query_samples.push(t0.elapsed().as_micros() as u64),
                         Err(_) => errors += 1,
                     }
                 } else {
                     let t0 = Instant::now();
-                    let entries: Vec<(u64, u64, NoMetadata)> = (0..batch as u64)
-                        .map(|i| (i, i * 10, NoMetadata))
-                        .collect();
+                    let entries: Vec<(u64, u64, NoMetadata)> =
+                        (0..batch as u64).map(|i| (i, i * 10, NoMetadata)).collect();
                     let mut buf = Vec::new();
                     codec.encode_register(&entries, &mut buf).ok();
                     match client.publish(&buf).await {
@@ -437,17 +470,35 @@ fn make_table_row(r: &RegistryBenchResult) -> Vec<String> {
         r.params.mode.to_string(),
         format!("{:.0}", r.query_rps),
         format!("{:.0}", r.register_rps),
-        r.query_latency.as_ref().map_or("-".into(), |l| l.p50_us.to_string()),
-        r.query_latency.as_ref().map_or("-".into(), |l| l.p99_us.to_string()),
-        r.query_latency.as_ref().map_or("-".into(), |l| l.p999_us.to_string()),
+        r.query_latency
+            .as_ref()
+            .map_or("-".into(), |l| l.p50_us.to_string()),
+        r.query_latency
+            .as_ref()
+            .map_or("-".into(), |l| l.p99_us.to_string()),
+        r.query_latency
+            .as_ref()
+            .map_or("-".into(), |l| l.p999_us.to_string()),
         format!("{:.1}", r.rss_delta_mb),
         format!("{:.2}", r.cpu_efficiency),
     ]
 }
 
 const TABLE_HEADERS: &[&str] = &[
-    "transport", "threads", "clients", "storage", "batch", "query_sz",
-    "mode", "q_rps", "r_rps", "q_p50µs", "q_p99µs", "q_p999µs", "rss_δMB", "cpu_eff",
+    "transport",
+    "threads",
+    "clients",
+    "storage",
+    "batch",
+    "query_sz",
+    "mode",
+    "q_rps",
+    "r_rps",
+    "q_p50µs",
+    "q_p99µs",
+    "q_p999µs",
+    "rss_δMB",
+    "cpu_eff",
 ];
 
 fn print_results(results: &[RegistryBenchResult], format: &OutputFormat) {
@@ -467,7 +518,10 @@ fn print_results(results: &[RegistryBenchResult], format: &OutputFormat) {
             print!("{}", table.to_csv());
         }
         OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(results).unwrap_or_default());
+            println!(
+                "{}",
+                serde_json::to_string_pretty(results).unwrap_or_default()
+            );
         }
     }
 }
@@ -506,8 +560,14 @@ fn main() -> Result<()> {
     for params in sweep_points {
         eprintln!(
             "Running: transport={} threads={} clients={} storage={} batch={} query_sz={} mode={} duration={}s",
-            params.transport, params.threads, params.clients, params.storage_size,
-            params.batch_size, params.query_size, params.mode, params.duration_secs
+            params.transport,
+            params.threads,
+            params.clients,
+            params.storage_size,
+            params.batch_size,
+            params.query_size,
+            params.mode,
+            params.duration_secs
         );
 
         let threads = params.threads;

--- a/lib/kvbm-registry/bin/bench.rs
+++ b/lib/kvbm-registry/bin/bench.rs
@@ -1,0 +1,525 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configurable sweep benchmark for the distributed registry.
+//!
+//! Run with:
+//! ```
+//! cargo run -p kvbm-registry --bin bench --features bench -- [OPTIONS]
+//! ```
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use clap::Parser;
+use kvbm_bench::{BenchTable, LatencyStats, OutputFormat, SweepRunner};
+use kvbm_registry::{
+    BinaryCodec, HashMapStorage, InProcessHub, NoMetadata, RegistryCodec,
+    Storage, UdsClientTransport, UdsHubTransport, VeloClientTransport, VeloHubTransport,
+    hub, OffloadStatus, QueryType, ResponseType,
+};
+use serde::{Deserialize, Serialize};
+use tokio::task::JoinSet;
+
+// ── Transport kind ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TransportKind {
+    Tcp,
+    Uds,
+    Inprocess,
+}
+
+impl std::fmt::Display for TransportKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TransportKind::Tcp => write!(f, "tcp"),
+            TransportKind::Uds => write!(f, "uds"),
+            TransportKind::Inprocess => write!(f, "inprocess"),
+        }
+    }
+}
+
+// ── Bench mode ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BenchMode {
+    Query,
+    Register,
+    Mixed,
+}
+
+impl std::fmt::Display for BenchMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BenchMode::Query => write!(f, "query"),
+            BenchMode::Register => write!(f, "register"),
+            BenchMode::Mixed => write!(f, "mixed"),
+        }
+    }
+}
+
+// ── Sweep params ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RegistryBenchParams {
+    pub transport: TransportKind,
+    pub threads: usize,
+    pub clients: usize,
+    pub storage_size: u64,
+    pub batch_size: usize,
+    pub query_size: usize,
+    pub duration_secs: u64,
+    pub mode: BenchMode,
+}
+
+// ── Bench result ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RegistryBenchResult {
+    pub params: RegistryBenchParams,
+    pub query_rps: f64,
+    pub register_rps: f64,
+    pub query_latency: Option<LatencyStats>,
+    pub register_latency: Option<LatencyStats>,
+    pub rss_delta_mb: f64,
+    pub cpu_efficiency: f64,
+    pub errors: u64,
+}
+
+// ── CLI args ───────────────────────────────────────────────────────────────
+
+#[derive(Parser, Debug)]
+#[command(about = "kvbm-registry benchmark")]
+struct Args {
+    #[arg(long, default_value = "tcp")]
+    transport: TransportKind,
+
+    #[arg(long, default_value_t = 4)]
+    threads: usize,
+
+    #[arg(long, default_value_t = 1)]
+    clients: usize,
+
+    #[arg(long, default_value_t = 100_000)]
+    storage_size: u64,
+
+    #[arg(long, default_value_t = 16)]
+    batch_size: usize,
+
+    #[arg(long, default_value_t = 16)]
+    query_size: usize,
+
+    #[arg(long, default_value_t = 10)]
+    duration: u64,
+
+    #[arg(long, default_value = "mixed")]
+    mode: BenchMode,
+
+    #[arg(long, default_value = "table")]
+    output: OutputFormat,
+
+    #[arg(long)]
+    sweep: Option<String>,
+
+    #[arg(long, default_value_t = 2)]
+    warmup: u64,
+}
+
+// ── Uniform client handle ──────────────────────────────────────────────────
+
+enum ClientHandle {
+    Tcp(tokio::sync::Mutex<VeloClientTransport>),
+    Uds(tokio::sync::Mutex<UdsClientTransport>),
+    InProcess(Arc<InProcessHub>),
+}
+
+impl ClientHandle {
+    async fn request(&self, data: &[u8]) -> Result<Vec<u8>> {
+        match self {
+            ClientHandle::Tcp(m) => m.lock().await.request(data).await,
+            ClientHandle::Uds(m) => m.lock().await.request(data).await,
+            ClientHandle::InProcess(hub) => Ok(hub.handle(data)),
+        }
+    }
+
+    async fn publish(&self, data: &[u8]) -> Result<()> {
+        match self {
+            ClientHandle::Tcp(m) => m.lock().await.publish(data).await,
+            ClientHandle::Uds(m) => m.lock().await.publish(data).await,
+            ClientHandle::InProcess(hub) => {
+                hub.handle(data);
+                Ok(())
+            }
+        }
+    }
+}
+
+// ── Pre-populate helper ────────────────────────────────────────────────────
+
+fn make_storage(size: u64) -> HashMapStorage<u64, u64> {
+    let s = HashMapStorage::with_capacity(size as usize);
+    for i in 0..size {
+        s.insert(i, i * 100);
+    }
+    s
+}
+
+// ── Bench runner ───────────────────────────────────────────────────────────
+
+async fn run_single(params: RegistryBenchParams, warmup_secs: u64) -> Result<RegistryBenchResult> {
+    let rss_before = kvbm_bench::sysinfo::rss_snapshot();
+    let cpu_before = kvbm_bench::sysinfo::cpu_time();
+
+    // Build transport and client handles based on kind
+    let (clients_vec, abort_hub): (Vec<Arc<ClientHandle>>, Option<tokio::task::AbortHandle>) =
+        match params.transport {
+            TransportKind::Tcp => {
+                let storage = make_storage(params.storage_size);
+                let registry_hub = hub::<u64, u64, NoMetadata, _>(storage).build();
+
+                // Use port 0 → OS picks free port
+                let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+                let port = listener.local_addr()?.port();
+                drop(listener);
+
+                let mut hub_transport = VeloHubTransport::bind_local(port).await?;
+                let jh = tokio::spawn(async move {
+                    loop {
+                        if registry_hub.process_one(&mut hub_transport).await.is_err() {
+                            break;
+                        }
+                    }
+                });
+
+                // Brief wait for hub to accept connections
+                tokio::time::sleep(Duration::from_millis(20)).await;
+
+                let mut handles = Vec::new();
+                for _ in 0..params.clients {
+                    let c = VeloClientTransport::connect_local(port).await?;
+                    handles.push(Arc::new(ClientHandle::Tcp(tokio::sync::Mutex::new(c))));
+                }
+                (handles, Some(jh.abort_handle()))
+            }
+
+            TransportKind::Uds => {
+                let storage = make_storage(params.storage_size);
+                let registry_hub = hub::<u64, u64, NoMetadata, _>(storage).build();
+
+                let (mut hub_transport, sock_path) = UdsHubTransport::bind_temp().await?;
+                let jh = tokio::spawn(async move {
+                    loop {
+                        if registry_hub.process_one(&mut hub_transport).await.is_err() {
+                            break;
+                        }
+                    }
+                });
+
+                tokio::time::sleep(Duration::from_millis(20)).await;
+
+                let mut handles = Vec::new();
+                for _ in 0..params.clients {
+                    let c = UdsClientTransport::connect(&sock_path).await?;
+                    handles.push(Arc::new(ClientHandle::Uds(tokio::sync::Mutex::new(c))));
+                }
+                (handles, Some(jh.abort_handle()))
+            }
+
+            TransportKind::Inprocess => {
+                let hub_obj = Arc::new(InProcessHub::new());
+
+                // Pre-populate a DashMap for the handler (avoids needing Arc<Storage>)
+                let store: Arc<dashmap::DashMap<u64, u64>> = Arc::new(dashmap::DashMap::with_capacity(params.storage_size as usize));
+                for i in 0..params.storage_size {
+                    store.insert(i, i * 100);
+                }
+
+                {
+                    let store2 = Arc::clone(&store);
+                    let codec = BinaryCodec::<u64, u64, NoMetadata>::new();
+                    hub_obj.set_handler(move |data: &[u8]| {
+                        if let Some(query) = codec.decode_query(data) {
+                            let mut buf = Vec::new();
+                            match query {
+                                QueryType::CanOffload(keys) => {
+                                    let statuses: Vec<_> = keys.iter().map(|k| {
+                                        if store2.contains_key(k) {
+                                            OffloadStatus::AlreadyStored
+                                        } else {
+                                            OffloadStatus::Granted
+                                        }
+                                    }).collect();
+                                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf).ok();
+                                }
+                                QueryType::Match(keys) => {
+                                    let entries: Vec<_> = keys.iter()
+                                        .filter_map(|k| store2.get(k).map(|v| (*k, *v, NoMetadata)))
+                                        .collect();
+                                    codec.encode_response(&ResponseType::Match(entries), &mut buf).ok();
+                                }
+                                QueryType::Remove(keys) => {
+                                    let count = keys.iter().filter(|k| store2.contains_key(k)).count();
+                                    codec.encode_response(&ResponseType::Remove(count), &mut buf).ok();
+                                }
+                                QueryType::Touch(keys) => {
+                                    codec.encode_response(&ResponseType::Touch(keys.len()), &mut buf).ok();
+                                }
+                            }
+                            buf
+                        } else {
+                            Vec::new()
+                        }
+                    });
+                }
+
+                let mut handles = Vec::new();
+                for _ in 0..params.clients {
+                    handles.push(Arc::new(ClientHandle::InProcess(Arc::clone(&hub_obj))));
+                }
+                (handles, None)
+            }
+        };
+
+    // Keys for queries
+    let query_keys: Vec<u64> = (0..params.query_size as u64).collect();
+
+    // ── Warmup ────────────────────────────────────────────────────────────
+    if warmup_secs > 0 {
+        let stop_warmup = Arc::new(AtomicBool::new(false));
+        let sw2 = Arc::clone(&stop_warmup);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(warmup_secs)).await;
+            sw2.store(true, Ordering::Relaxed);
+        });
+
+        let mut warmup_set = JoinSet::new();
+        for client in &clients_vec {
+            let client = Arc::clone(client);
+            let stop = Arc::clone(&stop_warmup);
+            let keys = query_keys.clone();
+            warmup_set.spawn(async move {
+                let codec = BinaryCodec::<u64, u64, NoMetadata>::new();
+                while !stop.load(Ordering::Relaxed) {
+                    let mut buf = Vec::new();
+                    codec.encode_query(&QueryType::CanOffload(keys.clone()), &mut buf).ok();
+                    client.request(&buf).await.ok();
+                }
+            });
+        }
+        tokio::time::sleep(Duration::from_secs(warmup_secs)).await;
+        warmup_set.abort_all();
+        while warmup_set.join_next().await.is_some() {}
+    }
+
+    // ── Measurement ───────────────────────────────────────────────────────
+    let stop = Arc::new(AtomicBool::new(false));
+    let wall_start = Instant::now();
+
+    {
+        let stop2 = Arc::clone(&stop);
+        let dur = params.duration_secs;
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(dur)).await;
+            stop2.store(true, Ordering::Relaxed);
+        });
+    }
+
+    let mut task_set = JoinSet::new();
+    for client in &clients_vec {
+        let client = Arc::clone(client);
+        let stop = Arc::clone(&stop);
+        let mode = params.mode;
+        let batch = params.batch_size;
+        let keys = query_keys.clone();
+
+        task_set.spawn(async move {
+            let codec = BinaryCodec::<u64, u64, NoMetadata>::new();
+            let mut query_samples: Vec<u64> = Vec::new();
+            let mut register_samples: Vec<u64> = Vec::new();
+            let mut errors = 0u64;
+            let mut op_idx = 0u64;
+
+            while !stop.load(Ordering::Relaxed) {
+                let do_query = match mode {
+                    BenchMode::Query => true,
+                    BenchMode::Register => false,
+                    BenchMode::Mixed => op_idx % 2 == 0,
+                };
+                op_idx += 1;
+
+                if do_query {
+                    let t0 = Instant::now();
+                    let mut buf = Vec::new();
+                    codec.encode_query(&QueryType::CanOffload(keys.clone()), &mut buf).ok();
+                    match client.request(&buf).await {
+                        Ok(_) => query_samples.push(t0.elapsed().as_micros() as u64),
+                        Err(_) => errors += 1,
+                    }
+                } else {
+                    let t0 = Instant::now();
+                    let entries: Vec<(u64, u64, NoMetadata)> = (0..batch as u64)
+                        .map(|i| (i, i * 10, NoMetadata))
+                        .collect();
+                    let mut buf = Vec::new();
+                    codec.encode_register(&entries, &mut buf).ok();
+                    match client.publish(&buf).await {
+                        Ok(_) => register_samples.push(t0.elapsed().as_micros() as u64),
+                        Err(_) => errors += 1,
+                    }
+                }
+            }
+
+            (query_samples, register_samples, errors)
+        });
+    }
+
+    let elapsed = wall_start.elapsed();
+    let mut all_query: Vec<u64> = Vec::new();
+    let mut all_register: Vec<u64> = Vec::new();
+    let mut total_errors = 0u64;
+
+    while let Some(res) = task_set.join_next().await {
+        match res {
+            Ok((q, r, e)) => {
+                all_query.extend(q);
+                all_register.extend(r);
+                total_errors += e;
+            }
+            Err(_) => total_errors += 1,
+        }
+    }
+
+    if let Some(ah) = abort_hub {
+        ah.abort();
+    }
+
+    let elapsed_secs = elapsed.as_secs_f64();
+    let query_rps = all_query.len() as f64 / elapsed_secs;
+    let register_rps = all_register.len() as f64 / elapsed_secs;
+    let query_latency = LatencyStats::from_micros(&all_query);
+    let register_latency = LatencyStats::from_micros(&all_register);
+
+    let rss_after = kvbm_bench::sysinfo::rss_snapshot();
+    let rss_delta_mb = (rss_after.rss_kb as f64 - rss_before.rss_kb as f64) / 1024.0;
+
+    let cpu_after = kvbm_bench::sysinfo::cpu_time();
+    let cpu_us =
+        (cpu_after.user_us + cpu_after.system_us) - (cpu_before.user_us + cpu_before.system_us);
+    let cpu_efficiency = cpu_us as f64 / (elapsed_secs * 1_000_000.0);
+
+    Ok(RegistryBenchResult {
+        params,
+        query_rps,
+        register_rps,
+        query_latency,
+        register_latency,
+        rss_delta_mb,
+        cpu_efficiency,
+        errors: total_errors,
+    })
+}
+
+// ── Output ─────────────────────────────────────────────────────────────────
+
+fn make_table_row(r: &RegistryBenchResult) -> Vec<String> {
+    vec![
+        r.params.transport.to_string(),
+        r.params.threads.to_string(),
+        r.params.clients.to_string(),
+        r.params.storage_size.to_string(),
+        r.params.batch_size.to_string(),
+        r.params.query_size.to_string(),
+        r.params.mode.to_string(),
+        format!("{:.0}", r.query_rps),
+        format!("{:.0}", r.register_rps),
+        r.query_latency.as_ref().map_or("-".into(), |l| l.p50_us.to_string()),
+        r.query_latency.as_ref().map_or("-".into(), |l| l.p99_us.to_string()),
+        r.query_latency.as_ref().map_or("-".into(), |l| l.p999_us.to_string()),
+        format!("{:.1}", r.rss_delta_mb),
+        format!("{:.2}", r.cpu_efficiency),
+    ]
+}
+
+const TABLE_HEADERS: &[&str] = &[
+    "transport", "threads", "clients", "storage", "batch", "query_sz",
+    "mode", "q_rps", "r_rps", "q_p50µs", "q_p99µs", "q_p999µs", "rss_δMB", "cpu_eff",
+];
+
+fn print_results(results: &[RegistryBenchResult], format: &OutputFormat) {
+    match format {
+        OutputFormat::Table => {
+            let mut table = BenchTable::new(TABLE_HEADERS);
+            for r in results {
+                table.add_row(&make_table_row(r));
+            }
+            table.print();
+        }
+        OutputFormat::Csv => {
+            let mut table = BenchTable::new(TABLE_HEADERS);
+            for r in results {
+                table.add_row(&make_table_row(r));
+            }
+            print!("{}", table.to_csv());
+        }
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(results).unwrap_or_default());
+        }
+    }
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // Print system info header
+    let sysinfo = kvbm_bench::sysinfo::collect();
+    eprintln!("{}", sysinfo);
+
+    // Determine sweep points
+    let sweep_points: Vec<RegistryBenchParams> = if let Some(ref sweep_path) = args.sweep {
+        let runner = SweepRunner::<RegistryBenchParams>::from_yaml_file(sweep_path)?;
+        eprintln!("Sweep: {} points", runner.len());
+        runner.points
+    } else {
+        vec![RegistryBenchParams {
+            transport: args.transport,
+            threads: args.threads,
+            clients: args.clients,
+            storage_size: args.storage_size,
+            batch_size: args.batch_size,
+            query_size: args.query_size,
+            duration_secs: args.duration,
+            mode: args.mode,
+        }]
+    };
+
+    let warmup = args.warmup;
+    let output = args.output.clone();
+    let mut all_results = Vec::new();
+
+    for params in sweep_points {
+        eprintln!(
+            "Running: transport={} threads={} clients={} storage={} batch={} query_sz={} mode={} duration={}s",
+            params.transport, params.threads, params.clients, params.storage_size,
+            params.batch_size, params.query_size, params.mode, params.duration_secs
+        );
+
+        let threads = params.threads;
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(threads)
+            .enable_all()
+            .build()?;
+
+        let result = runtime.block_on(run_single(params, warmup))?;
+        all_results.push(result);
+    }
+
+    print_results(&all_results, &output);
+    Ok(())
+}

--- a/lib/kvbm-registry/bin/sweep_default.yaml
+++ b/lib/kvbm-registry/bin/sweep_default.yaml
@@ -1,0 +1,10 @@
+# Cartesian product sweep — all combinations will be run
+# transport: [tcp, uds, inprocess]
+transport: [inprocess]
+threads: [1, 2, 4, 8]
+clients: [1, 2, 4, 8, 16]
+storage_size: [1000, 100000, 1000000]
+batch_size: [1, 16, 64, 256]
+query_size: [1, 16, 256, 1000, 10000, 50000]
+mode: [query, register, mixed]
+duration_secs: [10]

--- a/lib/kvbm-registry/src/config.rs
+++ b/lib/kvbm-registry/src/config.rs
@@ -261,6 +261,10 @@ impl RegistryClientConfig {
         self
     }
 
+    /// Create a velo TCP transport connected to the hub.
+    pub async fn create_transport(&self) -> Result<super::core::VeloClientTransport> {
+        super::core::VeloClientTransport::connect(self.hub_addr).await
+    }
 }
 
 #[cfg(test)]

--- a/lib/kvbm-registry/src/config.rs
+++ b/lib/kvbm-registry/src/config.rs
@@ -54,7 +54,10 @@ impl Default for RegistryHubConfig {
 impl RegistryHubConfig {
     /// Create a new config with specified capacity.
     pub fn with_capacity(capacity: u64) -> Self {
-        Self { capacity, ..Default::default() }
+        Self {
+            capacity,
+            ..Default::default()
+        }
     }
 
     /// Create config listening on a specific port on all interfaces.
@@ -307,8 +310,9 @@ mod tests {
 
     #[test]
     fn test_client_config_builder() {
-        let config =
-            RegistryClientConfig::default().with_local_cache(10_000).with_batch_size(50);
+        let config = RegistryClientConfig::default()
+            .with_local_cache(10_000)
+            .with_batch_size(50);
         assert_eq!(config.local_cache_capacity, 10_000);
         assert_eq!(config.batch_size, 50);
     }

--- a/lib/kvbm-registry/src/core/eviction.rs
+++ b/lib/kvbm-registry/src/core/eviction.rs
@@ -604,7 +604,7 @@ where
         {
             let mut positions = self.positions.write();
             let mut insertion_order = self.insertion_order.write();
-            for &(ref key, _) in &entries {
+            for (key, _) in &entries {
                 let position = key.position();
                 positions.insert(std::cmp::Reverse(position));
                 insertion_order.entry(position).or_default().push(*key);

--- a/lib/kvbm-registry/src/core/hub.rs
+++ b/lib/kvbm-registry/src/core/hub.rs
@@ -350,9 +350,7 @@ where
 mod tests {
     use super::*;
     use crate::core::hub_transport::InProcessHubTransport;
-    use crate::core::{
-        BinaryCodec, HashMapStorage, NoMetadata,
-    };
+    use crate::core::{BinaryCodec, HashMapStorage, NoMetadata};
 
     #[tokio::test]
     async fn test_hub_can_offload() {

--- a/lib/kvbm-registry/src/core/mod.rs
+++ b/lib/kvbm-registry/src/core/mod.rs
@@ -14,10 +14,13 @@ pub mod key;
 pub mod lease;
 pub mod metadata;
 pub mod metrics;
+pub mod persistence;
 pub mod registry;
 pub mod storage;
 pub mod transport;
 pub mod value;
+pub mod uds_hub_transport;
+pub mod velo_hub_transport;
 
 #[cfg(test)]
 mod tests;
@@ -46,6 +49,8 @@ pub use value::{RegistryValue, StorageBackend, StorageLocation};
 // Client
 pub use registry::{OffloadResult, Registry, RegistryClient};
 pub use transport::{InProcessHub, InProcessTransport, RegistryTransport};
+pub use uds_hub_transport::{UdsClientTransport, UdsHubTransport};
+pub use velo_hub_transport::{VeloClientTransport, VeloHubTransport};
 
 // Hub (Server)
 pub use hub::{HubStats, RegistryHub};
@@ -53,6 +58,12 @@ pub use hub_transport::{ClientId, HubMessage, HubTransport, InProcessClientHandl
 
 // Builder
 pub use builder::{ClientBuilder, HubBuilder, client, hub};
+
+// Persistence
+pub use persistence::{
+    AccessStats, HybridPersistence, LocalDiskBackend, PersistedEntry, PersistenceBackend,
+    PersistenceConfig, RegistrySnapshot, SnapshotPersistence, WalEntry, WalPersistence,
+};
 
 // Event Bus
 pub use events::{

--- a/lib/kvbm-registry/src/core/mod.rs
+++ b/lib/kvbm-registry/src/core/mod.rs
@@ -18,8 +18,8 @@ pub mod persistence;
 pub mod registry;
 pub mod storage;
 pub mod transport;
-pub mod value;
 pub mod uds_hub_transport;
+pub mod value;
 pub mod velo_hub_transport;
 
 #[cfg(test)]
@@ -54,7 +54,9 @@ pub use velo_hub_transport::{VeloClientTransport, VeloHubTransport};
 
 // Hub (Server)
 pub use hub::{HubStats, RegistryHub};
-pub use hub_transport::{ClientId, HubMessage, HubTransport, InProcessClientHandle, InProcessHubTransport};
+pub use hub_transport::{
+    ClientId, HubMessage, HubTransport, InProcessClientHandle, InProcessHubTransport,
+};
 
 // Builder
 pub use builder::{ClientBuilder, HubBuilder, client, hub};

--- a/lib/kvbm-registry/src/core/persistence.rs
+++ b/lib/kvbm-registry/src/core/persistence.rs
@@ -1,0 +1,735 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Persistence layer for the registry hub.
+//!
+//! Provides snapshot and WAL-based persistence for crash recovery.
+//!
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use bincode::config;
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+
+/// Persisted entry in the registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedEntry<K, V, M> {
+    pub key: K,
+    pub value: V,
+    pub metadata: Option<M>,
+}
+
+/// Access statistics for eviction tracking.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AccessStats {
+    /// Last access timestamp (milliseconds since epoch)
+    pub last_access_ms: u64,
+    /// Total access count
+    pub access_count: u64,
+}
+
+/// Full registry state for snapshots.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistrySnapshot<K, V, M> {
+    /// Protocol version for forward/backward compatibility
+    pub version: u32,
+    /// Snapshot sequence number
+    pub sequence: u64,
+    /// Timestamp when snapshot was taken
+    pub timestamp_ms: u64,
+    /// All entries in the registry
+    pub entries: Vec<PersistedEntry<K, V, M>>,
+    /// Access statistics for each key (for LRU/LFU)
+    pub access_stats: Vec<(K, AccessStats)>,
+}
+
+impl<K, V, M> Default for RegistrySnapshot<K, V, M> {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            sequence: 0,
+            timestamp_ms: 0,
+            entries: Vec::new(),
+            access_stats: Vec::new(),
+        }
+    }
+}
+
+/// WAL entry types for incremental persistence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum WalEntry<K, V, M> {
+    /// Register new entries
+    Register {
+        seq: u64,
+        entries: Vec<PersistedEntry<K, V, M>>,
+    },
+    /// Remove entries by key
+    Remove { seq: u64, keys: Vec<K> },
+    /// Touch entries (access notification)
+    Touch { seq: u64, keys: Vec<K> },
+    /// Checkpoint marker
+    Checkpoint { seq: u64, snapshot_seq: u64 },
+}
+
+/// Trait for persistence storage backends.
+#[async_trait]
+pub trait PersistenceBackend: Send + Sync {
+    /// Write data to a path (atomic if possible)
+    async fn write(&self, path: &str, data: &[u8]) -> Result<()>;
+
+    /// Read data from a path
+    async fn read(&self, path: &str) -> Result<Vec<u8>>;
+
+    /// Check if a path exists
+    async fn exists(&self, path: &str) -> Result<bool>;
+
+    /// Append data to a file (for WAL)
+    async fn append(&self, path: &str, data: &[u8]) -> Result<()>;
+
+    /// List files with prefix
+    async fn list(&self, prefix: &str) -> Result<Vec<String>>;
+
+    /// Delete a file
+    async fn delete(&self, path: &str) -> Result<()>;
+
+    /// Atomic rename (for safe snapshot writes)
+    async fn rename(&self, from: &str, to: &str) -> Result<()>;
+}
+
+/// Local disk persistence backend.
+pub struct LocalDiskBackend {
+    base_path: PathBuf,
+}
+
+impl LocalDiskBackend {
+    pub fn new(base_path: impl AsRef<Path>) -> Result<Self> {
+        let base_path = base_path.as_ref().to_path_buf();
+        std::fs::create_dir_all(&base_path)?;
+        Ok(Self { base_path })
+    }
+
+    fn full_path(&self, path: &str) -> PathBuf {
+        self.base_path.join(path)
+    }
+}
+
+#[async_trait]
+impl PersistenceBackend for LocalDiskBackend {
+    async fn write(&self, path: &str, data: &[u8]) -> Result<()> {
+        let full_path = self.full_path(path);
+
+        // Create parent directories if needed
+        if let Some(parent) = full_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        // Write to temp file first, then rename (atomic on most filesystems)
+        let temp_path = full_path.with_extension("tmp");
+        tokio::fs::write(&temp_path, data).await?;
+        tokio::fs::rename(&temp_path, &full_path).await?;
+
+        // Sync to ensure durability
+        if let Ok(file) = tokio::fs::File::open(&full_path).await {
+            let _ = file.sync_all().await;
+        }
+
+        Ok(())
+    }
+
+    async fn read(&self, path: &str) -> Result<Vec<u8>> {
+        let full_path = self.full_path(path);
+        Ok(tokio::fs::read(&full_path).await?)
+    }
+
+    async fn exists(&self, path: &str) -> Result<bool> {
+        let full_path = self.full_path(path);
+        Ok(full_path.exists())
+    }
+
+    async fn append(&self, path: &str, data: &[u8]) -> Result<()> {
+        let full_path = self.full_path(path);
+
+        // Create parent directories if needed
+        if let Some(parent) = full_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&full_path)
+            .await?;
+
+        file.write_all(data).await?;
+        file.sync_all().await?;
+
+        Ok(())
+    }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<String>> {
+        let search_path = self.full_path(prefix);
+
+        let mut results = Vec::new();
+
+        // If prefix is a directory, list its contents
+        if search_path.is_dir() {
+            let mut entries = tokio::fs::read_dir(&search_path).await?;
+            while let Some(entry) = entries.next_entry().await? {
+                let path = entry.path();
+                if let Ok(relative) = path.strip_prefix(&self.base_path) {
+                    results.push(relative.to_string_lossy().to_string());
+                }
+            }
+        } else {
+            // Otherwise, list files in parent that start with the prefix
+            let search_dir = search_path
+                .parent()
+                .unwrap_or(&self.base_path)
+                .to_path_buf();
+
+            if search_dir.exists() {
+                let mut entries = tokio::fs::read_dir(&search_dir).await?;
+                while let Some(entry) = entries.next_entry().await? {
+                    let path = entry.path();
+                    if let Ok(relative) = path.strip_prefix(&self.base_path) {
+                        let path_str = relative.to_string_lossy().to_string();
+                        if path_str.starts_with(prefix) {
+                            results.push(path_str);
+                        }
+                    }
+                }
+            }
+        }
+
+        results.sort();
+        Ok(results)
+    }
+
+    async fn delete(&self, path: &str) -> Result<()> {
+        let full_path = self.full_path(path);
+        if full_path.exists() {
+            tokio::fs::remove_file(&full_path).await?;
+        }
+        Ok(())
+    }
+
+    async fn rename(&self, from: &str, to: &str) -> Result<()> {
+        let from_path = self.full_path(from);
+        let to_path = self.full_path(to);
+        tokio::fs::rename(&from_path, &to_path).await?;
+        Ok(())
+    }
+}
+
+/// Snapshot-based persistence.
+pub struct SnapshotPersistence<K, V, M> {
+    backend: Box<dyn PersistenceBackend>,
+    snapshot_prefix: String,
+    ops_since_snapshot: AtomicU64,
+    snapshot_interval: u64,
+    retention_count: usize,
+    _phantom: std::marker::PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M> SnapshotPersistence<K, V, M>
+where
+    K: Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    M: Serialize + for<'de> Deserialize<'de> + Send + Sync,
+{
+    pub fn new(
+        backend: Box<dyn PersistenceBackend>,
+        snapshot_prefix: String,
+        snapshot_interval: u64,
+        retention_count: usize,
+    ) -> Self {
+        Self {
+            backend,
+            snapshot_prefix,
+            ops_since_snapshot: AtomicU64::new(0),
+            snapshot_interval,
+            retention_count,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Take a snapshot of the registry state.
+    pub async fn take_snapshot(&self, snapshot: &RegistrySnapshot<K, V, M>) -> Result<()> {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        let filename = format!(
+            "{}/snapshot-{:08}-{}.bin",
+            self.snapshot_prefix, snapshot.sequence, timestamp
+        );
+
+        let data = bincode::serde::encode_to_vec(snapshot, config::standard())?;
+        self.backend.write(&filename, &data).await?;
+        self.ops_since_snapshot.store(0, Ordering::Release);
+
+        tracing::info!(
+            seq = snapshot.sequence,
+            entries = snapshot.entries.len(),
+            "Snapshot saved: {}",
+            filename
+        );
+
+        // Clean up old snapshots
+        self.cleanup_old_snapshots().await?;
+
+        Ok(())
+    }
+
+    /// Load the latest snapshot.
+    pub async fn load_latest(&self) -> Result<Option<RegistrySnapshot<K, V, M>>> {
+        let files = self.backend.list(&self.snapshot_prefix).await?;
+
+        let snapshot_files: Vec<_> = files
+            .iter()
+            .filter(|f| f.contains("snapshot-") && f.ends_with(".bin"))
+            .collect();
+
+        if snapshot_files.is_empty() {
+            return Ok(None);
+        }
+
+        // Get the latest snapshot (highest sequence number)
+        let latest = snapshot_files.iter().max().unwrap();
+        let data = self.backend.read(latest).await?;
+        let (snapshot, _): (RegistrySnapshot<K, V, M>, _) =
+            bincode::serde::decode_from_slice(&data, config::standard())?;
+
+        tracing::info!(
+            seq = snapshot.sequence,
+            entries = snapshot.entries.len(),
+            "Loaded snapshot: {}",
+            latest
+        );
+
+        Ok(Some(snapshot))
+    }
+
+    /// Record an operation (for snapshot interval tracking).
+    pub fn record_operation(&self) {
+        self.ops_since_snapshot.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Check if we should take a snapshot.
+    pub fn should_snapshot(&self) -> bool {
+        self.ops_since_snapshot.load(Ordering::Relaxed) >= self.snapshot_interval
+    }
+
+    /// Clean up old snapshots, keeping only the most recent ones.
+    async fn cleanup_old_snapshots(&self) -> Result<()> {
+        let files = self.backend.list(&self.snapshot_prefix).await?;
+
+        let mut snapshot_files: Vec<_> = files
+            .iter()
+            .filter(|f| f.contains("snapshot-") && f.ends_with(".bin"))
+            .cloned()
+            .collect();
+
+        if snapshot_files.len() <= self.retention_count {
+            return Ok(());
+        }
+
+        snapshot_files.sort();
+        let to_delete = snapshot_files.len() - self.retention_count;
+
+        for file in snapshot_files.iter().take(to_delete) {
+            tracing::debug!("Deleting old snapshot: {}", file);
+            self.backend.delete(file).await?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Write-Ahead Log persistence.
+pub struct WalPersistence<K, V, M> {
+    backend: Box<dyn PersistenceBackend>,
+    wal_path: String,
+    current_seq: AtomicU64,
+    _phantom: std::marker::PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M> WalPersistence<K, V, M>
+where
+    K: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync,
+    V: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync,
+    M: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync,
+{
+    pub fn new(backend: Box<dyn PersistenceBackend>, wal_path: String) -> Self {
+        Self {
+            backend,
+            wal_path,
+            current_seq: AtomicU64::new(0),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Log a WAL entry.
+    pub async fn log(&self, entry: WalEntry<K, V, M>) -> Result<u64> {
+        let seq = self.current_seq.fetch_add(1, Ordering::SeqCst);
+
+        // Serialize with length prefix for safe recovery
+        let data = bincode::serde::encode_to_vec(&entry, config::standard())?;
+        let mut buf = Vec::with_capacity(4 + data.len());
+        buf.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&data);
+
+        self.backend.append(&self.wal_path, &buf).await?;
+
+        Ok(seq)
+    }
+
+    /// Replay WAL entries from disk.
+    pub async fn replay(&self) -> Result<Vec<WalEntry<K, V, M>>> {
+        if !self.backend.exists(&self.wal_path).await? {
+            return Ok(Vec::new());
+        }
+
+        let data = self.backend.read(&self.wal_path).await?;
+        let mut entries = Vec::new();
+        let mut pos = 0;
+
+        while pos + 4 <= data.len() {
+            let len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap_or([0; 4])) as usize;
+            pos += 4;
+
+            if pos + len > data.len() {
+                tracing::warn!("WAL truncated at position {} (expected {} bytes)", pos, len);
+                break;
+            }
+
+            match bincode::serde::decode_from_slice::<WalEntry<K, V, M>, _>(
+                &data[pos..pos + len],
+                config::standard(),
+            ) {
+                Ok((entry, _)) => entries.push(entry),
+                Err(e) => {
+                    tracing::warn!("Failed to deserialize WAL entry at position {}: {}", pos, e);
+                    break;
+                }
+            }
+            pos += len;
+        }
+
+        // Update sequence counter
+        if let Some(last_seq) = entries
+            .iter()
+            .map(|e| match e {
+                WalEntry::Register { seq, .. } => *seq,
+                WalEntry::Remove { seq, .. } => *seq,
+                WalEntry::Touch { seq, .. } => *seq,
+                WalEntry::Checkpoint { seq, .. } => *seq,
+            })
+            .max()
+        {
+            self.current_seq.store(last_seq + 1, Ordering::Release);
+        }
+
+        tracing::info!(entries = entries.len(), "Replayed WAL entries");
+        Ok(entries)
+    }
+
+    /// Truncate WAL after checkpoint.
+    pub async fn truncate(&self) -> Result<()> {
+        self.backend.delete(&self.wal_path).await?;
+        tracing::debug!("WAL truncated");
+        Ok(())
+    }
+
+    /// Get current sequence number.
+    pub fn current_seq(&self) -> u64 {
+        self.current_seq.load(Ordering::Relaxed)
+    }
+
+    /// Set sequence number (used during recovery).
+    pub fn set_seq(&self, seq: u64) {
+        self.current_seq.store(seq, Ordering::Release);
+    }
+}
+
+/// Hybrid persistence combining snapshots and WAL.
+pub struct HybridPersistence<K, V, M>
+where
+    K: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync,
+    V: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync,
+    M: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync,
+{
+    snapshot: SnapshotPersistence<K, V, M>,
+    wal: WalPersistence<K, V, M>,
+}
+
+impl<K, V, M> HybridPersistence<K, V, M>
+where
+    K: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
+    V: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
+    M: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
+{
+    /// Create new hybrid persistence.
+    ///
+    /// # Arguments
+    /// * `backend` - Storage backend (must be cloneable or create two instances)
+    /// * `base_prefix` - Base path/prefix for all persistence files
+    /// * `snapshot_interval` - Number of operations before taking a snapshot
+    /// * `retention_count` - Number of snapshots to retain
+    pub fn new(
+        snapshot_backend: Box<dyn PersistenceBackend>,
+        wal_backend: Box<dyn PersistenceBackend>,
+        base_prefix: &str,
+        snapshot_interval: u64,
+        retention_count: usize,
+    ) -> Self {
+        let snapshot = SnapshotPersistence::new(
+            snapshot_backend,
+            format!("{}/snapshots", base_prefix),
+            snapshot_interval,
+            retention_count,
+        );
+
+        let wal = WalPersistence::new(wal_backend, format!("{}/wal.log", base_prefix));
+
+        Self { snapshot, wal }
+    }
+
+    /// Log an operation to WAL and maybe trigger snapshot.
+    pub async fn log_operation(&self, entry: WalEntry<K, V, M>) -> Result<u64> {
+        let seq = self.wal.log(entry).await?;
+        self.snapshot.record_operation();
+        Ok(seq)
+    }
+
+    /// Take a checkpoint (snapshot + truncate WAL).
+    pub async fn checkpoint(&self, snapshot: &RegistrySnapshot<K, V, M>) -> Result<()> {
+        // Take snapshot
+        self.snapshot.take_snapshot(snapshot).await?;
+
+        // Log checkpoint to WAL
+        self.wal
+            .log(WalEntry::Checkpoint {
+                seq: self.wal.current_seq(),
+                snapshot_seq: snapshot.sequence,
+            })
+            .await?;
+
+        // Truncate WAL
+        self.wal.truncate().await?;
+
+        Ok(())
+    }
+
+    /// Recover state from persistence.
+    pub async fn recover(&self) -> Result<Option<RegistrySnapshot<K, V, M>>> {
+        // Load latest snapshot
+        let snapshot = self.snapshot.load_latest().await?.unwrap_or_default();
+
+        // Replay WAL entries after snapshot
+        let wal_entries = self.wal.replay().await?;
+
+        // Update sequence
+        self.wal.set_seq(snapshot.sequence + 1);
+
+        // Apply WAL entries to snapshot (caller should do this based on entry types)
+        if !wal_entries.is_empty() {
+            tracing::info!(
+                snapshot_seq = snapshot.sequence,
+                wal_entries = wal_entries.len(),
+                "Recovery: loaded snapshot + {} WAL entries",
+                wal_entries.len()
+            );
+        }
+
+        if snapshot.entries.is_empty() && wal_entries.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(snapshot))
+    }
+
+    /// Check if a snapshot should be taken.
+    pub fn should_snapshot(&self) -> bool {
+        self.snapshot.should_snapshot()
+    }
+
+    /// Get reference to snapshot persistence.
+    pub fn snapshot(&self) -> &SnapshotPersistence<K, V, M> {
+        &self.snapshot
+    }
+
+    /// Get reference to WAL persistence.
+    pub fn wal(&self) -> &WalPersistence<K, V, M> {
+        &self.wal
+    }
+}
+
+/// Configuration for persistence.
+#[derive(Debug, Clone)]
+pub struct PersistenceConfig {
+    /// Enable persistence
+    pub enabled: bool,
+    /// Base path/prefix for persistence files
+    pub base_path: String,
+    /// Snapshot interval (number of operations)
+    pub snapshot_interval: u64,
+    /// Number of snapshots to retain
+    pub snapshot_retention: usize,
+}
+
+impl Default for PersistenceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            base_path: "/tmp/registry".to_string(),
+            snapshot_interval: 10000,
+            snapshot_retention: 3,
+        }
+    }
+}
+
+impl PersistenceConfig {
+    /// Create from environment variables.
+    ///
+    /// Environment variables:
+    /// - `DYN_REGISTRY_PERSISTENCE_ENABLED`: "1" or "true" to enable
+    /// - `DYN_REGISTRY_PERSISTENCE_PATH`: Base path for persistence files
+    /// - `DYN_REGISTRY_PERSISTENCE_SNAPSHOT_INTERVAL`: Operations between snapshots
+    /// - `DYN_REGISTRY_PERSISTENCE_SNAPSHOT_RETENTION`: Number of snapshots to keep
+    pub fn from_env() -> Self {
+        let enabled = std::env::var("DYN_REGISTRY_PERSISTENCE_ENABLED")
+            .map(|v| v == "1" || v.to_lowercase() == "true")
+            .unwrap_or(false);
+
+        let base_path = std::env::var("DYN_REGISTRY_PERSISTENCE_PATH")
+            .unwrap_or_else(|_| "/tmp/registry".to_string());
+
+        let snapshot_interval = std::env::var("DYN_REGISTRY_PERSISTENCE_SNAPSHOT_INTERVAL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(10000);
+
+        let snapshot_retention = std::env::var("DYN_REGISTRY_PERSISTENCE_SNAPSHOT_RETENTION")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(3);
+
+        Self {
+            enabled,
+            base_path,
+            snapshot_interval,
+            snapshot_retention,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_local_disk_backend() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let backend = LocalDiskBackend::new(temp_dir.path()).unwrap();
+
+        // Test write and read
+        backend.write("test.bin", b"hello world").await.unwrap();
+        let data = backend.read("test.bin").await.unwrap();
+        assert_eq!(data, b"hello world");
+
+        // Test exists
+        assert!(backend.exists("test.bin").await.unwrap());
+        assert!(!backend.exists("nonexistent.bin").await.unwrap());
+
+        // Test append
+        backend.append("append.log", b"line1\n").await.unwrap();
+        backend.append("append.log", b"line2\n").await.unwrap();
+        let log = backend.read("append.log").await.unwrap();
+        assert_eq!(log, b"line1\nline2\n");
+
+        // Test list
+        backend.write("subdir/file1.bin", b"1").await.unwrap();
+        backend.write("subdir/file2.bin", b"2").await.unwrap();
+        let files = backend.list("subdir").await.unwrap();
+        assert_eq!(files.len(), 2);
+
+        // Test delete
+        backend.delete("test.bin").await.unwrap();
+        assert!(!backend.exists("test.bin").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_persistence() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let backend = Box::new(LocalDiskBackend::new(temp_dir.path()).unwrap());
+
+        let persistence: SnapshotPersistence<u64, String, ()> =
+            SnapshotPersistence::new(backend, "snapshots".to_string(), 100, 2);
+
+        // Create and save snapshot
+        let snapshot = RegistrySnapshot {
+            version: 1,
+            sequence: 1,
+            timestamp_ms: 12345,
+            entries: vec![
+                PersistedEntry {
+                    key: 1,
+                    value: "one".to_string(),
+                    metadata: None,
+                },
+                PersistedEntry {
+                    key: 2,
+                    value: "two".to_string(),
+                    metadata: None,
+                },
+            ],
+            access_stats: vec![],
+        };
+
+        persistence.take_snapshot(&snapshot).await.unwrap();
+
+        // Load snapshot
+        let loaded = persistence.load_latest().await.unwrap().unwrap();
+        assert_eq!(loaded.sequence, 1);
+        assert_eq!(loaded.entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_wal_persistence() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let backend = Box::new(LocalDiskBackend::new(temp_dir.path()).unwrap());
+
+        let wal: WalPersistence<u64, String, ()> =
+            WalPersistence::new(backend, "wal.log".to_string());
+
+        // Log entries
+        wal.log(WalEntry::Register {
+            seq: 1,
+            entries: vec![PersistedEntry {
+                key: 1,
+                value: "one".to_string(),
+                metadata: None,
+            }],
+        })
+        .await
+        .unwrap();
+
+        wal.log(WalEntry::Remove {
+            seq: 2,
+            keys: vec![1],
+        })
+        .await
+        .unwrap();
+
+        // Replay
+        let entries = wal.replay().await.unwrap();
+        assert_eq!(entries.len(), 2);
+    }
+}

--- a/lib/kvbm-registry/src/core/tests.rs
+++ b/lib/kvbm-registry/src/core/tests.rs
@@ -10,7 +10,7 @@ mod integration {
 
     use crate::core::{
         BinaryCodec, HashMapStorage, InProcessHubTransport, InProcessTransport, NoMetadata,
-        OffloadStatus, QueryType, Registry, RegistryCodec, RegistryTransport, ResponseType,
+        OffloadStatus, QueryType, Registry, RegistryCodec, ResponseType,
         Storage, client, hub,
     };
 

--- a/lib/kvbm-registry/src/core/tests.rs
+++ b/lib/kvbm-registry/src/core/tests.rs
@@ -10,8 +10,7 @@ mod integration {
 
     use crate::core::{
         BinaryCodec, HashMapStorage, InProcessHubTransport, InProcessTransport, NoMetadata,
-        OffloadStatus, QueryType, Registry, RegistryCodec, ResponseType,
-        Storage, client, hub,
+        OffloadStatus, QueryType, Registry, RegistryCodec, ResponseType, Storage, client, hub,
     };
 
     /// Full end-to-end test: Client <-> Hub using in-process transport.
@@ -197,9 +196,7 @@ mod integration {
     #[tokio::test]
     #[ignore]
     async fn test_velo_e2e() {
-        use crate::core::{
-            VeloClientTransport, VeloHubTransport,
-        };
+        use crate::core::{VeloClientTransport, VeloHubTransport};
 
         let port: u16 = 17560;
 

--- a/lib/kvbm-registry/src/core/tests.rs
+++ b/lib/kvbm-registry/src/core/tests.rs
@@ -194,7 +194,6 @@ mod integration {
     /// Velo TCP end-to-end test.
     ///
     /// Run manually: `cargo test -- --ignored test_velo_e2e`
-    #[cfg(feature = "_velo_transport")]
     #[tokio::test]
     #[ignore]
     async fn test_velo_e2e() {

--- a/lib/kvbm-registry/src/core/uds_hub_transport.rs
+++ b/lib/kvbm-registry/src/core/uds_hub_transport.rs
@@ -23,8 +23,8 @@ use tokio::io::{AsyncWriteExt, WriteHalf};
 use tokio::net::{UnixListener as TokioUnixListener, UnixStream};
 use tokio::sync::mpsc;
 use tokio_util::codec::FramedRead;
-use velo_transports::tcp::TcpFrameCodec;
 use velo_transports::MessageType;
+use velo_transports::tcp::TcpFrameCodec;
 
 use super::hub_transport::{ClientId, HubMessage, HubTransport};
 
@@ -180,7 +180,9 @@ impl HubTransport for UdsHubTransport {
                     client: envelope.client,
                     data: envelope.payload,
                 }),
-                MessageType::Ack => Ok(HubMessage::Publish { data: envelope.payload }),
+                MessageType::Ack => Ok(HubMessage::Publish {
+                    data: envelope.payload,
+                }),
                 MessageType::Response | MessageType::Event | MessageType::ShuttingDown => {
                     tracing::debug!(
                         msg_type = ?envelope.msg_type,
@@ -202,7 +204,10 @@ impl HubTransport for UdsHubTransport {
         TcpFrameCodec::encode_frame_sync(&mut frame, MessageType::Response, &[], data)
             .map_err(|e| anyhow!("UdsHubTransport: encode error: {e}"))?;
 
-        entry.write_all(&frame).await.map_err(|e| anyhow!("UdsHubTransport: write error: {e}"))
+        entry
+            .write_all(&frame)
+            .await
+            .map_err(|e| anyhow!("UdsHubTransport: write error: {e}"))
     }
 
     fn name(&self) -> &'static str {
@@ -224,7 +229,10 @@ impl UdsClientTransport {
         let stream = UnixStream::connect(path)
             .await
             .map_err(|e| anyhow!("UdsClientTransport: failed to connect to {:?}: {e}", path))?;
-        Ok(Self { stream, codec: TcpFrameCodec::new() })
+        Ok(Self {
+            stream,
+            codec: TcpFrameCodec::new(),
+        })
     }
 
     /// Send a request (query) and wait for the response.
@@ -263,7 +271,10 @@ impl UdsClientTransport {
         TcpFrameCodec::encode_frame_sync(&mut frame, MessageType::Ack, &[], data)
             .map_err(|e| anyhow!("UdsClientTransport: encode error: {e}"))?;
         use tokio::io::AsyncWriteExt;
-        self.stream.write_all(&frame).await.map_err(|e| anyhow!("{e}"))
+        self.stream
+            .write_all(&frame)
+            .await
+            .map_err(|e| anyhow!("{e}"))
     }
 }
 

--- a/lib/kvbm-registry/src/core/uds_hub_transport.rs
+++ b/lib/kvbm-registry/src/core/uds_hub_transport.rs
@@ -257,10 +257,10 @@ impl UdsClientTransport {
             use bytes::BytesMut;
             use tokio_util::codec::Decoder;
             let mut bm = BytesMut::from(buf.as_slice());
-            if let Some((msg_type, _header, payload)) = self.codec.decode(&mut bm)? {
-                if msg_type == MessageType::Response {
-                    return Ok(payload.to_vec());
-                }
+            if let Some((msg_type, _header, payload)) = self.codec.decode(&mut bm)?
+                && msg_type == MessageType::Response
+            {
+                return Ok(payload.to_vec());
             }
         }
     }

--- a/lib/kvbm-registry/src/core/uds_hub_transport.rs
+++ b/lib/kvbm-registry/src/core/uds_hub_transport.rs
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unix domain socket hub transport for the distributed registry.
+//!
+//! Mirrors `velo_hub_transport.rs` but uses `tokio::net::UnixListener` and
+//! `tokio::net::UnixStream` instead of TCP. The framing is identical —
+//! `TcpFrameCodec` is reused since the codec is transport-agnostic.
+//!
+//! Wire protocol:
+//! - `MessageType::Message`  → `HubMessage::Query`  (requires response)
+//! - `MessageType::Ack`      → `HubMessage::Publish` (fire-and-forget)
+//! - `MessageType::Response` → sent back to a specific client
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
+use dashmap::DashMap;
+use tokio::io::{AsyncWriteExt, WriteHalf};
+use tokio::net::{UnixListener as TokioUnixListener, UnixStream};
+use tokio::sync::mpsc;
+use tokio_util::codec::FramedRead;
+use velo_transports::tcp::TcpFrameCodec;
+use velo_transports::MessageType;
+
+use super::hub_transport::{ClientId, HubMessage, HubTransport};
+
+// ── Internal message envelope ──────────────────────────────────────────────
+
+struct Envelope {
+    client: ClientId,
+    msg_type: MessageType,
+    payload: Vec<u8>,
+}
+
+// ── UdsHubTransport ────────────────────────────────────────────────────────
+
+/// Unix domain socket hub transport.
+///
+/// All workers connect to a single UDS path. Queries use `MessageType::Message`
+/// (hub responds via `MessageType::Response`); registrations use `MessageType::Ack`
+/// (fire-and-forget).
+pub struct UdsHubTransport {
+    /// Incoming message channel (fed by per-connection reader tasks).
+    rx: mpsc::UnboundedReceiver<Envelope>,
+    /// Write halves for active connections, keyed by `ClientId`.
+    writers: Arc<DashMap<ClientId, WriteHalf<UnixStream>>>,
+    /// Background accept task handle.
+    _accept_handle: tokio::task::JoinHandle<()>,
+    /// Socket path (kept for cleanup).
+    socket_path: Option<PathBuf>,
+}
+
+impl UdsHubTransport {
+    /// Bind and start listening on the given UDS path.
+    pub async fn bind(path: &Path) -> Result<Self> {
+        // Remove stale socket if it exists
+        if path.exists() {
+            std::fs::remove_file(path).ok();
+        }
+
+        let listener = TokioUnixListener::bind(path)
+            .map_err(|e| anyhow!("UdsHubTransport: failed to bind {:?}: {e}", path))?;
+
+        tracing::info!(path = ?path, "UdsHubTransport bound");
+
+        let (tx, rx) = mpsc::unbounded_channel::<Envelope>();
+        let writers: Arc<DashMap<ClientId, WriteHalf<UnixStream>>> = Arc::new(DashMap::new());
+        let writers_clone = writers.clone();
+
+        let accept_handle = tokio::spawn(async move {
+            Self::accept_loop(listener, tx, writers_clone).await;
+        });
+
+        Ok(Self {
+            rx,
+            writers,
+            _accept_handle: accept_handle,
+            socket_path: Some(path.to_path_buf()),
+        })
+    }
+
+    /// Bind on a temporary socket file. Returns the transport and the path.
+    pub async fn bind_temp() -> Result<(Self, PathBuf)> {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("kvbm-registry-{}.sock", std::process::id()));
+        let transport = Self::bind(&path).await?;
+        Ok((transport, path))
+    }
+
+    // ── Accept loop ──────────────────────────────────────────────────
+
+    async fn accept_loop(
+        listener: TokioUnixListener,
+        tx: mpsc::UnboundedSender<Envelope>,
+        writers: Arc<DashMap<ClientId, WriteHalf<UnixStream>>>,
+    ) {
+        static CLIENT_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+        loop {
+            match listener.accept().await {
+                Ok((stream, _addr)) => {
+                    let id = CLIENT_COUNTER.fetch_add(1, Ordering::Relaxed);
+                    let client_id = ClientId::new(id.to_le_bytes().to_vec());
+
+                    let (read_half, write_half) = tokio::io::split(stream);
+                    writers.insert(client_id.clone(), write_half);
+
+                    let tx2 = tx.clone();
+                    let writers2 = writers.clone();
+                    tokio::spawn(async move {
+                        Self::read_loop(read_half, client_id.clone(), tx2).await;
+                        writers2.remove(&client_id);
+                        tracing::debug!("UdsHubTransport: client disconnected");
+                    });
+                }
+                Err(e) => {
+                    tracing::error!(err = %e, "UdsHubTransport: accept error");
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            }
+        }
+    }
+
+    // ── Per-connection read loop ──────────────────────────────────────
+
+    async fn read_loop(
+        read_half: tokio::io::ReadHalf<UnixStream>,
+        client_id: ClientId,
+        tx: mpsc::UnboundedSender<Envelope>,
+    ) {
+        let codec = TcpFrameCodec::new();
+        let mut framed = FramedRead::new(read_half, codec);
+
+        use futures_util::StreamExt;
+        while let Some(frame) = framed.next().await {
+            match frame {
+                Ok((msg_type, _header, payload)) => {
+                    let envelope = Envelope {
+                        client: client_id.clone(),
+                        msg_type,
+                        payload: payload.to_vec(),
+                    };
+                    if tx.send(envelope).is_err() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(err = %e, "UdsHubTransport: read error");
+                    break;
+                }
+            }
+        }
+    }
+}
+
+impl Drop for UdsHubTransport {
+    fn drop(&mut self) {
+        if let Some(path) = self.socket_path.take() {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+#[async_trait]
+impl HubTransport for UdsHubTransport {
+    async fn recv(&mut self) -> Result<HubMessage> {
+        loop {
+            let envelope = self
+                .rx
+                .recv()
+                .await
+                .ok_or_else(|| anyhow!("UdsHubTransport: all clients disconnected"))?;
+
+            return match envelope.msg_type {
+                MessageType::Message => Ok(HubMessage::Query {
+                    client: envelope.client,
+                    data: envelope.payload,
+                }),
+                MessageType::Ack => Ok(HubMessage::Publish { data: envelope.payload }),
+                MessageType::Response | MessageType::Event | MessageType::ShuttingDown => {
+                    tracing::debug!(
+                        msg_type = ?envelope.msg_type,
+                        "UdsHubTransport: unexpected frame type from client, skipping"
+                    );
+                    continue;
+                }
+            };
+        }
+    }
+
+    async fn respond(&mut self, client: &ClientId, data: &[u8]) -> Result<()> {
+        let mut entry = self
+            .writers
+            .get_mut(client)
+            .ok_or_else(|| anyhow!("UdsHubTransport: client not found"))?;
+
+        let mut frame = Vec::new();
+        TcpFrameCodec::encode_frame_sync(&mut frame, MessageType::Response, &[], data)
+            .map_err(|e| anyhow!("UdsHubTransport: encode error: {e}"))?;
+
+        entry.write_all(&frame).await.map_err(|e| anyhow!("UdsHubTransport: write error: {e}"))
+    }
+
+    fn name(&self) -> &'static str {
+        "uds"
+    }
+}
+
+// ── UdsClientTransport ─────────────────────────────────────────────────────
+
+/// Client-side UDS transport that connects to a `UdsHubTransport`.
+pub struct UdsClientTransport {
+    stream: UnixStream,
+    codec: TcpFrameCodec,
+}
+
+impl UdsClientTransport {
+    /// Connect to a hub at the given UDS path.
+    pub async fn connect(path: &Path) -> Result<Self> {
+        let stream = UnixStream::connect(path)
+            .await
+            .map_err(|e| anyhow!("UdsClientTransport: failed to connect to {:?}: {e}", path))?;
+        Ok(Self { stream, codec: TcpFrameCodec::new() })
+    }
+
+    /// Send a request (query) and wait for the response.
+    pub async fn request(&mut self, data: &[u8]) -> Result<Vec<u8>> {
+        let mut frame = Vec::new();
+        TcpFrameCodec::encode_frame_sync(&mut frame, MessageType::Message, &[], data)
+            .map_err(|e| anyhow!("UdsClientTransport: encode error: {e}"))?;
+
+        use tokio::io::AsyncWriteExt;
+        self.stream.write_all(&frame).await?;
+
+        use tokio::io::AsyncReadExt;
+        let mut buf = Vec::with_capacity(4096);
+        loop {
+            let mut tmp = [0u8; 4096];
+            let n = self.stream.read(&mut tmp).await?;
+            if n == 0 {
+                return Err(anyhow!("UdsClientTransport: connection closed"));
+            }
+            buf.extend_from_slice(&tmp[..n]);
+
+            use bytes::BytesMut;
+            use tokio_util::codec::Decoder;
+            let mut bm = BytesMut::from(buf.as_slice());
+            if let Some((msg_type, _header, payload)) = self.codec.decode(&mut bm)? {
+                if msg_type == MessageType::Response {
+                    return Ok(payload.to_vec());
+                }
+            }
+        }
+    }
+
+    /// Publish a registration (fire-and-forget).
+    pub async fn publish(&mut self, data: &[u8]) -> Result<()> {
+        let mut frame = Vec::new();
+        TcpFrameCodec::encode_frame_sync(&mut frame, MessageType::Ack, &[], data)
+            .map_err(|e| anyhow!("UdsClientTransport: encode error: {e}"))?;
+        use tokio::io::AsyncWriteExt;
+        self.stream.write_all(&frame).await.map_err(|e| anyhow!("{e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_uds_hub_roundtrip() {
+        let (mut hub, path) = UdsHubTransport::bind_temp().await.unwrap();
+
+        let path2 = path.clone();
+        let handle = tokio::spawn(async move {
+            let mut client = UdsClientTransport::connect(&path2).await.unwrap();
+            let response = client.request(b"hello").await.unwrap();
+            assert_eq!(response, b"olleh");
+        });
+
+        // Hub echoes reversed bytes
+        if let Ok(HubMessage::Query { client, data }) = hub.recv().await {
+            let mut rev = data;
+            rev.reverse();
+            hub.respond(&client, &rev).await.unwrap();
+        }
+
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_uds_hub_publish() {
+        let (mut hub, path) = UdsHubTransport::bind_temp().await.unwrap();
+
+        let path2 = path.clone();
+        let handle = tokio::spawn(async move {
+            let mut client = UdsClientTransport::connect(&path2).await.unwrap();
+            client.publish(b"register-me").await.unwrap();
+        });
+
+        if let Ok(HubMessage::Publish { data }) = hub.recv().await {
+            assert_eq!(data, b"register-me");
+        }
+
+        handle.await.unwrap();
+    }
+}

--- a/lib/kvbm-registry/src/core/velo_hub_transport.rs
+++ b/lib/kvbm-registry/src/core/velo_hub_transport.rs
@@ -26,8 +26,8 @@ use tokio::net::TcpListener as TokioTcpListener;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio_util::codec::FramedRead;
-use velo_transports::tcp::TcpFrameCodec;
 use velo_transports::MessageType;
+use velo_transports::tcp::TcpFrameCodec;
 
 use super::hub_transport::{ClientId, HubMessage, HubTransport};
 
@@ -72,7 +72,11 @@ impl VeloHubTransport {
             Self::accept_loop(listener, tx, writers_clone).await;
         });
 
-        Ok(Self { rx, writers, _accept_handle: accept_handle })
+        Ok(Self {
+            rx,
+            writers,
+            _accept_handle: accept_handle,
+        })
     }
 
     /// Bind on `127.0.0.1:<port>` (convenience for tests / single-host setups).
@@ -170,7 +174,9 @@ impl HubTransport for VeloHubTransport {
                     client: envelope.client,
                     data: envelope.payload,
                 }),
-                MessageType::Ack => Ok(HubMessage::Publish { data: envelope.payload }),
+                MessageType::Ack => Ok(HubMessage::Publish {
+                    data: envelope.payload,
+                }),
                 // Skip unexpected frame types (shouldn't arrive at hub, but be defensive)
                 MessageType::Response | MessageType::Event | MessageType::ShuttingDown => {
                     tracing::debug!(
@@ -193,7 +199,10 @@ impl HubTransport for VeloHubTransport {
         TcpFrameCodec::encode_frame_sync(&mut frame, MessageType::Response, &[], data)
             .map_err(|e| anyhow!("VeloHubTransport: encode error: {e}"))?;
 
-        entry.write_all(&frame).await.map_err(|e| anyhow!("VeloHubTransport: write error: {e}"))
+        entry
+            .write_all(&frame)
+            .await
+            .map_err(|e| anyhow!("VeloHubTransport: write error: {e}"))
     }
 
     fn name(&self) -> &'static str {
@@ -218,7 +227,10 @@ impl VeloClientTransport {
         let stream = TcpStream::connect(addr)
             .await
             .map_err(|e| anyhow!("VeloClientTransport: failed to connect to {addr}: {e}"))?;
-        Ok(Self { stream, codec: TcpFrameCodec::new() })
+        Ok(Self {
+            stream,
+            codec: TcpFrameCodec::new(),
+        })
     }
 
     /// Connect to `127.0.0.1:<port>`.
@@ -262,7 +274,10 @@ impl VeloClientTransport {
         let mut frame = Vec::new();
         TcpFrameCodec::encode_frame_sync(&mut frame, MessageType::Ack, &[], data)
             .map_err(|e| anyhow!("VeloClientTransport: encode error: {e}"))?;
-        self.stream.write_all(&frame).await.map_err(|e| anyhow!("{e}"))
+        self.stream
+            .write_all(&frame)
+            .await
+            .map_err(|e| anyhow!("{e}"))
     }
 }
 
@@ -272,16 +287,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_velo_hub_query_response() {
-        let _hub = VeloHubTransport::bind_local(0)
-            .await
-            .expect("bind failed");
+        let _hub = VeloHubTransport::bind_local(0).await.expect("bind failed");
 
         // Get the actual bound port by peeking at the TcpListener
         // (We use port 17891 in a retry loop for tests)
-        let hub = VeloHubTransport::bind_local(17891).await.unwrap_or_else(|_| {
-            // Skip test if port is in use
-            panic!("Port 17891 in use — run tests sequentially");
-        });
+        let hub = VeloHubTransport::bind_local(17891)
+            .await
+            .unwrap_or_else(|_| {
+                // Skip test if port is in use
+                panic!("Port 17891 in use — run tests sequentially");
+            });
         let _ = hub;
     }
 

--- a/lib/kvbm-registry/src/core/velo_hub_transport.rs
+++ b/lib/kvbm-registry/src/core/velo_hub_transport.rs
@@ -269,11 +269,10 @@ impl VeloClientTransport {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
 
     #[tokio::test]
     async fn test_velo_hub_query_response() {
-        let mut hub = VeloHubTransport::bind_local(0)
+        let _hub = VeloHubTransport::bind_local(0)
             .await
             .expect("bind failed");
 

--- a/lib/kvbm-registry/src/core/velo_hub_transport.rs
+++ b/lib/kvbm-registry/src/core/velo_hub_transport.rs
@@ -261,10 +261,10 @@ impl VeloClientTransport {
             use bytes::BytesMut;
             use tokio_util::codec::Decoder;
             let mut bm = BytesMut::from(buf.as_slice());
-            if let Some((msg_type, _header, payload)) = self.codec.decode(&mut bm)? {
-                if msg_type == MessageType::Response {
-                    return Ok(payload.to_vec());
-                }
+            if let Some((msg_type, _header, payload)) = self.codec.decode(&mut bm)?
+                && msg_type == MessageType::Response
+            {
+                return Ok(payload.to_vec());
             }
         }
     }

--- a/lib/kvbm-registry/src/core/velo_hub_transport.rs
+++ b/lib/kvbm-registry/src/core/velo_hub_transport.rs
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Velo-based hub transport for the distributed registry.
+//!
+//! Uses `velo-transports::tcp::TcpFrameCodec` for framing and
+//! `tokio::net::TcpListener` for accepting connections.
+//!
+//! Wire protocol over a single TCP port:
+//! - `MessageType::Message`  → `HubMessage::Query`  (requires response)
+//! - `MessageType::Ack`      → `HubMessage::Publish` (fire-and-forget)
+//! - `MessageType::Response` → sent back to a specific client
+//!
+//! This replaces the two-port ZMQ ROUTER+PULL pattern with a single
+//! multiplexed TCP endpoint that all workers connect to.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
+use dashmap::DashMap;
+use tokio::io::{AsyncWriteExt, WriteHalf};
+use tokio::net::TcpListener as TokioTcpListener;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tokio_util::codec::FramedRead;
+use velo_transports::tcp::TcpFrameCodec;
+use velo_transports::MessageType;
+
+use super::hub_transport::{ClientId, HubMessage, HubTransport};
+
+// ── Internal message envelope ──────────────────────────────────────────────
+
+struct Envelope {
+    client: ClientId,
+    msg_type: MessageType,
+    payload: Vec<u8>,
+}
+
+// ── VeloHubTransport ──────────────────────────────────────────────────────
+
+/// Velo-based hub transport.
+///
+/// All workers connect to a single TCP port. Queries use `MessageType::Message`
+/// (hub responds via `MessageType::Response`); registrations use `MessageType::Ack`
+/// (fire-and-forget).
+pub struct VeloHubTransport {
+    /// Incoming message channel (fed by per-connection reader tasks).
+    rx: mpsc::UnboundedReceiver<Envelope>,
+    /// Write halves for active connections, keyed by `ClientId`.
+    writers: Arc<DashMap<ClientId, WriteHalf<TcpStream>>>,
+    /// Background accept task handle (kept alive while hub is running).
+    _accept_handle: tokio::task::JoinHandle<()>,
+}
+
+impl VeloHubTransport {
+    /// Bind and start listening on `addr`.
+    pub async fn bind(addr: SocketAddr) -> Result<Self> {
+        let listener = TokioTcpListener::bind(addr)
+            .await
+            .map_err(|e| anyhow!("VeloHubTransport: failed to bind {addr}: {e}"))?;
+
+        tracing::info!(addr = %addr, "VeloHubTransport bound");
+
+        let (tx, rx) = mpsc::unbounded_channel::<Envelope>();
+        let writers: Arc<DashMap<ClientId, WriteHalf<TcpStream>>> = Arc::new(DashMap::new());
+        let writers_clone = writers.clone();
+
+        let accept_handle = tokio::spawn(async move {
+            Self::accept_loop(listener, tx, writers_clone).await;
+        });
+
+        Ok(Self { rx, writers, _accept_handle: accept_handle })
+    }
+
+    /// Bind on `127.0.0.1:<port>` (convenience for tests / single-host setups).
+    pub async fn bind_local(port: u16) -> Result<Self> {
+        Self::bind(format!("127.0.0.1:{port}").parse().unwrap()).await
+    }
+
+    /// Bind on all interfaces on `port`.
+    pub async fn bind_all(port: u16) -> Result<Self> {
+        Self::bind(format!("0.0.0.0:{port}").parse().unwrap()).await
+    }
+
+    // ── Accept loop ──────────────────────────────────────────────────
+
+    async fn accept_loop(
+        listener: TokioTcpListener,
+        tx: mpsc::UnboundedSender<Envelope>,
+        writers: Arc<DashMap<ClientId, WriteHalf<TcpStream>>>,
+    ) {
+        static CLIENT_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+        loop {
+            match listener.accept().await {
+                Ok((stream, peer)) => {
+                    let id = CLIENT_COUNTER.fetch_add(1, Ordering::Relaxed);
+                    let client_id = ClientId::new(id.to_le_bytes().to_vec());
+
+                    let (read_half, write_half) = tokio::io::split(stream);
+                    writers.insert(client_id.clone(), write_half);
+
+                    let tx2 = tx.clone();
+                    let writers2 = writers.clone();
+                    tokio::spawn(async move {
+                        Self::read_loop(read_half, client_id.clone(), tx2, peer).await;
+                        // Clean up writer when reader exits
+                        writers2.remove(&client_id);
+                        tracing::debug!(peer = %peer, "VeloHubTransport: client disconnected");
+                    });
+                }
+                Err(e) => {
+                    tracing::error!(err = %e, "VeloHubTransport: accept error");
+                    // Back off briefly to avoid tight loop on persistent errors
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            }
+        }
+    }
+
+    // ── Per-connection read loop ──────────────────────────────────────
+
+    async fn read_loop(
+        read_half: tokio::io::ReadHalf<TcpStream>,
+        client_id: ClientId,
+        tx: mpsc::UnboundedSender<Envelope>,
+        peer: SocketAddr,
+    ) {
+        let codec = TcpFrameCodec::new();
+        let mut framed = FramedRead::new(read_half, codec);
+
+        use futures_util::StreamExt;
+        while let Some(frame) = framed.next().await {
+            match frame {
+                Ok((msg_type, _header, payload)) => {
+                    let envelope = Envelope {
+                        client: client_id.clone(),
+                        msg_type,
+                        payload: payload.to_vec(),
+                    };
+                    if tx.send(envelope).is_err() {
+                        // Hub dropped, stop reading
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(peer = %peer, err = %e, "VeloHubTransport: read error");
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl HubTransport for VeloHubTransport {
+    async fn recv(&mut self) -> Result<HubMessage> {
+        loop {
+            let envelope = self
+                .rx
+                .recv()
+                .await
+                .ok_or_else(|| anyhow!("VeloHubTransport: all clients disconnected"))?;
+
+            return match envelope.msg_type {
+                MessageType::Message => Ok(HubMessage::Query {
+                    client: envelope.client,
+                    data: envelope.payload,
+                }),
+                MessageType::Ack => Ok(HubMessage::Publish { data: envelope.payload }),
+                // Skip unexpected frame types (shouldn't arrive at hub, but be defensive)
+                MessageType::Response | MessageType::Event | MessageType::ShuttingDown => {
+                    tracing::debug!(
+                        msg_type = ?envelope.msg_type,
+                        "VeloHubTransport: unexpected frame type from client, skipping"
+                    );
+                    continue;
+                }
+            };
+        }
+    }
+
+    async fn respond(&mut self, client: &ClientId, data: &[u8]) -> Result<()> {
+        let mut entry = self
+            .writers
+            .get_mut(client)
+            .ok_or_else(|| anyhow!("VeloHubTransport: client not found"))?;
+
+        let mut frame = Vec::new();
+        TcpFrameCodec::encode_frame_sync(&mut frame, MessageType::Response, &[], data)
+            .map_err(|e| anyhow!("VeloHubTransport: encode error: {e}"))?;
+
+        entry.write_all(&frame).await.map_err(|e| anyhow!("VeloHubTransport: write error: {e}"))
+    }
+
+    fn name(&self) -> &'static str {
+        "velo-tcp"
+    }
+}
+
+// ── VeloClientTransport ───────────────────────────────────────────────────
+
+/// Client-side transport that connects to a `VeloHubTransport`.
+///
+/// Implements `RegistryTransport` — workers use this to register blocks
+/// (fire-and-forget `Ack`) and query the hub (`Message` → `Response`).
+pub struct VeloClientTransport {
+    stream: TcpStream,
+    codec: TcpFrameCodec,
+}
+
+impl VeloClientTransport {
+    /// Connect to a hub at `addr`.
+    pub async fn connect(addr: SocketAddr) -> Result<Self> {
+        let stream = TcpStream::connect(addr)
+            .await
+            .map_err(|e| anyhow!("VeloClientTransport: failed to connect to {addr}: {e}"))?;
+        Ok(Self { stream, codec: TcpFrameCodec::new() })
+    }
+
+    /// Connect to `127.0.0.1:<port>`.
+    pub async fn connect_local(port: u16) -> Result<Self> {
+        Self::connect(format!("127.0.0.1:{port}").parse().unwrap()).await
+    }
+
+    /// Send a request (query) and wait for the response.
+    pub async fn request(&mut self, data: &[u8]) -> Result<Vec<u8>> {
+        // Send query frame
+        let mut frame = Vec::new();
+        TcpFrameCodec::encode_frame_sync(&mut frame, MessageType::Message, &[], data)
+            .map_err(|e| anyhow!("VeloClientTransport: encode error: {e}"))?;
+
+        self.stream.write_all(&frame).await?;
+
+        // Read response frame
+        use tokio::io::AsyncReadExt;
+        let mut buf = Vec::with_capacity(4096);
+        loop {
+            let mut tmp = [0u8; 4096];
+            let n = self.stream.read(&mut tmp).await?;
+            if n == 0 {
+                return Err(anyhow!("VeloClientTransport: connection closed"));
+            }
+            buf.extend_from_slice(&tmp[..n]);
+
+            use bytes::BytesMut;
+            use tokio_util::codec::Decoder;
+            let mut bm = BytesMut::from(buf.as_slice());
+            if let Some((msg_type, _header, payload)) = self.codec.decode(&mut bm)? {
+                if msg_type == MessageType::Response {
+                    return Ok(payload.to_vec());
+                }
+            }
+        }
+    }
+
+    /// Publish a registration (fire-and-forget).
+    pub async fn publish(&mut self, data: &[u8]) -> Result<()> {
+        let mut frame = Vec::new();
+        TcpFrameCodec::encode_frame_sync(&mut frame, MessageType::Ack, &[], data)
+            .map_err(|e| anyhow!("VeloClientTransport: encode error: {e}"))?;
+        self.stream.write_all(&frame).await.map_err(|e| anyhow!("{e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn test_velo_hub_query_response() {
+        let mut hub = VeloHubTransport::bind_local(0)
+            .await
+            .expect("bind failed");
+
+        // Get the actual bound port by peeking at the TcpListener
+        // (We use port 17891 in a retry loop for tests)
+        let hub = VeloHubTransport::bind_local(17891).await.unwrap_or_else(|_| {
+            // Skip test if port is in use
+            panic!("Port 17891 in use — run tests sequentially");
+        });
+        let _ = hub;
+    }
+
+    #[tokio::test]
+    async fn test_velo_hub_roundtrip() {
+        let port = 17892u16;
+
+        let mut hub = VeloHubTransport::bind_local(port).await.unwrap();
+
+        let handle = tokio::spawn(async move {
+            let mut client = VeloClientTransport::connect_local(port).await.unwrap();
+            let response = client.request(b"hello").await.unwrap();
+            assert_eq!(response, b"olleh");
+        });
+
+        // Hub echoes reversed bytes
+        if let Ok(HubMessage::Query { client, data }) = hub.recv().await {
+            let mut rev = data;
+            rev.reverse();
+            hub.respond(&client, &rev).await.unwrap();
+        }
+
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_velo_hub_publish() {
+        let port = 17893u16;
+        let mut hub = VeloHubTransport::bind_local(port).await.unwrap();
+
+        let handle = tokio::spawn(async move {
+            let mut client = VeloClientTransport::connect_local(port).await.unwrap();
+            client.publish(b"register-me").await.unwrap();
+        });
+
+        if let Ok(HubMessage::Publish { data }) = hub.recv().await {
+            assert_eq!(data, b"register-me");
+        }
+
+        handle.await.unwrap();
+    }
+}


### PR DESCRIPTION
#### Overview:

Adds network transports and a configurable sweep benchmark:

**Transports:**
- `VeloHubTransport` / `VeloClientTransport`: single TCP port via `velo-transports::TcpFrameCodec`
- `UdsHubTransport` / `UdsClientTransport`: Unix domain socket transport (~40x lower latency than TCP on single host)

**Benchmark (`bin/bench.rs`):** configurable transport, threads, clients, storage-size, batch-size, query-size, duration, mode; YAML cartesian-product sweep; table/CSV/JSON output.

**Results (AMD EPYC 7B13, 100k keys, mixed mode, dev build):**

| transport | clients | query_sz | q_rps | p50 | p99 |
|-----------|---------|----------|-------|-----|-----|
| uds | 1 | 16 | 1.0B | 98µs | 177µs |
| uds | 4 | 1000 | 157M | 2.0ms | 3.0ms |
| tcp | 4 | 1000 | 8.9M | 41ms | 43ms |

**Part of chain:** R0 → R1 → R2 → R3 → R4 → R5 → R6 → R7 → **R8**

#### Details:

- `src/core/velo_hub_transport.rs`: TCP hub/client using `velo-transports::TcpFrameCodec`; DashMap writer registry; accept loop with AtomicU64 client IDs
- `src/core/uds_hub_transport.rs`: UDS mirror of TCP transport
- `bin/bench.rs`: 530-line configurable benchmark binary
- `bin/sweep_default.yaml`, `bin/sweep_quick.yaml`: sweep parameter files

#### Where should the reviewer start?

Start with `src/core/velo_hub_transport.rs` for the TCP transport, then `bin/bench.rs` for the benchmark harness.

#### Related Issues:

- Relates to kvbm distributed registry chain (R8/8)