### PR TITLE
fix(router): apply worker hash suffix to local router endpoints during rolling updates

### DIFF
--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -25,6 +25,7 @@ from dynamo.router.args import (
     build_kv_router_config,
 )
 from dynamo.router.args import parse_args as parse_router_args
+from dynamo.router.endpoint_suffix import apply_worker_suffix_to_endpoint
 from dynamo.runtime import Client, DistributedRuntime, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -214,13 +215,17 @@ async def worker(runtime: DistributedRuntime):
     kv_router_config = build_kv_router_config(config)
     aic_perf_config = build_aic_perf_config(config)
 
+    worker_endpoint = apply_worker_suffix_to_endpoint(config.endpoint)
+    if worker_endpoint != config.endpoint:
+        logger.info(
+            "Resolved worker endpoint with namespace suffix: %s -> %s",
+            config.endpoint,
+            worker_endpoint,
+        )
+
     # Create handler
     handler = StandaloneRouterHandler(
-        runtime,
-        config.endpoint,
-        config.router_block_size,
-        kv_router_config,
-        aic_perf_config,
+        runtime, worker_endpoint, config.router_block_size, kv_router_config, aic_perf_config
     )
     await handler.initialize()
 

--- a/components/src/dynamo/router/endpoint_suffix.py
+++ b/components/src/dynamo/router/endpoint_suffix.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+
+def apply_worker_suffix_to_endpoint(endpoint_path: str) -> str:
+    """Apply DYN_NAMESPACE_WORKER_SUFFIX to endpoint namespace when present."""
+    suffix = os.environ.get("DYN_NAMESPACE_WORKER_SUFFIX")
+    if not suffix:
+        return endpoint_path
+    if "." in suffix:
+        return endpoint_path
+    parts = endpoint_path.split(".")
+    if len(parts) != 3:
+        return endpoint_path
+    namespace, component, endpoint = parts
+    return f"{namespace}-{suffix}.{component}.{endpoint}"

--- a/components/tests/test_router_endpoint_suffix.py
+++ b/components/tests/test_router_endpoint_suffix.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from dynamo.router.endpoint_suffix import apply_worker_suffix_to_endpoint
+
+
+def test_apply_worker_suffix_to_endpoint_without_suffix(monkeypatch):
+    monkeypatch.delenv("DYN_NAMESPACE_WORKER_SUFFIX", raising=False)
+    endpoint = "dynamo-test-gp-prefill-0.prefill.generate"
+    assert apply_worker_suffix_to_endpoint(endpoint) == endpoint
+
+
+def test_apply_worker_suffix_to_endpoint_with_suffix(monkeypatch):
+    monkeypatch.setenv("DYN_NAMESPACE_WORKER_SUFFIX", "7b81fa27")
+    endpoint = "dynamo-test-gp-prefill-0.prefill.generate"
+    assert (
+        apply_worker_suffix_to_endpoint(endpoint)
+        == "dynamo-test-gp-prefill-0-7b81fa27.prefill.generate"
+    )
+
+
+def test_apply_worker_suffix_to_endpoint_invalid_format(monkeypatch):
+    monkeypatch.setenv("DYN_NAMESPACE_WORKER_SUFFIX", "7b81fa27")
+    endpoint = "invalid-endpoint-format"
+    assert apply_worker_suffix_to_endpoint(endpoint) == endpoint
+
+
+def test_apply_worker_suffix_to_endpoint_ignores_invalid_suffix(monkeypatch):
+    monkeypatch.setenv("DYN_NAMESPACE_WORKER_SUFFIX", "bad.suffix")
+    endpoint = "dynamo-test-gp-prefill-0.prefill.generate"
+    assert apply_worker_suffix_to_endpoint(endpoint) == endpoint

--- a/deploy/operator/internal/dynamo/component_common.go
+++ b/deploy/operator/internal/dynamo/component_common.go
@@ -143,7 +143,7 @@ func (b *BaseComponentDefaults) getCommonContainer(context ComponentContext) cor
 		})
 	}
 
-	if context.Discovery.Mode == configv1alpha1.KubeDiscoveryModeContainer {
+if context.Discovery.Mode == configv1alpha1.KubeDiscoveryModeContainer {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  "CONTAINER_NAME",
 			Value: commonconsts.MainContainerName,
@@ -151,6 +151,15 @@ func (b *BaseComponentDefaults) getCommonContainer(context ComponentContext) cor
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  "DYN_KUBE_DISCOVERY_MODE",
 			Value: string(configv1alpha1.KubeDiscoveryModeContainer),
+		})
+	}
+
+	// Worker hash suffix is populated only for worker/router component contexts.
+	// Export it here so default components like LocalRouter can consume it.
+	if context.WorkerHashSuffix != "" {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  commonconsts.DynamoNamespaceWorkerSuffixEnvVar,
+			Value: context.WorkerHashSuffix,
 		})
 	}
 

--- a/deploy/operator/internal/dynamo/component_worker.go
+++ b/deploy/operator/internal/dynamo/component_worker.go
@@ -114,14 +114,6 @@ func (w *WorkerDefaults) GetBaseContainer(context ComponentContext) (corev1.Cont
 		},
 	}...)
 
-	if context.WorkerHashSuffix != "" {
-		container.Env = append(container.Env, []corev1.EnvVar{
-			{
-				Name:  commonconsts.DynamoNamespaceWorkerSuffixEnvVar,
-				Value: context.WorkerHashSuffix,
-			},
-		}...)
-	}
 
 	return container, nil
 }

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -387,8 +387,9 @@ func generateSingleDCD(
 	labels[commonconsts.KubeLabelDynamoGraphDeploymentName] = parentDGD.Name
 	deployment.Labels = labels
 
-	// only label worker DCDs with their hash for cleanup during rolling updates
-	if IsWorkerComponent(string(component.ComponentType)) {
+// Label worker DCDs and local router DCDs with current worker hash.
+	// Routers use this to resolve worker endpoints across rolling updates.
+	if IsWorkerComponent(string(component.ComponentType)) || IsRouterComponent(component) {
 		labels[commonconsts.KubeLabelDynamoWorkerHash] = rollingUpdateCtx.NewWorkerHash
 		podTemplate := ensurePodTemplate(&deployment.Spec.DynamoComponentDeploymentSharedSpec)
 		podTemplate.Labels[commonconsts.KubeLabelDynamoWorkerHash] = rollingUpdateCtx.NewWorkerHash
@@ -1397,6 +1398,15 @@ func IsWorkerComponent(componentType string) bool {
 		componentType == commonconsts.ComponentTypeDecode
 }
 
+func IsRouterComponent(component *v1alpha1.DynamoComponentDeploymentSharedSpec) bool {
+	if component == nil || component.ExtraPodSpec == nil || component.ExtraPodSpec.MainContainer == nil {
+		return false
+	}
+	main := component.ExtraPodSpec.MainContainer
+	joined := strings.Join(append(main.Command, main.Args...), " ")
+	return strings.Contains(joined, "dynamo.router")
+}
+
 // AddStandardEnvVars adds the standard environment variables that are common to
 // both checkpoint jobs and generated worker pods.
 func AddStandardEnvVars(container *corev1.Container, operatorConfig *configv1alpha1.OperatorConfiguration) {
@@ -1817,8 +1827,8 @@ func setMetricsLabels(labels map[string]string, dynamoGraphDeployment *v1beta1.D
 func generateComponentContext(component *v1beta1.DynamoComponentDeploymentSharedSpec, parentGraphDeploymentName string, namespace string, numberOfNodes int32, discovery DiscoveryContext) ComponentContext {
 	dynamoNamespace := v1beta1.ComputeDynamoNamespace(component.GlobalDynamoNamespace, namespace, parentGraphDeploymentName)
 	var workerHashSuffix string
-	labels := GetPodTemplateLabels(component)
-	if IsWorkerComponent(string(component.ComponentType)) && labels[commonconsts.KubeLabelDynamoWorkerHash] != "" {
+labels := GetPodTemplateLabels(component)
+	if (IsWorkerComponent(string(component.ComponentType)) || IsRouterComponent(component)) && labels[commonconsts.KubeLabelDynamoWorkerHash] != "" {
 		workerHashSuffix = labels[commonconsts.KubeLabelDynamoWorkerHash]
 	}
 

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -8710,6 +8710,19 @@ func TestGenerateComponentContext_WorkerHashSuffix(t *testing.T) {
 	}
 	compCtx3 := generateComponentContext(betaComponent(t, component3), "dgd", "ns", 1, DiscoveryContext{Backend: "kubernetes", Mode: configv1alpha1.KubeDiscoveryModePod})
 	assert.Empty(t, compCtx3.WorkerHashSuffix)
+
+	// LocalRouter (componentType=default) gets WorkerHashSuffix if labeled
+	component4 := &v1alpha1.DynamoComponentDeploymentSharedSpec{
+		ComponentType: commonconsts.ComponentTypeDefault,
+		Labels:        map[string]string{commonconsts.KubeLabelDynamoWorkerHash: "routerhash"},
+		ExtraPodSpec: &v1alpha1.ExtraPodSpec{
+			MainContainer: &corev1.Container{
+				Command: []string{"python3", "-m", "dynamo.router"},
+			},
+		},
+	}
+	compCtx4 := generateComponentContext(component4, "dgd", "ns", 1, "kubernetes")
+	assert.Equal(t, "routerhash", compCtx4.WorkerHashSuffix)
 }
 
 func TestWorkerDefaults_WorkerHashSuffixEnvVar(t *testing.T) {
@@ -8741,6 +8754,46 @@ func TestWorkerDefaults_WorkerHashSuffixEnvVar(t *testing.T) {
 		assert.NotEqual(t, commonconsts.DynamoNamespaceWorkerSuffixEnvVar, env.Name,
 			"DYN_NAMESPACE_WORKER_SUFFIX should not be set when suffix is empty")
 	}
+}
+
+func TestWorkerDefaults_EnvVarAppearsOnlyOnce(t *testing.T) {
+	w := NewWorkerDefaults()
+
+	container, err := w.GetBaseContainer(ComponentContext{
+		DynamoNamespace:  "ns-dgd",
+		ComponentType:    commonconsts.ComponentTypeWorker,
+		WorkerHashSuffix: "abc123",
+	})
+	assert.NoError(t, err)
+
+	count := 0
+	for _, env := range container.Env {
+		if env.Name == commonconsts.DynamoNamespaceWorkerSuffixEnvVar {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count,
+		"DYN_NAMESPACE_WORKER_SUFFIX should appear exactly once (set by BaseComponentDefaults, not duplicated in WorkerDefaults)")
+}
+
+func TestBaseComponentDefaults_WorkerHashSuffixEnvVar(t *testing.T) {
+	b := &BaseComponentDefaults{}
+
+	container, err := b.GetBaseContainer(ComponentContext{
+		DynamoNamespace:  "ns-dgd",
+		ComponentType:    commonconsts.ComponentTypeDefault,
+		WorkerHashSuffix: "routerhash",
+	})
+	assert.NoError(t, err)
+
+	found := false
+	for _, env := range container.Env {
+		if env.Name == commonconsts.DynamoNamespaceWorkerSuffixEnvVar {
+			assert.Equal(t, "routerhash", env.Value)
+			found = true
+		}
+	}
+	assert.True(t, found, "DYN_NAMESPACE_WORKER_SUFFIX should be set on default components when suffix exists")
 }
 
 func TestFrontendDefaults_NamespacePrefixEnvVar(t *testing.T) {


### PR DESCRIPTION
  #### Overview:                                                                                                                  
                                                                                                                                  
  Fixes endpoint resolution failures in GlobalPlanner disaggregated deployments during rolling updates. When workers rotate to a new hash suffix, the local router needs to resolve worker endpoints with the correct suffixed namespace. Previously, the router would fail with `no instances found` errors because it was using the base namespace while workers had moved to a suffixed  namespace.      
<img width="1968" height="723" alt="image" src="https://github.com/user-attachments/assets/b14a8045-d4e0-4934-a588-49c15a6d01df" />
  #### Details:


  This PR ensures the local router can correctly resolve worker endpoints during rolling updates by:                              
   
  1. **Router-side endpoint suffix application** (`components/src/dynamo/router/endpoint_suffix.py`):                             
     - New utility to apply `DYN_NAMESPACE_WORKER_SUFFIX` to endpoint paths
     - Router applies the suffix when resolving upstream worker endpoints                                                         
                                                                                                                                  
  2. **Operator labels router DCDs with worker hash** (`deploy/operator/internal/dynamo/graph.go`):                               
     - Added `IsRouterComponent()` helper to detect router components by checking if command/args contain `dynamo.router`         
     - Local router DCDs are now labeled with `dynamo.worker.hash` (same as workers)                                              
     - `generateComponentContext()` now sets `WorkerHashSuffix` for routers                                                       
                                                                                                                                  
  3. **Export suffix env var to router** (`deploy/operator/internal/dynamo/component_common.go`):                                 
     - `BaseComponentDefaults.getCommonContainer()` now exports `DYN_NAMESPACE_WORKER_SUFFIX` for components with  `WorkerHashSuffix` in context                                                                                                   
                  
  4. **Tests**:                                                                                                                   
     - `components/tests/test_router_endpoint_suffix.py`: Unit tests for endpoint suffix application
     - `deploy/operator/internal/dynamo/graph_test.go`: Tests for router component detection and suffix propagation               
                                                                                                                                  
  #### Where should the reviewer start?                                                                                           
                                                                                                                                  
  - `components/src/dynamo/router/endpoint_suffix.py` - Core logic for endpoint suffix application                                
  - `deploy/operator/internal/dynamo/graph.go` - `IsRouterComponent()` and labeling logic
  - `deploy/operator/internal/dynamo/component_common.go` - Env var export                                                        
                                                 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Router components now support worker hash suffixing, consistent with worker component behavior.
  * Worker endpoint resolution now applies configured suffix transformations during startup.

* **Chores**
  * Updated environment variable handling to propagate worker hash suffix configuration across router and component initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->