### PR TITLE
fix: guided decoding for reasoning models via structural_tag (TRT-LLM)

### DIFF
--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -30,10 +30,11 @@ class DynamoRuntimeConfig(ConfigBase):
     dyn_reasoning_parser: Optional[str] = None
     exclude_tools_when_tool_choice_none: bool = True
     # Server-level default for enable_thinking when combining reasoning with guided decoding.
-    # - True: Default thinking-on mode (reasoning before answer, e.g., DeepSeek-R1)
-    # - False: Default thinking-off mode (</think> at start, e.g., GLM-4.7)
-    # - None: No auto-generation, require explicit enable_thinking in request
+    # - True: Model generates <think>...</think> before the final answer (thinking-on)
+    # - False: Model skips the thinking phase (thinking-off)
+    # - None: No auto-generation; require explicit enable_thinking per request
     dyn_enable_thinking_default: Optional[bool] = None
+    dyn_prompt_injects_thinking_tag: bool = False
     custom_jinja_template: Optional[str] = None
     endpoint_types: str
     dump_config_to: Optional[str] = None
@@ -166,12 +167,26 @@ class DynamoRuntimeArgGroup(ArgGroup):
             env_var="DYN_ENABLE_THINKING_DEFAULT",
             default=None,
             help=(
-                "Server-level default for enable_thinking when combining reasoning with guided decoding. "
-                "Set to 'true' for thinking-on mode (e.g., DeepSeek-R1), 'false' for thinking-off mode "
-                "(e.g., GLM-4.7). If not set, guided decoding requires explicit enable_thinking in request. "
-                "For GLM-4.7, set to 'false' to enable structural_tag generation for reasoning + JSON output."
+                "Server-level default for thinking mode when combining reasoning with guided decoding. "
+                "Set to 'true' if the model generates <think>...</think> before the final answer "
+                "(thinking-on, e.g., DeepSeek-R1, Qwen3). Set to 'false' if the model skips the "
+                "thinking phase (thinking-off). If not set, guided decoding is applied without any "
+                "reasoning-aware structural_tag wrapping."
             ),
             type=lambda x: None if x.lower() == "none" else x.lower() == "true",
+        )
+        add_argument(
+            g,
+            flag_name="--dyn-prompt-injects-thinking-tag",
+            env_var="DYN_PROMPT_INJECTS_THINKING_TAG",
+            default=False,
+            help=(
+                "Set to true when the model's chat template already appends <think> to the end "
+                "of the prompt. Prevents the structural_tag from adding a duplicate <think> that "
+                "causes model degeneration with guided decoding. Applies to any model whose "
+                "template injects the reasoning start tag (e.g., GLM-4.7, Qwen3)."
+            ),
+            type=lambda x: x.lower() in ("true", "1", "yes"),
         )
         add_argument(
             g,

--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -29,6 +29,11 @@ class DynamoRuntimeConfig(ConfigBase):
     dyn_tool_call_parser: Optional[str] = None
     dyn_reasoning_parser: Optional[str] = None
     exclude_tools_when_tool_choice_none: bool = True
+    # Server-level default for enable_thinking when combining reasoning with guided decoding.
+    # - True: Default thinking-on mode (reasoning before answer, e.g., DeepSeek-R1)
+    # - False: Default thinking-off mode (</think> at start, e.g., GLM-4.7)
+    # - None: No auto-generation, require explicit enable_thinking in request
+    dyn_enable_thinking_default: Optional[bool] = None
     custom_jinja_template: Optional[str] = None
     endpoint_types: str
     dump_config_to: Optional[str] = None
@@ -154,6 +159,19 @@ class DynamoRuntimeArgGroup(ArgGroup):
             default=True,
             help="Exclude tool definitions from the chat template when tool_choice='none'. "
             "Prevents models from generating raw XML tool calls in the content field.",
+        )
+        add_argument(
+            g,
+            flag_name="--dyn-enable-thinking-default",
+            env_var="DYN_ENABLE_THINKING_DEFAULT",
+            default=None,
+            help=(
+                "Server-level default for enable_thinking when combining reasoning with guided decoding. "
+                "Set to 'true' for thinking-on mode (e.g., DeepSeek-R1), 'false' for thinking-off mode "
+                "(e.g., GLM-4.7). If not set, guided decoding requires explicit enable_thinking in request. "
+                "For GLM-4.7, set to 'false' to enable structural_tag generation for reasoning + JSON output."
+            ),
+            type=lambda x: None if x.lower() == "none" else x.lower() == "true",
         )
         add_argument(
             g,

--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -14,6 +14,32 @@ from dynamo.common.utils.namespace import get_worker_namespace
 from dynamo.common.utils.output_modalities import OutputModality
 
 
+def _parse_optional_bool(value: str) -> Optional[bool]:
+    """Parse a CLI/env string to Optional[bool]; raises on unrecognized values."""
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered == "none":
+        return None
+    raise argparse.ArgumentTypeError(
+        f"Invalid value {value!r}: expected one of true, false, none"
+    )
+
+
+def _parse_bool(value: str) -> bool:
+    """Parse a CLI/env string to bool; raises on unrecognized values."""
+    lowered = value.lower()
+    if lowered in {"true", "1", "yes"}:
+        return True
+    if lowered in {"false", "0", "no"}:
+        return False
+    raise argparse.ArgumentTypeError(
+        f"Invalid value {value!r}: expected one of true, false, 1, 0, yes, no"
+    )
+
+
 class DynamoRuntimeConfig(ConfigBase):
     """Configuration for Dynamo runtime (common across all backends)."""
 
@@ -173,7 +199,7 @@ class DynamoRuntimeArgGroup(ArgGroup):
                 "thinking phase (thinking-off). If not set, guided decoding is applied without any "
                 "reasoning-aware structural_tag wrapping."
             ),
-            type=lambda x: None if x.lower() == "none" else x.lower() == "true",
+            type=_parse_optional_bool,
         )
         add_argument(
             g,
@@ -186,7 +212,7 @@ class DynamoRuntimeArgGroup(ArgGroup):
                 "causes model degeneration with guided decoding. Applies to any model whose "
                 "template injects the reasoning start tag (e.g., GLM-4.7, Qwen3)."
             ),
-            type=lambda x: x.lower() in ("true", "1", "yes"),
+            type=_parse_bool,
         )
         add_argument(
             g,

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -530,7 +530,7 @@ class StreamingPostProcessor:
                 self.in_progress_tool_calls.clear()
             if len(delta) > 1:
                 choice = self._build_choice(output, delta)
-                if has_tool_calls and choice:
+                if has_tool_calls:
                     choice["finish_reason"] = "tool_calls"
         elif self.in_progress_tool_calls:
             choice = self._emit_tool_calls_choice(output)

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -355,7 +355,7 @@ class StreamingPostProcessor:
                 "role": "assistant",
                 "tool_calls": self._dump_in_progress_tool_calls(),
             },
-            "finish_reason": output.finish_reason,
+            "finish_reason": "tool_calls",
             "logprobs": output.logprobs,
         }
         self.in_progress_tool_calls.clear()
@@ -524,11 +524,14 @@ class StreamingPostProcessor:
                 delta["content"] = content
             if delta_message.reasoning:
                 delta["reasoning_content"] = delta_message.reasoning
-            if self.in_progress_tool_calls:
+            has_tool_calls = bool(self.in_progress_tool_calls)
+            if has_tool_calls:
                 delta["tool_calls"] = self._dump_in_progress_tool_calls()
                 self.in_progress_tool_calls.clear()
             if len(delta) > 1:
                 choice = self._build_choice(output, delta)
+                if has_tool_calls and choice:
+                    choice["finish_reason"] = "tool_calls"
         elif self.in_progress_tool_calls:
             choice = self._emit_tool_calls_choice(output)
         elif output.finish_reason:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1128,7 +1128,7 @@ class HandlerBase(BaseGenerativeHandler):
             if (
                 has_guided_decoding
                 and structural_tag is None
-                and enable_thinking is not None
+                and enable_thinking is True
             ):
                 # Build xgrammar content from guided decoding params
                 content = self._build_xgrammar_content(

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -121,7 +121,14 @@ class HandlerBase(BaseGenerativeHandler):
         self.additional_metrics = config.additional_metrics
         self.max_seq_len = config.max_seq_len
         # Server-level default for enable_thinking (reasoning + guided decoding)
-        self.enable_thinking_default = config.enable_thinking_default
+        # Coerce to bool — argparse returns bool but pydantic/config may stringify it
+        _etd = config.enable_thinking_default
+        if isinstance(_etd, str):
+            self.enable_thinking_default = _etd.lower() in ("true", "1", "yes")
+        elif _etd is None:
+            self.enable_thinking_default = None
+        else:
+            self.enable_thinking_default = bool(_etd)
 
     def check_error(self, result: dict) -> bool:
         """
@@ -1018,9 +1025,9 @@ class HandlerBase(BaseGenerativeHandler):
             xgrammar content dict, or None if no guided decoding is specified.
         """
         if json_schema is not None:
-            return {"type": "json_schema", "json_schema": json_schema}
+            return {"type": "json_schema", "json_schema": {"name": "guided_json", "schema": json_schema}}
         elif json_object:
-            return {"type": "json_schema", "json_schema": {"type": "object"}}
+            return {"type": "json_schema", "json_schema": {"name": "json_object", "schema": {"type": "object"}}}
         elif regex is not None:
             return {"type": "regex", "pattern": regex}
         elif grammar is not None:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -134,9 +134,11 @@ class HandlerBase(BaseGenerativeHandler):
             self.enable_thinking_default = None
         else:
             self.enable_thinking_default = bool(_etd)
-        self.prompt_injects_thinking_tag = bool(
-            getattr(config, "prompt_injects_thinking_tag", False)
-        )
+        _pitt = config.prompt_injects_thinking_tag
+        if isinstance(_pitt, str):
+            self.prompt_injects_thinking_tag = _pitt.lower() in ("true", "1", "yes")
+        else:
+            self.prompt_injects_thinking_tag = bool(_pitt)
 
     def check_error(self, result: dict) -> bool:
         """

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1082,7 +1082,9 @@ class HandlerBase(BaseGenerativeHandler):
             ],
         }
 
-    def _override_sampling_params(self, sampling_params, request: dict) -> SamplingParams:
+    def _override_sampling_params(
+        self, sampling_params, request: dict
+    ) -> SamplingParams:
         overrides = {
             key: value
             for key, value in request["sampling_options"].items()
@@ -1168,7 +1170,10 @@ class HandlerBase(BaseGenerativeHandler):
             # See tensorrt_llm/serve/openai_protocol.py lines 307-309
             if isinstance(structural_tag, dict):
                 # Check if already wrapped (user-provided full format)
-                if structural_tag.get("type") == "structural_tag" and "format" in structural_tag:
+                if (
+                    structural_tag.get("type") == "structural_tag"
+                    and "format" in structural_tag
+                ):
                     structural_tag_str = json.dumps(structural_tag)
                 else:
                     # Wrap inner format dict

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -84,11 +84,16 @@ class RequestHandlerConfig:
     disable_request_abort: bool = True
     additional_metrics: Optional["AdditionalMetricsCollector"] = None
     max_seq_len: Optional[int] = None
-    # Server-level default for enable_thinking when combining reasoning with guided decoding.
-    # - True: Default thinking-on mode (e.g., DeepSeek-R1 style)
-    # - False: Default thinking-off mode (e.g., GLM-4.7 style)
-    # - None: No auto-generation, require explicit enable_thinking in request
+    # Server-level default for thinking mode when combining reasoning with guided decoding.
+    # - True: Model generates <think>...</think> before the final answer (thinking-on)
+    # - False: Model skips the thinking phase (thinking-off)
+    # - None: No auto-generation; require explicit enable_thinking per request
     enable_thinking_default: Optional[bool] = None
+    # When True, the model's chat template already appends <think> to the end of the
+    # prompt. The structural_tag begin tag is set to "" to avoid a duplicate <think>
+    # that causes model degeneration. Applies to any model whose template injects the
+    # reasoning start tag (e.g., GLM-4.7, Qwen3).
+    prompt_injects_thinking_tag: bool = False
 
 
 class HandlerBase(BaseGenerativeHandler):
@@ -129,6 +134,9 @@ class HandlerBase(BaseGenerativeHandler):
             self.enable_thinking_default = None
         else:
             self.enable_thinking_default = bool(_etd)
+        self.prompt_injects_thinking_tag = bool(
+            getattr(config, "prompt_injects_thinking_tag", False)
+        )
 
     def check_error(self, result: dict) -> bool:
         """
@@ -1025,9 +1033,9 @@ class HandlerBase(BaseGenerativeHandler):
             xgrammar content dict, or None if no guided decoding is specified.
         """
         if json_schema is not None:
-            return {"type": "json_schema", "json_schema": {"name": "guided_json", "schema": json_schema}}
+            return {"type": "json_schema", "json_schema": json_schema}
         elif json_object:
-            return {"type": "json_schema", "json_schema": {"name": "json_object", "schema": {"type": "object"}}}
+            return {"type": "json_schema", "json_schema": {"type": "object"}}
         elif regex is not None:
             return {"type": "regex", "pattern": regex}
         elif grammar is not None:
@@ -1036,52 +1044,43 @@ class HandlerBase(BaseGenerativeHandler):
 
     @staticmethod
     def _generate_structural_tag_for_reasoning(
-        content: dict, enable_thinking: bool
+        content: dict,
+        prompt_injects_thinking_tag: bool = False,
     ) -> dict:
         """
-        Generate structural_tag for combining reasoning with guided decoding.
+        Generate a structural_tag for combining reasoning with guided decoding.
 
-        For models like GLM-4.7 that use <think>...</think> reasoning tags,
-        this creates an xgrammar structural_tag that allows free text in the
-        reasoning region while constraining the final output.
+        Creates an xgrammar structural_tag that treats the <think>...</think>
+        reasoning section as unconstrained free text and applies the guided
+        decoding constraint only to the final answer that follows </think>.
 
         Args:
             content: The xgrammar content dict (json_schema, regex, or grammar format).
-            enable_thinking: If True, generate thinking-on mode (sequence format).
-                           If False, generate thinking-off mode (triggered_tags format).
+            prompt_injects_thinking_tag: If True, the model's chat template already
+                appended <think> to the prompt. The structural_tag begin tag is set
+                to "" so xgrammar does not constrain the model to emit a duplicate
+                <think>, which would cause degenerate output. If False, xgrammar
+                constrains the model to produce <think> as the first output tokens.
 
         Returns:
-            A structural_tag dict in xgrammar format.
+            A structural_tag dict in xgrammar sequence format.
         """
-        if enable_thinking:
-            # Thinking-ON mode: Model generates <think>...</think> then JSON
-            # Format: sequence of [<think>any_text</think>, json_schema]
-            return {
-                "type": "sequence",
-                "elements": [
-                    {
-                        "type": "tag",
-                        "begin": "<think>",
-                        "content": {"type": "any_text"},
-                        "end": "</think>",
-                    },
-                    content,
-                ],
-            }
-        else:
-            # Thinking-OFF mode: Model may still emit </think> at start (from template)
-            # Trigger JSON constraint when </think> is encountered at generation start
-            return {
-                "type": "triggered_tags",
-                "triggers": ["</think>"],
-                "tags": [
-                    {
-                        "begin": "</think>",
-                        "content": content,
-                        "end": "",
-                    }
-                ],
-            }
+        # When the template already injected <think>, the model's generation starts
+        # mid-reasoning; the begin constraint must be empty to avoid a double <think>.
+        # When it did not, xgrammar must enforce <think> as the first output token.
+        begin_tag = "" if prompt_injects_thinking_tag else "<think>"
+        return {
+            "type": "sequence",
+            "elements": [
+                {
+                    "type": "tag",
+                    "begin": begin_tag,
+                    "content": {"type": "any_text"},
+                    "end": "</think>",
+                },
+                content,
+            ],
+        }
 
     def _override_sampling_params(self, sampling_params, request: dict) -> SamplingParams:
         overrides = {
@@ -1145,11 +1144,12 @@ class HandlerBase(BaseGenerativeHandler):
                     json_object=json_object,
                 )
                 if content is not None:
-                    # Generate mode-aware structural_tag for combining reasoning with
-                    # guided decoding. This allows <think>...</think> reasoning content
-                    # to be free text while constraining the final output.
+                    # Wrap the guided decoding constraint in a structural_tag that
+                    # treats <think>...</think> as unconstrained free text and applies
+                    # the constraint only to the final answer after </think>.
                     structural_tag = self._generate_structural_tag_for_reasoning(
-                        content, enable_thinking is True
+                        content,
+                        prompt_injects_thinking_tag=self.prompt_injects_thinking_tag,
                     )
                     # When using structural_tag, clear other params to avoid conflict
                     # (xgrammar uses structural_tag exclusively)
@@ -1157,9 +1157,10 @@ class HandlerBase(BaseGenerativeHandler):
                     regex = None
                     grammar = None
                     json_object = False
+                    tag_str = str(structural_tag)
                     logging.debug(
-                        f"Generated structural_tag for reasoning mode "
-                        f"(enable_thinking={enable_thinking}): {structural_tag}"
+                        "Generated structural_tag for reasoning mode: %s",
+                        tag_str[:200] + "..." if len(tag_str) > 200 else tag_str,
                     )
 
             # TRT-LLM expects structural_tag as a JSON string in ResponseFormat wrapper:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import dataclasses
+import json
 import logging
 import os
 import re
@@ -83,6 +84,11 @@ class RequestHandlerConfig:
     disable_request_abort: bool = True
     additional_metrics: Optional["AdditionalMetricsCollector"] = None
     max_seq_len: Optional[int] = None
+    # Server-level default for enable_thinking when combining reasoning with guided decoding.
+    # - True: Default thinking-on mode (e.g., DeepSeek-R1 style)
+    # - False: Default thinking-off mode (e.g., GLM-4.7 style)
+    # - None: No auto-generation, require explicit enable_thinking in request
+    enable_thinking_default: Optional[bool] = None
 
 
 class HandlerBase(BaseGenerativeHandler):
@@ -114,6 +120,8 @@ class HandlerBase(BaseGenerativeHandler):
         self.disable_request_abort = config.disable_request_abort
         self.additional_metrics = config.additional_metrics
         self.max_seq_len = config.max_seq_len
+        # Server-level default for enable_thinking (reasoning + guided decoding)
+        self.enable_thinking_default = config.enable_thinking_default
 
     def check_error(self, result: dict) -> bool:
         """
@@ -995,7 +1003,80 @@ class HandlerBase(BaseGenerativeHandler):
             await self._initiate_shutdown(e)
 
     @staticmethod
-    def _override_sampling_params(sampling_params, request: dict) -> SamplingParams:
+    def _build_xgrammar_content(
+        json_schema: Optional[dict] = None,
+        regex: Optional[str] = None,
+        grammar: Optional[str] = None,
+        json_object: bool = False,
+    ) -> Optional[dict]:
+        """
+        Build xgrammar content dict for structural_tag from guided decoding params.
+
+        See tensorrt_llm/serve/openai_protocol.py lines 260-269 for format reference.
+
+        Returns:
+            xgrammar content dict, or None if no guided decoding is specified.
+        """
+        if json_schema is not None:
+            return {"type": "json_schema", "json_schema": json_schema}
+        elif json_object:
+            return {"type": "json_schema", "json_schema": {"type": "object"}}
+        elif regex is not None:
+            return {"type": "regex", "pattern": regex}
+        elif grammar is not None:
+            return {"type": "grammar", "grammar": grammar}
+        return None
+
+    @staticmethod
+    def _generate_structural_tag_for_reasoning(
+        content: dict, enable_thinking: bool
+    ) -> dict:
+        """
+        Generate structural_tag for combining reasoning with guided decoding.
+
+        For models like GLM-4.7 that use <think>...</think> reasoning tags,
+        this creates an xgrammar structural_tag that allows free text in the
+        reasoning region while constraining the final output.
+
+        Args:
+            content: The xgrammar content dict (json_schema, regex, or grammar format).
+            enable_thinking: If True, generate thinking-on mode (sequence format).
+                           If False, generate thinking-off mode (triggered_tags format).
+
+        Returns:
+            A structural_tag dict in xgrammar format.
+        """
+        if enable_thinking:
+            # Thinking-ON mode: Model generates <think>...</think> then JSON
+            # Format: sequence of [<think>any_text</think>, json_schema]
+            return {
+                "type": "sequence",
+                "elements": [
+                    {
+                        "type": "tag",
+                        "begin": "<think>",
+                        "content": {"type": "any_text"},
+                        "end": "</think>",
+                    },
+                    content,
+                ],
+            }
+        else:
+            # Thinking-OFF mode: Model may still emit </think> at start (from template)
+            # Trigger JSON constraint when </think> is encountered at generation start
+            return {
+                "type": "triggered_tags",
+                "triggers": ["</think>"],
+                "tags": [
+                    {
+                        "begin": "</think>",
+                        "content": content,
+                        "end": "",
+                    }
+                ],
+            }
+
+    def _override_sampling_params(self, sampling_params, request: dict) -> SamplingParams:
         overrides = {
             key: value
             for key, value in request["sampling_options"].items()
@@ -1017,12 +1098,83 @@ class HandlerBase(BaseGenerativeHandler):
                 if valid_choices:
                     regex = "(" + "|".join(re.escape(c) for c in valid_choices) + ")"
 
+            # Mode-aware structural_tag generation for reasoning + guided decoding.
+            # Generate structural_tag for ALL guided decoding types (json, regex, grammar, json_object)
+            # when enable_thinking is set, to allow <think>...</think> before constrained output.
+            #
+            # Priority: request enable_thinking > server enable_thinking_default
+            # If neither is set, use normal guided decoding (no structural_tag wrapping).
+            structural_tag = guided_decoding.get("structural_tag")
+            json_schema = guided_decoding.get("json")
+            grammar = guided_decoding.get("grammar")
+            json_object = guided_decoding.get("json_object", False)
+            enable_thinking = guided_decoding.get("enable_thinking")
+
+            # Fall back to server-level default if request didn't specify
+            if enable_thinking is None:
+                enable_thinking = self.enable_thinking_default
+
+            # Generate structural_tag if:
+            # 1. Any guided decoding is specified (json, regex, grammar, json_object)
+            # 2. structural_tag is NOT already provided (user didn't override)
+            # 3. enable_thinking is set (from request or server default)
+            has_guided_decoding = (
+                json_schema is not None
+                or regex is not None
+                or grammar is not None
+                or json_object
+            )
+
+            if (
+                has_guided_decoding
+                and structural_tag is None
+                and enable_thinking is not None
+            ):
+                # Build xgrammar content from guided decoding params
+                content = self._build_xgrammar_content(
+                    json_schema=json_schema,
+                    regex=regex,
+                    grammar=grammar,
+                    json_object=json_object,
+                )
+                if content is not None:
+                    # Generate mode-aware structural_tag for combining reasoning with
+                    # guided decoding. This allows <think>...</think> reasoning content
+                    # to be free text while constraining the final output.
+                    structural_tag = self._generate_structural_tag_for_reasoning(
+                        content, enable_thinking is True
+                    )
+                    # When using structural_tag, clear other params to avoid conflict
+                    # (xgrammar uses structural_tag exclusively)
+                    json_schema = None
+                    regex = None
+                    grammar = None
+                    json_object = False
+                    logging.debug(
+                        f"Generated structural_tag for reasoning mode "
+                        f"(enable_thinking={enable_thinking}): {structural_tag}"
+                    )
+
+            # TRT-LLM expects structural_tag as a JSON string in ResponseFormat wrapper:
+            # {"type": "structural_tag", "format": {...}}
+            # See tensorrt_llm/serve/openai_protocol.py lines 307-309
+            if isinstance(structural_tag, dict):
+                # Check if already wrapped (user-provided full format)
+                if structural_tag.get("type") == "structural_tag" and "format" in structural_tag:
+                    structural_tag_str = json.dumps(structural_tag)
+                else:
+                    # Wrap inner format dict
+                    wrapped = {"type": "structural_tag", "format": structural_tag}
+                    structural_tag_str = json.dumps(wrapped)
+            else:
+                # Already a string (user-provided JSON or None)
+                structural_tag_str = structural_tag
             overrides["guided_decoding"] = GuidedDecodingParams(
-                json=guided_decoding.get("json"),
+                json=json_schema,
                 regex=regex,
-                grammar=guided_decoding.get("grammar"),
-                json_object=guided_decoding.get("json_object", False),
-                structural_tag=guided_decoding.get("structural_tag"),
+                grammar=grammar,
+                json_object=json_object,
+                structural_tag=structural_tag_str,
             )
 
         # NOTE: using `dataclasses.replace` has several benefits over a `setattr` based approach:

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -78,7 +78,9 @@ class TestOverrideSamplingParams:
             }
         }
 
-        result = self._make_handler()._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(
+            sampling_params, request
+        )
 
         assert result.temperature == 0
         assert result.top_k == 0
@@ -97,7 +99,9 @@ class TestOverrideSamplingParams:
             }
         }
 
-        result = self._make_handler()._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(
+            sampling_params, request
+        )
 
         assert result.temperature == original_temperature
         assert result.top_p == original_top_p
@@ -114,7 +118,9 @@ class TestOverrideSamplingParams:
             }
         }
 
-        result = self._make_handler()._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(
+            sampling_params, request
+        )
 
         assert result.temperature == 0.7
         assert result.top_p == 0.9
@@ -150,7 +156,9 @@ class TestOverrideSamplingParams:
             }
         }
 
-        result = self._make_handler()._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(
+            sampling_params, request
+        )
 
         assert result.temperature == 0
         assert result.top_p == original_top_p  # Unchanged
@@ -237,7 +245,9 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = self._make_handler()._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(
+            sampling_params, request
+        )
 
         assert not isinstance(
             result.guided_decoding, dict
@@ -262,7 +272,9 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = self._make_handler()._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(
+            sampling_params, request
+        )
 
         assert not isinstance(result.guided_decoding, dict)
         assert result.guided_decoding.regex == "(yes|no|maybe)"
@@ -279,7 +291,9 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = self._make_handler()._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(
+            sampling_params, request
+        )
 
         assert not isinstance(result.guided_decoding, dict)
         expected = (
@@ -301,7 +315,9 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = self._make_handler()._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(
+            sampling_params, request
+        )
 
         assert result.guided_decoding.regex == "[0-9]+"
 
@@ -316,7 +332,9 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = self._make_handler()._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(
+            sampling_params, request
+        )
 
         assert result.guided_decoding.regex is None
 
@@ -331,7 +349,9 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = self._make_handler()._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(
+            sampling_params, request
+        )
 
         assert not isinstance(result.guided_decoding, dict)
         assert result.guided_decoding.regex == "(yes|no)"
@@ -347,7 +367,9 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = self._make_handler()._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(
+            sampling_params, request
+        )
 
         assert result.guided_decoding.regex is None
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -52,6 +52,17 @@ class TestOverrideSamplingParams:
     ensures that falsy values like 0, False, and "" are correctly applied.
     """
 
+    def _make_handler(
+        self,
+        enable_thinking_default=None,
+        prompt_injects_thinking_tag=False,
+    ) -> HandlerBase:
+        """Create a _ConcreteHandler instance for testing _override_sampling_params."""
+        config = MagicMock()
+        config.enable_thinking_default = enable_thinking_default
+        config.prompt_injects_thinking_tag = prompt_injects_thinking_tag
+        return _ConcreteHandler(config)
+
     def test_falsy_values_are_applied(self):
         """Test that falsy values (0, False) are correctly set.
 
@@ -67,7 +78,7 @@ class TestOverrideSamplingParams:
             }
         }
 
-        result = HandlerBase._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(sampling_params, request)
 
         assert result.temperature == 0
         assert result.top_k == 0
@@ -86,7 +97,7 @@ class TestOverrideSamplingParams:
             }
         }
 
-        result = HandlerBase._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(sampling_params, request)
 
         assert result.temperature == original_temperature
         assert result.top_p == original_top_p
@@ -103,7 +114,7 @@ class TestOverrideSamplingParams:
             }
         }
 
-        result = HandlerBase._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(sampling_params, request)
 
         assert result.temperature == 0.7
         assert result.top_p == 0.9
@@ -123,7 +134,7 @@ class TestOverrideSamplingParams:
         }
 
         with pytest.raises(TypeError):
-            HandlerBase._override_sampling_params(sampling_params, request)
+            self._make_handler()._override_sampling_params(sampling_params, request)
 
     def test_mixed_values(self):
         """Test a mix of None, falsy, and truthy values."""
@@ -139,7 +150,7 @@ class TestOverrideSamplingParams:
             }
         }
 
-        result = HandlerBase._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(sampling_params, request)
 
         assert result.temperature == 0
         assert result.top_p == original_top_p  # Unchanged
@@ -151,7 +162,7 @@ class TestOverrideSamplingParams:
         request = {"sampling_options": {"non_existent_param": 123}}
 
         with pytest.raises(TypeError, match="unexpected keyword argument"):
-            _ = HandlerBase._override_sampling_params(sampling_params, request)
+            _ = self._make_handler()._override_sampling_params(sampling_params, request)
 
     def test_post_init_called_when_overriding(self):
         # This allows us to check that potential validation logic in `__post_init__` is run when
@@ -160,7 +171,7 @@ class TestOverrideSamplingParams:
         request = {"sampling_options": {"temperature": 0.5}}
 
         with mock.patch.object(MockSamplingParams, "__post_init__") as mock_post_init:
-            HandlerBase._override_sampling_params(sampling_params, request)
+            self._make_handler()._override_sampling_params(sampling_params, request)
 
         mock_post_init.assert_called_once()
 
@@ -173,6 +184,17 @@ class TestGuidedDecodingFromToolChoice:
     object before passing to TRT-LLM, which expects attribute access
     (e.g. .json_object, .json) on the guided_decoding field.
     """
+
+    def _make_handler(
+        self,
+        enable_thinking_default=None,
+        prompt_injects_thinking_tag=False,
+    ) -> HandlerBase:
+        """Create a _ConcreteHandler instance for testing _override_sampling_params."""
+        config = MagicMock()
+        config.enable_thinking_default = enable_thinking_default
+        config.prompt_injects_thinking_tag = prompt_injects_thinking_tag
+        return _ConcreteHandler(config)
 
     # Matches what the Rust frontend serializes when
     # tool_choice="required" with a single tool definition.
@@ -215,7 +237,7 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = HandlerBase._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(sampling_params, request)
 
         assert not isinstance(
             result.guided_decoding, dict
@@ -240,7 +262,7 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = HandlerBase._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(sampling_params, request)
 
         assert not isinstance(result.guided_decoding, dict)
         assert result.guided_decoding.regex == "(yes|no|maybe)"
@@ -257,7 +279,7 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = HandlerBase._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(sampling_params, request)
 
         assert not isinstance(result.guided_decoding, dict)
         expected = (
@@ -279,7 +301,7 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = HandlerBase._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(sampling_params, request)
 
         assert result.guided_decoding.regex == "[0-9]+"
 
@@ -294,7 +316,7 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = HandlerBase._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(sampling_params, request)
 
         assert result.guided_decoding.regex is None
 
@@ -309,7 +331,7 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = HandlerBase._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(sampling_params, request)
 
         assert not isinstance(result.guided_decoding, dict)
         assert result.guided_decoding.regex == "(yes|no)"
@@ -325,7 +347,7 @@ class TestGuidedDecodingFromToolChoice:
             }
         }
 
-        result = HandlerBase._override_sampling_params(sampling_params, request)
+        result = self._make_handler()._override_sampling_params(sampling_params, request)
 
         assert result.guided_decoding.regex is None
 

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -480,6 +480,7 @@ async def init_llm_worker(
             additional_metrics=additional_metrics,
             max_seq_len=config.max_seq_len,
             enable_thinking_default=config.dyn_enable_thinking_default,
+            prompt_injects_thinking_tag=config.dyn_prompt_injects_thinking_tag,
         )
 
         # Register the model with runtime config

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -479,6 +479,7 @@ async def init_llm_worker(
             disable_request_abort=config.disable_request_abort,
             additional_metrics=additional_metrics,
             max_seq_len=config.max_seq_len,
+            enable_thinking_default=config.dyn_enable_thinking_default,
         )
 
         # Register the model with runtime config

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1698,12 +1698,7 @@ mod tests {
                 false,
                 "glm45 + enable_thinking=true → enabled",
             ),
-            (
-                Some("glm45"),
-                None,
-                false,
-                "glm45 + no args → enabled",
-            ),
+            (Some("glm45"), None, false, "glm45 + no args → enabled"),
             (
                 Some("glm45"),
                 Some(&empty_args),

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -706,11 +706,19 @@ impl OpenAIPreprocessor {
         S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
     {
         // Try to parse reasoning content only if parser is configured
-        let should_parse_reasoning = self.runtime_config.reasoning_parser.is_some()
-            && !Self::is_reasoning_disabled_by_request(
-                self.runtime_config.reasoning_parser.as_deref(),
-                request.chat_template_args.as_ref(),
-            );
+        let is_disabled = Self::is_reasoning_disabled_by_request(
+            self.runtime_config.reasoning_parser.as_deref(),
+            request.chat_template_args.as_ref(),
+        );
+        let should_parse_reasoning = self.runtime_config.reasoning_parser.is_some() && !is_disabled;
+
+        tracing::debug!(
+            reasoning_parser = ?self.runtime_config.reasoning_parser,
+            chat_template_args = ?request.chat_template_args,
+            is_disabled_by_request = is_disabled,
+            should_parse_reasoning = should_parse_reasoning,
+            "Reasoning parser decision for postprocessing"
+        );
 
         // Reasoning Content Parsing Transformation Step
         // Current Solution:
@@ -1198,6 +1206,14 @@ impl OpenAIPreprocessor {
                 }
                 false
             }
+            Some("glm45") => {
+                if let Some(args) = chat_template_args
+                    && let Some(enable_thinking) = args.get("enable_thinking")
+                {
+                    return enable_thinking == &serde_json::Value::Bool(false);
+                }
+                false
+            }
             _ => false,
         }
     }
@@ -1249,11 +1265,21 @@ impl OpenAIPreprocessor {
                                 let parser_result =
                                     parser.parse_reasoning_streaming_incremental(text, &[]);
 
+                                let parsed_content = parser_result.get_some_normal_text();
+                                let parsed_reasoning = parser_result.get_some_reasoning();
+                                tracing::debug!(
+                                    has_content = parsed_content.is_some(),
+                                    content_preview = ?parsed_content.as_deref().map(|s| &s[..s.len().min(100)]),
+                                    has_reasoning = parsed_reasoning.is_some(),
+                                    reasoning_preview = ?parsed_reasoning.as_deref().map(|s| &s[..s.len().min(100)]),
+                                    "Reasoning parser output (after parsing)"
+                                );
+
                                 // Update this specific choice with parsed content
-                                choice.delta.content = parser_result.get_some_normal_text().map(
+                                choice.delta.content = parsed_content.map(
                                     dynamo_protocols::types::ChatCompletionMessageContent::Text,
                                 );
-                                choice.delta.reasoning_content = parser_result.get_some_reasoning();
+                                choice.delta.reasoning_content = parsed_reasoning;
                             }
                             // For multimodal content, pass through unchanged
                         }
@@ -1658,6 +1684,31 @@ mod tests {
                 Some(&empty_args),
                 false,
                 "deepseek_r1 + empty args → enabled",
+            ),
+            // glm45 uses "enable_thinking" key
+            (
+                Some("glm45"),
+                Some(&enable_thinking_false),
+                true,
+                "glm45 + enable_thinking=false → disabled",
+            ),
+            (
+                Some("glm45"),
+                Some(&enable_thinking_true),
+                false,
+                "glm45 + enable_thinking=true → enabled",
+            ),
+            (
+                Some("glm45"),
+                None,
+                false,
+                "glm45 + no args → enabled",
+            ),
+            (
+                Some("glm45"),
+                Some(&empty_args),
+                false,
+                "glm45 + empty args → enabled",
             ),
             (
                 Some("basic"),

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1267,11 +1267,17 @@ impl OpenAIPreprocessor {
 
                                 let parsed_content = parser_result.get_some_normal_text();
                                 let parsed_reasoning = parser_result.get_some_reasoning();
+                                let content_preview = parsed_content
+                                    .as_deref()
+                                    .map(|s| s.chars().take(100).collect::<String>());
+                                let reasoning_preview = parsed_reasoning
+                                    .as_deref()
+                                    .map(|s| s.chars().take(100).collect::<String>());
                                 tracing::debug!(
                                     has_content = parsed_content.is_some(),
-                                    content_preview = ?parsed_content.as_deref().map(|s| &s[..s.len().min(100)]),
+                                    content_preview = ?content_preview,
                                     has_reasoning = parsed_reasoning.is_some(),
-                                    reasoning_preview = ?parsed_reasoning.as_deref().map(|s| &s[..s.len().min(100)]),
+                                    reasoning_preview = ?reasoning_preview,
                                     "Reasoning parser output (after parsing)"
                                 );
 

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -486,11 +486,12 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
         let rendered = tmpl.render(&ctx)?;
 
         // Debug: log rendered prompt (last 500 chars to see generation prompt + thinking tags)
-        let prompt_tail = if rendered.len() > 500 {
-            &rendered[rendered.len() - 500..]
-        } else {
-            &rendered
-        };
+        let tail_start = rendered
+            .char_indices()
+            .rev()
+            .nth(499)
+            .map_or(0, |(i, _)| i);
+        let prompt_tail = &rendered[tail_start..];
         tracing::debug!(
             chat_template_args = ?req.chat_template_args(),
             prompt_tail = %prompt_tail,

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -486,11 +486,7 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
         let rendered = tmpl.render(&ctx)?;
 
         // Debug: log rendered prompt (last 500 chars to see generation prompt + thinking tags)
-        let tail_start = rendered
-            .char_indices()
-            .rev()
-            .nth(499)
-            .map_or(0, |(i, _)| i);
+        let tail_start = rendered.char_indices().rev().nth(499).map_or(0, |(i, _)| i);
         let prompt_tail = &rendered[tail_start..];
         tracing::debug!(
             chat_template_args = ?req.chat_template_args(),

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -483,7 +483,22 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
         } else {
             self.env.get_template("default")?
         };
-        Ok(tmpl.render(&ctx)?)
+        let rendered = tmpl.render(&ctx)?;
+
+        // Debug: log rendered prompt (last 500 chars to see generation prompt + thinking tags)
+        let prompt_tail = if rendered.len() > 500 {
+            &rendered[rendered.len() - 500..]
+        } else {
+            &rendered
+        };
+        tracing::debug!(
+            chat_template_args = ?req.chat_template_args(),
+            prompt_tail = %prompt_tail,
+            prompt_len = rendered.len(),
+            "Chat template rendered (showing last 500 chars)"
+        );
+
+        Ok(rendered)
     }
 }
 

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -975,7 +975,7 @@ mod tests {
     #[test]
     fn test_guided_grammar_deep_nesting_rejected() {
         let grammar = "(".repeat(501) + "a" + &")".repeat(501);
-        let result = GuidedDecodingOptions::validated(None, None, None, Some(grammar), None, None);
+        let result = GuidedDecodingOptions::validated(None, None, None, Some(grammar), None, None, None, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("nesting depth"));
     }
@@ -983,7 +983,7 @@ mod tests {
     #[test]
     fn test_guided_grammar_acceptable_nesting_ok() {
         let grammar = "(".repeat(500) + "a" + &")".repeat(500);
-        let result = GuidedDecodingOptions::validated(None, None, None, Some(grammar), None, None);
+        let result = GuidedDecodingOptions::validated(None, None, None, Some(grammar), None, None, None, None);
         assert!(result.is_ok());
     }
 }

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -341,7 +341,7 @@ pub struct SamplingOptions {
 
 /// Guided Decoding Options
 ///
-/// Only one of `json`, `regex`, `choice`, or `grammar` should be set.
+/// Only one of `json`, `regex`, `choice`, `grammar`, or `structural_tag` should be set.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct GuidedDecodingOptions {
     /// If specified, the output will follow the JSON schema. Can be a string, an object, or null.
@@ -367,6 +367,22 @@ pub struct GuidedDecodingOptions {
     /// If specified, whitespace pattern to use for guided decoding. Can be a string or null.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub whitespace_pattern: Option<String>,
+
+    /// If specified, structural tag format for mixed free-text and constrained regions.
+    /// Used for combining reasoning (free text) with structured output (JSON schema).
+    /// Format: {"type": "sequence", "elements": [...]} or {"type": "triggered_tags", ...}
+    /// Supported by xgrammar backend only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub structural_tag: Option<serde_json::Value>,
+
+    /// Hint for backend to enable mode-aware structural_tag generation.
+    /// When true AND guided_json is set but structural_tag is not, the backend should
+    /// generate structural_tag that allows <think>...</think> free text before JSON.
+    /// When false/None, the backend should generate structural_tag that triggers JSON
+    /// constraint immediately after </think> (for thinking-off mode).
+    /// This is used to combine reasoning parsing with guided decoding.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_thinking: Option<bool>,
 }
 
 impl GuidedDecodingOptions {
@@ -378,6 +394,8 @@ impl GuidedDecodingOptions {
         grammar: Option<String>,
         backend: Option<String>,
         whitespace_pattern: Option<String>,
+        structural_tag: Option<serde_json::Value>,
+        enable_thinking: Option<bool>,
     ) -> Self {
         Self {
             json,
@@ -386,6 +404,8 @@ impl GuidedDecodingOptions {
             grammar,
             backend,
             whitespace_pattern,
+            structural_tag,
+            enable_thinking,
         }
     }
 
@@ -397,8 +417,10 @@ impl GuidedDecodingOptions {
         grammar: Option<String>,
         backend: Option<String>,
         whitespace_pattern: Option<String>,
+        structural_tag: Option<serde_json::Value>,
+        enable_thinking: Option<bool>,
     ) -> Result<Self> {
-        let instance = Self::new(json, regex, choice, grammar, backend, whitespace_pattern);
+        let instance = Self::new(json, regex, choice, grammar, backend, whitespace_pattern, structural_tag, enable_thinking);
         instance.validate()?;
         Ok(instance)
     }
@@ -411,6 +433,8 @@ impl GuidedDecodingOptions {
         grammar: Option<String>,
         backend: Option<String>,
         whitespace_pattern: Option<String>,
+        structural_tag: Option<serde_json::Value>,
+        enable_thinking: Option<bool>,
     ) -> Result<Option<Self>> {
         let is_empty_choice = choice.as_ref().is_none_or(|v| v.is_empty());
         if json.is_none()
@@ -418,10 +442,11 @@ impl GuidedDecodingOptions {
             && is_empty_choice
             && grammar.is_none()
             && whitespace_pattern.is_none()
+            && structural_tag.is_none()
         {
             return Ok(None);
         }
-        let instance = Self::validated(json, regex, choice, grammar, backend, whitespace_pattern)?;
+        let instance = Self::validated(json, regex, choice, grammar, backend, whitespace_pattern, structural_tag, enable_thinking)?;
         Ok(Some(instance))
     }
 
@@ -434,6 +459,7 @@ impl GuidedDecodingOptions {
             self.choice.as_ref().is_some_and(|v| !v.is_empty()),
             self.grammar.is_some(),
             self.whitespace_pattern.is_some(),
+            self.structural_tag.is_some(),
         ]
         .iter()
         .filter(|&&v| v)
@@ -441,7 +467,7 @@ impl GuidedDecodingOptions {
 
         if count > 1 {
             return Err(anyhow::anyhow!(
-                "Only one of json, regex, choice, or grammar can be set, but multiple are specified: {:?}",
+                "Only one of json, regex, choice, grammar, or structural_tag can be set, but multiple are specified: {:?}",
                 self
             ));
         }
@@ -732,6 +758,7 @@ mod tests {
             None,
             backend.clone(),
             None,
+            None,
         );
         assert!(opts.is_ok());
         let opts = opts.unwrap();
@@ -741,10 +768,11 @@ mod tests {
         assert!(opts.grammar.is_none());
         assert_eq!(opts.backend, backend);
         assert!(opts.whitespace_pattern.is_none());
+        assert!(opts.structural_tag.is_none());
 
         // Only regex set
         let regex = Some(r"\d+".to_string());
-        let opts = GuidedDecodingOptions::validated(None, regex.clone(), None, None, None, None);
+        let opts = GuidedDecodingOptions::validated(None, regex.clone(), None, None, None, None, None);
         assert!(opts.is_ok());
         let opts = opts.unwrap();
         assert_eq!(opts.regex, regex);
@@ -755,7 +783,7 @@ mod tests {
 
         // Only choice set
         let choice = Some(vec!["A".to_string(), "B".to_string()]);
-        let opts = GuidedDecodingOptions::validated(None, None, choice.clone(), None, None, None);
+        let opts = GuidedDecodingOptions::validated(None, None, choice.clone(), None, None, None, None);
         assert!(opts.is_ok());
         let opts = opts.unwrap();
         assert_eq!(opts.choice, choice);
@@ -766,7 +794,7 @@ mod tests {
 
         // Only grammar set
         let grammar = Some("root ::= 'yes' | 'no'".to_string());
-        let opts = GuidedDecodingOptions::validated(None, None, None, grammar.clone(), None, None);
+        let opts = GuidedDecodingOptions::validated(None, None, None, grammar.clone(), None, None, None);
         assert!(opts.is_ok());
         let opts = opts.unwrap();
         assert_eq!(opts.grammar, grammar);
@@ -784,6 +812,7 @@ mod tests {
             None,
             None,
             whitespace_pattern.clone(),
+            None,
         );
         assert!(opts.is_ok());
         let opts = opts.unwrap();
@@ -793,10 +822,31 @@ mod tests {
         assert!(opts.choice.is_none());
         assert!(opts.grammar.is_none());
 
+        // Only structural_tag set
+        let structural_tag = Some(serde_json::json!({"type": "sequence", "elements": []}));
+        let opts = GuidedDecodingOptions::validated(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            structural_tag.clone(),
+        );
+        assert!(opts.is_ok());
+        let opts = opts.unwrap();
+        assert_eq!(opts.structural_tag, structural_tag);
+        assert!(opts.json.is_none());
+        assert!(opts.regex.is_none());
+        assert!(opts.choice.is_none());
+        assert!(opts.grammar.is_none());
+        assert!(opts.whitespace_pattern.is_none());
+
         // Multiple fields set (should error)
         let opts = GuidedDecodingOptions::validated(
             Some(serde_json::json!({})),
             Some(r"\d+".to_string()),
+            None,
             None,
             None,
             None,
@@ -808,6 +858,7 @@ mod tests {
             None,
             Some(r"\d+".to_string()),
             Some(vec!["A".to_string()]),
+            None,
             None,
             None,
             None,
@@ -821,25 +872,38 @@ mod tests {
             Some("root ::= 'yes'".to_string()),
             None,
             None,
+            None,
+        );
+        assert!(opts.is_err());
+
+        // structural_tag with json (should error)
+        let opts = GuidedDecodingOptions::validated(
+            Some(serde_json::json!({})),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(serde_json::json!({"type": "sequence"})),
         );
         assert!(opts.is_err());
 
         // All fields None (should be ok, but not useful)
-        let opts = GuidedDecodingOptions::validated(None, None, None, None, None, None);
+        let opts = GuidedDecodingOptions::validated(None, None, None, None, None, None, None);
         assert!(opts.is_ok());
     }
 
     #[test]
     fn test_guided_decoding_options_from_optional() {
         // All None returns Ok(None)
-        let opts = GuidedDecodingOptions::from_optional(None, None, None, None, None, None);
+        let opts = GuidedDecodingOptions::from_optional(None, None, None, None, None, None, None);
         assert!(opts.is_ok());
         assert!(opts.unwrap().is_none());
 
         // Only one set returns Ok(Some)
         let regex = Some(r"\w+".to_string());
         let opts =
-            GuidedDecodingOptions::from_optional(None, regex.clone(), None, None, None, None);
+            GuidedDecodingOptions::from_optional(None, regex.clone(), None, None, None, None, None);
         assert!(opts.is_ok());
         let val = opts.unwrap();
         assert!(val.is_some());
@@ -854,11 +918,12 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(opts.is_err());
 
         // Choice set but empty vector should not count as set
-        let opts = GuidedDecodingOptions::from_optional(None, None, Some(vec![]), None, None, None);
+        let opts = GuidedDecodingOptions::from_optional(None, None, Some(vec![]), None, None, None, None);
         assert!(opts.is_ok());
         let val = opts.unwrap();
         assert!(val.is_none());
@@ -871,12 +936,30 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(opts.is_ok());
         let val = opts.unwrap();
         assert!(val.is_some());
         let val = val.unwrap();
         assert_eq!(val.choice, Some(vec!["A".to_string()]));
+
+        // structural_tag set returns Ok(Some)
+        let structural_tag = Some(serde_json::json!({"type": "triggered_tags", "triggers": ["</think>"]}));
+        let opts = GuidedDecodingOptions::from_optional(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            structural_tag.clone(),
+        );
+        assert!(opts.is_ok());
+        let val = opts.unwrap();
+        assert!(val.is_some());
+        let val = val.unwrap();
+        assert_eq!(val.structural_tag, structural_tag);
     }
 
     #[test]

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -387,6 +387,7 @@ pub struct GuidedDecodingOptions {
 
 impl GuidedDecodingOptions {
     /// Construct without validation
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         json: Option<serde_json::Value>,
         regex: Option<String>,
@@ -410,6 +411,7 @@ impl GuidedDecodingOptions {
     }
 
     /// Construct and validate (fallible)
+    #[allow(clippy::too_many_arguments)]
     pub fn validated(
         json: Option<serde_json::Value>,
         regex: Option<String>,
@@ -426,6 +428,7 @@ impl GuidedDecodingOptions {
     }
 
     /// Construct only if one field is Some (fallible)
+    #[allow(clippy::too_many_arguments)]
     pub fn from_optional(
         json: Option<serde_json::Value>,
         regex: Option<String>,
@@ -931,7 +934,16 @@ mod tests {
         assert!(opts.is_err());
 
         // Choice set but empty vector should not count as set
-        let opts = GuidedDecodingOptions::from_optional(None, None, Some(vec![]), None, None, None, None, None);
+        let opts = GuidedDecodingOptions::from_optional(
+            None,
+            None,
+            Some(vec![]),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(opts.is_ok());
         let val = opts.unwrap();
         assert!(val.is_none());
@@ -954,7 +966,8 @@ mod tests {
         assert_eq!(val.choice, Some(vec!["A".to_string()]));
 
         // structural_tag set returns Ok(Some)
-        let structural_tag = Some(serde_json::json!({"type": "triggered_tags", "triggers": ["</think>"]}));
+        let structural_tag =
+            Some(serde_json::json!({"type": "triggered_tags", "triggers": ["</think>"]}));
         let opts = GuidedDecodingOptions::from_optional(
             None,
             None,
@@ -975,7 +988,16 @@ mod tests {
     #[test]
     fn test_guided_grammar_deep_nesting_rejected() {
         let grammar = "(".repeat(501) + "a" + &")".repeat(501);
-        let result = GuidedDecodingOptions::validated(None, None, None, Some(grammar), None, None, None, None);
+        let result = GuidedDecodingOptions::validated(
+            None,
+            None,
+            None,
+            Some(grammar),
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("nesting depth"));
     }
@@ -983,7 +1005,16 @@ mod tests {
     #[test]
     fn test_guided_grammar_acceptable_nesting_ok() {
         let grammar = "(".repeat(500) + "a" + &")".repeat(500);
-        let result = GuidedDecodingOptions::validated(None, None, None, Some(grammar), None, None, None, None);
+        let result = GuidedDecodingOptions::validated(
+            None,
+            None,
+            None,
+            Some(grammar),
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(result.is_ok());
     }
 }

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -759,6 +759,7 @@ mod tests {
             backend.clone(),
             None,
             None,
+            None,
         );
         assert!(opts.is_ok());
         let opts = opts.unwrap();
@@ -772,7 +773,7 @@ mod tests {
 
         // Only regex set
         let regex = Some(r"\d+".to_string());
-        let opts = GuidedDecodingOptions::validated(None, regex.clone(), None, None, None, None, None);
+        let opts = GuidedDecodingOptions::validated(None, regex.clone(), None, None, None, None, None, None);
         assert!(opts.is_ok());
         let opts = opts.unwrap();
         assert_eq!(opts.regex, regex);
@@ -783,7 +784,7 @@ mod tests {
 
         // Only choice set
         let choice = Some(vec!["A".to_string(), "B".to_string()]);
-        let opts = GuidedDecodingOptions::validated(None, None, choice.clone(), None, None, None, None);
+        let opts = GuidedDecodingOptions::validated(None, None, choice.clone(), None, None, None, None, None);
         assert!(opts.is_ok());
         let opts = opts.unwrap();
         assert_eq!(opts.choice, choice);
@@ -794,7 +795,7 @@ mod tests {
 
         // Only grammar set
         let grammar = Some("root ::= 'yes' | 'no'".to_string());
-        let opts = GuidedDecodingOptions::validated(None, None, None, grammar.clone(), None, None, None);
+        let opts = GuidedDecodingOptions::validated(None, None, None, grammar.clone(), None, None, None, None);
         assert!(opts.is_ok());
         let opts = opts.unwrap();
         assert_eq!(opts.grammar, grammar);
@@ -812,6 +813,7 @@ mod tests {
             None,
             None,
             whitespace_pattern.clone(),
+            None,
             None,
         );
         assert!(opts.is_ok());
@@ -832,6 +834,7 @@ mod tests {
             None,
             None,
             structural_tag.clone(),
+            None,
         );
         assert!(opts.is_ok());
         let opts = opts.unwrap();
@@ -851,6 +854,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(opts.is_err());
 
@@ -858,6 +862,7 @@ mod tests {
             None,
             Some(r"\d+".to_string()),
             Some(vec!["A".to_string()]),
+            None,
             None,
             None,
             None,
@@ -873,6 +878,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(opts.is_err());
 
@@ -885,25 +891,26 @@ mod tests {
             None,
             None,
             Some(serde_json::json!({"type": "sequence"})),
+            None,
         );
         assert!(opts.is_err());
 
         // All fields None (should be ok, but not useful)
-        let opts = GuidedDecodingOptions::validated(None, None, None, None, None, None, None);
+        let opts = GuidedDecodingOptions::validated(None, None, None, None, None, None, None, None);
         assert!(opts.is_ok());
     }
 
     #[test]
     fn test_guided_decoding_options_from_optional() {
         // All None returns Ok(None)
-        let opts = GuidedDecodingOptions::from_optional(None, None, None, None, None, None, None);
+        let opts = GuidedDecodingOptions::from_optional(None, None, None, None, None, None, None, None);
         assert!(opts.is_ok());
         assert!(opts.unwrap().is_none());
 
         // Only one set returns Ok(Some)
         let regex = Some(r"\w+".to_string());
         let opts =
-            GuidedDecodingOptions::from_optional(None, regex.clone(), None, None, None, None, None);
+            GuidedDecodingOptions::from_optional(None, regex.clone(), None, None, None, None, None, None);
         assert!(opts.is_ok());
         let val = opts.unwrap();
         assert!(val.is_some());
@@ -919,11 +926,12 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(opts.is_err());
 
         // Choice set but empty vector should not count as set
-        let opts = GuidedDecodingOptions::from_optional(None, None, Some(vec![]), None, None, None, None);
+        let opts = GuidedDecodingOptions::from_optional(None, None, Some(vec![]), None, None, None, None, None);
         assert!(opts.is_ok());
         let val = opts.unwrap();
         assert!(val.is_none());
@@ -933,6 +941,7 @@ mod tests {
             None,
             None,
             Some(vec!["A".to_string()]),
+            None,
             None,
             None,
             None,
@@ -954,6 +963,7 @@ mod tests {
             None,
             None,
             structural_tag.clone(),
+            None,
         );
         assert!(opts.is_ok());
         let val = opts.unwrap();

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -422,7 +422,16 @@ impl GuidedDecodingOptions {
         structural_tag: Option<serde_json::Value>,
         enable_thinking: Option<bool>,
     ) -> Result<Self> {
-        let instance = Self::new(json, regex, choice, grammar, backend, whitespace_pattern, structural_tag, enable_thinking);
+        let instance = Self::new(
+            json,
+            regex,
+            choice,
+            grammar,
+            backend,
+            whitespace_pattern,
+            structural_tag,
+            enable_thinking,
+        );
         instance.validate()?;
         Ok(instance)
     }
@@ -449,7 +458,16 @@ impl GuidedDecodingOptions {
         {
             return Ok(None);
         }
-        let instance = Self::validated(json, regex, choice, grammar, backend, whitespace_pattern, structural_tag, enable_thinking)?;
+        let instance = Self::validated(
+            json,
+            regex,
+            choice,
+            grammar,
+            backend,
+            whitespace_pattern,
+            structural_tag,
+            enable_thinking,
+        )?;
         Ok(Some(instance))
     }
 
@@ -776,7 +794,16 @@ mod tests {
 
         // Only regex set
         let regex = Some(r"\d+".to_string());
-        let opts = GuidedDecodingOptions::validated(None, regex.clone(), None, None, None, None, None, None);
+        let opts = GuidedDecodingOptions::validated(
+            None,
+            regex.clone(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(opts.is_ok());
         let opts = opts.unwrap();
         assert_eq!(opts.regex, regex);
@@ -787,7 +814,16 @@ mod tests {
 
         // Only choice set
         let choice = Some(vec!["A".to_string(), "B".to_string()]);
-        let opts = GuidedDecodingOptions::validated(None, None, choice.clone(), None, None, None, None, None);
+        let opts = GuidedDecodingOptions::validated(
+            None,
+            None,
+            choice.clone(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(opts.is_ok());
         let opts = opts.unwrap();
         assert_eq!(opts.choice, choice);
@@ -798,7 +834,16 @@ mod tests {
 
         // Only grammar set
         let grammar = Some("root ::= 'yes' | 'no'".to_string());
-        let opts = GuidedDecodingOptions::validated(None, None, None, grammar.clone(), None, None, None, None);
+        let opts = GuidedDecodingOptions::validated(
+            None,
+            None,
+            None,
+            grammar.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(opts.is_ok());
         let opts = opts.unwrap();
         assert_eq!(opts.grammar, grammar);
@@ -906,14 +951,23 @@ mod tests {
     #[test]
     fn test_guided_decoding_options_from_optional() {
         // All None returns Ok(None)
-        let opts = GuidedDecodingOptions::from_optional(None, None, None, None, None, None, None, None);
+        let opts =
+            GuidedDecodingOptions::from_optional(None, None, None, None, None, None, None, None);
         assert!(opts.is_ok());
         assert!(opts.unwrap().is_none());
 
         // Only one set returns Ok(Some)
         let regex = Some(r"\w+".to_string());
-        let opts =
-            GuidedDecodingOptions::from_optional(None, regex.clone(), None, None, None, None, None, None);
+        let opts = GuidedDecodingOptions::from_optional(
+            None,
+            regex.clone(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(opts.is_ok());
         let val = opts.unwrap();
         assert!(val.is_some());

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -134,6 +134,8 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
         let guided_grammar = self.get_guided_grammar();
         let guided_choice = self.get_guided_choice();
         let guided_whitespace_pattern = self.get_guided_whitespace_pattern();
+        let guided_structural_tag = self.get_guided_structural_tag();
+        let enable_thinking = self.get_enable_thinking();
 
         let guided_decoding = match common::GuidedDecodingOptions::from_optional(
             guided_json,
@@ -142,6 +144,8 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
             guided_grammar,
             guided_decoding_backend,
             guided_whitespace_pattern,
+            guided_structural_tag,
+            enable_thinking,
         ) {
             Ok(options) => options,
             Err(e) => {

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -239,6 +239,10 @@ impl CommonExtProvider for NvCreateChatCompletionRequest {
         self.common.guided_whitespace_pattern.clone()
     }
 
+    fn get_guided_structural_tag(&self) -> Option<serde_json::Value> {
+        self.common.guided_structural_tag.clone()
+    }
+
     fn get_top_k(&self) -> Option<i32> {
         self.common.top_k
     }
@@ -257,6 +261,17 @@ impl CommonExtProvider for NvCreateChatCompletionRequest {
 
     fn get_skip_special_tokens(&self) -> Option<bool> {
         self.common.skip_special_tokens
+    }
+
+    /// Get enable_thinking from chat_template_args for mode-aware structural_tag generation.
+    /// Returns Some(true) if chat_template_args contains "enable_thinking": true.
+    /// Returns Some(false) if chat_template_args contains "enable_thinking": false.
+    /// Returns None if enable_thinking is not specified.
+    fn get_enable_thinking(&self) -> Option<bool> {
+        self.chat_template_args
+            .as_ref()
+            .and_then(|args| args.get("enable_thinking"))
+            .and_then(|v| v.as_bool())
     }
 }
 

--- a/lib/llm/src/protocols/openai/common_ext.rs
+++ b/lib/llm/src/protocols/openai/common_ext.rs
@@ -74,6 +74,14 @@ pub struct CommonExt {
     #[allow(unused)] // Not used
     pub guided_whitespace_pattern: Option<String>,
 
+    /// If specified, structural tag format for mixed free-text and constrained regions.
+    /// Used for combining reasoning (free text) with structured output (JSON schema).
+    /// Format: {"type": "sequence", "elements": [...]} or {"type": "triggered_tags", ...}
+    /// Supported by xgrammar backend only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub guided_structural_tag: Option<serde_json::Value>,
+
     /// Whether to skip special tokens in the decoded output.
     /// When true, special tokens (like EOS, BOS, PAD) are removed from the output text.
     /// When false, special tokens are included in the output text.
@@ -102,6 +110,7 @@ pub trait CommonExtProvider {
     fn get_guided_decoding_backend(&self) -> Option<String>;
     #[allow(unused)] // Not used
     fn get_guided_whitespace_pattern(&self) -> Option<String>;
+    fn get_guided_structural_tag(&self) -> Option<serde_json::Value>;
 
     /// Other sampling Options
     fn get_top_k(&self) -> Option<i32>;
@@ -111,6 +120,12 @@ pub trait CommonExtProvider {
 
     /// Output Options
     fn get_skip_special_tokens(&self) -> Option<bool>;
+
+    /// Get enable_thinking from chat_template_args for mode-aware structural_tag generation.
+    /// Default implementation returns None. Override in types that have chat_template_args.
+    fn get_enable_thinking(&self) -> Option<bool> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/lib/llm/src/protocols/openai/common_ext.rs
+++ b/lib/llm/src/protocols/openai/common_ext.rs
@@ -220,6 +220,7 @@ mod tests {
             guided_choice: None,
             guided_decoding_backend: None,
             guided_whitespace_pattern: None,
+            guided_structural_tag: None,
             skip_special_tokens: None,
         };
         assert!(common_ext.validate().is_ok());

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -210,6 +210,10 @@ impl CommonExtProvider for NvCreateCompletionRequest {
         self.common.guided_whitespace_pattern.clone()
     }
 
+    fn get_guided_structural_tag(&self) -> Option<serde_json::Value> {
+        self.common.guided_structural_tag.clone()
+    }
+
     fn get_top_k(&self) -> Option<i32> {
         self.common.top_k
     }

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -531,7 +531,8 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
         // Set enable_thinking=true only when the Responses API caller explicitly requests
         // reasoning alongside guided decoding; this signals the Python handler to wrap the
         // guided decoding constraint in a structural_tag that allows free-text reasoning.
-        let chat_template_args = if response_format.is_some() && resp.inner.reasoning.is_some() {
+        let has_guided_decoding = response_format.is_some() || tools.is_some();
+        let chat_template_args = if has_guided_decoding && resp.inner.reasoning.is_some() {
             // Guided decoding WITH explicit reasoning → enable thinking
             // The Python handler generates a structural_tag with sequence format
             let mut args = std::collections::HashMap::new();

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -521,23 +521,31 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
         // Map service_tier
         let service_tier = resp.inner.service_tier.as_ref().map(convert_service_tier);
 
-        // FIX: Proper reasoning + guided decoding interaction
-        // Case 1: JSON schema WITHOUT reasoning → disable thinking
-        // Case 2: JSON schema WITH reasoning → enable thinking (requires structural_tag in Python layer)
-        let chat_template_args = if response_format.is_some() {
+        // Reasoning + guided decoding interaction for Responses API.
+        //
+        // The server-level reasoning parser is always active when configured. We should NOT
+        // disable it just because the `reasoning` param is absent — the model may still emit
+        // <think>...</think> content by default, and the reasoning parser needs to run to
+        // split reasoning_content from the final answer.
+        //
+        // Set enable_thinking=true only when the Responses API caller explicitly requests
+        // reasoning alongside guided decoding; this signals the Python handler to wrap the
+        // guided decoding constraint in a structural_tag that allows free-text reasoning.
+        let chat_template_args = if response_format.is_some() && resp.inner.reasoning.is_some() {
+            // Guided decoding WITH explicit reasoning → enable thinking
+            // The Python handler generates a structural_tag with sequence format
             let mut args = std::collections::HashMap::new();
-            if resp.inner.reasoning.is_none() {
-                // Case 1: Guided decoding without reasoning → disable thinking
-                // This prevents the server-level reasoning parser from treating all content as reasoning
-                args.insert("enable_thinking".to_string(), serde_json::Value::Bool(false));
-            } else {
-                // Case 2: Guided decoding WITH reasoning → enable thinking
-                // The Python handler should generate a structural_tag with sequence format:
-                // <think>...</think> for reasoning, then JSON schema constraint for final answer
-                args.insert("enable_thinking".to_string(), serde_json::Value::Bool(true));
-            }
+            args.insert("enable_thinking".to_string(), serde_json::Value::Bool(true));
             Some(args)
         } else {
+            // No guided decoding, or guided decoding without explicit reasoning param:
+            // Don't set chat_template_args — let the server's default reasoning parser
+            // handle it. The preprocessor will check prompt_injected_reasoning from the
+            // rendered template and enable reasoning parsing accordingly.
+            //
+            // Note: thinking-off with guided decoding is not currently expressible via
+            // the Responses API surface. It relies on the server's dyn_enable_thinking_default
+            // being unset (None), which applies plain guided decoding without structural_tag.
             None
         };
 

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -521,6 +521,26 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
         // Map service_tier
         let service_tier = resp.inner.service_tier.as_ref().map(convert_service_tier);
 
+        // FIX: Proper reasoning + guided decoding interaction
+        // Case 1: JSON schema WITHOUT reasoning → disable thinking
+        // Case 2: JSON schema WITH reasoning → enable thinking (requires structural_tag in Python layer)
+        let chat_template_args = if response_format.is_some() {
+            let mut args = std::collections::HashMap::new();
+            if resp.inner.reasoning.is_none() {
+                // Case 1: Guided decoding without reasoning → disable thinking
+                // This prevents the server-level reasoning parser from treating all content as reasoning
+                args.insert("enable_thinking".to_string(), serde_json::Value::Bool(false));
+            } else {
+                // Case 2: Guided decoding WITH reasoning → enable thinking
+                // The Python handler should generate a structural_tag with sequence format:
+                // <think>...</think> for reasoning, then JSON schema constraint for final answer
+                args.insert("enable_thinking".to_string(), serde_json::Value::Bool(true));
+            }
+            Some(args)
+        } else {
+            None
+        };
+
         Ok(NvCreateChatCompletionRequest {
             inner: CreateChatCompletionRequest {
                 messages,
@@ -540,7 +560,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
             },
             common: Default::default(),
             nvext: resp.nvext,
-            chat_template_args: None,
+            chat_template_args,
             media_io_kwargs: None,
             unsupported_fields: Default::default(),
         })

--- a/lib/llm/src/protocols/unified.rs
+++ b/lib/llm/src/protocols/unified.rs
@@ -373,6 +373,10 @@ impl CommonExtProvider for UnifiedRequest {
         self.inner.common.guided_structural_tag.clone()
     }
 
+    fn get_enable_thinking(&self) -> Option<bool> {
+        CommonExtProvider::get_enable_thinking(&self.inner)
+    }
+
     fn get_top_k(&self) -> Option<i32> {
         self.inner.common.top_k
     }

--- a/lib/llm/src/protocols/unified.rs
+++ b/lib/llm/src/protocols/unified.rs
@@ -369,6 +369,10 @@ impl CommonExtProvider for UnifiedRequest {
         self.inner.common.guided_whitespace_pattern.clone()
     }
 
+    fn get_guided_structural_tag(&self) -> Option<serde_json::Value> {
+        self.inner.common.guided_structural_tag.clone()
+    }
+
     fn get_top_k(&self) -> Option<i32> {
         self.inner.common.top_k
     }

--- a/lib/llm/tests/test_common_ext.rs
+++ b/lib/llm/tests/test_common_ext.rs
@@ -155,6 +155,24 @@ fn test_chat_completions_guided_decoding_from_common() {
         request.get_guided_decoding_backend(),
         Some("backend".to_string())
     );
+
+    // Test guided_structural_tag can be specified at root level
+    let json_str = r#"{
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "guided_structural_tag": {"type": "sequence", "elements": []}
+    }"#;
+
+    let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+
+    assert_eq!(
+        request.common.guided_structural_tag,
+        Some(serde_json::json!({"type": "sequence", "elements": []}))
+    );
+    assert_eq!(
+        request.get_guided_structural_tag(),
+        Some(serde_json::json!({"type": "sequence", "elements": []}))
+    );
 }
 
 #[test]
@@ -358,4 +376,57 @@ fn test_sampling_parameters_extraction() {
 
     assert_eq!(sampling_options.top_k, Some(42));
     assert_eq!(sampling_options.repetition_penalty, Some(1.3));
+}
+
+#[test]
+fn test_chat_completions_enable_thinking_extraction() {
+    use dynamo_llm::protocols::common::SamplingOptionsProvider;
+
+    // Test that enable_thinking is extracted from chat_template_args
+    let json_str = r#"{
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "guided_json": {"type": "object"},
+        "chat_template_args": {"enable_thinking": true}
+    }"#;
+
+    let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+
+    // Verify enable_thinking is extracted via the trait method
+    assert_eq!(request.get_enable_thinking(), Some(true));
+
+    // Verify it flows through to guided_decoding in sampling_options
+    let sampling = request.extract_sampling_options().unwrap();
+    let guided = sampling.guided_decoding.unwrap();
+    assert_eq!(guided.enable_thinking, Some(true));
+    assert_eq!(guided.json, Some(serde_json::json!({"type": "object"})));
+
+    // Test enable_thinking: false
+    let json_str_off = r#"{
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "guided_json": {"type": "object"},
+        "chat_template_args": {"enable_thinking": false}
+    }"#;
+
+    let request_off: NvCreateChatCompletionRequest = serde_json::from_str(json_str_off).unwrap();
+    assert_eq!(request_off.get_enable_thinking(), Some(false));
+
+    let sampling_off = request_off.extract_sampling_options().unwrap();
+    let guided_off = sampling_off.guided_decoding.unwrap();
+    assert_eq!(guided_off.enable_thinking, Some(false));
+
+    // Test without enable_thinking (should be None)
+    let json_str_none = r#"{
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "guided_json": {"type": "object"}
+    }"#;
+
+    let request_none: NvCreateChatCompletionRequest = serde_json::from_str(json_str_none).unwrap();
+    assert_eq!(request_none.get_enable_thinking(), None);
+
+    let sampling_none = request_none.extract_sampling_options().unwrap();
+    let guided_none = sampling_none.guided_decoding.unwrap();
+    assert_eq!(guided_none.enable_thinking, None);
 }


### PR DESCRIPTION
## Summary

When a reasoning model (e.g. DeepSeek-R1, GLM-4.7, Qwen3) is used with guided decoding (`response_format: json_schema`), Dynamo was applying the xgrammar constraint to the **entire** output — including the `<think>...</think>` reasoning section — causing malformed or degenerate responses.

**Root cause:** Dynamo calls TRT-LLM's engine API directly, bypassing TRT-LLM's HTTP server layer. This means TRT-LLM's `_response_format_to_guided_decoding_params()` — which automatically wraps JSON schemas in a `structural_tag` for reasoning models — never runs.

**Fix:** Replicate that logic inside Dynamo's `handler_base.py`. When `enable_thinking` is set (via request or server default), the guided decoding constraint is wrapped in an xgrammar `structural_tag` that treats `<think>...</think>` as unconstrained free text and enforces the constraint only on the final answer after `</think>`.

## Changes

### New server configuration flags (TRT-LLM backend)

| Flag | Env var | Description |
|------|---------|-------------|
| `--dyn-enable-thinking-default` | `DYN_ENABLE_THINKING_DEFAULT` | `true` if the model generates `<think>...</think>` before the final answer (e.g. DeepSeek-R1, Qwen3); `false` for thinking-off mode. Unset = no structural_tag wrapping. |
| `--dyn-prompt-injects-thinking-tag` | `DYN_PROMPT_INJECTS_THINKING_TAG` | Set to `true` when the model's chat template already appends `<think>` to the prompt (e.g. GLM-4.7, Qwen3). Prevents xgrammar from enforcing a duplicate `<think>` that causes model degeneration. |

### Example (DeepSeek-R1 + JSON schema)

```bash
# Thinking-on, template does NOT inject <think>
DYN_ENABLE_THINKING_DEFAULT=true \
DYN_PROMPT_INJECTS_THINKING_TAG=false \
dynamo serve ...
```

```bash
# Thinking-on, template DOES inject <think> (GLM-4.7, Qwen3)
DYN_ENABLE_THINKING_DEFAULT=true \
DYN_PROMPT_INJECTS_THINKING_TAG=true \
dynamo serve ...
```

### Structural tag generated (thinking-on, template does not inject `<think>`)

```json
{
  "type": "structural_tag",
  "format": {
    "type": "sequence",
    "elements": [
      { "type": "tag", "begin": "<think>", "content": { "type": "any_text" }, "end": "</think>" },
      { "type": "json_schema", "json_schema": { ... } }
    ]
  }
}
```

### Other fixes in this PR

- **`prepost.py`**: `finish_reason` is now correctly set to `"tool_calls"` when tool calls are present in a streaming chunk.
- **`preprocessor.rs`**: Adds `glm45` reasoning-disable logic — reasoning parsing is skipped when `enable_thinking: false` is set in `chat_template_args`.
- **`preprocessor/prompt/template/oai.rs`**: Adds debug logging for rendered chat template prompts.
- **`protocols/openai/responses/mod.rs`**: Wires `enable_thinking` into `chat_template_args` when the Responses API receives a request with both `response_format` and `reasoning`.
- **`protocols/common.rs`**: Extends `GuidedDecodingOptions` with `structural_tag` and `enable_thinking` fields to carry these through the Rust → Python pipeline.

## Impact

- **TRT-LLM backend only.** No changes to vLLM or SGLang paths.
- **Zero impact when guided decoding is not used.** The structural_tag is only generated when `has_guided_decoding && enable_thinking is True`.
- **User-provided `structural_tag`** in the request is always respected and never overwritten.

## Test plan

- [ ] DeepSeek-R1 + `response_format: json_schema` with `DYN_ENABLE_THINKING_DEFAULT=true` — verify JSON output follows `</think>`, reasoning content is free text
- [ ] GLM-4.7 + `response_format: json_schema` with `DYN_ENABLE_THINKING_DEFAULT=true DYN_PROMPT_INJECTS_THINKING_TAG=true` — verify no double `<think>` degeneration
- [ ] Request without `response_format` — verify no regression in reasoning parsing
- [ ] `finish_reason="tool_calls"` in streaming tool call responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added runtime configuration options to control thinking/reasoning defaults and template behavior
  * Extended guided decoding to support structural tags with automatic reasoning constraint generation

* **Bug Fixes**
  * Corrected finish reason for streaming responses containing tool calls

* **Improvements**
  * Enhanced reasoning parsing with improved logging and control flow for better debugging visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->