### PR TITLE
fix: minor fixes (test parser, verbose flags, and adding comments to clarify gpu_1 usage)

### DIFF
--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -37,7 +37,9 @@ JINJA_TEMPLATE_PATH = str(
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_0,
+    # gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64
+    # runners with "Failed to infer device type" even for mock tests.
+    pytest.mark.gpu_1,
     pytest.mark.pre_merge,
 ]
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -37,7 +37,7 @@ JINJA_TEMPLATE_PATH = str(
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
 

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -14,7 +14,7 @@ from dynamo.vllm.worker_factory import EngineSetupResult, WorkerFactory
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
 

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -14,7 +14,9 @@ from dynamo.vllm.worker_factory import EngineSetupResult, WorkerFactory
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_0,
+    # gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64
+    # runners with "Failed to infer device type" even for mock tests.
+    pytest.mark.gpu_1,
     pytest.mark.pre_merge,
 ]
 

--- a/tests/frontend/test_vllm_prepost_integration.py
+++ b/tests/frontend/test_vllm_prepost_integration.py
@@ -43,8 +43,7 @@ SEARCH_TOOL = {
 
 pytestmark = [
     pytest.mark.vllm,
-    # vllm frontend doesn't need or use the GPU, but in CI pytorch seems to look for the Device
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
     pytest.mark.integration,
     pytest.mark.parallel,

--- a/tests/frontend/test_vllm_prepost_integration.py
+++ b/tests/frontend/test_vllm_prepost_integration.py
@@ -43,7 +43,9 @@ SEARCH_TOOL = {
 
 pytestmark = [
     pytest.mark.vllm,
-    pytest.mark.gpu_0,
+    # gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64
+    # runners with "Failed to infer device type" even for mock tests.
+    pytest.mark.gpu_1,
     pytest.mark.pre_merge,
     pytest.mark.integration,
     pytest.mark.parallel,

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -194,8 +194,17 @@ def _aggregate_junit_xml(junit_dir: str) -> str | None:
 
 def _collect_tests(pytest_args: list[str], max_vram_gib: float) -> list[str]:
     """Run pytest --collect-only to get test IDs, filtered by --max-vram-gib."""
-    _strip_flags = {"-v", "-vv", "-vvv", "--verbose", "-s", "--capture=no"}
-    collect_args = [a for a in pytest_args if a not in _strip_flags]
+    _strip_exact = {"-v", "-vv", "-vvv", "--verbose", "-s", "--capture=no"}
+    collect_args = []
+    for a in pytest_args:
+        if a in _strip_exact:
+            continue
+        if a.startswith("-") and not a.startswith("--") and "v" in a:
+            stripped = a.replace("v", "")
+            if stripped != "-":
+                collect_args.append(stripped)
+            continue
+        collect_args.append(a)
     cmd = [
         sys.executable,
         "-m",
@@ -209,7 +218,7 @@ def _collect_tests(pytest_args: list[str], max_vram_gib: float) -> list[str]:
     test_ids = []
     for line in result.stdout.strip().split("\n"):
         line = line.strip()
-        if "::" in line and not line.startswith(" "):
+        if ".py::" in line and not line.startswith(" "):
             test_ids.append(line)
     return test_ids
 


### PR DESCRIPTION
#### Overview:

Fix two bugs in the parallel scheduler's test collector, and add comments to clarify gpu_1 usage (even though it doesn't actually use the GPU).

#### Details:

- Fix _collect_tests parser matching IPv6 addresses in docstrings as test IDs
- Strip combined verbose flags (-xvv) so --collect-only -q output stays quiet

#### Related Issues:

/coderabbit profile chill
