### PR TITLE
fix(frontend): Kimi tokenizer special token handling - use absolute token ID in tiktoken reserved token fallback names

### DIFF
--- a/lib/llm/src/tokenizers/tiktoken.rs
+++ b/lib/llm/src/tokenizers/tiktoken.rs
@@ -181,7 +181,7 @@ fn load_special_tokens(directory: &Path, num_base_tokens: usize) -> Result<FxHas
         // No tokenizer_config.json — generate default reserved tokens
         for i in 0..DEFAULT_NUM_RESERVED_SPECIAL_TOKENS {
             let id = num_base_tokens as u32 + i;
-            special_tokens.insert(format!("<|reserved_token_{i}|>"), id);
+            special_tokens.insert(format!("<|reserved_token_{id}|>"), id);
         }
         return Ok(special_tokens);
     }
@@ -222,14 +222,14 @@ fn load_special_tokens(directory: &Path, num_base_tokens: usize) -> Result<FxHas
         for i in 0..DEFAULT_NUM_RESERVED_SPECIAL_TOKENS {
             let id = num_base_tokens as u32 + i;
             if !used_ids.contains(&id) {
-                special_tokens.insert(format!("<|reserved_token_{i}|>"), id);
+                special_tokens.insert(format!("<|reserved_token_{id}|>"), id);
             }
         }
     } else {
         // No added_tokens_decoder — generate default reserved tokens
         for i in 0..DEFAULT_NUM_RESERVED_SPECIAL_TOKENS {
             let id = num_base_tokens as u32 + i;
-            special_tokens.insert(format!("<|reserved_token_{i}|>"), id);
+            special_tokens.insert(format!("<|reserved_token_{id}|>"), id);
         }
     }
 
@@ -433,8 +433,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = load_special_tokens(dir.path(), 100).unwrap();
         assert_eq!(tokens.len(), 256);
-        assert_eq!(tokens["<|reserved_token_0|>"], 100);
-        assert_eq!(tokens["<|reserved_token_255|>"], 355);
+        assert_eq!(tokens["<|reserved_token_100|>"], 100);
+        assert_eq!(tokens["<|reserved_token_355|>"], 355);
     }
 
     #[test]
@@ -659,5 +659,129 @@ mod tests {
             let decoded = tokenizer.decode(encoding.token_ids(), false).unwrap();
             assert_eq!(decoded, *input);
         }
+    }
+
+    /// Helper: create a tiktoken file containing all 256 single-byte tokens (ranks 0..255).
+    /// This gives a complete byte-level base vocabulary so any ASCII string can be encoded.
+    fn create_byte_level_tiktoken_file(dir: &Path) -> String {
+        let engine = base64::engine::general_purpose::STANDARD;
+        let mut content = String::new();
+        for byte_val in 0u16..256 {
+            let encoded = engine.encode(&[byte_val as u8]);
+            content.push_str(&format!("{encoded} {byte_val}\n"));
+        }
+        let file_path = dir.join("tiktoken.model");
+        std::fs::write(&file_path, &content).unwrap();
+        file_path.to_str().unwrap().to_string()
+    }
+
+    /// Regression test for Kimi K2.5 tokenizer inflation.
+    ///
+    /// Python's tokenization_kimi.py names unnamed reserved tokens by absolute ID:
+    ///   `<|reserved_token_{absolute_id}|>`
+    ///
+    /// The Rust code previously used relative offsets (0..255) as the naming index,
+    /// so when a prompt contained `<|reserved_token_258|>` the Rust tokenizer did NOT
+    /// recognize it as a special token. Each occurrence was encoded as multiple BPE
+    /// tokens instead of 1, inflating an 8192-token prompt to 9038 tokens and causing
+    /// TRT-LLM to reject the request.
+    #[test]
+    fn test_reserved_token_absolute_id_naming_kimi_k25_regression() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = create_byte_level_tiktoken_file(dir.path());
+
+        // config.json with kimi model type -> triggers KIMI_PATTERN
+        create_test_config(dir.path(), "kimi");
+
+        // tokenizer_config.json: BOS at 256, EOS at 257. Base vocab is IDs 0..255.
+        create_test_tokenizer_config(dir.path(), 256);
+
+        let tokenizer = TikTokenTokenizer::from_file_auto(&file_path).unwrap();
+
+        // ID 256 = [BOS], ID 257 = [EOS].
+        // ID 258 = first UNNAMED reserved token.
+        //   With fix:   named <|reserved_token_258|>  (absolute ID)
+        //   Before fix: named <|reserved_token_2|>    (relative offset)
+
+        // Single unnamed reserved token should be recognized as 1 special token.
+        let single = "<|reserved_token_258|>";
+        let enc = tokenizer.encode(single).unwrap();
+        assert_eq!(
+            enc.token_ids().len(),
+            1,
+            "'{single}' should be 1 special token, got {} tokens: {:?}. \
+             This means fallback naming still uses relative offsets instead of absolute IDs.",
+            enc.token_ids().len(),
+            enc.token_ids()
+        );
+        assert_eq!(enc.token_ids()[0], 258);
+
+        // Multiple unnamed reserved tokens in sequence (mini version of the benchmark).
+        // IDs 258..268 are all unnamed; with the fix they're <|reserved_token_258|>..267.
+        let multi: String = (258u32..268)
+            .map(|id| format!("<|reserved_token_{id}|>"))
+            .collect();
+        let enc_multi = tokenizer.encode(&multi).unwrap();
+        assert_eq!(
+            enc_multi.token_ids().len(),
+            10,
+            "10 reserved token strings should produce exactly 10 tokens, got {}: {:?}",
+            enc_multi.token_ids().len(),
+            enc_multi.token_ids()
+        );
+        let expected_ids: Vec<u32> = (258..268).collect();
+        assert_eq!(enc_multi.token_ids(), &expected_ids);
+    }
+
+    /// Confirm that the old relative-offset naming would cause token inflation.
+    /// Manually builds a tokenizer whose special-token map uses the WRONG names
+    /// (relative offsets), then shows the same string encodes as many tokens.
+    #[test]
+    fn test_relative_offset_naming_causes_inflation() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = create_byte_level_tiktoken_file(dir.path());
+
+        let encoder = parse_tiktoken_file(&file_path).unwrap();
+        let num_base_tokens = 256usize;
+
+        // Build special tokens with the OLD (buggy) relative-offset naming
+        let mut bad_special_tokens: FxHashMap<String, u32> = FxHashMap::default();
+        bad_special_tokens.insert("[BOS]".to_string(), 256);
+        bad_special_tokens.insert("[EOS]".to_string(), 257);
+        for i in 0..DEFAULT_NUM_RESERVED_SPECIAL_TOKENS {
+            let id = num_base_tokens as u32 + i;
+            if id != 256 && id != 257 {
+                // OLD naming: relative offset i, not absolute id
+                bad_special_tokens.insert(format!("<|reserved_token_{i}|>"), id);
+            }
+        }
+
+        let bad_tokenizer =
+            TikTokenTokenizer::from_file(&file_path, KIMI_PATTERN, bad_special_tokens).unwrap();
+
+        // With the wrong naming, <|reserved_token_258|> is NOT recognized as special.
+        // It gets split into byte-level BPE tokens -> many more than 1.
+        let input = "<|reserved_token_258|>";
+        let enc = bad_tokenizer.encode(input).unwrap();
+        assert!(
+            enc.token_ids().len() > 1,
+            "With buggy relative-offset naming, '{}' should NOT be recognized as a \
+             single special token. Got {} token(s): {:?}",
+            input,
+            enc.token_ids().len(),
+            enc.token_ids()
+        );
+
+        // Show the inflation: 10 reserved tokens produce far more than 10 BPE tokens.
+        let multi: String = (258u32..268)
+            .map(|id| format!("<|reserved_token_{id}|>"))
+            .collect();
+        let enc_multi = bad_tokenizer.encode(&multi).unwrap();
+        assert!(
+            enc_multi.token_ids().len() > 10,
+            "With buggy naming, 10 reserved token strings should inflate beyond 10 tokens. \
+             Got {}",
+            enc_multi.token_ids().len(),
+        );
     }
 }

--- a/lib/llm/src/tokenizers/tiktoken.rs
+++ b/lib/llm/src/tokenizers/tiktoken.rs
@@ -667,7 +667,7 @@ mod tests {
         let engine = base64::engine::general_purpose::STANDARD;
         let mut content = String::new();
         for byte_val in 0u16..256 {
-            let encoded = engine.encode(&[byte_val as u8]);
+            let encoded = engine.encode([byte_val as u8]);
             content.push_str(&format!("{encoded} {byte_val}\n"));
         }
         let file_path = dir.join("tiktoken.model");
@@ -741,7 +741,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let file_path = create_byte_level_tiktoken_file(dir.path());
 
-        let encoder = parse_tiktoken_file(&file_path).unwrap();
+        let _encoder = parse_tiktoken_file(&file_path).unwrap();
         let num_base_tokens = 256usize;
 
         // Build special tokens with the OLD (buggy) relative-offset naming


### PR DESCRIPTION
#### Overview:

Fixes Kimi K2.5 tokenizer inflation where the Rust tiktoken tokenizer encodes prompts into significantly more tokens than the Python reference tokenizer, causing TRT-LLM to reject requests with default_max_tokens (-806) must be greater than 0.

Source of truth : https://huggingface.co/moonshotai/Kimi-K2.5/blob/main/tokenization_kimi.py#L100
```
self.special_tokens = {
            special_tokens_mapping.get(i, f"<|reserved_token_{i}|>"): i
            for i in range(num_base_tokens, num_base_tokens +
                           self.num_reserved_special_tokens)
        }
```

Root cause: load_special_tokens() in tiktoken.rs generated fallback names for unnamed reserved token slots using the relative loop index (i, 0-255) instead of the absolute token ID (id, 163584-163839). Python's tokenization_kimi.py uses absolute IDs in f"<|reserved_token_{i}|>" where i is in range(num_base_tokens, num_base_tokens + 256).

When benchmark prompts contain reserved token strings by their absolute-ID names (e.g., <|reserved_token_163589|>), the Rust tokenizer failed to recognize them as special tokens and encoded each as ~7 BPE tokens instead of 1, inflating an 8192-token prompt to 9038 tokens.

Fix: format!("<|reserved_token_{i}|>") changed to format!("<|reserved_token_{id}|>") in 3 places.

Validated against the actual nvidia/Kimi-K2.5-NVFP4 tokenizer via vllm.tokenizers.get_tokenizer.


#### Details:

Python's tokenization_kimi.py names unnamed reserved tokens using the absolute token ID: `<|reserved_token_{absolute_id}|>` where the ID is in range(num_base_tokens, num_base_tokens + 256).

The Rust implementation was using the relative loop offset (0..255), producing names like `<|reserved_token_0|>` instead of the correct `<|reserved_token_163584|>`. When prompts contain these token strings by their absolute-ID names (as Kimi K2.5 benchmarks do), the Rust tokenizer fails to recognize them as special tokens and encodes each as multiple BPE tokens -- inflating an 8192-token prompt to 9038 tokens, exceeding max_seq_len and causing TRT-LLM rejection.

Fix: `format\!("<|reserved_token_{i}|>")` → `format\!("<|reserved_token_{id}|>")` in all three branches of load_special_tokens().


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes DIS-1663


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected special token recognition to use absolute token IDs, ensuring reserved tokens are properly encoded and identified.

* **Tests**
  * Added regression tests verifying correct tokenizer behavior and special token handling across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->