### PR TITLE
test(vllm): add embedding cache integration test for aggregated multimodal

### DIFF
--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -205,6 +205,7 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
                 encoder_cache[mm_hash] = self._cpu_store[mm_hash].to(
                     "cuda", non_blocking=True
                 )
+                logger.info("EC cache load: %s", mm_hash[:12])
             else:
                 logger.warning(
                     "start_load_caches: hash %s not in cpu_store, skipping", mm_hash
@@ -231,3 +232,8 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
             )
             return
         self._cpu_store[mm_hash] = encoder_cache[mm_hash].cpu()
+        logger.info(
+            "EC cache save: %s (%d bytes)",
+            mm_hash[:12],
+            encoder_cache[mm_hash].numel() * encoder_cache[mm_hash].element_size(),
+        )

--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -205,7 +205,7 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
                 encoder_cache[mm_hash] = self._cpu_store[mm_hash].to(
                     "cuda", non_blocking=True
                 )
-                logger.info("EC cache load: %s", mm_hash[:12])
+                logger.debug("EC cache load: %s", mm_hash[:12])
             else:
                 logger.warning(
                     "start_load_caches: hash %s not in cpu_store, skipping", mm_hash
@@ -232,7 +232,7 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
             )
             return
         self._cpu_store[mm_hash] = encoder_cache[mm_hash].cpu()
-        logger.info(
+        logger.debug(
             "EC cache save: %s (%d bytes)",
             mm_hash[:12],
             encoder_cache[mm_hash].numel() * encoder_cache[mm_hash].element_size(),

--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -205,6 +205,7 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
                 encoder_cache[mm_hash] = self._cpu_store[mm_hash].to(
                     "cuda", non_blocking=True
                 )
+                # E2E tests assert this log to confirm cache load path is exercised
                 logger.debug("EC cache load: %s", mm_hash[:12])
             else:
                 logger.warning(
@@ -232,6 +233,7 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
             )
             return
         self._cpu_store[mm_hash] = encoder_cache[mm_hash].cpu()
+        # E2E tests assert this log to confirm cache save path is exercised
         logger.debug(
             "EC cache save: %s (%d bytes)",
             mm_hash[:12],

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -830,6 +830,99 @@ vllm_configs = {
             ),
         ],
     ),
+    # Embedding cache integration test for aggregated multimodal.
+    # Validates the ec_both code path (DynamoMultimodalEmbeddingCacheConnector):
+    #   Payload 1: image A → GPU miss, save embedding to CPU store
+    #   Payload 2: image B (synthetic) → GPU miss, save B, evicts A from GPU cache
+    #   Payload 3: image A again → GPU miss, CPU hit, load from CPU store
+    # GPU encoder cache is shrunk via --max-num-batched-tokens so it holds ~1 image.
+    "multimodal_agg_embedding_cache": VLLMConfig(
+        name="multimodal_agg_embedding_cache",
+        directory=vllm_dir,
+        script_name="agg_multimodal.sh",
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.profiled_vram_gib(8.0),
+            pytest.mark.timeout(300),
+            pytest.mark.post_merge,
+            pytest.mark.multimodal,
+            pytest.mark.model("Qwen/Qwen3-VL-2B-Instruct"),
+        ],
+        model="Qwen/Qwen3-VL-2B-Instruct",
+        request_payloads=[
+            # Payload 1: image A — warms the embedding cache (save)
+            chat_payload(
+                [
+                    {
+                        "type": "text",
+                        "text": "What colors are in this image?",
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": MULTIMODAL_IMG_URL},
+                    },
+                ],
+                repeat_count=1,
+                expected_response=["green", "purple"],
+                expected_log=[
+                    r"Configuring ec_both mode with DynamoMultimodalEmbeddingCacheConnector",
+                    r"DynamoMultimodalEmbeddingCacheConnector initialized: capacity_gb=",
+                    r"EC cache save:",
+                ],
+                max_tokens=64,
+                temperature=0.0,
+            ),
+            # Payload 2: image B (synthetic 2x2 red PNG) — evicts image A from GPU cache
+            chat_payload(
+                [
+                    {
+                        "type": "text",
+                        "text": "What do you see?",
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/png;base64,"
+                            "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAA"
+                            "EElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg=="
+                        },
+                    },
+                ],
+                repeat_count=1,
+                expected_response=[],
+                max_tokens=64,
+                temperature=0.0,
+            ),
+            # Payload 3: image A again — GPU miss, CPU cache hit (load)
+            chat_payload(
+                [
+                    {
+                        "type": "text",
+                        "text": "What colors are in this image?",
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": MULTIMODAL_IMG_URL},
+                    },
+                ],
+                repeat_count=1,
+                expected_response=["green", "purple"],
+                expected_log=[
+                    r"EC cache load:",
+                ],
+                max_tokens=64,
+                temperature=0.0,
+            ),
+        ],
+        script_args=[
+            "--multimodal-embedding-cache-capacity-gb",
+            "0.5",
+            "--max-num-batched-tokens",
+            "256",
+            "--max-num-seqs",
+            "1",
+        ],
+    ),
 }
 
 

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -836,10 +836,15 @@ vllm_configs = {
     #   Payload 1: image A → GPU miss → encode → save to CPU store
     #   Payload 2: image B (synthetic) → GPU evicts A → save B to CPU store
     #   Payload 3: image A → GPU miss → CPU hit → load from CPU store
-    # GPU encoder cache is clamped to 1 image via --max-num-batched-tokens 256
-    # (encoder_cache_size = max(256, max_tokens_per_mm_item) = max_tokens_per_mm_item).
-    # --max-num-seqs 1 ensures sequential processing so cache state is deterministic.
-    # DYN_LOG=debug enables the connector's debug-level save/load logs.
+    #
+    # Eviction guarantee:
+    #   --mm-processor-kwargs pins min_pixels=max_pixels=3136 → all images become
+    #   56x56 → 4 encoder tokens each. --max-num-batched-tokens=4 makes
+    #   encoder_cache_size = max(4, max_tokens_per_mm_item=4) = 4, holding exactly
+    #   1 image. Image B's can_allocate() evicts A from the GPU encoder cache.
+    #   --max-num-seqs=1 ensures sequential processing for deterministic state.
+    #   --limit-mm-per-prompt disables video so only image tokens set the budget.
+    #   DYN_LOG=debug enables the connector's debug-level save/load logs.
     "multimodal_agg_embedding_cache": VLLMConfig(
         name="multimodal_agg_embedding_cache",
         directory=vllm_dir,
@@ -858,64 +863,55 @@ vllm_configs = {
             # Payload 1: image A — save to CPU store
             chat_payload(
                 [
-                    {
-                        "type": "text",
-                        "text": "What colors are in this image?",
-                    },
+                    {"type": "text", "text": "Describe briefly."},
                     {
                         "type": "image_url",
                         "image_url": {"url": MULTIMODAL_IMG_URL},
                     },
                 ],
                 repeat_count=1,
-                expected_response=["green", "purple"],
+                expected_response=[],
                 expected_log=[
                     r"Configuring ec_both mode with DynamoMultimodalEmbeddingCacheConnector",
                     r"DynamoMultimodalEmbeddingCacheConnector initialized: capacity_gb=",
                     r"EC cache save:",
                 ],
-                max_tokens=64,
+                max_tokens=16,
                 temperature=0.0,
             ),
             # Payload 2: image B (synthetic 2x2 red PNG) — evicts image A from GPU cache
             chat_payload(
                 [
-                    {
-                        "type": "text",
-                        "text": "What do you see?",
-                    },
+                    {"type": "text", "text": "Describe briefly."},
                     {
                         "type": "image_url",
                         "image_url": {
                             "url": "data:image/png;base64,"
-                            "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAA"
-                            "EElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg=="
+                            "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91Jpz"
+                            "AAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg=="
                         },
                     },
                 ],
                 repeat_count=1,
                 expected_response=[],
-                max_tokens=64,
+                max_tokens=16,
                 temperature=0.0,
             ),
             # Payload 3: image A again — GPU miss, CPU cache hit, load from CPU store
             chat_payload(
                 [
-                    {
-                        "type": "text",
-                        "text": "What colors are in this image?",
-                    },
+                    {"type": "text", "text": "Describe briefly."},
                     {
                         "type": "image_url",
                         "image_url": {"url": MULTIMODAL_IMG_URL},
                     },
                 ],
                 repeat_count=1,
-                expected_response=["green", "purple"],
+                expected_response=[],
                 expected_log=[
                     r"EC cache load:",
                 ],
-                max_tokens=64,
+                max_tokens=16,
                 temperature=0.0,
             ),
         ],
@@ -923,9 +919,13 @@ vllm_configs = {
             "--multimodal-embedding-cache-capacity-gb",
             "0.5",
             "--max-num-batched-tokens",
-            "256",
+            "4",
             "--max-num-seqs",
             "1",
+            "--mm-processor-kwargs",
+            '{"min_pixels": 3136, "max_pixels": 3136}',
+            "--limit-mm-per-prompt",
+            '{"video": 0}',
         ],
     ),
 }

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -831,10 +831,14 @@ vllm_configs = {
         ],
     ),
     # Embedding cache integration test for aggregated multimodal.
-    # Validates the ec_both code path (DynamoMultimodalEmbeddingCacheConnector):
-    #   - Connector is configured and initialized inside the vLLM engine
-    #   - Save path executes: embedding written to CPU store after encoding
-    #   - Multimodal inference produces correct responses with EC enabled
+    # Validates the ec_both code path (DynamoMultimodalEmbeddingCacheConnector)
+    # by exercising both the CPU cache save and load paths:
+    #   Payload 1: image A → GPU miss → encode → save to CPU store
+    #   Payload 2: image B (synthetic) → GPU evicts A → save B to CPU store
+    #   Payload 3: image A → GPU miss → CPU hit → load from CPU store
+    # GPU encoder cache is clamped to 1 image via --max-num-batched-tokens 256
+    # (encoder_cache_size = max(256, max_tokens_per_mm_item) = max_tokens_per_mm_item).
+    # --max-num-seqs 1 ensures sequential processing so cache state is deterministic.
     # DYN_LOG=debug enables the connector's debug-level save/load logs.
     "multimodal_agg_embedding_cache": VLLMConfig(
         name="multimodal_agg_embedding_cache",
@@ -851,6 +855,7 @@ vllm_configs = {
         model="Qwen/Qwen3-VL-2B-Instruct",
         env={"DYN_LOG": "debug"},
         request_payloads=[
+            # Payload 1: image A — save to CPU store
             chat_payload(
                 [
                     {
@@ -862,7 +867,7 @@ vllm_configs = {
                         "image_url": {"url": MULTIMODAL_IMG_URL},
                     },
                 ],
-                repeat_count=2,
+                repeat_count=1,
                 expected_response=["green", "purple"],
                 expected_log=[
                     r"Configuring ec_both mode with DynamoMultimodalEmbeddingCacheConnector",
@@ -872,10 +877,55 @@ vllm_configs = {
                 max_tokens=64,
                 temperature=0.0,
             ),
+            # Payload 2: image B (synthetic 2x2 red PNG) — evicts image A from GPU cache
+            chat_payload(
+                [
+                    {
+                        "type": "text",
+                        "text": "What do you see?",
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/png;base64,"
+                            "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAA"
+                            "EElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg=="
+                        },
+                    },
+                ],
+                repeat_count=1,
+                expected_response=[],
+                max_tokens=64,
+                temperature=0.0,
+            ),
+            # Payload 3: image A again — GPU miss, CPU cache hit, load from CPU store
+            chat_payload(
+                [
+                    {
+                        "type": "text",
+                        "text": "What colors are in this image?",
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": MULTIMODAL_IMG_URL},
+                    },
+                ],
+                repeat_count=1,
+                expected_response=["green", "purple"],
+                expected_log=[
+                    r"EC cache load:",
+                ],
+                max_tokens=64,
+                temperature=0.0,
+            ),
         ],
         script_args=[
             "--multimodal-embedding-cache-capacity-gb",
             "0.5",
+            "--max-num-batched-tokens",
+            "256",
+            "--max-num-seqs",
+            "1",
         ],
     ),
 }

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -832,10 +832,10 @@ vllm_configs = {
     ),
     # Embedding cache integration test for aggregated multimodal.
     # Validates the ec_both code path (DynamoMultimodalEmbeddingCacheConnector):
-    #   Payload 1: image A → GPU miss, save embedding to CPU store
-    #   Payload 2: image B (synthetic) → GPU miss, save B, evicts A from GPU cache
-    #   Payload 3: image A again → GPU miss, CPU hit, load from CPU store
-    # GPU encoder cache is shrunk via --max-num-batched-tokens so it holds ~1 image.
+    #   - Connector is configured and initialized inside the vLLM engine
+    #   - Save path executes: embedding written to CPU store after encoding
+    #   - Multimodal inference produces correct responses with EC enabled
+    # DYN_LOG=debug enables the connector's debug-level save/load logs.
     "multimodal_agg_embedding_cache": VLLMConfig(
         name="multimodal_agg_embedding_cache",
         directory=vllm_dir,
@@ -849,8 +849,8 @@ vllm_configs = {
             pytest.mark.model("Qwen/Qwen3-VL-2B-Instruct"),
         ],
         model="Qwen/Qwen3-VL-2B-Instruct",
+        env={"DYN_LOG": "debug"},
         request_payloads=[
-            # Payload 1: image A — warms the embedding cache (save)
             chat_payload(
                 [
                     {
@@ -862,7 +862,7 @@ vllm_configs = {
                         "image_url": {"url": MULTIMODAL_IMG_URL},
                     },
                 ],
-                repeat_count=1,
+                repeat_count=2,
                 expected_response=["green", "purple"],
                 expected_log=[
                     r"Configuring ec_both mode with DynamoMultimodalEmbeddingCacheConnector",
@@ -872,55 +872,10 @@ vllm_configs = {
                 max_tokens=64,
                 temperature=0.0,
             ),
-            # Payload 2: image B (synthetic 2x2 red PNG) — evicts image A from GPU cache
-            chat_payload(
-                [
-                    {
-                        "type": "text",
-                        "text": "What do you see?",
-                    },
-                    {
-                        "type": "image_url",
-                        "image_url": {
-                            "url": "data:image/png;base64,"
-                            "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAA"
-                            "EElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg=="
-                        },
-                    },
-                ],
-                repeat_count=1,
-                expected_response=[],
-                max_tokens=64,
-                temperature=0.0,
-            ),
-            # Payload 3: image A again — GPU miss, CPU cache hit (load)
-            chat_payload(
-                [
-                    {
-                        "type": "text",
-                        "text": "What colors are in this image?",
-                    },
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": MULTIMODAL_IMG_URL},
-                    },
-                ],
-                repeat_count=1,
-                expected_response=["green", "purple"],
-                expected_log=[
-                    r"EC cache load:",
-                ],
-                max_tokens=64,
-                temperature=0.0,
-            ),
         ],
         script_args=[
             "--multimodal-embedding-cache-capacity-gb",
             "0.5",
-            "--max-num-batched-tokens",
-            "256",
-            "--max-num-seqs",
-            "1",
         ],
     ),
 }


### PR DESCRIPTION
## Summary
- Adds an E2E integration test (`multimodal_agg_embedding_cache`) that validates the `ec_both` embedding cache path (`DynamoMultimodalEmbeddingCacheConnector`) in the Dynamo aggregated multimodal graph
- Tests both **save** and **load** paths with guaranteed GPU encoder cache eviction
- Adds DEBUG-level logs to the connector for save/load — only visible when `DYN_LOG=debug`

## How eviction is guaranteed

The test pins `min_pixels=max_pixels=3136` via `--mm-processor-kwargs`, forcing all images to 56x56 = exactly **4 encoder tokens** each. With `--max-num-batched-tokens=4`, the vLLM GPU encoder cache holds exactly 1 image:

```
encoder_cache_size = max(max_num_batched_tokens=4, max_tokens_per_mm_item=4) = 4
```

The 3-payload sequence:
1. **Image A** — GPU miss, encode, save to CPU store (asserts `EC cache save:`)
2. **Image B** (synthetic 2x2 PNG) — `can_allocate()` evicts A from GPU cache
3. **Image A** — `check_and_update_cache()` returns False (A evicted), our connector's `has_cache_item()` returns True (A in CPU store), `start_load_caches()` copies CPU to GPU (asserts `EC cache load:`)

Additional flags for determinism:
- `--max-num-seqs 1` — sequential processing, no concurrent cache references
- `--limit-mm-per-prompt '{"video": 0}'` — excludes video tokens from budget
- `DYN_LOG=debug` — enables debug logs for assertion

## Test plan
- Run `multimodal_agg_embedding_cache` on a GPU node with Qwen3-VL-2B-Instruct
- Verify all 3 payloads succeed (HTTP 200)
- Verify `EC cache save:` appears after payload 1
- Verify `EC cache load:` appears after payload 3
- Confirm existing unit tests still pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test scenario for multimodal embedding cache behavior, validating cache hit/miss operations and control flow.

* **Chores**
  * Enhanced debug logging for embedding cache operations to aid in troubleshooting and monitoring cache load/save activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->