### PR TITLE
refactor(operator): keep checkpoint job naming local

### DIFF
--- a/deploy/operator/internal/checkpointjob/job.go
+++ b/deploy/operator/internal/checkpointjob/job.go
@@ -18,7 +18,7 @@ import (
 )
 
 func DesiredCheckpointJobName(identityHash string, annotations map[string]string) string {
-	return snapshotprotocol.CheckpointJobName(identityHash, annotations[snapshotprotocol.CheckpointArtifactVersionAnnotation])
+	return "checkpoint-job-" + identityHash + "-" + snapshotprotocol.ArtifactVersion(annotations[snapshotprotocol.CheckpointArtifactVersionAnnotation])
 }
 
 func buildCheckpointWorkerDefaultEnv(

--- a/deploy/operator/internal/checkpointjob/job_test.go
+++ b/deploy/operator/internal/checkpointjob/job_test.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package checkpointjob
+
+import (
+	"testing"
+
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
+)
+
+func TestDesiredCheckpointJobName(t *testing.T) {
+	name := DesiredCheckpointJobName("abc123def4567890", map[string]string{
+		snapshotprotocol.CheckpointArtifactVersionAnnotation: "2",
+	})
+	if name != "checkpoint-job-abc123def4567890-2" {
+		t.Fatalf("unexpected checkpoint job name: %s", name)
+	}
+
+	defaultName := DesiredCheckpointJobName("abc123def4567890", nil)
+	if defaultName != "checkpoint-job-abc123def4567890-"+snapshotprotocol.DefaultCheckpointArtifactVersion {
+		t.Fatalf("unexpected default checkpoint job name: %s", defaultName)
+	}
+}

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -60,7 +60,9 @@ var testHash = func() string {
 	return hash
 }()
 
-var defaultCheckpointJobName = snapshotprotocol.CheckpointJobName(testHash, snapshotprotocol.DefaultCheckpointArtifactVersion)
+var defaultCheckpointJobName = checkpointjob.DesiredCheckpointJobName(testHash, map[string]string{
+	snapshotprotocol.CheckpointArtifactVersionAnnotation: snapshotprotocol.DefaultCheckpointArtifactVersion,
+})
 
 func checkpointTestScheme() *runtime.Scheme {
 	s := runtime.NewScheme()

--- a/deploy/snapshot/protocol/common.go
+++ b/deploy/snapshot/protocol/common.go
@@ -44,10 +44,6 @@ func ArtifactVersion(version string) string {
 	return version
 }
 
-func CheckpointJobName(checkpointID string, artifactVersion string) string {
-	return "checkpoint-job-" + checkpointID + "-" + ArtifactVersion(artifactVersion)
-}
-
 func ResolveCheckpointStorage(checkpointID string, version string, storage Storage) (Storage, error) {
 	resolved, err := resolveStorageConfig(storage)
 	if err != nil {


### PR DESCRIPTION
## Summary
- move checkpoint job name formatting out of `snapshot/protocol`
- keep the operator naming helper in `checkpointjob`
- add direct coverage for the operator helper and update the controller test fixture

## Testing
- cd deploy/operator && go test ./internal/checkpointjob ./internal/controller -run "TestDesiredCheckpointJobName|TestBuildCheckpointJob"
- cd deploy/snapshot && go test ./protocol
