### PR TITLE
feat: add INFO log in AggregatedHandler for request tracing

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
@@ -35,6 +35,7 @@ class AggregatedHandler(HandlerBase):
 
     async def generate(self, request: dict, context: Context):
         """Generate response, optionally using remote encoder for multimodal."""
+        logging.info("Indrajit auto run claude")
         logging.debug(f"AggregatedHandler Request ID: {context.id()}")
 
         embeddings = None


### PR DESCRIPTION
#### Overview:
Add an `INFO` level log message in `AggregatedHandler.generate()` to trace request invocations in aggregated mode.

#### Details:
- Added `logging.info("Indrajit auto run claude")` at the start of `AggregatedHandler.generate()` in `components/src/dynamo/trtllm/request_handlers/aggregated_handler.py`
- This log confirms the aggregated handler is invoked for each incoming request, useful for debugging and request tracing

#### Where should the reviewer start?
- `components/src/dynamo/trtllm/request_handlers/aggregated_handler.py` — single line change at the top of `generate()`

#### Related Issues:
- N/A

---

### Validation

Tested on **dynamo v1.0.0** with **Qwen/Qwen3-0.6B** in aggregated mode using `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0` container on an NVIDIA L40S GPU (46GB).

### Sample Requests & Responses

**Request 1:**
```json
POST localhost:8000/v1/chat/completions
{
  "model": "Qwen/Qwen3-0.6B",
  "messages": [{"role": "user", "content": "Say hello, request 1"}],
  "max_tokens": 10,
  "stream": false
}
```
**Response 1:**
```json
{
  "id": "chatcmpl-853d5d0e-9ebe-4900-b8bf-8b2940a66c4e",
  "choices": [{"index": 0, "message": {"content": "<think>\nOkay, the user wants me to say", "role": "assistant"}, "finish_reason": "length"}],
  "model": "Qwen/Qwen3-0.6B",
  "usage": {"prompt_tokens": 14, "completion_tokens": 10, "total_tokens": 24}
}
```

**Request 2:**
```json
POST localhost:8000/v1/chat/completions
{
  "model": "Qwen/Qwen3-0.6B",
  "messages": [{"role": "user", "content": "Say hello, request 2"}],
  "max_tokens": 10,
  "stream": false
}
```
**Response 2:**
```json
{
  "id": "chatcmpl-2b194327-83a7-4bd2-85fa-ac2c956423a9",
  "choices": [{"index": 0, "message": {"content": "<think>\nOkay, the user said \"Say hello", "role": "assistant"}, "finish_reason": "length"}],
  "model": "Qwen/Qwen3-0.6B",
  "usage": {"prompt_tokens": 14, "completion_tokens": 10, "total_tokens": 24}
}
```

**Request 3:**
```json
POST localhost:8000/v1/chat/completions
{
  "model": "Qwen/Qwen3-0.6B",
  "messages": [{"role": "user", "content": "Say hello, request 3"}],
  "max_tokens": 10,
  "stream": false
}
```
**Response 3:**
```json
{
  "id": "chatcmpl-5a5bb011-2eed-45cb-919c-bc9dc6c10960",
  "choices": [{"index": 0, "message": {"content": "<think>\nOkay, the user said \"Say hello", "role": "assistant"}, "finish_reason": "length"}],
  "model": "Qwen/Qwen3-0.6B",
  "usage": {"prompt_tokens": 14, "completion_tokens": 10, "total_tokens": 24}
}
```

**Request 4:**
```json
POST localhost:8000/v1/chat/completions
{
  "model": "Qwen/Qwen3-0.6B",
  "messages": [{"role": "user", "content": "Say hello, request 4"}],
  "max_tokens": 10,
  "stream": false
}
```
**Response 4:**
```json
{
  "id": "chatcmpl-3a102eaf-7059-415e-8305-d42bda86f152",
  "choices": [{"index": 0, "message": {"content": "<think>\nOkay, the user said \"Say hello", "role": "assistant"}, "finish_reason": "length"}],
  "model": "Qwen/Qwen3-0.6B",
  "usage": {"prompt_tokens": 14, "completion_tokens": 10, "total_tokens": 24}
}
```

**Request 5:**
```json
POST localhost:8000/v1/chat/completions
{
  "model": "Qwen/Qwen3-0.6B",
  "messages": [{"role": "user", "content": "Say hello, request 5"}],
  "max_tokens": 10,
  "stream": false
}
```
**Response 5:**
```json
{
  "id": "chatcmpl-d7000e41-67c7-49fe-9148-80ce3165dc7f",
  "choices": [{"index": 0, "message": {"content": "<think>\nOkay, the user said \"Say hello", "role": "assistant"}, "finish_reason": "length"}],
  "model": "Qwen/Qwen3-0.6B",
  "usage": {"prompt_tokens": 14, "completion_tokens": 10, "total_tokens": 24}
}
```

### New Logs Visible in Container (`docker logs dynamo-trtllm-agg`)

```
2026-04-01T08:05:09.710798Z INFO aggregated_handler.generate: Indrajit auto run claude
2026-04-01T08:05:09.762880Z INFO aggregated_handler.generate: Indrajit auto run claude
2026-04-01T08:05:09.813499Z INFO aggregated_handler.generate: Indrajit auto run claude
2026-04-01T08:05:09.863746Z INFO aggregated_handler.generate: Indrajit auto run claude
2026-04-01T08:05:09.913915Z INFO aggregated_handler.generate: Indrajit auto run claude
```

Each request triggers the `INFO` log line, confirming `AggregatedHandler.generate()` is invoked per request in aggregated mode.

### Checklist
- [x] Pre-commit hooks pass (isort, black, flake8, ruff, codespell, etc.)
- [x] Commit signed with DCO (`Signed-off-by`)
- [x] Conventional commit format used
- [x] Tested with dynamo-trtllm v1.0.0 container in aggregated mode
- [x] Verified log appears once per request

🤖 Generated with [Claude Code](https://claude.com/claude-code)