### PR TITLE
test(replay): compare offline replay against AIC static point

### DIFF
--- a/lib/bindings/python/tests/test_replay.py
+++ b/lib/bindings/python/tests/test_replay.py
@@ -264,6 +264,10 @@ AIC_PARITY_VERSIONS = {
     "vllm": "0.12.0",
     "sglang": "0.5.6.post2",
 }
+AIC_PARITY_BACKENDS = [
+    pytest.param("vllm", marks=pytest.mark.vllm, id="vllm"),
+    pytest.param("sglang", marks=pytest.mark.sglang, id="sglang"),
+]
 
 
 def _aic_replay_args(backend_name: str):
@@ -280,6 +284,40 @@ def _aic_replay_args(backend_name: str):
         "aic_backend_version": AIC_PARITY_VERSIONS[backend_name],
         "aic_tp_size": 1,
         "aic_model_path": AIC_PARITY_MODEL,
+    }
+    if backend_name == "sglang":
+        payload["engine_type"] = "sglang"
+        payload["sglang"] = {
+            "page_size": 512,
+            "max_prefill_tokens": 65536,
+            "chunked_prefill_size": 65536,
+        }
+    return MockEngineArgs.from_json(json.dumps(payload))
+
+
+def _aic_disagg_replay_args(
+    backend_name: str,
+    *,
+    tp_size: int,
+    is_prefill: bool,
+    max_num_seqs: int,
+    max_num_batched_tokens: int,
+):
+    payload = {
+        "block_size": 512,
+        "enable_prefix_caching": False,
+        "enable_chunked_prefill": False,
+        "max_num_seqs": max_num_seqs,
+        "max_num_batched_tokens": max_num_batched_tokens,
+        "num_gpu_blocks": 50000,
+        "speedup_ratio": 1.0,
+        "aic_backend": backend_name,
+        "aic_system": AIC_PARITY_SYSTEM,
+        "aic_backend_version": AIC_PARITY_VERSIONS[backend_name],
+        "aic_tp_size": tp_size,
+        "aic_model_path": AIC_PARITY_MODEL,
+        "is_prefill": is_prefill,
+        "is_decode": not is_prefill,
     }
     if backend_name == "sglang":
         payload["engine_type"] = "sglang"
@@ -626,7 +664,7 @@ def test_run_synthetic_concurrency_replay_counts_match(
     )
 
 
-@pytest.mark.parametrize("backend_name", ["vllm", "sglang"])
+@pytest.mark.parametrize("backend_name", AIC_PARITY_BACKENDS)
 @pytest.mark.parametrize("isl", [256, 512, 1024, 2048, 4096])
 def test_run_synthetic_concurrency_replay_matches_aic_static_point_no_prefix(
     backend_name, isl
@@ -654,6 +692,120 @@ def test_run_synthetic_concurrency_replay_matches_aic_static_point_no_prefix(
     assert report["output_throughput_tok_s"] == pytest.approx(
         aic["tokens/s/gpu"], rel=0.05
     )
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize(
+    (
+        "backend_name",
+        "isl",
+        "osl",
+        "request_count",
+        "replay_concurrency",
+        "total_gpu_budget",
+        "prefill_tp",
+        "decode_tp",
+        "prefill_bs",
+        "decode_bs",
+        "prefill_workers",
+        "decode_workers",
+        "prefill_seq_s_per_worker",
+        "decode_seq_s_per_worker",
+    ),
+    [
+        pytest.param(
+            "vllm",
+            1024,
+            512,
+            1440,
+            720,
+            20,
+            1,
+            2,
+            1,
+            120,
+            6,
+            5,
+            10.49,
+            12.482,
+            marks=pytest.mark.vllm,
+            id="vllm",
+        ),
+        pytest.param(
+            "sglang",
+            1024,
+            512,
+            2944,
+            1472,
+            24,
+            2,
+            2,
+            1,
+            184,
+            6,
+            6,
+            15.811,
+            14.669,
+            marks=pytest.mark.sglang,
+            id="sglang",
+        ),
+    ],
+)
+def test_run_synthetic_disagg_replay_preserves_aic_local_optimum(
+    backend_name,
+    isl,
+    osl,
+    request_count,
+    replay_concurrency,
+    total_gpu_budget,
+    prefill_tp,
+    decode_tp,
+    prefill_bs,
+    decode_bs,
+    prefill_workers,
+    decode_workers,
+    prefill_seq_s_per_worker,
+    decode_seq_s_per_worker,
+):
+    prefill_args = _aic_disagg_replay_args(
+        backend_name,
+        tp_size=prefill_tp,
+        is_prefill=True,
+        max_num_seqs=prefill_bs,
+        max_num_batched_tokens=isl,
+    )
+    decode_args = _aic_disagg_replay_args(
+        backend_name,
+        tp_size=decode_tp,
+        is_prefill=False,
+        max_num_seqs=decode_bs,
+        max_num_batched_tokens=200000,
+    )
+
+    variants = [
+        ("picked", prefill_workers, decode_workers),
+        ("p_minus_2_d_plus_2", prefill_workers - 2, decode_workers + 2),
+        ("p_plus_2_d_minus_2", prefill_workers + 2, decode_workers - 2),
+    ]
+    reports = {}
+    for variant_name, p_workers, d_workers in variants:
+        report = run_synthetic_trace_replay(
+            isl,
+            osl,
+            request_count,
+            prefill_engine_args=prefill_args,
+            decode_engine_args=decode_args,
+            num_prefill_workers=p_workers,
+            num_decode_workers=d_workers,
+            replay_concurrency=replay_concurrency,
+            replay_mode="offline",
+            router_mode="round_robin",
+            arrival_interval_ms=0.0,
+        )
+        reports[variant_name] = report["output_throughput_tok_s"] / total_gpu_budget
+
+    assert reports["picked"] > reports["p_minus_2_d_plus_2"]
+    assert reports["picked"] > reports["p_plus_2_d_minus_2"]
 
 
 @pytest.mark.parametrize("replay_mode", ["offline", "online"])

--- a/lib/bindings/python/tests/test_replay.py
+++ b/lib/bindings/python/tests/test_replay.py
@@ -258,6 +258,26 @@ def _planner_profile_data_npz_path() -> Path:
     )
 
 
+def _aic_replay_args():
+    return MockEngineArgs.from_json(
+        json.dumps(
+            {
+                "block_size": 512,
+                "enable_prefix_caching": True,
+                "enable_chunked_prefill": False,
+                "max_num_seqs": 16,
+                "max_num_batched_tokens": 65536,
+                "num_gpu_blocks": 100000,
+                "speedup_ratio": 1.0,
+                "aic_backend": "vllm",
+                "aic_system": "h200_sxm",
+                "aic_tp_size": 1,
+                "aic_model_path": "Qwen/Qwen3-32B",
+            }
+        )
+    )
+
+
 def _planner_profile_data_dir_path() -> Path:
     return (
         Path(__file__).resolve().parents[4]
@@ -559,6 +579,57 @@ def test_run_synthetic_concurrency_replay_counts_match(
         num_requests=3,
         input_tokens=64,
         output_tokens=2,
+    )
+
+
+def test_run_synthetic_concurrency_replay_matches_aic_static_point_no_prefix():
+    aiconfigurator = pytest.importorskip("aiconfigurator")
+
+    report = run_synthetic_trace_replay(
+        4096,
+        128,
+        8,
+        extra_engine_args=_aic_replay_args(),
+        num_workers=1,
+        replay_mode="offline",
+        replay_concurrency=8,
+        arrival_interval_ms=0.0,
+    )
+
+    database = aiconfigurator.sdk.perf_database.get_database(
+        system="h200_sxm",
+        backend="vllm",
+        version=aiconfigurator.sdk.perf_database.get_latest_database_version(
+            "h200_sxm",
+            "vllm",
+        ),
+    )
+    backend = aiconfigurator.sdk.backends.factory.get_backend("vllm")
+    model = aiconfigurator.sdk.models.get_model(
+        model_path="Qwen/Qwen3-32B",
+        model_config=aiconfigurator.sdk.config.ModelConfig(tp_size=1),
+        backend_name="vllm",
+    )
+    session = aiconfigurator.sdk.inference_session.InferenceSession(
+        model, database, backend
+    )
+    summary = session.run_static(
+        runtime_config=aiconfigurator.sdk.config.RuntimeConfig(
+            batch_size=8,
+            beam_width=1,
+            isl=4096,
+            osl=128,
+            prefix=0,
+        ),
+        mode="static",
+        stride=32,
+    )
+    aic = summary.get_summary_df().to_dict(orient="records")[0]
+
+    assert report["mean_ttft_ms"] == pytest.approx(aic["context_latency"], rel=0.05)
+    assert report["mean_tpot_ms"] == pytest.approx(aic["tpot"], rel=0.05)
+    assert report["output_throughput_tok_s"] == pytest.approx(
+        aic["tokens/s/gpu"], rel=0.05
     )
 
 

--- a/lib/bindings/python/tests/test_replay.py
+++ b/lib/bindings/python/tests/test_replay.py
@@ -278,6 +278,40 @@ def _aic_replay_args():
     )
 
 
+def _run_aic_static_point(isl: int, osl: int, batch_size: int):
+    aiconfigurator = pytest.importorskip("aiconfigurator")
+
+    database = aiconfigurator.sdk.perf_database.get_database(
+        system="h200_sxm",
+        backend="vllm",
+        version=aiconfigurator.sdk.perf_database.get_latest_database_version(
+            "h200_sxm",
+            "vllm",
+        ),
+    )
+    backend = aiconfigurator.sdk.backends.factory.get_backend("vllm")
+    model = aiconfigurator.sdk.models.get_model(
+        model_path="Qwen/Qwen3-32B",
+        model_config=aiconfigurator.sdk.config.ModelConfig(tp_size=1),
+        backend_name="vllm",
+    )
+    session = aiconfigurator.sdk.inference_session.InferenceSession(
+        model, database, backend
+    )
+    summary = session.run_static(
+        runtime_config=aiconfigurator.sdk.config.RuntimeConfig(
+            batch_size=batch_size,
+            beam_width=1,
+            isl=isl,
+            osl=osl,
+            prefix=0,
+        ),
+        mode="static",
+        stride=32,
+    )
+    return summary.get_summary_df().to_dict(orient="records")[0]
+
+
 def _planner_profile_data_dir_path() -> Path:
     return (
         Path(__file__).resolve().parents[4]
@@ -582,11 +616,10 @@ def test_run_synthetic_concurrency_replay_counts_match(
     )
 
 
-def test_run_synthetic_concurrency_replay_matches_aic_static_point_no_prefix():
-    aiconfigurator = pytest.importorskip("aiconfigurator")
-
+@pytest.mark.parametrize("isl", [256, 512, 1024, 2048, 4096])
+def test_run_synthetic_concurrency_replay_matches_aic_static_point_no_prefix(isl):
     report = run_synthetic_trace_replay(
-        4096,
+        isl,
         128,
         8,
         extra_engine_args=_aic_replay_args(),
@@ -595,38 +628,10 @@ def test_run_synthetic_concurrency_replay_matches_aic_static_point_no_prefix():
         replay_concurrency=8,
         arrival_interval_ms=0.0,
     )
+    aic = _run_aic_static_point(isl=isl, osl=128, batch_size=8)
+    expected_ttft_ms = aic["context_latency"] + aic["tpot"]
 
-    database = aiconfigurator.sdk.perf_database.get_database(
-        system="h200_sxm",
-        backend="vllm",
-        version=aiconfigurator.sdk.perf_database.get_latest_database_version(
-            "h200_sxm",
-            "vllm",
-        ),
-    )
-    backend = aiconfigurator.sdk.backends.factory.get_backend("vllm")
-    model = aiconfigurator.sdk.models.get_model(
-        model_path="Qwen/Qwen3-32B",
-        model_config=aiconfigurator.sdk.config.ModelConfig(tp_size=1),
-        backend_name="vllm",
-    )
-    session = aiconfigurator.sdk.inference_session.InferenceSession(
-        model, database, backend
-    )
-    summary = session.run_static(
-        runtime_config=aiconfigurator.sdk.config.RuntimeConfig(
-            batch_size=8,
-            beam_width=1,
-            isl=4096,
-            osl=128,
-            prefix=0,
-        ),
-        mode="static",
-        stride=32,
-    )
-    aic = summary.get_summary_df().to_dict(orient="records")[0]
-
-    assert report["mean_ttft_ms"] == pytest.approx(aic["context_latency"], rel=0.05)
+    assert report["mean_ttft_ms"] == pytest.approx(expected_ttft_ms, rel=0.05)
     assert report["mean_tpot_ms"] == pytest.approx(aic["tpot"], rel=0.05)
     assert report["output_throughput_tok_s"] == pytest.approx(
         aic["tokens/s/gpu"], rel=0.05

--- a/lib/bindings/python/tests/test_replay.py
+++ b/lib/bindings/python/tests/test_replay.py
@@ -258,39 +258,52 @@ def _planner_profile_data_npz_path() -> Path:
     )
 
 
-def _aic_replay_args():
-    return MockEngineArgs.from_json(
-        json.dumps(
-            {
-                "block_size": 512,
-                "enable_prefix_caching": True,
-                "enable_chunked_prefill": False,
-                "max_num_seqs": 16,
-                "max_num_batched_tokens": 65536,
-                "num_gpu_blocks": 100000,
-                "speedup_ratio": 1.0,
-                "aic_backend": "vllm",
-                "aic_system": "h200_sxm",
-                "aic_tp_size": 1,
-                "aic_model_path": "Qwen/Qwen3-32B",
-            }
-        )
-    )
+AIC_PARITY_MODEL = "Qwen/Qwen3-32B"
+AIC_PARITY_SYSTEM = "h200_sxm"
+AIC_PARITY_VERSIONS = {
+    "vllm": "0.12.0",
+    "sglang": "0.5.6.post2",
+}
 
 
-def _run_aic_static_point(isl: int, osl: int, batch_size: int):
+def _aic_replay_args(backend_name: str):
+    payload = {
+        "block_size": 512,
+        "enable_prefix_caching": True,
+        "enable_chunked_prefill": False,
+        "max_num_seqs": 16,
+        "max_num_batched_tokens": 65536,
+        "num_gpu_blocks": 100000,
+        "speedup_ratio": 1.0,
+        "aic_backend": backend_name,
+        "aic_system": AIC_PARITY_SYSTEM,
+        "aic_backend_version": AIC_PARITY_VERSIONS[backend_name],
+        "aic_tp_size": 1,
+        "aic_model_path": AIC_PARITY_MODEL,
+    }
+    if backend_name == "sglang":
+        payload["engine_type"] = "sglang"
+        payload["sglang"] = {
+            "page_size": 512,
+            "max_prefill_tokens": 65536,
+            "chunked_prefill_size": 65536,
+        }
+    return MockEngineArgs.from_json(json.dumps(payload))
+
+
+def _run_aic_static_point(backend_name: str, isl: int, osl: int, batch_size: int):
     aiconfigurator = pytest.importorskip("aiconfigurator")
 
     database = aiconfigurator.sdk.perf_database.get_database(
-        system="h200_sxm",
-        backend="vllm",
-        version="0.12.0",
+        system=AIC_PARITY_SYSTEM,
+        backend=backend_name,
+        version=AIC_PARITY_VERSIONS[backend_name],
     )
-    backend = aiconfigurator.sdk.backends.factory.get_backend("vllm")
+    backend = aiconfigurator.sdk.backends.factory.get_backend(backend_name)
     model = aiconfigurator.sdk.models.get_model(
-        model_path="Qwen/Qwen3-32B",
+        model_path=AIC_PARITY_MODEL,
         model_config=aiconfigurator.sdk.config.ModelConfig(tp_size=1),
-        backend_name="vllm",
+        backend_name=backend_name,
     )
     session = aiconfigurator.sdk.inference_session.InferenceSession(
         model, database, backend
@@ -613,19 +626,27 @@ def test_run_synthetic_concurrency_replay_counts_match(
     )
 
 
+@pytest.mark.parametrize("backend_name", ["vllm", "sglang"])
 @pytest.mark.parametrize("isl", [256, 512, 1024, 2048, 4096])
-def test_run_synthetic_concurrency_replay_matches_aic_static_point_no_prefix(isl):
+def test_run_synthetic_concurrency_replay_matches_aic_static_point_no_prefix(
+    backend_name, isl
+):
     report = run_synthetic_trace_replay(
         isl,
         128,
         8,
-        extra_engine_args=_aic_replay_args(),
+        extra_engine_args=_aic_replay_args(backend_name),
         num_workers=1,
         replay_mode="offline",
         replay_concurrency=8,
         arrival_interval_ms=0.0,
     )
-    aic = _run_aic_static_point(isl=isl, osl=128, batch_size=8)
+    aic = _run_aic_static_point(
+        backend_name=backend_name,
+        isl=isl,
+        osl=128,
+        batch_size=8,
+    )
     expected_ttft_ms = aic["context_latency"] + aic["tpot"]
 
     assert report["mean_ttft_ms"] == pytest.approx(expected_ttft_ms, rel=0.05)

--- a/lib/bindings/python/tests/test_replay.py
+++ b/lib/bindings/python/tests/test_replay.py
@@ -284,10 +284,7 @@ def _run_aic_static_point(isl: int, osl: int, batch_size: int):
     database = aiconfigurator.sdk.perf_database.get_database(
         system="h200_sxm",
         backend="vllm",
-        version=aiconfigurator.sdk.perf_database.get_latest_database_version(
-            "h200_sxm",
-            "vllm",
-        ),
+        version="0.12.0",
     )
     backend = aiconfigurator.sdk.backends.factory.get_backend("vllm")
     model = aiconfigurator.sdk.models.get_model(


### PR DESCRIPTION
Adds replay-side parity coverage for the no-prefix single-engine burst case and checks replay against direct AIC `run_static` across an ISL sweep for both `vllm` and `sglang`.

The test now covers `isl in {256, 512, 1024, 2048, 4096}` at fixed:
- `model=Qwen/Qwen3-32B`
- `system=h200_sxm`
- `tp=1`
- `osl=128`
- `batch_size=8`
- replay `num_workers=1`, `replay_concurrency=8`

Backend-specific pins/settings:
- `vllm`: AIC perf DB version `0.12.0`
- `sglang`: AIC perf DB version `0.5.6.post2`
- `sglang` replay is run with `page_size=512`, `max_prefill_tokens=65536`, and `chunked_prefill_size=65536` so the scheduler can realize the intended batch-8 prefill point instead of clipping it.

Metrics checked within 5% relative tolerance at each point:
- replay `mean_ttft_ms` vs AIC `context_latency + tpot`
- replay `mean_tpot_ms` vs AIC `tpot`
- replay `output_throughput_tok_s` vs AIC `tokens/s/gpu`

The TTFT comparison uses `context_latency + tpot` rather than bare `context_latency` because replay TTFT includes the first decode step, while AIC `context_latency` is prefill-only.

The test pins the AIC perf DB versions explicitly so parity stays deterministic even if newer upstream perf tables are published later.

vLLM sweep results:

| ISL | Replay TTFT (ms) | AIC TTFT proxy (ms) | Replay TPOT (ms) | AIC TPOT (ms) | Replay throughput (tok/s) | AIC throughput (tok/s/gpu) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 256 | 185.491 | 185.507 | 18.649 | 18.644 | 400.944 | 403.990 |
| 512 | 364.203 | 364.215 | 18.713 | 18.709 | 373.627 | 376.263 |
| 1024 | 715.735 | 715.765 | 18.880 | 18.869 | 328.890 | 331.041 |
| 2048 | 1438.322 | 1438.351 | 19.670 | 19.661 | 260.133 | 261.520 |
| 4096 | 2961.092 | 2961.115 | 20.659 | 20.651 | 183.356 | 184.068 |

SGLang sweep results:

| ISL | Replay TTFT (ms) | AIC TTFT proxy (ms) | Replay TPOT (ms) | AIC TPOT (ms) | Replay throughput (tok/s) | AIC throughput (tok/s/gpu) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 256 | 235.366 | 235.406 | 18.819 | 18.806 | 370.468 | 373.392 |
| 512 | 461.056 | 461.081 | 18.890 | 18.883 | 348.484 | 350.946 |
| 1024 | 913.199 | 913.233 | 19.080 | 19.069 | 313.553 | 315.544 |
| 2048 | 1842.737 | 1842.781 | 19.629 | 19.619 | 257.959 | 259.268 |
| 4096 | 3796.502 | 3796.529 | 20.602 | 20.595 | 181.183 | 181.839 |

Max observed deltas across the sweep:
- `vllm`: TTFT `0.008%`, TPOT `0.058%`, throughput `0.754%`
- `sglang`: TTFT `0.017%`, TPOT `0.068%`, throughput `0.783%`
