### PR TITLE
feat: add GB10 to known SKUs

### DIFF
--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -64,6 +64,7 @@ class GPUSKUType(str, Enum):
     B200SXM = "b200_sxm"
     A100SXM = "a100_sxm"
     L40S = "l40s"
+    GB10 = "gb10"
 
 
 class BackendType(str, Enum):

--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
@@ -584,6 +584,7 @@ spec:
                             - b200_sxm
                             - a100_sxm
                             - l40s
+                            - gb10
                         - enum:
                             - gb200_sxm
                             - h200_sxm
@@ -591,6 +592,7 @@ spec:
                             - b200_sxm
                             - a100_sxm
                             - l40s
+                            - gb10
                       description: |-
                         GPUSKU is the AIC hardware system identifier for the GPU.
                         When omitted, the operator auto-detects this via InferHardwareSystem from cluster GPU node labels.

--- a/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
@@ -175,7 +175,7 @@ const (
 )
 
 // GPUSKUType is the AIC hardware system identifier for a supported GPU.
-// +kubebuilder:validation:Enum=gb200_sxm;h200_sxm;h100_sxm;b200_sxm;a100_sxm;l40s
+// +kubebuilder:validation:Enum=gb200_sxm;h200_sxm;h100_sxm;b200_sxm;a100_sxm;l40s;gb10
 type GPUSKUType string
 
 const (
@@ -185,6 +185,7 @@ const (
 	GPUSKUTypeB200SXM  GPUSKUType = "b200_sxm"
 	GPUSKUTypeA100SXM  GPUSKUType = "a100_sxm"
 	GPUSKUTypeL40S     GPUSKUType = "l40s"
+	GPUSKUTypeGB10     GPUSKUType = "gb10"
 )
 
 // BackendType specifies the inference backend.
@@ -324,7 +325,7 @@ type HardwareSpec struct {
 	// GPUSKU is the AIC hardware system identifier for the GPU.
 	// When omitted, the operator auto-detects this via InferHardwareSystem from cluster GPU node labels.
 	// +optional
-	// +kubebuilder:validation:Enum=gb200_sxm;h200_sxm;h100_sxm;b200_sxm;a100_sxm;l40s
+	// +kubebuilder:validation:Enum=gb200_sxm;h200_sxm;h100_sxm;b200_sxm;a100_sxm;l40s;gb10
 	GPUSKU GPUSKUType `json:"gpuSku,omitempty"`
 
 	// VRAMMB is the VRAM per GPU in MiB.

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
@@ -584,6 +584,7 @@ spec:
                             - b200_sxm
                             - a100_sxm
                             - l40s
+                            - gb10
                         - enum:
                             - gb200_sxm
                             - h200_sxm
@@ -591,6 +592,7 @@ spec:
                             - b200_sxm
                             - a100_sxm
                             - l40s
+                            - gb10
                       description: |-
                         GPUSKU is the AIC hardware system identifier for the GPU.
                         When omitted, the operator auto-detects this via InferHardwareSystem from cluster GPU node labels.

--- a/deploy/operator/internal/gpu/discovery.go
+++ b/deploy/operator/internal/gpu/discovery.go
@@ -741,6 +741,7 @@ func InferHardwareSystem(gpuProduct string) nvidiacomv1beta1.GPUSKUType {
 		{"B200", nvidiacomv1beta1.GPUSKUTypeB200SXM},
 		{"A100", nvidiacomv1beta1.GPUSKUTypeA100SXM},
 		{"L40S", nvidiacomv1beta1.GPUSKUTypeL40S},
+		{"GB10", nvidiacomv1beta1.GPUSKUTypeGB10},
 	}
 
 	for _, p := range patterns {


### PR DESCRIPTION
#### Overview:

Update the profiler, DGDR, and discovery enums to have the GB10 variant.

#### Details:

Attempting to deploy DynamoGraphDeploymentRequests on a single-node k3s cluster on an NVIDIA DGX Spark with the GB10 SKU resulted in spec validation errors. This PR aims to add GB10 to the known SKUs. 

It depends on `aiconfigurator` having support for GB10 as well. A separate PR has been opened on that repo (link below).

#### Where should the reviewer start?

It's a very small PR only.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #7775 
- related GitHub issue: https://github.com/ai-dynamo/aiconfigurator/issues/676
- related PR: https://github.com/ai-dynamo/aiconfigurator/pull/677