### PR TITLE
fix(sglang): use incremental streaming output for completions

### DIFF
--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -18,6 +18,7 @@ fallback and any associated polyfills.
 import ipaddress
 import logging
 import socket
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -98,8 +99,42 @@ except ImportError:
             return f"tcp://{self.host}:{self.port}"
 
 
+def enable_disjoint_streaming_output(server_args: Any) -> None:
+    """
+    Enable SGLang's disjoint streaming output across ServerArgs field renames.
+
+    Covers sglang <= 0.5.x (`stream_output`) and newer releases
+    (`incremental_streaming_output`).
+    """
+    fields = getattr(type(server_args), "__dataclass_fields__", None)
+    if isinstance(fields, dict):
+        if "incremental_streaming_output" in fields:
+            server_args.incremental_streaming_output = True
+            return
+        if "stream_output" in fields:
+            server_args.stream_output = True
+            return
+        raise AttributeError(
+            "SGLang ServerArgs has neither 'incremental_streaming_output' nor "
+            "'stream_output'"
+        )
+
+    if hasattr(server_args, "incremental_streaming_output"):
+        server_args.incremental_streaming_output = True
+        return
+    if hasattr(server_args, "stream_output"):
+        server_args.stream_output = True
+        return
+
+    logger.debug(
+        "Skipping streaming output compatibility for non-ServerArgs object: %s",
+        type(server_args).__name__,
+    )
+
+
 __all__ = [
     "NetworkAddress",
+    "enable_disjoint_streaming_output",
     "get_local_ip_auto",
     "get_zmq_socket",
     "_SGLANG_HAS_NETWORK_MODULE",

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -25,6 +25,7 @@ from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.llm import fetch_model
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
+from dynamo.sglang._compat import enable_disjoint_streaming_output
 
 configure_dynamo_logging()
 
@@ -374,12 +375,10 @@ async def parse_args(args: list[str]) -> Config:
         )
 
     # Dynamo's streaming handlers expect disjoint output_ids from SGLang (only new
-    # tokens since last output), not cumulative tokens.
-    # sglang renamed stream_output -> incremental_streaming_output in PR #20614.
-    if hasattr(ServerArgs, "incremental_streaming_output"):
-        server_args.incremental_streaming_output = True
-    else:
-        server_args.stream_output = True
+    # tokens since last output), not cumulative tokens. Modern SGLang gates this
+    # behavior behind incremental_streaming_output, while older releases used
+    # stream_output.
+    enable_disjoint_streaming_output(server_args)
 
     if dynamo_config.use_sglang_tokenizer:
         warnings.warn(

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -24,8 +24,8 @@ from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.llm import fetch_model
 from dynamo.runtime.logging import configure_dynamo_logging
-from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
 from dynamo.sglang._compat import enable_disjoint_streaming_output
+from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
 
 configure_dynamo_logging()
 

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -284,6 +284,11 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
             // Update prompt_tokens from worker if provided (e.g., for embeddings)
             self.usage.prompt_tokens = completion_usage.prompt_tokens;
 
+            // Propagate completion token details if provided
+            if let Some(completion_details) = completion_usage.completion_tokens_details.as_ref() {
+                self.usage.completion_tokens_details = Some(completion_details.clone());
+            }
+
             // Propagate prompt token details if provided
             if let Some(prompt_details) = completion_usage.prompt_tokens_details.as_ref() {
                 self.usage.prompt_tokens_details = Some(prompt_details.clone());

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -283,7 +283,6 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
         if let Some(completion_usage) = delta.completion_usage.as_ref() {
             // Update prompt_tokens from worker if provided (e.g., for embeddings)
             self.usage.prompt_tokens = completion_usage.prompt_tokens;
-            self.usage.completion_tokens = completion_usage.completion_tokens;
 
             // Propagate completion token details if provided
             if let Some(completion_details) = completion_usage.completion_tokens_details.as_ref() {

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -283,6 +283,7 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
         if let Some(completion_usage) = delta.completion_usage.as_ref() {
             // Update prompt_tokens from worker if provided (e.g., for embeddings)
             self.usage.prompt_tokens = completion_usage.prompt_tokens;
+            self.usage.completion_tokens = completion_usage.completion_tokens;
 
             // Propagate completion token details if provided
             if let Some(completion_details) = completion_usage.completion_tokens_details.as_ref() {


### PR DESCRIPTION
## Summary
Fix Dynamo's SGLang `/v1/completions` streaming assumptions on current SGLang main.

- switch the SGLang integration to set `incremental_streaming_output = True`
- prefer the backend-reported final `completion_usage.completion_tokens` when building final completions usage

## Why
Dynamo still set `server_args.stream_output = True`, but current SGLang gates disjoint streaming chunks behind `incremental_streaming_output`.

Relevant SGLang change:
-  `Rename --stream-output to --incremental-streaming-output `([#20614](https://github.com/sgl-project/sglang/pull/20614))

Related SGLang follow-up that makes the incremental/cumulative split explicit:
- `Scope streaming backlog coalescing to incremental_streaming_output mode `([#21037](https://github.com/sgl-project/sglang/pull/21037))

Without this update, Dynamo can mis-handle cumulative streaming output on `/v1/completions`, which can in turn skew `usage.completion_tokens` and downstream benchmark metrics.

## Validation
- `python3 -m py_compile components/src/dynamo/sglang/args.py`
- `cargo fmt --check --manifest-path lib/llm/Cargo.toml --all`

## Notes
I also attempted an end-to-end mounted run against the local `dynamo` checkout, but the container-side local source install path still needs extra environment work unrelated to these code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of token counting in completion responses by properly updating completion token metrics from the worker instead of relying solely on accumulated token data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->