### PR TITLE
feat: kvbm-registry client, builder, and integration tests

### DIFF
--- a/lib/kvbm-registry/src/core/builder.rs
+++ b/lib/kvbm-registry/src/core/builder.rs
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Builder patterns for registry components.
+//!
+//! Provides ergonomic construction of registry clients and hubs with
+//! sensible defaults and fluent configuration.
+
+use std::marker::PhantomData;
+use std::time::Duration;
+
+use anyhow::Result;
+
+use super::codec::{BinaryCodec, RegistryCodec};
+use super::hub::RegistryHub;
+use super::hub_transport::HubTransport;
+use super::key::RegistryKey;
+use super::metadata::RegistryMetadata;
+use super::registry::RegistryClient;
+use super::storage::Storage;
+use super::transport::RegistryTransport;
+use super::value::RegistryValue;
+
+/// Builder for constructing a `RegistryClient`.
+///
+/// # Example
+///
+/// ```text
+/// let client = ClientBuilder::new(transport, BinaryCodec::new())
+///     .batch_size(50)
+///     .batch_timeout(Duration::from_millis(20))
+///     .build();
+/// ```
+pub struct ClientBuilder<K, V, M, T, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+    C: RegistryCodec<K, V, M>,
+{
+    transport: T,
+    codec: C,
+    batch_size: usize,
+    batch_timeout: Duration,
+    _phantom: PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M, T, C> ClientBuilder<K, V, M, T, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+    C: RegistryCodec<K, V, M>,
+{
+    /// Create a new client builder with the given transport and codec.
+    pub fn new(transport: T, codec: C) -> Self {
+        Self {
+            transport,
+            codec,
+            batch_size: 100,
+            batch_timeout: Duration::from_millis(10),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Set the batch size for registrations.
+    ///
+    /// When this many registrations are pending, they are automatically flushed.
+    /// Default: 100
+    pub fn batch_size(mut self, size: usize) -> Self {
+        self.batch_size = size;
+        self
+    }
+
+    /// Set the batch timeout for registrations.
+    ///
+    /// Pending registrations are flushed after this duration even if
+    /// the batch size hasn't been reached. Default: 10ms
+    pub fn batch_timeout(mut self, timeout: Duration) -> Self {
+        self.batch_timeout = timeout;
+        self
+    }
+
+    /// Build the registry client.
+    pub fn build(self) -> RegistryClient<K, V, M, T, C> {
+        RegistryClient::new(self.transport, self.codec)
+            .with_batch_size(self.batch_size)
+            .with_batch_timeout(self.batch_timeout)
+    }
+}
+
+/// Builder for constructing a `RegistryHub`.
+///
+/// # Example
+///
+/// ```text
+/// let hub = HubBuilder::new(storage, BinaryCodec::new())
+///     .lease_ttl(Duration::from_secs(60))
+///     .build();
+/// ```
+pub struct HubBuilder<K, V, M, S, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    S: Storage<K, V>,
+    C: RegistryCodec<K, V, M>,
+{
+    storage: S,
+    codec: C,
+    lease_ttl: Duration,
+    lease_cleanup_interval: Duration,
+    _phantom: PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M, S, C> HubBuilder<K, V, M, S, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    S: Storage<K, V>,
+    C: RegistryCodec<K, V, M>,
+{
+    /// Create a new hub builder with the given storage and codec.
+    pub fn new(storage: S, codec: C) -> Self {
+        Self {
+            storage,
+            codec,
+            lease_ttl: Duration::from_secs(30),
+            lease_cleanup_interval: Duration::from_secs(5),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Set the lease TTL for can_offload claims.
+    ///
+    /// Leases expire after this duration if not converted to registrations.
+    /// Default: 30 seconds
+    pub fn lease_ttl(mut self, ttl: Duration) -> Self {
+        self.lease_ttl = ttl;
+        self
+    }
+
+    /// Set the lease cleanup interval.
+    ///
+    /// Expired leases are cleaned up at this interval.
+    /// Default: 5 seconds
+    pub fn lease_cleanup_interval(mut self, interval: Duration) -> Self {
+        self.lease_cleanup_interval = interval;
+        self
+    }
+
+    /// Build the registry hub.
+    pub fn build(self) -> RegistryHub<K, V, M, S, C> {
+        use super::hub::HubConfig;
+        let config = HubConfig {
+            lease_ttl: self.lease_ttl,
+            lease_cleanup_interval: self.lease_cleanup_interval,
+        };
+        RegistryHub::with_config(self.storage, self.codec, config)
+    }
+
+    /// Build and serve the hub with the given transport.
+    ///
+    /// This consumes the builder and starts serving requests.
+    pub async fn serve<T: HubTransport>(self, transport: &mut T) -> Result<()> {
+        let hub = self.build();
+        hub.serve(transport).await
+    }
+}
+
+/// Convenience function to create a client builder with binary codec.
+///
+/// # Example
+///
+/// ```text
+/// let client = client(transport)
+///     .batch_size(50)
+///     .build();
+/// ```
+pub fn client<K, V, M, T>(transport: T) -> ClientBuilder<K, V, M, T, BinaryCodec<K, V, M>>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+{
+    ClientBuilder::new(transport, BinaryCodec::new())
+}
+
+/// Convenience function to create a hub builder with binary codec.
+///
+/// # Example
+///
+/// ```text
+/// let hub = hub(storage)
+///     .lease_ttl(Duration::from_secs(60))
+///     .build();
+/// ```
+pub fn hub<K, V, M, S>(storage: S) -> HubBuilder<K, V, M, S, BinaryCodec<K, V, M>>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    S: Storage<K, V>,
+{
+    HubBuilder::new(storage, BinaryCodec::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{
+        HashMapStorage, InProcessTransport, NoMetadata, OffloadStatus, QueryType, Registry,
+        ResponseType,
+    };
+
+    #[tokio::test]
+    async fn test_client_builder() {
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        let (transport, _rx) = InProcessTransport::new(move |data| {
+            let query = codec.decode_query(data);
+            match query {
+                Some(QueryType::CanOffload(keys)) => {
+                    let statuses: Vec<_> = keys.iter().map(|_| OffloadStatus::Granted).collect();
+                    let mut buf = Vec::new();
+                    codec
+                        .encode_response(&ResponseType::CanOffload(statuses), &mut buf)
+                        .unwrap();
+                    buf
+                }
+                _ => Vec::new(),
+            }
+        });
+
+        let built_client: RegistryClient<u64, u64, NoMetadata, _, _> = client(transport)
+            .batch_size(50)
+            .batch_timeout(Duration::from_millis(20))
+            .build();
+
+        let result = built_client.can_offload(&[1, 2, 3]).await.unwrap();
+        assert_eq!(result.can_offload.len(), 3);
+    }
+
+    #[test]
+    fn test_hub_builder() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+
+        let built_hub: RegistryHub<u64, u64, NoMetadata, _, _> = hub(storage)
+            .lease_ttl(Duration::from_secs(60))
+            .lease_cleanup_interval(Duration::from_secs(10))
+            .build();
+
+        assert!(built_hub.is_empty());
+
+        // Verify lease TTL was set
+        assert_eq!(built_hub.lease_manager().ttl(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_builder_with_custom_codec() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        let built_hub = HubBuilder::new(storage, codec)
+            .lease_ttl(Duration::from_secs(120))
+            .build();
+
+        assert_eq!(built_hub.lease_manager().ttl(), Duration::from_secs(120));
+    }
+}

--- a/lib/kvbm-registry/src/core/mod.rs
+++ b/lib/kvbm-registry/src/core/mod.rs
@@ -3,6 +3,7 @@
 
 //! Core traits and types for the pluggable registry architecture.
 
+pub mod builder;
 pub mod codec;
 pub mod error;
 pub mod events;
@@ -13,9 +14,13 @@ pub mod key;
 pub mod lease;
 pub mod metadata;
 pub mod metrics;
+pub mod registry;
 pub mod storage;
 pub mod transport;
 pub mod value;
+
+#[cfg(test)]
+mod tests;
 
 // Codec
 pub use codec::{
@@ -38,12 +43,16 @@ pub use key::{CompositeKey, Key128, PositionalKey, RegistryKey};
 pub use metadata::{NoMetadata, PositionMetadata, RegistryMetadata, TimestampMetadata};
 pub use value::{RegistryValue, StorageBackend, StorageLocation};
 
-// Transport
+// Client
+pub use registry::{OffloadResult, Registry, RegistryClient};
 pub use transport::{InProcessHub, InProcessTransport, RegistryTransport};
 
 // Hub (Server)
 pub use hub::{HubStats, RegistryHub};
 pub use hub_transport::{ClientId, HubMessage, HubTransport, InProcessClientHandle, InProcessHubTransport};
+
+// Builder
+pub use builder::{ClientBuilder, HubBuilder, client, hub};
 
 // Event Bus
 pub use events::{

--- a/lib/kvbm-registry/src/core/mod.rs
+++ b/lib/kvbm-registry/src/core/mod.rs
@@ -49,7 +49,9 @@ pub use transport::{InProcessHub, InProcessTransport, RegistryTransport};
 
 // Hub (Server)
 pub use hub::{HubStats, RegistryHub};
-pub use hub_transport::{ClientId, HubMessage, HubTransport, InProcessClientHandle, InProcessHubTransport};
+pub use hub_transport::{
+    ClientId, HubMessage, HubTransport, InProcessClientHandle, InProcessHubTransport,
+};
 
 // Builder
 pub use builder::{ClientBuilder, HubBuilder, client, hub};

--- a/lib/kvbm-registry/src/core/registry.rs
+++ b/lib/kvbm-registry/src/core/registry.rs
@@ -1,0 +1,530 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generic registry client.
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use super::codec::{BinaryCodec, OffloadStatus, QueryType, RegistryCodec, ResponseType};
+use super::key::RegistryKey;
+use super::metadata::RegistryMetadata;
+use super::transport::RegistryTransport;
+use super::value::RegistryValue;
+
+#[derive(Debug, Clone)]
+pub struct OffloadResult<K> {
+    pub can_offload: Vec<K>,
+    pub already_stored: Vec<K>,
+    pub leased: Vec<K>,
+}
+
+impl<K> Default for OffloadResult<K> {
+    fn default() -> Self {
+        Self {
+            can_offload: Vec::new(),
+            already_stored: Vec::new(),
+            leased: Vec::new(),
+        }
+    }
+}
+
+#[async_trait]
+pub trait Registry<K, V, M>: Send + Sync
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+{
+    async fn register(&self, entries: &[(K, V, M)]) -> Result<()>;
+    async fn can_offload(&self, keys: &[K]) -> Result<OffloadResult<K>>;
+    async fn match_prefix(&self, keys: &[K]) -> Result<Vec<(K, V, M)>>;
+    async fn flush(&self) -> Result<()>;
+
+    /// Remove/invalidate entries from the registry by key.
+    /// Returns the number of entries that were removed.
+    /// This is used to clean up stale entries (e.g., when object storage returns NoSuchKey).
+    async fn remove(&self, keys: &[K]) -> Result<usize>;
+
+    /// Notify the registry that entries were accessed (cache hit).
+    ///
+    /// Used for LRU/LFU eviction policies to track access recency/frequency.
+    /// Returns the number of keys that were touched (acknowledged).
+    ///
+    /// This is typically called after a successful onboard from G4 storage,
+    /// or when blocks are accessed from G2 (host) cache.
+    async fn touch(&self, keys: &[K]) -> Result<usize>;
+}
+
+/// Pending batch state.
+struct PendingBatch<K, V, M> {
+    entries: Vec<(K, V, M)>,
+    /// When the first entry was added to this batch.
+    first_entry_time: Option<tokio::time::Instant>,
+}
+
+impl<K, V, M> Default for PendingBatch<K, V, M> {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            first_entry_time: None,
+        }
+    }
+}
+
+impl<K: Clone, V: Clone, M: Clone> PendingBatch<K, V, M> {
+    fn add(&mut self, entries: &[(K, V, M)]) {
+        if self.first_entry_time.is_none() && !entries.is_empty() {
+            self.first_entry_time = Some(tokio::time::Instant::now());
+        }
+        self.entries.extend(entries.iter().cloned());
+    }
+
+    fn take(&mut self) -> Vec<(K, V, M)> {
+        self.first_entry_time = None;
+        std::mem::take(&mut self.entries)
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Check if the batch has exceeded the timeout.
+    fn is_timed_out(&self, timeout: Duration) -> bool {
+        self.first_entry_time
+            .map(|t| t.elapsed() >= timeout)
+            .unwrap_or(false)
+    }
+}
+
+pub struct RegistryClient<K, V, M, T, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+    C: RegistryCodec<K, V, M>,
+{
+    transport: T,
+    codec: C,
+    pending: Arc<Mutex<PendingBatch<K, V, M>>>,
+    batch_size: usize,
+    batch_timeout: Duration,
+    _phantom: PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M, T, C> RegistryClient<K, V, M, T, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+    C: RegistryCodec<K, V, M>,
+{
+    pub fn new(transport: T, codec: C) -> Self {
+        Self {
+            transport,
+            codec,
+            pending: Arc::new(Mutex::new(PendingBatch::default())),
+            batch_size: 100,
+            batch_timeout: Duration::from_millis(10),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn with_batch_size(mut self, size: usize) -> Self {
+        self.batch_size = size;
+        self
+    }
+
+    pub fn with_batch_timeout(mut self, timeout: Duration) -> Self {
+        self.batch_timeout = timeout;
+        self
+    }
+
+    /// Start a background task that flushes pending entries on timeout.
+    ///
+    /// Returns a handle that can be used to stop the task.
+    pub fn start_batch_flush_task(
+        self: &Arc<Self>,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> tokio::task::JoinHandle<()>
+    where
+        K: 'static,
+        V: 'static,
+        M: 'static,
+        T: 'static,
+        C: 'static,
+    {
+        let client = Arc::clone(self);
+        let timeout = self.batch_timeout;
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(timeout / 2);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => {
+                        tracing::debug!("Batch flush task shutting down");
+                        // Final flush on shutdown
+                        let _ = client.flush().await;
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        // Check if batch has timed out
+                        let should_flush = {
+                            let pending = client.pending.lock().await;
+                            !pending.is_empty() && pending.is_timed_out(timeout)
+                        };
+
+                        if should_flush
+                            && let Err(e) = client.flush().await
+                        {
+                            tracing::warn!(error = %e, "Batch flush failed");
+                        }
+                    }
+                }
+            }
+        })
+    }
+}
+
+#[async_trait]
+impl<K, V, M, T, C> Registry<K, V, M> for RegistryClient<K, V, M, T, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+    C: RegistryCodec<K, V, M>,
+{
+    async fn register(&self, entries: &[(K, V, M)]) -> Result<()> {
+        let should_flush = {
+            let mut pending = self.pending.lock().await;
+            pending.add(entries);
+            pending.len() >= self.batch_size
+        };
+
+        if should_flush {
+            self.flush().await?;
+        }
+
+        Ok(())
+    }
+
+    async fn can_offload(&self, keys: &[K]) -> Result<OffloadResult<K>> {
+        if keys.is_empty() {
+            return Ok(OffloadResult::default());
+        }
+
+        let mut buf = Vec::new();
+        self.codec
+            .encode_query(&QueryType::CanOffload(keys.to_vec()), &mut buf)?;
+
+        let response = self.transport.request(&buf).await?;
+        let decoded = self
+            .codec
+            .decode_response(&response)
+            .ok_or_else(|| anyhow::anyhow!("invalid response"))?;
+
+        match decoded {
+            ResponseType::CanOffload(statuses) => {
+                let mut result = OffloadResult::default();
+                for (key, status) in keys.iter().zip(statuses.iter()) {
+                    match status {
+                        OffloadStatus::Granted => result.can_offload.push(*key),
+                        OffloadStatus::AlreadyStored => result.already_stored.push(*key),
+                        OffloadStatus::Leased => result.leased.push(*key),
+                    }
+                }
+                Ok(result)
+            }
+            _ => Err(anyhow::anyhow!("unexpected response type for can_offload")),
+        }
+    }
+
+    async fn match_prefix(&self, keys: &[K]) -> Result<Vec<(K, V, M)>> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut buf = Vec::new();
+        self.codec
+            .encode_query(&QueryType::Match(keys.to_vec()), &mut buf)?;
+
+        let response = self.transport.request(&buf).await?;
+        let decoded = self
+            .codec
+            .decode_response(&response)
+            .ok_or_else(|| anyhow::anyhow!("invalid response"))?;
+
+        match decoded {
+            ResponseType::Match(entries) => Ok(entries),
+            _ => Err(anyhow::anyhow!("unexpected response type for match_prefix")),
+        }
+    }
+
+    async fn flush(&self) -> Result<()> {
+        let entries = {
+            let mut pending = self.pending.lock().await;
+            pending.take()
+        };
+
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        let mut buf = Vec::new();
+        self.codec.encode_register(&entries, &mut buf)?;
+        self.transport.publish(&buf).await
+    }
+
+    async fn remove(&self, keys: &[K]) -> Result<usize> {
+        if keys.is_empty() {
+            return Ok(0);
+        }
+
+        let mut buf = Vec::new();
+        self.codec
+            .encode_query(&QueryType::Remove(keys.to_vec()), &mut buf)?;
+
+        let response = self.transport.request(&buf).await?;
+        let decoded = self
+            .codec
+            .decode_response(&response)
+            .ok_or_else(|| anyhow::anyhow!("invalid response"))?;
+
+        match decoded {
+            ResponseType::Remove(count) => Ok(count),
+            _ => Err(anyhow::anyhow!("unexpected response type for remove")),
+        }
+    }
+
+    async fn touch(&self, keys: &[K]) -> Result<usize> {
+        if keys.is_empty() {
+            return Ok(0);
+        }
+
+        let mut buf = Vec::new();
+        self.codec
+            .encode_query(&QueryType::Touch(keys.to_vec()), &mut buf)?;
+
+        let response = self.transport.request(&buf).await?;
+        let decoded = self
+            .codec
+            .decode_response(&response)
+            .ok_or_else(|| anyhow::anyhow!("invalid response"))?;
+
+        match decoded {
+            ResponseType::Touch(count) => Ok(count),
+            _ => Err(anyhow::anyhow!("unexpected response type for touch")),
+        }
+    }
+}
+
+/// Create a simple registry client with binary codec.
+pub fn simple_client<K, V, M, T>(transport: T) -> RegistryClient<K, V, M, T, BinaryCodec<K, V, M>>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+{
+    RegistryClient::new(transport, BinaryCodec::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::codec::BinaryCodec;
+    use crate::core::metadata::NoMetadata;
+    use crate::core::transport::InProcessTransport;
+
+    #[tokio::test]
+    async fn test_registry_client_can_offload() {
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        let (transport, _rx) = InProcessTransport::new(move |data| {
+            let query = codec.decode_query(data);
+            match query {
+                Some(QueryType::CanOffload(keys)) => {
+                    let statuses: Vec<_> = keys
+                        .iter()
+                        .map(|k| {
+                            if *k % 2 == 0 {
+                                OffloadStatus::AlreadyStored
+                            } else {
+                                OffloadStatus::Granted
+                            }
+                        })
+                        .collect();
+                    let mut buf = Vec::new();
+                    codec
+                        .encode_response(&ResponseType::CanOffload(statuses), &mut buf)
+                        .unwrap();
+                    buf
+                }
+                _ => Vec::new(),
+            }
+        });
+
+        let client: RegistryClient<u64, u64, NoMetadata, _, _> =
+            RegistryClient::new(transport, BinaryCodec::new());
+
+        let result = client.can_offload(&[1, 2, 3, 4]).await.unwrap();
+
+        assert_eq!(result.can_offload, vec![1, 3]);
+        assert_eq!(result.already_stored, vec![2, 4]);
+    }
+
+    #[tokio::test]
+    async fn test_registry_client_leased_status() {
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        let (transport, _rx) = InProcessTransport::new(move |data| {
+            let query = codec.decode_query(data);
+            match query {
+                Some(QueryType::CanOffload(keys)) => {
+                    let statuses: Vec<_> = keys
+                        .iter()
+                        .map(|k| {
+                            if *k == 1 {
+                                OffloadStatus::Leased
+                            } else {
+                                OffloadStatus::Granted
+                            }
+                        })
+                        .collect();
+                    let mut buf = Vec::new();
+                    codec
+                        .encode_response(&ResponseType::CanOffload(statuses), &mut buf)
+                        .unwrap();
+                    buf
+                }
+                _ => Vec::new(),
+            }
+        });
+
+        let client: RegistryClient<u64, u64, NoMetadata, _, _> =
+            RegistryClient::new(transport, BinaryCodec::new());
+
+        let result = client.can_offload(&[1, 2, 3]).await.unwrap();
+
+        assert_eq!(result.leased, vec![1]);
+        assert_eq!(result.can_offload, vec![2, 3]);
+    }
+
+    #[tokio::test]
+    async fn test_registry_client_match() {
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        let (transport, _rx) = InProcessTransport::new(move |data| {
+            let query = codec.decode_query(data);
+            match query {
+                Some(QueryType::Match(keys)) => {
+                    let entries: Vec<_> = keys
+                        .into_iter()
+                        .take(2)
+                        .map(|k| (k, k * 100, NoMetadata))
+                        .collect();
+                    let mut buf = Vec::new();
+                    codec
+                        .encode_response(&ResponseType::Match(entries), &mut buf)
+                        .unwrap();
+                    buf
+                }
+                _ => Vec::new(),
+            }
+        });
+
+        let client: RegistryClient<u64, u64, NoMetadata, _, _> =
+            RegistryClient::new(transport, BinaryCodec::new());
+
+        let result = client.match_prefix(&[1, 2, 3, 4]).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], (1, 100, NoMetadata));
+        assert_eq!(result[1], (2, 200, NoMetadata));
+    }
+
+    #[tokio::test]
+    async fn test_batch_size_flush() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let flush_count = Arc::new(AtomicUsize::new(0));
+        let flush_count_clone = Arc::clone(&flush_count);
+
+        let (transport, mut rx) = InProcessTransport::new(move |_| Vec::new());
+
+        // Count publishes in background
+        let flush_counter = flush_count_clone;
+        tokio::spawn(async move {
+            while (rx.recv().await).is_some() {
+                flush_counter.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+
+        let client: RegistryClient<u64, u64, NoMetadata, _, _> =
+            RegistryClient::new(transport, BinaryCodec::new()).with_batch_size(3);
+
+        // Add 2 entries (below threshold)
+        client
+            .register(&[(1, 100, NoMetadata), (2, 200, NoMetadata)])
+            .await
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        assert_eq!(flush_count.load(Ordering::SeqCst), 0);
+
+        // Add 1 more (reaches threshold of 3)
+        client.register(&[(3, 300, NoMetadata)]).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        assert_eq!(flush_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_batch_timeout_flush() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let flush_count = Arc::new(AtomicUsize::new(0));
+        let flush_count_clone = Arc::clone(&flush_count);
+
+        let (transport, mut rx) = InProcessTransport::new(move |_| Vec::new());
+
+        // Count publishes in background
+        let flush_counter = flush_count_clone;
+        tokio::spawn(async move {
+            while (rx.recv().await).is_some() {
+                flush_counter.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+
+        let client = Arc::new(
+            RegistryClient::<u64, u64, NoMetadata, _, _>::new(transport, BinaryCodec::new())
+                .with_batch_size(100) // High batch size
+                .with_batch_timeout(Duration::from_millis(50)), // Short timeout
+        );
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let _task = client.start_batch_flush_task(cancel.clone());
+
+        // Add entries (below batch size threshold)
+        client.register(&[(1, 100, NoMetadata)]).await.unwrap();
+
+        // Wait for timeout to trigger flush
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert!(flush_count.load(Ordering::SeqCst) >= 1);
+
+        cancel.cancel();
+    }
+}

--- a/lib/kvbm-registry/src/core/tests.rs
+++ b/lib/kvbm-registry/src/core/tests.rs
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the registry.
+
+#[cfg(test)]
+mod integration {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use crate::core::{
+        BinaryCodec, HashMapStorage, InProcessHubTransport, InProcessTransport, NoMetadata,
+        OffloadStatus, QueryType, Registry, RegistryCodec, RegistryTransport, ResponseType,
+        Storage, client, hub,
+    };
+
+    /// Full end-to-end test: Client <-> Hub using in-process transport.
+    #[tokio::test]
+    async fn test_client_hub_integration() {
+        // Create hub with storage using the builder
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        storage.insert(1, 100);
+        storage.insert(2, 200);
+
+        let registry_hub = hub::<u64, u64, NoMetadata, _>(storage)
+            .lease_ttl(Duration::from_secs(30))
+            .build();
+
+        // Create in-process transport pair
+        let (mut hub_transport, client_handle) = InProcessHubTransport::new();
+
+        // Spawn hub server
+        let hub_task = tokio::spawn(async move {
+            for _ in 0..3 {
+                registry_hub.process_one(&mut hub_transport).await.ok();
+            }
+        });
+
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        // Test can_offload
+        let mut buf = Vec::new();
+        codec
+            .encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf)
+            .unwrap();
+        let response = client_handle.request(&buf).await.unwrap();
+        let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
+        match decoded {
+            ResponseType::CanOffload(statuses) => {
+                assert_eq!(statuses[0], OffloadStatus::AlreadyStored);
+                assert_eq!(statuses[1], OffloadStatus::Granted);
+            }
+            _ => panic!("Wrong response"),
+        }
+
+        // Test match
+        buf.clear();
+        codec
+            .encode_query(&QueryType::Match(vec![1, 2]), &mut buf)
+            .unwrap();
+        let response = client_handle.request(&buf).await.unwrap();
+        let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
+        match decoded {
+            ResponseType::Match(entries) => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0], (1, 100, NoMetadata));
+                assert_eq!(entries[1], (2, 200, NoMetadata));
+            }
+            _ => panic!("Wrong response"),
+        }
+
+        // One more query to complete hub_task
+        buf.clear();
+        codec
+            .encode_query(&QueryType::CanOffload(vec![1]), &mut buf)
+            .unwrap();
+        let _ = client_handle.request(&buf).await;
+
+        hub_task.await.unwrap();
+    }
+
+    /// Test with mock hub (simpler, no spawning).
+    #[tokio::test]
+    async fn test_full_registry_flow() {
+        let hub_storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        hub_storage.insert(1, 100);
+        hub_storage.insert(2, 200);
+        hub_storage.insert(3, 300);
+
+        let (transport, _rx) = InProcessTransport::new(move |data| {
+            let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+            if let Some(query) = codec.decode_query(data) {
+                let mut buf = Vec::new();
+                match query {
+                    QueryType::CanOffload(keys) => {
+                        let statuses: Vec<_> = keys
+                            .iter()
+                            .map(|k| {
+                                if hub_storage.contains(k) {
+                                    OffloadStatus::AlreadyStored
+                                } else {
+                                    OffloadStatus::Granted
+                                }
+                            })
+                            .collect();
+                        codec
+                            .encode_response(&ResponseType::CanOffload(statuses), &mut buf)
+                            .unwrap();
+                    }
+                    QueryType::Match(keys) => {
+                        let entries: Vec<_> = keys
+                            .iter()
+                            .filter_map(|k| hub_storage.get(k).map(|v| (*k, v, NoMetadata)))
+                            .collect();
+                        codec
+                            .encode_response(&ResponseType::Match(entries), &mut buf)
+                            .unwrap();
+                    }
+                    QueryType::Remove(keys) => {
+                        // Count how many keys would be removed (exist in storage)
+                        let removed_count = keys.iter().filter(|k| hub_storage.contains(k)).count();
+                        codec
+                            .encode_response(&ResponseType::Remove(removed_count), &mut buf)
+                            .unwrap();
+                    }
+                    QueryType::Touch(keys) => {
+                        // Touch is a no-op - just acknowledge
+                        codec
+                            .encode_response(&ResponseType::Touch(keys.len()), &mut buf)
+                            .unwrap();
+                    }
+                }
+                buf
+            } else {
+                Vec::new()
+            }
+        });
+
+        // Build client using the builder
+        let registry_client = client::<u64, u64, NoMetadata, _>(transport)
+            .batch_size(100)
+            .build();
+
+        // Test can_offload
+        let result = registry_client.can_offload(&[1, 2, 5, 6]).await.unwrap();
+        assert_eq!(result.already_stored, vec![1, 2]);
+        assert_eq!(result.can_offload, vec![5, 6]);
+
+        // Test match_prefix
+        let matched = registry_client.match_prefix(&[1, 2, 3]).await.unwrap();
+        assert_eq!(matched.len(), 3);
+        assert_eq!(matched[0].1, 100);
+        assert_eq!(matched[1].1, 200);
+        assert_eq!(matched[2].1, 300);
+    }
+
+    /// Test batched registration and flush.
+    #[tokio::test]
+    async fn test_register_and_flush() {
+        use std::sync::Mutex;
+
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let received_clone = received.clone();
+
+        let (transport, mut rx) = InProcessTransport::new(move |_data| Vec::new());
+
+        let received_for_task = received_clone.clone();
+        tokio::spawn(async move {
+            while let Some(data) = rx.recv().await {
+                received_for_task.lock().unwrap().push(data);
+            }
+        });
+
+        // Build client with custom batch size using the builder
+        let registry_client = client::<u64, u64, NoMetadata, _>(transport)
+            .batch_size(10)
+            .build();
+
+        registry_client
+            .register(&[(1, 100, NoMetadata), (2, 200, NoMetadata)])
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        assert!(received.lock().unwrap().is_empty());
+
+        registry_client.flush().await.unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        assert_eq!(received.lock().unwrap().len(), 1);
+    }
+
+    /// Velo TCP end-to-end test.
+    ///
+    /// Run manually: `cargo test -- --ignored test_velo_e2e`
+    #[cfg(feature = "_velo_transport")]
+    #[tokio::test]
+    #[ignore]
+    async fn test_velo_e2e() {
+        use crate::core::{
+            VeloClientTransport, VeloHubTransport,
+        };
+
+        let port: u16 = 17560;
+
+        // Create hub with pre-populated storage
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        storage.insert(1, 100);
+        storage.insert(2, 200);
+
+        let registry_hub = hub::<u64, u64, NoMetadata, _>(storage)
+            .lease_ttl(Duration::from_secs(30))
+            .build();
+
+        // Bind hub transport
+        let mut hub_transport = VeloHubTransport::bind_local(port).await.unwrap();
+
+        // Start hub server task
+        let hub_handle = tokio::spawn(async move {
+            // Serve until no more clients
+            loop {
+                match registry_hub.process_one(&mut hub_transport).await {
+                    Ok(()) => {}
+                    Err(_) => break,
+                }
+            }
+        });
+
+        // Wait for hub to be ready
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Connect client
+        let mut transport = VeloClientTransport::connect_local(port).await.unwrap();
+
+        let codec = BinaryCodec::<u64, u64, NoMetadata>::new();
+
+        // Test can_offload
+        let mut buf = Vec::new();
+        codec
+            .encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf)
+            .unwrap();
+        let response = transport.request(&buf).await.expect("Request failed");
+        let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
+
+        match decoded {
+            ResponseType::CanOffload(statuses) => {
+                assert_eq!(statuses[0], OffloadStatus::AlreadyStored);
+                assert_eq!(statuses[1], OffloadStatus::Granted);
+            }
+            _ => panic!("Wrong response type"),
+        }
+
+        // Test match
+        buf.clear();
+        codec
+            .encode_query(&QueryType::Match(vec![1, 2]), &mut buf)
+            .unwrap();
+        let response = transport.request(&buf).await.expect("Match request failed");
+        let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
+
+        match decoded {
+            ResponseType::Match(entries) => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0], (1, 100, NoMetadata));
+                assert_eq!(entries[1], (2, 200, NoMetadata));
+            }
+            _ => panic!("Wrong response type"),
+        }
+
+        hub_handle.abort();
+    }
+}

--- a/lib/kvbm-registry/src/core/tests.rs
+++ b/lib/kvbm-registry/src/core/tests.rs
@@ -10,8 +10,7 @@ mod integration {
 
     use crate::core::{
         BinaryCodec, HashMapStorage, InProcessHubTransport, InProcessTransport, NoMetadata,
-        OffloadStatus, QueryType, Registry, RegistryCodec, RegistryTransport, ResponseType,
-        Storage, client, hub,
+        OffloadStatus, QueryType, Registry, RegistryCodec, ResponseType, Storage, client, hub,
     };
 
     /// Full end-to-end test: Client <-> Hub using in-process transport.


### PR DESCRIPTION
#### Overview:

Wires everything together with a public-facing API:
- `RegistryClient<K,V,M>` with `can_offload()`, `match_blocks()`, `remove()`, `touch()`, `register()`
- `hub()` builder function for ergonomic hub construction (optional eviction, metrics, lease config)
- End-to-end integration tests using `InProcessHubTransport` (80 tests, all passing in Docker)

**Part of chain:** R0 → R1 → R2 → R3 → R4 → R5 → R6 → **R7** → R8

#### Details:

- `src/core/registry.rs`: `RegistryClient<K,V,M>` — public API wrapping transport + codec
- `src/core/builder.rs`: `RegistryHubBuilder`, `hub()` convenience function
- `src/core/tests.rs`: 80 integration tests (register, query, eviction, lease expiry roundtrip)

#### Where should the reviewer start?

Start with `src/core/registry.rs` (the public `RegistryClient` API) then `src/core/tests.rs` for end-to-end flow.

#### Related Issues:

- Relates to kvbm distributed registry chain (R7/8)