### PR TITLE
feat: add Intel XPU support to profiler and WebUI

### DIFF
--- a/components/src/dynamo/planner/monitoring/dgd_services.py
+++ b/components/src/dynamo/planner/monitoring/dgd_services.py
@@ -146,40 +146,58 @@ class Service(BaseModel):
             return None
 
     def get_gpu_count(self) -> int:
-        """Get the GPU count from the component's resource specification.
+        """Get the accelerator count for this component.
 
-        GPU count is read from the v1beta1 main container resources
-        (``nvidia.com/gpu``).
+        Resolution order:
+        1. ``resources.limits["nvidia.com/gpu"]`` or the matching request
+           (NVIDIA device-plugin style)
+        2. ``--tensor-parallel-size`` / ``--tp`` from the main container args
+           (Intel DRA deployments omit GPU resources and use resource claims instead;
+           TP size equals the number of devices per worker)
 
         Returns:
-            The number of GPUs configured for this component
+            The number of GPUs/XPUs configured for this component
 
         Raises:
-            ValueError: If GPU count is not specified or invalid
+            ValueError: If GPU count cannot be determined
         """
-        resources = get_main_container(self.service).get("resources", {})
+        main_container = get_main_container(self.service)
+        resources = main_container.get("resources", {})
         limits = resources.get("limits", {})
         requests = resources.get("requests", {})
 
-        # Prefer limits, fall back to requests. For GPUs, Kubernetes device plugins
+        # 1. Prefer limits, fall back to requests. For GPUs, Kubernetes device plugins
         # typically treat requests and limits as equivalent since GPUs are
         # non-compressible and allocated exclusively (no fractional sharing).
         gpu_str = limits.get(GPU_RESOURCE_KEY) or requests.get(GPU_RESOURCE_KEY)
+        if gpu_str is not None:
+            try:
+                return int(gpu_str)
+            except (ValueError, TypeError) as err:
+                raise ValueError(
+                    f"Invalid GPU count '{gpu_str}' for component '{self.name}'. "
+                    f"GPU count must be an integer."
+                ) from err
 
-        if gpu_str is None:
-            raise ValueError(
-                f"No GPU count specified for component '{self.name}'. "
-                f"Please set main container resources.limits.{GPU_RESOURCE_KEY} "
-                f"or resources.requests.{GPU_RESOURCE_KEY} in the DGD."
-            )
+        # 2. DRA fallback: Intel XPU deployments use resourceClaims and do not set
+        # nvidia.com/gpu. Infer device count from --tensor-parallel-size / --tp in
+        # the container args (TP size == number of devices per worker).
+        args = break_arguments(main_container.get("args", []))
+        for i, arg in enumerate(args):
+            if arg in ("--tensor-parallel-size", "--tp") and i + 1 < len(args):
+                try:
+                    return int(args[i + 1])
+                except (ValueError, TypeError) as err:
+                    raise ValueError(
+                        f"Invalid --tensor-parallel-size value '{args[i + 1]}' "
+                        f"for component '{self.name}'."
+                    ) from err
 
-        try:
-            return int(gpu_str)
-        except (ValueError, TypeError) as err:
-            raise ValueError(
-                f"Invalid GPU count '{gpu_str}' for component '{self.name}'. "
-                f"GPU count must be an integer."
-            ) from err
+        raise ValueError(
+            f"No GPU/XPU count specified for component '{self.name}'. "
+            f"Set main container resources.limits.{GPU_RESOURCE_KEY}, "
+            f"resources.requests.{GPU_RESOURCE_KEY}, or --tensor-parallel-size/--tp."
+        )
 
 
 def get_component_from_type_or_name(

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -976,7 +976,7 @@ def test_service_get_gpu_count_missing_raises_error():
     )
     with pytest.raises(ValueError) as exc_info:
         service.get_gpu_count()
-    assert "No GPU count specified" in str(exc_info.value)
+    assert "No GPU/XPU count specified" in str(exc_info.value)
     assert "test-service" in str(exc_info.value)
 
 

--- a/components/src/dynamo/profiler/__main__.py
+++ b/components/src/dynamo/profiler/__main__.py
@@ -34,7 +34,10 @@ from pathlib import Path
 
 import yaml
 
-from dynamo.profiler.utils.dgdr_v1beta1_types import DynamoGraphDeploymentRequestSpec
+from dynamo.profiler.utils.dgdr_v1beta1_types import (
+    DeviceType,
+    DynamoGraphDeploymentRequestSpec,
+)
 
 from .profile_sla import run_profile
 from .utils.profile_common import (
@@ -156,12 +159,18 @@ def _parse_args() -> tuple[DynamoGraphDeploymentRequestSpec, ProfilerOperational
     args = parser.parse_args()
 
     dgdr = _parse_dgdr_spec(args.config)
+    device_type = (
+        dgdr.hardware.deviceType
+        if dgdr.hardware and dgdr.hardware.deviceType
+        else DeviceType.Cuda
+    )
     ops = ProfilerOperationalConfig(
         output_dir=args.output_dir,
         deployment_timeout=args.deployment_timeout,
         prefill_interpolation_granularity=args.prefill_interpolation_granularity,
         decode_interpolation_granularity=args.decode_interpolation_granularity,
         dry_run=args.dry_run,
+        device_type=device_type,
     )
 
     return dgdr, ops

--- a/components/src/dynamo/profiler/profile_sla.py
+++ b/components/src/dynamo/profiler/profile_sla.py
@@ -27,6 +27,7 @@ from deploy.utils.dynamo_deployment import cleanup_remaining_deployments
 from dynamo.profiler.interpolation import run_interpolation
 from dynamo.profiler.rapid import run_rapid
 from dynamo.profiler.thorough import run_thorough
+from dynamo.profiler.utils.config_modifiers import CONFIG_MODIFIERS
 from dynamo.profiler.utils.config_modifiers.parallelization_mapping import (
     PickedParallelConfig,
 )
@@ -43,8 +44,10 @@ from dynamo.profiler.utils.dgd_materialization import (
 )
 from dynamo.profiler.utils.dgdr_v1beta1_types import (
     BackendType,
+    DeviceType,
     DynamoGraphDeploymentRequestSpec,
     ProfilingPhase,
+    XPUSKUType,
 )
 from dynamo.profiler.utils.dgdr_validate import (
     valid_dgdr_spec,
@@ -91,7 +94,13 @@ def _extract_profiler_params(dgdr: DynamoGraphDeploymentRequestSpec) -> tuple:
     """Pull all profiler parameters from dgdr and log them."""
     model = dgdr.model
     backend = BackendType(dgdr.backend).value.lower()
-    system = dgdr.hardware.gpuSku.lower()
+    # Map gpuSku → AIC system identifier.  This is NOT device_type derivation;
+    # device_type is set once in __main__.py and passed via ops.device_type.
+    sku = dgdr.hardware.gpuSku
+    if isinstance(sku, XPUSKUType):
+        system = sku.aic_system
+    else:
+        system = sku.lower()
     total_gpus = dgdr.hardware.totalGpus
     isl = dgdr.workload.isl
     osl = dgdr.workload.osl
@@ -265,9 +274,21 @@ def _write_final_output(ops: ProfilerOperationalConfig, final_config: Any) -> bo
     else:
         with open(output_file, "w") as f:
             if isinstance(final_config, list):
-                yaml.safe_dump_all(final_config, f, sort_keys=False)
+                # Extract any _xpu_resource_claim_template embedded in DGD docs
+                docs: list = []
+                for doc in final_config:
+                    if isinstance(doc, dict) and "_xpu_resource_claim_template" in doc:
+                        docs.append(doc.pop("_xpu_resource_claim_template"))
+                    docs.append(doc)
+                yaml.safe_dump_all(docs, f, sort_keys=False)
             else:
-                yaml.safe_dump(final_config, f, sort_keys=False)
+                xpu_rct = None
+                if isinstance(final_config, dict):
+                    xpu_rct = final_config.pop("_xpu_resource_claim_template", None)
+                if xpu_rct:
+                    yaml.safe_dump_all([xpu_rct, final_config], f, sort_keys=False)
+                else:
+                    yaml.safe_dump(final_config, f, sort_keys=False)
         logger.info("Final DGD config saved to %s", output_file)
 
     write_profiler_status(
@@ -411,6 +432,24 @@ async def run_profile(
 
         base_dgd_config = pick_result.get("dgd_config") if not ops.dry_run else None
         resolved_backend = pick_result.get("resolved_backend", backend)
+
+        # Inject device-specific env vars (e.g. VLLM_TARGET_DEVICE=xpu) into
+        # the clean picked DGD blueprint. Consumer-specific overrides and
+        # tolerations are applied later by materialize_dgd.
+        if base_dgd_config and ops.device_type != DeviceType.Cuda:
+            _modifier = CONFIG_MODIFIERS.get(resolved_backend)
+            if _modifier and hasattr(_modifier, "set_device_type"):
+                try:
+                    base_dgd_config = _modifier.set_device_type(
+                        base_dgd_config, ops.device_type
+                    )
+                    logger.info(
+                        "Injected device_type='%s' into picked DGD config.",
+                        ops.device_type,
+                    )
+                except Exception as _e:
+                    logger.error("Could not inject device_type into DGD config: %s", _e)
+                    raise
 
         dgd_override = dgdr.overrides.dgd if dgdr.overrides else None
         job_tolerations = get_profiling_job_tolerations(dgdr)

--- a/components/src/dynamo/profiler/tests/unit/test_vllm_xpu.py
+++ b/components/src/dynamo/profiler/tests/unit/test_vllm_xpu.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for vLLM XPU / set_device_type paths."""
+
+import copy
+
+import pytest
+
+from dynamo.profiler.utils.config_modifiers import CONFIG_MODIFIERS
+from dynamo.profiler.utils.dgdr_v1beta1_types import DeviceType
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.planner,
+    pytest.mark.parallel,
+]
+
+
+def _make_agg_config(*, gpu_count: str = "2", metadata_name: str = "vllm-agg") -> dict:
+    """Return a minimal vLLM aggregated DGD config dict."""
+    return {
+        "apiVersion": "nvidia.com/v1alpha1",
+        "kind": "DynamoGraphDeployment",
+        "metadata": {"name": metadata_name},
+        "spec": {
+            "services": {
+                "Frontend": {
+                    "componentType": "frontend",
+                    "replicas": 1,
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest",
+                        }
+                    },
+                },
+                "VllmDecodeWorker": {
+                    "componentType": "worker",
+                    "replicas": 1,
+                    "resources": {
+                        "limits": {"gpu": gpu_count},
+                        "requests": {"gpu": gpu_count},
+                    },
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest",
+                            "args": ["--model", "Qwen/Qwen3-0.6B"],
+                        }
+                    },
+                },
+            }
+        },
+    }
+
+
+def _make_disagg_config(*, gpu_count: str = "1") -> dict:
+    """Return a minimal vLLM disaggregated DGD config dict with prefill + decode workers."""
+    return {
+        "apiVersion": "nvidia.com/v1alpha1",
+        "kind": "DynamoGraphDeployment",
+        "metadata": {"name": "vllm-disagg"},
+        "spec": {
+            "services": {
+                "Frontend": {
+                    "componentType": "frontend",
+                    "replicas": 1,
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest",
+                        }
+                    },
+                },
+                "VllmPrefillWorker": {
+                    "componentType": "worker",
+                    "subComponentType": "prefill",
+                    "replicas": 1,
+                    "resources": {
+                        "limits": {"gpu": gpu_count},
+                        "requests": {"gpu": gpu_count},
+                    },
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest",
+                            "args": ["--model", "Qwen/Qwen3-0.6B"],
+                        }
+                    },
+                },
+                "VllmDecodeWorker": {
+                    "componentType": "worker",
+                    "subComponentType": "decode",
+                    "replicas": 1,
+                    "resources": {
+                        "limits": {"gpu": gpu_count},
+                        "requests": {"gpu": gpu_count},
+                    },
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest",
+                            "args": ["--model", "Qwen/Qwen3-0.6B"],
+                        }
+                    },
+                },
+            }
+        },
+    }
+
+
+class TestSetDeviceTypeCudaNoop:
+    """set_device_type is a no-op for CUDA (default) device type."""
+
+    def test_cuda_string_returns_unchanged(self) -> None:
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config()
+        original = copy.deepcopy(config)
+        result = modifier.set_device_type(config, "cuda")
+        assert result == original
+
+    def test_cuda_enum_returns_unchanged(self) -> None:
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config()
+        original = copy.deepcopy(config)
+        result = modifier.set_device_type(config, DeviceType.Cuda)
+        assert result == original
+
+
+class TestSetDeviceTypeXpu:
+    """set_device_type injects XPU-specific config when device_type is 'xpu'."""
+
+    def test_injects_vllm_target_device_env(self) -> None:
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config()
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        worker = result["spec"]["services"]["VllmDecodeWorker"]
+        env = worker["extraPodSpec"]["mainContainer"]["env"]
+        env_names = {e["name"]: e["value"] for e in env if isinstance(e, dict)}
+        assert env_names.get("VLLM_TARGET_DEVICE") == "xpu"
+
+    def test_removes_gpu_resource_limits_and_requests(self) -> None:
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config(gpu_count="4")
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        worker = result["spec"]["services"]["VllmDecodeWorker"]
+        resources = worker.get("resources") or {}
+        limits = resources.get("limits") or {}
+        requests = resources.get("requests") or {}
+        assert "gpu" not in limits
+        assert "gpu" not in requests
+
+    def test_creates_resource_claim_template(self) -> None:
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config()
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        rct = result.get("_xpu_resource_claim_template")
+        assert rct is not None
+        assert rct["kind"] == "ResourceClaimTemplate"
+        assert rct["apiVersion"] == "resource.k8s.io/v1"
+
+    def test_template_name_derived_from_metadata(self) -> None:
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config(metadata_name="my-deployment")
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        rct = result["_xpu_resource_claim_template"]
+        assert rct["metadata"]["name"] == "my-deployment-gpu-template"
+
+        worker = result["spec"]["services"]["VllmDecodeWorker"]
+        pod_claims = worker["extraPodSpec"]["resourceClaims"]
+        assert any(
+            rc.get("resourceClaimTemplateName") == "my-deployment-gpu-template"
+            for rc in pod_claims
+        )
+
+    def test_template_name_fallback_without_metadata_name(self) -> None:
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config(metadata_name="")
+        # Empty name should fall back to "gpu-template"
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+        rct = result["_xpu_resource_claim_template"]
+        assert rct["metadata"]["name"] == "gpu-template"
+
+    def test_gpu_count_from_resources(self) -> None:
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config(gpu_count="4")
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        rct = result["_xpu_resource_claim_template"]
+        devices = rct["spec"]["spec"]["devices"]["requests"][0]
+        assert devices["exactly"]["count"] == 4
+        assert devices["exactly"]["deviceClassName"] == "gpu.intel.com"
+
+    def test_gpu_count_fallback_when_no_resources(self) -> None:
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config()
+        # Remove resources entirely
+        del config["spec"]["services"]["VllmDecodeWorker"]["resources"]
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        rct = result["_xpu_resource_claim_template"]
+        devices = rct["spec"]["spec"]["devices"]["requests"][0]
+        # Fallback default is 1
+        assert devices["exactly"]["count"] == 1
+
+    def test_gpu_count_inferred_from_tensor_parallel_size(self) -> None:
+        """When resources have no gpu field, gpu count is inferred from --tensor-parallel-size."""
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config()
+        # Remove gpu from resources but keep --tensor-parallel-size in args
+        del config["spec"]["services"]["VllmDecodeWorker"]["resources"]
+        config["spec"]["services"]["VllmDecodeWorker"]["extraPodSpec"]["mainContainer"][
+            "args"
+        ] = ["--model", "Qwen/Qwen3-0.6B", "--tensor-parallel-size", "8"]
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        rct = result["_xpu_resource_claim_template"]
+        devices = rct["spec"]["spec"]["devices"]["requests"][0]
+        assert devices["exactly"]["count"] == 8
+
+    def test_gpu_count_inferred_from_tp_alias(self) -> None:
+        """--tp alias is also recognized for inferring gpu count."""
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config()
+        del config["spec"]["services"]["VllmDecodeWorker"]["resources"]
+        config["spec"]["services"]["VllmDecodeWorker"]["extraPodSpec"]["mainContainer"][
+            "args"
+        ] = ["--model", "Qwen/Qwen3-0.6B", "--tp", "4"]
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        rct = result["_xpu_resource_claim_template"]
+        devices = rct["spec"]["spec"]["devices"]["requests"][0]
+        assert devices["exactly"]["count"] == 4
+
+    def test_worker_pod_has_resource_claims(self) -> None:
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config()
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        worker = result["spec"]["services"]["VllmDecodeWorker"]
+        # Pod-level resourceClaims
+        pod_claims = worker["extraPodSpec"]["resourceClaims"]
+        assert any(rc.get("name") == "gpu" for rc in pod_claims)
+        # Container-level claims
+        container_resources = worker["extraPodSpec"]["mainContainer"]["resources"]
+        assert any(c.get("name") == "gpu" for c in container_resources["claims"])
+
+    def test_frontend_not_modified(self) -> None:
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config()
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        result_frontend = result["spec"]["services"]["Frontend"]
+        # Frontend should not have env, resourceClaims, or _xpu modifications
+        fe_container = result_frontend.get("extraPodSpec", {}).get("mainContainer", {})
+        assert "env" not in fe_container or fe_container["env"] is None
+
+    def test_xpu_string_accepted(self) -> None:
+        """set_device_type accepts 'xpu' as a plain string (not only DeviceType enum)."""
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config()
+        result = modifier.set_device_type(config, "xpu")
+
+        assert "_xpu_resource_claim_template" in result
+
+    def test_disagg_both_workers_get_xpu_config(self) -> None:
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_disagg_config()
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        for worker_name in ("VllmPrefillWorker", "VllmDecodeWorker"):
+            worker = result["spec"]["services"][worker_name]
+            env = worker["extraPodSpec"]["mainContainer"]["env"]
+            env_names = {e["name"]: e["value"] for e in env if isinstance(e, dict)}
+            assert (
+                env_names.get("VLLM_TARGET_DEVICE") == "xpu"
+            ), f"{worker_name} missing VLLM_TARGET_DEVICE env"
+            pod_claims = worker["extraPodSpec"]["resourceClaims"]
+            assert any(
+                rc.get("name") == "gpu" for rc in pod_claims
+            ), f"{worker_name} missing resourceClaim"
+
+    def test_idempotent_double_call(self) -> None:
+        """Calling set_device_type twice should not duplicate env vars or claims."""
+        modifier = CONFIG_MODIFIERS["vllm"]
+        config = _make_agg_config()
+        result1 = modifier.set_device_type(config, DeviceType.Xpu)
+        result2 = modifier.set_device_type(result1, DeviceType.Xpu)
+
+        worker = result2["spec"]["services"]["VllmDecodeWorker"]
+        env = worker["extraPodSpec"]["mainContainer"]["env"]
+        device_envs = [
+            e
+            for e in env
+            if isinstance(e, dict) and e.get("name") == "VLLM_TARGET_DEVICE"
+        ]
+        assert (
+            len(device_envs) == 1
+        ), "VLLM_TARGET_DEVICE env var should not be duplicated"
+
+        pod_claims = worker["extraPodSpec"]["resourceClaims"]
+        gpu_claims = [rc for rc in pod_claims if rc.get("name") == "gpu"]
+        assert len(gpu_claims) == 1, "GPU resource claim should not be duplicated"

--- a/components/src/dynamo/profiler/thorough.py
+++ b/components/src/dynamo/profiler/thorough.py
@@ -15,6 +15,7 @@
 
 """THOROUGH search strategy: enumerate candidates, deploy, benchmark, pick."""
 
+import copy
 import logging
 import os
 from itertools import chain
@@ -44,6 +45,7 @@ from dynamo.profiler.utils.dgd_materialization import (
     materialize_dgd,
 )
 from dynamo.profiler.utils.dgdr_v1beta1_types import (
+    DeviceType,
     DynamoGraphDeploymentRequestSpec,
     ModelCacheSpec,
     ProfilingPhase,
@@ -117,8 +119,17 @@ async def _benchmark_prefill_candidates(
         os.makedirs(work_dir, exist_ok=True)
 
         config_fn = f"{work_dir}/config.yaml"
+        dgd = copy.deepcopy(candidate.dgd_config)
+        xpu_rct = (
+            dgd.pop("_xpu_resource_claim_template", None)
+            if isinstance(dgd, dict)
+            else None
+        )
         with open(config_fn, "w") as f:
-            yaml.dump(candidate.dgd_config, f)
+            if xpu_rct:
+                yaml.safe_dump_all([xpu_rct, dgd], f, sort_keys=False)
+            else:
+                yaml.dump(dgd, f)
 
         model_name, model_path = config_modifier.get_model_name(candidate.dgd_config)
         frontend_port = config_modifier.get_port(candidate.dgd_config)
@@ -230,8 +241,17 @@ async def _benchmark_decode_candidates(
         os.makedirs(work_dir, exist_ok=True)
 
         config_fn = f"{work_dir}/config.yaml"
+        dgd = copy.deepcopy(candidate.dgd_config)
+        xpu_rct = (
+            dgd.pop("_xpu_resource_claim_template", None)
+            if isinstance(dgd, dict)
+            else None
+        )
         with open(config_fn, "w") as f:
-            yaml.dump(candidate.dgd_config, f)
+            if xpu_rct:
+                yaml.safe_dump_all([xpu_rct, dgd], f, sort_keys=False)
+            else:
+                yaml.dump(dgd, f)
 
         model_name, model_path = config_modifier.get_model_name(candidate.dgd_config)
         frontend_port = config_modifier.get_port(candidate.dgd_config)
@@ -425,6 +445,27 @@ async def run_thorough(
         len(prefill_candidates),
         len(decode_candidates),
     )
+
+    # Propagate device_type (e.g. "xpu") into all candidate DGD configs so
+    # that workers are deployed with the correct VLLM_TARGET_DEVICE env var.
+    device_type = getattr(ops, "device_type", DeviceType.Cuda)
+    if device_type != DeviceType.Cuda:
+        _modifier_cls = CONFIG_MODIFIERS.get(backend)
+        if _modifier_cls and hasattr(_modifier_cls, "set_device_type"):
+            for candidate in prefill_candidates:
+                candidate.dgd_config = _modifier_cls.set_device_type(
+                    candidate.dgd_config, device_type
+                )
+            for candidate in decode_candidates:
+                candidate.dgd_config = _modifier_cls.set_device_type(
+                    candidate.dgd_config, device_type
+                )
+            logger.info(
+                "Injected device_type='%s' into %d prefill + %d decode candidates.",
+                device_type,
+                len(prefill_candidates),
+                len(decode_candidates),
+            )
 
     config_modifier = CONFIG_MODIFIERS[backend]
     dgd_override = dgdr.overrides.dgd if dgdr.overrides else None

--- a/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
@@ -28,6 +28,7 @@ from dynamo.profiler.utils.defaults import (
     EngineType,
     resolve_deploy_path,
 )
+from dynamo.profiler.utils.dgdr_v1beta1_types import DeviceType
 from dynamo.profiler.utils.model_info import get_mamba_cache_align_block_size
 
 logger = logging.getLogger(__name__)
@@ -138,6 +139,153 @@ class VllmV1ConfigModifier(BaseConfigModifier):
             decode_gpus=decode_gpus,
             num_gpus_per_node=num_gpus_per_node,
         )
+
+    @classmethod
+    def set_device_type(cls, config: dict, device_type: str) -> dict:
+        """Inject XPU-specific configuration when device_type is 'xpu'.
+
+        For NVIDIA CUDA (default), this method is a no-op.
+        For Intel XPU:
+        - Adds ``VLLM_TARGET_DEVICE=xpu`` to each worker's env.
+        - Removes generic ``gpu`` resource limits/requests (not used by Intel DRA).
+        - Adds a ``ResourceClaimTemplate`` for Intel DRA (``gpu.intel.com``) and
+          the matching ``resourceClaims`` + ``claims`` references to each worker
+          pod spec, following the pattern in
+          ``examples/backends/vllm/deploy/agg_xpu_dra.yaml``.
+        """
+        device_str = (
+            device_type.value
+            if isinstance(device_type, DeviceType)
+            else str(device_type).lower()
+        )
+        if device_str != DeviceType.Xpu.value:
+            return config
+
+        cfg = Config.model_validate(config)
+        worker_names: list[str] = []
+        gpu_count_per_worker = 1  # fallback; see resolution order below
+        gpu_count_parsed = False
+        for name, service in cfg.spec.services.items():
+            if name in cls._NON_WORKER_SERVICES:
+                continue
+            if not service.extraPodSpec or not service.extraPodSpec.mainContainer:
+                continue
+
+            container = service.extraPodSpec.mainContainer
+
+            # 1. Inject VLLM_TARGET_DEVICE=xpu env var
+            env: list = list(container.model_extra.get("env") or [])
+            if not any(
+                isinstance(e, dict) and e.get("name") == "VLLM_TARGET_DEVICE"
+                for e in env
+            ):
+                env.append({"name": "VLLM_TARGET_DEVICE", "value": "xpu"})
+            container.model_extra["env"] = env
+
+            # 2. Remove NVIDIA-style gpu resource requests/limits (incompatible
+            #    with DRA).  Capture the GPU count first so we can use it in the
+            #    ResourceClaimTemplate.
+            #
+            #    Resolution order for gpu_count_per_worker:
+            #      a) resources.limits["gpu"] or resources.requests["gpu"]
+            #      b) --tensor-parallel-size from worker args (TP size == GPUs per worker)
+            #      c) fallback to 1 (single device)
+            if service.resources:
+                for bucket in ("requests", "limits"):
+                    res_dict = getattr(service.resources, bucket, None) or {}
+                    if isinstance(res_dict, dict):
+                        gpu_val = res_dict.pop("gpu", None)
+                        if gpu_val is not None:
+                            try:
+                                gpu_count_per_worker = int(gpu_val)
+                                gpu_count_parsed = True
+                            except (ValueError, TypeError):
+                                pass
+                        setattr(service.resources, bucket, res_dict or None)
+
+            # If gpu count was not in resources, infer from --tensor-parallel-size
+            if not gpu_count_parsed and container.args:
+                args = list(container.args)
+                for i, arg in enumerate(args):
+                    if arg in ("--tensor-parallel-size", "--tp") and i + 1 < len(args):
+                        try:
+                            gpu_count_per_worker = int(args[i + 1])
+                            gpu_count_parsed = True
+                        except (ValueError, TypeError):
+                            pass
+                        break
+
+            worker_names.append(name)
+
+        if not gpu_count_parsed and worker_names:
+            logger.warning(
+                "No gpu resource count found in worker config (resources or "
+                "--tensor-parallel-size); defaulting to %d GPU(s) per worker "
+                "for ResourceClaimTemplate.",
+                gpu_count_per_worker,
+            )
+
+        # 3. Add a single shared ResourceClaimTemplate for Intel DRA and wire
+        #    each worker pod to use it.  Derive template name from the DGD
+        #    metadata to avoid collisions across deployments in the same namespace.
+        template_name = (
+            f"{cfg.metadata.name}-gpu-template" if cfg.metadata.name else "gpu-template"
+        )
+        if worker_names:
+            # Attach resourceClaims + container claims to each worker's extraPodSpec
+            for name in worker_names:
+                service = cfg.spec.services[name]
+                pod_extra = service.extraPodSpec.model_extra
+                # resourceClaims at pod level
+                pod_extra.setdefault("resourceClaims", [])
+                existing_claim_names = [
+                    rc.get("name")
+                    for rc in pod_extra["resourceClaims"]
+                    if isinstance(rc, dict)
+                ]
+                if "gpu" not in existing_claim_names:
+                    pod_extra["resourceClaims"].append(
+                        {"name": "gpu", "resourceClaimTemplateName": template_name}
+                    )
+                # claims at container level (grants access to the pod-level claim)
+                container = service.extraPodSpec.mainContainer
+                container_resources = container.model_extra.get("resources") or {}
+                claims: list = container_resources.get("claims") or []
+                if not any(
+                    isinstance(c, dict) and c.get("name") == "gpu" for c in claims
+                ):
+                    claims.append({"name": "gpu"})
+                container_resources["claims"] = claims
+                container.model_extra["resources"] = container_resources
+
+        dumped = cfg.model_dump()
+
+        # 4. Prepend the ResourceClaimTemplate as a separate K8s document.
+        #    Callers that write multi-doc YAML will naturally pick this up.
+        #    We tag it in a wrapper key so dgd_generation can detect and
+        #    emit it as a separate YAML document.
+        resource_claim_template = {
+            "apiVersion": "resource.k8s.io/v1",
+            "kind": "ResourceClaimTemplate",
+            "metadata": {"name": template_name},
+            "spec": {
+                "spec": {
+                    "devices": {
+                        "requests": [
+                            {
+                                "name": "gpu",
+                                "exactly": {
+                                    "deviceClassName": "gpu.intel.com",
+                                    "count": gpu_count_per_worker,
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+        }
+        dumped["_xpu_resource_claim_template"] = resource_claim_template
+        return dumped
 
     @classmethod
     def convert_config(

--- a/components/src/dynamo/profiler/utils/defaults.py
+++ b/components/src/dynamo/profiler/utils/defaults.py
@@ -46,6 +46,16 @@ AIPERF_PREFILL_ATTN_DP_NUM_REQ_RATIO = 4
 DEFAULT_GPU_COST_PER_HOUR = 3.0  # Cost per GPU per hour in dollars
 
 
+class DeviceLabel(str, Enum):
+    """Display labels for device types in the WebUI."""
+
+    GPU = "GPU"
+    XPU = "XPU"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 class EngineType(str, Enum):
     PREFILL = "prefill"
     DECODE = "decode"

--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -22,7 +22,7 @@ DO NOT EDIT MANUALLY - regenerate using the script.
 """
 
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -57,6 +57,11 @@ class SearchStrategy(str, Enum):
     Thorough = "thorough"
 
 
+class DeviceType(str, Enum):
+    Cuda = "cuda"
+    Xpu = "xpu"
+
+
 class GPUSKUType(str, Enum):
     GB200SXM = "gb200_sxm"
     GB10 = "gb10"
@@ -75,6 +80,15 @@ class GPUSKUType(str, Enum):
     T4 = "t4"
     MI200 = "mi200"
     MI300 = "mi300"
+
+
+class XPUSKUType(str, Enum):
+    IntelArcProB60 = "b60"
+
+    @property
+    def aic_system(self) -> str:
+        """Return the AIC system identifier (enum value is already the AIC name)."""
+        return self.value
 
 
 class BackendType(str, Enum):
@@ -216,9 +230,13 @@ class FeaturesSpec(BaseModel):
 class HardwareSpec(BaseModel):
     """HardwareSpec describes the GPU hardware for profiling and deployment. All fields are auto-detected from cluster GPU nodes when omitted (requires cluster-wide mode with GPU discovery enabled). gpuSku is a selector (restricts which nodes are considered); the other fields are pure overrides passed to the profiler. If all four fields are set, discovery is skipped."""
 
-    gpuSku: Optional[GPUSKUType] = Field(
+    deviceType: DeviceType = Field(
+        default="cuda",
+        description="DeviceType is the accelerator device category. Supported values: 'cuda' (NVIDIA GPU), 'xpu' (Intel XPU). Defaults to 'cuda'.",
+    )
+    gpuSku: Optional[Union[GPUSKUType, XPUSKUType]] = Field(
         default=None,
-        description="GPUSKU selects the GPU type to target. When omitted, auto-detected by selecting the GPU with the highest node count, then highest VRAM. In mixed-GPU clusters, set this to choose which GPU type to use. Discovery and totalGpus are then restricted to nodes matching this SKU.",
+        description="GPUSKU is the AIC hardware system identifier for the GPU. When omitted, the operator auto-detects this via InferHardwareSystem from cluster GPU node labels.",
     )
     vramMb: Optional[float] = Field(
         default=None,
@@ -240,6 +258,26 @@ class HardwareSpec(BaseModel):
         default=None,
         description="RDMA indicates whether the cluster has RDMA-capable networking available for Dynamo data movement.  Semantics / usage: - This is capability metadata used for profiling, planning, and deployment decisions. - It does NOT install, enable, or configure RDMA (e.g., drivers, SR-IOV, NVIDIA network operator, GPUDirect settings). It only expresses availability/intent. - When omitted, the operator may attempt best-effort discovery (e.g., via node labels indicating RDMA/SR-IOV capability and/or presence of NVIDIA network-operator RDMA components). If discovery is unavailable, it may remain unset.  Impact of wrong / missing values: - False positive (set true when RDMA is not actually usable end-to-end) may cause plans or deployments to assume RDMA is available; depending on the runtime transport selection and fallback behavior, this can lead to connection/setup failures or performance regressions. - False negative (set false when RDMA is available) will typically avoid RDMA-optimized paths and fall back to non-RDMA transports, usually remaining functional but potentially slower. - If unset and undiscovered, consumers should treat RDMA availability as unknown and use conservative defaults / fallback transports. ",
     )
+
+    @model_validator(mode="after")
+    def _derive_device_type_from_sku(self) -> "HardwareSpec":
+        """Auto-derive deviceType from gpuSku when not explicitly set.
+
+        If gpuSku identifies an Intel XPU accelerator and deviceType was not
+        explicitly provided by the user, set deviceType to 'xpu'.  This
+        prevents the silent misconfiguration where a user specifies an Intel
+        SKU but the default 'cuda' deviceType bypasses all XPU-specific logic.
+        """
+        if isinstance(self.gpuSku, XPUSKUType):
+            if "deviceType" not in self.model_fields_set:
+                # Not explicitly provided — auto-derive from XPU SKU.
+                self.deviceType = DeviceType.Xpu
+            elif self.deviceType != DeviceType.Xpu:
+                raise ValueError(
+                    f"gpuSku '{self.gpuSku}' is an Intel XPU accelerator but deviceType is "
+                    f"'{self.deviceType}'. Set deviceType to 'xpu' or omit it to auto-derive."
+                )
+        return self
 
 
 class DynamoGraphDeploymentRequestSpec(BaseModel):

--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -236,7 +236,7 @@ class HardwareSpec(BaseModel):
     )
     gpuSku: Optional[Union[GPUSKUType, XPUSKUType]] = Field(
         default=None,
-        description="GPUSKU is the AIC hardware system identifier for the GPU. When omitted, the operator auto-detects this via InferHardwareSystem from cluster GPU node labels.",
+        description="GPUSKU selects the GPU type to target. When omitted, auto-detected by selecting the GPU with the highest node count, then highest VRAM. In mixed-GPU clusters, set this to choose which GPU type to use. Discovery and totalGpus are then restricted to nodes matching this SKU.",
     )
     vramMb: Optional[float] = Field(
         default=None,

--- a/components/src/dynamo/profiler/utils/profile_common.py
+++ b/components/src/dynamo/profiler/utils/profile_common.py
@@ -27,6 +27,7 @@ from dynamo.profiler.utils.config_modifiers.parallelization_mapping import (
     PickedParallelConfig,
 )
 from dynamo.profiler.utils.dgdr_v1beta1_types import (
+    DeviceType,
     DynamoGraphDeploymentRequestSpec,
     ProfilingPhase,
 )
@@ -132,6 +133,9 @@ class ProfilerOperationalConfig:
     decode_interpolation_granularity: int = DEFAULT_DECODE_INTERPOLATION_GRANULARITY
     dry_run: bool = DEFAULT_DRY_RUN
     current_phase: ProfilingPhase = field(default=ProfilingPhase.Initializing)
+    # Device type: "cuda" for NVIDIA GPUs, "xpu" for Intel GPUs/Gaudi.
+    # Populated from hardware.deviceType in the DGDR spec.
+    device_type: DeviceType = DeviceType.Cuda
 
 
 # ---------------------------------------------------------------------------

--- a/deploy/operator/api/scripts/generate_pydantic_from_go.py
+++ b/deploy/operator/api/scripts/generate_pydantic_from_go.py
@@ -79,6 +79,27 @@ _STRUCT_EXTRAS: dict = {
             raise ValueError("ttft and itl must both be provided together.")
         return self
 """,
+    "HardwareSpec": """\
+    @model_validator(mode="after")
+    def _derive_device_type_from_sku(self) -> "HardwareSpec":
+        \"\"\"Auto-derive deviceType from gpuSku when not explicitly set.
+
+        If gpuSku identifies an Intel XPU accelerator and deviceType was not
+        explicitly provided by the user, set deviceType to 'xpu'.  This
+        prevents the silent misconfiguration where a user specifies an Intel
+        SKU but the default 'cuda' deviceType bypasses all XPU-specific logic.
+        \"\"\"
+        if isinstance(self.gpuSku, XPUSKUType):
+            if "deviceType" not in self.model_fields_set:
+                # Not explicitly provided — auto-derive from XPU SKU.
+                self.deviceType = DeviceType.Xpu
+            elif self.deviceType != DeviceType.Xpu:
+                raise ValueError(
+                    f"gpuSku '{self.gpuSku}' is an Intel XPU accelerator but deviceType is "
+                    f"'{self.deviceType}'. Set deviceType to 'xpu' or omit it to auto-derive."
+                )
+        return self
+""",
 }
 
 # Per-field Python type overrides.  Maps (StructName, json_field_name) → Python type string.
@@ -87,6 +108,20 @@ _STRUCT_EXTRAS: dict = {
 _FIELD_TYPE_OVERRIDES: dict[tuple[str, str], str] = {
     # FeaturesSpec.planner is opaque in Go but strongly typed in Python.
     ("FeaturesSpec", "planner"): "Optional[PlannerConfig]",
+    # HardwareSpec.gpuSku accepts both NVIDIA GPU and Intel XPU SKUs in Python.
+    ("HardwareSpec", "gpuSku"): "Optional[Union[GPUSKUType, XPUSKUType]]",
+}
+
+# Extra Python code appended after the enum values for specific enum classes.
+# Used for properties or methods that cannot be expressed in Go.
+_ENUM_EXTRAS: dict[str, str] = {
+    "XPUSKUType": """\
+
+    @property
+    def aic_system(self) -> str:
+        \"\"\"Return the AIC system identifier (enum value is already the AIC name).\"\"\"
+        return self.value
+""",
 }
 
 _SPDX_HEADER = """\
@@ -471,7 +506,7 @@ class GoToPydanticConverter:
             '"""',
             "",
             "from enum import Enum",
-            "from typing import Any, Dict, List, Optional",
+            "from typing import Any, Dict, List, Optional, Union",
             "",
             "from pydantic import BaseModel, Field, model_validator",
             "",
@@ -509,6 +544,12 @@ class GoToPydanticConverter:
             else:
                 for const_name, const_value in enum.values:
                     lines.append(f'    {const_name} = "{const_value}"')
+
+            # Append any enum-specific extras (properties, methods)
+            enum_extra = _ENUM_EXTRAS.get(enum.name)
+            if enum_extra:
+                for extra_line in enum_extra.splitlines():
+                    lines.append(extra_line)
 
         # Generate struct models
         for struct in self.structs:

--- a/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
@@ -175,6 +175,15 @@ const (
 	SearchStrategyThorough SearchStrategy = "thorough"
 )
 
+// DeviceType is the accelerator device category.
+// +kubebuilder:validation:Enum=cuda;xpu
+type DeviceType string
+
+const (
+	DeviceTypeCuda DeviceType = "cuda"
+	DeviceTypeXpu  DeviceType = "xpu"
+)
+
 // GPUSKUType is the AIC hardware system identifier for a supported GPU.
 // +kubebuilder:validation:Enum=gb200_sxm;gb10;b200_sxm;h200_sxm;h100_sxm;h100_pcie;a100_sxm;a100_pcie;a30;l40s;l40;l4;v100_sxm;v100_pcie;t4;mi200;mi300
 type GPUSKUType string
@@ -203,6 +212,14 @@ const (
 	// --- AMD ---
 	GPUSKUTypeMI200 GPUSKUType = "mi200"
 	GPUSKUTypeMI300 GPUSKUType = "mi300"
+)
+
+// XPUSKUType is the AIC hardware system identifier for a supported Intel XPU.
+// +kubebuilder:validation:Enum=b60
+type XPUSKUType string
+
+const (
+	XPUSKUTypeIntelArcProB60 XPUSKUType = "b60"
 )
 
 // BackendType specifies the inference backend.
@@ -366,11 +383,14 @@ type FeaturesSpec struct {
 // the other fields are pure overrides passed to the profiler.
 // If all four fields are set, discovery is skipped.
 type HardwareSpec struct {
-	// GPUSKU selects the GPU type to target.
-	// When omitted, auto-detected by selecting the GPU with the highest
-	// node count, then highest VRAM. In mixed-GPU clusters, set this to
-	// choose which GPU type to use. Discovery and totalGpus are then
-	// restricted to nodes matching this SKU.
+	// DeviceType is the accelerator device category.
+	// Supported values: 'cuda' (NVIDIA GPU), 'xpu' (Intel XPU). Defaults to 'cuda'.
+	// +optional
+	// +kubebuilder:default="cuda"
+	DeviceType DeviceType `json:"deviceType,omitempty"`
+
+	// GPUSKU is the AIC hardware system identifier for the GPU.
+	// When omitted, the operator auto-detects this via InferHardwareSystem from cluster GPU node labels.
 	// +optional
 	// +kubebuilder:validation:Enum=gb200_sxm;gb10;b200_sxm;h200_sxm;h100_sxm;h100_pcie;a100_sxm;a100_pcie;a30;l40s;l40;l4;v100_sxm;v100_pcie;t4;mi200;mi300
 	GPUSKU GPUSKUType `json:"gpuSku,omitempty"`

--- a/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
@@ -389,8 +389,11 @@ type HardwareSpec struct {
 	// +kubebuilder:default="cuda"
 	DeviceType DeviceType `json:"deviceType,omitempty"`
 
-	// GPUSKU is the AIC hardware system identifier for the GPU.
-	// When omitted, the operator auto-detects this via InferHardwareSystem from cluster GPU node labels.
+	// GPUSKU selects the GPU type to target.
+	// When omitted, auto-detected by selecting the GPU with the highest
+	// node count, then highest VRAM. In mixed-GPU clusters, set this to
+	// choose which GPU type to use. Discovery and totalGpus are then
+	// restricted to nodes matching this SKU.
 	// +optional
 	// +kubebuilder:validation:Enum=gb200_sxm;gb10;b200_sxm;h200_sxm;h100_sxm;h100_pcie;a100_sxm;a100_pcie;a30;l40s;l40;l4;v100_sxm;v100_pcie;t4;mi200;mi300
 	GPUSKU GPUSKUType `json:"gpuSku,omitempty"`

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
@@ -626,8 +626,11 @@ spec:
                             - mi200
                             - mi300
                       description: |-
-                        GPUSKU is the AIC hardware system identifier for the GPU.
-                        When omitted, the operator auto-detects this via InferHardwareSystem from cluster GPU node labels.
+                        GPUSKU selects the GPU type to target.
+                        When omitted, auto-detected by selecting the GPU with the highest
+                        node count, then highest VRAM. In mixed-GPU clusters, set this to
+                        choose which GPU type to use. Discovery and totalGpus are then
+                        restricted to nodes matching this SKU.
                       type: string
                     interconnect:
                       description: |-

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
@@ -578,6 +578,15 @@ spec:
                     Hardware describes the hardware resources available for profiling and deployment.
                     Typically auto-filled by the operator from cluster discovery.
                   properties:
+                    deviceType:
+                      default: cuda
+                      description: |-
+                        DeviceType is the accelerator device category.
+                        Supported values: 'cuda' (NVIDIA GPU), 'xpu' (Intel XPU). Defaults to 'cuda'.
+                      enum:
+                        - cuda
+                        - xpu
+                      type: string
                     gpuSku:
                       allOf:
                         - enum:
@@ -617,11 +626,8 @@ spec:
                             - mi200
                             - mi300
                       description: |-
-                        GPUSKU selects the GPU type to target.
-                        When omitted, auto-detected by selecting the GPU with the highest
-                        node count, then highest VRAM. In mixed-GPU clusters, set this to
-                        choose which GPU type to use. Discovery and totalGpus are then
-                        restricted to nodes matching this SKU.
+                        GPUSKU is the AIC hardware system identifier for the GPU.
+                        When omitted, the operator auto-detects this via InferHardwareSystem from cluster GPU node labels.
                       type: string
                     interconnect:
                       description: |-

--- a/docs/kubernetes/api-reference.md
+++ b/docs/kubernetes/api-reference.md
@@ -2004,6 +2004,24 @@ _Appears in:_
 | `availableReplicas` _integer_ | AvailableReplicas is the number of replicas that are available and ready. |  | Optional: \{\} <br /> |
 
 
+#### DeviceType
+
+_Underlying type:_ _string_
+
+DeviceType is the accelerator device category.
+
+_Validation:_
+- Enum: [cuda xpu]
+
+_Appears in:_
+- [HardwareSpec](#hardwarespec)
+
+| Field | Description |
+| --- | --- |
+| `cuda` |  |
+| `xpu` |  |
+
+
 #### DynamoCheckpointIdentity
 
 
@@ -2571,6 +2589,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `deviceType` _[DeviceType](#devicetype)_ | DeviceType is the accelerator device category.<br />Supported values: 'cuda' (NVIDIA GPU), 'xpu' (Intel XPU). Defaults to 'cuda'. | cuda | Enum: [cuda xpu] <br />Optional: \{\} <br /> |
 | `gpuSku` _[GPUSKUType](#gpuskutype)_ | GPUSKU selects the GPU type to target.<br />When omitted, auto-detected by selecting the GPU with the highest<br />node count, then highest VRAM. In mixed-GPU clusters, set this to<br />choose which GPU type to use. Discovery and totalGpus are then<br />restricted to nodes matching this SKU. |  | Enum: [gb200_sxm gb10 b200_sxm h200_sxm h100_sxm h100_pcie a100_sxm a100_pcie a30 l40s l40 l4 v100_sxm v100_pcie t4 mi200 mi300] <br />Optional: \{\} <br /> |
 | `vramMb` _float_ | VRAMMB is the VRAM per GPU in MiB.<br />When omitted, auto-detected from cluster GPU nodes. |  | Optional: \{\} <br /> |
 | `totalGpus` _integer_ | TotalGPUs is the GPU budget for profiling and deployment.<br />The profiler uses this to determine parallelism and replica count.<br />When omitted, computed by counting GPUs on discovered nodes<br />(filtered by gpuSku when set), temporarily capped at 32 to<br />limit profiler search space. This cap may be removed in a future<br />release. Set this field explicitly to override. |  | Optional: \{\} <br /> |
@@ -3044,6 +3063,8 @@ _Appears in:_
 | `osl` _integer_ | OSL is the Output Sequence Length (number of tokens). | 1000 | Optional: \{\} <br /> |
 | `concurrency` _float_ | Concurrency is the target concurrency level.<br />Required (or RequestRate) when the planner is disabled. |  | Optional: \{\} <br /> |
 | `requestRate` _float_ | RequestRate is the target request rate (req/s).<br />Required (or Concurrency) when the planner is disabled. |  | Optional: \{\} <br /> |
+
+
 
 
 


### PR DESCRIPTION
#### Overview:

Add Intel XPU support to the Dynamo profiler and WebUI. The profiler previously assumed NVIDIA CUDA hardware throughout: it generated NVIDIA-specific Kubernetes resource manifests and hardcoded "GPU" labels everywhere in the UI. This PR makes those paths device-aware so the profiler works end-to-end on Intel XPU clusters.

#### Details:

**Data model / spec (`dgdr_v1beta1_types.py`, `profile_common.py`, `__main__.py`)**
- Add `XPUSKUType` enum for Intel XPU accelerators (`IntelArcProB60 = "b60"` — Intel Arc Pro B60, Xe2 Battlemage); enum values are AIC system identifiers directly, so the XPU path goes through AIC just like CUDA
- Add `deviceType` field to `HardwareSpec` (default `"cuda"`); auto-derived to `"xpu"` when an `XPUSKUType` SKU is specified (with validation error if explicitly set to a conflicting value)
- Add `device_type: str = "cuda"` to `ProfilerOperationalConfig`; populated from the DGDR spec at startup

**Profiling pipeline (`profile_sla.py`, `thorough.py`)**
- XPU path goes through AIC (Intel B60 is registered in the AIC database as `"b60"`); `device_type` is injected into every candidate DGD config before K8s deployment, and into the final picked config before writing output
- `_xpu_resource_claim_template` embedded in DGD configs is extracted and emitted as a separate `---` YAML document in the final output (both in `_write_final_output` and in `thorough.py` benchmark helpers)

**Kubernetes YAML generation (`config_modifiers/vllm.py`)**
- New `set_device_type()` classmethod on the vLLM config modifier:
  - CUDA: no-op
  - XPU: injects `VLLM_TARGET_DEVICE=xpu` env var; removes NVIDIA `gpu` resource limits; adds Intel DRA `resourceClaims` at pod level and `resources.claims` at container level; embeds a `ResourceClaimTemplate` (`deviceClassName: gpu.intel.com`) tagged as `_xpu_resource_claim_template` for callers to emit as a separate YAML document

**WebUI (`webui/utils.py`)**
- Add `_get_device_label(args)` helper: checks `args.device_type`, then `VLLM_TARGET_DEVICE` env var, falls back to `"GPU"`
- Replace every hardcoded `"GPU"` string in chart labels, axis titles, table column headers, dataset labels, tooltip lines, and help text with device-aware equivalents
- Embed `deviceLabel` field in the generated `webui_data.json` for use by frontend JS