### PR TITLE
feat: support chat_template.json as a prompt formatter artifact

### DIFF
--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -105,8 +105,14 @@ impl TokenizerKind {
 pub enum PromptFormatterArtifact {
     HfTokenizerConfigJson(CheckedFile),
     #[serde(alias = "hf_chat_template")]
-    HfChatTemplateJinja { is_custom: bool, file: CheckedFile },
-    HfChatTemplateJson { is_custom: bool, file: CheckedFile },
+    HfChatTemplateJinja {
+        is_custom: bool,
+        file: CheckedFile,
+    },
+    HfChatTemplateJson {
+        is_custom: bool,
+        file: CheckedFile,
+    },
 }
 
 impl PromptFormatterArtifact {
@@ -114,7 +120,9 @@ impl PromptFormatterArtifact {
         match self {
             PromptFormatterArtifact::HfTokenizerConfigJson(c) => c.checksum().to_string(),
             PromptFormatterArtifact::HfChatTemplateJinja { file: c, .. }
-            | PromptFormatterArtifact::HfChatTemplateJson { file: c, .. } => c.checksum().to_string(),
+            | PromptFormatterArtifact::HfChatTemplateJson { file: c, .. } => {
+                c.checksum().to_string()
+            }
         }
     }
 

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -104,14 +104,17 @@ impl TokenizerKind {
 #[serde(rename_all = "snake_case")]
 pub enum PromptFormatterArtifact {
     HfTokenizerConfigJson(CheckedFile),
-    HfChatTemplate { is_custom: bool, file: CheckedFile },
+    #[serde(alias = "hf_chat_template")]
+    HfChatTemplateJinja { is_custom: bool, file: CheckedFile },
+    HfChatTemplateJson { is_custom: bool, file: CheckedFile },
 }
 
 impl PromptFormatterArtifact {
     pub fn checksum(&self) -> String {
         match self {
             PromptFormatterArtifact::HfTokenizerConfigJson(c) => c.checksum().to_string(),
-            PromptFormatterArtifact::HfChatTemplate { file: c, .. } => c.checksum().to_string(),
+            PromptFormatterArtifact::HfChatTemplateJinja { file: c, .. }
+            | PromptFormatterArtifact::HfChatTemplateJson { file: c, .. } => c.checksum().to_string(),
         }
     }
 
@@ -119,21 +122,24 @@ impl PromptFormatterArtifact {
     pub fn is_local(&self) -> bool {
         match self {
             PromptFormatterArtifact::HfTokenizerConfigJson(c) => c.is_local(),
-            PromptFormatterArtifact::HfChatTemplate { file: c, .. } => c.is_local(),
+            PromptFormatterArtifact::HfChatTemplateJinja { file: c, .. }
+            | PromptFormatterArtifact::HfChatTemplateJson { file: c, .. } => c.is_local(),
         }
     }
 
     pub fn update_dir(&mut self, dir: &Path) {
         match self {
             PromptFormatterArtifact::HfTokenizerConfigJson(c) => c.update_dir(dir),
-            PromptFormatterArtifact::HfChatTemplate { file: c, .. } => c.update_dir(dir),
+            PromptFormatterArtifact::HfChatTemplateJinja { file: c, .. }
+            | PromptFormatterArtifact::HfChatTemplateJson { file: c, .. } => c.update_dir(dir),
         }
     }
 
     pub fn is_custom(&self) -> bool {
         match self {
             PromptFormatterArtifact::HfTokenizerConfigJson(_) => false,
-            PromptFormatterArtifact::HfChatTemplate { is_custom, .. } => *is_custom,
+            PromptFormatterArtifact::HfChatTemplateJinja { is_custom, .. }
+            | PromptFormatterArtifact::HfChatTemplateJson { is_custom, .. } => *is_custom,
         }
     }
 }
@@ -553,10 +559,16 @@ impl ModelDeploymentCard {
 
         // We only "move" the chat template if it came form the repo. If we have a custom template
         // file we cannot download that from HF.
-        if let Some(PromptFormatterArtifact::HfChatTemplate {
-            file: src_file,
-            is_custom,
-        }) = self.chat_template_file.as_mut()
+        if let Some(
+            PromptFormatterArtifact::HfChatTemplateJinja {
+                file: src_file,
+                is_custom,
+            }
+            | PromptFormatterArtifact::HfChatTemplateJson {
+                file: src_file,
+                is_custom,
+            },
+        ) = self.chat_template_file.as_mut()
         {
             if *is_custom {
                 tracing::info!(
@@ -708,7 +720,7 @@ impl ModelDeploymentCard {
                 )
             })?;
 
-            Some(PromptFormatterArtifact::HfChatTemplate {
+            Some(PromptFormatterArtifact::HfChatTemplateJinja {
                 is_custom: custom_template_path.is_some(),
                 file: CheckedFile::from_disk(template_path)?,
             })
@@ -1001,13 +1013,29 @@ impl PromptFormatterArtifact {
     }
 
     pub fn chat_template_from_disk(directory: &Path) -> Result<Option<Self>> {
-        match CheckedFile::from_disk(directory.join("chat_template.jinja")) {
-            Ok(f) => Ok(Some(Self::HfChatTemplate {
+        // Try chat_template.jinja first (raw Jinja template)
+        let jinja_path = directory.join("chat_template.jinja");
+        if jinja_path.exists() {
+            let f = CheckedFile::from_disk(&jinja_path)
+                .with_context(|| format!("Failed to load {}", jinja_path.display()))?;
+            return Ok(Some(Self::HfChatTemplateJinja {
                 file: f,
                 is_custom: false,
-            })),
-            Err(_) => Ok(None),
+            }));
         }
+
+        // Try chat_template.json (JSON with "chat_template" key, e.g. Qwen3-Omni)
+        let json_path = directory.join("chat_template.json");
+        if json_path.exists() {
+            let f = CheckedFile::from_disk(&json_path)
+                .with_context(|| format!("Failed to load {}", json_path.display()))?;
+            return Ok(Some(Self::HfChatTemplateJson {
+                file: f,
+                is_custom: false,
+            }));
+        }
+
+        Ok(None)
     }
 }
 

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -104,7 +104,7 @@ impl TokenizerKind {
 #[serde(rename_all = "snake_case")]
 pub enum PromptFormatterArtifact {
     HfTokenizerConfigJson(CheckedFile),
-    #[serde(alias = "hf_chat_template")]
+    #[serde(rename = "hf_chat_template", alias = "hf_chat_template_jinja")]
     HfChatTemplateJinja {
         is_custom: bool,
         file: CheckedFile,

--- a/lib/llm/src/preprocessor/prompt/template.rs
+++ b/lib/llm/src/preprocessor/prompt/template.rs
@@ -58,21 +58,57 @@ impl PromptFormatter {
                 // stores the chat template in a separate file, we check if the file exists and
                 // put the chat template into config as normalization.
                 // This may also be a custom template provided via CLI flag.
-                if let Some(PromptFormatterArtifact::HfChatTemplate {
-                    file: checked_file, ..
-                }) = mdc.chat_template_file.as_ref()
-                {
-                    let Some(chat_template_file) = checked_file.path() else {
-                        anyhow::bail!(
-                            "HfChatTemplate for {} is a URL, cannot load",
-                            mdc.display_name
-                        );
-                    };
-                    let chat_template =
-                        std::fs::read_to_string(chat_template_file).with_context(|| {
-                            format!("fs:read_to_string '{}'", chat_template_file.display())
+                match mdc.chat_template_file.as_ref() {
+                    Some(PromptFormatterArtifact::HfChatTemplateJinja {
+                        file: checked_file,
+                        ..
+                    }) => {
+                        let Some(path) = checked_file.path() else {
+                            anyhow::bail!(
+                                "HfChatTemplateJinja for {} is a URL, cannot load",
+                                mdc.display_name
+                            );
+                        };
+                        let chat_template =
+                            std::fs::read_to_string(path).with_context(|| {
+                                format!("fs:read_to_string '{}'", path.display())
+                            })?;
+                        config.chat_template =
+                            Some(ChatTemplateValue(either::Left(chat_template)));
+                    }
+                    Some(PromptFormatterArtifact::HfChatTemplateJson {
+                        file: checked_file,
+                        ..
+                    }) => {
+                        let Some(path) = checked_file.path() else {
+                            anyhow::bail!(
+                                "HfChatTemplateJson for {} is a URL, cannot load",
+                                mdc.display_name
+                            );
+                        };
+                        let raw = std::fs::read_to_string(path).with_context(|| {
+                            format!("fs:read_to_string '{}'", path.display())
                         })?;
-                    config.chat_template = Some(ChatTemplateValue(either::Left(chat_template)));
+                        let wrapper: serde_json::Value =
+                            serde_json::from_str(&raw).with_context(|| {
+                                format!("Failed to parse '{}' as JSON", path.display())
+                            })?;
+                        let field = wrapper.get("chat_template").ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "'{}' does not contain a 'chat_template' field",
+                                path.display()
+                            )
+                        })?;
+                        let value = serde_json::from_value::<ChatTemplateValue>(field.clone())
+                            .with_context(|| {
+                                format!(
+                                    "Failed to deserialize 'chat_template' in '{}'",
+                                    path.display()
+                                )
+                            })?;
+                        config.chat_template = Some(value);
+                    }
+                    _ => {}
                 }
                 Self::from_parts(
                     config,
@@ -82,8 +118,9 @@ impl PromptFormatter {
                     mdc.runtime_config.exclude_tools_when_tool_choice_none,
                 )
             }
-            PromptFormatterArtifact::HfChatTemplate { .. } => Err(anyhow::anyhow!(
-                "prompt_formatter should not have type HfChatTemplate"
+            PromptFormatterArtifact::HfChatTemplateJinja { .. }
+            | PromptFormatterArtifact::HfChatTemplateJson { .. } => Err(anyhow::anyhow!(
+                "prompt_formatter should not have type HfChatTemplate*"
             )),
         }
     }

--- a/lib/llm/src/preprocessor/prompt/template.rs
+++ b/lib/llm/src/preprocessor/prompt/template.rs
@@ -69,12 +69,9 @@ impl PromptFormatter {
                                 mdc.display_name
                             );
                         };
-                        let chat_template =
-                            std::fs::read_to_string(path).with_context(|| {
-                                format!("fs:read_to_string '{}'", path.display())
-                            })?;
-                        config.chat_template =
-                            Some(ChatTemplateValue(either::Left(chat_template)));
+                        let chat_template = std::fs::read_to_string(path)
+                            .with_context(|| format!("fs:read_to_string '{}'", path.display()))?;
+                        config.chat_template = Some(ChatTemplateValue(either::Left(chat_template)));
                     }
                     Some(PromptFormatterArtifact::HfChatTemplateJson {
                         file: checked_file,
@@ -86,9 +83,8 @@ impl PromptFormatter {
                                 mdc.display_name
                             );
                         };
-                        let raw = std::fs::read_to_string(path).with_context(|| {
-                            format!("fs:read_to_string '{}'", path.display())
-                        })?;
+                        let raw = std::fs::read_to_string(path)
+                            .with_context(|| format!("fs:read_to_string '{}'", path.display()))?;
                         let wrapper: serde_json::Value =
                             serde_json::from_str(&raw).with_context(|| {
                                 format!("Failed to parse '{}' as JSON", path.display())

--- a/lib/llm/tests/data/sample-models/mock-no-tokenizer-json/chat_template.json
+++ b/lib/llm/tests/data/sample-models/mock-no-tokenizer-json/chat_template.json
@@ -1,0 +1,1 @@
+{"chat_template": "{%- for message in messages %}{%- if message.role == 'user' %}{{ '<|im_start|>user\n' + message.content + '<|im_end|>\n' }}{%- elif message.role == 'assistant' %}{{ '<|im_start|>assistant\n' + message.content + '<|im_end|>\n' }}{%- endif %}{%- endfor %}{%- if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{%- endif %}"}

--- a/lib/llm/tests/data/sample-models/mock-no-tokenizer-json/tokenizer_config.json
+++ b/lib/llm/tests/data/sample-models/mock-no-tokenizer-json/tokenizer_config.json
@@ -2,6 +2,5 @@
   "bos_token": "<|endoftext|>",
   "eos_token": "<|im_end|>",
   "model_max_length": 32768,
-  "tokenizer_class": "Qwen2Tokenizer",
-  "chat_template": "{% for message in messages %}{{ message.content }}{% endfor %}"
+  "tokenizer_class": "Qwen2Tokenizer"
 }

--- a/lib/llm/tests/model_card.rs
+++ b/lib/llm/tests/model_card.rs
@@ -70,3 +70,24 @@ async fn test_model_loads_without_tokenizer_json() {
     // Model info should still be loaded
     assert!(mdc.model_info.is_some());
 }
+
+/// chat_template.json should be picked up as a fallback when chat_template.jinja
+/// does not exist (e.g. Qwen3-Omni). The fixture's tokenizer_config.json has no
+/// inline chat_template, so this is the only template source.
+#[tokio::test]
+async fn test_chat_template_json_fallback() {
+    let path = "tests/data/sample-models/mock-no-tokenizer-json";
+    let mdc = ModelDeploymentCard::load_from_disk(path, None).unwrap();
+    match &mdc.chat_template_file {
+        Some(PromptFormatterArtifact::HfChatTemplateJson { file, is_custom }) => {
+            assert!(!is_custom, "Should not be marked as custom template");
+            let p = file.path().expect("Should be a local path");
+            assert!(
+                p.ends_with("chat_template.json"),
+                "Expected chat_template.json, got {:?}",
+                p
+            );
+        }
+        other => panic!("Expected HfChatTemplateJson, got {:?}", other),
+    }
+}

--- a/lib/llm/tests/preprocessor.rs
+++ b/lib/llm/tests/preprocessor.rs
@@ -76,7 +76,7 @@ async fn maybe_download_model(local_path: &str, model: &str, revision: &str) -> 
     let repo = Repo::with_revision(String::from(model), RepoType::Model, String::from(revision));
 
     let files_to_download = vec!["config.json", "tokenizer.json", "tokenizer_config.json"];
-    let optional_files = vec!["generation_config.json", "chat_template.jinja"];
+    let optional_files = vec!["generation_config.json", "chat_template.jinja", "chat_template.json"];
     let repo_builder = api.repo(repo);
 
     let mut downloaded_path = PathBuf::new();

--- a/lib/llm/tests/preprocessor.rs
+++ b/lib/llm/tests/preprocessor.rs
@@ -76,7 +76,11 @@ async fn maybe_download_model(local_path: &str, model: &str, revision: &str) -> 
     let repo = Repo::with_revision(String::from(model), RepoType::Model, String::from(revision));
 
     let files_to_download = vec!["config.json", "tokenizer.json", "tokenizer_config.json"];
-    let optional_files = vec!["generation_config.json", "chat_template.jinja", "chat_template.json"];
+    let optional_files = vec![
+        "generation_config.json",
+        "chat_template.jinja",
+        "chat_template.json",
+    ];
     let repo_builder = api.repo(repo);
 
     let mut downloaded_path = PathBuf::new();


### PR DESCRIPTION
#### Overview:

Add support for `chat_template.json` as a prompt formatter artifact. Models like Qwen3-Omni ship this format instead of `chat_template.jinja`.

#### Details:

- **Rename** `HfChatTemplate` → `HfChatTemplateJinja` with `#[serde(alias = "hf_chat_template")]` for backward compat
- **Add** `HfChatTemplateJson` variant to `PromptFormatterArtifact` for JSON-formatted templates
- **Update** `chat_template_from_disk()` to try `.jinja` first, then `.json`, with explicit `exists()` checks to propagate real errors
- **Update** `template.rs` `from_mdc()`: Jinja arm reads raw text (existing behavior), JSON arm parses the file and extracts the `chat_template` field as `ChatTemplateValue` (supports both string and structured `[{name, template}]` payloads)
- **Add** test fixture and `test_chat_template_json_fallback` test
- **Add** `chat_template.json` to optional model download list in preprocessor tests

#### Where should the reviewer start?

- `lib/llm/src/model_card.rs` — enum rename + new variant + `chat_template_from_disk()` changes
- `lib/llm/src/preprocessor/prompt/template.rs` — JSON parsing in `from_mdc()`

#### Related Issues:

- Closes #7737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for JSON-formatted chat templates. The system now automatically detects and loads chat templates in either Jinja or JSON format, expanding template compatibility options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->