### PR TITLE
fix(runtime): RAII inflight guard and semaphore admission for TCP connections

### DIFF
--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -635,25 +635,35 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         let stream_context = response_stream.context();
         let context_for_monitoring = stream_context.clone();
 
+        // Build the guard BEFORE constructing the stream so that a
+        // drop-before-first-poll (client disconnects immediately after the
+        // request is accepted) still triggers Drop and releases the scheduler
+        // slot + deferred session close.  If the guard were built inside the
+        // `async_stream::stream!` closure, it would never be constructed — and
+        // `chooser.free()` + `deferred_close` would never fire — in that case.
+        let guard = RequestGuard {
+            chooser: chooser.clone(),
+            scheduler_tracked,
+            context_id: context_id.clone(),
+            tracker: tracker.clone(),
+            request_metrics: request_metrics.clone(),
+            cumulative_osl: 0,
+            metrics_recorded: false,
+            freed: false,
+            prefill_marked: false,
+            first_token_recorded: false,
+            track_output_blocks: scheduler_tracked && track_output_blocks,
+            current_total_blocks: isl_tokens.div_ceil(block_size),
+            isl_tokens,
+            block_size,
+            expected_output_tokens,
+            deferred_close,
+        };
+
         let wrapped_stream = Box::pin(async_stream::stream! {
-            let mut guard = RequestGuard {
-                chooser: chooser.clone(),
-                scheduler_tracked,
-                context_id: context_id.clone(),
-                tracker: tracker.clone(),
-                request_metrics: request_metrics.clone(),
-                cumulative_osl: 0,
-                metrics_recorded: false,
-                freed: false,
-                prefill_marked: false,
-                first_token_recorded: false,
-                track_output_blocks: scheduler_tracked && track_output_blocks,
-                current_total_blocks: isl_tokens.div_ceil(block_size),
-                isl_tokens,
-                block_size,
-                expected_output_tokens,
-                deferred_close,
-            };
+            // Move guard into the stream closure. Drop fires here if the stream
+            // is polled to completion, or via the outer Drop if never polled.
+            let mut guard = guard;
 
             loop {
                 tokio::select! {

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -151,6 +151,23 @@ struct PendingRequest {
     response_tx: oneshot::Sender<Result<Bytes>>,
 }
 
+/// RAII guard that decrements the inflight counter on drop.
+///
+/// Guarantees `fetch_sub` runs on ALL exit paths from `send_request`:
+/// - Normal return (success or `?` propagation)
+/// - `tokio::time::timeout` cancellation (future dropped mid-await)
+/// - Any other future drop (e.g., select! branch cancellation)
+///
+/// The guard must be constructed AFTER `inflight.fetch_add` and held until
+/// the caller no longer needs the slot counted.
+struct InflightGuard(Arc<AtomicU64>);
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
 /// TCP connection with lock-free submit and batched write/read tasks.
 ///
 /// Design: SegQueue submit → batched writer task → reader task → oneshot response
@@ -585,8 +602,13 @@ impl TcpConnection {
             anyhow::bail!("Connection unhealthy (tasks failed)");
         }
 
-        // Increment inflight before push (for capacity heuristic)
+        // Increment inflight counter and attach a RAII guard that decrements it
+        // on ALL exit paths: normal return, `?` propagation, timeout cancellation,
+        // or any other future drop.  Without the guard, a tokio::time::timeout
+        // drop would skip the fetch_sub, permanently inflating the counter and
+        // blocking idle-host cleanup (inflight > 0 guard in cleanup_idle_hosts).
         self.inflight.fetch_add(1, Ordering::Relaxed);
+        let _inflight_guard = InflightGuard(self.inflight.clone());
 
         // Lock-free submit: ~20-40ns
         self.submit_queue.push(PendingRequest {
@@ -597,17 +619,12 @@ impl TcpConnection {
         // Wake writer if it was sleeping
         self.writer_notify.notify_one();
 
-        // Await response
+        // Await response. On timeout the enclosing future is dropped here:
+        // `_inflight_guard` drops → fetch_sub runs automatically.
+        // `_permit` drops → semaphore slot is released automatically.
         let result = response_rx
             .await
             .map_err(|_| anyhow::anyhow!("Reader task closed"))?;
-
-        // Decrement inflight after response.
-        // NOTE: this decrement is NOT reached if the outer timeout drops this
-        // future before response_rx resolves, leaving the inflight counter
-        // temporarily inflated.  The RAII InflightGuard (bis/tcp-inflight-guard)
-        // fixes that; the admission semaphore above already bounds total memory.
-        self.inflight.fetch_sub(1, Ordering::Relaxed);
 
         if trace && let Some(start) = e2e_start {
             let e2e_ns = start.elapsed().as_nanos() as u64;

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -164,7 +164,10 @@ struct InflightGuard(Arc<AtomicU64>);
 
 impl Drop for InflightGuard {
     fn drop(&mut self) {
-        self.0.fetch_sub(1, Ordering::Relaxed);
+        // Release: pairs with the Acquire loads in available_capacity() and
+        // cleanup_idle_hosts() so the decrement is visible to any reader that
+        // subsequently observes the updated counter value.
+        self.0.fetch_sub(1, Ordering::Release);
     }
 }
 
@@ -607,7 +610,9 @@ impl TcpConnection {
         // or any other future drop.  Without the guard, a tokio::time::timeout
         // drop would skip the fetch_sub, permanently inflating the counter and
         // blocking idle-host cleanup (inflight > 0 guard in cleanup_idle_hosts).
-        self.inflight.fetch_add(1, Ordering::Relaxed);
+        // Release: symmetric with the Release in InflightGuard::drop so that
+        // Acquire loads in available_capacity() see a consistent value.
+        self.inflight.fetch_add(1, Ordering::Release);
         let _inflight_guard = InflightGuard(self.inflight.clone());
 
         // Lock-free submit: ~20-40ns
@@ -641,7 +646,9 @@ impl TcpConnection {
 
     /// Available capacity (advisory, for cold path growth heuristic)
     fn available_capacity(&self) -> usize {
-        let inflight = self.inflight.load(Ordering::Relaxed) as usize;
+        // Acquire: pairs with the Release in fetch_add/fetch_sub so we observe
+        // the most recently committed inflight value from any other thread.
+        let inflight = self.inflight.load(Ordering::Acquire) as usize;
         self.channel_buffer.saturating_sub(inflight)
     }
 }
@@ -1086,7 +1093,7 @@ impl TcpConnectionPool {
                 // a long-running request with no new checkouts would look
                 // idle but killing it would fail legitimate work.
                 let snap = entry.value().snapshot.load();
-                !snap.iter().any(|c| c.inflight.load(Ordering::Relaxed) > 0)
+                !snap.iter().any(|c| c.inflight.load(Ordering::Acquire) > 0)
             })
             .map(|entry| *entry.key())
             .collect();
@@ -1121,7 +1128,7 @@ impl TcpConnectionPool {
             let snap = entry.value().snapshot.load();
             for conn in snap.iter() {
                 if conn.is_healthy() {
-                    if conn.inflight.load(Ordering::Relaxed) > 0 {
+                    if conn.inflight.load(Ordering::Acquire) > 0 {
                         active += 1;
                     } else {
                         idle += 1;


### PR DESCRIPTION
## Overview

Three correctness fixes on top of PR #7806 (lock-free pool), targeting bugs identified during review of the admission semaphore commit:

1. Inflight counter is never decremented when `tokio::time::timeout` cancels a request — permanently inflates the counter, causing spurious pool growth and blocking idle host cleanup.
2. `Relaxed` memory ordering on the inflight atomic provides no visibility guarantee to readers on other cores.
3. `RequestGuard` in `push_router.rs` is constructed inside a lazy `async_stream` body — if the stream is dropped before its first poll, scheduler and KV reservation resources leak permanently.

---

## Changes

### Fix 1 — RAII InflightGuard (`tcp_client.rs`)

`TcpConnection::send_request` incremented `inflight` before the queue push and decremented it after `response_rx.await` resolved. `TcpRequestClient::send_request` wraps the call with `tokio::time::timeout`. When the timeout fires, Tokio drops the future at the `await` suspension point — the `fetch_sub` below it never executes. Every timed-out request permanently inflates the counter by one.

**Cascading effects:**
- `available_capacity()` returns `channel_buffer.saturating_sub(inflight)` — once leaked count reaches `channel_buffer` this returns 0, triggering `should_grow()` and opening a new connection for every subsequent request regardless of actual load.
- `cleanup_idle_hosts()` skips eviction for any host where any connection shows `inflight > 0` — a permanently inflated counter pins connections and file descriptors indefinitely.

**Fix:** `InflightGuard(Arc<AtomicU64>)` RAII struct. `Drop` calls `fetch_sub(1, Release)`. The guard is constructed immediately after `fetch_add` and held across the `await` — dropped automatically on every exit path including timeout cancellation.

```rust
self.inflight.fetch_add(1, Ordering::Release);
let _inflight_guard = InflightGuard(self.inflight.clone());
// ...
let result = response_rx.await ...;  // future dropped here on timeout — guard.drop() fires
```

### Fix 2 — Release/Acquire ordering on inflight counter (`tcp_client.rs`)

`fetch_add`, `fetch_sub`, and all `load` calls used `Ordering::Relaxed`. On weakly-ordered architectures (ARM, POWER) this provides no happens-before guarantee: a reader on another core calling `available_capacity()` or `cleanup_idle_hosts()` could observe a stale counter value long after `fetch_sub` had logically completed.

**Fix:** All writes (`fetch_add`, `fetch_sub` in `InflightGuard::drop`) use `Ordering::Release`. All reads (`load` in `available_capacity()`, both `inflight > 0` checks in `cleanup_idle_hosts()` and `connection_counts()`) use `Ordering::Acquire`. Any `Acquire` load that observes the updated value is guaranteed to see the write as fully committed.

### Fix 3 — RequestGuard hoisted before `async_stream` body (`push_router.rs`)

`RequestGuard` was constructed inside the `async_stream::stream!` closure:

```rust
let wrapped_stream = Box::pin(async_stream::stream! {
    let mut guard = RequestGuard { ... };  // never constructed if stream is dropped unpolled
    loop { ... }
    guard.finish().await;
});
```

`async_stream::stream!` is a lazy generator — the body does not execute until the stream is first polled. If the caller drops the returned `ResponseStream` before polling it (client disconnects between request acceptance and first `next()` call), the closure body never runs. `RequestGuard` is never constructed and its `Drop` implementation never fires.

**Permanent consequences:** `chooser.free()` is never called (KV router slot permanently occupied); `deferred_close` (`SessionCloseAction`) never executes (backend session never closed); if `scheduler_tracked`, the scheduler in-flight counter never decrements. Under sustained disconnects this silently exhausts KV router capacity and leaks backend sessions.

**Fix:** `RequestGuard` is constructed before `Box::pin(async_stream::stream! { ... })` and moved into the closure. The guard lives on the heap as part of the `Pin<Box<...>>` stream. Dropping the stream without polling runs Rust's drop glue on the `Box` contents, reaching `RequestGuard::drop()` unconditionally. No changes to `finish()`, `Drop`, or any other guard logic are needed.

```rust
// Constructed eagerly — Drop fires whether or not the stream is ever polled.
let guard = RequestGuard { ... };

let wrapped_stream = Box::pin(async_stream::stream! {
    let mut guard = guard;  // moved in
    loop { ... }
    guard.finish().await;
});
```

---

## Files changed

| File | Notes |
|---|---|
| `lib/runtime/src/pipeline/network/egress/tcp_client.rs` | `InflightGuard` struct, `Release`/`Acquire` ordering on all inflight accesses |
| `lib/llm/src/kv_router/push_router.rs` | `RequestGuard` hoisted above `async_stream` body |

---

## Where to start reviewing

`InflightGuard` struct definition and its usage in `TcpConnection::send_request`, then the `RequestGuard` construction site in `push_router.rs` around `Box::pin(async_stream::stream! {...})`.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/7807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
