### PR TITLE
feat(tcp): server-side write batching in TCP ingress

### DIFF
--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -32,11 +32,13 @@ const DEFAULT_WORKER_POOL_SIZE: usize = 1500;
 /// this is 4X the worker pool size to handle burst traffic
 const DEFAULT_WORK_QUEUE_SIZE: usize = 6000;
 
+const WRITE_BUF_CAPACITY: usize = 65536;
+
 /// Get maximum message size from environment or use default
 fn get_max_message_size() -> usize {
     std::env::var("DYN_TCP_MAX_MESSAGE_SIZE")
         .ok()
-        .and_then(|s| s.parse::<usize>().ok())
+        .and_then(|s: String| s.parse::<usize>().ok())
         .unwrap_or(DEFAULT_MAX_MESSAGE_SIZE)
 }
 
@@ -559,7 +561,7 @@ impl SharedTcpServer {
         write_half: tokio::io::WriteHalf<TcpStream>,
         mut response_rx: tokio::sync::mpsc::UnboundedReceiver<Bytes>,
     ) -> Result<()> {
-        let mut writer = tokio::io::BufWriter::with_capacity(64 * 1024, write_half);
+        let mut writer = tokio::io::BufWriter::with_capacity(WRITE_BUF_CAPACITY, write_half);
 
         while let Some(first) = response_rx.recv().await {
             writer.write_all(&first).await?;

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -503,38 +503,51 @@ impl SharedTcpServer {
                 endpoint_name: handler.endpoint_name.clone(),
             };
 
-            // ACK FIRST (before queuing)
-            // Send acknowledgment immediately so multiplexed clients are not blocked
-            // waiting for the work queue to have capacity.
-            let ack_response = TcpResponseMessage::empty();
-            if let Ok(encoded_ack) = ack_response.encode()
-                && response_tx.send(encoded_ack).is_err()
-            {
-                tracing::debug!("Write task closed, ending read loop");
-                handler.inflight.fetch_sub(1, Ordering::SeqCst);
-                handler.notify.notify_one();
-                break;
-            }
-
-            // QUEUE SECOND (backpressure on subsequent reads, NOT on ACK)
+            // Send to worker pool with backpressure - BEFORE sending ACK
             match work_tx.send(work_item).await {
                 Ok(_) => {
+                    // Send acknowledgment ONLY after successful queuing
+                    let ack_response = TcpResponseMessage::empty();
+                    if let Ok(encoded_ack) = ack_response.encode()
+                        && response_tx.send(encoded_ack).is_err()
+                    {
+                        tracing::debug!("Write task closed, ending read loop");
+                        // Clean up inflight counter since work was queued but ACK failed
+                        handler.inflight.fetch_sub(1, Ordering::SeqCst);
+                        handler.notify.notify_one();
+                        break;
+                    }
+
                     tracing::trace!(
                         endpoint = handler.endpoint_name.as_str(),
                         instance_id = handler.instance_id,
-                        "Request acknowledged and queued"
+                        "Request queued and acknowledged"
                     );
                 }
                 Err(e) => {
-                    tracing::error!(
+                    tracing::warn!(
                         endpoint = handler.endpoint_name.as_str(),
                         instance_id = handler.instance_id,
                         error = %e,
-                        "Work queue closed after ACK sent; cannot send error (would corrupt FIFO)"
+                        "Failed to queue work to worker pool, sending error response"
                     );
+
+                    // Send error response to client instead of ACK
+                    let error_response =
+                        TcpResponseMessage::new(Bytes::from(format!("Server overloaded: {}", e)));
+                    if let Ok(encoded) = error_response.encode() {
+                        let _ = response_tx.send(encoded);
+                    }
+
+                    // Clean up inflight counter
                     handler.inflight.fetch_sub(1, Ordering::SeqCst);
                     handler.notify.notify_one();
-                    break; // Channel closed = fatal
+
+                    // If channel is closed, break the loop
+                    if matches!(e, tokio::sync::mpsc::error::SendError(_)) {
+                        tracing::error!("Worker pool channel closed, shutting down read loop");
+                        break;
+                    }
                 }
             }
         }

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -503,51 +503,38 @@ impl SharedTcpServer {
                 endpoint_name: handler.endpoint_name.clone(),
             };
 
-            // Send to worker pool with backpressure - BEFORE sending ACK
+            // ACK FIRST (before queuing)
+            // Send acknowledgment immediately so multiplexed clients are not blocked
+            // waiting for the work queue to have capacity.
+            let ack_response = TcpResponseMessage::empty();
+            if let Ok(encoded_ack) = ack_response.encode()
+                && response_tx.send(encoded_ack).is_err()
+            {
+                tracing::debug!("Write task closed, ending read loop");
+                handler.inflight.fetch_sub(1, Ordering::SeqCst);
+                handler.notify.notify_one();
+                break;
+            }
+
+            // QUEUE SECOND (backpressure on subsequent reads, NOT on ACK)
             match work_tx.send(work_item).await {
                 Ok(_) => {
-                    // Send acknowledgment ONLY after successful queuing
-                    let ack_response = TcpResponseMessage::empty();
-                    if let Ok(encoded_ack) = ack_response.encode()
-                        && response_tx.send(encoded_ack).is_err()
-                    {
-                        tracing::debug!("Write task closed, ending read loop");
-                        // Clean up inflight counter since work was queued but ACK failed
-                        handler.inflight.fetch_sub(1, Ordering::SeqCst);
-                        handler.notify.notify_one();
-                        break;
-                    }
-
                     tracing::trace!(
                         endpoint = handler.endpoint_name.as_str(),
                         instance_id = handler.instance_id,
-                        "Request queued and acknowledged"
+                        "Request acknowledged and queued"
                     );
                 }
                 Err(e) => {
-                    tracing::warn!(
+                    tracing::error!(
                         endpoint = handler.endpoint_name.as_str(),
                         instance_id = handler.instance_id,
                         error = %e,
-                        "Failed to queue work to worker pool, sending error response"
+                        "Work queue closed after ACK sent; cannot send error (would corrupt FIFO)"
                     );
-
-                    // Send error response to client instead of ACK
-                    let error_response =
-                        TcpResponseMessage::new(Bytes::from(format!("Server overloaded: {}", e)));
-                    if let Ok(encoded) = error_response.encode() {
-                        let _ = response_tx.send(encoded);
-                    }
-
-                    // Clean up inflight counter
                     handler.inflight.fetch_sub(1, Ordering::SeqCst);
                     handler.notify.notify_one();
-
-                    // If channel is closed, break the loop
-                    if matches!(e, tokio::sync::mpsc::error::SendError(_)) {
-                        tracing::error!("Worker pool channel closed, shutting down read loop");
-                        break;
-                    }
+                    break; // Channel closed = fatal
                 }
             }
         }
@@ -556,12 +543,21 @@ impl SharedTcpServer {
     }
 
     async fn write_loop(
-        mut write_half: tokio::io::WriteHalf<TcpStream>,
+        write_half: tokio::io::WriteHalf<TcpStream>,
         mut response_rx: tokio::sync::mpsc::UnboundedReceiver<Bytes>,
     ) -> Result<()> {
-        while let Some(response) = response_rx.recv().await {
-            write_half.write_all(&response).await?;
-            write_half.flush().await?;
+        let mut writer = tokio::io::BufWriter::with_capacity(64 * 1024, write_half);
+
+        while let Some(first) = response_rx.recv().await {
+            writer.write_all(&first).await?;
+
+            // Drain all immediately available responses into the same batch
+            while let Ok(response) = response_rx.try_recv() {
+                writer.write_all(&response).await?;
+            }
+
+            // Single flush for entire batch (replaces per-response flush)
+            writer.flush().await?;
         }
         Ok(())
     }

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -558,21 +558,22 @@ impl SharedTcpServer {
     }
 
     async fn write_loop(
-        write_half: tokio::io::WriteHalf<TcpStream>,
+        mut write_half: tokio::io::WriteHalf<TcpStream>,
         mut response_rx: tokio::sync::mpsc::UnboundedReceiver<Bytes>,
     ) -> Result<()> {
-        let mut writer = tokio::io::BufWriter::with_capacity(WRITE_BUF_CAPACITY, write_half);
+        let mut batch = BytesMut::with_capacity(WRITE_BUF_CAPACITY);
 
         while let Some(first) = response_rx.recv().await {
-            writer.write_all(&first).await?;
+            batch.extend_from_slice(&first);
 
             // Drain all immediately available responses into the same batch
             while let Ok(response) = response_rx.try_recv() {
-                writer.write_all(&response).await?;
+                batch.extend_from_slice(&response);
             }
 
-            // Single flush for entire batch (replaces per-response flush)
-            writer.flush().await?;
+            // Single write for entire batch — goes straight to socket, nothing buffered
+            write_half.write_all(&batch).await?;
+            batch.clear();
         }
         Ok(())
     }


### PR DESCRIPTION
## Overview

Adds write batching to the TCP ingress server's `write_loop`. Instead of flushing each response individually, wrap the write half in a 64 KB `BufWriter` and drain all immediately-available responses into a single batch before flushing. This reduces syscall overhead under load.

The ACK-before-queue ordering change from the original commit has been reverted -- the read loop is unchanged from main.

Part-1 of https://github.com/ai-dynamo/dynamo/pull/6615

## Changes

- `write_loop`: Replace per-response `write_all` + `flush` with `BufWriter` + batch drain (`try_recv` loop) + single `flush`

## Test plan

- [x] Existing `test_graceful_shutdown_waits_for_inflight_tcp_requests` passes
- [x] Existing `test_worker_pool_bounds_concurrency` passes
- [x] `cargo check -p dynamo-runtime` clean (no warnings)