### PR TITLE
chore(ci): simplify planner no-cuda workflow handling [DYN-2547]

### DIFF
--- a/.github/actions/build-flavor/action.yml
+++ b/.github/actions/build-flavor/action.yml
@@ -4,10 +4,6 @@ inputs:
   framework:
     description: 'Framework name (e.g. dynamo, vllm, sglang, trtllm)'
     required: true
-  builder_flavor:
-    description: 'Optional BuildKit routing flavor override (vllm, sglang, trtllm, general)'
-    required: false
-    default: ''
   target:
     description: 'Target stage for Docker rendering'
     required: true
@@ -15,13 +11,8 @@ inputs:
     description: 'Docker platform string (e.g. linux/amd64, linux/amd64,linux/arm64)'
     required: true
   cuda_version:
-    description: 'CUDA version to build (e.g., 12.9, 13.0)'
-    required: false
-    default: ''
-  cpu_only:
-    description: 'Build and tag this image as CPU-only. The shared container render/build path still requires a default CUDA version internally.'
-    required: false
-    default: 'false'
+    description: 'CUDA version to build (e.g., 12.9, 13.0). Pass an empty string for planner.'
+    required: true
   builder_name:
     description: 'Buildkit builder name'
     required: true
@@ -93,21 +84,15 @@ inputs:
     required: false
     default: 'false'
 outputs:
-  target_tag_plain:
-    description: 'Target tag (without registry prefix)'
-    value: ${{ steps.calculate-target-tag.outputs.target_tag_plain }}
-  test_tag_plain:
-    description: 'Test tag (without registry prefix)'
-    value: ${{ steps.calculate-target-tag.outputs.test_tag_plain }}
-  cuda_version_plain:
-    description: 'CUDA major version (e.g., 12 from 12.9)'
-    value: ${{ steps.calculate-target-tag.outputs.cuda_version_plain }}
-  image_variant_label:
-    description: 'Image variant label used in job names and cache namespaces (e.g. cpu, cuda12)'
-    value: ${{ steps.calculate-target-tag.outputs.image_variant_label }}
-  image_tag_suffix:
-    description: 'Image tag suffix including leading hyphen (e.g. -cpu, -cuda12)'
-    value: ${{ steps.calculate-target-tag.outputs.image_tag_suffix }}
+  image_name:
+    description: 'Image name without registry prefix'
+    value: ${{ steps.define-image.outputs.image_name }}
+  image_tag:
+    description: 'Runtime image tag without registry prefix'
+    value: ${{ steps.define-image.outputs.image_tag }}
+  test_image_tag:
+    description: 'Test image tag without registry prefix'
+    value: ${{ steps.define-image.outputs.test_image_tag }}
 
 runs:
   using: "composite"
@@ -120,72 +105,64 @@ runs:
         azure_acr_hostname: ${{ inputs.azure_acr_hostname }}
         azure_acr_user: ${{ inputs.azure_acr_user }}
         azure_acr_password: ${{ inputs.azure_acr_password }}
-    - name: Calculate target tag
-      id: calculate-target-tag
+    - name: Define image names and tags
+      id: define-image
       shell: bash
       run: |
-        if [[ "${{ inputs.cpu_only }}" == "true" ]]; then
-          CUDA_VERSION_RAW="${{ inputs.cuda_version }}"
-          if [[ -z "$CUDA_VERSION_RAW" ]]; then
-            # Planner still shares the CUDA-backed wheel builder path today even
-            # though the final runtime image is CPU-only. Keep that detail
-            # internal to the build action instead of surfacing it in job names.
-            CUDA_VERSION_RAW="12.9"
-          fi
-          CUDA_VERSION=${CUDA_VERSION_RAW%%.*}
-          IMAGE_VARIANT_LABEL="cpu"
-          IMAGE_TAG_SUFFIX="-cpu"
-          BUILDER_CUDA_VERSION=""
-        else
-          CUDA_VERSION_RAW="${{ inputs.cuda_version }}"
-          if [[ -z "$CUDA_VERSION_RAW" ]]; then
-            echo "cuda_version is required unless cpu_only=true" >&2
-            exit 1
-          fi
-          CUDA_VERSION=${CUDA_VERSION_RAW%%.*}
-          IMAGE_VARIANT_LABEL="cuda${CUDA_VERSION}"
-          IMAGE_TAG_SUFFIX="-cuda${CUDA_VERSION}"
-          BUILDER_CUDA_VERSION="${CUDA_VERSION_RAW}"
+        CUDA_VERSION_RAW="${{ inputs.cuda_version }}"
+        if [[ -z "$CUDA_VERSION_RAW" && ! ( "${{ inputs.framework }}" == "dynamo" && "${{ inputs.target }}" == "planner" ) ]]; then
+          echo "cuda_version must be non-empty unless framework=dynamo and target=planner" >&2
+          exit 1
         fi
+        IMAGE_TAG_SUFFIX=""
+        IMAGE_DISPLAY_NAME="${{ inputs.target }}"
+        if [[ -n "$CUDA_VERSION_RAW" ]]; then
+          CUDA_VERSION_MAJOR="${CUDA_VERSION_RAW%%.*}"
+          IMAGE_TAG_SUFFIX="-cuda${CUDA_VERSION_MAJOR}"
+          IMAGE_DISPLAY_NAME="cuda${CUDA_VERSION_RAW}"
+        fi
+
+        # Planner still shares the CUDA-backed render/build path today even
+        # though its final image has no CUDA suffix.
+        RENDER_CUDA_VERSION="${CUDA_VERSION_RAW:-12.9}"
         EFA_SUFFIX=""
         if [ "${{ inputs.make_efa }}" == "true" ]; then
           EFA_SUFFIX="-efa"
         fi
-        TARGET_TAG_PLAIN="${{ github.sha }}-${{ inputs.framework }}-${{ inputs.target }}${EFA_SUFFIX}"
-        TEST_TAG_PLAIN="${{ github.sha }}-${{ inputs.framework }}-${{ inputs.target }}${EFA_SUFFIX}-test"
-        DEFAULT_TARGET_IMAGE_URI="${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_default_region }}.amazonaws.com/ai-dynamo/dynamo:${TARGET_TAG_PLAIN}${IMAGE_TAG_SUFFIX}"
-        TEST_IMAGE_URI="${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_default_region }}.amazonaws.com/ai-dynamo/dynamo:${TEST_TAG_PLAIN}${IMAGE_TAG_SUFFIX}"
+        IMAGE_NAME="ai-dynamo/dynamo"
+        IMAGE_TAG="${{ github.sha }}-${{ inputs.framework }}-${{ inputs.target }}${EFA_SUFFIX}${IMAGE_TAG_SUFFIX}"
+        TEST_IMAGE_TAG="${{ github.sha }}-${{ inputs.framework }}-${{ inputs.target }}${EFA_SUFFIX}-test${IMAGE_TAG_SUFFIX}"
+        DEFAULT_TARGET_IMAGE_URI="${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_default_region }}.amazonaws.com/${IMAGE_NAME}:${IMAGE_TAG}"
+        TEST_IMAGE_URI="${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_default_region }}.amazonaws.com/${IMAGE_NAME}:${TEST_IMAGE_TAG}"
+        echo "image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
+        echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+        echo "test_image_tag=${TEST_IMAGE_TAG}" >> $GITHUB_OUTPUT
         echo "default_target_image_uri=${DEFAULT_TARGET_IMAGE_URI}" >> $GITHUB_OUTPUT
         echo "test_image_uri=${TEST_IMAGE_URI}" >> $GITHUB_OUTPUT
-        echo "target_tag_plain=${TARGET_TAG_PLAIN}" >> $GITHUB_OUTPUT
-        echo "test_tag_plain=${TEST_TAG_PLAIN}" >> $GITHUB_OUTPUT
-        echo "cuda_version_plain=${CUDA_VERSION}" >> $GITHUB_OUTPUT
-        echo "effective_cuda_version=${CUDA_VERSION_RAW}" >> $GITHUB_OUTPUT
-        echo "builder_cuda_version=${BUILDER_CUDA_VERSION}" >> $GITHUB_OUTPUT
-        echo "image_variant_label=${IMAGE_VARIANT_LABEL}" >> $GITHUB_OUTPUT
-        echo "image_tag_suffix=${IMAGE_TAG_SUFFIX}" >> $GITHUB_OUTPUT
+        echo "tag_suffix=${IMAGE_TAG_SUFFIX}" >> $GITHUB_OUTPUT
+        echo "image_display_name=${IMAGE_DISPLAY_NAME}" >> $GITHUB_OUTPUT
+        echo "render_cuda_version=${RENDER_CUDA_VERSION}" >> $GITHUB_OUTPUT
     - name: Initialize Dynamo Builder
       uses: ./.github/actions/init-dynamo-builder
       with:
         builder_name: ${{ inputs.builder_name }}
-        flavor: ${{ inputs.builder_flavor != '' && inputs.builder_flavor || inputs.framework }}
+        flavor: ${{ contains(fromJson('["vllm","sglang","trtllm"]'), inputs.framework) && inputs.framework || 'general' }}
         arch: ${{ inputs.platform }}
-        cuda_version: ${{ steps.calculate-target-tag.outputs.builder_cuda_version }}
+        cuda_version: ${{ inputs.cuda_version }}
         fresh_builder: ${{ inputs.fresh_builder }}
     - name: Calculate extra tags
       id: extra-tags
       shell: bash
       env:
         EXTRA_TAGS: ${{ inputs.extra_tags }}
-        IMAGE_TAG_SUFFIX: ${{ steps.calculate-target-tag.outputs.image_tag_suffix }}
+        TAG_SUFFIX: ${{ steps.define-image.outputs.tag_suffix }}
       run: |
         ECR_REGISTRY="${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_default_region }}.amazonaws.com"
-        ACR_REGISTRY="${{ inputs.azure_acr_hostname }}"
         RESULT=""
         if [ -n "$EXTRA_TAGS" ]; then
           while IFS= read -r tag; do
             if [ -n "$tag" ]; then
-              RESULT+="${ECR_REGISTRY}/ai-dynamo/dynamo:${tag}${IMAGE_TAG_SUFFIX}"$'\n'
+              RESULT+="${ECR_REGISTRY}/ai-dynamo/dynamo:${tag}${TAG_SUFFIX}"$'\n'
             fi
           done <<< "$EXTRA_TAGS"
         fi
@@ -200,12 +177,11 @@ runs:
       shell: bash
       run: |
         echo "=== Build Container Inputs ==="
-        echo "image_tag: ${{ steps.calculate-target-tag.outputs.default_target_image_uri }}"
+        echo "image_tag: ${{ steps.define-image.outputs.default_target_image_uri }}"
         echo "framework: ${{ inputs.framework }}"
         echo "target: ${{ inputs.target }}"
         echo "platform: ${{ inputs.platform }}"
-        echo "image_variant: ${{ steps.calculate-target-tag.outputs.image_variant_label }}"
-        echo "effective_build_cuda_version: ${{ steps.calculate-target-tag.outputs.effective_cuda_version }}"
+        echo "cuda_version: ${{ inputs.cuda_version }}"
         echo "no_cache: ${{ inputs.no_cache }}"
         echo "extra_tags: ${{ steps.extra-tags.outputs.tags }}"
         echo "push_image: ${{ inputs.push_image }}"
@@ -223,7 +199,7 @@ runs:
             --target=${{ inputs.target }} \
             --framework=${{ inputs.framework }} \
             --platform=${{ inputs.platform }} \
-            --cuda-version=${{ steps.calculate-target-tag.outputs.effective_cuda_version }} \
+            --cuda-version=${{ steps.define-image.outputs.render_cuda_version }} \
             ${MAKE_EFA_FLAG} \
             --show-result \
             --output-short-filename
@@ -231,11 +207,11 @@ runs:
       id: build-image
       uses: ./.github/actions/docker-remote-build
       with:
-        image_tag: ${{ steps.calculate-target-tag.outputs.default_target_image_uri }}
+        image_tag: ${{ steps.define-image.outputs.default_target_image_uri }}
         framework: ${{ inputs.framework }}
         target: ${{ inputs.target }}
         platform: ${{ inputs.platform }}
-        cuda_version: ${{ steps.calculate-target-tag.outputs.effective_cuda_version }}
+        cuda_version: ${{ steps.define-image.outputs.render_cuda_version }}
         aws_default_region: ${{ inputs.aws_default_region }}
         sccache_s3_bucket: ${{ inputs.sccache_s3_bucket }}
         aws_account_id: ${{ inputs.aws_account_id }}
@@ -253,17 +229,21 @@ runs:
       uses: ./.github/actions/builder-refresher
       with:
         builder_name: ${{ inputs.builder_name }}
-        flavor: ${{ inputs.builder_flavor != '' && inputs.builder_flavor || inputs.framework }}
+        flavor: ${{ contains(fromJson('["vllm","sglang","trtllm"]'), inputs.framework) && inputs.framework || 'general' }}
         arch: ${{ inputs.platform }}
-        cuda_version: ${{ steps.calculate-target-tag.outputs.builder_cuda_version }}
+        cuda_version: ${{ inputs.cuda_version }}
     - name: Build and Push Test Image
       if: ${{ inputs.target != 'dev' }}
       shell: bash
       env:
         ECR_HOSTNAME: ${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_default_region }}.amazonaws.com
       run: |
-        IMAGE_VARIANT="${{ steps.calculate-target-tag.outputs.image_variant_label }}"
-        CACHE_TAG="test-${{ inputs.framework }}-${IMAGE_VARIANT}-cache"
+        CACHE_KEY="${{ inputs.target }}"
+        if [[ -n "${{ inputs.cuda_version }}" ]]; then
+          CACHE_KEY="cuda${{ steps.define-image.outputs.render_cuda_version }}"
+          CACHE_KEY="${CACHE_KEY%%.*}"
+        fi
+        CACHE_TAG="test-${{ inputs.framework }}-${CACHE_KEY}-cache"
         CACHE_ARGS="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG}"
         CACHE_ARGS+=" --cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:release-${CACHE_TAG}"
         if [[ "$GITHUB_REF_NAME" == "main" ]]; then
@@ -290,18 +270,18 @@ runs:
           ${NO_CACHE_ARG} \
           --platform ${{ inputs.platform }} \
           -f container/Dockerfile.test \
-          --build-arg BASE_IMAGE=${{ steps.calculate-target-tag.outputs.default_target_image_uri }} \
+          --build-arg BASE_IMAGE=${{ steps.define-image.outputs.default_target_image_uri }} \
           ${CACHE_ARGS} \
-          -t ${{ steps.calculate-target-tag.outputs.test_image_uri }} .
+          -t ${{ steps.define-image.outputs.test_image_uri }} .
     - name: Show summary
       shell: bash
       if: ${{ inputs.push_image == 'true' && inputs.show_summary == 'true' }}
       run: |
-        echo "### 🐳 ${{ inputs.framework }}-${{ steps.calculate-target-tag.outputs.image_variant_label }} Default Image" >> $GITHUB_STEP_SUMMARY
+        echo "### 🐳 ${{ inputs.framework }}-${{ steps.define-image.outputs.image_display_name }} Default Image" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "| Image URI |" >> $GITHUB_STEP_SUMMARY
         echo "|-----|" >> $GITHUB_STEP_SUMMARY
-        echo "| \`${{ steps.calculate-target-tag.outputs.default_target_image_uri }}\` |" >> $GITHUB_STEP_SUMMARY
+        echo "| \`${{ steps.define-image.outputs.default_target_image_uri }}\` |" >> $GITHUB_STEP_SUMMARY
         EXTRA_TAGS="${{ steps.extra-tags.outputs.tags }}"
         if [ -n "$EXTRA_TAGS" ]; then
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/build-flavor/action.yml
+++ b/.github/actions/build-flavor/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Docker platform string (e.g. linux/amd64, linux/amd64,linux/arm64)'
     required: true
   cuda_version:
-    description: 'CUDA version to build (e.g., 12.9, 13.0). Pass an empty string for planner.'
+    description: 'CUDA version to build (e.g., 12.9, 13.0). Use an empty string for no-CUDA targets.'
     required: true
   builder_name:
     description: 'Buildkit builder name'

--- a/.github/workflows/build-flavor.yml
+++ b/.github/workflows/build-flavor.yml
@@ -131,11 +131,11 @@ jobs:
         uses: ./.github/actions/skopeo-copy
         with:
           source_registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
-          source_image: ai-dynamo/dynamo
-          source_tag: ${{ steps.build.outputs.target_tag_plain }}-cuda${{ steps.build.outputs.cuda_version_plain }}
+          source_image: ${{ steps.build.outputs.image_name }}
+          source_tag: ${{ steps.build.outputs.image_tag }}
           target_registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          target_image: ai-dynamo/dynamo
-          target_tag: ${{ steps.build.outputs.target_tag_plain }}-cuda${{ steps.build.outputs.cuda_version_plain }}
+          target_image: ${{ steps.build.outputs.image_name }}
+          target_tag: ${{ steps.build.outputs.image_tag }}
           source_aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           source_aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
           target_azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
@@ -147,12 +147,9 @@ jobs:
         if: inputs.run_compliance_scan
         shell: bash
         run: |
+          echo "runtime_image=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/${{ steps.build.outputs.image_name }}:${{ steps.build.outputs.image_tag }}" >> $GITHUB_OUTPUT
           CUDA_MAJOR="${{ matrix.cuda_version }}"
-          CUDA_MAJOR="${CUDA_MAJOR%%.*}"
-          TARGET_TAG="${{ github.sha }}-${{ inputs.framework }}-${{ inputs.target }}"
-          IMAGE="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${TARGET_TAG}-cuda${CUDA_MAJOR}"
-          echo "runtime_image=${IMAGE}" >> $GITHUB_OUTPUT
-          echo "cuda_major=${CUDA_MAJOR}" >> $GITHUB_OUTPUT
+          echo "cuda_major=${CUDA_MAJOR%%.*}" >> $GITHUB_OUTPUT
       - name: Compliance scan (amd64)
         if: inputs.run_compliance_scan && contains(inputs.platform, 'amd64')
         uses: ./.github/actions/compliance-scan

--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -10,11 +10,6 @@ on:
         description: 'Framework name (e.g. dynamo, vllm, sglang, trtllm)'
         required: true
         type: string
-      builder_flavor:
-        description: 'Optional BuildKit routing flavor override (vllm, sglang, trtllm, general)'
-        required: false
-        type: string
-        default: ''
       target:
         description: 'Target stage for Docker rendering'
         required: true
@@ -24,15 +19,9 @@ on:
         required: true
         type: string
       cuda_version:
-        description: 'CUDA version to build (e.g., 12.9, 13.0)'
-        required: false
+        description: 'CUDA version to build (e.g., 12.9, 13.0). Pass an empty string for planner.'
+        required: true
         type: string
-        default: ''
-      cpu_only:
-        description: 'Build and test this target as a CPU-only image variant'
-        required: false
-        type: boolean
-        default: false
       build_timeout_minutes:
         description: 'Timeout in minutes for the build step'
         required: false
@@ -159,14 +148,13 @@ jobs:
   # ============================================================================
   build:
     if: inputs.build_image
-    name: Build ${{ inputs.cpu_only && 'cpu' || format('cuda{0}', inputs.cuda_version) }}
+    name: Build ${{ inputs.cuda_version != '' && format('cuda{0}', inputs.cuda_version) || inputs.target }}
     runs-on: prod-builder-v3
     timeout-minutes: ${{ inputs.build_timeout_minutes }}
     outputs:
-      target_tag_plain: ${{ steps.build.outputs.target_tag_plain }}
-      test_tag_plain: ${{ steps.build.outputs.test_tag_plain }}
-      image_variant_label: ${{ steps.build.outputs.image_variant_label }}
-      image_tag_suffix: ${{ steps.build.outputs.image_tag_suffix }}
+      image_name: ${{ steps.build.outputs.image_name }}
+      image_tag: ${{ steps.build.outputs.image_tag }}
+      test_image_tag: ${{ steps.build.outputs.test_image_tag }}
       compliance_arches: ${{ steps.compliance-arches.outputs.arches }}
       test_runners: ${{ steps.test-runners.outputs.runners }}
     env:
@@ -207,11 +195,9 @@ jobs:
         uses: ./.github/actions/build-flavor
         with:
           framework: ${{ inputs.framework }}
-          builder_flavor: ${{ inputs.builder_flavor }}
           target: ${{ inputs.target }}
           platform: ${{ inputs.platform }}
           cuda_version: ${{ inputs.cuda_version }}
-          cpu_only: ${{ inputs.cpu_only }}
           builder_name: ${{ inputs.builder_name }}
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -240,7 +226,7 @@ jobs:
         ( inputs.run_cpu_only_tests || inputs.run_single_gpu_tests ) &&
         inputs.build_image
     needs: [build]
-    name: Test ${{ inputs.cpu_only && 'cpu' || format('cuda{0}', inputs.cuda_version) }} (${{ matrix.arch }})
+    name: Test ${{ inputs.cuda_version != '' && format('cuda{0}', inputs.cuda_version) || inputs.target }} (${{ matrix.arch }})
     strategy:
       fail-fast: false
       matrix:
@@ -251,13 +237,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
-      - name: Calculate target tag
+      - name: Calculate image URIs
         id: calculate-target-tag
         shell: bash
         run: |
-          RUNTIME_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${{ needs.build.outputs.target_tag_plain }}${{ needs.build.outputs.image_tag_suffix }}
+          RUNTIME_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/${{ needs.build.outputs.image_name }}:${{ needs.build.outputs.image_tag }}
           echo "runtime_image=${RUNTIME_IMAGE}" >> $GITHUB_OUTPUT
-          TEST_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${{ needs.build.outputs.test_tag_plain }}${{ needs.build.outputs.image_tag_suffix }}
+          TEST_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/${{ needs.build.outputs.image_name }}:${{ needs.build.outputs.test_image_tag }}
           echo "test_image=${TEST_IMAGE}" >> $GITHUB_OUTPUT
       - name: Docker Login
         uses: ./.github/actions/docker-login
@@ -344,20 +330,20 @@ jobs:
         inputs.run_multi_gpu_tests &&
         inputs.build_image
     needs: [build]
-    name: Multi-gpu test ${{ inputs.cpu_only && 'cpu' || format('cuda{0}', inputs.cuda_version) }}
+    name: Multi-gpu test ${{ inputs.cuda_version != '' && format('cuda{0}', inputs.cuda_version) || inputs.target }}
     runs-on: prod-tester-amd-gpu-4-v1
     env:
       FRAMEWORK: ${{ inputs.framework }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
-      - name: Calculate target tag
+      - name: Calculate image URIs
         id: calculate-target-tag
         shell: bash
         run: |
-          RUNTIME_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${{ needs.build.outputs.target_tag_plain }}${{ needs.build.outputs.image_tag_suffix }}
+          RUNTIME_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/${{ needs.build.outputs.image_name }}:${{ needs.build.outputs.image_tag }}
           echo "runtime_image=${RUNTIME_IMAGE}" >> $GITHUB_OUTPUT
-          TEST_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${{ needs.build.outputs.test_tag_plain }}${{ needs.build.outputs.image_tag_suffix }}
+          TEST_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/${{ needs.build.outputs.image_name }}:${{ needs.build.outputs.test_image_tag }}
           echo "test_image=${TEST_IMAGE}" >> $GITHUB_OUTPUT
       - name: Docker Login
         uses: ./.github/actions/docker-login
@@ -403,7 +389,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: ${{ fromJson(needs.build.outputs.compliance_arches) }}
-    name: Compliance ${{ inputs.cpu_only && 'cpu' || format('cuda{0}', inputs.cuda_version) }}-${{ matrix.arch }}
+    name: Compliance ${{ inputs.cuda_version != '' && format('cuda{0}', inputs.cuda_version) || inputs.target }}-${{ matrix.arch }}
     runs-on: prod-builder-v3
     steps:
       - name: Checkout repository
@@ -420,17 +406,23 @@ jobs:
         id: images
         shell: bash
         run: |
-          echo "image_variant_label=${{ needs.build.outputs.image_variant_label }}" >> $GITHUB_OUTPUT
-          RUNTIME_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${{ needs.build.outputs.target_tag_plain }}${{ needs.build.outputs.image_tag_suffix }}
+          RUNTIME_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/${{ needs.build.outputs.image_name }}:${{ needs.build.outputs.image_tag }}
           echo "runtime_image=${RUNTIME_IMAGE}" >> $GITHUB_OUTPUT
           # Sanitize arch for artifact name: linux/amd64 -> amd64 (artifact names can't contain /)
           ARCH="${{ matrix.arch }}"
           echo "arch_suffix=${ARCH#linux/}" >> $GITHUB_OUTPUT
+          CUDA_VERSION="${{ inputs.cuda_version }}"
+          if [[ -n "$CUDA_VERSION" ]]; then
+            CUDA_VERSION="${CUDA_VERSION%%.*}"
+            echo "artifact_variant=cuda${CUDA_VERSION}" >> $GITHUB_OUTPUT
+          else
+            echo "artifact_variant=${{ inputs.target }}" >> $GITHUB_OUTPUT
+          fi
       - name: Compliance scan
         uses: ./.github/actions/compliance-scan
         with:
           image: ${{ steps.images.outputs.runtime_image }}
-          artifact_name: compliance-${{ inputs.framework }}-${{ inputs.target }}${{ inputs.make_efa && '-efa' || '' }}-${{ steps.images.outputs.image_variant_label }}-${{ steps.images.outputs.arch_suffix }}
+          artifact_name: compliance-${{ inputs.framework }}-${{ inputs.target }}${{ inputs.make_efa && '-efa' || '' }}-${{ steps.images.outputs.artifact_variant }}-${{ steps.images.outputs.arch_suffix }}
           arch: ${{ matrix.arch }}
           framework: ${{ inputs.framework }}
           target: ${{ inputs.target }}
@@ -448,10 +440,10 @@ jobs:
       inputs.copy_to_acr &&
       needs.build.result == 'success' &&
       (needs.test.result == 'success' || needs.test.result == 'skipped')
-    name: copy-to-acr ${{ inputs.cpu_only && 'cpu' || format('cuda{0}', inputs.cuda_version) }}
+    name: copy-to-acr ${{ inputs.cuda_version != '' && format('cuda{0}', inputs.cuda_version) || inputs.target }}
     runs-on: prod-default-small-v2
     outputs:
-      target_tag_plain: ${{ needs.build.outputs.target_tag_plain }}
+      image_tag: ${{ needs.build.outputs.image_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
@@ -461,11 +453,11 @@ jobs:
         uses: ./.github/actions/skopeo-copy
         with:
           source_registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
-          source_image: ai-dynamo/dynamo
-          source_tag: ${{ needs.build.outputs.target_tag_plain }}${{ needs.build.outputs.image_tag_suffix }}
+          source_image: ${{ needs.build.outputs.image_name }}
+          source_tag: ${{ needs.build.outputs.image_tag }}
           target_registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          target_image: ai-dynamo/dynamo
-          target_tag: ${{ needs.build.outputs.target_tag_plain }}${{ needs.build.outputs.image_tag_suffix }}
+          target_image: ${{ needs.build.outputs.image_name }}
+          target_tag: ${{ needs.build.outputs.image_tag }}
           source_aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           source_aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
           target_azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}

--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -19,7 +19,7 @@ on:
         required: true
         type: string
       cuda_version:
-        description: 'CUDA version to build (e.g., 12.9, 13.0). Pass an empty string for planner.'
+        description: 'CUDA version to build (e.g., 12.9, 13.0). Use an empty string for no-CUDA targets.'
         required: true
         type: string
       build_timeout_minutes:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -187,10 +187,9 @@ jobs:
     uses: ./.github/workflows/build-test-distribute-flavor.yml
     with:
       framework: dynamo
-      builder_flavor: general
       target: planner
       platform: 'linux/amd64'
-      cpu_only: true
+      cuda_version: ''
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       build_timeout_minutes: 45
       run_cpu_only_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -189,7 +189,7 @@ jobs:
       framework: dynamo
       target: planner
       platform: 'linux/amd64'
-      cuda_version: ''
+      cuda_version: '' # no-CUDA planner target
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       build_timeout_minutes: 45
       run_cpu_only_tests: true


### PR DESCRIPTION
## Summary
- remove `builder_flavor` and `cpu_only` from the shared planner build/test workflow path
- keep planner on the shared reusable workflow with `cuda_version: ''`
- simplify the shared build action outputs to `image_name`, `image_tag`, and `test_image_tag`
- remove planner `cpu`/`cuda` suffixes from job names and image tags while preserving existing CUDA behavior for framework images

## What changed
- infer BuildKit routing from `framework` inside the build action (`vllm`, `sglang`, `trtllm`, otherwise `general`)
- keep the planner-only empty-`cuda_version` case explicit and reject empty CUDA values for other callers
- use a single image metadata step in the build action instead of the previous variant/tag-suffix output plumbing
- update the reusable build/test workflow and `pr.yaml` planner caller to use the simplified contract
- update the non-planner `build-flavor.yml` workflow to consume the new action outputs

## Validation
- parsed modified workflow/action YAML with `yaml.safe_load`
- ran `git diff --check`
- did not run full GitHub Actions locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Simplified build and distribution workflow image naming and versioning logic to improve consistency across configurations.
* Enhanced CUDA version handling in the build pipeline for better support of different hardware requirements.
* Refactored centralized image metadata generation to streamline artifact management and improve overall build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->