### PR TITLE
fix: separate quiesce state from discovery registration

### DIFF
--- a/components/src/dynamo/common/utils/snapshot.py
+++ b/components/src/dynamo/common/utils/snapshot.py
@@ -73,7 +73,6 @@ class CheckpointConfig:
                 logger.info("Restore signal detected (SIGCONT)")
                 logger.info("Resuming model after restore")
                 await quiesce_controller.resume()
-                quiesce_controller.mark_resumed()
                 return True
 
             logger.info("Checkpoint completion signal detected (SIGUSR1)")

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -30,6 +30,13 @@ from dynamo.sglang.publisher import DynamoSglangPublisher
 
 
 class SGLangEngineQuiesceController:
+    """Manage SGLang engine memory release and resume transitions.
+
+    This controller only tracks engine state. Discovery registration is kept in
+    the request handler because registration can fail after the engine is already
+    serving again.
+    """
+
     def __init__(self, engine: sgl.Engine):
         self._engine = engine
         self._quiesced_tags: Optional[list[str]] = None
@@ -40,6 +47,7 @@ class SGLangEngineQuiesceController:
         return self._is_quiesced
 
     async def quiesce(self, tags: Optional[list[str]] = None) -> bool:
+        """Pause generation and release the requested GPU memory."""
         if self._is_quiesced:
             return False
 
@@ -58,6 +66,7 @@ class SGLangEngineQuiesceController:
         return True
 
     async def resume(self, tags: Optional[list[str]] = None) -> bool:
+        """Restore GPU memory and continue generation."""
         if not self._is_quiesced:
             return False
 
@@ -74,11 +83,9 @@ class SGLangEngineQuiesceController:
         await self._engine.tokenizer_manager.continue_generation(
             ContinueGenerationReqInput()
         )
-        return True
-
-    def mark_resumed(self) -> None:
         self._quiesced_tags = None
         self._is_quiesced = False
+        return True
 
 
 RequestT = TypeVar("RequestT")
@@ -207,6 +214,8 @@ class BaseWorkerHandler(BaseGenerativeHandler[RequestT, ResponseT]):
             SGLangEngineQuiesceController(engine) if engine is not None else None
         )
         self._quiesce_lock = asyncio.Lock()
+        # Discovery can fail after the engine state has already changed.
+        self._endpoint_needs_registration = False
 
     def _priority_kwargs(self, priority: Any) -> Dict[str, Any]:
         if priority is not None and self._engine_supports_priority:
@@ -246,8 +255,12 @@ class BaseWorkerHandler(BaseGenerativeHandler[RequestT, ResponseT]):
 
             try:
                 # Stop new requests and drain in-flight work before releasing memory.
-                if self.generate_endpoint is not None:
+                if (
+                    self.generate_endpoint is not None
+                    and not self._endpoint_needs_registration
+                ):
                     await self.generate_endpoint.unregister_endpoint_instance()
+                    self._endpoint_needs_registration = True
 
                 await self._quiesce_controller.quiesce(tags)
 
@@ -283,18 +296,25 @@ class BaseWorkerHandler(BaseGenerativeHandler[RequestT, ResponseT]):
         body = body or {}
         tags = body.get("tags")
         async with self._quiesce_lock:
-            if not self._quiesce_controller.is_quiesced:
+            if (
+                not self._quiesce_controller.is_quiesced
+                and not self._endpoint_needs_registration
+            ):
                 return {
                     "status": "ok",
                     "message": "Memory already resumed",
                 }
 
             try:
-                await self._quiesce_controller.resume(tags)
+                if self._quiesce_controller.is_quiesced:
+                    await self._quiesce_controller.resume(tags)
 
-                if self.generate_endpoint is not None:
+                if (
+                    self.generate_endpoint is not None
+                    and self._endpoint_needs_registration
+                ):
                     await self.generate_endpoint.register_endpoint_instance()
-                self._quiesce_controller.mark_resumed()
+                    self._endpoint_needs_registration = False
 
                 return {
                     "status": "ok",

--- a/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
@@ -61,6 +61,7 @@ def _make_handler() -> _TestWorkerHandler:
     )
     handler._quiesce_controller = SGLangEngineQuiesceController(handler.engine)
     handler._quiesce_lock = asyncio.Lock()
+    handler._endpoint_needs_registration = False
     return handler
 
 
@@ -192,7 +193,7 @@ async def test_resume_returns_error_when_worker_has_no_tokenizer_manager():
 
 
 @pytest.mark.asyncio
-async def test_resume_keeps_quiesced_state_when_register_fails():
+async def test_resume_tracks_awake_state_when_register_fails():
     handler = _make_handler()
     await handler.release_memory_occupation({})
     handler.generate_endpoint.register_endpoint_instance = AsyncMock(
@@ -203,4 +204,23 @@ async def test_resume_keeps_quiesced_state_when_register_fails():
 
     assert result["status"] == "error"
     assert handler._quiesce_controller is not None
-    assert handler._quiesce_controller.is_quiesced is True
+    assert handler._quiesce_controller.is_quiesced is False
+    assert handler._endpoint_needs_registration is True
+
+
+@pytest.mark.asyncio
+async def test_resume_retries_registration_without_rewaking_engine():
+    handler = _make_handler()
+    await handler.release_memory_occupation({})
+    handler.generate_endpoint.register_endpoint_instance = AsyncMock(
+        side_effect=[RuntimeError("discovery write timeout"), None]
+    )
+
+    first_result = await handler.resume_memory_occupation({})
+    second_result = await handler.resume_memory_occupation({})
+
+    assert first_result["status"] == "error"
+    assert second_result["status"] == "ok"
+    handler.engine.tokenizer_manager.resume_memory_occupation.assert_awaited_once()
+    handler.engine.tokenizer_manager.continue_generation.assert_awaited_once()
+    assert handler.generate_endpoint.register_endpoint_instance.await_count == 2

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -67,6 +67,13 @@ logger = logging.getLogger(__name__)
 
 
 class VllmEngineQuiesceController:
+    """Manage vLLM engine sleep and wake transitions.
+
+    This controller only tracks engine state. Discovery registration is kept in
+    the request handler because registration can fail after the engine is already
+    awake.
+    """
+
     def __init__(self, engine_client: Any):
         self._engine_client = engine_client
         self._is_quiesced = False
@@ -76,6 +83,7 @@ class VllmEngineQuiesceController:
         return self._is_quiesced
 
     async def quiesce(self, *args: object) -> bool:
+        """Pause generation and put the engine into sleep mode."""
         if self._is_quiesced:
             return False
 
@@ -89,6 +97,7 @@ class VllmEngineQuiesceController:
         return True
 
     async def resume(self, tags: list[str] | None = None) -> bool:
+        """Wake the engine and resume generation."""
         if not self._is_quiesced:
             return False
 
@@ -97,10 +106,8 @@ class VllmEngineQuiesceController:
         else:
             await self._engine_client.wake_up(tags)
         await self._engine_client.resume_generation()
-        return True
-
-    def mark_resumed(self) -> None:
         self._is_quiesced = False
+        return True
 
 
 @dataclass(frozen=True)
@@ -395,6 +402,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         self.dp_range = get_dp_range_for_worker(self.engine_client.vllm_config)
         self._quiesce_controller = VllmEngineQuiesceController(self.engine_client)
         self._quiesce_lock = asyncio.Lock()
+        # Discovery can fail after the engine state has already changed.
+        self._endpoint_needs_registration = False
 
         # Initialize InputParamManager for text-in-text-out mode
         tokenizer = None
@@ -473,8 +482,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
             try:
                 # Step 1: Unregister endpoint instance before memory transitions.
-                if self.generate_endpoint is not None:
+                if (
+                    self.generate_endpoint is not None
+                    and not self._endpoint_needs_registration
+                ):
                     await self.generate_endpoint.unregister_endpoint_instance()
+                    self._endpoint_needs_registration = True
                     logger.info(
                         "[Sleep] Unregistered endpoint from discovery - worker removed from routing pool"
                     )
@@ -582,18 +595,25 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         body = body or {}
         tags = body.get("tags")
         async with self._quiesce_lock:
-            if not self._quiesce_controller.is_quiesced:
+            if (
+                not self._quiesce_controller.is_quiesced
+                and not self._endpoint_needs_registration
+            ):
                 return {"status": "ok", "message": "Engine already awake"}
 
             try:
                 # Step 1: Wake engine first - must be ready before accepting requests
-                await self._quiesce_controller.resume(tags)
-                if self.generate_endpoint is not None:
+                if self._quiesce_controller.is_quiesced:
+                    await self._quiesce_controller.resume(tags)
+                if (
+                    self.generate_endpoint is not None
+                    and self._endpoint_needs_registration
+                ):
                     await self.generate_endpoint.register_endpoint_instance()
+                    self._endpoint_needs_registration = False
                     logger.info(
                         "[Wake] Re-registered endpoint to discovery - worker added back to routing pool"
                     )
-                self._quiesce_controller.mark_resumed()
 
                 return {
                     "status": "ok",
@@ -1496,6 +1516,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
 
 class DecodeWorkerHandler(BaseWorkerHandler):
+    """Serve decode-phase generation requests from an already-prefilled prompt."""
+
     def __init__(
         self,
         runtime,
@@ -1730,6 +1752,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
 
 class PrefillWorkerHandler(BaseWorkerHandler):
+    """Serve prefill requests and forward decode state to downstream workers."""
+
     def __init__(
         self,
         runtime,

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1516,8 +1516,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
 
 class DecodeWorkerHandler(BaseWorkerHandler):
-    """Serve decode-phase generation requests from an already-prefilled prompt."""
-
     def __init__(
         self,
         runtime,
@@ -1752,8 +1750,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
 
 class PrefillWorkerHandler(BaseWorkerHandler):
-    """Serve prefill requests and forward decode state to downstream workers."""
-
     def __init__(
         self,
         runtime,

--- a/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
@@ -36,6 +36,7 @@ def _make_handler() -> _TestWorkerHandler:
     )
     handler._quiesce_controller = VllmEngineQuiesceController(handler.engine_client)
     handler._quiesce_lock = asyncio.Lock()
+    handler._endpoint_needs_registration = False
     return handler
 
 
@@ -95,6 +96,7 @@ async def test_quiesce_without_level_uses_vllm_default_sleep():
 async def test_wake_up_passes_explicit_tags_from_request():
     handler = _make_handler()
     await handler._quiesce_controller.quiesce(1)
+    handler._endpoint_needs_registration = True
 
     result = await handler.wake_up({"tags": ["weights"]})
 
@@ -122,6 +124,7 @@ async def test_sleep_returns_error_for_unregister_failure():
 async def test_wake_up_returns_error_for_register_failure():
     handler = _make_handler()
     await handler._quiesce_controller.quiesce(1)
+    handler._endpoint_needs_registration = True
     handler.generate_endpoint.register_endpoint_instance = AsyncMock(
         side_effect=RuntimeError("discovery write timeout")
     )
@@ -131,4 +134,23 @@ async def test_wake_up_returns_error_for_register_failure():
     assert result["status"] == "error"
     handler.engine_client.wake_up.assert_awaited_once_with()
     handler.engine_client.resume_generation.assert_awaited_once()
-    assert handler._quiesce_controller.is_quiesced is True
+    assert handler._quiesce_controller.is_quiesced is False
+    assert handler._endpoint_needs_registration is True
+
+
+@pytest.mark.asyncio
+async def test_wake_up_retries_registration_without_rewaking_engine():
+    handler = _make_handler()
+    await handler.sleep({"level": 1})
+    handler.generate_endpoint.register_endpoint_instance = AsyncMock(
+        side_effect=[RuntimeError("discovery write timeout"), None]
+    )
+
+    first_result = await handler.wake_up({})
+    second_result = await handler.wake_up({})
+
+    assert first_result["status"] == "error"
+    assert second_result["status"] == "ok"
+    handler.engine_client.wake_up.assert_awaited_once_with()
+    handler.engine_client.resume_generation.assert_awaited_once()
+    assert handler.generate_endpoint.register_endpoint_instance.await_count == 2

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -4,10 +4,14 @@
 """Unit tests for worker_factory.py"""
 
 import asyncio
+import sys
+import types
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+import dynamo.vllm.worker_factory as worker_factory_module
 from dynamo.vllm.constants import DisaggregationMode
 from dynamo.vllm.worker_factory import EngineSetupResult, WorkerFactory
 
@@ -202,3 +206,97 @@ class TestCreate:
             shutdown_endpoints,
             snapshot_engine=snapshot_engine,
         )
+
+    async def test_shadow_mode_wakes_with_resume_only(
+        self, factory: WorkerFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = _make_config(
+            namespace="test-ns",
+            component="decode",
+            endpoint="generate",
+            endpoint_types="generate",
+            gms_shadow_mode=True,
+            enable_multimodal=False,
+            use_vllm_tokenizer=False,
+            frontend_decoding=False,
+            custom_jinja_template=None,
+            engine_args=Mock(enable_lora=False),
+        )
+        runtime = Mock()
+        generate_endpoint = Mock()
+        generate_endpoint.connection_id.return_value = 123
+        clear_endpoint = Mock()
+        runtime.endpoint.side_effect = [generate_endpoint, clear_endpoint]
+        shutdown_event = asyncio.Event()
+        shutdown_endpoints: list = []
+
+        engine_client = Mock()
+        vllm_config = Mock()
+        vllm_config.cache_config.num_gpu_blocks = 8
+        vllm_config.additional_config = {}
+        vllm_config.model_config = Mock(max_model_len=128)
+        factory.setup_vllm_engine.return_value = (
+            engine_client,
+            vllm_config,
+            Mock(),
+            Mock(),
+            Mock(),
+        )
+        factory.setup_kv_event_publisher.return_value = None
+        factory.setup_fpm_relay.return_value = None
+        factory.setup_metrics_collection = Mock()
+        factory._maybe_get_encode_worker_client = AsyncMock(return_value=None)  # type: ignore[method-assign]
+        factory.register_vllm_model = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("stop after shadow wake")
+        )
+
+        lock = SimpleNamespace(acquire=AsyncMock())
+        flock_module = types.ModuleType("gpu_memory_service.failover_lock.flock")
+        flock_module.FlockFailoverLock = Mock(return_value=lock)
+        monkeypatch.setitem(sys.modules, "gpu_memory_service", types.ModuleType("gms"))
+        monkeypatch.setitem(
+            sys.modules,
+            "gpu_memory_service.failover_lock",
+            types.ModuleType("gpu_memory_service.failover_lock"),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "gpu_memory_service.failover_lock.flock",
+            flock_module,
+        )
+
+        quiesce_controller = SimpleNamespace(
+            quiesce=AsyncMock(),
+            resume=AsyncMock(),
+        )
+        handler = Mock()
+        handler._quiesce_controller = quiesce_controller
+        handler.add_temp_dir = Mock()
+        handler.sleep = AsyncMock()
+        handler.wake_up = AsyncMock()
+        handler.scale_elastic_ep = AsyncMock()
+        handler.cleanup = Mock()
+
+        monkeypatch.setattr(
+            worker_factory_module,
+            "DecodeWorkerHandler",
+            Mock(return_value=handler),
+        )
+        monkeypatch.setattr(
+            worker_factory_module,
+            "parse_endpoint_types",
+            Mock(return_value=Mock()),
+        )
+
+        with pytest.raises(RuntimeError, match="stop after shadow wake"):
+            await factory._create_decode_worker(
+                runtime,
+                config,
+                shutdown_event,
+                shutdown_endpoints,
+            )
+
+        quiesce_controller.quiesce.assert_awaited_once_with(1)
+        quiesce_controller.resume.assert_awaited_once_with()
+        runtime.set_health_status.assert_called_once_with(True)
+        lock.acquire.assert_awaited_once_with(engine_id="engine-0")

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -537,7 +537,6 @@ class WorkerFactory:
             logger.info("[Shadow] Lock acquired, waking engine")
 
             await handler._quiesce_controller.resume()
-            handler._quiesce_controller.mark_resumed()
             logger.info("[Shadow] Engine awake, registering with discovery")
 
         await self.register_vllm_model(


### PR DESCRIPTION
## Summary
- move quiesce controller state transitions back into `resume()` for both vLLM and SGLang
- track pending discovery re-registration separately in the worker handlers so partial wake failures can be retried without re-waking the engine
- add regression tests for registration failure recovery and add docstrings only to the quiesce controller classes

## Why
A partial wake-up failure could leave the engine awake while the controller still reported `is_quiesced = True`. That made later `wake_up()` and `sleep()` calls take the wrong path because a single flag was representing both engine sleep state and discovery registration state.

This change separates those concerns:
- the quiesce controller owns only engine state
- the handler owns whether endpoint registration still needs to be retried
