### PR TITLE
ci: remove -amd64 suffix from GAIE deploy test image tag

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -438,7 +438,7 @@ jobs:
           extra_pytest_args: >-
             -m framework_with_gaie
             --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-frontend
-            --image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-vllm-runtime-cuda12-amd64
+            --image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-vllm-runtime-cuda12
 
   deploy-status-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- The GAIE deploy test in `post-merge-ci.yml` was requesting the image tag `<sha>-vllm-runtime-cuda12-amd64`, but the build pipeline pushes `<sha>-vllm-runtime-cuda12` (no arch suffix)
- This caused `ImagePullBackOff` on the vLLM worker pods, leading to a 900s pytest timeout on every post-merge run
- Fixes https://github.com/ai-dynamo/dynamo/actions/runs/23925916542/job/69788612482

## Test plan
- [ ] Verify post-merge GAIE deploy test passes with the corrected image tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD deployment test configuration to use the latest container image reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->