### PR TITLE
fix: rename stale max_vram_gib marker to profiled_vram_gib

### DIFF
--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
@@ -21,7 +21,7 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
     pytest.mark.gpu_1,  # sglang tests run on GPU-enabled workers
-    pytest.mark.max_vram_gib(0),
+    pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
 ]
 


### PR DESCRIPTION
#### Overview:

Fix the wrong marker

#### Details:

Missed a file, renamed.

#### Where should the reviewer start?

test_sglang.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-visible changes in this release. This update addresses internal test infrastructure and profiling categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->