### PR TITLE
feat: add I2I (image-to-image) support for SGLang diffusion backend

### DIFF
--- a/components/src/dynamo/common/protocols/image_protocol.py
+++ b/components/src/dynamo/common/protocols/image_protocol.py
@@ -65,8 +65,23 @@ class NvCreateImageRequest(BaseModel):
     moderation: Optional[str] = None
     """Content moderation level: auto or low."""
 
+    input_reference: Optional[str] = None
+    """Optional image reference that guides generation (for I2I)."""
+
+    seed: Optional[int] = None
+    """Random seed (top-level, SGLang-compatible)."""
+
+    negative_prompt: Optional[str] = None
+    """Negative prompt (top-level, SGLang-compatible)."""
+
+    num_inference_steps: Optional[int] = None
+    """Denoising steps (top-level, SGLang-compatible)."""
+
+    guidance_scale: Optional[float] = None
+    """CFG guidance scale (top-level, SGLang-compatible)."""
+
     nvext: Optional[ImageNvExt] = None
-    """NVIDIA extensions."""
+    """NVIDIA extensions (takes precedence over top-level params)."""
 
 
 class ImageData(BaseModel):

--- a/components/src/dynamo/common/protocols/image_protocol.py
+++ b/components/src/dynamo/common/protocols/image_protocol.py
@@ -68,20 +68,8 @@ class NvCreateImageRequest(BaseModel):
     input_reference: Optional[str] = None
     """Optional image reference that guides generation (for I2I)."""
 
-    seed: Optional[int] = None
-    """Random seed (top-level, SGLang-compatible)."""
-
-    negative_prompt: Optional[str] = None
-    """Negative prompt (top-level, SGLang-compatible)."""
-
-    num_inference_steps: Optional[int] = None
-    """Denoising steps (top-level, SGLang-compatible)."""
-
-    guidance_scale: Optional[float] = None
-    """CFG guidance scale (top-level, SGLang-compatible)."""
-
     nvext: Optional[ImageNvExt] = None
-    """NVIDIA extensions (takes precedence over top-level params)."""
+    """NVIDIA extensions."""
 
 
 class ImageData(BaseModel):

--- a/components/src/dynamo/sglang/protocol.py
+++ b/components/src/dynamo/sglang/protocol.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 
 from dynamo.common.multimodal import TransferRequest
+from dynamo.common.protocols.image_protocol import ImageNvExt
 
 TokenIdType = int
 
@@ -143,22 +144,16 @@ class DisaggSglangMultimodalRequest(BaseModel):
 # ============================================================================
 
 
-class NvExt(BaseModel):
-    """NVIDIA extensions for image generation"""
-
-    negative_prompt: Optional[str] = None
-    num_inference_steps: Optional[int] = 50
-    guidance_scale: float = 7.5
-    seed: Optional[int] = None
-    annotations: Optional[list[str]] = None
-
-
 class CreateImageRequest(BaseModel):
     """OpenAI /v1/images/generations and /v1/images/edits compatible request.
 
     Generation params (seed, guidance_scale, etc.) can be specified either
     at the top level (SGLang-compatible) or nested under ``nvext``
     (Dynamo convention).  When both are present, ``nvext`` wins.
+
+    Uses the shared ``ImageNvExt`` from ``dynamo.common.protocols.image_protocol``
+    for the ``nvext`` field. SGLang-specific defaults (guidance_scale=7.5,
+    num_inference_steps=50) are applied in the handler, not the model.
     """
 
     prompt: str
@@ -168,16 +163,17 @@ class CreateImageRequest(BaseModel):
     quality: Optional[str] = "standard"  # standard, hd
     response_format: Optional[str] = "url"  # url or b64_json
     user: Optional[str] = None
-    input_reference: Optional[str] = None  # For I2I (image-to-image) - image path/url
+    input_reference: Optional[str] = None  # For I2I/TI2I - image path/url
 
-    # Top-level generation params (SGLang-compatible)
+    # Top-level generation params (SGLang-compatible).
+    # These mirror fields in NvCreateImageRequest (image_protocol.py & images.rs).
     seed: Optional[int] = None
     negative_prompt: Optional[str] = None
     num_inference_steps: Optional[int] = None
     guidance_scale: Optional[float] = None
 
     # NVIDIA extensions nested under nvext (takes precedence over top-level)
-    nvext: Optional[NvExt] = None
+    nvext: Optional[ImageNvExt] = None
 
 
 class ImageData(BaseModel):

--- a/components/src/dynamo/sglang/protocol.py
+++ b/components/src/dynamo/sglang/protocol.py
@@ -154,7 +154,12 @@ class NvExt(BaseModel):
 
 
 class CreateImageRequest(BaseModel):
-    """OpenAI /v1/images/generations compatible request"""
+    """OpenAI /v1/images/generations and /v1/images/edits compatible request.
+
+    Generation params (seed, guidance_scale, etc.) can be specified either
+    at the top level (SGLang-compatible) or nested under ``nvext``
+    (Dynamo convention).  When both are present, ``nvext`` wins.
+    """
 
     prompt: str
     model: str  # e.g. "stabilityai/stable-diffusion-3.5-medium"
@@ -163,8 +168,15 @@ class CreateImageRequest(BaseModel):
     quality: Optional[str] = "standard"  # standard, hd
     response_format: Optional[str] = "url"  # url or b64_json
     user: Optional[str] = None
+    input_reference: Optional[str] = None  # For I2I (image-to-image) - image path/url
 
-    # NVIDIA extensions nested under nvext
+    # Top-level generation params (SGLang-compatible)
+    seed: Optional[int] = None
+    negative_prompt: Optional[str] = None
+    num_inference_steps: Optional[int] = None
+    guidance_scale: Optional[float] = None
+
+    # NVIDIA extensions nested under nvext (takes precedence over top-level)
     nvext: Optional[NvExt] = None
 
 

--- a/components/src/dynamo/sglang/protocol.py
+++ b/components/src/dynamo/sglang/protocol.py
@@ -147,12 +147,8 @@ class DisaggSglangMultimodalRequest(BaseModel):
 class CreateImageRequest(BaseModel):
     """OpenAI /v1/images/generations and /v1/images/edits compatible request.
 
-    Generation params (seed, guidance_scale, etc.) can be specified either
-    at the top level (SGLang-compatible) or nested under ``nvext``
-    (Dynamo convention).  When both are present, ``nvext`` wins.
-
-    Uses the shared ``ImageNvExt`` from ``dynamo.common.protocols.image_protocol``
-    for the ``nvext`` field. SGLang-specific defaults (guidance_scale=7.5,
+    Generation params (seed, guidance_scale, num_inference_steps, negative_prompt)
+    are specified under ``nvext``.  SGLang-specific defaults (guidance_scale=7.5,
     num_inference_steps=50) are applied in the handler, not the model.
     """
 
@@ -165,14 +161,6 @@ class CreateImageRequest(BaseModel):
     user: Optional[str] = None
     input_reference: Optional[str] = None  # For I2I/TI2I - image path/url
 
-    # Top-level generation params (SGLang-compatible).
-    # These mirror fields in NvCreateImageRequest (image_protocol.py & images.rs).
-    seed: Optional[int] = None
-    negative_prompt: Optional[str] = None
-    num_inference_steps: Optional[int] = None
-    guidance_scale: Optional[float] = None
-
-    # NVIDIA extensions nested under nvext (takes precedence over top-level)
     nvext: Optional[ImageNvExt] = None
 
 

--- a/components/src/dynamo/sglang/request_handlers/image_diffusion/image_diffusion_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/image_diffusion/image_diffusion_handler.py
@@ -92,8 +92,18 @@ class ImageDiffusionWorkerHandler(BaseGenerativeHandler):
         try:
             req = CreateImageRequest(**request)
 
-            # get extra parameters
-            nvext = req.nvext or NvExt()
+            # When nvext is provided, use it; otherwise fall back to top-level params
+            if req.nvext is not None:
+                nvext = req.nvext
+            else:
+                nvext = NvExt(
+                    seed=req.seed,
+                    negative_prompt=req.negative_prompt,
+                    num_inference_steps=req.num_inference_steps,
+                    guidance_scale=req.guidance_scale
+                    if req.guidance_scale is not None
+                    else 7.5,
+                )
             nvext.num_inference_steps = min(
                 nvext.num_inference_steps or 50, MAX_NUM_INFERENCE_STEPS
             )
@@ -108,6 +118,7 @@ class ImageDiffusionWorkerHandler(BaseGenerativeHandler):
                 num_inference_steps=nvext.num_inference_steps,
                 guidance_scale=nvext.guidance_scale,
                 seed=nvext.seed,
+                input_reference=req.input_reference,
             )
 
             context_id = context.id()
@@ -145,6 +156,7 @@ class ImageDiffusionWorkerHandler(BaseGenerativeHandler):
         guidance_scale: float,
         seed: Optional[int],
         negative_prompt: Optional[str] = None,
+        input_reference: Optional[str] = None,
     ) -> list[bytes]:
         """Generate images using SGLang DiffGenerator"""
         args = {
@@ -157,6 +169,11 @@ class ImageDiffusionWorkerHandler(BaseGenerativeHandler):
             "guidance_scale": guidance_scale,
             "seed": seed if seed else random.randint(0, 1000000),
         }
+
+        # Add image_path for I2I if provided
+        if input_reference:
+            args["image_path"] = input_reference
+
         result = await asyncio.to_thread(
             self.generator.generate,
             sampling_params_kwargs=args,

--- a/components/src/dynamo/sglang/request_handlers/image_diffusion/image_diffusion_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/image_diffusion/image_diffusion_handler.py
@@ -14,16 +14,19 @@ import torch
 from PIL import Image
 
 from dynamo._core import Context
+from dynamo.common.protocols.image_protocol import ImageNvExt
 from dynamo.common.storage import upload_to_fs
 from dynamo.common.utils.otel_tracing import build_trace_headers
 from dynamo.sglang.args import Config
-from dynamo.sglang.protocol import CreateImageRequest, ImageData, ImagesResponse, NvExt
+from dynamo.sglang.protocol import CreateImageRequest, ImageData, ImagesResponse
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.handler_base import BaseGenerativeHandler
 
 logger = logging.getLogger(__name__)
 
 MAX_NUM_INFERENCE_STEPS = 50
+DEFAULT_NUM_INFERENCE_STEPS = 50
+DEFAULT_GUIDANCE_SCALE = 7.5
 
 
 class ImageDiffusionWorkerHandler(BaseGenerativeHandler):
@@ -92,20 +95,34 @@ class ImageDiffusionWorkerHandler(BaseGenerativeHandler):
         try:
             req = CreateImageRequest(**request)
 
-            # When nvext is provided, use it; otherwise fall back to top-level params
+            # When nvext is provided, use it; otherwise build from top-level params.
+            # ImageNvExt has no opinionated defaults — SGLang defaults applied below.
             if req.nvext is not None:
                 nvext = req.nvext
             else:
-                nvext = NvExt(
+                nvext = ImageNvExt(
                     seed=req.seed,
                     negative_prompt=req.negative_prompt,
                     num_inference_steps=req.num_inference_steps,
-                    guidance_scale=req.guidance_scale
-                    if req.guidance_scale is not None
-                    else 7.5,
+                    guidance_scale=req.guidance_scale,
                 )
-            nvext.num_inference_steps = min(
-                nvext.num_inference_steps or 50, MAX_NUM_INFERENCE_STEPS
+
+            # Apply SGLang-specific defaults for unset values
+            raw_steps = (
+                nvext.num_inference_steps
+                if nvext.num_inference_steps is not None
+                else DEFAULT_NUM_INFERENCE_STEPS
+            )
+            if raw_steps > MAX_NUM_INFERENCE_STEPS:
+                logger.warning(
+                    f"num_inference_steps={raw_steps} exceeds max "
+                    f"{MAX_NUM_INFERENCE_STEPS}, clamping"
+                )
+            num_inference_steps = min(raw_steps, MAX_NUM_INFERENCE_STEPS)
+            guidance_scale = (
+                nvext.guidance_scale
+                if nvext.guidance_scale is not None
+                else DEFAULT_GUIDANCE_SCALE
             )
 
             width, height = self._parse_size(req.size)
@@ -115,8 +132,8 @@ class ImageDiffusionWorkerHandler(BaseGenerativeHandler):
                 negative_prompt=nvext.negative_prompt,
                 width=width,
                 height=height,
-                num_inference_steps=nvext.num_inference_steps,
-                guidance_scale=nvext.guidance_scale,
+                num_inference_steps=num_inference_steps,
+                guidance_scale=guidance_scale,
                 seed=nvext.seed,
                 input_reference=req.input_reference,
             )
@@ -167,11 +184,13 @@ class ImageDiffusionWorkerHandler(BaseGenerativeHandler):
             "num_inference_steps": num_inference_steps,
             "save_output": False,  # We handle saving ourselves
             "guidance_scale": guidance_scale,
-            "seed": seed if seed else random.randint(0, 1000000),
+            "seed": seed if seed is not None else random.randint(0, 1000000),
         }
 
-        # Add image_path for I2I if provided
-        if input_reference:
+        # Add image_path for I2I/TI2I if provided
+        if input_reference is not None:
+            if not input_reference.strip():
+                raise ValueError("input_reference must be a non-empty string")
             args["image_path"] = input_reference
 
         result = await asyncio.to_thread(
@@ -192,7 +211,7 @@ class ImageDiffusionWorkerHandler(BaseGenerativeHandler):
         for img in images:
             if isinstance(img, bytes):
                 image_bytes_list.append(img)
-            elif Image is not None and isinstance(img, Image.Image):
+            elif isinstance(img, Image.Image):
                 # Convert PIL Image to bytes
                 buf = io.BytesIO()
                 img.save(buf, format="PNG")

--- a/components/src/dynamo/sglang/request_handlers/image_diffusion/image_diffusion_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/image_diffusion/image_diffusion_handler.py
@@ -95,35 +95,17 @@ class ImageDiffusionWorkerHandler(BaseGenerativeHandler):
         try:
             req = CreateImageRequest(**request)
 
-            # When nvext is provided, use it; otherwise build from top-level params.
-            # ImageNvExt has no opinionated defaults — SGLang defaults applied below.
-            if req.nvext is not None:
-                nvext = req.nvext
-            else:
-                nvext = ImageNvExt(
-                    seed=req.seed,
-                    negative_prompt=req.negative_prompt,
-                    num_inference_steps=req.num_inference_steps,
-                    guidance_scale=req.guidance_scale,
-                )
+            nvext = req.nvext or ImageNvExt()
 
             # Apply SGLang-specific defaults for unset values
-            raw_steps = (
-                nvext.num_inference_steps
-                if nvext.num_inference_steps is not None
-                else DEFAULT_NUM_INFERENCE_STEPS
-            )
+            raw_steps = nvext.num_inference_steps or DEFAULT_NUM_INFERENCE_STEPS
             if raw_steps > MAX_NUM_INFERENCE_STEPS:
                 logger.warning(
                     f"num_inference_steps={raw_steps} exceeds max "
                     f"{MAX_NUM_INFERENCE_STEPS}, clamping"
                 )
             num_inference_steps = min(raw_steps, MAX_NUM_INFERENCE_STEPS)
-            guidance_scale = (
-                nvext.guidance_scale
-                if nvext.guidance_scale is not None
-                else DEFAULT_GUIDANCE_SCALE
-            )
+            guidance_scale = nvext.guidance_scale or DEFAULT_GUIDANCE_SCALE
 
             width, height = self._parse_size(req.size)
 

--- a/components/src/dynamo/sglang/tests/test_sglang_image_diffusion_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_image_diffusion_handler.py
@@ -438,34 +438,3 @@ class TestImageDiffusionWorkerHandler:
         call_args = handler.generator.generate.call_args
         sampling_params = call_args[1]["sampling_params_kwargs"]
         assert "image_path" not in sampling_params
-
-    @pytest.mark.asyncio
-    async def test_generate_top_level_params(self, handler, mock_context):
-        """Test SGLang-style request with params at top level (no nvext)."""
-        test_image = Image.new("RGB", (256, 256), color="blue")
-
-        handler.generator.generate = Mock(
-            return_value=SimpleNamespace(frames=[test_image])
-        )
-
-        request = {
-            "prompt": "A blue square",
-            "model": "test-model",
-            "size": "256x256",
-            "response_format": "b64_json",
-            "seed": 123,
-            "negative_prompt": "ugly",
-            "num_inference_steps": 20,
-            "guidance_scale": 3.0,
-        }
-
-        results = []
-        async for result in handler.generate(request, mock_context):
-            results.append(result)
-
-        call_args = handler.generator.generate.call_args
-        params = call_args[1]["sampling_params_kwargs"]
-        assert params["seed"] == 123
-        assert params["negative_prompt"] == "ugly"
-        assert params["num_inference_steps"] == 20
-        assert params["guidance_scale"] == 3.0

--- a/components/src/dynamo/sglang/tests/test_sglang_image_diffusion_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_image_diffusion_handler.py
@@ -6,7 +6,7 @@
 import base64
 import io
 from types import SimpleNamespace
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from PIL import Image
@@ -347,7 +347,7 @@ class TestImageDiffusionWorkerHandler:
         """Test that nvext parameters are passed to the generator."""
         test_image = Image.new("RGB", (256, 256), color="yellow")
 
-        handler._generate_images = Mock(return_value=[test_image.tobytes()])
+        handler._generate_images = AsyncMock(return_value=[test_image.tobytes()])
 
         request = {
             "prompt": "A yellow square",
@@ -382,4 +382,87 @@ class TestImageDiffusionWorkerHandler:
             guidance_scale=7.5,
             seed=42,
             negative_prompt="negative",
+            input_reference=None,
         )
+
+    @pytest.mark.asyncio
+    async def test_generate_i2i_passes_image_path(self, handler, mock_context):
+        """Test that input_reference is passed as image_path to the generator."""
+        test_image = Image.new("RGB", (256, 256), color="green")
+
+        handler.generator.generate = Mock(
+            return_value=SimpleNamespace(frames=[test_image])
+        )
+
+        request = {
+            "prompt": "Transform this image",
+            "model": "test-model",
+            "size": "256x256",
+            "response_format": "b64_json",
+            "input_reference": "/tmp/test_input.png",
+        }
+
+        results = []
+        async for result in handler.generate(request, mock_context):
+            results.append(result)
+
+        # Verify image_path was passed to the generator
+        call_args = handler.generator.generate.call_args
+        sampling_params = call_args[1]["sampling_params_kwargs"]
+        assert sampling_params["image_path"] == "/tmp/test_input.png"
+
+    @pytest.mark.asyncio
+    async def test_generate_t2i_no_image_path(self, handler, mock_context):
+        """Test that image_path is NOT passed when input_reference is absent."""
+        test_image = Image.new("RGB", (256, 256), color="red")
+
+        handler.generator.generate = Mock(
+            return_value=SimpleNamespace(frames=[test_image])
+        )
+
+        request = {
+            "prompt": "A red square",
+            "model": "test-model",
+            "size": "256x256",
+            "response_format": "b64_json",
+        }
+
+        results = []
+        async for result in handler.generate(request, mock_context):
+            results.append(result)
+
+        # Verify image_path was NOT passed
+        call_args = handler.generator.generate.call_args
+        sampling_params = call_args[1]["sampling_params_kwargs"]
+        assert "image_path" not in sampling_params
+
+    @pytest.mark.asyncio
+    async def test_generate_top_level_params(self, handler, mock_context):
+        """Test SGLang-style request with params at top level (no nvext)."""
+        test_image = Image.new("RGB", (256, 256), color="blue")
+
+        handler.generator.generate = Mock(
+            return_value=SimpleNamespace(frames=[test_image])
+        )
+
+        request = {
+            "prompt": "A blue square",
+            "model": "test-model",
+            "size": "256x256",
+            "response_format": "b64_json",
+            "seed": 123,
+            "negative_prompt": "ugly",
+            "num_inference_steps": 20,
+            "guidance_scale": 3.0,
+        }
+
+        results = []
+        async for result in handler.generate(request, mock_context):
+            results.append(result)
+
+        call_args = handler.generator.generate.call_args
+        params = call_args[1]["sampling_params_kwargs"]
+        assert params["seed"] == 123
+        assert params["negative_prompt"] == "ugly"
+        assert params["num_inference_steps"] == 20
+        assert params["guidance_scale"] == 3.0

--- a/components/src/dynamo/sglang/tests/test_sglang_image_diffusion_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_image_diffusion_handler.py
@@ -386,7 +386,9 @@ class TestImageDiffusionWorkerHandler:
         )
 
     @pytest.mark.asyncio
-    async def test_generate_i2i_passes_image_path(self, handler, mock_context):
+    async def test_generate_i2i_passes_image_path(
+        self, handler, mock_context, tmp_path
+    ):
         """Test that input_reference is passed as image_path to the generator."""
         test_image = Image.new("RGB", (256, 256), color="green")
 
@@ -394,12 +396,13 @@ class TestImageDiffusionWorkerHandler:
             return_value=SimpleNamespace(frames=[test_image])
         )
 
+        input_ref = str(tmp_path / "test_input.png")
         request = {
             "prompt": "Transform this image",
             "model": "test-model",
             "size": "256x256",
             "response_format": "b64_json",
-            "input_reference": "/tmp/test_input.png",
+            "input_reference": input_ref,
         }
 
         results = []
@@ -409,7 +412,7 @@ class TestImageDiffusionWorkerHandler:
         # Verify image_path was passed to the generator
         call_args = handler.generator.generate.call_args
         sampling_params = call_args[1]["sampling_params_kwargs"]
-        assert sampling_params["image_path"] == "/tmp/test_input.png"
+        assert sampling_params["image_path"] == input_ref
 
     @pytest.mark.asyncio
     async def test_generate_t2i_no_image_path(self, handler, mock_context):

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2035,7 +2035,7 @@ pub fn images_router(
     path: Option<String>,
 ) -> (Vec<RouteDoc>, Router) {
     let generations_path = path.unwrap_or("/v1/images/generations".to_string());
-    let edits_path = "/v1/images/edits".to_string();
+    let edits_path = generations_path.replace("/generations", "/edits");
     let doc = RouteDoc::new(axum::http::Method::POST, &generations_path);
     let edits_doc = RouteDoc::new(axum::http::Method::POST, &edits_path);
     let router = Router::new()

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2025,20 +2025,23 @@ async fn images(
     Ok(Json(response).into_response())
 }
 
-/// Create an Axum [`Router`] for the OpenAI API Images endpoint
-/// If not path is provided, the default path is `/v1/images/generations`
+/// Create an Axum [`Router`] for the OpenAI API Images endpoints.
+/// Registers both `/v1/images/generations` (T2I) and `/v1/images/edits` (I2I).
 pub fn images_router(
     state: Arc<service_v2::State>,
     path: Option<String>,
 ) -> (Vec<RouteDoc>, Router) {
     let path = path.unwrap_or("/v1/images/generations".to_string());
+    let edits_path = path.replace("/generations", "/edits");
     let doc = RouteDoc::new(axum::http::Method::POST, &path);
+    let edits_doc = RouteDoc::new(axum::http::Method::POST, &edits_path);
     let router = Router::new()
         .route(&path, post(images))
+        .route(&edits_path, post(images))
         .layer(middleware::from_fn(smart_json_error_middleware))
         .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .with_state(state);
-    (vec![doc], router)
+    (vec![doc, edits_doc], router)
 }
 
 async fn videos(

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2025,11 +2025,29 @@ async fn images(
     Ok(Json(response).into_response())
 }
 
+/// Handler for `/v1/images/edits` (I2I). Requires `input_reference`.
+async fn images_edits(
+    state: State<Arc<service_v2::State>>,
+    headers: HeaderMap,
+    Json(request): Json<NvCreateImageRequest>,
+) -> Result<Response, ErrorResponse> {
+    if request.input_reference.is_none() {
+        let code = StatusCode::BAD_REQUEST;
+        return Err((
+            code,
+            Json(ErrorMessage {
+                message: "input_reference is required for /v1/images/edits".to_string(),
+                error_type: map_error_code_to_error_type(code),
+                code: code.as_u16(),
+            }),
+        ));
+    }
+    images(state, headers, Json(request)).await
+}
+
 /// Create an Axum [`Router`] for the OpenAI API Images endpoints.
-/// Registers both `/v1/images/generations` (T2I) and `/v1/images/edits` (I2I).
-/// Both routes use the same handler — I2I vs T2I is determined by the
-/// presence of `input_reference` in the request body, not by the route.
-/// `/edits` is registered for OpenAI API compatibility.
+/// `/v1/images/generations` accepts optional `input_reference` (T2I or TI2I).
+/// `/v1/images/edits` requires `input_reference` (I2I).
 pub fn images_router(
     state: Arc<service_v2::State>,
     path: Option<String>,
@@ -2040,7 +2058,7 @@ pub fn images_router(
     let edits_doc = RouteDoc::new(axum::http::Method::POST, &edits_path);
     let router = Router::new()
         .route(&generations_path, post(images))
-        .route(&edits_path, post(images))
+        .route(&edits_path, post(images_edits))
         .layer(middleware::from_fn(smart_json_error_middleware))
         .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .with_state(state);

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2027,16 +2027,19 @@ async fn images(
 
 /// Create an Axum [`Router`] for the OpenAI API Images endpoints.
 /// Registers both `/v1/images/generations` (T2I) and `/v1/images/edits` (I2I).
+/// Both routes use the same handler — I2I vs T2I is determined by the
+/// presence of `input_reference` in the request body, not by the route.
+/// `/edits` is registered for OpenAI API compatibility.
 pub fn images_router(
     state: Arc<service_v2::State>,
     path: Option<String>,
 ) -> (Vec<RouteDoc>, Router) {
-    let path = path.unwrap_or("/v1/images/generations".to_string());
-    let edits_path = path.replace("/generations", "/edits");
-    let doc = RouteDoc::new(axum::http::Method::POST, &path);
+    let generations_path = path.unwrap_or("/v1/images/generations".to_string());
+    let edits_path = "/v1/images/edits".to_string();
+    let doc = RouteDoc::new(axum::http::Method::POST, &generations_path);
     let edits_doc = RouteDoc::new(axum::http::Method::POST, &edits_path);
     let router = Router::new()
-        .route(&path, post(images))
+        .route(&generations_path, post(images))
         .route(&edits_path, post(images))
         .layer(middleware::from_fn(smart_json_error_middleware))
         .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))

--- a/lib/llm/src/protocols/openai/images.rs
+++ b/lib/llm/src/protocols/openai/images.rs
@@ -11,18 +11,26 @@ mod nvext;
 pub use aggregator::DeltaAggregator;
 pub use nvext::{NvExt, NvExtProvider};
 
+/// Image generation request with NVIDIA extensions.
+///
+/// Generation params (seed, guidance_scale, etc.) can be specified at the top level
+/// (SGLang-native format) or nested under `nvext` (Dynamo convention). The Python
+/// handler merges them, with `nvext` taking precedence. Top-level fields exist because
+/// SGLang's native API uses them, and requiring `nvext` wrapping would break SGLang
+/// client compatibility.
 #[derive(Serialize, Deserialize, Validate, Debug, Clone)]
 pub struct NvCreateImageRequest {
     #[serde(flatten)]
     pub inner: dynamo_protocols::types::CreateImageRequest,
 
-    /// Optional image reference that guides generation (for I2I)
+    /// Optional image reference that guides generation (for I2I/TI2I).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_reference: Option<String>,
 
     /// Random seed. Top-level alternative to nvext; nvext takes precedence.
+    /// i64 to match PyTorch's torch.manual_seed() accepted range.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub seed: Option<u32>,
+    pub seed: Option<i64>,
 
     /// Negative prompt. Top-level alternative to nvext; nvext takes precedence.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/lib/llm/src/protocols/openai/images.rs
+++ b/lib/llm/src/protocols/openai/images.rs
@@ -16,6 +16,26 @@ pub struct NvCreateImageRequest {
     #[serde(flatten)]
     pub inner: dynamo_protocols::types::CreateImageRequest,
 
+    /// Optional image reference that guides generation (for I2I)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_reference: Option<String>,
+
+    /// Random seed. Top-level alternative to nvext; nvext takes precedence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seed: Option<u32>,
+
+    /// Negative prompt. Top-level alternative to nvext; nvext takes precedence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub negative_prompt: Option<String>,
+
+    /// Number of denoising steps. Top-level alternative to nvext; nvext takes precedence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_inference_steps: Option<u32>,
+
+    /// CFG guidance scale. Top-level alternative to nvext; nvext takes precedence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guidance_scale: Option<f32>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nvext: Option<NvExt>,
 }

--- a/lib/llm/src/protocols/openai/images.rs
+++ b/lib/llm/src/protocols/openai/images.rs
@@ -12,12 +12,6 @@ pub use aggregator::DeltaAggregator;
 pub use nvext::{NvExt, NvExtProvider};
 
 /// Image generation request with NVIDIA extensions.
-///
-/// Generation params (seed, guidance_scale, etc.) can be specified at the top level
-/// (SGLang-native format) or nested under `nvext` (Dynamo convention). The Python
-/// handler merges them, with `nvext` taking precedence. Top-level fields exist because
-/// SGLang's native API uses them, and requiring `nvext` wrapping would break SGLang
-/// client compatibility.
 #[derive(Serialize, Deserialize, Validate, Debug, Clone)]
 pub struct NvCreateImageRequest {
     #[serde(flatten)]
@@ -26,23 +20,6 @@ pub struct NvCreateImageRequest {
     /// Optional image reference that guides generation (for I2I/TI2I).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_reference: Option<String>,
-
-    /// Random seed. Top-level alternative to nvext; nvext takes precedence.
-    /// i64 to match PyTorch's torch.manual_seed() accepted range.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub seed: Option<i64>,
-
-    /// Negative prompt. Top-level alternative to nvext; nvext takes precedence.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub negative_prompt: Option<String>,
-
-    /// Number of denoising steps. Top-level alternative to nvext; nvext takes precedence.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub num_inference_steps: Option<u32>,
-
-    /// CFG guidance scale. Top-level alternative to nvext; nvext takes precedence.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub guidance_scale: Option<f32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nvext: Option<NvExt>,

--- a/lib/llm/src/protocols/openai/images/nvext.rs
+++ b/lib/llm/src/protocols/openai/images/nvext.rs
@@ -37,9 +37,10 @@ pub struct NvExt {
     pub guidance_scale: Option<f32>,
 
     /// The seed for the random number generator.
+    /// i64 to match PyTorch's torch.manual_seed() accepted range.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
-    pub seed: Option<u32>,
+    pub seed: Option<i64>,
 }
 
 impl Default for NvExt {


### PR DESCRIPTION
#### Overview:

  - Add `/v1/images/edits` route for I2I (image-to-image) generation, alongside existing `/v1/images/generations`
  - Add `input_reference` field to image generation protocol (Rust + Python) to pass a conditioning image to SGLang's `DiffGenerator` as `image_path`
  - Accept generation params (`seed`, `negative_prompt`, `num_inference_steps`, `guidance_scale`) at the top level for
  SGLang API compatibility, in addition to nested `nvext`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/v1/images/edits` endpoint enabling image editing workflows
  * Image-to-image generation now supported via input reference parameter
  * Extended generation controls: seed, negative prompt, inference steps, and guidance scale for enhanced image customization

* **Tests**
  * Added comprehensive test coverage for new image generation parameters and editing functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->