### PR TITLE
fix: reuse elapsed duration in InflightGuard::Drop [DIS-1643]

### DIFF
--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -1045,7 +1045,7 @@ impl Drop for InflightGuard {
             .with_label_values(&[&self.model])
             .observe(duration);
 
-        let elapsed_ms = self.timer.elapsed().as_millis();
+        let elapsed_ms = (duration * 1000.0) as u64;
         let status_str = self.status.as_str();
         match self.status {
             Status::Error => {


### PR DESCRIPTION
## Summary
Reuse the `duration` variable already captured at the top of `InflightGuard::Drop` instead of calling `self.timer.elapsed()` a second time for the lifecycle log. Same value, avoids redundant syscall.

## Test plan
- [x] `cargo clippy -p dynamo-llm -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal metrics calculation for improved efficiency. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->