### PR TITLE
fix: call inflight.mark_error() in media handler error paths

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1998,7 +1998,9 @@ async fn images(
                 .metrics_clone()
                 .inc_rejection(&model, super::metrics::Endpoint::Images);
         }
-        ErrorMessage::from_anyhow(e, "Failed to generate images")
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to generate images");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
     })?;
 
     // Process stream to collect metrics and drop http_queue_guard on first response
@@ -2018,7 +2020,9 @@ async fn images(
         .await
         .map_err(|e| {
             tracing::error!("Failed to fold images stream for {}: {:?}", request_id, e);
-            ErrorMessage::internal_server_error("Failed to fold images stream")
+            let err_response = ErrorMessage::internal_server_error("Failed to fold images stream");
+            inflight.mark_error(extract_error_type_from_response(&err_response));
+            err_response
         })?;
 
     inflight.mark_ok();
@@ -2085,7 +2089,9 @@ async fn videos(
                 .metrics_clone()
                 .inc_rejection(&model, super::metrics::Endpoint::Videos);
         }
-        ErrorMessage::from_anyhow(e, "Failed to generate videos")
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to generate videos");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
     })?;
 
     // Process stream to collect metrics and drop http_queue_guard on first token
@@ -2105,7 +2111,9 @@ async fn videos(
         .await
         .map_err(|e| {
             tracing::error!("Failed to fold videos stream for {}: {:?}", request_id, e);
-            ErrorMessage::internal_server_error("Failed to fold videos stream")
+            let err_response = ErrorMessage::internal_server_error("Failed to fold videos stream");
+            inflight.mark_error(extract_error_type_from_response(&err_response));
+            err_response
         })?;
 
     inflight.mark_ok();
@@ -2150,7 +2158,9 @@ async fn video_stream(
                 .metrics_clone()
                 .inc_rejection(&model, super::metrics::Endpoint::Videos);
         }
-        ErrorMessage::from_anyhow(e, "Failed to start video stream")
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to start video stream");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
     })?;
 
     // Capture the context to cancel the stream if the client disconnects.
@@ -2234,6 +2244,7 @@ async fn video_stream(
                 }
                 _ = ctx.stopped() => {
                     tracing::trace!("Context stopped; breaking MJPEG stream");
+                    inflight.mark_error(ErrorType::Cancelled);
                     break;
                 }
             }
@@ -2249,6 +2260,8 @@ async fn video_stream(
         .body(Body::from_stream(monitored_stream))
         .map(|r| r.into_response())
         .map_err(|e| {
+            // inflight is already owned by the monitored_stream which handles
+            // mark_ok (stream end) and mark_error (cancellation).
             ErrorMessage::internal_server_error(&format!("Failed to build MJPEG response: {e}"))
         })
 }


### PR DESCRIPTION
Fixes #7645

## Problem
The three media handlers (images, videos, video_stream) in `lib/llm/src/http/service/openai.rs` did not call `inflight.mark_error()` on error paths in `engine.generate()`, causing inflight request counters to leak on failures.

## Fix
Added `inflight.mark_error()` calls on all error paths in images() and videos(). For video_stream(), the inflight guard is already owned by the monitored stream which handles both mark_ok (natural end) and mark_error (cancellation).

## Test
- `cargo check --package dynamo-llm`: passes
- Pattern matches existing error handling in chat completion handlers

Fixes #7645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and tracking for image and video generation requests, ensuring more reliable error reporting when failures occur.
  * Improved handling of cancelled video streaming operations with proper state tracking.
  * More consistent error response patterns across image, video, and streaming endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-dynamo/dynamo/pull/7917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
