### PR TITLE
chore(multimodal): add notes/warn about encoder disagg not supporting video_url yet

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -419,6 +419,11 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # Without encode worker, the embedding will be generated internally by vLLM.
         if encode_worker_client is None:
             return None
+        logger.warning(
+            "Separate multimodal encode-worker routing only applies to image_url "
+            "inputs. video_url inputs are not sent to the encode worker and will "
+            "be processed on the prefill/PD worker instead."
+        )
         # Embedding loader consist of two main components:
         # 1) An remote encode worker client and matching embedding receiver,
         #    which can request remote encode and handle the transfer of embeddings

--- a/docs/features/multimodal/encoder-disaggregation.md
+++ b/docs/features/multimodal/encoder-disaggregation.md
@@ -29,7 +29,7 @@ For simple deployments or development/testing, the aggregated (EPD) pattern is e
 
 | Backend | E/PD | E/P/D | Notes |
 |---------|------|-------|-------|
-| **vLLM** | ✅ | ✅ | NIXL transfer for embeddings; NIXL KV cache transfer for P/D |
+| **vLLM** | ✅ | ✅ | Separate encode worker currently handles `image_url` inputs; `video_url` inputs stay on the prefill/PD path |
 | **TRT-LLM** | ❌ | ✅ | Supports image URLs (via `MultimodalEncoder`) and pre-computed embeddings (via NIXL) |
 | **SGLang** | ✅ | ✅ | NIXL for embeddings; bootstrap mechanism for P/D KV transfer |
 

--- a/docs/features/multimodal/multimodal-vllm.md
+++ b/docs/features/multimodal/multimodal-vllm.md
@@ -109,7 +109,11 @@ curl http://localhost:8000/v1/chat/completions \
 
 ### E/PD Serving (Encode + PD)
 
-Use `disagg_multimodal_e_pd.sh` when you want a separate encode worker and a combined prefill/decode worker. This path is primarily useful for image-centric workloads and embedding-cache experiments; use `agg_multimodal.sh` or `disagg_multimodal_epd.sh` for general video serving.
+Use `disagg_multimodal_e_pd.sh` when you want a separate encode worker and a combined prefill/decode worker. This path is primarily useful for image-centric workloads and embedding-cache experiments.
+
+<Warning>
+When a separate encode worker is deployed with the current vLLM path, only `image_url` inputs are routed to it. `video_url` inputs are still processed on the combined PD worker.
+</Warning>
 
 ```bash
 cd $DYNAMO_HOME/examples/backends/vllm
@@ -124,7 +128,11 @@ bash launch/disagg_multimodal_e_pd.sh --model Qwen/Qwen3-VL-2B-Instruct --single
 
 ### E/P/D Serving (Full Disaggregation)
 
-Use the full disaggregated launcher when you want separate encode, prefill, and decode workers for image/video workloads:
+Use `disagg_multimodal_epd.sh` when you want separate encode, prefill, and decode workers for multimodal workloads.
+
+<Warning>
+In the current vLLM implementation, the separate encode worker is only used for `image_url` inputs. `video_url` inputs are still processed on the prefill worker, not on the encode worker.
+</Warning>
 
 ```bash
 cd $DYNAMO_HOME/examples/backends/vllm


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Future support for full EPD disagg + video_url input is more involved, definitely impacts embedding transfer, likely impacts embedding cache, didn't want to focus on the full push yet yet, but for future reference this branch has a first draft attempt: https://github.com/ai-dynamo/dynamo/compare/main...rmccormick/video-epd-v1

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-dynamo/dynamo/pull/7890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated multimodal serving documentation to clarify input routing: image inputs are processed by dedicated encode worker, while video inputs are handled by prefill worker.

* **Improvements**
  * Added runtime warning clarifying encode-worker routing behavior for different input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->