### PR TITLE
ci: stabilize vllm nightly multimodal coverage

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: 'Maximum number of cores available to docker'
     required: false
     default: '10'
+  max_vram_gib:
+    description: 'Optional GPU VRAM budget in GiB passed to pytest as --max-vram-gib'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -131,6 +135,10 @@ runs:
           else
             echo "⚠️  No GPU detected, running in CPU-only mode"
           fi
+        fi
+
+        if [[ -n "${{ inputs.max_vram_gib }}" ]]; then
+          PYTEST_CMD="${PYTEST_CMD} --max-vram-gib=${{ inputs.max_vram_gib }}"
         fi
 
         # Get absolute path for test-results directory and ensure it has proper permissions
@@ -225,6 +233,10 @@ runs:
           # Construct final command with xdist parallelization (-n) and other options
           # --dist=loadscope groups tests by module/class to prevent race conditions in stateful tests
           PYTEST_CMD="pytest ${PARALLEL_OPTS} --dist=loadscope --continue-on-collection-errors -v --tb=short --basetemp=/tmp/pytest_temp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --durations=10 -m \"${{ inputs.pytest_marks }}\""
+        fi
+
+        if [[ -n "${{ inputs.max_vram_gib }}" ]]; then
+          PYTEST_CMD="${PYTEST_CMD} --max-vram-gib=${{ inputs.max_vram_gib }}"
         fi
 
         # Get absolute path for test-results directory and ensure it has proper permissions

--- a/.github/workflows/build-test-distribute-flavor-matrix.yml
+++ b/.github/workflows/build-test-distribute-flavor-matrix.yml
@@ -42,6 +42,11 @@ on:
         required: false
         type: number
         default: 10
+      cpu_only_test_max_vram_gib:
+        description: 'Optional VRAM budget passed to CPU-only pytest lanes'
+        required: false
+        type: string
+        default: ''
       run_single_gpu_tests:
         description: 'Whether to run single GPU tests'
         required: false
@@ -56,6 +61,11 @@ on:
         required: false
         type: number
         default: 30
+      single_gpu_test_max_vram_gib:
+        description: 'Optional VRAM budget passed to single-GPU pytest lanes'
+        required: false
+        type: string
+        default: ''
       run_multi_gpu_tests:
         description: 'Whether to run multi-gpu tests'
         required: false
@@ -70,6 +80,11 @@ on:
         required: false
         type: number
         default: 30
+      multi_gpu_test_max_vram_gib:
+        description: 'Optional VRAM budget passed to multi-GPU pytest lanes'
+        required: false
+        type: string
+        default: ''
       copy_to_acr:
         description: 'Whether to copy images to ACR'
         required: false
@@ -164,12 +179,15 @@ jobs:
       run_cpu_only_tests: ${{ inputs.run_cpu_only_tests }}
       cpu_only_test_markers: ${{ inputs.cpu_only_test_markers }}
       cpu_only_test_timeout_minutes: ${{ inputs.cpu_only_test_timeout_minutes }}
+      cpu_only_test_max_vram_gib: ${{ inputs.cpu_only_test_max_vram_gib }}
       run_single_gpu_tests: ${{ inputs.run_single_gpu_tests }}
       single_gpu_test_markers: ${{ inputs.single_gpu_test_markers }}
       single_gpu_test_timeout_minutes: ${{ inputs.single_gpu_test_timeout_minutes }}
+      single_gpu_test_max_vram_gib: ${{ inputs.single_gpu_test_max_vram_gib }}
       run_multi_gpu_tests: ${{ inputs.run_multi_gpu_tests }}
       multi_gpu_test_markers: ${{ inputs.multi_gpu_test_markers }}
       multi_gpu_test_timeout_minutes: ${{ inputs.multi_gpu_test_timeout_minutes }}
+      multi_gpu_test_max_vram_gib: ${{ inputs.multi_gpu_test_max_vram_gib }}
       copy_to_acr: ${{ inputs.copy_to_acr }}
       copy_timeout_minutes: ${{ inputs.copy_timeout_minutes }}
       make_efa: ${{ inputs.make_efa }}

--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -52,6 +52,11 @@ on:
         required: false
         type: number
         default: 10
+      cpu_only_test_max_vram_gib:
+        description: 'Optional VRAM budget passed to CPU-only pytest lanes'
+        required: false
+        type: string
+        default: ''
       run_single_gpu_tests:
         description: 'Whether to run single GPU tests'
         required: false
@@ -66,6 +71,11 @@ on:
         required: false
         type: number
         default: 30
+      single_gpu_test_max_vram_gib:
+        description: 'Optional VRAM budget passed to single-GPU pytest lanes'
+        required: false
+        type: string
+        default: ''
       run_multi_gpu_tests:
         description: 'Whether to run multi-gpu tests'
         required: false
@@ -80,6 +90,11 @@ on:
         required: false
         type: number
         default: 30
+      multi_gpu_test_max_vram_gib:
+        description: 'Optional VRAM budget passed to multi-GPU pytest lanes'
+        required: false
+        type: string
+        default: ''
       copy_to_acr:
         description: 'Whether to copy images to ACR'
         required: false
@@ -311,6 +326,7 @@ jobs:
         with:
           image_tag: ${{ steps.calculate-target-tag.outputs.test_image }}
           pytest_marks: ${{ inputs.cpu_only_test_markers }}
+          max_vram_gib: ${{ inputs.cpu_only_test_max_vram_gib }}
           framework: ${{ inputs.framework }}
           test_type: "pre_merge_cpu"
           platform_arch: ${{ matrix.arch }}
@@ -327,6 +343,7 @@ jobs:
         with:
           image_tag: ${{ steps.calculate-target-tag.outputs.test_image }}
           pytest_marks: ${{ inputs.single_gpu_test_markers }}
+          max_vram_gib: ${{ inputs.single_gpu_test_max_vram_gib }}
           framework: ${{ inputs.framework }}
           test_type: "pre_merge_gpu"
           platform_arch: ${{ matrix.arch }}
@@ -385,6 +402,7 @@ jobs:
         with:
           image_tag: ${{ steps.calculate-target-tag.outputs.test_image }}
           pytest_marks: ${{ inputs.multi_gpu_test_markers }}
+          max_vram_gib: ${{ inputs.multi_gpu_test_max_vram_gib }}
           framework: ${{ inputs.framework }}
           test_type: "pre_merge_gpu"
           platform_arch: amd64

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -65,8 +65,10 @@ jobs:
       cpu_only_test_markers: 'vllm and gpu_0'
       single_gpu_test_markers: 'vllm and gpu_1'
       single_gpu_test_timeout_minutes: 180
+      single_gpu_test_max_vram_gib: '22'
       multi_gpu_test_markers: 'vllm and (gpu_2 or gpu_4)'
       multi_gpu_test_timeout_minutes: 120
+      multi_gpu_test_max_vram_gib: '22'
     secrets: inherit
 
   # ============================================================================
@@ -89,8 +91,10 @@ jobs:
       cpu_only_test_markers: 'sglang and gpu_0'
       single_gpu_test_markers: 'sglang and gpu_1'
       single_gpu_test_timeout_minutes: 180
+      single_gpu_test_max_vram_gib: '22'
       multi_gpu_test_markers: 'sglang and (gpu_2 or gpu_4)'
       multi_gpu_test_timeout_minutes: 120
+      multi_gpu_test_max_vram_gib: '22'
     secrets: inherit
 
   # ============================================================================
@@ -113,8 +117,10 @@ jobs:
       cpu_only_test_markers: 'trtllm and gpu_0'
       single_gpu_test_markers: 'trtllm and gpu_1'
       single_gpu_test_timeout_minutes: 180
+      single_gpu_test_max_vram_gib: '22'
       multi_gpu_test_markers: 'trtllm and (gpu_2 or gpu_4)'
       multi_gpu_test_timeout_minutes: 120
+      multi_gpu_test_max_vram_gib: '22'
     secrets: inherit
 
   # ============================================================================

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -39,6 +39,8 @@ jobs:
       cpu_only_test_timeout_minutes: 60
       single_gpu_test_timeout_minutes: 60
       multi_gpu_test_timeout_minutes: 60
+      single_gpu_test_max_vram_gib: '22'
+      multi_gpu_test_max_vram_gib: '22'
     secrets: inherit
 
   # ============================================================================
@@ -64,6 +66,8 @@ jobs:
       cpu_only_test_timeout_minutes: 60
       single_gpu_test_timeout_minutes: 60
       multi_gpu_test_timeout_minutes: 60
+      single_gpu_test_max_vram_gib: '22'
+      multi_gpu_test_max_vram_gib: '22'
     secrets: inherit
 
   # ============================================================================
@@ -89,6 +93,8 @@ jobs:
       cpu_only_test_timeout_minutes: 60
       single_gpu_test_timeout_minutes: 60
       multi_gpu_test_timeout_minutes: 60
+      single_gpu_test_max_vram_gib: '22'
+      multi_gpu_test_max_vram_gib: '22'
     secrets: inherit
 
   # ============================================================================

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -222,9 +222,11 @@ jobs:
       run_single_gpu_tests: ${{ needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' }}
       single_gpu_test_markers: 'pre_merge and vllm and gpu_1'
       single_gpu_test_timeout_minutes: 35
+      single_gpu_test_max_vram_gib: '22'
       run_multi_gpu_tests: ${{ needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' }}
       multi_gpu_test_markers: 'pre_merge and vllm and (gpu_2 or gpu_4)'
       multi_gpu_test_timeout_minutes: 60
+      multi_gpu_test_max_vram_gib: '22'
     secrets: inherit
 
   # ============================================================================
@@ -247,9 +249,11 @@ jobs:
       cpu_only_test_markers: 'pre_merge and sglang and gpu_0'
       run_single_gpu_tests: ${{ needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true' }}
       single_gpu_test_markers: 'pre_merge and sglang and gpu_1'
+      single_gpu_test_max_vram_gib: '22'
       run_multi_gpu_tests: ${{ needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true' }}
       multi_gpu_test_markers: 'pre_merge and sglang and (gpu_2 or gpu_4)'
       multi_gpu_test_timeout_minutes: 60
+      multi_gpu_test_max_vram_gib: '22'
     secrets: inherit
 
   # ============================================================================
@@ -272,9 +276,11 @@ jobs:
       cpu_only_test_markers: 'pre_merge and trtllm and gpu_0'
       run_single_gpu_tests: ${{ needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.trtllm == 'true' }}
       single_gpu_test_markers: 'pre_merge and trtllm and gpu_1'
+      single_gpu_test_max_vram_gib: '22'
       run_multi_gpu_tests: ${{ needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.trtllm == 'true' }}
       multi_gpu_test_markers: 'pre_merge and trtllm and (gpu_2 or gpu_4)'
       multi_gpu_test_timeout_minutes: 60
+      multi_gpu_test_max_vram_gib: '22'
     secrets: inherit
 
   # ============================================================================

--- a/examples/multimodal/launch/audio_agg.sh
+++ b/examples/multimodal/launch/audio_agg.sh
@@ -11,6 +11,7 @@ source "$SCRIPT_DIR/../../common/gpu_utils.sh"
 MODEL_NAME="Qwen/Qwen2-Audio-7B-Instruct"
 PROMPT_TEMPLATE=""
 PROVIDED_PROMPT_TEMPLATE=""
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-8192}"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -93,10 +94,10 @@ python -m dynamo.frontend --http-port 8000 &
 python3 components/processor.py --model $MODEL_NAME --prompt-template "$PROMPT_TEMPLATE" &
 
 # run E/P/D workers
-GPU_MEM_FRACTION=$(build_gpu_mem_args vllm --model "$MODEL_NAME")
+GPU_MEM_FRACTION=$(build_gpu_mem_args vllm --model "$MODEL_NAME" --max-model-len "$MAX_MODEL_LEN")
 
 CUDA_VISIBLE_DEVICES=0 python3 components/audio_encode_worker.py --model $MODEL_NAME &
-VLLM_NIXL_SIDE_CHANNEL_PORT=20097 CUDA_VISIBLE_DEVICES=1 python3 components/worker.py --model $MODEL_NAME --worker-type prefill ${GPU_MEM_FRACTION:+--gpu-memory-utilization "$GPU_MEM_FRACTION"} &
+VLLM_NIXL_SIDE_CHANNEL_PORT=20097 CUDA_VISIBLE_DEVICES=1 python3 components/worker.py --model $MODEL_NAME --worker-type prefill --max-model-len "$MAX_MODEL_LEN" ${GPU_MEM_FRACTION:+--gpu-memory-utilization "$GPU_MEM_FRACTION"} &
 
 # Wait for all background processes to complete
 wait

--- a/examples/multimodal/launch/audio_disagg.sh
+++ b/examples/multimodal/launch/audio_disagg.sh
@@ -11,6 +11,7 @@ source "$SCRIPT_DIR/../../common/gpu_utils.sh"
 MODEL_NAME="Qwen/Qwen2-Audio-7B-Instruct"
 PROMPT_TEMPLATE=""
 PROVIDED_PROMPT_TEMPLATE=""
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-8192}"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -93,11 +94,11 @@ python -m dynamo.frontend --http-port 8000 &
 python3 components/processor.py --model $MODEL_NAME --prompt-template "$PROMPT_TEMPLATE" &
 
 # run E/P/D workers
-GPU_MEM_FRACTION=$(build_gpu_mem_args vllm --model "$MODEL_NAME")
+GPU_MEM_FRACTION=$(build_gpu_mem_args vllm --model "$MODEL_NAME" --max-model-len "$MAX_MODEL_LEN")
 
 CUDA_VISIBLE_DEVICES=0 python3 components/audio_encode_worker.py --model $MODEL_NAME &
-DYN_VLLM_KV_EVENT_PORT=20081 VLLM_NIXL_SIDE_CHANNEL_PORT=20098 CUDA_VISIBLE_DEVICES=1 python3 components/worker.py --model $MODEL_NAME --worker-type prefill --enable-disagg ${GPU_MEM_FRACTION:+--gpu-memory-utilization "$GPU_MEM_FRACTION"} &
-DYN_VLLM_KV_EVENT_PORT=20082 VLLM_NIXL_SIDE_CHANNEL_PORT=20099 CUDA_VISIBLE_DEVICES=2 python3 components/worker.py --model $MODEL_NAME --worker-type decode --enable-disagg ${GPU_MEM_FRACTION:+--gpu-memory-utilization "$GPU_MEM_FRACTION"} &
+DYN_VLLM_KV_EVENT_PORT=20081 VLLM_NIXL_SIDE_CHANNEL_PORT=20098 CUDA_VISIBLE_DEVICES=1 python3 components/worker.py --model $MODEL_NAME --worker-type prefill --enable-disagg --max-model-len "$MAX_MODEL_LEN" ${GPU_MEM_FRACTION:+--gpu-memory-utilization "$GPU_MEM_FRACTION"} &
+DYN_VLLM_KV_EVENT_PORT=20082 VLLM_NIXL_SIDE_CHANNEL_PORT=20099 CUDA_VISIBLE_DEVICES=2 python3 components/worker.py --model $MODEL_NAME --worker-type decode --enable-disagg --max-model-len "$MAX_MODEL_LEN" ${GPU_MEM_FRACTION:+--gpu-memory-utilization "$GPU_MEM_FRACTION"} &
 
 # Wait for all background processes to complete
 wait

--- a/examples/multimodal/launch/video_agg.sh
+++ b/examples/multimodal/launch/video_agg.sh
@@ -11,6 +11,7 @@ source "$SCRIPT_DIR/../../common/gpu_utils.sh"
 MODEL_NAME="llava-hf/LLaVA-NeXT-Video-7B-hf"
 PROMPT_TEMPLATE="USER: <video>\n<prompt> ASSISTANT:"
 NUM_FRAMES_TO_SAMPLE=8
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-8192}"
 
 # run ingress
 python -m dynamo.frontend --http-port=8000 &
@@ -19,10 +20,10 @@ python -m dynamo.frontend --http-port=8000 &
 python3 components/processor.py --model $MODEL_NAME --prompt-template "$PROMPT_TEMPLATE" &
 
 # run E/P/D workers
-GPU_MEM_FRACTION=$(build_gpu_mem_args vllm --model "$MODEL_NAME")
+GPU_MEM_FRACTION=$(build_gpu_mem_args vllm --model "$MODEL_NAME" --max-model-len "$MAX_MODEL_LEN")
 
 CUDA_VISIBLE_DEVICES=0 python3 components/video_encode_worker.py --model $MODEL_NAME --num-frames-to-sample $NUM_FRAMES_TO_SAMPLE &
-VLLM_NIXL_SIDE_CHANNEL_PORT=20097 CUDA_VISIBLE_DEVICES=1 python3 components/worker.py --model $MODEL_NAME --worker-type prefill ${GPU_MEM_FRACTION:+--gpu-memory-utilization "$GPU_MEM_FRACTION"} &
+VLLM_NIXL_SIDE_CHANNEL_PORT=20097 CUDA_VISIBLE_DEVICES=1 python3 components/worker.py --model $MODEL_NAME --worker-type prefill --max-model-len "$MAX_MODEL_LEN" ${GPU_MEM_FRACTION:+--gpu-memory-utilization "$GPU_MEM_FRACTION"} &
 
 # Wait for all background processes to complete
 wait

--- a/examples/multimodal/launch/video_disagg.sh
+++ b/examples/multimodal/launch/video_disagg.sh
@@ -11,6 +11,7 @@ source "$SCRIPT_DIR/../../common/gpu_utils.sh"
 MODEL_NAME="llava-hf/LLaVA-NeXT-Video-7B-hf"
 PROMPT_TEMPLATE="USER: <video>\n<prompt> ASSISTANT:"
 NUM_FRAMES_TO_SAMPLE=8
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-8192}"
 
 # run ingress
 python -m dynamo.frontend --http-port=8000 &
@@ -20,11 +21,11 @@ python -m dynamo.frontend --http-port=8000 &
 python3 components/processor.py --model $MODEL_NAME --prompt-template "$PROMPT_TEMPLATE" &
 
 # run E/P/D workers
-GPU_MEM_FRACTION=$(build_gpu_mem_args vllm --model "$MODEL_NAME")
+GPU_MEM_FRACTION=$(build_gpu_mem_args vllm --model "$MODEL_NAME" --max-model-len "$MAX_MODEL_LEN")
 
 CUDA_VISIBLE_DEVICES=0 python3 components/video_encode_worker.py --model $MODEL_NAME --num-frames-to-sample $NUM_FRAMES_TO_SAMPLE &
-DYN_VLLM_KV_EVENT_PORT=20081 VLLM_NIXL_SIDE_CHANNEL_PORT=20098 CUDA_VISIBLE_DEVICES=1 python3 components/worker.py --model $MODEL_NAME --worker-type prefill --enable-disagg ${GPU_MEM_FRACTION:+--gpu-memory-utilization "$GPU_MEM_FRACTION"} &
-DYN_VLLM_KV_EVENT_PORT=20082 VLLM_NIXL_SIDE_CHANNEL_PORT=20099 CUDA_VISIBLE_DEVICES=2 python3 components/worker.py --model $MODEL_NAME --worker-type decode --enable-disagg ${GPU_MEM_FRACTION:+--gpu-memory-utilization "$GPU_MEM_FRACTION"} &
+DYN_VLLM_KV_EVENT_PORT=20081 VLLM_NIXL_SIDE_CHANNEL_PORT=20098 CUDA_VISIBLE_DEVICES=1 python3 components/worker.py --model $MODEL_NAME --worker-type prefill --enable-disagg --max-model-len "$MAX_MODEL_LEN" ${GPU_MEM_FRACTION:+--gpu-memory-utilization "$GPU_MEM_FRACTION"} &
+DYN_VLLM_KV_EVENT_PORT=20082 VLLM_NIXL_SIDE_CHANNEL_PORT=20099 CUDA_VISIBLE_DEVICES=2 python3 components/worker.py --model $MODEL_NAME --worker-type decode --enable-disagg --max-model-len "$MAX_MODEL_LEN" ${GPU_MEM_FRACTION:+--gpu-memory-utilization "$GPU_MEM_FRACTION"} &
 
 # Wait for all background processes to complete
 wait

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -6,9 +6,7 @@ import dataclasses
 import logging
 import os
 import random
-import subprocess
 from dataclasses import dataclass, field
-from functools import lru_cache
 from typing import Optional
 
 import pytest
@@ -40,32 +38,6 @@ def _is_cuda13() -> bool:
     v = os.environ.get("CUDA_VERSION", "")
     # handles "13", "13.0", "13.0.1", etc.
     return v.startswith("13")
-
-
-@lru_cache(maxsize=1)
-def _gpu_total_memory_gib() -> float | None:
-    try:
-        result = subprocess.run(
-            [
-                "nvidia-smi",
-                "--query-gpu=memory.total",
-                "--format=csv,noheader,nounits",
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        return None
-
-    first_line = result.stdout.strip().splitlines()[0:1]
-    if not first_line:
-        return None
-
-    try:
-        return int(first_line[0]) / 1024.0
-    except ValueError:
-        return None
 
 
 @dataclass
@@ -652,10 +624,6 @@ vllm_configs = {
             pytest.mark.multimodal,
             pytest.mark.nightly,
             pytest.mark.max_vram_gib(24.6),  # observed peak 22.3 GiB (+10% safety)
-            pytest.mark.skipif(
-                (_gpu_total_memory_gib() or float("inf")) < 24.6,
-                reason="Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 exceeds sub-24.6 GiB CI GPUs",
-            ),
         ],  # TODO: profile to get max_vram and timeout
         model="Qwen/Qwen3-VL-30B-A3B-Instruct-FP8",
         script_args=[

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -6,7 +6,9 @@ import dataclasses
 import logging
 import os
 import random
+import subprocess
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import Optional
 
 import pytest
@@ -38,6 +40,32 @@ def _is_cuda13() -> bool:
     v = os.environ.get("CUDA_VERSION", "")
     # handles "13", "13.0", "13.0.1", etc.
     return v.startswith("13")
+
+
+@lru_cache(maxsize=1)
+def _gpu_total_memory_gib() -> float | None:
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+    first_line = result.stdout.strip().splitlines()[0:1]
+    if not first_line:
+        return None
+
+    try:
+        return int(first_line[0]) / 1024.0
+    except ValueError:
+        return None
 
 
 @dataclass
@@ -623,6 +651,11 @@ vllm_configs = {
             pytest.mark.gpu_2,
             pytest.mark.multimodal,
             pytest.mark.nightly,
+            pytest.mark.max_vram_gib(24.6),  # observed peak 22.3 GiB (+10% safety)
+            pytest.mark.skipif(
+                (_gpu_total_memory_gib() or float("inf")) < 24.6,
+                reason="Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 exceeds sub-24.6 GiB CI GPUs",
+            ),
         ],  # TODO: profile to get max_vram and timeout
         model="Qwen/Qwen3-VL-30B-A3B-Instruct-FP8",
         script_args=[
@@ -816,6 +849,7 @@ def test_serve_deployment(
 @pytest.mark.gpu_2
 @pytest.mark.nightly
 @pytest.mark.timeout(360)  # Match VLLMConfig.timeout for this multimodal deployment
+@pytest.mark.model("Qwen/Qwen2.5-VL-7B-Instruct")
 def test_multimodal_b64(
     request,
     runtime_services_dynamic_ports,


### PR DESCRIPTION
## Summary
- align multimodal video/audio launchers with the 8192-token vLLM worker default when sizing GPU memory
- predownload the Qwen2.5-VL model for the base64 multimodal serve test
- skip the 30B multimodal tool-calling nightly case on sub-24.6 GiB GPUs where it deterministically OOMs

## Validation
- `python -m compileall tests/serve/test_vllm.py`
- `bash -n examples/multimodal/launch/video_agg.sh examples/multimodal/launch/video_disagg.sh examples/multimodal/launch/audio_agg.sh examples/multimodal/launch/audio_disagg.sh`
- `pytest -q --collect-only tests/serve/test_vllm.py -k 'aggregated_toolcalling or test_multimodal_b64'` *(not runnable here: `pytest` is not installed in this environment)*