### PR TITLE
fix: treat optional component import failures as warnings in sanity_check.py

### DIFF
--- a/deploy/sanity_check.py
+++ b/deploy/sanity_check.py
@@ -156,11 +156,19 @@ import os
 import platform
 import resource
 import shutil
+import site
 import subprocess
 import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    tomllib = None
+
+_LOG = logging.getLogger(__name__)
 
 # Path constants
 DYNAMO_RUNTIME_SRC_PATH = "lib/bindings/python/src/dynamo"
@@ -2962,9 +2970,6 @@ class DynamoFrameworkInfo(NodeInfo):
 
         # Add package info if installed
         if is_installed:
-            import glob
-            import site
-
             for site_dir in site.getsitepackages():
                 # Look specifically for ai_dynamo (not ai_dynamo_runtime)
                 dist_pattern = os.path.join(site_dir, "ai_dynamo-*.dist-info")
@@ -2985,22 +2990,32 @@ class DynamoFrameworkInfo(NodeInfo):
                         direct_url_path = os.path.join(path, "direct_url.json")
                         if os.path.exists(direct_url_path):
                             try:
-                                with open(direct_url_path, "r") as f:
-                                    import json as _json
-
-                                    du = _json.loads(f.read())
+                                with open(direct_url_path, "r", encoding="utf-8") as f:
+                                    du = json.loads(f.read())
+                            except (OSError, json.JSONDecodeError) as exc:
+                                dist_node.add_child(
+                                    NodeInfo(
+                                        label="→",
+                                        desc=self._replace_home_with_var(
+                                            f"{direct_url_path}: {exc}"
+                                        ),
+                                        status=NodeStatus.WARNING,
+                                    )
+                                )
+                            else:
                                 url = du.get("url", "")
                                 is_editable = (du.get("dir_info") or {}).get(
                                     "editable", False
                                 )
                                 if url.startswith("file://") and is_editable:
                                     target = url[len("file://") :]
-                                    # Resolve to the actual package source dir via pyproject.toml
+                                    resolved_target = target
                                     pyproject = os.path.join(target, "pyproject.toml")
-                                    if os.path.exists(pyproject):
+                                    if (
+                                        os.path.exists(pyproject)
+                                        and tomllib is not None
+                                    ):
                                         try:
-                                            import tomllib
-
                                             with open(pyproject, "rb") as pf:
                                                 cfg = tomllib.load(pf)
                                             pkgs = (
@@ -3012,20 +3027,35 @@ class DynamoFrameworkInfo(NodeInfo):
                                                 .get("packages", [])
                                             )
                                             if pkgs:
-                                                target = os.path.join(
+                                                resolved_target = os.path.join(
                                                     target, os.path.dirname(pkgs[0])
                                                 )
-                                        except Exception:
-                                            pass
-                                    display_target = self._replace_home_with_var(target)
+                                        except (
+                                            OSError,
+                                            tomllib.TOMLDecodeError,
+                                        ) as exc:
+                                            _LOG.debug(
+                                                "editable pyproject resolve failed: %s",
+                                                exc,
+                                            )
+                                            dist_node.add_child(
+                                                NodeInfo(
+                                                    label="→",
+                                                    desc=self._replace_home_with_var(
+                                                        f"{pyproject}: {exc}"
+                                                    ),
+                                                    status=NodeStatus.WARNING,
+                                                )
+                                            )
+                                    display_target = self._replace_home_with_var(
+                                        resolved_target
+                                    )
                                     points_to = NodeInfo(
                                         label="→",
                                         desc=display_target,
                                         status=NodeStatus.INFO,
                                     )
                                     dist_node.add_child(points_to)
-                            except Exception:
-                                pass
                         self.add_child(dist_node)
                     except Exception:
                         dist_node = NodeInfo(
@@ -3075,13 +3105,21 @@ class DynamoFrameworkInfo(NodeInfo):
                         )
                         self.add_child(component_node)
                         components_found = True
-                except ImportError as e:
-                    # Module's dependencies not installed (e.g., planner in non-planner images).
-                    # Treat as warning so the sanity check doesn't fail for optional components.
+                except ModuleNotFoundError as e:
+                    # Missing optional dependency (e.g., planner stack without kubernetes).
                     padded_name = f"{component:<{max_len}}"
                     error_msg = str(e) if str(e) else "Import failed"
                     component_node = NodeInfo(
                         label=padded_name, desc=error_msg, status=NodeStatus.WARNING
+                    )
+                    self.add_child(component_node)
+                    import_failures.append(component)
+                except ImportError as e:
+                    # e.g. "cannot import name ..." — treat as a real packaging/code issue.
+                    padded_name = f"{component:<{max_len}}"
+                    error_msg = str(e) if str(e) else "Import failed"
+                    component_node = NodeInfo(
+                        label=padded_name, desc=error_msg, status=NodeStatus.ERROR
                     )
                     self.add_child(component_node)
                     import_failures.append(component)

--- a/deploy/sanity_check.py
+++ b/deploy/sanity_check.py
@@ -2981,6 +2981,51 @@ class DynamoFrameworkInfo(NodeInfo):
                             status=NodeStatus.INFO,
                             metadata={"part_of_previous": True},
                         )
+                        # Check for editable install via direct_url.json
+                        direct_url_path = os.path.join(path, "direct_url.json")
+                        if os.path.exists(direct_url_path):
+                            try:
+                                with open(direct_url_path, "r") as f:
+                                    import json as _json
+
+                                    du = _json.loads(f.read())
+                                url = du.get("url", "")
+                                is_editable = (du.get("dir_info") or {}).get(
+                                    "editable", False
+                                )
+                                if url.startswith("file://") and is_editable:
+                                    target = url[len("file://") :]
+                                    # Resolve to the actual package source dir via pyproject.toml
+                                    pyproject = os.path.join(target, "pyproject.toml")
+                                    if os.path.exists(pyproject):
+                                        try:
+                                            import tomllib
+
+                                            with open(pyproject, "rb") as pf:
+                                                cfg = tomllib.load(pf)
+                                            pkgs = (
+                                                cfg.get("tool", {})
+                                                .get("hatch", {})
+                                                .get("build", {})
+                                                .get("targets", {})
+                                                .get("wheel", {})
+                                                .get("packages", [])
+                                            )
+                                            if pkgs:
+                                                target = os.path.join(
+                                                    target, os.path.dirname(pkgs[0])
+                                                )
+                                        except Exception:
+                                            pass
+                                    display_target = self._replace_home_with_var(target)
+                                    points_to = NodeInfo(
+                                        label="→",
+                                        desc=display_target,
+                                        status=NodeStatus.INFO,
+                                    )
+                                    dist_node.add_child(points_to)
+                            except Exception:
+                                pass
                         self.add_child(dist_node)
                     except Exception:
                         dist_node = NodeInfo(
@@ -3031,15 +3076,15 @@ class DynamoFrameworkInfo(NodeInfo):
                         self.add_child(component_node)
                         components_found = True
                 except ImportError as e:
-                    # Module not importable - show as error
+                    # Module's dependencies not installed (e.g., planner in non-planner images).
+                    # Treat as warning so the sanity check doesn't fail for optional components.
                     padded_name = f"{component:<{max_len}}"
                     error_msg = str(e) if str(e) else "Import failed"
                     component_node = NodeInfo(
-                        label=padded_name, desc=error_msg, status=NodeStatus.ERROR
+                        label=padded_name, desc=error_msg, status=NodeStatus.WARNING
                     )
                     self.add_child(component_node)
                     import_failures.append(component)
-                    # Don't set components_found to True for failed imports
 
             # Update status and value based on whether we found components
             if components_found:


### PR DESCRIPTION
#### Overview:

Sanity check fails since #7748 removed planner deps from non-planner images. This downgrades optional component import failures from errors to warnings.

#### Details:

- Framework `ImportError` now shows ⚠️ (warning) instead of ❌ (error), no longer triggers exit code 1
- Add editable install `→:` display for framework section, matching runtime section
- Runtime component imports remain errors (essential)

#### Where should the reviewer start?

`deploy/sanity_check.py` — `ImportError` handler ~line 3062, `direct_url.json` reader ~line 2984.

#### Related Issues:

Fixes regression from #7748

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced detection and resolution of editable package installations.
  * Import failures for framework components now reported as warnings instead of errors, improving diagnostic output clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->