### PR TITLE
feat: kvbm-registry events and lease management

### DIFF
--- a/lib/kvbm-registry/src/core/events.rs
+++ b/lib/kvbm-registry/src/core/events.rs
@@ -1,0 +1,411 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Event bus infrastructure for registry events.
+//!
+//! Provides a pub/sub event system for broadcasting cache events to workers
+//! and interested components. Events are fire-and-forget, enabling real-time
+//! coordination across the cluster.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────────────┐
+//! │                         DISTRIBUTED EVENT BUS                                │
+//! │                                                                              │
+//! │   Pluggable Backends:  InProcess │ ZMQ PUB/SUB │ NATS │ Redis │ etc.        │
+//! └─────────────────────────────────────────────────────────────────────────────┘
+//!          ▲              ▲              ▲              ▲              ▲
+//!          │              │              │              │              │
+//!     ┌────┴────┐    ┌────┴────┐    ┌────┴────┐    ┌────┴────┐    ┌────┴────┐
+//!     │Worker 1 │    │Worker 2 │    │Worker 3 │    │Registry │    │ Metrics │
+//!     │ emit()  │    │ emit()  │    │ emit()  │    │   Hub   │    │ Service │
+//!     │on_event │    │on_event │    │on_event │    │on_event │    │on_event │
+//!     └─────────┘    └─────────┘    └─────────┘    └─────────┘    └─────────┘
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+/// Topic/channel for event routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EventTopic {
+    /// Cache hit/miss events (for eviction decisions)
+    CacheAccess,
+    /// Block lifecycle events (offload, evict, invalidate)
+    BlockLifecycle,
+    /// Cluster membership changes
+    ClusterMembership,
+    /// Metrics and telemetry
+    Metrics,
+}
+
+/// Storage tier for events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum StorageTier {
+    /// G1 - GPU memory
+    Device = 0,
+    /// G2 - CPU pinned memory
+    Host = 1,
+    /// G3 - Local disk
+    Disk = 2,
+    /// G4 - Remote storage (object/shared disk)
+    Remote = 3,
+}
+
+/// Remote storage type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum StorageType {
+    Object,
+    Disk,
+}
+
+/// Reason for eviction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EvictionReason {
+    /// Hit capacity limit
+    Capacity,
+    /// Least recently used
+    Lru,
+    /// Least frequently used
+    Lfu,
+    /// Explicit eviction request
+    Manual,
+    /// Worker shutting down
+    Shutdown,
+}
+
+/// Core event types - extensible with #[non_exhaustive].
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RegistryEvent {
+    // ═══════════════════════════════════════════════════════════════════
+    // CACHE ACCESS EVENTS (Topic: CacheAccess)
+    // ═══════════════════════════════════════════════════════════════════
+    /// Cache hit - block was found and used
+    CacheHit {
+        sequence_hashes: Vec<u64>,
+        tier: StorageTier,
+        worker_id: u64,
+        timestamp_ms: u64,
+    },
+
+    /// Cache miss - block was not found
+    CacheMiss {
+        sequence_hashes: Vec<u64>,
+        tier: StorageTier,
+        worker_id: u64,
+    },
+
+    // ═══════════════════════════════════════════════════════════════════
+    // BLOCK LIFECYCLE EVENTS (Topic: BlockLifecycle)
+    // ═══════════════════════════════════════════════════════════════════
+    /// Blocks offloaded to remote storage
+    BlocksOffloaded {
+        sequence_hashes: Vec<u64>,
+        storage_type: StorageType,
+        location: String,
+        worker_id: u64,
+    },
+
+    /// Blocks onboarded from remote storage
+    BlocksOnboarded {
+        sequence_hashes: Vec<u64>,
+        storage_type: StorageType,
+        location: String,
+        worker_id: u64,
+    },
+
+    /// Blocks evicted from a tier
+    BlocksEvicted {
+        sequence_hashes: Vec<u64>,
+        tier: StorageTier,
+        worker_id: u64,
+        reason: EvictionReason,
+    },
+
+    /// Blocks invalidated (e.g., NoSuchKey error)
+    BlocksInvalidated {
+        sequence_hashes: Vec<u64>,
+        reason: String,
+        worker_id: u64,
+    },
+
+    // ═══════════════════════════════════════════════════════════════════
+    // CLUSTER EVENTS (Topic: ClusterMembership)
+    // ═══════════════════════════════════════════════════════════════════
+    /// Worker joined the cluster
+    WorkerJoined { worker_id: u64 },
+
+    /// Worker left the cluster
+    WorkerLeft { worker_id: u64, graceful: bool },
+}
+
+impl RegistryEvent {
+    /// Get the topic for this event.
+    pub fn topic(&self) -> EventTopic {
+        match self {
+            RegistryEvent::CacheHit { .. } | RegistryEvent::CacheMiss { .. } => {
+                EventTopic::CacheAccess
+            }
+            RegistryEvent::BlocksOffloaded { .. }
+            | RegistryEvent::BlocksOnboarded { .. }
+            | RegistryEvent::BlocksEvicted { .. }
+            | RegistryEvent::BlocksInvalidated { .. } => EventTopic::BlockLifecycle,
+            RegistryEvent::WorkerJoined { .. } | RegistryEvent::WorkerLeft { .. } => {
+                EventTopic::ClusterMembership
+            }
+        }
+    }
+
+    /// Get current timestamp in milliseconds.
+    pub fn now_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+    }
+}
+
+/// Trait for event bus implementations.
+#[async_trait]
+pub trait EventBus: Send + Sync {
+    /// Publish an event (fire-and-forget).
+    async fn publish(&self, event: RegistryEvent) -> Result<()>;
+
+    /// Subscribe to events on a topic.
+    fn subscribe(&self, topic: EventTopic) -> EventReceiver;
+
+    /// Batch publish for efficiency.
+    async fn publish_batch(&self, events: Vec<RegistryEvent>) -> Result<()> {
+        for event in events {
+            self.publish(event).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Event receiver for subscriptions.
+pub type EventReceiver = broadcast::Receiver<RegistryEvent>;
+
+/// In-process event bus implementation.
+///
+/// Uses tokio broadcast channels for zero-copy event distribution.
+/// Suitable for single-node deployments or testing.
+pub struct InProcessEventBus {
+    channels: RwLock<HashMap<EventTopic, broadcast::Sender<RegistryEvent>>>,
+    channel_capacity: usize,
+}
+
+impl InProcessEventBus {
+    /// Create a new in-process event bus.
+    pub fn new(channel_capacity: usize) -> Self {
+        Self {
+            channels: RwLock::new(HashMap::new()),
+            channel_capacity,
+        }
+    }
+
+    fn get_or_create_channel(&self, topic: EventTopic) -> broadcast::Sender<RegistryEvent> {
+        {
+            let channels = self.channels.read();
+            if let Some(sender) = channels.get(&topic) {
+                return sender.clone();
+            }
+        }
+
+        let mut channels = self.channels.write();
+        channels
+            .entry(topic)
+            .or_insert_with(|| broadcast::channel(self.channel_capacity).0)
+            .clone()
+    }
+}
+
+impl Default for InProcessEventBus {
+    fn default() -> Self {
+        Self::new(1024)
+    }
+}
+
+#[async_trait]
+impl EventBus for InProcessEventBus {
+    async fn publish(&self, event: RegistryEvent) -> Result<()> {
+        let topic = event.topic();
+        let sender = self.get_or_create_channel(topic);
+        // Ignore send errors (no subscribers is fine for fire-and-forget)
+        let _ = sender.send(event);
+        Ok(())
+    }
+
+    fn subscribe(&self, topic: EventTopic) -> EventReceiver {
+        let sender = self.get_or_create_channel(topic);
+        sender.subscribe()
+    }
+}
+
+/// Event handler trait for processing received events.
+#[async_trait]
+pub trait EventHandler: Send + Sync {
+    /// Handle a received event.
+    async fn on_event(&self, event: RegistryEvent) -> Result<()>;
+}
+
+/// Spawn a background task to process events from a subscription.
+pub fn spawn_event_handler<H: EventHandler + 'static>(
+    mut receiver: EventReceiver,
+    handler: Arc<H>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match receiver.recv().await {
+                Ok(event) => {
+                    if let Err(e) = handler.on_event(event).await {
+                        tracing::warn!(error = %e, "Event handler error");
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(skipped = n, "Event handler lagged, skipped events");
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    tracing::debug!("Event channel closed, handler shutting down");
+                    break;
+                }
+            }
+        }
+    })
+}
+
+/// Configuration for the event bus.
+#[derive(Debug, Clone)]
+pub struct EventBusConfig {
+    /// Backend type: "in_process", "zmq", "nats", "redis"
+    pub backend: String,
+    /// Channel capacity for in-process bus
+    pub channel_capacity: usize,
+    /// Connection URL (for network backends)
+    pub url: Option<String>,
+}
+
+impl Default for EventBusConfig {
+    fn default() -> Self {
+        Self {
+            backend: "in_process".to_string(),
+            channel_capacity: 1024,
+            url: None,
+        }
+    }
+}
+
+impl EventBusConfig {
+    /// Create from environment variables.
+    ///
+    /// Environment variables:
+    /// - `DYN_EVENT_BUS_BACKEND`: "in_process", "zmq", "nats", "redis"
+    /// - `DYN_EVENT_BUS_CAPACITY`: Channel capacity (default: 1024)
+    /// - `DYN_EVENT_BUS_URL`: Connection URL for network backends
+    pub fn from_env() -> Self {
+        let backend =
+            std::env::var("DYN_EVENT_BUS_BACKEND").unwrap_or_else(|_| "in_process".to_string());
+
+        let channel_capacity = std::env::var("DYN_EVENT_BUS_CAPACITY")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1024);
+
+        let url = std::env::var("DYN_EVENT_BUS_URL").ok();
+
+        Self {
+            backend,
+            channel_capacity,
+            url,
+        }
+    }
+
+    /// Build an event bus from this configuration.
+    pub fn build(&self) -> Box<dyn EventBus> {
+        // Future: Add ZMQ, NATS, Redis backends based on self.backend
+        let _ = self.backend.as_str(); // Reserved for future backend selection
+        Box::new(InProcessEventBus::new(self.channel_capacity))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[tokio::test]
+    async fn test_in_process_event_bus() {
+        let bus = InProcessEventBus::new(100);
+
+        // Subscribe before publishing
+        let mut receiver = bus.subscribe(EventTopic::CacheAccess);
+
+        // Publish event
+        let event = RegistryEvent::CacheHit {
+            sequence_hashes: vec![1, 2, 3],
+            tier: StorageTier::Host,
+            worker_id: 0,
+            timestamp_ms: RegistryEvent::now_ms(),
+        };
+        bus.publish(event.clone()).await.unwrap();
+
+        // Receive event
+        let received = receiver.recv().await.unwrap();
+        match received {
+            RegistryEvent::CacheHit {
+                sequence_hashes, ..
+            } => {
+                assert_eq!(sequence_hashes, vec![1, 2, 3]);
+            }
+            _ => panic!("Wrong event type"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_event_handler() {
+        struct TestHandler {
+            count: AtomicU64,
+        }
+
+        #[async_trait]
+        impl EventHandler for TestHandler {
+            async fn on_event(&self, _event: RegistryEvent) -> Result<()> {
+                self.count.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+        }
+
+        let bus = InProcessEventBus::new(100);
+        let handler = Arc::new(TestHandler {
+            count: AtomicU64::new(0),
+        });
+
+        let receiver = bus.subscribe(EventTopic::CacheAccess);
+        let _task = spawn_event_handler(receiver, handler.clone());
+
+        // Publish events
+        for i in 0..5 {
+            bus.publish(RegistryEvent::CacheHit {
+                sequence_hashes: vec![i],
+                tier: StorageTier::Host,
+                worker_id: 0,
+                timestamp_ms: RegistryEvent::now_ms(),
+            })
+            .await
+            .unwrap();
+        }
+
+        // Give handler time to process
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        assert_eq!(handler.count.load(Ordering::Relaxed), 5);
+    }
+}

--- a/lib/kvbm-registry/src/core/events.rs
+++ b/lib/kvbm-registry/src/core/events.rs
@@ -329,9 +329,10 @@ impl EventBusConfig {
     }
 
     /// Build an event bus from this configuration.
+    ///
+    /// Currently always returns an [`InProcessEventBus`].
+    /// Future backends (ZMQ, NATS, Redis) will be selected via `self.backend`.
     pub fn build(&self) -> Box<dyn EventBus> {
-        // Future: Add ZMQ, NATS, Redis backends based on self.backend
-        let _ = self.backend.as_str(); // Reserved for future backend selection
         Box::new(InProcessEventBus::new(self.channel_capacity))
     }
 }

--- a/lib/kvbm-registry/src/core/lease.rs
+++ b/lib/kvbm-registry/src/core/lease.rs
@@ -1,0 +1,336 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lease management for preventing duplicate storage.
+//!
+//! When a client requests to offload keys, they receive leases that grant
+//! exclusive rights to store those keys. Other clients see `Leased` status
+//! until the lease expires or the key is registered.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use parking_lot::RwLock;
+use tracing::debug;
+
+/// Information about an active lease.
+#[derive(Debug, Clone)]
+pub struct LeaseInfo {
+    /// Client that holds the lease.
+    pub client_id: u64,
+    /// When the lease was granted.
+    pub granted_at: Instant,
+    /// When the lease expires.
+    pub expires_at: Instant,
+}
+
+impl LeaseInfo {
+    /// Check if the lease has expired.
+    pub fn is_expired(&self) -> bool {
+        Instant::now() >= self.expires_at
+    }
+
+    /// Get remaining time until expiration.
+    pub fn remaining(&self) -> Duration {
+        self.expires_at.saturating_duration_since(Instant::now())
+    }
+}
+
+/// Manages leases for registry keys.
+///
+/// Leases prevent race conditions where multiple workers try to store
+/// the same block simultaneously. When a client calls `can_offload`,
+/// they receive a lease granting exclusive rights to store the key.
+///
+/// # Lease Lifecycle
+///
+/// 1. Client calls `can_offload([k1, k2, k3])`
+/// 2. Hub grants leases for keys not already stored/leased
+/// 3. Client stores the blocks to object storage
+/// 4. Client calls `register([k1, k2, k3])` to convert leases to entries
+/// 5. If client crashes, leases expire after TTL
+///
+/// # Thread Safety
+///
+/// The lease manager uses `RwLock` for concurrent access from multiple
+/// hub tasks.
+pub struct LeaseManager<K>
+where
+    K: Eq + Hash + Clone,
+{
+    /// Active leases: key -> lease info
+    leases: RwLock<HashMap<K, LeaseInfo>>,
+    /// Default lease duration
+    lease_ttl: Duration,
+    /// Counter for generating unique client IDs
+    client_counter: AtomicU64,
+    /// Statistics
+    leases_granted: AtomicU64,
+    leases_expired: AtomicU64,
+    leases_converted: AtomicU64,
+}
+
+impl<K> LeaseManager<K>
+where
+    K: Eq + Hash + Clone,
+{
+    /// Create a new lease manager with the given TTL.
+    pub fn new(lease_ttl: Duration) -> Self {
+        Self {
+            leases: RwLock::new(HashMap::new()),
+            lease_ttl,
+            client_counter: AtomicU64::new(1),
+            leases_granted: AtomicU64::new(0),
+            leases_expired: AtomicU64::new(0),
+            leases_converted: AtomicU64::new(0),
+        }
+    }
+
+    /// Create with default TTL of 30 seconds.
+    pub fn with_default_ttl() -> Self {
+        Self::new(Duration::from_secs(30))
+    }
+
+    /// Generate a unique client ID.
+    pub fn next_client_id(&self) -> u64 {
+        self.client_counter.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Try to acquire a lease for a key.
+    ///
+    /// Returns `Some(lease_info)` if the lease was granted,
+    /// `None` if the key is already leased by another client.
+    pub fn try_acquire(&self, key: K, client_id: u64) -> Option<LeaseInfo> {
+        let now = Instant::now();
+        let mut leases = self.leases.write();
+
+        // Check if there's an existing lease
+        if let Some(existing) = leases.get(&key)
+            && !existing.is_expired()
+            && existing.client_id != client_id
+        {
+            // Another client holds an active lease
+            return None;
+        }
+
+        let info = LeaseInfo {
+            client_id,
+            granted_at: now,
+            expires_at: now + self.lease_ttl,
+        };
+
+        leases.insert(key, info.clone());
+        self.leases_granted.fetch_add(1, Ordering::Relaxed);
+        Some(info)
+    }
+
+    /// Check if a key is currently leased (and not expired).
+    pub fn is_leased(&self, key: &K) -> bool {
+        let leases = self.leases.read();
+        leases.get(key).map(|l| !l.is_expired()).unwrap_or(false)
+    }
+
+    /// Check if a key is leased by a specific client.
+    pub fn is_leased_by(&self, key: &K, client_id: u64) -> bool {
+        let leases = self.leases.read();
+        leases
+            .get(key)
+            .map(|l| !l.is_expired() && l.client_id == client_id)
+            .unwrap_or(false)
+    }
+
+    /// Get lease info for a key.
+    pub fn get_lease(&self, key: &K) -> Option<LeaseInfo> {
+        let leases = self.leases.read();
+        leases.get(key).filter(|l| !l.is_expired()).cloned()
+    }
+
+    /// Release a lease (called when registration completes).
+    ///
+    /// Returns true if the lease was released.
+    pub fn release(&self, key: &K) -> bool {
+        let mut leases = self.leases.write();
+        if leases.remove(key).is_some() {
+            self.leases_converted.fetch_add(1, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Release multiple leases.
+    pub fn release_many(&self, keys: &[K]) {
+        let mut leases = self.leases.write();
+        for key in keys {
+            if leases.remove(key).is_some() {
+                self.leases_converted.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Clean up expired leases.
+    ///
+    /// Returns the number of leases that were expired.
+    pub fn cleanup_expired(&self) -> usize {
+        let mut leases = self.leases.write();
+        let before = leases.len();
+        leases.retain(|_, info| !info.is_expired());
+        let expired = before - leases.len();
+        self.leases_expired
+            .fetch_add(expired as u64, Ordering::Relaxed);
+        expired
+    }
+
+    /// Get the number of active leases.
+    pub fn active_count(&self) -> usize {
+        let leases = self.leases.read();
+        leases.values().filter(|l| !l.is_expired()).count()
+    }
+
+    /// Get the total number of leases (including potentially expired).
+    pub fn total_count(&self) -> usize {
+        self.leases.read().len()
+    }
+
+    /// Get lease statistics.
+    pub fn stats(&self) -> LeaseStats {
+        LeaseStats {
+            active: self.active_count(),
+            granted: self.leases_granted.load(Ordering::Relaxed),
+            expired: self.leases_expired.load(Ordering::Relaxed),
+            converted: self.leases_converted.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Get the lease TTL.
+    pub fn ttl(&self) -> Duration {
+        self.lease_ttl
+    }
+}
+
+/// Statistics about lease activity.
+#[derive(Debug, Clone, Default)]
+pub struct LeaseStats {
+    /// Currently active leases.
+    pub active: usize,
+    /// Total leases granted.
+    pub granted: u64,
+    /// Leases that expired without registration.
+    pub expired: u64,
+    /// Leases converted to stored entries.
+    pub converted: u64,
+}
+
+/// Background task that periodically cleans up expired leases.
+pub async fn lease_cleanup_task<K>(
+    manager: std::sync::Arc<LeaseManager<K>>,
+    interval: Duration,
+    cancel: tokio_util::sync::CancellationToken,
+) where
+    K: Eq + Hash + Clone + Send + Sync + 'static,
+{
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                debug!("Lease cleanup task shutting down");
+                break;
+            }
+            _ = ticker.tick() => {
+                let expired = manager.cleanup_expired();
+                if expired > 0 {
+                    debug!(expired, active = manager.active_count(), "Cleaned up expired leases");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_acquire_lease() {
+        let manager = LeaseManager::<u64>::new(Duration::from_secs(30));
+
+        // First client can acquire
+        let lease = manager.try_acquire(1, 100);
+        assert!(lease.is_some());
+        assert!(manager.is_leased(&1));
+        assert!(manager.is_leased_by(&1, 100));
+
+        // Same client can re-acquire (refresh)
+        let lease2 = manager.try_acquire(1, 100);
+        assert!(lease2.is_some());
+
+        // Different client cannot acquire
+        let lease3 = manager.try_acquire(1, 200);
+        assert!(lease3.is_none());
+    }
+
+    #[test]
+    fn test_lease_expiration() {
+        let manager = LeaseManager::<u64>::new(Duration::from_millis(10));
+
+        // Acquire lease
+        let _lease = manager.try_acquire(1, 100);
+        assert!(manager.is_leased(&1));
+
+        // Wait for expiration
+        std::thread::sleep(Duration::from_millis(20));
+
+        // Lease should be expired
+        assert!(!manager.is_leased(&1));
+
+        // Another client can now acquire
+        let lease2 = manager.try_acquire(1, 200);
+        assert!(lease2.is_some());
+    }
+
+    #[test]
+    fn test_release_lease() {
+        let manager = LeaseManager::<u64>::new(Duration::from_secs(30));
+
+        manager.try_acquire(1, 100);
+        assert!(manager.is_leased(&1));
+
+        manager.release(&1);
+        assert!(!manager.is_leased(&1));
+    }
+
+    #[test]
+    fn test_cleanup_expired() {
+        let manager = LeaseManager::<u64>::new(Duration::from_millis(10));
+
+        manager.try_acquire(1, 100);
+        manager.try_acquire(2, 100);
+        manager.try_acquire(3, 100);
+
+        assert_eq!(manager.total_count(), 3);
+
+        std::thread::sleep(Duration::from_millis(20));
+
+        let expired = manager.cleanup_expired();
+        assert_eq!(expired, 3);
+        assert_eq!(manager.total_count(), 0);
+    }
+
+    #[test]
+    fn test_stats() {
+        let manager = LeaseManager::<u64>::new(Duration::from_secs(30));
+
+        manager.try_acquire(1, 100);
+        manager.try_acquire(2, 100);
+        manager.release(&1);
+
+        let stats = manager.stats();
+        assert_eq!(stats.granted, 2);
+        assert_eq!(stats.converted, 1);
+        assert_eq!(stats.active, 1);
+    }
+}

--- a/lib/kvbm-registry/src/core/mod.rs
+++ b/lib/kvbm-registry/src/core/mod.rs
@@ -4,7 +4,9 @@
 //! Core traits and types for the pluggable registry architecture.
 
 pub mod error;
+pub mod events;
 pub mod key;
+pub mod lease;
 pub mod metadata;
 pub mod storage;
 pub mod transport;
@@ -12,6 +14,9 @@ pub mod value;
 
 // Error types
 pub use error::{RegistryError, RegistryResult};
+
+// Lease management
+pub use lease::{LeaseInfo, LeaseManager};
 
 // Storage
 pub use storage::{FlatStorage, HashMapStorage, PositionalStorageKey, RadixStorage, Storage};
@@ -23,3 +28,9 @@ pub use value::{RegistryValue, StorageBackend, StorageLocation};
 
 // Transport
 pub use transport::{InProcessHub, InProcessTransport, RegistryTransport};
+
+// Event Bus
+pub use events::{
+    EventBus, EventBusConfig, EventHandler, EventReceiver, EventTopic, EvictionReason,
+    InProcessEventBus, RegistryEvent, StorageTier, StorageType,
+};


### PR DESCRIPTION
#### Overview:

Adds time-based ownership and change notification to the registry:
- `EventBus<E>` with tokio broadcast channels for registry change events
- `LeaseManager<K>` with per-key TTL, heartbeat renewal, and background expiry

Both are consumed by the hub in R6.

**Part of chain:** R0 → R1 → **R2** → R3 → R4 → R5 → R6 → R7 → R8

#### Details:

- `src/core/events.rs`: `RegistryEvent<K,V,M>` enum; `EventBus<E>` with `subscribe()` / `publish()`
- `src/core/lease.rs`: `LeaseManager<K>`, `LeaseConfig` (ttl_secs, heartbeat_interval), background expiry task

#### Where should the reviewer start?

Start with `src/core/events.rs` (`EventBus`) then `src/core/lease.rs` (`LeaseManager`).

#### Related Issues:

- Relates to kvbm distributed registry chain (R2/8)