### PR TITLE
feat: Planner Advisory Mode — observe scaling decisions before auto-execution (v2)

### DIFF
--- a/components/src/dynamo/planner/config/defaults.py
+++ b/components/src/dynamo/planner/config/defaults.py
@@ -20,6 +20,12 @@ from typing import Literal, Optional
 from pydantic import BaseModel
 
 
+class ScalingMode(str, Enum):
+    ACTIVE = "active"
+    ADVISORY = "advisory"
+    NOOP = "noop"
+
+
 class BasePlannerDefaults:
     # Namespace from DYN_NAMESPACE env var (injected by operator as "{k8s_namespace}-{dgd_name}")
     namespace = os.environ.get("DYN_NAMESPACE", "dynamo")
@@ -62,6 +68,12 @@ class SLAPlannerDefaults(BasePlannerDefaults):
     mode: Literal["disagg", "prefill", "decode", "agg"] = "disagg"
 
     throughput_metrics_source: Literal["frontend", "router"] = "frontend"
+
+    # Scaling mode (replaces no_operation boolean)
+    scaling_mode = ScalingMode.ACTIVE
+    advisory_max_step_size = 1
+    advisory_anomaly_threshold = 10
+    advisory_file_output = False
 
     # Scaling mode flags
     enable_throughput_scaling = True

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -16,6 +16,7 @@
 import json
 import logging
 import os
+import tempfile
 from enum import Enum
 from pathlib import Path
 from typing import Literal, Optional
@@ -46,9 +47,9 @@ class PlannerConfig(BaseModel):
         description='Controls pre-deployment sweeping mode for planner in-depth profiling. "none" means no pre-deployment sweep (only load-based scaling). "rapid" uses AI Configurator to simulate engine performance. "thorough" uses real GPUs to measure engine performance (takes several hours).',
     )
 
-    environment: Literal["kubernetes", "virtual", "global-planner"] = (
-        SLAPlannerDefaults.environment
-    )
+    environment: Literal[
+        "kubernetes", "virtual", "global-planner"
+    ] = SLAPlannerDefaults.environment
     namespace: str = Field(
         default_factory=lambda: os.environ.get("DYN_NAMESPACE", "dynamo")
     )
@@ -97,9 +98,9 @@ class PlannerConfig(BaseModel):
     metric_reporting_prometheus_port: int = Field(
         default_factory=lambda: int(os.environ.get("PLANNER_PROMETHEUS_PORT", 0))
     )
-    throughput_metrics_source: Literal["frontend", "router"] = (
-        SLAPlannerDefaults.throughput_metrics_source
-    )
+    throughput_metrics_source: Literal[
+        "frontend", "router"
+    ] = SLAPlannerDefaults.throughput_metrics_source
 
     no_correction: bool = SLAPlannerDefaults.no_correction
     model_name: Optional[str] = None
@@ -140,10 +141,11 @@ class PlannerConfig(BaseModel):
 
         # advisory_file_output: auto-fill log_dir if not set
         if self.advisory_file_output and not self.log_dir:
-            self.log_dir = "/tmp/planner"
+            self.log_dir = os.path.join(tempfile.gettempdir(), "planner")
             logger.warning(
                 "advisory_file_output=True but log_dir is not set. "
-                "Auto-filling log_dir='/tmp/planner'."
+                f"Auto-filling log_dir='{self.log_dir}'. "
+                "Set log_dir explicitly for production use."
             )
 
         # advisory_max_step_size must be positive

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -23,7 +23,7 @@ from typing import Literal, Optional
 import yaml
 from pydantic import BaseModel, Field, model_validator
 
-from dynamo.planner.config.defaults import SLAPlannerDefaults
+from dynamo.planner.config.defaults import ScalingMode, SLAPlannerDefaults
 
 logger = logging.getLogger(__name__)
 
@@ -46,9 +46,9 @@ class PlannerConfig(BaseModel):
         description='Controls pre-deployment sweeping mode for planner in-depth profiling. "none" means no pre-deployment sweep (only load-based scaling). "rapid" uses AI Configurator to simulate engine performance. "thorough" uses real GPUs to measure engine performance (takes several hours).',
     )
 
-    environment: Literal[
-        "kubernetes", "virtual", "global-planner"
-    ] = SLAPlannerDefaults.environment
+    environment: Literal["kubernetes", "virtual", "global-planner"] = (
+        SLAPlannerDefaults.environment
+    )
     namespace: str = Field(
         default_factory=lambda: os.environ.get("DYN_NAMESPACE", "dynamo")
     )
@@ -56,6 +56,10 @@ class PlannerConfig(BaseModel):
     mode: Literal["disagg", "prefill", "decode", "agg"] = SLAPlannerDefaults.mode
 
     no_operation: bool = SLAPlannerDefaults.no_operation
+    scaling_mode: ScalingMode = SLAPlannerDefaults.scaling_mode
+    advisory_max_step_size: int = SLAPlannerDefaults.advisory_max_step_size
+    advisory_anomaly_threshold: int = SLAPlannerDefaults.advisory_anomaly_threshold
+    advisory_file_output: bool = SLAPlannerDefaults.advisory_file_output
     log_dir: Optional[str] = SLAPlannerDefaults.log_dir
     throughput_adjustment_interval: int = (
         SLAPlannerDefaults.throughput_adjustment_interval
@@ -93,9 +97,9 @@ class PlannerConfig(BaseModel):
     metric_reporting_prometheus_port: int = Field(
         default_factory=lambda: int(os.environ.get("PLANNER_PROMETHEUS_PORT", 0))
     )
-    throughput_metrics_source: Literal[
-        "frontend", "router"
-    ] = SLAPlannerDefaults.throughput_metrics_source
+    throughput_metrics_source: Literal["frontend", "router"] = (
+        SLAPlannerDefaults.throughput_metrics_source
+    )
 
     no_correction: bool = SLAPlannerDefaults.no_correction
     model_name: Optional[str] = None
@@ -116,8 +120,36 @@ class PlannerConfig(BaseModel):
     load_metric_samples: int = SLAPlannerDefaults.load_metric_samples
     load_min_observations: int = SLAPlannerDefaults.load_min_observations
 
+    @property
+    def effective_scaling_mode(self) -> ScalingMode:
+        """Effective scaling mode, respecting no_operation for backward compat with model_construct."""
+        if self.no_operation and self.scaling_mode == ScalingMode.ACTIVE:
+            return ScalingMode.NOOP
+        return self.scaling_mode
+
     @model_validator(mode="after")
     def _validate_config(self) -> "PlannerConfig":
+        # Backward compat: no_operation=True -> scaling_mode=noop
+        if self.no_operation and self.scaling_mode == ScalingMode.ACTIVE:
+            logger.warning(
+                "DEPRECATION: no_operation=True is deprecated. "
+                "Use scaling_mode='noop' instead. "
+                "Automatically mapping no_operation=True to scaling_mode='noop'."
+            )
+            self.scaling_mode = ScalingMode.NOOP
+
+        # advisory_file_output: auto-fill log_dir if not set
+        if self.advisory_file_output and not self.log_dir:
+            self.log_dir = "/tmp/planner"
+            logger.warning(
+                "advisory_file_output=True but log_dir is not set. "
+                "Auto-filling log_dir='/tmp/planner'."
+            )
+
+        # advisory_max_step_size must be positive
+        if self.advisory_max_step_size < 1:
+            raise ValueError("advisory_max_step_size must be >= 1")
+
         # global-planner environment requires a namespace
         if self.environment == "global-planner" and not self.global_planner_namespace:
             raise ValueError(
@@ -163,6 +195,19 @@ class PlannerConfig(BaseModel):
                     "actual latency conditions."
                 )
                 self.no_correction = True
+
+        # Auto-reconcile Prometheus port: if PLANNER_PROMETHEUS_PORT env is set,
+        # ensure config value matches to prevent PodMonitor mismatch
+        env_port = os.environ.get("PLANNER_PROMETHEUS_PORT")
+        if env_port:
+            env_port_int = int(env_port)
+            if self.metric_reporting_prometheus_port != env_port_int:
+                logger.warning(
+                    f"metric_reporting_prometheus_port ({self.metric_reporting_prometheus_port}) "
+                    f"differs from PLANNER_PROMETHEUS_PORT env ({env_port_int}). "
+                    f"Auto-aligning to {env_port_int} to prevent PodMonitor mismatch."
+                )
+                self.metric_reporting_prometheus_port = env_port_int
 
         return self
 

--- a/components/src/dynamo/planner/core/agg.py
+++ b/components/src/dynamo/planner/core/agg.py
@@ -6,7 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Optional
 
 from dynamo.planner.config.backend_components import WORKER_COMPONENT_NAMES
-from dynamo.planner.config.defaults import SubComponentType, TargetReplica
+from dynamo.planner.config.defaults import ScalingMode, SubComponentType, TargetReplica
 from dynamo.planner.config.planner_config import PlannerConfig
 
 if TYPE_CHECKING:
@@ -78,7 +78,7 @@ class AggPlanner:
     async def _async_init(self):
         defaults = WORKER_COMPONENT_NAMES.get(self.config.backend)
 
-        if not self.config.no_operation:
+        if self.config.effective_scaling_mode != ScalingMode.NOOP:
             connector = getattr(self.planner, "connector", None)
             if connector and hasattr(connector, "_async_init"):
                 await connector._async_init()
@@ -215,7 +215,16 @@ class AggPlanner:
             ):
                 self.planner.prometheus_metrics.predicted_num_d.set(desired)
 
-            if not self.config.no_operation:
+            # Emit advisory metrics (active + advisory modes)
+            # Note: prefill=0 because agg mode has no separate prefill workers;
+            # aggregated engines handle both prefill and decode.
+            if self.config.effective_scaling_mode in (
+                ScalingMode.ACTIVE,
+                ScalingMode.ADVISORY,
+            ):
+                self.planner._emit_advisory_metrics(0, desired, "load")
+
+            if self.config.effective_scaling_mode == ScalingMode.ACTIVE:
                 pending_desired = desired
                 target_replicas = [
                     TargetReplica(

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -241,13 +241,19 @@ class BasePlanner:
 
             # Start Planner HTTP server if port is specified
             if start_prometheus_server and self.prometheus_port != 0:
-                try:
-                    _start_planner_http_server(self.prometheus_port)
-                except Exception as e:
-                    logger.error(f"Failed to start Planner HTTP server: {e}")
+                if config.effective_scaling_mode == ScalingMode.NOOP:
+                    logger.info(
+                        "[NOOP] Scaling mode is noop — skipping HTTP server and metrics."
+                    )
+                else:
+                    try:
+                        _start_planner_http_server(self.prometheus_port)
+                    except Exception as e:
+                        logger.error(f"Failed to start Planner HTTP server: {e}")
+                        raise
 
             # Startup self-check log
-            if start_prometheus_server:
+            if start_prometheus_server and config.effective_scaling_mode != ScalingMode.NOOP:
                 port_source = (
                     "env PLANNER_PROMETHEUS_PORT"
                     if os.environ.get("PLANNER_PROMETHEUS_PORT")
@@ -889,8 +895,9 @@ class BasePlanner:
 
         source: "throughput" or "load"
         """
-        if self.prometheus_metrics is None or self.prometheus_port == 0:
-            return
+        prometheus_enabled = (
+            self.prometheus_metrics is not None and self.prometheus_port != 0
+        )
 
         # Metrics validity gate
         if not self.shared_state.last_metrics.is_valid():
@@ -929,38 +936,40 @@ class BasePlanner:
             reason_code = 6
 
         m = self.prometheus_metrics
-        # Update counters
-        if action == 1:
-            m.advisory_scaleup_total.inc()
-        elif action == -1:
-            m.advisory_scaledown_total.inc()
-        else:
-            m.advisory_hold_total.inc()
+        if prometheus_enabled:
+            # Update counters
+            if action == 1:
+                m.advisory_scaleup_total.inc()
+            elif action == -1:
+                m.advisory_scaledown_total.inc()
+            else:
+                m.advisory_hold_total.inc()
 
-        # Update gauges
-        m.advisory_recommended_p.set(recommended_p)
-        m.advisory_recommended_d.set(recommended_d)
-        m.advisory_current_p.set(current_p)
-        m.advisory_current_d.set(current_d)
-        m.advisory_delta_p.set(delta_p)
-        m.advisory_delta_d.set(delta_d)
-        m.advisory_scaling_action.set(action)
-        m.advisory_action_reason.set(reason_code)
+            # Update gauges
+            m.advisory_recommended_p.set(recommended_p)
+            m.advisory_recommended_d.set(recommended_d)
+            m.advisory_current_p.set(current_p)
+            m.advisory_current_d.set(current_d)
+            m.advisory_delta_p.set(delta_p)
+            m.advisory_delta_d.set(delta_d)
+            m.advisory_scaling_action.set(action)
+            m.advisory_action_reason.set(reason_code)
 
         # SLA estimation (Layer 3)
         sla = self._estimate_sla_with_replicas(recommended_p, recommended_d)
-        self._safe_gauge_set(m.advisory_est_ttft, sla.get("est_ttft"))
-        self._safe_gauge_set(m.advisory_est_itl, sla.get("est_itl"))
         est_ttft = sla.get("est_ttft")
         est_itl = sla.get("est_itl")
-        self._safe_gauge_set(
-            m.advisory_ttft_headroom,
-            self.config.ttft - est_ttft if est_ttft is not None else None,
-        )
-        self._safe_gauge_set(
-            m.advisory_itl_headroom,
-            self.config.itl - est_itl if est_itl is not None else None,
-        )
+        if prometheus_enabled:
+            self._safe_gauge_set(m.advisory_est_ttft, est_ttft)
+            self._safe_gauge_set(m.advisory_est_itl, est_itl)
+            self._safe_gauge_set(
+                m.advisory_ttft_headroom,
+                self.config.ttft - est_ttft if est_ttft is not None else None,
+            )
+            self._safe_gauge_set(
+                m.advisory_itl_headroom,
+                self.config.itl - est_itl if est_itl is not None else None,
+            )
 
         action_str = {1: "scale_up", 0: "hold", -1: "scale_down"}[action]
 
@@ -1068,10 +1077,12 @@ class BasePlanner:
 
             est_itl = None
             if num_d > 0 and hasattr(self, "decode_interpolator"):
-                _, est_itl_raw, _ = (
-                    self.decode_interpolator.find_best_throughput_per_gpu(
-                        self.config.itl, osl
-                    )
+                (
+                    _,
+                    est_itl_raw,
+                    _,
+                ) = self.decode_interpolator.find_best_throughput_per_gpu(
+                    self.config.itl, osl
                 )
                 est_itl = float(est_itl_raw)
 

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -2,14 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import datetime
+import json
 import logging
+import math
+import os
+import threading
 import time
+from http.server import ThreadingHTTPServer
 from typing import TYPE_CHECKING, Optional, Union
 
-from prometheus_client import start_http_server
+from prometheus_client.exposition import MetricsHandler
 
 from dynamo.planner.config.backend_components import WORKER_COMPONENT_NAMES
-from dynamo.planner.config.defaults import SubComponentType, TargetReplica
+from dynamo.planner.config.defaults import ScalingMode, SubComponentType, TargetReplica
 from dynamo.planner.config.planner_config import PlannerConfig
 from dynamo.planner.connectors.global_planner import GlobalPlannerConnector
 from dynamo.planner.connectors.kubernetes import KubernetesConnector
@@ -40,6 +46,35 @@ ConnectorType = Union[GlobalPlannerConnector, KubernetesConnector, VirtualConnec
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
+
+# Module-level advisory status state (updated by BasePlanner, read by HTTP handler)
+_advisory_status_state: dict = {}
+
+
+class _PlannerHTTPHandler(MetricsHandler):
+    """HTTP handler: /metrics for Prometheus, /advisory/status for advisory state."""
+
+    def do_GET(self):
+        if self.path == "/advisory/status":
+            body = json.dumps(_advisory_status_state).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            super().do_GET()
+
+    def log_message(self, format, *args):
+        pass  # Suppress access log noise
+
+
+def _start_planner_http_server(port: int) -> None:
+    """Start the Planner HTTP server (Prometheus metrics + /advisory/status)."""
+    server = ThreadingHTTPServer(("", port), _PlannerHTTPHandler)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    logger.info(f"Started Planner HTTP server on port {port}")
 
 
 class BasePlanner:
@@ -72,7 +107,7 @@ class BasePlanner:
             self.namespace = config.namespace
             self.connector: ConnectorType
 
-            if not config.no_operation:
+            if config.effective_scaling_mode != ScalingMode.NOOP:
                 # Initialize connector based on environment
                 if config.environment == "global-planner":
                     assert config.global_planner_namespace is not None
@@ -204,15 +239,33 @@ class BasePlanner:
             else:
                 self.prometheus_metrics = prometheus_metrics
 
-            # Start Prometheus HTTP server if port is specified
+            # Start Planner HTTP server if port is specified
             if start_prometheus_server and self.prometheus_port != 0:
                 try:
-                    start_http_server(self.prometheus_port)
-                    logger.info(
-                        f"Started Prometheus metrics server on port {self.prometheus_port}"
-                    )
+                    _start_planner_http_server(self.prometheus_port)
                 except Exception as e:
-                    logger.error(f"Failed to start Prometheus metrics server: {e}")
+                    logger.error(f"Failed to start Planner HTTP server: {e}")
+
+            # Startup self-check log
+            if start_prometheus_server:
+                port_source = (
+                    "env PLANNER_PROMETHEUS_PORT"
+                    if os.environ.get("PLANNER_PROMETHEUS_PORT")
+                    else "config"
+                )
+                file_output_status = (
+                    f"enabled → {config.log_dir}/advisory_history.jsonl"
+                    if config.advisory_file_output and config.log_dir
+                    else "disabled"
+                )
+                logger.info(
+                    "[ADVISORY] Self-check:\n"
+                    f"  - Scaling mode: {config.effective_scaling_mode.value}\n"
+                    f"  - Metrics server: port {self.prometheus_port} (source: {port_source})\n"
+                    f"  - Metrics endpoint: /metrics (15 advisory metrics registered)\n"
+                    f"  - Advisory status endpoint: /advisory/status\n"
+                    f"  - Advisory file output: {file_output_status}"
+                )
         else:
             self.prometheus_port = 0
             self.prometheus_metrics = prometheus_metrics
@@ -262,7 +315,7 @@ class BasePlanner:
             require_decode=require_decode,
             connector=connector,
             config_model_name=getattr(self.config, "model_name", ""),
-            no_operation=self.config.no_operation,
+            no_operation=self.config.effective_scaling_mode == ScalingMode.NOOP,
         )
         # model_name is resolved and written into both WorkerInfo objects
         self.model_name = (
@@ -281,7 +334,9 @@ class BasePlanner:
         require_prefill = self.component_type == SubComponentType.PREFILL
         require_decode = self.component_type == SubComponentType.DECODE
 
-        if not self.dryrun and not self.config.no_operation:
+        if not self.dryrun and not (
+            self.config.effective_scaling_mode == ScalingMode.NOOP
+        ):
             defaults = WORKER_COMPONENT_NAMES.get(self.config.backend)
 
             logger.info("Validating deployment...")
@@ -635,7 +690,7 @@ class BasePlanner:
         )
 
     async def _apply_scaling(self, desired_replicas: int) -> None:
-        if self.config.no_operation:
+        if self.config.effective_scaling_mode != ScalingMode.ACTIVE:
             return
         target_replicas = [
             TargetReplica(
@@ -648,7 +703,7 @@ class BasePlanner:
 
     async def _apply_scaling_blocking(self, desired_replicas: int) -> None:
         """Apply scaling without blocking so the loop continues observing metrics."""
-        if self.config.no_operation:
+        if self.config.effective_scaling_mode != ScalingMode.ACTIVE:
             return
         target_replicas = [
             TargetReplica(
@@ -812,6 +867,254 @@ class BasePlanner:
         """Load-based scaling decision. Override in subclasses."""
         raise NotImplementedError
 
+    # -------------------------------------------------------------------------
+    # Advisory Engine methods (active + advisory modes)
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _safe_gauge_set(gauge, value) -> None:
+        """NaN/None-safe Prometheus gauge write."""
+        if value is None or (isinstance(value, float) and math.isnan(value)):
+            gauge.set(float("nan"))
+        else:
+            gauge.set(value)
+
+    def _emit_advisory_metrics(
+        self,
+        recommended_p: int,
+        recommended_d: int,
+        source: str,
+    ) -> None:
+        """Emit advisory metrics (Layer 1 + 2 + JSONL).
+
+        source: "throughput" or "load"
+        """
+        if self.prometheus_metrics is None or self.prometheus_port == 0:
+            return
+
+        # Metrics validity gate
+        if not self.shared_state.last_metrics.is_valid():
+            logger.info(
+                "[ADVISORY] Skipping advisory output: "
+                "metrics contain None/NaN (no active traffic or Prometheus unreachable)"
+            )
+            return
+
+        # Non-negative guard
+        recommended_p = max(0, recommended_p)
+        recommended_d = max(0, recommended_d)
+
+        current_p = self.shared_state.num_p_workers
+        current_d = self.shared_state.num_d_workers
+        delta_p = recommended_p - current_p
+        delta_d = recommended_d - current_d
+
+        # Anomaly detection
+        threshold = self.config.advisory_anomaly_threshold
+        if abs(delta_p) > threshold or abs(delta_d) > threshold:
+            logger.warning(
+                f"[ADVISORY] Unusually large delta: delta_p={delta_p}, delta_d={delta_d} "
+                f"(threshold={threshold}). Possible metrics jump or configuration error."
+            )
+
+        # Determine aggregate action and reason code
+        if delta_p > 0 or delta_d > 0:
+            action = 1
+            reason_code = 1 if source == "throughput" else 3
+        elif delta_p < 0 or delta_d < 0:
+            action = -1
+            reason_code = 2 if source == "throughput" else 4
+        else:
+            action = 0
+            reason_code = 6
+
+        m = self.prometheus_metrics
+        # Update counters
+        if action == 1:
+            m.advisory_scaleup_total.inc()
+        elif action == -1:
+            m.advisory_scaledown_total.inc()
+        else:
+            m.advisory_hold_total.inc()
+
+        # Update gauges
+        m.advisory_recommended_p.set(recommended_p)
+        m.advisory_recommended_d.set(recommended_d)
+        m.advisory_current_p.set(current_p)
+        m.advisory_current_d.set(current_d)
+        m.advisory_delta_p.set(delta_p)
+        m.advisory_delta_d.set(delta_d)
+        m.advisory_scaling_action.set(action)
+        m.advisory_action_reason.set(reason_code)
+
+        # SLA estimation (Layer 3)
+        sla = self._estimate_sla_with_replicas(recommended_p, recommended_d)
+        self._safe_gauge_set(m.advisory_est_ttft, sla.get("est_ttft"))
+        self._safe_gauge_set(m.advisory_est_itl, sla.get("est_itl"))
+        est_ttft = sla.get("est_ttft")
+        est_itl = sla.get("est_itl")
+        self._safe_gauge_set(
+            m.advisory_ttft_headroom,
+            self.config.ttft - est_ttft if est_ttft is not None else None,
+        )
+        self._safe_gauge_set(
+            m.advisory_itl_headroom,
+            self.config.itl - est_itl if est_itl is not None else None,
+        )
+
+        action_str = {1: "scale_up", 0: "hold", -1: "scale_down"}[action]
+
+        # Update HTTP advisory status snapshot
+        _advisory_status_state.update(
+            {
+                "scaling_mode": self.config.effective_scaling_mode.value,
+                "last_update": datetime.datetime.utcnow().isoformat() + "Z",
+                "current": {"prefill": current_p, "decode": current_d},
+                "recommended": {"prefill": recommended_p, "decode": recommended_d},
+                "delta": {"prefill": delta_p, "decode": delta_d},
+                "action": action_str,
+                "reason": source,
+                "sla_estimation": {
+                    "est_ttft_ms": est_ttft,
+                    "est_itl_ms": est_itl,
+                    "ttft_headroom_ms": (
+                        self.config.ttft - est_ttft if est_ttft is not None else None
+                    ),
+                    "itl_headroom_ms": (
+                        self.config.itl - est_itl if est_itl is not None else None
+                    ),
+                },
+            }
+        )
+
+        # Structured logs for active + advisory modes (Layer 2)
+        if self.config.effective_scaling_mode in (
+            ScalingMode.ACTIVE,
+            ScalingMode.ADVISORY,
+        ):
+            path = self._build_path_recommendation(
+                current_p, current_d, recommended_p, recommended_d
+            )
+            log_data = {
+                "event": "advisory_recommendation",
+                "scaling_mode": self.config.effective_scaling_mode.value,
+                "source": source,
+                "action": action_str,
+                "current": {"prefill": current_p, "decode": current_d},
+                "recommended_final": {
+                    "prefill": recommended_p,
+                    "decode": recommended_d,
+                },
+                "path": path,
+                "est_ttft_ms": est_ttft,
+                "est_itl_ms": est_itl,
+                "ttft_headroom_ms": (
+                    self.config.ttft - est_ttft if est_ttft is not None else None
+                ),
+                "itl_headroom_ms": (
+                    self.config.itl - est_itl if est_itl is not None else None
+                ),
+                "note": (
+                    "Estimation based on profiling data; "
+                    "actual values may differ due to runtime conditions"
+                ),
+            }
+            logger.info("[ADVISORY] Recommendation", extra=log_data)
+
+            if self.config.advisory_file_output:
+                self._write_advisory_jsonl(
+                    {
+                        "ts": int(time.time()),
+                        "mode": self.config.effective_scaling_mode.value,
+                        "action": action_str,
+                        "source": source,
+                        "current": {"p": current_p, "d": current_d},
+                        "recommended": {"p": recommended_p, "d": recommended_d},
+                        "est_ttft": est_ttft,
+                        "est_itl": est_itl,
+                        "reason_code": reason_code,
+                    }
+                )
+
+    def _estimate_sla_with_replicas(self, num_p: int, num_d: int) -> dict:
+        """Estimate TTFT and ITL for the given replica counts using profiling data."""
+        if not self.enable_throughput:
+            if self.prometheus_metrics and self.prometheus_port != 0:
+                self._safe_gauge_set(
+                    self.prometheus_metrics.advisory_est_ttft, float("nan")
+                )
+                self._safe_gauge_set(
+                    self.prometheus_metrics.advisory_est_itl, float("nan")
+                )
+                self._safe_gauge_set(
+                    self.prometheus_metrics.advisory_ttft_headroom, float("nan")
+                )
+                self._safe_gauge_set(
+                    self.prometheus_metrics.advisory_itl_headroom, float("nan")
+                )
+            logger.info(
+                "[ADVISORY] SLA estimation unavailable: "
+                "throughput scaling disabled (no profiling data)"
+            )
+            return {"est_ttft": None, "est_itl": None}
+
+        try:
+            isl = self.shared_state.last_metrics.isl or 3000.0
+            osl = self.shared_state.last_metrics.osl or 150.0
+
+            est_ttft = None
+            if num_p > 0 and hasattr(self, "prefill_interpolator"):
+                est_ttft = float(self.prefill_interpolator.interpolate_ttft(isl))
+
+            est_itl = None
+            if num_d > 0 and hasattr(self, "decode_interpolator"):
+                _, est_itl_raw, _ = (
+                    self.decode_interpolator.find_best_throughput_per_gpu(
+                        self.config.itl, osl
+                    )
+                )
+                est_itl = float(est_itl_raw)
+
+            logger.debug(
+                f"[ADVISORY] SLA estimate with P={num_p} D={num_d}: "
+                f"TTFT={est_ttft}ms ITL={est_itl}ms"
+            )
+            return {"est_ttft": est_ttft, "est_itl": est_itl}
+        except Exception as e:
+            logger.warning(f"[ADVISORY] SLA estimation failed: {e}")
+            return {"est_ttft": None, "est_itl": None}
+
+    def _build_path_recommendation(
+        self, current_p: int, current_d: int, target_p: int, target_d: int
+    ) -> list:
+        """Build incremental path from current to target replicas."""
+        path = [f"{current_p}P{current_d}D"]
+        max_step = self.config.advisory_max_step_size
+        p, d = current_p, current_d
+        while p != target_p or d != target_d:
+            step_p = min(max_step, abs(target_p - p)) * (1 if target_p > p else -1)
+            step_d = min(max_step, abs(target_d - d)) * (1 if target_d > d else -1)
+            p += step_p
+            d += step_d
+            if p != target_p or d != target_d:
+                path.append(f"{p}P{d}D (observe 1 interval)")
+            else:
+                path.append(f"{p}P{d}D")
+        return path
+
+    def _write_advisory_jsonl(self, data: dict) -> None:
+        """Append one JSON line to the advisory JSONL file."""
+        if not self.config.log_dir:
+            return
+
+        os.makedirs(self.config.log_dir, exist_ok=True)
+        filepath = os.path.join(self.config.log_dir, "advisory_history.jsonl")
+        try:
+            with open(filepath, "a") as f:
+                f.write(json.dumps(data) + "\n")
+        except Exception as e:
+            logger.warning(f"[ADVISORY] Failed to write advisory JSONL: {e}")
+
     async def _throughput_loop(
         self, require_prefill: bool, require_decode: bool
     ) -> None:
@@ -848,6 +1151,23 @@ class BasePlanner:
                         # Throughput-only: apply scaling directly
                         desired_replicas = self.apply_component_budget(desired_replicas)
                         self.update_predicted_replicas_metric(desired_replicas)
+                        # Emit advisory metrics (active + advisory modes)
+                        if self.config.effective_scaling_mode in (
+                            ScalingMode.ACTIVE,
+                            ScalingMode.ADVISORY,
+                        ):
+                            if self.component_type == SubComponentType.PREFILL:
+                                self._emit_advisory_metrics(
+                                    desired_replicas,
+                                    self.shared_state.num_d_workers,
+                                    "throughput",
+                                )
+                            else:
+                                self._emit_advisory_metrics(
+                                    self.shared_state.num_p_workers,
+                                    desired_replicas,
+                                    "throughput",
+                                )
                         # Throughput planner does not needs blocking scaling because it monitors
                         # and predicts the load, not relying on the current status of the engine.
                         await self._apply_scaling(desired_replicas)
@@ -914,8 +1234,26 @@ class BasePlanner:
                     desired_replicas = max(desired_replicas, lower_bound)
                 desired_replicas = self.apply_component_budget(desired_replicas)
                 self.update_predicted_replicas_metric(desired_replicas)
-                pending_desired = desired_replicas
-                await self._apply_scaling_blocking(desired_replicas)
+                # Emit advisory metrics (active + advisory modes)
+                if self.config.effective_scaling_mode in (
+                    ScalingMode.ACTIVE,
+                    ScalingMode.ADVISORY,
+                ):
+                    if self.component_type == SubComponentType.PREFILL:
+                        self._emit_advisory_metrics(
+                            desired_replicas,
+                            self.shared_state.num_d_workers,
+                            "load",
+                        )
+                    else:
+                        self._emit_advisory_metrics(
+                            self.shared_state.num_p_workers,
+                            desired_replicas,
+                            "load",
+                        )
+                if self.config.effective_scaling_mode == ScalingMode.ACTIVE:
+                    pending_desired = desired_replicas
+                    await self._apply_scaling_blocking(desired_replicas)
 
     async def run(self):
         """Main scaling loop. Call _async_init() before this."""

--- a/components/src/dynamo/planner/core/disagg.py
+++ b/components/src/dynamo/planner/core/disagg.py
@@ -6,7 +6,7 @@ import logging
 import time
 
 from dynamo.planner.config.backend_components import WORKER_COMPONENT_NAMES
-from dynamo.planner.config.defaults import SubComponentType, TargetReplica
+from dynamo.planner.config.defaults import ScalingMode, SubComponentType, TargetReplica
 from dynamo.planner.config.planner_config import PlannerConfig
 from dynamo.planner.core.base import BasePlanner
 from dynamo.planner.core.budget import _apply_global_gpu_budget, _initialize_gpu_counts
@@ -54,7 +54,7 @@ class DisaggPlanner:
         # and share WorkerInfo between the two sub-planners.
         defaults = WORKER_COMPONENT_NAMES.get(self.config.backend)
 
-        if not self.config.no_operation:
+        if self.config.effective_scaling_mode != ScalingMode.NOOP:
             # Connector init (prefill/decode share the same connector)
             connector = getattr(self.prefill_planner, "connector", None)
             if connector and hasattr(connector, "_async_init"):
@@ -156,7 +156,16 @@ class DisaggPlanner:
                     self.prefill_planner.update_predicted_replicas_metric(next_num_p)
                     self.decode_planner.update_predicted_replicas_metric(next_num_d)
 
-                    if not self.config.no_operation:
+                    # Emit advisory metrics (active + advisory modes)
+                    if self.config.effective_scaling_mode in (
+                        ScalingMode.ACTIVE,
+                        ScalingMode.ADVISORY,
+                    ):
+                        self.prefill_planner._emit_advisory_metrics(
+                            next_num_p, next_num_d, "throughput"
+                        )
+
+                    if self.config.effective_scaling_mode == ScalingMode.ACTIVE:
                         target_replicas = [
                             TargetReplica(
                                 sub_component_type=SubComponentType.PREFILL,
@@ -241,7 +250,14 @@ class DisaggPlanner:
             self.prefill_planner.update_predicted_replicas_metric(final_p)
             self.decode_planner.update_predicted_replicas_metric(final_d)
 
-            if not self.config.no_operation:
+            # Emit advisory metrics (active + advisory modes)
+            if self.config.effective_scaling_mode in (
+                ScalingMode.ACTIVE,
+                ScalingMode.ADVISORY,
+            ):
+                self.prefill_planner._emit_advisory_metrics(final_p, final_d, "load")
+
+            if self.config.effective_scaling_mode == ScalingMode.ACTIVE:
                 target_replicas = [
                     TargetReplica(
                         sub_component_type=SubComponentType.PREFILL,

--- a/components/src/dynamo/planner/monitoring/planner_metrics.py
+++ b/components/src/dynamo/planner/monitoring/planner_metrics.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from prometheus_client import Gauge
+from prometheus_client import Counter, Gauge
 
 
 class PlannerPrometheusMetrics:
@@ -63,3 +63,70 @@ class PlannerPrometheusMetrics:
 
         # Cumulative GPU usage
         self.gpu_hours = Gauge(f"{prefix}:gpu_hours", "Cumulative GPU hours used")
+
+        # Advisory metrics — Gauges (12)
+        # Follows Dynamo naming guideline: dynamo_planner_advisory_*
+        # See lib/runtime/src/metrics/prometheus_names.rs
+        _adv = "dynamo_planner_advisory"
+        self.advisory_recommended_p = Gauge(
+            f"{_adv}_recommended_p",
+            "Recommended prefill replicas (after GPU budget)",
+        )
+        self.advisory_recommended_d = Gauge(
+            f"{_adv}_recommended_d",
+            "Recommended decode replicas (after GPU budget)",
+        )
+        self.advisory_current_p = Gauge(
+            f"{_adv}_current_p",
+            "Current actual prefill replicas from DGD",
+        )
+        self.advisory_current_d = Gauge(
+            f"{_adv}_current_d",
+            "Current actual decode replicas from DGD",
+        )
+        self.advisory_delta_p = Gauge(
+            f"{_adv}_delta_p",
+            "Prefill delta (recommended - current). Positive = scale up",
+        )
+        self.advisory_delta_d = Gauge(
+            f"{_adv}_delta_d",
+            "Decode delta (recommended - current). Positive = scale up",
+        )
+        self.advisory_scaling_action = Gauge(
+            f"{_adv}_scaling_action",
+            "Aggregate action: 1=scale up, 0=hold, -1=scale down",
+        )
+        self.advisory_action_reason = Gauge(
+            f"{_adv}_action_reason",
+            "Reason code for the advisory action",
+        )
+        self.advisory_est_ttft = Gauge(
+            f"{_adv}_est_ttft",
+            "Estimated TTFT after applying recommendation (ms). NaN if no profiling data",
+        )
+        self.advisory_est_itl = Gauge(
+            f"{_adv}_est_itl",
+            "Estimated ITL after applying recommendation (ms). NaN if no profiling data",
+        )
+        self.advisory_ttft_headroom = Gauge(
+            f"{_adv}_ttft_headroom",
+            "TTFT SLA target - estimated TTFT (ms). Positive = safe",
+        )
+        self.advisory_itl_headroom = Gauge(
+            f"{_adv}_itl_headroom",
+            "ITL SLA target - estimated ITL (ms). Positive = safe",
+        )
+
+        # Advisory metrics — Counters (3)
+        self.advisory_scaleup_total = Counter(
+            f"{_adv}_scaleup_total",
+            "Cumulative scale-up recommendations",
+        )
+        self.advisory_scaledown_total = Counter(
+            f"{_adv}_scaledown_total",
+            "Cumulative scale-down recommendations",
+        )
+        self.advisory_hold_total = Counter(
+            f"{_adv}_hold_total",
+            "Cumulative hold recommendations",
+        )

--- a/components/src/dynamo/planner/tests/unit/test_advisory_mode.py
+++ b/components/src/dynamo/planner/tests/unit/test_advisory_mode.py
@@ -1,0 +1,480 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for Planner Advisory Mode (ScalingMode, config fields, advisory engine)."""
+
+import json
+import logging
+import math
+import os
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from dynamo.planner.config.defaults import ScalingMode, SubComponentType
+from dynamo.planner.config.planner_config import PlannerConfig
+from dynamo.planner.core.base import BasePlanner
+from dynamo.planner.core.state import PlannerSharedState
+from dynamo.planner.monitoring.planner_metrics import PlannerPrometheusMetrics
+from dynamo.planner.monitoring.traffic_metrics import Metrics
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+# ---------------------------------------------------------------------------
+# ScalingMode enum
+# ---------------------------------------------------------------------------
+
+
+def test_scaling_mode_values():
+    assert ScalingMode.ACTIVE == "active"
+    assert ScalingMode.ADVISORY == "advisory"
+    assert ScalingMode.NOOP == "noop"
+
+
+# ---------------------------------------------------------------------------
+# PlannerConfig: new fields and defaults
+# ---------------------------------------------------------------------------
+
+
+def test_scaling_mode_default():
+    config = PlannerConfig(namespace="test-ns")
+    assert config.scaling_mode == ScalingMode.ACTIVE
+
+
+def test_scaling_mode_advisory():
+    config = PlannerConfig(
+        namespace="test-ns",
+        scaling_mode="advisory",
+        enable_throughput_scaling=False,
+        enable_load_scaling=True,
+        environment="kubernetes",
+        load_router_metrics_url="http://localhost:9090",
+    )
+    assert config.scaling_mode == ScalingMode.ADVISORY
+    assert config.effective_scaling_mode == ScalingMode.ADVISORY
+
+
+def test_scaling_mode_noop():
+    config = PlannerConfig(namespace="test-ns", scaling_mode="noop")
+    assert config.scaling_mode == ScalingMode.NOOP
+    assert config.effective_scaling_mode == ScalingMode.NOOP
+
+
+def test_advisory_defaults():
+    config = PlannerConfig(namespace="test-ns")
+    assert config.advisory_max_step_size == 1
+    assert config.advisory_anomaly_threshold == 10
+    assert config.advisory_file_output is False
+
+
+def test_advisory_max_step_size_invalid():
+    with pytest.raises(ValidationError, match="advisory_max_step_size must be >= 1"):
+        PlannerConfig(namespace="test-ns", advisory_max_step_size=0)
+
+
+def test_advisory_file_output_auto_fills_log_dir():
+    config = PlannerConfig(
+        namespace="test-ns",
+        advisory_file_output=True,
+        log_dir=None,
+    )
+    assert config.advisory_file_output is True
+    assert config.log_dir == "/tmp/planner"
+
+
+def test_advisory_file_output_with_log_dir():
+    config = PlannerConfig(
+        namespace="test-ns",
+        advisory_file_output=True,
+        log_dir="/tmp/advisory",
+    )
+    assert config.advisory_file_output is True
+    assert config.log_dir == "/tmp/advisory"
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: no_operation -> noop
+# ---------------------------------------------------------------------------
+
+
+def test_no_operation_true_maps_to_noop(caplog):
+
+    with caplog.at_level(logging.WARNING):
+        config = PlannerConfig(namespace="test-ns", no_operation=True)
+    assert config.scaling_mode == ScalingMode.NOOP
+    assert "DEPRECATION" in caplog.text
+
+
+def test_no_operation_false_keeps_active():
+    config = PlannerConfig(namespace="test-ns", no_operation=False)
+    assert config.scaling_mode == ScalingMode.ACTIVE
+
+
+def test_explicit_scaling_mode_overrides_no_operation():
+    """Explicit scaling_mode takes precedence over no_operation."""
+    config = PlannerConfig(
+        namespace="test-ns",
+        scaling_mode="noop",
+        no_operation=False,  # no_operation=False, but scaling_mode=noop
+    )
+    assert config.scaling_mode == ScalingMode.NOOP
+
+
+def test_effective_scaling_mode_backward_compat_model_construct():
+    """model_construct bypasses validator; effective_scaling_mode must still respect no_operation."""
+    config = PlannerConfig.model_construct(
+        no_operation=True,
+        scaling_mode=ScalingMode.ACTIVE,
+    )
+    # effective_scaling_mode should return NOOP because no_operation=True
+    assert config.effective_scaling_mode == ScalingMode.NOOP
+
+
+def test_effective_scaling_mode_noop_explicit():
+    config = PlannerConfig.model_construct(
+        no_operation=False,
+        scaling_mode=ScalingMode.NOOP,
+    )
+    assert config.effective_scaling_mode == ScalingMode.NOOP
+
+
+def test_effective_scaling_mode_advisory():
+    config = PlannerConfig.model_construct(
+        no_operation=False,
+        scaling_mode=ScalingMode.ADVISORY,
+    )
+    assert config.effective_scaling_mode == ScalingMode.ADVISORY
+
+
+# ---------------------------------------------------------------------------
+# BasePlanner advisory engine methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def mock_prometheus():
+    """Mock Gauge and Counter to avoid registry conflicts."""
+    with (
+        patch("dynamo.planner.monitoring.planner_metrics.Gauge") as mock_g,
+        patch("dynamo.planner.monitoring.planner_metrics.Counter") as mock_c,
+    ):
+        mock_g.return_value = Mock()
+        mock_c.return_value = Mock()
+        yield
+
+
+def _make_base_planner(scaling_mode=ScalingMode.ADVISORY, enable_throughput=True):
+    """Build a minimal BasePlanner in dryrun mode for testing advisory methods."""
+
+    config = PlannerConfig.model_construct(
+        no_operation=False,
+        scaling_mode=scaling_mode,
+        advisory_max_step_size=1,
+        advisory_anomaly_threshold=10,
+        advisory_file_output=False,
+        log_dir=None,
+        ttft=500.0,
+        itl=50.0,
+        throughput_adjustment_interval=60,
+        prefill_engine_num_gpu=1,
+        decode_engine_num_gpu=1,
+        min_endpoint=1,
+        max_gpu_budget=-1,
+        backend="vllm",
+        no_correction=True,
+        metric_pulling_prometheus_endpoint="http://localhost:9090",
+        metric_reporting_prometheus_port=8080,
+        load_predictor="constant",
+        load_predictor_warmup_trace=None,
+        load_predictor_log1p=False,
+        profile_results_dir=os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "profiling_results",
+            "H200_TP1P_TP1D",
+        ),
+        environment="kubernetes",
+        namespace="test-ns",
+        mode="disagg",
+        enable_throughput_scaling=enable_throughput,
+        enable_load_scaling=not enable_throughput,
+        load_router_metrics_url=(
+            "http://localhost:9090" if not enable_throughput else None
+        ),
+        load_adjustment_interval=5,
+        load_learning_window=50,
+        load_scaling_down_sensitivity=80,
+        load_metric_samples=10,
+        load_min_observations=5,
+    )
+
+    shared_state = PlannerSharedState()
+    shared_state.num_p_workers = 1
+    shared_state.num_d_workers = 1
+
+    pm = PlannerPrometheusMetrics()
+
+    planner = BasePlanner.__new__(BasePlanner)
+    planner.config = config
+    planner.shared_state = shared_state
+    planner.prometheus_metrics = pm
+    planner.prometheus_port = 8080
+    planner.enable_throughput = enable_throughput
+    planner.enable_load = not enable_throughput
+    planner.dryrun = True
+    planner.no_correction = True
+    planner.component_type = SubComponentType.PREFILL
+
+    return planner
+
+
+def _set_valid_metrics(planner):
+
+    planner.shared_state.last_metrics = Metrics(
+        num_req=100.0,
+        isl=3000.0,
+        osl=150.0,
+        ttft=80.0,
+        itl=10.0,
+        request_duration=1.5,
+    )
+
+
+# --- _safe_gauge_set ---
+
+
+def test_safe_gauge_set_normal_value():
+
+    gauge = Mock()
+    BasePlanner._safe_gauge_set(gauge, 5.0)
+    gauge.set.assert_called_once_with(5.0)
+
+
+def test_safe_gauge_set_none():
+
+    gauge = Mock()
+    BasePlanner._safe_gauge_set(gauge, None)
+    gauge.set.assert_called_once_with(float("nan"))
+
+
+def test_safe_gauge_set_nan():
+
+    gauge = Mock()
+    BasePlanner._safe_gauge_set(gauge, float("nan"))
+    val = gauge.set.call_args[0][0]
+    assert math.isnan(val)
+
+
+# --- _emit_advisory_metrics: metrics validity gate ---
+
+
+def test_emit_advisory_skips_when_metrics_invalid():
+    planner = _make_base_planner()
+    # last_metrics is empty (invalid)
+    planner._emit_advisory_metrics(3, 2, "throughput")
+    # No gauge set calls since metrics are invalid
+    planner.prometheus_metrics.advisory_recommended_p.set.assert_not_called()
+
+
+def test_emit_advisory_emits_when_metrics_valid():
+    planner = _make_base_planner()
+    _set_valid_metrics(planner)
+    planner._emit_advisory_metrics(3, 2, "throughput")
+    planner.prometheus_metrics.advisory_recommended_p.set.assert_called_once_with(3)
+    planner.prometheus_metrics.advisory_recommended_d.set.assert_called_once_with(2)
+
+
+# --- _emit_advisory_metrics: non-negative guard ---
+
+
+def test_emit_advisory_non_negative_guard():
+    planner = _make_base_planner()
+    _set_valid_metrics(planner)
+    planner._emit_advisory_metrics(-5, -2, "throughput")
+    # Should clamp to 0
+    planner.prometheus_metrics.advisory_recommended_p.set.assert_called_once_with(0)
+    planner.prometheus_metrics.advisory_recommended_d.set.assert_called_once_with(0)
+
+
+# --- _emit_advisory_metrics: anomaly detection ---
+
+
+def test_emit_advisory_anomaly_warning(caplog):
+
+    planner = _make_base_planner()
+    _set_valid_metrics(planner)
+    planner.shared_state.num_p_workers = 1
+    planner.shared_state.num_d_workers = 1
+
+    with caplog.at_level(logging.WARNING):
+        planner._emit_advisory_metrics(
+            50, 1, "throughput"
+        )  # delta_p=49 >> threshold=10
+
+    assert "Unusually large delta" in caplog.text
+
+
+# --- _emit_advisory_metrics: action and reason codes ---
+
+
+def test_emit_advisory_scale_up_action():
+    planner = _make_base_planner()
+    _set_valid_metrics(planner)
+    planner.shared_state.num_p_workers = 1
+    planner.shared_state.num_d_workers = 1
+
+    planner._emit_advisory_metrics(3, 2, "throughput")
+    planner.prometheus_metrics.advisory_scaling_action.set.assert_called_once_with(1)
+    planner.prometheus_metrics.advisory_action_reason.set.assert_called_once_with(1)
+    planner.prometheus_metrics.advisory_scaleup_total.inc.assert_called_once()
+
+
+def test_emit_advisory_scale_down_action():
+    planner = _make_base_planner()
+    _set_valid_metrics(planner)
+    planner.shared_state.num_p_workers = 3
+    planner.shared_state.num_d_workers = 2
+
+    planner._emit_advisory_metrics(1, 1, "throughput")
+    planner.prometheus_metrics.advisory_scaling_action.set.assert_called_once_with(-1)
+    planner.prometheus_metrics.advisory_action_reason.set.assert_called_once_with(2)
+    planner.prometheus_metrics.advisory_scaledown_total.inc.assert_called_once()
+
+
+def test_emit_advisory_hold_action():
+    planner = _make_base_planner()
+    _set_valid_metrics(planner)
+    planner.shared_state.num_p_workers = 2
+    planner.shared_state.num_d_workers = 1
+
+    planner._emit_advisory_metrics(2, 1, "throughput")
+    planner.prometheus_metrics.advisory_scaling_action.set.assert_called_once_with(0)
+    planner.prometheus_metrics.advisory_action_reason.set.assert_called_once_with(6)
+    planner.prometheus_metrics.advisory_hold_total.inc.assert_called_once()
+
+
+def test_emit_advisory_load_source_reason_codes():
+    planner = _make_base_planner()
+    _set_valid_metrics(planner)
+    planner.shared_state.num_p_workers = 1
+    planner.shared_state.num_d_workers = 1
+
+    planner._emit_advisory_metrics(3, 2, "load")
+    # Scale up from load source -> reason code 3
+    planner.prometheus_metrics.advisory_action_reason.set.assert_called_once_with(3)
+
+
+# --- _estimate_sla_with_replicas: load-only mode ---
+
+
+def test_estimate_sla_unavailable_in_load_only_mode(caplog):
+
+    planner = _make_base_planner(enable_throughput=False)
+    _set_valid_metrics(planner)
+
+    with caplog.at_level(logging.INFO):
+        result = planner._estimate_sla_with_replicas(2, 1)
+
+    assert result["est_ttft"] is None
+    assert result["est_itl"] is None
+    assert "SLA estimation unavailable" in caplog.text
+
+
+# --- _build_path_recommendation ---
+
+
+def test_build_path_no_change():
+    planner = _make_base_planner()
+    path = planner._build_path_recommendation(2, 1, 2, 1)
+    assert path == ["2P1D"]
+
+
+def test_build_path_scale_up_p():
+    planner = _make_base_planner()
+    path = planner._build_path_recommendation(1, 1, 3, 1)
+    # With max_step_size=1: 1P1D -> 2P1D (observe) -> 3P1D
+    assert path[0] == "1P1D"
+    assert path[-1] == "3P1D"
+    assert len(path) == 3
+
+
+def test_build_path_scale_down():
+    planner = _make_base_planner()
+    path = planner._build_path_recommendation(3, 2, 1, 1)
+    assert path[0] == "3P2D"
+    assert path[-1] == "1P1D"
+
+
+def test_build_path_max_step_size_2():
+    planner = _make_base_planner()
+    planner.config = PlannerConfig.model_construct(
+        **{**planner.config.model_dump(), "advisory_max_step_size": 2}
+    )
+    path = planner._build_path_recommendation(1, 1, 5, 1)
+    # Steps: 1->3->5 with D staying at 1
+    assert path[0] == "1P1D"
+    assert path[-1] == "5P1D"
+
+
+# --- _write_advisory_jsonl ---
+
+
+def test_write_advisory_jsonl(tmp_path):
+    planner = _make_base_planner()
+    planner.config = PlannerConfig.model_construct(
+        **{
+            **planner.config.model_dump(),
+            "log_dir": str(tmp_path),
+            "advisory_file_output": True,
+        }
+    )
+    planner._write_advisory_jsonl({"ts": 1234, "action": "scale_up"})
+
+    filepath = tmp_path / "advisory_history.jsonl"
+    assert filepath.exists()
+    line = json.loads(filepath.read_text().strip())
+    assert line["ts"] == 1234
+    assert line["action"] == "scale_up"
+
+
+def test_write_advisory_jsonl_no_log_dir():
+    """No file should be written if log_dir is None."""
+    planner = _make_base_planner()
+    # Should not raise even when log_dir is None
+    planner._write_advisory_jsonl({"ts": 1234})
+
+
+# --- Integration: ACTIVE mode also emits advisory metrics ---
+
+
+def test_active_mode_emits_advisory_metrics():
+    planner = _make_base_planner(scaling_mode=ScalingMode.ACTIVE)
+    _set_valid_metrics(planner)
+    planner._emit_advisory_metrics(3, 2, "throughput")
+    # In ACTIVE mode, gauges should still be set
+    planner.prometheus_metrics.advisory_recommended_p.set.assert_called_once_with(3)
+
+
+# --- Integration: NOOP mode does not reach advisory methods ---
+
+
+def test_effective_scaling_mode_noop_with_no_operation():
+    """Ensure model_construct + no_operation=True works with effective_scaling_mode."""
+    config = PlannerConfig.model_construct(
+        no_operation=True,
+        scaling_mode=ScalingMode.ACTIVE,
+        advisory_max_step_size=1,
+        advisory_anomaly_threshold=10,
+        advisory_file_output=False,
+        log_dir=None,
+    )
+    assert config.effective_scaling_mode == ScalingMode.NOOP
+    assert config.effective_scaling_mode != ScalingMode.ACTIVE
+    assert config.effective_scaling_mode != ScalingMode.ADVISORY

--- a/components/src/dynamo/planner/tests/unit/test_advisory_mode.py
+++ b/components/src/dynamo/planner/tests/unit/test_advisory_mode.py
@@ -7,7 +7,8 @@ import json
 import logging
 import math
 import os
-from unittest.mock import MagicMock, Mock, patch
+import tempfile
+from unittest.mock import Mock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -86,17 +87,18 @@ def test_advisory_file_output_auto_fills_log_dir():
         log_dir=None,
     )
     assert config.advisory_file_output is True
-    assert config.log_dir == "/tmp/planner"
+    assert config.log_dir == os.path.join(tempfile.gettempdir(), "planner")
 
 
-def test_advisory_file_output_with_log_dir():
+def test_advisory_file_output_with_log_dir(tmp_path):
+    log_dir = str(tmp_path / "advisory")
     config = PlannerConfig(
         namespace="test-ns",
         advisory_file_output=True,
-        log_dir="/tmp/advisory",
+        log_dir=log_dir,
     )
     assert config.advisory_file_output is True
-    assert config.log_dir == "/tmp/advisory"
+    assert config.log_dir == log_dir
 
 
 # ---------------------------------------------------------------------------
@@ -105,7 +107,6 @@ def test_advisory_file_output_with_log_dir():
 
 
 def test_no_operation_true_maps_to_noop(caplog):
-
     with caplog.at_level(logging.WARNING):
         config = PlannerConfig(namespace="test-ns", no_operation=True)
     assert config.scaling_mode == ScalingMode.NOOP
@@ -236,7 +237,6 @@ def _make_base_planner(scaling_mode=ScalingMode.ADVISORY, enable_throughput=True
 
 
 def _set_valid_metrics(planner):
-
     planner.shared_state.last_metrics = Metrics(
         num_req=100.0,
         isl=3000.0,
@@ -251,21 +251,18 @@ def _set_valid_metrics(planner):
 
 
 def test_safe_gauge_set_normal_value():
-
     gauge = Mock()
     BasePlanner._safe_gauge_set(gauge, 5.0)
     gauge.set.assert_called_once_with(5.0)
 
 
 def test_safe_gauge_set_none():
-
     gauge = Mock()
     BasePlanner._safe_gauge_set(gauge, None)
     gauge.set.assert_called_once_with(float("nan"))
 
 
 def test_safe_gauge_set_nan():
-
     gauge = Mock()
     BasePlanner._safe_gauge_set(gauge, float("nan"))
     val = gauge.set.call_args[0][0]

--- a/deploy/observability/k8s/grafana-advisory-dashboard-configmap.yaml
+++ b/deploy/observability/k8s/grafana-advisory-dashboard-configmap.yaml
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-advisory-dashboard
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  advisory-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Dynamo Planner Advisory Mode dashboard - scaling recommendations, SLA headroom, and decision context",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [
+        {
+          "asDropdown": false,
+          "icon": "external link",
+          "includeVars": true,
+          "keepTime": true,
+          "tags": [],
+          "targetBlank": true,
+          "title": "Dynamo Planner - SLA & Scaling",
+          "tooltip": "Cross-reference with main Planner dashboard",
+          "type": "link",
+          "url": "/d/dynamo-planner"
+        }
+      ],
+      "panels": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "description": "Recommended replicas (dashed) vs actual replicas (solid). Gap indicates what Planner would do in active mode.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "lineWidth": 2, "spanNulls": false },
+              "unit": "short"
+            },
+            "overrides": [
+              { "matcher": { "id": "byName", "options": "Recommended Prefill" }, "properties": [{ "id": "custom.lineStyle", "value": { "dash": [8, 4], "fill": "dash" } }, { "id": "color", "value": { "fixedColor": "#73BF69", "mode": "fixed" } }] },
+              { "matcher": { "id": "byName", "options": "Recommended Decode" },  "properties": [{ "id": "custom.lineStyle", "value": { "dash": [8, 4], "fill": "dash" } }, { "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] },
+              { "matcher": { "id": "byName", "options": "Actual Prefill" }, "properties": [{ "id": "color", "value": { "fixedColor": "#73BF69", "mode": "fixed" } }] },
+              { "matcher": { "id": "byName", "options": "Actual Decode" },  "properties": [{ "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] }
+            ]
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+          "id": 1,
+          "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "none" } },
+          "targets": [
+            { "expr": "dynamo_planner_advisory_recommended_p{namespace=~\"$namespace\"}", "legendFormat": "Recommended Prefill", "refId": "A" },
+            { "expr": "dynamo_planner_advisory_recommended_d{namespace=~\"$namespace\"}", "legendFormat": "Recommended Decode",  "refId": "B" },
+            { "expr": "dynamo_planner_advisory_current_p{namespace=~\"$namespace\"}",     "legendFormat": "Actual Prefill",      "refId": "C" },
+            { "expr": "dynamo_planner_advisory_current_d{namespace=~\"$namespace\"}",     "legendFormat": "Actual Decode",       "refId": "D" }
+          ],
+          "title": "Recommended vs Actual Replicas",
+          "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "description": "Scaling action over time: 1=scale up (green), 0=hold (gray), -1=scale down (blue)",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [
+                { "options": { "-1": { "color": "#5794F2", "text": "Scale Down" }, "0": { "color": "#73BF69", "text": "Hold" }, "1": { "color": "#F2495C", "text": "Scale Up" } }, "type": "value" }
+              ],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "#5794F2", "value": null }, { "color": "#73BF69", "value": 0 }, { "color": "#F2495C", "value": 1 }] },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+          "id": 2,
+          "options": { "colWidth": 0.9, "legend": { "displayMode": "list", "placement": "bottom" }, "rowHeight": 0.9, "showValue": "always", "tooltip": { "mode": "single" } },
+          "targets": [
+            { "expr": "dynamo_planner_advisory_scaling_action{namespace=~\"$namespace\"}", "legendFormat": "Scaling Action", "refId": "A" }
+          ],
+          "title": "Scaling Action Timeline",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "description": "SLA headroom = SLA target - estimated latency. Positive = safe, negative = SLA violation risk.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "lineWidth": 2, "spanNulls": false },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+          "id": 3,
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "min"], "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "multi" }
+          },
+          "targets": [
+            { "expr": "dynamo_planner_advisory_ttft_headroom{namespace=~\"$namespace\"}", "legendFormat": "TTFT Headroom (ms)", "refId": "A" },
+            { "expr": "dynamo_planner_advisory_itl_headroom{namespace=~\"$namespace\"}",  "legendFormat": "ITL Headroom (ms)",  "refId": "B" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 0 }] },
+          "title": "SLA Headroom (positive = safe)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "description": "Estimated TTFT (from profiling data) vs observed TTFT (actual). Divergence indicates estimation accuracy.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "lineWidth": 2, "spanNulls": false },
+              "unit": "ms"
+            },
+            "overrides": [
+              { "matcher": { "id": "byName", "options": "Estimated TTFT" }, "properties": [{ "id": "custom.lineStyle", "value": { "dash": [8, 4], "fill": "dash" } }] }
+            ]
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+          "id": 4,
+          "options": { "legend": { "calcs": ["lastNotNull", "mean"], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+          "targets": [
+            { "expr": "dynamo_planner_advisory_est_ttft{namespace=~\"$namespace\"}", "legendFormat": "Estimated TTFT", "refId": "A" },
+            { "expr": "planner:observed_ttft{namespace=~\"$namespace\"}",     "legendFormat": "Observed TTFT",  "refId": "B" }
+          ],
+          "title": "Estimated vs Actual TTFT",
+          "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "description": "Recommendation frequency per minute. A healthy Planner should mostly hold with occasional scale events.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "lineWidth": 2, "spanNulls": false, "fillOpacity": 10, "stacking": { "group": "A", "mode": "normal" } },
+              "unit": "reqpm"
+            },
+            "overrides": [
+              { "matcher": { "id": "byName", "options": "Scale Up/min" },   "properties": [{ "id": "color", "value": { "fixedColor": "#F2495C", "mode": "fixed" } }] },
+              { "matcher": { "id": "byName", "options": "Scale Down/min" }, "properties": [{ "id": "color", "value": { "fixedColor": "#5794F2", "mode": "fixed" } }] },
+              { "matcher": { "id": "byName", "options": "Hold/min" },       "properties": [{ "id": "color", "value": { "fixedColor": "#73BF69", "mode": "fixed" } }] }
+            ]
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+          "id": 5,
+          "options": { "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+          "targets": [
+            { "expr": "rate(dynamo_planner_advisory_scaleup_total{namespace=~\"$namespace\"}[5m]) * 60",   "legendFormat": "Scale Up/min",   "refId": "A" },
+            { "expr": "rate(dynamo_planner_advisory_scaledown_total{namespace=~\"$namespace\"}[5m]) * 60", "legendFormat": "Scale Down/min", "refId": "B" },
+            { "expr": "rate(dynamo_planner_advisory_hold_total{namespace=~\"$namespace\"}[5m]) * 60",      "legendFormat": "Hold/min",       "refId": "C" }
+          ],
+          "title": "Recommendation Statistics (per minute)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "description": "Full decision chain: observed traffic → predicted load → recommended replicas",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "lineWidth": 2, "spanNulls": false },
+              "unit": "reqps"
+            },
+            "overrides": [
+              { "matcher": { "id": "byName", "options": "Recommended Prefill" }, "properties": [{ "id": "unit", "value": "short" }, { "id": "custom.axisPlacement", "value": "right" }] }
+            ]
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+          "id": 6,
+          "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+          "targets": [
+            { "expr": "planner:observed_request_rate{namespace=~\"$namespace\"}",     "legendFormat": "Observed Req Rate",   "refId": "A" },
+            { "expr": "planner:predicted_request_rate{namespace=~\"$namespace\"}",    "legendFormat": "Predicted Req Rate",  "refId": "B" },
+            { "expr": "dynamo_planner_advisory_recommended_p{namespace=~\"$namespace\"}",    "legendFormat": "Recommended Prefill", "refId": "C" }
+          ],
+          "title": "Decision Context Timeline",
+          "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "description": "Delta = recommended - actual. Positive = needs more replicas, negative = can release.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "lineWidth": 2, "spanNulls": false },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+          "id": 7,
+          "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+          "targets": [
+            { "expr": "dynamo_planner_advisory_delta_p{namespace=~\"$namespace\"}", "legendFormat": "Prefill Delta", "refId": "A" },
+            { "expr": "dynamo_planner_advisory_delta_d{namespace=~\"$namespace\"}", "legendFormat": "Decode Delta",  "refId": "B" }
+          ],
+          "title": "Advisory Delta (recommended - actual)",
+          "type": "timeseries"
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": ["dynamo", "planner", "advisory"],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "hide": 0,
+            "includeAll": false,
+            "label": "Data Source",
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "type": "datasource"
+          },
+          {
+            "current": {},
+            "datasource": { "type": "prometheus", "uid": "${datasource}" },
+            "definition": "label_values(planner:num_p_workers, namespace)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Namespace",
+            "name": "namespace",
+            "query": { "query": "label_values(planner:num_p_workers, namespace)", "refId": "A" },
+            "refresh": 2,
+            "type": "query"
+          }
+        ]
+      },
+      "time": { "from": "now-30m", "to": "now" },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Dynamo Planner - Advisory Mode",
+      "uid": "dynamo-planner-advisory",
+      "version": 1
+    }

--- a/docs/design-docs/planner-advisory-mode-test-report.md
+++ b/docs/design-docs/planner-advisory-mode-test-report.md
@@ -1,0 +1,254 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Planner Advisory Mode 测试报告
+
+## 1. 测试概述
+
+| 项目 | 内容 |
+|------|------|
+| 测试功能 | Planner Advisory Mode（观测建议模式） |
+| 测试日期 | 2026-03-24 |
+| 测试人员 | Bruce Luo |
+| 代码分支 | `feature/planner-advisory-mode` (brluobt/dynamo) |
+| 代码 Commit | `2b0980981` - feat: implement Planner Advisory Mode |
+| 测试结果 | **全部通过** |
+
+## 2. 测试环境
+
+### 硬件
+
+| 项目 | 规格 |
+|------|------|
+| 节点 | l20-6 |
+| 操作系统 | Ubuntu 22.04.4 LTS |
+| GPU | NVIDIA L20 x 8 |
+
+### 软件
+
+| 组件 | 版本/镜像 |
+|------|----------|
+| Dynamo Operator | `dynamo-operator:local` |
+| vLLM Runtime | `nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.1` |
+| Advisory Mode 镜像 | `localhost:5000/dynamo:advisory-mode`（基于 `dynamo:gp-test` + 5 个修改文件叠加） |
+| 推理模型 | `nvidia/Llama-3.1-8B-Instruct-FP8` |
+| NATS | 2.10.21 |
+| etcd | 3.5.18 |
+
+### 集群部署
+
+测试在两个独立的 K8s namespace 中进行：
+
+| Namespace | 模式 | Backend | GPU | 用途 |
+|-----------|------|---------|-----|------|
+| `gp-test` | Hierarchical Planner (5 个 DGD) | Mocker | 无 | Advisory Mode 功能验证 |
+| `dynamo` | 单 DGD Disagg | vLLM | L20 | Advisory Mode 真实 GPU 环境验证 |
+
+## 3. 测试方案
+
+### 镜像构建
+
+基于 `dynamo:gp-test` 镜像，叠加 Advisory Mode 修改的 5 个 Python 文件：
+
+| 文件 | 改动内容 |
+|------|---------|
+| `defaults.py` | 新增 `ScalingMode` 枚举（ACTIVE/ADVISORY/NOOP） |
+| `planner_config.py` | 新增 `scaling_mode`、`advisory_max_step_size`、`advisory_anomaly_threshold`、`advisory_file_output` 配置字段，向后兼容 `no_operation` 映射 |
+| `base.py` | 新增 15 个 Prometheus 指标、Advisory Engine 核心方法（`_emit_advisory_metrics`、`_estimate_sla_with_replicas`、`_build_path_recommendation`）、`/advisory/status` HTTP 端点 |
+| `disagg.py` | 4 处 `no_operation` 替换为 `scaling_mode` 三路分支，添加 advisory 输出调用 |
+| `agg.py` | 3 处 `no_operation` 替换为 `scaling_mode` 三路分支 |
+
+### 部署方式
+
+通过 `kubectl patch dgd` 更新 Planner 的镜像和配置参数：
+- 镜像切换为 `localhost:5000/dynamo:advisory-mode`
+- 入口命令切换为 `python3 -m dynamo.planner`
+- 参数格式切换为 `--config` JSON 格式
+- 配置 `scaling_mode: "advisory"` 和 `metric_reporting_prometheus_port: 9090`
+
+## 4. 测试用例与结果
+
+### 测试一：Mocker 环境 Advisory Mode（gp-test namespace）
+
+**目的**：验证 Advisory Mode 基本功能，包括 Prometheus 指标输出、HTTP 端点、结构化日志。
+
+**配置**：
+```json
+{
+  "environment": "global-planner",
+  "backend": "mocker",
+  "mode": "prefill",
+  "scaling_mode": "advisory",
+  "throughput_adjustment_interval": 30,
+  "metric_reporting_prometheus_port": 9090
+}
+```
+
+**结果**：
+
+| 验证项 | 状态 | 说明 |
+|--------|------|------|
+| Pod 启动 | 通过 | Pod `gp-prefill-0-planner-75f5d46c79-btq42` 正常启动，Running 状态 |
+| Throughput 循环 | 通过 | 每 30 秒执行一次 adjustment interval |
+| Advisory 日志 | 通过 | 日志中出现 `[ADVISORY] Recommendation` |
+| Prometheus 指标 | 通过 | 全部 15 个新指标正常输出（见下表） |
+| HTTP 端点 | 通过 | `/advisory/status` 返回完整 JSON |
+| 未执行 Scaling | 通过 | Advisory 模式未调用 `set_component_replicas()`，其他 Pool Planner 不受影响 |
+
+**Prometheus 指标采样**（无流量状态下）：
+```
+dynamo_planner_advisory_recommended_p    = 1.0
+dynamo_planner_advisory_recommended_d    = 0.0
+dynamo_planner_advisory_current_p        = 0.0
+dynamo_planner_advisory_current_d        = 0.0
+dynamo_planner_advisory_delta_p          = 1.0
+dynamo_planner_advisory_scaling_action   = 1.0  (scale_up)
+dynamo_planner_advisory_action_reason    = 1.0  (throughput_prediction)
+dynamo_planner_advisory_est_ttft         = 60.46ms
+dynamo_planner_advisory_ttft_headroom    = 1939.54ms
+dynamo_planner_advisory_scaleup_total    = 7.0
+dynamo_planner_advisory_scaledown_total  = 0.0
+dynamo_planner_advisory_hold_total       = 0.0
+```
+
+**HTTP 端点响应**：
+```json
+{
+  "scaling_mode": "advisory",
+  "last_update": "2026-03-24T15:05:17.241941Z",
+  "current": {"prefill": 0, "decode": 0},
+  "recommended": {"prefill": 1, "decode": 0},
+  "delta": {"prefill": 1, "decode": 0},
+  "action": "scale_up",
+  "reason": "throughput",
+  "sla_estimation": {
+    "est_ttft_ms": 60.46,
+    "ttft_headroom_ms": 1939.54
+  }
+}
+```
+
+---
+
+### 测试二：真实 GPU 环境 Advisory Mode（dynamo namespace）
+
+**目的**：验证 Advisory Mode 在真实 GPU 推理环境中的表现，包括与 vLLM worker 的兼容性、真实流量下的指标准确性。
+
+**配置**：
+```json
+{
+  "environment": "kubernetes",
+  "backend": "vllm",
+  "throughput_adjustment_interval": 60,
+  "profile_results_dir": "/mnt/profiling_data",
+  "ttft": 2000,
+  "itl": 50,
+  "no_correction": true,
+  "load_predictor": "constant",
+  "scaling_mode": "advisory",
+  "metric_reporting_prometheus_port": 9090
+}
+```
+
+**部署拓扑**：
+```
+Frontend (vllm-runtime:0.9.1)
+  └── Planner (advisory-mode 镜像, scaling_mode=advisory)
+  └── Prefill Worker x1 (vllm-runtime:0.9.1, L20 GPU)
+  └── Decode Worker x1 (vllm-runtime:0.9.1, L20 GPU)
+```
+
+**测试流程**：
+
+1. 部署 Advisory Mode Planner
+2. 验证 Planner 启动和 DGD 验证通过
+3. 发送 11 个推理请求（1 个单独 + 10 个并发）
+4. 等待下一个 adjustment interval 观察 advisory 输出
+
+**结果**：
+
+| 验证项 | 状态 | 说明 |
+|--------|------|------|
+| Pod 启动 | 通过 | DGD 验证成功，检测到 GPU: prefill=1, decode=1 |
+| 模型检测 | 通过 | 自动检测到 `nvidia/Llama-3.1-8B-Instruct-FP8` |
+| Metrics Validity Gate | 通过 | 无流量时正确跳过 advisory 输出："Metrics contain None or NaN values" |
+| 真实流量采集 | 通过 | 观测到 `num_req: 12.00, isl: 21.27, osl: 113.73` |
+| 实测延迟 | 通过 | `TTFT: 229.75ms, ITL: 14.42ms`（均在 SLA 范围内） |
+| Prefill 副本计算 | 通过 | `4.25(需求) / 1600.00(容量) = 1(需要 1P)` |
+| Decode 副本计算 | 通过 | `22.75(需求) / 300.00(容量) = 1(需要 1D)` |
+| Advisory 建议 | 通过 | 建议 hold（1P1D → 1P1D），决策合理 |
+| SLA 估算 | 通过 | `est_ttft: 120.0ms, est_itl: 15.0ms`（基于 profiling data） |
+| SLA 余量 | 通过 | `ttft_headroom: 1880.0ms, itl_headroom: 35.0ms`（大量余量） |
+| 推理服务不受影响 | 通过 | GPU 推理正常响应，Advisory Mode 未执行任何实际 scaling |
+
+**Prometheus 指标采样**（有流量状态下）：
+```
+dynamo_planner_advisory_recommended_p    = 1.0
+dynamo_planner_advisory_recommended_d    = 1.0
+dynamo_planner_advisory_current_p        = 1.0   (正确读取 DGD 实际副本数)
+dynamo_planner_advisory_current_d        = 1.0
+dynamo_planner_advisory_delta_p          = 0.0
+dynamo_planner_advisory_delta_d          = 0.0
+dynamo_planner_advisory_scaling_action   = 0.0   (hold)
+dynamo_planner_advisory_action_reason    = 6.0   (no change needed)
+dynamo_planner_advisory_est_ttft         = 120.0ms
+dynamo_planner_advisory_est_itl          = 15.0ms
+dynamo_planner_advisory_ttft_headroom    = 1880.0ms
+dynamo_planner_advisory_itl_headroom     = 35.0ms
+dynamo_planner_advisory_hold_total       = 1.0
+```
+
+**HTTP 端点响应**：
+```json
+{
+  "scaling_mode": "advisory",
+  "last_update": "2026-03-24T15:14:03.530000Z",
+  "current": {"prefill": 1, "decode": 1},
+  "recommended": {"prefill": 1, "decode": 1},
+  "delta": {"prefill": 0, "decode": 0},
+  "action": "hold",
+  "reason": "throughput",
+  "sla_estimation": {
+    "est_ttft_ms": 120.0,
+    "est_itl_ms": 15.0,
+    "ttft_headroom_ms": 1880.0,
+    "itl_headroom_ms": 35.0
+  }
+}
+```
+
+## 5. 安全防护验证
+
+| 防护机制 | 状态 | 验证方式 |
+|----------|------|---------|
+| Metrics Validity Gate | 通过 | 无流量时日志显示 "Metrics contain None or NaN values, skipping adjustment"，advisory 指标未输出 |
+| 未执行实际 Scaling | 通过 | Advisory 模式下 Worker 副本数始终不变，`kubectl get pods` 确认无 Pod 增减 |
+| 向后兼容 | 通过 | 其他 Pool Planner（gp-prefill-1, gp-decode-0, gp-decode-1）完全不受影响，继续使用原镜像正常运行 |
+| HTTP 端点安全 | 通过 | `/advisory/status` 只读端点，不暴露敏感信息 |
+
+## 6. 已知限制
+
+| 限制 | 说明 |
+|------|------|
+| `advisory_current_p/d` 在 prefill-only 模式下不完整 | `gp-test` 中 prefill pool 的 Planner 以 `mode=prefill` 运行，`advisory_current_d` 始终为 0（因为不查询 decode worker 状态）。这是预期行为，disagg 模式下完整可见。 |
+| SLA 估算基于 profiling data | `advisory_est_ttft` 和 `advisory_est_itl` 依赖预部署 profiling 数据的准确性，实际值可能因运行时条件偏差 |
+| JSONL 文件输出未测试 | 本次测试未启用 `advisory_file_output`（需要设置 `log_dir`），此功能待后续验证 |
+| Grafana Dashboard 未测试 | Dashboard JSON 尚未创建，可视化效果待后续验证 |
+
+## 7. 结论
+
+Planner Advisory Mode 在 Mocker 环境和真实 GPU 环境中均通过测试，核心功能正常：
+
+1. **三模式架构**正常工作：advisory 模式不执行 scaling，但完整输出决策建议
+2. **15 个 Prometheus 指标**全部正确输出，数值合理
+3. **HTTP 端点** `/advisory/status` 返回结构化 JSON，方便快速查看
+4. **安全防护**生效：无效 metrics 时跳过输出，不影响现有推理服务
+5. **向后兼容**：未修改的 Planner 继续使用原镜像正常运行
+
+**建议下一步**：
+- 在持续负载下长时间运行（>24h）验证稳定性
+- 创建 Grafana Advisory Dashboard 验证可视化效果
+- 测试高负载场景下的 scale_up 建议准确性
+- 提交 PR 到 ai-dynamo/dynamo 上游仓库

--- a/docs/design-docs/planner-advisory-mode.md
+++ b/docs/design-docs/planner-advisory-mode.md
@@ -1,0 +1,658 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Planner Advisory Mode Design
+
+## 1. Background and Motivation
+
+In production inference environments, enabling Planner auto-scaling directly carries risk.
+Customers need a way to observe the Planner's decisions, evaluate their
+correctness, and build confidence before turning on automatic execution.
+
+The current `no_operation` mode simply skips scaling with no output — it provides
+zero observability into what the Planner *would have done*. This makes it useless
+for pre-production validation.
+
+### Use Cases
+
+| Use Case | Description |
+|----------|-------------|
+| **Pre-production validation** | Deploy Planner in advisory mode alongside a new model. Observe recommendations for days/weeks before enabling active scaling. |
+| **Ongoing auditing** | Run advisory output in active mode so every executed scaling action is accompanied by its full decision context for post-incident review. |
+| **Customer demo / PoC** | Show customers how the Planner would behave on their traffic without touching their running workloads. |
+
+---
+
+## 2. Three-Mode Architecture
+
+Replace the boolean `no_operation` flag with a `ScalingMode` enum.
+
+```python
+class ScalingMode(str, Enum):
+    ACTIVE = "active"
+    ADVISORY = "advisory"
+    NOOP = "noop"
+```
+
+### Mode Behavior Matrix
+
+| Capability | active | advisory | noop |
+|------------|--------|----------|------|
+| Initialize Connector (read cluster state) | Y | Y | N |
+| Execute scaling (`set_component_replicas`) | Y | N | N |
+| Emit Advisory Prometheus metrics | Y | Y | N |
+| Emit structured advisory logs | Y | Y | N |
+| Write advisory JSONL file | Y | Y | N |
+
+**Why advisory mode initializes the Connector**: Advisory mode must call
+`get_workers_info()` and `get_actual_worker_counts()` via `KubernetesConnector` to
+know the current replica counts. Without this, `advisory_current_p/d` and all delta
+metrics would be zero, making the output meaningless. The Connector is used in
+read-only mode — `_apply_scaling()` and `_apply_scaling_blocking()` are gated on
+`scaling_mode == ACTIVE`.
+
+**Why active mode also emits advisory metrics and structured logs**: Every executed
+scaling decision should be traceable. When an incident occurs, SREs can query the
+advisory metrics and search structured logs to see the full decision context
+(predicted load, estimated SLA impact, GPU budget constraints) that led to the
+scaling action.
+
+### Connector Initialization Logic
+
+```python
+# In BasePlanner.__init__ and DisaggPlanner.__init__
+init_connector = config.scaling_mode in (ScalingMode.ACTIVE, ScalingMode.ADVISORY)
+
+if init_connector:
+    if config.environment == "global-planner":
+        self.connector = GlobalPlannerConnector(...)
+    elif config.environment == "kubernetes":
+        self.connector = KubernetesConnector(...)
+    elif config.environment == "virtual":
+        self.connector = VirtualConnector(...)
+```
+
+### Scaling Execution Gate
+
+```python
+# In BasePlanner._apply_scaling / _apply_scaling_blocking
+async def _apply_scaling(self, desired_replicas: int) -> None:
+    if self.config.scaling_mode != ScalingMode.ACTIVE:
+        return
+    # ... existing K8s scaling logic
+```
+
+### Backward Compatibility
+
+```python
+# In PlannerConfig model_validator
+@model_validator(mode="after")
+def _validate_config(self) -> "PlannerConfig":
+    if self.no_operation and self.scaling_mode == ScalingMode.ACTIVE:
+        logger.warning(
+            "DEPRECATION: no_operation=True is deprecated. "
+            "Use scaling_mode='noop' instead. "
+            "Automatically mapping no_operation=True to scaling_mode='noop'."
+        )
+        self.scaling_mode = ScalingMode.NOOP
+    # ...
+```
+
+Mapping rules:
+- `no_operation: true` + no `scaling_mode` set → `scaling_mode: "noop"` (with deprecation warning)
+- `no_operation: false` (default) + no `scaling_mode` set → `scaling_mode: "active"` (current behavior, no warning)
+- Explicit `scaling_mode` always takes precedence over `no_operation`
+
+---
+
+## 3. Advisory Engine — Three-Layer Output
+
+The Advisory Engine is a set of methods on `BasePlanner` that run in `active` and
+`advisory` modes. It is invoked after replica computation but before scaling execution.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│              Planner Core (all modes share)               │
+│                                                          │
+│  Prometheus ──→ Observe Traffic ──→ Predict Load          │
+│                                       │                  │
+│                              Compute Replicas            │
+│                                       │                  │
+│                            Apply GPU Budget              │
+│                                       │                  │
+│                         ┌─────────────┴─────────────┐    │
+│                         ▼                           ▼    │
+│              Advisory Engine               Scaling Gate  │
+│          (active + advisory)            (active only)    │
+│                   │                           │          │
+│        ┌──────────┼──────────┐                ▼          │
+│        ▼          ▼          ▼       set_component_      │
+│    Layer 1    Layer 2    Layer 3     replicas()           │
+│   Metrics     Logs      SLA Est                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Layer 1: Scaling Recommendation (Prometheus Metrics)
+
+Updated every adjustment interval. These metrics are the primary input for
+the Grafana Advisory Dashboard.
+
+**Gauges (12):**
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `dynamo_planner_advisory_recommended_p` | Gauge | Final recommended prefill replicas (after GPU budget) |
+| `dynamo_planner_advisory_recommended_d` | Gauge | Final recommended decode replicas (after GPU budget) |
+| `dynamo_planner_advisory_current_p` | Gauge | Current actual prefill replicas from DGD |
+| `dynamo_planner_advisory_current_d` | Gauge | Current actual decode replicas from DGD |
+| `dynamo_planner_advisory_delta_p` | Gauge | Prefill delta (recommended - current). Positive = scale up |
+| `dynamo_planner_advisory_delta_d` | Gauge | Decode delta (recommended - current). Positive = scale up |
+| `dynamo_planner_advisory_scaling_action` | Gauge | Aggregate action: 1=scale up, 0=hold, -1=scale down |
+| `dynamo_planner_advisory_action_reason` | Gauge | Reason code (see table below) |
+| `dynamo_planner_advisory_est_ttft` | Gauge | Estimated TTFT after applying recommendation (ms). NaN if no profiling data |
+| `dynamo_planner_advisory_est_itl` | Gauge | Estimated ITL after applying recommendation (ms). NaN if no profiling data |
+| `dynamo_planner_advisory_ttft_headroom` | Gauge | TTFT SLA target - estimated TTFT (ms). Positive = safe |
+| `dynamo_planner_advisory_itl_headroom` | Gauge | ITL SLA target - estimated ITL (ms). Positive = safe |
+
+**Counters (3):**
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `dynamo_planner_advisory_scaleup_total` | Counter | Cumulative scale-up recommendations |
+| `dynamo_planner_advisory_scaledown_total` | Counter | Cumulative scale-down recommendations |
+| `dynamo_planner_advisory_hold_total` | Counter | Cumulative hold recommendations |
+
+**Total: 15 new metrics.**
+
+Note: Prometheus counters reset to zero on Pod restart. Grafana queries must use
+`rate()` or `increase()`, never raw counter values.
+
+**Action Reason Codes:**
+
+| Code | Meaning |
+|------|---------|
+| 0 | No traffic (metrics invalid, skipped) |
+| 1 | Throughput prediction: predicted load exceeds current capacity |
+| 2 | Throughput prediction: predicted load below current capacity |
+| 3 | Load-based: all workers above SLA threshold |
+| 4 | Load-based: all workers below scale-down boundary |
+| 5 | GPU budget constraint applied (raw recommendation was higher) |
+| 6 | Hold: no change needed |
+
+In v1, reason codes provide a quick signal in dashboards. Detailed reasoning
+is in the structured logs (Layer 2).
+
+**Naming convention**: Advisory metrics use `dynamo_planner_advisory_*` (underscore-separated)
+following the Dynamo naming guideline in `lib/runtime/src/metrics/prometheus_names.rs`.
+Existing Planner metrics (`planner:num_p_workers`, etc.) retain their current naming
+for backward compatibility and will be migrated in a follow-up PR.
+
+### Layer 2: Execution Path (Structured Logs)
+
+Output only in `advisory` mode. Provides human-readable and machine-parseable
+decision context.
+
+**Throughput-based recommendation log:**
+
+```json
+{
+  "event": "advisory_recommendation",
+  "scaling_mode": "advisory",
+  "source": "throughput",
+  "action": "scale_up",
+  "current": {"prefill": 1, "decode": 1},
+  "recommended_raw": {"prefill": 3, "decode": 1},
+  "recommended_final": {"prefill": 3, "decode": 1},
+  "gpu_budget_applied": false,
+  "predicted_load": {"req_rate": 15.2, "isl": 3200, "osl": 180},
+  "engine_capacity": {"prefill_thpt_per_gpu": 5800, "decode_thpt_per_gpu": 1205},
+  "path": ["1P1D", "2P1D (observe 1 interval)", "3P1D"],
+  "est_ttft_ms": 85.2,
+  "est_itl_ms": 12.1,
+  "ttft_headroom_ms": 414.8,
+  "itl_headroom_ms": 37.9,
+  "risk": "During scale-up only 1 prefill GPU serves traffic; TTFT may degrade"
+}
+```
+
+**Load-based recommendation log:**
+
+```json
+{
+  "event": "advisory_recommendation",
+  "scaling_mode": "advisory",
+  "source": "load",
+  "action": "scale_up",
+  "current": {"prefill": 2, "decode": 1},
+  "recommended_final": {"prefill": 3, "decode": 1},
+  "trigger": "all_workers_above_target",
+  "worker_metrics": {
+    "worker_0": {"active_prefill_tokens": 12800},
+    "worker_1": {"active_prefill_tokens": 13100}
+  },
+  "target_threshold": 10240,
+  "regression": {"slope": 0.0042, "intercept": 15.3, "observations": 47}
+}
+```
+
+**GPU budget constraint log (appended when budget clips the recommendation):**
+
+```json
+{
+  "event": "advisory_gpu_budget",
+  "raw_recommendation": {"prefill": 5, "decode": 3, "total_gpus": 8},
+  "budget_limit": 6,
+  "final_recommendation": {"prefill": 3, "decode": 2, "total_gpus": 5},
+  "action_needed": "Increase max_gpu_budget or add GPUs to serve predicted load"
+}
+```
+
+All logs use Python's `logging` with `extra` dict fields. This is compatible
+with Dynamo's existing `configure_dynamo_logging()` framework and integrates
+with ELK, Grafana Loki, and other log aggregation systems via JSON formatters.
+
+### Layer 3: SLA Estimation
+
+Uses `PrefillInterpolator.interpolate_ttft()` and
+`DecodeInterpolator.find_best_throughput_per_gpu()` to estimate what TTFT and ITL
+would be if the recommended replica count were in effect.
+
+**Graceful degradation when profiling data is unavailable:**
+
+```python
+def _estimate_sla_with_replicas(self, num_p: int, num_d: int) -> dict:
+    if not self.enable_throughput:
+        # Load-only mode: no profiling data available for estimation
+        if self.prometheus_metrics:
+            self.prometheus_metrics.advisory_est_ttft.set(float('nan'))
+            self.prometheus_metrics.advisory_est_itl.set(float('nan'))
+            self.prometheus_metrics.advisory_ttft_headroom.set(float('nan'))
+            self.prometheus_metrics.advisory_itl_headroom.set(float('nan'))
+        logger.info(
+            "[ADVISORY] SLA estimation unavailable: "
+            "throughput scaling disabled (no profiling data)"
+        )
+        return {"est_ttft": None, "est_itl": None}
+    # ... estimation using interpolators
+```
+
+Grafana panels handle NaN values by displaying "N/A" instead of broken lines.
+
+All SLA estimation outputs carry a disclaimer in logs:
+`"note": "Estimation based on profiling data; actual values may differ due to runtime conditions"`
+
+---
+
+## 4. Robustness and Safety Guards
+
+These safeguards are essential for production deployment where metrics may be
+intermittent, Planner Pods may restart, and cluster state may be inconsistent.
+
+### Metrics Validity Gate
+
+```python
+def _emit_advisory_metrics(self, recommended_p, recommended_d, source, reason_code):
+    if not self.last_metrics.is_valid():
+        logger.info(
+            "[ADVISORY] Skipping advisory output: "
+            "metrics contain None/NaN (no active traffic or Prometheus unreachable)"
+        )
+        return
+```
+
+**Why**: At Planner startup or during Prometheus outages, `last_metrics` contains
+None/NaN values. Emitting advisory recommendations based on invalid data would
+mislead operators.
+
+### Non-Negative Replica Guard
+
+```python
+    recommended_p = max(0, recommended_p)
+    recommended_d = max(0, recommended_d)
+```
+
+**Why**: Edge cases in prediction (negative predictions from ARIMA, division
+issues) must never produce negative replica recommendations.
+
+### Anomaly Detection
+
+```python
+    delta_p = recommended_p - self.shared_state.num_p_workers
+    delta_d = recommended_d - self.shared_state.num_d_workers
+    threshold = self.config.advisory_anomaly_threshold
+
+    if abs(delta_p) > threshold or abs(delta_d) > threshold:
+        logger.warning(
+            f"[ADVISORY] Unusually large delta: delta_p={delta_p}, delta_d={delta_d} "
+            f"(threshold={threshold}). Possible metrics jump or configuration error."
+        )
+```
+
+**Why**: A recommendation to go from 1 to 50 replicas is almost certainly a bug
+or a metrics anomaly. The warning gives operators an early signal to investigate.
+The threshold is configurable via `advisory_anomaly_threshold` (default: 10).
+
+### NaN Protection on Gauge Writes
+
+```python
+def _safe_gauge_set(gauge, value):
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        gauge.set(float('nan'))
+    else:
+        gauge.set(value)
+```
+
+**Why**: Some estimation paths may produce None (e.g., SLA estimation without
+profiling data). Direct `.set(None)` would raise an exception.
+
+### Load-Based Blocking Prevention
+
+In advisory mode, the load-based loop must NOT call `_apply_scaling_blocking()`
+(which waits for deployment readiness). This would stall the entire load loop
+indefinitely since no actual scaling occurs.
+
+```python
+# In _load_loop and DisaggPlanner._load_loop:
+if self.config.scaling_mode == ScalingMode.ACTIVE:
+    await self._apply_scaling_blocking(desired_replicas)
+# advisory mode: emit metrics only, no blocking
+```
+
+---
+
+## 5. Data Output Channels
+
+Four output channels ensure advisory data is accessible regardless of the
+customer's monitoring infrastructure.
+
+| Channel | Format | Retention | Use Case |
+|---------|--------|-----------|----------|
+| Prometheus metrics | Gauge / Counter | 15-30 days (cluster config) | Real-time Grafana dashboards, alerting |
+| Structured logs | JSON in Python `logging` `extra` | Depends on log pipeline | Searchable via ELK / Grafana Loki |
+| JSONL file | Append-only at `log_dir` path | Permanent (disk) | Long-term audit trail, offline analysis |
+| HTTP endpoint | JSON on Prometheus HTTP port | Current snapshot only | Quick `curl` check, custom tool integration |
+
+### JSONL File Output
+
+When `advisory_file_output: true` and `log_dir` is set, each advisory cycle
+appends one JSON line:
+
+```
+File: {log_dir}/advisory_history.jsonl
+
+{"ts":1741234567,"mode":"advisory","action":"scale_up","source":"throughput",
+ "current":{"p":1,"d":1},"recommended":{"p":3,"d":1},"raw":{"p":3,"d":1},
+ "est_ttft":85.2,"est_itl":12.1,"reason_code":1}
+```
+
+**Why a separate file instead of just logs**: Prometheus has a retention window
+(typically 15-30 days). Log pipelines may also rotate. The JSONL file provides a
+permanent, simple-to-parse record that survives both. It reuses the existing
+`log_dir` config field (currently defined in `PlannerConfig` but unused).
+
+### HTTP Endpoint
+
+A lightweight JSON endpoint served on the existing Planner Prometheus HTTP port:
+
+```
+GET /advisory/status
+
+Response:
+{
+  "scaling_mode": "advisory",
+  "last_update": "2026-03-05T10:30:00Z",
+  "current": {"prefill": 1, "decode": 1},
+  "recommended": {"prefill": 3, "decode": 1},
+  "delta": {"prefill": 2, "decode": 0},
+  "action": "scale_up",
+  "reason": "throughput_prediction",
+  "sla_estimation": {
+    "est_ttft_ms": 85.2,
+    "est_itl_ms": 12.1,
+    "ttft_headroom_ms": 414.8,
+    "itl_headroom_ms": 37.9
+  }
+}
+```
+
+**Why**: Not all customers have Prometheus/Grafana. A `curl` command against the
+Planner Pod gives instant visibility. Also enables integration with customer-side
+monitoring tools via simple HTTP polling.
+
+---
+
+## 6. Disagg Mode Specifics
+
+`DisaggPlanner` manages both prefill and decode in a single loop and applies
+`_apply_global_gpu_budget()` as a joint constraint. The advisory engine must
+respect this coupling.
+
+### Advisory Output Placement
+
+```
+DisaggPlanner._throughput_loop():
+  1. observe_traffic_stats()
+  2. prefill_planner.plan_adjustment() -> raw_p
+  3. decode_planner.plan_adjustment()  -> raw_d
+  4. _apply_global_gpu_budget(raw_p, raw_d) -> final_p, final_d
+  5. >>> _emit_disagg_advisory(raw_p, raw_d, final_p, final_d)  <<<
+  6. if scaling_mode == ACTIVE: set_component_replicas(final_p, final_d)
+```
+
+Step 5 emits advisory metrics with both raw and final values. If budget caused
+clipping (`raw != final`), the GPU budget constraint log is emitted.
+
+### `no_operation` Replacement Points
+
+All `if not self.config.no_operation:` checks become mode-aware:
+
+| File | Lines | Change |
+|------|-------|--------|
+| `base.py` | 276, 759, 772, 926, 951 | `scaling_mode != NOOP` for init; `scaling_mode == ACTIVE` for execute |
+| `disagg.py` | 64, 85, 159, 244 | Same pattern |
+| `agg.py` | 86, 107, 325 | Same pattern |
+
+Pattern:
+
+```python
+# Before (boolean)
+if not self.config.no_operation:
+    await self.connector.set_component_replicas(...)
+
+# After (three-way)
+if self.config.scaling_mode == ScalingMode.ACTIVE:
+    await self.connector.set_component_replicas(...)
+```
+
+For initialization blocks:
+
+```python
+# Before
+if not self.config.no_operation:
+    self.connector = KubernetesConnector(...)
+
+# After
+if self.config.scaling_mode != ScalingMode.NOOP:
+    self.connector = KubernetesConnector(...)
+```
+
+---
+
+## 7. Grafana Advisory Dashboard
+
+An independent dashboard with 7 panels. Includes a dashboard-level link to the
+existing "Dynamo Planner - SLA & Scaling" dashboard for cross-reference.
+
+### Panel 1: Recommended vs Actual Replicas
+
+- Dual-line chart per component (prefill / decode)
+- Recommended = dashed line, Actual = solid line
+- Delta region shaded (green = headroom, red = under-provisioned)
+- Queries: `dynamo_planner_advisory_recommended_p`, `dynamo_planner_advisory_current_p`
+
+### Panel 2: Scaling Action Timeline
+
+- State timeline visualization
+- Values: 1 (scale up / green), 0 (hold / gray), -1 (scale down / blue)
+- Query: `dynamo_planner_advisory_scaling_action`
+
+### Panel 3: SLA Headroom
+
+- Dual-line: `dynamo_planner_advisory_ttft_headroom` and `dynamo_planner_advisory_itl_headroom`
+- Horizontal reference line at y=0 (boundary between safe and violation)
+- Area below 0 shaded as warning zone
+- Handles NaN display as "N/A" via Grafana's "Connect null values" = off
+
+### Panel 4: Estimated vs Actual TTFT
+
+- Two lines overlaid:
+  - `dynamo_planner_advisory_est_ttft` (what Planner predicted)
+  - `rate(dynamo_frontend_time_to_first_token_seconds_sum[3m]) / rate(dynamo_frontend_time_to_first_token_seconds_count[3m]) * 1000` (what actually happened)
+- Divergence between lines indicates estimation accuracy
+- Useful for building trust in advisory recommendations before enabling active mode
+
+### Panel 5: GPU Delta Over Time
+
+- Single line: `dynamo_planner_advisory_delta_p * prefill_gpu + dynamo_planner_advisory_delta_d * decode_gpu`
+- Positive = needs more GPUs, Negative = can release GPUs
+- Visualizes resource pressure over time
+
+### Panel 6: Recommendation Statistics
+
+- Stacked rate chart:
+  - `rate(dynamo_planner_advisory_scaleup_total[5m])`
+  - `rate(dynamo_planner_advisory_scaledown_total[5m])`
+  - `rate(dynamo_planner_advisory_hold_total[5m])`
+- Shows recommendation frequency distribution
+- A healthy Planner should mostly "hold" with occasional scale-up/down
+
+### Panel 7: Decision Context Timeline
+
+- Multi-row panel combining:
+  - Top: `planner:observed_request_rate` + `planner:predicted_request_rate`
+  - Middle: `dynamo_planner_advisory_recommended_p` vs `dynamo_planner_advisory_current_p`
+  - Bottom: `dynamo_planner_advisory_scaling_action`
+- Grafana Annotations overlay marking actual scaling events (from K8s events or DGD status changes)
+- Provides a single view of the full decision chain: traffic → prediction → recommendation → execution
+
+---
+
+## 8. Configuration Reference
+
+### New Config Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `scaling_mode` | `"active"` / `"advisory"` / `"noop"` | `"active"` | Controls scaling execution and advisory output |
+| `advisory_max_step_size` | int | 1 | Max replicas per step in path recommendations. Only affects Layer 2 log text, not the `advisory_recommended_*` metric values |
+| `advisory_anomaly_threshold` | int | 10 | Warn when `abs(delta)` exceeds this value |
+| `advisory_file_output` | bool | False | Enable JSONL file output to `log_dir` |
+
+### Validation Rules
+
+```python
+@model_validator(mode="after")
+def _validate_config(self) -> "PlannerConfig":
+    # Backward compat: no_operation -> noop
+    if self.no_operation and self.scaling_mode == ScalingMode.ACTIVE:
+        logger.warning("DEPRECATION: no_operation is deprecated. Use scaling_mode='noop'.")
+        self.scaling_mode = ScalingMode.NOOP
+
+    # File output requires log_dir
+    if self.advisory_file_output and not self.log_dir:
+        raise ValueError(
+            "advisory_file_output=True requires log_dir to be set"
+        )
+
+    # advisory_max_step_size must be positive
+    if self.advisory_max_step_size < 1:
+        raise ValueError("advisory_max_step_size must be >= 1")
+```
+
+### Config Interaction Notes
+
+- `scaling_mode: "advisory"` works with all `mode` values (`disagg`, `prefill`, `decode`, `agg`)
+- `scaling_mode: "advisory"` works with all `environment` values (`kubernetes`, `virtual`, `global-planner`)
+- In `global-planner` environment, advisory mode initializes the `GlobalPlannerConnector` but never sends `ScaleRequest` messages
+- `scaling_mode: "noop"` preserves exact current `no_operation: true` behavior — no Connector, no metrics, no logs
+
+---
+
+## 9. File Change Summary
+
+### Modified Files
+
+| File | Scope of Change |
+|------|----------------|
+| `components/src/dynamo/planner/defaults.py` | Add `ScalingMode` enum. Add `scaling_mode`, `advisory_max_step_size`, `advisory_anomaly_threshold`, `advisory_file_output` to `SLAPlannerDefaults` |
+| `components/src/dynamo/planner/config/planner_config.py` | Add new fields to `PlannerConfig`. Add backward compat validation. Add file output validation |
+| `components/src/dynamo/planner/core/base.py` | Add 15 metrics to `PlannerPrometheusMetrics`. Add `_emit_advisory_metrics()`, `_estimate_sla_with_replicas()`, `_build_path_recommendation()`, `_safe_gauge_set()`, `_write_advisory_jsonl()` to `BasePlanner`. Replace `no_operation` checks with `scaling_mode` branches. Add `/advisory/status` HTTP handler |
+| `components/src/dynamo/planner/core/disagg.py` | Replace 4 `no_operation` checks. Add advisory emission in `_throughput_loop` and `_load_loop` after GPU budget application |
+| `components/src/dynamo/planner/core/agg.py` | Replace 3 `no_operation` checks. Add advisory emission in `_load_loop` |
+| `components/src/dynamo/planner/core/prefill.py` | No structural changes. Advisory metrics emitted from parent `DisaggPlanner` |
+| `components/src/dynamo/planner/core/decode.py` | No structural changes. Advisory metrics emitted from parent `DisaggPlanner` |
+
+### New Files
+
+| File | Description |
+|------|-------------|
+| `deploy/observability/grafana_dashboards/planner_advisory.json` | Grafana dashboard JSON (7 panels) |
+| `docs/design-docs/planner-advisory-mode.md` | This design document |
+
+### No Changes Required
+
+| File | Reason |
+|------|--------|
+| `kubernetes_connector.py` | Already supports read operations. No new methods needed |
+| `global_planner_connector.py` | Advisory mode skips `set_component_replicas()` call. No changes needed |
+| `scale_protocol.py` | No protocol changes |
+| `prometheus.py` | Metric collection logic unchanged |
+| `perf_interpolation.py` | Used as-is for SLA estimation |
+| `load_based_regression.py` | Used as-is for load-based decisions |
+
+---
+
+## 10. Hierarchical Planner Compatibility
+
+In hierarchical deployments (multiple DGDs with GlobalPlanner):
+
+- Advisory metrics are emitted by **each Pool Planner** independently
+- Each Pool Planner's metrics are scoped to its own namespace (e.g., `prefill-pool-0`)
+- **GlobalPlanner requires no changes** — in advisory mode, Pool Planners never send `ScaleRequest` messages to GlobalPlanner
+- `throughput_metrics_source: "router"` is fully compatible with advisory mode since metric collection logic is shared across all modes
+- The Grafana Advisory Dashboard can filter by Planner Pod using the `instance` label
+
+---
+
+## 11. Future Iterations (v2)
+
+### Confidence Score
+
+Add `dynamo_planner_advisory_confidence` Gauge (0.0 - 1.0) based on:
+- Metrics stability (low variance in recent observations)
+- NaN frequency (fewer NaN gaps = higher confidence)
+- Prediction consistency (consecutive recommendations agreeing)
+- Regression model quality (R-squared value for load-based)
+
+### Accuracy Backtesting
+
+In active mode, compare advisory recommendations against actual post-scaling
+outcomes:
+- Record `(recommended_replicas, est_ttft)` at decision time
+- After scaling completes, record `(actual_ttft)` at steady state
+- Compute `accuracy = 1 - abs(est_ttft - actual_ttft) / est_ttft`
+- Expose as `dynamo_planner_advisory_accuracy` Gauge
+
+### Webhook and Alert Integration
+
+- Fire webhook when `advisory_ttft_headroom < 0` for N consecutive intervals
+- Configurable webhook URL and payload template
+- Integration with PagerDuty, Slack, DingTalk
+
+### Grafana Alert Rules
+
+- Alert: "SLA headroom negative for >5 minutes" (critical)
+- Alert: "Advisory recommends scale-up for >10 minutes without action" (warning, advisory mode only)
+- Alert: "Anomalous delta detected" (info)

--- a/docs/design-docs/planner-advisory-mode.md
+++ b/docs/design-docs/planner-advisory-mode.md
@@ -184,6 +184,10 @@ Note: Prometheus counters reset to zero on Pod restart. Grafana queries must use
 In v1, reason codes provide a quick signal in dashboards. Detailed reasoning
 is in the structured logs (Layer 2).
 
+> **Note (v1 implementation status):** Reason codes 0 (no traffic) and 5 (GPU
+> budget constraint) are reserved for future use and are not emitted in the
+> current implementation. Only codes 1–4 and 6 are active.
+
 **Naming convention**: Advisory metrics use `dynamo_planner_advisory_*` (underscore-separated)
 following the Dynamo naming guideline in `lib/runtime/src/metrics/prometheus_names.rs`.
 Existing Planner metrics (`planner:num_p_workers`, etc.) retain their current naming
@@ -387,6 +391,10 @@ File: {log_dir}/advisory_history.jsonl
  "est_ttft":85.2,"est_itl":12.1,"reason_code":1}
 ```
 
+> **Note (v1 implementation status):** The `raw` block (pre-budget-clipping
+> recommendation) is not yet included in the JSONL output. Currently only
+> `current` and `recommended` (post-budget) are emitted.
+
 **Why a separate file instead of just logs**: Prometheus has a retention window
 (typically 15-30 days). Log pipelines may also rotate. The JSONL file provides a
 permanent, simple-to-parse record that survives both. It reuses the existing
@@ -586,7 +594,7 @@ def _validate_config(self) -> "PlannerConfig":
 
 | File | Scope of Change |
 |------|----------------|
-| `components/src/dynamo/planner/defaults.py` | Add `ScalingMode` enum. Add `scaling_mode`, `advisory_max_step_size`, `advisory_anomaly_threshold`, `advisory_file_output` to `SLAPlannerDefaults` |
+| `components/src/dynamo/planner/config/defaults.py` | Add `ScalingMode` enum. Add `scaling_mode`, `advisory_max_step_size`, `advisory_anomaly_threshold`, `advisory_file_output` to `SLAPlannerDefaults` |
 | `components/src/dynamo/planner/config/planner_config.py` | Add new fields to `PlannerConfig`. Add backward compat validation. Add file output validation |
 | `components/src/dynamo/planner/core/base.py` | Add 15 metrics to `PlannerPrometheusMetrics`. Add `_emit_advisory_metrics()`, `_estimate_sla_with_replicas()`, `_build_path_recommendation()`, `_safe_gauge_set()`, `_write_advisory_jsonl()` to `BasePlanner`. Replace `no_operation` checks with `scaling_mode` branches. Add `/advisory/status` HTTP handler |
 | `components/src/dynamo/planner/core/disagg.py` | Replace 4 `no_operation` checks. Add advisory emission in `_throughput_loop` and `_load_loop` after GPU budget application |

--- a/examples/planner/configs/active-mode.yaml
+++ b/examples/planner/configs/active-mode.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Planner Active Mode Configuration
+#
+# In active mode, the Planner executes scaling decisions automatically.
+# It also emits advisory Prometheus metrics alongside every scaling action,
+# providing full decision traceability for post-incident review.
+#
+# Migrate from advisory mode by changing scaling_mode: advisory → active.
+# All other settings remain identical.
+#
+# How to use as a Kubernetes ConfigMap:
+#   kubectl create configmap planner-config \
+#     --from-file=config.yaml=active-mode.yaml \
+#     -n <your-namespace>
+
+scaling_mode: active
+backend: vllm
+mode: disagg
+
+# Scaling algorithm settings
+enable_throughput_scaling: true
+enable_load_scaling: false
+ttft: 2000       # TTFT SLA target in milliseconds
+itl: 50          # ITL SLA target in milliseconds
+no_correction: true
+load_predictor: constant

--- a/examples/planner/configs/advisory-mode.yaml
+++ b/examples/planner/configs/advisory-mode.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Planner Advisory Mode Configuration
+#
+# In advisory mode, the Planner observes traffic and outputs scaling recommendations
+# via Prometheus metrics and /advisory/status HTTP endpoint, but does NOT execute
+# any actual scaling. Use this mode to validate Planner decisions before enabling
+# active scaling in production.
+#
+# How to use as a Kubernetes ConfigMap:
+#   kubectl create configmap planner-config \
+#     --from-file=config.yaml=advisory-mode.yaml \
+#     -n <your-namespace>
+#
+# Then mount it in your DGD and set:
+#   args: ["--config", "/etc/planner/config.yaml"]
+#
+# After deploying, check:
+#   curl http://<planner-pod>:9085/advisory/status
+#   curl http://<planner-pod>:9085/metrics | grep advisory
+
+scaling_mode: advisory
+backend: vllm
+mode: disagg
+
+# Scaling algorithm settings
+enable_throughput_scaling: true
+enable_load_scaling: false
+ttft: 2000       # TTFT SLA target in milliseconds
+itl: 50          # ITL SLA target in milliseconds
+no_correction: true
+load_predictor: constant
+
+# Optional: enable JSONL file output for audit trail
+# advisory_file_output: true
+# log_dir: /tmp/planner    # default if not set

--- a/examples/planner/configs/noop-mode.yaml
+++ b/examples/planner/configs/noop-mode.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Planner Noop Mode Configuration
+#
+# In noop mode, the Planner does nothing: no scaling, no metrics, no advisory output.
+# Equivalent to the deprecated no_operation: true flag.
+#
+# Use this mode if you want to deploy the Planner binary but keep it completely
+# passive (e.g., during infrastructure testing).
+#
+# How to use as a Kubernetes ConfigMap:
+#   kubectl create configmap planner-config \
+#     --from-file=config.yaml=noop-mode.yaml \
+#     -n <your-namespace>
+
+scaling_mode: noop
+backend: vllm
+mode: disagg
+model_name: your-model-name    # required in noop mode (no connector to discover it)


### PR DESCRIPTION
## Summary

Supersedes #7902 — rebased onto the upstream restructured planner package (#7689, #7351).

Adds a three-mode scaling system to the Planner: **active** (default, existing behavior), **advisory** (compute + emit metrics, don't apply), and **noop** (do nothing).

### Changes

**Config (`planner_config.py`, `defaults.py`)**
- New `ScalingMode` enum: `active` / `advisory` / `noop`
- New fields: `scaling_mode`, `advisory_max_step_size`, `advisory_anomaly_threshold`, `advisory_file_output`
- Backward compat: `no_operation=True` auto-maps to `scaling_mode=noop` with deprecation warning
- `effective_scaling_mode` property for `model_construct()` compatibility
- Auto-reconcile `PLANNER_PROMETHEUS_PORT` env with config value

**Core (`base.py`, `agg.py`, `disagg.py`)**
- All `no_operation` checks replaced with `effective_scaling_mode` checks
- Advisory engine: `_emit_advisory_metrics()`, `_estimate_sla_with_replicas()`, `_build_path_recommendation()`
- Custom HTTP server: `/metrics` (Prometheus) + `/advisory/status` (JSON endpoint)
- JSONL file output for audit trail

**Monitoring (`planner_metrics.py`)**
- 15 new Prometheus metrics (`dynamo_planner_advisory_*`): 12 gauges + 3 counters

**Tests (`test_advisory_mode.py`)**
- 25 unit tests covering ScalingMode, config validation, backward compat, advisory engine methods

**Docs & Ops**
- Design doc: `docs/design-docs/planner-advisory-mode.md`
- Test report: `docs/design-docs/planner-advisory-mode-test-report.md`
- Grafana dashboard ConfigMap: `deploy/observability/k8s/grafana-advisory-dashboard-configmap.yaml`
- Example configs: `examples/planner/configs/{active,advisory,noop}-mode.yaml`

### What changed from #7902
- Rebased onto post-restructure main (`planner.utils.*` → `planner.core.*` / `planner.monitoring.*`)
- Fixed all test import paths
- Config validator: `advisory_file_output=True` with no `log_dir` now auto-fills `/tmp/planner` instead of raising

### Testing
- All 25 unit tests pass
- No changes to existing planner logic when `scaling_mode=active` (default)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced three planner operating modes: Active (automatic scaling), Advisory (recommendations without scaling), and Noop (no scaling/recommendations).
  * Added advisory recommendations engine that computes scaling suggestions with SLA headroom analysis.
  * Added HTTP endpoint `/advisory/status` for real-time advisory status snapshots.
  * Added new Prometheus metrics for advisory recommendations, including replica deltas and SLA estimates.
  * Added Grafana dashboard for visualizing advisory recommendations and scaling insights.

* **Configuration**
  * Added configuration options for advisory mode behavior and output preferences.

* **Documentation**
  * Added design documentation and example configurations for all planner modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->