### PR TITLE
fix: prefer worker kv_used_blocks for busy detection

### DIFF
--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -140,7 +140,9 @@ class DynamoSglangPublisher:
                     else self.dp_rank
                 )
                 active_decode_blocks = kv_metrics.kv_active_blocks
-                self.metrics_publisher.publish(dp_rank, active_decode_blocks)
+                self.metrics_publisher.publish(
+                    dp_rank, active_decode_blocks, active_decode_blocks
+                )
                 dp_rank_str = str(dp_rank)
                 # Publish total blocks (always available in KvMetrics)
                 self.component_gauges.set_total_blocks(

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -410,7 +410,7 @@ class Publisher:
 
         # Publish initial metrics with 0 active blocks
         # TRT-LLM doesn't use data parallelism currently (dp_rank="0")
-        self.metrics_publisher.publish(None, 0)
+        self.metrics_publisher.publish(None, 0, 0)
         self.component_gauges.set_total_blocks("0", 0)
         self.component_gauges.set_gpu_cache_usage("0", 0.0)
 
@@ -478,7 +478,7 @@ class Publisher:
             logging.debug(f"Publishing stats: kv_active_blocks: {kv_active_blocks}")
             # TRT-LLM doesn't use data parallelism currently (dp_rank=None for NATS, "0" for Prometheus)
             assert self.metrics_publisher is not None
-            self.metrics_publisher.publish(None, kv_active_blocks)
+            self.metrics_publisher.publish(None, kv_active_blocks, kv_active_blocks)
 
             # Publish Prometheus metrics
             self.component_gauges.set_total_blocks("0", kv_total_blocks)

--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -58,7 +58,7 @@ class DynamoStatLoggerPublisher(StatLoggerBase):
         **kwargs: object,
     ) -> None:
         active_decode_blocks = int(self.num_gpu_block * scheduler_stats.kv_cache_usage)
-        self.inner.publish(self.dp_rank, active_decode_blocks)
+        self.inner.publish(self.dp_rank, active_decode_blocks, active_decode_blocks)
 
         dp_rank_str = str(self.dp_rank)
         self.component_gauges.set_total_blocks(dp_rank_str, self.num_gpu_block)

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -231,11 +231,17 @@ impl WorkerMetricsPublisher {
     ///
     /// # Arguments
     /// * `dp_rank` - Data parallel rank of the worker (None defaults to 0)
-    /// * `active_decode_blocks` - Number of active KV cache blocks
-    #[pyo3(signature = (dp_rank, active_decode_blocks))]
-    fn publish(&self, dp_rank: Option<u32>, active_decode_blocks: u64) -> PyResult<()> {
+    /// * `active_decode_blocks` - Scheduler-compatible active decode block count
+    /// * `kv_used_blocks` - Authoritative total KV blocks currently in use
+    #[pyo3(signature = (dp_rank, active_decode_blocks, kv_used_blocks))]
+    fn publish(
+        &self,
+        dp_rank: Option<u32>,
+        active_decode_blocks: u64,
+        kv_used_blocks: u64,
+    ) -> PyResult<()> {
         self.inner
-            .publish(dp_rank, active_decode_blocks)
+            .publish(dp_rank, active_decode_blocks, kv_used_blocks)
             .map_err(to_pyerr)
     }
 }

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -433,13 +433,15 @@ class WorkerMetricsPublisher:
         self,
         dp_rank: Optional[int],
         active_decode_blocks: int,
+        kv_used_blocks: int,
     ) -> None:
         """
         Publish worker metrics for load monitoring.
 
         Args:
             dp_rank: Data parallel rank of the worker (None defaults to 0)
-            active_decode_blocks: Number of active KV cache blocks
+            active_decode_blocks: Scheduler-compatible active decode block count
+            kv_used_blocks: Authoritative total KV blocks currently in use
         """
         ...
 
@@ -2035,4 +2037,3 @@ class StreamIncomplete(DynamoException):
     """The response stream was terminated before completion."""
 
     ...
-

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -360,8 +360,8 @@ pub struct WorkerSelectionResult {
 
 /// Active load metrics for a worker, used for busy detection.
 ///
-/// Published by workers (with only `active_decode_blocks`) and by the scheduler
-/// (with both `active_decode_blocks` and `active_prefill_tokens`).
+/// Published by workers (with `active_decode_blocks` and `kv_used_blocks`) and by
+/// the scheduler (with `active_decode_blocks` and `active_prefill_tokens`).
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct ActiveLoad {
     pub worker_id: WorkerId,
@@ -371,6 +371,12 @@ pub struct ActiveLoad {
     pub active_decode_blocks: Option<u64>,
     /// Number of active prefill tokens (from scheduler's view).
     pub active_prefill_tokens: Option<u64>,
+    /// Total KV blocks currently in use on the worker.
+    ///
+    /// This is published by workers only and is the authoritative signal for
+    /// backend KV occupancy used by busy detection.
+    #[serde(default)]
+    pub kv_used_blocks: Option<u64>,
 }
 
 /// A [`LocalBlockHash`] is a hash computed from the token IDs, optional multimodal metadata,

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -619,6 +619,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             dp_rank: worker.dp_rank,
             active_decode_blocks: Some(active_blocks as u64),
             active_prefill_tokens: Some(active_tokens as u64),
+            kv_used_blocks: None,
         };
 
         self.publisher.publish_load(active_load);

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -91,6 +91,7 @@ impl LoadThresholdConfig {
 #[derive(Clone, Debug, Default)]
 pub struct WorkerLoadState {
     pub active_decode_blocks: HashMap<u32, u64>,
+    pub kv_used_blocks: HashMap<u32, u64>,
     pub kv_total_blocks: HashMap<u32, u64>,
     pub active_prefill_tokens: HashMap<u32, u64>,
     /// max_num_batched_tokens from runtime config (same for all dp_ranks)
@@ -103,7 +104,8 @@ impl WorkerLoadState {
     /// For each dp_rank, a dp_rank is busy if ANY of these conditions is met (OR logic):
     /// 1. `active_prefill_tokens > active_prefill_tokens_threshold` (absolute threshold)
     /// 2. `active_prefill_tokens > frac * max_num_batched_tokens` (fraction-based threshold)
-    /// 3. `active_decode_blocks / total_blocks > active_decode_blocks_threshold` (blocks threshold)
+    /// 3. `kv_used_blocks / total_blocks > active_decode_blocks_threshold` (blocks threshold)
+    ///    falling back to `active_decode_blocks` for older worker payloads
     ///
     /// If none of these checks can be performed (missing data), that dp_rank is considered free.
     ///
@@ -118,6 +120,7 @@ impl WorkerLoadState {
         let all_dp_ranks: std::collections::HashSet<_> = self
             .active_decode_blocks
             .keys()
+            .chain(self.kv_used_blocks.keys())
             .chain(self.active_prefill_tokens.keys())
             .copied()
             .collect();
@@ -150,13 +153,18 @@ impl WorkerLoadState {
 
             // Check 3: blocks threshold
             // Skip if total_blocks is 0 (no capacity means threshold check is meaningless)
-            if let (Some(&active_blocks), Some(&total_blocks)) = (
-                self.active_decode_blocks.get(&dp_rank),
-                self.kv_total_blocks.get(&dp_rank),
-            ) && total_blocks > 0
-                && (active_blocks as f64) > (active_decode_blocks_threshold * total_blocks as f64)
+            if let Some(&total_blocks) = self.kv_total_blocks.get(&dp_rank)
+                && total_blocks > 0
             {
-                return true; // This dp_rank is busy due to blocks
+                let used_blocks = self
+                    .kv_used_blocks
+                    .get(&dp_rank)
+                    .or(self.active_decode_blocks.get(&dp_rank));
+                if let Some(&used_blocks) = used_blocks
+                    && (used_blocks as f64) > (active_decode_blocks_threshold * total_blocks as f64)
+                {
+                    return true; // This dp_rank is busy due to blocks
+                }
             }
 
             // If we can't perform any check or no threshold exceeded, this dp_rank is free
@@ -511,6 +519,9 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                             if let Some(active_blocks) = active_load.active_decode_blocks {
                                 state.active_decode_blocks.insert(dp_rank, active_blocks);
                             }
+                            if let Some(kv_used_blocks) = active_load.kv_used_blocks {
+                                state.kv_used_blocks.insert(dp_rank, kv_used_blocks);
+                            }
                             if let Some(active_tokens) = active_load.active_prefill_tokens {
                                 state.active_prefill_tokens.insert(dp_rank, active_tokens);
                             }
@@ -646,5 +657,38 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
         });
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WorkerLoadState;
+
+    #[test]
+    fn is_busy_prefers_kv_used_blocks_over_active_decode_blocks() {
+        let mut state = WorkerLoadState::default();
+        state.active_decode_blocks.insert(0, 10);
+        state.kv_used_blocks.insert(0, 90);
+        state.kv_total_blocks.insert(0, 100);
+
+        assert!(state.is_busy(0.6, u64::MAX, 2.0));
+    }
+
+    #[test]
+    fn is_busy_falls_back_to_active_decode_blocks_when_kv_used_missing() {
+        let mut state = WorkerLoadState::default();
+        state.active_decode_blocks.insert(0, 90);
+        state.kv_total_blocks.insert(0, 100);
+
+        assert!(state.is_busy(0.6, u64::MAX, 2.0));
+    }
+
+    #[test]
+    fn is_busy_recognizes_dp_rank_known_only_from_kv_used_blocks() {
+        let mut state = WorkerLoadState::default();
+        state.kv_used_blocks.insert(0, 90);
+        state.kv_total_blocks.insert(0, 100);
+
+        assert!(state.is_busy(0.6, u64::MAX, 2.0));
     }
 }

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -1203,7 +1203,8 @@ mod test_integration_publisher {
         // Test 1: Publish 10 different metrics with 0.5ms intervals
         // Only the last one should be published after 1ms of stability
         for i in 0..10 {
-            publisher.publish(None, (i * 100) as u64).unwrap();
+            let value = (i * 100) as u64;
+            publisher.publish(None, value, value).unwrap();
             tokio::time::sleep(tokio::time::Duration::from_micros(100)).await;
         }
 
@@ -1220,6 +1221,7 @@ mod test_integration_publisher {
         assert_eq!(event.worker_id, worker_id);
         assert_eq!(event.active_decode_blocks, Some(900)); // Last value: 9 * 100
         assert_eq!(event.active_prefill_tokens, None); // Worker doesn't publish prefill tokens
+        assert_eq!(event.kv_used_blocks, Some(900));
 
         // Ensure no more events are waiting
         let no_msg =
@@ -1228,7 +1230,7 @@ mod test_integration_publisher {
 
         // Test 2: Publish 10 more metrics with same active_decode_blocks - should not trigger publish
         for _ in 0..10 {
-            publisher.publish(None, 900).unwrap(); // Keep same as last published
+            publisher.publish(None, 900, 900).unwrap(); // Keep same as last published
             tokio::time::sleep(tokio::time::Duration::from_micros(100)).await;
         }
 

--- a/lib/llm/src/kv_router/publisher/worker_metrics.rs
+++ b/lib/llm/src/kv_router/publisher/worker_metrics.rs
@@ -14,6 +14,7 @@ use crate::kv_router::KV_METRICS_SUBJECT;
 struct WorkerMetrics {
     dp_rank: DpRank,
     active_decode_blocks: u64,
+    kv_used_blocks: u64,
 }
 
 pub struct WorkerMetricsPublisher {
@@ -27,15 +28,22 @@ impl WorkerMetricsPublisher {
         Ok(Self { tx, rx })
     }
 
-    pub fn publish(&self, dp_rank: Option<DpRank>, active_decode_blocks: u64) -> Result<()> {
+    pub fn publish(
+        &self,
+        dp_rank: Option<DpRank>,
+        active_decode_blocks: u64,
+        kv_used_blocks: u64,
+    ) -> Result<()> {
         let metrics = WorkerMetrics {
             dp_rank: dp_rank.unwrap_or(0),
             active_decode_blocks,
+            kv_used_blocks,
         };
         tracing::trace!(
-            "Publish metrics: dp_rank={}, active_decode_blocks={}",
+            "Publish metrics: dp_rank={}, active_decode_blocks={}, kv_used_blocks={}",
             metrics.dp_rank,
-            metrics.active_decode_blocks
+            metrics.active_decode_blocks,
+            metrics.kv_used_blocks
         );
         self.tx
             .send(metrics)
@@ -97,6 +105,7 @@ impl WorkerMetricsPublisher {
                                 dp_rank: metrics.dp_rank,
                                 active_decode_blocks: Some(metrics.active_decode_blocks),
                                 active_prefill_tokens: None,
+                                kv_used_blocks: Some(metrics.kv_used_blocks),
                             };
 
                             if let Err(e) = event_publisher.publish(&active_load).await {

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -553,7 +553,11 @@ impl MockEngine {
                             let metrics = metrics_rx.borrow().clone();
 
                             // Publish metrics using flat API
-                            if let Err(e) = publisher.publish(Some(metrics.dp_rank), metrics.active_decode_blocks) {
+                            if let Err(e) = publisher.publish(
+                                Some(metrics.dp_rank),
+                                metrics.active_decode_blocks,
+                                metrics.active_decode_blocks,
+                            ) {
                                 tracing::warn!("Failed to publish metrics for DP rank {}: {e}", metrics.dp_rank);
                             } else {
                                 tracing::trace!("Published metrics for DP rank {}", metrics.dp_rank);


### PR DESCRIPTION
Fix proposal #7753

Codex:

## Summary

This changes frontend busy detection to prefer worker-reported backend KV occupancy over scheduler-local active block counts.

## Root cause

`ActiveLoad.active_decode_blocks` was overloaded with two different meanings:

- worker publishers used it for real backend KV usage
- scheduler publishers used it for router-local active-sequence blocks

`KvWorkerMonitor` stored the last value it received and `is_busy()` used that for `active_decode_blocks / kv_total_blocks > threshold`, so scheduler messages could overwrite the worker's accurate value and prevent load shedding.

## What changed

- add `kv_used_blocks: Option<u64>` to `ActiveLoad`
- have worker publishers populate `kv_used_blocks`
- leave `kv_used_blocks` unset in scheduler publishes
- make `KvWorkerMonitor::is_busy()` prefer `kv_used_blocks` and fall back to `active_decode_blocks` for older payloads
- update Python bindings and backend publishers to pass the new field
- add coverage for the precedence and fallback behavior

## Impact

This keeps routing behavior unchanged while fixing `active_decode_blocks_threshold` so it uses the worker's authoritative KV-usage signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced metrics collection to track KV cache block usage alongside existing metrics. The scheduler now receives more precise KV occupancy data from workers, enabling improved busy detection and resource utilization monitoring. Busy detection logic now prioritizes actual KV block usage when available, with fallback to prior metrics for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->