### PR TITLE
fix: Fix multinode gang scheduling by setting MinAvailable to replica count on cliques

### DIFF
--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1436,12 +1436,17 @@ func GenerateGrovePodCliqueSet(
 				}
 			}
 
+			minAvailable := int32(1)
+			if isMultinode {
+				minAvailable = r.Replicas
+			}
+
 			clique := &grovev1alpha1.PodCliqueTemplateSpec{
 				Name: strings.ToLower(r.Name),
 				Spec: grovev1alpha1.PodCliqueSpec{
 					RoleName:     strings.ToLower(r.Name),
 					Replicas:     r.Replicas,
-					MinAvailable: ptr.To(int32(1)),
+					MinAvailable: ptr.To(minAvailable),
 					PodSpec:      *podSpec,
 				},
 			}

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -2255,14 +2255,14 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 									"nvidia.com/annotation1": "annotation1",
 									"nvidia.com/annotation2": "annotation2",
 								},
-							Spec: grovev1alpha1.PodCliqueSpec{
-								RoleName:     "worker-wkr",
-								Replicas:     2,
-								MinAvailable: ptr.To(int32(2)),
-								// StartsAfter: []string{"worker-ldr"},
-								PodSpec: corev1.PodSpec{
-									RestartPolicy:                 corev1.RestartPolicyAlways,
-									TerminationGracePeriodSeconds: ptr.To(int64(60)),
+								Spec: grovev1alpha1.PodCliqueSpec{
+									RoleName:     "worker-wkr",
+									Replicas:     2,
+									MinAvailable: ptr.To(int32(2)),
+									// StartsAfter: []string{"worker-ldr"},
+									PodSpec: corev1.PodSpec{
+										RestartPolicy:                 corev1.RestartPolicyAlways,
+										TerminationGracePeriodSeconds: ptr.To(int64(60)),
 										SecurityContext: &corev1.PodSecurityContext{
 											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
 										},
@@ -3253,13 +3253,13 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 									"nvidia.com/annotation1": "annotation1",
 									"nvidia.com/annotation2": "annotation2",
 								},
-							Spec: grovev1alpha1.PodCliqueSpec{
-								RoleName:     "worker-wkr",
-								Replicas:     2,
-								MinAvailable: ptr.To(int32(2)),
-								// StartsAfter: []string{"worker-ldr"},
-								PodSpec: corev1.PodSpec{
-									TerminationGracePeriodSeconds: ptr.To(int64(60)),
+								Spec: grovev1alpha1.PodCliqueSpec{
+									RoleName:     "worker-wkr",
+									Replicas:     2,
+									MinAvailable: ptr.To(int32(2)),
+									// StartsAfter: []string{"worker-ldr"},
+									PodSpec: corev1.PodSpec{
+										TerminationGracePeriodSeconds: ptr.To(int64(60)),
 										SecurityContext: &corev1.PodSecurityContext{
 											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
 										},

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -2255,14 +2255,14 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 									"nvidia.com/annotation1": "annotation1",
 									"nvidia.com/annotation2": "annotation2",
 								},
-								Spec: grovev1alpha1.PodCliqueSpec{
-									RoleName:     "worker-wkr",
-									Replicas:     2,
-									MinAvailable: ptr.To(int32(1)),
-									// StartsAfter: []string{"worker-ldr"},
-									PodSpec: corev1.PodSpec{
-										RestartPolicy:                 corev1.RestartPolicyAlways,
-										TerminationGracePeriodSeconds: ptr.To(int64(60)),
+							Spec: grovev1alpha1.PodCliqueSpec{
+								RoleName:     "worker-wkr",
+								Replicas:     2,
+								MinAvailable: ptr.To(int32(2)),
+								// StartsAfter: []string{"worker-ldr"},
+								PodSpec: corev1.PodSpec{
+									RestartPolicy:                 corev1.RestartPolicyAlways,
+									TerminationGracePeriodSeconds: ptr.To(int64(60)),
 										SecurityContext: &corev1.PodSecurityContext{
 											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
 										},
@@ -3253,13 +3253,13 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 									"nvidia.com/annotation1": "annotation1",
 									"nvidia.com/annotation2": "annotation2",
 								},
-								Spec: grovev1alpha1.PodCliqueSpec{
-									RoleName:     "worker-wkr",
-									Replicas:     2,
-									MinAvailable: ptr.To(int32(1)),
-									// StartsAfter: []string{"worker-ldr"},
-									PodSpec: corev1.PodSpec{
-										TerminationGracePeriodSeconds: ptr.To(int64(60)),
+							Spec: grovev1alpha1.PodCliqueSpec{
+								RoleName:     "worker-wkr",
+								Replicas:     2,
+								MinAvailable: ptr.To(int32(2)),
+								// StartsAfter: []string{"worker-ldr"},
+								PodSpec: corev1.PodSpec{
+									TerminationGracePeriodSeconds: ptr.To(int64(60)),
 										SecurityContext: &corev1.PodSecurityContext{
 											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
 										},


### PR DESCRIPTION

## Fix multinode DGD MinAvailable breaking gang scheduling
Fixes https://github.com/ai-dynamo/dynamo/issues/7811
### Problem
When the Dynamo operator creates a PodCliqueSet from a multinode DynamoGraphDeployment (`nodeCount > 1`), it hardcodes `MinAvailable: 1` on every PodClique. For a 3-node deployment this produces a worker clique with `replicas: 2, minAvailable: 1`, meaning KAI only gang-schedules 1 leader + 1 worker together. The remaining workers are best-effort and may be placed minutes to hours later, causing NCCL timeouts since distributed init requires all nodes present simultaneously.
### Fix
Set each clique's `MinAvailable` to its `Replicas` count when the service is multinode. Non-multinode services retain `MinAvailable: 1` to preserve rolling-update behavior.
| Clique (NodeCount=3) | Replicas | MinAvailable (before) | MinAvailable (after) |
|---|---|---|---|
| `worker-ldr` | 1 | 1 | 1 |
| `worker-wkr` | 2 | 1 | **2** |
### Changes
- `deploy/operator/internal/dynamo/graph.go` — Compute `minAvailable` from `r.Replicas` when `isMultinode` instead of hardcoding `1`
- `deploy/operator/internal/dynamo/graph_test.go` — Update expected `MinAvailable` in both multinode test cases (`sglang`, `vllm`)
### Testing
All existing tests pass, including:
- `test_generate_grove_pod_clique_set_single_node`
- `test_generate_grove_pod_gang_set_multinode_sglang`
- `test_generate_grove_pod_gang_set_multinode_vllm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated minimum pod availability requirements for multinode deployments. Pod readiness constraints now adjust based on replica count for multinode services instead of using a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->