### PR TITLE
fix(kv-router): lazily register workers in slot tracker

### DIFF
--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -394,7 +394,18 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         } = req;
 
         if !self.workers.read().index.contains_key(&worker) {
-            return Err(SequenceError::WorkerNotFound { worker });
+            // The selector already picked this worker from the discovery watch,
+            // but the slot tracker hasn't been updated yet. Lazily register it
+            // so we don't drop tracking for this request.
+            let mut table = self.workers.write();
+            if !table.index.contains_key(&worker) {
+                tracing::debug!(?worker, "Lazily registering worker in slot tracker");
+                let idx = table.slots.len();
+                table
+                    .slots
+                    .push((worker, RwLock::new(ActiveSequences::new(self.block_size))));
+                table.index.insert(worker, idx);
+            }
         }
 
         if let Some(existing_worker) = self.request_to_worker.get(&request_id) {


### PR DESCRIPTION
## Summary

- Fix race between the worker selector (which uses the live discovery watch) and the slot tracker's `WorkerTable` (which is updated asynchronously by a monitor task). When a request arrives before the monitor fires `update_workers`, the selector picks the worker but `add_request` fails with `WorkerNotFound`, dropping prefill/output block tracking for that request.
- Instead of returning an error, lazily register the worker in the `WorkerTable` on first request -- same pattern as `register_external_workers` but inline for a single worker.
- Eliminates the "Failed to add request: Worker not found" and "Failed to mark prefill completed" warnings that appear on every request when using KV routing.

## Test plan

- [x] Launch `agg_router.sh` with KV routing enabled
- [x] Send requests and verify no "Worker not found" or "Failed to mark prefill" warnings in logs
- [x] Verify prefill/decode tracking works correctly (scheduler metrics show accurate running-req counts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced worker request handling to automatically register missing workers into the system instead of immediately returning errors, improving system reliability and robustness in worker discovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->