### PR TITLE
fix: prevent LoRA churn from dropping worker runtime configs

### DIFF
--- a/lib/llm/src/discovery/runtime_configs.rs
+++ b/lib/llm/src/discovery/runtime_configs.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use tokio::sync::watch;
 
 use dynamo_runtime::component::Endpoint;
-use dynamo_runtime::discovery::{DiscoveryQuery, watch_and_extract_field};
+use dynamo_runtime::discovery::{DiscoveryQuery, watch_and_extract_base_model_field};
 use dynamo_runtime::prelude::DistributedRuntimeProvider;
 
 use crate::local_model::runtime_config::ModelRuntimeConfig;
@@ -29,7 +29,7 @@ pub async fn runtime_config_watch(endpoint: &Endpoint) -> anyhow::Result<Runtime
     let client = endpoint.client().await?;
     let mut instance_ids_rx = client.instance_avail_watcher();
 
-    // Source 2: runtime configs from discovery (watches DiscoveryQuery::EndpointModels)
+    // Source 2: worker runtime configs from base model cards in discovery
     let discovery = component.drt().discovery();
     let eid = endpoint.id();
     let stream = discovery
@@ -43,7 +43,7 @@ pub async fn runtime_config_watch(endpoint: &Endpoint) -> anyhow::Result<Runtime
         )
         .await?;
     let mut configs_rx =
-        watch_and_extract_field(stream, |card: ModelDeploymentCard| card.runtime_config);
+        watch_and_extract_base_model_field(stream, |card: ModelDeploymentCard| card.runtime_config);
 
     let (tx, rx) = watch::channel(HashMap::new());
 

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -20,7 +20,7 @@ use crate::kv_router::KV_METRICS_SUBJECT;
 use crate::kv_router::metrics::WORKER_LOAD_METRICS;
 use crate::model_card::ModelDeploymentCard;
 use dynamo_runtime::component::Client;
-use dynamo_runtime::discovery::{DiscoveryQuery, watch_and_extract_field};
+use dynamo_runtime::discovery::{DiscoveryQuery, watch_and_extract_base_model_field};
 use dynamo_runtime::pipeline::{WorkerLoadMonitor, async_trait};
 use dynamo_runtime::traits::DistributedRuntimeProvider;
 use dynamo_runtime::transports::event_plane::EventSubscriber;
@@ -341,7 +341,7 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
 
         let cancellation_token = component.drt().child_token();
 
-        // Watch for runtime config updates from model deployment cards via discovery interface
+        // Watch for worker runtime config updates from base model cards via discovery interface
         let discovery = component.drt().discovery();
         let discovery_stream = match discovery
             .list_and_watch(DiscoveryQuery::AllModels, Some(cancellation_token.clone()))
@@ -356,7 +356,7 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
             }
         };
         let mut config_events_rx =
-            watch_and_extract_field(discovery_stream, |card: ModelDeploymentCard| {
+            watch_and_extract_base_model_field(discovery_stream, |card: ModelDeploymentCard| {
                 card.runtime_config
             });
 

--- a/lib/runtime/src/discovery/mock.rs
+++ b/lib/runtime/src/discovery/mock.rs
@@ -170,13 +170,13 @@ impl Discovery for MockDiscovery {
     }
 
     async fn unregister(&self, instance: DiscoveryInstance) -> Result<()> {
-        let instance_id = instance.instance_id();
+        let target_id = instance.id();
 
         self.registry
             .instances
             .lock()
             .unwrap()
-            .retain(|i| i.instance_id() != instance_id);
+            .retain(|i| i.id() != target_id);
 
         Ok(())
     }
@@ -478,5 +478,64 @@ mod tests {
         assert!(err.to_string().contains(
             "Cannot register model 'adapter-a' on endpoint 'ns/comp/generate': a different model 'base-model' is already registered there"
         ));
+    }
+
+    #[tokio::test]
+    async fn unregister_lora_adapter_keeps_base_and_other_loras() {
+        let registry = SharedMockRegistry::new();
+        let discovery = MockDiscovery::new(Some(1), registry);
+
+        let base = discovery
+            .register(DiscoverySpec::Model {
+                namespace: "ns".to_string(),
+                component: "comp".to_string(),
+                endpoint: "generate".to_string(),
+                card_json: serde_json::json!({
+                    "display_name": "base-model",
+                    "source_path": "base-repo",
+                }),
+                model_suffix: None,
+            })
+            .await
+            .unwrap();
+
+        let lora_a = discovery
+            .register(lora_model_spec(
+                "ns",
+                "comp",
+                "generate",
+                "adapter-a",
+                "base-repo",
+                "adapter-a",
+            ))
+            .await
+            .unwrap();
+        let lora_b = discovery
+            .register(lora_model_spec(
+                "ns",
+                "comp",
+                "generate",
+                "adapter-b",
+                "base-repo",
+                "adapter-b",
+            ))
+            .await
+            .unwrap();
+
+        discovery.unregister(lora_a).await.unwrap();
+
+        let instances = discovery
+            .list(DiscoveryQuery::EndpointModels {
+                namespace: "ns".to_string(),
+                component: "comp".to_string(),
+                endpoint: "generate".to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(instances.len(), 2);
+        let instance_ids: Vec<_> = instances.iter().map(DiscoveryInstance::id).collect();
+        assert!(instance_ids.contains(&base.id()));
+        assert!(instance_ids.contains(&lora_b.id()));
     }
 }

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -21,7 +21,7 @@ pub use kube::{KubeDiscoveryClient, hash_pod_name};
 
 pub mod utils;
 use crate::component::TransportType;
-pub use utils::watch_and_extract_field;
+pub use utils::{watch_and_extract_base_model_field, watch_and_extract_field};
 
 /// Transport kind for event plane - used for configuration and env var selection.
 ///

--- a/lib/runtime/src/discovery/utils.rs
+++ b/lib/runtime/src/discovery/utils.rs
@@ -38,6 +38,10 @@ use super::{DiscoveryEvent, DiscoveryInstance, DiscoveryStream};
 ///     // Use config...
 /// }
 /// ```
+///
+/// This helper is only appropriate when the watched objects are keyed solely by
+/// raw `instance_id`. For model-card streams, use
+/// `watch_and_extract_base_model_field` when reducing to worker-level state.
 pub fn watch_and_extract_field<T, V, F>(
     stream: DiscoveryStream,
     extractor: F,
@@ -103,4 +107,255 @@ where
     });
 
     rx
+}
+
+/// Helper to watch a model-card discovery stream and extract a field from base model cards only.
+///
+/// This is intended for worker-level fields such as runtime config where LoRA model-card churn
+/// must not add, replace, or delete the worker's state.
+pub fn watch_and_extract_base_model_field<T, V, F>(
+    stream: DiscoveryStream,
+    extractor: F,
+) -> tokio::sync::watch::Receiver<std::collections::HashMap<u64, V>>
+where
+    T: for<'de> Deserialize<'de> + 'static,
+    V: Clone + Send + Sync + 'static,
+    F: Fn(T) -> V + Send + 'static,
+{
+    use futures::StreamExt;
+    use std::collections::HashMap;
+
+    let (tx, rx) = tokio::sync::watch::channel(HashMap::new());
+
+    tokio::spawn(async move {
+        let mut state: HashMap<u64, V> = HashMap::new();
+        let mut stream = stream;
+
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(DiscoveryEvent::Added(DiscoveryInstance::Model {
+                    instance_id,
+                    card_json,
+                    model_suffix,
+                    ..
+                })) => {
+                    // Runtime config and similar worker-level state is sourced from the
+                    // canonical base model card, not LoRA overlays on the same worker.
+                    if model_suffix.is_some() {
+                        continue;
+                    }
+
+                    let deserialized: T = match serde_json::from_value(card_json) {
+                        Ok(d) => d,
+                        Err(e) => {
+                            tracing::warn!(
+                                instance_id,
+                                error = %e,
+                                "Failed to deserialize base model discovery instance, skipping"
+                            );
+                            continue;
+                        }
+                    };
+
+                    let value = extractor(deserialized);
+                    state.insert(instance_id, value);
+                    if tx.send(state.clone()).is_err() {
+                        tracing::debug!(
+                            "watch_and_extract_base_model_field receiver dropped, stopping"
+                        );
+                        break;
+                    }
+                }
+                Ok(DiscoveryEvent::Added(_)) => {
+                    tracing::debug!(
+                        "watch_and_extract_base_model_field received non-model discovery instance"
+                    );
+                }
+                Ok(DiscoveryEvent::Removed(id)) => {
+                    let model_id = match id.extract_model_id() {
+                        Ok(model_id) => model_id,
+                        Err(_) => {
+                            tracing::debug!(
+                                "watch_and_extract_base_model_field received non-model removal"
+                            );
+                            continue;
+                        }
+                    };
+
+                    if model_id.model_suffix.is_some() {
+                        continue;
+                    }
+
+                    state.remove(&model_id.instance_id);
+                    if tx.send(state.clone()).is_err() {
+                        tracing::debug!(
+                            "watch_and_extract_base_model_field receiver dropped, stopping"
+                        );
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "Discovery event stream error in watch_and_extract_base_model_field"
+                    );
+                }
+            }
+        }
+
+        tracing::debug!("watch_and_extract_base_model_field task stopped");
+    });
+
+    rx
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    use serde::{Deserialize, Serialize};
+
+    use super::watch_and_extract_base_model_field;
+    use crate::discovery::{
+        Discovery, DiscoveryQuery, DiscoverySpec, MockDiscovery, SharedMockRegistry,
+    };
+
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    struct TestCard {
+        runtime_config: u32,
+    }
+
+    fn endpoint_model_query() -> DiscoveryQuery {
+        DiscoveryQuery::EndpointModels {
+            namespace: "ns".to_string(),
+            component: "comp".to_string(),
+            endpoint: "generate".to_string(),
+        }
+    }
+
+    fn base_model_spec(runtime_config: u32) -> DiscoverySpec {
+        DiscoverySpec::Model {
+            namespace: "ns".to_string(),
+            component: "comp".to_string(),
+            endpoint: "generate".to_string(),
+            card_json: serde_json::json!({
+                "display_name": "base-model",
+                "source_path": "base-repo",
+                "runtime_config": runtime_config,
+            }),
+            model_suffix: None,
+        }
+    }
+
+    fn lora_model_spec(name: &str, runtime_config: u32) -> DiscoverySpec {
+        DiscoverySpec::Model {
+            namespace: "ns".to_string(),
+            component: "comp".to_string(),
+            endpoint: "generate".to_string(),
+            card_json: serde_json::json!({
+                "display_name": name,
+                "source_path": "base-repo",
+                "runtime_config": runtime_config,
+                "lora": {
+                    "name": name,
+                },
+            }),
+            model_suffix: Some(name.to_string()),
+        }
+    }
+
+    async fn wait_for_state<F>(
+        rx: &mut tokio::sync::watch::Receiver<HashMap<u64, u32>>,
+        predicate: F,
+    ) where
+        F: Fn(&HashMap<u64, u32>) -> bool,
+    {
+        if predicate(&rx.borrow()) {
+            return;
+        }
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                rx.changed()
+                    .await
+                    .expect("base model field watch should remain open");
+                if predicate(&rx.borrow()) {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for watch state");
+    }
+
+    #[tokio::test]
+    async fn watch_and_extract_base_model_field_ignores_lora_add_remove() {
+        let registry = SharedMockRegistry::new();
+        let discovery = MockDiscovery::new(Some(0xabc), registry);
+
+        let stream = discovery
+            .list_and_watch(endpoint_model_query(), None)
+            .await
+            .unwrap();
+        let mut rx =
+            watch_and_extract_base_model_field(stream, |card: TestCard| card.runtime_config);
+
+        let base = discovery.register(base_model_spec(42)).await.unwrap();
+        let lora_a = discovery
+            .register(lora_model_spec("adapter-a", 100))
+            .await
+            .unwrap();
+        let _lora_b = discovery
+            .register(lora_model_spec("adapter-b", 101))
+            .await
+            .unwrap();
+
+        wait_for_state(&mut rx, |state| state.get(&0xabc) == Some(&42)).await;
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(rx.borrow().get(&0xabc), Some(&42));
+
+        discovery.unregister(lora_a).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(rx.borrow().get(&0xabc), Some(&42));
+
+        discovery.unregister(base).await.unwrap();
+        wait_for_state(&mut rx, |state| !state.contains_key(&0xabc)).await;
+    }
+
+    #[tokio::test]
+    async fn watch_and_extract_base_model_field_handles_lora_before_base_and_base_removal() {
+        let registry = SharedMockRegistry::new();
+        let discovery = MockDiscovery::new(Some(0xabc), registry);
+
+        let stream = discovery
+            .list_and_watch(endpoint_model_query(), None)
+            .await
+            .unwrap();
+        let mut rx =
+            watch_and_extract_base_model_field(stream, |card: TestCard| card.runtime_config);
+
+        let lora_a = discovery
+            .register(lora_model_spec("adapter-a", 100))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(rx.borrow().is_empty());
+
+        let base = discovery.register(base_model_spec(42)).await.unwrap();
+        let _lora_b = discovery
+            .register(lora_model_spec("adapter-b", 101))
+            .await
+            .unwrap();
+
+        wait_for_state(&mut rx, |state| state.get(&0xabc) == Some(&42)).await;
+
+        discovery.unregister(lora_a).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(rx.borrow().get(&0xabc), Some(&42));
+
+        discovery.unregister(base).await.unwrap();
+        wait_for_state(&mut rx, |state| state.is_empty()).await;
+    }
 }


### PR DESCRIPTION
## Summary

This changes runtime-config watches to treat the base model card as the canonical worker-level source and ignore LoRA model-card churn.

Fixes #7758.

## Root cause

`runtime_config_watch()` and `KvWorkerMonitor` were consuming model-card discovery through a helper that keyed extracted state only by raw `instance_id`.

That collapses distinct model-card identities:

- base model card: `(namespace, component, endpoint, instance_id, None)`
- LoRA model card: `(namespace, component, endpoint, instance_id, Some(model_suffix))`

As a result, unregistering one LoRA could remove the runtime config for the entire worker even while the base card and other LoRAs were still present.

## What changed

- added `watch_and_extract_base_model_field()` for worker-level fields derived from model-card streams
- switched `runtime_config_watch()` to consume base model cards only
- switched `KvWorkerMonitor` runtime-config tracking to consume base model cards only
- fixed `MockDiscovery::unregister()` to remove by full discovery identity instead of raw `instance_id`
- added tests covering LoRA add/remove churn and ordering

## Impact

This keeps worker runtime config tied to worker lifecycle rather than adapter churn, so unloading a single LoRA no longer drops a healthy worker out of routing.

## Validation

- `watch_and_extract_base_model_field_ignores_lora_add_remove`
- `watch_and_extract_base_model_field_handles_lora_before_base_and_base_removal`
- `unregister_lora_adapter_keeps_base_and_other_loras`
