### PR TITLE
fix: remove sanity check from CI; it is only meant for developers to quickly check for correct compilation/inference dependencies

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -173,28 +173,6 @@ runs:
         # Exit with the build's exit code
         exit ${BUILD_EXIT_CODE}
 
-    - name: Run Sanity Check on Runtime Image
-      if: inputs.target == 'runtime'
-      shell: bash
-      run: |
-        IMAGE_TAG="${{ steps.build.outputs.image_tag }}"
-        echo "Running sanity check on image: $IMAGE_TAG"
-
-        # Run the sanity check script inside the container
-        # The script is located in /workspace/deploy/sanity_check.py in runtime containers
-        export WORKSPACE=/workspace
-
-        set +e
-        docker run --rm "$IMAGE_TAG" python ${WORKSPACE}/deploy/sanity_check.py --runtime-check --no-gpu-check
-        SANITY_CHECK_EXIT_CODE=$?
-        set -e
-        if [ ${SANITY_CHECK_EXIT_CODE} -ne 0 ]; then
-          echo "ERROR: Sanity check failed - ai-dynamo packages not properly installed"
-          exit ${SANITY_CHECK_EXIT_CODE}
-        else
-          echo "✅ Sanity check passed"
-        fi
-
     - name: Capture Build Metrics
       id: metrics
       shell: bash

--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -279,29 +279,6 @@ jobs:
           duration=$((end_time - start_time))
           echo "⏱️ Image pull duration: ${duration}s"
 
-      - name: Run Sanity Check on Runtime Image
-        shell: bash
-        run: |
-          echo "Running sanity check on image: ${{ steps.calculate-target-tag.outputs.runtime_image }}"
-
-          # Run the sanity check script inside the container
-          # The script is located in /workspace/deploy/sanity_check.py in runtime containers
-          export WORKSPACE=/workspace
-          SANITY_FLAGS="--runtime-check --no-gpu-check"
-          if [[ "${{ inputs.target }}" == "planner" ]]; then
-            SANITY_FLAGS="${SANITY_FLAGS} --no-framework-check"
-          fi
-
-          set +e
-          docker run --rm "${{ steps.calculate-target-tag.outputs.runtime_image }}" python ${WORKSPACE}/deploy/sanity_check.py ${SANITY_FLAGS}
-          SANITY_CHECK_EXIT_CODE=$?
-          set -e
-          if [ ${SANITY_CHECK_EXIT_CODE} -ne 0 ]; then
-            echo "ERROR: Sanity check failed - ai-dynamo packages not properly installed"
-            exit ${SANITY_CHECK_EXIT_CODE}
-          else
-            echo "✅ Sanity check passed"
-          fi
       # Run CPU-only tests first (parallelized for speed)
       # These are unit tests marked with gpu_0 that don't require GPU hardware
       - name: Run CPU-only tests (parallelized)

--- a/deploy/sanity_check.py
+++ b/deploy/sanity_check.py
@@ -156,11 +156,19 @@ import os
 import platform
 import resource
 import shutil
+import site
 import subprocess
 import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    tomllib = None
+
+_LOG = logging.getLogger(__name__)
 
 # Path constants
 DYNAMO_RUNTIME_SRC_PATH = "lib/bindings/python/src/dynamo"
@@ -2962,9 +2970,6 @@ class DynamoFrameworkInfo(NodeInfo):
 
         # Add package info if installed
         if is_installed:
-            import glob
-            import site
-
             for site_dir in site.getsitepackages():
                 # Look specifically for ai_dynamo (not ai_dynamo_runtime)
                 dist_pattern = os.path.join(site_dir, "ai_dynamo-*.dist-info")
@@ -2985,22 +2990,32 @@ class DynamoFrameworkInfo(NodeInfo):
                         direct_url_path = os.path.join(path, "direct_url.json")
                         if os.path.exists(direct_url_path):
                             try:
-                                with open(direct_url_path, "r") as f:
-                                    import json as _json
-
-                                    du = _json.loads(f.read())
+                                with open(direct_url_path, "r", encoding="utf-8") as f:
+                                    du = json.loads(f.read())
+                            except (OSError, json.JSONDecodeError) as exc:
+                                dist_node.add_child(
+                                    NodeInfo(
+                                        label="→",
+                                        desc=self._replace_home_with_var(
+                                            f"{direct_url_path}: {exc}"
+                                        ),
+                                        status=NodeStatus.WARNING,
+                                    )
+                                )
+                            else:
                                 url = du.get("url", "")
                                 is_editable = (du.get("dir_info") or {}).get(
                                     "editable", False
                                 )
                                 if url.startswith("file://") and is_editable:
                                     target = url[len("file://") :]
-                                    # Resolve to the actual package source dir via pyproject.toml
+                                    resolved_target = target
                                     pyproject = os.path.join(target, "pyproject.toml")
-                                    if os.path.exists(pyproject):
+                                    if (
+                                        os.path.exists(pyproject)
+                                        and tomllib is not None
+                                    ):
                                         try:
-                                            import tomllib
-
                                             with open(pyproject, "rb") as pf:
                                                 cfg = tomllib.load(pf)
                                             pkgs = (
@@ -3012,20 +3027,35 @@ class DynamoFrameworkInfo(NodeInfo):
                                                 .get("packages", [])
                                             )
                                             if pkgs:
-                                                target = os.path.join(
+                                                resolved_target = os.path.join(
                                                     target, os.path.dirname(pkgs[0])
                                                 )
-                                        except Exception:
-                                            pass
-                                    display_target = self._replace_home_with_var(target)
+                                        except (
+                                            OSError,
+                                            tomllib.TOMLDecodeError,
+                                        ) as exc:
+                                            _LOG.debug(
+                                                "editable pyproject resolve failed: %s",
+                                                exc,
+                                            )
+                                            dist_node.add_child(
+                                                NodeInfo(
+                                                    label="→",
+                                                    desc=self._replace_home_with_var(
+                                                        f"{pyproject}: {exc}"
+                                                    ),
+                                                    status=NodeStatus.WARNING,
+                                                )
+                                            )
+                                    display_target = self._replace_home_with_var(
+                                        resolved_target
+                                    )
                                     points_to = NodeInfo(
                                         label="→",
                                         desc=display_target,
                                         status=NodeStatus.INFO,
                                     )
                                     dist_node.add_child(points_to)
-                            except Exception:
-                                pass
                         self.add_child(dist_node)
                     except Exception:
                         dist_node = NodeInfo(
@@ -3075,13 +3105,21 @@ class DynamoFrameworkInfo(NodeInfo):
                         )
                         self.add_child(component_node)
                         components_found = True
-                except ImportError as e:
-                    # Module's dependencies not installed (e.g., planner in non-planner images).
-                    # Treat as warning so the sanity check doesn't fail for optional components.
+                except ModuleNotFoundError as e:
+                    # Missing optional dependency (e.g., planner stack without kubernetes).
                     padded_name = f"{component:<{max_len}}"
                     error_msg = str(e) if str(e) else "Import failed"
                     component_node = NodeInfo(
                         label=padded_name, desc=error_msg, status=NodeStatus.WARNING
+                    )
+                    self.add_child(component_node)
+                    import_failures.append(component)
+                except ImportError as e:
+                    # e.g. "cannot import name ..." — treat as a real packaging/code issue.
+                    padded_name = f"{component:<{max_len}}"
+                    error_msg = str(e) if str(e) else "Import failed"
+                    component_node = NodeInfo(
+                        label=padded_name, desc=error_msg, status=NodeStatus.ERROR
                     )
                     self.add_child(component_node)
                     import_failures.append(component)

--- a/deploy/sanity_check.py
+++ b/deploy/sanity_check.py
@@ -2981,6 +2981,51 @@ class DynamoFrameworkInfo(NodeInfo):
                             status=NodeStatus.INFO,
                             metadata={"part_of_previous": True},
                         )
+                        # Check for editable install via direct_url.json
+                        direct_url_path = os.path.join(path, "direct_url.json")
+                        if os.path.exists(direct_url_path):
+                            try:
+                                with open(direct_url_path, "r") as f:
+                                    import json as _json
+
+                                    du = _json.loads(f.read())
+                                url = du.get("url", "")
+                                is_editable = (du.get("dir_info") or {}).get(
+                                    "editable", False
+                                )
+                                if url.startswith("file://") and is_editable:
+                                    target = url[len("file://") :]
+                                    # Resolve to the actual package source dir via pyproject.toml
+                                    pyproject = os.path.join(target, "pyproject.toml")
+                                    if os.path.exists(pyproject):
+                                        try:
+                                            import tomllib
+
+                                            with open(pyproject, "rb") as pf:
+                                                cfg = tomllib.load(pf)
+                                            pkgs = (
+                                                cfg.get("tool", {})
+                                                .get("hatch", {})
+                                                .get("build", {})
+                                                .get("targets", {})
+                                                .get("wheel", {})
+                                                .get("packages", [])
+                                            )
+                                            if pkgs:
+                                                target = os.path.join(
+                                                    target, os.path.dirname(pkgs[0])
+                                                )
+                                        except Exception:
+                                            pass
+                                    display_target = self._replace_home_with_var(target)
+                                    points_to = NodeInfo(
+                                        label="→",
+                                        desc=display_target,
+                                        status=NodeStatus.INFO,
+                                    )
+                                    dist_node.add_child(points_to)
+                            except Exception:
+                                pass
                         self.add_child(dist_node)
                     except Exception:
                         dist_node = NodeInfo(
@@ -3031,15 +3076,15 @@ class DynamoFrameworkInfo(NodeInfo):
                         self.add_child(component_node)
                         components_found = True
                 except ImportError as e:
-                    # Module not importable - show as error
+                    # Module's dependencies not installed (e.g., planner in non-planner images).
+                    # Treat as warning so the sanity check doesn't fail for optional components.
                     padded_name = f"{component:<{max_len}}"
                     error_msg = str(e) if str(e) else "Import failed"
                     component_node = NodeInfo(
-                        label=padded_name, desc=error_msg, status=NodeStatus.ERROR
+                        label=padded_name, desc=error_msg, status=NodeStatus.WARNING
                     )
                     self.add_child(component_node)
                     import_failures.append(component)
-                    # Don't set components_found to True for failed imports
 
             # Update status and value based on whether we found components
             if components_found:


### PR DESCRIPTION
#### Overview:

This PR stops running the runtime `sanity_check.py` step inside CI after Docker images are built or pulled, and it relaxes optional-component import failures in `deploy/sanity_check.py` to warnings so the checker is less brittle for non-core paths.

#### Details:

- Remove the "Run Sanity Check on Runtime Image" step from the composite `docker-build` action when `target == runtime`.
- Remove the same post-pull sanity check step from `build-test-distribute-flavor.yml` before CPU-only tests.
- In `sanity_check.py`, treat failures when importing optional components as warnings instead of hard failures (previous commit on this branch).

#### Where should the reviewer start?

- `.github/actions/docker-build/action.yml` — sanity check step removed after build.
- `.github/workflows/build-test-distribute-flavor.yml` — sanity check step removed after image pull.
- `deploy/sanity_check.py` — optional import behavior (if reviewing the full branch vs `main`).


/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed runtime sanity checks from Docker build and test workflows to improve overall CI/CD pipeline efficiency.

* **Changes**
  * Added detection support for editable package installations in the deployment validation process.
  * Framework component import failures are now treated as non-blocking warnings instead of errors, allowing builds to continue when optional dependencies are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->