### PR TITLE
docs: add bilingual Dynamo learning tutorials

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,0 +1,107 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Dynamo Learning Tutorials
+subtitle: An intuition-first, source-grounded guide to the distributed inference stack
+---
+
+# Dynamo Learning Tutorials
+
+Most docs tell you what Dynamo can do. This tutorial track explains why the architecture exists, which source files implement each idea, and how to reason about the math without getting buried in notation.
+
+Dynamo sits above serving engines such as SGLang, TensorRT-LLM, and vLLM. The engines still run the model forward pass. Dynamo coordinates the cluster around them: frontend ingress, worker discovery, request routing, disaggregated prefill/decode, KV event propagation, multi-tier cache movement, and autoscaling.
+
+> [!TIP]
+> If you are new to Dynamo, read these pages in order. If you already know the product surface, jump directly to [Architecture](architecture.md) or [Source Tour](source-tour.md).
+
+## What you will learn
+
+- Why prefill and decode want different hardware shapes
+- Why KV-aware routing can beat naive load balancing
+- Why KVBM treats memory as a tiered system instead of "GPU or bust"
+- How the planner turns latency goals into replica counts
+- Which Python entrypoints and Rust crates own each subsystem
+
+## Reading map
+
+| Page | What it teaches | Best read after |
+|---|---|---|
+| [Quick Start](quick-start.md) | The simplest correct mental model of Dynamo | The repo `README.md` |
+| [Architecture](architecture.md) | How the request, control, and state planes fit together | Quick Start |
+| [Math and Systems Theory](math-theory.md) | Router cost, queue priority, planner math, and transfer logic | Architecture |
+| [Source Tour](source-tour.md) | Where to read the actual Python and Rust implementation | Any page |
+
+## One-picture mental model
+
+```mermaid
+flowchart LR
+    Client[Client / SDK] --> Frontend[Frontend<br/>HTTP + preprocessing]
+
+    subgraph RequestPlane[Request plane]
+        Frontend --> Router[Router]
+        Router --> Prefill[Prefill workers]
+        Router --> Decode[Decode workers]
+        Decode --> Frontend
+    end
+
+    subgraph StatePlane[State and storage plane]
+        Prefill --> KVEvents[KV events]
+        Decode --> KVEvents
+        Prefill --> KVBM[KVBM]
+        Decode --> KVBM
+        Prefill --> NIXL[NIXL / data transfer]
+        NIXL --> Decode
+        KVBM --> HostTier[CPU pinned memory]
+        KVBM --> DiskTier[Local SSD / remote storage]
+    end
+
+    subgraph ControlPlane[Control plane]
+        Planner[Planner] -. metrics .-> Frontend
+        Planner -. scaling .-> Prefill
+        Planner -. scaling .-> Decode
+        Discovery[Discovery backend] -. membership .-> Frontend
+        Discovery -. membership .-> Router
+        Discovery -. registration .-> Prefill
+        Discovery -. registration .-> Decode
+    end
+```
+
+## Core code landmarks
+
+| Subsystem | First file to open | Why it matters |
+|---|---|---|
+| Frontend ingress | `components/src/dynamo/frontend/main.py` | Parses CLI flags, configures `DistributedRuntime`, and selects the router mode |
+| Distributed runtime | `lib/runtime/src/distributed.rs` | Owns discovery, request transport, health, metrics, and the local runtime root |
+| KV routing | `lib/llm/src/kv_router.rs` | Connects overlap indexing, worker selection, and routing state updates |
+| Queue policy | `lib/kv-router/src/scheduling/policy.rs` | Encodes FCFS, LCFS, and WSPT in compact math |
+| Autoscaling | `components/src/dynamo/planner/core/disagg.py` | Runs the split prefill/decode planning loop |
+| Memory transfer | `lib/kvbm-physical/src/transfer/strategy.rs` | Chooses direct versus staged movement across GPU, host, disk, and remote memory |
+
+## What this tutorial adds beyond the existing docs
+
+The official docs already provide component-level and design-level coverage:
+
+- [Overall Architecture](../design-docs/architecture.md)
+- [Disaggregated Serving](../design-docs/disagg-serving.md)
+- [Router Guide](../components/router/router-guide.md)
+- [KVBM Guide](../components/kvbm/kvbm-guide.md)
+- [Planner Guide](../components/planner/planner-guide.md)
+
+This tutorial track complements them by doing three extra things:
+
+1. It starts from plain-language intuition before using systems vocabulary.
+2. It ties each concept back to concrete source files.
+3. It explains the formulas with small numeric examples instead of only showing the symbolic form.
+
+## Recommended reading styles
+
+| If you are... | Start with |
+|---|---|
+| A new user trying to understand the product | [Quick Start](quick-start.md) |
+| A systems engineer evaluating architecture tradeoffs | [Architecture](architecture.md) |
+| Someone debugging router or planner behavior | [Math and Systems Theory](math-theory.md) |
+| A contributor preparing to read code | [Source Tour](source-tour.md) |
+
+## Continue
+
+Start with [Quick Start](quick-start.md), then read [Architecture](architecture.md).

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -1,0 +1,237 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Dynamo Architecture
+subtitle: Request plane, control plane, state plane, and the code that binds them
+---
+
+# Dynamo Architecture
+
+The most useful way to understand Dynamo is to stop thinking of it as a single server and start thinking of it as three cooperating planes:
+
+- a **request plane** that keeps tokens flowing
+- a **control plane** that decides how much capacity should exist
+- a **state plane** that decides where KV cache lives and how it moves
+
+That split is visible not only in the product story, but also in the source tree.
+
+## Macro architecture
+
+```mermaid
+flowchart TB
+    Client[Clients / SDKs]
+
+    subgraph RequestPlane[Request plane]
+        Frontend[Frontend<br/>HTTP + preprocessing]
+        Router[Router / PrefillRouter]
+        Prefill[Prefill workers]
+        Decode[Decode workers]
+        Client --> Frontend
+        Frontend --> Router
+        Router --> Prefill
+        Router --> Decode
+        Decode --> Frontend
+    end
+
+    subgraph ControlPlane[Control plane]
+        Planner[Planner]
+        GlobalPlanner[Global planner]
+        Connector[Connector layer]
+        Discovery[Discovery backend]
+        Planner --> Connector
+        GlobalPlanner --> Connector
+        Discovery -. worker membership .-> Frontend
+        Discovery -. worker membership .-> Router
+        Discovery -. registration .-> Prefill
+        Discovery -. registration .-> Decode
+    end
+
+    subgraph StatePlane[State and storage plane]
+        KVIndexer[KV indexer]
+        EventPlane[Event plane]
+        KVBM[KVBM]
+        NIXL[NIXL]
+        HostTier[Host pinned memory]
+        DiskTier[Disk / remote]
+
+        Prefill --> EventPlane
+        Decode --> EventPlane
+        EventPlane --> KVIndexer
+        Prefill --> KVBM
+        Decode --> KVBM
+        KVBM --> HostTier
+        KVBM --> DiskTier
+        Prefill --> NIXL
+        NIXL --> Decode
+    end
+```
+
+## The request plane
+
+The request plane is the fast path:
+
+- **Frontend** normalizes OpenAI-compatible requests, applies chat templates, tokenizes, and exposes HTTP routes.
+- **Router** decides which worker should process the request.
+- **Prefill workers** compute prompt KV state.
+- **Decode workers** generate output tokens and stream them back.
+
+Important files:
+
+| Role | Files |
+|---|---|
+| Frontend process entry | `components/src/dynamo/frontend/main.py` |
+| Frontend argument model | `components/src/dynamo/frontend/frontend_args.py` |
+| Pre/post-processing | `components/src/dynamo/frontend/prepost.py` |
+| KV router orchestration | `lib/llm/src/kv_router.rs` |
+| Queue policies | `lib/kv-router/src/scheduling/policy.rs` |
+| Queue admission and utilization gates | `lib/kv-router/src/scheduling/queue.rs` |
+
+### Why routing is more than load balancing
+
+The router tracks two different costs at once:
+
+1. **How much new prefill work** would be needed on a worker
+2. **How much decode pressure** that worker is already carrying
+
+That is why Dynamo can prefer a worker with a warm prefix cache even if another worker looks less busy at first glance.
+
+## The control plane
+
+The control plane is the adaptation loop. It is responsible for deciding whether the current deployment shape still matches traffic.
+
+Important files:
+
+| Role | Files |
+|---|---|
+| Planner entrypoint | `components/src/dynamo/planner/__main__.py` |
+| Disaggregated planning loop | `components/src/dynamo/planner/core/disagg.py` |
+| Prefill planner | `components/src/dynamo/planner/core/prefill.py` |
+| Decode planner | `components/src/dynamo/planner/core/decode.py` |
+| Load-based regression | `components/src/dynamo/planner/core/load/fpm_regression.py` |
+| Global planner | `components/src/dynamo/global_planner/scale_handler.py` |
+
+The planner can use two broad signal families:
+
+- **throughput-based planning** from profiling data and forecasted traffic
+- **load-based planning** from live ForwardPassMetrics
+
+The key architectural point is that Dynamo does not treat scaling as a separate external concern. Scaling is wired into the runtime model of prefill and decode.
+
+## The state plane
+
+The state plane covers everything that makes cache reuse and cross-worker handoff possible:
+
+- KV events
+- global KV indexing
+- KVBM
+- NIXL transfer
+
+Important files:
+
+| Role | Files |
+|---|---|
+| Runtime root | `lib/runtime/src/distributed.rs` |
+| Discovery abstraction | `lib/runtime/src/discovery/mod.rs` |
+| Request-plane manager | `lib/runtime/src/pipeline/network/manager.rs` |
+| Event-plane transport | `lib/runtime/src/transports/event_plane/mod.rs` |
+| KVBM transfer policy | `lib/kvbm-physical/src/transfer/strategy.rs` |
+| KVBM physical manager | `lib/kvbm-physical/src/manager/mod.rs` |
+
+This is where Dynamo starts looking like an operating system for KV cache instead of a plain inference wrapper.
+
+## End-to-end disaggregated walkthrough
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant FE as Frontend
+    participant R as Router
+    participant P as Prefill worker
+    participant D as Decode worker
+    participant EP as Event plane
+
+    Client->>FE: request
+    FE->>FE: validate + template + tokenize
+    FE->>R: route query
+    R->>P: prefill request
+    P->>P: compute KV blocks
+    P-->>R: disaggregated_params
+    R->>D: decode request + transfer metadata
+    P->>D: direct KV handoff via NIXL
+    D-->>FE: token stream
+    FE-->>Client: response
+    P->>EP: KV stored events
+    D->>EP: completion / release events
+```
+
+Two details matter here:
+
+- The prefill worker can finish first and hand off state instead of performing decode itself.
+- The state handoff is fast only if the system can see the worker topology, choose the right transfer path, and understand where the KV blocks live.
+
+## The three communication planes
+
+```mermaid
+flowchart LR
+    DiscoveryPlane[Discovery plane<br/>who exists?]
+    RequestPlane[Request plane<br/>who serves this request?]
+    EventPlane[Event plane<br/>what changed in cache state?]
+
+    DiscoveryPlane --> RequestPlane
+    RequestPlane --> EventPlane
+    EventPlane --> RequestPlane
+```
+
+### Discovery plane
+
+The discovery plane answers membership and liveness questions.
+
+- Kubernetes mode uses native resources and metadata.
+- KV-store mode can use etcd, file-backed state, or in-memory discovery.
+
+Relevant code starts in `lib/runtime/src/discovery/mod.rs`.
+
+### Request plane
+
+The request plane answers "how do bytes actually move between components?"
+
+Dynamo can use multiple transport styles depending on deployment mode, but the shared control point lives in the runtime network manager.
+
+Relevant code starts in `lib/runtime/src/pipeline/network/manager.rs`.
+
+### Event plane
+
+The event plane answers "how do components learn that cache state changed?"
+
+That includes KV events, forward-pass metrics, and other asynchronous coordination signals.
+
+Relevant code starts in `lib/runtime/src/transports/event_plane/mod.rs`.
+
+## Why the repo is split between Python and Rust
+
+The split is deliberate:
+
+- **Python** owns CLI ergonomics, backend integration, and fast feature adaptation.
+- **Rust** owns hot-path routing, runtime coordination, transport infrastructure, and memory-sensitive internals.
+
+This is why a typical Dynamo process starts in a Python module such as `components/src/dynamo/frontend/main.py`, but the long-lived system substrate is powered by Rust crates under `lib/`.
+
+## Fault handling and elasticity are part of the architecture
+
+Dynamo assumes the cluster will change while requests are flowing:
+
+- workers join and leave
+- replicas scale up and down
+- KV state may move across tiers
+- routers need to keep making good decisions under partial information
+
+That is why discovery, eventing, and autoscaling appear in the architecture diagrams right next to the serving path instead of being treated as background details.
+
+## Suggested next readings
+
+- [Math and Systems Theory](math-theory.md) for routing cost and scaling formulas
+- [Source Tour](source-tour.md) for a concrete reading path through the code
+- [Overall Architecture](../design-docs/architecture.md)
+- [Request Plane](../design-docs/request-plane.md)
+- [Discovery Plane](../design-docs/discovery-plane.md)
+- [Event Plane](../design-docs/event-plane.md)

--- a/docs/en/math-theory.md
+++ b/docs/en/math-theory.md
@@ -1,0 +1,268 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Dynamo Math and Systems Theory
+subtitle: Router cost, queue priority, scaling formulas, and transfer-path intuition
+---
+
+# Dynamo Math and Systems Theory
+
+This page translates the core formulas behind Dynamo into plain language and tiny numeric examples.
+
+The goal is not to impress you with symbols. The goal is to let you look at a log line or a source file and immediately know what the number is trying to approximate.
+
+## 1. Router cost: cached work versus busy workers
+
+The router design docs describe a simple but powerful idea:
+
+$$
+\text{new\_prefill\_tokens} = \text{isl\_tokens} - \text{overlap\_blocks} \times \text{block\_size}
+$$
+
+$$
+\text{cost} = \text{overlap\_score\_weight} \times \text{prefill\_blocks} + \text{decode\_blocks}
+$$
+
+Where:
+
+- `isl_tokens` means input sequence length
+- `overlap_blocks` means how many KV blocks are already reusable on a worker
+- `block_size` means tokens per KV block
+- `prefill_blocks` means how many blocks still need fresh prefill computation
+- `decode_blocks` means how much decode work is already active on the worker
+
+This logic appears conceptually in [Router Design](../design-docs/router-design.md) and operationally in `lib/llm/src/kv_router.rs`.
+
+### A small example
+
+Suppose a request has:
+
+- `isl_tokens = 1024`
+- `block_size = 16`
+
+Now compare three workers:
+
+| Worker | Cached overlap | New prefill tokens | Decode blocks | Cost when `overlap_score_weight = 1` |
+|---|---:|---:|---:|---:|
+| A | 10 blocks | `1024 - 10*16 = 864` | 4 | high |
+| B | 40 blocks | `1024 - 40*16 = 384` | 6 | medium |
+| C | 55 blocks | `1024 - 55*16 = 144` | 9 | often lowest |
+
+Why can C still win even though it is busier on decode? Because reusing a large prefix can save far more work than a small load imbalance costs.
+
+### Grocery-store analogy
+
+Imagine three cashiers:
+
+- one has a short line but must scan your entire cart from scratch
+- one has a slightly longer line but half your groceries are already bagged
+- one has a longer line but almost all your groceries are already bagged
+
+The best cashier is not automatically the least busy one. It is the one with the lowest **remaining work** after reuse is counted.
+
+## 2. Queue priority: why WSPT favors short uncached work
+
+In `lib/kv-router/src/scheduling/policy.rs`, Dynamo exposes FCFS, LCFS, and WSPT.
+
+The WSPT key is:
+
+$$
+\text{priority} = \frac{1 + \text{priority\_jump}}{\text{new\_tokens}}
+$$
+
+with:
+
+$$
+\text{new\_tokens} = \max(1, \text{isl\_tokens} - \text{cached\_tokens})
+$$
+
+And:
+
+$$
+\text{cached\_tokens} = \text{max\_overlap\_blocks} \times \text{block\_size}
+$$
+
+### What the variables mean
+
+- `priority_jump` is an explicit priority boost
+- `new_tokens` is the estimated prefill work that still has to happen
+- higher priority value means the request should be scheduled sooner
+
+### A tiny numeric example
+
+Assume:
+
+- block size = 16
+- both requests have `priority_jump = 0`
+
+Request 1:
+
+- `isl_tokens = 1024`
+- cached overlap = 60 blocks
+- cached tokens = `60 * 16 = 960`
+- new tokens = `1024 - 960 = 64`
+- priority = `1 / 64 = 0.015625`
+
+Request 2:
+
+- `isl_tokens = 1024`
+- cached overlap = 0 blocks
+- new tokens = `1024`
+- priority = `1 / 1024 = 0.0009765625`
+
+Request 1 gets scheduled earlier because almost all of its work is already done.
+
+### Why this is a good systems heuristic
+
+WSPT is not just "favor short requests." In Dynamo it is really "favor requests with the lowest **uncached** work."
+
+That is much closer to what actually burns GPU time.
+
+## 3. Planner math: how latency goals become replica counts
+
+The planner design docs summarize the throughput-based logic with formulas like:
+
+$$
+\text{predicted\_prefill\_load}
+= \frac{\text{next\_requests} \times \text{next\_isl}}{\text{interval}}
+$$
+
+$$
+\text{prefill\_replicas}
+=
+\left\lceil
+\frac{\text{predicted\_prefill\_load}}
+{\text{throughput\_per\_gpu} \times \text{gpus\_per\_engine}}
+\right\rceil
+$$
+
+and:
+
+$$
+\text{decode\_replicas}
+=
+\left\lceil
+\frac{\text{next\_requests} \times \text{next\_osl}}
+{\text{interval} \times \text{throughput\_per\_gpu} \times \text{gpus\_per\_engine}}
+\right\rceil
+$$
+
+The implementation is more nuanced because it includes correction factors, interpolators, and separate prefill/decode reasoning, but this simplified view captures the intuition.
+
+### A tiny prefill example
+
+Suppose the next interval predicts:
+
+- `next_requests = 120`
+- `next_isl = 4000`
+- `interval = 60 seconds`
+- `throughput_per_gpu = 4000 tokens/second`
+- `gpus_per_engine = 2`
+
+Then:
+
+$$
+\text{predicted\_prefill\_load}
+= \frac{120 \times 4000}{60}
+= 8000 \text{ tokens/second}
+$$
+
+Each engine contributes:
+
+$$
+4000 \times 2 = 8000 \text{ tokens/second}
+$$
+
+So:
+
+$$
+\text{prefill\_replicas} = \lceil 8000 / 8000 \rceil = 1
+$$
+
+If traffic doubles, the answer becomes 2.
+
+### A tiny decode example
+
+Suppose:
+
+- `next_requests = 120`
+- `next_osl = 300`
+- `interval = 60`
+- `throughput_per_gpu = 300 tokens/second`
+- `gpus_per_engine = 2`
+
+Then:
+
+$$
+\frac{120 \times 300}{60} = 600 \text{ output tokens/second}
+$$
+
+Each engine contributes:
+
+$$
+300 \times 2 = 600 \text{ output tokens/second}
+$$
+
+So decode also needs:
+
+$$
+\lceil 600 / 600 \rceil = 1
+$$
+
+The key Dynamo insight is that **prefill and decode can scale independently** when their bottlenecks differ.
+
+## 4. Transfer strategy: when direct copy is impossible
+
+`lib/kvbm-physical/src/transfer/strategy.rs` encodes a decision tree for moving KV blocks between memory locations.
+
+At a high level:
+
+- host to host can use plain memcpy
+- pinned host to device can use CUDA H2D
+- device to pinned host can use CUDA D2H
+- device to device can use CUDA D2D
+- device to remote may need either direct GPU RDMA or a host bounce buffer
+
+```mermaid
+flowchart TD
+    Start[Need to move KV blocks] --> LocalOrRemote{Is source or destination remote?}
+
+    LocalOrRemote -- No --> LocalPaths[Use local path selection<br/>Memcpy / CUDA H2D / CUDA D2H / CUDA D2D]
+    LocalOrRemote -- Yes --> DeviceRemote{Is a device involved?}
+
+    DeviceRemote -- No --> RemoteHost[Host to remote via NIXL]
+    DeviceRemote -- Yes --> DirectRDMA{GPU RDMA allowed?}
+
+    DirectRDMA -- Yes --> DirectTransfer[Direct NIXL transfer]
+    DirectRDMA -- No --> TwoHop[Stage through pinned host memory<br/>Device -> Pinned -> Remote]
+```
+
+### Plain-language intuition
+
+Think of a sofa that needs to move from apartment A to apartment B:
+
+- if the hallway is wide enough, move it directly
+- if the hallway is too narrow, place it in a staging area first
+
+KVBM makes the same choice for KV blocks:
+
+- direct path when hardware and capabilities permit
+- two-hop path when the direct route is not safe or available
+
+## 5. Why these formulas matter in practice
+
+All four ideas above are doing the same job:
+
+- estimate remaining work instead of raw request count
+- estimate system capacity instead of guessing
+- choose the cheapest safe movement path instead of assuming one memory tier
+
+That is why Dynamo feels like a systems project first and an "AI wrapper" second.
+
+## Related readings
+
+- [Architecture](architecture.md)
+- [Source Tour](source-tour.md)
+- [Router Design](../design-docs/router-design.md)
+- [Planner Design](../design-docs/planner-design.md)
+- [KVBM Design](../design-docs/kvbm-design.md)

--- a/docs/en/quick-start.md
+++ b/docs/en/quick-start.md
@@ -1,0 +1,142 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Dynamo Quick Start
+subtitle: Build the right mental model before diving into the source
+---
+
+# Dynamo Quick Start
+
+Imagine an airport with two very different bottlenecks:
+
+- check-in is heavy, parallel, and front-loaded
+- boarding is lighter per passenger but keeps going for a long time
+
+LLM inference has the same shape:
+
+- **prefill** is the expensive "digest the prompt" phase
+- **decode** is the long-running "generate one more token" phase
+
+Running both phases on the same worker pool is often convenient, but not always efficient. Dynamo exists to coordinate these phases across many workers and nodes without losing cache locality or operational control.
+
+## Dynamo in one sentence
+
+Dynamo is a distributed inference runtime and control layer that turns multiple backend workers into one coordinated serving system.
+
+## The pains Dynamo fixes
+
+| Pain | What goes wrong without orchestration | What Dynamo adds |
+|---|---|---|
+| Mixed long and short prompts | Long prefills can block decoding traffic | Disaggregated prefill/decode and smarter routing |
+| Repeated prompt prefixes | The same prompt work gets recomputed | KV-aware routing and global KV visibility |
+| GPU memory pressure | Long contexts fall out of HBM too early | KVBM with host, disk, and remote tiers |
+| Bursty traffic | Static replica counts miss latency targets | Planner-driven scaling loops |
+| Multi-node deployments | Discovery and worker coordination become ad hoc | Discovery, request, and event planes |
+
+## From user request to generated tokens
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Frontend
+    participant Router
+    participant Prefill
+    participant Decode
+    participant EventPlane as Event Plane
+
+    Client->>Frontend: OpenAI-compatible request
+    Frontend->>Frontend: validate, template, tokenize
+    Frontend->>Router: route request
+    Router->>Prefill: choose prefill worker
+    Prefill-->>Router: transfer metadata + cache state
+    Router->>Decode: choose decode worker
+    Prefill->>Decode: transfer KV via NIXL
+    Decode-->>Frontend: stream tokens
+    Frontend-->>Client: response
+    Prefill->>EventPlane: publish KV events
+    Decode->>EventPlane: publish completion / cache updates
+```
+
+The important idea is that the router is not "just" a load balancer. It is deciding where to spend compute, where to reuse compute, and when the next phase should run on a different worker.
+
+## Try the smallest local setup
+
+For the simplest path, you do not need Kubernetes, and you do not even need etcd or NATS if you are only trying the basic aggregated flow.
+
+```bash
+# Terminal 1: start the frontend
+python3 -m dynamo.frontend \
+  --http-port 8000 \
+  --discovery-backend file
+
+# Terminal 2: start a worker
+python3 -m dynamo.sglang \
+  --model-path Qwen/Qwen3-0.6B \
+  --discovery-backend file
+
+# Terminal 3: send a request
+curl -s localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "Explain Dynamo in one sentence."}],
+    "max_tokens": 64
+  }'
+```
+
+> [!NOTE]
+> KV-aware routing and durable KV event flows need the event path to be configured. The tiny local setup above is meant to teach the request path, not the full production topology.
+
+## Map that local run to the implementation
+
+| What you launched | Main files | What they do |
+|---|---|---|
+| `python -m dynamo.frontend` | `components/src/dynamo/frontend/__main__.py`, `components/src/dynamo/frontend/main.py` | Build the frontend process, parse arguments, construct runtime, choose router behavior |
+| `DistributedRuntime(...)` | `lib/runtime/src/distributed.rs` | Own the discovery client, request-plane manager, health, metrics, and transport setup |
+| Router selection | `dynamo.llm.RouterMode`, `lib/llm/src/kv_router.rs` | Decide whether the frontend routes round-robin, random, direct, or KV-aware |
+| Worker backend | `components/src/dynamo/sglang/main.py`, `components/src/dynamo/vllm/main.py`, `components/src/dynamo/trtllm/main.py` | Launch the backend worker and connect it to Dynamo runtime services |
+
+## Aggregated versus disaggregated serving
+
+```mermaid
+flowchart LR
+    subgraph Aggregated[Aggregated]
+        AClient[Client] --> AFE[Frontend]
+        AFE --> AWorker[Worker does prefill + decode]
+        AWorker --> AFE
+    end
+
+    subgraph Disaggregated[Disaggregated]
+        DClient[Client] --> DFE[Frontend]
+        DFE --> DRouter[Router]
+        DRouter --> DPrefill[Prefill worker]
+        DRouter --> DDecode[Decode worker]
+        DPrefill --> DDecode
+        DDecode --> DFE
+    end
+```
+
+Aggregated mode is simpler and often the right starting point.
+
+Disaggregated mode becomes attractive when:
+
+- prompts are long and variable
+- decode traffic must stay smooth
+- prefill and decode want different hardware or replica counts
+- cross-worker KV handoff is still cheaper than recomputing the prompt
+
+## What to watch during your first debugging session
+
+1. **Frontend logs**: check which router mode is active and whether discovery succeeded.
+2. **Worker registration**: if the frontend sees zero workers, start with discovery backend settings.
+3. **Request plane mismatches**: TCP, HTTP, and NATS modes must align across components.
+4. **KV events**: if KV-aware routing is not improving latency, confirm that cache events are actually flowing.
+5. **Metrics and health**: the runtime and planner both depend on clean signal paths.
+
+## Practical intuition to keep in mind
+
+- Dynamo does **not** replace the backend engine.
+- Dynamo does **not** make every deployment disaggregated by default.
+- Dynamo's value comes from **coordination**: better placement, better reuse, and better control loops.
+
+From here, go to [Architecture](architecture.md) for the full picture, then [Math and Systems Theory](math-theory.md) to understand the cost functions and scaling formulas.

--- a/docs/en/source-tour.md
+++ b/docs/en/source-tour.md
@@ -1,0 +1,168 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Dynamo Source Tour
+subtitle: A practical reading order for the Python entrypoints and Rust core
+---
+
+# Dynamo Source Tour
+
+The Dynamo monorepo is large enough that a random walk is a poor learning strategy.
+
+The best approach is:
+
+1. start at Python entrypoints
+2. identify where each process hands responsibility to the runtime
+3. follow the hot path into Rust
+
+## Repo map at 10,000 feet
+
+```mermaid
+flowchart TB
+    Repo[Dynamo repo]
+
+    Repo --> Components[components/src/dynamo<br/>Python processes and backend integrations]
+    Repo --> Lib[lib/<br/>Rust runtime, routing, memory, events]
+    Repo --> Docs[docs/<br/>design docs, guides, references]
+    Repo --> Deploy[deploy/<br/>local and Kubernetes deployment assets]
+
+    Components --> FE[frontend/]
+    Components --> RouterPy[router/]
+    Components --> PlannerPy[planner/]
+    Components --> Backends[sglang/ vllm/ trtllm/]
+
+    Lib --> Runtime[lib/runtime]
+    Lib --> LLM[lib/llm]
+    Lib --> KvRouter[lib/kv-router]
+    Lib --> KVBM[lib/kvbm-*]
+    Lib --> Memory[lib/memory]
+    Lib --> Events[lib/velo-events]
+```
+
+## If you only have 30 minutes, read these first
+
+| Goal | Files to open |
+|---|---|
+| Understand process startup | `components/src/dynamo/frontend/main.py` |
+| Understand runtime construction | `lib/runtime/src/distributed.rs` |
+| Understand routing decisions | `lib/llm/src/kv_router.rs` |
+| Understand queue policy math | `lib/kv-router/src/scheduling/policy.rs` |
+| Understand disaggregated autoscaling | `components/src/dynamo/planner/core/disagg.py` |
+| Understand memory movement | `lib/kvbm-physical/src/transfer/strategy.rs` |
+
+## Start from Python entrypoints
+
+These are the best "doors" into the system:
+
+| Process | Entrypoint | What you learn |
+|---|---|---|
+| Frontend | `components/src/dynamo/frontend/__main__.py` and `main.py` | CLI flags, router mode, runtime bootstrap, HTTP serving |
+| Standalone router | `components/src/dynamo/router/__main__.py` | Router process shape and backend-specific arguments |
+| Planner | `components/src/dynamo/planner/__main__.py` | Autoscaling bootstrap, config wiring, runtime integration |
+| Global planner | `components/src/dynamo/global_planner/__main__.py` | Cross-pool or higher-level scaling logic |
+| SGLang backend | `components/src/dynamo/sglang/main.py` | Worker registration and backend-specific runtime setup |
+| vLLM backend | `components/src/dynamo/vllm/main.py` | Worker lifecycle, handlers, instrumentation |
+| TRT-LLM backend | `components/src/dynamo/trtllm/main.py` | TensorRT-LLM integration hooks |
+
+## Then follow one request across the codebase
+
+```mermaid
+flowchart LR
+    A[Client request] --> B[components/src/dynamo/frontend/main.py]
+    B --> C[components/src/dynamo/frontend/prepost.py]
+    C --> D[lib/runtime/src/distributed.rs]
+    D --> E[lib/llm/src/kv_router.rs]
+    E --> F[lib/kv-router/src/scheduling/policy.rs]
+    E --> G[lib/kv-router/src/indexer/radix_tree.rs]
+    E --> H[backend worker main.py]
+    H --> I[lib/runtime request + event transport]
+```
+
+That path is useful because it shows the boundary between:
+
+- request normalization
+- runtime coordination
+- worker selection
+- backend execution
+
+## Subsystem-by-subsystem reading guide
+
+### Frontend and preprocessing
+
+Start here when you want to know how an OpenAI-compatible request becomes an internal engine request:
+
+- `components/src/dynamo/frontend/main.py`
+- `components/src/dynamo/frontend/prepost.py`
+- `components/src/dynamo/frontend/vllm_processor.py`
+- `components/src/dynamo/frontend/sglang_processor.py`
+
+### Routing and KV overlap
+
+Start here when you want to understand why one worker is chosen over another:
+
+- `lib/llm/src/kv_router.rs`
+- `lib/kv-router/src/scheduling/queue.rs`
+- `lib/kv-router/src/scheduling/policy.rs`
+- `lib/kv-router/src/indexer/kv_indexer.rs`
+- `lib/kv-router/src/indexer/radix_tree.rs`
+
+### Discovery, request plane, and event plane
+
+Start here when you want to understand cluster coordination:
+
+- `lib/runtime/src/distributed.rs`
+- `lib/runtime/src/discovery/mod.rs`
+- `lib/runtime/src/pipeline/network/manager.rs`
+- `lib/runtime/src/transports/event_plane/mod.rs`
+
+### Planner and autoscaling
+
+Start here when you want to explain why replica counts changed:
+
+- `components/src/dynamo/planner/__main__.py`
+- `components/src/dynamo/planner/core/disagg.py`
+- `components/src/dynamo/planner/core/prefill.py`
+- `components/src/dynamo/planner/core/decode.py`
+- `components/src/dynamo/planner/core/load/fpm_regression.py`
+
+### KVBM and transfer logic
+
+Start here when you want to understand tiered KV storage and movement:
+
+- `lib/kvbm-physical/src/manager/mod.rs`
+- `lib/kvbm-physical/src/layout/mod.rs`
+- `lib/kvbm-physical/src/transfer/mod.rs`
+- `lib/kvbm-physical/src/transfer/strategy.rs`
+- `lib/memory/src/nixl/agent.rs`
+
+## Suggested reading orders by role
+
+| If you are... | Reading order |
+|---|---|
+| A new contributor | Frontend -> Distributed runtime -> KV router -> One backend |
+| A routing engineer | KV router -> queue policy -> radix tree -> KV events docs |
+| A platform engineer | Distributed runtime -> discovery -> planner -> connectors |
+| A memory / systems engineer | KVBM design -> transfer strategy -> NIXL agent -> storage backends |
+
+## Fast debugging checklist
+
+| Symptom | Start reading here |
+|---|---|
+| Frontend starts but sees no workers | `lib/runtime/src/discovery/mod.rs` |
+| Router makes surprising worker choices | `lib/llm/src/kv_router.rs` and `lib/kv-router/src/scheduling/policy.rs` |
+| Scaling decisions look wrong | `components/src/dynamo/planner/core/disagg.py` and `../design-docs/planner-design.md` |
+| KV transfer is slower than expected | `lib/kvbm-physical/src/transfer/strategy.rs` and `../design-docs/kvbm-design.md` |
+| Event-driven cache visibility seems stale | `lib/runtime/src/transports/event_plane/mod.rs` and `../design-docs/router-design.md` |
+
+## Final advice
+
+Read source with a question, not with a flashlight.
+
+Good questions are:
+
+- Where is this process constructed?
+- Which layer owns this decision?
+- What quantity is the system trying to estimate?
+- Which path is hot, and which path is control-only?
+
+If you keep those questions in front of you, Dynamo becomes much easier to navigate.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -314,6 +314,17 @@ navigation:
             path: en/math-theory.md
           - page: Source Tour
             path: en/source-tour.md
+      - section: 中文
+        path: zh/README.md
+        contents:
+          - page: 快速入门
+            path: zh/quick-start.md
+          - page: 架构原理
+            path: zh/architecture.md
+          - page: 数学与系统原理
+            path: zh/math-theory.md
+          - page: 源码导览
+            path: zh/source-tour.md
 
   # ==================== Documentation ====================
   - section: Documentation

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -300,6 +300,21 @@ navigation:
         path: blogs/flash-indexer/flash-indexer.md
         slug: flash-indexer
 
+  # ==================== Learning Tutorials ====================
+  - section: Learning Tutorials
+    contents:
+      - section: English
+        path: en/README.md
+        contents:
+          - page: Quick Start
+            path: en/quick-start.md
+          - page: Architecture
+            path: en/architecture.md
+          - page: Math and Systems Theory
+            path: en/math-theory.md
+          - page: Source Tour
+            path: en/source-tour.md
+
   # ==================== Documentation ====================
   - section: Documentation
     contents:

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -1,0 +1,113 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Dynamo 学习教程
+subtitle: 一套从直觉到源码的分布式推理系统入门与深潜指南
+---
+
+# Dynamo 学习教程
+
+很多文档会告诉你 Dynamo 能做什么，但不一定告诉你 **为什么它必须这样设计**、**这些设计在源码里到底落在哪**。
+
+这套教程的目标，就是把 Dynamo 从“听起来很厉害的分布式推理框架”，拆成一套你能真正抓住的系统直觉：
+
+- 用户请求是怎么进来的
+- 为什么 prefill 和 decode 应该分家
+- 为什么 KV cache 不是“有没有缓存”这么简单
+- 为什么 autoscaling 不是简单地“看 QPS 加机器”
+- 这些逻辑分别由哪些 Python 入口和 Rust 核心库实现
+
+> [!TIP]
+> 如果你第一次接触 Dynamo，建议按顺序阅读本教程；如果你已经知道产品能力，建议直接跳到 [架构原理](architecture.md) 或 [源码导览](source-tour.md)。
+
+## 你将学到什么
+
+- 为什么 prefill 与 decode 对硬件资源的偏好天然不同
+- 为什么 KV-aware routing 往往比朴素负载均衡更快
+- 为什么 KVBM 要把显存、内存、磁盘、远端存储看成一个分层系统
+- Planner 怎样把延迟目标翻译成副本数
+- Dynamo 的关键子系统在源码中的真实入口文件
+
+## 阅读地图
+
+| 页面 | 主要回答什么问题 | 最适合什么时候读 |
+|---|---|---|
+| [快速入门](quick-start.md) | 先建立最不容易错的整体心智模型 | 看完仓库 `README.md` 之后 |
+| [架构原理](architecture.md) | 请求面、控制面、状态面的配合方式 | 快速入门之后 |
+| [数学与系统原理](math-theory.md) | Router 成本函数、队列优先级、Planner 公式、传输策略 | 理解架构之后 |
+| [源码导览](source-tour.md) | 应该按什么顺序读 Python / Rust 实现 | 任意阶段都可 |
+
+## 一张图先把 Dynamo 看顺
+
+```mermaid
+flowchart LR
+    Client[客户端 / SDK] --> Frontend[Frontend<br/>HTTP + 预处理]
+
+    subgraph RequestPlane[请求面]
+        Frontend --> Router[Router]
+        Router --> Prefill[Prefill workers]
+        Router --> Decode[Decode workers]
+        Decode --> Frontend
+    end
+
+    subgraph StatePlane[状态与存储面]
+        Prefill --> KVEvents[KV events]
+        Decode --> KVEvents
+        Prefill --> KVBM[KVBM]
+        Decode --> KVBM
+        Prefill --> NIXL[NIXL / 数据传输]
+        NIXL --> Decode
+        KVBM --> HostTier[CPU pinned memory]
+        KVBM --> DiskTier[本地 SSD / 远端存储]
+    end
+
+    subgraph ControlPlane[控制面]
+        Planner[Planner] -. metrics .-> Frontend
+        Planner -. scaling .-> Prefill
+        Planner -. scaling .-> Decode
+        Discovery[Discovery backend] -. membership .-> Frontend
+        Discovery -. membership .-> Router
+        Discovery -. registration .-> Prefill
+        Discovery -. registration .-> Decode
+    end
+```
+
+## 先记住这几个源码地标
+
+| 子系统 | 最值得先打开的文件 | 为什么重要 |
+|---|---|---|
+| Frontend 入口 | `components/src/dynamo/frontend/main.py` | CLI 解析、运行时构建、router mode 选择都从这里开始 |
+| 分布式运行时 | `lib/runtime/src/distributed.rs` | discovery、request plane、health、metrics 都挂在这里 |
+| KV 路由 | `lib/llm/src/kv_router.rs` | overlap 计算、worker 选择、状态更新的核心 |
+| 队列策略 | `lib/kv-router/src/scheduling/policy.rs` | FCFS / LCFS / WSPT 的数学本体 |
+| Autoscaling | `components/src/dynamo/planner/core/disagg.py` | prefill / decode 分离伸缩的主循环 |
+| 内存搬运 | `lib/kvbm-physical/src/transfer/strategy.rs` | GPU、Host、Disk、Remote 之间如何选传输路径 |
+
+## 这套教程相比现有设计文档多做了什么
+
+官方文档已经覆盖了组件设计和系统设计：
+
+- [Overall Architecture](../design-docs/architecture.md)
+- [Disaggregated Serving](../design-docs/disagg-serving.md)
+- [Router Guide](../components/router/router-guide.md)
+- [KVBM Guide](../components/kvbm/kvbm-guide.md)
+- [Planner Guide](../components/planner/planner-guide.md)
+
+本教程额外补上了三件事：
+
+1. 先用大白话建立直觉，再进入系统术语。
+2. 每个关键概念都尽量指向真实源码文件。
+3. 所有核心公式都给出极简数字例子，而不是只放符号。
+
+## 推荐阅读方式
+
+| 你的角色 | 最推荐起点 |
+|---|---|
+| 刚接触 Dynamo 的使用者 | [快速入门](quick-start.md) |
+| 想评估系统设计优劣的架构师 | [架构原理](architecture.md) |
+| 正在排查 router / planner 行为的工程师 | [数学与系统原理](math-theory.md) |
+| 想直接看源码的新贡献者 | [源码导览](source-tour.md) |
+
+## 下一步
+
+建议先读 [快速入门](quick-start.md)，再进入 [架构原理](architecture.md)。

--- a/docs/zh/architecture.md
+++ b/docs/zh/architecture.md
@@ -1,0 +1,244 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Dynamo 架构原理
+subtitle: 从请求面、控制面、状态面理解 Dynamo 的系统骨架
+---
+
+# Dynamo 架构原理
+
+理解 Dynamo 最有效的方法，不是把它当作“一个很强的推理服务”，而是把它拆成三条并行协作的系统平面：
+
+- **请求面**：保证 token 真正流起来
+- **控制面**：决定当前到底该有多少算力副本
+- **状态面**：决定 KV cache 在哪里、怎么流、谁能看到
+
+这不是抽象概念，而是会直接映射到源码目录与运行时职责。
+
+## 宏观骨架图
+
+```mermaid
+flowchart TB
+    Client[Clients / SDKs]
+
+    subgraph RequestPlane[请求面]
+        Frontend[Frontend<br/>HTTP + 预处理]
+        Router[Router / PrefillRouter]
+        Prefill[Prefill workers]
+        Decode[Decode workers]
+        Client --> Frontend
+        Frontend --> Router
+        Router --> Prefill
+        Router --> Decode
+        Decode --> Frontend
+    end
+
+    subgraph ControlPlane[控制面]
+        Planner[Planner]
+        GlobalPlanner[Global planner]
+        Connector[Connector layer]
+        Discovery[Discovery backend]
+        Planner --> Connector
+        GlobalPlanner --> Connector
+        Discovery -. worker membership .-> Frontend
+        Discovery -. worker membership .-> Router
+        Discovery -. registration .-> Prefill
+        Discovery -. registration .-> Decode
+    end
+
+    subgraph StatePlane[状态与存储面]
+        KVIndexer[KV indexer]
+        EventPlane[Event plane]
+        KVBM[KVBM]
+        NIXL[NIXL]
+        HostTier[Host pinned memory]
+        DiskTier[Disk / remote]
+
+        Prefill --> EventPlane
+        Decode --> EventPlane
+        EventPlane --> KVIndexer
+        Prefill --> KVBM
+        Decode --> KVBM
+        KVBM --> HostTier
+        KVBM --> DiskTier
+        Prefill --> NIXL
+        NIXL --> Decode
+    end
+```
+
+## 请求面：真正让 token 流动的热路径
+
+请求面是系统最敏感的快路径，主要包含：
+
+- **Frontend**：接收 OpenAI 兼容请求、做模板处理、tokenize、参数校验
+- **Router**：判断请求应该去哪个 worker
+- **Prefill workers**：计算 prompt 的 KV 状态
+- **Decode workers**：继续生成 token，并流式回传
+
+关键源码：
+
+| 角色 | 文件 |
+|---|---|
+| Frontend 主入口 | `components/src/dynamo/frontend/main.py` |
+| Frontend 参数定义 | `components/src/dynamo/frontend/frontend_args.py` |
+| 预处理 / 后处理 | `components/src/dynamo/frontend/prepost.py` |
+| KV 路由主体 | `lib/llm/src/kv_router.rs` |
+| 队列优先级策略 | `lib/kv-router/src/scheduling/policy.rs` |
+| 队列准入与利用率门控 | `lib/kv-router/src/scheduling/queue.rs` |
+
+### 为什么 Router 不只是负载均衡
+
+在 Dynamo 里，router 同时在意两件事：
+
+1. 这个 worker 还需要补多少 **新的 prefill 计算**
+2. 这个 worker 当前已经背了多少 **decode 压力**
+
+所以 Dynamo 不会机械地把请求丢给“最空闲”的 worker，而是会倾向于把请求送去 **剩余真实工作量更小** 的地方。
+
+## 控制面：决定系统应该长成什么样
+
+控制面本质上是一个持续运行的调整回路，用来回答：
+
+> 当前这波流量下，prefill 和 decode 分别应该有多少副本？
+
+关键源码：
+
+| 角色 | 文件 |
+|---|---|
+| Planner 入口 | `components/src/dynamo/planner/__main__.py` |
+| 解耦模式主循环 | `components/src/dynamo/planner/core/disagg.py` |
+| Prefill planner | `components/src/dynamo/planner/core/prefill.py` |
+| Decode planner | `components/src/dynamo/planner/core/decode.py` |
+| Load-based regression | `components/src/dynamo/planner/core/load/fpm_regression.py` |
+| Global planner | `components/src/dynamo/global_planner/scale_handler.py` |
+
+Planner 主要利用两类信号：
+
+- **throughput-based**：依赖 profiling 数据与未来流量预测
+- **load-based**：依赖实时 ForwardPassMetrics
+
+最关键的系统思想在于：  
+**Dynamo 并不把 scaling 当成系统外部附属功能，而是把它直接建模进 prefill / decode 的运行时结构。**
+
+## 状态面：让缓存复用、跨节点传输、分层存储真正成立
+
+状态面主要覆盖：
+
+- KV events
+- KVIndexer
+- KVBM
+- NIXL 数据传输
+
+关键源码：
+
+| 角色 | 文件 |
+|---|---|
+| 运行时根对象 | `lib/runtime/src/distributed.rs` |
+| Discovery 抽象 | `lib/runtime/src/discovery/mod.rs` |
+| Request-plane manager | `lib/runtime/src/pipeline/network/manager.rs` |
+| Event-plane transport | `lib/runtime/src/transports/event_plane/mod.rs` |
+| KVBM 传输策略 | `lib/kvbm-physical/src/transfer/strategy.rs` |
+| KVBM 物理层管理 | `lib/kvbm-physical/src/manager/mod.rs` |
+
+这也是 Dynamo 最“系统工程化”的部分：它不再把 KV cache 看成单块显存里的临时结构，而是看成一个 **可以跨层迁移、跨组件可见、跨节点协调** 的状态对象。
+
+## 一次解耦请求的完整旅程
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant FE as Frontend
+    participant R as Router
+    participant P as Prefill worker
+    participant D as Decode worker
+    participant EP as Event plane
+
+    Client->>FE: request
+    FE->>FE: 校验 + 模板处理 + tokenize
+    FE->>R: 发起路由
+    R->>P: prefill request
+    P->>P: 计算 KV blocks
+    P-->>R: disaggregated_params
+    R->>D: decode request + transfer metadata
+    P->>D: 通过 NIXL 直接传输 KV
+    D-->>FE: token stream
+    FE-->>Client: response
+    P->>EP: 发布 KV stored 事件
+    D->>EP: 发布完成 / 释放事件
+```
+
+这里有两个特别关键的点：
+
+- prefill worker 可以在算完 prompt 后，把状态交给 decode worker，而不是自己继续做 decode
+- 这个交接要想高效，系统必须知道 worker 拓扑、缓存位置、传输能力，以及如何选最合适的路径
+
+## Dynamo 的三条通信平面
+
+```mermaid
+flowchart LR
+    DiscoveryPlane[Discovery plane<br/>谁存在？]
+    RequestPlane[Request plane<br/>请求怎么送？]
+    EventPlane[Event plane<br/>缓存状态怎么同步？]
+
+    DiscoveryPlane --> RequestPlane
+    RequestPlane --> EventPlane
+    EventPlane --> RequestPlane
+```
+
+### Discovery plane
+
+它负责回答“当前有哪些组件存在、哪些是活的”。
+
+- 在 Kubernetes 模式下，依赖 K8s 原生资源与元数据
+- 在非 K8s 环境下，可以走 etcd、file、memory 等后端
+
+最值得先看的文件是 `lib/runtime/src/discovery/mod.rs`。
+
+### Request plane
+
+它负责回答“组件之间的请求字节流到底怎么走”。
+
+无论底层走 TCP、HTTP 还是 NATS，统一控制点都在运行时 network manager 里。
+
+最值得先看的文件是 `lib/runtime/src/pipeline/network/manager.rs`。
+
+### Event plane
+
+它负责回答“系统怎样知道缓存状态已经变化了”。
+
+包括但不限于：
+
+- KV 事件
+- forward pass metrics
+- 其他异步控制信号
+
+最值得先看的文件是 `lib/runtime/src/transports/event_plane/mod.rs`。
+
+## 为什么仓库同时大量使用 Python 与 Rust
+
+这个分工不是历史包袱，而是刻意为之：
+
+- **Python**：CLI 入口、后端集成、外部生态对接、快速迭代
+- **Rust**：热路径路由、分布式运行时、传输基础设施、内存敏感逻辑
+
+所以你通常会从 Python 入口如 `components/src/dynamo/frontend/main.py` 进入系统，但真正承载长期核心能力的，是 `lib/` 下的 Rust crate。
+
+## 在 Dynamo 里，容错与弹性不是“附属功能”
+
+Dynamo 默认假设集群在请求流动期间会发生变化：
+
+- worker 会加入或退出
+- 副本会扩缩容
+- KV state 会在不同层级间迁移
+- router 必须在信息不完美的情况下继续做出可接受的决策
+
+所以 discovery、eventing、autoscaling 在架构图里和 serving path 是并列的，而不是后排背景板。
+
+## 建议继续阅读
+
+- [数学与系统原理](math-theory.md)
+- [源码导览](source-tour.md)
+- [Overall Architecture](../design-docs/architecture.md)
+- [Request Plane](../design-docs/request-plane.md)
+- [Discovery Plane](../design-docs/discovery-plane.md)
+- [Event Plane](../design-docs/event-plane.md)

--- a/docs/zh/math-theory.md
+++ b/docs/zh/math-theory.md
@@ -1,0 +1,281 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Dynamo 数学与系统原理
+subtitle: 把路由成本、队列优先级、伸缩公式、传输策略讲到一看就懂
+---
+
+# Dynamo 数学与系统原理
+
+这一页的目标非常明确：
+
+把 Dynamo 里最关键的几个公式，翻译成 **“变量到底在描述什么现实量”**，再用小到不能再小的数字例子，把它们讲到几乎不用背。
+
+## 1. Router 成本函数：缓存复用与繁忙程度的平衡
+
+Router 设计文档里有一个非常核心的想法：
+
+$$
+\text{new\_prefill\_tokens} = \text{isl\_tokens} - \text{overlap\_blocks} \times \text{block\_size}
+$$
+
+$$
+\text{cost} = \text{overlap\_score\_weight} \times \text{prefill\_blocks} + \text{decode\_blocks}
+$$
+
+这些符号翻译成人话就是：
+
+- `isl_tokens`：这次输入一共有多少 token
+- `overlap_blocks`：这个 worker 已经缓存了多少可复用的块
+- `block_size`：一个 KV block 里有多少 token
+- `prefill_blocks`：还需要重新算多少块
+- `decode_blocks`：这个 worker 当前 decode 压力有多大
+
+相关源码与文档：
+
+- `lib/llm/src/kv_router.rs`
+- [Router Design](../design-docs/router-design.md)
+
+### 一个极简数字例子
+
+假设这次请求有：
+
+- `isl_tokens = 1024`
+- `block_size = 16`
+
+现在有三个 worker：
+
+| Worker | 已缓存 overlap | 还需新算的 token | 当前 decode blocks | 当 `overlap_score_weight = 1` 时的直觉成本 |
+|---|---:|---:|---:|---|
+| A | 10 blocks | `1024 - 10*16 = 864` | 4 | 很高 |
+| B | 40 blocks | `1024 - 40*16 = 384` | 6 | 中等 |
+| C | 55 blocks | `1024 - 55*16 = 144` | 9 | 往往最低 |
+
+为什么 C 可能反而最好？  
+因为虽然它 decode 更忙，但它几乎不用重新做 prefill 了。
+
+### 买菜阿姨也能懂的版本
+
+想象你去三个摊位买菜：
+
+- 第一个摊位排队人少，但所有菜都得现称
+- 第二个摊位稍微挤一点，但一半菜已经打包好了
+- 第三个摊位再挤一些，但你想买的菜几乎全都已经打包好了
+
+真正决定你多久拿到菜的，不是“队伍长度”本身，而是 **队伍长度 + 剩余未完成工作量**。
+
+Dynamo Router 做的就是这个判断。
+
+## 2. 队列优先级：为什么 WSPT 会偏爱“短且缓存命中高”的请求
+
+在 `lib/kv-router/src/scheduling/policy.rs` 里，Dynamo 支持 FCFS、LCFS、WSPT。
+
+其中 WSPT 的关键形式是：
+
+$$
+\text{priority} = \frac{1 + \text{priority\_jump}}{\text{new\_tokens}}
+$$
+
+其中：
+
+$$
+\text{new\_tokens} = \max(1, \text{isl\_tokens} - \text{cached\_tokens})
+$$
+
+而：
+
+$$
+\text{cached\_tokens} = \text{max\_overlap\_blocks} \times \text{block\_size}
+$$
+
+### 每个量真正代表什么
+
+- `priority_jump`：人为附加的优先级加成
+- `new_tokens`：这次请求真正还要新算多少 token
+- 优先级值越大，越应该先被调度
+
+### 一个非常小的数字例子
+
+假设：
+
+- `block_size = 16`
+- 两个请求的 `priority_jump = 0`
+
+请求 1：
+
+- `isl_tokens = 1024`
+- overlap = 60 blocks
+- 已缓存 token = `60 * 16 = 960`
+- `new_tokens = 1024 - 960 = 64`
+- `priority = 1 / 64 = 0.015625`
+
+请求 2：
+
+- `isl_tokens = 1024`
+- overlap = 0
+- `new_tokens = 1024`
+- `priority = 1 / 1024 = 0.0009765625`
+
+所以请求 1 明显应该更早执行，因为它几乎没剩多少新工作。
+
+### 这里的本质美感是什么
+
+WSPT 在 Dynamo 里真正优化的，不是“短请求优先”，而是：
+
+> **未被缓存覆盖的剩余工作量更小的请求优先。**
+
+这和真实 GPU 计算成本是高度贴合的。
+
+## 3. Planner 公式：延迟目标如何变成副本数
+
+Planner 设计文档里，吞吐驱动的思路可以抽象成：
+
+$$
+\text{predicted\_prefill\_load}
+= \frac{\text{next\_requests} \times \text{next\_isl}}{\text{interval}}
+$$
+
+$$
+\text{prefill\_replicas}
+=
+\left\lceil
+\frac{\text{predicted\_prefill\_load}}
+{\text{throughput\_per\_gpu} \times \text{gpus\_per\_engine}}
+\right\rceil
+$$
+
+以及：
+
+$$
+\text{decode\_replicas}
+=
+\left\lceil
+\frac{\text{next\_requests} \times \text{next\_osl}}
+{\text{interval} \times \text{throughput\_per\_gpu} \times \text{gpus\_per\_engine}}
+\right\rceil
+$$
+
+相关文档与实现：
+
+- [Planner Design](../design-docs/planner-design.md)
+- `components/src/dynamo/planner/core/disagg.py`
+
+### 一个最小 prefill 例子
+
+假设下一时间窗预测到：
+
+- `next_requests = 120`
+- `next_isl = 4000`
+- `interval = 60 秒`
+- `throughput_per_gpu = 4000 tokens/s`
+- `gpus_per_engine = 2`
+
+那么：
+
+$$
+\text{predicted\_prefill\_load}
+= \frac{120 \times 4000}{60}
+= 8000 \text{ tokens/s}
+$$
+
+而每个 engine 的能力是：
+
+$$
+4000 \times 2 = 8000 \text{ tokens/s}
+$$
+
+所以：
+
+$$
+\text{prefill\_replicas} = \lceil 8000 / 8000 \rceil = 1
+$$
+
+如果流量翻倍，结果自然变成 2。
+
+### 一个最小 decode 例子
+
+假设：
+
+- `next_requests = 120`
+- `next_osl = 300`
+- `interval = 60`
+- `throughput_per_gpu = 300 tokens/s`
+- `gpus_per_engine = 2`
+
+则：
+
+$$
+\frac{120 \times 300}{60} = 600 \text{ output tokens/s}
+$$
+
+每个 engine 能提供：
+
+$$
+300 \times 2 = 600 \text{ output tokens/s}
+$$
+
+所以：
+
+$$
+\lceil 600 / 600 \rceil = 1
+$$
+
+这里最重要的不是算术本身，而是 Dynamo 的设计思想：
+
+> **prefill 和 decode 的副本数不必相同，它们可以根据各自瓶颈独立伸缩。**
+
+## 4. 传输策略：为什么有时不能直接搬
+
+在 `lib/kvbm-physical/src/transfer/strategy.rs` 里，KVBM 会根据源位置和目标位置来选择传输路径。
+
+大致规律是：
+
+- host 到 host：走 memcpy
+- pinned host 到 device：走 CUDA H2D
+- device 到 pinned host：走 CUDA D2H
+- device 到 device：走 CUDA D2D
+- device 到 remote：要么直接 GPU RDMA，要么先借 host 做中转
+
+```mermaid
+flowchart TD
+    Start[需要搬运 KV blocks] --> LocalOrRemote{源或目标是否为 remote?}
+
+    LocalOrRemote -- 否 --> LocalPaths[走本地路径选择<br/>Memcpy / CUDA H2D / CUDA D2H / CUDA D2D]
+    LocalOrRemote -- 是 --> DeviceRemote{是否涉及 device?}
+
+    DeviceRemote -- 否 --> RemoteHost[Host 到 remote 走 NIXL]
+    DeviceRemote -- 是 --> DirectRDMA{是否允许 GPU RDMA?}
+
+    DirectRDMA -- 是 --> DirectTransfer[直接 NIXL 传输]
+    DirectRDMA -- 否 --> TwoHop[先经过 pinned host 中转<br/>Device -> Pinned -> Remote]
+```
+
+### 一个特别生活化的理解
+
+搬沙发时，如果门足够大，就直接进屋。  
+如果门太窄，就得先放到中转区，再换角度搬进去。
+
+KVBM 也是一样：
+
+- **直达路径**：硬件和能力允许时，直接搬
+- **两跳路径**：不允许直达时，借助 host 内存做缓冲
+
+这不是“性能不够好时的妥协”，而是 **工程上保证正确性与可移植性的必要策略**。
+
+## 5. 为什么这些公式在系统里不是装饰品
+
+你会发现，上面四类公式虽然长得不同，但它们都在做同一件事：
+
+- 估算真实剩余工作量，而不是只看请求数量
+- 估算系统真实容量，而不是拍脑袋扩容
+- 选择最低成本、仍然安全的内存迁移路径，而不是假设世界只有显存
+
+这也是为什么 Dynamo 本质上更像一个 **分布式系统工程项目**，而不只是一个“套在 LLM 外面的调度壳”。
+
+## 建议配套阅读
+
+- [架构原理](architecture.md)
+- [源码导览](source-tour.md)
+- [Router Design](../design-docs/router-design.md)
+- [Planner Design](../design-docs/planner-design.md)
+- [KVBM Design](../design-docs/kvbm-design.md)

--- a/docs/zh/quick-start.md
+++ b/docs/zh/quick-start.md
@@ -1,0 +1,150 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Dynamo 快速入门
+subtitle: 先建立不会错的系统直觉，再下潜源码
+---
+
+# Dynamo 快速入门
+
+把 LLM 推理想成一个大型机场，会更容易理解 Dynamo。
+
+机场里通常有两类完全不同的瓶颈：
+
+- 值机：前面很重，一次性工作量大
+- 登机：单次动作轻，但会持续很久
+
+LLM 推理也是这样：
+
+- **prefill**：把整段 prompt“读懂、编码、写进 KV cache”，一次性开销大
+- **decode**：每次只生成少量 token，但要持续进行很多轮
+
+如果所有请求都强行塞进同一类 worker，系统会出现很典型的问题：长 prompt 把短请求拖住，缓存复用率不稳定，GPU 压力结构失衡，扩缩容也变得粗糙。
+
+这就是 Dynamo 出现的原因。
+
+## 一句话理解 Dynamo
+
+Dynamo 是一个位于推理引擎之上的 **分布式推理编排层**，负责把多个 worker、多个节点、多个缓存层，组织成一个协调工作的整体系统。
+
+## 它主要解决哪些痛点
+
+| 痛点 | 没有编排层时会怎样 | Dynamo 怎么解决 |
+|---|---|---|
+| 长短 prompt 混跑 | 长 prefill 会把 decode 拖慢 | 把 prefill / decode 解耦，并做更聪明的路由 |
+| 重复前缀很多 | 同样的 prompt 前缀被重复计算 | 依靠 KV-aware routing 优先命中已有缓存 |
+| 显存不够 | 长上下文很快把 HBM 挤爆 | KVBM 让缓存可下沉到 host / disk / remote |
+| 流量突发 | 静态副本数总是慢半拍 | Planner 根据延迟目标做自动扩缩容 |
+| 多节点复杂 | 服务发现和组件协作容易失控 | 用 discovery / request / event 三条平面拆开管理 |
+
+## 一次请求到底怎么走
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Frontend
+    participant Router
+    participant Prefill
+    participant Decode
+    participant EventPlane as Event Plane
+
+    Client->>Frontend: OpenAI 兼容请求
+    Frontend->>Frontend: 校验、模板处理、tokenize
+    Frontend->>Router: 发起路由
+    Router->>Prefill: 选择 prefill worker
+    Prefill-->>Router: 返回 transfer metadata
+    Router->>Decode: 选择 decode worker
+    Prefill->>Decode: 通过 NIXL 传输 KV
+    Decode-->>Frontend: 流式返回 token
+    Frontend-->>Client: 最终响应
+    Prefill->>EventPlane: 发布 KV 事件
+    Decode->>EventPlane: 发布完成 / 释放事件
+```
+
+这里最关键的一点是：
+
+**Router 在 Dynamo 里不是一个“普通负载均衡器”，而是一个“剩余工作量评估器”。**
+
+它不仅看哪个 worker 忙不忙，还看哪个 worker 已经拥有你需要的 KV 前缀。
+
+## 本地最小可运行示例
+
+如果你只是想先建立对请求链路的感知，甚至不需要 Kubernetes。
+
+```bash
+# 终端 1：启动 frontend
+python3 -m dynamo.frontend \
+  --http-port 8000 \
+  --discovery-backend file
+
+# 终端 2：启动 worker
+python3 -m dynamo.sglang \
+  --model-path Qwen/Qwen3-0.6B \
+  --discovery-backend file
+
+# 终端 3：发送请求
+curl -s localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "用一句话解释 Dynamo。"}],
+    "max_tokens": 64
+  }'
+```
+
+> [!NOTE]
+> 上面的最小例子主要是为了看懂 request path。若要真正体验 KV-aware routing、durable KV events、生产级 cache visibility，还需要把 event plane 等组件配完整。
+
+## 把这次运行映射回源码
+
+| 你启动的东西 | 关键文件 | 它们负责什么 |
+|---|---|---|
+| `python -m dynamo.frontend` | `components/src/dynamo/frontend/__main__.py`、`components/src/dynamo/frontend/main.py` | 解析参数、构建运行时、决定 router mode、起 HTTP 服务 |
+| `DistributedRuntime(...)` | `lib/runtime/src/distributed.rs` | 管 discovery、request transport、health、metrics |
+| 路由选择 | `dynamo.llm.RouterMode`、`lib/llm/src/kv_router.rs` | 决定是 round-robin、random、direct 还是 KV-aware |
+| 后端 worker | `components/src/dynamo/sglang/main.py`、`components/src/dynamo/vllm/main.py`、`components/src/dynamo/trtllm/main.py` | 启动具体推理引擎并接入 Dynamo 运行时 |
+
+## 聚合式与解耦式服务
+
+```mermaid
+flowchart LR
+    subgraph Aggregated[聚合式]
+        AClient[Client] --> AFE[Frontend]
+        AFE --> AWorker[同一 worker 做 prefill + decode]
+        AWorker --> AFE
+    end
+
+    subgraph Disaggregated[解耦式]
+        DClient[Client] --> DFE[Frontend]
+        DFE --> DRouter[Router]
+        DRouter --> DPrefill[Prefill worker]
+        DRouter --> DDecode[Decode worker]
+        DPrefill --> DDecode
+        DDecode --> DFE
+    end
+```
+
+聚合式更简单，很多时候也是起步的最佳方式。
+
+解耦式更适合这些场景：
+
+- prompt 很长，而且长度波动大
+- decode 必须平稳，不能被大 prefill 拖住
+- prefill 和 decode 适合不同的硬件形态
+- 跨 worker 传 KV 的代价，已经小于重新算一次 prompt 的代价
+
+## 第一次排障时最值得看什么
+
+1. **Frontend 日志**：看当前启用了哪种 router mode。
+2. **Worker 注册情况**：如果 frontend 看不到 worker，先查 discovery backend。
+3. **Request plane 是否一致**：TCP / HTTP / NATS 模式要对齐。
+4. **KV 事件有没有真正流动**：否则 KV-aware routing 只会停留在配置层。
+5. **Metrics 与 health 信号是否正常**：Planner 与 runtime 都依赖它们。
+
+## 一定要记住的直觉
+
+- Dynamo **不是** 替代推理引擎。
+- Dynamo **不是** 所有部署都强制解耦。
+- Dynamo 的价值核心是 **协调**：更好的算力复用、更好的放置、更好的控制环。
+
+下一页建议读 [架构原理](architecture.md)，看完整体结构；再读 [数学与系统原理](math-theory.md)，把成本函数和伸缩公式真正看透。

--- a/docs/zh/source-tour.md
+++ b/docs/zh/source-tour.md
@@ -1,0 +1,168 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Dynamo 源码导览
+subtitle: 按最省时间、最不迷路的顺序阅读 Dynamo 源码
+---
+
+# Dynamo 源码导览
+
+Dynamo 的 monorepo 很大，如果你随机乱翻，极容易在还没建立系统边界前就被细节淹没。
+
+最推荐的读法是：
+
+1. 先看 Python 入口进程
+2. 看清它们把职责交给了哪些运行时对象
+3. 再顺着热路径进入 Rust 核心实现
+
+## 仓库的俯视图
+
+```mermaid
+flowchart TB
+    Repo[Dynamo repo]
+
+    Repo --> Components[components/src/dynamo<br/>Python 进程与后端集成]
+    Repo --> Lib[lib/<br/>Rust runtime、routing、memory、events]
+    Repo --> Docs[docs/<br/>设计文档、用户文档、参考资料]
+    Repo --> Deploy[deploy/<br/>本地与 Kubernetes 部署资产]
+
+    Components --> FE[frontend/]
+    Components --> RouterPy[router/]
+    Components --> PlannerPy[planner/]
+    Components --> Backends[sglang/ vllm/ trtllm/]
+
+    Lib --> Runtime[lib/runtime]
+    Lib --> LLM[lib/llm]
+    Lib --> KvRouter[lib/kv-router]
+    Lib --> KVBM[lib/kvbm-*]
+    Lib --> Memory[lib/memory]
+    Lib --> Events[lib/velo-events]
+```
+
+## 如果你只有 30 分钟，先读这些
+
+| 目标 | 最值得打开的文件 |
+|---|---|
+| 看懂进程怎么启动 | `components/src/dynamo/frontend/main.py` |
+| 看懂运行时怎么被构建 | `lib/runtime/src/distributed.rs` |
+| 看懂路由为什么这么选 worker | `lib/llm/src/kv_router.rs` |
+| 看懂队列策略数学 | `lib/kv-router/src/scheduling/policy.rs` |
+| 看懂解耦式 autoscaling | `components/src/dynamo/planner/core/disagg.py` |
+| 看懂内存搬运逻辑 | `lib/kvbm-physical/src/transfer/strategy.rs` |
+
+## 从 Python 入口开始最稳
+
+这些文件最适合作为“系统入口门”：
+
+| 进程 | 入口 | 你会看懂什么 |
+|---|---|---|
+| Frontend | `components/src/dynamo/frontend/__main__.py` 与 `main.py` | CLI 参数、router mode、runtime bootstrap、HTTP 服务 |
+| Standalone router | `components/src/dynamo/router/__main__.py` | router 进程如何配置与起跑 |
+| Planner | `components/src/dynamo/planner/__main__.py` | autoscaling 初始化、配置装配、与 runtime 的关系 |
+| Global planner | `components/src/dynamo/global_planner/__main__.py` | 更高层次的 pool / 规模控制 |
+| SGLang backend | `components/src/dynamo/sglang/main.py` | worker 注册、SGLang 后端接入方式 |
+| vLLM backend | `components/src/dynamo/vllm/main.py` | worker 生命周期、handler、监控注入 |
+| TRT-LLM backend | `components/src/dynamo/trtllm/main.py` | TensorRT-LLM 的集成路径 |
+
+## 然后沿着一条真实请求链往前走
+
+```mermaid
+flowchart LR
+    A[客户端请求] --> B[components/src/dynamo/frontend/main.py]
+    B --> C[components/src/dynamo/frontend/prepost.py]
+    C --> D[lib/runtime/src/distributed.rs]
+    D --> E[lib/llm/src/kv_router.rs]
+    E --> F[lib/kv-router/src/scheduling/policy.rs]
+    E --> G[lib/kv-router/src/indexer/radix_tree.rs]
+    E --> H[backend worker main.py]
+    H --> I[lib/runtime request + event transport]
+```
+
+这条路线非常有用，因为它能帮你迅速分清：
+
+- 请求预处理是谁负责
+- 分布式运行时是谁负责
+- worker 选择是谁负责
+- 真正推理执行是谁负责
+
+## 按子系统拆开的推荐阅读顺序
+
+### Frontend 与预处理
+
+当你想知道 OpenAI 兼容请求是怎么变成内部引擎请求时，看这里：
+
+- `components/src/dynamo/frontend/main.py`
+- `components/src/dynamo/frontend/prepost.py`
+- `components/src/dynamo/frontend/vllm_processor.py`
+- `components/src/dynamo/frontend/sglang_processor.py`
+
+### Routing 与 KV overlap
+
+当你想知道为什么请求被送到某个特定 worker 时，看这里：
+
+- `lib/llm/src/kv_router.rs`
+- `lib/kv-router/src/scheduling/queue.rs`
+- `lib/kv-router/src/scheduling/policy.rs`
+- `lib/kv-router/src/indexer/kv_indexer.rs`
+- `lib/kv-router/src/indexer/radix_tree.rs`
+
+### Discovery / Request plane / Event plane
+
+当你想知道集群协调是怎么成立的时，看这里：
+
+- `lib/runtime/src/distributed.rs`
+- `lib/runtime/src/discovery/mod.rs`
+- `lib/runtime/src/pipeline/network/manager.rs`
+- `lib/runtime/src/transports/event_plane/mod.rs`
+
+### Planner 与 autoscaling
+
+当你想解释副本数为什么变化时，看这里：
+
+- `components/src/dynamo/planner/__main__.py`
+- `components/src/dynamo/planner/core/disagg.py`
+- `components/src/dynamo/planner/core/prefill.py`
+- `components/src/dynamo/planner/core/decode.py`
+- `components/src/dynamo/planner/core/load/fpm_regression.py`
+
+### KVBM 与分层存储
+
+当你想弄懂 KV cache 的多层迁移与传输路径时，看这里：
+
+- `lib/kvbm-physical/src/manager/mod.rs`
+- `lib/kvbm-physical/src/layout/mod.rs`
+- `lib/kvbm-physical/src/transfer/mod.rs`
+- `lib/kvbm-physical/src/transfer/strategy.rs`
+- `lib/memory/src/nixl/agent.rs`
+
+## 按角色选择阅读顺序
+
+| 你的角色 | 推荐阅读顺序 |
+|---|---|
+| 新贡献者 | Frontend -> Distributed runtime -> KV router -> 任一 backend |
+| 路由工程师 | KV router -> queue policy -> radix tree -> KV 事件文档 |
+| 平台工程师 | Distributed runtime -> discovery -> planner -> connectors |
+| 内存 / 系统工程师 | KVBM design -> transfer strategy -> NIXL agent -> storage backends |
+
+## 快速排障对照表
+
+| 现象 | 最应该先看哪里 |
+|---|---|
+| Frontend 起了但看不到 worker | `lib/runtime/src/discovery/mod.rs` |
+| Router 选 worker 很反直觉 | `lib/llm/src/kv_router.rs` 与 `lib/kv-router/src/scheduling/policy.rs` |
+| Scaling 决策不符合预期 | `components/src/dynamo/planner/core/disagg.py` 与 `../design-docs/planner-design.md` |
+| KV 传输比想象中慢 | `lib/kvbm-physical/src/transfer/strategy.rs` 与 `../design-docs/kvbm-design.md` |
+| Cache 可见性似乎不同步 | `lib/runtime/src/transports/event_plane/mod.rs` 与 `../design-docs/router-design.md` |
+
+## 最后一个读源码建议
+
+不要拿手电筒式地乱扫源码，而要带着问题读。
+
+最好的问题通常是：
+
+- 这个进程是从哪里被构建出来的？
+- 这个决策到底归哪个层负责？
+- 这个数字在试图估计什么真实量？
+- 这是热路径，还是控制路径？
+
+只要你一直带着这些问题，Dynamo 的源码结构会清晰很多。


### PR DESCRIPTION
#### Overview:

Add a new bilingual `Learning Tutorials` documentation subtree for Dynamo, with source-grounded English and Chinese deep-dive pages that explain the architecture, request/control/state planes, KV-aware routing, KVBM memory tiering, planner math, and code reading paths.

#### Details:

- add `docs/en/` tutorial pages: landing page, quick start, architecture, math/system theory, and source tour
- add `docs/zh/` tutorial pages with the same structure, rewritten for Chinese readability
- add a new `Learning Tutorials` section to `docs/index.yml`
- ground the content in actual Dynamo source files and existing design docs
- include Mermaid diagrams and simplified numeric explanations for router, planner, and transfer logic

#### Where should the reviewer start?

- `docs/index.yml`
- `docs/en/README.md`
- `docs/en/architecture.md`
- `docs/en/math-theory.md`
- `docs/zh/README.md`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to GitHub issue: #7725


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive learning tutorial track covering Quick Start, Architecture, Math and Systems Theory, and Source Tour
  * Tutorials available in both English and Chinese
  * Includes architecture diagrams, request flow walkthroughs, code navigation guides, and first-session troubleshooting checklists
  * New Learning Tutorials section added to documentation navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->