### PR TITLE
fix(llm): retry worker-local ZMQ subscriber startup

### DIFF
--- a/lib/llm/src/fpm_publisher.rs
+++ b/lib/llm/src/fpm_publisher.rs
@@ -15,8 +15,9 @@ use std::time::Duration;
 
 use anyhow::Result;
 use tokio_util::sync::CancellationToken;
-use zeromq::{Socket, SocketRecv, SubSocket};
+use zeromq::SocketRecv;
 
+use crate::utils::zmq::connect_sub_socket_with_retry;
 use dynamo_runtime::component::Component;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
 use dynamo_runtime::transports::event_plane::EventPublisher;
@@ -61,15 +62,11 @@ impl FpmEventRelay {
         publisher: EventPublisher,
         cancel: CancellationToken,
     ) {
-        let mut socket = SubSocket::new();
-        if let Err(e) = socket.subscribe("").await {
-            tracing::error!("FPM relay: failed to subscribe on ZMQ socket: {e}");
+        let Some(mut socket) =
+            connect_sub_socket_with_retry(&zmq_endpoint, None, &cancel, "FPM relay").await
+        else {
             return;
-        }
-        if let Err(e) = socket.connect(&zmq_endpoint).await {
-            tracing::error!("FPM relay: failed to connect ZMQ SUB to {zmq_endpoint}: {e}");
-            return;
-        }
+        };
         tracing::info!("FPM relay: connected to {zmq_endpoint}");
 
         let mut consecutive_errors: u32 = 0;

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -907,6 +907,67 @@ mod tests_startup_helpers {
         let _ = listener_handle.await;
     }
 
+    #[tokio::test]
+    async fn test_start_zmq_listener_retries_initial_connect_until_publisher_binds() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<PlacementEvent>();
+        let endpoint = "tcp://127.0.0.1:15556";
+        let topic = "".to_string();
+        let token = dynamo_runtime::CancellationToken::new();
+        let next_event_id = Arc::new(AtomicU64::new(0));
+
+        let listener_handle = tokio::spawn({
+            let token = token.clone();
+            let next_event_id = next_event_id.clone();
+            start_zmq_listener(endpoint.to_string(), topic, 1, tx, token, 4, next_event_id)
+        });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        let mut pub_socket = PubSocket::new();
+        pub_socket.bind(endpoint).await.unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        let batch = KvEventBatch {
+            ts: 0.0,
+            events: vec![RawKvEvent::BlockStored {
+                block_hashes: vec![BlockHashValue::Unsigned(7)],
+                parent_block_hash: None,
+                token_ids: vec![0, 1, 2, 3],
+                block_size: 4,
+                medium: None,
+                lora_name: None,
+                block_mm_infos: None,
+                is_eagle: None,
+            }],
+            data_parallel_rank: Some(0),
+        };
+
+        let msg = ZmqMessage::try_from(vec![
+            Bytes::from(""),
+            Bytes::from(1_u64.to_be_bytes().to_vec()),
+            Bytes::from(rmps::to_vec(&batch).unwrap()),
+        ])
+        .expect("Failed to create ZmqMessage");
+
+        pub_socket.send(msg).await.unwrap();
+
+        let event = tokio::time::timeout(tokio::time::Duration::from_secs(3), rx.recv())
+            .await
+            .expect("timed out waiting for message")
+            .expect("channel closed unexpectedly")
+            .event;
+
+        let KvCacheEventData::Stored(KvCacheStoreData { blocks, .. }) = event.data else {
+            panic!("expected KvCacheStoreData");
+        };
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].block_hash.0, 7);
+
+        token.cancel();
+        let _ = listener_handle.await;
+    }
+
     //--------------------------------------------------------------------
     // Test distributed recovery: Router queries worker's LocalKvIndexer after outage
     //--------------------------------------------------------------------

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -907,67 +907,6 @@ mod tests_startup_helpers {
         let _ = listener_handle.await;
     }
 
-    #[tokio::test]
-    async fn test_start_zmq_listener_retries_initial_connect_until_publisher_binds() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<PlacementEvent>();
-        let endpoint = "tcp://127.0.0.1:15556";
-        let topic = "".to_string();
-        let token = dynamo_runtime::CancellationToken::new();
-        let next_event_id = Arc::new(AtomicU64::new(0));
-
-        let listener_handle = tokio::spawn({
-            let token = token.clone();
-            let next_event_id = next_event_id.clone();
-            start_zmq_listener(endpoint.to_string(), topic, 1, tx, token, 4, next_event_id)
-        });
-
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-
-        let mut pub_socket = PubSocket::new();
-        pub_socket.bind(endpoint).await.unwrap();
-
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-
-        let batch = KvEventBatch {
-            ts: 0.0,
-            events: vec![RawKvEvent::BlockStored {
-                block_hashes: vec![BlockHashValue::Unsigned(7)],
-                parent_block_hash: None,
-                token_ids: vec![0, 1, 2, 3],
-                block_size: 4,
-                medium: None,
-                lora_name: None,
-                block_mm_infos: None,
-                is_eagle: None,
-            }],
-            data_parallel_rank: Some(0),
-        };
-
-        let msg = ZmqMessage::try_from(vec![
-            Bytes::from(""),
-            Bytes::from(1_u64.to_be_bytes().to_vec()),
-            Bytes::from(rmps::to_vec(&batch).unwrap()),
-        ])
-        .expect("Failed to create ZmqMessage");
-
-        pub_socket.send(msg).await.unwrap();
-
-        let event = tokio::time::timeout(tokio::time::Duration::from_secs(3), rx.recv())
-            .await
-            .expect("timed out waiting for message")
-            .expect("channel closed unexpectedly")
-            .event;
-
-        let KvCacheEventData::Stored(KvCacheStoreData { blocks, .. }) = event.data else {
-            panic!("expected KvCacheStoreData");
-        };
-        assert_eq!(blocks.len(), 1);
-        assert_eq!(blocks[0].block_hash.0, 7);
-
-        token.cancel();
-        let _ = listener_handle.await;
-    }
-
     //--------------------------------------------------------------------
     // Test distributed recovery: Router queries worker's LocalKvIndexer after outage
     //--------------------------------------------------------------------

--- a/lib/llm/src/kv_router/publisher/zmq_listener.rs
+++ b/lib/llm/src/kv_router/publisher/zmq_listener.rs
@@ -8,8 +8,9 @@ use std::time::Duration;
 use rmp_serde as rmps;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use zeromq::{Socket, SocketRecv, SubSocket};
+use zeromq::SocketRecv;
 
+use crate::utils::zmq::connect_sub_socket_with_retry;
 use dynamo_kv_router::protocols::*;
 use dynamo_kv_router::zmq_wire::*;
 
@@ -41,17 +42,16 @@ pub(super) async fn start_zmq_listener(
     );
 
     let warning_count = Arc::new(AtomicU32::new(0));
-    let mut socket = SubSocket::new();
-
-    if let Err(e) = socket.subscribe(&zmq_topic).await {
-        tracing::error!("Failed to subscribe on ZMQ socket: {}", e);
+    let Some(mut socket) = connect_sub_socket_with_retry(
+        &zmq_endpoint,
+        Some(&zmq_topic),
+        &cancellation_token,
+        "ZMQ listener",
+    )
+    .await
+    else {
         return;
-    }
-
-    if let Err(e) = socket.connect(&zmq_endpoint).await {
-        tracing::error!("Failed to connect ZMQ SUB socket to {zmq_endpoint}: {e}");
-        return;
-    }
+    };
 
     let mut consecutive_errors = 0u32;
     #[expect(unused_assignments)]

--- a/lib/llm/src/utils/mod.rs
+++ b/lib/llm/src/utils/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod lora;
 pub mod prefix_matcher;
+pub mod zmq;
 
 pub use lora::lora_name_to_id;
 pub use prefix_matcher::{MarkerMatcher, MatchResult};

--- a/lib/llm/src/utils/zmq.rs
+++ b/lib/llm/src/utils/zmq.rs
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use zeromq::{Socket, SubSocket};
+
+const INITIAL_SETUP_BACKOFF_MS: u64 = 10;
+const MAX_SETUP_BACKOFF_MS: u64 = 5000;
+const MAX_SETUP_BACKOFF_EXPONENT: u32 = 8;
+
+fn calculate_setup_backoff_ms(consecutive_errors: u32) -> u64 {
+    std::cmp::min(
+        INITIAL_SETUP_BACKOFF_MS * 2_u64.pow(consecutive_errors.min(MAX_SETUP_BACKOFF_EXPONENT)),
+        MAX_SETUP_BACKOFF_MS,
+    )
+}
+
+pub(crate) async fn connect_sub_socket_with_retry(
+    zmq_endpoint: &str,
+    zmq_topic: Option<&str>,
+    cancellation_token: &CancellationToken,
+    log_prefix: &str,
+) -> Option<SubSocket> {
+    let mut consecutive_errors = 0u32;
+    let topic = zmq_topic.unwrap_or("");
+
+    loop {
+        if cancellation_token.is_cancelled() {
+            tracing::debug!("{log_prefix}: cancelled before connecting to {zmq_endpoint}");
+            return None;
+        }
+
+        let mut socket = SubSocket::new();
+
+        match socket.subscribe(topic).await {
+            Ok(()) => {}
+            Err(e) => {
+                consecutive_errors += 1;
+                let backoff_ms = calculate_setup_backoff_ms(consecutive_errors);
+                tracing::warn!(
+                    error=%e,
+                    consecutive_errors=%consecutive_errors,
+                    backoff_ms=%backoff_ms,
+                    "{log_prefix}: failed to subscribe on ZMQ socket during setup, retrying"
+                );
+                tokio::select! {
+                    biased;
+                    _ = cancellation_token.cancelled() => return None,
+                    _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => {}
+                }
+                continue;
+            }
+        }
+
+        match socket.connect(zmq_endpoint).await {
+            Ok(()) => return Some(socket),
+            Err(e) => {
+                consecutive_errors += 1;
+                let backoff_ms = calculate_setup_backoff_ms(consecutive_errors);
+                tracing::warn!(
+                    error=%e,
+                    consecutive_errors=%consecutive_errors,
+                    backoff_ms=%backoff_ms,
+                    "{log_prefix}: failed to connect ZMQ SUB during setup, retrying"
+                );
+                tokio::select! {
+                    biased;
+                    _ = cancellation_token.cancelled() => return None,
+                    _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => {}
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Retry the initial SUB subscribe/connect setup for KV and FPM worker-local relays so a startup ordering race does not permanently disable event flow. This also factors the shared setup retry into a small llm ZMQ utility and adds a KV listener regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced connection resilience with automatic exponential backoff retry logic.
  * Consolidated socket connection setup for improved maintainability.

* **Tests**
  * Added test coverage for connection retry behavior during service startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->