### PR TITLE
fix: adapt the import path change for ToT vLLM

### DIFF
--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -14,7 +14,6 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from vllm.config import CacheConfig, LoadConfig, ModelConfig, VllmConfig
-from vllm.inputs.data import TokensPrompt
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.tasks import GENERATION_TASKS
@@ -38,6 +37,13 @@ from dynamo.runtime import Client, DistributedRuntime
 
 from .prepost import StreamingPostProcessor, preprocess_chat_request
 from .utils import random_uuid
+
+# Try importing from new vLLM (https://github.com/vllm-project/vllm/pull/35182), fallback to old structure
+try:
+    from vllm.inputs.llm import TokensPrompt
+except ImportError:
+    from vllm.inputs.data import TokensPrompt
+
 
 logger = logging.getLogger(__name__)
 

--- a/components/src/dynamo/vllm/multimodal_utils/chat_processor.py
+++ b/components/src/dynamo/vllm/multimodal_utils/chat_processor.py
@@ -20,7 +20,6 @@ from typing import AsyncIterator, List, Optional, Protocol, Union, runtime_check
 from vllm.config import ModelConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.entrypoints.chat_utils import ConversationMessage
-from vllm.inputs.data import TokensPrompt
 from vllm.sampling_params import SamplingParams
 from vllm.tokenizers import TokenizerLike as AnyTokenizer
 
@@ -45,6 +44,12 @@ except ImportError:
         BaseModelPath,
         OpenAIServingModels,
     )
+
+# Try importing from new vLLM (https://github.com/vllm-project/vllm/pull/35182), fallback to old structure
+try:
+    from vllm.inputs.llm import TokensPrompt
+except ImportError:
+    from vllm.inputs.data import TokensPrompt
 
 
 class StubEngineClient:

--- a/components/src/dynamo/vllm/multimodal_utils/protocol.py
+++ b/components/src/dynamo/vllm/multimodal_utils/protocol.py
@@ -22,14 +22,20 @@ import torch
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 from pydantic_core import core_schema
 from typing_extensions import NotRequired
-from vllm.inputs.data import TokensPrompt
 from vllm.logprobs import PromptLogprobs
-from vllm.multimodal.inputs import MultiModalUUIDDict  # noqa: F401
 from vllm.outputs import CompletionOutput
 from vllm.sampling_params import SamplingParams
 from vllm.v1.metrics.stats import RequestStateStats
 
 from dynamo.common.multimodal.embedding_transfer import TransferRequest
+
+# Try importing from new vLLM (https://github.com/vllm-project/vllm/pull/35182), fallback to old structure
+try:
+    from vllm.inputs.llm import MultiModalUUIDDict  # noqa: F401
+    from vllm.inputs.llm import TokensPrompt
+except ImportError:
+    from vllm.inputs.data import TokensPrompt
+    from vllm.multimodal.inputs import MultiModalUUIDDict  # noqa: F401
 
 
 class Request(BaseModel):

--- a/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
@@ -23,7 +23,6 @@ _chat_protocol = importlib.import_module(
     "vllm.entrypoints.openai.chat_completion.protocol"
 )
 _engine_protocol = importlib.import_module("vllm.entrypoints.openai.engine.protocol")
-_inputs_data = importlib.import_module("vllm.inputs.data")
 _reasoning = importlib.import_module("vllm.reasoning")
 _sampling_params = importlib.import_module("vllm.sampling_params")
 _tool_parsers = importlib.import_module("vllm.tool_parsers")
@@ -34,7 +33,6 @@ _output_processor_mod = importlib.import_module("vllm.v1.engine.output_processor
 ChatCompletionRequest = _chat_protocol.ChatCompletionRequest
 DeltaMessage = _engine_protocol.DeltaMessage
 DeltaToolCall = _engine_protocol.DeltaToolCall
-TokensPrompt = _inputs_data.TokensPrompt
 ReasoningParser = _reasoning.ReasoningParser
 ReasoningParserManager = _reasoning.ReasoningParserManager
 RequestOutputKind = _sampling_params.RequestOutputKind
@@ -47,6 +45,14 @@ FinishReason = _engine.FinishReason
 InputProcessor = _input_processor_mod.InputProcessor
 OutputProcessor = _output_processor_mod.OutputProcessor
 OutputProcessorOutput = _output_processor_mod.OutputProcessorOutput
+
+# Try importing from new vLLM (https://github.com/vllm-project/vllm/pull/35182), fallback to legacy location
+try:
+    _inputs_mod = importlib.import_module("vllm.inputs.llm")
+except (ImportError, ModuleNotFoundError):
+    _inputs_mod = importlib.import_module("vllm.inputs.data")
+
+TokensPrompt = _inputs_mod.TokensPrompt
 
 pytestmark = [
     pytest.mark.vllm,

--- a/examples/multimodal/components/worker.py
+++ b/examples/multimodal/components/worker.py
@@ -17,7 +17,6 @@ from typing import Tuple
 import torch
 import uvloop
 from vllm.distributed.kv_events import ZmqEventPublisher
-from vllm.inputs.data import TokensPrompt
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.v1.engine.async_llm import AsyncLLM
@@ -39,6 +38,12 @@ from utils.args import (
 from utils.image_loader import ImageLoader
 from utils.model import construct_mm_data
 from utils.protocol import MyRequestOutput, vLLMMultimodalRequest
+
+# Try importing from new vLLM (https://github.com/vllm-project/vllm/pull/35182), fallback to old structure
+try:
+    from vllm.inputs.llm import TokensPrompt
+except ImportError:
+    from vllm.inputs.data import TokensPrompt
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)

--- a/examples/multimodal/utils/chat_processor.py
+++ b/examples/multimodal/utils/chat_processor.py
@@ -27,10 +27,15 @@ from vllm.entrypoints.openai.completion.serving import OpenAIServingCompletion
 from vllm.entrypoints.openai.engine.protocol import RequestResponseMetadata
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
-from vllm.inputs.data import TokensPrompt
 from vllm.renderers.registry import renderer_from_config
 from vllm.sampling_params import SamplingParams
 from vllm.tokenizers import TokenizerLike as AnyTokenizer
+
+# Try importing from new vLLM (https://github.com/vllm-project/vllm/pull/35182), fallback to old structure
+try:
+    from vllm.inputs.llm import TokensPrompt
+except ImportError:
+    from vllm.inputs.data import TokensPrompt
 
 
 class StubEngineClient:

--- a/examples/multimodal/utils/protocol.py
+++ b/examples/multimodal/utils/protocol.py
@@ -21,14 +21,20 @@ import msgspec
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 from pydantic_core import core_schema
 from typing_extensions import NotRequired
-from vllm.inputs.data import TokensPrompt
 from vllm.logprobs import PromptLogprobs
-from vllm.multimodal.inputs import MultiModalUUIDDict  # noqa: F401
 from vllm.outputs import CompletionOutput
 from vllm.sampling_params import SamplingParams
 from vllm.v1.metrics.stats import RequestStateStats
 
 import dynamo.nixl_connect as connect
+
+# Try importing from new vLLM (https://github.com/vllm-project/vllm/pull/35182), fallback to old structure
+try:
+    from vllm.inputs.llm import MultiModalUUIDDict  # noqa: F401
+    from vllm.inputs.llm import TokensPrompt
+except ImportError:
+    from vllm.inputs.data import TokensPrompt
+    from vllm.multimodal.inputs import MultiModalUUIDDict  # noqa: F401
 
 
 class Request(BaseModel):


### PR DESCRIPTION
#### Overview:

Adapt the import path change for ToT vLLM, with a fallback to the old import path for older vLLM versions.

#### Details:

This vLLM PR (https://github.com/vllm-project/vllm/pull/35182) changed the inputs path in vLLM. Update the import path on our end to ensure we stay compatible with these changes during the vLLM version upgrade, while still falling back to the old import path for older versions.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated vLLM library compatibility across the codebase to support multiple versions through enhanced import resolution logic.

* **Chores**
  * Improved dependency handling to gracefully support both current and legacy versions of the vLLM library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->