### PR TITLE
fix(snapshot): harden loopback-only restore and force SGLang PyNccl

### DIFF
--- a/components/src/dynamo/sglang/__main__.py
+++ b/components/src/dynamo/sglang/__main__.py
@@ -6,6 +6,11 @@ import os
 if "PYTHONHASHSEED" not in os.environ:
     os.environ["PYTHONHASHSEED"] = "0"
 
+if os.environ.get("DYN_READY_FOR_CHECKPOINT_FILE"):
+    from dynamo.sglang.patches import apply_snapshot_patches
+
+    apply_snapshot_patches()
+
 from dynamo.sglang.main import main
 
 if __name__ == "__main__":

--- a/components/src/dynamo/sglang/patches.py
+++ b/components/src/dynamo/sglang/patches.py
@@ -34,6 +34,17 @@ def _configure_snapshot_dist_init() -> None:
     )
 
 
+def run_scheduler_process_with_snapshot_patches(*args, **kwargs):
+    apply_snapshot_patches()
+
+    from sglang.srt.managers.scheduler import run_scheduler_process
+
+    return run_scheduler_process(*args, **kwargs)
+
+
+run_scheduler_process_with_snapshot_patches._dynamo_snapshot_patch = True
+
+
 def apply_snapshot_patches() -> None:
     global _snapshot_patches_applied
 
@@ -43,9 +54,15 @@ def apply_snapshot_patches() -> None:
     _configure_snapshot_dist_init()
 
     from sglang.srt.distributed.device_communicators import pynccl as pynccl_module
+    from sglang.srt.distributed import parallel_state as parallel_state_module
+    from sglang.srt.entrypoints import engine as engine_module
 
     original_init = pynccl_module.PyNcclCommunicator.__init__
-    if getattr(original_init, "_dynamo_snapshot_patch", False):
+    original_init_group = parallel_state_module.init_model_parallel_group
+    current_scheduler_entrypoint = engine_module.Engine.run_scheduler_process_func
+    if getattr(original_init, "_dynamo_snapshot_patch", False) and getattr(
+        original_init_group, "_dynamo_snapshot_patch", False
+    ) and getattr(current_scheduler_entrypoint, "_dynamo_snapshot_patch", False):
         _snapshot_patches_applied = True
         return
 
@@ -54,7 +71,21 @@ def apply_snapshot_patches() -> None:
         if getattr(self, "available", False) and getattr(self, "world_size", 1) > 1:
             self.disabled = False
 
+    def patched_init_model_parallel_group(*args, **kwargs):
+        group = original_init_group(*args, **kwargs)
+        pynccl_comm = getattr(group, "pynccl_comm", None)
+        if pynccl_comm is not None and getattr(group, "world_size", 1) > 1:
+            pynccl_comm.disabled = False
+        return group
+
     patched_init._dynamo_snapshot_patch = True
+    patched_init_model_parallel_group._dynamo_snapshot_patch = True
     pynccl_module.PyNcclCommunicator.__init__ = patched_init
+    parallel_state_module.init_model_parallel_group = patched_init_model_parallel_group
+    engine_module.Engine.run_scheduler_process_func = staticmethod(
+        run_scheduler_process_with_snapshot_patches
+    )
     _snapshot_patches_applied = True
-    logger.info("Enabled SGLang PyNccl communicator by default for checkpoint mode")
+    logger.info(
+        "Forced SGLang PyNccl communicators on in checkpoint mode, including spawned schedulers"
+    )

--- a/components/src/dynamo/sglang/patches.py
+++ b/components/src/dynamo/sglang/patches.py
@@ -53,16 +53,18 @@ def apply_snapshot_patches() -> None:
 
     _configure_snapshot_dist_init()
 
-    from sglang.srt.distributed.device_communicators import pynccl as pynccl_module
     from sglang.srt.distributed import parallel_state as parallel_state_module
+    from sglang.srt.distributed.device_communicators import pynccl as pynccl_module
     from sglang.srt.entrypoints import engine as engine_module
 
     original_init = pynccl_module.PyNcclCommunicator.__init__
     original_init_group = parallel_state_module.init_model_parallel_group
     current_scheduler_entrypoint = engine_module.Engine.run_scheduler_process_func
-    if getattr(original_init, "_dynamo_snapshot_patch", False) and getattr(
-        original_init_group, "_dynamo_snapshot_patch", False
-    ) and getattr(current_scheduler_entrypoint, "_dynamo_snapshot_patch", False):
+    if (
+        getattr(original_init, "_dynamo_snapshot_patch", False)
+        and getattr(original_init_group, "_dynamo_snapshot_patch", False)
+        and getattr(current_scheduler_entrypoint, "_dynamo_snapshot_patch", False)
+    ):
         _snapshot_patches_applied = True
         return
 

--- a/components/src/dynamo/sglang/patches.py
+++ b/components/src/dynamo/sglang/patches.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_snapshot_patches_applied = False
+
+
+def _configure_snapshot_dist_init() -> None:
+    pod_uid = os.environ.get("POD_UID", "checkpoint")
+    store_path = Path("/tmp") / f"dynamo-sglang-dist-init-{pod_uid}"
+    try:
+        store_path.unlink()
+    except FileNotFoundError:
+        pass
+
+    override = f"file://{store_path}"
+    previous = os.environ.get("SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE")
+    if previous and previous != override:
+        logger.warning(
+            "Overriding SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE=%r with %r for checkpoint mode "
+            "to avoid TCPStore listeners that CRIU rejects under tcp-loopback-only",
+            previous,
+            override,
+        )
+    os.environ["SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE"] = override
+    logger.info(
+        "Using file-based torch distributed init for checkpoint mode: %s",
+        store_path,
+    )
+
+
+def apply_snapshot_patches() -> None:
+    global _snapshot_patches_applied
+
+    if _snapshot_patches_applied:
+        return
+
+    _configure_snapshot_dist_init()
+
+    from sglang.srt.distributed.device_communicators import pynccl as pynccl_module
+
+    original_init = pynccl_module.PyNcclCommunicator.__init__
+    if getattr(original_init, "_dynamo_snapshot_patch", False):
+        _snapshot_patches_applied = True
+        return
+
+    def patched_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        if getattr(self, "available", False) and getattr(self, "world_size", 1) > 1:
+            self.disabled = False
+
+    patched_init._dynamo_snapshot_patch = True
+    pynccl_module.PyNcclCommunicator.__init__ = patched_init
+    _snapshot_patches_applied = True
+    logger.info("Enabled SGLang PyNccl communicator by default for checkpoint mode")

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -3,12 +3,16 @@
 
 """Unit tests for SGLang backend components."""
 
+import importlib
+import os
 import re
 import sys
+import types
 from pathlib import Path
 
 import pytest
 import yaml
+import sglang.srt.distributed.device_communicators as device_communicators
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
 
 from dynamo.sglang.args import parse_args
@@ -16,6 +20,7 @@ from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
     SglangPrefillHealthCheckPayload,
 )
+from dynamo.sglang import patches as sglang_patches
 from dynamo.sglang.tests.conftest import make_cli_args_fixture
 
 # Get path relative to this test file
@@ -36,6 +41,43 @@ pytestmark = [
 # Create SGLang-specific CLI args fixture
 # This will use monkeypatch to write to argv
 mock_sglang_cli = make_cli_args_fixture("dynamo.sglang")
+
+
+def test_snapshot_patches_force_file_dist_init_and_pynccl(monkeypatch):
+    """Checkpoint mode should avoid TCPStore listeners and keep PyNccl enabled."""
+
+    class FakePyNcclCommunicator:
+        def __init__(self, *args, **kwargs):
+            self.available = kwargs.get("available", True)
+            self.world_size = kwargs.get("world_size", 2)
+            self.disabled = True
+
+    fake_pynccl_module = types.SimpleNamespace(PyNcclCommunicator=FakePyNcclCommunicator)
+    stale_store_path = Path("/tmp/dynamo-sglang-dist-init-test-pod")
+    stale_store_path.write_text("stale", encoding="utf-8")
+
+    monkeypatch.setenv("POD_UID", "test-pod")
+    monkeypatch.setenv("SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE", "tcp://127.0.0.1:1234")
+    monkeypatch.setattr(device_communicators, "pynccl", fake_pynccl_module, raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang.srt.distributed.device_communicators.pynccl",
+        fake_pynccl_module,
+    )
+
+    patches = importlib.reload(sglang_patches)
+    patches.apply_snapshot_patches()
+
+    assert os.environ["SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE"] == (
+        "file:///tmp/dynamo-sglang-dist-init-test-pod"
+    )
+    assert not stale_store_path.exists()
+
+    communicator = fake_pynccl_module.PyNcclCommunicator(world_size=2, available=True)
+    assert communicator.disabled is False
+
+    single_rank = fake_pynccl_module.PyNcclCommunicator(world_size=1, available=True)
+    assert single_rank.disabled is True
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -12,16 +12,16 @@ from pathlib import Path
 
 import pytest
 import sglang.srt.distributed as distributed_module
-import yaml
 import sglang.srt.distributed.device_communicators as device_communicators
+import yaml
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
 
+from dynamo.sglang import patches as sglang_patches
 from dynamo.sglang.args import parse_args
 from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
     SglangPrefillHealthCheckPayload,
 )
-from dynamo.sglang import patches as sglang_patches
 from dynamo.sglang.tests.conftest import make_cli_args_fixture
 
 # Get path relative to this test file
@@ -69,7 +69,9 @@ def test_snapshot_patches_force_file_dist_init_and_pynccl(monkeypatch):
     class FakeEngine:
         run_scheduler_process_func = staticmethod(fake_run_scheduler_process)
 
-    fake_pynccl_module = types.SimpleNamespace(PyNcclCommunicator=FakePyNcclCommunicator)
+    fake_pynccl_module = types.SimpleNamespace(
+        PyNcclCommunicator=FakePyNcclCommunicator
+    )
     fake_parallel_state_module = types.SimpleNamespace(
         init_model_parallel_group=fake_init_model_parallel_group
     )
@@ -79,8 +81,12 @@ def test_snapshot_patches_force_file_dist_init_and_pynccl(monkeypatch):
     stale_store_path.write_text("stale", encoding="utf-8")
 
     monkeypatch.setenv("POD_UID", "test-pod")
-    monkeypatch.setenv("SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE", "tcp://127.0.0.1:1234")
-    monkeypatch.setattr(device_communicators, "pynccl", fake_pynccl_module, raising=False)
+    monkeypatch.setenv(
+        "SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE", "tcp://127.0.0.1:1234"
+    )
+    monkeypatch.setattr(
+        device_communicators, "pynccl", fake_pynccl_module, raising=False
+    )
     monkeypatch.setattr(
         distributed_module,
         "parallel_state",
@@ -97,7 +103,9 @@ def test_snapshot_patches_force_file_dist_init_and_pynccl(monkeypatch):
         "sglang.srt.distributed.parallel_state",
         fake_parallel_state_module,
     )
-    monkeypatch.setitem(sys.modules, "sglang.srt.entrypoints.engine", fake_engine_module)
+    monkeypatch.setitem(
+        sys.modules, "sglang.srt.entrypoints.engine", fake_engine_module
+    )
 
     patches = importlib.reload(sglang_patches)
     patches.apply_snapshot_patches()

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -11,6 +11,7 @@ import types
 from pathlib import Path
 
 import pytest
+import sglang.srt.distributed as distributed_module
 import yaml
 import sglang.srt.distributed.device_communicators as device_communicators
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
@@ -52,18 +53,51 @@ def test_snapshot_patches_force_file_dist_init_and_pynccl(monkeypatch):
             self.world_size = kwargs.get("world_size", 2)
             self.disabled = True
 
+    class FakeGroup:
+        def __init__(self):
+            self.world_size = 2
+            self.pynccl_comm = FakePyNcclCommunicator(world_size=2, available=True)
+
+    def fake_init_model_parallel_group(*args, **kwargs):
+        return FakeGroup()
+
+    scheduler_calls = []
+
+    def fake_run_scheduler_process(*args, **kwargs):
+        scheduler_calls.append((args, kwargs))
+
+    class FakeEngine:
+        run_scheduler_process_func = staticmethod(fake_run_scheduler_process)
+
     fake_pynccl_module = types.SimpleNamespace(PyNcclCommunicator=FakePyNcclCommunicator)
+    fake_parallel_state_module = types.SimpleNamespace(
+        init_model_parallel_group=fake_init_model_parallel_group
+    )
+    fake_engine_module = types.ModuleType("sglang.srt.entrypoints.engine")
+    fake_engine_module.Engine = FakeEngine
     stale_store_path = Path("/tmp/dynamo-sglang-dist-init-test-pod")
     stale_store_path.write_text("stale", encoding="utf-8")
 
     monkeypatch.setenv("POD_UID", "test-pod")
     monkeypatch.setenv("SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE", "tcp://127.0.0.1:1234")
     monkeypatch.setattr(device_communicators, "pynccl", fake_pynccl_module, raising=False)
+    monkeypatch.setattr(
+        distributed_module,
+        "parallel_state",
+        fake_parallel_state_module,
+        raising=False,
+    )
     monkeypatch.setitem(
         sys.modules,
         "sglang.srt.distributed.device_communicators.pynccl",
         fake_pynccl_module,
     )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang.srt.distributed.parallel_state",
+        fake_parallel_state_module,
+    )
+    monkeypatch.setitem(sys.modules, "sglang.srt.entrypoints.engine", fake_engine_module)
 
     patches = importlib.reload(sglang_patches)
     patches.apply_snapshot_patches()
@@ -75,6 +109,12 @@ def test_snapshot_patches_force_file_dist_init_and_pynccl(monkeypatch):
 
     communicator = fake_pynccl_module.PyNcclCommunicator(world_size=2, available=True)
     assert communicator.disabled is False
+
+    group = fake_parallel_state_module.init_model_parallel_group([], 0, "gloo")
+    assert group.pynccl_comm.disabled is False
+
+    FakeEngine.run_scheduler_process_func("tp0", rank=0)
+    assert scheduler_calls == [(("tp0",), {"rank": 0})]
 
     single_rank = fake_pynccl_module.PyNcclCommunicator(world_size=1, available=True)
     assert single_rank.disabled is True

--- a/deploy/helm/charts/snapshot/templates/configmap.yaml
+++ b/deploy/helm/charts/snapshot/templates/configmap.yaml
@@ -33,6 +33,7 @@ data:
       workDir: {{ .Values.config.criu.workDir | quote }}
       leaveRunning: {{ .Values.config.criu.leaveRunning }}
       shellJob: {{ .Values.config.criu.shellJob }}
+      socketPolicy: {{ .Values.config.criu.socketPolicy | quote }}
       tcpClose: {{ .Values.config.criu.tcpClose }}
       tcpEstablished: {{ .Values.config.criu.tcpEstablished }}
       fileLocks: {{ .Values.config.criu.fileLocks }}

--- a/deploy/helm/charts/snapshot/values.yaml
+++ b/deploy/helm/charts/snapshot/values.yaml
@@ -154,6 +154,7 @@ config:
     # K8s-specific options (recommended defaults for containers)
     leaveRunning: true      # Keep process running after checkpoint
     shellJob: true          # Containers are often session leaders
+    socketPolicy: ""        # "", close-all-connected, preserve-all-connected, preserve-loopback-only
     tcpClose: true          # Close non-listening TCP sockets on restore
     tcpEstablished: false   # Preserve established TCP sockets during restore
     fileLocks: true         # Applications use file locks

--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -107,7 +107,10 @@ RUN git init /tmp/criu \
     && cd /tmp/criu \
     && git remote add origin ${CRIU_REPO} \
     && git fetch --depth 1 origin ${CRIU_REF} \
-    && git checkout FETCH_HEAD \
+    && git checkout FETCH_HEAD
+
+RUN python3 -c 'from pathlib import Path; path = Path("/tmp/criu/criu/sk-tcp.c"); text = path.read_text(); marker = "#ifndef IN_LOOPBACK\n#define IN_LOOPBACK(addr) ((((long int)(addr)) & 0xff000000) == 0x7f000000)\n#endif\n"; path.write_text(text if "#ifndef IN_LOOPBACK" in text else text.replace("#include <netinet/in.h>\n", "#include <netinet/in.h>\n" + marker, 1))' \
+    && cd /tmp/criu \
     && make -j$(nproc) \
     && make DESTDIR=/criu-install install-criu install-lib install-cuda_plugin
 

--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -18,7 +18,7 @@ ARG DOCKER_PROXY
 ARG GO_VERSION=1.25
 # Default to upstream CRIU development branch. Custom forks can override both
 # args at build time, for example:
-#   --build-arg CRIU_REPO=https://github.com/galletas1712/criu.git
+#   --build-arg CRIU_REPO=https://github.com/<owner>/criu.git
 #   --build-arg CRIU_REF=<fork-branch-or-sha>
 ARG CRIU_REPO=https://github.com/checkpoint-restore/criu.git
 ARG CRIU_REF=criu-dev

--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -18,7 +18,7 @@ ARG DOCKER_PROXY
 ARG GO_VERSION=1.25
 # Default to upstream CRIU development branch. Custom forks can override both
 # args at build time, for example:
-#   --build-arg CRIU_REPO=https://github.com/<owner>/criu.git
+#   --build-arg CRIU_REPO=<git-remote-url>
 #   --build-arg CRIU_REF=<fork-branch-or-sha>
 ARG CRIU_REPO=https://github.com/checkpoint-restore/criu.git
 ARG CRIU_REF=criu-dev

--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -16,8 +16,12 @@
 # =============================================================================
 ARG DOCKER_PROXY
 ARG GO_VERSION=1.25
-ARG CRIU_REPO=https://github.com/dfeigin-nv/criu.git
-ARG CRIU_COMMIT=777baaf27f6a76f743c9bf24b64886297dc0129b
+# Default to upstream CRIU development branch. Custom forks can override both
+# args at build time, for example:
+#   --build-arg CRIU_REPO=https://github.com/galletas1712/criu.git
+#   --build-arg CRIU_COMMIT=<fork-branch-or-sha>
+ARG CRIU_REPO=https://github.com/checkpoint-restore/criu.git
+ARG CRIU_COMMIT=criu-dev
 ARG AGENT_BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.11-cuda13.0-devel-ubuntu24.04
 
 # For placeholder target only - this default allows agent builds to succeed,

--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -19,9 +19,9 @@ ARG GO_VERSION=1.25
 # Default to upstream CRIU development branch. Custom forks can override both
 # args at build time, for example:
 #   --build-arg CRIU_REPO=https://github.com/galletas1712/criu.git
-#   --build-arg CRIU_COMMIT=<fork-branch-or-sha>
+#   --build-arg CRIU_REF=<fork-branch-or-sha>
 ARG CRIU_REPO=https://github.com/checkpoint-restore/criu.git
-ARG CRIU_COMMIT=criu-dev
+ARG CRIU_REF=criu-dev
 ARG AGENT_BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.11-cuda13.0-devel-ubuntu24.04
 
 # For placeholder target only - this default allows agent builds to succeed,
@@ -80,7 +80,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s
 FROM ubuntu:24.04 AS criu-builder
 
 ARG CRIU_REPO
-ARG CRIU_COMMIT
+ARG CRIU_REF
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
@@ -106,7 +106,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN git init /tmp/criu \
     && cd /tmp/criu \
     && git remote add origin ${CRIU_REPO} \
-    && git fetch --depth 1 origin ${CRIU_COMMIT} \
+    && git fetch --depth 1 origin ${CRIU_REF} \
     && git checkout FETCH_HEAD \
     && make -j$(nproc) \
     && make DESTDIR=/criu-install install-criu install-lib install-cuda_plugin

--- a/deploy/snapshot/Makefile
+++ b/deploy/snapshot/Makefile
@@ -5,6 +5,9 @@
 IMG ?= nvcr.io/nvidian/dynamo-dev/snapshot-agent:latest
 PLACEHOLDER_IMG ?= nvcr.io/nvidian/dynamo-dev/dynamo-vllm-placeholder:latest
 # PLACEHOLDER_BASE_IMG must be provided when building placeholder (no default)
+# Optional CRIU source override for snapshot image builds. If unset, the
+# Dockerfile defaults are used.
+CRIU_BUILD_ARGS = $(if $(CRIU_REPO),--build-arg CRIU_REPO=$(CRIU_REPO),) $(if $(CRIU_REF),--build-arg CRIU_REF=$(CRIU_REF),)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -63,7 +66,9 @@ build: fmt vet ## Build snapshot-agent binary.
 
 .PHONY: docker-build-agent
 docker-build-agent: ## Build snapshot-agent docker image (linux/amd64 only).
-	$(CONTAINER_TOOL) build --platform ${RUNTIME_IMAGE_PLATFORM} --target agent -t ${IMG} .
+	$(CONTAINER_TOOL) build --platform ${RUNTIME_IMAGE_PLATFORM} --target agent \
+		$(CRIU_BUILD_ARGS) \
+		-t ${IMG} .
 
 .PHONY: docker-build-placeholder
 docker-build-placeholder: ## Build placeholder image for checkpoint restore (linux/amd64 only). Requires PLACEHOLDER_BASE_IMG.
@@ -77,6 +82,7 @@ endif
 	fi; \
 	if [ -z "$$BASE_IMAGE_USER" ]; then BASE_IMAGE_USER=root; fi; \
 	$(CONTAINER_TOOL) build --platform ${RUNTIME_IMAGE_PLATFORM} --target placeholder \
+		$(CRIU_BUILD_ARGS) \
 		--build-arg BASE_IMAGE=${PLACEHOLDER_BASE_IMG} \
 		--build-arg BASE_IMAGE_USER=$$BASE_IMAGE_USER \
 		-t ${PLACEHOLDER_IMG} .

--- a/deploy/snapshot/internal/criu/dump.go
+++ b/deploy/snapshot/internal/criu/dump.go
@@ -128,6 +128,10 @@ func buildCRIUConf(c *types.CRIUSettings) string {
 		return ""
 	}
 	var content string
+	policy, err := c.ResolvedSocketPolicy()
+	if err == nil && policy == types.SocketPolicyPreserveLoopbackOnly {
+		content += "tcp-loopback-only\n"
+	}
 	if c.LibDir != "" {
 		content += "libdir " + c.LibDir + "\n"
 	}

--- a/deploy/snapshot/internal/criu/util.go
+++ b/deploy/snapshot/internal/criu/util.go
@@ -43,17 +43,29 @@ func shouldSetCgroupRoot(cgMode criurpc.CriuCgMode) bool {
 
 // applyCommonSettings sets CRIU options shared between dump and restore.
 func applyCommonSettings(opts *criurpc.CriuOpts, settings *types.CRIUSettings) error {
-	if settings.TcpClose && settings.TcpEstablished {
-		return fmt.Errorf("tcpClose and tcpEstablished cannot both be true")
+	policy, err := settings.ResolvedSocketPolicy()
+	if err != nil {
+		return err
 	}
 
 	opts.LogLevel = proto.Int32(settings.LogLevel)
 	opts.ShellJob = proto.Bool(settings.ShellJob)
-	opts.TcpClose = proto.Bool(settings.TcpClose)
-	opts.TcpEstablished = proto.Bool(settings.TcpEstablished)
 	opts.FileLocks = proto.Bool(settings.FileLocks)
 	opts.ExtUnixSk = proto.Bool(settings.ExtUnixSk)
 	opts.LinkRemap = proto.Bool(settings.LinkRemap)
+	switch policy {
+	case types.SocketPolicyCloseAllConnected:
+		opts.TcpClose = proto.Bool(true)
+		opts.TcpEstablished = proto.Bool(false)
+	case types.SocketPolicyPreserveAllConnected:
+		opts.TcpClose = proto.Bool(false)
+		opts.TcpEstablished = proto.Bool(true)
+	case types.SocketPolicyPreserveLoopbackOnly:
+		opts.TcpClose = proto.Bool(false)
+		opts.TcpEstablished = proto.Bool(false)
+	default:
+		return fmt.Errorf("unsupported socket policy %q", policy)
+	}
 
 	opts.ManageCgroups = proto.Bool(true)
 	cgMode, _, err := parseManageCgroupsMode(settings.ManageCgroupsMode)

--- a/deploy/snapshot/internal/criu/util_test.go
+++ b/deploy/snapshot/internal/criu/util_test.go
@@ -48,15 +48,15 @@ func TestParseManageCgroupsMode(t *testing.T) {
 }
 
 func TestApplyCommonSettings(t *testing.T) {
-	t.Run("valid mode sets all fields", func(t *testing.T) {
-		opts := &criurpc.CriuOpts{}
-		settings := &types.CRIUSettings{
-			LogLevel:          4,
-			ShellJob:          true,
-			TcpEstablished:    true,
-			FileLocks:         true,
-			ExtUnixSk:         true,
-			LinkRemap:         true,
+		t.Run("valid mode sets all fields", func(t *testing.T) {
+			opts := &criurpc.CriuOpts{}
+			settings := &types.CRIUSettings{
+				LogLevel:          4,
+				ShellJob:          true,
+				SocketPolicy:      string(types.SocketPolicyPreserveAllConnected),
+				FileLocks:         true,
+				ExtUnixSk:         true,
+				LinkRemap:         true,
 			ManageCgroupsMode: "soft",
 		}
 
@@ -101,17 +101,33 @@ func TestApplyCommonSettings(t *testing.T) {
 		}
 	})
 
-	t.Run("conflicting tcp settings return error", func(t *testing.T) {
-		opts := &criurpc.CriuOpts{}
-		settings := &types.CRIUSettings{
-			TcpClose:       true,
-			TcpEstablished: true,
-		}
-		if err := applyCommonSettings(opts, settings); err == nil {
-			t.Error("expected error for conflicting tcp settings")
-		}
-	})
-}
+		t.Run("conflicting tcp settings return error", func(t *testing.T) {
+			opts := &criurpc.CriuOpts{}
+			settings := &types.CRIUSettings{
+				TcpClose:       true,
+				TcpEstablished: true,
+			}
+			if err := applyCommonSettings(opts, settings); err == nil {
+				t.Error("expected error for conflicting tcp settings")
+			}
+		})
+
+		t.Run("loopback-only policy leaves both tcp flags disabled", func(t *testing.T) {
+			opts := &criurpc.CriuOpts{}
+			settings := &types.CRIUSettings{
+				SocketPolicy: string(types.SocketPolicyPreserveLoopbackOnly),
+			}
+			if err := applyCommonSettings(opts, settings); err != nil {
+				t.Fatalf("applyCommonSettings: %v", err)
+			}
+			if opts.GetTcpEstablished() {
+				t.Error("TcpEstablished should be false for loopback-only policy")
+			}
+			if opts.GetTcpClose() {
+				t.Error("TcpClose should be false for loopback-only policy")
+			}
+		})
+	}
 
 func TestBuildRestoreExtMounts(t *testing.T) {
 	t.Run("normal manifest with ExtMnt", func(t *testing.T) {

--- a/deploy/snapshot/internal/types/config.go
+++ b/deploy/snapshot/internal/types/config.go
@@ -39,11 +39,8 @@ func (c *AgentConfig) Validate() error {
 	if strings.TrimSpace(c.Storage.BasePath) == "" {
 		return &ConfigError{Field: "storage.basePath", Message: "storage.basePath is required"}
 	}
-	if c.CRIU.TcpClose && c.CRIU.TcpEstablished {
-		return &ConfigError{
-			Field:   "criu",
-			Message: "tcpClose and tcpEstablished cannot both be true",
-		}
+	if err := c.CRIU.Validate(); err != nil {
+		return err
 	}
 	return c.Restore.Validate()
 }
@@ -83,6 +80,7 @@ type CRIUSettings struct {
 	LazyPages         bool   `yaml:"lazyPages"`
 	LeaveRunning      bool   `yaml:"leaveRunning"`
 	ShellJob          bool   `yaml:"shellJob"`
+	SocketPolicy      string `yaml:"socketPolicy"`
 	TcpClose          bool   `yaml:"tcpClose"`
 	TcpEstablished    bool   `yaml:"tcpEstablished"`
 	FileLocks         bool   `yaml:"fileLocks"`
@@ -99,6 +97,52 @@ type CRIUSettings struct {
 	LibDir            string `yaml:"libDir"`
 	AllowUprobes      bool   `yaml:"allowUprobes"`
 	SkipInFlight      bool   `yaml:"skipInFlight"`
+}
+
+type SocketPolicy string
+
+const (
+	SocketPolicyCloseAllConnected    SocketPolicy = "close-all-connected"
+	SocketPolicyPreserveAllConnected SocketPolicy = "preserve-all-connected"
+	SocketPolicyPreserveLoopbackOnly SocketPolicy = "preserve-loopback-only"
+)
+
+func (c CRIUSettings) Validate() error {
+	_, err := c.ResolvedSocketPolicy()
+	return err
+}
+
+func (c CRIUSettings) ResolvedSocketPolicy() (SocketPolicy, error) {
+	policy := SocketPolicy(strings.TrimSpace(c.SocketPolicy))
+	switch policy {
+	case "":
+		if c.TcpClose && c.TcpEstablished {
+			return "", &ConfigError{
+				Field:   "criu",
+				Message: "tcpClose and tcpEstablished cannot both be true",
+			}
+		}
+		if c.TcpClose {
+			return SocketPolicyCloseAllConnected, nil
+		}
+		if c.TcpEstablished {
+			return SocketPolicyPreserveAllConnected, nil
+		}
+		return SocketPolicyPreserveLoopbackOnly, nil
+	case SocketPolicyCloseAllConnected, SocketPolicyPreserveAllConnected, SocketPolicyPreserveLoopbackOnly:
+		if c.TcpClose || c.TcpEstablished {
+			return "", &ConfigError{
+				Field:   "criu",
+				Message: "socketPolicy cannot be combined with legacy tcpClose/tcpEstablished settings",
+			}
+		}
+		return policy, nil
+	default:
+		return "", &ConfigError{
+			Field:   "criu.socketPolicy",
+			Message: fmt.Sprintf("invalid socket policy %q", c.SocketPolicy),
+		}
+	}
 }
 
 // OverlaySettings is the static config for rootfs exclusions.

--- a/deploy/snapshot/internal/types/config_test.go
+++ b/deploy/snapshot/internal/types/config_test.go
@@ -1,0 +1,45 @@
+package types
+
+import "testing"
+
+func TestResolvedSocketPolicy(t *testing.T) {
+	t.Run("legacy tcpClose maps to close-all-connected", func(t *testing.T) {
+		policy, err := (CRIUSettings{TcpClose: true}).ResolvedSocketPolicy()
+		if err != nil {
+			t.Fatalf("ResolvedSocketPolicy: %v", err)
+		}
+		if policy != SocketPolicyCloseAllConnected {
+			t.Fatalf("policy = %q, want %q", policy, SocketPolicyCloseAllConnected)
+		}
+	})
+
+	t.Run("legacy tcpEstablished maps to preserve-all-connected", func(t *testing.T) {
+		policy, err := (CRIUSettings{TcpEstablished: true}).ResolvedSocketPolicy()
+		if err != nil {
+			t.Fatalf("ResolvedSocketPolicy: %v", err)
+		}
+		if policy != SocketPolicyPreserveAllConnected {
+			t.Fatalf("policy = %q, want %q", policy, SocketPolicyPreserveAllConnected)
+		}
+	})
+
+	t.Run("empty settings default to preserve-loopback-only", func(t *testing.T) {
+		policy, err := (CRIUSettings{}).ResolvedSocketPolicy()
+		if err != nil {
+			t.Fatalf("ResolvedSocketPolicy: %v", err)
+		}
+		if policy != SocketPolicyPreserveLoopbackOnly {
+			t.Fatalf("policy = %q, want %q", policy, SocketPolicyPreserveLoopbackOnly)
+		}
+	})
+
+	t.Run("explicit policy rejects legacy tcp flags", func(t *testing.T) {
+		_, err := (CRIUSettings{
+			SocketPolicy:   string(SocketPolicyPreserveLoopbackOnly),
+			TcpEstablished: true,
+		}).ResolvedSocketPolicy()
+		if err == nil {
+			t.Fatal("expected error when socketPolicy and legacy tcp flags are combined")
+		}
+	})
+}

--- a/docs/kubernetes/snapshot.md
+++ b/docs/kubernetes/snapshot.md
@@ -60,13 +60,13 @@ defaults are used.
 ```bash
 make docker-build-agent \
   IMG=registry.example.com/dynamo/snapshot-agent:1.0.0 \
-  CRIU_REPO=https://github.com/<owner>/criu.git \
+  CRIU_REPO="${YOUR_CRIU_REPO}" \
   CRIU_REF=<branch-or-sha>
 
 make docker-build-placeholder \
   PLACEHOLDER_BASE_IMG="${RUNTIME_IMAGE}" \
   PLACEHOLDER_IMG="${PLACEHOLDER_IMAGE}" \
-  CRIU_REPO=https://github.com/<owner>/criu.git \
+  CRIU_REPO="${YOUR_CRIU_REPO}" \
   CRIU_REF=<branch-or-sha>
 ```
 

--- a/docs/kubernetes/snapshot.md
+++ b/docs/kubernetes/snapshot.md
@@ -53,6 +53,23 @@ make docker-push-placeholder \
 
 The placeholder image preserves the normal runtime entrypoint/command contract and adds the `criu`, `cuda-checkpoint`, and `nsrestore` tooling needed for checkpoint and restore.
 
+To build either snapshot image against a custom CRIU fork or ref, pass
+`CRIU_REPO` and `CRIU_REF` through `make`. If they are unset, the Dockerfile
+defaults are used.
+
+```bash
+make docker-build-agent \
+  IMG=registry.example.com/dynamo/snapshot-agent:1.0.0 \
+  CRIU_REPO=https://github.com/<owner>/criu.git \
+  CRIU_REF=<branch-or-sha>
+
+make docker-build-placeholder \
+  PLACEHOLDER_BASE_IMG="${RUNTIME_IMAGE}" \
+  PLACEHOLDER_IMG="${PLACEHOLDER_IMAGE}" \
+  CRIU_REPO=https://github.com/<owner>/criu.git \
+  CRIU_REF=<branch-or-sha>
+```
+
 ### 2. Enable operator checkpointing
 
 Whether you are installing or upgrading `dynamo-platform`, the operator only needs checkpointing enabled:


### PR DESCRIPTION
#### Overview:

Depends on #7744. Harden loopback-only snapshot restore for TP SGLang.

#### Details:

- add `preserve-loopback-only` socket policy support
- force file-based distributed init in checkpoint mode
- keep PyNccl enabled in spawned SGLang scheduler processes
- extend unit coverage for the snapshot patching path

#### Where should the reviewer start?

- `deploy/snapshot/internal/types/config.go`
- `deploy/snapshot/internal/criu/util.go`
- `components/src/dynamo/sglang/patches.py`

#### Testing:

- `python3 -m py_compile components/src/dynamo/sglang/patches.py components/src/dynamo/sglang/snapshot.py components/src/dynamo/sglang/tests/test_sglang_unit.py`
- local stubbed smoke test for `apply_snapshot_patches()`
- manual AKS-dev TP=2 checkpoint/restore validation with successful post-restore `/v1/models` and `/v1/chat/completions`
