### PR TITLE
feat: add kvbm-bench and kvbm-registry crate scaffolding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ members = [
     "lib/velo-common",
     "lib/velo-transports",
     "lib/velo-events",
+    "lib/kvbm-bench",
+    "lib/kvbm-registry",
 ]
 resolver = "3"
 
@@ -58,6 +60,10 @@ kvbm-physical = { path = "lib/kvbm-physical", version = "0.1.0" }
 velo-common = { path = "lib/velo-common", version = "0.1.0" }
 velo-transports = { path = "lib/velo-transports", version = "0.1.0" }
 velo-events = { path = "lib/velo-events", version = "0.1.0" }
+
+# kvbm-bench and kvbm-registry
+kvbm-bench = { path = "lib/kvbm-bench" }
+kvbm-registry = { path = "lib/kvbm-registry" }
 
 # External dependencies
 anyhow = { version = "1" }

--- a/lib/kvbm-bench/Cargo.toml
+++ b/lib/kvbm-bench/Cargo.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "kvbm-bench"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = "0.9"
+clap = { version = "4.5", features = ["derive"] }
+comfy-table = "7"
+csv = "1.3"

--- a/lib/kvbm-bench/Cargo.toml
+++ b/lib/kvbm-bench/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+libc = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = "0.9"

--- a/lib/kvbm-bench/src/latency.rs
+++ b/lib/kvbm-bench/src/latency.rs
@@ -16,8 +16,11 @@ pub struct LatencyStats {
     pub p99_us: u64,
     pub p999_us: u64,
     pub max_us: u64,
-    pub throughput_ops_sec: f64,
-    pub total_elapsed_secs: f64,
+    /// Cumulative service time divided by count — valid only for serial runs.
+    /// Use wall-clock elapsed from the runner for true throughput.
+    pub cumulative_latency_ops_sec: f64,
+    /// Sum of all per-operation latencies in seconds.
+    pub cumulative_latency_secs: f64,
 }
 
 impl LatencyStats {
@@ -43,9 +46,9 @@ impl LatencyStats {
         let p99_us = percentile(&sorted, 99.0);
         let p999_us = percentile(&sorted, 99.9);
 
-        let total_elapsed_secs = sum as f64 / 1_000_000.0;
-        let throughput_ops_sec = if total_elapsed_secs > 0.0 {
-            count as f64 / total_elapsed_secs
+        let cumulative_latency_secs = sum as f64 / 1_000_000.0;
+        let cumulative_latency_ops_sec = if cumulative_latency_secs > 0.0 {
+            count as f64 / cumulative_latency_secs
         } else {
             0.0
         };
@@ -59,8 +62,8 @@ impl LatencyStats {
             p99_us,
             p999_us,
             max_us,
-            throughput_ops_sec,
-            total_elapsed_secs,
+            cumulative_latency_ops_sec,
+            cumulative_latency_secs,
         })
     }
 

--- a/lib/kvbm-bench/src/latency.rs
+++ b/lib/kvbm-bench/src/latency.rs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Latency statistics computation.
+
+use serde::{Deserialize, Serialize};
+
+/// Latency statistics computed from a set of timing samples.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LatencyStats {
+    pub count: usize,
+    pub min_us: u64,
+    pub avg_us: u64,
+    pub p50_us: u64,
+    pub p95_us: u64,
+    pub p99_us: u64,
+    pub p999_us: u64,
+    pub max_us: u64,
+    pub throughput_ops_sec: f64,
+    pub total_elapsed_secs: f64,
+}
+
+impl LatencyStats {
+    /// Compute latency statistics from a slice of microsecond samples.
+    ///
+    /// Returns `None` if `samples` is empty.
+    pub fn from_micros(samples: &[u64]) -> Option<Self> {
+        if samples.is_empty() {
+            return None;
+        }
+
+        let mut sorted = samples.to_vec();
+        sorted.sort_unstable();
+
+        let count = sorted.len();
+        let min_us = sorted[0];
+        let max_us = sorted[count - 1];
+        let sum: u64 = sorted.iter().sum();
+        let avg_us = sum / count as u64;
+
+        let p50_us = percentile(&sorted, 50.0);
+        let p95_us = percentile(&sorted, 95.0);
+        let p99_us = percentile(&sorted, 99.0);
+        let p999_us = percentile(&sorted, 99.9);
+
+        let total_elapsed_secs = sum as f64 / 1_000_000.0;
+        let throughput_ops_sec = if total_elapsed_secs > 0.0 {
+            count as f64 / total_elapsed_secs
+        } else {
+            0.0
+        };
+
+        Some(Self {
+            count,
+            min_us,
+            avg_us,
+            p50_us,
+            p95_us,
+            p99_us,
+            p999_us,
+            max_us,
+            throughput_ops_sec,
+            total_elapsed_secs,
+        })
+    }
+
+    /// Compute latency statistics from a slice of `Duration` samples.
+    ///
+    /// Returns `None` if `samples` is empty.
+    pub fn from_durations(samples: &[std::time::Duration]) -> Option<Self> {
+        let micros: Vec<u64> = samples.iter().map(|d| d.as_micros() as u64).collect();
+        Self::from_micros(&micros)
+    }
+}
+
+fn percentile(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = ((p / 100.0) * (sorted.len() - 1) as f64).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}

--- a/lib/kvbm-bench/src/lib.rs
+++ b/lib/kvbm-bench/src/lib.rs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared benchmarking infrastructure for kvbm crates.
+
+pub mod latency;
+pub mod output;
+pub mod sweep;
+pub mod sysinfo;
+pub mod table;
+
+pub use latency::LatencyStats;
+pub use output::OutputFormat;
+pub use sweep::SweepRunner;
+pub use sysinfo::{CpuTime, RssSnapshot, SystemInfo};
+pub use table::BenchTable;

--- a/lib/kvbm-bench/src/output.rs
+++ b/lib/kvbm-bench/src/output.rs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Output format selection.
+
+/// Output format for benchmark results.
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub enum OutputFormat {
+    /// Pretty-printed table using comfy-table.
+    Table,
+    /// Comma-separated values.
+    Csv,
+    /// JSON array.
+    Json,
+}

--- a/lib/kvbm-bench/src/sweep.rs
+++ b/lib/kvbm-bench/src/sweep.rs
@@ -150,8 +150,20 @@ configs:
 "#;
         let runner = SweepRunner::<TestParams>::from_yaml_str(yaml).unwrap();
         assert_eq!(runner.len(), 2);
-        assert_eq!(runner.points[0], TestParams { threads: 4, clients: 8 });
-        assert_eq!(runner.points[1], TestParams { threads: 2, clients: 16 });
+        assert_eq!(
+            runner.points[0],
+            TestParams {
+                threads: 4,
+                clients: 8
+            }
+        );
+        assert_eq!(
+            runner.points[1],
+            TestParams {
+                threads: 2,
+                clients: 16
+            }
+        );
     }
 
     #[test]
@@ -173,6 +185,12 @@ clients: 8
 "#;
         let runner = SweepRunner::<TestParams>::from_yaml_str(yaml).unwrap();
         assert_eq!(runner.len(), 1);
-        assert_eq!(runner.points[0], TestParams { threads: 4, clients: 8 });
+        assert_eq!(
+            runner.points[0],
+            TestParams {
+                threads: 4,
+                clients: 8
+            }
+        );
     }
 }

--- a/lib/kvbm-bench/src/sweep.rs
+++ b/lib/kvbm-bench/src/sweep.rs
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generic YAML cartesian-product sweep runner.
+
+use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
+use serde_yaml::Value;
+
+/// A sweep runner that holds a list of parameter combinations.
+///
+/// Supports two YAML formats:
+///
+/// **Explicit mode** — list of configs under a `configs:` key:
+/// ```yaml
+/// configs:
+///   - threads: 4
+///     clients: 8
+/// ```
+///
+/// **Cartesian product mode** — arrays at the top level generate all combinations:
+/// ```yaml
+/// threads: [1, 2, 4, 8]
+/// clients: [1, 4, 16]
+/// ```
+pub struct SweepRunner<P> {
+    pub points: Vec<P>,
+}
+
+impl<P: DeserializeOwned + Clone> SweepRunner<P> {
+    /// Load sweep points from a YAML file.
+    pub fn from_yaml_file(path: &str) -> Result<Self> {
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read sweep file: {path}"))?;
+        Self::from_yaml_str(&contents)
+    }
+
+    /// Load sweep points from a YAML string.
+    pub fn from_yaml_str(s: &str) -> Result<Self> {
+        let value: Value = serde_yaml::from_str(s).context("Failed to parse sweep YAML")?;
+
+        let points = match &value {
+            Value::Mapping(map) => {
+                // Check for explicit `configs:` key
+                if let Some(configs_val) = map.get("configs") {
+                    // Explicit mode
+                    let configs: Vec<P> = serde_yaml::from_value(configs_val.clone())
+                        .context("Failed to deserialize explicit configs")?;
+                    configs
+                } else {
+                    // Cartesian product mode
+                    cartesian_product_from_mapping(map)?
+                }
+            }
+            _ => anyhow::bail!("Sweep YAML must be a mapping at the top level"),
+        };
+
+        Ok(Self { points })
+    }
+
+    /// Number of sweep points.
+    pub fn len(&self) -> usize {
+        self.points.len()
+    }
+
+    /// Returns true if there are no sweep points.
+    pub fn is_empty(&self) -> bool {
+        self.points.is_empty()
+    }
+}
+
+/// Generate cartesian product from a YAML mapping where each value may be
+/// a scalar (single point) or a sequence (multiple values).
+fn cartesian_product_from_mapping<P: DeserializeOwned>(
+    map: &serde_yaml::Mapping,
+) -> Result<Vec<P>> {
+    // Collect (key, values) pairs
+    let mut keys: Vec<Value> = Vec::new();
+    let mut value_lists: Vec<Vec<Value>> = Vec::new();
+
+    for (k, v) in map.iter() {
+        keys.push(k.clone());
+        match v {
+            Value::Sequence(seq) => value_lists.push(seq.clone()),
+            scalar => value_lists.push(vec![scalar.clone()]),
+        }
+    }
+
+    if keys.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Generate cartesian product of all value lists
+    let combinations = cartesian_product(&value_lists);
+
+    let mut points = Vec::with_capacity(combinations.len());
+    for combo in combinations {
+        let mut mapping = serde_yaml::Mapping::new();
+        for (k, v) in keys.iter().zip(combo.iter()) {
+            mapping.insert(k.clone(), v.clone());
+        }
+        let p: P = serde_yaml::from_value(Value::Mapping(mapping))
+            .context("Failed to deserialize sweep point")?;
+        points.push(p);
+    }
+
+    Ok(points)
+}
+
+/// Compute cartesian product of a slice of value lists.
+fn cartesian_product(lists: &[Vec<Value>]) -> Vec<Vec<Value>> {
+    if lists.is_empty() {
+        return vec![vec![]];
+    }
+
+    let mut result = vec![vec![]];
+    for list in lists {
+        let mut new_result = Vec::new();
+        for existing in &result {
+            for item in list {
+                let mut combo = existing.clone();
+                combo.push(item.clone());
+                new_result.push(combo);
+            }
+        }
+        result = new_result;
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Clone, Deserialize, PartialEq)]
+    struct TestParams {
+        threads: usize,
+        clients: usize,
+    }
+
+    #[test]
+    fn test_explicit_mode() {
+        let yaml = r#"
+configs:
+  - threads: 4
+    clients: 8
+  - threads: 2
+    clients: 16
+"#;
+        let runner = SweepRunner::<TestParams>::from_yaml_str(yaml).unwrap();
+        assert_eq!(runner.len(), 2);
+        assert_eq!(runner.points[0], TestParams { threads: 4, clients: 8 });
+        assert_eq!(runner.points[1], TestParams { threads: 2, clients: 16 });
+    }
+
+    #[test]
+    fn test_cartesian_mode() {
+        let yaml = r#"
+threads: [1, 2]
+clients: [4, 8]
+"#;
+        let runner = SweepRunner::<TestParams>::from_yaml_str(yaml).unwrap();
+        // 2 * 2 = 4 combinations
+        assert_eq!(runner.len(), 4);
+    }
+
+    #[test]
+    fn test_single_values() {
+        let yaml = r#"
+threads: 4
+clients: 8
+"#;
+        let runner = SweepRunner::<TestParams>::from_yaml_str(yaml).unwrap();
+        assert_eq!(runner.len(), 1);
+        assert_eq!(runner.points[0], TestParams { threads: 4, clients: 8 });
+    }
+}

--- a/lib/kvbm-bench/src/sysinfo.rs
+++ b/lib/kvbm-bench/src/sysinfo.rs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! System information collection from /proc.
+
+use serde::{Deserialize, Serialize};
+
+/// System information snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SystemInfo {
+    pub hostname: String,
+    pub os: String,
+    pub kernel: String,
+    pub cpu_model: String,
+    pub cpu_threads: usize,
+    pub memory_total_gb: f64,
+}
+
+/// Collect system information from /proc and /etc.
+pub fn collect() -> SystemInfo {
+    let hostname = std::fs::read_to_string("/etc/hostname")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
+    let os = std::fs::read_to_string("/etc/os-release")
+        .unwrap_or_default()
+        .lines()
+        .find(|l| l.starts_with("PRETTY_NAME="))
+        .map(|l| l.trim_start_matches("PRETTY_NAME=").trim_matches('"').to_string())
+        .unwrap_or_else(|| "Unknown".to_string());
+
+    let kernel = std::fs::read_to_string("/proc/version")
+        .unwrap_or_default()
+        .split_whitespace()
+        .nth(2)
+        .unwrap_or("Unknown")
+        .to_string();
+
+    let cpuinfo = std::fs::read_to_string("/proc/cpuinfo").unwrap_or_default();
+
+    let cpu_model = cpuinfo
+        .lines()
+        .find(|l| l.starts_with("model name"))
+        .and_then(|l| l.split(':').nth(1))
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "Unknown".to_string());
+
+    let cpu_threads = cpuinfo.lines().filter(|l| l.starts_with("processor")).count();
+
+    let meminfo = std::fs::read_to_string("/proc/meminfo").unwrap_or_default();
+    let memory_total_kb: u64 = meminfo
+        .lines()
+        .find(|l| l.starts_with("MemTotal:"))
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let memory_total_gb = memory_total_kb as f64 / (1024.0 * 1024.0);
+
+    SystemInfo { hostname, os, kernel, cpu_model, cpu_threads, memory_total_gb }
+}
+
+impl std::fmt::Display for SystemInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Host: {} | OS: {} | Kernel: {} | CPU: {} ({} threads) | RAM: {:.1} GB",
+            self.hostname,
+            self.os,
+            self.kernel,
+            self.cpu_model,
+            self.cpu_threads,
+            self.memory_total_gb
+        )
+    }
+}
+
+/// Resident set size snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RssSnapshot {
+    pub rss_kb: u64,
+    pub peak_rss_kb: u64,
+}
+
+/// Read RSS and peak RSS from /proc/self/status.
+pub fn rss_snapshot() -> RssSnapshot {
+    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    let mut rss_kb = 0u64;
+    let mut peak_rss_kb = 0u64;
+    for line in status.lines() {
+        if line.starts_with("VmRSS:") {
+            rss_kb = line.split_whitespace().nth(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+        } else if line.starts_with("VmPeak:") {
+            peak_rss_kb = line.split_whitespace().nth(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+        }
+    }
+    RssSnapshot { rss_kb, peak_rss_kb }
+}
+
+/// CPU time snapshot from /proc/self/stat.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CpuTime {
+    pub user_us: u64,
+    pub system_us: u64,
+}
+
+/// Read user and system CPU time from /proc/self/stat.
+pub fn cpu_time() -> CpuTime {
+    let stat = std::fs::read_to_string("/proc/self/stat").unwrap_or_default();
+    let fields: Vec<&str> = stat.split_whitespace().collect();
+    // Fields 13 (utime) and 14 (stime) in /proc/self/stat (0-indexed)
+    // utime is at index 13, stime at index 14
+    let utime_ticks: u64 = fields.get(13).and_then(|s| s.parse().ok()).unwrap_or(0);
+    let stime_ticks: u64 = fields.get(14).and_then(|s| s.parse().ok()).unwrap_or(0);
+
+    // Convert from clock ticks to microseconds (typically 100 ticks/sec)
+    let ticks_per_sec = tick_rate();
+    let user_us = utime_ticks * 1_000_000 / ticks_per_sec;
+    let system_us = stime_ticks * 1_000_000 / ticks_per_sec;
+
+    CpuTime { user_us, system_us }
+}
+
+fn tick_rate() -> u64 {
+    // On Linux, sysconf(_SC_CLK_TCK) is typically 100
+    libc_clock_tck()
+}
+
+fn libc_clock_tck() -> u64 {
+    // Read from /proc/self/stat — fall back to 100 if we can't determine
+    // We parse it directly from the OS via a syscall-free approach
+    // Most Linux systems use 100 Hz (USER_HZ = 100)
+    100
+}

--- a/lib/kvbm-bench/src/sysinfo.rs
+++ b/lib/kvbm-bench/src/sysinfo.rs
@@ -27,7 +27,11 @@ pub fn collect() -> SystemInfo {
         .unwrap_or_default()
         .lines()
         .find(|l| l.starts_with("PRETTY_NAME="))
-        .map(|l| l.trim_start_matches("PRETTY_NAME=").trim_matches('"').to_string())
+        .map(|l| {
+            l.trim_start_matches("PRETTY_NAME=")
+                .trim_matches('"')
+                .to_string()
+        })
         .unwrap_or_else(|| "Unknown".to_string());
 
     let kernel = std::fs::read_to_string("/proc/version")
@@ -46,7 +50,10 @@ pub fn collect() -> SystemInfo {
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|| "Unknown".to_string());
 
-    let cpu_threads = cpuinfo.lines().filter(|l| l.starts_with("processor")).count();
+    let cpu_threads = cpuinfo
+        .lines()
+        .filter(|l| l.starts_with("processor"))
+        .count();
 
     let meminfo = std::fs::read_to_string("/proc/meminfo").unwrap_or_default();
     let memory_total_kb: u64 = meminfo
@@ -57,7 +64,14 @@ pub fn collect() -> SystemInfo {
         .unwrap_or(0);
     let memory_total_gb = memory_total_kb as f64 / (1024.0 * 1024.0);
 
-    SystemInfo { hostname, os, kernel, cpu_model, cpu_threads, memory_total_gb }
+    SystemInfo {
+        hostname,
+        os,
+        kernel,
+        cpu_model,
+        cpu_threads,
+        memory_total_gb,
+    }
 }
 
 impl std::fmt::Display for SystemInfo {
@@ -89,12 +103,23 @@ pub fn rss_snapshot() -> RssSnapshot {
     let mut peak_rss_kb = 0u64;
     for line in status.lines() {
         if line.starts_with("VmRSS:") {
-            rss_kb = line.split_whitespace().nth(1).and_then(|s| s.parse().ok()).unwrap_or(0);
-        } else if line.starts_with("VmPeak:") {
-            peak_rss_kb = line.split_whitespace().nth(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+            rss_kb = line
+                .split_whitespace()
+                .nth(1)
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+        } else if line.starts_with("VmHWM:") {
+            peak_rss_kb = line
+                .split_whitespace()
+                .nth(1)
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
         }
     }
-    RssSnapshot { rss_kb, peak_rss_kb }
+    RssSnapshot {
+        rss_kb,
+        peak_rss_kb,
+    }
 }
 
 /// CPU time snapshot from /proc/self/stat.
@@ -122,13 +147,16 @@ pub fn cpu_time() -> CpuTime {
 }
 
 fn tick_rate() -> u64 {
-    // On Linux, sysconf(_SC_CLK_TCK) is typically 100
     libc_clock_tck()
 }
 
 fn libc_clock_tck() -> u64 {
-    // Read from /proc/self/stat — fall back to 100 if we can't determine
-    // We parse it directly from the OS via a syscall-free approach
-    // Most Linux systems use 100 Hz (USER_HZ = 100)
-    100
+    // SAFETY: sysconf is async-signal-safe and has no preconditions for _SC_CLK_TCK.
+    let tck = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+    if tck <= 0 {
+        // Spec allows -1 on error; fall back to the common 100 Hz default.
+        100
+    } else {
+        tck as u64
+    }
 }

--- a/lib/kvbm-bench/src/table.rs
+++ b/lib/kvbm-bench/src/table.rs
@@ -27,7 +27,8 @@ impl BenchTable {
 
     /// Add a row of cells to the table.
     pub fn add_row(&mut self, cells: &[String]) {
-        self.table.add_row(cells.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+        self.table
+            .add_row(cells.iter().map(|s| s.to_string()).collect::<Vec<_>>());
         self.rows.push(cells.to_vec());
     }
 
@@ -37,12 +38,34 @@ impl BenchTable {
     }
 
     /// Render the table as CSV.
+    ///
+    /// Fields containing commas, double-quotes, or newlines are quoted per RFC 4180.
     pub fn to_csv(&self) -> String {
+        let escape = |s: &str| {
+            if s.contains(',') || s.contains('"') || s.contains('\n') {
+                format!("\"{}\"", s.replace('"', "\"\""))
+            } else {
+                s.to_string()
+            }
+        };
+
         let mut out = String::new();
-        out.push_str(&self.headers.join(","));
+        out.push_str(
+            &self
+                .headers
+                .iter()
+                .map(|s| escape(s))
+                .collect::<Vec<_>>()
+                .join(","),
+        );
         out.push('\n');
         for row in &self.rows {
-            out.push_str(&row.join(","));
+            out.push_str(
+                &row.iter()
+                    .map(|s| escape(s))
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
             out.push('\n');
         }
         out

--- a/lib/kvbm-bench/src/table.rs
+++ b/lib/kvbm-bench/src/table.rs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! comfy-table output helper.
+
+use comfy_table::{Table, presets};
+
+/// A formatted table for benchmark output.
+pub struct BenchTable {
+    table: Table,
+    headers: Vec<String>,
+    rows: Vec<Vec<String>>,
+}
+
+impl BenchTable {
+    /// Create a new table with the given column headers.
+    pub fn new(headers: &[&str]) -> Self {
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL);
+        table.set_header(headers.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+        Self {
+            table,
+            headers: headers.iter().map(|s| s.to_string()).collect(),
+            rows: Vec::new(),
+        }
+    }
+
+    /// Add a row of cells to the table.
+    pub fn add_row(&mut self, cells: &[String]) {
+        self.table.add_row(cells.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+        self.rows.push(cells.to_vec());
+    }
+
+    /// Print the table to stdout.
+    pub fn print(&self) {
+        println!("{}", self.table);
+    }
+
+    /// Render the table as CSV.
+    pub fn to_csv(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&self.headers.join(","));
+        out.push('\n');
+        for row in &self.rows {
+            out.push_str(&row.join(","));
+            out.push('\n');
+        }
+        out
+    }
+}

--- a/lib/kvbm-registry/Cargo.toml
+++ b/lib/kvbm-registry/Cargo.toml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "kvbm-registry"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+bincode = { version = "2.0.1", features = ["serde", "derive"] }
+bytes = { workspace = true }
+dashmap = { version = "5.5.3" }
+futures-util = { workspace = true }
+parking_lot = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+velo-transports = { workspace = true }
+
+# ZMQ hub transport (still present in hub_transport.rs from R6)
+tmq = { workspace = true }
+
+[dependencies.kvbm-bench]
+path = "../kvbm-bench"
+optional = true
+
+[dependencies.clap]
+version = "4.5"
+features = ["derive"]
+optional = true
+
+[dependencies.serde_yaml]
+version = "0.9"
+optional = true
+
+[dependencies.serde_json]
+version = "1"
+optional = true
+
+[[bin]]
+name = "bench"
+path = "bin/bench.rs"
+required-features = ["bench"]
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[features]
+bench = ["dep:kvbm-bench", "dep:clap", "dep:serde_yaml", "dep:serde_json"]

--- a/lib/kvbm-registry/src/config.rs
+++ b/lib/kvbm-registry/src/config.rs
@@ -54,7 +54,10 @@ impl Default for RegistryHubConfig {
 impl RegistryHubConfig {
     /// Create a new config with specified capacity.
     pub fn with_capacity(capacity: u64) -> Self {
-        Self { capacity, ..Default::default() }
+        Self {
+            capacity,
+            ..Default::default()
+        }
     }
 
     /// Create config listening on a specific port on all interfaces.
@@ -105,10 +108,13 @@ impl RegistryHubConfig {
 /// ```
 #[derive(Debug, Clone)]
 pub struct RegistryClientConfig {
-    /// Hub address to connect to.
+    /// Hub address to connect to, as a `"host:port"` string.
+    ///
+    /// Stored as a string so that DNS hostnames are accepted. Resolution is
+    /// deferred to connection time via [`std::net::ToSocketAddrs`].
     ///
     /// Example: "192.168.1.100:5555", "leader.local:5555"
-    pub hub_addr: SocketAddr,
+    pub hub_addr: String,
 
     /// Worker rank (0-indexed).
     ///
@@ -150,7 +156,7 @@ pub struct RegistryClientConfig {
 impl Default for RegistryClientConfig {
     fn default() -> Self {
         Self {
-            hub_addr: "127.0.0.1:5555".parse().unwrap(),
+            hub_addr: "127.0.0.1:5555".to_string(),
             rank: None,
             world_size: None,
             namespace: default_namespace(None, None),
@@ -184,12 +190,12 @@ impl RegistryClientConfig {
     }
 
     /// Create config connecting to a specific hub address.
+    ///
+    /// Accepts both IP literals and DNS hostnames. Resolution happens at
+    /// connection time via [`std::net::ToSocketAddrs`].
     pub fn connect_to(hub_host: &str, port: u16) -> Self {
         Self {
-            hub_addr: format!("{hub_host}:{port}").parse().unwrap_or_else(|_| {
-                // Fall back to 127.0.0.1 if the host is not an IP literal
-                format!("127.0.0.1:{port}").parse().unwrap()
-            }),
+            hub_addr: format!("{hub_host}:{port}"),
             ..Default::default()
         }
     }
@@ -209,9 +215,7 @@ impl RegistryClientConfig {
     pub fn from_env() -> Self {
         Self {
             hub_addr: std::env::var("DYN_REGISTRY_CLIENT_ADDR")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or_else(|| "127.0.0.1:5555".parse().unwrap()),
+                .unwrap_or_else(|_| "127.0.0.1:5555".to_string()),
             rank: None,
             world_size: None,
             namespace: std::env::var("DYN_REGISTRY_CLIENT_NAMESPACE")
@@ -260,7 +264,6 @@ impl RegistryClientConfig {
         self.namespace = default_namespace(self.rank, self.world_size);
         self
     }
-
 }
 
 #[cfg(test)]
@@ -289,7 +292,7 @@ mod tests {
     #[test]
     fn test_client_config_default() {
         let config = RegistryClientConfig::default();
-        assert_eq!(config.hub_addr.port(), 5555);
+        assert_eq!(config.hub_addr, "127.0.0.1:5555");
         assert_eq!(config.batch_size, 100);
         assert_eq!(config.batch_timeout, Duration::from_millis(10));
         assert_eq!(config.local_cache_capacity, 0);
@@ -298,13 +301,20 @@ mod tests {
     #[test]
     fn test_client_config_connect_to() {
         let config = RegistryClientConfig::connect_to("127.0.0.1", 6000);
-        assert_eq!(config.hub_addr.port(), 6000);
+        assert_eq!(config.hub_addr, "127.0.0.1:6000");
+    }
+
+    #[test]
+    fn test_client_config_connect_to_hostname() {
+        let config = RegistryClientConfig::connect_to("leader.local", 5555);
+        assert_eq!(config.hub_addr, "leader.local:5555");
     }
 
     #[test]
     fn test_client_config_builder() {
-        let config =
-            RegistryClientConfig::default().with_local_cache(10_000).with_batch_size(50);
+        let config = RegistryClientConfig::default()
+            .with_local_cache(10_000)
+            .with_batch_size(50);
         assert_eq!(config.local_cache_capacity, 10_000);
         assert_eq!(config.batch_size, 50);
     }

--- a/lib/kvbm-registry/src/config.rs
+++ b/lib/kvbm-registry/src/config.rs
@@ -1,0 +1,326 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration types for the distributed registry.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use anyhow::Result;
+
+/// Hub configuration for the registry server.
+///
+/// # Example
+/// ```text
+/// let config = RegistryHubConfig {
+///     capacity: 1_000_000,
+///     addr: "0.0.0.0:5555".parse().unwrap(),
+///     lease_timeout: Duration::from_secs(30),
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct RegistryHubConfig {
+    /// Registry capacity (number of entries).
+    pub capacity: u64,
+
+    /// TCP address to bind on.
+    ///
+    /// All workers connect to this single port; queries and registrations
+    /// are multiplexed over the same connection using frame type tagging.
+    ///
+    /// Example: "0.0.0.0:5555", "127.0.0.1:5555"
+    pub addr: SocketAddr,
+
+    /// Lease timeout for `can_offload` claims.
+    ///
+    /// When a worker calls `can_offload`, it gets exclusive leases on the
+    /// returned hashes. If the worker doesn't call `register` within this
+    /// timeout, the leases expire and other workers can claim them.
+    ///
+    /// Default: 30 seconds
+    pub lease_timeout: Duration,
+}
+
+impl Default for RegistryHubConfig {
+    fn default() -> Self {
+        Self {
+            capacity: 1_000_000,
+            addr: "0.0.0.0:5555".parse().unwrap(),
+            lease_timeout: Duration::from_secs(30),
+        }
+    }
+}
+
+impl RegistryHubConfig {
+    /// Create a new config with specified capacity.
+    pub fn with_capacity(capacity: u64) -> Self {
+        Self { capacity, ..Default::default() }
+    }
+
+    /// Create config listening on a specific port on all interfaces.
+    pub fn on_port(port: u16) -> Self {
+        Self {
+            addr: format!("0.0.0.0:{port}").parse().unwrap(),
+            ..Default::default()
+        }
+    }
+
+    /// Create config from environment variables.
+    ///
+    /// Environment variables:
+    /// - `DYN_REGISTRY_HUB_CAPACITY`: Registry capacity (default: 1000000)
+    /// - `DYN_REGISTRY_HUB_ADDR`: Hub bind address (default: 0.0.0.0:5555)
+    /// - `DYN_REGISTRY_HUB_LEASE_TIMEOUT_SECS`: Lease timeout in seconds (default: 30)
+    pub fn from_env() -> Self {
+        Self {
+            capacity: std::env::var("DYN_REGISTRY_HUB_CAPACITY")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(1_000_000),
+            addr: std::env::var("DYN_REGISTRY_HUB_ADDR")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| "0.0.0.0:5555".parse().unwrap()),
+            lease_timeout: Duration::from_secs(
+                std::env::var("DYN_REGISTRY_HUB_LEASE_TIMEOUT_SECS")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(30),
+            ),
+        }
+    }
+
+    /// Set lease timeout.
+    pub fn with_lease_timeout(mut self, timeout: Duration) -> Self {
+        self.lease_timeout = timeout;
+        self
+    }
+}
+
+/// Client configuration for registry workers.
+///
+/// # Example
+/// ```text
+/// let config = RegistryClientConfig::connect_to("leader.local", 5555);
+/// ```
+#[derive(Debug, Clone)]
+pub struct RegistryClientConfig {
+    /// Hub address to connect to.
+    ///
+    /// Example: "192.168.1.100:5555", "leader.local:5555"
+    pub hub_addr: SocketAddr,
+
+    /// Worker rank (0-indexed).
+    ///
+    /// Used to generate the default namespace if not explicitly set.
+    pub rank: Option<usize>,
+
+    /// Total number of workers.
+    ///
+    /// Used to generate the default namespace if not explicitly set.
+    pub world_size: Option<usize>,
+
+    /// Namespace for this worker's storage.
+    ///
+    /// Used as part of the registry key to enable cross-instance deduplication.
+    /// Can represent a bucket, directory, or any storage-specific identifier.
+    /// If not set, defaults to "worker-{rank}-{world_size}" or "worker-{pid}".
+    /// Example: "worker-0-8", "instance-abc123", "/mnt/cache/worker-0"
+    pub namespace: String,
+
+    /// Batch size for registrations before auto-flush.
+    ///
+    /// Registrations are batched for efficiency. When the batch reaches
+    /// this size, it's automatically sent to the hub.
+    pub batch_size: usize,
+
+    /// Batch timeout before auto-flush.
+    ///
+    /// If a batch has been pending for this duration without reaching
+    /// `batch_size`, it's automatically flushed.
+    pub batch_timeout: Duration,
+
+    /// Optional local cache capacity (0 = disabled).
+    ///
+    /// If > 0, the client maintains a local cache to reduce
+    /// network round-trips for frequently accessed hashes.
+    pub local_cache_capacity: u64,
+}
+
+impl Default for RegistryClientConfig {
+    fn default() -> Self {
+        Self {
+            hub_addr: "127.0.0.1:5555".parse().unwrap(),
+            rank: None,
+            world_size: None,
+            namespace: default_namespace(None, None),
+            batch_size: 100,
+            batch_timeout: Duration::from_millis(10),
+            local_cache_capacity: 0,
+        }
+    }
+}
+
+/// Generate a unique default namespace to prevent accidental cross-worker deduplication.
+///
+/// Format: `worker-{rank}-{world_size}` (e.g., "worker-0-8")
+/// Falls back to `worker-{pid}` if rank/world_size are unavailable.
+fn default_namespace(rank: Option<usize>, world_size: Option<usize>) -> String {
+    match (rank, world_size) {
+        (Some(r), Some(ws)) => format!("worker-{r}-{ws}"),
+        (Some(r), None) => format!("worker-{r}"),
+        _ => format!("worker-{}", std::process::id()),
+    }
+}
+
+impl RegistryClientConfig {
+    /// Check if distributed registry is enabled via environment.
+    ///
+    /// Returns true if `DYN_REGISTRY_ENABLE=1` or `DYN_REGISTRY_ENABLE=true`
+    pub fn is_enabled() -> bool {
+        std::env::var("DYN_REGISTRY_ENABLE")
+            .map(|v| v == "1" || v.to_lowercase() == "true")
+            .unwrap_or(false)
+    }
+
+    /// Create config connecting to a specific hub address.
+    pub fn connect_to(hub_host: &str, port: u16) -> Self {
+        Self {
+            hub_addr: format!("{hub_host}:{port}").parse().unwrap_or_else(|_| {
+                // Fall back to 127.0.0.1 if the host is not an IP literal
+                format!("127.0.0.1:{port}").parse().unwrap()
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// Create config from environment variables.
+    ///
+    /// Environment variables:
+    /// - `DYN_REGISTRY_ENABLE`: Set to "1" or "true" to enable distributed registry
+    /// - `DYN_REGISTRY_CLIENT_ADDR`: Hub address to connect to (default: 127.0.0.1:5555)
+    /// - `DYN_REGISTRY_CLIENT_NAMESPACE`: Namespace identifier (default: "worker-{pid}")
+    /// - `DYN_REGISTRY_CLIENT_BATCH_SIZE`: Batch size (default: 100)
+    /// - `DYN_REGISTRY_CLIENT_BATCH_TIMEOUT_MS`: Batch timeout in ms (default: 10)
+    /// - `DYN_REGISTRY_CLIENT_LOCAL_CACHE`: Local cache capacity (default: 0)
+    ///
+    /// Note: For rank/world_size-based namespaces, use `with_rank_and_world_size()`
+    /// after calling `from_env()`.
+    pub fn from_env() -> Self {
+        Self {
+            hub_addr: std::env::var("DYN_REGISTRY_CLIENT_ADDR")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| "127.0.0.1:5555".parse().unwrap()),
+            rank: None,
+            world_size: None,
+            namespace: std::env::var("DYN_REGISTRY_CLIENT_NAMESPACE")
+                .unwrap_or_else(|_| default_namespace(None, None)),
+            batch_size: std::env::var("DYN_REGISTRY_CLIENT_BATCH_SIZE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(100),
+            batch_timeout: Duration::from_millis(
+                std::env::var("DYN_REGISTRY_CLIENT_BATCH_TIMEOUT_MS")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(10),
+            ),
+            local_cache_capacity: std::env::var("DYN_REGISTRY_CLIENT_LOCAL_CACHE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0),
+        }
+    }
+
+    /// Enable local caching with specified capacity.
+    pub fn with_local_cache(mut self, capacity: u64) -> Self {
+        self.local_cache_capacity = capacity;
+        self
+    }
+
+    /// Set batch size.
+    pub fn with_batch_size(mut self, size: usize) -> Self {
+        self.batch_size = size;
+        self
+    }
+
+    /// Set namespace explicitly.
+    pub fn with_namespace(mut self, namespace: impl Into<String>) -> Self {
+        self.namespace = namespace.into();
+        self
+    }
+
+    /// Set rank and world size, updating the namespace accordingly.
+    ///
+    /// This generates a namespace of the form "worker-{rank}-{world_size}".
+    pub fn with_rank_and_world_size(mut self, rank: usize, world_size: usize) -> Self {
+        self.rank = Some(rank);
+        self.world_size = Some(world_size);
+        self.namespace = default_namespace(self.rank, self.world_size);
+        self
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hub_config_default() {
+        let config = RegistryHubConfig::default();
+        assert_eq!(config.capacity, 1_000_000);
+        assert_eq!(config.addr.port(), 5555);
+    }
+
+    #[test]
+    fn test_hub_config_with_capacity() {
+        let config = RegistryHubConfig::with_capacity(500_000);
+        assert_eq!(config.capacity, 500_000);
+    }
+
+    #[test]
+    fn test_hub_config_on_port() {
+        let config = RegistryHubConfig::on_port(6000);
+        assert_eq!(config.addr.port(), 6000);
+    }
+
+    #[test]
+    fn test_client_config_default() {
+        let config = RegistryClientConfig::default();
+        assert_eq!(config.hub_addr.port(), 5555);
+        assert_eq!(config.batch_size, 100);
+        assert_eq!(config.batch_timeout, Duration::from_millis(10));
+        assert_eq!(config.local_cache_capacity, 0);
+    }
+
+    #[test]
+    fn test_client_config_connect_to() {
+        let config = RegistryClientConfig::connect_to("127.0.0.1", 6000);
+        assert_eq!(config.hub_addr.port(), 6000);
+    }
+
+    #[test]
+    fn test_client_config_builder() {
+        let config =
+            RegistryClientConfig::default().with_local_cache(10_000).with_batch_size(50);
+        assert_eq!(config.local_cache_capacity, 10_000);
+        assert_eq!(config.batch_size, 50);
+    }
+
+    #[test]
+    fn test_client_config_with_rank_and_world_size() {
+        let config = RegistryClientConfig::default().with_rank_and_world_size(3, 8);
+        assert_eq!(config.rank, Some(3));
+        assert_eq!(config.world_size, Some(8));
+        assert_eq!(config.namespace, "worker-3-8");
+    }
+
+    #[test]
+    fn test_default_namespace_fallback() {
+        let config = RegistryClientConfig::default();
+        assert!(config.namespace.starts_with("worker-"));
+        assert!(config.namespace.contains(&std::process::id().to_string()));
+    }
+}

--- a/lib/kvbm-registry/src/core/mod.rs
+++ b/lib/kvbm-registry/src/core/mod.rs
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Core traits and types for the pluggable registry architecture.

--- a/lib/kvbm-registry/src/lib.rs
+++ b/lib/kvbm-registry/src/lib.rs
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod config;
+pub mod core;
+
+pub use config::{RegistryClientConfig, RegistryHubConfig};
+pub use core::*;


### PR DESCRIPTION
#### Overview:

Introduces two new crates:
- `kvbm-bench`: shared benchmark infrastructure (LatencyStats, SweepRunner, BenchTable, sysinfo, OutputFormat)
- `kvbm-registry`: standalone distributed KV block registry (scaffold only)

The registry code will be added in subsequent commits (R1-R8).

**Part of chain:** R0 → R1 → R2 → R3 → R4 → R5 → R6 → R7 → R8

#### Details:

- `lib/kvbm-bench/Cargo.toml` + `src/`: latency stats, sweep runner, table output, sysinfo (RSS + CPU via `/proc/self/status`)
- `lib/kvbm-registry/Cargo.toml` + `src/lib.rs` + `src/config.rs`: crate skeleton with `RegistryHubConfig` / `RegistryClientConfig`
- `Cargo.toml`: adds both crates to workspace members and `[workspace.dependencies]`

#### Where should the reviewer start?

Start with `lib/kvbm-registry/Cargo.toml` for the dependency graph, then `lib/kvbm-bench/src/lib.rs` for the bench crate surface.

#### Related Issues:

- Relates to kvbm distributed registry chain (R0/8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmarking infrastructure: Comprehensive latency profiling with percentile calculations, automatic system information gathering (CPU details, memory usage, OS info), parameter sweep configuration, and flexible result formatting (table, CSV, JSON)
  * Registry framework: Distributed registry system with configurable hub and client support, batch processing, namespace management, and caching capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->