### PR TITLE
fix: tool call loss under speculative decoding

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -1322,3 +1322,197 @@ impl Default for JailedStreamBuilder {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_protocols::types::CreateChatCompletionStreamResponse;
+    use futures::stream;
+
+    /// Helper: build a single-choice stream chunk with text content
+    #[allow(deprecated)]
+    fn text_chunk(text: &str) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        let choice = ChatChoiceStream {
+            index: 0,
+            delta: ChatCompletionStreamResponseDelta {
+                role: Some(Role::Assistant),
+                content: Some(dynamo_protocols::types::ChatCompletionMessageContent::Text(
+                    text.to_string(),
+                )),
+                tool_calls: None,
+                function_call: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: None,
+            stop_reason: None,
+            logprobs: None,
+        };
+
+        Annotated {
+            data: Some(NvCreateChatCompletionStreamResponse {
+                inner: CreateChatCompletionStreamResponse {
+                    id: "id-42".to_string(),
+                    object: "chat.completion.chunk".to_string(),
+                    created: 0,
+                    model: "test-model".to_string(),
+                    choices: vec![choice],
+                    usage: None,
+                    service_tier: None,
+                    system_fingerprint: None,
+                },
+                nvext: None,
+            }),
+            id: None,
+            event: None,
+            comment: None,
+            error: None,
+        }
+    }
+
+    /// Collect all emitted tool calls from the jailed stream output
+    fn collect_tool_calls(
+        responses: &[Annotated<NvCreateChatCompletionStreamResponse>],
+    ) -> Vec<(String, String)> {
+        let mut tool_calls = Vec::new();
+        for resp in responses {
+            if let Some(ref data) = resp.data {
+                for choice in &data.inner.choices {
+                    if let Some(ref tcs) = choice.delta.tool_calls {
+                        for tc in tcs {
+                            if let Some(ref func) = tc.function {
+                                let name = func.name.clone().unwrap_or_default();
+                                let args = func.arguments.clone().unwrap_or_default();
+                                tool_calls.push((name, args));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        tool_calls
+    }
+
+    /// Collect all emitted text content from the jailed stream output
+    fn collect_text_content(
+        responses: &[Annotated<NvCreateChatCompletionStreamResponse>],
+    ) -> String {
+        responses
+            .iter()
+            .flat_map(|r| r.data.iter())
+            .flat_map(|d| d.inner.choices.iter())
+            .filter_map(|c| {
+                if let Some(dynamo_protocols::types::ChatCompletionMessageContent::Text(t)) =
+                    &c.delta.content
+                {
+                    Some(t.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_multi_tool_call_single_chunk() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![text_chunk(
+            "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}\n</tool_call>\n<tool_call>\n{\"name\": \"get_time\", \"arguments\": {\"timezone\": \"PST\"}}\n</tool_call>",
+        )];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+
+        assert!(
+            tool_calls.len() >= 2,
+            "Expected at least 2 tool calls, got {}: {:?}",
+            tool_calls.len(),
+            tool_calls
+        );
+
+        let names: Vec<&str> = tool_calls.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(
+            names.contains(&"get_weather"),
+            "Missing get_weather tool call. Got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"get_time"),
+            "Missing get_time tool call. Got: {:?}",
+            names
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multi_tool_call_multiple_chunks() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![
+            text_chunk("<tool_call>\n{\"name\": \"get_weather\", \"arguments\""),
+            text_chunk(
+                ": {\"location\": \"SF\"}}\n</tool_call>\n<tool_call>\n{\"name\": \"get_time\"",
+            ),
+            text_chunk(", \"arguments\": {\"timezone\": \"PST\"}}\n</tool_call>"),
+        ];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+
+        assert!(
+            tool_calls.len() >= 2,
+            "Expected at least 2 tool calls, got {}: {:?}",
+            tool_calls.len(),
+            tool_calls
+        );
+
+        let names: Vec<&str> = tool_calls.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(
+            names.contains(&"get_weather"),
+            "Missing get_weather tool call. Got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"get_time"),
+            "Missing get_time tool call. Got: {:?}",
+            names
+        );
+    }
+
+    #[tokio::test]
+    async fn test_trailing_text_not_re_jailed() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![text_chunk(
+            "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}\n</tool_call>\nDone!",
+        )];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+
+        assert_eq!(
+            tool_calls.len(),
+            1,
+            "Expected exactly 1 tool call, got {}: {:?}",
+            tool_calls.len(),
+            tool_calls
+        );
+        assert_eq!(tool_calls[0].0, "get_weather");
+
+        let all_text = collect_text_content(&responses);
+        assert!(
+            all_text.contains("Done!"),
+            "Trailing text 'Done!' should appear in output. Got text: {:?}",
+            all_text
+        );
+    }
+}

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -232,17 +232,22 @@ impl ChoiceJailState {
 
                         // Handle trailing content if any
                         if !trailing_part.is_empty() {
-                            #[allow(deprecated)]
-                            let trailing_choice = create_choice_stream(
-                                choice.index,
-                                choice.delta.role,
-                                trailing_part,
-                                None,
-                                choice.finish_reason,
-                                None,
-                                choice.logprobs.clone(),
-                            );
-                            emissions.push(ChoiceEmission::Trailing(trailing_choice));
+                            if jail_stream.should_start_jail(trailing_part) {
+                                self.is_jailed = true;
+                                self.accumulated_content = trailing_part.to_string();
+                            } else {
+                                #[allow(deprecated)]
+                                let trailing_choice = create_choice_stream(
+                                    choice.index,
+                                    choice.delta.role,
+                                    trailing_part,
+                                    None,
+                                    choice.finish_reason,
+                                    None,
+                                    choice.logprobs.clone(),
+                                );
+                                emissions.push(ChoiceEmission::Trailing(trailing_choice));
+                            }
                         }
                     } else {
                         // Start jailing with the marker and suffix
@@ -347,23 +352,29 @@ impl ChoiceJailState {
                     emissions.push(ChoiceEmission::Content(unjailed_choice));
                 }
 
-                // Handle trailing content if any
-                if !trailing_part.is_empty() {
-                    #[allow(deprecated)]
-                    let trailing_choice = create_choice_stream(
-                        choice.index,
-                        choice.delta.role,
-                        trailing_part,
-                        None,
-                        choice.finish_reason,
-                        None,
-                        choice.logprobs.clone(),
-                    );
-                    emissions.push(ChoiceEmission::Trailing(trailing_choice));
-                }
-
-                // End jailing
+                // End jailing before processing trailing content
+                let trailing_owned = trailing_part.to_string();
                 self.end_jail();
+
+                // Handle trailing content if any
+                if !trailing_owned.is_empty() {
+                    if jail_stream.should_start_jail(&trailing_owned) {
+                        self.is_jailed = true;
+                        self.accumulated_content = trailing_owned;
+                    } else {
+                        #[allow(deprecated)]
+                        let trailing_choice = create_choice_stream(
+                            choice.index,
+                            choice.delta.role,
+                            &trailing_owned,
+                            None,
+                            choice.finish_reason,
+                            None,
+                            choice.logprobs.clone(),
+                        );
+                        emissions.push(ChoiceEmission::Trailing(trailing_choice));
+                    }
+                }
             }
             // If not unjailing, don't emit anything (still accumulating)
         }
@@ -682,13 +693,13 @@ impl JailedStream {
                 let dummy_response = NvCreateChatCompletionStreamResponse {
                     inner: dynamo_protocols::types::CreateChatCompletionStreamResponse {
                         id: last_stream_id,
-                        object: "chat.completion.chunk".to_string(),
+                    object: "chat.completion.chunk".to_string(),
                         created: last_stream_created,
                         model: last_stream_model,
-                        choices: Vec::new(),
-                        usage: None,
-                        service_tier: None,
-                        system_fingerprint: None,
+                    choices: Vec::new(),
+                    usage: None,
+                    service_tier: None,
+                    system_fingerprint: None,
                     },
                     nvext: None,
                 };


### PR DESCRIPTION
#### Overview:

When a model uses speculative decoding and generates multiple tokens per step, the jail stream can silently drop subsequent tool calls after the first one completes. This happens because trailing content beyond the first tool call boundary is emitted as plain text (`ChoiceEmission::Trailing`) and never re-evaluated for tool call patterns. The fix re-processes trailing content through `should_start_jail()` and re-enters jail mode when a new tool call is detected.

#### Details:

The jail mechanism in `process_content()` accumulates tokens while "jailed" and checks for completion via `should_end_jail()`. When a complete tool call is detected:

1. `should_exit_jail_early()` calls `try_tool_call_parse_aggregate()` => confirms at least one tool call parses successfully.
2. `find_tool_call_end_position()` locates the end marker (e.g. `</tool_call>`, `</tool_call_end>`) and returns `split_pos`.
3. The accumulated text is split at `split_pos` into `jailed_part` and `trailing_part`.
4. **Bug**: `trailing_part` was unconditionally emitted as `ChoiceEmission::Trailing` that bypasses the jail entirely.

With single-token generation this was fine: the model stops exactly at the tool call boundary, so `trailing_part` is empty. With speculative decoding the model can generate past the boundary, producing a `trailing_part` like `<tool_call>{"name":"get_wea` — the start of the next tool call, which gets lost.

**Fix**
In both code paths trailing content is now checked via `should_start_jail()`:
- If it matches a tool call start pattern then re-enter jail
- Otherwise emit as `ChoiceEmission::Trailing`

#### Reproducer

Start the backend:
```bash
python -m dynamo.sglang \
  --discovery-backend file \
  --disable-radix-cache \
  --model-path Qwen/Qwen3.5-35B-A3B-FP8 \
  --dyn-tool-call-parser qwen3_coder \
  --dyn-reasoning-parser qwen3 \
  --speculative-algo NEXTN \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4

python3 -m dynamo.frontend --discovery-backend file --http-port 8000
```

Send a request that requires multiple tool calls:
```python
from openai import OpenAI

tools = [
    {
        "type": "function",
        "function": {
            "name": "get_weather",
            "description": "Get the current weather in a given location",
            "parameters": {
                "type": "object",
                "properties": {
                    "location": {
                        "type": "string",
                        "description": "The city, e.g. San Francisco",
                    },
                },
                "required": ["location"],
            },
        },
    }
]

client = OpenAI(base_url="http://localhost:8000/v1", api_key="foo")
response = client.chat.completions.create(
    model="Qwen/Qwen3.5-35B-A3B-FP8",
    messages=[{"role": "user", "content": "What is the weather in Tokyo and Seoul?"}],
    tools=tools,
    temperature=0,
    extra_body={"chat_template_args": {"enable_thinking": False}},
)
print(response.choices[0].message.content)
print(response.choices[0].message.tool_calls)
```

Before fix:
```python
>>> print(response.choices[0].message.tool_calls)
[ChatCompletionMessageFunctionToolCall(
    id='call-5d2b0779-efe7-4d51-8e0f-6191807198ad',
    function=Function(arguments='{"location":"Tokyo"}', name='get_weather'),
    type='function'
)]

>>> print(response.choices[0].message.content)

<tool_call>
<function=get_weather>
<parameter=location>
Seoul
</parameter>
</function>
</tool_call>
```

After fix:
```python
>>> print(response.choices[0].message.tool_calls)
[ChatCompletionMessageFunctionToolCall(
    id='call-63c18a5d-c730-425a-9f5f-089f5b2049fe',
    function=Function(arguments='{"location":"Tokyo"}', name='get_weather'),
    type='function'
), ChatCompletionMessageFunctionToolCall(
    id='call-79c4bebd-71a8-4347-baf4-f5b4defa7265',
    function=Function(arguments='{"location":"Seoul"}', name='get_weather'),
    type='function'
)]

>>> print(response.choices[0].message.content)
None
```

#### Where should the reviewer start?

`dynamo/lib/llm/src/protocols/openai/chat_completions/jail.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved content filtering behavior to more reliably handle edge cases during response generation, ensuring more consistent processing when handling content at filtering state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->