### PR TITLE
fix: tempo -> loki matching with trace_id

### DIFF
--- a/deploy/observability/tempo-datasource.yml
+++ b/deploy/observability/tempo-datasource.yml
@@ -20,7 +20,7 @@ datasources:
         filterByTraceID: false
         filterBySpanID: false
         customQuery: true
-        query: '{service_name=~".+"} | trace_id = "$${__trace.traceId}"'
+        query: '{service_name=~".+"} | json | trace_id = "$${__span.traceId}"'
         spanStartTimeShift: "-1h"
         spanEndTimeShift: "1h"
       search:

--- a/deploy/observability/tempo.yaml
+++ b/deploy/observability/tempo.yaml
@@ -32,5 +32,5 @@ compactor:
   compaction:
     compaction_window: 1h
     max_compaction_objects: 1000000
-    block_retention: 1h
+    block_retention: 72h
     compacted_block_retention: 10m


### PR DESCRIPTION
#### Overview:

Small fix -- when going from Tempo trace to Loki log, the trace_id needs to be parsed from a json. For non-json lines `| json |` is a no-op, so this addition won't break anything.
Checked that this query works correctly on the Grafana while the original does not retrieve any matching logs.

Also increased default block retention to 72h, I felt that 1h is too short to cover a typical benchmarking workflow. 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated trace-to-logs correlation query mechanism for improved trace linking
  * Extended trace data retention period from 1 hour to 72 hours

<!-- end of auto-generated comment: release notes by coderabbit.ai -->