### PR TITLE
fix: frontend readiness waits for initial discovery

### DIFF
--- a/lib/bindings/python/rust/llm/fpm.rs
+++ b/lib/bindings/python/rust/llm/fpm.rs
@@ -560,9 +560,12 @@ impl FpmEventSubscriber {
                                     if removed > 0 {
                                         tracing::info!(
                                             "FPM tracker: removed {removed} entries for \
-                                             worker_id={removed_id} (MDC removed)"
+                                            worker_id={removed_id} (MDC removed)"
                                         );
                                     }
+                                }
+                                Some(Ok(DiscoveryEvent::InitialSyncComplete)) => {
+                                    tracing::debug!("FPM tracker: initial discovery sync completed");
                                 }
                                 Some(Err(e)) => {
                                     tracing::warn!("FPM tracker: discovery error: {e}");

--- a/lib/kv-router/src/standalone_indexer/runtime/discovery.rs
+++ b/lib/kv-router/src/standalone_indexer/runtime/discovery.rs
@@ -111,6 +111,9 @@ pub async fn spawn_discovery_watcher(
                     tracing::info!(instance_id, "Discovery: removing worker");
                     registry.remove_worker_from_discovery(instance_id).await;
                 }
+                DiscoveryEvent::InitialSyncComplete => {
+                    tracing::debug!("Standalone indexer discovery initial sync completed");
+                }
             }
         }
 

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 use tokio::sync::Notify;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::oneshot;
 
 use anyhow::Context as _;
 use dashmap::DashSet;
@@ -153,11 +154,20 @@ impl ModelWatcher {
         &self,
         mut discovery_stream: DiscoveryStream,
         namespace_filter: NamespaceFilter,
-    ) {
+        mut initial_sync_tx: Option<oneshot::Sender<anyhow::Result<()>>>,
+    ) -> anyhow::Result<()> {
+        let mut initial_sync_complete = false;
+        let mut initial_sync_error: Option<anyhow::Error> = None;
+
         while let Some(result) = discovery_stream.next().await {
             let event = match result {
                 Ok(event) => event,
                 Err(err) => {
+                    if !initial_sync_complete && initial_sync_error.is_none() {
+                        initial_sync_error = Some(anyhow::anyhow!(
+                            "discovery stream error before initial sync completed: {err}"
+                        ));
+                    }
                     tracing::error!(%err, "Error in discovery stream");
                     continue;
                 }
@@ -192,6 +202,11 @@ impl ModelWatcher {
                             }
                         }
                         _ => {
+                            if !initial_sync_complete && initial_sync_error.is_none() {
+                                initial_sync_error = Some(anyhow::anyhow!(
+                                    "unexpected non-model discovery instance during model watch"
+                                ));
+                            }
                             tracing::error!(
                                 "Unexpected discovery instance type (expected ModelCard)"
                             );
@@ -216,6 +231,13 @@ impl ModelWatcher {
                     if let Some(model) = self.manager.get_model(card.name())
                         && !model.is_checksum_compatible(&ws_key, card.mdcsum())
                     {
+                        if !initial_sync_complete && initial_sync_error.is_none() {
+                            initial_sync_error = Some(anyhow::anyhow!(
+                                "checksum mismatch while registering model '{}' in namespace '{}'",
+                                card.name(),
+                                mcid.namespace
+                            ));
+                        }
                         tracing::error!(
                             model_name = card.name(),
                             namespace = mcid.namespace,
@@ -243,6 +265,13 @@ impl ModelWatcher {
                             self.notify_on_model.notify_waiters();
                         }
                         Err(err) => {
+                            if !initial_sync_complete && initial_sync_error.is_none() {
+                                initial_sync_error = Some(anyhow::anyhow!(
+                                    "failed to register model '{}' in namespace '{}': {err:#}",
+                                    card.name(),
+                                    mcid.namespace
+                                ));
+                            }
                             tracing::error!(
                                 model_name = card.name(),
                                 namespace = mcid.namespace,
@@ -279,8 +308,28 @@ impl ModelWatcher {
                         }
                     }
                 }
+                DiscoveryEvent::InitialSyncComplete => {
+                    tracing::info!("Initial model discovery replay completed");
+                    initial_sync_complete = true;
+                    if let Some(tx) = initial_sync_tx.take() {
+                        let result = match initial_sync_error.take() {
+                            Some(err) => Err(err),
+                            None => Ok(()),
+                        };
+                        let _ = tx.send(result);
+                    }
+                }
             }
         }
+
+        if let Some(tx) = initial_sync_tx.take() {
+            let err = initial_sync_error.unwrap_or_else(|| {
+                anyhow::anyhow!("discovery stream ended before initial sync completed")
+            });
+            let _ = tx.send(Err(err));
+        }
+
+        anyhow::bail!("discovery stream ended")
     }
 
     /// Handle a worker removal. Cleans up per-namespace WorkerSets and the Model itself
@@ -429,10 +478,6 @@ impl ModelWatcher {
         );
         self.manager
             .save_model_card(&mcid.to_path(), card.clone())?;
-
-        if let Some(tx) = &self.model_update_tx {
-            tx.send(ModelUpdate::Added(card.clone())).await.ok();
-        }
 
         let checksum = card.mdcsum();
         let namespace = mcid.namespace.clone();
@@ -801,6 +846,10 @@ impl ModelWatcher {
                 "Prefill model registered and router activated successfully"
             );
 
+            if let Some(tx) = &self.model_update_tx {
+                tx.send(ModelUpdate::Added(card.clone())).await.ok();
+            }
+
             return Ok(());
         } else {
             // Reject unsupported combinations
@@ -815,6 +864,10 @@ impl ModelWatcher {
         // Add the completed WorkerSet to the Model
         self.manager
             .add_worker_set(card.name(), &ws_key, worker_set);
+
+        if let Some(tx) = &self.model_update_tx {
+            tx.send(ModelUpdate::Added(card.clone())).await.ok();
+        }
 
         Ok(())
     }

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -131,8 +131,8 @@ pub async fn prepare_engine(
                 local_model.namespace_prefix(),
             );
             let _watcher_task = tokio::spawn(async move {
-                inner_watch_obj
-                    .watch(discovery_stream, namespace_filter)
+                let _ = inner_watch_obj
+                    .watch(discovery_stream, namespace_filter, None)
                     .await;
             });
             tracing::info!("Waiting for remote model..");

--- a/lib/llm/src/entrypoint/input/grpc.rs
+++ b/lib/llm/src/entrypoint/input/grpc.rs
@@ -137,7 +137,9 @@ async fn run_watcher(
 
     // Pass the discovery stream to the watcher
     let _watcher_task = tokio::spawn(async move {
-        watch_obj.watch(discovery_stream, namespace_filter).await;
+        let _ = watch_obj
+            .watch(discovery_stream, namespace_filter, None)
+            .await;
     });
 
     Ok(())

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -168,6 +168,9 @@ async fn run_watcher(
     metrics: Arc<crate::http::service::metrics::Metrics>,
     chat_engine_factory: Option<ChatEngineFactoryCallback>,
 ) -> anyhow::Result<()> {
+    let startup_state = http_service.state_clone();
+    startup_state.mark_initial_discovery_pending();
+
     let mut watch_obj = ModelWatcher::new(
         runtime.clone(),
         model_manager,
@@ -197,9 +200,37 @@ async fn run_watcher(
         }
     });
 
+    let (startup_tx, startup_rx) = tokio::sync::oneshot::channel::<anyhow::Result<()>>();
+
+    let startup_state_for_completion = startup_state.clone();
+    let _startup_task = tokio::spawn(async move {
+        match startup_rx.await {
+            Ok(Ok(())) => {
+                tracing::info!("Initial model discovery completed successfully");
+                startup_state_for_completion.mark_initial_discovery_complete();
+            }
+            Ok(Err(err)) => {
+                tracing::error!(error = %err, "Initial model discovery failed");
+                startup_state_for_completion.mark_initial_discovery_failed(err.to_string());
+            }
+            Err(_) => {
+                let message = "Initial model discovery task exited before signaling readiness";
+                tracing::error!(message);
+                startup_state_for_completion.mark_initial_discovery_failed(message);
+            }
+        }
+    });
+
+    let startup_state_for_watcher = startup_state.clone();
     // Pass the discovery stream to the watcher
     let _watcher_task = tokio::spawn(async move {
-        watch_obj.watch(discovery_stream, namespace_filter).await;
+        if let Err(err) = watch_obj
+            .watch(discovery_stream, namespace_filter, Some(startup_tx))
+            .await
+        {
+            tracing::error!(error = %err, "Model discovery watcher stopped");
+            startup_state_for_watcher.mark_initial_discovery_failed(err.to_string());
+        }
     });
 
     Ok(())

--- a/lib/llm/src/http/service/health.rs
+++ b/lib/llm/src/http/service/health.rs
@@ -63,6 +63,28 @@ async fn live_handler(
 async fn health_handler(
     axum::extract::State(state): axum::extract::State<Arc<service_v2::State>>,
 ) -> impl IntoResponse {
+    let (status_code, status, message) = if state.is_cancelled() {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "shutting_down",
+            "Service is shutting down".to_string(),
+        )
+    } else if let Some(error) = state.initial_discovery_error() {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "not_ready",
+            format!("Initial model discovery failed: {error}"),
+        )
+    } else if !state.initial_discovery_complete() {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "not_ready",
+            "Initial model discovery in progress".to_string(),
+        )
+    } else {
+        (StatusCode::OK, "healthy", "Service is healthy".to_string())
+    };
+
     let instances = match list_all_instances(state.discovery()).await {
         Ok(instances) => instances,
         Err(err) => {
@@ -77,9 +99,12 @@ async fn health_handler(
     endpoints.sort();
     endpoints.dedup();
     (
-        StatusCode::OK,
+        status_code,
         Json(json!({
-            "status": "healthy",
+            "status": status,
+            "message": message,
+            "initial_discovery_complete": state.initial_discovery_complete(),
+            "initial_discovery_error": state.initial_discovery_error(),
             "endpoints": endpoints,
             "instances": instances
         })),

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1742,9 +1742,9 @@ pub fn validate_response_unsupported_fields(
 // todo - abstract this to the top level lib.rs to be reused
 // todo - move the service_observer to its own state/arc
 fn check_ready(_state: &Arc<service_v2::State>) -> Result<(), ErrorResponse> {
-    // if state.service_observer.stage() != ServiceStage::Ready {
-    //     return Err(ErrorMessage::service_unavailable());
-    // }
+    if !_state.is_ready() {
+        return Err(ErrorMessage::_service_unavailable());
+    }
     Ok(())
 }
 

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use axum::body::Body;
 use axum::http::Response;
+use parking_lot::RwLock;
 
 use super::Metrics;
 use super::RouteDoc;
@@ -46,6 +47,8 @@ pub struct State {
     manager: Arc<ModelManager>,
     discovery_client: Arc<dyn Discovery>,
     flags: StateFlags,
+    initial_discovery_complete: AtomicBool,
+    initial_discovery_error: RwLock<Option<String>>,
     cancel_token: CancellationToken,
 }
 
@@ -127,6 +130,8 @@ impl State {
                 responses_endpoints_enabled: AtomicBool::new(false),
                 anthropic_endpoints_enabled: AtomicBool::new(false),
             },
+            initial_discovery_complete: AtomicBool::new(true),
+            initial_discovery_error: RwLock::new(None),
             cancel_token,
         }
     }
@@ -156,6 +161,36 @@ impl State {
     /// Get the cancellation token
     pub fn cancel_token(&self) -> &CancellationToken {
         &self.cancel_token
+    }
+
+    pub fn mark_initial_discovery_pending(&self) {
+        *self.initial_discovery_error.write() = None;
+        self.initial_discovery_complete
+            .store(false, Ordering::Release);
+    }
+
+    pub fn mark_initial_discovery_complete(&self) {
+        *self.initial_discovery_error.write() = None;
+        self.initial_discovery_complete
+            .store(true, Ordering::Release);
+    }
+
+    pub fn mark_initial_discovery_failed(&self, error: impl Into<String>) {
+        *self.initial_discovery_error.write() = Some(error.into());
+        self.initial_discovery_complete
+            .store(false, Ordering::Release);
+    }
+
+    pub fn initial_discovery_complete(&self) -> bool {
+        self.initial_discovery_complete.load(Ordering::Acquire)
+    }
+
+    pub fn initial_discovery_error(&self) -> Option<String> {
+        self.initial_discovery_error.read().clone()
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.initial_discovery_complete()
     }
 
     // TODO

--- a/lib/llm/src/kv_router/worker_query.rs
+++ b/lib/llm/src/kv_router/worker_query.rs
@@ -245,6 +245,9 @@ impl WorkerQueryClient {
                     };
                     self.handle_removed_worker_dp(worker_id, dp_rank).await;
                 }
+                DiscoveryEvent::InitialSyncComplete => {
+                    tracing::debug!("Worker query discovery initial sync completed");
+                }
             }
         }
 

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -345,6 +345,9 @@ impl Client {
                     DiscoveryEvent::Removed(id) => {
                         map.remove(&id.instance_id());
                     }
+                    DiscoveryEvent::InitialSyncComplete => {
+                        // The current state already reflects the initial snapshot.
+                    }
                 }
 
                 let instances: Vec<Instance> = map.values().cloned().collect();

--- a/lib/runtime/src/discovery/kube.rs
+++ b/lib/runtime/src/discovery/kube.rs
@@ -327,6 +327,17 @@ impl Discovery for KubeDiscoveryClient {
                 }
             }
 
+            if event_tx
+                .send(Ok(DiscoveryEvent::InitialSyncComplete))
+                .is_err()
+            {
+                tracing::debug!(
+                    stream_id = %stream_id,
+                    "Watch receiver dropped during initial sync completion"
+                );
+                return;
+            }
+
             // Track known instances by their unique ID
             let mut known: HashSet<DiscoveryInstanceId> = initial.into_keys().collect();
 

--- a/lib/runtime/src/discovery/kv_store.rs
+++ b/lib/runtime/src/discovery/kv_store.rs
@@ -582,6 +582,7 @@ impl Discovery for KVStoreDiscovery {
                         );
                         Some(DiscoveryEvent::Removed(id))
                     }
+                    kv::WatchEvent::InitialSyncComplete => Some(DiscoveryEvent::InitialSyncComplete),
                 };
 
                 if let Some(event) = discovery_event {
@@ -706,6 +707,10 @@ mod tests {
             };
             client_clone.register(spec).await.unwrap();
         });
+
+        // The watch should explicitly signal that the initial snapshot is complete.
+        let event = stream.next().await.unwrap().unwrap();
+        assert_eq!(event, DiscoveryEvent::InitialSyncComplete);
 
         // Wait for the added event
         let event = stream.next().await.unwrap().unwrap();

--- a/lib/runtime/src/discovery/mock.rs
+++ b/lib/runtime/src/discovery/mock.rs
@@ -195,12 +195,26 @@ impl Discovery for MockDiscovery {
         query: DiscoveryQuery,
         _cancel_token: Option<CancellationToken>,
     ) -> Result<DiscoveryStream> {
-        use std::collections::HashSet;
-
         let registry = self.registry.clone();
 
         let stream = async_stream::stream! {
-            let mut known_instances: HashSet<DiscoveryInstanceId> = HashSet::new();
+            use std::collections::HashSet;
+
+            let initial: Vec<_> = {
+                let instances = registry.instances.lock().unwrap();
+                instances
+                    .iter()
+                    .filter(|instance| matches_query(instance, &query))
+                    .cloned()
+                    .collect()
+            };
+            let mut known_instances: HashSet<DiscoveryInstanceId> =
+                initial.iter().map(|instance| instance.id()).collect();
+
+            for instance in initial {
+                yield Ok(DiscoveryEvent::Added(instance));
+            }
+            yield Ok(DiscoveryEvent::InitialSyncComplete);
 
             loop {
                 let current: Vec<_> = {
@@ -302,6 +316,9 @@ mod tests {
 
         // Start watching
         let mut stream = client1.list_and_watch(query.clone(), None).await.unwrap();
+
+        let event = stream.next().await.unwrap().unwrap();
+        assert_eq!(event, DiscoveryEvent::InitialSyncComplete);
 
         // Add first instance
         client1.register(spec.clone()).await.unwrap();

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -678,6 +678,8 @@ pub enum DiscoveryEvent {
     Added(DiscoveryInstance),
     /// An instance was removed (identified by its unique ID)
     Removed(DiscoveryInstanceId),
+    /// The initial replay for this watch stream has completed.
+    InitialSyncComplete,
 }
 
 /// Stream type for discovery events

--- a/lib/runtime/src/discovery/utils.rs
+++ b/lib/runtime/src/discovery/utils.rs
@@ -92,6 +92,9 @@ where
                         break;
                     }
                 }
+                Ok(DiscoveryEvent::InitialSyncComplete) => {
+                    // The initial snapshot has already been materialized into `state`.
+                }
                 Err(e) => {
                     tracing::error!(error = %e, "Discovery event stream error in watch_and_extract_field");
                     // Continue processing other events

--- a/lib/runtime/src/storage/kv.rs
+++ b/lib/runtime/src/storage/kv.rs
@@ -109,6 +109,8 @@ impl KeyValue {
 pub enum WatchEvent {
     Put(KeyValue),
     Delete(Key),
+    /// Sent exactly once after the initial point-in-time snapshot has been emitted.
+    InitialSyncComplete,
 }
 
 #[async_trait]
@@ -344,6 +346,13 @@ impl Manager {
                 {
                     tracing::error!(bucket_name, %err, "KeyValueStoreManager.watch failed adding existing key to channel");
                 }
+            }
+
+            if let Err(err) = tx
+                .send_timeout(WatchEvent::InitialSyncComplete, WATCH_SEND_TIMEOUT)
+                .await
+            {
+                tracing::error!(bucket_name, %err, "KeyValueStoreManager.watch failed adding initial sync marker to channel");
             }
 
             // Now block waiting for new entries

--- a/lib/runtime/src/transports/event_plane/dynamic_subscriber.rs
+++ b/lib/runtime/src/transports/event_plane/dynamic_subscriber.rs
@@ -158,6 +158,9 @@ impl DynamicSubscriber {
                             tracing::warn!(instance_id = %id_str, "No active endpoint found for removed stream instance");
                         }
                     }
+                    Ok(DiscoveryEvent::InitialSyncComplete) => {
+                        tracing::debug!("Dynamic subscriber initial discovery sync completed");
+                    }
                     Err(e) => {
                         tracing::error!(error = %e, "Discovery watch error");
                         break;


### PR DESCRIPTION
Fixes #7762.

## What changed

This PR makes frontend readiness wait for initial model discovery instead of reporting healthy as soon as the HTTP server starts.

It does three things:
- adds an explicit `InitialSyncComplete` event to discovery streams so the frontend can tell when the initial replay has finished
- gates frontend `/health` and request handling on initial discovery completion and surfaces startup discovery failures
- moves model-added notification until after worker set registration succeeds so endpoints are not exposed before the model is actually usable

## Why

The frontend currently starts model discovery in a background task and immediately starts serving. The readiness probe points at `/health`, but `/health` always returns `200 OK` and request handlers use a stub readiness check.

That means a new frontend replica can become Ready and receive traffic before its local `ModelManager` has converged.

## Impact

After this change:
- a new frontend stays `NotReady` until the initial discovery replay completes
- request handlers return `503 Service Unavailable` until the frontend is actually ready
- startup discovery failures are visible through `/health` instead of being silently treated as healthy

## Root cause

Readiness was tied to process liveness rather than discovery convergence. The watcher had no explicit initial-sync signal, `/health` always returned success, and HTTP handlers did not enforce readiness.