### PR TITLE
feat(kvbm): XPU Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,6 +2062,7 @@ dependencies = [
  "anyhow",
  "cudarc",
  "dynamo-config",
+ "level-zero",
  "libc",
  "nix 0.30.1",
  "nixl-sys",
@@ -4060,6 +4061,22 @@ name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
+name = "level-zero"
+version = "0.2.0"
+dependencies = [
+ "level-zero-sys",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "level-zero-sys"
+version = "0.2.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ velo-common = { path = "lib/velo-common", version = "0.1.0" }
 velo-transports = { path = "lib/velo-transports", version = "0.1.0" }
 velo-events = { path = "lib/velo-events", version = "0.1.0" }
 
+# Level Zero
+level-zero = { path = "../level-zero-rc/level-zero" }
+
 # External dependencies
 anyhow = { version = "1" }
 async-nats = { version = "0.45.0", features = ["service"] }

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import argparse
 import asyncio
 import logging
@@ -34,7 +36,13 @@ from dynamo.llm import (
 )
 from dynamo.runtime import Endpoint
 from dynamo.runtime.logging import configure_dynamo_logging
-from dynamo.vllm.omni.args import OmniConfig
+try:
+    from dynamo.vllm.omni.args import OmniConfig
+
+    OMNI_AVAILABLE = True
+except ImportError:
+    OmniConfig = None
+    OMNI_AVAILABLE = False
 from dynamo.vllm.worker_factory import WorkerFactory
 
 from . import envs

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import argparse
 import asyncio
 import logging
@@ -36,13 +34,7 @@ from dynamo.llm import (
 )
 from dynamo.runtime import Endpoint
 from dynamo.runtime.logging import configure_dynamo_logging
-try:
-    from dynamo.vllm.omni.args import OmniConfig
-
-    OMNI_AVAILABLE = True
-except ImportError:
-    OmniConfig = None
-    OMNI_AVAILABLE = False
+from dynamo.vllm.omni.args import OmniConfig
 from dynamo.vllm.worker_factory import WorkerFactory
 
 from . import envs

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1689,6 +1689,7 @@ dependencies = [
  "anyhow",
  "cudarc",
  "dynamo-config",
+ "level-zero",
  "libc",
  "nix 0.30.1",
  "nixl-sys",
@@ -3376,6 +3377,22 @@ name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
+name = "level-zero"
+version = "0.2.0"
+dependencies = [
+ "level-zero-sys",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "level-zero-sys"
+version = "0.2.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libc"

--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/connector_worker.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/connector_worker.py
@@ -77,24 +77,34 @@ class KvConnectorWorker:
             )
         ]
 
-        events = [
-            torch.cuda.Event(enable_timing=False, interprocess=False)
-            for _ in range(len(ordered_kv_caches))
-        ]
+        first_tensor = ordered_kv_caches[0][1]
+        self.device_type = first_tensor.device.type
+        self.device_id = first_tensor.device.index if self.device_type=="cuda" else (first_tensor.device.index or 0)
 
-        # events are lazy, if we don't record them once here, the raw handles we pass to rust will be null
-        for event in events:
-            event.record(torch.cuda.current_stream())
-
-        raw_event_handles = [event.cuda_event for event in events]
-
+        if self.device_type == "cuda":
+            events = [
+                torch.cuda.Event(enable_timing=False, interprocess=False)
+                for _ in range(len(ordered_kv_caches))
+            ]
+            # Events are lazy: record once so raw handles are valid.
+            for event in events:
+                event.record(torch.cuda.current_stream(self.device_id))
+            raw_event_handles = [event.cuda_event for event in events]
+        elif self.device_type == "xpu":
+            events = [torch.xpu.Event(enable_timing=False) for _ in range(len(ordered_kv_caches))]
+            for event in events:
+                event.record(torch.xpu.current_stream(self.device_id))
+            # Pass raw SYCL event handles for Rust-side XPU waiting.
+            raw_event_handles = [event.sycl_event for event in events]
+        else:
+            raise NotImplementedError(f"Unsupported KV cache device type: {self.device_type}")
+        
         self.events = {
             layer_name: event
             for (layer_name, _tensor), event in zip(ordered_kv_caches, events)
         }
 
         # Get first tensor to extract common properties
-        first_tensor = ordered_kv_caches[0][1]
         shape = first_tensor.shape
 
         # Validate all tensors have same shape
@@ -107,7 +117,6 @@ class KvConnectorWorker:
         # TODO: Assume the block dimension is within the first 2. This will break if you're doing something weird like having 1 or 2 device blocks.
         num_device_blocks = max(shape[0], shape[1])
         page_size = cache_config.block_size
-        device_id = first_tensor.device.index
 
         # Determine cache dtype
         if cache_config.cache_dtype == "auto":
@@ -119,8 +128,9 @@ class KvConnectorWorker:
         self._connector.register_kv_caches(
             num_device_blocks,
             page_size,
-            device_id,
+            self.device_id,
             kv_cache_dtype.itemsize,
+            self.device_type,
             ordered_kv_caches,
             raw_event_handles,
         )
@@ -181,7 +191,14 @@ class KvConnectorWorker:
             attn_metadata (AttentionMetadata): the attention metadata.
             **kwargs: additional arguments for the save operation.
         """
-        self.events[layer_name].record(torch.cuda.current_stream())
+        if self.device_type == "cuda":
+            self.events[layer_name].record(torch.cuda.current_stream(self.device_id))
+        elif self.device_type == "xpu":
+            self.events[layer_name].record(torch.xpu.current_stream(self.device_id))
+            # Host wait for XPU path until Rust-side XPU event wait is available.
+            self.events[layer_name].synchronize()
+        else:
+            raise NotImplementedError(f"Unsupported KV cache device type: {self.device_type}")
         self._connector.save_kv_layer(layer_name, kv_layer)
 
     def get_finished(

--- a/lib/bindings/kvbm/src/block_manager.rs
+++ b/lib/bindings/kvbm/src/block_manager.rs
@@ -183,6 +183,8 @@ impl BlockManager {
 
         let rt = get_current_tokio_handle();
 
+        config = config.device_type(String::from("cuda"));
+
         let config = config.build().map_err(to_pyerr)?;
         Ok(BlockManager {
             inner: rt
@@ -369,6 +371,8 @@ impl BlockManagerBuilder {
             config_builder =
                 config_builder.consolidator_config(engine_ep, output_ep, engine_source);
         }
+
+        config_builder = config_builder.device_type(String::from("cuda"));
 
         let config = config_builder.build()?;
 

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
@@ -32,6 +32,7 @@ pub trait Worker: Send + Sync {
         page_size: usize,
         device_id: usize,
         dtype_width_bytes: usize,
+        device_type: String,
         kv_caches: Vec<(String, Arc<VllmTensor>)>,
         raw_event_handles: Vec<u64>,
         device_layout_type: Option<LayoutType>,
@@ -72,8 +73,11 @@ pub struct KvConnectorWorker {
     iteration: u64,
     layers_complete: usize,
 
-    /// cuda events created by the python side
+    /// cuda/ze events created by the python side
     layer_events: Vec<u64>,
+
+    /// Device type (e.g., "cuda", "xpu")
+    device_type: String,
 }
 
 impl KvConnectorWorker {
@@ -112,6 +116,7 @@ impl KvConnectorWorker {
             layers_complete: 0,
             kv_cache_layers: Vec::new(),
             layer_events: Vec::new(),
+            device_type: String::new(),
         })
     }
 }
@@ -127,6 +132,7 @@ impl Worker for KvConnectorWorker {
         page_size: usize,
         device_id: usize,
         dtype_width_bytes: usize,
+        device_type: String,
         kv_caches: Vec<(String, Arc<VllmTensor>)>,
         raw_event_handles: Vec<u64>,
         device_layout_type: Option<LayoutType>,
@@ -164,6 +170,7 @@ impl Worker for KvConnectorWorker {
         }
 
         self.layer_events = raw_event_handles;
+        self.device_type = device_type;
 
         // Auto-detect device layout type if not explicitly provided
         let detected_device_layout_type = match device_layout_type {
@@ -200,6 +207,7 @@ impl Worker for KvConnectorWorker {
             .page_size(page_size)
             .tensors(vllm_tensors)
             .device_id(device_id)
+            .device_type(self.device_type.clone())
             .dtype_width_bytes(dtype_width_bytes)
             .scheduler_client(Some(self.transfer_client.clone()))
             .device_layout_type(detected_device_layout_type)
@@ -328,7 +336,7 @@ impl Worker for KvConnectorWorker {
             // block on the the completion of the last layer
             // todo(ryan): capture the context, pass this to the scheduler to do the await on another thread
             // or put the event on a stream and use stream waits to keep it all on device.
-            event_sync_blocking(self.layer_events[self.layers_complete - 1]);
+            event_sync_blocking_for_device(self.layer_events[self.layers_complete - 1], &self.device_type);
             for operation in &offloading_operations {
                 tracing::debug!(
                     request_id = %operation.request_id,
@@ -485,13 +493,14 @@ impl PyKvConnectorWorker {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (num_device_blocks, page_size, device_id, dtype_width_bytes, kv_caches, raw_event_handles, device_layout_type=None, host_layout_type=None, disk_layout_type=None))]
+    #[pyo3(signature = (num_device_blocks, page_size, device_id, dtype_width_bytes, device_type, kv_caches, raw_event_handles, device_layout_type=None, host_layout_type=None, disk_layout_type=None))]
     pub fn register_kv_caches(
         &mut self,
         num_device_blocks: usize,
         page_size: usize,
         device_id: usize,
         dtype_width_bytes: usize,
+        device_type: String,
         kv_caches: Vec<(String, Py<PyAny>)>,
         raw_event_handles: Vec<u64>,
         device_layout_type: Option<PyLayoutType>,
@@ -511,6 +520,7 @@ impl PyKvConnectorWorker {
                 page_size,
                 device_id,
                 dtype_width_bytes,
+                device_type,
                 rust_kv_caches,
                 raw_event_handles,
                 device_layout_type.map(|py_layout| py_layout.into()),
@@ -564,10 +574,28 @@ fn _get_current_context() -> CUcontext {
 }
 
 pub fn event_sync_blocking(event: u64) {
+    cuda_event_sync_blocking(event);
+}
+
+fn cuda_event_sync_blocking(event: u64) {
     let status = unsafe { cuEventSynchronize(event as CUevent) };
     assert_eq!(
         status,
         cudaError_enum::CUDA_SUCCESS,
         "cuEventSynchronize failed"
     );
+}
+
+/// Dispatch event synchronization based on device type.
+///
+/// For XPU/ZE, event sync is handled on the Python side (host wait via
+/// `torch.xpu.Event.synchronize()`) before calling into Rust, so we skip here.
+pub fn event_sync_blocking_for_device(event: u64, device_type: &str) {
+    match device_type {
+        "cuda" => cuda_event_sync_blocking(event),
+        "xpu" | "ze" => {
+            // No-op: XPU events are synchronized on the Python side.
+        }
+        other => panic!("Unsupported device type for event sync: {}", other),
+    }
 }

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1705,6 +1705,7 @@ dependencies = [
  "anyhow",
  "cudarc",
  "dynamo-config",
+ "level-zero",
  "libc",
  "nix 0.30.1",
  "nixl-sys",
@@ -3428,6 +3429,22 @@ name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
+name = "level-zero"
+version = "0.2.0"
+dependencies = [
+ "level-zero-sys",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "level-zero-sys"
+version = "0.2.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libc"

--- a/lib/kvbm-physical/src/layout/builder.rs
+++ b/lib/kvbm-physical/src/layout/builder.rs
@@ -30,7 +30,7 @@ use std::marker::PhantomData;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use dynamo_memory::{DeviceStorage, PinnedStorage};
+use dynamo_memory::{DeviceContext, DeviceStorage, PinnedStorage};
 
 const REGION_ALIGNMENT: usize = 512;
 
@@ -45,10 +45,10 @@ pub enum LayoutKind {
 #[derive(Debug, Clone)]
 enum AllocationKind {
     System,
-    /// Pinned (page-locked) host memory. If `device_id` is Some, NUMA-aware
-    /// allocation is used on the GPU's NUMA node (when NUMA is enabled).
+    /// Pinned (page-locked) host memory. If `device_ctx` is Some, NUMA-aware
+    /// allocation is used on the device's NUMA node (when NUMA is enabled).
     Pinned {
-        device_id: Option<u32>,
+        device_ctx: Option<DeviceContext>,
     },
     Device {
         device_id: u32,
@@ -232,9 +232,9 @@ impl PhysicalLayoutBuilder<HasConfig, HasLayout, NoMemory> {
     ///   (disable with `DYN_MEMORY_DISABLE_NUMA=1`). If `None`, uses direct allocation.
     pub fn allocate_pinned(
         self,
-        device_id: Option<u32>,
+        device_ctx: Option<DeviceContext>,
     ) -> PhysicalLayoutBuilder<HasConfig, HasLayout, HasMemory> {
-        self.set_memory_plan(MemoryPlan::Allocate(AllocationKind::Pinned { device_id }))
+        self.set_memory_plan(MemoryPlan::Allocate(AllocationKind::Pinned { device_ctx }))
     }
 
     /// Allocate device memory on the specified CUDA device (or the context device if `None`).
@@ -459,8 +459,8 @@ fn allocate_regions(
 
     let base_entry = match strategy {
         AllocationKind::System => allocate_system_entry(reserve_size, agent)?,
-        AllocationKind::Pinned { device_id } => {
-            allocate_pinned_entry(reserve_size, agent, device_id)?
+        AllocationKind::Pinned { device_ctx } => {
+            allocate_pinned_entry(reserve_size, agent, device_ctx.as_ref())?
         }
         AllocationKind::Device { device_id } => {
             allocate_device_entry(reserve_size, agent, device_id)?
@@ -480,10 +480,14 @@ fn allocate_system_entry(size: usize, agent: &NixlAgent) -> Result<MemoryEntry> 
 fn allocate_pinned_entry(
     size: usize,
     agent: &NixlAgent,
-    device_id: Option<u32>,
+    device_ctx: Option<&DeviceContext>,
 ) -> Result<MemoryEntry> {
-    let storage = PinnedStorage::new_for_device(size, device_id)
-        .map_err(|e| anyhow!("failed to allocate pinned memory ({size} bytes): {e}"))?;
+    let storage = if let Some(ctx) = device_ctx {
+        PinnedStorage::new_with_context(size, ctx)
+    } else {
+        PinnedStorage::new_for_device(size, None)
+    }
+    .map_err(|e| anyhow!("failed to allocate pinned memory ({size} bytes): {e}"))?;
     register_storage(storage, agent)
 }
 

--- a/lib/llm/src/block_manager.rs
+++ b/lib/llm/src/block_manager.rs
@@ -307,7 +307,7 @@ mod tests {
             builder.device_layout(
                 KvManagerLayoutConfig::builder()
                     .num_blocks(device)
-                    .allocator(storage::DeviceAllocator::new(0).unwrap())
+                    .allocator(storage::DeviceAllocator::default())
                     .build()
                     .unwrap(),
             )

--- a/lib/llm/src/block_manager/block/transfer.rs
+++ b/lib/llm/src/block_manager/block/transfer.rs
@@ -6,6 +6,7 @@ mod cuda;
 mod memcpy;
 mod nixl;
 mod strategy;
+mod ze;
 
 use super::*;
 
@@ -21,7 +22,47 @@ use tokio::sync::oneshot;
 
 pub use crate::block_manager::storage::{CudaAccessible, Local, Remote};
 pub use async_trait::async_trait;
-pub use context::{PoolConfig, TransferContext};
+pub use context::{DeviceContextExt, DeviceStream, PoolConfig, TransferContext};
+
+fn copy_block<Source, Destination>(
+    source: &Source,
+    destination: &mut Destination,
+    stream: DeviceStream,
+    strategy: TransferStrategy,
+) -> Result<(), TransferError>
+where
+    Source: BlockDataProvider,
+    Destination: BlockDataProviderMut,
+{
+    match stream {
+        DeviceStream::Cuda(cuda_stream) => {
+            cuda::copy_block(source, destination, cuda_stream.as_ref(), strategy)
+        }
+        DeviceStream::Ze(ze_queue) => {
+            ze::copy_block(source, destination, ze_queue.as_ref(), strategy)
+        }
+    }
+}
+
+fn copy_blocks_with_customized_kernel<Source, Destination>(
+    sources: &[Source],
+    destinations: &mut [Destination],
+    stream: DeviceStream,
+    ctx: &TransferContext,
+) -> Result<(), TransferError>
+where
+    Source: BlockDataProvider,
+    Destination: BlockDataProviderMut,
+{
+    match stream {
+        DeviceStream::Cuda(cuda_stream) => {
+            cuda::copy_blocks_with_customized_kernel(sources, destinations, cuda_stream.as_ref(), ctx)
+        }
+        DeviceStream::Ze(ze_queue) => {
+            ze::copy_blocks_with_customized_kernel(sources, destinations, ze_queue.as_ref(), ctx)
+        }
+    }
+}
 
 /// A block that can be the target of a write
 pub trait Writable {}
@@ -81,7 +122,7 @@ impl NixlTransfer {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CudaTransferMode {
+pub enum TransferMode {
     /// Use the custom CUDA kernel for G1 <-> G2 transfers
     Custom,
     /// Use the default CUDA async memcpy for G1 <-> G2 transfers
@@ -91,11 +132,11 @@ pub enum CudaTransferMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransferStrategy {
     Memcpy,
-    CudaAsyncH2D,
-    CudaAsyncD2H,
-    CudaAsyncD2D,
-    CudaBlockingH2D,
-    CudaBlockingD2H,
+    AsyncH2D,
+    AsyncD2H,
+    AsyncD2D,
+    BlockingH2D,
+    BlockingD2H,
     Nixl(NixlTransfer),
     Invalid,
 }
@@ -142,27 +183,27 @@ where
 }
 
 #[inline]
-fn resolve_cuda_transfer_mode(
+fn resolve_transfer_mode(
     base_strategy: TransferStrategy,
     is_contiguous: bool,
-) -> CudaTransferMode {
+) -> TransferMode {
     match base_strategy {
-        TransferStrategy::CudaAsyncH2D => {
+        TransferStrategy::AsyncH2D => {
             if is_contiguous {
-                CudaTransferMode::Default
+                TransferMode::Default
             } else {
-                CudaTransferMode::Custom
+                TransferMode::Custom
             }
         }
-        TransferStrategy::CudaAsyncD2H => {
+        TransferStrategy::AsyncD2H => {
             if is_contiguous {
-                CudaTransferMode::Default
+                TransferMode::Default
             } else {
-                CudaTransferMode::Custom
+                TransferMode::Custom
             }
         }
         other => panic!(
-            "resolve_cuda_strategy called with non-CUDA strategy: {:?}",
+            "resolve_transfer_mode called with non-CUDA strategy: {:?}",
             other
         ),
     }
@@ -206,52 +247,51 @@ where
             tx.send(()).unwrap();
             Ok(rx)
         }
-        TransferStrategy::CudaAsyncH2D
-        | TransferStrategy::CudaAsyncD2H
-        | TransferStrategy::CudaAsyncD2D => {
+        TransferStrategy::AsyncH2D
+        | TransferStrategy::AsyncD2H
+        | TransferStrategy::AsyncD2D => {
             tracing::debug!(
-                "Transfer: Using CUDA strategy: {:?}",
+                "Transfer: Using strategy: {:?}",
                 RB::write_to_strategy()
             );
 
-            if RB::write_to_strategy() == TransferStrategy::CudaAsyncH2D
-                || RB::write_to_strategy() == TransferStrategy::CudaAsyncD2H
+            if RB::write_to_strategy() == TransferStrategy::AsyncH2D
+                || RB::write_to_strategy() == TransferStrategy::AsyncD2H
             {
                 let is_contiguous = sources[0].block_data().is_fully_contiguous()
                     && targets[0].block_data().is_fully_contiguous();
                 let transfer_mode =
-                    resolve_cuda_transfer_mode(RB::write_to_strategy(), is_contiguous);
+                    resolve_transfer_mode(RB::write_to_strategy(), is_contiguous);
 
                 match transfer_mode {
-                    CudaTransferMode::Custom => {
-                        let selected_stream = ctx.stream();
-                        cuda::copy_blocks_with_customized_kernel(
+                    TransferMode::Custom => {
+                        copy_blocks_with_customized_kernel(
                             sources,
                             targets,
-                            selected_stream.as_ref(),
+                            ctx.stream(),
                             &ctx,
                         )?;
                     }
-                    CudaTransferMode::Default => {
+                    TransferMode::Default => {
                         for (src, dst) in sources.iter().zip(targets.iter_mut()) {
-                            cuda::copy_block(
+                            copy_block(
                                 src,
                                 dst,
-                                ctx.stream().as_ref(),
+                                ctx.stream(),
                                 RB::write_to_strategy(),
                             )?;
                         }
                     }
                 };
-                ctx.cuda_event(tx)?;
+                ctx.device_event(tx)?;
 
                 Ok(rx)
             } else {
                 // Fall back to individual copy for D2Dblocks
                 for (src, dst) in sources.iter().zip(targets.iter_mut()) {
-                    cuda::copy_block(src, dst, ctx.stream().as_ref(), RB::write_to_strategy())?;
+                    copy_block(src, dst, ctx.stream(), RB::write_to_strategy())?;
                 }
-                ctx.cuda_event(tx)?;
+                ctx.device_event(tx)?;
                 Ok(rx)
             }
         }
@@ -315,7 +355,7 @@ mod tests {
 
         assert_eq!(
             <SystemStorage as WriteToStrategy<DeviceStorage>>::write_to_strategy(),
-            TransferStrategy::CudaBlockingH2D
+            TransferStrategy::BlockingH2D
         );
 
         assert_eq!(
@@ -334,7 +374,7 @@ mod tests {
         );
         assert_eq!(
             <PinnedStorage as WriteToStrategy<DeviceStorage>>::write_to_strategy(),
-            TransferStrategy::CudaAsyncH2D
+            TransferStrategy::AsyncH2D
         );
         assert_eq!(
             <PinnedStorage as WriteToStrategy<NixlStorage>>::write_to_strategy(),
@@ -344,15 +384,15 @@ mod tests {
         // Device to ...
         assert_eq!(
             <DeviceStorage as WriteToStrategy<SystemStorage>>::write_to_strategy(),
-            TransferStrategy::CudaBlockingD2H
+            TransferStrategy::BlockingD2H
         );
         assert_eq!(
             <DeviceStorage as WriteToStrategy<PinnedStorage>>::write_to_strategy(),
-            TransferStrategy::CudaAsyncD2H
+            TransferStrategy::AsyncD2H
         );
         assert_eq!(
             <DeviceStorage as WriteToStrategy<DeviceStorage>>::write_to_strategy(),
-            TransferStrategy::CudaAsyncD2D
+            TransferStrategy::AsyncD2D
         );
         assert_eq!(
             <DeviceStorage as WriteToStrategy<NixlStorage>>::write_to_strategy(),

--- a/lib/llm/src/block_manager/block/transfer/context.rs
+++ b/lib/llm/src/block_manager/block/transfer/context.rs
@@ -3,17 +3,15 @@
 
 use super::*;
 
-use cudarc::driver::{CudaEvent, CudaStream, sys::CUevent_flags};
+use cudarc::driver::{CudaContext, CudaStream};
+use dynamo_memory::{BackendType, DeviceContext, ZeCommandQueue, ZeContext, pool::CudaMemPool};
 use nixl_sys::Agent as NixlAgent;
 
 use anyhow::Result;
-use dynamo_memory::pool::CudaMemPool;
 use dynamo_runtime::utils::pool::{Returnable, SyncPool, SyncPoolItem};
 use std::sync::Arc;
-use std::thread::JoinHandle;
 use tokio::runtime::Handle;
-use tokio::sync::{mpsc, oneshot};
-use tokio_util::sync::CancellationToken;
+use tokio::sync::oneshot;
 
 // ============================================================================
 // Legacy: Pinned Buffer Resource for Old Pooling (to be removed)
@@ -98,7 +96,6 @@ impl TransferResources {
         src_addresses: &[u64],
         dst_addresses: &[u64],
     ) -> Result<(), TransferError> {
-        // Returns (), not pointers
         if src_addresses.len() != dst_addresses.len() {
             return Err(TransferError::ExecutionError(format!(
                 "Address array length mismatch: src={}, dst={}",
@@ -109,7 +106,6 @@ impl TransferResources {
 
         let required_size = std::mem::size_of_val(src_addresses);
 
-        // Check buffer sizes
         if self.src_buffer.size < required_size || self.dst_buffer.size < required_size {
             return Err(TransferError::ExecutionError(format!(
                 "Buffer too small: {}B needed",
@@ -117,7 +113,6 @@ impl TransferResources {
             )));
         }
 
-        // Copy addresses to pinned buffers
         unsafe {
             std::ptr::copy_nonoverlapping(
                 src_addresses.as_ptr(),
@@ -157,7 +152,6 @@ impl Drop for TransferResources {
             self.src_buffer.id,
             self.dst_buffer.id
         );
-        // SyncPoolItem Drop handles returning buffers to pool automatically
     }
 }
 
@@ -170,118 +164,106 @@ pub struct PoolConfig {
     pub num_layers: usize,
 }
 
+// ============================================================================
+// Device memory pool wrapper
+// ============================================================================
+
+/// Backend-agnostic device stream.
+#[derive(Clone)]
+pub enum DeviceStream {
+    /// CUDA stream.
+    Cuda(Arc<CudaStream>),
+    /// Level Zero command queue.
+    Ze(Arc<ZeCommandQueue>),
+}
+
+/// Extension trait for DeviceContext — creates a DeviceStream by downcasting
+/// to the concrete backend and calling its `new_stream()` method.
+pub trait DeviceContextExt {
+    fn new_stream(&self) -> anyhow::Result<DeviceStream>;
+}
+
+impl DeviceContextExt for DeviceContext {
+    fn new_stream(&self) -> anyhow::Result<DeviceStream> {
+        match self.backend_type() {
+            BackendType::Cuda => {
+                let cuda_ctx = self.backend.as_any()
+                    .downcast_ref::<Arc<CudaContext>>()
+                    .expect("BackendType::Cuda but downcast to Arc<CudaContext> failed");
+                Ok(DeviceStream::Cuda(cuda_ctx.new_stream()?))
+            }
+            BackendType::Ze => {
+                let ze_ctx = self.backend.as_any()
+                    .downcast_ref::<Arc<ZeContext>>()
+                    .expect("BackendType::Ze but downcast to Arc<ZeContext> failed");
+                Ok(DeviceStream::Ze(ze_ctx.new_stream()?))
+            }
+        }
+    }
+}
+
+/// Type-erased device memory pool.
+pub enum DeviceMemPool {
+    /// CUDA stream-ordered memory pool.
+    Cuda(Arc<CudaMemPool>),
+    /// Level Zero memory pool.
+    Ze(Arc<super::ze::ZeMemPool>),
+}
+
+// ============================================================================
+// TransferBackend trait
+// ============================================================================
+
+/// Backend-specific operations for transfer contexts.
+pub(super) trait TransferBackend: Send + Sync {
+    /// Get the device memory pool, if configured.
+    fn device_mem_pool(&self) -> Option<DeviceMemPool>;
+
+    /// Record a device event and notify `tx` when it completes.
+    fn device_event(&self, tx: oneshot::Sender<()>) -> Result<(), TransferError>;
+
+    /// Acquire a pinned buffer from the legacy pool.
+    fn acquire_resources_for_transfer_sync(
+        &self,
+        size: usize,
+    ) -> Result<SyncPoolItem<PinnedBuffer>, TransferError>;
+
+    /// Get the device stream.
+    fn device_stream(&self) -> DeviceStream;
+
+    /// Shut down the backend (cancel workers, join threads).
+    fn shutdown(&mut self);
+}
+
+// ============================================================================
+// TransferContext
+// ============================================================================
+
 pub struct TransferContext {
     nixl_agent: Arc<Option<NixlAgent>>,
-    stream: Arc<CudaStream>,
     async_rt_handle: Handle,
-
-    // NEW: CUDA memory pool for stream-ordered host memory allocation
-    cuda_mem_pool: Option<Arc<CudaMemPool>>,
-
-    // LEGACY: Old pinned buffer pool (still used by TransferResources)
-    pinned_buffer_pool: Option<SyncPinnedBufferPool>,
-
-    cuda_event_tx: mpsc::UnboundedSender<(CudaEvent, oneshot::Sender<()>)>,
-    cuda_event_worker: Option<JoinHandle<()>>,
-    cancel_token: CancellationToken,
+    backend: Box<dyn TransferBackend>,
 }
 
 impl TransferContext {
     pub fn new(
         nixl_agent: Arc<Option<NixlAgent>>,
-        stream: Arc<CudaStream>,
+        stream: DeviceStream,
         async_rt_handle: Handle,
         config: Option<PoolConfig>,
     ) -> Result<Self, anyhow::Error> {
-        let (cuda_event_tx, cuda_event_rx) =
-            mpsc::unbounded_channel::<(CudaEvent, oneshot::Sender<()>)>();
-
-        let cancel_token = CancellationToken::new();
-
-        let cancel_token_clone = cancel_token.clone();
-        let cuda_event_worker = Self::setup_cuda_event_worker(cuda_event_rx, cancel_token_clone);
-
-        let pool = {
-            tracing::debug!(
-                "Pinned buffer pool is no longer used for kernel transfers and will be removed in the future"
-            );
-            None
-        };
-
-        // Create CUDA memory pool for stream-ordered allocation
-        let cuda_mem_pool = if let Some(ref cfg) = config {
-            if cfg.enable_pool {
-                // Calculate total reserve size for pre-warming
-                let num_buffers = cfg.max_concurrent_transfers * 2 + 2;
-                let buffer_size = cfg.max_transfer_batch_size
-                    * cfg.num_outer_components
-                    * cfg.num_layers
-                    * std::mem::size_of::<u64>();
-                let reserve_size = num_buffers * buffer_size;
-
-                tracing::info!(
-                    "Creating CUDA memory pool: {} buffers × {}KB = {}MB total",
-                    num_buffers,
-                    buffer_size / 1024,
-                    reserve_size / (1024 * 1024)
-                );
-
-                let pool = CudaMemPool::builder(stream.context().clone(), reserve_size)
-                    .release_threshold(128 * 1024 * 1024) // Release memory above 128MB back to OS
-                    .build()
-                    .map_err(|e| anyhow::anyhow!("Failed to create CUDA memory pool: {}", e))?;
-
-                tracing::info!(
-                    "CUDA memory pool created successfully (DEVICE memory, stream-ordered allocation, pre-warmed with {}MB)",
-                    reserve_size / (1024 * 1024)
-                );
-                Some(Arc::new(pool))
-            } else {
-                tracing::debug!("CUDA memory pool disabled by configuration");
-                None
+        let backend: Box<dyn TransferBackend> = match &stream {
+            DeviceStream::Cuda(cuda_stream) => {
+                Box::new(super::cuda::TransferBackendCuda::new(cuda_stream.clone(), config.as_ref())?)
             }
-        } else {
-            tracing::debug!("No pool configuration provided - CUDA memory pool disabled");
-            None
+            DeviceStream::Ze(ze_queue) => {
+                Box::new(super::ze::TransferBackendZe::new(ze_queue.clone(), config.as_ref()))
+            }
         };
-
         Ok(Self {
             nixl_agent,
-            stream,
             async_rt_handle,
-            cuda_mem_pool,
-            pinned_buffer_pool: pool,
-            cuda_event_tx,
-            cuda_event_worker: Some(cuda_event_worker),
-            cancel_token,
-        })
-    }
-
-    fn setup_cuda_event_worker(
-        mut cuda_event_rx: mpsc::UnboundedReceiver<(CudaEvent, oneshot::Sender<()>)>,
-        cancel_token: CancellationToken,
-    ) -> JoinHandle<()> {
-        std::thread::spawn(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed to build Tokio runtime for CUDA event worker.");
-
-            runtime.block_on(async move {
-                loop {
-                    tokio::select! {
-                        Some((event, tx)) = cuda_event_rx.recv() => {
-                            if let Err(e) = event.synchronize() {
-                                tracing::error!("Error synchronizing CUDA event: {}", e);
-                            }
-                            let _ = tx.send(());
-                        }
-                        _ = cancel_token.cancelled() => {
-                            break;
-                        }
-                    }
-                }
-            });
+            backend,
         })
     }
 
@@ -289,80 +271,35 @@ impl TransferContext {
         self.nixl_agent.clone()
     }
 
-    pub fn stream(&self) -> &Arc<CudaStream> {
-        &self.stream
+    /// Get the device stream.
+    pub fn stream(&self) -> DeviceStream {
+        self.backend.device_stream()
     }
 
     pub fn async_rt_handle(&self) -> &Handle {
         &self.async_rt_handle
     }
 
-    /// Get the CUDA memory pool for stream-ordered allocations
-    pub fn cuda_mem_pool(&self) -> Option<&Arc<CudaMemPool>> {
-        self.cuda_mem_pool.as_ref()
+    /// Get the device memory pool for stream-ordered allocations.
+    pub fn device_mem_pool(&self) -> Option<DeviceMemPool> {
+        self.backend.device_mem_pool()
     }
 
-    pub fn cuda_event(&self, tx: oneshot::Sender<()>) -> Result<(), TransferError> {
-        let event = self
-            .stream
-            .record_event(Some(CUevent_flags::CU_EVENT_BLOCKING_SYNC))
-            .map_err(|e| TransferError::ExecutionError(e.to_string()))?;
-
-        self.cuda_event_tx
-            .send((event, tx))
-            .map_err(|_| TransferError::ExecutionError("CUDA event worker exited.".into()))?;
-        Ok(())
+    pub fn device_event(&self, tx: oneshot::Sender<()>) -> Result<(), TransferError> {
+        self.backend.device_event(tx)
     }
 
     pub fn acquire_resources_for_transfer_sync(
         &self,
         size: usize,
     ) -> Result<SyncPoolItem<PinnedBuffer>, TransferError> {
-        let ptr_array_size = size * std::mem::size_of::<u64>();
-
-        tracing::debug!(
-            "Acquiring pinned buffer: need {} bytes for {} addresses",
-            ptr_array_size,
-            size
-        );
-
-        if let Some(pool) = &self.pinned_buffer_pool {
-            tracing::debug!("Pool available - acquiring buffer (blocking)...");
-
-            // All buffers are the same size, so just acquire one directly
-            let buffer = pool.acquire_blocking();
-
-            // Validate that the requested size fits in the buffer
-            if buffer.size < ptr_array_size {
-                return Err(TransferError::ExecutionError(format!(
-                    "Buffer too small: need {}KB but buffer is only {}KB (addresses: {})",
-                    ptr_array_size / 1024,
-                    buffer.size / 1024,
-                    size
-                )));
-            }
-
-            Ok(buffer)
-        } else {
-            tracing::warn!(
-                "No pinned buffer pool configured - this should not happen in production"
-            );
-            // No pool configured - this is a configuration error
-            Err(TransferError::ExecutionError(
-                "No sync pool configured - TransferContext must be created with a pool".into(),
-            ))
-        }
+        self.backend.acquire_resources_for_transfer_sync(size)
     }
 }
 
 impl Drop for TransferContext {
     fn drop(&mut self) {
-        self.cancel_token.cancel();
-        if let Some(handle) = self.cuda_event_worker.take()
-            && let Err(e) = handle.join()
-        {
-            tracing::error!("Error joining CUDA event worker: {:?}", e);
-        }
+        self.backend.shutdown();
     }
 }
 

--- a/lib/llm/src/block_manager/block/transfer/cuda.rs
+++ b/lib/llm/src/block_manager/block/transfer/cuda.rs
@@ -2,18 +2,207 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use super::context::{
+    DeviceMemPool, DeviceStream, PinnedBuffer, PoolConfig, SyncPinnedBufferPool, TransferBackend,
+};
 
 use super::TransferError;
 use crate::block_manager::block::{BlockDataProvider, BlockDataProviderMut};
 
 use anyhow::Result;
-use cudarc::driver::CudaStream;
+use cudarc::driver::{CudaEvent, CudaStream, sys::CUevent_flags};
 use cudarc::driver::result as cuda_result;
-use cudarc::driver::sys::{CUevent_flags, CUresult, cuMemcpyHtoDAsync_v2};
+use cudarc::driver::sys::{CUresult, cuMemcpyHtoDAsync_v2};
+use dynamo_memory::pool::CudaMemPool;
 use dynamo_runtime::config::environment_names::cuda as env_cuda;
+use dynamo_runtime::utils::pool::SyncPoolItem;
 use std::ops::Range;
-use std::sync::Mutex;
-use std::sync::OnceLock;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::JoinHandle;
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+
+// ============================================================================
+// CUDA transfer backend
+// ============================================================================
+
+pub(super) struct TransferBackendCuda {
+    stream: Arc<CudaStream>,
+    cuda_mem_pool: Option<Arc<CudaMemPool>>,
+    pinned_buffer_pool: Option<SyncPinnedBufferPool>,
+    cuda_event_tx: mpsc::UnboundedSender<(CudaEvent, oneshot::Sender<()>)>,
+    cuda_event_worker: Option<JoinHandle<()>>,
+    cancel_token: CancellationToken,
+}
+
+impl TransferBackendCuda {
+    pub fn new(
+        stream: Arc<CudaStream>,
+        config: Option<&PoolConfig>,
+    ) -> Result<Self, anyhow::Error> {
+        let (cuda_event_tx, cuda_event_rx) =
+            mpsc::unbounded_channel::<(CudaEvent, oneshot::Sender<()>)>();
+
+        let cancel_token = CancellationToken::new();
+        let cuda_event_worker =
+            Self::setup_cuda_event_worker(cuda_event_rx, cancel_token.clone());
+
+        let pool = {
+            tracing::debug!(
+                "Pinned buffer pool is no longer used for kernel transfers and will be removed in the future"
+            );
+            None
+        };
+
+        // Create CUDA memory pool for stream-ordered allocation
+        let device_mem_pool = if let Some(cfg) = config {
+            if cfg.enable_pool {
+                let num_buffers = cfg.max_concurrent_transfers * 2 + 2;
+                let buffer_size = cfg.max_transfer_batch_size
+                    * cfg.num_outer_components
+                    * cfg.num_layers
+                    * std::mem::size_of::<u64>();
+                let reserve_size = num_buffers * buffer_size;
+
+                tracing::info!(
+                    "Creating CUDA memory pool: {} buffers × {}KB = {}MB total",
+                    num_buffers,
+                    buffer_size / 1024,
+                    reserve_size / (1024 * 1024)
+                );
+
+                let cuda_pool =
+                    CudaMemPool::builder(stream.context().clone(), reserve_size)
+                        .release_threshold(128 * 1024 * 1024)
+                        .build()
+                        .map_err(|e| {
+                            anyhow::anyhow!("Failed to create CUDA memory pool: {}", e)
+                        })?;
+
+                tracing::info!(
+                    "CUDA memory pool created successfully (DEVICE memory, stream-ordered allocation, pre-warmed with {}MB)",
+                    reserve_size / (1024 * 1024)
+                );
+                Some(Arc::new(cuda_pool))
+            } else {
+                tracing::debug!("CUDA memory pool disabled by configuration");
+                None
+            }
+        } else {
+            tracing::debug!("No pool configuration provided - CUDA memory pool disabled");
+            None
+        };
+
+        Ok(Self {
+            stream,
+            cuda_mem_pool: device_mem_pool,
+            pinned_buffer_pool: pool,
+            cuda_event_tx,
+            cuda_event_worker: Some(cuda_event_worker),
+            cancel_token,
+        })
+    }
+
+    fn setup_cuda_event_worker(
+        mut cuda_event_rx: mpsc::UnboundedReceiver<(CudaEvent, oneshot::Sender<()>)>,
+        cancel_token: CancellationToken,
+    ) -> JoinHandle<()> {
+        std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Failed to build Tokio runtime for CUDA event worker.");
+
+            runtime.block_on(async move {
+                loop {
+                    tokio::select! {
+                        Some((event, tx)) = cuda_event_rx.recv() => {
+                            if let Err(e) = event.synchronize() {
+                                tracing::error!("Error synchronizing CUDA event: {}", e);
+                            }
+                            let _ = tx.send(());
+                        }
+                        _ = cancel_token.cancelled() => {
+                            break;
+                        }
+                    }
+                }
+            });
+        })
+    }
+}
+
+impl TransferBackend for TransferBackendCuda {
+    fn device_mem_pool(&self) -> Option<DeviceMemPool> {
+        self.cuda_mem_pool.as_ref().map(|p| DeviceMemPool::Cuda(p.clone()))
+    }
+
+    fn device_event(&self, tx: oneshot::Sender<()>) -> Result<(), TransferError> {
+        let event = self
+            .stream
+            .record_event(Some(CUevent_flags::CU_EVENT_BLOCKING_SYNC))
+            .map_err(|e| TransferError::ExecutionError(e.to_string()))?;
+
+        self.cuda_event_tx
+            .send((event, tx))
+            .map_err(|_| TransferError::ExecutionError("CUDA event worker exited.".into()))?;
+        Ok(())
+    }
+
+    fn acquire_resources_for_transfer_sync(
+        &self,
+        size: usize,
+    ) -> Result<SyncPoolItem<PinnedBuffer>, TransferError> {
+        let ptr_array_size = size * std::mem::size_of::<u64>();
+
+        tracing::debug!(
+            "Acquiring pinned buffer: need {} bytes for {} addresses",
+            ptr_array_size,
+            size
+        );
+
+        if let Some(pool) = &self.pinned_buffer_pool {
+            tracing::debug!("Pool available - acquiring buffer (blocking)...");
+
+            let buffer = pool.acquire_blocking();
+
+            if buffer.size < ptr_array_size {
+                return Err(TransferError::ExecutionError(format!(
+                    "Buffer too small: need {}KB but buffer is only {}KB (addresses: {})",
+                    ptr_array_size / 1024,
+                    buffer.size / 1024,
+                    size
+                )));
+            }
+
+            Ok(buffer)
+        } else {
+            tracing::warn!(
+                "No pinned buffer pool configured - this should not happen in production"
+            );
+            Err(TransferError::ExecutionError(
+                "No sync pool configured - TransferContext must be created with a pool".into(),
+            ))
+        }
+    }
+
+    fn device_stream(&self) -> DeviceStream {
+        DeviceStream::Cuda(self.stream.clone())
+    }
+
+    fn shutdown(&mut self) {
+        self.cancel_token.cancel();
+        if let Some(handle) = self.cuda_event_worker.take()
+            && let Err(e) = handle.join()
+        {
+            tracing::error!("Error joining CUDA event worker: {:?}", e);
+        }
+    }
+}
+
+// ============================================================================
+// CUDA copy operations
+// ============================================================================
 
 // Global storage for kernel function - store as usize to avoid Send/Sync issues
 static COPY_KERNEL_MODULE: Mutex<Option<usize>> = Mutex::new(None);
@@ -28,9 +217,9 @@ type CudaMemcpyFnPtr = unsafe fn(
 
 fn cuda_memcpy_fn_ptr(strategy: &TransferStrategy) -> Result<CudaMemcpyFnPtr, TransferError> {
     match strategy {
-        TransferStrategy::CudaAsyncH2D => Ok(cuda_memcpy_h2d),
-        TransferStrategy::CudaAsyncD2H => Ok(cuda_memcpy_d2h),
-        TransferStrategy::CudaAsyncD2D => Ok(cuda_memcpy_d2d),
+        TransferStrategy::AsyncH2D => Ok(cuda_memcpy_h2d),
+        TransferStrategy::AsyncD2H => Ok(cuda_memcpy_d2h),
+        TransferStrategy::AsyncD2D => Ok(cuda_memcpy_d2d),
         _ => Err(TransferError::ExecutionError(
             "Unsupported copy strategy for CUDA memcpy async".into(),
         )),
@@ -215,12 +404,12 @@ where
 
     let size = src_addresses.len() * std::mem::size_of::<u64>();
 
-    let pool = ctx.cuda_mem_pool().ok_or_else(|| {
-        TransferError::ExecutionError(
+    let Some(super::context::DeviceMemPool::Cuda(pool)) = ctx.device_mem_pool() else {
+        return Err(TransferError::ExecutionError(
             "TransferContext was not instantiated with a CudaPool; please report this error"
                 .to_string(),
-        )
-    })?;
+        ));
+    };
 
     // Allocate DEVICE memory from pool (stream-ordered)
     let src_buffer = pool.alloc_async(size, stream).map_err(|e| {
@@ -399,19 +588,19 @@ fn expected_strategy<Source: Storage, Dest: Storage>() -> TransferStrategy {
             if src == std::any::TypeId::of::<PinnedStorage>()
                 && dst == std::any::TypeId::of::<DeviceStorage>() =>
         {
-            TransferStrategy::CudaAsyncH2D
+            TransferStrategy::AsyncH2D
         }
         (src, dst)
             if src == std::any::TypeId::of::<DeviceStorage>()
                 && dst == std::any::TypeId::of::<PinnedStorage>() =>
         {
-            TransferStrategy::CudaAsyncD2H
+            TransferStrategy::AsyncD2H
         }
         (src, dst)
             if src == std::any::TypeId::of::<DeviceStorage>()
                 && dst == std::any::TypeId::of::<DeviceStorage>() =>
         {
-            TransferStrategy::CudaAsyncD2D
+            TransferStrategy::AsyncD2D
         }
         _ => TransferStrategy::Invalid,
     }
@@ -657,9 +846,7 @@ mod tests {
         let device_allocator = DeviceAllocator::default();
         let pinned_allocator = PinnedAllocator::default();
 
-        let ctx = device_allocator.ctx().clone();
-
-        // Create CUDA stream
+        let ctx = crate::block_manager::storage::cuda::Cuda::device_or_create(0).unwrap();
         let stream = ctx.new_stream().unwrap();
 
         // Allocate host and device memory
@@ -744,7 +931,7 @@ mod tests {
         fn test_h2d_fc_host_to_ls_device() {
             let device_allocator = DeviceAllocator::default();
             let pinned_allocator = PinnedAllocator::default();
-            let ctx = device_allocator.ctx().clone();
+            let ctx = crate::block_manager::storage::cuda::Cuda::device_or_create(0).unwrap();
             let stream = ctx.new_stream().unwrap();
 
             let config = create_test_config();
@@ -861,7 +1048,7 @@ mod tests {
         fn test_d2h_ls_device_to_fc_host() {
             let device_allocator = DeviceAllocator::default();
             let pinned_allocator = PinnedAllocator::default();
-            let ctx = device_allocator.ctx().clone();
+            let ctx = crate::block_manager::storage::cuda::Cuda::device_or_create(0).unwrap();
             let stream = ctx.new_stream().unwrap();
 
             let config = create_test_config();
@@ -991,7 +1178,7 @@ mod tests {
         fn test_bidirectional_layout_transfers() {
             let device_allocator = DeviceAllocator::default();
             let pinned_allocator = PinnedAllocator::default();
-            let ctx = device_allocator.ctx().clone();
+            let ctx = crate::block_manager::storage::cuda::Cuda::device_or_create(0).unwrap();
             let stream = ctx.new_stream().unwrap();
 
             let config = create_test_config();
@@ -1100,7 +1287,7 @@ mod tests {
         fn test_layout_transfer_alignment_performance() {
             let device_allocator = DeviceAllocator::default();
             let pinned_allocator = PinnedAllocator::default();
-            let ctx = device_allocator.ctx().clone();
+            let ctx = crate::block_manager::storage::cuda::Cuda::device_or_create(0).unwrap();
             let stream = ctx.new_stream().unwrap();
 
             // Test different alignments

--- a/lib/llm/src/block_manager/block/transfer/strategy.rs
+++ b/lib/llm/src/block_manager/block/transfer/strategy.rs
@@ -58,7 +58,7 @@ impl WriteToStrategy<PinnedStorage> for SystemStorage {
 impl WriteToStrategy<DeviceStorage> for SystemStorage {
     #[inline(always)]
     fn write_to_strategy() -> TransferStrategy {
-        TransferStrategy::CudaBlockingH2D
+        TransferStrategy::BlockingH2D
     }
 }
 
@@ -86,7 +86,7 @@ impl WriteToStrategy<PinnedStorage> for PinnedStorage {
 impl WriteToStrategy<DeviceStorage> for PinnedStorage {
     #[inline(always)]
     fn write_to_strategy() -> TransferStrategy {
-        TransferStrategy::CudaAsyncH2D
+        TransferStrategy::AsyncH2D
     }
 }
 
@@ -100,21 +100,21 @@ impl WriteToStrategy<DiskStorage> for DeviceStorage {
 impl WriteToStrategy<SystemStorage> for DeviceStorage {
     #[inline(always)]
     fn write_to_strategy() -> TransferStrategy {
-        TransferStrategy::CudaBlockingD2H
+        TransferStrategy::BlockingD2H
     }
 }
 
 impl WriteToStrategy<PinnedStorage> for DeviceStorage {
     #[inline(always)]
     fn write_to_strategy() -> TransferStrategy {
-        TransferStrategy::CudaAsyncD2H
+        TransferStrategy::AsyncD2H
     }
 }
 
 impl WriteToStrategy<DeviceStorage> for DeviceStorage {
     #[inline(always)]
     fn write_to_strategy() -> TransferStrategy {
-        TransferStrategy::CudaAsyncD2D
+        TransferStrategy::AsyncD2D
     }
 }
 
@@ -181,7 +181,7 @@ mod tests {
 
         assert_eq!(
             <SystemStorage as WriteToStrategy<DeviceStorage>>::write_to_strategy(),
-            TransferStrategy::CudaBlockingH2D
+            TransferStrategy::BlockingH2D
         );
 
         assert_eq!(
@@ -200,7 +200,7 @@ mod tests {
         );
         assert_eq!(
             <PinnedStorage as WriteToStrategy<DeviceStorage>>::write_to_strategy(),
-            TransferStrategy::CudaAsyncH2D
+            TransferStrategy::AsyncH2D
         );
         assert_eq!(
             <PinnedStorage as WriteToStrategy<NixlStorage>>::write_to_strategy(),
@@ -210,15 +210,15 @@ mod tests {
         // Device to ...
         assert_eq!(
             <DeviceStorage as WriteToStrategy<SystemStorage>>::write_to_strategy(),
-            TransferStrategy::CudaBlockingD2H
+            TransferStrategy::BlockingD2H
         );
         assert_eq!(
             <DeviceStorage as WriteToStrategy<PinnedStorage>>::write_to_strategy(),
-            TransferStrategy::CudaAsyncD2H
+            TransferStrategy::AsyncD2H
         );
         assert_eq!(
             <DeviceStorage as WriteToStrategy<DeviceStorage>>::write_to_strategy(),
-            TransferStrategy::CudaAsyncD2D
+            TransferStrategy::AsyncD2D
         );
         assert_eq!(
             <DeviceStorage as WriteToStrategy<NixlStorage>>::write_to_strategy(),
@@ -259,7 +259,7 @@ mod tests {
 
         assert_eq!(
             <SystemStorage as ReadFromStrategy<DeviceStorage>>::read_from_strategy(),
-            TransferStrategy::CudaBlockingD2H
+            TransferStrategy::BlockingD2H
         );
 
         assert_eq!(
@@ -280,7 +280,7 @@ mod tests {
 
         assert_eq!(
             <PinnedStorage as ReadFromStrategy<DeviceStorage>>::read_from_strategy(),
-            TransferStrategy::CudaAsyncD2H
+            TransferStrategy::AsyncD2H
         );
 
         assert_eq!(
@@ -291,17 +291,17 @@ mod tests {
         // Device to ...
         assert_eq!(
             <DeviceStorage as ReadFromStrategy<SystemStorage>>::read_from_strategy(),
-            TransferStrategy::CudaBlockingH2D
+            TransferStrategy::BlockingH2D
         );
 
         assert_eq!(
             <DeviceStorage as ReadFromStrategy<PinnedStorage>>::read_from_strategy(),
-            TransferStrategy::CudaAsyncH2D
+            TransferStrategy::AsyncH2D
         );
 
         assert_eq!(
             <DeviceStorage as ReadFromStrategy<DeviceStorage>>::read_from_strategy(),
-            TransferStrategy::CudaAsyncD2D
+            TransferStrategy::AsyncD2D
         );
 
         assert_eq!(

--- a/lib/llm/src/block_manager/block/transfer/ze.rs
+++ b/lib/llm/src/block_manager/block/transfer/ze.rs
@@ -1,0 +1,421 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use super::context::{DeviceMemPool, DeviceStream, PinnedBuffer, TransferBackend};
+use super::TransferError;
+
+use dynamo_memory::{ZeCommandQueue, ZeEvent, ZeEventPool};
+use dynamo_memory::ze::ZE_EVENT_SCOPE_FLAG_HOST;
+use dynamo_runtime::utils::pool::SyncPoolItem;
+use std::ffi::c_void;
+use std::ops::Range;
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+
+// ============================================================================
+// Ze transfer backend
+// ============================================================================
+
+#[derive(Debug, Default)]
+pub struct ZeMemPool;
+
+pub(super) struct TransferBackendZe {
+    queue: Arc<ZeCommandQueue>,
+    ze_mem_pool: Option<Arc<ZeMemPool>>,
+    ze_event_tx: mpsc::UnboundedSender<(Arc<ZeEventPool>, ZeEvent, oneshot::Sender<()>)>,
+    ze_event_worker: Option<JoinHandle<()>>,
+    cancel_token: CancellationToken,
+}
+
+impl TransferBackendZe {
+    pub fn new(queue: Arc<ZeCommandQueue>, _config: Option<&super::context::PoolConfig>) -> Self {
+        let (ze_event_tx, ze_event_rx) =
+            mpsc::unbounded_channel::<(Arc<ZeEventPool>, ZeEvent, oneshot::Sender<()>)>();
+
+        let cancel_token = CancellationToken::new();
+        let ze_event_worker = Self::setup_ze_event_worker(ze_event_rx, cancel_token.clone());
+
+        Self {
+            queue,
+            ze_mem_pool: None,
+            ze_event_tx,
+            ze_event_worker: Some(ze_event_worker),
+            cancel_token,
+        }
+    }
+
+    fn setup_ze_event_worker(
+        mut ze_event_rx: mpsc::UnboundedReceiver<(Arc<ZeEventPool>, ZeEvent, oneshot::Sender<()>)>,
+        cancel_token: CancellationToken,
+    ) -> JoinHandle<()> {
+        std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Failed to build Tokio runtime for Ze event worker.");
+
+            runtime.block_on(async move {
+                loop {
+                    tokio::select! {
+                        Some((_pool, event, tx)) = ze_event_rx.recv() => {
+                            if let Err(e) = event.host_synchronize(u64::MAX) {
+                                tracing::error!("Error synchronizing Ze event: {:?}", e);
+                            }
+                            let _ = tx.send(());
+                        }
+                        _ = cancel_token.cancelled() => {
+                            break;
+                        }
+                    }
+                }
+            });
+        })
+    }
+}
+
+impl TransferBackend for TransferBackendZe {
+    fn device_mem_pool(&self) -> Option<DeviceMemPool> {
+        None
+    }
+
+    fn device_event(&self, tx: oneshot::Sender<()>) -> Result<(), TransferError> {
+        let event_pool = self.queue.event_pool().clone();
+        let event = event_pool
+            .create_event(0, ZE_EVENT_SCOPE_FLAG_HOST, ZE_EVENT_SCOPE_FLAG_HOST)
+            .map_err(|e| {
+                TransferError::ExecutionError(format!("Ze event creation failed: {:?}", e))
+            })?;
+
+        // Create a command list that signals the event, then execute it.
+        // Without this, the event is never signaled and host_synchronize hangs.
+        let mut list = self.queue.create_command_list().map_err(|e| {
+            TransferError::ExecutionError(format!("Ze command list creation failed: {:?}", e))
+        })?;
+        list.append_signal_event(&event).map_err(|e| {
+            TransferError::ExecutionError(format!("Ze append_signal_event failed: {:?}", e))
+        })?;
+        list.close().map_err(|e| {
+            TransferError::ExecutionError(format!("Ze command list close failed: {:?}", e))
+        })?;
+        self.queue.execute_nonblocking(&mut list).map_err(|e| {
+            TransferError::ExecutionError(format!("Ze command list execute failed: {:?}", e))
+        })?;
+
+        self.ze_event_tx
+            .send((event_pool, event, tx))
+            .map_err(|_| TransferError::ExecutionError("Ze event worker exited.".into()))?;
+        Ok(())
+    }
+
+    fn acquire_resources_for_transfer_sync(
+        &self,
+        _size: usize,
+    ) -> Result<SyncPoolItem<PinnedBuffer>, TransferError> {
+        Err(TransferError::ExecutionError(
+            "Ze pinned buffer pool not yet implemented".into(),
+        ))
+    }
+
+    fn device_stream(&self) -> DeviceStream {
+        DeviceStream::Ze(self.queue.clone())
+    }
+
+    fn shutdown(&mut self) {
+        self.cancel_token.cancel();
+        if let Some(handle) = self.ze_event_worker.take()
+            && let Err(e) = handle.join()
+        {
+            tracing::error!("Error joining Ze event worker: {:?}", e);
+        }
+    }
+}
+
+// ============================================================================
+// Ze copy operations
+// ============================================================================
+
+type ZeMemcpyFnPtr = fn(
+    src_ptr: *const u8,
+    dst_ptr: *mut u8,
+    size: usize,
+    queue: &ZeCommandQueue,
+) -> Result<(), TransferError>;
+
+fn ze_memcpy_fn_ptr(strategy: &TransferStrategy) -> Result<ZeMemcpyFnPtr, TransferError> {
+    match strategy {
+        TransferStrategy::AsyncH2D | TransferStrategy::BlockingH2D => Ok(ze_memcpy_h2d),
+        TransferStrategy::AsyncD2H | TransferStrategy::BlockingD2H => Ok(ze_memcpy_d2h),
+        _ => Err(TransferError::ExecutionError(format!(
+            "Unsupported ZE copy strategy: {:?}",
+            strategy
+        ))),
+    }
+}
+
+/// Copy a block using ZE memcpy primitives.
+pub fn copy_block<'a, Source, Destination>(
+    sources: &'a Source,
+    destinations: &'a mut Destination,
+    queue: &ZeCommandQueue,
+    strategy: TransferStrategy,
+) -> Result<(), TransferError>
+where
+    Source: BlockDataProvider,
+    Destination: BlockDataProviderMut,
+{
+    let src_data = sources.block_data();
+    let dst_data = destinations.block_data_mut();
+    let memcpy_fn = ze_memcpy_fn_ptr(&strategy)?;
+
+    if src_data.is_fully_contiguous() && dst_data.is_fully_contiguous() {
+        let src_view = src_data.block_view()?;
+        let mut dst_view = dst_data.block_view_mut()?;
+
+        debug_assert_eq!(src_view.size(), dst_view.size());
+        unsafe {
+            tracing::debug!(
+                "ZE copy_block contiguous: strategy={:?}, src=0x{:x}, dst=0x{:x}, size={}",
+                strategy,
+                src_view.as_ptr() as usize,
+                dst_view.as_mut_ptr() as usize,
+                src_view.size()
+            );
+            memcpy_fn(
+                src_view.as_ptr(),
+                dst_view.as_mut_ptr(),
+                src_view.size(),
+                queue,
+            )?;
+        }
+    } else {
+        assert_eq!(src_data.num_layers(), dst_data.num_layers());
+        copy_layers(
+            0..src_data.num_layers(),
+            sources,
+            destinations,
+            queue,
+            strategy,
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Temporary ZE implementation for API parity with CUDA custom kernel path.
+///
+/// This currently falls back to batched ZE memcpys with a single command list.
+pub fn copy_blocks_with_customized_kernel<'a, Source, Destination>(
+    sources: &'a [Source],
+    destinations: &'a mut [Destination],
+    queue: &ZeCommandQueue,
+    _ctx: &crate::block_manager::block::transfer::TransferContext,
+) -> Result<(), TransferError>
+where
+    Source: BlockDataProvider,
+    Destination: BlockDataProviderMut,
+{
+    if sources.len() != destinations.len() {
+        return Err(TransferError::CountMismatch(
+            sources.len(),
+            destinations.len(),
+        ));
+    }
+
+    let mut list = queue.create_command_list().map_err(|e| {
+        TransferError::ExecutionError(format!(
+            "ZE custom batch command list creation failed: {:?}",
+            e
+        ))
+    })?;
+
+    for (src, dst) in sources.iter().zip(destinations.iter_mut()) {
+        let src_data = src.block_data();
+        let dst_data = dst.block_data_mut();
+
+        if src_data.is_fully_contiguous() && dst_data.is_fully_contiguous() {
+            let src_view = src_data.block_view()?;
+            let mut dst_view = dst_data.block_view_mut()?;
+
+            debug_assert_eq!(src_view.size(), dst_view.size());
+
+            if src_view.size() == 0 {
+                continue;
+            }
+
+            unsafe {
+                tracing::debug!(
+                    "ZE copy_blocks_with_customized_kernel contiguous: src=0x{:x}, dst=0x{:x}, size={}",
+                    src_view.as_ptr() as usize,
+                    dst_view.as_mut_ptr() as usize,
+                    src_view.size()
+                );
+                list.append_memcpy(
+                    dst_view.as_mut_ptr() as *mut c_void,
+                    src_view.as_ptr() as *const c_void,
+                    src_view.size(),
+                )
+                .map_err(|e| {
+                    TransferError::ExecutionError(format!(
+                        "ZE custom batch append_memcpy (contiguous) failed: {:?}",
+                        e
+                    ))
+                })?;
+            }
+        } else {
+            assert_eq!(src_data.num_layers(), dst_data.num_layers());
+            assert_eq!(src_data.num_outer_dims(), dst_data.num_outer_dims());
+
+            for layer_idx in 0..src_data.num_layers() {
+                for outer_idx in 0..src_data.num_outer_dims() {
+                    let src_view = src_data.layer_view(layer_idx, outer_idx)?;
+                    let mut dst_view = dst_data.layer_view_mut(layer_idx, outer_idx)?;
+
+                    debug_assert_eq!(src_view.size(), dst_view.size());
+
+                    if src_view.size() == 0 {
+                        continue;
+                    }
+
+                    unsafe {
+                        tracing::debug!(
+                            "ZE copy_blocks_with_customized_kernel layered: layer={}, outer={}, src=0x{:x}, dst=0x{:x}, size={}",
+                            layer_idx,
+                            outer_idx,
+                            src_view.as_ptr() as usize,
+                            dst_view.as_mut_ptr() as usize,
+                            src_view.size()
+                        );
+                        list.append_memcpy(
+                            dst_view.as_mut_ptr() as *mut c_void,
+                            src_view.as_ptr() as *const c_void,
+                            src_view.size(),
+                        )
+                        .map_err(|e| {
+                            TransferError::ExecutionError(format!(
+                                "ZE custom batch append_memcpy (layered) failed: {:?}",
+                                e
+                            ))
+                        })?;
+                    }
+                }
+            }
+        }
+    }
+
+    list.close().map_err(|e| {
+        TransferError::ExecutionError(format!("ZE custom batch list close failed: {:?}", e))
+    })?;
+    queue.execute_nonblocking(&mut list).map_err(|e| {
+        TransferError::ExecutionError(format!("ZE custom batch queue submit failed: {:?}", e))
+    })?;
+
+    Ok(())
+}
+
+/// Copy a range of layers from source to destination using ZE memcpy.
+pub fn copy_layers<'a, Source, Destination>(
+    layer_range: Range<usize>,
+    sources: &'a Source,
+    destinations: &'a mut Destination,
+    queue: &ZeCommandQueue,
+    strategy: TransferStrategy,
+) -> Result<(), TransferError>
+where
+    Source: BlockDataProvider,
+    Destination: BlockDataProviderMut,
+{
+    let src_data = sources.block_data();
+    let dst_data = destinations.block_data_mut();
+    let memcpy_fn = ze_memcpy_fn_ptr(&strategy)?;
+
+    assert_eq!(src_data.num_outer_dims(), dst_data.num_outer_dims());
+
+    for layer_idx in layer_range {
+        for outer_idx in 0..src_data.num_outer_dims() {
+            let src_view = src_data.layer_view(layer_idx, outer_idx)?;
+            let mut dst_view = dst_data.layer_view_mut(layer_idx, outer_idx)?;
+
+            debug_assert_eq!(src_view.size(), dst_view.size());
+            unsafe {
+                tracing::debug!(
+                    "ZE copy_layers: strategy={:?}, layer={}, outer={}, src=0x{:x}, dst=0x{:x}, size={}",
+                    strategy,
+                    layer_idx,
+                    outer_idx,
+                    src_view.as_ptr() as usize,
+                    dst_view.as_mut_ptr() as usize,
+                    src_view.size()
+                );
+                memcpy_fn(
+                    src_view.as_ptr(),
+                    dst_view.as_mut_ptr(),
+                    src_view.size(),
+                    queue,
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[inline(always)]
+fn ze_memcpy_d2h(
+    src_ptr: *const u8,
+    dst_ptr: *mut u8,
+    size: usize,
+    queue: &ZeCommandQueue,
+) -> Result<(), TransferError> {
+    debug_assert!(!src_ptr.is_null(), "Source ZE device pointer is null");
+    debug_assert!(!dst_ptr.is_null(), "Destination host pointer is null");
+
+    if size == 0 {
+        return Ok(());
+    }
+
+    let mut list = queue.create_command_list().map_err(|e| {
+        TransferError::ExecutionError(format!("ZE D2H command list creation failed: {:?}", e))
+    })?;
+    list.append_memcpy(dst_ptr as *mut c_void, src_ptr as *const c_void, size)
+        .map_err(|e| {
+            TransferError::ExecutionError(format!("ZE D2H append_memcpy failed: {:?}", e))
+        })?;
+    list.close()
+        .map_err(|e| TransferError::ExecutionError(format!("ZE D2H list close failed: {:?}", e)))?;
+    queue.execute_nonblocking(&mut list).map_err(|e| {
+        TransferError::ExecutionError(format!("ZE D2H queue submit failed: {:?}", e))
+    })?;
+    Ok(())
+}
+
+#[inline(always)]
+fn ze_memcpy_h2d(
+    src_ptr: *const u8,
+    dst_ptr: *mut u8,
+    size: usize,
+    queue: &ZeCommandQueue,
+) -> Result<(), TransferError> {
+    debug_assert!(!src_ptr.is_null(), "Source host pointer is null");
+    debug_assert!(!dst_ptr.is_null(), "Destination ZE device pointer is null");
+
+    if size == 0 {
+        return Ok(());
+    }
+
+    let mut list = queue.create_command_list().map_err(|e| {
+        TransferError::ExecutionError(format!("ZE H2D command list creation failed: {:?}", e))
+    })?;
+    list.append_memcpy(dst_ptr as *mut c_void, src_ptr as *const c_void, size)
+        .map_err(|e| {
+            TransferError::ExecutionError(format!("ZE H2D append_memcpy failed: {:?}", e))
+        })?;
+    list.close()
+        .map_err(|e| TransferError::ExecutionError(format!("ZE H2D list close failed: {:?}", e)))?;
+    queue.execute_nonblocking(&mut list).map_err(|e| {
+        TransferError::ExecutionError(format!("ZE H2D queue submit failed: {:?}", e))
+    })?;
+    Ok(())
+}

--- a/lib/llm/src/block_manager/config.rs
+++ b/lib/llm/src/block_manager/config.rs
@@ -214,6 +214,10 @@ pub struct KvBlockManagerConfig {
     #[builder(default, setter(custom))]
     pub consolidator_config:
         Option<crate::block_manager::kv_consolidator::KvEventConsolidatorConfig>,
+
+    /// Device backend type: "cuda" or "ze"
+    #[builder(default = "String::from(\"cuda\")")]
+    pub device_type: String,
 }
 
 impl KvBlockManagerConfig {

--- a/lib/llm/src/block_manager/distributed/worker.rs
+++ b/lib/llm/src/block_manager/distributed/worker.rs
@@ -12,12 +12,12 @@ use crate::block_manager::{
     BasicMetadata, BlockMetadata, LayoutConfigBuilder, NixlLayout, Storage,
     block::{
         Block, layout_to_blocks, locality,
-        transfer::{PoolConfig, TransferContext},
+        transfer::{DeviceContextExt, PoolConfig, TransferContext},
     },
     connector::scheduler::TransferSchedulerClient,
     layout::LayoutType,
     offload::{max_concurrent_transfers, max_transfer_batch_size},
-    storage::{DeviceAllocator, DeviceStorage, DiskAllocator, PinnedAllocator, torch::TorchTensor},
+    storage::{DeviceAllocator, DeviceBackend, DeviceStorage, DiskAllocator, PinnedAllocator, torch::TorchTensor},
 };
 
 use derive_builder::Builder;
@@ -53,11 +53,14 @@ impl WorkerState {
 pub fn load_and_validate_tensors(
     tensors: &[Arc<dyn TorchTensor>],
     device_id: usize,
+    device_type: &str,
 ) -> anyhow::Result<(Vec<DeviceStorage>, Vec<usize>)> {
     let mut shape = None;
 
     let mut device_tensors = Vec::with_capacity(tensors.len());
-    let allocator = DeviceAllocator::new(device_id)?;
+    let backend = DeviceBackend::from_str(device_type)
+        .map_err(|e| anyhow::anyhow!(e))?;
+    let allocator = DeviceAllocator::new_with_backend(device_id, backend)?;
 
     for tensor in tensors {
         // Check the stride, and ensure our tensor is contiguous.
@@ -120,19 +123,22 @@ async fn perform_allocation_and_build_handler(
         num_outer_components: device_layout.config().outer_dim,
         num_layers: device_layout.config().num_layers,
     };
+    let backend = DeviceBackend::from_str(&worker_config.device_type)
+        .map_err(|e| anyhow::anyhow!(e))?;
     let transfer_context = Arc::new(
         TransferContext::new(
             Arc::new(Some(agent)),
-            DeviceAllocator::new(device_id)?.ctx().new_stream()?,
+            DeviceAllocator::new_with_backend(device_id, backend)?.ctx().new_stream()?,
             Handle::current(),
             Some(pool_config),
         )
         .map_err(|e| {
             anyhow::anyhow!(
-                "Failed to create transfer context for worker {} with CUDA memory pool: {}. \
-                 This is a critical error - the worker cannot start without CUDA memory pools. \
+                "Failed to create transfer context for worker {} with {} memory pool: {}. \
+                 This is a critical error - the worker cannot start without memory pools. \
                  Please ensure sufficient GPU memory is available on device {}.",
                 worker_id,
+                worker_config.device_type,
                 e,
                 device_id
             )
@@ -148,7 +154,8 @@ async fn perform_allocation_and_build_handler(
     )?);
     // host
     let host_blocks = if leader_meta.num_host_blocks > 0 {
-        let host_allocator = Arc::new(PinnedAllocator::new(device_id)?);
+        let host_ctx = backend.create(device_id)?;
+        let host_allocator = Arc::new(PinnedAllocator::new_with_context(host_ctx));
 
         let host_layout = layout_builder
             .num_blocks(leader_meta.num_host_blocks)
@@ -391,6 +398,9 @@ pub struct KvbmWorkerConfig {
     #[builder(default = "0")]
     device_id: usize,
 
+    #[builder(default = "String::from(\"cuda\")")]
+    device_type: String,
+
     #[builder(default = "2")]
     dtype_width_bytes: usize,
 
@@ -437,7 +447,7 @@ impl KvbmWorker {
             return Err(anyhow::anyhow!("num_device_blocks must be greater than 0"));
         }
 
-        let (device_tensors, shape) = load_and_validate_tensors(&config.tensors, config.device_id)?;
+        let (device_tensors, shape) = load_and_validate_tensors(&config.tensors, config.device_id, &config.device_type)?;
 
         if shape.len() < 3 {
             return Err(anyhow::anyhow!(format!(

--- a/lib/llm/src/block_manager/offload.rs
+++ b/lib/llm/src/block_manager/offload.rs
@@ -35,10 +35,10 @@
 use super::block::{
     BlockError, BlockMetadata, BlockState, ImmutableBlock, MutableBlock,
     locality::LocalityProvider,
-    transfer::{PoolConfig, TransferContext},
+    transfer::{DeviceContextExt, PoolConfig, TransferContext},
 };
 use super::pool::{BlockPool, BlockPoolError};
-use super::storage::{Cuda, Storage};
+use super::storage::{DeviceBackend, Storage};
 use super::{DeviceStorage, DiskStorage, KvManagerModelConfig, PinnedStorage};
 use nixl_sys::Agent as NixlAgent;
 use std::sync::{
@@ -125,6 +125,8 @@ pub struct OffloadManagerConfig {
     pub kvbm_metrics: Option<crate::block_manager::metrics_kvbm::KvbmMetrics>,
     /// If true, offload directly from device (G1) to disk (G3), bypassing host (G2)
     pub bypass_cpu_mem: bool,
+    /// Device backend type: "cuda" or "ze"
+    pub device_type: String,
 }
 
 /// The offload manager handles all block transfers between different cache levels.
@@ -186,7 +188,9 @@ impl<Locality: LocalityProvider + 'static, Metadata: BlockMetadata>
             bypass_cpu_mem: config.bypass_cpu_mem,
         });
 
-        let cuda_ctx = Cuda::device_or_create(0)?;
+        let backend = DeviceBackend::from_str(&config.device_type)
+            .map_err(|e| anyhow::anyhow!(e))?;
+        let device_ctx = backend.create(0)?;
 
         let max_concurrent_transfers = max_concurrent_transfers();
         let max_transfer_batch_size = max_transfer_batch_size();
@@ -209,14 +213,14 @@ impl<Locality: LocalityProvider + 'static, Metadata: BlockMetadata>
         let device_offload_transfer_ctx = Arc::new(
             TransferContext::new(
                 config.nixl_agent.clone(),
-                cuda_ctx.new_stream()?,
+                device_ctx.new_stream()?,
                 config.async_rt_handle.clone(),
                 Some(pool_config.clone()),
             )
             .map_err(|e| {
                 anyhow::anyhow!(
-                    "Failed to create device offload transfer context with CUDA memory pool: {}. \
-                     This is a critical error - the system cannot operate without CUDA memory pools. \
+                    "Failed to create device offload transfer context with Device memory pool: {}. \
+                     This is a critical error - the system cannot operate without Device memory pools. \
                      Please ensure sufficient GPU memory is available.",
                     e
                 )
@@ -257,13 +261,14 @@ impl<Locality: LocalityProvider + 'static, Metadata: BlockMetadata>
         let transfer_ctx = Arc::new(
             TransferContext::new(
                 config.nixl_agent.clone(),
-                cuda_ctx.new_stream()?,
+                device_ctx.new_stream()?,
                 config.async_rt_handle.clone(),
                 Some(pool_config),
             )
             .map_err(|e| {
                 anyhow::anyhow!(
-                    "Failed to create transfer context for host onboard operations: {}",
+                    "Failed to create transfer context for host onboard operations with {} backend: {}",
+                    config.device_type,
                     e
                 )
             })?,
@@ -775,7 +780,7 @@ mod tests {
         layout::{FullyContiguous, LayerSeparate, LayoutType, nixl::NixlLayout},
         pool::{BlockRegistrationDuplicationSetting, ManagedBlockPool},
         storage::{
-            DeviceAllocator, DeviceStorage, DiskAllocator, DiskStorage, PinnedAllocator,
+            DeviceAllocator, DeviceStorage, DiskAllocator, DiskStorage, PinnedAllocator, 
             PinnedStorage, StorageAllocator, StorageType,
         },
     };

--- a/lib/llm/src/block_manager/state.rs
+++ b/lib/llm/src/block_manager/state.rs
@@ -158,6 +158,7 @@ impl<R: LogicalResources, Metadata: BlockMetadata>
             model_config,
             kvbm_metrics: resources.config.kvbm_metrics.clone(),
             bypass_cpu_mem,
+            device_type: resources.config.device_type.clone(),
         };
 
         let offload_manager = OffloadManager::new(
@@ -284,6 +285,7 @@ impl<Metadata: BlockMetadata> KvBlockManagerState<locality::Local, Metadata> {
             model_config,
             kvbm_metrics: resources.config.kvbm_metrics.clone(),
             bypass_cpu_mem,
+            device_type: resources.config.device_type.clone(),
         };
 
         let offload_manager = OffloadManager::new(

--- a/lib/llm/src/block_manager/storage.rs
+++ b/lib/llm/src/block_manager/storage.rs
@@ -71,6 +71,7 @@ pub mod disk;
 pub mod nixl;
 pub mod object;
 pub mod torch;
+pub mod ze;
 
 pub use cuda::*;
 pub use disk::*;
@@ -82,8 +83,11 @@ use std::{
     collections::HashMap,
     fmt::Debug,
     ptr::NonNull,
+    sync::Arc,
 };
 
+use cudarc::driver::CudaContext;
+use dynamo_memory::MemoryDescriptor as _;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -121,7 +125,6 @@ pub trait Remote {}
 /// Marker trait for [`Storage`] types that can be accessed by the standard
 /// mechanisms of the system, e.g. `memcpy`, `memset`, etc.
 pub trait SystemAccessible {}
-pub trait CudaAccessible {}
 
 /// Errors that can occur during storage operations
 #[derive(Debug, Error)]
@@ -338,6 +341,228 @@ pub trait StorageAllocator<S: Storage>: Send + Sync {
     fn allocate(&self, size: usize) -> Result<S, StorageError>;
 }
 
+// ---------------------------------------------------------------------------
+// DeviceStorage (multi-backend)
+// ---------------------------------------------------------------------------
+
+/// An enum indicating the type of device storage.
+/// This is needed to ensure ownership of memory is correctly handled.
+/// When building a [`DeviceStorage`] from a torch tensor, we need to ensure that
+/// the torch tensor is not GCed until the [`DeviceStorage`] is dropped.
+/// For ZE backend, the device buffer must be kept alive so its Drop impl frees
+/// the memory.
+pub(crate) enum DeviceStorageType {
+    Owned {
+        /// Backend-specific ownership handle. For Ze, holds a `DeviceBuffer`
+        /// whose `Drop` frees memory. `None` for CUDA (freed via driver API).
+        _backend_handle: Option<Box<dyn std::any::Any + Send + Sync>>,
+    },
+    Torch {
+        _tensor: Arc<dyn TorchTensor>,
+    },
+}
+
+impl std::fmt::Debug for DeviceStorageType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Owned { .. } => write!(f, "Owned"),
+            Self::Torch { .. } => write!(f, "Torch"),
+        }
+    }
+}
+
+/// Device memory storage supporting CUDA and ZE backends.
+#[derive(Debug)]
+pub struct DeviceStorage {
+    pub(crate) ptr: u64,
+    pub(crate) size: usize,
+    pub(crate) ctx: DeviceContext,
+    pub(crate) handles: RegistrationHandles,
+    pub(crate) storage_type: DeviceStorageType,
+}
+
+impl Local for DeviceStorage {}
+impl CudaAccessible for DeviceStorage {}
+
+impl DeviceStorage {
+    /// Create a new device storage using a [`DeviceContext`].
+    pub fn new(ctx: &DeviceContext, size: usize) -> Result<Self, StorageError> {
+        let (ptr, _device_id, metadata) =
+            unsafe { ctx.backend.alloc_device(size)? };
+        Ok(Self {
+            ptr,
+            size,
+            ctx: ctx.clone(),
+            handles: RegistrationHandles::new(),
+            storage_type: DeviceStorageType::Owned {
+                _backend_handle: metadata,
+            },
+        })
+    }
+
+    pub fn new_from_torch(
+        ctx: &DeviceContext,
+        tensor: Arc<dyn TorchTensor>,
+    ) -> Result<Self, StorageError> {
+        let device = tensor.device();
+        let desc = dynamo_memory::TorchTensorDescriptor {
+            data_ptr: tensor.data_ptr(),
+            size_bytes: tensor.size_bytes(),
+            is_cuda: matches!(device, TorchDevice::Cuda(_)),
+            is_xpu: torch::is_ze(tensor.as_ref()),
+            device_id: match device {
+                TorchDevice::Cuda(id) => id as u32,
+                _ => 0,
+            },
+        };
+
+        let (ptr, size) = ctx.backend.new_from_torch(&desc)?;
+
+        Ok(Self {
+            ptr,
+            size,
+            ctx: ctx.clone(),
+            handles: RegistrationHandles::new(),
+            storage_type: DeviceStorageType::Torch { _tensor: tensor },
+        })
+    }
+
+    /// Get the device context.
+    pub fn device_ctx(&self) -> &DeviceContext {
+        &self.ctx
+    }
+}
+
+impl Storage for DeviceStorage {
+    fn storage_type(&self) -> StorageType {
+        StorageType::Device(self.ctx.backend.device_id())
+    }
+
+    fn addr(&self) -> u64 {
+        self.ptr
+    }
+
+    fn size(&self) -> usize {
+        self.size
+    }
+
+    unsafe fn as_ptr(&self) -> *const u8 {
+        self.ptr as *const u8
+    }
+
+    unsafe fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.ptr as *mut u8
+    }
+}
+
+impl Drop for DeviceStorage {
+    fn drop(&mut self) {
+        self.handles.release();
+        match &self.storage_type {
+            DeviceStorageType::Owned { _backend_handle } => {
+                if _backend_handle.is_some() {
+                    // ZE: memory is freed by the DeviceBuffer's Drop impl
+                    // (stored in the _backend_handle box).
+                } else {
+                    // CUDA: free via driver API.
+                    unsafe { cudarc::driver::result::free_sync(self.ptr as _) }.unwrap()
+                }
+            }
+            DeviceStorageType::Torch { _tensor } => {
+                // Do nothing. The torch storage is responsible for cleaning up itself.
+            }
+        }
+    }
+}
+
+impl RegisterableStorage for DeviceStorage {
+    fn register(
+        &mut self,
+        key: &str,
+        handle: Box<dyn RegistationHandle>,
+    ) -> Result<(), StorageError> {
+        self.handles.register(key, handle)
+    }
+
+    fn is_registered(&self, key: &str) -> bool {
+        self.handles.is_registered(key)
+    }
+
+    fn registration_handle(&self, key: &str) -> Option<&dyn RegistationHandle> {
+        self.handles.registration_handle(key)
+    }
+}
+
+/// Backend selector for device allocation.
+#[derive(Debug, Clone, Copy)]
+pub enum DeviceBackend {
+    Cuda,
+    Ze,
+}
+
+impl DeviceBackend {
+    /// Create the backend context for the given device.
+    pub fn create(&self, device_id: usize) -> Result<DeviceContext, StorageError> {
+        match self {
+            DeviceBackend::Cuda => Ok(DeviceContext::new(cuda::Cuda::device_or_create(device_id)?)),
+            DeviceBackend::Ze => Ok(DeviceContext::new(dynamo_memory::Ze::device_or_create(device_id)?)),
+        }
+    }
+
+    /// Parse a device type string into a DeviceBackend.
+    pub fn from_str(s: &str) -> Result<Self, StorageError> {
+        match s {
+            "cuda" => Ok(DeviceBackend::Cuda),
+            "xpu" | "ze" => Ok(DeviceBackend::Ze),
+            other => Err(StorageError::OperationFailed(format!(
+                "Unsupported device_type: {}",
+                other
+            ))),
+        }
+    }
+}
+
+/// Allocator for DeviceStorage
+pub struct DeviceAllocator {
+    ctx: DeviceContext,
+}
+
+impl DeviceAllocator {
+    /// Create a new device allocator with the default CUDA backend.
+    pub fn new(device_id: usize) -> Result<Self, StorageError> {
+        Self::new_with_backend(device_id, DeviceBackend::Cuda)
+    }
+
+    /// Create a new device allocator with the specified backend.
+    pub fn new_with_backend(device_id: usize, backend: DeviceBackend) -> Result<Self, StorageError> {
+        Ok(Self {
+            ctx: backend.create(device_id)?,
+        })
+    }
+
+    pub fn ctx(&self) -> &DeviceContext {
+        &self.ctx
+    }
+}
+
+impl Default for DeviceAllocator {
+    fn default() -> Self {
+        Self {
+            ctx: DeviceContext::new(CudaContext::new(0).expect("Failed to create CUDA context")),
+        }
+    }
+}
+
+impl StorageAllocator<DeviceStorage> for DeviceAllocator {
+    fn allocate(&self, size: usize) -> Result<DeviceStorage, StorageError> {
+        DeviceStorage::new(&self.ctx, size)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SystemStorage
+// ---------------------------------------------------------------------------
+
 /// System memory storage implementation using pinned memory
 #[derive(Debug)]
 pub struct SystemStorage {
@@ -452,6 +677,173 @@ impl StorageAllocator<SystemStorage> for SystemAllocator {
     }
 }
 
+// ---------------------------------------------------------------------------
+// PinnedStorage
+// ---------------------------------------------------------------------------
+
+/// Pinned host memory storage using CUDA page-locked memory.
+/// Wraps [`dynamo_memory::PinnedStorage`] and adds registration handle support.
+#[derive(Debug)]
+pub struct PinnedStorage {
+    inner: dynamo_memory::PinnedStorage,
+    handles: RegistrationHandles,
+}
+
+impl Local for PinnedStorage {}
+impl SystemAccessible for PinnedStorage {}
+impl CudaAccessible for PinnedStorage {}
+
+impl PinnedStorage {
+    /// Create a new pinned storage with the given size.
+    ///
+    /// Uses write-combined allocation with NUMA-awareness when enabled.
+    /// Prefer [`new_for_device`](Self::new_for_device) for new code.
+    ///
+    /// TODO(KVBM-336): remove PinnedStorage::new in the future
+    #[deprecated(since = "1.0.0", note = "Use PinnedStorage::new_for_device instead")]
+    pub fn new(ctx: &Arc<CudaContext>, size: usize) -> Result<Self, StorageError> {
+        let inner =
+            dynamo_memory::PinnedStorage::new_for_device(size, Some(ctx.cu_device() as u32))?;
+        Ok(Self {
+            inner,
+            handles: RegistrationHandles::new(),
+        })
+    }
+
+    /// Create a new pinned storage, optionally NUMA-aware for a specific GPU.
+    ///
+    /// Delegates NUMA-aware allocation and write-combined selection to
+    /// [`dynamo_memory::PinnedStorage::new_for_device`].
+    ///
+    /// When `device_id` is `None`, allocates on device 0 without NUMA awareness.
+    pub fn new_for_device(size: usize, device_id: Option<u32>) -> Result<Self, StorageError> {
+        // Warn once if the legacy opt-in env var is still set.
+        static DEPRECATION_WARN: std::sync::Once = std::sync::Once::new();
+        if std::env::var("DYN_KVBM_ENABLE_NUMA").is_ok() {
+            DEPRECATION_WARN.call_once(|| {
+                tracing::warn!(
+                    "DYN_KVBM_ENABLE_NUMA is deprecated for PinnedStorage::new_for_device; \
+                     NUMA is now enabled by default. Use DYN_MEMORY_DISABLE_NUMA=1 to disable."
+                );
+            });
+        }
+        let inner = dynamo_memory::PinnedStorage::new_for_device(size, device_id)?;
+        Ok(Self {
+            inner,
+            handles: RegistrationHandles::new(),
+        })
+    }
+
+    /// Create a new pinned storage using an existing [`DeviceContext`].
+    pub fn new_with_context(size: usize, ctx: &DeviceContext) -> Result<Self, StorageError> {
+        let inner = dynamo_memory::PinnedStorage::new_with_context(size, ctx)?;
+        Ok(Self {
+            inner,
+            handles: RegistrationHandles::new(),
+        })
+    }
+}
+
+impl Drop for PinnedStorage {
+    fn drop(&mut self) {
+        self.handles.release();
+        // inner Drop handles free_host
+    }
+}
+
+impl Storage for PinnedStorage {
+    fn storage_type(&self) -> StorageType {
+        StorageType::Pinned
+    }
+
+    fn addr(&self) -> u64 {
+        self.inner.addr() as u64
+    }
+
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+
+    unsafe fn as_ptr(&self) -> *const u8 {
+        unsafe { self.inner.as_ptr() }
+    }
+
+    unsafe fn as_mut_ptr(&mut self) -> *mut u8 {
+        unsafe { self.inner.as_mut_ptr() }
+    }
+}
+
+impl RegisterableStorage for PinnedStorage {
+    fn register(
+        &mut self,
+        key: &str,
+        handle: Box<dyn RegistationHandle>,
+    ) -> Result<(), StorageError> {
+        self.handles.register(key, handle)
+    }
+
+    fn is_registered(&self, key: &str) -> bool {
+        self.handles.is_registered(key)
+    }
+
+    fn registration_handle(&self, key: &str) -> Option<&dyn RegistationHandle> {
+        self.handles.registration_handle(key)
+    }
+}
+
+impl StorageMemset for PinnedStorage {
+    fn memset(&mut self, value: u8, offset: usize, size: usize) -> Result<(), StorageError> {
+        if offset + size > self.inner.size() {
+            return Err(StorageError::OperationFailed(
+                "memset: offset + size > storage size".into(),
+            ));
+        }
+        unsafe {
+            let ptr = self.inner.as_mut_ptr().add(offset);
+            std::ptr::write_bytes(ptr, value, size);
+        }
+        Ok(())
+    }
+}
+
+/// Allocator for PinnedStorage
+pub struct PinnedAllocator {
+    ctx: DeviceContext,
+}
+
+impl Default for PinnedAllocator {
+    fn default() -> Self {
+        Self {
+            ctx: DeviceContext::new(Cuda::device_or_create(0).expect("Failed to create CUDA context")),
+        }
+    }
+}
+
+impl PinnedAllocator {
+    /// Create a new pinned allocator for the specified device (CUDA backend).
+    ///
+    /// The device_id determines which NUMA node pinned memory will be allocated
+    /// on when NUMA-aware allocation is enabled.
+    pub fn new(device_id: usize) -> Result<Self, StorageError> {
+        Ok(Self {
+            ctx: DeviceContext::new(Cuda::device_or_create(device_id)?),
+        })
+    }
+
+    /// Create a new pinned allocator from an existing DeviceContext.
+    ///
+    /// This supports both CUDA and ZE backends.
+    pub fn new_with_context(ctx: DeviceContext) -> Self {
+        Self { ctx }
+    }
+}
+
+impl StorageAllocator<PinnedStorage> for PinnedAllocator {
+    fn allocate(&self, size: usize) -> Result<PinnedStorage, StorageError> {
+        PinnedStorage::new_with_context(size, &self.ctx)
+    }
+}
+
 #[allow(missing_docs)]
 pub mod tests {
     use super::*;
@@ -536,6 +928,106 @@ pub mod tests {
         fn allocate(&self, size: usize) -> Result<NullHostStorage, StorageError> {
             Ok(NullHostStorage::new(size as u64))
         }
+    }
+}
+
+#[cfg(all(test, feature = "testing-cuda"))]
+mod device_storage_tests {
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    struct MockTensor {
+        device: TorchDevice,
+        data_ptr: u64,
+        size_bytes: usize,
+    }
+
+    impl MockTensor {
+        pub fn new(device: TorchDevice, data_ptr: u64, size_bytes: usize) -> Self {
+            Self {
+                device,
+                data_ptr,
+                size_bytes,
+            }
+        }
+    }
+
+    impl TorchTensor for MockTensor {
+        fn device(&self) -> TorchDevice {
+            self.device.clone()
+        }
+
+        fn data_ptr(&self) -> u64 {
+            self.data_ptr
+        }
+
+        fn size_bytes(&self) -> usize {
+            self.size_bytes
+        }
+
+        fn shape(&self) -> Vec<usize> {
+            vec![self.size_bytes]
+        }
+
+        fn stride(&self) -> Vec<usize> {
+            vec![1]
+        }
+    }
+
+    #[test]
+    fn test_device_storage_from_torch_valid_tensor() {
+        let cuda_ctx = cuda::Cuda::device_or_create(0).expect("Failed to create CUDA context");
+        let ctx = DeviceContext::new(cuda_ctx);
+        let size_bytes = 1024;
+
+        let actual_storage =
+            std::mem::ManuallyDrop::new(DeviceStorage::new(&ctx, size_bytes).unwrap());
+
+        let tensor = MockTensor::new(TorchDevice::Cuda(0), actual_storage.addr(), size_bytes);
+
+        let storage = DeviceStorage::new_from_torch(&ctx, Arc::new(tensor)).unwrap();
+
+        assert_eq!(storage.size(), size_bytes);
+        assert_eq!(storage.storage_type(), StorageType::Device(0));
+        assert_eq!(storage.addr(), actual_storage.addr());
+    }
+
+    #[test]
+    fn test_device_storage_from_torch_cpu_tensor_fails() {
+        let cuda_ctx = cuda::Cuda::device_or_create(0).expect("Failed to create CUDA context");
+        let ctx = DeviceContext::new(cuda_ctx);
+        let size_bytes = 1024;
+
+        let actual_storage = DeviceStorage::new(&ctx, size_bytes).unwrap();
+
+        let tensor = MockTensor::new(
+            TorchDevice::Other("cpu".to_string()),
+            actual_storage.addr(),
+            size_bytes,
+        );
+
+        let result = DeviceStorage::new_from_torch(&ctx, Arc::new(tensor));
+        assert!(result.is_err());
+
+        if let Err(StorageError::InvalidConfig(msg)) = result {
+            assert!(msg.contains("Tensor is not CUDA"));
+        } else {
+            panic!("Expected InvalidConfig error for CPU tensor");
+        }
+    }
+
+    #[test]
+    fn test_device_storage_wrong_device() {
+        let cuda_ctx = cuda::Cuda::device_or_create(0).expect("Failed to create CUDA context");
+        let ctx = DeviceContext::new(cuda_ctx);
+        let size_bytes = 1024;
+
+        let actual_storage = DeviceStorage::new(&ctx, size_bytes).unwrap();
+
+        let tensor = MockTensor::new(TorchDevice::Cuda(1), actual_storage.addr(), size_bytes);
+
+        let result = DeviceStorage::new_from_torch(&ctx, Arc::new(tensor));
+        assert!(result.is_err());
     }
 }
 

--- a/lib/llm/src/block_manager/storage/cuda.rs
+++ b/lib/llm/src/block_manager/storage/cuda.rs
@@ -4,19 +4,17 @@
 //! # CUDA Storage Support
 //!
 //! This module provides CUDA-specific storage implementations for the block manager.
-//! It is conditionally compiled based on the `cuda` feature flag.
 //!
-//! ## Features
+//! ## Types
 //!
-//! The following types are available when the `cuda` feature is enabled:
 //! - [`PinnedStorage`] - Page-locked host memory for efficient GPU transfers
-//! - [`DeviceStorage`] - Direct GPU memory allocation
+//! - [`DeviceContext`] - Unified device context for multi-backend support
+//! - [`StorageBackendOps`] - Trait abstracting backend-specific allocation
+//! - [`CudaAccessible`] - Trait for CUDA-accessible storage types
 //!
 //! ## Storage Allocators
 //!
-//! The module provides allocators for each storage type:
 //! - [`PinnedAllocator`] - Creates pinned host memory allocations
-//! - [`DeviceAllocator`] - Creates device memory allocations
 //!
 //! ## CUDA Context Management
 //!
@@ -29,43 +27,12 @@
 //!
 //! ### Using Allocators
 //! ```rust,ignore
-//! use dynamo_llm::block_manager::storage::{DeviceAllocator, PinnedAllocator, StorageAllocator};
+//! use dynamo_llm::block_manager::storage::{PinnedAllocator, StorageAllocator};
 //!
 //! // Create a pinned memory allocator
 //! let pinned_allocator = PinnedAllocator::default();
 //! let pinned_storage = pinned_allocator.allocate(1024).unwrap();
-//!
-//! // Create a device memory allocator for a specific device
-//! let device_allocator = DeviceAllocator::new(1).unwrap();  // Use device 1
-//! let device_storage = device_allocator.allocate(1024).unwrap();
 //! ```
-//!
-//! ### Memory Operations
-//! ```rust,ignore
-//! use dynamo_llm::block_manager::storage::{
-//!     PinnedAllocator, StorageAllocator, Storage, StorageMemset
-//! };
-//!
-//! // Initialize memory
-//! let mut storage = PinnedAllocator::default().allocate(1024).unwrap();
-//!
-//! // Initialize memory
-//! storage.memset(0, 0, 1024).unwrap();
-//!
-//! // Access memory through raw pointers (requires unsafe)
-//! unsafe {
-//!     let ptr = storage.as_mut_ptr();
-//!     // Use the pointer...
-//! }
-//! ```
-//!
-//! ## Safety
-//!
-//! All CUDA operations are wrapped in safe Rust interfaces that ensure:
-//! - Proper resource cleanup
-//! - Thread safety
-//! - Memory alignment requirements
-//! - Error handling for CUDA operations
 
 use super::*;
 
@@ -75,16 +42,18 @@ use std::{
 };
 
 use cudarc::driver::CudaContext;
-use dynamo_memory::MemoryDescriptor as _;
+pub use dynamo_memory::StorageBackendOps;
+
+/// Reuse `dynamo_memory::DeviceContext` — a type-erased wrapper around
+/// `Arc<dyn StorageBackendOps>`. Construct via `DeviceContext::new(backend)`.
+pub type DeviceContext = dynamo_memory::DeviceContext;
+
+// ---------------------------------------------------------------------------
+// CUDA traits & context management
+// ---------------------------------------------------------------------------
 
 /// Trait for [Storage] types that can be accessed by CUDA
 pub trait CudaAccessible: Storage {}
-
-/// Trait for types that can provide a CUDA context.
-pub trait CudaContextProivder {
-    /// Get a referene to the [`CudaContext`].
-    fn cuda_context(&self) -> &Arc<CudaContext>;
-}
 
 /// Singleton for managing CUDA contexts.
 pub struct Cuda {
@@ -158,419 +127,11 @@ impl Cuda {
     }
 }
 
-/// Pinned host memory storage using CUDA page-locked memory.
-/// Wraps [`dynamo_memory::PinnedStorage`] and adds registration handle support.
-#[derive(Debug)]
-pub struct PinnedStorage {
-    inner: dynamo_memory::PinnedStorage,
-    handles: RegistrationHandles,
-}
 
-impl Local for PinnedStorage {}
-impl SystemAccessible for PinnedStorage {}
-impl CudaAccessible for PinnedStorage {}
-
-impl PinnedStorage {
-    /// Create a new pinned storage with the given size.
-    ///
-    /// Uses write-combined allocation with NUMA-awareness when enabled.
-    /// Prefer [`new_for_device`](Self::new_for_device) for new code.
-    ///
-    /// TODO(KVBM-336): remove PinnedStorage::new in the future
-    #[deprecated(since = "1.0.0", note = "Use PinnedStorage::new_for_device instead")]
-    pub fn new(ctx: &Arc<CudaContext>, size: usize) -> Result<Self, StorageError> {
-        let inner =
-            dynamo_memory::PinnedStorage::new_for_device(size, Some(ctx.cu_device() as u32))?;
-        Ok(Self {
-            inner,
-            handles: RegistrationHandles::new(),
-        })
-    }
-
-    /// Create a new pinned storage, optionally NUMA-aware for a specific GPU.
-    ///
-    /// Delegates NUMA-aware allocation and write-combined selection to
-    /// [`dynamo_memory::PinnedStorage::new_for_device`].
-    ///
-    /// When `device_id` is `None`, allocates on device 0 without NUMA awareness.
-    pub fn new_for_device(size: usize, device_id: Option<u32>) -> Result<Self, StorageError> {
-        // Warn once if the legacy opt-in env var is still set.
-        static DEPRECATION_WARN: std::sync::Once = std::sync::Once::new();
-        if std::env::var("DYN_KVBM_ENABLE_NUMA").is_ok() {
-            DEPRECATION_WARN.call_once(|| {
-                tracing::warn!(
-                    "DYN_KVBM_ENABLE_NUMA is deprecated for PinnedStorage::new_for_device; \
-                     NUMA is now enabled by default. Use DYN_MEMORY_DISABLE_NUMA=1 to disable."
-                );
-            });
-        }
-        let inner = dynamo_memory::PinnedStorage::new_for_device(size, device_id)?;
-        Ok(Self {
-            inner,
-            handles: RegistrationHandles::new(),
-        })
-    }
-}
-
-impl Drop for PinnedStorage {
-    fn drop(&mut self) {
-        self.handles.release();
-        // inner Drop handles free_host
-    }
-}
-
-impl Storage for PinnedStorage {
-    fn storage_type(&self) -> StorageType {
-        StorageType::Pinned
-    }
-
-    fn addr(&self) -> u64 {
-        self.inner.addr() as u64
-    }
-
-    fn size(&self) -> usize {
-        self.inner.size()
-    }
-
-    unsafe fn as_ptr(&self) -> *const u8 {
-        unsafe { self.inner.as_ptr() }
-    }
-
-    unsafe fn as_mut_ptr(&mut self) -> *mut u8 {
-        unsafe { self.inner.as_mut_ptr() }
-    }
-}
-
-impl CudaContextProivder for PinnedStorage {
-    fn cuda_context(&self) -> &Arc<CudaContext> {
-        self.inner.ctx()
-    }
-}
-
-impl RegisterableStorage for PinnedStorage {
-    fn register(
-        &mut self,
-        key: &str,
-        handle: Box<dyn RegistationHandle>,
-    ) -> Result<(), StorageError> {
-        self.handles.register(key, handle)
-    }
-
-    fn is_registered(&self, key: &str) -> bool {
-        self.handles.is_registered(key)
-    }
-
-    fn registration_handle(&self, key: &str) -> Option<&dyn RegistationHandle> {
-        self.handles.registration_handle(key)
-    }
-}
-
-impl StorageMemset for PinnedStorage {
-    fn memset(&mut self, value: u8, offset: usize, size: usize) -> Result<(), StorageError> {
-        if offset + size > self.inner.size() {
-            return Err(StorageError::OperationFailed(
-                "memset: offset + size > storage size".into(),
-            ));
-        }
-        unsafe {
-            let ptr = self.inner.as_mut_ptr().add(offset);
-            std::ptr::write_bytes(ptr, value, size);
-        }
-        Ok(())
-    }
-}
-
-/// Allocator for PinnedStorage
-pub struct PinnedAllocator {
-    ctx: Arc<CudaContext>,
-}
-
-impl Default for PinnedAllocator {
-    fn default() -> Self {
-        Self {
-            ctx: Cuda::device_or_create(0).expect("Failed to create CUDA context"),
-        }
-    }
-}
-
-impl PinnedAllocator {
-    /// Create a new pinned allocator for the specified device.
-    ///
-    /// The device_id determines which NUMA node pinned memory will be allocated
-    /// on when NUMA-aware allocation is enabled.
-    pub fn new(device_id: usize) -> Result<Self, StorageError> {
-        Ok(Self {
-            ctx: Cuda::device_or_create(device_id)?,
-        })
-    }
-}
-
-impl StorageAllocator<PinnedStorage> for PinnedAllocator {
-    fn allocate(&self, size: usize) -> Result<PinnedStorage, StorageError> {
-        PinnedStorage::new_for_device(size, Some(self.ctx.cu_device() as u32))
-    }
-}
-
-/// An enum indicating the type of device storage.
-/// This is needed to ensure ownership of memory is correctly handled.
-/// When building a [`DeviceStorage`] from a torch tensor, we need to ensure that
-/// the torch tensor is not GCed until the [`DeviceStorage`] is dropped.
-/// Because of this, we need to store a reference to the torch tensor in the [`DeviceStorage`]
-#[derive(Debug)]
-enum DeviceStorageType {
-    Owned,                                   // Memory that we allocated ourselves.
-    Torch { _tensor: Arc<dyn TorchTensor> }, // Memory that came from a torch tensor.
-}
-
-/// CUDA device memory storage
-#[derive(Debug)]
-pub struct DeviceStorage {
-    ptr: u64,
-    size: usize,
-    ctx: Arc<CudaContext>,
-    handles: RegistrationHandles,
-    _storage_type: DeviceStorageType,
-}
-
-impl Local for DeviceStorage {}
-impl CudaAccessible for DeviceStorage {}
-
-impl DeviceStorage {
-    /// Create a new device storage with the given size
-    pub fn new(ctx: &Arc<CudaContext>, size: usize) -> Result<Self, StorageError> {
-        ctx.bind_to_thread().map_err(StorageError::Cuda)?;
-        let ptr = unsafe { cudarc::driver::result::malloc_sync(size).map_err(StorageError::Cuda)? };
-
-        Ok(Self {
-            ptr,
-            size,
-            ctx: ctx.clone(),
-            handles: RegistrationHandles::new(),
-            _storage_type: DeviceStorageType::Owned,
-        })
-    }
-
-    pub fn new_from_torch(
-        ctx: &Arc<CudaContext>,
-        tensor: Arc<dyn TorchTensor>,
-    ) -> Result<Self, StorageError> {
-        let device = tensor.device();
-
-        let TorchDevice::Cuda(device_id) = device else {
-            return Err(StorageError::InvalidConfig("Tensor is not CUDA!".into()));
-        };
-
-        if device_id != ctx.cu_device() as usize {
-            return Err(StorageError::InvalidConfig(
-                "Tensor is not on the same device as the context!".into(),
-            ));
-        }
-
-        let data_ptr = tensor.data_ptr();
-        let size = tensor.size_bytes();
-
-        Ok(Self {
-            ptr: data_ptr,
-            size,
-            ctx: ctx.clone(),
-            handles: RegistrationHandles::new(),
-            _storage_type: DeviceStorageType::Torch { _tensor: tensor },
-        })
-    }
-
-    /// Get the CUDA context
-    pub fn context(&self) -> &Arc<CudaContext> {
-        &self.ctx
-    }
-}
-
-impl Storage for DeviceStorage {
-    fn storage_type(&self) -> StorageType {
-        StorageType::Device(self.ctx.cu_device() as u32)
-    }
-
-    fn addr(&self) -> u64 {
-        self.ptr
-    }
-
-    fn size(&self) -> usize {
-        self.size
-    }
-
-    unsafe fn as_ptr(&self) -> *const u8 {
-        self.ptr as *const u8
-    }
-
-    unsafe fn as_mut_ptr(&mut self) -> *mut u8 {
-        self.ptr as *mut u8
-    }
-}
-
-impl CudaContextProivder for DeviceStorage {
-    fn cuda_context(&self) -> &Arc<CudaContext> {
-        &self.ctx
-    }
-}
-
-impl Drop for DeviceStorage {
-    fn drop(&mut self) {
-        self.handles.release();
-        match &self._storage_type {
-            DeviceStorageType::Owned => {
-                unsafe { cudarc::driver::result::free_sync(self.ptr as _) }.unwrap()
-            }
-            DeviceStorageType::Torch { _tensor } => {
-                // Do nothing. The torch storage is resposible for cleaning up itself.
-            }
-        }
-    }
-}
-
-impl RegisterableStorage for DeviceStorage {
-    fn register(
-        &mut self,
-        key: &str,
-        handle: Box<dyn RegistationHandle>,
-    ) -> Result<(), StorageError> {
-        self.handles.register(key, handle)
-    }
-
-    fn is_registered(&self, key: &str) -> bool {
-        self.handles.is_registered(key)
-    }
-
-    fn registration_handle(&self, key: &str) -> Option<&dyn RegistationHandle> {
-        self.handles.registration_handle(key)
-    }
-}
-
-/// Allocator for DeviceStorage
-pub struct DeviceAllocator {
-    ctx: Arc<CudaContext>,
-}
-
-impl Default for DeviceAllocator {
-    fn default() -> Self {
-        Self {
-            ctx: CudaContext::new(0).expect("Failed to create CUDA context"),
-        }
-    }
-}
-
-impl DeviceAllocator {
-    /// Create a new device allocator
-    pub fn new(device_id: usize) -> Result<Self, StorageError> {
-        Ok(Self {
-            ctx: Cuda::device_or_create(device_id)?,
-        })
-    }
-
-    pub fn ctx(&self) -> &Arc<CudaContext> {
-        &self.ctx
-    }
-}
-
-impl StorageAllocator<DeviceStorage> for DeviceAllocator {
-    fn allocate(&self, size: usize) -> Result<DeviceStorage, StorageError> {
-        DeviceStorage::new(&self.ctx, size)
-    }
-}
 
 #[cfg(all(test, feature = "testing-cuda"))]
 mod tests {
     use super::*;
-
-    #[derive(Debug, Clone)]
-    struct MockTensor {
-        device: TorchDevice,
-        data_ptr: u64,
-        size_bytes: usize,
-    }
-
-    impl MockTensor {
-        pub fn new(device: TorchDevice, data_ptr: u64, size_bytes: usize) -> Self {
-            Self {
-                device,
-                data_ptr,
-                size_bytes,
-            }
-        }
-    }
-
-    impl TorchTensor for MockTensor {
-        fn device(&self) -> TorchDevice {
-            self.device.clone()
-        }
-
-        fn data_ptr(&self) -> u64 {
-            self.data_ptr
-        }
-
-        fn size_bytes(&self) -> usize {
-            self.size_bytes
-        }
-
-        fn shape(&self) -> Vec<usize> {
-            vec![self.size_bytes]
-        }
-
-        fn stride(&self) -> Vec<usize> {
-            vec![1]
-        }
-    }
-
-    #[test]
-    fn test_device_storage_from_torch_valid_tensor() {
-        let ctx = Cuda::device_or_create(0).expect("Failed to create CUDA context");
-        let size_bytes = 1024;
-
-        let actual_storage =
-            std::mem::ManuallyDrop::new(DeviceStorage::new(&ctx, size_bytes).unwrap());
-
-        let tensor = MockTensor::new(TorchDevice::Cuda(0), actual_storage.addr(), size_bytes);
-
-        let storage = DeviceStorage::new_from_torch(&ctx, Arc::new(tensor)).unwrap();
-
-        assert_eq!(storage.size(), size_bytes);
-        assert_eq!(storage.storage_type(), StorageType::Device(0));
-        assert_eq!(storage.addr(), actual_storage.addr());
-    }
-
-    #[test]
-    fn test_device_storage_from_torch_cpu_tensor_fails() {
-        let ctx = Cuda::device_or_create(0).expect("Failed to create CUDA context");
-        let size_bytes = 1024;
-
-        let actual_storage = DeviceStorage::new(&ctx, size_bytes).unwrap();
-
-        let tensor = MockTensor::new(
-            TorchDevice::Other("cpu".to_string()),
-            actual_storage.addr(),
-            size_bytes,
-        );
-
-        let result = DeviceStorage::new_from_torch(&ctx, Arc::new(tensor));
-        assert!(result.is_err());
-
-        if let Err(StorageError::InvalidConfig(msg)) = result {
-            assert!(msg.contains("Tensor is not CUDA"));
-        } else {
-            panic!("Expected InvalidConfig error for CPU tensor");
-        }
-    }
-
-    #[test]
-    fn test_device_storage_wrong_device() {
-        let ctx = Cuda::device_or_create(0).expect("Failed to create CUDA context");
-        let size_bytes = 1024;
-
-        let actual_storage = DeviceStorage::new(&ctx, size_bytes).unwrap();
-
-        let tensor = MockTensor::new(TorchDevice::Cuda(1), actual_storage.addr(), size_bytes);
-
-        let result = DeviceStorage::new_from_torch(&ctx, Arc::new(tensor));
-        assert!(result.is_err());
-    }
 
     /// Test PinnedStorage::new (deprecated) allocates usable pinned memory.
     #[allow(deprecated)]

--- a/lib/llm/src/block_manager/storage/nixl.rs
+++ b/lib/llm/src/block_manager/storage/nixl.rs
@@ -70,7 +70,7 @@ use derive_getters::Getters;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    CudaContextProivder, DeviceStorage, DiskStorage, PinnedStorage, RegistationHandle,
+    DeviceStorage, DiskStorage, PinnedStorage, RegistationHandle,
     RegisterableStorage, Remote, Storage, StorageError, StorageType, SystemStorage,
 };
 
@@ -369,7 +369,7 @@ impl NixlDescriptor for DeviceStorage {
     }
 
     fn device_id(&self) -> u64 {
-        CudaContextProivder::cuda_context(self).cu_device() as u64
+        self.ctx.backend.device_id() as u64
     }
 }
 

--- a/lib/llm/src/block_manager/storage/torch.rs
+++ b/lib/llm/src/block_manager/storage/torch.rs
@@ -7,6 +7,11 @@ pub enum TorchDevice {
     Other(String),
 }
 
+/// Check if a tensor is on an XPU/Ze device.
+pub fn is_ze(tensor: &dyn TorchTensor) -> bool {
+    matches!(tensor.device(), TorchDevice::Other(ref s) if s == "xpu")
+}
+
 pub trait TorchTensor: std::fmt::Debug + Send + Sync {
     fn device(&self) -> TorchDevice;
     fn data_ptr(&self) -> u64;

--- a/lib/llm/src/block_manager/storage/ze.rs
+++ b/lib/llm/src/block_manager/storage/ze.rs
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! ZE-specific extensions for DeviceStorage (torch tensor integration).
+
+// This file previously contained the deprecated `new_from_torch_ze` function.
+// It has been removed as it was never called and the functionality is now
+// handled by the unified `DeviceStorage::new_from_torch()` method.

--- a/lib/memory/Cargo.toml
+++ b/lib/memory/Cargo.toml
@@ -32,6 +32,7 @@ serde = { workspace = true}
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
+level-zero = { workspace = true }
 libc = { version = "0.2" }
 nix = { version = "0.30", features = ["fs"] }
 offset-allocator = "0.2"

--- a/lib/memory/src/device.rs
+++ b/lib/memory/src/device.rs
@@ -4,10 +4,52 @@
 //! CUDA device memory storage.
 
 use super::{MemoryDescriptor, Result, StorageError, StorageKind, nixl::NixlDescriptor};
+use super::pinned::StorageBackendOps;
 use cudarc::driver::CudaContext;
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
+
+/// Unified device context backed by a type-erased [`StorageBackendOps`].
+///
+/// Construct via [`DeviceContext::new`] with any backend that implements
+/// `StorageBackendOps` (e.g. `Arc<CudaContext>`, `Arc<ZeContext>`).
+#[derive(Clone)]
+pub struct DeviceContext {
+    /// The underlying backend for memory operations.
+    pub backend: Arc<dyn StorageBackendOps>,
+}
+
+impl std::fmt::Debug for DeviceContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DeviceContext(device={})", self.backend.device_id())
+    }
+}
+
+impl DeviceContext {
+    /// Create a new device context from any backend implementing
+    /// [`StorageBackendOps`].
+    pub fn new<B: StorageBackendOps + 'static>(backend: B) -> Self {
+        Self {
+            backend: Arc::new(backend),
+        }
+    }
+
+    /// Get the backend type (CUDA or Ze).
+    pub fn backend_type(&self) -> super::pinned::BackendType {
+        self.backend.backend_type()
+    }
+
+    /// Check if this context uses CUDA backend.
+    pub fn is_cuda(&self) -> bool {
+        self.backend.backend_type() == super::pinned::BackendType::Cuda
+    }
+
+    /// Check if this context uses Ze backend.
+    pub fn is_ze(&self) -> bool {
+        self.backend.backend_type() == super::pinned::BackendType::Ze
+    }
+}
 
 /// Get or create a CUDA context for the given device.
 pub(crate) fn cuda_context(device_id: u32) -> Result<Arc<CudaContext>> {

--- a/lib/memory/src/lib.rs
+++ b/lib/memory/src/lib.rs
@@ -33,19 +33,21 @@ mod external;
 mod pinned;
 mod system;
 mod tensor;
+pub mod ze;
 
 #[cfg(test)]
 mod tests;
 
 pub use arena::{ArenaAllocator, ArenaBuffer, ArenaError};
-pub use device::DeviceStorage;
+pub use device::{DeviceContext, DeviceStorage};
+pub use ze::{Ze, ZeCommandQueue, ZeContext, ZeError, ZeEvent, ZeEventPool};
 #[cfg(target_os = "linux")]
 pub use disk::DiskStorage;
 pub use external::ExternalDeviceMemory;
 #[cfg(target_os = "linux")]
 pub use numa::{NumaNode, is_numa_disabled};
 pub use offset::OffsetBuffer;
-pub use pinned::PinnedStorage;
+pub use pinned::{BackendType, PinnedStorage, StorageBackendOps, TorchTensorDescriptor};
 pub use pool::{CudaMemPool, CudaMemPoolBuilder};
 pub use system::SystemStorage;
 pub use tensor::{TensorDescriptor, TensorDescriptorExt};

--- a/lib/memory/src/pinned.rs
+++ b/lib/memory/src/pinned.rs
@@ -1,12 +1,112 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! CUDA pinned host memory storage.
+//! Pinned host memory storage supporting CUDA and Ze backends.
 
 use super::{MemoryDescriptor, Result, StorageError, StorageKind, actions, nixl::NixlDescriptor};
+use super::device::DeviceContext;
 use cudarc::driver::CudaContext;
 use std::any::Any;
 use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// Backend Type
+// ---------------------------------------------------------------------------
+
+/// Backend type identifier for storage operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendType {
+    /// CUDA backend (NVIDIA GPUs).
+    Cuda,
+    /// Level Zero backend (Intel GPUs).
+    Ze,
+}
+
+// ---------------------------------------------------------------------------
+// StorageBackendOps – single trait for backend-specific alloc/free
+// ---------------------------------------------------------------------------
+
+/// Backend operations for pinned and device memory allocation.
+///
+/// This is the single definition of this trait – the llm layer imports and
+/// reuses it rather than defining its own copy.
+pub trait StorageBackendOps: Send + Sync {
+    /// Allocate pinned host memory.
+    ///
+    /// # Safety
+    /// Caller must ensure proper context binding if required by the backend.
+    unsafe fn alloc_pinned(&self, size: usize) -> Result<*mut u8>;
+
+    /// Free pinned host memory.
+    ///
+    /// # Safety
+    /// Caller must ensure ptr was allocated by this backend and size matches.
+    unsafe fn free_pinned(&self, ptr: u64, size: usize) -> Result<()>;
+
+    /// Allocate device memory. Returns `(ptr, device_id, optional_metadata)`.
+    ///
+    /// The metadata (`Option<Box<dyn Any + Send + Sync>>`) allows backends to
+    /// keep ownership handles alive (e.g. Ze `DeviceBuffer` whose `Drop` frees
+    /// the memory). CUDA returns `None`.
+    ///
+    /// # Safety
+    /// Caller must ensure proper context binding if required by the backend.
+    unsafe fn alloc_device(
+        &self,
+        size: usize,
+    ) -> Result<(u64, u32, Option<Box<dyn Any + Send + Sync>>)>;
+
+    /// Free device memory.
+    ///
+    /// # Safety
+    /// Caller must ensure ptr was allocated by this backend.
+    unsafe fn free_device(&self, ptr: u64) -> Result<()>;
+
+    /// Get the device ID for this backend context.
+    fn device_id(&self) -> u32;
+
+    /// Get the backend type (CUDA or Ze).
+    fn backend_type(&self) -> BackendType;
+
+    /// Downcast to concrete type for backend-specific operations.
+    fn as_any(&self) -> &dyn std::any::Any;
+
+    /// Create device storage from a torch tensor descriptor.
+    ///
+    /// The caller extracts tensor metadata into a [`TorchTensorDescriptor`],
+    /// and this method validates that the tensor matches the backend
+    /// (device type and device ID).
+    ///
+    /// Returns `(ptr, size)` on success.
+    ///
+    /// # Errors
+    /// Returns error if:
+    /// - Tensor device type doesn't match backend type
+    /// - Tensor device ID doesn't match context device ID (where applicable)
+    fn new_from_torch(&self, desc: &TorchTensorDescriptor) -> Result<(u64, usize)>;
+}
+
+/// Descriptor carrying extracted torch tensor metadata across crate boundaries.
+///
+/// Higher-level crates (e.g. llm) populate this from their `TorchTensor` trait
+/// objects and pass it to [`StorageBackendOps::new_from_torch`] for validation.
+#[derive(Debug, Clone)]
+pub struct TorchTensorDescriptor {
+    /// Device pointer to tensor data.
+    pub data_ptr: u64,
+    /// Size in bytes.
+    pub size_bytes: usize,
+    /// True if tensor is on a CUDA device.
+    pub is_cuda: bool,
+    /// True if tensor is on an XPU/Ze device.
+    pub is_xpu: bool,
+    /// Device ID (CUDA device ordinal, or 0 for XPU).
+    pub device_id: u32,
+}
+
+// ---------------------------------------------------------------------------
+// CUDA implementation
+// ---------------------------------------------------------------------------
 
 /// Whether to use write-combined pinned allocations.
 ///
@@ -46,39 +146,84 @@ static USE_WRITE_COMBINED: std::sync::LazyLock<bool> = std::sync::LazyLock::new(
 ///
 /// # Safety
 /// Caller must ensure a valid CUDA context is bound to the current thread.
-unsafe fn malloc_host_prefer_writecombined(size: usize) -> Result<*mut u8> {
-    if *USE_WRITE_COMBINED {
-        // SAFETY: caller guarantees a valid CUDA context is bound to the current thread
-        unsafe {
-            cudarc::driver::result::malloc_host(
-                size,
-                cudarc::driver::sys::CU_MEMHOSTALLOC_WRITECOMBINED,
-            )
-        }
-        .map(|ptr| ptr as *mut u8)
-        .map_err(StorageError::Cuda)
+pub(crate) unsafe fn malloc_host_prefer_writecombined(size: usize) -> Result<*mut u8> {
+    let flags = if *USE_WRITE_COMBINED {
+        cudarc::driver::sys::CU_MEMHOSTALLOC_WRITECOMBINED
     } else {
-        // SAFETY: caller guarantees a valid CUDA context is bound to the current thread
-        unsafe {
-            cudarc::driver::result::malloc_host(
-                size,
-                cudarc::driver::sys::CU_MEMHOSTALLOC_DEVICEMAP,
-            )
-        }
+        cudarc::driver::sys::CU_MEMHOSTALLOC_DEVICEMAP
+    };
+    unsafe { cudarc::driver::result::malloc_host(size, flags) }
         .map(|ptr| ptr as *mut u8)
         .map_err(StorageError::Cuda)
+}
+
+impl StorageBackendOps for Arc<CudaContext> {
+    unsafe fn alloc_pinned(&self, size: usize) -> Result<*mut u8> {
+        self.bind_to_thread().map_err(StorageError::Cuda)?;
+        unsafe { malloc_host_prefer_writecombined(size) }
+    }
+
+    unsafe fn free_pinned(&self, ptr: u64, _size: usize) -> Result<()> {
+        unsafe { cudarc::driver::result::free_host(ptr as _) }.map_err(StorageError::Cuda)
+    }
+
+    unsafe fn alloc_device(
+        &self,
+        size: usize,
+    ) -> Result<(u64, u32, Option<Box<dyn Any + Send + Sync>>)> {
+        self.bind_to_thread().map_err(StorageError::Cuda)?;
+        let ptr =
+            unsafe { cudarc::driver::result::malloc_sync(size) }.map_err(StorageError::Cuda)?;
+        Ok((ptr, self.cu_device() as u32, None))
+    }
+
+    unsafe fn free_device(&self, ptr: u64) -> Result<()> {
+        unsafe { cudarc::driver::result::free_sync(ptr as _) }.map_err(StorageError::Cuda)
+    }
+
+    fn device_id(&self) -> u32 {
+        self.cu_device() as u32
+    }
+
+    fn backend_type(&self) -> BackendType {
+        BackendType::Cuda
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn new_from_torch(&self, desc: &TorchTensorDescriptor) -> Result<(u64, usize)> {
+        if !desc.is_cuda {
+            return Err(StorageError::OperationFailed(
+                "Tensor is not CUDA!".into(),
+            ));
+        }
+        if desc.device_id != self.cu_device() as u32 {
+            return Err(StorageError::OperationFailed(
+                "Tensor is not on the same device as the context!".into(),
+            ));
+        }
+        Ok((desc.data_ptr, desc.size_bytes))
     }
 }
 
-/// CUDA pinned host memory allocated via cudaHostAlloc.
+// ---------------------------------------------------------------------------
+// PinnedStorage
+// ---------------------------------------------------------------------------
+
+/// Pinned host memory supporting CUDA and Ze backends.
+///
+/// For CUDA: allocated via `cudaHostAlloc` (page-locked, optionally write-combined).
+/// For Ze: allocated via system allocator with 64-byte alignment.
 #[derive(Debug)]
 pub struct PinnedStorage {
     /// Host pointer to the pinned memory.
     ptr: usize,
     /// Size of the allocation in bytes.
     len: usize,
-    /// CUDA context used for allocation and deallocation.
-    ctx: Arc<CudaContext>,
+    /// Device context used for allocation and deallocation.
+    ctx: DeviceContext,
 }
 
 unsafe impl Send for PinnedStorage {}
@@ -162,13 +307,42 @@ impl PinnedStorage {
 
                 assert!(!ptr.is_null(), "Failed to allocate pinned memory");
                 assert!(ptr.is_aligned(), "Pinned memory is not aligned");
-                assert!(len < isize::MAX as usize);
+            assert!(len < isize::MAX as usize);
 
                 ptr as usize
             }
         };
 
-        Ok(Self { ptr, len, ctx })
+        Ok(Self { ptr, len, ctx: DeviceContext::new(ctx) })
+    }
+
+    /// Allocate pinned host memory using an existing [`DeviceContext`].
+    ///
+    /// Dispatches to the appropriate backend based on the context type:
+    /// - CUDA: delegates to [`new_for_device`](Self::new_for_device)
+    /// - Ze: allocates via the Ze backend directly
+    pub fn new_with_context(len: usize, ctx: &DeviceContext) -> Result<Self> {
+        match ctx.backend.backend_type() {
+            BackendType::Cuda => {
+                Self::new_for_device(len, Some(ctx.backend.device_id()))
+            }
+            BackendType::Ze => {
+                if len == 0 {
+                    return Err(StorageError::AllocationFailed(
+                        "zero-sized allocations are not supported".into(),
+                    ));
+                }
+                let raw = unsafe { ctx.backend.alloc_pinned(len)? };
+                assert!(!raw.is_null(), "Failed to allocate pinned memory");
+                assert!(raw.is_aligned(), "Pinned memory is not aligned");
+                assert!(len < isize::MAX as usize);
+                Ok(Self {
+                    ptr: raw as usize,
+                    len,
+                    ctx: ctx.clone(),
+                })
+            }
+        }
     }
 
     /// Get a pointer to the underlying memory.
@@ -188,22 +362,19 @@ impl PinnedStorage {
         self.ptr as *mut u8
     }
 
-    /// Get a reference to the CUDA context used for this allocation.
-    pub fn ctx(&self) -> &Arc<CudaContext> {
+    /// Get a reference to the device context.
+    pub fn device_context(&self) -> &DeviceContext {
         &self.ctx
     }
 }
 
 impl Drop for PinnedStorage {
     fn drop(&mut self) {
-        if let Err(e) = self.ctx.bind_to_thread() {
-            tracing::debug!("failed to bind CUDA context for free: {e}");
-        }
         unsafe {
-            if let Err(e) = cudarc::driver::result::free_host(self.ptr as _) {
+            if let Err(e) = self.ctx.backend.free_pinned(self.ptr as u64, self.len) {
                 tracing::debug!("failed to free pinned memory: {e}");
             }
-        };
+        }
     }
 }
 

--- a/lib/memory/src/ze.rs
+++ b/lib/memory/src/ze.rs
@@ -1,0 +1,359 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Level Zero (Ze) device context and memory management.
+//!
+//! Provides [`ZeContext`] for Intel GPU device management, including:
+//! - Device and driver initialization
+//! - Command queue and event pool creation
+//! - Pinned host and device memory allocation via [`StorageBackendOps`]
+//! - Singleton [`Ze`] for managing per-device contexts
+
+use crate::{StorageError, pinned::StorageBackendOps};
+
+pub use level_zero::{Event as ZeEvent, EventPool as ZeEventPool, ZE_EVENT_SCOPE_FLAG_HOST};
+use level_zero::{self, CommandList, CommandQueue, Context, Device, Driver, EventPool};
+use std::{
+    alloc::{Layout, alloc, dealloc},
+    collections::HashMap,
+    sync::{Arc, Mutex, OnceLock},
+};
+
+// ---------------------------------------------------------------------------
+// ZeError
+// ---------------------------------------------------------------------------
+
+/// Errors specific to Level Zero operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ZeError {
+    /// Error from the Level Zero backend.
+    #[error("Level Zero backend error: {0:?}")]
+    Backend(level_zero::Error),
+    /// No Level Zero driver found.
+    #[error("No Level Zero driver found")]
+    NoDriver,
+    /// No Level Zero device found.
+    #[error("No Level Zero device found")]
+    NoDevice,
+    /// Invalid device index.
+    #[error("Invalid device index: {0}")]
+    InvalidDeviceIndex(usize),
+}
+
+impl From<level_zero::Error> for ZeError {
+    fn from(value: level_zero::Error) -> Self {
+        Self::Backend(value)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ZeContext
+// ---------------------------------------------------------------------------
+
+/// Full Level Zero device context with driver, device, and command queue.
+pub struct ZeContext {
+    /// Ze device ordinal.
+    pub device_id: usize,
+    /// Level Zero driver handle.
+    pub driver: Driver,
+    /// Level Zero device handle.
+    pub device: Device,
+    /// Level Zero context handle.
+    pub context: Arc<Context>,
+    /// Default command queue for this device.
+    queue: Arc<ZeCommandQueue>,
+}
+
+// SAFETY:
+// Level Zero handles are opaque driver-managed resources intended to be passed
+// across threads. Dynamo shares a single context/queue wrapper behind Arc for
+// transfer workers; no Rust aliasing guarantees are violated by moving/sharing
+// these handle containers between threads.
+unsafe impl Send for ZeContext {}
+// SAFETY: See Send rationale above.
+unsafe impl Sync for ZeContext {}
+
+impl std::fmt::Debug for ZeContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ZeContext")
+            .field("device_id", &self.device_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ZeContext {
+    /// Initialize a new Ze context for the given device index.
+    pub fn new(device_index: usize) -> Result<Arc<Self>, ZeError> {
+        level_zero::init().map_err(ZeError::from)?;
+
+        let drivers = level_zero::drivers().map_err(ZeError::from)?;
+        let Some(driver) = drivers.first().copied() else {
+            return Err(ZeError::NoDriver);
+        };
+
+        let devices = driver.devices().map_err(ZeError::from)?;
+        if devices.is_empty() {
+            return Err(ZeError::NoDevice);
+        }
+        let Some(device) = devices.get(device_index).copied() else {
+            return Err(ZeError::InvalidDeviceIndex(device_index));
+        };
+
+        let context = Arc::new(Context::create(&driver).map_err(ZeError::from)?);
+        let queue = ZeCommandQueue::new(context.clone(), device)?;
+        Ok(Arc::new(Self {
+            device_id: device_index,
+            driver,
+            device,
+            context,
+            queue,
+        }))
+    }
+
+    /// Get the default command queue for this context.
+    pub fn command_queue(&self) -> Arc<ZeCommandQueue> {
+        self.queue.clone()
+    }
+
+    /// Create a new command queue (analogous to CudaContext::new_stream).
+    pub fn new_stream(&self) -> Result<Arc<ZeCommandQueue>, ZeError> {
+        ZeCommandQueue::new(self.context.clone(), self.device)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ZeCommandQueue
+// ---------------------------------------------------------------------------
+
+/// Wrapper around a Level Zero command queue with associated context and events.
+pub struct ZeCommandQueue {
+    handle: CommandQueue,
+    context: Arc<Context>,
+    device: Device,
+    event_pool: Arc<EventPool>,
+}
+
+// SAFETY:
+// Command queue handles are externally synchronized by the Level Zero runtime;
+// this wrapper only forwards API calls and stores opaque handles.
+unsafe impl Send for ZeCommandQueue {}
+// SAFETY: See Send rationale above.
+unsafe impl Sync for ZeCommandQueue {}
+
+impl ZeCommandQueue {
+    fn new(context: Arc<Context>, device: Device) -> Result<Arc<Self>, ZeError> {
+        let handle = context
+            .create_command_queue(&device)
+            .map_err(ZeError::from)?;
+        let event_pool = context
+            .create_event_pool(&[device], 1, 0)
+            .map_err(ZeError::from)?;
+        Ok(Arc::new(Self {
+            handle,
+            context,
+            device,
+            event_pool: Arc::new(event_pool),
+        }))
+    }
+
+    /// Execute a command list without blocking.
+    pub fn execute_nonblocking(&self, list: &mut CommandList) -> Result<(), ZeError> {
+        self.handle.execute_nonblocking(list).map_err(ZeError::from)
+    }
+
+    /// Create a new command list for this device.
+    pub fn create_command_list(&self) -> Result<CommandList, ZeError> {
+        self.context
+            .create_command_list(&self.device)
+            .map_err(ZeError::from)
+    }
+
+    /// Get the Level Zero context.
+    pub fn context(&self) -> &Arc<Context> {
+        &self.context
+    }
+
+    /// Get the Level Zero device.
+    pub fn device(&self) -> Device {
+        self.device
+    }
+
+    /// Get the event pool.
+    pub fn event_pool(&self) -> &Arc<EventPool> {
+        &self.event_pool
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host memory helpers
+// ---------------------------------------------------------------------------
+
+fn ze_host_layout(size: usize) -> Result<Layout, StorageError> {
+    Layout::from_size_align(size.max(1), 64).map_err(|e| {
+        StorageError::AllocationFailed(format!("Invalid ZE host allocation layout: {}", e))
+    })
+}
+
+pub(crate) unsafe fn malloc_host_prefer_writecombined_ze(
+    size: usize,
+) -> Result<*mut u8, StorageError> {
+    let layout = ze_host_layout(size)?;
+    // SAFETY: `layout` is validated by `ze_host_layout`.
+    let ptr = unsafe { alloc(layout) };
+    if ptr.is_null() {
+        return Err(StorageError::AllocationFailed(format!(
+            "ZE host allocation failed for {} bytes",
+            size
+        )));
+    }
+    tracing::debug!(
+        "Allocated ZE host memory at 0x{:x} (size={})",
+        ptr as usize,
+        size
+    );
+    Ok(ptr)
+}
+
+pub(crate) unsafe fn free_host_ze(ptr: *mut u8, size: usize) -> Result<(), StorageError> {
+    let layout = ze_host_layout(size)?;
+    // SAFETY: `layout` is validated by `ze_host_layout`, and caller guarantees
+    // that `ptr` was allocated with this layout.
+    unsafe { dealloc(ptr, layout) };
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Ze singleton
+// ---------------------------------------------------------------------------
+
+/// Singleton manager for Level Zero device contexts.
+pub struct Ze {
+    contexts: Mutex<HashMap<usize, Arc<ZeContext>>>,
+}
+
+impl Ze {
+    fn new() -> Self {
+        Self {
+            contexts: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Check if Level Zero is available on this system.
+    /// Returns true only if the loader library exists.
+    pub fn is_available() -> bool {
+        std::fs::metadata("/usr/lib/x86_64-linux-gnu/libze_loader.so.1")
+            .or_else(|_| std::fs::metadata("/usr/lib/x86_64-linux-gnu/libze_loader.so"))
+            .or_else(|_| std::fs::metadata("/usr/local/lib/libze_loader.so.1"))
+            .or_else(|_| std::fs::metadata("/usr/local/lib/libze_loader.so"))
+            .is_ok()
+    }
+
+    /// Get an existing ZE context for a specific device.
+    pub fn device(device_id: usize) -> Option<Arc<ZeContext>> {
+        Ze::instance().get_existing_context(device_id)
+    }
+
+    /// Get or lazily create a ZE context for a specific device.
+    pub fn device_or_create(device_id: usize) -> Result<Arc<ZeContext>, StorageError> {
+        Ze::instance().get_context(device_id)
+    }
+
+    /// Check if a ZE context exists for a specific device.
+    pub fn is_initialized(device_id: usize) -> bool {
+        Ze::instance().has_context(device_id)
+    }
+
+    fn instance() -> &'static Ze {
+        static INSTANCE: OnceLock<Ze> = OnceLock::new();
+        INSTANCE.get_or_init(Ze::new)
+    }
+
+    fn get_context(&self, device_id: usize) -> Result<Arc<ZeContext>, StorageError> {
+        if let Some(ctx) = self.contexts.lock().unwrap().get(&device_id) {
+            return Ok(ctx.clone());
+        }
+
+        let ctx = ZeContext::new(device_id)
+            .map_err(|e| StorageError::OperationFailed(format!("ZE context error: {:?}", e)))?;
+
+        self.contexts.lock().unwrap().insert(device_id, ctx.clone());
+
+        Ok(ctx)
+    }
+
+    /// Get a context if it exists, but don't create one.
+    pub fn get_existing_context(&self, device_id: usize) -> Option<Arc<ZeContext>> {
+        self.contexts.lock().unwrap().get(&device_id).cloned()
+    }
+
+    /// Check if a context exists for a device.
+    pub fn has_context(&self, device_id: usize) -> bool {
+        self.contexts.lock().unwrap().contains_key(&device_id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// StorageBackendOps for Arc<ZeContext>
+// ---------------------------------------------------------------------------
+
+impl StorageBackendOps for Arc<ZeContext> {
+    unsafe fn alloc_pinned(&self, size: usize) -> Result<*mut u8, StorageError> {
+        unsafe { malloc_host_prefer_writecombined_ze(size) }
+    }
+
+    unsafe fn free_pinned(&self, ptr: u64, size: usize) -> Result<(), StorageError> {
+        unsafe { free_host_ze(ptr as *mut u8, size) }
+    }
+
+    unsafe fn alloc_device(
+        &self,
+        size: usize,
+    ) -> Result<(u64, u32, Option<Box<dyn std::any::Any + Send + Sync>>), StorageError> {
+        let ze_device_buffer = self
+            .context
+            .alloc_device(&self.device, size, 1)
+            .map_err(|e| {
+                StorageError::OperationFailed(format!(
+                    "ZE alloc_device failed for {} bytes: {:?}",
+                    size, e
+                ))
+            })?;
+
+        let ptr = ze_device_buffer.as_mut_ptr() as u64;
+        Ok((
+            ptr,
+            self.device_id as u32,
+            Some(Box::new(ze_device_buffer)),
+        ))
+    }
+
+    unsafe fn free_device(&self, _ptr: u64) -> Result<(), StorageError> {
+        // Memory freed by DeviceBuffer's Drop implementation
+        // which is stored as the type-erased metadata box.
+        Ok(())
+    }
+
+    fn device_id(&self) -> u32 {
+        self.device_id as u32
+    }
+
+    fn backend_type(&self) -> crate::pinned::BackendType {
+        crate::pinned::BackendType::Ze
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn new_from_torch(
+        &self,
+        desc: &crate::pinned::TorchTensorDescriptor,
+    ) -> crate::Result<(u64, usize)> {
+        if !desc.is_xpu {
+            return Err(crate::StorageError::OperationFailed(
+                "Tensor is not an XPU/ZE tensor!".into(),
+            ));
+        }
+        Ok((desc.data_ptr, desc.size_bytes))
+    }
+}


### PR DESCRIPTION
# XPU Support: Architecture Changes

Core works:
1. `Storage` in lib/llm/src/block_manager/storage.rs, lib/llm/src/block_manager/storage/*
2. `Transfer` in lib/llm/src/block_manager/block/transfer.rs
3. Passdown of the device_type
4. Guide to add a new device

Design goals:
1. We tried to keep flows, function calls, and parameters the same.
2. There are still many trade-offs to discuss.

See the slides for figures.


## Storage Layer

### New Abstractions

#### `StorageBackendOps` Trait
Single interface for all backend memory operations:

```rust
trait StorageBackendOps {
    unsafe fn alloc_pinned();
    unsafe fn free_pinned();
    unsafe fn alloc_device();
    unsafe fn free_device();
    fn new_from_torch();
    ...
}
```

#### `DeviceContext`
Type-erased backend wrapper:

```rust
pub struct DeviceContext {
    pub backend: Arc<dyn StorageBackendOps>,
}
```

#### Implementations
- impl StorageBackendOps for Arc\<CudaContext\>
- impl StorageBackendOps for Arc\<ZeContext\>

### Refactored Types
Change these to device-agnostic and moved them from storage/cuda.rs → storage.rs:
- DeviceStorage (ctx: Arc<CudaContext> → DeviceContext)
- DeviceAllocator
- PinnedStorage
- PinnedAllocator

### DeviceBackend Enum
```rust
enum DeviceBackend { Cuda, Ze }
```
#### Add DeviceBackend to lib/llm/src/block_manager/storage.rs
---

## Transfer Layer
New abstractions:
### DeviceStream
```rust
enum DeviceStream {
    Cuda(Arc<CudaStream>),
    Ze(Arc<ZeCommandQueue>),
}
```

### TransferBackend Trait
```rust
trait TransferBackend {
    fn device_mem_pool();
    fn device_event(tx);
    fn device_stream();
    fn acquire_resources_for_transfer_sync();
}
```
#### Implementations
- impl TransferBackend for TransferBackendCuda
- impl TransferBackend for TransferBackendZe

Before:  
```rust  
  struct TransferContext {
      stream: Arc<CudaStream>, 
      cuda_mem_pool: Option<Arc<CudaMemPool>>,
      cuda_event_tx: mpsc::Sender<...>, 
      cuda_event_worker: JoinHandle, 
      // ... CUDA-specific fields  
  }
``` 

After:

```rust
  struct TransferContext {
      nixl_agent: Arc<Option<NixlAgent>>,
      async_rt_handle: Handle,
      backend: Box<dyn TransferBackend>,  // ◄── Single polymorphic field
  } 
```
We do enum dispatch (instead of trait-implementation) way here to keep the TransferContext interface same, or lots of changes are needed.


### Dispatch Example
```rust
fn copy_block(stream: &DeviceStream, ...) {
    match stream {
        DeviceStream::Cuda(s) => cuda::copy_block(...),
        DeviceStream::Ze(q) => ze::copy_block(...),
    }
}
```
copy_blocks_with_customized_kernel is same as copy_block

  Removed "Cuda" prefix to be backend-agnostic:                                                                                                                                                                                                                                 
  - CudaAsyncH2D → AsyncH2D                                                                                                                                                                                                                                                     
  - CudaAsyncD2H → AsyncD2H                                                                                                                                                                                                                                                     
  - CudaAsyncD2D → AsyncD2D
  - CudaBlockingH2D → BlockingH2D                                                                                                                                                                                                                                               
  - CudaBlockingD2H → BlockingD2H  


---

## Device Type Propagation

### Connector Worker Path
1. Python tensor.device.type
6. FFI → register_kv_caches
7. Config → device_type
8. Worker validation
9. Allocation → DeviceBackend → TransferContext

### Block Manager Path
1. BlockManager::new() (default "cuda")
2. State init
3. OffloadManager → TransferContext

---

## Supporting Changes

### TorchTensorDescriptor
```rust
pub struct TorchTensorDescriptor {
    data_ptr,
    size_bytes,
    is_cuda,
    is_xpu,
    device_id,
}
```

---

## Adding New Device (HPU)

### Memory
- Create hpu.rs
- Implement StorageBackendOps
- Extend enums

### Transfer
- Add DeviceStream::Hpu
- Implement TransferBackendHpu
- Update dispatch

### Python
- Add "hpu" handling in connector_worker


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Level Zero (Ze) GPU backend support alongside CUDA for broader hardware compatibility
  * Introduced device-agnostic memory and transfer abstractions enabling flexible multi-backend operations

* **Configuration**
  * Enhanced block manager configuration with explicit device-type specification for improved hardware flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->