### PR TITLE
feat: Lightweight CLI and composite action for pushing CI/CD metrics

### DIFF
--- a/.github/actions/push-metrics/action.yml
+++ b/.github/actions/push-metrics/action.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/actions/push-metrics/action.yml
+++ b/.github/actions/push-metrics/action.yml
@@ -67,7 +67,12 @@ runs:
         SCRIPT_DIR="${REPO_ROOT}/deploy/metrics"
         export PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH}"
 
-        python3 -m pip install --quiet opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http 2>/dev/null || true
+        # Install deps — try multiple methods for different runner environments
+        python3 -m pip install --quiet --break-system-packages opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http 2>/dev/null \
+          || python3 -m pip install --quiet --user opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http 2>/dev/null \
+          || python3 -m pip install --quiet opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http 2>/dev/null \
+          || pip install --quiet opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http 2>/dev/null \
+          || echo "Warning: could not install opentelemetry packages"
 
         python3 "${SCRIPT_DIR}/cicd_push.py" \
           ${OTLP_ENDPOINT:+--otlp-endpoint "$OTLP_ENDPOINT"} \

--- a/.github/actions/push-metrics/action.yml
+++ b/.github/actions/push-metrics/action.yml
@@ -14,18 +14,15 @@
 # limitations under the License.
 
 name: 'Push CI/CD Metrics'
-description: 'Push test results and build metrics to OTLP telemetry endpoint and/or Loki'
+description: 'Push test results and build metrics to OTLP endpoint (metrics + logs)'
 
 inputs:
   otlp-endpoint:
     description: 'OTLP HTTP endpoint (e.g., https://otlp-http.nvidia.com)'
-    required: false
+    required: true
   otlp-token:
     description: 'Bearer token for OTLP authentication'
-    required: false
-  loki-url:
-    description: 'Loki base URL'
-    required: false
+    required: true
   test-results:
     description: 'Path to directory containing JUnit XML test results'
     required: false
@@ -53,7 +50,7 @@ runs:
   steps:
     - name: Install metrics dependencies
       shell: bash
-      run: pip install --quiet opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http requests 2>/dev/null || true
+      run: pip install --quiet opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http 2>/dev/null || true
 
     - name: Push CI/CD metrics
       if: always()
@@ -61,7 +58,6 @@ runs:
       env:
         OTLP_ENDPOINT: ${{ inputs.otlp-endpoint }}
         OTLP_TOKEN: ${{ inputs.otlp-token }}
-        LOKI_URL: ${{ inputs.loki-url }}
         TEST_RESULTS: ${{ inputs.test-results }}
         BUILD_METRICS: ${{ inputs.build-metrics }}
         FRAMEWORK: ${{ inputs.framework }}
@@ -76,9 +72,8 @@ runs:
         export PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH}"
 
         python3 "${SCRIPT_DIR}/cicd_push.py" \
-          ${OTLP_ENDPOINT:+--otlp-endpoint "$OTLP_ENDPOINT"} \
-          ${OTLP_TOKEN:+--otlp-token "$OTLP_TOKEN"} \
-          ${LOKI_URL:+--loki-url "$LOKI_URL"} \
+          --otlp-endpoint "$OTLP_ENDPOINT" \
+          --otlp-token "$OTLP_TOKEN" \
           ${TEST_RESULTS:+--test-results "$TEST_RESULTS"} \
           ${BUILD_METRICS:+--build-metrics "$BUILD_METRICS"} \
           ${FRAMEWORK:+--framework "$FRAMEWORK"} \

--- a/.github/actions/push-metrics/action.yml
+++ b/.github/actions/push-metrics/action.yml
@@ -48,10 +48,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install metrics dependencies
-      shell: bash
-      run: pip install --quiet opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http 2>/dev/null || true
-
     - name: Push CI/CD metrics
       if: always()
       shell: bash
@@ -70,6 +66,8 @@ runs:
         REPO_ROOT="$(cd "${{ github.action_path }}/../../.." && pwd)"
         SCRIPT_DIR="${REPO_ROOT}/deploy/metrics"
         export PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH}"
+
+        python3 -m pip install --quiet opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http 2>/dev/null || true
 
         python3 "${SCRIPT_DIR}/cicd_push.py" \
           ${OTLP_ENDPOINT:+--otlp-endpoint "$OTLP_ENDPOINT"} \

--- a/.github/actions/push-metrics/action.yml
+++ b/.github/actions/push-metrics/action.yml
@@ -19,10 +19,10 @@ description: 'Push test results and build metrics to OTLP endpoint (metrics + lo
 inputs:
   otlp-endpoint:
     description: 'OTLP HTTP endpoint (e.g., https://otlp-http.nvidia.com)'
-    required: true
+    required: false
   otlp-token:
     description: 'Bearer token for OTLP authentication'
-    required: true
+    required: false
   test-results:
     description: 'Path to directory containing JUnit XML test results'
     required: false
@@ -72,8 +72,8 @@ runs:
         export PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH}"
 
         python3 "${SCRIPT_DIR}/cicd_push.py" \
-          --otlp-endpoint "$OTLP_ENDPOINT" \
-          --otlp-token "$OTLP_TOKEN" \
+          ${OTLP_ENDPOINT:+--otlp-endpoint "$OTLP_ENDPOINT"} \
+          ${OTLP_TOKEN:+--otlp-token "$OTLP_TOKEN"} \
           ${TEST_RESULTS:+--test-results "$TEST_RESULTS"} \
           ${BUILD_METRICS:+--build-metrics "$BUILD_METRICS"} \
           ${FRAMEWORK:+--framework "$FRAMEWORK"} \

--- a/.github/actions/push-metrics/action.yml
+++ b/.github/actions/push-metrics/action.yml
@@ -14,11 +14,14 @@
 # limitations under the License.
 
 name: 'Push CI/CD Metrics'
-description: 'Push test results and build metrics to Prometheus and Loki from within a CI job'
+description: 'Push test results and build metrics to OTLP telemetry endpoint and/or Loki'
 
 inputs:
-  pushgateway-url:
-    description: 'Prometheus Pushgateway URL'
+  otlp-endpoint:
+    description: 'OTLP HTTP endpoint (e.g., https://otlp-http.nvidia.com)'
+    required: false
+  otlp-token:
+    description: 'Bearer token for OTLP authentication'
     required: false
   loki-url:
     description: 'Loki base URL'
@@ -50,13 +53,14 @@ runs:
   steps:
     - name: Install metrics dependencies
       shell: bash
-      run: pip install --quiet prometheus-client requests 2>/dev/null || true
+      run: pip install --quiet opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http requests 2>/dev/null || true
 
     - name: Push CI/CD metrics
       if: always()
       shell: bash
       env:
-        PUSHGATEWAY_URL: ${{ inputs.pushgateway-url }}
+        OTLP_ENDPOINT: ${{ inputs.otlp-endpoint }}
+        OTLP_TOKEN: ${{ inputs.otlp-token }}
         LOKI_URL: ${{ inputs.loki-url }}
         TEST_RESULTS: ${{ inputs.test-results }}
         BUILD_METRICS: ${{ inputs.build-metrics }}
@@ -72,7 +76,8 @@ runs:
         export PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH}"
 
         python3 "${SCRIPT_DIR}/cicd_push.py" \
-          ${PUSHGATEWAY_URL:+--pushgateway-url "$PUSHGATEWAY_URL"} \
+          ${OTLP_ENDPOINT:+--otlp-endpoint "$OTLP_ENDPOINT"} \
+          ${OTLP_TOKEN:+--otlp-token "$OTLP_TOKEN"} \
           ${LOKI_URL:+--loki-url "$LOKI_URL"} \
           ${TEST_RESULTS:+--test-results "$TEST_RESULTS"} \
           ${BUILD_METRICS:+--build-metrics "$BUILD_METRICS"} \

--- a/.github/actions/push-metrics/action.yml
+++ b/.github/actions/push-metrics/action.yml
@@ -64,7 +64,7 @@ runs:
         TEST_TYPE: ${{ inputs.test-type }}
         ARCH: ${{ inputs.arch }}
         CUDA_VERSION: ${{ inputs.cuda-version }}
-        JOB_STATUS: ${{ inputs.job-status || job.status }}
+        JOB_STATUS: ${{ inputs.job-status }}
         JOB_STARTED_AT: ${{ github.run_started_at }}
       run: |
         REPO_ROOT="$(cd "${{ github.action_path }}/../../.." && pwd)"

--- a/.github/actions/push-metrics/action.yml
+++ b/.github/actions/push-metrics/action.yml
@@ -1,0 +1,69 @@
+name: 'Push CI/CD Metrics'
+description: 'Push test results and build metrics to Prometheus and Loki from within a CI job'
+
+inputs:
+  pushgateway-url:
+    description: 'Prometheus Pushgateway URL'
+    required: false
+  loki-url:
+    description: 'Loki base URL'
+    required: false
+  test-results:
+    description: 'Path to directory containing JUnit XML test results'
+    required: false
+  build-metrics:
+    description: 'Path to build_metrics.json file'
+    required: false
+  framework:
+    description: 'Framework name (e.g., sglang, vllm, tensorrt-llm)'
+    required: false
+  test-type:
+    description: 'Test type (e.g., pre_merge, nightly, post_merge)'
+    required: false
+  arch:
+    description: 'Architecture override (defaults to runner arch)'
+    required: false
+  cuda-version:
+    description: 'CUDA version (e.g., 12.8)'
+    required: false
+  job-status:
+    description: 'Job status — pass ${{ job.status }} for automatic detection'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install metrics dependencies
+      shell: bash
+      run: pip install --quiet prometheus-client requests 2>/dev/null || true
+
+    - name: Push CI/CD metrics
+      if: always()
+      shell: bash
+      env:
+        PUSHGATEWAY_URL: ${{ inputs.pushgateway-url }}
+        LOKI_URL: ${{ inputs.loki-url }}
+        TEST_RESULTS: ${{ inputs.test-results }}
+        BUILD_METRICS: ${{ inputs.build-metrics }}
+        FRAMEWORK: ${{ inputs.framework }}
+        TEST_TYPE: ${{ inputs.test-type }}
+        ARCH: ${{ inputs.arch }}
+        CUDA_VERSION: ${{ inputs.cuda-version }}
+        JOB_STATUS: ${{ inputs.job-status || job.status }}
+        JOB_STARTED_AT: ${{ github.run_started_at }}
+      run: |
+        REPO_ROOT="$(cd "${{ github.action_path }}/../../.." && pwd)"
+        SCRIPT_DIR="${REPO_ROOT}/deploy/metrics"
+        export PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH}"
+
+        python3 "${SCRIPT_DIR}/cicd_push.py" \
+          ${PUSHGATEWAY_URL:+--pushgateway-url "$PUSHGATEWAY_URL"} \
+          ${LOKI_URL:+--loki-url "$LOKI_URL"} \
+          ${TEST_RESULTS:+--test-results "$TEST_RESULTS"} \
+          ${BUILD_METRICS:+--build-metrics "$BUILD_METRICS"} \
+          ${FRAMEWORK:+--framework "$FRAMEWORK"} \
+          ${TEST_TYPE:+--test-type "$TEST_TYPE"} \
+          ${ARCH:+--arch "$ARCH"} \
+          ${CUDA_VERSION:+--cuda-version "$CUDA_VERSION"} \
+          ${JOB_STATUS:+--job-status "$JOB_STATUS"} \
+          ${JOB_STARTED_AT:+--job-started-at "$JOB_STARTED_AT"}

--- a/.github/actions/push-metrics/action.yml
+++ b/.github/actions/push-metrics/action.yml
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: 'Push CI/CD Metrics'
 description: 'Push test results and build metrics to Prometheus and Loki from within a CI job'
 

--- a/.github/actions/push-metrics/action.yml
+++ b/.github/actions/push-metrics/action.yml
@@ -42,7 +42,7 @@ inputs:
     description: 'CUDA version (e.g., 12.8)'
     required: false
   job-status:
-    description: 'Job status — pass ${{ job.status }} for automatic detection'
+    description: 'Job status (success/failure/cancelled)'
     required: false
 
 runs:

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -303,7 +303,7 @@ runs:
         docker rm -f dynamo-minio-test 2>/dev/null || true
 
     - name: Push Test Metrics
-      if: always() && env.OTLP_ENDPOINT != ''
+      if: always()
       uses: ./.github/actions/push-metrics
       with:
         otlp-endpoint: ${{ env.OTLP_ENDPOINT }}

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -303,12 +303,11 @@ runs:
         docker rm -f dynamo-minio-test 2>/dev/null || true
 
     - name: Push Test Metrics
-      if: always()
+      if: always() && env.OTLP_ENDPOINT != ''
       uses: ./.github/actions/push-metrics
       with:
         otlp-endpoint: ${{ env.OTLP_ENDPOINT }}
         otlp-token: ${{ env.OTLP_TOKEN }}
-        loki-url: ${{ env.LOKI_URL }}
         test-results: test-results/
         framework: ${{ inputs.framework }}
         test-type: ${{ inputs.test_type }}

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -293,7 +293,8 @@ runs:
           ERROR_TESTS=0
         fi
 
-        exit ${TEST_EXIT_CODE}
+        # Don't exit here — let Push Metrics and Upload run first
+        echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV
 
     - name: Cleanup MinIO Service
       if: always() && inputs.start_minio == 'true'
@@ -316,8 +317,13 @@ runs:
 
     - name: Upload Test Results
       uses: actions/upload-artifact@v4
-      if: always()  # Always upload test results, even if tests failed
+      if: always()
       with:
         name: test-results-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}
         path: test-results/pytest_test_report_${{ inputs.framework }}_${{ env.STR_TEST_TYPE }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml
         retention-days: 7
+
+    - name: Exit with test result
+      if: always()
+      shell: bash
+      run: exit ${TEST_EXIT_CODE:-0}

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -302,6 +302,18 @@ runs:
         echo "🧹 Cleaning up MinIO container..."
         docker rm -f dynamo-minio-test 2>/dev/null || true
 
+    - name: Push Test Metrics
+      if: always()
+      uses: ./.github/actions/push-metrics
+      with:
+        pushgateway-url: ${{ env.PUSHGATEWAY_URL }}
+        loki-url: ${{ env.LOKI_URL }}
+        test-results: test-results/
+        framework: ${{ inputs.framework }}
+        test-type: ${{ inputs.test_type }}
+        arch: ${{ inputs.platform_arch }}
+        job-status: ${{ env.TEST_EXIT_CODE == '0' && 'success' || 'failure' }}
+
     - name: Upload Test Results
       uses: actions/upload-artifact@v4
       if: always()  # Always upload test results, even if tests failed

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -306,7 +306,8 @@ runs:
       if: always()
       uses: ./.github/actions/push-metrics
       with:
-        pushgateway-url: ${{ env.PUSHGATEWAY_URL }}
+        otlp-endpoint: ${{ env.OTLP_ENDPOINT }}
+        otlp-token: ${{ env.OTLP_TOKEN }}
         loki-url: ${{ env.LOKI_URL }}
         test-results: test-results/
         framework: ${{ inputs.framework }}

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -40,6 +40,7 @@ examples:
   - 'deploy/pre-deployment/**'
 
 ignore:
+  - 'deploy/metrics/**'
   - '.lycheeignore'
   - '.pre-commit-config.yaml'
   - '.coderabbit.yaml'

--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -234,6 +234,16 @@ jobs:
           fresh_builder: ${{ inputs.fresh_builder }}
           extra_tags: ${{ inputs.extra_tags }}
           show_summary: ${{ inputs.push_image && inputs.show_summary }}
+      - name: Push Build Metrics
+        if: always()
+        uses: ./.github/actions/push-metrics
+        with:
+          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
+          otlp-token: ${{ secrets.OTLP_TOKEN }}
+          framework: ${{ inputs.framework }}
+          arch: ${{ inputs.platform }}
+          cuda-version: ${{ inputs.cuda_version }}
+          job-status: ${{ job.status }}
 
 
   # ============================================================================

--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -153,6 +153,10 @@ on:
         required: false
       HF_TOKEN:
         required: false
+      OTLP_ENDPOINT:
+        required: false
+      OTLP_TOKEN:
+        required: false
 jobs:
   # ============================================================================
   # BUILD

--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -248,6 +248,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       FRAMEWORK: ${{ inputs.framework }}
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
+      OTLP_TOKEN: ${{ secrets.OTLP_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
@@ -348,6 +350,8 @@ jobs:
     runs-on: prod-tester-amd-gpu-4-v1
     env:
       FRAMEWORK: ${{ inputs.framework }}
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
+      OTLP_TOKEN: ${{ secrets.OTLP_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -252,6 +252,8 @@ jobs:
     timeout-minutes: 30
     env:
       IMAGE_TAG: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${{ needs.build.outputs.test_tag_suffix }}
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
+      OTLP_TOKEN: ${{ secrets.OTLP_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
@@ -284,6 +286,8 @@ jobs:
     timeout-minutes: 30
     env:
       IMAGE_TAG: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${{ needs.build.outputs.test_tag_suffix }}
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
+      OTLP_TOKEN: ${{ secrets.OTLP_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -48,6 +48,47 @@ jobs:
         run: |
           echo "builder_name=${{ env.BUILDER_NAME }}" >> $GITHUB_OUTPUT
 
+  test-metrics-push-gitlab-group:
+    runs-on:
+      group: gitlab_ci_runners
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+      - name: Test DNS resolution
+        run: |
+          echo "=== Runner: gitlab_ci_runners group ==="
+          echo "=== DNS test ==="
+          nslookup otlp-http.nvidia.com || dig otlp-http.nvidia.com || echo "DNS failed"
+          echo "=== Curl test ==="
+          curl -sf --max-time 5 https://otlp-http.nvidia.com/ || echo "Curl failed (expected - no GET handler)"
+      - name: Push test metric
+        uses: ./.github/actions/push-metrics
+        with:
+          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
+          otlp-token: ${{ secrets.OTLP_TOKEN }}
+          framework: dns-test-gitlab-group
+          job-status: success
+
+  test-metrics-push-gitlab:
+    runs-on: gitlab
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+      - name: Test DNS resolution
+        run: |
+          echo "=== Runner: gitlab ==="
+          echo "=== DNS test ==="
+          nslookup otlp-http.nvidia.com || dig otlp-http.nvidia.com || echo "DNS failed"
+          echo "=== Curl test ==="
+          curl -sf --max-time 5 https://otlp-http.nvidia.com/ || echo "Curl failed (expected - no GET handler)"
+      - name: Push test metric
+        uses: ./.github/actions/push-metrics
+        with:
+          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
+          otlp-token: ${{ secrets.OTLP_TOKEN }}
+          framework: dns-test-gitlab
+          job-status: success
+
   dynamo-status-check:
     runs-on: ubuntu-latest
     needs: [changed-files, build, rust-checks, mypy, test-parallel, test-sequential]

--- a/deploy/metrics/README.md
+++ b/deploy/metrics/README.md
@@ -1,1 +1,2 @@
 # CI metrics push via OTLP
+

--- a/deploy/metrics/README.md
+++ b/deploy/metrics/README.md
@@ -1,0 +1,1 @@
+# CI metrics push via OTLP

--- a/deploy/metrics/cicd_push.py
+++ b/deploy/metrics/cicd_push.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/deploy/metrics/cicd_push.py
+++ b/deploy/metrics/cicd_push.py
@@ -34,6 +34,7 @@ Usage:
 """
 
 import argparse
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -269,7 +270,9 @@ def parse_args() -> argparse.Namespace:
     )
 
     # Targets
-    parser.add_argument("--pushgateway-url", help="Prometheus Pushgateway URL")
+    parser.add_argument("--otlp-endpoint", help="OTLP HTTP endpoint (e.g. https://otlp-http.nvidia.com)")
+    parser.add_argument("--otlp-token", help="Bearer token for OTLP auth (or set OTLP_TOKEN env / use --otlp-token-file)")
+    parser.add_argument("--otlp-token-file", help="File containing the OTLP bearer token")
     parser.add_argument("--loki-url", help="Loki base URL")
 
     # Data sources
@@ -287,7 +290,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--job-status", help="Job conclusion: success/failure/cancelled")
 
     # Behavior
-    parser.add_argument("--pushgateway-job", default="cicd_push", help="Prometheus job label")
+    parser.add_argument("--service-name", default="dynamo-cicd-metrics", help="OTLP service name")
     parser.add_argument("--dry-run", action="store_true", help="Log without pushing")
 
     return parser.parse_args()
@@ -296,8 +299,19 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
 
-    if not args.pushgateway_url and not args.loki_url:
-        print("Error: at least one of --pushgateway-url or --loki-url is required")
+    # Resolve OTLP token
+    otlp_token = args.otlp_token or os.environ.get("OTLP_TOKEN") or os.environ.get("OTEL_AUTH_TOKEN") or ""
+    if not otlp_token and args.otlp_token_file:
+        try:
+            with open(args.otlp_token_file) as f:
+                otlp_token = f.read().strip()
+        except Exception as e:
+            print(f"Warning: could not read token file {args.otlp_token_file}: {e}")
+
+    otlp_endpoint = args.otlp_endpoint or os.environ.get("OTLP_ENDPOINT") or ""
+
+    if not otlp_endpoint and not args.loki_url:
+        print("Error: at least one of --otlp-endpoint or --loki-url is required")
         sys.exit(1)
     if not args.test_results and not args.build_metrics:
         print("Error: at least one of --test-results or --build-metrics is required")
@@ -318,10 +332,11 @@ def main() -> None:
 
     # Initialize exporters
     prometheus = PrometheusExporter(
-        pushgateway_url=args.pushgateway_url or "",
-        job_name=args.pushgateway_job,
+        otlp_endpoint=otlp_endpoint,
+        otlp_token=otlp_token,
+        service_name=args.service_name,
         dry_run=args.dry_run,
-    ) if args.pushgateway_url else None
+    ) if otlp_endpoint else None
 
     loki = LokiExporter(
         loki_url=args.loki_url or "",
@@ -378,10 +393,9 @@ def main() -> None:
                 print("Warning: build metrics missing 'container' field")
 
     # ── 4. Push ───────────────────────────────────────────────────────
-    grouping_key = {"run_id": ctx.run_id, "job_name": ctx.job_name} if ctx.run_id else None
-
     if prometheus:
-        prometheus.push(grouping_key=grouping_key)
+        prometheus.push()
+        prometheus.shutdown()
     if loki:
         loki.flush()
 
@@ -389,7 +403,7 @@ def main() -> None:
     if prometheus:
         summary = prometheus.get_summary()
         parts = [f"{k}={v}" for k, v in sorted(summary.items()) if v > 0]
-        print(f"Prometheus: {', '.join(parts) if parts else 'no metrics'}")
+        print(f"OTLP metrics: {', '.join(parts) if parts else 'none'}")
     if loki:
         summary = loki.get_summary()
         parts = [f"{k}={v}" for k, v in sorted(summary.items()) if v > 0]

--- a/deploy/metrics/cicd_push.py
+++ b/deploy/metrics/cicd_push.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 CI/CD Metrics Push Client
 

--- a/deploy/metrics/cicd_push.py
+++ b/deploy/metrics/cicd_push.py
@@ -325,11 +325,11 @@ def main() -> None:
     otlp_endpoint = args.otlp_endpoint or os.environ.get("OTLP_ENDPOINT") or ""
 
     if not otlp_endpoint:
-        print("Error: --otlp-endpoint is required (or set OTLP_ENDPOINT)")
-        sys.exit(1)
+        print("No OTLP endpoint configured, skipping metrics push.")
+        sys.exit(0)
     if not args.test_results and not args.build_metrics:
-        print("Error: at least one of --test-results or --build-metrics is required")
-        sys.exit(1)
+        print("No test-results or build-metrics provided, skipping.")
+        sys.exit(0)
 
     # Read GitHub context from environment
     ctx = GitHubActionsContext.from_env()

--- a/deploy/metrics/cicd_push.py
+++ b/deploy/metrics/cicd_push.py
@@ -327,9 +327,6 @@ def main() -> None:
     if not otlp_endpoint:
         print("No OTLP endpoint configured, skipping metrics push.")
         sys.exit(0)
-    if not args.test_results and not args.build_metrics:
-        print("No test-results or build-metrics provided, skipping.")
-        sys.exit(0)
 
     # Read GitHub context from environment
     ctx = GitHubActionsContext.from_env()

--- a/deploy/metrics/cicd_push.py
+++ b/deploy/metrics/cicd_push.py
@@ -38,11 +38,11 @@ import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
+from loki_exporter import LokiExporter
 from opensearch_schema import (
     FIELD_ARCH,
-    FIELD_BRANCH,
     FIELD_BUILD_DURATION_SEC,
     FIELD_BUILD_FRAMEWORK,
     FIELD_BUILD_PLATFORM,
@@ -51,13 +51,9 @@ from opensearch_schema import (
     FIELD_BUILT_STEPS,
     FIELD_CACHE_HIT_RATE,
     FIELD_CACHED_STEPS,
-    FIELD_COMMIT_SHA,
     FIELD_ERROR_MESSAGE,
     FIELD_FRAMEWORK,
-    FIELD_GITHUB_EVENT,
     FIELD_ID,
-    FIELD_JOB_ID,
-    FIELD_JOB_NAME,
     FIELD_LAYER_CACHED,
     FIELD_LAYER_COMMAND,
     FIELD_LAYER_DURATION_SEC,
@@ -66,10 +62,6 @@ from opensearch_schema import (
     FIELD_LAYER_STATUS,
     FIELD_LAYER_STEP_NAME,
     FIELD_LAYER_STEP_NUMBER,
-    FIELD_PR_ID,
-    FIELD_REPO,
-    FIELD_RUN_ID,
-    FIELD_RUNNER_NAME,
     FIELD_STAGE_CACHE_HIT_RATE,
     FIELD_STAGE_DURATION_SEC,
     FIELD_STAGE_NAME,
@@ -80,16 +72,11 @@ from opensearch_schema import (
     FIELD_TEST_STATUS,
     FIELD_TEST_TYPE,
     FIELD_TOTAL_STEPS,
-    FIELD_USER_ALIAS,
-    FIELD_WORKFLOW_ID,
-    FIELD_WORKFLOW_NAME,
 )
 from parsers.build_metrics import parse_build_metrics_json
 from parsers.github_context import GitHubActionsContext
 from parsers.junit_xml import parse_junit_xml_directory
 from prometheus_exporter import PrometheusExporter
-from loki_exporter import LokiExporter
-
 
 # ── Document builders ─────────────────────────────────────────────────────
 # These construct the same s_*/l_* prefixed dicts the exporters expect.
@@ -107,7 +94,9 @@ def build_job_document(
     doc = {**common}
     doc[FIELD_ID] = f"ci-push-job-{ctx.run_id}-{ctx.job_name}"
     doc[FIELD_STATUS] = status
-    doc["l_status_number"] = 1 if status == "success" else (0 if status == "failure" else None)
+    doc["l_status_number"] = (
+        1 if status == "success" else (0 if status == "failure" else None)
+    )
     doc["s_runner_prefix"] = _extract_runner_prefix(ctx.runner_name)
     doc["@timestamp"] = timestamp
 
@@ -144,7 +133,11 @@ def build_test_document(
     doc[FIELD_TEST_DURATION] = int(test["time"] * 1000)  # ms
     doc[FIELD_TEST_STATUS] = test["status"]
     doc[FIELD_STATUS] = test["status"]
-    doc["l_test_status_number"] = 1 if test["status"] == "passed" else (0 if test["status"] in ("failed", "error") else None)
+    doc["l_test_status_number"] = (
+        1
+        if test["status"] == "passed"
+        else (0 if test["status"] in ("failed", "error") else None)
+    )
     doc[FIELD_FRAMEWORK] = args.framework or "unknown"
     doc[FIELD_TEST_TYPE] = args.test_type or "unknown"
     doc[FIELD_ARCH] = args.arch or common.get("s_arch", "unknown")
@@ -254,7 +247,9 @@ def _extract_runner_prefix(runner_name: str) -> str:
     if version_match:
         return version_match.group(1)
 
-    runner_suffix_match = re.match(r"^(.*?)-[a-z0-9]{4,8}-runner-[a-z0-9]+$", runner_name)
+    runner_suffix_match = re.match(
+        r"^(.*?)-[a-z0-9]{4,8}-runner-[a-z0-9]+$", runner_name
+    )
     if runner_suffix_match:
         return runner_suffix_match.group(1)
 
@@ -270,12 +265,21 @@ def parse_args() -> argparse.Namespace:
     )
 
     # Targets
-    parser.add_argument("--otlp-endpoint", help="OTLP HTTP endpoint (e.g. https://otlp-http.nvidia.com)")
-    parser.add_argument("--otlp-token", help="Bearer token for OTLP auth (or set OTLP_TOKEN env / use --otlp-token-file)")
-    parser.add_argument("--otlp-token-file", help="File containing the OTLP bearer token")
+    parser.add_argument(
+        "--otlp-endpoint", help="OTLP HTTP endpoint (e.g. https://otlp-http.nvidia.com)"
+    )
+    parser.add_argument(
+        "--otlp-token",
+        help="Bearer token for OTLP auth (or set OTLP_TOKEN env / use --otlp-token-file)",
+    )
+    parser.add_argument(
+        "--otlp-token-file", help="File containing the OTLP bearer token"
+    )
 
     # Data sources
-    parser.add_argument("--test-results", help="Path to directory containing JUnit XML files")
+    parser.add_argument(
+        "--test-results", help="Path to directory containing JUnit XML files"
+    )
     parser.add_argument("--build-metrics", help="Path to build_metrics.json file")
 
     # Metadata
@@ -285,11 +289,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--cuda-version", help="CUDA version")
 
     # Job timing
-    parser.add_argument("--job-started-at", help="Job start time ISO 8601 (from github.run_started_at)")
-    parser.add_argument("--job-status", help="Job conclusion: success/failure/cancelled")
+    parser.add_argument(
+        "--job-started-at", help="Job start time ISO 8601 (from github.run_started_at)"
+    )
+    parser.add_argument(
+        "--job-status", help="Job conclusion: success/failure/cancelled"
+    )
 
     # Behavior
-    parser.add_argument("--service-name", default="dynamo-cicd-metrics", help="OTLP service name")
+    parser.add_argument(
+        "--service-name", default="dynamo-cicd-metrics", help="OTLP service name"
+    )
     parser.add_argument("--dry-run", action="store_true", help="Log without pushing")
 
     return parser.parse_args()
@@ -299,7 +309,12 @@ def main() -> None:
     args = parse_args()
 
     # Resolve OTLP token
-    otlp_token = args.otlp_token or os.environ.get("OTLP_TOKEN") or os.environ.get("OTEL_AUTH_TOKEN") or ""
+    otlp_token = (
+        args.otlp_token
+        or os.environ.get("OTLP_TOKEN")
+        or os.environ.get("OTEL_AUTH_TOKEN")
+        or ""
+    )
     if not otlp_token and args.otlp_token_file:
         try:
             with open(args.otlp_token_file) as f:
@@ -371,19 +386,29 @@ def main() -> None:
         else:
             metrics = parse_build_metrics_json(metrics_path)
             if metrics and "container" in metrics:
-                container_doc = build_container_document(metrics, common, args, timestamp)
+                container_doc = build_container_document(
+                    metrics, common, args, timestamp
+                )
                 prometheus.record_container(container_doc)
-                print(f"Recorded container metrics: {container_doc.get(FIELD_BUILD_FRAMEWORK)}")
+                print(
+                    f"Recorded container metrics: {container_doc.get(FIELD_BUILD_FRAMEWORK)}"
+                )
 
                 for stage in metrics.get("stages", []):
-                    stage_doc = build_stage_document(stage, metrics, common, args, timestamp)
+                    stage_doc = build_stage_document(
+                        stage, metrics, common, args, timestamp
+                    )
                     prometheus.record_stage(stage_doc)
 
                 for layer in metrics.get("layers", []):
-                    layer_doc = build_layer_document(layer, metrics, common, args, timestamp)
+                    layer_doc = build_layer_document(
+                        layer, metrics, common, args, timestamp
+                    )
                     loki.record_build_layer(layer_doc)
 
-                print(f"Recorded {len(metrics.get('stages', []))} stages, {len(metrics.get('layers', []))} layers")
+                print(
+                    f"Recorded {len(metrics.get('stages', []))} stages, {len(metrics.get('layers', []))} layers"
+                )
             else:
                 print("Warning: build metrics missing 'container' field")
 

--- a/deploy/metrics/cicd_push.py
+++ b/deploy/metrics/cicd_push.py
@@ -273,7 +273,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--otlp-endpoint", help="OTLP HTTP endpoint (e.g. https://otlp-http.nvidia.com)")
     parser.add_argument("--otlp-token", help="Bearer token for OTLP auth (or set OTLP_TOKEN env / use --otlp-token-file)")
     parser.add_argument("--otlp-token-file", help="File containing the OTLP bearer token")
-    parser.add_argument("--loki-url", help="Loki base URL")
 
     # Data sources
     parser.add_argument("--test-results", help="Path to directory containing JUnit XML files")
@@ -310,8 +309,8 @@ def main() -> None:
 
     otlp_endpoint = args.otlp_endpoint or os.environ.get("OTLP_ENDPOINT") or ""
 
-    if not otlp_endpoint and not args.loki_url:
-        print("Error: at least one of --otlp-endpoint or --loki-url is required")
+    if not otlp_endpoint:
+        print("Error: --otlp-endpoint is required (or set OTLP_ENDPOINT)")
         sys.exit(1)
     if not args.test_results and not args.build_metrics:
         print("Error: at least one of --test-results or --build-metrics is required")
@@ -330,23 +329,24 @@ def main() -> None:
     common = ctx.to_common_fields()
     timestamp = datetime.now(timezone.utc).isoformat()
 
-    # Initialize exporters
+    # Initialize exporters — both metrics and logs go through OTLP
     prometheus = PrometheusExporter(
         otlp_endpoint=otlp_endpoint,
         otlp_token=otlp_token,
         service_name=args.service_name,
         dry_run=args.dry_run,
-    ) if otlp_endpoint else None
+    )
 
     loki = LokiExporter(
-        loki_url=args.loki_url or "",
+        otlp_endpoint=otlp_endpoint,
+        otlp_token=otlp_token,
+        service_name=args.service_name,
         dry_run=args.dry_run,
-    ) if args.loki_url else None
+    )
 
     # ── 1. Job-level metrics ──────────────────────────────────────────
     job_doc = build_job_document(ctx, args, timestamp)
-    if prometheus:
-        prometheus.record_job(job_doc)
+    prometheus.record_job(job_doc)
     print(f"Recorded job metrics: {ctx.job_name} status={args.job_status}")
 
     # ── 2. Test results ───────────────────────────────────────────────
@@ -360,10 +360,8 @@ def main() -> None:
 
             for test in tests:
                 doc = build_test_document(test, common, args, timestamp)
-                if prometheus:
-                    prometheus.record_test(doc)
-                if loki:
-                    loki.record_test_result(doc)
+                prometheus.record_test(doc)
+                loki.record_test_result(doc)
 
     # ── 3. Build metrics ──────────────────────────────────────────────
     if args.build_metrics:
@@ -374,40 +372,34 @@ def main() -> None:
             metrics = parse_build_metrics_json(metrics_path)
             if metrics and "container" in metrics:
                 container_doc = build_container_document(metrics, common, args, timestamp)
-                if prometheus:
-                    prometheus.record_container(container_doc)
+                prometheus.record_container(container_doc)
                 print(f"Recorded container metrics: {container_doc.get(FIELD_BUILD_FRAMEWORK)}")
 
                 for stage in metrics.get("stages", []):
                     stage_doc = build_stage_document(stage, metrics, common, args, timestamp)
-                    if prometheus:
-                        prometheus.record_stage(stage_doc)
+                    prometheus.record_stage(stage_doc)
 
                 for layer in metrics.get("layers", []):
                     layer_doc = build_layer_document(layer, metrics, common, args, timestamp)
-                    if loki:
-                        loki.record_build_layer(layer_doc)
+                    loki.record_build_layer(layer_doc)
 
                 print(f"Recorded {len(metrics.get('stages', []))} stages, {len(metrics.get('layers', []))} layers")
             else:
                 print("Warning: build metrics missing 'container' field")
 
     # ── 4. Push ───────────────────────────────────────────────────────
-    if prometheus:
-        prometheus.push()
-        prometheus.shutdown()
-    if loki:
-        loki.flush()
+    prometheus.push()
+    prometheus.shutdown()
+    loki.flush()
+    loki.shutdown()
 
     # Summary
-    if prometheus:
-        summary = prometheus.get_summary()
-        parts = [f"{k}={v}" for k, v in sorted(summary.items()) if v > 0]
-        print(f"OTLP metrics: {', '.join(parts) if parts else 'none'}")
-    if loki:
-        summary = loki.get_summary()
-        parts = [f"{k}={v}" for k, v in sorted(summary.items()) if v > 0]
-        print(f"Loki: {', '.join(parts) if parts else 'no entries'}")
+    prom_summary = prometheus.get_summary()
+    loki_summary = loki.get_summary()
+    parts = [f"{k}={v}" for k, v in sorted(prom_summary.items()) if v > 0]
+    print(f"OTLP metrics: {', '.join(parts) if parts else 'none'}")
+    parts = [f"{k}={v}" for k, v in sorted(loki_summary.items()) if v > 0]
+    print(f"OTLP logs: {', '.join(parts) if parts else 'none'}")
 
     print("Done.")
 

--- a/deploy/metrics/cicd_push.py
+++ b/deploy/metrics/cicd_push.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""
+CI/CD Metrics Push Client
+
+Lightweight CLI that runs as a GitHub Actions step to push test results and
+build metrics directly to Prometheus Pushgateway and Loki.  Replaces the
+cron-based artifact-download pipeline for data that the CI job already has.
+
+Usage:
+    python cicd_push.py \
+        --pushgateway-url http://pushgateway:9091 \
+        --loki-url http://loki:3100 \
+        --test-results ./test-results/ \
+        --build-metrics ./build_metrics.json \
+        --framework sglang \
+        --test-type pre_merge \
+        --cuda-version 12.8 \
+        --job-status success \
+        --job-started-at 2025-04-01T12:00:00Z
+"""
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from opensearch_schema import (
+    FIELD_ARCH,
+    FIELD_BRANCH,
+    FIELD_BUILD_DURATION_SEC,
+    FIELD_BUILD_FRAMEWORK,
+    FIELD_BUILD_PLATFORM,
+    FIELD_BUILD_SIZE_BYTES,
+    FIELD_BUILD_TARGET,
+    FIELD_BUILT_STEPS,
+    FIELD_CACHE_HIT_RATE,
+    FIELD_CACHED_STEPS,
+    FIELD_COMMIT_SHA,
+    FIELD_ERROR_MESSAGE,
+    FIELD_FRAMEWORK,
+    FIELD_GITHUB_EVENT,
+    FIELD_ID,
+    FIELD_JOB_ID,
+    FIELD_JOB_NAME,
+    FIELD_LAYER_CACHED,
+    FIELD_LAYER_COMMAND,
+    FIELD_LAYER_DURATION_SEC,
+    FIELD_LAYER_SIZE_TRANSFERRED,
+    FIELD_LAYER_STAGE,
+    FIELD_LAYER_STATUS,
+    FIELD_LAYER_STEP_NAME,
+    FIELD_LAYER_STEP_NUMBER,
+    FIELD_PR_ID,
+    FIELD_REPO,
+    FIELD_RUN_ID,
+    FIELD_RUNNER_NAME,
+    FIELD_STAGE_CACHE_HIT_RATE,
+    FIELD_STAGE_DURATION_SEC,
+    FIELD_STAGE_NAME,
+    FIELD_STATUS,
+    FIELD_TEST_CLASSNAME,
+    FIELD_TEST_DURATION,
+    FIELD_TEST_NAME,
+    FIELD_TEST_STATUS,
+    FIELD_TEST_TYPE,
+    FIELD_TOTAL_STEPS,
+    FIELD_USER_ALIAS,
+    FIELD_WORKFLOW_ID,
+    FIELD_WORKFLOW_NAME,
+)
+from parsers.build_metrics import parse_build_metrics_json
+from parsers.github_context import GitHubActionsContext
+from parsers.junit_xml import parse_junit_xml_directory
+from prometheus_exporter import PrometheusExporter
+from loki_exporter import LokiExporter
+
+
+# ── Document builders ─────────────────────────────────────────────────────
+# These construct the same s_*/l_* prefixed dicts the exporters expect.
+
+
+def build_job_document(
+    ctx: GitHubActionsContext,
+    args: argparse.Namespace,
+    timestamp: str,
+) -> Dict[str, Any]:
+    """Build a job-level metrics document."""
+    common = ctx.to_common_fields()
+    status = args.job_status or "unknown"
+
+    doc = {**common}
+    doc[FIELD_ID] = f"ci-push-job-{ctx.run_id}-{ctx.job_name}"
+    doc[FIELD_STATUS] = status
+    doc["l_status_number"] = 1 if status == "success" else (0 if status == "failure" else None)
+    doc["s_runner_prefix"] = _extract_runner_prefix(ctx.runner_name)
+    doc["@timestamp"] = timestamp
+
+    # Duration from --job-started-at
+    if args.job_started_at:
+        try:
+            started = datetime.fromisoformat(args.job_started_at.replace("Z", "+00:00"))
+            now = datetime.now(timezone.utc)
+            doc["l_duration_sec"] = max(0, int((now - started).total_seconds()))
+        except Exception:
+            doc["l_duration_sec"] = 0
+    else:
+        doc["l_duration_sec"] = 0
+
+    doc["l_queue_time_sec"] = 0  # Not available without API call
+    return doc
+
+
+def build_test_document(
+    test: Dict[str, Any],
+    common: Dict[str, Any],
+    args: argparse.Namespace,
+    timestamp: str,
+) -> Dict[str, Any]:
+    """Build an individual test result document."""
+    test_name = test["name"]
+    test_classname = test.get("classname", "")
+    full_name = f"{test_classname}::{test_name}" if test_classname else test_name
+
+    doc = {**common}
+    doc[FIELD_ID] = f"ci-push-test-{common['s_job_id']}-{hash(full_name) & 0x7FFFFFFF}"
+    doc[FIELD_TEST_NAME] = test_name
+    doc[FIELD_TEST_CLASSNAME] = test_classname
+    doc[FIELD_TEST_DURATION] = int(test["time"] * 1000)  # ms
+    doc[FIELD_TEST_STATUS] = test["status"]
+    doc[FIELD_STATUS] = test["status"]
+    doc["l_test_status_number"] = 1 if test["status"] == "passed" else (0 if test["status"] in ("failed", "error") else None)
+    doc[FIELD_FRAMEWORK] = args.framework or "unknown"
+    doc[FIELD_TEST_TYPE] = args.test_type or "unknown"
+    doc[FIELD_ARCH] = args.arch or common.get("s_arch", "unknown")
+    doc["s_cuda_version"] = args.cuda_version or ""
+    doc["@timestamp"] = timestamp
+
+    error_msg = test.get("error_message", "")
+    if error_msg:
+        doc[FIELD_ERROR_MESSAGE] = error_msg[:1000]
+
+    return doc
+
+
+def build_container_document(
+    metrics: Dict[str, Any],
+    common: Dict[str, Any],
+    args: argparse.Namespace,
+    timestamp: str,
+) -> Dict[str, Any]:
+    """Build container-level build metrics document."""
+    container = metrics.get("container", {})
+    framework = container.get("framework", args.framework or "unknown")
+
+    doc = {**common}
+    doc[FIELD_ID] = f"ci-push-container-{common['s_job_id']}-{framework}"
+    doc[FIELD_STATUS] = args.job_status or "unknown"
+    doc[FIELD_BUILD_FRAMEWORK] = framework
+    doc[FIELD_BUILD_TARGET] = container.get("target", "unknown")
+    doc[FIELD_BUILD_PLATFORM] = container.get("platform", "unknown")
+    doc[FIELD_BUILD_SIZE_BYTES] = container.get("image_size_bytes", 0)
+    doc[FIELD_TOTAL_STEPS] = container.get("total_steps", 0)
+    doc[FIELD_CACHED_STEPS] = container.get("cached_steps", 0)
+    doc[FIELD_BUILT_STEPS] = container.get("built_steps", 0)
+    doc[FIELD_CACHE_HIT_RATE] = container.get("overall_cache_hit_rate", 0.0)
+    doc[FIELD_BUILD_DURATION_SEC] = container.get("build_duration_sec", 0)
+    doc["s_cuda_version"] = args.cuda_version or ""
+
+    if "build_end_time" in container:
+        doc["@timestamp"] = container["build_end_time"]
+    else:
+        doc["@timestamp"] = timestamp
+
+    return doc
+
+
+def build_stage_document(
+    stage: Dict[str, Any],
+    metrics: Dict[str, Any],
+    common: Dict[str, Any],
+    args: argparse.Namespace,
+    timestamp: str,
+) -> Dict[str, Any]:
+    """Build stage-level build metrics document."""
+    container = metrics.get("container", {})
+    framework = container.get("framework", args.framework or "unknown")
+    stage_name = stage.get("stage_name", "unknown")
+
+    doc = {**common}
+    doc[FIELD_ID] = f"ci-push-stage-{common['s_job_id']}-{framework}-{stage_name}"
+    doc[FIELD_BUILD_FRAMEWORK] = framework
+    doc[FIELD_STAGE_NAME] = stage_name
+    doc[FIELD_STAGE_DURATION_SEC] = stage.get("build_duration_sec", 0.0)
+    doc[FIELD_STAGE_CACHE_HIT_RATE] = stage.get("cache_hit_rate", 0.0)
+    doc["s_cuda_version"] = args.cuda_version or ""
+    doc["@timestamp"] = container.get("build_end_time", timestamp)
+    return doc
+
+
+def build_layer_document(
+    layer: Dict[str, Any],
+    metrics: Dict[str, Any],
+    common: Dict[str, Any],
+    args: argparse.Namespace,
+    timestamp: str,
+) -> Dict[str, Any]:
+    """Build layer-level build event document (for Loki)."""
+    container = metrics.get("container", {})
+    framework = container.get("framework", args.framework or "unknown")
+
+    doc = {**common}
+    doc[FIELD_BUILD_FRAMEWORK] = framework
+    doc[FIELD_LAYER_STAGE] = layer.get("stage", "unknown")
+    doc[FIELD_LAYER_STEP_NUMBER] = layer.get("step_number", 0)
+    doc[FIELD_LAYER_STEP_NAME] = layer.get("step_name", "unknown")
+    doc[FIELD_LAYER_COMMAND] = layer.get("command", "")
+    doc[FIELD_LAYER_STATUS] = layer.get("status", "unknown")
+    doc[FIELD_LAYER_CACHED] = layer.get("cached", False)
+    doc[FIELD_LAYER_DURATION_SEC] = layer.get("duration_sec", 0.0)
+    doc[FIELD_LAYER_SIZE_TRANSFERRED] = layer.get("size_transferred", 0)
+    doc["s_cuda_version"] = args.cuda_version or ""
+    doc["@timestamp"] = container.get("build_end_time", timestamp)
+    return doc
+
+
+def _extract_runner_prefix(runner_name: str) -> str:
+    """Extract runner prefix (same logic as WorkflowMetricsProcessor)."""
+    if not runner_name:
+        return "unknown"
+    import re
+
+    if " " in runner_name:
+        parts = runner_name.rsplit(" ", 1)
+        if len(parts) == 2 and parts[1].isdigit():
+            return parts[0]
+
+    version_match = re.match(r"^(.*-v\d+)", runner_name)
+    if version_match:
+        return version_match.group(1)
+
+    runner_suffix_match = re.match(r"^(.*?)-[a-z0-9]{4,8}-runner-[a-z0-9]+$", runner_name)
+    if runner_suffix_match:
+        return runner_suffix_match.group(1)
+
+    return runner_name
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Push CI/CD metrics directly from a GitHub Actions job",
+    )
+
+    # Targets
+    parser.add_argument("--pushgateway-url", help="Prometheus Pushgateway URL")
+    parser.add_argument("--loki-url", help="Loki base URL")
+
+    # Data sources
+    parser.add_argument("--test-results", help="Path to directory containing JUnit XML files")
+    parser.add_argument("--build-metrics", help="Path to build_metrics.json file")
+
+    # Metadata
+    parser.add_argument("--framework", help="Framework name (e.g. sglang, vllm)")
+    parser.add_argument("--test-type", help="Test type (e.g. pre_merge, nightly)")
+    parser.add_argument("--arch", help="Architecture (default: from RUNNER_ARCH)")
+    parser.add_argument("--cuda-version", help="CUDA version")
+
+    # Job timing
+    parser.add_argument("--job-started-at", help="Job start time ISO 8601 (from github.run_started_at)")
+    parser.add_argument("--job-status", help="Job conclusion: success/failure/cancelled")
+
+    # Behavior
+    parser.add_argument("--pushgateway-job", default="cicd_push", help="Prometheus job label")
+    parser.add_argument("--dry-run", action="store_true", help="Log without pushing")
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if not args.pushgateway_url and not args.loki_url:
+        print("Error: at least one of --pushgateway-url or --loki-url is required")
+        sys.exit(1)
+    if not args.test_results and not args.build_metrics:
+        print("Error: at least one of --test-results or --build-metrics is required")
+        sys.exit(1)
+
+    # Read GitHub context from environment
+    ctx = GitHubActionsContext.from_env()
+    if not ctx.repo:
+        print("Warning: GITHUB_REPOSITORY not set — running outside CI?")
+
+    if args.arch:
+        pass  # explicit override
+    elif ctx.runner_arch:
+        args.arch = ctx.runner_arch.lower()
+
+    common = ctx.to_common_fields()
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    # Initialize exporters
+    prometheus = PrometheusExporter(
+        pushgateway_url=args.pushgateway_url or "",
+        job_name=args.pushgateway_job,
+        dry_run=args.dry_run,
+    ) if args.pushgateway_url else None
+
+    loki = LokiExporter(
+        loki_url=args.loki_url or "",
+        dry_run=args.dry_run,
+    ) if args.loki_url else None
+
+    # ── 1. Job-level metrics ──────────────────────────────────────────
+    job_doc = build_job_document(ctx, args, timestamp)
+    if prometheus:
+        prometheus.record_job(job_doc)
+    print(f"Recorded job metrics: {ctx.job_name} status={args.job_status}")
+
+    # ── 2. Test results ───────────────────────────────────────────────
+    if args.test_results:
+        test_dir = Path(args.test_results)
+        if not test_dir.exists():
+            print(f"Warning: test-results path does not exist: {test_dir}")
+        else:
+            tests = parse_junit_xml_directory(test_dir)
+            print(f"Parsed {len(tests)} test results from {test_dir}")
+
+            for test in tests:
+                doc = build_test_document(test, common, args, timestamp)
+                if prometheus:
+                    prometheus.record_test(doc)
+                if loki:
+                    loki.record_test_result(doc)
+
+    # ── 3. Build metrics ──────────────────────────────────────────────
+    if args.build_metrics:
+        metrics_path = Path(args.build_metrics)
+        if not metrics_path.exists():
+            print(f"Warning: build-metrics path does not exist: {metrics_path}")
+        else:
+            metrics = parse_build_metrics_json(metrics_path)
+            if metrics and "container" in metrics:
+                container_doc = build_container_document(metrics, common, args, timestamp)
+                if prometheus:
+                    prometheus.record_container(container_doc)
+                print(f"Recorded container metrics: {container_doc.get(FIELD_BUILD_FRAMEWORK)}")
+
+                for stage in metrics.get("stages", []):
+                    stage_doc = build_stage_document(stage, metrics, common, args, timestamp)
+                    if prometheus:
+                        prometheus.record_stage(stage_doc)
+
+                for layer in metrics.get("layers", []):
+                    layer_doc = build_layer_document(layer, metrics, common, args, timestamp)
+                    if loki:
+                        loki.record_build_layer(layer_doc)
+
+                print(f"Recorded {len(metrics.get('stages', []))} stages, {len(metrics.get('layers', []))} layers")
+            else:
+                print("Warning: build metrics missing 'container' field")
+
+    # ── 4. Push ───────────────────────────────────────────────────────
+    grouping_key = {"run_id": ctx.run_id, "job_name": ctx.job_name} if ctx.run_id else None
+
+    if prometheus:
+        prometheus.push(grouping_key=grouping_key)
+    if loki:
+        loki.flush()
+
+    # Summary
+    if prometheus:
+        summary = prometheus.get_summary()
+        parts = [f"{k}={v}" for k, v in sorted(summary.items()) if v > 0]
+        print(f"Prometheus: {', '.join(parts) if parts else 'no metrics'}")
+    if loki:
+        summary = loki.get_summary()
+        parts = [f"{k}={v}" for k, v in sorted(summary.items()) if v > 0]
+        print(f"Loki: {', '.join(parts) if parts else 'no entries'}")
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/metrics/loki_exporter.py
+++ b/deploy/metrics/loki_exporter.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/deploy/metrics/loki_exporter.py
+++ b/deploy/metrics/loki_exporter.py
@@ -1,0 +1,278 @@
+"""
+Loki HTTP push exporter for CI/CD event logs.
+
+Pushes structured JSON logs to Loki via the /loki/api/v1/push endpoint.
+Handles high-cardinality data that doesn't belong in Prometheus:
+steps, layers, reviews, commits, issues, and full test/PR event details.
+"""
+
+import json
+import logging
+import time
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+import requests
+
+log = logging.getLogger(__name__)
+
+# Maximum batch size before auto-flush
+_MAX_BATCH_SIZE = 100
+
+
+class LokiExporter:
+    """Exports CI/CD event logs to Loki via HTTP push."""
+
+    def __init__(self, loki_url: str, dry_run: bool = False):
+        """
+        Args:
+            loki_url: Loki base URL (e.g., "http://loki:3100")
+            dry_run: If True, log what would be sent without actually pushing
+        """
+        self.loki_url = loki_url.rstrip("/") if loki_url else ""
+        self.push_url = f"{self.loki_url}/loki/api/v1/push" if self.loki_url else ""
+        self.dry_run = dry_run
+
+        # Batched entries keyed by stream label tuple
+        self._streams: Dict[tuple, List[tuple]] = defaultdict(list)
+
+        # Counters
+        self._counters: Dict[str, int] = defaultdict(int)
+
+        # Session for connection pooling
+        self._session = requests.Session()
+        self._session.headers.update({"Content-Type": "application/json"})
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def record_test_result(self, doc: Dict[str, Any]) -> None:
+        """Record a test result event for Loki."""
+        stream_labels = {
+            "source": "cicd",
+            "type": "test_result",
+            "repo": doc.get("s_repo", ""),
+            "branch": doc.get("s_branch", ""),
+            "framework": doc.get("s_framework", "unknown"),
+        }
+        body = {
+            "commit_sha": doc.get("s_commit_sha", ""),
+            "test_name": doc.get("s_test_name", ""),
+            "test_classname": doc.get("s_test_classname", ""),
+            "status": doc.get("s_test_status", doc.get("s_status", "")),
+            "duration_ms": doc.get("l_test_duration_ms", 0),
+            "error_message": doc.get("s_error_message", ""),
+            "job_id": doc.get("s_job_id", ""),
+            "job_name": doc.get("s_job_name", ""),
+            "run_id": doc.get("s_run_id", ""),
+            "workflow_name": doc.get("s_workflow_name", ""),
+            "pr_id": doc.get("s_pr_id", ""),
+            "arch": doc.get("s_arch", ""),
+            "cuda_version": doc.get("s_cuda_version", ""),
+            "test_type": doc.get("s_test_type", ""),
+        }
+        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        self._counters["test_results"] += 1
+
+    def record_build_layer(self, doc: Dict[str, Any]) -> None:
+        """Record a build layer event for Loki."""
+        stream_labels = {
+            "source": "cicd",
+            "type": "build_layer",
+            "repo": doc.get("s_repo", ""),
+            "framework": doc.get("s_build_framework", "unknown"),
+        }
+        body = {
+            "commit_sha": doc.get("s_commit_sha", ""),
+            "stage_name": doc.get("s_stage", ""),
+            "step_number": doc.get("l_step_number", 0),
+            "step_name": doc.get("s_step_name", ""),
+            "command": doc.get("s_command", ""),
+            "cached": doc.get("b_cached", False),
+            "duration_sec": doc.get("f_duration_sec", 0),
+            "size_transferred": doc.get("l_size_transferred", 0),
+            "job_id": doc.get("s_job_id", ""),
+            "branch": doc.get("s_branch", ""),
+            "cuda_version": doc.get("s_cuda_version", ""),
+        }
+        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        self._counters["build_layers"] += 1
+
+    def record_workflow_step(self, doc: Dict[str, Any]) -> None:
+        """Record a workflow step event for Loki."""
+        stream_labels = {
+            "source": "cicd",
+            "type": "workflow_step",
+            "repo": doc.get("s_repo", ""),
+        }
+        body = {
+            "commit_sha": doc.get("s_commit_sha", ""),
+            "step_name": doc.get("s_step_name", ""),
+            "step_number": doc.get("l_step_number", 0),
+            "command": doc.get("s_command", ""),
+            "status": doc.get("s_status", ""),
+            "duration_sec": doc.get("l_duration_sec", 0),
+            "job_id": doc.get("s_job_id", ""),
+            "job_name": doc.get("s_job_name", ""),
+            "workflow_name": doc.get("s_workflow_name", ""),
+            "branch": doc.get("s_branch", ""),
+        }
+        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        self._counters["workflow_steps"] += 1
+
+    def record_pr_event(self, doc: Dict[str, Any]) -> None:
+        """Record a PR event for Loki."""
+        stream_labels = {
+            "source": "cicd",
+            "type": "pr_event",
+            "repo": doc.get("s_repo", ""),
+        }
+        body = {
+            "commit_sha": doc.get("s_commit_sha", ""),
+            "pr_number": doc.get("l_pr_number", 0),
+            "author": doc.get("s_author", ""),
+            "author_association": doc.get("s_author_association", ""),
+            "is_external": doc.get("b_is_external", False),
+            "state": doc.get("s_state", ""),
+            "merged_by": doc.get("s_merged_by", ""),
+            "time_to_merge_hours": doc.get("l_time_to_merge_hours"),
+            "base_branch": doc.get("s_base_branch", ""),
+            "created_at": doc.get("ts_created_at", ""),
+            "merged_at": doc.get("ts_merged_at", ""),
+        }
+        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        self._counters["pr_events"] += 1
+
+    def record_review(self, doc: Dict[str, Any]) -> None:
+        """Record a review event for Loki."""
+        stream_labels = {
+            "source": "cicd",
+            "type": "review",
+            "repo": doc.get("s_repo", ""),
+        }
+        body = {
+            "reviewer": doc.get("s_reviewer", ""),
+            "state": doc.get("s_state", ""),
+        }
+        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        self._counters["reviews"] += 1
+
+    def record_commit(self, doc: Dict[str, Any]) -> None:
+        """Record a commit event for Loki."""
+        stream_labels = {
+            "source": "cicd",
+            "type": "commit",
+            "repo": doc.get("s_repo", ""),
+        }
+        body = {
+            "sha": doc.get("s_sha", ""),
+            "author": doc.get("s_author", ""),
+            "committer": doc.get("s_committer", ""),
+            "branch": doc.get("s_branch", ""),
+            "committed_at": doc.get("ts_committed_at", ""),
+        }
+        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        self._counters["commits"] += 1
+
+    def record_issue(self, doc: Dict[str, Any]) -> None:
+        """Record an issue event for Loki."""
+        stream_labels = {
+            "source": "cicd",
+            "type": "issue",
+            "repo": doc.get("s_repo", ""),
+        }
+        body = {
+            "issue_number": doc.get("l_issue_number", 0),
+            "author": doc.get("s_author", ""),
+            "author_association": doc.get("s_author_association", ""),
+            "is_external": doc.get("b_is_external", False),
+            "state": doc.get("s_state", ""),
+            "comments_count": doc.get("l_comments_count", 0),
+            "labels": doc.get("s_labels", ""),
+            "assignee": doc.get("s_assignee", ""),
+            "closed_by": doc.get("s_closed_by", ""),
+            "created_at": doc.get("ts_created_at", ""),
+            "closed_at": doc.get("ts_closed_at", ""),
+            "time_to_close_hours": doc.get("l_time_to_close_hours"),
+        }
+        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        self._counters["issues"] += 1
+
+    # ── Flush / Push ──────────────────────────────────────────────────────────
+
+    def flush(self) -> None:
+        """Flush all buffered entries to Loki."""
+        if not self._streams:
+            return
+
+        if self.dry_run:
+            total = sum(len(entries) for entries in self._streams.values())
+            log.info("[DRY RUN] Would push %d entries to Loki across %d streams",
+                     total, len(self._streams))
+            self._streams.clear()
+            return
+
+        if not self.push_url:
+            log.warning("LOKI_URL not configured, skipping Loki push")
+            self._streams.clear()
+            return
+
+        # Build Loki push payload
+        streams = []
+        for label_key, entries in self._streams.items():
+            label_dict = dict(label_key)
+            streams.append({
+                "stream": label_dict,
+                "values": entries,
+            })
+
+        payload = {"streams": streams}
+
+        try:
+            resp = self._session.post(self.push_url, json=payload, timeout=30)
+            if resp.status_code in (200, 204):
+                total = sum(len(s["values"]) for s in streams)
+                log.info("Pushed %d entries to Loki across %d streams", total, len(streams))
+            else:
+                log.error("Loki push failed: HTTP %d — %s", resp.status_code, resp.text[:500])
+        except Exception:
+            log.exception("Failed to push entries to Loki")
+        finally:
+            self._streams.clear()
+
+    # ── Internal ──────────────────────────────────────────────────────────────
+
+    def _add_entry(
+        self,
+        stream_labels: Dict[str, str],
+        body: Dict[str, Any],
+        timestamp: Optional[str] = None,
+    ) -> None:
+        """Add an entry to the buffer, auto-flushing if the batch is large."""
+        # Convert stream labels to a hashable key
+        key = tuple(sorted(stream_labels.items()))
+
+        # Loki expects [timestamp_ns, json_line]
+        ts_ns = self._to_nanoseconds(timestamp)
+        line = json.dumps(body, default=str)
+
+        self._streams[key].append([str(ts_ns), line])
+
+        # Auto-flush if any stream gets too large
+        if len(self._streams[key]) >= _MAX_BATCH_SIZE:
+            self.flush()
+
+    @staticmethod
+    def _to_nanoseconds(timestamp: Optional[str]) -> int:
+        """Convert an ISO timestamp to nanoseconds since epoch, or use current time."""
+        if not timestamp:
+            return int(time.time() * 1e9)
+        try:
+            from datetime import datetime, timezone
+            dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            return int(dt.timestamp() * 1e9)
+        except Exception:
+            return int(time.time() * 1e9)
+
+    def get_summary(self) -> Dict[str, int]:
+        """Return counts of recorded entries."""
+        return dict(self._counters)

--- a/deploy/metrics/loki_exporter.py
+++ b/deploy/metrics/loki_exporter.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Loki HTTP push exporter for CI/CD event logs.
 

--- a/deploy/metrics/loki_exporter.py
+++ b/deploy/metrics/loki_exporter.py
@@ -13,68 +13,113 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Loki HTTP push exporter for CI/CD event logs.
+OpenTelemetry OTLP log exporter for CI/CD event logs.
 
-Pushes structured JSON logs to Loki via the /loki/api/v1/push endpoint.
-Handles high-cardinality data that doesn't belong in Prometheus:
-steps, layers, reviews, commits, issues, and full test/PR event details.
+Pushes structured log records to an OTLP HTTP endpoint (e.g.,
+https://otlp-http.nvidia.com/v1/logs) routed to Loki.  Handles
+high-cardinality data: steps, layers, reviews, commits, issues,
+and full test/PR event details.
+
+The public record_*() API accepts the same OpenSearch-shaped dicts
+as the previous native-Loki implementation.
 """
 
 import json
 import logging
-import time
 from collections import defaultdict
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
-import requests
+from opentelemetry import _logs as logs_api
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
 
 log = logging.getLogger(__name__)
 
-# Maximum batch size before auto-flush
-_MAX_BATCH_SIZE = 100
-
 
 class LokiExporter:
-    """Exports CI/CD event logs to Loki via HTTP push."""
+    """Exports CI/CD event logs via OpenTelemetry OTLP HTTP.
 
-    def __init__(self, loki_url: str, dry_run: bool = False):
-        """
-        Args:
-            loki_url: Loki base URL (e.g., "http://loki:3100")
-            dry_run: If True, log what would be sent without actually pushing
-        """
-        self.loki_url = loki_url.rstrip("/") if loki_url else ""
-        self.push_url = f"{self.loki_url}/loki/api/v1/push" if self.loki_url else ""
+    Despite the class name (kept for backward compatibility), this now
+    pushes log records through the OpenTelemetry SDK to any OTLP endpoint
+    that routes to Loki (or any log backend).
+    """
+
+    def __init__(
+        self,
+        otlp_endpoint: str = "",
+        otlp_token: str = "",
+        service_name: str = "dynamo-cicd-metrics",
+        dry_run: bool = False,
+    ):
         self.dry_run = dry_run
-
-        # Batched entries keyed by stream label tuple
-        self._streams: Dict[tuple, List[tuple]] = defaultdict(list)
-
-        # Counters
+        self.otlp_endpoint = otlp_endpoint
+        self.otlp_token = otlp_token
         self._counters: Dict[str, int] = defaultdict(int)
+        self._provider: Optional[LoggerProvider] = None
+        self._otel_logger = None
 
-        # Session for connection pooling
-        self._session = requests.Session()
-        self._session.headers.update({"Content-Type": "application/json"})
+        if not self.dry_run and self.otlp_endpoint:
+            self._setup_provider(service_name)
 
-    # ── Public API ────────────────────────────────────────────────────────────
+    def _setup_provider(self, service_name: str) -> None:
+        resource_attrs: Dict[str, str] = {"service.name": service_name}
+        if self.otlp_token:
+            resource_attrs["authorization"] = self.otlp_token
+
+        resource = Resource.create(resource_attrs)
+
+        headers: Dict[str, str] = {}
+        if self.otlp_token:
+            headers["Authorization"] = f"Bearer {self.otlp_token}"
+
+        endpoint = self.otlp_endpoint
+        if not endpoint.endswith("/v1/logs"):
+            endpoint = endpoint.rstrip("/") + "/v1/logs"
+
+        exporter = OTLPLogExporter(
+            endpoint=endpoint,
+            headers=headers,
+            timeout=30,
+        )
+
+        self._provider = LoggerProvider(resource=resource)
+        self._provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+        self._otel_logger = self._provider.get_logger("cicd-logs", "1.0.0")
+
+    # ── Internal helper ───────────────────────────────────────────────────
+
+    def _emit(self, body: str, attributes: Dict[str, Any]) -> None:
+        """Emit a single structured log record."""
+        if self.dry_run or not self._otel_logger:
+            return
+        # Clean attributes: OTel only accepts str/int/float/bool values
+        clean_attrs = {k: v for k, v in attributes.items() if v is not None}
+        self._otel_logger.emit(
+            logs_api.LogRecord(
+                body=body,
+                severity_text="INFO",
+                severity_number=logs_api.SeverityNumber.INFO,
+                attributes=clean_attrs,
+            )
+        )
+
+    # ── Public API (same signatures as before) ────────────────────────────
 
     def record_test_result(self, doc: Dict[str, Any]) -> None:
-        """Record a test result event for Loki."""
-        stream_labels = {
+        """Record a test result event."""
+        attrs = {
             "source": "cicd",
             "type": "test_result",
             "repo": doc.get("s_repo", ""),
             "branch": doc.get("s_branch", ""),
             "framework": doc.get("s_framework", "unknown"),
-        }
-        body = {
             "commit_sha": doc.get("s_commit_sha", ""),
             "test_name": doc.get("s_test_name", ""),
             "test_classname": doc.get("s_test_classname", ""),
             "status": doc.get("s_test_status", doc.get("s_status", "")),
             "duration_ms": doc.get("l_test_duration_ms", 0),
-            "error_message": doc.get("s_error_message", ""),
             "job_id": doc.get("s_job_id", ""),
             "job_name": doc.get("s_job_name", ""),
             "run_id": doc.get("s_run_id", ""),
@@ -84,18 +129,20 @@ class LokiExporter:
             "cuda_version": doc.get("s_cuda_version", ""),
             "test_type": doc.get("s_test_type", ""),
         }
-        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        error_msg = doc.get("s_error_message", "")
+        if error_msg:
+            attrs["error_message"] = error_msg
+        body = json.dumps({k: v for k, v in attrs.items() if v}, default=str)
+        self._emit(body, attrs)
         self._counters["test_results"] += 1
 
     def record_build_layer(self, doc: Dict[str, Any]) -> None:
-        """Record a build layer event for Loki."""
-        stream_labels = {
+        """Record a build layer event."""
+        attrs = {
             "source": "cicd",
             "type": "build_layer",
             "repo": doc.get("s_repo", ""),
             "framework": doc.get("s_build_framework", "unknown"),
-        }
-        body = {
             "commit_sha": doc.get("s_commit_sha", ""),
             "stage_name": doc.get("s_stage", ""),
             "step_number": doc.get("l_step_number", 0),
@@ -108,17 +155,16 @@ class LokiExporter:
             "branch": doc.get("s_branch", ""),
             "cuda_version": doc.get("s_cuda_version", ""),
         }
-        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        body = json.dumps({k: v for k, v in attrs.items() if v}, default=str)
+        self._emit(body, attrs)
         self._counters["build_layers"] += 1
 
     def record_workflow_step(self, doc: Dict[str, Any]) -> None:
-        """Record a workflow step event for Loki."""
-        stream_labels = {
+        """Record a workflow step event."""
+        attrs = {
             "source": "cicd",
             "type": "workflow_step",
             "repo": doc.get("s_repo", ""),
-        }
-        body = {
             "commit_sha": doc.get("s_commit_sha", ""),
             "step_name": doc.get("s_step_name", ""),
             "step_number": doc.get("l_step_number", 0),
@@ -130,17 +176,16 @@ class LokiExporter:
             "workflow_name": doc.get("s_workflow_name", ""),
             "branch": doc.get("s_branch", ""),
         }
-        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        body = json.dumps({k: v for k, v in attrs.items() if v}, default=str)
+        self._emit(body, attrs)
         self._counters["workflow_steps"] += 1
 
     def record_pr_event(self, doc: Dict[str, Any]) -> None:
-        """Record a PR event for Loki."""
-        stream_labels = {
+        """Record a PR event."""
+        attrs = {
             "source": "cicd",
             "type": "pr_event",
             "repo": doc.get("s_repo", ""),
-        }
-        body = {
             "commit_sha": doc.get("s_commit_sha", ""),
             "pr_number": doc.get("l_pr_number", 0),
             "author": doc.get("s_author", ""),
@@ -153,48 +198,45 @@ class LokiExporter:
             "created_at": doc.get("ts_created_at", ""),
             "merged_at": doc.get("ts_merged_at", ""),
         }
-        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        body = json.dumps({k: v for k, v in attrs.items() if v}, default=str)
+        self._emit(body, attrs)
         self._counters["pr_events"] += 1
 
     def record_review(self, doc: Dict[str, Any]) -> None:
-        """Record a review event for Loki."""
-        stream_labels = {
+        """Record a review event."""
+        attrs = {
             "source": "cicd",
             "type": "review",
             "repo": doc.get("s_repo", ""),
-        }
-        body = {
             "reviewer": doc.get("s_reviewer", ""),
             "state": doc.get("s_state", ""),
         }
-        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        body = json.dumps({k: v for k, v in attrs.items() if v}, default=str)
+        self._emit(body, attrs)
         self._counters["reviews"] += 1
 
     def record_commit(self, doc: Dict[str, Any]) -> None:
-        """Record a commit event for Loki."""
-        stream_labels = {
+        """Record a commit event."""
+        attrs = {
             "source": "cicd",
             "type": "commit",
             "repo": doc.get("s_repo", ""),
-        }
-        body = {
             "sha": doc.get("s_sha", ""),
             "author": doc.get("s_author", ""),
             "committer": doc.get("s_committer", ""),
             "branch": doc.get("s_branch", ""),
             "committed_at": doc.get("ts_committed_at", ""),
         }
-        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        body = json.dumps({k: v for k, v in attrs.items() if v}, default=str)
+        self._emit(body, attrs)
         self._counters["commits"] += 1
 
     def record_issue(self, doc: Dict[str, Any]) -> None:
-        """Record an issue event for Loki."""
-        stream_labels = {
+        """Record an issue event."""
+        attrs = {
             "source": "cicd",
             "type": "issue",
             "repo": doc.get("s_repo", ""),
-        }
-        body = {
             "issue_number": doc.get("l_issue_number", 0),
             "author": doc.get("s_author", ""),
             "author_association": doc.get("s_author_association", ""),
@@ -208,85 +250,38 @@ class LokiExporter:
             "closed_at": doc.get("ts_closed_at", ""),
             "time_to_close_hours": doc.get("l_time_to_close_hours"),
         }
-        self._add_entry(stream_labels, body, doc.get("@timestamp"))
+        body = json.dumps({k: v for k, v in attrs.items() if v}, default=str)
+        self._emit(body, attrs)
         self._counters["issues"] += 1
 
-    # ── Flush / Push ──────────────────────────────────────────────────────────
+    # ── Flush ─────────────────────────────────────────────────────────────
 
     def flush(self) -> None:
-        """Flush all buffered entries to Loki."""
-        if not self._streams:
-            return
-
+        """Flush all pending log records to the OTLP endpoint."""
         if self.dry_run:
-            total = sum(len(entries) for entries in self._streams.values())
-            log.info("[DRY RUN] Would push %d entries to Loki across %d streams",
-                     total, len(self._streams))
-            self._streams.clear()
+            log.info("[DRY RUN] Would flush logs to OTLP endpoint")
             return
 
-        if not self.push_url:
-            log.warning("LOKI_URL not configured, skipping Loki push")
-            self._streams.clear()
+        if not self._provider:
+            log.warning("OTLP endpoint not configured, skipping log flush")
             return
-
-        # Build Loki push payload
-        streams = []
-        for label_key, entries in self._streams.items():
-            label_dict = dict(label_key)
-            streams.append({
-                "stream": label_dict,
-                "values": entries,
-            })
-
-        payload = {"streams": streams}
 
         try:
-            resp = self._session.post(self.push_url, json=payload, timeout=30)
-            if resp.status_code in (200, 204):
-                total = sum(len(s["values"]) for s in streams)
-                log.info("Pushed %d entries to Loki across %d streams", total, len(streams))
+            result = self._provider.force_flush(timeout_millis=30000)
+            if result:
+                log.info("Flushed logs to OTLP endpoint %s", self.otlp_endpoint)
             else:
-                log.error("Loki push failed: HTTP %d — %s", resp.status_code, resp.text[:500])
+                log.warning("OTLP log flush returned False")
         except Exception:
-            log.exception("Failed to push entries to Loki")
-        finally:
-            self._streams.clear()
+            log.exception("Failed to flush logs to OTLP endpoint")
 
-    # ── Internal ──────────────────────────────────────────────────────────────
-
-    def _add_entry(
-        self,
-        stream_labels: Dict[str, str],
-        body: Dict[str, Any],
-        timestamp: Optional[str] = None,
-    ) -> None:
-        """Add an entry to the buffer, auto-flushing if the batch is large."""
-        # Convert stream labels to a hashable key
-        key = tuple(sorted(stream_labels.items()))
-
-        # Loki expects [timestamp_ns, json_line]
-        ts_ns = self._to_nanoseconds(timestamp)
-        line = json.dumps(body, default=str)
-
-        self._streams[key].append([str(ts_ns), line])
-
-        # Auto-flush if any stream gets too large
-        if len(self._streams[key]) >= _MAX_BATCH_SIZE:
-            self.flush()
-
-    @staticmethod
-    def _to_nanoseconds(timestamp: Optional[str]) -> int:
-        """Convert an ISO timestamp to nanoseconds since epoch, or use current time."""
-        if not timestamp:
-            return int(time.time() * 1e9)
-        try:
-            from datetime import datetime, timezone
-            dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-            return int(dt.timestamp() * 1e9)
-        except Exception:
-            return int(time.time() * 1e9)
+    def shutdown(self) -> None:
+        """Shutdown the logger provider."""
+        if self._provider:
+            try:
+                self._provider.shutdown()
+            except Exception:
+                log.exception("Error shutting down log provider")
 
     def get_summary(self) -> Dict[str, int]:
-        """Return counts of recorded entries."""
         return dict(self._counters)

--- a/deploy/metrics/opensearch_schema.py
+++ b/deploy/metrics/opensearch_schema.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/deploy/metrics/opensearch_schema.py
+++ b/deploy/metrics/opensearch_schema.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 OpenSearch Schema Definitions for GitHub Metrics
 

--- a/deploy/metrics/opensearch_schema.py
+++ b/deploy/metrics/opensearch_schema.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""
+OpenSearch Schema Definitions for GitHub Metrics
+
+This file contains all field name constants used across different OpenSearch indices.
+Modify this file to update field names across all metrics uploaders.
+
+Field naming conventions:
+- s_* : String fields
+- l_* : Long (integer) fields
+- f_* : Float fields
+- b_* : Boolean fields
+- ts_*: Timestamp fields
+"""
+
+# ============================================================================
+# Test Result Fields
+# ============================================================================
+
+TEST_FIELDS = {
+    # Test identification
+    "test_name": "s_test_name",
+    "test_classname": "s_test_classname",
+    "test_duration_ms": "l_test_duration_ms",
+    "test_status": "s_test_status",
+    "error_message": "s_error_message",
+}
+
+# ============================================================================
+# Build Metrics Fields
+# ============================================================================
+
+# Container-level fields
+CONTAINER_FIELDS = {
+    "build_duration_sec": "l_build_duration_sec",
+    "build_start_time": "ts_build_start_time",
+    "build_end_time": "ts_build_end_time",
+    "build_framework": "s_build_framework",
+    "build_target": "s_build_target",
+    "build_platform": "s_build_platform",
+    "build_size_bytes": "l_build_size_bytes",
+    "total_size_transferred": "l_total_size_transferred_bytes",
+    "total_steps": "l_total_steps",
+    "cached_steps": "l_cached_steps",
+    "built_steps": "l_built_steps",
+    "cache_hit_rate": "f_cache_hit_rate",
+}
+
+# Stage-level fields
+STAGE_FIELDS = {
+    "stage_name": "s_stage_name",
+    "stage_total_steps": "l_stage_total_steps",
+    "stage_cached_steps": "l_stage_cached_steps",
+    "stage_built_steps": "l_stage_built_steps",
+    "stage_duration_sec": "f_stage_duration_sec",
+    "stage_cache_hit_rate": "f_stage_cache_hit_rate",
+}
+
+# Layer-level fields
+LAYER_FIELDS = {
+    "layer_step_number": "l_step_number",
+    "layer_step_name": "s_step_name",
+    "layer_command": "s_command",
+    "layer_status": "s_layer_status",
+    "layer_cached": "b_cached",
+    "layer_duration_sec": "f_duration_sec",
+    "layer_size_transferred": "l_size_transferred",
+    "layer_stage": "s_stage",
+}
+
+# ============================================================================
+# Workflow Metrics Fields
+# ============================================================================
+
+WORKFLOW_FIELDS = {
+    # Workflow identification
+    "workflow_id": "s_workflow_id",
+    "workflow_name": "s_workflow_name",
+
+    # Status fields
+    "status": "s_status",
+    "status_number": "l_status_number",
+
+    # Timing fields
+    "queue_time_sec": "l_queue_time_sec",
+    "duration_sec": "l_duration_sec",
+
+    # Retry fields
+    "run_attempt": "l_run_attempt",
+    "retry_count": "l_retry_count",
+
+    # Annotation fields
+    "annotation_count": "l_annotation_count",
+    "annotation_failure_count": "l_annotation_failure_count",
+    "annotation_warning_count": "l_annotation_warning_count",
+    "annotation_notice_count": "l_annotation_notice_count",
+    "annotation_messages": "s_annotation_messages",
+}
+
+JOB_FIELDS = {
+    # Job identification
+    "job_id": "s_job_id",
+    "job_name": "s_job_name",
+
+    # Runner fields
+    "runner_id": "s_runner_id",
+    "runner_name": "s_runner_name",
+    "runner_prefix": "s_runner_prefix",
+
+    # Status fields
+    "status": "s_status",
+    "status_number": "l_status_number",
+
+    # Timing fields
+    "queue_time_sec": "l_queue_time_sec",
+    "duration_sec": "l_duration_sec",
+
+    # Retry fields
+    "run_attempt": "l_run_attempt",
+    "retry_count": "l_retry_count",
+
+    # Annotation fields
+    "annotation_count": "l_annotation_count",
+    "annotation_failure_count": "l_annotation_failure_count",
+    "annotation_warning_count": "l_annotation_warning_count",
+    "annotation_notice_count": "l_annotation_notice_count",
+    "annotation_messages": "s_annotation_messages",
+}
+
+STEP_FIELDS = {
+    # Step identification
+    "step_id": "s_step_id",
+    "step_run_id": "s_step_run_id",
+    "step_name": "s_step_name",
+    "step_number": "l_step_number",
+    "command": "s_command",
+
+    # Status fields
+    "status": "s_status",
+    "status_number": "l_status_number",
+
+    # Timing fields
+    "duration_sec": "l_duration_sec",
+
+    # Retry fields
+    "run_attempt": "l_run_attempt",
+    "retry_count": "l_retry_count",
+}
+
+# ============================================================================
+# GitHub Stats Fields
+# ============================================================================
+
+PR_FIELDS = {
+    "pr_number": "l_pr_number",
+    "author": "s_author",
+    "author_association": "s_author_association",
+    "is_external": "b_is_external",
+    "is_first_time_contributor": "b_is_first_time_contributor",
+    "state": "s_state",
+    "merged": "b_merged",
+    "draft": "b_draft",
+    "merged_by": "s_merged_by",
+    "created_at": "ts_created_at",
+    "merged_at": "ts_merged_at",
+    "time_to_merge_hours": "l_time_to_merge_hours",
+    "base_branch": "s_base_branch",
+}
+
+REVIEW_FIELDS = {
+    "reviewer": "s_reviewer",
+    "state": "s_state",  # APPROVED, CHANGES_REQUESTED, COMMENTED
+}
+
+COMMIT_FIELDS = {
+    "sha": "s_sha",
+    "author": "s_author",
+    "committer": "s_committer",
+    "branch": "s_branch",
+    "committed_at": "ts_committed_at",
+}
+
+ISSUE_FIELDS = {
+    "issue_number": "l_issue_number",
+    "author": "s_author",
+    "author_association": "s_author_association",
+    "is_external": "b_is_external",
+    "state": "s_state",
+    "comments_count": "l_comments_count",
+    "labels": "s_labels",
+    "assignee": "s_assignee",
+    "closed_by": "s_closed_by",
+    "created_at": "ts_created_at",
+    "closed_at": "ts_closed_at",
+    "time_to_close_hours": "l_time_to_close_hours",
+}
+
+# ============================================================================
+# Common Context Fields (shared across all metrics)
+# ============================================================================
+
+COMMON_FIELDS = {
+    # Document ID
+    "id": "_id",
+
+    # Repository context
+    "repo": "s_repo",
+    "user_alias": "s_user_alias",
+    "commit_sha": "s_commit_sha",
+    "branch": "s_branch",
+    "pr_id": "s_pr_id",
+
+    # Workflow context
+    "workflow_id": "s_workflow_id",
+    "workflow_name": "s_workflow_name",
+    "github_event": "s_github_event",
+    "run_id": "s_run_id",
+
+    # Job context
+    "job_id": "s_job_id",
+    "job_name": "s_job_name",
+    "runner_name": "s_runner_name",
+
+    # Step context
+    "step_id": "s_step_id",
+
+    # Test/Build context
+    "status": "s_status",
+    "framework": "s_framework",
+    "test_type": "s_test_type",
+    "arch": "s_arch",
+
+    # Timestamp
+    "timestamp": "@timestamp",
+}
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+def get_field(category: str, field_name: str) -> str:
+    """
+    Get a field name from a category
+
+    Args:
+        category: One of 'test', 'container', 'stage', 'layer', 'workflow',
+                 'job', 'step', 'pr', 'review', 'commit', 'issue', 'common'
+        field_name: The field name (without prefix)
+
+    Returns:
+        The full OpenSearch field name (with prefix)
+
+    Example:
+        >>> get_field('common', 'job_id')
+        's_job_id'
+    """
+    categories = {
+        'test': TEST_FIELDS,
+        'container': CONTAINER_FIELDS,
+        'stage': STAGE_FIELDS,
+        'layer': LAYER_FIELDS,
+        'workflow': WORKFLOW_FIELDS,
+        'job': JOB_FIELDS,
+        'step': STEP_FIELDS,
+        'pr': PR_FIELDS,
+        'review': REVIEW_FIELDS,
+        'commit': COMMIT_FIELDS,
+        'issue': ISSUE_FIELDS,
+        'common': COMMON_FIELDS,
+    }
+
+    if category not in categories:
+        raise ValueError(f"Unknown category: {category}")
+
+    if field_name not in categories[category]:
+        raise ValueError(f"Unknown field '{field_name}' in category '{category}'")
+
+    return categories[category][field_name]
+
+
+def get_all_fields(category: str) -> dict:
+    """
+    Get all fields for a category
+
+    Args:
+        category: One of 'test', 'container', 'stage', 'layer', etc.
+
+    Returns:
+        Dictionary mapping field names to OpenSearch field names
+    """
+    categories = {
+        'test': TEST_FIELDS,
+        'container': CONTAINER_FIELDS,
+        'stage': STAGE_FIELDS,
+        'layer': LAYER_FIELDS,
+        'workflow': WORKFLOW_FIELDS,
+        'job': JOB_FIELDS,
+        'step': STEP_FIELDS,
+        'pr': PR_FIELDS,
+        'review': REVIEW_FIELDS,
+        'commit': COMMIT_FIELDS,
+        'issue': ISSUE_FIELDS,
+        'common': COMMON_FIELDS,
+    }
+
+    if category not in categories:
+        raise ValueError(f"Unknown category: {category}")
+
+    return categories[category].copy()
+
+
+# ============================================================================
+# Constants for backward compatibility
+# ============================================================================
+
+# Export all field constants for direct import
+# This maintains backward compatibility with existing code
+
+# Test fields
+FIELD_TEST_NAME = TEST_FIELDS["test_name"]
+FIELD_TEST_CLASSNAME = TEST_FIELDS["test_classname"]
+FIELD_TEST_DURATION = TEST_FIELDS["test_duration_ms"]
+FIELD_TEST_STATUS = TEST_FIELDS["test_status"]
+FIELD_ERROR_MESSAGE = TEST_FIELDS["error_message"]
+
+# Container fields
+FIELD_BUILD_DURATION_SEC = CONTAINER_FIELDS["build_duration_sec"]
+FIELD_BUILD_START_TIME = CONTAINER_FIELDS["build_start_time"]
+FIELD_BUILD_END_TIME = CONTAINER_FIELDS["build_end_time"]
+FIELD_BUILD_FRAMEWORK = CONTAINER_FIELDS["build_framework"]
+FIELD_BUILD_TARGET = CONTAINER_FIELDS["build_target"]
+FIELD_BUILD_PLATFORM = CONTAINER_FIELDS["build_platform"]
+FIELD_BUILD_SIZE_BYTES = CONTAINER_FIELDS["build_size_bytes"]
+FIELD_TOTAL_SIZE_TRANSFERRED = CONTAINER_FIELDS["total_size_transferred"]
+FIELD_TOTAL_STEPS = CONTAINER_FIELDS["total_steps"]
+FIELD_CACHED_STEPS = CONTAINER_FIELDS["cached_steps"]
+FIELD_BUILT_STEPS = CONTAINER_FIELDS["built_steps"]
+FIELD_CACHE_HIT_RATE = CONTAINER_FIELDS["cache_hit_rate"]
+
+# Stage fields
+FIELD_STAGE_NAME = STAGE_FIELDS["stage_name"]
+FIELD_STAGE_TOTAL_STEPS = STAGE_FIELDS["stage_total_steps"]
+FIELD_STAGE_CACHED_STEPS = STAGE_FIELDS["stage_cached_steps"]
+FIELD_STAGE_BUILT_STEPS = STAGE_FIELDS["stage_built_steps"]
+FIELD_STAGE_DURATION_SEC = STAGE_FIELDS["stage_duration_sec"]
+FIELD_STAGE_CACHE_HIT_RATE = STAGE_FIELDS["stage_cache_hit_rate"]
+
+# Layer fields
+FIELD_LAYER_STEP_NUMBER = LAYER_FIELDS["layer_step_number"]
+FIELD_LAYER_STEP_NAME = LAYER_FIELDS["layer_step_name"]
+FIELD_LAYER_COMMAND = LAYER_FIELDS["layer_command"]
+FIELD_LAYER_STATUS = LAYER_FIELDS["layer_status"]
+FIELD_LAYER_CACHED = LAYER_FIELDS["layer_cached"]
+FIELD_LAYER_DURATION_SEC = LAYER_FIELDS["layer_duration_sec"]
+FIELD_LAYER_SIZE_TRANSFERRED = LAYER_FIELDS["layer_size_transferred"]
+FIELD_LAYER_STAGE = LAYER_FIELDS["layer_stage"]
+
+# Workflow/Job/Step annotation fields
+FIELD_ANNOTATION_COUNT = WORKFLOW_FIELDS["annotation_count"]
+FIELD_ANNOTATION_FAILURE_COUNT = WORKFLOW_FIELDS["annotation_failure_count"]
+FIELD_ANNOTATION_WARNING_COUNT = WORKFLOW_FIELDS["annotation_warning_count"]
+FIELD_ANNOTATION_NOTICE_COUNT = WORKFLOW_FIELDS["annotation_notice_count"]
+FIELD_ANNOTATION_MESSAGES = WORKFLOW_FIELDS["annotation_messages"]
+FIELD_RUNNER_PREFIX = JOB_FIELDS["runner_prefix"]
+FIELD_RUN_ATTEMPT = WORKFLOW_FIELDS["run_attempt"]
+FIELD_RETRY_COUNT = WORKFLOW_FIELDS["retry_count"]
+
+# Common context fields
+FIELD_ID = COMMON_FIELDS["id"]
+FIELD_JOB_NAME = COMMON_FIELDS["job_name"]
+FIELD_JOB_ID = COMMON_FIELDS["job_id"]
+FIELD_STEP_ID = COMMON_FIELDS["step_id"]
+FIELD_STATUS = COMMON_FIELDS["status"]
+FIELD_FRAMEWORK = COMMON_FIELDS["framework"]
+FIELD_TEST_TYPE = COMMON_FIELDS["test_type"]
+FIELD_ARCH = COMMON_FIELDS["arch"]
+FIELD_USER_ALIAS = COMMON_FIELDS["user_alias"]
+FIELD_REPO = COMMON_FIELDS["repo"]
+FIELD_WORKFLOW_NAME = COMMON_FIELDS["workflow_name"]
+FIELD_GITHUB_EVENT = COMMON_FIELDS["github_event"]
+FIELD_BRANCH = COMMON_FIELDS["branch"]
+FIELD_WORKFLOW_ID = COMMON_FIELDS["workflow_id"]
+FIELD_COMMIT_SHA = COMMON_FIELDS["commit_sha"]
+FIELD_PR_ID = COMMON_FIELDS["pr_id"]
+FIELD_RUN_ID = COMMON_FIELDS["run_id"]
+FIELD_RUNNER_NAME = COMMON_FIELDS["runner_name"]

--- a/deploy/metrics/opensearch_schema.py
+++ b/deploy/metrics/opensearch_schema.py
@@ -90,19 +90,15 @@ WORKFLOW_FIELDS = {
     # Workflow identification
     "workflow_id": "s_workflow_id",
     "workflow_name": "s_workflow_name",
-
     # Status fields
     "status": "s_status",
     "status_number": "l_status_number",
-
     # Timing fields
     "queue_time_sec": "l_queue_time_sec",
     "duration_sec": "l_duration_sec",
-
     # Retry fields
     "run_attempt": "l_run_attempt",
     "retry_count": "l_retry_count",
-
     # Annotation fields
     "annotation_count": "l_annotation_count",
     "annotation_failure_count": "l_annotation_failure_count",
@@ -115,24 +111,19 @@ JOB_FIELDS = {
     # Job identification
     "job_id": "s_job_id",
     "job_name": "s_job_name",
-
     # Runner fields
     "runner_id": "s_runner_id",
     "runner_name": "s_runner_name",
     "runner_prefix": "s_runner_prefix",
-
     # Status fields
     "status": "s_status",
     "status_number": "l_status_number",
-
     # Timing fields
     "queue_time_sec": "l_queue_time_sec",
     "duration_sec": "l_duration_sec",
-
     # Retry fields
     "run_attempt": "l_run_attempt",
     "retry_count": "l_retry_count",
-
     # Annotation fields
     "annotation_count": "l_annotation_count",
     "annotation_failure_count": "l_annotation_failure_count",
@@ -148,14 +139,11 @@ STEP_FIELDS = {
     "step_name": "s_step_name",
     "step_number": "l_step_number",
     "command": "s_command",
-
     # Status fields
     "status": "s_status",
     "status_number": "l_status_number",
-
     # Timing fields
     "duration_sec": "l_duration_sec",
-
     # Retry fields
     "run_attempt": "l_run_attempt",
     "retry_count": "l_retry_count",
@@ -216,34 +204,28 @@ ISSUE_FIELDS = {
 COMMON_FIELDS = {
     # Document ID
     "id": "_id",
-
     # Repository context
     "repo": "s_repo",
     "user_alias": "s_user_alias",
     "commit_sha": "s_commit_sha",
     "branch": "s_branch",
     "pr_id": "s_pr_id",
-
     # Workflow context
     "workflow_id": "s_workflow_id",
     "workflow_name": "s_workflow_name",
     "github_event": "s_github_event",
     "run_id": "s_run_id",
-
     # Job context
     "job_id": "s_job_id",
     "job_name": "s_job_name",
     "runner_name": "s_runner_name",
-
     # Step context
     "step_id": "s_step_id",
-
     # Test/Build context
     "status": "s_status",
     "framework": "s_framework",
     "test_type": "s_test_type",
     "arch": "s_arch",
-
     # Timestamp
     "timestamp": "@timestamp",
 }
@@ -251,6 +233,7 @@ COMMON_FIELDS = {
 # ============================================================================
 # Helper Functions
 # ============================================================================
+
 
 def get_field(category: str, field_name: str) -> str:
     """
@@ -269,18 +252,18 @@ def get_field(category: str, field_name: str) -> str:
         's_job_id'
     """
     categories = {
-        'test': TEST_FIELDS,
-        'container': CONTAINER_FIELDS,
-        'stage': STAGE_FIELDS,
-        'layer': LAYER_FIELDS,
-        'workflow': WORKFLOW_FIELDS,
-        'job': JOB_FIELDS,
-        'step': STEP_FIELDS,
-        'pr': PR_FIELDS,
-        'review': REVIEW_FIELDS,
-        'commit': COMMIT_FIELDS,
-        'issue': ISSUE_FIELDS,
-        'common': COMMON_FIELDS,
+        "test": TEST_FIELDS,
+        "container": CONTAINER_FIELDS,
+        "stage": STAGE_FIELDS,
+        "layer": LAYER_FIELDS,
+        "workflow": WORKFLOW_FIELDS,
+        "job": JOB_FIELDS,
+        "step": STEP_FIELDS,
+        "pr": PR_FIELDS,
+        "review": REVIEW_FIELDS,
+        "commit": COMMIT_FIELDS,
+        "issue": ISSUE_FIELDS,
+        "common": COMMON_FIELDS,
     }
 
     if category not in categories:
@@ -303,18 +286,18 @@ def get_all_fields(category: str) -> dict:
         Dictionary mapping field names to OpenSearch field names
     """
     categories = {
-        'test': TEST_FIELDS,
-        'container': CONTAINER_FIELDS,
-        'stage': STAGE_FIELDS,
-        'layer': LAYER_FIELDS,
-        'workflow': WORKFLOW_FIELDS,
-        'job': JOB_FIELDS,
-        'step': STEP_FIELDS,
-        'pr': PR_FIELDS,
-        'review': REVIEW_FIELDS,
-        'commit': COMMIT_FIELDS,
-        'issue': ISSUE_FIELDS,
-        'common': COMMON_FIELDS,
+        "test": TEST_FIELDS,
+        "container": CONTAINER_FIELDS,
+        "stage": STAGE_FIELDS,
+        "layer": LAYER_FIELDS,
+        "workflow": WORKFLOW_FIELDS,
+        "job": JOB_FIELDS,
+        "step": STEP_FIELDS,
+        "pr": PR_FIELDS,
+        "review": REVIEW_FIELDS,
+        "commit": COMMIT_FIELDS,
+        "issue": ISSUE_FIELDS,
+        "common": COMMON_FIELDS,
     }
 
     if category not in categories:

--- a/deploy/metrics/parsers/__init__.py
+++ b/deploy/metrics/parsers/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/deploy/metrics/parsers/__init__.py
+++ b/deploy/metrics/parsers/__init__.py
@@ -1,0 +1,12 @@
+"""Shared parsers for CI/CD metrics — used by both cicd_push.py and unified_metrics_uploader.py."""
+
+from parsers.junit_xml import parse_junit_xml, parse_junit_xml_directory
+from parsers.build_metrics import parse_build_metrics_json
+from parsers.github_context import GitHubActionsContext
+
+__all__ = [
+    "parse_junit_xml",
+    "parse_junit_xml_directory",
+    "parse_build_metrics_json",
+    "GitHubActionsContext",
+]

--- a/deploy/metrics/parsers/__init__.py
+++ b/deploy/metrics/parsers/__init__.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Shared parsers for CI/CD metrics — used by both cicd_push.py and unified_metrics_uploader.py."""
 
 from parsers.junit_xml import parse_junit_xml, parse_junit_xml_directory

--- a/deploy/metrics/parsers/__init__.py
+++ b/deploy/metrics/parsers/__init__.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 """Shared parsers for CI/CD metrics — used by both cicd_push.py and unified_metrics_uploader.py."""
 
-from parsers.junit_xml import parse_junit_xml, parse_junit_xml_directory
 from parsers.build_metrics import parse_build_metrics_json
 from parsers.github_context import GitHubActionsContext
+from parsers.junit_xml import parse_junit_xml, parse_junit_xml_directory
 
 __all__ = [
     "parse_junit_xml",

--- a/deploy/metrics/parsers/build_metrics.py
+++ b/deploy/metrics/parsers/build_metrics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/deploy/metrics/parsers/build_metrics.py
+++ b/deploy/metrics/parsers/build_metrics.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Build metrics JSON parser — extracted from BuildMetricsProcessor._extract_build_metrics."""
 
 import json

--- a/deploy/metrics/parsers/build_metrics.py
+++ b/deploy/metrics/parsers/build_metrics.py
@@ -63,7 +63,9 @@ def _extract_from_zip(zip_path: Path) -> Optional[Dict[str, Any]]:
                 if (
                     file_name.endswith("build_metrics.json")
                     or file_name == "build_metrics.json"
-                    or (file_name.startswith("metrics-") and file_name.endswith(".json"))
+                    or (
+                        file_name.startswith("metrics-") and file_name.endswith(".json")
+                    )
                     or file_name.endswith("-metrics.json")
                     or (file_name.startswith("build-") and file_name.endswith(".json"))
                 ):

--- a/deploy/metrics/parsers/build_metrics.py
+++ b/deploy/metrics/parsers/build_metrics.py
@@ -1,0 +1,61 @@
+"""Build metrics JSON parser — extracted from BuildMetricsProcessor._extract_build_metrics."""
+
+import json
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def parse_build_metrics_json(path: Path) -> Optional[Dict[str, Any]]:
+    """
+    Parse build metrics from a JSON file **or** a ZIP archive containing one.
+
+    In the cron path *path* is a ZIP downloaded from GitHub artifacts.
+    In the CI push path *path* is the JSON file directly on disk.
+
+    Returns:
+        Dict with ``container``, ``stages``, ``layers`` keys, or ``None``.
+    """
+    if not path.exists():
+        print(f"Build metrics file not found: {path}")
+        return None
+
+    # Direct JSON file
+    if path.suffix == ".json":
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except Exception as e:
+            print(f"Error reading build metrics JSON {path}: {e}")
+            return None
+
+    # ZIP archive (artifact download path)
+    if path.suffix == ".zip":
+        return _extract_from_zip(path)
+
+    # Try as JSON regardless of extension
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return _extract_from_zip(path)
+
+
+def _extract_from_zip(zip_path: Path) -> Optional[Dict[str, Any]]:
+    """Extract build metrics JSON from a ZIP archive."""
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zip_ref:
+            for file_name in zip_ref.namelist():
+                if (
+                    file_name.endswith("build_metrics.json")
+                    or file_name == "build_metrics.json"
+                    or (file_name.startswith("metrics-") and file_name.endswith(".json"))
+                    or file_name.endswith("-metrics.json")
+                    or (file_name.startswith("build-") and file_name.endswith(".json"))
+                ):
+                    with zip_ref.open(file_name) as f:
+                        return json.load(f)
+        return None
+    except Exception as e:
+        print(f"Error extracting build metrics from ZIP {zip_path}: {e}")
+        return None

--- a/deploy/metrics/parsers/github_context.py
+++ b/deploy/metrics/parsers/github_context.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/deploy/metrics/parsers/github_context.py
+++ b/deploy/metrics/parsers/github_context.py
@@ -1,0 +1,106 @@
+"""Read GitHub Actions environment variables into a structured context object."""
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class GitHubActionsContext:
+    """Context gathered from GitHub Actions environment variables.
+
+    All fields have sensible defaults so the object can be constructed
+    outside CI (e.g. in tests or dry-run mode) by passing explicit values.
+    """
+
+    repo: str = ""
+    run_id: str = ""
+    run_number: str = ""
+    run_attempt: int = 1
+    workflow_name: str = ""
+    job_name: str = ""
+    commit_sha: str = ""
+    branch: str = ""
+    actor: str = ""
+    event_name: str = ""
+    runner_name: str = ""
+    runner_os: str = ""
+    runner_arch: str = ""
+    pr_number: Optional[str] = None
+
+    # ── Factory ──────────────────────────────────────────────────────────
+
+    @classmethod
+    def from_env(cls) -> "GitHubActionsContext":
+        """Build context from current environment variables."""
+        pr_number = cls._extract_pr_number()
+        return cls(
+            repo=os.getenv("GITHUB_REPOSITORY", ""),
+            run_id=os.getenv("GITHUB_RUN_ID", ""),
+            run_number=os.getenv("GITHUB_RUN_NUMBER", ""),
+            run_attempt=int(os.getenv("GITHUB_RUN_ATTEMPT", "1")),
+            workflow_name=os.getenv("GITHUB_WORKFLOW", ""),
+            job_name=os.getenv("GITHUB_JOB", ""),
+            commit_sha=os.getenv("GITHUB_SHA", ""),
+            branch=os.getenv("GITHUB_REF_NAME", ""),
+            actor=os.getenv("GITHUB_ACTOR", ""),
+            event_name=os.getenv("GITHUB_EVENT_NAME", ""),
+            runner_name=os.getenv("RUNNER_NAME", ""),
+            runner_os=os.getenv("RUNNER_OS", ""),
+            runner_arch=os.getenv("RUNNER_ARCH", ""),
+            pr_number=pr_number,
+        )
+
+    # ── Conversion ───────────────────────────────────────────────────────
+
+    def to_common_fields(self) -> Dict[str, Any]:
+        """Return the ``s_*`` / ``l_*`` prefixed dict that the exporters expect."""
+        return {
+            "s_repo": self.repo,
+            "s_run_id": self.run_id,
+            "s_workflow_id": self.run_id,  # alias used by exporters
+            "s_workflow_name": self.workflow_name,
+            "s_job_name": self.job_name,
+            "s_job_id": self.job_name,  # best available in CI context
+            "s_commit_sha": self.commit_sha,
+            "s_branch": self.branch,
+            "s_user_alias": self.actor,
+            "s_github_event": self.event_name,
+            "s_pr_id": self.pr_number or "N/A",
+            "s_runner_name": self.runner_name,
+            "l_run_attempt": self.run_attempt,
+            "l_retry_count": max(0, self.run_attempt - 1),
+        }
+
+    # ── Helpers ───────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _extract_pr_number() -> Optional[str]:
+        """Try to extract the PR number from the CI environment.
+
+        Methods (in priority order):
+        1. ``GITHUB_EVENT_PATH`` JSON → ``event.pull_request.number``
+        2. ``GITHUB_REF`` pattern ``refs/pull/<N>/merge``
+        """
+        # Method 1: event payload JSON
+        event_path = os.getenv("GITHUB_EVENT_PATH")
+        if event_path:
+            try:
+                with open(event_path) as f:
+                    data = json.load(f)
+                pr_num = (data.get("pull_request") or data.get("number") or
+                          (data.get("pull_request", {}) or {}).get("number"))
+                if pr_num:
+                    return str(pr_num)
+            except Exception:
+                pass
+
+        # Method 2: ref pattern
+        ref = os.getenv("GITHUB_REF", "")
+        m = re.match(r"refs/pull/(\d+)/", ref)
+        if m:
+            return m.group(1)
+
+        return None

--- a/deploy/metrics/parsers/github_context.py
+++ b/deploy/metrics/parsers/github_context.py
@@ -17,7 +17,7 @@
 import json
 import os
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 
@@ -104,8 +104,11 @@ class GitHubActionsContext:
             try:
                 with open(event_path) as f:
                     data = json.load(f)
-                pr_num = (data.get("pull_request") or data.get("number") or
-                          (data.get("pull_request", {}) or {}).get("number"))
+                pr_num = (
+                    data.get("pull_request")
+                    or data.get("number")
+                    or (data.get("pull_request", {}) or {}).get("number")
+                )
                 if pr_num:
                     return str(pr_num)
             except Exception:

--- a/deploy/metrics/parsers/github_context.py
+++ b/deploy/metrics/parsers/github_context.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Read GitHub Actions environment variables into a structured context object."""
 
 import json

--- a/deploy/metrics/parsers/junit_xml.py
+++ b/deploy/metrics/parsers/junit_xml.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/deploy/metrics/parsers/junit_xml.py
+++ b/deploy/metrics/parsers/junit_xml.py
@@ -1,0 +1,76 @@
+"""JUnit XML parser — extracted from TestResultsProcessor._parse_junit_xml."""
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def parse_junit_xml(xml_path: Path) -> List[Dict[str, Any]]:
+    """
+    Parse a JUnit XML file and extract test results.
+
+    Returns:
+        List of dicts with keys: classname, name, time (float seconds),
+        status (passed|failed|error|skipped), error_message
+    """
+    tests: List[Dict[str, Any]] = []
+
+    try:
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+
+        # Handle both <testsuites> and <testsuite> as root
+        testsuites = root.findall(".//testsuite")
+        if not testsuites and root.tag == "testsuite":
+            testsuites = [root]
+
+        for testsuite in testsuites:
+            for testcase in testsuite.findall("testcase"):
+                test_classname = testcase.get("classname", "")
+                test_name = testcase.get("name", "")
+                test_time = float(testcase.get("time", 0))
+                test_status = "passed"
+                error_msg = ""
+
+                failure_elem = testcase.find("failure")
+                if failure_elem is not None:
+                    test_status = "failed"
+                    error_msg = failure_elem.get("message", "")
+                    if not error_msg and failure_elem.text:
+                        error_msg = failure_elem.text
+
+                error_elem = testcase.find("error")
+                if error_elem is not None:
+                    test_status = "error"
+                    error_msg = error_elem.get("message", "")
+                    if not error_msg and error_elem.text:
+                        error_msg = error_elem.text
+
+                skipped_elem = testcase.find("skipped")
+                if skipped_elem is not None:
+                    test_status = "skipped"
+                    error_msg = skipped_elem.get("message", "")
+
+                tests.append(
+                    {
+                        "classname": test_classname,
+                        "name": test_name,
+                        "time": test_time,
+                        "status": test_status,
+                        "error_message": error_msg,
+                    }
+                )
+
+    except Exception as e:
+        print(f"Error parsing JUnit XML {xml_path}: {e}")
+
+    return tests
+
+
+def parse_junit_xml_directory(dir_path: Path) -> List[Dict[str, Any]]:
+    """Find all .xml files recursively under *dir_path* and parse each as JUnit XML."""
+    all_tests: List[Dict[str, Any]] = []
+    xml_files = sorted(dir_path.rglob("*.xml"))
+    for xml_file in xml_files:
+        all_tests.extend(parse_junit_xml(xml_file))
+    return all_tests

--- a/deploy/metrics/parsers/junit_xml.py
+++ b/deploy/metrics/parsers/junit_xml.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """JUnit XML parser — extracted from TestResultsProcessor._parse_junit_xml."""
 
 import xml.etree.ElementTree as ET

--- a/deploy/metrics/prometheus_exporter.py
+++ b/deploy/metrics/prometheus_exporter.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/deploy/metrics/prometheus_exporter.py
+++ b/deploy/metrics/prometheus_exporter.py
@@ -13,180 +13,121 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Prometheus Pushgateway exporter for CI/CD metrics.
+OpenTelemetry OTLP metrics exporter for CI/CD metrics.
 
-Pushes metrics to Prometheus via Pushgateway, matching the schema defined in the
-migration plan. Designed to be called alongside the existing OpenSearch uploader
-during the dual-write phase.
+Pushes metrics to an OTLP HTTP endpoint (e.g., https://otlp-http.nvidia.com/v1/metrics)
+using the OpenTelemetry SDK. The public API (record_workflow, record_job, record_test, etc.)
+accepts the same OpenSearch-shaped dicts as the previous Pushgateway implementation.
 """
 
 import logging
+import os
 from collections import defaultdict
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
-from prometheus_client import (
-    CollectorRegistry,
-    Counter,
-    Gauge,
-    Histogram,
-    push_to_gateway,
-)
+from opentelemetry import metrics
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
 
 log = logging.getLogger(__name__)
 
-# Histogram bucket definitions from the plan
-WORKFLOW_DURATION_BUCKETS = (60, 120, 300, 600, 900, 1200, 1800, 3600, 7200)
-WORKFLOW_QUEUE_BUCKETS = (10, 30, 60, 120, 300, 600, 900)
-JOB_DURATION_BUCKETS = (30, 60, 120, 300, 600, 900, 1800, 3600)
-JOB_QUEUE_BUCKETS = (5, 10, 30, 60, 120, 300, 600)
-TEST_DURATION_BUCKETS = (0.1, 0.5, 1, 5, 10, 30, 60, 120, 300)
-CONTAINER_BUILD_DURATION_BUCKETS = (60, 120, 300, 600, 900, 1200, 1800, 3600)
-PR_MERGE_DURATION_BUCKETS = (1, 4, 8, 24, 48, 72, 168, 336)
-
 
 class PrometheusExporter:
-    """Exports CI/CD metrics to Prometheus via Pushgateway."""
+    """Exports CI/CD metrics via OpenTelemetry OTLP HTTP.
 
-    def __init__(self, pushgateway_url: str, job_name: str = "cicd_metrics", dry_run: bool = False):
-        self.pushgateway_url = pushgateway_url
-        self.job_name = job_name
+    Despite the class name (kept for backward compatibility), this now uses
+    the OpenTelemetry SDK to push metrics to any OTLP-compatible endpoint.
+    """
+
+    def __init__(
+        self,
+        otlp_endpoint: str = "",
+        otlp_token: str = "",
+        service_name: str = "dynamo-cicd-metrics",
+        dry_run: bool = False,
+        # Legacy parameter names — still accepted for backward compat
+        pushgateway_url: str = "",
+        job_name: str = "cicd_metrics",
+    ):
         self.dry_run = dry_run
-        self.registry = CollectorRegistry()
-
+        self.otlp_endpoint = otlp_endpoint or pushgateway_url
+        self.otlp_token = otlp_token
+        self.service_name = service_name
         self._counters: Dict[str, int] = defaultdict(int)
+        self._provider: Optional[MeterProvider] = None
 
-        # ── Workflow metrics ──
-        self.workflow_total = Counter(
-            "cicd_workflow_total",
-            "Total workflow runs",
-            ["repo", "workflow_name", "branch", "commit_sha", "status"],
-            registry=self.registry,
-        )
-        self.workflow_duration = Histogram(
-            "cicd_workflow_duration_seconds",
-            "Workflow duration in seconds",
-            ["repo", "workflow_name", "branch", "commit_sha", "status"],
-            buckets=WORKFLOW_DURATION_BUCKETS,
-            registry=self.registry,
-        )
-        self.workflow_queue_time = Histogram(
-            "cicd_workflow_queue_time_seconds",
-            "Workflow queue time in seconds",
-            ["repo", "workflow_name", "branch", "commit_sha"],
-            buckets=WORKFLOW_QUEUE_BUCKETS,
-            registry=self.registry,
-        )
+        if not self.dry_run and self.otlp_endpoint:
+            self._setup_provider()
 
-        # ── Job metrics ──
-        self.job_total = Counter(
-            "cicd_job_total",
-            "Total job runs",
-            ["repo", "workflow_name", "job_name", "branch", "commit_sha", "status", "runner_prefix"],
-            registry=self.registry,
-        )
-        self.job_duration = Histogram(
-            "cicd_job_duration_seconds",
-            "Job duration in seconds",
-            ["repo", "workflow_name", "job_name", "branch", "commit_sha", "runner_prefix"],
-            buckets=JOB_DURATION_BUCKETS,
-            registry=self.registry,
-        )
-        self.job_queue_time = Histogram(
-            "cicd_job_queue_time_seconds",
-            "Job queue time in seconds",
-            ["repo", "job_name", "branch", "commit_sha", "runner_prefix"],
-            buckets=JOB_QUEUE_BUCKETS,
-            registry=self.registry,
-        )
-        self.job_annotation_total = Gauge(
-            "cicd_job_annotation_total",
-            "Job annotation counts by severity",
-            ["repo", "job_name", "commit_sha", "severity"],
-            registry=self.registry,
+        # Create meter (works in dry-run too — just won't export)
+        self._meter = metrics.get_meter("cicd-metrics", "1.0.0")
+        self._instruments: Dict[str, Any] = {}
+
+    # ── Provider setup ────────────────────────────────────────────────────
+
+    def _setup_provider(self) -> None:
+        """Configure the OpenTelemetry MeterProvider with OTLP exporter."""
+        resource_attrs = {
+            "service.name": self.service_name,
+            "service.version": "1.0.0",
+        }
+        if self.otlp_token:
+            resource_attrs["authorization"] = self.otlp_token
+
+        resource = Resource.create(resource_attrs)
+
+        headers = {}
+        if self.otlp_token:
+            headers["Authorization"] = f"Bearer {self.otlp_token}"
+
+        endpoint = self.otlp_endpoint
+        if not endpoint.endswith("/v1/metrics"):
+            endpoint = endpoint.rstrip("/") + "/v1/metrics"
+
+        exporter = OTLPMetricExporter(
+            endpoint=endpoint,
+            headers=headers,
+            timeout=30,
         )
 
-        # ── Test metrics ──
-        self.test_total = Counter(
-            "cicd_test_total",
-            "Total test results",
-            ["repo", "framework", "test_type", "arch", "cuda_version", "branch", "commit_sha", "status"],
-            registry=self.registry,
-        )
-        self.test_status = Gauge(
-            "cicd_test_status",
-            "Per-test pass/fail status (1=pass, 0=fail)",
-            ["repo", "framework", "test_type", "arch", "cuda_version", "branch", "commit_sha", "test_name", "job_name"],
-            registry=self.registry,
-        )
-        self.test_duration = Histogram(
-            "cicd_test_duration_seconds",
-            "Test duration in seconds",
-            ["repo", "framework", "test_type", "arch", "cuda_version", "branch", "commit_sha"],
-            buckets=TEST_DURATION_BUCKETS,
-            registry=self.registry,
+        reader = PeriodicExportingMetricReader(
+            exporter=exporter,
+            export_interval_millis=60000,
         )
 
-        # ── Container build metrics ──
-        self.container_image_size = Gauge(
-            "cicd_container_image_size_bytes",
-            "Container image size in bytes",
-            ["repo", "framework", "target", "platform", "cuda_version", "branch", "commit_sha"],
-            registry=self.registry,
-        )
-        self.container_build_duration = Histogram(
-            "cicd_container_build_duration_seconds",
-            "Container build duration in seconds",
-            ["repo", "framework", "target", "platform", "cuda_version", "branch", "commit_sha"],
-            buckets=CONTAINER_BUILD_DURATION_BUCKETS,
-            registry=self.registry,
-        )
-        self.container_cache_hit_rate = Gauge(
-            "cicd_container_cache_hit_rate",
-            "Docker layer cache hit rate (0.0-1.0)",
-            ["repo", "framework", "cuda_version", "branch", "commit_sha"],
-            registry=self.registry,
-        )
-        self.container_sccache_hit_rate = Gauge(
-            "cicd_container_sccache_hit_rate",
-            "sccache compilation cache hit rate (0.0-1.0)",
-            ["repo", "framework", "cuda_version", "branch", "commit_sha"],
-            registry=self.registry,
-        )
-        self.container_steps_total = Gauge(
-            "cicd_container_steps_total",
-            "Container build step counts by type",
-            ["repo", "framework", "cuda_version", "branch", "commit_sha", "type"],
-            registry=self.registry,
-        )
-        self.container_stage_duration = Gauge(
-            "cicd_container_stage_duration_seconds",
-            "Container stage duration in seconds",
-            ["repo", "framework", "stage_name", "cuda_version", "branch", "commit_sha"],
-            registry=self.registry,
-        )
-        self.container_stage_cache_hit_rate = Gauge(
-            "cicd_container_stage_cache_hit_rate",
-            "Container stage cache hit rate",
-            ["repo", "framework", "stage_name", "cuda_version", "branch", "commit_sha"],
-            registry=self.registry,
-        )
+        self._provider = MeterProvider(resource=resource, metric_readers=[reader])
+        metrics.set_meter_provider(self._provider)
 
-        # ── PR metrics ──
-        self.pr_total = Counter(
-            "cicd_pr_total",
-            "Total pull requests",
-            ["repo", "state", "is_external", "base_branch"],
-            registry=self.registry,
-        )
-        self.pr_merge_duration = Histogram(
-            "cicd_pr_merge_duration_hours",
-            "PR time-to-merge in hours",
-            ["repo", "base_branch", "is_external"],
-            buckets=PR_MERGE_DURATION_BUCKETS,
-            registry=self.registry,
-        )
+    # ── Instrument helpers ────────────────────────────────────────────────
 
-    # ── Public API ────────────────────────────────────────────────────────────
+    def _counter(self, name: str, description: str = "", unit: str = "1"):
+        key = f"counter_{name}"
+        if key not in self._instruments:
+            self._instruments[key] = self._meter.create_counter(
+                name=name, description=description, unit=unit,
+            )
+        return self._instruments[key]
+
+    def _histogram(self, name: str, description: str = "", unit: str = "1"):
+        key = f"histogram_{name}"
+        if key not in self._instruments:
+            self._instruments[key] = self._meter.create_histogram(
+                name=name, description=description, unit=unit,
+            )
+        return self._instruments[key]
+
+    def _gauge(self, name: str, description: str = "", unit: str = "1"):
+        """Up-down counter used as a settable gauge."""
+        key = f"gauge_{name}"
+        if key not in self._instruments:
+            self._instruments[key] = self._meter.create_gauge(
+                name=name, description=description, unit=unit,
+            )
+        return self._instruments[key]
+
+    # ── Public API (same signatures as before) ────────────────────────────
 
     def record_workflow(self, doc: Dict[str, Any]) -> None:
         """Record a workflow run from an OpenSearch-shaped document."""
@@ -198,15 +139,15 @@ class PrometheusExporter:
         duration = doc.get("l_duration_sec", 0)
         queue_time = doc.get("l_queue_time_sec", 0)
 
-        labels = dict(repo=repo, workflow_name=workflow_name, branch=branch,
-                       commit_sha=commit_sha, status=status)
-        self.workflow_total.labels(**labels).inc()
+        attrs = dict(repo=repo, workflow_name=workflow_name, branch=branch,
+                     commit_sha=commit_sha, status=status)
+
+        self._counter("cicd_workflow_total", "Total workflow runs").add(1, attrs)
         if duration > 0:
-            self.workflow_duration.labels(**labels).observe(duration)
+            self._histogram("cicd_workflow_duration_seconds", "Workflow duration", "s").record(duration, attrs)
         if queue_time > 0:
-            queue_labels = dict(repo=repo, workflow_name=workflow_name,
-                                branch=branch, commit_sha=commit_sha)
-            self.workflow_queue_time.labels(**queue_labels).observe(queue_time)
+            queue_attrs = dict(repo=repo, workflow_name=workflow_name, branch=branch, commit_sha=commit_sha)
+            self._histogram("cicd_workflow_queue_time_seconds", "Workflow queue time", "s").record(queue_time, queue_attrs)
 
         self._counters["workflows"] += 1
 
@@ -222,23 +163,19 @@ class PrometheusExporter:
         duration = doc.get("l_duration_sec", 0)
         queue_time = doc.get("l_queue_time_sec", 0)
 
-        self.job_total.labels(
-            repo=repo, workflow_name=workflow_name, job_name=job_name,
-            branch=branch, commit_sha=commit_sha, status=status,
-            runner_prefix=runner_prefix,
-        ).inc()
-        if duration > 0:
-            self.job_duration.labels(
-                repo=repo, workflow_name=workflow_name, job_name=job_name,
-                branch=branch, commit_sha=commit_sha, runner_prefix=runner_prefix,
-            ).observe(duration)
-        if queue_time > 0:
-            self.job_queue_time.labels(
-                repo=repo, job_name=job_name, branch=branch,
-                commit_sha=commit_sha, runner_prefix=runner_prefix,
-            ).observe(queue_time)
+        attrs = dict(repo=repo, workflow_name=workflow_name, job_name=job_name,
+                     branch=branch, commit_sha=commit_sha, status=status,
+                     runner_prefix=runner_prefix)
 
-        # Annotations
+        self._counter("cicd_job_total", "Total job runs").add(1, attrs)
+        if duration > 0:
+            dur_attrs = {k: v for k, v in attrs.items() if k != "status"}
+            self._histogram("cicd_job_duration_seconds", "Job duration", "s").record(duration, dur_attrs)
+        if queue_time > 0:
+            q_attrs = dict(repo=repo, job_name=job_name, branch=branch,
+                           commit_sha=commit_sha, runner_prefix=runner_prefix)
+            self._histogram("cicd_job_queue_time_seconds", "Job queue time", "s").record(queue_time, q_attrs)
+
         for severity, field in [
             ("failure", "l_annotation_failure_count"),
             ("warning", "l_annotation_warning_count"),
@@ -246,10 +183,9 @@ class PrometheusExporter:
         ]:
             count = doc.get(field, 0)
             if count > 0:
-                self.job_annotation_total.labels(
-                    repo=repo, job_name=job_name, commit_sha=commit_sha,
-                    severity=severity,
-                ).set(count)
+                self._gauge("cicd_job_annotation_total", "Job annotations").set(
+                    count, dict(repo=repo, job_name=job_name, commit_sha=commit_sha, severity=severity),
+                )
 
         self._counters["jobs"] += 1
 
@@ -267,27 +203,21 @@ class PrometheusExporter:
         job_name = doc.get("s_job_name", "")
         duration_ms = doc.get("l_test_duration_ms", 0)
 
-        # Aggregate counter
-        self.test_total.labels(
-            repo=repo, framework=framework, test_type=test_type, arch=arch,
-            cuda_version=cuda_version, branch=branch, commit_sha=commit_sha,
-            status=status,
-        ).inc()
+        base_attrs = dict(repo=repo, framework=framework, test_type=test_type, arch=arch,
+                          cuda_version=cuda_version, branch=branch, commit_sha=commit_sha)
 
-        # Per-test status gauge (only for pass/fail, skip skipped)
+        self._counter("cicd_test_total", "Total test results").add(1, {**base_attrs, "status": status})
+
         if status in ("passed", "failed", "error"):
-            self.test_status.labels(
-                repo=repo, framework=framework, test_type=test_type, arch=arch,
-                cuda_version=cuda_version, branch=branch, commit_sha=commit_sha,
-                test_name=test_name, job_name=job_name,
-            ).set(1 if status == "passed" else 0)
+            self._gauge("cicd_test_status", "Per-test pass/fail (1=pass, 0=fail)").set(
+                1 if status == "passed" else 0,
+                {**base_attrs, "test_name": test_name, "job_name": job_name},
+            )
 
-        # Duration histogram (convert ms to seconds)
         if duration_ms > 0:
-            self.test_duration.labels(
-                repo=repo, framework=framework, test_type=test_type, arch=arch,
-                cuda_version=cuda_version, branch=branch, commit_sha=commit_sha,
-            ).observe(duration_ms / 1000.0)
+            self._histogram("cicd_test_duration_seconds", "Test duration", "s").record(
+                duration_ms / 1000.0, base_attrs,
+            )
 
         self._counters["tests"] += 1
 
@@ -301,42 +231,29 @@ class PrometheusExporter:
         branch = doc.get("s_branch", "")
         commit_sha = doc.get("s_commit_sha", "")
 
-        # Image size
+        full_attrs = dict(repo=repo, framework=framework, target=target, platform=platform,
+                          cuda_version=cuda_version, branch=branch, commit_sha=commit_sha)
+        cache_attrs = dict(repo=repo, framework=framework, cuda_version=cuda_version,
+                           branch=branch, commit_sha=commit_sha)
+
         size_bytes = doc.get("l_build_size_bytes", 0)
         if size_bytes > 0:
-            self.container_image_size.labels(
-                repo=repo, framework=framework, target=target, platform=platform,
-                cuda_version=cuda_version, branch=branch, commit_sha=commit_sha,
-            ).set(size_bytes)
+            self._gauge("cicd_container_image_size_bytes", "Container image size", "By").set(size_bytes, full_attrs)
 
-        # Build duration
         duration = doc.get("l_build_duration_sec", 0)
         if duration > 0:
-            self.container_build_duration.labels(
-                repo=repo, framework=framework, target=target, platform=platform,
-                cuda_version=cuda_version, branch=branch, commit_sha=commit_sha,
-            ).observe(duration)
+            self._histogram("cicd_container_build_duration_seconds", "Build duration", "s").record(duration, full_attrs)
 
-        # Cache hit rate
         cache_hit_rate = doc.get("f_cache_hit_rate", -1)
         if cache_hit_rate >= 0:
-            self.container_cache_hit_rate.labels(
-                repo=repo, framework=framework, cuda_version=cuda_version,
-                branch=branch, commit_sha=commit_sha,
-            ).set(cache_hit_rate)
+            self._gauge("cicd_container_cache_hit_rate", "Docker cache hit rate").set(cache_hit_rate, cache_attrs)
 
-        # Step counts
-        for type_name, field in [
-            ("total", "l_total_steps"),
-            ("cached", "l_cached_steps"),
-            ("built", "l_built_steps"),
-        ]:
+        for type_name, field in [("total", "l_total_steps"), ("cached", "l_cached_steps"), ("built", "l_built_steps")]:
             val = doc.get(field, 0)
             if val > 0:
-                self.container_steps_total.labels(
-                    repo=repo, framework=framework, cuda_version=cuda_version,
-                    branch=branch, commit_sha=commit_sha, type=type_name,
-                ).set(val)
+                self._gauge("cicd_container_steps_total", "Build step counts").set(
+                    val, {**cache_attrs, "type": type_name},
+                )
 
         self._counters["containers"] += 1
 
@@ -349,16 +266,16 @@ class PrometheusExporter:
         branch = doc.get("s_branch", "")
         commit_sha = doc.get("s_commit_sha", "")
 
-        labels = dict(repo=repo, framework=framework, stage_name=stage_name,
-                       cuda_version=cuda_version, branch=branch, commit_sha=commit_sha)
+        attrs = dict(repo=repo, framework=framework, stage_name=stage_name,
+                     cuda_version=cuda_version, branch=branch, commit_sha=commit_sha)
 
         duration = doc.get("f_stage_duration_sec", 0)
         if duration > 0:
-            self.container_stage_duration.labels(**labels).set(duration)
+            self._gauge("cicd_container_stage_duration_seconds", "Stage duration", "s").set(duration, attrs)
 
         cache_rate = doc.get("f_stage_cache_hit_rate", -1)
         if cache_rate >= 0:
-            self.container_stage_cache_hit_rate.labels(**labels).set(cache_rate)
+            self._gauge("cicd_container_stage_cache_hit_rate", "Stage cache rate").set(cache_rate, attrs)
 
         self._counters["stages"] += 1
 
@@ -369,56 +286,57 @@ class PrometheusExporter:
         is_external = str(doc.get("b_is_external", False)).lower()
         base_branch = doc.get("s_base_branch", "")
 
-        self.pr_total.labels(
-            repo=repo, state=state, is_external=is_external, base_branch=base_branch,
-        ).inc()
+        self._counter("cicd_pr_total", "Total pull requests").add(
+            1, dict(repo=repo, state=state, is_external=is_external, base_branch=base_branch),
+        )
 
-        # Time-to-merge histogram
         ttm = doc.get("l_time_to_merge_hours")
         if ttm is not None and ttm > 0:
-            self.pr_merge_duration.labels(
-                repo=repo, base_branch=base_branch, is_external=is_external,
-            ).observe(ttm)
+            self._histogram("cicd_pr_merge_duration_hours", "PR time-to-merge", "h").record(
+                ttm, dict(repo=repo, base_branch=base_branch, is_external=is_external),
+            )
 
         self._counters["prs"] += 1
 
-    # ── Push to gateway ───────────────────────────────────────────────────────
+    # ── Flush / Push ──────────────────────────────────────────────────────
 
     def push(self, grouping_key: Optional[Dict[str, str]] = None) -> None:
-        """Push all collected metrics to the Pushgateway.
+        """Flush all pending metrics to the OTLP endpoint.
 
-        Args:
-            grouping_key: Optional dict of additional grouping labels. When pushing
-                from CI, pass ``{"run_id": ..., "job_name": ...}`` to avoid
-                collisions between concurrent jobs.
+        The grouping_key parameter is accepted for backward compatibility
+        but is not used with OTLP (each metric carries its own attributes).
         """
         if self.dry_run:
-            log.info("[DRY RUN] Would push to Pushgateway at %s", self.pushgateway_url)
+            log.info("[DRY RUN] Would push to OTLP endpoint %s", self.otlp_endpoint)
             self._log_summary()
             return
 
-        if not self.pushgateway_url:
-            log.warning("PUSHGATEWAY_URL not configured, skipping Prometheus push")
+        if not self._provider:
+            log.warning("OTLP endpoint not configured, skipping push")
             return
 
         try:
-            push_to_gateway(
-                self.pushgateway_url,
-                job=self.job_name,
-                grouping_key=grouping_key or {},
-                registry=self.registry,
-            )
-            log.info("Pushed metrics to Pushgateway at %s", self.pushgateway_url)
+            success = self._provider.force_flush(timeout_millis=30000)
+            if success:
+                log.info("Flushed metrics to OTLP endpoint %s", self.otlp_endpoint)
+            else:
+                log.warning("OTLP flush returned False — some metrics may not have been exported")
             self._log_summary()
         except Exception:
-            log.exception("Failed to push metrics to Pushgateway")
+            log.exception("Failed to flush metrics to OTLP endpoint")
+
+    def shutdown(self) -> None:
+        """Shutdown the meter provider and release resources."""
+        if self._provider:
+            try:
+                self._provider.shutdown()
+            except Exception:
+                log.exception("Error shutting down meter provider")
 
     def _log_summary(self) -> None:
-        """Log a summary of recorded metrics."""
         parts = [f"{k}={v}" for k, v in sorted(self._counters.items()) if v > 0]
         if parts:
-            log.info("Prometheus metrics recorded: %s", ", ".join(parts))
+            log.info("Metrics recorded: %s", ", ".join(parts))
 
     def get_summary(self) -> Dict[str, int]:
-        """Return counts of recorded metrics."""
         return dict(self._counters)

--- a/deploy/metrics/prometheus_exporter.py
+++ b/deploy/metrics/prometheus_exporter.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Prometheus Pushgateway exporter for CI/CD metrics.
 

--- a/deploy/metrics/prometheus_exporter.py
+++ b/deploy/metrics/prometheus_exporter.py
@@ -21,7 +21,6 @@ accepts the same OpenSearch-shaped dicts as the previous Pushgateway implementat
 """
 
 import logging
-import os
 from collections import defaultdict
 from typing import Any, Dict, Optional
 
@@ -103,7 +102,9 @@ class PrometheusExporter:
         key = f"counter_{name}"
         if key not in self._instruments:
             self._instruments[key] = self._meter.create_counter(
-                name=name, description=description, unit=unit,
+                name=name,
+                description=description,
+                unit=unit,
             )
         return self._instruments[key]
 
@@ -111,7 +112,9 @@ class PrometheusExporter:
         key = f"histogram_{name}"
         if key not in self._instruments:
             self._instruments[key] = self._meter.create_histogram(
-                name=name, description=description, unit=unit,
+                name=name,
+                description=description,
+                unit=unit,
             )
         return self._instruments[key]
 
@@ -120,7 +123,9 @@ class PrometheusExporter:
         key = f"gauge_{name}"
         if key not in self._instruments:
             self._instruments[key] = self._meter.create_gauge(
-                name=name, description=description, unit=unit,
+                name=name,
+                description=description,
+                unit=unit,
             )
         return self._instruments[key]
 
@@ -136,15 +141,29 @@ class PrometheusExporter:
         duration = doc.get("l_duration_sec", 0)
         queue_time = doc.get("l_queue_time_sec", 0)
 
-        attrs = dict(repo=repo, workflow_name=workflow_name, branch=branch,
-                     commit_sha=commit_sha, status=status)
+        attrs = dict(
+            repo=repo,
+            workflow_name=workflow_name,
+            branch=branch,
+            commit_sha=commit_sha,
+            status=status,
+        )
 
         self._counter("cicd_workflow_total", "Total workflow runs").add(1, attrs)
         if duration > 0:
-            self._histogram("cicd_workflow_duration_seconds", "Workflow duration", "s").record(duration, attrs)
+            self._histogram(
+                "cicd_workflow_duration_seconds", "Workflow duration", "s"
+            ).record(duration, attrs)
         if queue_time > 0:
-            queue_attrs = dict(repo=repo, workflow_name=workflow_name, branch=branch, commit_sha=commit_sha)
-            self._histogram("cicd_workflow_queue_time_seconds", "Workflow queue time", "s").record(queue_time, queue_attrs)
+            queue_attrs = dict(
+                repo=repo,
+                workflow_name=workflow_name,
+                branch=branch,
+                commit_sha=commit_sha,
+            )
+            self._histogram(
+                "cicd_workflow_queue_time_seconds", "Workflow queue time", "s"
+            ).record(queue_time, queue_attrs)
 
         self._counters["workflows"] += 1
 
@@ -160,18 +179,33 @@ class PrometheusExporter:
         duration = doc.get("l_duration_sec", 0)
         queue_time = doc.get("l_queue_time_sec", 0)
 
-        attrs = dict(repo=repo, workflow_name=workflow_name, job_name=job_name,
-                     branch=branch, commit_sha=commit_sha, status=status,
-                     runner_prefix=runner_prefix)
+        attrs = dict(
+            repo=repo,
+            workflow_name=workflow_name,
+            job_name=job_name,
+            branch=branch,
+            commit_sha=commit_sha,
+            status=status,
+            runner_prefix=runner_prefix,
+        )
 
         self._counter("cicd_job_total", "Total job runs").add(1, attrs)
         if duration > 0:
             dur_attrs = {k: v for k, v in attrs.items() if k != "status"}
-            self._histogram("cicd_job_duration_seconds", "Job duration", "s").record(duration, dur_attrs)
+            self._histogram("cicd_job_duration_seconds", "Job duration", "s").record(
+                duration, dur_attrs
+            )
         if queue_time > 0:
-            q_attrs = dict(repo=repo, job_name=job_name, branch=branch,
-                           commit_sha=commit_sha, runner_prefix=runner_prefix)
-            self._histogram("cicd_job_queue_time_seconds", "Job queue time", "s").record(queue_time, q_attrs)
+            q_attrs = dict(
+                repo=repo,
+                job_name=job_name,
+                branch=branch,
+                commit_sha=commit_sha,
+                runner_prefix=runner_prefix,
+            )
+            self._histogram(
+                "cicd_job_queue_time_seconds", "Job queue time", "s"
+            ).record(queue_time, q_attrs)
 
         for severity, field in [
             ("failure", "l_annotation_failure_count"),
@@ -181,7 +215,13 @@ class PrometheusExporter:
             count = doc.get(field, 0)
             if count > 0:
                 self._gauge("cicd_job_annotation_total", "Job annotations").set(
-                    count, dict(repo=repo, job_name=job_name, commit_sha=commit_sha, severity=severity),
+                    count,
+                    dict(
+                        repo=repo,
+                        job_name=job_name,
+                        commit_sha=commit_sha,
+                        severity=severity,
+                    ),
                 )
 
         self._counters["jobs"] += 1
@@ -200,10 +240,19 @@ class PrometheusExporter:
         job_name = doc.get("s_job_name", "")
         duration_ms = doc.get("l_test_duration_ms", 0)
 
-        base_attrs = dict(repo=repo, framework=framework, test_type=test_type, arch=arch,
-                          cuda_version=cuda_version, branch=branch, commit_sha=commit_sha)
+        base_attrs = dict(
+            repo=repo,
+            framework=framework,
+            test_type=test_type,
+            arch=arch,
+            cuda_version=cuda_version,
+            branch=branch,
+            commit_sha=commit_sha,
+        )
 
-        self._counter("cicd_test_total", "Total test results").add(1, {**base_attrs, "status": status})
+        self._counter("cicd_test_total", "Total test results").add(
+            1, {**base_attrs, "status": status}
+        )
 
         if status in ("passed", "failed", "error"):
             self._gauge("cicd_test_status", "Per-test pass/fail (1=pass, 0=fail)").set(
@@ -213,7 +262,8 @@ class PrometheusExporter:
 
         if duration_ms > 0:
             self._histogram("cicd_test_duration_seconds", "Test duration", "s").record(
-                duration_ms / 1000.0, base_attrs,
+                duration_ms / 1000.0,
+                base_attrs,
             )
 
         self._counters["tests"] += 1
@@ -228,28 +278,51 @@ class PrometheusExporter:
         branch = doc.get("s_branch", "")
         commit_sha = doc.get("s_commit_sha", "")
 
-        full_attrs = dict(repo=repo, framework=framework, target=target, platform=platform,
-                          cuda_version=cuda_version, branch=branch, commit_sha=commit_sha)
-        cache_attrs = dict(repo=repo, framework=framework, cuda_version=cuda_version,
-                           branch=branch, commit_sha=commit_sha)
+        full_attrs = dict(
+            repo=repo,
+            framework=framework,
+            target=target,
+            platform=platform,
+            cuda_version=cuda_version,
+            branch=branch,
+            commit_sha=commit_sha,
+        )
+        cache_attrs = dict(
+            repo=repo,
+            framework=framework,
+            cuda_version=cuda_version,
+            branch=branch,
+            commit_sha=commit_sha,
+        )
 
         size_bytes = doc.get("l_build_size_bytes", 0)
         if size_bytes > 0:
-            self._gauge("cicd_container_image_size_bytes", "Container image size", "By").set(size_bytes, full_attrs)
+            self._gauge(
+                "cicd_container_image_size_bytes", "Container image size", "By"
+            ).set(size_bytes, full_attrs)
 
         duration = doc.get("l_build_duration_sec", 0)
         if duration > 0:
-            self._histogram("cicd_container_build_duration_seconds", "Build duration", "s").record(duration, full_attrs)
+            self._histogram(
+                "cicd_container_build_duration_seconds", "Build duration", "s"
+            ).record(duration, full_attrs)
 
         cache_hit_rate = doc.get("f_cache_hit_rate", -1)
         if cache_hit_rate >= 0:
-            self._gauge("cicd_container_cache_hit_rate", "Docker cache hit rate").set(cache_hit_rate, cache_attrs)
+            self._gauge("cicd_container_cache_hit_rate", "Docker cache hit rate").set(
+                cache_hit_rate, cache_attrs
+            )
 
-        for type_name, field in [("total", "l_total_steps"), ("cached", "l_cached_steps"), ("built", "l_built_steps")]:
+        for type_name, field in [
+            ("total", "l_total_steps"),
+            ("cached", "l_cached_steps"),
+            ("built", "l_built_steps"),
+        ]:
             val = doc.get(field, 0)
             if val > 0:
                 self._gauge("cicd_container_steps_total", "Build step counts").set(
-                    val, {**cache_attrs, "type": type_name},
+                    val,
+                    {**cache_attrs, "type": type_name},
                 )
 
         self._counters["containers"] += 1
@@ -263,16 +336,26 @@ class PrometheusExporter:
         branch = doc.get("s_branch", "")
         commit_sha = doc.get("s_commit_sha", "")
 
-        attrs = dict(repo=repo, framework=framework, stage_name=stage_name,
-                     cuda_version=cuda_version, branch=branch, commit_sha=commit_sha)
+        attrs = dict(
+            repo=repo,
+            framework=framework,
+            stage_name=stage_name,
+            cuda_version=cuda_version,
+            branch=branch,
+            commit_sha=commit_sha,
+        )
 
         duration = doc.get("f_stage_duration_sec", 0)
         if duration > 0:
-            self._gauge("cicd_container_stage_duration_seconds", "Stage duration", "s").set(duration, attrs)
+            self._gauge(
+                "cicd_container_stage_duration_seconds", "Stage duration", "s"
+            ).set(duration, attrs)
 
         cache_rate = doc.get("f_stage_cache_hit_rate", -1)
         if cache_rate >= 0:
-            self._gauge("cicd_container_stage_cache_hit_rate", "Stage cache rate").set(cache_rate, attrs)
+            self._gauge("cicd_container_stage_cache_hit_rate", "Stage cache rate").set(
+                cache_rate, attrs
+            )
 
         self._counters["stages"] += 1
 
@@ -284,13 +367,19 @@ class PrometheusExporter:
         base_branch = doc.get("s_base_branch", "")
 
         self._counter("cicd_pr_total", "Total pull requests").add(
-            1, dict(repo=repo, state=state, is_external=is_external, base_branch=base_branch),
+            1,
+            dict(
+                repo=repo, state=state, is_external=is_external, base_branch=base_branch
+            ),
         )
 
         ttm = doc.get("l_time_to_merge_hours")
         if ttm is not None and ttm > 0:
-            self._histogram("cicd_pr_merge_duration_hours", "PR time-to-merge", "h").record(
-                ttm, dict(repo=repo, base_branch=base_branch, is_external=is_external),
+            self._histogram(
+                "cicd_pr_merge_duration_hours", "PR time-to-merge", "h"
+            ).record(
+                ttm,
+                dict(repo=repo, base_branch=base_branch, is_external=is_external),
             )
 
         self._counters["prs"] += 1
@@ -317,7 +406,9 @@ class PrometheusExporter:
             if success:
                 log.info("Flushed metrics to OTLP endpoint %s", self.otlp_endpoint)
             else:
-                log.warning("OTLP flush returned False — some metrics may not have been exported")
+                log.warning(
+                    "OTLP flush returned False — some metrics may not have been exported"
+                )
             self._log_summary()
         except Exception:
             log.exception("Failed to flush metrics to OTLP endpoint")

--- a/deploy/metrics/prometheus_exporter.py
+++ b/deploy/metrics/prometheus_exporter.py
@@ -47,12 +47,9 @@ class PrometheusExporter:
         otlp_token: str = "",
         service_name: str = "dynamo-cicd-metrics",
         dry_run: bool = False,
-        # Legacy parameter names — still accepted for backward compat
-        pushgateway_url: str = "",
-        job_name: str = "cicd_metrics",
     ):
         self.dry_run = dry_run
-        self.otlp_endpoint = otlp_endpoint or pushgateway_url
+        self.otlp_endpoint = otlp_endpoint
         self.otlp_token = otlp_token
         self.service_name = service_name
         self._counters: Dict[str, int] = defaultdict(int)

--- a/deploy/metrics/prometheus_exporter.py
+++ b/deploy/metrics/prometheus_exporter.py
@@ -1,0 +1,410 @@
+"""
+Prometheus Pushgateway exporter for CI/CD metrics.
+
+Pushes metrics to Prometheus via Pushgateway, matching the schema defined in the
+migration plan. Designed to be called alongside the existing OpenSearch uploader
+during the dual-write phase.
+"""
+
+import logging
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+from prometheus_client import (
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    push_to_gateway,
+)
+
+log = logging.getLogger(__name__)
+
+# Histogram bucket definitions from the plan
+WORKFLOW_DURATION_BUCKETS = (60, 120, 300, 600, 900, 1200, 1800, 3600, 7200)
+WORKFLOW_QUEUE_BUCKETS = (10, 30, 60, 120, 300, 600, 900)
+JOB_DURATION_BUCKETS = (30, 60, 120, 300, 600, 900, 1800, 3600)
+JOB_QUEUE_BUCKETS = (5, 10, 30, 60, 120, 300, 600)
+TEST_DURATION_BUCKETS = (0.1, 0.5, 1, 5, 10, 30, 60, 120, 300)
+CONTAINER_BUILD_DURATION_BUCKETS = (60, 120, 300, 600, 900, 1200, 1800, 3600)
+PR_MERGE_DURATION_BUCKETS = (1, 4, 8, 24, 48, 72, 168, 336)
+
+
+class PrometheusExporter:
+    """Exports CI/CD metrics to Prometheus via Pushgateway."""
+
+    def __init__(self, pushgateway_url: str, job_name: str = "cicd_metrics", dry_run: bool = False):
+        self.pushgateway_url = pushgateway_url
+        self.job_name = job_name
+        self.dry_run = dry_run
+        self.registry = CollectorRegistry()
+
+        self._counters: Dict[str, int] = defaultdict(int)
+
+        # ── Workflow metrics ──
+        self.workflow_total = Counter(
+            "cicd_workflow_total",
+            "Total workflow runs",
+            ["repo", "workflow_name", "branch", "commit_sha", "status"],
+            registry=self.registry,
+        )
+        self.workflow_duration = Histogram(
+            "cicd_workflow_duration_seconds",
+            "Workflow duration in seconds",
+            ["repo", "workflow_name", "branch", "commit_sha", "status"],
+            buckets=WORKFLOW_DURATION_BUCKETS,
+            registry=self.registry,
+        )
+        self.workflow_queue_time = Histogram(
+            "cicd_workflow_queue_time_seconds",
+            "Workflow queue time in seconds",
+            ["repo", "workflow_name", "branch", "commit_sha"],
+            buckets=WORKFLOW_QUEUE_BUCKETS,
+            registry=self.registry,
+        )
+
+        # ── Job metrics ──
+        self.job_total = Counter(
+            "cicd_job_total",
+            "Total job runs",
+            ["repo", "workflow_name", "job_name", "branch", "commit_sha", "status", "runner_prefix"],
+            registry=self.registry,
+        )
+        self.job_duration = Histogram(
+            "cicd_job_duration_seconds",
+            "Job duration in seconds",
+            ["repo", "workflow_name", "job_name", "branch", "commit_sha", "runner_prefix"],
+            buckets=JOB_DURATION_BUCKETS,
+            registry=self.registry,
+        )
+        self.job_queue_time = Histogram(
+            "cicd_job_queue_time_seconds",
+            "Job queue time in seconds",
+            ["repo", "job_name", "branch", "commit_sha", "runner_prefix"],
+            buckets=JOB_QUEUE_BUCKETS,
+            registry=self.registry,
+        )
+        self.job_annotation_total = Gauge(
+            "cicd_job_annotation_total",
+            "Job annotation counts by severity",
+            ["repo", "job_name", "commit_sha", "severity"],
+            registry=self.registry,
+        )
+
+        # ── Test metrics ──
+        self.test_total = Counter(
+            "cicd_test_total",
+            "Total test results",
+            ["repo", "framework", "test_type", "arch", "cuda_version", "branch", "commit_sha", "status"],
+            registry=self.registry,
+        )
+        self.test_status = Gauge(
+            "cicd_test_status",
+            "Per-test pass/fail status (1=pass, 0=fail)",
+            ["repo", "framework", "test_type", "arch", "cuda_version", "branch", "commit_sha", "test_name", "job_name"],
+            registry=self.registry,
+        )
+        self.test_duration = Histogram(
+            "cicd_test_duration_seconds",
+            "Test duration in seconds",
+            ["repo", "framework", "test_type", "arch", "cuda_version", "branch", "commit_sha"],
+            buckets=TEST_DURATION_BUCKETS,
+            registry=self.registry,
+        )
+
+        # ── Container build metrics ──
+        self.container_image_size = Gauge(
+            "cicd_container_image_size_bytes",
+            "Container image size in bytes",
+            ["repo", "framework", "target", "platform", "cuda_version", "branch", "commit_sha"],
+            registry=self.registry,
+        )
+        self.container_build_duration = Histogram(
+            "cicd_container_build_duration_seconds",
+            "Container build duration in seconds",
+            ["repo", "framework", "target", "platform", "cuda_version", "branch", "commit_sha"],
+            buckets=CONTAINER_BUILD_DURATION_BUCKETS,
+            registry=self.registry,
+        )
+        self.container_cache_hit_rate = Gauge(
+            "cicd_container_cache_hit_rate",
+            "Docker layer cache hit rate (0.0-1.0)",
+            ["repo", "framework", "cuda_version", "branch", "commit_sha"],
+            registry=self.registry,
+        )
+        self.container_sccache_hit_rate = Gauge(
+            "cicd_container_sccache_hit_rate",
+            "sccache compilation cache hit rate (0.0-1.0)",
+            ["repo", "framework", "cuda_version", "branch", "commit_sha"],
+            registry=self.registry,
+        )
+        self.container_steps_total = Gauge(
+            "cicd_container_steps_total",
+            "Container build step counts by type",
+            ["repo", "framework", "cuda_version", "branch", "commit_sha", "type"],
+            registry=self.registry,
+        )
+        self.container_stage_duration = Gauge(
+            "cicd_container_stage_duration_seconds",
+            "Container stage duration in seconds",
+            ["repo", "framework", "stage_name", "cuda_version", "branch", "commit_sha"],
+            registry=self.registry,
+        )
+        self.container_stage_cache_hit_rate = Gauge(
+            "cicd_container_stage_cache_hit_rate",
+            "Container stage cache hit rate",
+            ["repo", "framework", "stage_name", "cuda_version", "branch", "commit_sha"],
+            registry=self.registry,
+        )
+
+        # ── PR metrics ──
+        self.pr_total = Counter(
+            "cicd_pr_total",
+            "Total pull requests",
+            ["repo", "state", "is_external", "base_branch"],
+            registry=self.registry,
+        )
+        self.pr_merge_duration = Histogram(
+            "cicd_pr_merge_duration_hours",
+            "PR time-to-merge in hours",
+            ["repo", "base_branch", "is_external"],
+            buckets=PR_MERGE_DURATION_BUCKETS,
+            registry=self.registry,
+        )
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def record_workflow(self, doc: Dict[str, Any]) -> None:
+        """Record a workflow run from an OpenSearch-shaped document."""
+        repo = doc.get("s_repo", "")
+        workflow_name = doc.get("s_workflow_name", "")
+        branch = doc.get("s_branch", "")
+        commit_sha = doc.get("s_commit_sha", "")
+        status = doc.get("s_status", "unknown")
+        duration = doc.get("l_duration_sec", 0)
+        queue_time = doc.get("l_queue_time_sec", 0)
+
+        labels = dict(repo=repo, workflow_name=workflow_name, branch=branch,
+                       commit_sha=commit_sha, status=status)
+        self.workflow_total.labels(**labels).inc()
+        if duration > 0:
+            self.workflow_duration.labels(**labels).observe(duration)
+        if queue_time > 0:
+            queue_labels = dict(repo=repo, workflow_name=workflow_name,
+                                branch=branch, commit_sha=commit_sha)
+            self.workflow_queue_time.labels(**queue_labels).observe(queue_time)
+
+        self._counters["workflows"] += 1
+
+    def record_job(self, doc: Dict[str, Any]) -> None:
+        """Record a job run from an OpenSearch-shaped document."""
+        repo = doc.get("s_repo", "")
+        workflow_name = doc.get("s_workflow_name", "")
+        job_name = doc.get("s_job_name", "")
+        branch = doc.get("s_branch", "")
+        commit_sha = doc.get("s_commit_sha", "")
+        status = doc.get("s_status", "unknown")
+        runner_prefix = doc.get("s_runner_prefix", "unknown")
+        duration = doc.get("l_duration_sec", 0)
+        queue_time = doc.get("l_queue_time_sec", 0)
+
+        self.job_total.labels(
+            repo=repo, workflow_name=workflow_name, job_name=job_name,
+            branch=branch, commit_sha=commit_sha, status=status,
+            runner_prefix=runner_prefix,
+        ).inc()
+        if duration > 0:
+            self.job_duration.labels(
+                repo=repo, workflow_name=workflow_name, job_name=job_name,
+                branch=branch, commit_sha=commit_sha, runner_prefix=runner_prefix,
+            ).observe(duration)
+        if queue_time > 0:
+            self.job_queue_time.labels(
+                repo=repo, job_name=job_name, branch=branch,
+                commit_sha=commit_sha, runner_prefix=runner_prefix,
+            ).observe(queue_time)
+
+        # Annotations
+        for severity, field in [
+            ("failure", "l_annotation_failure_count"),
+            ("warning", "l_annotation_warning_count"),
+            ("notice", "l_annotation_notice_count"),
+        ]:
+            count = doc.get(field, 0)
+            if count > 0:
+                self.job_annotation_total.labels(
+                    repo=repo, job_name=job_name, commit_sha=commit_sha,
+                    severity=severity,
+                ).set(count)
+
+        self._counters["jobs"] += 1
+
+    def record_test(self, doc: Dict[str, Any]) -> None:
+        """Record a test result from an OpenSearch-shaped document."""
+        repo = doc.get("s_repo", "")
+        framework = doc.get("s_framework", "unknown")
+        test_type = doc.get("s_test_type", "unknown")
+        arch = doc.get("s_arch", "unknown")
+        cuda_version = doc.get("s_cuda_version", "")
+        branch = doc.get("s_branch", "")
+        commit_sha = doc.get("s_commit_sha", "")
+        status = doc.get("s_test_status", doc.get("s_status", "unknown"))
+        test_name = doc.get("s_test_name", "")
+        job_name = doc.get("s_job_name", "")
+        duration_ms = doc.get("l_test_duration_ms", 0)
+
+        # Aggregate counter
+        self.test_total.labels(
+            repo=repo, framework=framework, test_type=test_type, arch=arch,
+            cuda_version=cuda_version, branch=branch, commit_sha=commit_sha,
+            status=status,
+        ).inc()
+
+        # Per-test status gauge (only for pass/fail, skip skipped)
+        if status in ("passed", "failed", "error"):
+            self.test_status.labels(
+                repo=repo, framework=framework, test_type=test_type, arch=arch,
+                cuda_version=cuda_version, branch=branch, commit_sha=commit_sha,
+                test_name=test_name, job_name=job_name,
+            ).set(1 if status == "passed" else 0)
+
+        # Duration histogram (convert ms to seconds)
+        if duration_ms > 0:
+            self.test_duration.labels(
+                repo=repo, framework=framework, test_type=test_type, arch=arch,
+                cuda_version=cuda_version, branch=branch, commit_sha=commit_sha,
+            ).observe(duration_ms / 1000.0)
+
+        self._counters["tests"] += 1
+
+    def record_container(self, doc: Dict[str, Any]) -> None:
+        """Record container build metrics from an OpenSearch-shaped document."""
+        repo = doc.get("s_repo", "")
+        framework = doc.get("s_build_framework", "unknown")
+        target = doc.get("s_build_target", "unknown")
+        platform = doc.get("s_build_platform", "unknown")
+        cuda_version = doc.get("s_cuda_version", "")
+        branch = doc.get("s_branch", "")
+        commit_sha = doc.get("s_commit_sha", "")
+
+        # Image size
+        size_bytes = doc.get("l_build_size_bytes", 0)
+        if size_bytes > 0:
+            self.container_image_size.labels(
+                repo=repo, framework=framework, target=target, platform=platform,
+                cuda_version=cuda_version, branch=branch, commit_sha=commit_sha,
+            ).set(size_bytes)
+
+        # Build duration
+        duration = doc.get("l_build_duration_sec", 0)
+        if duration > 0:
+            self.container_build_duration.labels(
+                repo=repo, framework=framework, target=target, platform=platform,
+                cuda_version=cuda_version, branch=branch, commit_sha=commit_sha,
+            ).observe(duration)
+
+        # Cache hit rate
+        cache_hit_rate = doc.get("f_cache_hit_rate", -1)
+        if cache_hit_rate >= 0:
+            self.container_cache_hit_rate.labels(
+                repo=repo, framework=framework, cuda_version=cuda_version,
+                branch=branch, commit_sha=commit_sha,
+            ).set(cache_hit_rate)
+
+        # Step counts
+        for type_name, field in [
+            ("total", "l_total_steps"),
+            ("cached", "l_cached_steps"),
+            ("built", "l_built_steps"),
+        ]:
+            val = doc.get(field, 0)
+            if val > 0:
+                self.container_steps_total.labels(
+                    repo=repo, framework=framework, cuda_version=cuda_version,
+                    branch=branch, commit_sha=commit_sha, type=type_name,
+                ).set(val)
+
+        self._counters["containers"] += 1
+
+    def record_stage(self, doc: Dict[str, Any]) -> None:
+        """Record container stage metrics from an OpenSearch-shaped document."""
+        repo = doc.get("s_repo", "")
+        framework = doc.get("s_build_framework", "unknown")
+        stage_name = doc.get("s_stage_name", "unknown")
+        cuda_version = doc.get("s_cuda_version", "")
+        branch = doc.get("s_branch", "")
+        commit_sha = doc.get("s_commit_sha", "")
+
+        labels = dict(repo=repo, framework=framework, stage_name=stage_name,
+                       cuda_version=cuda_version, branch=branch, commit_sha=commit_sha)
+
+        duration = doc.get("f_stage_duration_sec", 0)
+        if duration > 0:
+            self.container_stage_duration.labels(**labels).set(duration)
+
+        cache_rate = doc.get("f_stage_cache_hit_rate", -1)
+        if cache_rate >= 0:
+            self.container_stage_cache_hit_rate.labels(**labels).set(cache_rate)
+
+        self._counters["stages"] += 1
+
+    def record_pr(self, doc: Dict[str, Any]) -> None:
+        """Record PR metrics from an OpenSearch-shaped document."""
+        repo = doc.get("s_repo", "")
+        state = doc.get("s_state", "unknown")
+        is_external = str(doc.get("b_is_external", False)).lower()
+        base_branch = doc.get("s_base_branch", "")
+
+        self.pr_total.labels(
+            repo=repo, state=state, is_external=is_external, base_branch=base_branch,
+        ).inc()
+
+        # Time-to-merge histogram
+        ttm = doc.get("l_time_to_merge_hours")
+        if ttm is not None and ttm > 0:
+            self.pr_merge_duration.labels(
+                repo=repo, base_branch=base_branch, is_external=is_external,
+            ).observe(ttm)
+
+        self._counters["prs"] += 1
+
+    # ── Push to gateway ───────────────────────────────────────────────────────
+
+    def push(self, grouping_key: Optional[Dict[str, str]] = None) -> None:
+        """Push all collected metrics to the Pushgateway.
+
+        Args:
+            grouping_key: Optional dict of additional grouping labels. When pushing
+                from CI, pass ``{"run_id": ..., "job_name": ...}`` to avoid
+                collisions between concurrent jobs.
+        """
+        if self.dry_run:
+            log.info("[DRY RUN] Would push to Pushgateway at %s", self.pushgateway_url)
+            self._log_summary()
+            return
+
+        if not self.pushgateway_url:
+            log.warning("PUSHGATEWAY_URL not configured, skipping Prometheus push")
+            return
+
+        try:
+            push_to_gateway(
+                self.pushgateway_url,
+                job=self.job_name,
+                grouping_key=grouping_key or {},
+                registry=self.registry,
+            )
+            log.info("Pushed metrics to Pushgateway at %s", self.pushgateway_url)
+            self._log_summary()
+        except Exception:
+            log.exception("Failed to push metrics to Pushgateway")
+
+    def _log_summary(self) -> None:
+        """Log a summary of recorded metrics."""
+        parts = [f"{k}={v}" for k, v in sorted(self._counters.items()) if v > 0]
+        if parts:
+            log.info("Prometheus metrics recorded: %s", ", ".join(parts))
+
+    def get_summary(self) -> Dict[str, int]:
+        """Return counts of recorded metrics."""
+        return dict(self._counters)


### PR DESCRIPTION
  (test results, build metrics, job status) directly from GitHub
  Actions jobs to Prometheus Pushgateway and Loki — no cron polling
  or artifact download round-trip needed.

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated CI/CD metrics collection and export to Prometheus and Loki monitoring systems.
  * Metrics now capture test results, build performance, job execution times, and container layer data.
  * New GitHub Actions integration automatically collects and pushes metrics from CI/CD jobs to monitoring backends.
  * Support for custom metadata including framework type, architecture, and CUDA version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->