### PR TITLE
feat: trace infrastructure — spans, targets, request ID propagation

### DIFF
--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -124,7 +124,7 @@ async fn handler_anthropic_messages(
     }
 
     // Create request context
-    let request_id = get_or_create_request_id(None, &headers);
+    let request_id = get_or_create_request_id(&headers);
     let streaming = request.stream;
     let cancellation_labels = CancellationLabels {
         model: request.model.clone(),

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -291,37 +291,43 @@ pub async fn smart_json_error_middleware(request: Request<Body>, next: Next) -> 
     }
 }
 
-/// Get the request ID from a primary source, or next from the headers, or lastly create a new one if not present
-// TODO: Similar function exists in lib/llm/src/grpc/service/openai.rs but with different signature and simpler logic
-pub(super) fn get_or_create_request_id(primary: Option<&str>, headers: &HeaderMap) -> String {
-    // Try to get request id from trace context
+/// Validate the `x-dynamo-request-id` header and return the request ID.
+///
+/// If the header is present but invalid (not UTF-8 or not a UUID), a warning is logged
+/// and a new UUID is generated instead of returning an error.
+///
+/// The request ID comes from the trace context — `make_inference_request_span()` guarantees it by
+/// generating a UUID when the client doesn't provide one.
+pub(super) fn get_or_create_request_id(headers: &HeaderMap) -> String {
+    // Validate x-dynamo-request-id header if present, warn on invalid values
+    if let Some(raw) = headers.get(DYNAMO_REQUEST_ID_HEADER) {
+        match raw.to_str() {
+            Err(_) => {
+                tracing::warn!(
+                    "{} header must be a valid UTF-8 string",
+                    DYNAMO_REQUEST_ID_HEADER
+                );
+            }
+            Ok(s) if uuid::Uuid::parse_str(s).is_err() => {
+                tracing::warn!(
+                    "{} header must be a valid UUID, got: {}",
+                    DYNAMO_REQUEST_ID_HEADER,
+                    s
+                );
+            }
+            Ok(_) => {} // Valid header, will be picked up from trace context below
+        }
+    }
+
+    // Prefer trace context (set by make_inference_request_span via DistributedTraceIdLayer)
     if let Some(trace_context) = get_distributed_tracing_context()
         && let Some(x_dynamo_request_id) = trace_context.x_dynamo_request_id
     {
         return x_dynamo_request_id;
     }
 
-    // Try to get the request ID from the primary source
-    if let Some(primary) = primary
-        && let Ok(uuid) = uuid::Uuid::parse_str(primary)
-    {
-        return uuid.to_string();
-    }
-
-    // Try to get the request ID header as a string slice
-    let request_id_opt = headers
-        .get(DYNAMO_REQUEST_ID_HEADER)
-        .and_then(|h| h.to_str().ok());
-
-    // Try to parse the request ID as a UUID, or generate a new one if missing/invalid
-    let uuid = match request_id_opt {
-        Some(request_id) => {
-            uuid::Uuid::parse_str(request_id).unwrap_or_else(|_| uuid::Uuid::new_v4())
-        }
-        None => uuid::Uuid::new_v4(),
-    };
-
-    uuid.to_string()
+    // Fallback: generate new UUID
+    uuid::Uuid::new_v4().to_string()
 }
 
 /// OpenAI Completions Request Handler
@@ -343,7 +349,7 @@ async fn handler_completions(
     request.nvext = apply_header_routing_overrides(request.nvext.take(), &headers);
 
     // create the context for the request
-    let request_id = get_or_create_request_id(request.inner.user.as_deref(), &headers);
+    let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
     let cancellation_labels = CancellationLabels {
         model: request.inner.model.clone(),
@@ -723,7 +729,7 @@ async fn embeddings(
     // return a 503 if the service is not ready
     check_ready(&state)?;
 
-    let request_id = get_or_create_request_id(request.inner.user.as_deref(), &headers);
+    let request_id = get_or_create_request_id(&headers);
     let request = Context::with_id(request, request_id);
     let request_id = request.id().to_string();
 
@@ -801,7 +807,7 @@ async fn handler_chat_completions(
     request.nvext = apply_header_routing_overrides(request.nvext.take(), &headers);
 
     // create the context for the request
-    let request_id = get_or_create_request_id(request.inner.user.as_deref(), &headers);
+    let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
     let cancellation_labels = CancellationLabels {
         model: request.inner.model.clone(),
@@ -1410,7 +1416,7 @@ async fn handler_responses(
     request.nvext = apply_header_routing_overrides(request.nvext.take(), &headers);
 
     // create the context for the request
-    let request_id = get_or_create_request_id(None, &headers);
+    let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
     let cancellation_labels = CancellationLabels {
         model: request.inner.model.clone().unwrap_or_default(),
@@ -1902,7 +1908,7 @@ async fn images(
     // return a 503 if the service is not ready
     check_ready(&state)?;
 
-    let request_id = get_or_create_request_id(request.inner.user.as_deref(), &headers);
+    let request_id = get_or_create_request_id(&headers);
     let request = Context::with_id(request, request_id);
     let request_id = request.id().to_string();
 
@@ -1995,7 +2001,7 @@ async fn videos(
     // return a 503 if the service is not ready
     check_ready(&state)?;
 
-    let request_id = get_or_create_request_id(request.user.as_deref(), &headers);
+    let request_id = get_or_create_request_id(&headers);
     let request = Context::with_id(request, request_id);
     let request_id = request.id().to_string();
 
@@ -2066,7 +2072,7 @@ async fn video_stream(
 ) -> Result<Response, ErrorResponse> {
     check_ready(&state)?;
 
-    let request_id = get_or_create_request_id(request.user.as_deref(), &headers);
+    let request_id = get_or_create_request_id(&headers);
     let request = Context::with_id(request, request_id);
     let model = request.model.clone();
 
@@ -2220,7 +2226,7 @@ async fn audio_speech(
     check_ready(&state)?;
 
     let response_format = request.response_format.clone();
-    let request_id = get_or_create_request_id(request.user.as_deref(), &headers);
+    let request_id = get_or_create_request_id(&headers);
     let request = Context::with_id(request, request_id);
     let request_id = request.id().to_string();
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -299,14 +299,21 @@ pub async fn smart_json_error_middleware(request: Request<Body>, next: Next) -> 
 /// The request ID comes from the trace context — `make_inference_request_span()` guarantees it by
 /// generating a UUID when the client doesn't provide one.
 pub(super) fn get_or_create_request_id(headers: &HeaderMap) -> String {
-    // Validate x-dynamo-request-id header if present, warn on invalid values
-    if let Some(raw) = headers.get(DYNAMO_REQUEST_ID_HEADER) {
+    // Validate x-dynamo-request-id header if present, warn on invalid values.
+    // DEP #7812: x-dynamo-request-id is deprecated — clients should rely on
+    // server-generated request IDs instead of supplying their own.
+    let validated_header = if let Some(raw) = headers.get(DYNAMO_REQUEST_ID_HEADER) {
+        tracing::warn!(
+            "{} header is deprecated (DEP #7812); server-generated request IDs should be used instead",
+            DYNAMO_REQUEST_ID_HEADER
+        );
         match raw.to_str() {
             Err(_) => {
                 tracing::warn!(
                     "{} header must be a valid UTF-8 string",
                     DYNAMO_REQUEST_ID_HEADER
                 );
+                None
             }
             Ok(s) if uuid::Uuid::parse_str(s).is_err() => {
                 tracing::warn!(
@@ -314,10 +321,13 @@ pub(super) fn get_or_create_request_id(headers: &HeaderMap) -> String {
                     DYNAMO_REQUEST_ID_HEADER,
                     s
                 );
+                None
             }
-            Ok(_) => {} // Valid header, will be picked up from trace context below
+            Ok(s) => Some(s.to_string()),
         }
-    }
+    } else {
+        None
+    };
 
     // Prefer trace context (set by make_inference_request_span via DistributedTraceIdLayer)
     if let Some(trace_context) = get_distributed_tracing_context()
@@ -326,8 +336,8 @@ pub(super) fn get_or_create_request_id(headers: &HeaderMap) -> String {
         return x_dynamo_request_id;
     }
 
-    // Fallback: generate new UUID
-    uuid::Uuid::new_v4().to_string()
+    // Fallback: use validated header for backwards compat, or generate new UUID
+    validated_header.unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
 }
 
 /// OpenAI Completions Request Handler

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -291,13 +291,15 @@ pub async fn smart_json_error_middleware(request: Request<Body>, next: Next) -> 
     }
 }
 
-/// Validate the `x-dynamo-request-id` header and return the request ID.
+/// Return the request ID for the current request.
 ///
-/// If the header is present but invalid (not UTF-8 or not a UUID), a warning is logged
-/// and a new UUID is generated instead of returning an error.
+/// The canonical request ID is set by `make_inference_request_span()` and stored
+/// in the `DistributedTraceContext` via `DistributedTraceIdLayer`. This function
+/// retrieves it, falling back to a validated `x-dynamo-request-id` header value
+/// (deprecated, DEP #7812) or a new UUID.
 ///
-/// The request ID comes from the trace context — `make_inference_request_span()` guarantees it by
-/// generating a UUID when the client doesn't provide one.
+/// **Deprecation (DEP #7812):** The `x-dynamo-request-id` header is deprecated.
+/// Clients should rely on server-generated request IDs instead of supplying their own.
 pub(super) fn get_or_create_request_id(headers: &HeaderMap) -> String {
     // Validate x-dynamo-request-id header if present, warn on invalid values.
     // DEP #7812: x-dynamo-request-id is deprecated — clients should rely on
@@ -331,9 +333,9 @@ pub(super) fn get_or_create_request_id(headers: &HeaderMap) -> String {
 
     // Prefer trace context (set by make_inference_request_span via DistributedTraceIdLayer)
     if let Some(trace_context) = get_distributed_tracing_context()
-        && let Some(x_dynamo_request_id) = trace_context.x_dynamo_request_id
+        && let Some(request_id) = trace_context.request_id
     {
-        return x_dynamo_request_id;
+        return request_id;
     }
 
     // Fallback: use validated header for backwards compat, or generate new UUID

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -28,7 +28,7 @@ use derive_builder::Builder;
 use dynamo_runtime::config::env_is_truthy;
 use dynamo_runtime::config::environment_names::llm as env_llm;
 use dynamo_runtime::discovery::Discovery;
-use dynamo_runtime::logging::make_request_span;
+use dynamo_runtime::logging::{make_inference_request_span, make_system_request_span};
 use dynamo_runtime::metrics::{
     frontend_perf::ensure_frontend_perf_metrics_registered_prometheus,
     request_plane::ensure_request_plane_metrics_registered_prometheus,
@@ -39,6 +39,19 @@ use std::net::SocketAddr;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tower_http::trace::TraceLayer;
+
+/// Middleware that echoes `x-request-id` from request to response headers.
+async fn echo_request_id_header(
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let x_request_id = request.headers().get("x-request-id").cloned();
+    let mut response = next.run(request).await;
+    if let Some(value) = x_request_id {
+        response.headers_mut().insert("x-request-id", value);
+    }
+    response
+}
 
 /// HTTP service shared state
 pub struct State {
@@ -491,11 +504,37 @@ impl HttpServiceConfigBuilder {
             tracing::warn!("Failed to register transport metrics: {}", e);
         }
 
-        let mut router = axum::Router::new();
-
         let mut all_docs = Vec::new();
 
-        let mut routes = vec![
+        // on_response callback for system routes (health, metrics, models)
+        let on_response_system = |response: &Response<Body>,
+                                  latency: Duration,
+                                  _span: &tracing::Span| {
+            let status = response.status();
+            let latency_ms = latency.as_millis();
+            if status.is_server_error() {
+                tracing::error!(status = %status.as_u16(), latency_ms = %latency_ms, "http response sent");
+            } else if status.is_client_error() {
+                tracing::warn!(status = %status.as_u16(), latency_ms = %latency_ms, "http response sent");
+            } else {
+                tracing::debug!(status = %status.as_u16(), latency_ms = %latency_ms, "http response sent");
+            }
+        };
+        // on_response callback for inference routes (completions, chat, embeddings, etc.)
+        let on_response_inference = |response: &Response<Body>,
+                                     latency: Duration,
+                                     _span: &tracing::Span| {
+            let status = response.status();
+            let latency_ms = latency.as_millis();
+            if status.is_server_error() || status.is_client_error() {
+                tracing::error!(status = %status.as_u16(), latency_ms = %latency_ms, "http response sent");
+            } else {
+                tracing::info!(status = %status.as_u16(), latency_ms = %latency_ms, "http response sent");
+            }
+        };
+
+        // System routes (health, metrics, models) — debug-level spans
+        let system_routes = vec![
             metrics::router(
                 registry,
                 var(HTTP_SVC_METRICS_PATH_ENV).ok(),
@@ -506,54 +545,41 @@ impl HttpServiceConfigBuilder {
             super::health::live_check_router(state.clone(), var(HTTP_SVC_LIVE_PATH_ENV).ok()),
             super::busy_threshold::busy_threshold_router(state.clone(), None),
         ];
-
-        let endpoint_routes =
-            HttpServiceConfigBuilder::get_endpoints_router(state.clone(), &config.request_template);
-        routes.extend(endpoint_routes);
-        for (route_docs, route) in routes {
-            router = router.merge(route);
+        let mut system_router = axum::Router::new();
+        for (route_docs, route) in system_routes {
+            system_router = system_router.merge(route);
             all_docs.extend(route_docs);
         }
+        system_router = system_router.layer(
+            TraceLayer::new_for_http()
+                .make_span_with(make_system_request_span)
+                .on_response(on_response_system),
+        );
 
-        // Add OpenAPI documentation routes (must be after all other routes so it can document them)
-        // Note: The path parameter is currently unused as SwaggerUi requires static paths
+        // Inference routes (completions, chat, embeddings, etc.) — info-level spans
+        let endpoint_routes =
+            HttpServiceConfigBuilder::get_endpoints_router(state.clone(), &config.request_template);
+        let mut inference_router = axum::Router::new();
+        for (route_docs, route) in endpoint_routes {
+            inference_router = inference_router.merge(route);
+            all_docs.extend(route_docs);
+        }
+        inference_router = inference_router.layer(
+            TraceLayer::new_for_http()
+                .make_span_with(make_inference_request_span)
+                .on_response(on_response_inference),
+        );
+
+        // OpenAPI documentation routes (system)
         let (openapi_docs, openapi_route) =
             super::openapi_docs::openapi_router(all_docs.clone(), None);
-        router = router.merge(openapi_route);
+        system_router = system_router.merge(openapi_route);
         all_docs.extend(openapi_docs);
 
-        // Add span for tracing
-        // Add on_response callback for logging response status code
-        router = router.layer(
-            TraceLayer::new_for_http()
-                .make_span_with(make_request_span)
-                .on_response(
-                    |response: &Response<Body>, latency: Duration, _span: &tracing::Span| {
-                        let status = response.status();
-                        let latency_ms = latency.as_millis();
+        let router = system_router.merge(inference_router);
 
-                        if status.is_server_error() {
-                            tracing::error!(
-                                status = %status.as_u16(),
-                                latency_ms = %latency_ms,
-                                "request completed with server error"
-                            );
-                        } else if status.is_client_error() {
-                            tracing::warn!(
-                                status = %status.as_u16(),
-                                latency_ms = %latency_ms,
-                                "request completed with client request error"
-                            );
-                        } else {
-                            tracing::debug!(
-                                status = %status.as_u16(),
-                                latency_ms = %latency_ms,
-                                "request completed"
-                            );
-                        }
-                    },
-                ),
-        );
+        // Echo x-request-id from request to response headers for client correlation
+        let router = router.layer(axum::middleware::from_fn(echo_request_id_header));
 
         Ok(HttpService {
             state,

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -506,24 +506,8 @@ impl HttpServiceConfigBuilder {
 
         let mut all_docs = Vec::new();
 
-        // on_response callback for system routes (health, metrics, models)
-        let on_response_system = |response: &Response<Body>,
-                                  latency: Duration,
-                                  _span: &tracing::Span| {
-            let status = response.status();
-            let latency_ms = latency.as_millis();
-            if status.is_server_error() {
-                tracing::error!(status = %status.as_u16(), latency_ms = %latency_ms, "http response sent");
-            } else if status.is_client_error() {
-                tracing::warn!(status = %status.as_u16(), latency_ms = %latency_ms, "http response sent");
-            } else {
-                tracing::debug!(status = %status.as_u16(), latency_ms = %latency_ms, "http response sent");
-            }
-        };
-        // on_response callback for inference routes (completions, chat, embeddings, etc.)
-        let on_response_inference = |response: &Response<Body>,
-                                     latency: Duration,
-                                     _span: &tracing::Span| {
+        // Shared on_response callback for both system and inference routes
+        let on_response = |response: &Response<Body>, latency: Duration, _span: &tracing::Span| {
             let status = response.status();
             let latency_ms = latency.as_millis();
             if status.is_server_error() || status.is_client_error() {
@@ -553,7 +537,7 @@ impl HttpServiceConfigBuilder {
         system_router = system_router.layer(
             TraceLayer::new_for_http()
                 .make_span_with(make_system_request_span)
-                .on_response(on_response_system),
+                .on_response(on_response),
         );
 
         // Inference routes (completions, chat, embeddings, etc.) — info-level spans
@@ -567,7 +551,7 @@ impl HttpServiceConfigBuilder {
         inference_router = inference_router.layer(
             TraceLayer::new_for_http()
                 .make_span_with(make_inference_request_span)
-                .on_response(on_response_inference),
+                .on_response(on_response),
         );
 
         // OpenAPI documentation routes (system)

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -173,7 +173,7 @@ pub struct DistributedTraceContext {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub x_request_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub x_dynamo_request_id: Option<String>,
+    pub request_id: Option<String>,
 }
 
 /// Pending context data collected in on_new_span, to be finalized in on_enter
@@ -184,7 +184,7 @@ struct PendingDistributedTraceContext {
     parent_id: Option<String>,
     tracestate: Option<String>,
     x_request_id: Option<String>,
-    x_dynamo_request_id: Option<String>,
+    request_id: Option<String>,
 }
 
 /// Macro to emit a tracing event at a dynamic level with a custom target.
@@ -232,7 +232,7 @@ pub struct TraceParent {
     pub parent_id: Option<String>,
     pub tracestate: Option<String>,
     pub x_request_id: Option<String>,
-    pub x_dynamo_request_id: Option<String>,
+    pub request_id: Option<String>,
 }
 
 pub trait GenericHeaders {
@@ -257,7 +257,7 @@ impl TraceParent {
         let mut parent_id = None;
         let mut tracestate = None;
         let mut x_request_id = None;
-        let mut x_dynamo_request_id = None;
+        let mut request_id = None;
 
         if let Some(header_value) = headers.get("traceparent") {
             (trace_id, parent_id) = parse_traceparent(header_value);
@@ -271,19 +271,21 @@ impl TraceParent {
             tracestate = Some(header_value.to_string());
         }
 
-        if let Some(header_value) = headers.get("x-dynamo-request-id") {
-            x_dynamo_request_id = Some(header_value.to_string());
+        // Read request-id from internal headers, with fallback to deprecated x-dynamo-request-id
+        if let Some(header_value) = headers.get("request-id") {
+            request_id = Some(header_value.to_string());
+        } else if let Some(header_value) = headers.get("x-dynamo-request-id") {
+            request_id = Some(header_value.to_string());
         }
 
         // Validate UUID format
-        let x_dynamo_request_id =
-            x_dynamo_request_id.filter(|id| uuid::Uuid::parse_str(id).is_ok());
+        let request_id = request_id.filter(|id| uuid::Uuid::parse_str(id).is_ok());
         TraceParent {
             trace_id,
             parent_id,
             tracestate,
             x_request_id,
-            x_dynamo_request_id,
+            request_id,
         }
     }
 }
@@ -301,11 +303,11 @@ pub fn make_inference_request_span<B>(req: &Request<B>) -> Span {
 
     let otel_context = extract_otel_context_from_http_headers(req.headers());
 
-    // Generate a request ID if the client didn't provide one so that workers
-    // (which read request_id from the span/trace context) always
-    // have a consistent ID to correlate with.
+    // Ensure every inference request has a request_id on the span.
+    // This is the single source of truth — workers and get_or_create_request_id
+    // read it back via DistributedTraceIdLayer.
     let request_id = trace_parent
-        .x_dynamo_request_id
+        .request_id
         .unwrap_or_else(|| Uuid::new_v4().to_string());
 
     let span = tracing::info_span!(
@@ -336,25 +338,39 @@ pub fn make_inference_request_span<B>(req: &Request<B>) -> Span {
 
 /// Create a span for system endpoints (health, metrics, models, engine, loras, etc.).
 ///
-/// Uses `target: "system_span"` which follows normal DYN_LOG filtering — these
-/// endpoints are polled frequently and don't need to be visible at INFO level.
-/// Preserves inbound trace context so management operations (e.g. /engine/*, /v1/loras)
-/// can be correlated with the caller's trace.
+/// Same structure as `make_inference_request_span` but uses `target: "system_span"`
+/// which follows normal DYN_LOG filtering (debug level by default). The inference
+/// span target `request_span` is always-on via a `request_span=trace` directive;
+/// system spans are not, keeping high-frequency polling endpoints quiet.
 pub fn make_system_request_span<B>(req: &Request<B>) -> Span {
     let method = req.method();
     let uri = req.uri();
+    let version = format!("{:?}", req.version());
     let trace_parent = TraceParent::from_headers(req.headers());
     let otel_context = extract_otel_context_from_http_headers(req.headers());
+
+    // Ensure every system request has a request_id on the span.
+    let request_id = trace_parent
+        .request_id
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
 
     let span = tracing::debug_span!(
         target: "system_span",
         "http-request",
         method = %method,
         uri = %uri,
+        version = %version,
         trace_id = trace_parent.trace_id,
         parent_id = trace_parent.parent_id,
         x_request_id = trace_parent.x_request_id,
-        request_id = trace_parent.x_dynamo_request_id,
+        request_id = %request_id,
+        model = tracing::field::Empty,
+        input_tokens = tracing::field::Empty,
+        output_tokens = tracing::field::Empty,
+        ttft_ms = tracing::field::Empty,
+        avg_itl_ms = tracing::field::Empty,
+        prefill_worker_id = tracing::field::Empty,
+        decode_worker_id = tracing::field::Empty,
     );
 
     if let Some(context) = otel_context {
@@ -418,7 +434,7 @@ pub fn make_handle_payload_span(
             trace_id = trace_id.as_str(),
             parent_id = parent_id.as_str(),
             x_request_id = trace_parent.x_request_id,
-            request_id = trace_parent.x_dynamo_request_id,
+            request_id = trace_parent.request_id,
             tracestate = trace_parent.tracestate,
             component = component,
             endpoint = endpoint,
@@ -435,7 +451,7 @@ pub fn make_handle_payload_span(
             target: "request_span",
             "handle_payload",
             x_request_id = trace_parent.x_request_id,
-            request_id = trace_parent.x_dynamo_request_id,
+            request_id = trace_parent.request_id,
             tracestate = trace_parent.tracestate,
             component = component,
             endpoint = endpoint,
@@ -455,7 +471,11 @@ pub fn make_handle_payload_span_from_tcp_headers(
 ) -> Span {
     let (otel_context, trace_id, parent_span_id) = extract_otel_context_from_tcp_headers(headers);
     let x_request_id = headers.get("x-request-id").cloned();
-    let x_dynamo_request_id = headers.get("x-dynamo-request-id").cloned();
+    let request_id = headers
+        .get("request-id")
+        .or_else(|| headers.get("x-dynamo-request-id"))
+        .filter(|id| uuid::Uuid::parse_str(id).is_ok())
+        .cloned();
     let tracestate = headers.get("tracestate").cloned();
 
     if let (Some(trace_id), Some(parent_id)) = (trace_id.as_ref(), parent_span_id.as_ref()) {
@@ -465,7 +485,7 @@ pub fn make_handle_payload_span_from_tcp_headers(
             trace_id = trace_id.as_str(),
             parent_id = parent_id.as_str(),
             x_request_id = x_request_id,
-            request_id = x_dynamo_request_id,
+            request_id = request_id,
             tracestate = tracestate,
             component = component,
             endpoint = endpoint,
@@ -482,7 +502,7 @@ pub fn make_handle_payload_span_from_tcp_headers(
             target: "request_span",
             "handle_payload",
             x_request_id = x_request_id,
-            request_id = x_dynamo_request_id,
+            request_id = request_id,
             tracestate = tracestate,
             component = component,
             endpoint = endpoint,
@@ -618,8 +638,8 @@ pub fn inject_trace_headers_into_map(headers: &mut std::collections::HashMap<Str
         if let Some(x_request_id) = trace_context.x_request_id {
             headers.insert("x-request-id".to_string(), x_request_id);
         }
-        if let Some(x_dynamo_request_id) = trace_context.x_dynamo_request_id {
-            headers.insert("x-dynamo-request-id".to_string(), x_dynamo_request_id);
+        if let Some(request_id) = trace_context.request_id {
+            headers.insert("request-id".to_string(), request_id);
         }
     }
 }
@@ -651,8 +671,6 @@ pub fn make_client_request_span(
                 trace_id = ctx.trace_id.as_str(),
                 parent_id = ctx.span_id.as_str(),
                 x_request_id = ctx.x_request_id.as_deref(),
-                x_dynamo_request_id = ctx.x_dynamo_request_id.as_deref(),
-                // tracestate = ctx.tracestate.as_deref(),
             )
         } else {
             tracing::info_span!(
@@ -662,8 +680,6 @@ pub fn make_client_request_span(
                 trace_id = ctx.trace_id.as_str(),
                 parent_id = ctx.span_id.as_str(),
                 x_request_id = ctx.x_request_id.as_deref(),
-                x_dynamo_request_id = ctx.x_dynamo_request_id.as_deref(),
-                // tracestate = ctx.tracestate.as_deref(),
             )
         };
 
@@ -730,7 +746,7 @@ where
             let mut parent_id: Option<String> = None;
             let mut span_id: Option<String> = None;
             let mut x_request_id: Option<String> = None;
-            let mut x_dynamo_request_id: Option<String> = None;
+            let mut request_id: Option<String> = None;
             let mut tracestate: Option<String> = None;
             let mut visitor = FieldVisitor::default();
             attrs.record(&mut visitor);
@@ -774,9 +790,9 @@ where
 
             // Extract request_id (with backward compat for x_dynamo_request_id)
             if let Some(request_id_input) = visitor.fields.get("request_id") {
-                x_dynamo_request_id = Some(request_id_input.to_string());
+                request_id = Some(request_id_input.to_string());
             } else if let Some(x_request_id_input) = visitor.fields.get("x_dynamo_request_id") {
-                x_dynamo_request_id = Some(x_request_id_input.to_string());
+                request_id = Some(x_request_id_input.to_string());
             }
 
             // Inherit trace context from parent span if available
@@ -808,7 +824,7 @@ where
                 parent_id,
                 tracestate,
                 x_request_id,
-                x_dynamo_request_id,
+                request_id,
             });
         }
     }
@@ -841,7 +857,7 @@ where
             let parent_id = pending.parent_id;
             let tracestate = pending.tracestate;
             let x_request_id = pending.x_request_id;
-            let x_dynamo_request_id = pending.x_dynamo_request_id;
+            let request_id = pending.request_id;
 
             // Try to extract from OtelData if not already set
             // Need to drop extensions_mut to get immutable borrow for OtelData
@@ -893,7 +909,7 @@ where
                 start: Some(Instant::now()),
                 end: None,
                 x_request_id,
-                x_dynamo_request_id,
+                request_id,
             });
 
             drop(extensions);
@@ -1330,10 +1346,10 @@ where
                     visitor.fields.remove("x_request_id");
                 }
 
-                if let Some(x_dynamo_request_id) = tracing_context.x_dynamo_request_id.clone() {
+                if let Some(request_id) = tracing_context.request_id.clone() {
                     visitor.fields.insert(
                         "request_id".to_string(),
-                        serde_json::Value::String(x_dynamo_request_id),
+                        serde_json::Value::String(request_id),
                     );
                 } else {
                     visitor.fields.remove("request_id");

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -334,19 +334,34 @@ pub fn make_inference_request_span<B>(req: &Request<B>) -> Span {
     span
 }
 
-/// Create a span for system endpoints (health, metrics, models, etc.).
+/// Create a span for system endpoints (health, metrics, models, engine, loras, etc.).
 ///
 /// Uses `target: "system_span"` which follows normal DYN_LOG filtering — these
 /// endpoints are polled frequently and don't need to be visible at INFO level.
+/// Preserves inbound trace context so management operations (e.g. /engine/*, /v1/loras)
+/// can be correlated with the caller's trace.
 pub fn make_system_request_span<B>(req: &Request<B>) -> Span {
     let method = req.method();
     let uri = req.uri();
-    tracing::debug_span!(
+    let trace_parent = TraceParent::from_headers(req.headers());
+    let otel_context = extract_otel_context_from_http_headers(req.headers());
+
+    let span = tracing::debug_span!(
         target: "system_span",
         "http-request",
         method = %method,
         uri = %uri,
-    )
+        trace_id = trace_parent.trace_id,
+        parent_id = trace_parent.parent_id,
+        x_request_id = trace_parent.x_request_id,
+        request_id = trace_parent.x_dynamo_request_id,
+    );
+
+    if let Some(context) = otel_context {
+        let _ = span.set_parent(context);
+    }
+
+    span
 }
 
 /// Extract OpenTelemetry context from HTTP headers for distributed tracing

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -288,8 +288,12 @@ impl TraceParent {
     }
 }
 
-// Takes Axum request and returning a span
-pub fn make_request_span<B>(req: &Request<B>) -> Span {
+/// Create a span for inference request endpoints (completions, chat, embeddings, etc.).
+///
+/// Uses `target: "request_span"` which is always allowed through the DYN_LOG filter
+/// (via `request_span=trace` directive in `filters()`). This ensures request context
+/// (request_id, model, trace_id) is always available on log events.
+pub fn make_inference_request_span<B>(req: &Request<B>) -> Span {
     let method = req.method();
     let uri = req.uri();
     let version = format!("{:?}", req.version());
@@ -297,7 +301,15 @@ pub fn make_request_span<B>(req: &Request<B>) -> Span {
 
     let otel_context = extract_otel_context_from_http_headers(req.headers());
 
+    // Generate a request ID if the client didn't provide one so that workers
+    // (which read request_id from the span/trace context) always
+    // have a consistent ID to correlate with.
+    let request_id = trace_parent
+        .x_dynamo_request_id
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+
     let span = tracing::info_span!(
+            target: "request_span",
         "http-request",
         method = %method,
         uri = %uri,
@@ -305,7 +317,14 @@ pub fn make_request_span<B>(req: &Request<B>) -> Span {
         trace_id = trace_parent.trace_id,
         parent_id = trace_parent.parent_id,
         x_request_id = trace_parent.x_request_id,
-        x_dynamo_request_id = trace_parent.x_dynamo_request_id,
+        request_id = %request_id,
+        model = tracing::field::Empty,
+        input_tokens = tracing::field::Empty,
+        output_tokens = tracing::field::Empty,
+        ttft_ms = tracing::field::Empty,
+        avg_itl_ms = tracing::field::Empty,
+        prefill_worker_id = tracing::field::Empty,
+        decode_worker_id = tracing::field::Empty,
     );
 
     if let Some(context) = otel_context {
@@ -313,6 +332,21 @@ pub fn make_request_span<B>(req: &Request<B>) -> Span {
     }
 
     span
+}
+
+/// Create a span for system endpoints (health, metrics, models, etc.).
+///
+/// Uses `target: "system_span"` which follows normal DYN_LOG filtering — these
+/// endpoints are polled frequently and don't need to be visible at INFO level.
+pub fn make_system_request_span<B>(req: &Request<B>) -> Span {
+    let method = req.method();
+    let uri = req.uri();
+    tracing::debug_span!(
+        target: "system_span",
+        "http-request",
+        method = %method,
+        uri = %uri,
+    )
 }
 
 /// Extract OpenTelemetry context from HTTP headers for distributed tracing
@@ -364,11 +398,12 @@ pub fn make_handle_payload_span(
 
     if let (Some(trace_id), Some(parent_id)) = (trace_id.as_ref(), parent_span_id.as_ref()) {
         let span = tracing::info_span!(
+            target: "request_span",
             "handle_payload",
             trace_id = trace_id.as_str(),
             parent_id = parent_id.as_str(),
             x_request_id = trace_parent.x_request_id,
-            x_dynamo_request_id = trace_parent.x_dynamo_request_id,
+            request_id = trace_parent.x_dynamo_request_id,
             tracestate = trace_parent.tracestate,
             component = component,
             endpoint = endpoint,
@@ -382,9 +417,10 @@ pub fn make_handle_payload_span(
         span
     } else {
         tracing::info_span!(
+            target: "request_span",
             "handle_payload",
             x_request_id = trace_parent.x_request_id,
-            x_dynamo_request_id = trace_parent.x_dynamo_request_id,
+            request_id = trace_parent.x_dynamo_request_id,
             tracestate = trace_parent.tracestate,
             component = component,
             endpoint = endpoint,
@@ -409,11 +445,12 @@ pub fn make_handle_payload_span_from_tcp_headers(
 
     if let (Some(trace_id), Some(parent_id)) = (trace_id.as_ref(), parent_span_id.as_ref()) {
         let span = tracing::info_span!(
+            target: "request_span",
             "handle_payload",
             trace_id = trace_id.as_str(),
             parent_id = parent_id.as_str(),
             x_request_id = x_request_id,
-            x_dynamo_request_id = x_dynamo_request_id,
+            request_id = x_dynamo_request_id,
             tracestate = tracestate,
             component = component,
             endpoint = endpoint,
@@ -427,9 +464,10 @@ pub fn make_handle_payload_span_from_tcp_headers(
         span
     } else {
         tracing::info_span!(
+            target: "request_span",
             "handle_payload",
             x_request_id = x_request_id,
-            x_dynamo_request_id = x_dynamo_request_id,
+            request_id = x_dynamo_request_id,
             tracestate = tracestate,
             component = component,
             endpoint = endpoint,
@@ -719,8 +757,10 @@ where
                 x_request_id = Some(x_request_id_input.to_string());
             }
 
-            // Extract x_dynamo_request_id
-            if let Some(x_request_id_input) = visitor.fields.get("x_dynamo_request_id") {
+            // Extract request_id (with backward compat for x_dynamo_request_id)
+            if let Some(request_id_input) = visitor.fields.get("request_id") {
+                x_dynamo_request_id = Some(request_id_input.to_string());
+            } else if let Some(x_request_id_input) = visitor.fields.get("x_dynamo_request_id") {
                 x_dynamo_request_id = Some(x_request_id_input.to_string());
             }
 
@@ -1043,6 +1083,12 @@ fn filters(config: LoggingConfig) -> EnvFilter {
         filter_layer = filter_layer.add_directive("span_event=trace".parse().unwrap());
     }
 
+    // Always allow infrastructure request spans regardless of DYN_LOG level.
+    // This ensures request context (request_id, model, trace_id) is always
+    // available on log events, even when DYN_LOG=error or DYN_LOG=warn.
+    // Can be overridden via DYN_LOG=request_span=<level> if needed.
+    filter_layer = filter_layer.add_directive("request_span=trace".parse().unwrap());
+
     filter_layer
 }
 
@@ -1271,12 +1317,14 @@ where
 
                 if let Some(x_dynamo_request_id) = tracing_context.x_dynamo_request_id.clone() {
                     visitor.fields.insert(
-                        "x_dynamo_request_id".to_string(),
+                        "request_id".to_string(),
                         serde_json::Value::String(x_dynamo_request_id),
                     );
                 } else {
-                    visitor.fields.remove("x_dynamo_request_id");
+                    visitor.fields.remove("request_id");
                 }
+                // Remove old field name if present
+                visitor.fields.remove("x_dynamo_request_id");
             } else {
                 tracing::error!(
                     "Distributed Trace Context not found, falling back to internal ids"

--- a/lib/runtime/src/pipeline/network/ingress/http_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/http_endpoint.rs
@@ -263,7 +263,7 @@ async fn handle_shared_request(
                 trace_id = traceparent.trace_id,
                 parent_id = traceparent.parent_id,
                 x_request_id = traceparent.x_request_id,
-                x_dynamo_request_id = traceparent.x_dynamo_request_id,
+                request_id = traceparent.request_id,
                 tracestate = traceparent.tracestate
             ))
             .await;
@@ -308,10 +308,13 @@ impl TraceParent {
             traceparent.x_request_id = Some(s.to_string());
         }
 
-        if let Some(value) = headers.get("x-dynamo-request-id")
+        // Read request-id from internal headers, with fallback to deprecated x-dynamo-request-id
+        if let Some(value) = headers
+            .get("request-id")
+            .or_else(|| headers.get("x-dynamo-request-id"))
             && let Ok(s) = value.to_str()
         {
-            traceparent.x_dynamo_request_id = Some(s.to_string());
+            traceparent.request_id = Some(s.to_string());
         }
 
         traceparent
@@ -380,7 +383,7 @@ mod tests {
         assert_eq!(traceparent.trace_id, Some("test-trace-id".to_string()));
         assert_eq!(traceparent.tracestate, Some("test-state".to_string()));
         assert_eq!(traceparent.x_request_id, Some("req-123".to_string()));
-        assert_eq!(traceparent.x_dynamo_request_id, Some("dyn-456".to_string()));
+        assert_eq!(traceparent.request_id, Some("dyn-456".to_string()));
     }
 
     #[test]

--- a/lib/runtime/src/pipeline/network/ingress/push_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_endpoint.rs
@@ -102,7 +102,7 @@ impl PushEndpoint {
                         instance_id,
                     )
                 } else {
-                    tracing::info_span!("handle_payload")
+                    tracing::info_span!(target: "request_span", "handle_payload")
                 };
 
                 tokio::spawn(async move {

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -8,7 +8,7 @@ use crate::config::HealthStatus;
 use crate::config::environment_names::logging as env_logging;
 use crate::config::environment_names::runtime::canary as env_canary;
 use crate::config::environment_names::runtime::system as env_system;
-use crate::logging::make_request_span;
+use crate::logging::make_system_request_span;
 use crate::metrics::MetricsHierarchy;
 use crate::traits::DistributedRuntimeProvider;
 use axum::{
@@ -221,7 +221,7 @@ pub async fn spawn_system_status_server(
             tracing::info!("[fallback handler] called");
             (StatusCode::NOT_FOUND, "Route not found").into_response()
         })
-        .layer(TraceLayer::new_for_http().make_span_with(make_request_span));
+        .layer(TraceLayer::new_for_http().make_span_with(make_system_request_span));
 
     let address = format!("{}:{}", host, port);
     tracing::info!("[spawn_system_status_server] binding to: {address}");


### PR DESCRIPTION
## Summary
- Split HTTP router into system (debug-level) and inference (info-level) trace layers with separate `on_response` callbacks
- Add `make_inference_request_span` with always-on `request_span` target and empty span fields for downstream recording
- `get_or_create_request_id` now returns `String` (warns on invalid UUID instead of 400)
- Rename span field `x_dynamo_request_id` → `request_id` for consistency
- Add `echo_request_id_header` middleware to copy `x-request-id` from request to response headers
- Add `request_span=trace` filter directive so request context is always visible

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy -p dynamo-llm -p dynamo-runtime --no-deps` clean
- [ ] CI checks pass

Part 1 of 4 for DIS-1643: Consistent Error Tracing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request IDs are now echoed in response headers for improved request tracing.

* **Improvements**
  * Request ID handling now prefers distributed tracing context and falls back to generating a UUID when needed, improving trace reliability.
  * Logging and tracing reorganized with separate system vs. inference spans and unified response-level logging for clearer diagnostics.
  * Trace output now uses a consolidated request_id field for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->