### PR TITLE
fix(ci): include benchmarks in test image

### DIFF
--- a/container/Dockerfile.test
+++ b/container/Dockerfile.test
@@ -26,3 +26,4 @@ USER dynamo
 
 # Copy pytest configuration (markers, filterwarnings, asyncio_mode, etc.)
 COPY --chmod=664 --chown=dynamo:0 pyproject.toml /workspace/pyproject.toml
+COPY --chmod=775 --chown=dynamo:0 benchmarks/ /workspace/benchmarks/


### PR DESCRIPTION
Add the benchmarks source tree to the test image so benchmark sweep tests can import  during CI collection without changing the slim sglang runtime image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker test image configuration to include benchmarks directory with adjusted filesystem permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->