### PR TITLE
feat(kvbm): add remote KV-block transfer via NIXL (disk + S3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,6 +2016,7 @@ dependencies = [
  "nixl-sys",
  "object_store",
  "offset-allocator",
+ "once_cell",
  "oneshot",
  "parking_lot",
  "prometheus",

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -20,6 +20,7 @@ default = ["block-manager"]
 testing-full = ["testing-cuda", "testing-nixl"]
 testing-cuda = ["dep:cudarc", "dynamo-memory/testing-cuda"]
 testing-nixl = ["dep:nixl-sys", "dynamo-memory/testing-nixl"]
+testing-remote-storage = []  # Requires NIXL OBJ/POSIX backends; used for remote transfer integration tests
 testing-etcd = []
 block-manager = ["dep:nixl-sys", "dep:cudarc", "dep:nix", "dep:aligned-vec"]
 # Forward the NVTX feature to dynamo-runtime (build with --features nvtx or dynamo-llm/nvtx)
@@ -71,6 +72,7 @@ hf-hub = { workspace = true }
 humantime = { workspace = true }                           # input/batch
 rand = { workspace = true }
 oneshot = { workspace = true }
+once_cell = { version = "1" }
 parking_lot = { workspace = true }
 prometheus = { workspace = true }
 serde = { workspace = true }

--- a/lib/llm/src/block_manager/block/transfer.rs
+++ b/lib/llm/src/block_manager/block/transfer.rs
@@ -1,11 +1,20 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod checksum;
 pub mod context;
 mod cuda;
+mod disk_transfer;
 mod memcpy;
 mod nixl;
+mod object_transfer;
+pub mod remote;
 mod strategy;
+
+#[cfg(all(test, feature = "testing-nixl", feature = "testing-remote-storage"))]
+mod remote_tests;
+
+pub use disk_transfer::{clear_remote_disk_fd_cache, take_fd_open_durations};
 
 use super::*;
 
@@ -60,6 +69,9 @@ pub enum TransferError {
 
     #[error("Mismatched {0:?} worker ID: {1} != {2}")]
     MismatchedWorkerID(BlockTarget, usize, usize),
+
+    #[error("Transfer was cancelled")]
+    Cancelled,
 
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/lib/llm/src/block_manager/block/transfer/checksum.rs
+++ b/lib/llm/src/block_manager/block/transfer/checksum.rs
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Block checksum computation for transfer verification.
+//!
+//! Provides blake3-based checksums for validating data integrity during transfers.
+//! Used for G4 (remote storage) validation and general transfer verification.
+
+use blake3::Hasher;
+
+/// Checksum type - blake3 hash as hex string.
+pub type BlockChecksum = String;
+
+/// Compute blake3 checksum for a byte slice.
+///
+/// Returns the checksum as a hex string.
+#[inline]
+pub fn compute_checksum(data: &[u8]) -> BlockChecksum {
+    blake3::hash(data).to_string()
+}
+
+/// Compute checksum for data at a raw pointer.
+///
+/// # Safety
+/// Caller must ensure `ptr` is valid for `size` bytes.
+#[inline]
+pub unsafe fn compute_checksum_raw(ptr: *const u8, size: usize) -> BlockChecksum {
+    let slice = unsafe { std::slice::from_raw_parts(ptr, size) };
+    compute_checksum(slice)
+}
+
+/// Verify that data matches an expected checksum.
+#[inline]
+pub fn verify_checksum(data: &[u8], expected: &str) -> bool {
+    compute_checksum(data) == expected
+}
+
+/// Compute checksum using a hasher (for incremental hashing).
+///
+/// Useful when checksumming data from multiple non-contiguous regions.
+pub struct ChecksumBuilder {
+    hasher: Hasher,
+}
+
+impl ChecksumBuilder {
+    /// Create a new checksum builder.
+    pub fn new() -> Self {
+        Self {
+            hasher: Hasher::new(),
+        }
+    }
+
+    /// Add data to the checksum.
+    pub fn update(&mut self, data: &[u8]) -> &mut Self {
+        self.hasher.update(data);
+        self
+    }
+
+    /// Add data from a raw pointer.
+    ///
+    /// # Safety
+    /// Caller must ensure `ptr` is valid for `size` bytes.
+    pub unsafe fn update_raw(&mut self, ptr: *const u8, size: usize) -> &mut Self {
+        let slice = unsafe { std::slice::from_raw_parts(ptr, size) };
+        self.hasher.update(slice);
+        self
+    }
+
+    /// Finalize and return the checksum.
+    pub fn finalize(self) -> BlockChecksum {
+        self.hasher.finalize().to_string()
+    }
+}
+
+impl Default for ChecksumBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_checksum() {
+        let data = b"hello world";
+        let checksum = compute_checksum(data);
+
+        // blake3 produces 64-char hex string
+        assert_eq!(checksum.len(), 64);
+
+        // Same data should produce same checksum
+        assert_eq!(checksum, compute_checksum(data));
+    }
+
+    #[test]
+    fn test_verify_checksum() {
+        let data = b"test data";
+        let checksum = compute_checksum(data);
+
+        assert!(verify_checksum(data, &checksum));
+        assert!(!verify_checksum(b"different data", &checksum));
+    }
+
+    #[test]
+    fn test_checksum_builder() {
+        let data1 = b"hello ";
+        let data2 = b"world";
+
+        // Build incrementally
+        let mut builder = ChecksumBuilder::new();
+        builder.update(data1);
+        builder.update(data2);
+        let incremental = builder.finalize();
+
+        // Compare to full computation
+        let full = compute_checksum(b"hello world");
+
+        assert_eq!(incremental, full);
+    }
+
+    #[test]
+    fn test_compute_checksum_raw() {
+        let data = vec![1u8, 2, 3, 4, 5];
+        let checksum1 = compute_checksum(&data);
+        let checksum2 = unsafe { compute_checksum_raw(data.as_ptr(), data.len()) };
+
+        assert_eq!(checksum1, checksum2);
+    }
+}

--- a/lib/llm/src/block_manager/block/transfer/context.rs
+++ b/lib/llm/src/block_manager/block/transfer/context.rs
@@ -172,7 +172,9 @@ pub struct PoolConfig {
 
 pub struct TransferContext {
     nixl_agent: Arc<Option<NixlAgent>>,
-    stream: Arc<CudaStream>,
+    /// `None` when constructed via [`TransferContext::without_cuda`] (POSIX/OBJ
+    /// remote-transfer tests that run without a GPU).
+    stream: Option<Arc<CudaStream>>,
     async_rt_handle: Handle,
 
     // NEW: CUDA memory pool for stream-ordered host memory allocation
@@ -247,7 +249,7 @@ impl TransferContext {
 
         Ok(Self {
             nixl_agent,
-            stream,
+            stream: Some(stream),
             async_rt_handle,
             cuda_mem_pool,
             pinned_buffer_pool: pool,
@@ -255,6 +257,36 @@ impl TransferContext {
             cuda_event_worker: Some(cuda_event_worker),
             cancel_token,
         })
+    }
+
+    /// Construct a `TransferContext` for NIXL remote-storage transfers only.
+    ///
+    /// Omits the CUDA stream; suitable for POSIX (disk) and OBJ (S3) transfer
+    /// paths that never touch GPU memory.  Calling `stream()` or `cuda_event()`
+    /// on a context built this way will panic / return an error — those methods
+    /// are only reachable from the GPU-to-GPU copy path, which is not exercised
+    /// by remote-storage transfers.
+    pub fn without_cuda(
+        nixl_agent: Arc<Option<NixlAgent>>,
+        async_rt_handle: Handle,
+    ) -> Self {
+        let (cuda_event_tx, cuda_event_rx) =
+            mpsc::unbounded_channel::<(CudaEvent, oneshot::Sender<()>)>();
+
+        let cancel_token = CancellationToken::new();
+        let cancel_token_clone = cancel_token.clone();
+        let cuda_event_worker = Self::setup_cuda_event_worker(cuda_event_rx, cancel_token_clone);
+
+        Self {
+            nixl_agent,
+            stream: None,
+            async_rt_handle,
+            cuda_mem_pool: None,
+            pinned_buffer_pool: None,
+            cuda_event_tx,
+            cuda_event_worker: Some(cuda_event_worker),
+            cancel_token,
+        }
     }
 
     fn setup_cuda_event_worker(
@@ -289,8 +321,12 @@ impl TransferContext {
         self.nixl_agent.clone()
     }
 
+    /// Returns the CUDA stream, or panics if this context was created via
+    /// [`Self::without_cuda()`].  Only call from code paths that require a GPU.
     pub fn stream(&self) -> &Arc<CudaStream> {
-        &self.stream
+        self.stream
+            .as_ref()
+            .expect("stream() called on a no-CUDA TransferContext")
     }
 
     pub fn async_rt_handle(&self) -> &Handle {
@@ -303,8 +339,12 @@ impl TransferContext {
     }
 
     pub fn cuda_event(&self, tx: oneshot::Sender<()>) -> Result<(), TransferError> {
-        let event = self
-            .stream
+        let stream = self.stream.as_ref().ok_or_else(|| {
+            TransferError::ExecutionError(
+                "cuda_event() called on a no-CUDA TransferContext".to_string(),
+            )
+        })?;
+        let event = stream
             .record_event(Some(CUevent_flags::CU_EVENT_BLOCKING_SYNC))
             .map_err(|e| TransferError::ExecutionError(e.to_string()))?;
 
@@ -378,7 +418,7 @@ pub mod v2 {
     #[derive(Clone)]
     pub struct TransferContext {
         nixl_agent: Arc<Option<NixlAgent>>,
-        stream: Arc<CudaStream>,
+        stream: Option<Arc<CudaStream>>,
         async_rt_handle: Handle,
     }
 
@@ -395,7 +435,19 @@ pub mod v2 {
         ) -> Self {
             Self {
                 nixl_agent,
-                stream,
+                stream: Some(stream),
+                async_rt_handle,
+            }
+        }
+
+        /// Constructor for NIXL POSIX/OBJ remote-transfer paths; omits the CUDA stream.
+        pub fn without_cuda(
+            nixl_agent: Arc<Option<NixlAgent>>,
+            async_rt_handle: Handle,
+        ) -> Self {
+            Self {
+                nixl_agent,
+                stream: None,
                 async_rt_handle,
             }
         }
@@ -404,8 +456,11 @@ pub mod v2 {
             self.nixl_agent.clone()
         }
 
+        /// Returns the CUDA stream, or panics if constructed via [`Self::without_cuda()`].
         pub fn stream(&self) -> &Arc<CudaStream> {
-            &self.stream
+            self.stream
+                .as_ref()
+                .expect("stream() called on a no-CUDA TransferContext")
         }
 
         pub fn async_rt_handle(&self) -> &Handle {
@@ -413,8 +468,12 @@ pub mod v2 {
         }
 
         pub fn record_event(&self) -> Result<EventSynchronizer, TransferError> {
-            let event = self
-                .stream
+            let stream = self.stream.as_ref().ok_or_else(|| {
+                TransferError::ExecutionError(
+                    "record_event() called on a no-CUDA TransferContext".to_string(),
+                )
+            })?;
+            let event = stream
                 .record_event(Some(CUevent_flags::CU_EVENT_BLOCKING_SYNC))
                 .map_err(|e| TransferError::ExecutionError(e.to_string()))?;
 

--- a/lib/llm/src/block_manager/block/transfer/disk_transfer.rs
+++ b/lib/llm/src/block_manager/block/transfer/disk_transfer.rs
@@ -1,0 +1,521 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! NIXL POSIX/GDS-MT disk-backend transfer implementation.
+
+use super::*;
+use super::remote::{RemoteBlockDescriptor, RemoteKey, RemoteTransferDirection};
+use crate::block_manager::config::RemoteTransferContext;
+use crate::block_manager::storage::RemoteDiskStorage;
+use crate::block_manager::storage::nixl::NixlRegisterableStorage;
+use dynamo_runtime::config::environment_names::kvbm::remote_disk as env;
+use nixl_sys::{Agent as NixlAgent, MemType, MemoryRegion, NixlDescriptor, OptArgs, XferDescList, XferOp};
+use once_cell::sync::Lazy;
+use parking_lot::Mutex as SyncMutex;
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::sync::Mutex as AsyncMutex;
+use tokio_util::sync::CancellationToken;
+
+// ── FD cache ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_REMOTE_DISK_FD_CACHE_MAX_ENTRIES: usize = 131_072;
+const DEFAULT_O_DIRECT_ALIGNMENT_FALLBACK: usize = 4096;
+
+static REMOTE_DISK_FD_CACHE_MAX_ENTRIES: Lazy<usize> = Lazy::new(|| {
+    std::env::var(env::DYN_KVBM_REMOTE_DISK_FD_CACHE_MAX_ENTRIES)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_REMOTE_DISK_FD_CACHE_MAX_ENTRIES)
+});
+
+static REMOTE_DISK_FD_CACHE: Lazy<AsyncMutex<RemoteDiskFdCache>> =
+    Lazy::new(|| AsyncMutex::new(RemoteDiskFdCache::new(*REMOTE_DISK_FD_CACHE_MAX_ENTRIES)));
+
+#[derive(Debug, Clone, Copy)]
+struct RemoteDiskAlignmentConfig {
+    quantum: usize,
+    validate: bool,
+}
+
+static REMOTE_DISK_ALIGNMENT_CONFIG: Lazy<RemoteDiskAlignmentConfig> = Lazy::new(|| {
+    let page_size = nix::unistd::sysconf(nix::unistd::SysconfVar::PAGE_SIZE)
+        .ok()
+        .flatten()
+        .and_then(|v| usize::try_from(v).ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_O_DIRECT_ALIGNMENT_FALLBACK);
+
+    let alignment_override = std::env::var(env::DYN_KVBM_REMOTE_DISK_ALIGNMENT_BYTES)
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|v| *v > 0);
+
+    let quantum = alignment_override.unwrap_or(page_size);
+    let validate = std::env::var(env::DYN_KVBM_REMOTE_DISK_VALIDATE_ALIGNMENT)
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    tracing::info!(
+        target: "kvbm-g4",
+        page_size,
+        alignment_quantum = quantum,
+        validate_alignment = validate,
+        "remote disk alignment config initialized"
+    );
+
+    RemoteDiskAlignmentConfig { quantum, validate }
+});
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RemoteDiskFdCacheKey {
+    path: String,
+    use_odirect: bool,
+}
+
+#[derive(Debug)]
+struct RemoteDiskFdCacheEntry {
+    storage: Arc<SyncMutex<RemoteDiskStorage>>,
+    last_access_tick: u64,
+}
+
+#[derive(Debug)]
+struct RemoteDiskFdCache {
+    entries: HashMap<RemoteDiskFdCacheKey, RemoteDiskFdCacheEntry>,
+    access_tick: u64,
+    max_entries: usize,
+}
+
+impl RemoteDiskFdCache {
+    fn new(max_entries: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            access_tick: 0,
+            max_entries,
+        }
+    }
+
+    fn next_tick(&mut self) -> u64 {
+        self.access_tick = self.access_tick.wrapping_add(1);
+        self.access_tick
+    }
+
+    fn get(&mut self, key: &RemoteDiskFdCacheKey) -> Option<Arc<SyncMutex<RemoteDiskStorage>>> {
+        let tick = self.next_tick();
+        let entry = self.entries.get_mut(key)?;
+        entry.last_access_tick = tick;
+        Some(entry.storage.clone())
+    }
+
+    fn insert(
+        &mut self,
+        key: RemoteDiskFdCacheKey,
+        storage: Arc<SyncMutex<RemoteDiskStorage>>,
+    ) -> Arc<SyncMutex<RemoteDiskStorage>> {
+        if self.max_entries > 0 && self.entries.len() >= self.max_entries {
+            self.evict_lru();
+        }
+
+        let tick = self.next_tick();
+        self.entries.insert(
+            key,
+            RemoteDiskFdCacheEntry {
+                storage: storage.clone(),
+                last_access_tick: tick,
+            },
+        );
+        storage
+    }
+
+    fn evict_lru(&mut self) {
+        let Some(lru_key) = self
+            .entries
+            .iter()
+            .min_by_key(|(_, entry)| entry.last_access_tick)
+            .map(|(k, _)| k.clone())
+        else {
+            return;
+        };
+
+        self.entries.remove(&lru_key);
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+        self.access_tick = 0;
+    }
+}
+
+/// Drop all cached remote-disk file descriptors and their NIXL registrations.
+///
+/// Call this between benchmark sweep points or whenever the NIXL agent/backend
+/// changes so that subsequent transfers re-open and re-register files against
+/// the current agent.
+pub async fn clear_remote_disk_fd_cache() {
+    REMOTE_DISK_FD_CACHE.lock().await.clear();
+}
+
+static FD_OPEN_DURATIONS: Lazy<parking_lot::Mutex<Vec<Duration>>> =
+    Lazy::new(|| parking_lot::Mutex::new(Vec::new()));
+
+/// Drain and return all recorded per-file open+register durations.
+pub fn take_fd_open_durations() -> Vec<Duration> {
+    std::mem::take(&mut *FD_OPEN_DURATIONS.lock())
+}
+
+async fn get_or_open_remote_disk_storage(
+    agent: &NixlAgent,
+    path: &str,
+    block_size: usize,
+    create: bool,
+    use_odirect: bool,
+    preallocate: bool,
+) -> Result<Arc<SyncMutex<RemoteDiskStorage>>, TransferError> {
+    let key = RemoteDiskFdCacheKey {
+        path: path.to_string(),
+        use_odirect,
+    };
+
+    {
+        let mut cache = REMOTE_DISK_FD_CACHE.lock().await;
+        if let Some(storage) = cache.get(&key) {
+            return Ok(storage);
+        }
+    }
+
+    let fd_start = std::time::Instant::now();
+    let mut storage =
+        RemoteDiskStorage::open(path, block_size, create, use_odirect, preallocate).map_err(|e| {
+            TransferError::ExecutionError(format!(
+                "Failed to {} RemoteDiskStorage at {}: {:?}",
+                if create { "create" } else { "open" },
+                path,
+                e
+            ))
+        })?;
+    storage.nixl_register(agent, None).map_err(|e| {
+        TransferError::ExecutionError(format!("Failed to register disk storage {}: {:?}", path, e))
+    })?;
+    FD_OPEN_DURATIONS.lock().push(fd_start.elapsed());
+
+    let storage = Arc::new(SyncMutex::new(storage));
+
+    let mut cache = REMOTE_DISK_FD_CACHE.lock().await;
+    if let Some(existing) = cache.get(&key) {
+        return Ok(existing);
+    }
+
+    Ok(cache.insert(key, storage))
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+/// Execute a disk transfer via NIXL (POSIX or GDS-MT backend).
+///
+/// `pub(crate)` — called exclusively from [`super::nixl::execute_remote_transfer`].
+pub(crate) async fn execute_disk_transfer<LB>(
+    direction: RemoteTransferDirection,
+    descriptors: &[RemoteBlockDescriptor],
+    local_blocks: &[LB],
+    block_size: usize,
+    ctx: &RemoteTransferContext,
+    cancel_token: &CancellationToken,
+) -> Result<(), TransferError>
+where
+    LB: ReadableBlock + WritableBlock + Local,
+    <LB as StorageTypeProvider>::StorageType: NixlDescriptor,
+{
+    let nixl_agent_arc = ctx.nixl_agent();
+    let agent = nixl_agent_arc
+        .as_ref()
+        .as_ref()
+        .ok_or_else(|| TransferError::ExecutionError("NIXL agent not available".to_string()))?;
+    execute_disk_transfer_nixl(
+        agent,
+        direction,
+        descriptors,
+        local_blocks,
+        block_size,
+        ctx,
+        cancel_token,
+    )
+    .await
+}
+
+// ── NIXL POSIX / GDS-MT path ──────────────────────────────────────────────────
+
+async fn execute_disk_transfer_nixl<LB>(
+    agent: &NixlAgent,
+    direction: RemoteTransferDirection,
+    descriptors: &[RemoteBlockDescriptor],
+    local_blocks: &[LB],
+    block_size: usize,
+    ctx: &RemoteTransferContext,
+    cancel_token: &CancellationToken,
+) -> Result<(), TransferError>
+where
+    LB: ReadableBlock + WritableBlock + Local,
+    <LB as StorageTypeProvider>::StorageType: NixlDescriptor,
+{
+    let num_blocks = descriptors.len();
+    let op = if matches!(direction, RemoteTransferDirection::Offload) {
+        "write"
+    } else {
+        "read"
+    };
+    let base = ctx.base_path().unwrap_or("(none)");
+    tracing::info!(
+        target: "kvbm-diag",
+        direction = op,
+        base_path = base,
+        num_blocks,
+        block_size,
+        "Disk transfer starting"
+    );
+
+    // For Offload (write): create files
+    // For Onboard (read): open existing files
+    let create_files = matches!(direction, RemoteTransferDirection::Offload);
+
+    // Determine per-direction backend from transfer flags.
+    //
+    // Offload: use GDS_MT when DISK_FLAG_GDS_WRITE is set, else POSIX.
+    // Onboard: use GDS_MT when DISK_FLAG_GDS_READ is set AND the backend is
+    //          available; fall back to POSIX otherwise.
+    use crate::block_manager::config::{DISK_FLAG_GDS_READ, DISK_FLAG_GDS_WRITE};
+    let flags = ctx.disk_transfer_flags();
+    let gds_write = flags & DISK_FLAG_GDS_WRITE != 0;
+    let gds_read = flags & DISK_FLAG_GDS_READ != 0;
+
+    // Resolve the GDS_MT backend handle once (None if not loaded in agent).
+    let gds_backend = agent.get_backend("GDS_MT");
+
+    // Optional: allow POSIX backend to also open files with O_DIRECT.
+    // This is independent from backend selection (GDS_MT vs POSIX).
+    let posix_odirect = std::env::var(env::DYN_KVBM_REMOTE_DISK_O_DIRECT)
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    // Determine whether this direction will use GDS backend.
+    let use_gds_backend = if create_files {
+        gds_write
+    } else {
+        gds_read && gds_backend.is_some()
+    };
+
+    // Enable O_DIRECT when using GDS backend, and optionally for POSIX when
+    // DYN_KVBM_REMOTE_DISK_O_DIRECT is set.
+    let use_odirect = use_gds_backend || (!use_gds_backend && posix_odirect);
+
+    let alignment_cfg = *REMOTE_DISK_ALIGNMENT_CONFIG;
+    if use_odirect && alignment_cfg.validate && !block_size.is_multiple_of(alignment_cfg.quantum) {
+        return Err(TransferError::ExecutionError(format!(
+            "O_DIRECT alignment validation failed: block_size must be {}-byte aligned (got {}). \
+             Set {}=false to disable validation.",
+            alignment_cfg.quantum, block_size, env::DYN_KVBM_REMOTE_DISK_VALIDATE_ALIGNMENT
+        )));
+    }
+
+    // Use a scope block to ensure all non-Send types are dropped before await
+    // (OptArgs contains NonNull which is !Send)
+    let (xfer_req, still_pending, _disk_storages, bounce_storage, _bounce_reg) = {
+        let worker_id = ctx.worker_id() as usize;
+        let world_size = ctx.world_size();
+
+        let mut file_paths: Vec<String> = Vec::with_capacity(num_blocks);
+        for desc in descriptors.iter() {
+            let file_path = match desc.key() {
+                RemoteKey::Disk(disk_key) => {
+                    let hash = desc.sequence_hash().ok_or_else(|| {
+                        TransferError::ExecutionError(
+                            "Disk descriptor missing sequence_hash metadata".to_string(),
+                        )
+                    })?;
+                    let base = ctx.base_path().unwrap_or(&disk_key.path);
+                    format!("{}/{:016x}_{}_{}", base, hash, worker_id, world_size)
+                }
+                _ => {
+                    return Err(TransferError::IncompatibleTypes(
+                        "Expected Disk key for disk storage transfer".to_string(),
+                    ));
+                }
+            };
+            file_paths.push(file_path);
+        }
+
+        if let Some(first) = file_paths.first() {
+            tracing::info!(
+                target: "kvbm-diag",
+                direction = op,
+                first_file = %first,
+                num_blocks,
+                "Disk transfer files (showing first)"
+            );
+        }
+
+        let disk_storages = {
+            let mut storages: Vec<Arc<SyncMutex<RemoteDiskStorage>>> =
+                Vec::with_capacity(num_blocks);
+            for path in &file_paths {
+                let storage = get_or_open_remote_disk_storage(
+                    agent,
+                    path,
+                    block_size,
+                    create_files,
+                    use_odirect,
+                    use_gds_backend,
+                )
+                .await?;
+                storages.push(storage);
+            }
+            storages
+        };
+
+        // Allocate a contiguous, page-aligned bounce buffer when requested.
+        // Useful when user block buffers are not page-aligned (required for O_DIRECT).
+        let use_bounce_buf = std::env::var(env::DYN_KVBM_NIXL_BOUNCE_BUFFER)
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+
+        let (bounce_storage, _bounce_reg_handle): (
+            Option<nixl_sys::SystemStorage>,
+            Option<nixl_sys::RegistrationHandle>,
+        ) = if use_bounce_buf {
+            let buf = nixl_sys::SystemStorage::new(num_blocks * block_size).map_err(|e| {
+                TransferError::ExecutionError(format!("Failed to allocate bounce buffer: {:?}", e))
+            })?;
+            let handle = agent.register_memory(&buf, None).map_err(|e| {
+                TransferError::ExecutionError(format!(
+                    "Failed to register bounce buffer: {:?}",
+                    e
+                ))
+            })?;
+            (Some(buf), Some(handle))
+        } else {
+            (None, None)
+        };
+
+        // Build transfer descriptor lists for disk
+        let mut src_dl = XferDescList::new(MemType::Dram).map_err(|e| {
+            TransferError::ExecutionError(format!("Failed to create src_dl: {:?}", e))
+        })?;
+        let mut dst_dl = XferDescList::new(MemType::File).map_err(|e| {
+            TransferError::ExecutionError(format!("Failed to create dst_dl: {:?}", e))
+        })?;
+
+        for (i, (block, disk_storage)) in local_blocks.iter().zip(disk_storages.iter()).enumerate() {
+            let addr = if let Some(ref storage) = bounce_storage {
+                unsafe { MemoryRegion::as_ptr(storage) as usize + i * block_size }
+            } else {
+                let block_view = block.block_data().block_view()?;
+                unsafe { block_view.as_ptr() as usize }
+            };
+
+            if bounce_storage.is_none() && use_odirect && alignment_cfg.validate && !addr.is_multiple_of(alignment_cfg.quantum)
+            {
+                return Err(TransferError::ExecutionError(format!(
+                    "O_DIRECT alignment validation failed: host buffer address must be {}-byte aligned; got 0x{:x}. \
+                     Set {}=false to disable validation.",
+                    alignment_cfg.quantum, addr, env::DYN_KVBM_REMOTE_DISK_VALIDATE_ALIGNMENT
+                )));
+            }
+
+            // Add DRAM source descriptor
+            let _ = src_dl.add_desc(addr, block_size, 0);
+
+            // Add FILE destination descriptor using the actual file descriptor
+            let fd = disk_storage.lock().fd();
+            let _ = dst_dl.add_desc(0, block_size, fd);
+        }
+
+        // Determine the transfer operation
+        let xfer_op = match direction {
+            RemoteTransferDirection::Offload => XferOp::Write,
+            RemoteTransferDirection::Onboard => XferOp::Read,
+        };
+
+        // Build OptArgs inside scope block so it's dropped before any await.
+        // OptArgs contains NonNull which is !Send; it must not be held across await.
+        // Offload: always POSIX when gds_write=false; GDS_MT when true.
+        // Onboard: GDS_MT if available, else let NIXL fall through to POSIX.
+        let opt_args: Option<OptArgs> = {
+            let backend_name = if create_files {
+                if gds_write {
+                    Some("GDS_MT")
+                } else {
+                    Some("POSIX")
+                }
+            } else if gds_read {
+                if gds_backend.is_some() {
+                    Some("GDS_MT")
+                } else {
+                    Some("POSIX")
+                }
+            } else {
+                Some("POSIX")
+            };
+            backend_name.and_then(|name| {
+                let backend = agent.get_backend(name)?;
+                let mut opt = OptArgs::new().ok()?;
+                opt.add_backend(&backend).ok()?;
+                Some(opt)
+            })
+        };
+        let opt_ref = opt_args.as_ref();
+
+        // Create transfer request, pinning the backend via OptArgs when set.
+        let agent_name = agent.name();
+        let xfer_req = agent
+            .create_xfer_req(xfer_op, &src_dl, &dst_dl, &agent_name, opt_ref)
+            .map_err(|e| {
+                TransferError::ExecutionError(format!("Failed to create xfer_req: {:?}", e))
+            })?;
+
+        let still_pending = agent.post_xfer_req(&xfer_req, opt_ref).map_err(|e| {
+            TransferError::ExecutionError(format!("Failed to post xfer_req: {:?}", e))
+        })?;
+
+        (xfer_req, still_pending, disk_storages, bounce_storage, _bounce_reg_handle)
+    };
+
+    if still_pending {
+        use tracing::Instrument;
+        let nixl_span = tracing::info_span!(
+            "nixl_io",
+            otel.name = match direction {
+                RemoteTransferDirection::Onboard => "kvbm.nixl_read",
+                RemoteTransferDirection::Offload => "kvbm.nixl_write",
+            },
+            description = "NIXL disk I/O (post + completion wait)",
+            num_blocks,
+            direction = op,
+        );
+        super::nixl::poll_transfer_completion(agent, &xfer_req, cancel_token)
+            .instrument(nixl_span)
+            .await?;
+    }
+
+    // For onboard with bounce buffer: copy from bounce into actual block views.
+    if let Some(ref storage) = bounce_storage {
+        let src_base = unsafe { MemoryRegion::as_ptr(storage) };
+        for (i, block) in local_blocks.iter().enumerate() {
+            let block_view = block.block_data().block_view()?;
+            // Safety: NIXL has completed the transfer; the backing memory is
+            // exclusively owned by this transfer at this point. We write through
+            // the raw pointer because &[LB] does not give us &mut access.
+            let dst = unsafe { block_view.as_ptr() as *mut u8 };
+            unsafe {
+                std::ptr::copy_nonoverlapping(src_base.add(i * block_size), dst, block_size);
+            }
+        }
+    }
+
+    tracing::debug!(
+        "Disk transfer complete: {} blocks, direction={:?}, bounce={}",
+        num_blocks,
+        direction,
+        bounce_storage.is_some(),
+    );
+
+    Ok(())
+}

--- a/lib/llm/src/block_manager/block/transfer/nixl.rs
+++ b/lib/llm/src/block_manager/block/transfer/nixl.rs
@@ -3,9 +3,45 @@
 
 use super::*;
 
+use super::remote::{RemoteBlockDescriptor, RemoteStorageKind, RemoteTransferDirection};
+use crate::block_manager::config::RemoteTransferContext;
 use anyhow::Result;
-use nixl_sys::{MemoryRegion, NixlDescriptor, XferDescList, XferStatus};
+use nixl_sys::{Agent as NixlAgent, MemoryRegion, NixlDescriptor, XferDescList, XferRequest, XferStatus};
 use std::future::Future;
+use tokio_util::sync::CancellationToken;
+
+/// Poll transfer status inline with cancellation support.
+///
+/// Yields to the Tokio executor between each status check so other tasks
+/// can make progress. Uses `yield_now` rather than a sleep so completion
+/// is detected as soon as the executor schedules this task again — no
+/// artificial latency floor.
+///
+/// Note: nixl-sys 0.10.1 acquires a write lock inside `get_xfer_status`
+/// even though the C++ layer only takes a shared lock. Under heavy
+/// concurrency this serializes all concurrent polls. A fix to nixl-sys
+/// to use `.read()` is tracked separately.
+pub(crate) async fn poll_transfer_completion(
+    agent: &NixlAgent,
+    xfer_req: &XferRequest,
+    cancel_token: &CancellationToken,
+) -> Result<(), TransferError> {
+    loop {
+        if cancel_token.is_cancelled() {
+            return Err(TransferError::Cancelled);
+        }
+        match agent.get_xfer_status(xfer_req) {
+            Ok(XferStatus::Success) => return Ok(()),
+            Ok(XferStatus::InProgress) => tokio::task::yield_now().await,
+            Err(e) => {
+                return Err(TransferError::ExecutionError(format!(
+                    "Transfer status check failed: {}",
+                    e
+                )));
+            }
+        }
+    }
+}
 
 fn append_xfer_request<Source, Destination>(
     src: &Source,
@@ -150,3 +186,488 @@ where
         Ok(Box::new(std::future::ready(())))
     }
 }
+
+/// Execute a remote storage transfer (object storage or disk).
+///
+/// Dispatches to [`super::object_transfer::execute_object_transfer`] or
+/// [`super::disk_transfer::execute_disk_transfer`] based on `kind`.
+pub async fn execute_remote_transfer<LB>(
+    direction: RemoteTransferDirection,
+    kind: RemoteStorageKind,
+    descriptors: &[RemoteBlockDescriptor],
+    local_blocks: &[LB],
+    ctx: &RemoteTransferContext,
+    cancel_token: &CancellationToken,
+) -> Result<(), TransferError>
+where
+    LB: ReadableBlock + WritableBlock + Local,
+    <LB as StorageTypeProvider>::StorageType: NixlDescriptor,
+{
+    if descriptors.is_empty() || local_blocks.is_empty() {
+        return Ok(());
+    }
+
+    if descriptors.len() != local_blocks.len() {
+        return Err(TransferError::CountMismatch(
+            descriptors.len(),
+            local_blocks.len(),
+        ));
+    }
+
+    if cancel_token.is_cancelled() {
+        return Err(TransferError::Cancelled);
+    }
+
+    let block_size = local_blocks[0].block_data().block_view()?.size();
+
+    tracing::debug!(
+        "Remote transfer: {} blocks, direction={:?}, kind={:?}, block_size={}",
+        descriptors.len(),
+        direction,
+        kind,
+        block_size
+    );
+
+    match kind {
+        RemoteStorageKind::Object => {
+            super::object_transfer::execute_object_transfer(
+                direction,
+                descriptors,
+                local_blocks,
+                block_size,
+                ctx,
+                cancel_token,
+            )
+            .await
+        }
+        RemoteStorageKind::Disk => {
+            super::disk_transfer::execute_disk_transfer(
+                direction,
+                descriptors,
+                local_blocks,
+                block_size,
+                ctx,
+                cancel_token,
+            )
+            .await
+        }
+    }
+}
+
+
+#[cfg(all(test, feature = "testing-cuda", feature = "testing-nixl"))]
+mod tests {
+    use super::*;
+    use crate::block_manager::block::transfer::context::TransferContext;
+    use crate::block_manager::{
+        LayoutConfig,
+        block::{BasicMetadata, Block, BlockData, locality},
+        config::{RemoteStorageConfig, RemoteTransferContext, DISK_FLAGS_POSIX_BOTH},
+        layout::{BlockLayoutConfig, FullyContiguous, nixl::NixlLayout},
+        storage::{PinnedAllocator, PinnedStorage},
+    };
+    use cudarc::driver::CudaContext;
+    use std::sync::Arc;
+
+    // Shared NIXL agent with OBJ and POSIX backends
+    lazy_static::lazy_static! {
+        static ref TEST_AGENT: Arc<Option<NixlAgent>> = {
+            let agent = NixlAgent::new("nixl-transfer-test").expect("Failed to create NIXL agent");
+
+            // Create OBJ backend for object storage
+            if let Ok((_, params)) = agent.get_plugin_params("OBJ") {
+                match agent.create_backend("OBJ", &params) {
+                    Ok(_) => eprintln!("OBJ backend created"),
+                    Err(e) => eprintln!("OBJ backend failed: {}", e),
+                }
+            } else {
+                eprintln!("OBJ plugin not found");
+            }
+
+            // Create POSIX backend for disk storage
+            if let Ok((_, params)) = agent.get_plugin_params("POSIX") {
+                match agent.create_backend("POSIX", &params) {
+                    Ok(_) => eprintln!("POSIX backend created"),
+                    Err(e) => eprintln!("POSIX backend failed: {}", e),
+                }
+            } else {
+                eprintln!("POSIX plugin not found");
+            }
+
+            Arc::new(Some(agent))
+        };
+
+        static ref CUDA_CTX: Arc<CudaContext> = {
+            CudaContext::new(0).expect("Failed to create CUDA context")
+        };
+    }
+
+    fn create_test_layout(num_blocks: usize) -> FullyContiguous<PinnedStorage> {
+        let config = LayoutConfig::builder()
+            .num_blocks(num_blocks)
+            .num_layers(2)
+            .outer_dim(1)
+            .page_size(4)
+            .inner_dim(64)
+            .dtype_width_bytes(2)
+            .build()
+            .unwrap();
+
+        let allocator = PinnedAllocator::new().unwrap();
+        FullyContiguous::allocate(config, &allocator).unwrap()
+    }
+
+    fn create_transfer_context() -> Arc<TransferContext> {
+        let stream = CUDA_CTX.default_stream();
+        let handle = tokio::runtime::Handle::current();
+        Arc::new(
+            TransferContext::new(TEST_AGENT.clone(), stream, handle, None)
+                .expect("TransferContext::new for NIXL tests"),
+        )
+    }
+
+    fn create_disk_remote_context(base: Arc<TransferContext>, path: &str) -> RemoteTransferContext {
+        RemoteTransferContext::new(base, RemoteStorageConfig::disk(path, DISK_FLAGS_POSIX_BOTH))
+    }
+
+    fn create_object_remote_context(
+        base: Arc<TransferContext>,
+        bucket: &str,
+    ) -> RemoteTransferContext {
+        RemoteTransferContext::new(base, RemoteStorageConfig::object(bucket))
+    }
+
+    #[tokio::test]
+    async fn test_execute_remote_transfer_empty_descriptors() {
+        let base_ctx = create_transfer_context();
+        let remote_ctx = create_disk_remote_context(base_ctx, "/tmp/nixl-test");
+        let cancel_token = CancellationToken::new();
+
+        let descriptors: Vec<RemoteBlockDescriptor> = vec![];
+        let local_blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = vec![];
+
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Offload,
+            RemoteStorageKind::Disk,
+            &descriptors,
+            &local_blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_execute_remote_transfer_count_mismatch() {
+        let base_ctx = create_transfer_context();
+        let remote_ctx = create_disk_remote_context(base_ctx, "/tmp/nixl-test");
+        let cancel_token = CancellationToken::new();
+
+        // Create 2 descriptors but 1 block - should fail
+        let descriptors = vec![
+            RemoteBlockDescriptor::disk_from_hash("/tmp", 0x1234, 1024, 0, 1),
+            RemoteBlockDescriptor::disk_from_hash("/tmp", 0x5678, 1024, 0, 1),
+        ];
+
+        let mut layout = create_test_layout(1);
+        layout
+            .nixl_register(TEST_AGENT.as_ref().as_ref().unwrap(), None)
+            .unwrap();
+        let layout = Arc::new(layout);
+        let blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = (0..1)
+            .map(|i| {
+                let data = BlockData::new(layout.clone(), i, 0, 0);
+                Block::new(data, BasicMetadata::default()).unwrap()
+            })
+            .collect();
+
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Offload,
+            RemoteStorageKind::Disk,
+            &descriptors,
+            &blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        assert!(matches!(result, Err(TransferError::CountMismatch(2, 1))));
+    }
+
+    #[tokio::test]
+    async fn test_execute_remote_transfer_early_cancellation() {
+        let base_ctx = create_transfer_context();
+        let remote_ctx = create_disk_remote_context(base_ctx, "/tmp/nixl-test");
+        let cancel_token = CancellationToken::new();
+
+        // Cancel before starting
+        cancel_token.cancel();
+
+        let descriptors = vec![RemoteBlockDescriptor::disk_from_hash(
+            "/tmp", 0x1234, 1024, 0, 1,
+        )];
+
+        let mut layout = create_test_layout(1);
+        layout
+            .nixl_register(TEST_AGENT.as_ref().as_ref().unwrap(), None)
+            .unwrap();
+        let layout = Arc::new(layout);
+        let blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = (0..1)
+            .map(|i| {
+                let data = BlockData::new(layout.clone(), i, 0, 0);
+                Block::new(data, BasicMetadata::default()).unwrap()
+            })
+            .collect();
+
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Offload,
+            RemoteStorageKind::Disk,
+            &descriptors,
+            &blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        assert!(matches!(result, Err(TransferError::Cancelled)));
+    }
+
+    /// Test disk transfer using POSIX backend - writes data to disk and reads it back
+    #[tokio::test]
+    async fn test_posix_disk_transfer_roundtrip() {
+        use tempfile::tempdir;
+
+        let temp_dir = tempdir().unwrap();
+        let base_path = temp_dir.path().to_str().unwrap().to_string();
+
+        let base_ctx = create_transfer_context();
+        let remote_ctx = create_disk_remote_context(base_ctx, &base_path);
+        let cancel_token = CancellationToken::new();
+
+        // Create blocks and fill with test data
+        let mut layout = create_test_layout(2);
+        layout
+            .nixl_register(TEST_AGENT.as_ref().as_ref().unwrap(), None)
+            .unwrap();
+        let block_size = layout.layout_data_bytes() / layout.num_blocks();
+        let layout = Arc::new(layout);
+
+        let mut blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = (0..2)
+            .map(|i| {
+                let data = BlockData::new(layout.clone(), i, 0, 0);
+                Block::new(data, BasicMetadata::default()).unwrap()
+            })
+            .collect();
+
+        // Fill blocks with recognizable pattern
+        for (i, block) in blocks.iter_mut().enumerate() {
+            let mut view = block.block_data_mut().block_view_mut().unwrap();
+            let slice = unsafe { std::slice::from_raw_parts_mut(view.as_mut_ptr(), view.size()) };
+            for (j, byte) in slice.iter_mut().enumerate() {
+                *byte = ((i * 100 + j) % 256) as u8;
+            }
+        }
+
+        let descriptors: Vec<RemoteBlockDescriptor> = (0..2u64)
+            .map(|i| {
+                RemoteBlockDescriptor::disk_from_hash(&base_path, 0x1000 + i, block_size, 0, 1)
+            })
+            .collect();
+
+        // Offload (write to disk via POSIX)
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Offload,
+            RemoteStorageKind::Disk,
+            &descriptors,
+            &blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        if result.is_err() {
+            eprintln!(
+                "POSIX disk transfer test skipped - backend may not be available: {:?}",
+                result
+            );
+            return;
+        }
+        assert!(result.is_ok(), "POSIX Offload failed: {:?}", result);
+
+        // Drop offload blocks to ensure we're not reusing cached memory
+        drop(blocks);
+
+        // Create fresh blocks for onboarding (different memory)
+        let mut onboard_layout = create_test_layout(2);
+        onboard_layout
+            .nixl_register(TEST_AGENT.as_ref().as_ref().unwrap(), None)
+            .unwrap();
+        let onboard_layout = Arc::new(onboard_layout);
+
+        let onboard_blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = (0..2)
+            .map(|i| {
+                let data = BlockData::new(onboard_layout.clone(), i, 0, 0);
+                Block::new(data, BasicMetadata::default()).unwrap()
+            })
+            .collect();
+
+        // Verify onboard blocks start zeroed (not containing our pattern)
+        for block in onboard_blocks.iter() {
+            let view = block.block_data().block_view().unwrap();
+            let slice = unsafe { std::slice::from_raw_parts(view.as_ptr(), view.size()) };
+            assert!(
+                slice.iter().all(|&b| b == 0),
+                "Onboard blocks should start zeroed"
+            );
+        }
+
+        // Onboard (read from disk via POSIX) into fresh blocks
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Onboard,
+            RemoteStorageKind::Disk,
+            &descriptors,
+            &onboard_blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        assert!(result.is_ok(), "POSIX Onboard failed: {:?}", result);
+
+        // Verify data was restored to the new blocks
+        for (i, block) in onboard_blocks.iter().enumerate() {
+            let view = block.block_data().block_view().unwrap();
+            let slice = unsafe { std::slice::from_raw_parts(view.as_ptr(), view.size()) };
+            for (j, &byte) in slice.iter().enumerate() {
+                let expected = ((i * 100 + j) % 256) as u8;
+                assert_eq!(
+                    byte, expected,
+                    "POSIX: Data mismatch at block {} byte {}",
+                    i, j
+                );
+            }
+        }
+        eprintln!("POSIX disk roundtrip transfer successful (using separate blocks for onboard)");
+    }
+
+    /// Test object storage transfer using OBJ backend - writes data to S3/object store and reads it back
+    #[tokio::test]
+    async fn test_obj_object_storage_transfer_roundtrip() {
+        let bucket =
+            std::env::var(dynamo_runtime::config::environment_names::kvbm::testing::NIXL_TEST_BUCKET).unwrap_or_else(|_| "nixl-test-bucket".to_string());
+
+        let base_ctx = create_transfer_context();
+        let remote_ctx = create_object_remote_context(base_ctx, &bucket);
+        let cancel_token = CancellationToken::new();
+
+        // Create blocks and fill with test data
+        let mut layout = create_test_layout(2);
+        layout
+            .nixl_register(TEST_AGENT.as_ref().as_ref().unwrap(), None)
+            .unwrap();
+        let block_size = layout.layout_data_bytes() / layout.num_blocks();
+        let layout = Arc::new(layout);
+
+        let mut blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = (0..2)
+            .map(|i| {
+                let data = BlockData::new(layout.clone(), i, 0, 0);
+                Block::new(data, BasicMetadata::default()).unwrap()
+            })
+            .collect();
+
+        for (i, block) in blocks.iter_mut().enumerate() {
+            let mut view = block.block_data_mut().block_view_mut().unwrap();
+            let slice = unsafe { std::slice::from_raw_parts_mut(view.as_mut_ptr(), view.size()) };
+            for (j, byte) in slice.iter_mut().enumerate() {
+                *byte = ((i * 200 + j) % 256) as u8;
+            }
+        }
+
+        // Use unique sequence hashes for this test run
+        let test_id = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+
+        let descriptors: Vec<RemoteBlockDescriptor> = (0..2u64)
+            .map(|i| RemoteBlockDescriptor::object_from_hash(&bucket, test_id + i, block_size))
+            .collect();
+
+        // Offload (write to object storage via OBJ)
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Offload,
+            RemoteStorageKind::Object,
+            &descriptors,
+            &blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        if result.is_err() {
+            eprintln!(
+                "OBJ object storage test skipped - backend may not be available or S3 not configured: {:?}",
+                result
+            );
+            return;
+        }
+        assert!(result.is_ok(), "OBJ Offload failed: {:?}", result);
+
+        // Drop offload blocks to ensure we're not reusing cached memory
+        drop(blocks);
+
+        // Create fresh blocks for onboarding (different memory)
+        let mut onboard_layout = create_test_layout(2);
+        onboard_layout
+            .nixl_register(TEST_AGENT.as_ref().as_ref().unwrap(), None)
+            .unwrap();
+        let onboard_layout = Arc::new(onboard_layout);
+
+        let onboard_blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = (0..2)
+            .map(|i| {
+                let data = BlockData::new(onboard_layout.clone(), i, 0, 0);
+                Block::new(data, BasicMetadata::default()).unwrap()
+            })
+            .collect();
+
+        // Verify onboard blocks start zeroed (not containing our pattern)
+        for block in onboard_blocks.iter() {
+            let view = block.block_data().block_view().unwrap();
+            let slice = unsafe { std::slice::from_raw_parts(view.as_ptr(), view.size()) };
+            assert!(
+                slice.iter().all(|&b| b == 0),
+                "Onboard blocks should start zeroed"
+            );
+        }
+
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Onboard,
+            RemoteStorageKind::Object,
+            &descriptors,
+            &onboard_blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        assert!(result.is_ok(), "OBJ Onboard failed: {:?}", result);
+
+        // Verify data was restored to the new blocks
+        for (i, block) in onboard_blocks.iter().enumerate() {
+            let view = block.block_data().block_view().unwrap();
+            let slice = unsafe { std::slice::from_raw_parts(view.as_ptr(), view.size()) };
+            for (j, &byte) in slice.iter().enumerate() {
+                let expected = ((i * 200 + j) % 256) as u8;
+                assert_eq!(
+                    byte, expected,
+                    "OBJ: Data mismatch at block {} byte {}",
+                    i, j
+                );
+            }
+        }
+        eprintln!("OBJ object storage roundtrip transfer successful");
+    }
+}
+

--- a/lib/llm/src/block_manager/block/transfer/object_transfer.rs
+++ b/lib/llm/src/block_manager/block/transfer/object_transfer.rs
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! NIXL OBJ-backend transfer implementation (object / S3 storage).
+
+use super::*;
+use super::remote::{RemoteBlockDescriptor, RemoteKey, RemoteTransferDirection};
+use crate::block_manager::config::RemoteTransferContext;
+use crate::block_manager::storage::ObjectStorage;
+use nixl_sys::{MemType, NixlDescriptor, XferDescList, XferOp};
+use tokio_util::sync::CancellationToken;
+
+/// Execute an object-storage (S3 / NIXL OBJ) transfer.
+///
+/// `pub(crate)` — called exclusively from [`super::nixl::execute_remote_transfer`].
+pub(crate) async fn execute_object_transfer<LB>(
+    direction: RemoteTransferDirection,
+    descriptors: &[RemoteBlockDescriptor],
+    local_blocks: &[LB],
+    block_size: usize,
+    ctx: &RemoteTransferContext,
+    cancel_token: &CancellationToken,
+) -> Result<(), TransferError>
+where
+    LB: ReadableBlock + WritableBlock + Local,
+    <LB as StorageTypeProvider>::StorageType: NixlDescriptor,
+{
+    let nixl_agent_arc = ctx.nixl_agent();
+    let agent = nixl_agent_arc
+        .as_ref()
+        .as_ref()
+        .ok_or_else(|| TransferError::ExecutionError("NIXL agent not available".to_string()))?;
+
+    let num_blocks = descriptors.len();
+    let worker_id = ctx.worker_id() as usize;
+
+    // Resolve bucket template once — `{worker_id}` is substituted if present.
+    // Falls back to the per-descriptor bucket when no template is configured.
+    let resolved_bucket_from_ctx = ctx.config().resolve_bucket(worker_id);
+
+    // Use a scope block to ensure all non-Send types are dropped before await
+    let (xfer_req, still_pending) = {
+        // Register ALL object storage regions with NIXL, collecting hashes for reuse below.
+        let mut obj_storages = Vec::with_capacity(num_blocks);
+        let mut _registration_handles = Vec::with_capacity(num_blocks);
+        let mut sequence_hashes = Vec::with_capacity(num_blocks);
+
+        for desc in descriptors.iter() {
+            // Prefer the ctx-level resolved bucket (supports {worker_id} templates);
+            // fall back to the per-descriptor bucket for backwards compatibility.
+            let desc_bucket = match desc.key() {
+                RemoteKey::Object(obj_key) => obj_key.bucket.as_str(),
+                _ => {
+                    return Err(TransferError::IncompatibleTypes(
+                        "Expected Object key for object storage transfer".to_string(),
+                    ));
+                }
+            };
+            let bucket = resolved_bucket_from_ctx.as_deref().unwrap_or(desc_bucket);
+
+            let sequence_hash = desc.sequence_hash().ok_or_else(|| {
+                TransferError::ExecutionError(format!(
+                    "Descriptor missing sequence_hash: {:?}",
+                    desc.key()
+                ))
+            })?;
+            sequence_hashes.push(sequence_hash);
+
+            let obj_storage = ObjectStorage::new(bucket, sequence_hash, block_size).map_err(|e| {
+                TransferError::ExecutionError(format!("Failed to create ObjectStorage: {:?}", e))
+            })?;
+
+            let handle = agent.register_memory(&obj_storage, None).map_err(|e| {
+                TransferError::ExecutionError(format!("Failed to register object storage: {:?}", e))
+            })?;
+
+            obj_storages.push(obj_storage);
+            _registration_handles.push(handle);
+        }
+
+        // Build transfer descriptor lists
+        let mut src_dl = XferDescList::new(MemType::Dram).map_err(|e| {
+            TransferError::ExecutionError(format!("Failed to create src_dl: {:?}", e))
+        })?;
+        let mut dst_dl = XferDescList::new(MemType::Object).map_err(|e| {
+            TransferError::ExecutionError(format!("Failed to create dst_dl: {:?}", e))
+        })?;
+
+        for (block, &seq_hash) in local_blocks.iter().zip(sequence_hashes.iter()) {
+            let block_view = block.block_data().block_view()?;
+            let addr = unsafe { block_view.as_ptr() as usize };
+
+            src_dl.add_desc(addr, block_size, 0);
+            dst_dl.add_desc(0, block_size, seq_hash);
+        }
+
+        let xfer_op = match direction {
+            RemoteTransferDirection::Offload => XferOp::Write,
+            RemoteTransferDirection::Onboard => XferOp::Read,
+        };
+
+        let agent_name = agent.name();
+        let xfer_req = agent
+            .create_xfer_req(xfer_op, &src_dl, &dst_dl, &agent_name, None)
+            .map_err(|e| {
+                TransferError::ExecutionError(format!("Failed to create xfer_req: {:?}", e))
+            })?;
+
+        let still_pending = agent.post_xfer_req(&xfer_req, None).map_err(|e| {
+            TransferError::ExecutionError(format!("Failed to post xfer_req: {:?}", e))
+        })?;
+
+        (xfer_req, still_pending)
+    };
+
+    if still_pending {
+        use tracing::Instrument;
+        let nixl_span = tracing::info_span!(
+            "nixl_io",
+            otel.name = match direction {
+                RemoteTransferDirection::Onboard => "kvbm.nixl_read",
+                RemoteTransferDirection::Offload => "kvbm.nixl_write",
+            },
+            description = "NIXL object store I/O (post + completion wait)",
+            num_blocks,
+            direction = ?direction,
+        );
+        super::nixl::poll_transfer_completion(agent, &xfer_req, cancel_token)
+            .instrument(nixl_span)
+            .await?;
+    }
+
+    tracing::debug!(
+        "Object transfer complete: {} blocks, direction={:?}, worker={}",
+        num_blocks,
+        direction,
+        worker_id,
+    );
+
+    Ok(())
+}

--- a/lib/llm/src/block_manager/block/transfer/remote.rs
+++ b/lib/llm/src/block_manager/block/transfer/remote.rs
@@ -1,0 +1,615 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Remote storage transfer abstractions for remote transfers.
+//!
+//! This module provides the core types for remote storage transfers:
+//! - [`RemoteKey`] - Abstract key for remote storage (object or disk)
+//! - [`RemoteBlockDescriptor`] - Descriptor for a block in remote storage
+//! - [`RemoteTransferPipeline`] - Transfer pipeline configuration
+//! - [`RemoteTransferHandle`] - Handle for async transfer operations
+//!
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use super::TransferError;
+
+/// Kind of remote storage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RemoteStorageKind {
+    Object,
+    Disk,
+}
+
+/// A key that identifies a block in remote storage.
+///
+/// This is an abstract type that can represent different addressing schemes:
+/// - Object storage: bucket + object key
+/// - Remote disk: path + offset/key
+///
+/// The key must be serializable for registry storage and network transmission.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RemoteKey {
+    /// Object storage
+    Object(ObjectKey),
+    /// Remote disk
+    Disk(DiskKey),
+}
+
+/// Key for object storage - bucket + object identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ObjectKey {
+    /// Bucket/container name
+    pub bucket: String,
+    /// Object key/path within bucket
+    pub key: String,
+}
+
+impl ObjectKey {
+    /// Create a new object key.
+    pub fn new(bucket: impl Into<String>, key: impl Into<String>) -> Self {
+        Self {
+            bucket: bucket.into(),
+            key: key.into(),
+        }
+    }
+
+    /// Create from sequence hash (common pattern: hash as hex string).
+    pub fn from_hash(bucket: impl Into<String>, hash: u64) -> Self {
+        Self {
+            bucket: bucket.into(),
+            key: format!("{:016x}", hash),
+        }
+    }
+
+    /// Parse the hex key back to a `u64` hash.
+    ///
+    /// Returns `None` if the key was not created via [`from_hash`] and cannot
+    /// be parsed as a 64-bit hex integer.
+    pub fn parse_hash(&self) -> Option<u64> {
+        u64::from_str_radix(&self.key, 16).ok()
+    }
+}
+
+/// Key for remote disk storage - path + identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DiskKey {
+    /// Base path (mount point, share path, etc.)
+    pub path: String,
+    /// Block identifier within the path (could be filename, offset, etc.)
+    pub key: String,
+}
+
+impl DiskKey {
+    /// Create a new disk key.
+    pub fn new(path: impl Into<String>, key: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            key: key.into(),
+        }
+    }
+
+    /// Create from sequence hash with topology suffix for uniqueness.
+    ///
+    /// Format: `<sequence_hash_hex>_<worker_id>_<world_size>`.
+    pub fn from_hash(
+        path: impl Into<String>,
+        hash: u64,
+        worker_id: usize,
+        world_size: usize,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            key: format!("{:016x}_{}_{}", hash, worker_id, world_size),
+        }
+    }
+
+    /// Get full path (path + key).
+    pub fn full_path(&self) -> String {
+        format!("{}/{}", self.path, self.key)
+    }
+}
+
+impl RemoteKey {
+    /// Get the storage kind.
+    pub fn kind(&self) -> RemoteStorageKind {
+        match self {
+            RemoteKey::Object(_) => RemoteStorageKind::Object,
+            RemoteKey::Disk(_) => RemoteStorageKind::Disk,
+        }
+    }
+
+    /// Get the "raw" key portion (for NIXL device_id).
+    /// Returns hash of the key for use in NIXL descriptors.
+    pub fn nixl_device_id(&self) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Create object key.
+    pub fn object(bucket: impl Into<String>, key: impl Into<String>) -> Self {
+        RemoteKey::Object(ObjectKey::new(bucket, key))
+    }
+
+    /// Create disk key.
+    pub fn disk(path: impl Into<String>, key: impl Into<String>) -> Self {
+        RemoteKey::Disk(DiskKey::new(path, key))
+    }
+
+    /// Get the sequence hash if this is an object key created from a hash.
+    pub fn sequence_hash(&self) -> Option<u64> {
+        match self {
+            RemoteKey::Object(obj) => obj.parse_hash(),
+            RemoteKey::Disk(disk) => {
+                // Backward compatible: supports both "<hash>" and "<hash>_<rank>_<world_size>".
+                let hash_prefix = disk.key.split('_').next().unwrap_or(&disk.key);
+                u64::from_str_radix(hash_prefix, 16).ok()
+            }
+        }
+    }
+
+    /// Get the location (bucket for Object, path for Disk).
+    pub fn location(&self) -> &str {
+        match self {
+            RemoteKey::Object(obj) => &obj.bucket,
+            RemoteKey::Disk(disk) => &disk.path,
+        }
+    }
+
+    /// Get the identifier portion (object key or disk filename).
+    pub fn identifier(&self) -> &str {
+        match self {
+            RemoteKey::Object(obj) => &obj.key,
+            RemoteKey::Disk(disk) => &disk.key,
+        }
+    }
+
+    /// Create object key from sequence hash (common pattern).
+    pub fn object_from_hash(bucket: impl Into<String>, hash: u64) -> Self {
+        RemoteKey::Object(ObjectKey::from_hash(bucket, hash))
+    }
+
+    /// Create disk key from sequence hash with topology suffix.
+    pub fn disk_from_hash(
+        path: impl Into<String>,
+        hash: u64,
+        worker_id: usize,
+        world_size: usize,
+    ) -> Self {
+        RemoteKey::Disk(DiskKey::from_hash(path, hash, worker_id, world_size))
+    }
+}
+
+/// Core metadata associated with a remote block.
+#[derive(Debug, Clone, Copy)]
+pub struct RemoteBlockMetadata {
+    pub sequence_hash: u64,
+}
+
+impl RemoteBlockMetadata {
+    pub fn new(sequence_hash: u64) -> Self {
+        Self { sequence_hash }
+    }
+}
+
+/// Descriptor for a block in remote storage.
+///
+/// Unlike local blocks which have memory addresses, remote blocks
+/// are identified by keys. The descriptor includes both the key
+/// and size information needed for transfers.
+#[derive(Debug, Clone)]
+pub struct RemoteBlockDescriptor {
+    /// Key identifying the block in remote storage
+    key: RemoteKey,
+    /// Size of the block in bytes
+    size: usize,
+    /// Optional metadata
+    metadata: Option<RemoteBlockMetadata>,
+}
+
+impl RemoteBlockDescriptor {
+    /// Create a new descriptor with just key and size.
+    pub fn new(key: RemoteKey, size: usize) -> Self {
+        Self {
+            key,
+            size,
+            metadata: None,
+        }
+    }
+
+    /// Create with metadata.
+    pub fn with_metadata(key: RemoteKey, size: usize, metadata: RemoteBlockMetadata) -> Self {
+        Self {
+            key,
+            size,
+            metadata: Some(metadata),
+        }
+    }
+
+    pub fn object(bucket: impl Into<String>, key: impl Into<String>, size: usize) -> Self {
+        Self::new(RemoteKey::object(bucket, key), size)
+    }
+
+    pub fn object_from_hash(bucket: impl Into<String>, hash: u64, size: usize) -> Self {
+        let bucket = bucket.into();
+        let mut desc = Self::new(RemoteKey::Object(ObjectKey::from_hash(&bucket, hash)), size);
+        desc.metadata = Some(RemoteBlockMetadata::new(hash));
+        desc
+    }
+
+    pub fn disk(path: impl Into<String>, key: impl Into<String>, size: usize) -> Self {
+        Self::new(RemoteKey::disk(path, key), size)
+    }
+
+    pub fn disk_from_hash(
+        path: impl Into<String>,
+        hash: u64,
+        size: usize,
+        worker_id: usize,
+        world_size: usize,
+    ) -> Self {
+        let path = path.into();
+        let mut desc = Self::new(
+            RemoteKey::Disk(DiskKey::from_hash(&path, hash, worker_id, world_size)),
+            size,
+        );
+        desc.metadata = Some(RemoteBlockMetadata::new(hash));
+        desc
+    }
+
+    pub fn key(&self) -> &RemoteKey {
+        &self.key
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    pub fn kind(&self) -> RemoteStorageKind {
+        self.key.kind()
+    }
+
+    pub fn metadata(&self) -> Option<&RemoteBlockMetadata> {
+        self.metadata.as_ref()
+    }
+
+    pub fn set_metadata(&mut self, metadata: RemoteBlockMetadata) {
+        self.metadata = Some(metadata);
+    }
+
+    pub fn sequence_hash(&self) -> Option<u64> {
+        self.metadata.as_ref().map(|m| m.sequence_hash)
+    }
+}
+
+/// Direction of remote transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteTransferDirection {
+    Onboard,
+    Offload,
+}
+
+impl RemoteTransferDirection {
+    pub fn is_onboard(&self) -> bool {
+        matches!(self, Self::Onboard)
+    }
+    pub fn is_offload(&self) -> bool {
+        matches!(self, Self::Offload)
+    }
+}
+
+/// Defines a complete transfer pipeline for remote storage.
+///
+/// Supports:
+/// - Remote -> Local (onboard to host)
+/// - Local -> Remote (offload from host)
+/// - Remote -> Bounce -> Device (full onboard pipeline)
+/// - Device -> Bounce -> Remote (full offload pipeline)
+#[derive(Debug, Clone)]
+pub enum RemoteTransferPipeline {
+    Direct {
+        direction: RemoteTransferDirection,
+        remote_descriptors: Vec<RemoteBlockDescriptor>,
+    },
+
+    WithBounce {
+        direction: RemoteTransferDirection,
+        remote_descriptors: Vec<RemoteBlockDescriptor>,
+        bounce_block_ids: Vec<usize>,
+        device_block_ids: Vec<usize>,
+    },
+}
+
+impl RemoteTransferPipeline {
+    pub fn offload_direct(descriptors: Vec<RemoteBlockDescriptor>) -> Self {
+        Self::Direct {
+            direction: RemoteTransferDirection::Offload,
+            remote_descriptors: descriptors,
+        }
+    }
+
+    pub fn onboard_direct(descriptors: Vec<RemoteBlockDescriptor>) -> Self {
+        Self::Direct {
+            direction: RemoteTransferDirection::Onboard,
+            remote_descriptors: descriptors,
+        }
+    }
+
+    pub fn offload_with_bounce(
+        descriptors: Vec<RemoteBlockDescriptor>,
+        bounce_ids: Vec<usize>,
+        device_ids: Vec<usize>,
+    ) -> Self {
+        Self::WithBounce {
+            direction: RemoteTransferDirection::Offload,
+            remote_descriptors: descriptors,
+            bounce_block_ids: bounce_ids,
+            device_block_ids: device_ids,
+        }
+    }
+
+    pub fn onboard_with_bounce(
+        descriptors: Vec<RemoteBlockDescriptor>,
+        bounce_ids: Vec<usize>,
+        device_ids: Vec<usize>,
+    ) -> Self {
+        Self::WithBounce {
+            direction: RemoteTransferDirection::Onboard,
+            remote_descriptors: descriptors,
+            bounce_block_ids: bounce_ids,
+            device_block_ids: device_ids,
+        }
+    }
+
+    pub fn direction(&self) -> RemoteTransferDirection {
+        match self {
+            Self::Direct { direction, .. } => *direction,
+            Self::WithBounce { direction, .. } => *direction,
+        }
+    }
+
+    pub fn descriptors(&self) -> &[RemoteBlockDescriptor] {
+        match self {
+            Self::Direct {
+                remote_descriptors, ..
+            } => remote_descriptors,
+            Self::WithBounce {
+                remote_descriptors, ..
+            } => remote_descriptors,
+        }
+    }
+
+    pub fn has_bounce(&self) -> bool {
+        matches!(self, Self::WithBounce { .. })
+    }
+
+    pub fn num_blocks(&self) -> usize {
+        self.descriptors().len()
+    }
+
+    pub fn bounce_block_ids(&self) -> Option<&[usize]> {
+        match self {
+            Self::Direct { .. } => None,
+            Self::WithBounce {
+                bounce_block_ids, ..
+            } => Some(bounce_block_ids),
+        }
+    }
+
+    pub fn device_block_ids(&self) -> Option<&[usize]> {
+        match self {
+            Self::Direct { .. } => None,
+            Self::WithBounce {
+                device_block_ids, ..
+            } => Some(device_block_ids),
+        }
+    }
+
+    /// Execute the remote transfer using the provided context and local blocks.
+    ///
+    /// For transfers with bounce buffers, this executes the remote<->bounce transfer.
+    /// The bounce<->device transfer should be handled separately via the local transfer system.
+    pub async fn execute<LB>(
+        &self,
+        local_blocks: &[LB],
+        ctx: &crate::block_manager::config::RemoteTransferContext,
+        cancel_token: &CancellationToken,
+    ) -> Result<(), TransferError>
+    where
+        LB: crate::block_manager::block::ReadableBlock
+            + crate::block_manager::block::WritableBlock
+            + crate::block_manager::storage::Local,
+        <LB as crate::block_manager::block::StorageTypeProvider>::StorageType:
+            nixl_sys::NixlDescriptor,
+    {
+        let descriptors = self.descriptors();
+        if descriptors.is_empty() {
+            return Ok(());
+        }
+
+        let direction = self.direction();
+        let kind = descriptors[0].kind();
+
+        super::nixl::execute_remote_transfer(
+            direction,
+            kind,
+            descriptors,
+            local_blocks,
+            ctx,
+            cancel_token,
+        )
+        .await
+    }
+}
+
+/// Strategy for remote transfers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteTransferStrategy {
+    ObjectRead,
+    ObjectWrite,
+    DiskRead,
+    DiskWrite,
+}
+
+impl RemoteTransferStrategy {
+    pub fn is_read(&self) -> bool {
+        matches!(self, Self::ObjectRead | Self::DiskRead)
+    }
+    pub fn is_write(&self) -> bool {
+        matches!(self, Self::ObjectWrite | Self::DiskWrite)
+    }
+    pub fn is_object(&self) -> bool {
+        matches!(self, Self::ObjectRead | Self::ObjectWrite)
+    }
+    pub fn is_disk(&self) -> bool {
+        matches!(self, Self::DiskRead | Self::DiskWrite)
+    }
+
+    pub fn from_direction_and_kind(
+        direction: RemoteTransferDirection,
+        kind: RemoteStorageKind,
+    ) -> Self {
+        match (direction, kind) {
+            (RemoteTransferDirection::Onboard, RemoteStorageKind::Object) => Self::ObjectRead,
+            (RemoteTransferDirection::Offload, RemoteStorageKind::Object) => Self::ObjectWrite,
+            (RemoteTransferDirection::Onboard, RemoteStorageKind::Disk) => Self::DiskRead,
+            (RemoteTransferDirection::Offload, RemoteStorageKind::Disk) => Self::DiskWrite,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RemoteTransferHandle {
+    completion: oneshot::Receiver<Result<(), TransferError>>,
+    cancel_token: CancellationToken,
+}
+
+impl RemoteTransferHandle {
+    #[allow(dead_code)]
+    pub(crate) fn new(
+        completion: oneshot::Receiver<Result<(), TransferError>>,
+        cancel_token: CancellationToken,
+    ) -> Self {
+        Self {
+            completion,
+            cancel_token,
+        }
+    }
+
+    pub fn cancel(&self) {
+        self.cancel_token.cancel();
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel_token.is_cancelled()
+    }
+
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    pub async fn wait(self) -> Result<(), TransferError> {
+        self.completion
+            .await
+            .map_err(|_| TransferError::ExecutionError("Transfer task dropped".to_string()))?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_object_key_from_hash() {
+        let key = ObjectKey::from_hash("my-bucket", 0x1234567890abcdef);
+        assert_eq!(key.bucket, "my-bucket");
+        assert_eq!(key.key, "1234567890abcdef");
+        assert_eq!(key.parse_hash(), Some(0x1234567890abcdef));
+    }
+
+    #[test]
+    fn test_disk_key_full_path() {
+        let key = DiskKey::new("/mnt/nfs", "block_001");
+        assert_eq!(key.full_path(), "/mnt/nfs/block_001");
+    }
+
+    #[test]
+    fn test_remote_key_kind() {
+        let obj_key = RemoteKey::object("bucket", "key");
+        assert_eq!(obj_key.kind(), RemoteStorageKind::Object);
+
+        let disk_key = RemoteKey::disk("/path", "key");
+        assert_eq!(disk_key.kind(), RemoteStorageKind::Disk);
+    }
+
+    #[test]
+    fn test_remote_block_descriptor() {
+        let desc = RemoteBlockDescriptor::object_from_hash("bucket", 0x1234, 4096);
+        assert_eq!(desc.size(), 4096);
+        assert_eq!(desc.kind(), RemoteStorageKind::Object);
+        assert_eq!(desc.sequence_hash(), Some(0x1234));
+    }
+
+    #[test]
+    fn test_remote_transfer_pipeline() {
+        let descs = vec![
+            RemoteBlockDescriptor::object_from_hash("bucket", 0x1234, 4096),
+            RemoteBlockDescriptor::object_from_hash("bucket", 0x5678, 4096),
+        ];
+
+        // Direct offload
+        let pipeline = RemoteTransferPipeline::offload_direct(descs.clone());
+        assert_eq!(pipeline.direction(), RemoteTransferDirection::Offload);
+        assert!(!pipeline.has_bounce());
+        assert_eq!(pipeline.num_blocks(), 2);
+
+        // With bounce
+        let pipeline = RemoteTransferPipeline::onboard_with_bounce(descs, vec![0, 1], vec![10, 11]);
+        assert_eq!(pipeline.direction(), RemoteTransferDirection::Onboard);
+        assert!(pipeline.has_bounce());
+    }
+
+    #[test]
+    fn test_remote_transfer_strategy() {
+        assert!(RemoteTransferStrategy::ObjectRead.is_read());
+        assert!(RemoteTransferStrategy::ObjectRead.is_object());
+        assert!(!RemoteTransferStrategy::ObjectRead.is_write());
+        assert!(!RemoteTransferStrategy::ObjectRead.is_disk());
+
+        assert!(RemoteTransferStrategy::DiskWrite.is_write());
+        assert!(RemoteTransferStrategy::DiskWrite.is_disk());
+        assert_eq!(
+            RemoteTransferStrategy::from_direction_and_kind(
+                RemoteTransferDirection::Onboard,
+                RemoteStorageKind::Object,
+            ),
+            RemoteTransferStrategy::ObjectRead
+        );
+        assert_eq!(
+            RemoteTransferStrategy::from_direction_and_kind(
+                RemoteTransferDirection::Offload,
+                RemoteStorageKind::Disk,
+            ),
+            RemoteTransferStrategy::DiskWrite
+        );
+    }
+
+    #[test]
+    fn test_remote_block_metadata() {
+        let meta = RemoteBlockMetadata::new(0x1234);
+        assert_eq!(meta.sequence_hash, 0x1234);
+    }
+
+    #[test]
+    fn test_remote_transfer_direction() {
+        assert!(RemoteTransferDirection::Onboard.is_onboard());
+        assert!(!RemoteTransferDirection::Onboard.is_offload());
+        assert!(RemoteTransferDirection::Offload.is_offload());
+        assert!(!RemoteTransferDirection::Offload.is_onboard());
+    }
+}

--- a/lib/llm/src/block_manager/block/transfer/remote_tests.rs
+++ b/lib/llm/src/block_manager/block/transfer/remote_tests.rs
@@ -1,0 +1,645 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! No-CUDA integration tests for remote (S3 / disk) block transfers.
+//!
+//! Gated on `testing-nixl` + `testing-remote-storage` features so they only
+//! run in environments where NIXL and an S3/disk backend are available.
+//!
+//! Run disk tests:  `cargo test ... remote_tests::disk`
+//! Run S3 tests:    `cargo test ... remote_tests::s3`
+
+use std::sync::Arc;
+
+use nixl_sys::Agent as NixlAgent;
+use tokio_util::sync::CancellationToken;
+
+use crate::block_manager::{
+    LayoutConfig,
+    block::{BasicMetadata, Block, BlockData, locality},
+    block::data::{BlockDataExt, BlockDataProvider, BlockDataProviderMut},
+    config::{RemoteStorageConfig, RemoteTransferContext, DISK_FLAGS_POSIX_BOTH},
+    layout::{FullyContiguous, nixl::NixlLayout},
+    storage::SystemAllocator,
+};
+use crate::block_manager::block::transfer::context::TransferContext;
+use crate::block_manager::block::transfer::TransferError;
+
+use super::nixl::execute_remote_transfer;
+use super::remote::{RemoteBlockDescriptor, RemoteStorageKind, RemoteTransferDirection};
+
+// ── Shared NIXL agents (POSIX + OBJ, no CUDA) ────────────────────────────────
+//
+// All agents are static lazy-initialized so that OBJ backend creation —
+// which touches the global AWS SDK client — happens exactly once per agent
+// and never concurrently with another agent's initialization. Concurrent
+// `create_backend("OBJ", …)` calls in the same process would corrupt the
+// shared S3-client state and cause NIXL_ERR_BACKEND on transfers.
+
+/// Register an OBJ backend on an existing NixlAgent, pointing at `bucket`.
+///
+/// Reads `KVBM_TEST_S3_ENDPOINT`, `AWS_ACCESS_KEY_ID`, and
+/// `AWS_SECRET_ACCESS_KEY` from the environment when present.
+fn register_obj_backend(agent: &NixlAgent, agent_name: &str, bucket: &str) {
+    if let Ok((_, params)) = agent.get_plugin_params("OBJ") {
+        let result = params.clone().and_then(|mut p| {
+            p.set("bucket", bucket)?;
+            if let Ok(endpoint) = std::env::var(dynamo_runtime::config::environment_names::kvbm::testing::KVBM_TEST_S3_ENDPOINT) {
+                // endpoint_override expects host:port only; scheme is a separate param.
+                let (scheme, host_port) = if let Some(h) = endpoint.strip_prefix("http://") {
+                    ("http", h)
+                } else if let Some(h) = endpoint.strip_prefix("https://") {
+                    ("https", h)
+                } else {
+                    ("https", endpoint.as_str())
+                };
+                p.set("endpoint_override", host_port)?;
+                p.set("scheme", scheme)?;
+            }
+            // Pass credentials explicitly so the AWS SDK does not fall back to
+            // the EC2 instance-metadata service (which would time out).
+            if let Ok(key) = std::env::var("AWS_ACCESS_KEY_ID") {
+                p.set("access_key", &key)?;
+            }
+            if let Ok(secret) = std::env::var("AWS_SECRET_ACCESS_KEY") {
+                p.set("secret_key", &secret)?;
+            }
+            agent.create_backend("OBJ", &p)
+        });
+        match result {
+            Ok(_) => eprintln!("[nocuda] OBJ backend ready ({agent_name} → {bucket})"),
+            Err(e) => eprintln!("[nocuda] OBJ backend failed ({agent_name} → {bucket}): {e}"),
+        }
+    }
+}
+
+/// Create a NixlAgent with an OBJ backend pointed at `bucket`.
+///
+/// Used by TP-isolation tests that need a per-worker agent; each call
+/// produces a fresh agent independent of the shared `TEST_AGENT`.
+fn create_obj_agent(agent_name: &str, bucket: &str) -> Arc<Option<NixlAgent>> {
+    let agent = NixlAgent::new(agent_name).expect("NixlAgent::new failed");
+    register_obj_backend(&agent, agent_name, bucket);
+    Arc::new(Some(agent))
+}
+
+lazy_static::lazy_static! {
+    /// Shared agent with both POSIX and OBJ backends for the single-worker tests.
+    static ref TEST_AGENT: Arc<Option<NixlAgent>> = {
+        let agent = NixlAgent::new("kvbm-nocuda-test").expect("NixlAgent::new failed");
+
+        if let Ok((_, params)) = agent.get_plugin_params("POSIX") {
+            match agent.create_backend("POSIX", &params) {
+                Ok(_)  => eprintln!("[nocuda] POSIX backend ready"),
+                Err(e) => eprintln!("[nocuda] POSIX backend failed: {e}"),
+            }
+        }
+
+        let bucket = std::env::var(dynamo_runtime::config::environment_names::kvbm::testing::KVBM_TEST_S3_BUCKET)
+            .unwrap_or_else(|_| "kvbm-test-bucket".into());
+        register_obj_backend(&agent, "kvbm-nocuda-test", &bucket);
+
+        Arc::new(Some(agent))
+    };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Build a `TransferContext` using the given agent (no CUDA).
+fn make_transfer_ctx_for(agent: Arc<Option<NixlAgent>>) -> Arc<TransferContext> {
+    let handle = tokio::runtime::Handle::current();
+    Arc::new(TransferContext::without_cuda(agent, handle))
+}
+
+/// Build a `TransferContext` backed by the shared `TEST_AGENT`.
+fn make_transfer_ctx() -> Arc<TransferContext> {
+    make_transfer_ctx_for(TEST_AGENT.clone())
+}
+
+/// Allocate a `FullyContiguous<SystemStorage>` layout, register it with the
+/// shared NIXL agent, and return `Block<SystemStorage>` instances for each slot.
+fn alloc_system_blocks(
+    num_blocks: usize,
+    block_size: usize,
+) -> (
+    Arc<FullyContiguous<crate::block_manager::storage::SystemStorage>>,
+    Vec<Block<crate::block_manager::storage::SystemStorage, locality::Local, BasicMetadata>>,
+) {
+    alloc_system_blocks_with_agent(
+        num_blocks,
+        block_size,
+        TEST_AGENT.as_ref().as_ref().unwrap(),
+    )
+}
+
+/// Same as `alloc_system_blocks` but registers with a caller-supplied agent.
+///
+/// Used by tests that create per-worker agents (e.g. TP isolation tests).
+fn alloc_system_blocks_with_agent(
+    num_blocks: usize,
+    block_size: usize,
+    agent: &NixlAgent,
+) -> (
+    Arc<FullyContiguous<crate::block_manager::storage::SystemStorage>>,
+    Vec<Block<crate::block_manager::storage::SystemStorage, locality::Local, BasicMetadata>>,
+) {
+    // One-layer, one-page layout so block_size == inner_dim (bytes = inner_dim * dtype_width).
+    // We use dtype_width=1 so inner_dim directly controls bytes per block.
+    let config = LayoutConfig::builder()
+        .num_blocks(num_blocks)
+        .num_layers(1)
+        .outer_dim(1)
+        .page_size(1)
+        .inner_dim(block_size)
+        .dtype_width_bytes(1)
+        .build()
+        .unwrap();
+
+    let mut layout = FullyContiguous::allocate(config, &SystemAllocator).unwrap();
+    layout
+        .nixl_register(agent, None)
+        .expect("NIXL registration failed for SystemStorage");
+    let layout = Arc::new(layout);
+
+    let blocks: Vec<_> = (0..num_blocks)
+        .map(|i| {
+            let data = BlockData::new(layout.clone(), i, 0, 0);
+            Block::new(data, BasicMetadata::default()).unwrap()
+        })
+        .collect();
+
+    (layout, blocks)
+}
+
+fn disk_test_path() -> String {
+    std::env::var(dynamo_runtime::config::environment_names::kvbm::testing::KVBM_TEST_DISK_PATH)
+        .unwrap_or_else(|_| "/tmp/kvbm-nocuda-tests".into())
+}
+
+fn s3_bucket() -> String {
+    std::env::var(dynamo_runtime::config::environment_names::kvbm::testing::KVBM_TEST_S3_BUCKET)
+        .unwrap_or_else(|_| "kvbm-test-bucket".into())
+}
+
+fn s3_endpoint() -> Option<String> {
+    std::env::var(dynamo_runtime::config::environment_names::kvbm::testing::KVBM_TEST_S3_ENDPOINT)
+        .ok()
+}
+
+// ── POSIX disk tests ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn disk_offload_onboard_roundtrip() {
+    let base_path = disk_test_path();
+    std::fs::create_dir_all(&base_path).unwrap();
+
+    let num_blocks = 4;
+    let block_size = 4096;
+    let (_layout, mut blocks) = alloc_system_blocks(num_blocks, block_size);
+
+    // Fill blocks with deterministic data.
+    for (i, block) in blocks.iter_mut().enumerate() {
+        let mut view = block.block_data_mut().block_view_mut().unwrap();
+        let slice =
+            unsafe { std::slice::from_raw_parts_mut(view.as_mut_ptr(), view.size()) };
+        for (j, byte) in slice.iter_mut().enumerate() {
+            *byte = ((i * 37 + j) % 256) as u8;
+        }
+    }
+
+    // Build descriptors — one file per block.
+    let descriptors: Vec<_> = (0..num_blocks)
+        .map(|i| RemoteBlockDescriptor::disk_from_hash(&base_path, i as u64, block_size, 0, 1))
+        .collect();
+
+    let base_ctx = make_transfer_ctx();
+    let remote_ctx = RemoteTransferContext::new(
+        base_ctx.clone(),
+        RemoteStorageConfig::disk(&base_path, DISK_FLAGS_POSIX_BOTH),
+    );
+    let cancel = CancellationToken::new();
+
+    // Offload.
+    execute_remote_transfer(
+        RemoteTransferDirection::Offload,
+        RemoteStorageKind::Disk,
+        &descriptors,
+        &blocks,
+        &remote_ctx,
+        &cancel,
+    )
+    .await
+    .expect("disk offload failed");
+
+    // Zero out local blocks.
+    for block in blocks.iter_mut() {
+        let mut view = block.block_data_mut().block_view_mut().unwrap();
+        let slice =
+            unsafe { std::slice::from_raw_parts_mut(view.as_mut_ptr(), view.size()) };
+        slice.fill(0);
+    }
+
+    // Onboard.
+    execute_remote_transfer(
+        RemoteTransferDirection::Onboard,
+        RemoteStorageKind::Disk,
+        &descriptors,
+        &blocks,
+        &remote_ctx,
+        &cancel,
+    )
+    .await
+    .expect("disk onboard failed");
+
+    // Verify data survived the round-trip.
+    for (i, block) in blocks.iter().enumerate() {
+        let view = block.block_data().block_view().unwrap();
+        let slice = unsafe { std::slice::from_raw_parts(view.as_ptr(), view.size()) };
+        for (j, &byte) in slice.iter().enumerate() {
+            let expected = ((i * 37 + j) % 256) as u8;
+            assert_eq!(byte, expected, "disk: mismatch at block {i} byte {j}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn disk_transfer_cancellation_before_start() {
+    let base_path = disk_test_path();
+    std::fs::create_dir_all(&base_path).unwrap();
+
+    let (_layout, blocks) = alloc_system_blocks(2, 4096);
+    let descriptors: Vec<_> = (0..2)
+        .map(|i| RemoteBlockDescriptor::disk_from_hash(&base_path, 0xCAFE + i as u64, 4096, 0, 1))
+        .collect();
+
+    let base_ctx = make_transfer_ctx();
+    let remote_ctx = RemoteTransferContext::new(
+        base_ctx,
+        RemoteStorageConfig::disk(&base_path, DISK_FLAGS_POSIX_BOTH),
+    );
+
+    let cancel = CancellationToken::new();
+    cancel.cancel(); // Cancel before the transfer starts.
+
+    let result = execute_remote_transfer(
+        RemoteTransferDirection::Offload,
+        RemoteStorageKind::Disk,
+        &descriptors,
+        &blocks,
+        &remote_ctx,
+        &cancel,
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(TransferError::Cancelled)),
+        "expected Cancelled, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn disk_offload_rejects_mismatched_block_count() {
+    let base_path = disk_test_path();
+    std::fs::create_dir_all(&base_path).unwrap();
+
+    let (_layout, blocks) = alloc_system_blocks(1, 4096);
+    // Two descriptors but only one block.
+    let descriptors = vec![
+        RemoteBlockDescriptor::disk_from_hash(&base_path, 0x1111, 4096, 0, 1),
+        RemoteBlockDescriptor::disk_from_hash(&base_path, 0x2222, 4096, 0, 1),
+    ];
+
+    let base_ctx = make_transfer_ctx();
+    let remote_ctx = RemoteTransferContext::new(
+        base_ctx,
+        RemoteStorageConfig::disk(&base_path, DISK_FLAGS_POSIX_BOTH),
+    );
+    let cancel = CancellationToken::new();
+
+    let result = execute_remote_transfer(
+        RemoteTransferDirection::Offload,
+        RemoteStorageKind::Disk,
+        &descriptors,
+        &blocks,
+        &remote_ctx,
+        &cancel,
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(TransferError::CountMismatch(2, 1))),
+        "expected CountMismatch(2,1), got {result:?}"
+    );
+}
+
+/// Simulate TP=2: two workers each offload then onboard the same sequence hash.
+/// Workers must read back their own data, not each other's, because the file
+/// name encodes `worker_id` and `world_size`.
+#[tokio::test]
+async fn disk_tp2_workers_are_isolated() {
+    let base_path = disk_test_path();
+    std::fs::create_dir_all(&base_path).unwrap();
+
+    let block_size = 4096;
+    let world_size = 2;
+    let hash = 0xABCD_1234_u64;
+
+    // Each worker writes a distinct pattern so we can detect cross-worker reads.
+    for worker_id in 0..world_size {
+        let (_layout, mut blocks) = alloc_system_blocks(1, block_size);
+        let fill_byte = (0xA0 + worker_id) as u8;
+        {
+            let mut view = blocks[0].block_data_mut().block_view_mut().unwrap();
+            let slice =
+                unsafe { std::slice::from_raw_parts_mut(view.as_mut_ptr(), view.size()) };
+            slice.fill(fill_byte);
+        }
+
+        let desc = vec![RemoteBlockDescriptor::disk_from_hash(
+            &base_path, hash, block_size, worker_id, world_size,
+        )];
+        let ctx = RemoteTransferContext::new(
+            make_transfer_ctx(),
+            RemoteStorageConfig::disk(&base_path, DISK_FLAGS_POSIX_BOTH),
+        )
+        .with_topology(worker_id as u64, world_size);
+        let cancel = CancellationToken::new();
+
+        execute_remote_transfer(
+            RemoteTransferDirection::Offload,
+            RemoteStorageKind::Disk,
+            &desc,
+            &blocks,
+            &ctx,
+            &cancel,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("worker {worker_id} offload failed: {e:?}"));
+    }
+
+    // Each worker onboards and verifies it gets its own data.
+    for worker_id in 0..world_size {
+        let (_layout, mut blocks) = alloc_system_blocks(1, block_size);
+        {
+            let mut view = blocks[0].block_data_mut().block_view_mut().unwrap();
+            let slice =
+                unsafe { std::slice::from_raw_parts_mut(view.as_mut_ptr(), view.size()) };
+            slice.fill(0);
+        }
+
+        let desc = vec![RemoteBlockDescriptor::disk_from_hash(
+            &base_path, hash, block_size, worker_id, world_size,
+        )];
+        let ctx = RemoteTransferContext::new(
+            make_transfer_ctx(),
+            RemoteStorageConfig::disk(&base_path, DISK_FLAGS_POSIX_BOTH),
+        )
+        .with_topology(worker_id as u64, world_size);
+        let cancel = CancellationToken::new();
+
+        execute_remote_transfer(
+            RemoteTransferDirection::Onboard,
+            RemoteStorageKind::Disk,
+            &desc,
+            &blocks,
+            &ctx,
+            &cancel,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("worker {worker_id} onboard failed: {e:?}"));
+
+        let expected_byte = (0xA0 + worker_id) as u8;
+        let view = blocks[0].block_data().block_view().unwrap();
+        let slice = unsafe { std::slice::from_raw_parts(view.as_ptr(), view.size()) };
+        assert!(
+            slice.iter().all(|&b| b == expected_byte),
+            "worker {worker_id}: expected all bytes to be 0x{expected_byte:02x}",
+        );
+    }
+}
+
+// ── S3 / OBJ tests ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn s3_offload_onboard_roundtrip() {
+    let bucket = s3_bucket();
+    let endpoint = s3_endpoint();
+
+    let num_blocks = 4;
+    let block_size = 4096;
+    let (_layout, mut blocks) = alloc_system_blocks(num_blocks, block_size);
+
+    // Fill blocks with deterministic data.
+    for (i, block) in blocks.iter_mut().enumerate() {
+        let mut view = block.block_data_mut().block_view_mut().unwrap();
+        let slice =
+            unsafe { std::slice::from_raw_parts_mut(view.as_mut_ptr(), view.size()) };
+        for (j, byte) in slice.iter_mut().enumerate() {
+            *byte = ((i * 53 + j) % 256) as u8;
+        }
+    }
+
+    let descriptors: Vec<_> = (0..num_blocks)
+        .map(|i| RemoteBlockDescriptor::object_from_hash(&bucket, 0xDEAD_0000 + i as u64, block_size))
+        .collect();
+
+    let base_ctx = make_transfer_ctx();
+    let remote_ctx = RemoteTransferContext::for_object_with_options(
+        base_ctx.clone(),
+        Some(bucket.clone()),
+        endpoint.clone(),
+        Some("us-east-1".into()),
+        0,
+    );
+    let cancel = CancellationToken::new();
+
+    // Offload to S3.
+    execute_remote_transfer(
+        RemoteTransferDirection::Offload,
+        RemoteStorageKind::Object,
+        &descriptors,
+        &blocks,
+        &remote_ctx,
+        &cancel,
+    )
+    .await
+    .expect("S3 offload failed");
+
+    // Zero out local blocks.
+    for block in blocks.iter_mut() {
+        let mut view = block.block_data_mut().block_view_mut().unwrap();
+        let slice =
+            unsafe { std::slice::from_raw_parts_mut(view.as_mut_ptr(), view.size()) };
+        slice.fill(0);
+    }
+
+    // Onboard from S3.
+    execute_remote_transfer(
+        RemoteTransferDirection::Onboard,
+        RemoteStorageKind::Object,
+        &descriptors,
+        &blocks,
+        &remote_ctx,
+        &cancel,
+    )
+    .await
+    .expect("S3 onboard failed");
+
+    // Verify.
+    for (i, block) in blocks.iter().enumerate() {
+        let view = block.block_data().block_view().unwrap();
+        let slice = unsafe { std::slice::from_raw_parts(view.as_ptr(), view.size()) };
+        for (j, &byte) in slice.iter().enumerate() {
+            let expected = ((i * 53 + j) % 256) as u8;
+            assert_eq!(byte, expected, "S3: mismatch at block {i} byte {j}");
+        }
+    }
+}
+
+/// Simulate TP=2 with S3: each worker uses a separate bucket so the same
+/// sequence hash maps to distinct S3 objects and TP ranks cannot cross-read.
+///
+/// Each worker has its own NixlAgent with an OBJ backend pointing at its
+/// own bucket (`<base>-0`, `<base>-1`).  NIXL allows multiple OBJ agents
+/// per process; in production each TP rank is a separate OS process anyway.
+#[tokio::test]
+async fn s3_tp2_workers_are_isolated() {
+    let base_bucket = s3_bucket();
+
+    let block_size = 4096;
+    let world_size = 2_usize;
+    let hash = 0xBEEF_5678_u64;
+
+    // Offload from each worker into its own bucket.
+    for worker_id in 0..world_size {
+        let worker_bucket = format!("{base_bucket}-{worker_id}");
+        let agent = create_obj_agent(
+            &format!("kvbm-test-w{worker_id}-write"),
+            &worker_bucket,
+        );
+        let agent_ref = agent.as_ref().as_ref().unwrap();
+        let (_layout, mut blocks) =
+            alloc_system_blocks_with_agent(1, block_size, agent_ref);
+        let fill_byte = (0xB0 + worker_id) as u8;
+        {
+            let mut view = blocks[0].block_data_mut().block_view_mut().unwrap();
+            let slice =
+                unsafe { std::slice::from_raw_parts_mut(view.as_mut_ptr(), view.size()) };
+            slice.fill(fill_byte);
+        }
+
+        let descs = vec![RemoteBlockDescriptor::object_from_hash(
+            &worker_bucket,
+            hash,
+            block_size,
+        )];
+        let ctx = RemoteTransferContext::for_object_with_options(
+            make_transfer_ctx_for(agent),
+            Some(worker_bucket.clone()),
+            s3_endpoint(),
+            Some("us-east-1".into()),
+            worker_id as u64,
+        );
+        let cancel = CancellationToken::new();
+
+        execute_remote_transfer(
+            RemoteTransferDirection::Offload,
+            RemoteStorageKind::Object,
+            &descs,
+            &blocks,
+            &ctx,
+            &cancel,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("worker {worker_id} S3 offload failed: {e:?}"));
+    }
+
+    // Onboard from each worker's bucket and verify data isolation.
+    for worker_id in 0..world_size {
+        let worker_bucket = format!("{base_bucket}-{worker_id}");
+        let agent = create_obj_agent(
+            &format!("kvbm-test-w{worker_id}-read"),
+            &worker_bucket,
+        );
+        let agent_ref = agent.as_ref().as_ref().unwrap();
+        let (_layout, mut blocks) =
+            alloc_system_blocks_with_agent(1, block_size, agent_ref);
+        {
+            let mut view = blocks[0].block_data_mut().block_view_mut().unwrap();
+            let slice =
+                unsafe { std::slice::from_raw_parts_mut(view.as_mut_ptr(), view.size()) };
+            slice.fill(0);
+        }
+
+        let descs = vec![RemoteBlockDescriptor::object_from_hash(
+            &worker_bucket,
+            hash,
+            block_size,
+        )];
+        let ctx = RemoteTransferContext::for_object_with_options(
+            make_transfer_ctx_for(agent),
+            Some(worker_bucket.clone()),
+            s3_endpoint(),
+            Some("us-east-1".into()),
+            worker_id as u64,
+        );
+        let cancel = CancellationToken::new();
+
+        execute_remote_transfer(
+            RemoteTransferDirection::Onboard,
+            RemoteStorageKind::Object,
+            &descs,
+            &blocks,
+            &ctx,
+            &cancel,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("worker {worker_id} S3 onboard failed: {e:?}"));
+
+        let expected_byte = (0xB0 + worker_id) as u8;
+        let view = blocks[0].block_data().block_view().unwrap();
+        let slice = unsafe { std::slice::from_raw_parts(view.as_ptr(), view.size()) };
+        assert!(
+            slice.iter().all(|&b| b == expected_byte),
+            "worker {worker_id}: expected all bytes 0x{expected_byte:02x}, isolation failed",
+        );
+    }
+}
+
+#[tokio::test]
+async fn s3_transfer_cancellation_before_start() {
+    let bucket = s3_bucket();
+    let endpoint = s3_endpoint();
+
+    let (_layout, blocks) = alloc_system_blocks(2, 4096);
+    let descriptors: Vec<_> = (0..2)
+        .map(|i| RemoteBlockDescriptor::object_from_hash(&bucket, 0xCAFE_0000 + i as u64, 4096))
+        .collect();
+
+    let base_ctx = make_transfer_ctx();
+    let remote_ctx = RemoteTransferContext::for_object_with_options(
+        base_ctx,
+        Some(bucket),
+        endpoint,
+        Some("us-east-1".into()),
+        0,
+    );
+
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+
+    let result = execute_remote_transfer(
+        RemoteTransferDirection::Offload,
+        RemoteStorageKind::Object,
+        &descriptors,
+        &blocks,
+        &remote_ctx,
+        &cancel,
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(TransferError::Cancelled)),
+        "expected Cancelled, got {result:?}"
+    );
+}

--- a/lib/llm/src/block_manager/config.rs
+++ b/lib/llm/src/block_manager/config.rs
@@ -3,6 +3,7 @@
 
 use super::events::EventManager;
 use super::*;
+use crate::block_manager::block::transfer::TransferContext;
 use dynamo_runtime::config::environment_names::kvbm::cpu_cache as env_cpu_cache;
 use dynamo_runtime::config::environment_names::kvbm::disk_cache as env_disk_cache;
 use prometheus::Registry;
@@ -302,4 +303,436 @@ pub fn should_bypass_cpu_cache() -> bool {
     let disk_cache_set = disk_cache_gb_set || disk_cache_override_set;
 
     disk_cache_set && !cpu_cache_set
+}
+
+/// Bit flags for RemoteDiskStorage (G4) transfer backend selection.
+///
+/// Bit 0: use GDS_MT for offload (write)
+/// Bit 1: use GDS_MT for onboard (read); falls back to POSIX if GDS_MT unavailable
+///
+/// Common combinations:
+///   `DISK_FLAGS_GDS_BOTH`       (0b11) — GDS for both directions (default)
+///   `DISK_FLAGS_GDS_READS_ONLY` (0b10) — POSIX write + GDS read (hybrid, works on any FS)
+///   `DISK_FLAGS_POSIX_BOTH`     (0b00) — POSIX for both directions
+pub type DiskTransferFlags = u8;
+pub const DISK_FLAG_GDS_WRITE: DiskTransferFlags = 0b01;
+pub const DISK_FLAG_GDS_READ: DiskTransferFlags = 0b10;
+pub const DISK_FLAGS_GDS_BOTH: DiskTransferFlags = DISK_FLAG_GDS_WRITE | DISK_FLAG_GDS_READ;
+pub const DISK_FLAGS_POSIX_BOTH: DiskTransferFlags = 0b00;
+pub const DISK_FLAGS_GDS_READS_ONLY: DiskTransferFlags = DISK_FLAG_GDS_READ;
+
+#[derive(Clone, Debug)]
+pub enum RemoteStorageConfig {
+    /// Object storage (S3-compatible).
+    ///
+    /// `bucket_template` may contain `{worker_id}` which is resolved per-TP-rank
+    /// at transfer / registry time.  It must NOT be resolved early so that
+    /// `register_tp` can derive the correct bucket for every worker.
+    Object {
+        bucket_template: Option<String>,
+        endpoint: Option<String>,
+        region: Option<String>,
+        access_key: Option<String>,
+        secret_key: Option<String>,
+        session_token: Option<String>,
+        scheme: Option<String>,
+        use_virtual_addressing: Option<bool>,
+        req_checksum: Option<String>,
+        ca_bundle: Option<String>,
+    },
+    Disk {
+        base_path: String,
+        transfer_flags: DiskTransferFlags,
+    },
+}
+
+impl RemoteStorageConfig {
+    pub fn object(bucket: impl Into<String>) -> Self {
+        Self::Object {
+            bucket_template: Some(bucket.into()),
+            endpoint: None,
+            region: None,
+            access_key: None,
+            secret_key: None,
+            session_token: None,
+            scheme: None,
+            use_virtual_addressing: None,
+            req_checksum: None,
+            ca_bundle: None,
+        }
+    }
+
+    pub fn object_with_options(
+        bucket: Option<String>,
+        endpoint: Option<String>,
+        region: Option<String>,
+    ) -> Self {
+        Self::Object {
+            bucket_template: bucket,
+            endpoint,
+            region,
+            access_key: None,
+            secret_key: None,
+            session_token: None,
+            scheme: None,
+            use_virtual_addressing: None,
+            req_checksum: None,
+            ca_bundle: None,
+        }
+    }
+
+    /// Resolve `{worker_id}` in the bucket template for a specific TP rank.
+    pub fn resolve_bucket(&self, worker_id: usize) -> Option<String> {
+        match self {
+            Self::Object {
+                bucket_template, ..
+            } => bucket_template
+                .as_deref()
+                .map(|t| t.replace("{worker_id}", &worker_id.to_string())),
+            _ => None,
+        }
+    }
+
+    pub fn disk(base_path: impl Into<String>, transfer_flags: DiskTransferFlags) -> Self {
+        Self::Disk {
+            base_path: base_path.into(),
+            transfer_flags,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RemoteTransferContext {
+    base: Arc<TransferContext>,
+    config: RemoteStorageConfig,
+    worker_id: u64,
+    world_size: usize,
+}
+
+#[derive(Clone)]
+pub struct RemoteContextConfig {
+    pub remote_storage_config: RemoteStorageConfig,
+    pub worker_id: u64,
+}
+
+impl RemoteTransferContext {
+    pub fn for_object(base: Arc<TransferContext>, bucket_template: Option<String>) -> Self {
+        Self {
+            base,
+            config: RemoteStorageConfig::object_with_options(bucket_template, None, None),
+            worker_id: 0,
+            world_size: 1,
+        }
+    }
+
+    pub fn for_object_with_options(
+        base: Arc<TransferContext>,
+        bucket_template: Option<String>,
+        endpoint: Option<String>,
+        region: Option<String>,
+        worker_id: u64,
+    ) -> Self {
+        Self {
+            base,
+            config: RemoteStorageConfig::object_with_options(bucket_template, endpoint, region),
+            worker_id,
+            world_size: 1,
+        }
+    }
+
+    pub fn for_disk(
+        base: Arc<TransferContext>,
+        base_path: String,
+        transfer_flags: DiskTransferFlags,
+    ) -> Self {
+        Self {
+            base,
+            config: RemoteStorageConfig::Disk {
+                base_path,
+                transfer_flags,
+            },
+            worker_id: 0,
+            world_size: 1,
+        }
+    }
+
+    pub fn new(base: Arc<TransferContext>, config: RemoteStorageConfig) -> Self {
+        Self {
+            base,
+            config,
+            worker_id: 0,
+            world_size: 1,
+        }
+    }
+
+    pub fn with_topology(mut self, worker_id: u64, world_size: usize) -> Self {
+        self.worker_id = worker_id;
+        self.world_size = world_size;
+        self
+    }
+
+    pub fn base(&self) -> &Arc<TransferContext> {
+        &self.base
+    }
+
+    pub fn config(&self) -> &RemoteStorageConfig {
+        &self.config
+    }
+
+    pub fn nixl_agent(&self) -> Arc<Option<NixlAgent>> {
+        self.base.nixl_agent()
+    }
+
+    pub fn async_rt_handle(&self) -> &tokio::runtime::Handle {
+        self.base.async_rt_handle()
+    }
+
+    pub fn worker_id(&self) -> u64 {
+        self.worker_id
+    }
+
+    pub fn world_size(&self) -> usize {
+        self.world_size
+    }
+
+    pub fn bucket_template(&self) -> Option<&str> {
+        match &self.config {
+            RemoteStorageConfig::Object {
+                bucket_template, ..
+            } => bucket_template.as_deref(),
+            _ => None,
+        }
+    }
+
+    pub fn base_path(&self) -> Option<&str> {
+        match &self.config {
+            RemoteStorageConfig::Disk { base_path, .. } => Some(base_path),
+            _ => None,
+        }
+    }
+
+    pub fn disk_transfer_flags(&self) -> DiskTransferFlags {
+        match &self.config {
+            RemoteStorageConfig::Disk { transfer_flags, .. } => *transfer_flags,
+            _ => DISK_FLAGS_GDS_BOTH,
+        }
+    }
+
+}
+
+impl std::fmt::Debug for RemoteTransferContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RemoteTransferContext")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod remote_storage_config_tests {
+        use super::*;
+
+        #[test]
+        fn test_object_with_bucket() {
+            let config = RemoteStorageConfig::object("my-bucket");
+            match config {
+                RemoteStorageConfig::Object {
+                    bucket_template,
+                    endpoint,
+                    region,
+                    ..
+                } => {
+                    assert_eq!(bucket_template, Some("my-bucket".to_string()));
+                    assert!(endpoint.is_none());
+                    assert!(region.is_none());
+                }
+                _ => panic!("Expected Object variant"),
+            }
+        }
+
+        #[test]
+        fn test_object_with_options() {
+            let config = RemoteStorageConfig::object_with_options(
+                Some("test-bucket".to_string()),
+                Some("http://localhost:9000".to_string()),
+                Some("us-west-2".to_string()),
+            );
+            match config {
+                RemoteStorageConfig::Object {
+                    bucket_template,
+                    endpoint,
+                    region,
+                    ..
+                } => {
+                    assert_eq!(bucket_template, Some("test-bucket".to_string()));
+                    assert_eq!(endpoint, Some("http://localhost:9000".to_string()));
+                    assert_eq!(region, Some("us-west-2".to_string()));
+                }
+                _ => panic!("Expected Object variant"),
+            }
+        }
+
+        #[test]
+        fn test_object_with_no_bucket() {
+            let config = RemoteStorageConfig::object_with_options(None, None, None);
+            match config {
+                RemoteStorageConfig::Object {
+                    bucket_template,
+                    endpoint,
+                    region,
+                    ..
+                } => {
+                    assert!(bucket_template.is_none());
+                    assert!(endpoint.is_none());
+                    assert!(region.is_none());
+                }
+                _ => panic!("Expected Object variant"),
+            }
+        }
+
+        #[test]
+        fn test_resolve_bucket_with_worker_id() {
+            let config = RemoteStorageConfig::object("kvcache-{worker_id}");
+            assert_eq!(config.resolve_bucket(0), Some("kvcache-0".to_string()));
+            assert_eq!(config.resolve_bucket(3), Some("kvcache-3".to_string()));
+        }
+
+        #[test]
+        fn test_resolve_bucket_without_template() {
+            let config = RemoteStorageConfig::object("flat-bucket");
+            assert_eq!(config.resolve_bucket(0), Some("flat-bucket".to_string()));
+            assert_eq!(config.resolve_bucket(5), Some("flat-bucket".to_string()));
+        }
+
+        #[test]
+        fn test_disk_config_posix() {
+            let config = RemoteStorageConfig::disk("/mnt/kv-cache", DISK_FLAGS_POSIX_BOTH);
+            match config {
+                RemoteStorageConfig::Disk {
+                    base_path,
+                    transfer_flags,
+                } => {
+                    assert_eq!(base_path, "/mnt/kv-cache");
+                    assert_eq!(transfer_flags, DISK_FLAGS_POSIX_BOTH);
+                }
+                _ => panic!("Expected Disk variant"),
+            }
+        }
+
+        #[test]
+        fn test_disk_config_gds() {
+            let config = RemoteStorageConfig::disk("/mnt/nvme", DISK_FLAGS_GDS_BOTH);
+            match config {
+                RemoteStorageConfig::Disk {
+                    base_path,
+                    transfer_flags,
+                } => {
+                    assert_eq!(base_path, "/mnt/nvme");
+                    assert_eq!(transfer_flags, DISK_FLAGS_GDS_BOTH);
+                }
+                _ => panic!("Expected Disk variant"),
+            }
+        }
+
+        #[test]
+        fn test_disk_config_gds_reads_only() {
+            let config = RemoteStorageConfig::disk("/mnt/nfs", DISK_FLAGS_GDS_READS_ONLY);
+            match config {
+                RemoteStorageConfig::Disk {
+                    base_path,
+                    transfer_flags,
+                } => {
+                    assert_eq!(base_path, "/mnt/nfs");
+                    assert_eq!(transfer_flags & DISK_FLAG_GDS_READ, DISK_FLAG_GDS_READ);
+                    assert_eq!(transfer_flags & DISK_FLAG_GDS_WRITE, 0);
+                }
+                _ => panic!("Expected Disk variant"),
+            }
+        }
+
+        #[test]
+        fn test_config_clone() {
+            let config = RemoteStorageConfig::object("bucket");
+            let cloned = config.clone();
+            match (config, cloned) {
+                (
+                    RemoteStorageConfig::Object {
+                        bucket_template: b1,
+                        ..
+                    },
+                    RemoteStorageConfig::Object {
+                        bucket_template: b2,
+                        ..
+                    },
+                ) => {
+                    assert_eq!(b1, b2);
+                }
+                _ => panic!("Clone should preserve variant"),
+            }
+        }
+
+        #[test]
+        fn test_config_debug() {
+            let config = RemoteStorageConfig::object("debug-bucket");
+            let debug_str = format!("{:?}", config);
+            assert!(debug_str.contains("Object"));
+            assert!(debug_str.contains("debug-bucket"));
+        }
+    }
+
+    mod remote_context_config_tests {
+        use super::*;
+
+        #[test]
+        fn test_remote_context_config_object() {
+            let config = RemoteContextConfig {
+                remote_storage_config: RemoteStorageConfig::object("test-bucket"),
+                worker_id: 42,
+            };
+            assert_eq!(config.worker_id, 42);
+            match config.remote_storage_config {
+                RemoteStorageConfig::Object {
+                    bucket_template, ..
+                } => {
+                    assert_eq!(bucket_template, Some("test-bucket".to_string()));
+                }
+                _ => panic!("Expected Object variant"),
+            }
+        }
+
+        #[test]
+        fn test_remote_context_config_disk() {
+            let config = RemoteContextConfig {
+                remote_storage_config: RemoteStorageConfig::disk(
+                    "/data/cache",
+                    DISK_FLAGS_GDS_BOTH,
+                ),
+                worker_id: 7,
+            };
+            assert_eq!(config.worker_id, 7);
+            match config.remote_storage_config {
+                RemoteStorageConfig::Disk {
+                    base_path,
+                    transfer_flags,
+                } => {
+                    assert_eq!(base_path, "/data/cache");
+                    assert_eq!(transfer_flags, DISK_FLAGS_GDS_BOTH);
+                }
+                _ => panic!("Expected Disk variant"),
+            }
+        }
+
+        #[test]
+        fn test_remote_context_config_clone() {
+            let config = RemoteContextConfig {
+                remote_storage_config: RemoteStorageConfig::object("clone-bucket"),
+                worker_id: 123,
+            };
+            let cloned = config.clone();
+            assert_eq!(cloned.worker_id, 123);
+        }
+    }
 }

--- a/lib/llm/src/block_manager/storage/disk.rs
+++ b/lib/llm/src/block_manager/storage/disk.rs
@@ -12,7 +12,7 @@ use std::ffi::CStr;
 use std::ffi::CString;
 use std::fs::File;
 use std::io::Write;
-use std::os::unix::io::{FromRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::path::Path;
 
 const DISK_CACHE_KEY: &str = "DYN_KVBM_DISK_CACHE_DIR";
@@ -27,6 +27,8 @@ pub struct DiskStorage {
     size: usize,
     handles: RegistrationHandles,
     unlinked: bool,
+    /// When true, the file is NOT unlinked on drop (for persistent storage use cases)
+    persist: bool,
 }
 
 impl Local for DiskStorage {}
@@ -323,6 +325,89 @@ impl DiskStorage {
             size,
             handles: RegistrationHandles::new(),
             unlinked: false,
+            persist: false, // Temp files are auto-cleaned
+        })
+    }
+
+    /// Create or open a DiskStorage at a specific path.
+    ///
+    /// This is used for remote disk transfers where the path is specified by the
+    /// transfer descriptor (e.g., from RemoteBlockDescriptor's DiskKey).
+    ///
+    /// # Arguments
+    /// * `path` - Full path to the file
+    /// * `size` - Size of the storage in bytes
+    /// * `create` - If true, create the file (O_CREAT). If false, file must exist.
+    /// * `persist` - If true, the file is NOT unlinked when DiskStorage is dropped.
+    ///   Use `true` for files that should outlive the DiskStorage instance.
+    pub fn new_at_path(
+        path: &str,
+        size: usize,
+        create: bool,
+        persist: bool,
+    ) -> Result<Self, StorageError> {
+        use nix::fcntl::{OFlag, open};
+        use nix::sys::stat::Mode;
+
+        // Ensure parent directory exists
+        if let Some(parent) = Path::new(path).parent()
+            && !parent.exists()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                StorageError::AllocationFailed(format!(
+                    "Failed to create parent directory for {}: {}",
+                    path, e
+                ))
+            })?;
+        }
+
+        // Build open flags
+        let mut flags = OFlag::O_RDWR | OFlag::O_CLOEXEC;
+        if create {
+            flags |= OFlag::O_CREAT;
+        }
+
+        // Optionally add O_DIRECT
+        let disable_o_direct = std::env::var(DISK_DISABLE_O_DIRECT_KEY).is_ok();
+        if !disable_o_direct {
+            flags |= OFlag::O_DIRECT;
+        }
+
+        // Open/create the file
+        let mode = Mode::from_bits_truncate(0o644);
+        let raw_fd = open(path, flags, mode).map_err(|e| {
+            StorageError::AllocationFailed(format!(
+                "Failed to {} file {}: {}",
+                if create { "create" } else { "open" },
+                path,
+                e
+            ))
+        })?;
+
+        // Allocate space if creating
+        if create {
+            allocate_file(raw_fd, size as u64).map_err(|e| {
+                unsafe { nix::libc::close(raw_fd) };
+                StorageError::AllocationFailed(format!("Failed to allocate file {}: {}", path, e))
+            })?;
+        }
+
+        tracing::info!(
+            "DiskStorage {} at path: fd={}, file={}, size={} bytes, persist={}",
+            if create { "created" } else { "opened" },
+            raw_fd,
+            path,
+            size,
+            persist
+        );
+
+        Ok(Self {
+            fd: raw_fd as u64,
+            file_name: path.to_string(),
+            size,
+            handles: RegistrationHandles::new(),
+            unlinked: false,
+            persist,
         })
     }
 
@@ -361,25 +446,48 @@ impl DiskStorage {
     pub fn unlinked(&self) -> bool {
         self.unlinked
     }
+
+    pub fn persist(&self) -> bool {
+        self.persist
+    }
 }
 
 impl Drop for DiskStorage {
     fn drop(&mut self) {
-        tracing::warn!(
-            "DiskStorage being dropped: fd={}, file={}, size={} bytes, already_unlinked={}",
-            self.fd,
-            self.file_name,
-            self.size,
-            self.unlinked
-        );
+        // Warn only when a non-persistent file hasn't been unlinked yet — it's
+        // about to be deleted implicitly, which may be unexpected.  For
+        // persist=true (normal offload path) or already-unlinked temp files,
+        // a debug message is sufficient.
+        if !self.persist && !self.unlinked {
+            tracing::warn!(
+                "DiskStorage being dropped without prior unlink: fd={}, file={}, size={} bytes",
+                self.fd,
+                self.file_name,
+                self.size,
+            );
+        } else {
+            tracing::trace!(
+                "DiskStorage being dropped: fd={}, file={}, size={} bytes, already_unlinked={}, persist={}",
+                self.fd,
+                self.file_name,
+                self.size,
+                self.unlinked,
+                self.persist
+            );
+        }
 
         self.handles.release();
-        let _ = self.unlink();
 
-        tracing::info!(
-            "DiskStorage dropped and cleaned up: fd={}, file={}",
+        // Only unlink if this is a temporary file (not persisted)
+        if !self.persist {
+            let _ = self.unlink();
+        }
+
+        tracing::trace!(
+            "DiskStorage dropped and cleaned up: fd={}, file={}, persist={}",
             self.fd,
-            self.file_name
+            self.file_name,
+            self.persist
         );
     }
 }
@@ -421,6 +529,171 @@ impl RegisterableStorage for DiskStorage {
 
     fn registration_handle(&self, key: &str) -> Option<&dyn RegistationHandle> {
         self.handles.registration_handle(key)
+    }
+}
+
+/// Short-lived file handle used exclusively for G4 remote disk transfers.
+///
+/// Each instance opens a single file for the duration of one NIXL transfer,
+/// then closes the fd automatically on drop via [`OwnedFd`].  The file itself
+/// is never unlinked — ownership of files on disk belongs to the block manager.
+///
+/// This type exists to prevent fd leaks in the transfer path.  [`DiskStorage`]
+/// holds a raw `u64` fd with no RAII close, which is fine for long-lived pool
+/// storage but accumulates open fds when hundreds of short-lived handles are
+/// created per transfer.
+#[derive(Debug)]
+pub struct RemoteDiskStorage {
+    fd: OwnedFd,
+    file_name: String,
+    size: usize,
+    handles: RegistrationHandles,
+}
+
+impl RemoteDiskStorage {
+    /// Open (or create) a file at `path` for a single NIXL transfer.
+    ///
+    /// * `create`       — `true` on offload (creates the file), `false` on onboard.
+    /// * `use_odirect`  — when `true`, opens with `O_DIRECT` for direct I/O.
+    /// * `preallocate`  — when `true`, pre-allocates disk blocks via `fallocate`.
+    ///   Only needed for GDS_MT which DMAs directly to disk blocks. POSIX writes
+    ///   allocate blocks naturally on write; no pre-allocation required.
+    pub fn open(
+        path: &str,
+        size: usize,
+        create: bool,
+        use_odirect: bool,
+        preallocate: bool,
+    ) -> Result<Self, StorageError> {
+        use nix::fcntl::{OFlag, open};
+        use nix::sys::stat::Mode;
+
+        if let Some(parent) = Path::new(path).parent()
+            && !parent.exists()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                StorageError::AllocationFailed(format!(
+                    "Failed to create parent directory for {}: {}",
+                    path, e
+                ))
+            })?;
+        }
+
+        let mut flags = if create {
+            OFlag::O_RDWR | OFlag::O_CLOEXEC
+        } else {
+            OFlag::O_RDONLY | OFlag::O_CLOEXEC
+        };
+        if create {
+            flags |= OFlag::O_CREAT;
+        }
+        if use_odirect && std::env::var(DISK_DISABLE_O_DIRECT_KEY).is_err() {
+            flags |= OFlag::O_DIRECT;
+        }
+
+        let mode = Mode::from_bits_truncate(0o644);
+        let raw_fd = open(path, flags, mode).map_err(|e| {
+            StorageError::AllocationFailed(format!(
+                "Failed to {} file {}: {}",
+                if create { "create" } else { "open" },
+                path,
+                e
+            ))
+        })?;
+
+        if create && preallocate {
+            allocate_file(raw_fd, size as u64).map_err(|e| {
+                unsafe { nix::libc::close(raw_fd) };
+                StorageError::AllocationFailed(format!("Failed to allocate file {}: {}", path, e))
+            })?;
+        }
+
+        tracing::debug!(
+            "RemoteDiskStorage opened: fd={}, file={}, size={} bytes, create={}, odirect={}, preallocate={}",
+            raw_fd,
+            path,
+            size,
+            create,
+            use_odirect,
+            preallocate
+        );
+
+        Ok(Self {
+            fd: unsafe { OwnedFd::from_raw_fd(raw_fd) },
+            file_name: path.to_string(),
+            size,
+            handles: RegistrationHandles::new(),
+        })
+    }
+
+    pub fn fd(&self) -> u64 {
+        self.fd.as_raw_fd() as u64
+    }
+
+    /// Flush written data to the storage device.
+    ///
+    /// Must be called after a POSIX offload and before GDS onboard so that
+    /// O_DIRECT reads see committed data rather than dirty page-cache pages.
+    pub fn fdatasync(&self) -> Result<(), StorageError> {
+        nix::unistd::fdatasync(self.fd.as_raw_fd()).map_err(|e| {
+            StorageError::AllocationFailed(format!("fdatasync failed on {}: {}", self.file_name, e))
+        })
+    }
+}
+
+impl Local for RemoteDiskStorage {}
+impl SystemAccessible for RemoteDiskStorage {}
+
+impl Storage for RemoteDiskStorage {
+    fn storage_type(&self) -> StorageType {
+        StorageType::Disk(self.fd())
+    }
+
+    fn addr(&self) -> u64 {
+        0
+    }
+
+    fn size(&self) -> usize {
+        self.size
+    }
+
+    unsafe fn as_ptr(&self) -> *const u8 {
+        std::ptr::null()
+    }
+
+    unsafe fn as_mut_ptr(&mut self) -> *mut u8 {
+        std::ptr::null_mut()
+    }
+}
+
+impl RegisterableStorage for RemoteDiskStorage {
+    fn register(
+        &mut self,
+        key: &str,
+        handle: Box<dyn RegistationHandle>,
+    ) -> Result<(), StorageError> {
+        self.handles.register(key, handle)
+    }
+
+    fn is_registered(&self, key: &str) -> bool {
+        self.handles.is_registered(key)
+    }
+
+    fn registration_handle(&self, key: &str) -> Option<&dyn RegistationHandle> {
+        self.handles.registration_handle(key)
+    }
+}
+
+impl Drop for RemoteDiskStorage {
+    fn drop(&mut self) {
+        // Deregister from NIXL before OwnedFd closes the fd.
+        self.handles.release();
+        // OwnedFd::drop() closes the fd here.
+        tracing::trace!(
+            "RemoteDiskStorage dropped: file={}, size={}",
+            self.file_name,
+            self.size
+        );
     }
 }
 

--- a/lib/llm/src/block_manager/storage/nixl.rs
+++ b/lib/llm/src/block_manager/storage/nixl.rs
@@ -71,7 +71,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     CudaContextProivder, DeviceStorage, DiskStorage, PinnedStorage, RegistationHandle,
-    RegisterableStorage, Remote, Storage, StorageError, StorageType, SystemStorage,
+    RegisterableStorage, Remote, RemoteDiskStorage, Storage, StorageError, StorageType,
+    SystemStorage,
 };
 
 /// NIXL remote descriptor
@@ -387,7 +388,12 @@ impl NixlRegisterableStorage for DiskStorage {
         }
 
         handle_nixl_register(self, agent, opt_args)?;
-        self.unlink()?;
+
+        // Only unlink if this is a temporary file (not persisted).
+        // For persistent files, we need to keep the path accessible for later reads.
+        if !self.persist() {
+            self.unlink()?;
+        }
         Ok(())
     }
 }
@@ -408,6 +414,33 @@ impl NixlDescriptor for DiskStorage {
     }
 
     /// Nixl treats the file descriptor as the device ID.
+    fn device_id(&self) -> u64 {
+        self.fd()
+    }
+}
+
+// RemoteDiskStorage — short-lived transfer handle with RAII fd close.
+
+impl NixlAccessible for RemoteDiskStorage {}
+
+/// Use the default nixl_register impl (register only, no unlink — files are persistent).
+impl NixlRegisterableStorage for RemoteDiskStorage {}
+
+impl MemoryRegion for RemoteDiskStorage {
+    unsafe fn as_ptr(&self) -> *const u8 {
+        unsafe { Storage::as_ptr(self) }
+    }
+
+    fn size(&self) -> usize {
+        Storage::size(self)
+    }
+}
+
+impl NixlDescriptor for RemoteDiskStorage {
+    fn mem_type(&self) -> MemType {
+        MemType::File
+    }
+
     fn device_id(&self) -> u64 {
         self.fd()
     }

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -261,6 +261,46 @@ pub mod kvbm {
         /// Example: DYN_KVBM_NIXL_BACKEND_UCX=true
         pub const PREFIX: &str = "DYN_KVBM_NIXL_BACKEND_";
     }
+
+    /// Remote disk transfer configuration
+    pub mod remote_disk {
+        /// Enable O_DIRECT for POSIX disk transfers (set to "1" or "true")
+        pub const DYN_KVBM_REMOTE_DISK_O_DIRECT: &str = "DYN_KVBM_REMOTE_DISK_O_DIRECT";
+
+        /// Validate that host buffer addresses are aligned to the O_DIRECT quantum
+        /// before submitting a transfer (set to "1" or "true"; default off)
+        pub const DYN_KVBM_REMOTE_DISK_VALIDATE_ALIGNMENT: &str =
+            "DYN_KVBM_REMOTE_DISK_VALIDATE_ALIGNMENT";
+
+        /// Override the O_DIRECT alignment quantum in bytes (default: page size)
+        pub const DYN_KVBM_REMOTE_DISK_ALIGNMENT_BYTES: &str =
+            "DYN_KVBM_REMOTE_DISK_ALIGNMENT_BYTES";
+
+        /// Maximum number of cached file descriptors in the remote disk fd cache
+        /// (default: 131072)
+        pub const DYN_KVBM_REMOTE_DISK_FD_CACHE_MAX_ENTRIES: &str =
+            "DYN_KVBM_REMOTE_DISK_FD_CACHE_MAX_ENTRIES";
+
+        /// Enable NIXL-path bounce buffer for misaligned O_DIRECT reads
+        /// (set to "1" or "true"; default off)
+        pub const DYN_KVBM_NIXL_BOUNCE_BUFFER: &str = "DYN_KVBM_NIXL_BOUNCE_BUFFER";
+
+    }
+
+    /// KVBM test-only environment variables
+    pub mod testing {
+        /// S3 bucket name used by KVBM integration tests
+        pub const KVBM_TEST_S3_BUCKET: &str = "KVBM_TEST_S3_BUCKET";
+
+        /// S3 endpoint URL used by KVBM integration tests (e.g. "http://minio:9000")
+        pub const KVBM_TEST_S3_ENDPOINT: &str = "KVBM_TEST_S3_ENDPOINT";
+
+        /// Local filesystem path used by KVBM disk integration tests
+        pub const KVBM_TEST_DISK_PATH: &str = "KVBM_TEST_DISK_PATH";
+
+        /// S3 bucket name used by NIXL CUDA integration tests
+        pub const NIXL_TEST_BUCKET: &str = "NIXL_TEST_BUCKET";
+    }
 }
 
 /// LLM (Language Model) inference environment variables
@@ -475,6 +515,15 @@ mod tests {
             kvbm::leader::DYN_KVBM_LEADER_ZMQ_HOST,
             kvbm::leader::DYN_KVBM_LEADER_ZMQ_PUB_PORT,
             kvbm::leader::DYN_KVBM_LEADER_ZMQ_ACK_PORT,
+            kvbm::remote_disk::DYN_KVBM_REMOTE_DISK_O_DIRECT,
+            kvbm::remote_disk::DYN_KVBM_REMOTE_DISK_VALIDATE_ALIGNMENT,
+            kvbm::remote_disk::DYN_KVBM_REMOTE_DISK_ALIGNMENT_BYTES,
+            kvbm::remote_disk::DYN_KVBM_REMOTE_DISK_FD_CACHE_MAX_ENTRIES,
+            kvbm::remote_disk::DYN_KVBM_NIXL_BOUNCE_BUFFER,
+            kvbm::testing::KVBM_TEST_S3_BUCKET,
+            kvbm::testing::KVBM_TEST_S3_ENDPOINT,
+            kvbm::testing::KVBM_TEST_DISK_PATH,
+            kvbm::testing::NIXL_TEST_BUCKET,
             // LLM
             llm::DYN_HTTP_BODY_LIMIT_MB,
             llm::DYN_LORA_ENABLED,


### PR DESCRIPTION
Adds remote offload/onboard support to the KV block manager using NIXL as the transport layer, with two backends:

  - Disk/POSIX (and GDS-MT): sequence-hash-addressed files with an LRU FD cache to amortise open/register cost across transfers
  - Object/S3: NIXL OBJ backend with per-worker bucket templating

Key additions:
  transfer/remote.rs          — RemoteBlockDescriptor, RemoteKey, routing
  transfer/disk_transfer.rs   — FD cache + disk transfer logic
  transfer/object_transfer.rs — S3/object transfer logic
  transfer/remote_tests.rs    — 7 integration tests (roundtrip,
                                cancellation, worker isolation)
  transfer/checksum.rs        — block checksum helpers
  block_manager/config.rs     — RemoteTransferContext, bucket templating

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
