### PR TITLE
fix: replace panic with warn+break on TCP stream read errors

### DIFF
--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -268,9 +268,14 @@ async fn handle_reader(
                         }
                     }
                     Some(Err(e)) => {
-                        // TODO(#171) - address fatal errors
-                        // in this case the binary representation of the message is invalid
-                        panic!("fatal error - failed to decode message from stream; invalid line protocol: {e:?}");
+                        // Connection reset (TCP RST from peer panic/crash) or
+                        // protocol decode error. Either way the stream is broken —
+                        // log and break so only this connection is affected, not
+                        // the whole worker.
+                        tracing::warn!(
+                            "tcp stream read error, closing connection: {e:?}"
+                        );
+                        break;
                     }
                     None => {
                         tracing::debug!("tcp stream closed by server");


### PR DESCRIPTION
## Summary
- **tcp/client.rs**: Replace `panic!` with `warn! + break` on stream read errors (e.g. `ECONNRESET` from TCP RST) in the `Some(Err(_))` branch of the TCP reader — prevents a single bad connection from killing all workers via panic cascade
- Follows the same `break` pattern as the existing `None` (stream closed) handler at line 280

## Details
The `handle_reader` function previously panicked on any decode error or connection reset in the TCP stream. This is a latent risk: if a peer crashes or sends malformed data, the resulting `ECONNRESET` or decode failure would panic the worker, potentially cascading across all connected workers.

The fix downgrades the panic to `tracing::warn!` and breaks out of the read loop, tearing down only the affected connection while leaving other workers unaffected.

## Test plan
- [ ] Verify TCP RST from frontend doesn't kill workers (graceful warn + break)
- [ ] Run pre-merge CI (Rust clippy, cargo test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)