### PR TITLE
feat: map reasoning_effort to model-specific chat template args

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -46,7 +46,7 @@ use crate::protocols::common::preprocessor::{
 use crate::protocols::common::timing::RequestTracker;
 use crate::tokenizers::Encoding;
 
-use dynamo_parsers::{ReasoningParser, ReasoningParserType};
+use dynamo_parsers::{ReasoningParser, ReasoningParserType, get_reasoning_template_key};
 use dynamo_runtime::engine::{AsyncEngine, AsyncEngineContextProvider, ResponseStream};
 use dynamo_runtime::pipeline::{
     AsyncEngineContext, Error, ManyOut, Operator, SingleIn, async_trait,
@@ -1225,10 +1225,14 @@ impl OpenAIPreprocessor {
 
     /// Override chat_template_args based on reasoning_effort
     fn apply_reasoning_overrides_to_template_args(
-        reasoning_parser: Option<&str>,
+        parser_name: Option<&str>,
         reasoning_effort: Option<&dynamo_protocols::types::ReasoningEffort>,
         chat_template_args: &mut Option<std::collections::HashMap<String, serde_json::Value>>,
     ) {
+        let Some(parser_name) = parser_name else {
+            return;
+        };
+
         let enable_thinking: Option<bool> = match reasoning_effort {
             None => None,
             Some(dynamo_protocols::types::ReasoningEffort::None) => Some(false),
@@ -1237,19 +1241,14 @@ impl OpenAIPreprocessor {
         let Some(enabled) = enable_thinking else {
             return;
         };
+
+        let thinking_template_key = get_reasoning_template_key(parser_name);
+
         let args = chat_template_args.get_or_insert_with(std::collections::HashMap::new);
-        match reasoning_parser {
-            Some("kimi_k25") | Some("deepseek_r1") => {
-                args.insert("thinking".to_string(), serde_json::Value::Bool(enabled));
-            }
-            _ => {
-                // Generic fallback: most templates use enable_thinking
-                args.insert(
-                    "enable_thinking".to_string(),
-                    serde_json::Value::Bool(enabled),
-                );
-            }
-        }
+        args.insert(
+            thinking_template_key.to_string(),
+            serde_json::Value::Bool(enabled),
+        );
     }
 
     /// Check if reasoning parsing should be disabled based on per-request parameters.
@@ -1263,41 +1262,27 @@ impl OpenAIPreprocessor {
         reasoning_parser: Option<&str>,
         chat_template_args: Option<&std::collections::HashMap<String, serde_json::Value>>,
     ) -> bool {
-        match reasoning_parser {
-            Some("kimi_k25") => {
-                if let Some(args) = chat_template_args
-                    && let Some(thinking) = args.get("thinking")
-                {
-                    return thinking == &serde_json::Value::Bool(false);
-                }
-                false
-            }
-            Some("nemotron_nano") | Some("nemotron3") => {
-                if let Some(args) = chat_template_args {
-                    if let Some(enable_thinking) = args.get("enable_thinking")
-                        && enable_thinking == &serde_json::Value::Bool(false)
-                    {
-                        return true;
-                    }
-                    if let Some(force_nonempty) = args.get("force_nonempty_content")
-                        && force_nonempty == &serde_json::Value::Bool(true)
-                    {
-                        return true;
-                    }
-                }
-                false
-            }
-            Some("deepseek_r1") | Some("deepseek_v4") | Some("deepseek-v4")
-            | Some("deepseekv4") => {
-                if let Some(args) = chat_template_args {
-                    if let Some(thinking) = args.get("thinking") {
-                        return thinking == &serde_json::Value::Bool(false);
-                    }
-                    if let Some(mode) = args.get("thinking_mode").and_then(|v| v.as_str()) {
-                        return mode == "chat";
-                    }
-                }
-                false
+        let Some(name) = reasoning_parser else {
+            return false;
+        };
+        let Some(args) = chat_template_args else {
+            return false;
+        };
+
+        // Generic: check the parser's own thinking template key
+        let key = get_reasoning_template_key(name);
+        if args.get(key) == Some(&serde_json::Value::Bool(false)) {
+            return true;
+        }
+
+        // Model-specific additional disable conditions
+        match name {
+            "deepseek_r1" | "deepseek_v4" | "deepseek-v4" | "deepseekv4" => args
+                .get("thinking_mode")
+                .and_then(|v| v.as_str())
+                .is_some_and(|mode| mode == "chat"),
+            "nemotron_nano" | "nemotron3" => {
+                args.get("force_nonempty_content") == Some(&serde_json::Value::Bool(true))
             }
             _ => false,
         }
@@ -1937,27 +1922,6 @@ mod tests {
                 None,
                 "basic + no effort → args unchanged",
             ),
-            (
-                Some("kimi_k25"),
-                None,
-                None,
-                None,
-                "kimi_k25 + no effort → args unchanged",
-            ),
-            (
-                Some("deepseek_r1"),
-                None,
-                None,
-                None,
-                "deepseek_r1 + no effort → args unchanged",
-            ),
-            (
-                None,
-                None,
-                None,
-                None,
-                "no parser + no effort → args unchanged",
-            ),
             // ReasoningEffort::None → explicitly disables reasoning
             (
                 Some("basic"),
@@ -1966,28 +1930,7 @@ mod tests {
                 Some(false),
                 "basic + None → enable_thinking=false",
             ),
-            (
-                Some("kimi_k25"),
-                Some(ReasoningEffort::None),
-                Some("thinking"),
-                Some(false),
-                "kimi_k25 + None → thinking=false",
-            ),
-            (
-                Some("deepseek_r1"),
-                Some(ReasoningEffort::None),
-                Some("thinking"),
-                Some(false),
-                "deepseek_r1 + None → thinking=false",
-            ),
-            (
-                None,
-                Some(ReasoningEffort::None),
-                Some("enable_thinking"),
-                Some(false),
-                "no parser + None → enable_thinking=false",
-            ),
-            // Generic / unknown parsers → "enable_thinking" = true
+            // Generic parsers → "enable_thinking" = true
             (
                 Some("basic"),
                 Some(ReasoningEffort::Minimal),
@@ -2002,20 +1945,13 @@ mod tests {
                 Some(true),
                 "nemotron_nano + Low → enable_thinking=true",
             ),
-            (
-                None,
-                Some(ReasoningEffort::Medium),
-                Some("enable_thinking"),
-                Some(true),
-                "no parser + Medium → enable_thinking=true",
-            ),
             // kimi_k25 → "thinking" = true
             (
                 Some("kimi_k25"),
-                Some(ReasoningEffort::High),
+                Some(ReasoningEffort::Medium),
                 Some("thinking"),
                 Some(true),
-                "kimi_k25 + High → thinking=true",
+                "kimi_k25 + Medium → thinking=true",
             ),
             // deepseek_r1 → "thinking" = true
             (

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1223,6 +1223,35 @@ impl OpenAIPreprocessor {
         jail.apply_with_finish_reason(stream)
     }
 
+    /// Override chat_template_args based on reasoning_effort
+    fn apply_reasoning_overrides_to_template_args(
+        reasoning_parser: Option<&str>,
+        reasoning_effort: Option<&dynamo_protocols::types::ReasoningEffort>,
+        chat_template_args: &mut Option<std::collections::HashMap<String, serde_json::Value>>,
+    ) {
+        let enable_thinking: Option<bool> = match reasoning_effort {
+            None => None,
+            Some(dynamo_protocols::types::ReasoningEffort::None) => Some(false),
+            _ => Some(true),
+        };
+        let Some(enabled) = enable_thinking else {
+            return;
+        };
+        let args = chat_template_args.get_or_insert_with(std::collections::HashMap::new);
+        match reasoning_parser {
+            Some("kimi_k25") | Some("deepseek_r1") => {
+                args.insert("thinking".to_string(), serde_json::Value::Bool(enabled));
+            }
+            _ => {
+                // Generic fallback: most templates use enable_thinking
+                args.insert(
+                    "enable_thinking".to_string(),
+                    serde_json::Value::Bool(enabled),
+                );
+            }
+        }
+    }
+
     /// Check if reasoning parsing should be disabled based on per-request parameters.
     /// For kimi_k25: disabled when chat_template_args contains "thinking": false.
     /// For nemotron_nano: disabled when chat_template_args contains "enable_thinking": false
@@ -1387,6 +1416,13 @@ impl
 
         // Set stream=true for internal processing (after audit capture)
         request.inner.stream = Some(true);
+
+        // Override chat_template_args based on reasoning_effort
+        Self::apply_reasoning_overrides_to_template_args(
+            self.runtime_config.reasoning_parser.as_deref(),
+            request.inner.reasoning_effort.as_ref(),
+            &mut request.chat_template_args,
+        );
 
         // create a response generator
         let response_generator = request.response_generator(context.id().to_string());
@@ -1882,6 +1918,138 @@ mod tests {
                 OpenAIPreprocessor::is_reasoning_disabled_by_request(parser, args),
                 expected,
                 "FAILED: {desc}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_apply_reasoning_overrides_to_template_args() {
+        use dynamo_protocols::types::ReasoningEffort;
+
+        // (parser, effort, expected_key, expected_value, description)
+        // expected_key = None means the call should leave args unchanged.
+        let cases: Vec<(
+            Option<&str>,
+            Option<ReasoningEffort>,
+            Option<&str>,
+            Option<bool>,
+            &str,
+        )> = vec![
+            // No effort → args unchanged regardless of parser
+            (Some("basic"), None, None, None, "basic + no effort → args unchanged"),
+            (Some("kimi_k25"), None, None, None, "kimi_k25 + no effort → args unchanged"),
+            (Some("deepseek_r1"), None, None, None, "deepseek_r1 + no effort → args unchanged"),
+            (None, None, None, None, "no parser + no effort → args unchanged"),
+            // ReasoningEffort::None → explicitly disables reasoning
+            (
+                Some("basic"),
+                Some(ReasoningEffort::None),
+                Some("enable_thinking"),
+                Some(false),
+                "basic + None → enable_thinking=false",
+            ),
+            (
+                Some("kimi_k25"),
+                Some(ReasoningEffort::None),
+                Some("thinking"),
+                Some(false),
+                "kimi_k25 + None → thinking=false",
+            ),
+            (
+                Some("deepseek_r1"),
+                Some(ReasoningEffort::None),
+                Some("thinking"),
+                Some(false),
+                "deepseek_r1 + None → thinking=false",
+            ),
+            (
+                None,
+                Some(ReasoningEffort::None),
+                Some("enable_thinking"),
+                Some(false),
+                "no parser + None → enable_thinking=false",
+            ),
+            // Generic / unknown parsers → "enable_thinking" = true
+            (
+                Some("basic"),
+                Some(ReasoningEffort::Minimal),
+                Some("enable_thinking"),
+                Some(true),
+                "basic + Minimal → enable_thinking=true",
+            ),
+            (
+                Some("nemotron_nano"),
+                Some(ReasoningEffort::Low),
+                Some("enable_thinking"),
+                Some(true),
+                "nemotron_nano + Low → enable_thinking=true",
+            ),
+            (
+                None,
+                Some(ReasoningEffort::Medium),
+                Some("enable_thinking"),
+                Some(true),
+                "no parser + Medium → enable_thinking=true",
+            ),
+            // kimi_k25 → "thinking" = true
+            (
+                Some("kimi_k25"),
+                Some(ReasoningEffort::High),
+                Some("thinking"),
+                Some(true),
+                "kimi_k25 + High → thinking=true",
+            ),
+            // deepseek_r1 → "thinking" = true
+            (
+                Some("deepseek_r1"),
+                Some(ReasoningEffort::High),
+                Some("thinking"),
+                Some(true),
+                "deepseek_r1 + High → thinking=true",
+            ),
+        ];
+
+        for (parser, effort, expected_key, expected_value, desc) in &cases {
+            let mut args = None;
+            OpenAIPreprocessor::apply_reasoning_overrides_to_template_args(
+                *parser,
+                effort.as_ref(),
+                &mut args,
+            );
+            match (expected_key, expected_value) {
+                (None, _) => {
+                    assert!(args.is_none(), "FAILED (args should stay unchanged): {desc}");
+                }
+                (Some(key), Some(val)) => {
+                    let map = args.as_ref().unwrap_or_else(|| {
+                        panic!("FAILED (args should be Some): {desc}");
+                    });
+                    assert_eq!(
+                        map.get(*key),
+                        Some(&serde_json::Value::Bool(*val)),
+                        "FAILED: {desc}",
+                    );
+                }
+                _ => unreachable!("bad test case: {desc}"),
+            }
+        }
+
+        // Separate check: pre-existing keys are preserved when args is already Some
+        {
+            let mut args = Some(std::collections::HashMap::from([(
+                "custom".to_string(),
+                serde_json::Value::String("keep_me".to_string()),
+            )]));
+            OpenAIPreprocessor::apply_reasoning_overrides_to_template_args(
+                Some("basic"),
+                Some(&ReasoningEffort::High),
+                &mut args,
+            );
+            let map = args.as_ref().unwrap();
+            assert_eq!(
+                map.get("custom"),
+                Some(&serde_json::Value::String("keep_me".to_string())),
+                "pre-existing keys must survive",
             );
         }
     }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1928,18 +1928,36 @@ mod tests {
 
         // (parser, effort, expected_key, expected_value, description)
         // expected_key = None means the call should leave args unchanged.
-        let cases: Vec<(
-            Option<&str>,
-            Option<ReasoningEffort>,
-            Option<&str>,
-            Option<bool>,
-            &str,
-        )> = vec![
+        let cases = [
             // No effort → args unchanged regardless of parser
-            (Some("basic"), None, None, None, "basic + no effort → args unchanged"),
-            (Some("kimi_k25"), None, None, None, "kimi_k25 + no effort → args unchanged"),
-            (Some("deepseek_r1"), None, None, None, "deepseek_r1 + no effort → args unchanged"),
-            (None, None, None, None, "no parser + no effort → args unchanged"),
+            (
+                Some("basic"),
+                None,
+                None,
+                None,
+                "basic + no effort → args unchanged",
+            ),
+            (
+                Some("kimi_k25"),
+                None,
+                None,
+                None,
+                "kimi_k25 + no effort → args unchanged",
+            ),
+            (
+                Some("deepseek_r1"),
+                None,
+                None,
+                None,
+                "deepseek_r1 + no effort → args unchanged",
+            ),
+            (
+                None,
+                None,
+                None,
+                None,
+                "no parser + no effort → args unchanged",
+            ),
             // ReasoningEffort::None → explicitly disables reasoning
             (
                 Some("basic"),
@@ -2018,7 +2036,10 @@ mod tests {
             );
             match (expected_key, expected_value) {
                 (None, _) => {
-                    assert!(args.is_none(), "FAILED (args should stay unchanged): {desc}");
+                    assert!(
+                        args.is_none(),
+                        "FAILED (args should stay unchanged): {desc}"
+                    );
                 }
                 (Some(key), Some(val)) => {
                     let map = args.as_ref().unwrap_or_else(|| {

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -69,9 +69,9 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ParserConfig> {
         // the HF model / vLLM recipe / chat-template author picked. We accept
         // all three separator conventions (snake / kebab / concat) rather than
         // force a single canonical form on users.
-        map.insert("deepseek_v4", ParserConfig::new(DeepSeekV4));
-        map.insert("deepseek-v4", ParserConfig::new(DeepSeekV4));
-        map.insert("deepseekv4", ParserConfig::new(DeepSeekV4));
+        map.insert("deepseek_v4", ParserConfig::with_key(DeepSeekV4, "thinking"));
+        map.insert("deepseek-v4", ParserConfig::with_key(DeepSeekV4, "thinking"));
+        map.insert("deepseekv4", ParserConfig::with_key(DeepSeekV4, "thinking"));
         map.insert("nemotron_deci", ParserConfig::new(NemotronDeci));
         map.insert("kimi", ParserConfig::new(Kimi));
         map.insert("kimi_k25", ParserConfig::with_key(KimiK25, "thinking"));

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -19,16 +19,43 @@ pub use minimax_append_think_parser::MiniMaxAppendThinkParser;
 /// `KimiK2ParserConfig::default().section_start` in `crate::tool_calling::config`.
 pub(crate) const KIMI_K2_TOOL_SECTION_BEGIN: &str = "<|tool_calls_section_begin|>";
 
-static REASONING_PARSER_MAP: OnceLock<HashMap<&'static str, ReasoningParserType>> = OnceLock::new();
+static REASONING_PARSER_MAP: OnceLock<HashMap<&'static str, ParserConfig>> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy)]
+struct ParserConfig {
+    parser_type: ReasoningParserType,
+    /// chat template arg key that controls reasoning on/off
+    thinking_template_key: &'static str,
+}
+
+impl ParserConfig {
+    fn new(parser_type: ReasoningParserType) -> Self {
+        Self {
+            parser_type,
+            thinking_template_key: "enable_thinking",
+        }
+    }
+
+    fn with_key(parser_type: ReasoningParserType, key: &'static str) -> Self {
+        Self {
+            parser_type,
+            thinking_template_key: key,
+        }
+    }
+}
 
 /// Initialize the global reasoning parser map
-fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserType> {
+fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ParserConfig> {
     REASONING_PARSER_MAP.get_or_init(|| {
+        use ReasoningParserType::*;
         let mut map = HashMap::new();
-        map.insert("deepseek_r1", ReasoningParserType::DeepseekR1);
-        map.insert("basic", ReasoningParserType::Basic);
-        map.insert("gpt_oss", ReasoningParserType::GptOss);
-        map.insert("qwen3", ReasoningParserType::Qwen);
+        map.insert(
+            "deepseek_r1",
+            ParserConfig::with_key(DeepseekR1, "thinking"),
+        );
+        map.insert("basic", ParserConfig::new(Basic));
+        map.insert("gpt_oss", ParserConfig::new(GptOss));
+        map.insert("qwen3", ParserConfig::new(Qwen));
         // DeepSeek-V4 uses the same `<think>` / `</think>` delimiters as Qwen
         // (confirmed against deepseek-ai/DeepSeek-V4-Pro's encoding_dsv4.py)
         // so it delegates to the same `BasicReasoningParser` config today. We
@@ -42,21 +69,21 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserT
         // the HF model / vLLM recipe / chat-template author picked. We accept
         // all three separator conventions (snake / kebab / concat) rather than
         // force a single canonical form on users.
-        map.insert("deepseek_v4", ReasoningParserType::DeepSeekV4);
-        map.insert("deepseek-v4", ReasoningParserType::DeepSeekV4);
-        map.insert("deepseekv4", ReasoningParserType::DeepSeekV4);
-        map.insert("nemotron_deci", ReasoningParserType::NemotronDeci);
-        map.insert("kimi", ReasoningParserType::Kimi);
-        map.insert("kimi_k25", ReasoningParserType::KimiK25);
-        map.insert("step3", ReasoningParserType::Step3);
-        map.insert("mistral", ReasoningParserType::Mistral);
-        map.insert("granite", ReasoningParserType::Granite);
-        map.insert("nemotron_nano", ReasoningParserType::DeepseekR1); // nemotron nano is ...</think>
-        map.insert("nemotron3", ReasoningParserType::DeepseekR1);
-        map.insert("glm45", ReasoningParserType::NemotronDeci); // GLM-4.5/5 is <think>...</think>, no force_reasoning
+        map.insert("deepseek_v4", ParserConfig::new(DeepSeekV4));
+        map.insert("deepseek-v4", ParserConfig::new(DeepSeekV4));
+        map.insert("deepseekv4", ParserConfig::new(DeepSeekV4));
+        map.insert("nemotron_deci", ParserConfig::new(NemotronDeci));
+        map.insert("kimi", ParserConfig::new(Kimi));
+        map.insert("kimi_k25", ParserConfig::with_key(KimiK25, "thinking"));
+        map.insert("step3", ParserConfig::new(Step3));
+        map.insert("mistral", ParserConfig::new(Mistral));
+        map.insert("granite", ParserConfig::new(Granite));
+        map.insert("nemotron_nano", ParserConfig::new(DeepseekR1)); // nemotron nano is ...</think>
+        map.insert("nemotron3", ParserConfig::new(DeepseekR1));
+        map.insert("glm45", ParserConfig::new(NemotronDeci)); // GLM-4.5/5 is <think>...</think>, no force_reasoning
         map.insert(
             "minimax_append_think",
-            ReasoningParserType::MiniMaxAppendThink,
+            ParserConfig::new(MiniMaxAppendThink),
         );
         map
     })
@@ -65,6 +92,15 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserT
 /// Get all available reasoning parser names
 pub fn get_available_reasoning_parsers() -> Vec<&'static str> {
     get_reasoning_parser_map().keys().copied().collect()
+}
+
+/// Returns the chat template arg key that controls reasoning for the given parser name
+pub fn get_reasoning_template_key(name: &str) -> &'static str {
+    let normalized = name.to_lowercase();
+    get_reasoning_parser_map()
+        .get(normalized.as_str())
+        .map(|c| c.thinking_template_key)
+        .unwrap_or("enable_thinking")
 }
 
 #[derive(Debug, Clone, Default)]
@@ -250,7 +286,7 @@ impl ReasoningParserType {
         let normalized_name = name.to_lowercase();
 
         match parser_map.get(normalized_name.as_str()) {
-            Some(parser_type) => parser_type.get_reasoning_parser(),
+            Some(config) => config.parser_type.get_reasoning_parser(),
             None => {
                 tracing::warn!(
                     parser_name = name,
@@ -534,5 +570,20 @@ mod tests {
         }
         assert_eq!(all_reasoning, "reasoning done.");
         assert_eq!(all_content, "Hello world");
+    }
+
+    #[test]
+    fn test_get_reasoning_template_key() {
+        // Parsers that default to "enable_thinking"
+        assert_eq!(get_reasoning_template_key("basic"), "enable_thinking");
+        assert_eq!(
+            get_reasoning_template_key("nemotron_nano"),
+            "enable_thinking"
+        );
+        // Parsers that use "thinking" key
+        assert_eq!(get_reasoning_template_key("deepseek_r1"), "thinking");
+        assert_eq!(get_reasoning_template_key("kimi_k25"), "thinking");
+        // Unknown parser falls back to "enable_thinking"
+        assert_eq!(get_reasoning_template_key("nonexistent"), "enable_thinking");
     }
 }

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -69,8 +69,14 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ParserConfig> {
         // the HF model / vLLM recipe / chat-template author picked. We accept
         // all three separator conventions (snake / kebab / concat) rather than
         // force a single canonical form on users.
-        map.insert("deepseek_v4", ParserConfig::with_key(DeepSeekV4, "thinking"));
-        map.insert("deepseek-v4", ParserConfig::with_key(DeepSeekV4, "thinking"));
+        map.insert(
+            "deepseek_v4",
+            ParserConfig::with_key(DeepSeekV4, "thinking"),
+        );
+        map.insert(
+            "deepseek-v4",
+            ParserConfig::with_key(DeepSeekV4, "thinking"),
+        );
         map.insert("deepseekv4", ParserConfig::with_key(DeepSeekV4, "thinking"));
         map.insert("nemotron_deci", ParserConfig::new(NemotronDeci));
         map.insert("kimi", ParserConfig::new(Kimi));


### PR DESCRIPTION
#### Overview:

Currently, the `reasoning_effort` parameter in the Chat Completions API is accepted but has no effect on reasoning models. Users who want to control thinking behavior must manually set model-specific `chat_template_args` (e.g., `enable_thinking` for Qwen, `thinking` for DeepSeek/Kimi), which breaks OpenAI compatibility and forces users to learn per-model internals.

This PR makes `reasoning_effort` actually work by translating it into the correct `chat_template_args` key before template rendering:
- `reasoning_effort: "none"` → disable thinking (`false`)
- `reasoning_effort: "minimal" | "low" | "medium" | "high"` → enable thinking (`true`)
- No `reasoning_effort` → no override (existing behavior preserved)

#### Details:

- Added `None` variant to `ReasoningEffort` enum so users can explicitly disable reasoning via `"reasoning_effort": "none"`.
- New `apply_reasoning_overrides_to_template_args` translates `(reasoning_parser, reasoning_effort)` into the correct template arg: `"thinking"` for kimi_k25/deepseek_r1, `"enable_thinking"` for everything else.
- Called in the chat completion `Operator::generate` before template rendering, so the override is in place by the time `apply_template` runs.

#### Where should the reviewer start?

`lib/llm/src/preprocessor.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "None" reasoning effort level option
  * Enhanced reasoning configuration handling for improved compatibility with different reasoning engines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->