### PR TITLE
fix: use dict sampling params in prefill warmup

### DIFF
--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -29,13 +29,12 @@ async def _warmup_prefill_engine(engine: sgl.Engine, server_args) -> None:
     logging.info("Start of prefill disaggregation warmup ...")
     try:
         from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
-        from sglang.srt.sampling.sampling_params import SamplingParams
 
-        sampling_params = SamplingParams(
-            temperature=0.0,
-            max_new_tokens=8,
-            ignore_eos=True,
-        )
+        sampling_params = {
+            "temperature": 0.0,
+            "max_new_tokens": 8,
+            "ignore_eos": True,
+        }
 
         async def _do_warmup():
             results = await engine.async_generate(


### PR DESCRIPTION
## Summary
- switch Dynamo's SGLang prefill warmup to pass plain dict sampling params
- stop depending on SGLang's internal SamplingParams object on the Engine.async_generate boundary

## Why
related issue: https://github.com/sgl-project/sglang/issues/21814
SGLang's public generate boundary expects sampling_params as a dict or list of dicts. Dynamo's prefill warmup was constructing an internal SGLang SamplingParams object instead, which is a tighter-than-necessary coupling to SGLang internals and can trigger warmup failures on builds that only accept dict-shaped request inputs.

This change keeps Dynamo on SGLang's documented API surface for warmup requests.

## Validation
- python3 -m py_compile components/src/dynamo/sglang/init_llm.py
- pytest not available in the current environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal LLM initialization logic for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->