### PR TITLE
refactor(operator): own checkpoint job observation

### DIFF
--- a/deploy/operator/internal/checkpointjob/observation.go
+++ b/deploy/operator/internal/checkpointjob/observation.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package checkpointjob
+
+import (
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type ObservationPhase string
+
+const (
+	ObservationPhaseRunning                ObservationPhase = "running"
+	ObservationPhaseWaitingForConfirmation ObservationPhase = "waiting_for_confirmation"
+	ObservationPhaseReady                  ObservationPhase = "ready"
+	ObservationPhaseFailed                 ObservationPhase = "failed"
+)
+
+type Observation struct {
+	Phase   ObservationPhase
+	Reason  string
+	Message string
+}
+
+func Observe(job *batchv1.Job, checkpointWorkerActive bool) Observation {
+	jobComplete := false
+	jobFailed := false
+	for _, condition := range job.Status.Conditions {
+		if condition.Status != corev1.ConditionTrue {
+			continue
+		}
+		if condition.Type == batchv1.JobComplete {
+			jobComplete = true
+			continue
+		}
+		if condition.Type == batchv1.JobFailed {
+			jobFailed = true
+		}
+	}
+
+	status := job.Annotations[snapshotprotocol.CheckpointStatusAnnotation]
+	if status == snapshotprotocol.CheckpointStatusFailed {
+		observation := Observation{
+			Phase:   ObservationPhaseFailed,
+			Reason:  "JobFailed",
+			Message: "Checkpoint job failed",
+		}
+		if jobComplete {
+			observation.Reason = "CheckpointVerificationFailed"
+			observation.Message = "Checkpoint job completed but snapshot-agent reported checkpoint failure"
+		}
+		return observation
+	}
+
+	if jobComplete {
+		if status == snapshotprotocol.CheckpointStatusCompleted {
+			return Observation{
+				Phase:   ObservationPhaseReady,
+				Reason:  "JobSucceeded",
+				Message: "Checkpoint job completed successfully",
+			}
+		}
+		if checkpointWorkerActive {
+			return Observation{Phase: ObservationPhaseWaitingForConfirmation}
+		}
+		return Observation{
+			Phase:   ObservationPhaseFailed,
+			Reason:  "CheckpointVerificationFailed",
+			Message: "Checkpoint job completed without snapshot-agent completion confirmation",
+		}
+	}
+
+	if jobFailed {
+		return Observation{
+			Phase:   ObservationPhaseFailed,
+			Reason:  "JobFailed",
+			Message: "Checkpoint job failed",
+		}
+	}
+
+	return Observation{Phase: ObservationPhaseRunning}
+}

--- a/deploy/operator/internal/checkpointjob/observation_test.go
+++ b/deploy/operator/internal/checkpointjob/observation_test.go
@@ -1,17 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package protocol
+package checkpointjob
 
 import (
 	"testing"
 
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestObserveCheckpointJob(t *testing.T) {
+func TestObserve(t *testing.T) {
 	makeJob := func(annotation string, conditions ...batchv1.JobCondition) *batchv1.Job {
 		job := &batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
@@ -22,7 +23,7 @@ func TestObserveCheckpointJob(t *testing.T) {
 			},
 		}
 		if annotation != "" {
-			job.Annotations[CheckpointStatusAnnotation] = annotation
+			job.Annotations[snapshotprotocol.CheckpointStatusAnnotation] = annotation
 		}
 		return job
 	}
@@ -31,22 +32,22 @@ func TestObserveCheckpointJob(t *testing.T) {
 		name                   string
 		job                    *batchv1.Job
 		checkpointWorkerActive bool
-		wantPhase              CheckpointJobPhase
+		wantPhase              ObservationPhase
 		wantReason             string
 		wantMessage            string
 	}{
 		{
 			name:      "running job stays running",
 			job:       makeJob(""),
-			wantPhase: CheckpointJobPhaseRunning,
+			wantPhase: ObservationPhaseRunning,
 		},
 		{
 			name: "completed job with completion annotation is ready",
 			job: makeJob(
-				CheckpointStatusCompleted,
+				snapshotprotocol.CheckpointStatusCompleted,
 				batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
 			),
-			wantPhase:   CheckpointJobPhaseReady,
+			wantPhase:   ObservationPhaseReady,
 			wantReason:  "JobSucceeded",
 			wantMessage: "Checkpoint job completed successfully",
 		},
@@ -57,7 +58,7 @@ func TestObserveCheckpointJob(t *testing.T) {
 				batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
 			),
 			checkpointWorkerActive: true,
-			wantPhase:              CheckpointJobPhaseWaitingForConfirmation,
+			wantPhase:              ObservationPhaseWaitingForConfirmation,
 		},
 		{
 			name: "completed job fails without confirmation once worker is inactive",
@@ -65,18 +66,18 @@ func TestObserveCheckpointJob(t *testing.T) {
 				"",
 				batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
 			),
-			wantPhase:   CheckpointJobPhaseFailed,
+			wantPhase:   ObservationPhaseFailed,
 			wantReason:  "CheckpointVerificationFailed",
 			wantMessage: "Checkpoint job completed without snapshot-agent completion confirmation",
 		},
 		{
 			name: "failed checkpoint annotation wins over completed job",
 			job: makeJob(
-				CheckpointStatusFailed,
+				snapshotprotocol.CheckpointStatusFailed,
 				batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
 			),
 			checkpointWorkerActive: true,
-			wantPhase:              CheckpointJobPhaseFailed,
+			wantPhase:              ObservationPhaseFailed,
 			wantReason:             "CheckpointVerificationFailed",
 			wantMessage:            "Checkpoint job completed but snapshot-agent reported checkpoint failure",
 		},
@@ -84,7 +85,7 @@ func TestObserveCheckpointJob(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			observation := ObserveCheckpointJob(tc.job, tc.checkpointWorkerActive)
+			observation := Observe(tc.job, tc.checkpointWorkerActive)
 			if observation.Phase != tc.wantPhase {
 				t.Fatalf("phase = %q, want %q", observation.Phase, tc.wantPhase)
 			}

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -42,7 +42,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpointjob"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 // CheckpointReconciler reconciles a DynamoCheckpoint object
@@ -274,12 +273,12 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 		}
 	}
 
-	observation := snapshotprotocol.ObserveCheckpointJob(job, checkpointWorkerActive)
+	observation := checkpointjob.Observe(job, checkpointWorkerActive)
 	switch observation.Phase {
-	case snapshotprotocol.CheckpointJobPhaseWaitingForConfirmation:
+	case checkpointjob.ObservationPhaseWaitingForConfirmation:
 		logger.V(1).Info("Checkpoint job is complete but checkpoint worker is still active; waiting for terminal watcher status", "job", job.Name)
 		return ctrl.Result{RequeueAfter: time.Second}, nil
-	case snapshotprotocol.CheckpointJobPhaseReady:
+	case checkpointjob.ObservationPhaseReady:
 		logger.Info("Checkpoint Job succeeded", "job", job.Name)
 		r.Recorder.Event(ckpt, corev1.EventTypeNormal, "CheckpointReady", observation.Message)
 
@@ -298,7 +297,7 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
-	case snapshotprotocol.CheckpointJobPhaseFailed:
+	case checkpointjob.ObservationPhaseFailed:
 		logger.Info("Checkpoint Job failed", "job", job.Name, "message", observation.Message)
 		r.Recorder.Event(ckpt, corev1.EventTypeWarning, "CheckpointFailed", observation.Message)
 

--- a/deploy/snapshot/protocol/checkpoint.go
+++ b/deploy/snapshot/protocol/checkpoint.go
@@ -23,21 +23,6 @@ type CheckpointJobOptions struct {
 	WrapLaunchJob         bool
 }
 
-type CheckpointJobPhase string
-
-const (
-	CheckpointJobPhaseRunning                CheckpointJobPhase = "running"
-	CheckpointJobPhaseWaitingForConfirmation CheckpointJobPhase = "waiting_for_confirmation"
-	CheckpointJobPhaseReady                  CheckpointJobPhase = "ready"
-	CheckpointJobPhaseFailed                 CheckpointJobPhase = "failed"
-)
-
-type CheckpointJobObservation struct {
-	Phase   CheckpointJobPhase
-	Reason  string
-	Message string
-}
-
 func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOptions) (*batchv1.Job, error) {
 	podTemplate = podTemplate.DeepCopy()
 	if podTemplate.Labels == nil {
@@ -90,65 +75,6 @@ func EnsureLocalhostSeccompProfile(podSpec *corev1.PodSpec, profile string) {
 		Type:             corev1.SeccompProfileTypeLocalhost,
 		LocalhostProfile: &profile,
 	}
-}
-
-func ObserveCheckpointJob(job *batchv1.Job, checkpointWorkerActive bool) CheckpointJobObservation {
-	jobComplete := false
-	jobFailed := false
-	for _, condition := range job.Status.Conditions {
-		if condition.Status != corev1.ConditionTrue {
-			continue
-		}
-		if condition.Type == batchv1.JobComplete {
-			jobComplete = true
-			continue
-		}
-		if condition.Type == batchv1.JobFailed {
-			jobFailed = true
-		}
-	}
-
-	status := job.Annotations[CheckpointStatusAnnotation]
-	if status == CheckpointStatusFailed {
-		observation := CheckpointJobObservation{
-			Phase:   CheckpointJobPhaseFailed,
-			Reason:  "JobFailed",
-			Message: "Checkpoint job failed",
-		}
-		if jobComplete {
-			observation.Reason = "CheckpointVerificationFailed"
-			observation.Message = "Checkpoint job completed but snapshot-agent reported checkpoint failure"
-		}
-		return observation
-	}
-
-	if jobComplete {
-		if status == CheckpointStatusCompleted {
-			return CheckpointJobObservation{
-				Phase:   CheckpointJobPhaseReady,
-				Reason:  "JobSucceeded",
-				Message: "Checkpoint job completed successfully",
-			}
-		}
-		if checkpointWorkerActive {
-			return CheckpointJobObservation{Phase: CheckpointJobPhaseWaitingForConfirmation}
-		}
-		return CheckpointJobObservation{
-			Phase:   CheckpointJobPhaseFailed,
-			Reason:  "CheckpointVerificationFailed",
-			Message: "Checkpoint job completed without snapshot-agent completion confirmation",
-		}
-	}
-
-	if jobFailed {
-		return CheckpointJobObservation{
-			Phase:   CheckpointJobPhaseFailed,
-			Reason:  "JobFailed",
-			Message: "Checkpoint job failed",
-		}
-	}
-
-	return CheckpointJobObservation{Phase: CheckpointJobPhaseRunning}
 }
 
 func wrapWithCudaCheckpointLaunchJob(command []string, args []string) ([]string, []string) {


### PR DESCRIPTION
## Summary
- move checkpoint job observation state out of `snapshot/protocol`
- keep the reconciler-specific state machine under `operator/internal/checkpointjob`
- move the observation test coverage alongside the operator-owned logic

## Testing
- cd deploy/operator && go test ./internal/checkpointjob ./internal/controller -run "TestObserve|TestCheckpointReconciler"
- cd deploy/snapshot && go test ./protocol
