### PR TITLE
test(kvbm): add MLA CI tests for vLLM and TensorRT-LLM

### DIFF
--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/connector_worker.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/connector_worker.py
@@ -7,6 +7,7 @@ Implementation of vLLM KV cache manager protocol.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -30,6 +31,39 @@ if TYPE_CHECKING:
 # )
 
 from kvbm.vllm_integration.rust import KvConnectorWorker as RustKvConnectorWorker
+
+
+@dataclass
+class KvTensorLayout:
+    """Semantic description of the KV cache tensor layout.
+
+    Python derives this from VllmConfig (which has the model architecture)
+    so that Rust does not need to guess from raw tensor shapes.
+
+    For MLA models, outer_dim and inner_dim are set explicitly because Rust's
+    shape-based inference cannot distinguish the fused KV latent axis from the
+    block/page axis.  For standard attention the fields are None, which tells
+    Rust to fall back to its own contiguity-based inference (already correct).
+    """
+
+    outer_dim: Optional[int]  # None = let Rust detect; 1 for MLA
+    inner_dim: Optional[int]  # None = let Rust detect; head_size for MLA
+
+    @classmethod
+    def from_vllm_config(
+        cls, vllm_config: "VllmConfig", shape: "torch.Size", use_mla: bool = False
+    ) -> "KvTensorLayout":
+        if use_mla:
+            # MLA tensors are 3D: [num_blocks, page_size, head_size]
+            # No outer_dim axis — K and V are fused into a single latent.
+            return cls(outer_dim=1, inner_dim=shape[-1])
+        else:
+            # Standard attention: Rust already infers outer_dim and inner_dim
+            # correctly from tensor strides/contiguity.  Don't guess here —
+            # the block dimension can be at position 0 or 1 depending on the
+            # attention backend, so shape[1] is not reliably outer_dim.
+            return cls(outer_dim=None, inner_dim=None)
+
 
 DistributedRuntime = None
 if is_dyn_runtime_enabled():
@@ -103,11 +137,17 @@ class KvConnectorWorker:
                 "Hybrid models with different KV cache shapes are not supported yet."
             )
 
-        # Extract parameters
-        # TODO: Assume the block dimension is within the first 2. This will break if you're doing something weird like having 1 or 2 device blocks.
-        num_device_blocks = max(shape[0], shape[1])
         page_size = cache_config.block_size
+        use_mla = getattr(self.vllm_config.model_config, "use_mla", False)
+
+        # MLA tensors are [num_blocks, page_size, head_size] — block dim is always axis 0.
+        # Standard attention tensors are [outer_dim, num_blocks, ...] or [num_blocks, outer_dim, ...]
+        # — block dim is whichever axis is larger, which is unambiguous as long as
+        # num_blocks >> outer_dim (always true in practice).
+        num_device_blocks = shape[0] if use_mla else max(shape[0], shape[1])
         device_id = first_tensor.device.index
+
+        layout = KvTensorLayout.from_vllm_config(self.vllm_config, shape, use_mla)
 
         # Determine cache dtype
         if cache_config.cache_dtype == "auto":
@@ -123,6 +163,8 @@ class KvConnectorWorker:
             kv_cache_dtype.itemsize,
             ordered_kv_caches,
             raw_event_handles,
+            outer_dim=layout.outer_dim,
+            inner_dim=layout.inner_dim,
         )
 
     def bind_connector_metadata(self, data: bytes) -> None:

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
@@ -37,6 +37,8 @@ pub trait Worker: Send + Sync {
         device_layout_type: Option<LayoutType>,
         host_layout_type: Option<LayoutType>,
         disk_layout_type: Option<LayoutType>,
+        outer_dim: Option<usize>,
+        inner_dim: Option<usize>,
     ) -> anyhow::Result<()>;
 
     fn bind_connector_metadata(&mut self, metadata: Vec<u8>) -> anyhow::Result<()>;
@@ -132,6 +134,8 @@ impl Worker for KvConnectorWorker {
         device_layout_type: Option<LayoutType>,
         host_layout_type: Option<LayoutType>,
         disk_layout_type: Option<LayoutType>,
+        outer_dim: Option<usize>,
+        inner_dim: Option<usize>,
     ) -> anyhow::Result<()> {
         if self.kvbm_worker.get().is_some() {
             tracing::warn!("kvbm worker already registered");
@@ -194,7 +198,7 @@ impl Worker for KvConnectorWorker {
             }
         };
 
-        let config = KvbmWorkerConfig::builder()
+        let mut config_builder = KvbmWorkerConfig::builder()
             .cancel_token(get_current_cancel_token())
             .num_device_blocks(num_device_blocks)
             .page_size(page_size)
@@ -206,8 +210,14 @@ impl Worker for KvConnectorWorker {
             .host_layout_type(host_layout_type.unwrap_or(LayoutType::FullyContiguous))
             .disk_layout_type(disk_layout_type.unwrap_or(LayoutType::FullyContiguous))
             .leader_pub_url(get_leader_zmq_pub_url())
-            .leader_ack_url(get_leader_zmq_ack_url())
-            .build()?;
+            .leader_ack_url(get_leader_zmq_ack_url());
+        if let Some(od) = outer_dim {
+            config_builder = config_builder.outer_dim(Some(od));
+        }
+        if let Some(id) = inner_dim {
+            config_builder = config_builder.inner_dim(Some(id));
+        }
+        let config = config_builder.build()?;
 
         let worker = get_current_tokio_handle().block_on(async move {
             let worker = KvbmWorker::new(config, false).await?;
@@ -485,7 +495,7 @@ impl PyKvConnectorWorker {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (num_device_blocks, page_size, device_id, dtype_width_bytes, kv_caches, raw_event_handles, device_layout_type=None, host_layout_type=None, disk_layout_type=None))]
+    #[pyo3(signature = (num_device_blocks, page_size, device_id, dtype_width_bytes, kv_caches, raw_event_handles, device_layout_type=None, host_layout_type=None, disk_layout_type=None, outer_dim=None, inner_dim=None))]
     pub fn register_kv_caches(
         &mut self,
         num_device_blocks: usize,
@@ -497,6 +507,8 @@ impl PyKvConnectorWorker {
         device_layout_type: Option<PyLayoutType>,
         host_layout_type: Option<PyLayoutType>,
         disk_layout_type: Option<PyLayoutType>,
+        outer_dim: Option<usize>,
+        inner_dim: Option<usize>,
     ) -> PyResult<()> {
         // Convert Python tensors to Rust VllmTensor objects
         let mut rust_kv_caches = Vec::new();
@@ -516,6 +528,8 @@ impl PyKvConnectorWorker {
                 device_layout_type.map(|py_layout| py_layout.into()),
                 host_layout_type.map(|py_layout| py_layout.into()),
                 disk_layout_type.map(|py_layout| py_layout.into()),
+                outer_dim,
+                inner_dim,
             )
             .map_err(to_pyerr)
     }

--- a/lib/llm/src/block_manager/distributed/worker.rs
+++ b/lib/llm/src/block_manager/distributed/worker.rs
@@ -25,6 +25,7 @@ use nixl_sys::Agent as NixlAgent;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use validator::Validate;
 
 use tokio::runtime::Handle;
 use tokio_util::sync::CancellationToken;
@@ -394,13 +395,23 @@ impl Handler for BlockTransferDispatch {
     }
 }
 
-#[derive(Builder, Clone)]
+fn validate_page_size(value: usize) -> Result<(), validator::ValidationError> {
+    if !value.is_power_of_two() {
+        return Err(validator::ValidationError::new(
+            "page_size_not_power_of_two",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Builder, Clone, Validate)]
 #[builder(pattern = "owned")]
 pub struct KvbmWorkerConfig {
     cancel_token: CancellationToken,
 
     num_device_blocks: usize,
 
+    #[validate(custom(function = "validate_page_size"), range(max = 1024))]
     #[builder(default = "32")]
     page_size: usize,
 
@@ -421,6 +432,18 @@ pub struct KvbmWorkerConfig {
 
     #[builder(default = "LayoutType::FullyContiguous")]
     disk_layout_type: LayoutType,
+
+    /// Explicit outer dimension (1 for MLA, 2 for standard K/V).
+    /// When set, skips shape inference. Python should always provide this.
+    #[validate(range(min = 1, max = 2))]
+    #[builder(default = "None")]
+    pub outer_dim: Option<usize>,
+
+    /// Explicit inner dimension (head_size for MLA, num_heads * head_dim for standard).
+    /// When set, skips shape inference. Python should always provide this.
+    #[validate(range(min = 1))]
+    #[builder(default = "None")]
+    pub inner_dim: Option<usize>,
 
     #[builder(default = "None")]
     scheduler_client: Option<TransferSchedulerClient>,
@@ -444,6 +467,33 @@ impl KvbmWorkerConfig {
     pub fn builder() -> KvbmWorkerConfigBuilder {
         KvbmWorkerConfigBuilder::default()
     }
+
+    /// Validate configuration contract before use.
+    ///
+    /// Field-level rules (`outer_dim`, `inner_dim`, `page_size`) are enforced via
+    /// `#[validate]` attributes on the struct. This method additionally checks the
+    /// cross-field coupling invariant: `outer_dim` and `inner_dim` must both be
+    /// `Some` or both be `None`.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        // Run derive-based field validators (#[validate] attributes).
+        <Self as Validate>::validate(self)
+            .map_err(|e| anyhow::anyhow!("KvbmWorkerConfig validation failed: {}", e))?;
+
+        // Cross-field: outer_dim and inner_dim must be coupled (both Some or both None).
+        match (self.outer_dim, self.inner_dim) {
+            (Some(_), None) | (None, Some(_)) => {
+                anyhow::bail!(
+                    "outer_dim and inner_dim must be provided together (both Some or both None); \
+                     got outer_dim={:?}, inner_dim={:?}",
+                    self.outer_dim,
+                    self.inner_dim
+                );
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
 }
 
 pub struct KvbmWorker {
@@ -459,6 +509,8 @@ impl KvbmWorker {
             config.page_size,
             config.dtype_width_bytes
         );
+
+        config.validate()?;
 
         if config.num_device_blocks == 0 {
             return Err(anyhow::anyhow!("num_device_blocks must be greater than 0"));
@@ -476,8 +528,10 @@ impl KvbmWorker {
         let (layout_type, num_layers, outer_dim, inner_dim) = match config.device_layout_type {
             LayoutType::FullyContiguous => {
                 let num_layers = shape[1];
-                let outer_dim = shape[2];
-                let inner_dim = shape[3..].iter().product::<usize>() / config.page_size;
+                let outer_dim = config.outer_dim.unwrap_or(shape[2]);
+                let inner_dim = config
+                    .inner_dim
+                    .unwrap_or_else(|| shape[3..].iter().product::<usize>() / config.page_size);
                 tracing::info!(
                     "Inferred layout: num_layers={}, outer_dim={}, page_size={}, inner_dim={}",
                     num_layers,
@@ -494,21 +548,37 @@ impl KvbmWorker {
                 )
             }
             LayoutType::LayerSeparate { outer_contiguous } => {
-                // Use the already-detected layout type from config (no re-detection needed)
                 let layout_type = config.device_layout_type;
+                let num_layers = device_tensors.len();
 
-                // Extract outer_dim based on the provided outer_contiguous value
-                let outer_dim = if outer_contiguous {
-                    shape[0] // Outer contiguous: [outer_dim, n_blocks, ...]
-                } else {
-                    shape[1] // Block contiguous: [n_blocks, outer_dim, ...]
+                let (outer_dim, inner_dim) = match (config.outer_dim, config.inner_dim) {
+                    // Explicit dims provided by caller (e.g. Python via KvTensorLayout) — use as-is.
+                    (Some(od), Some(id)) => (od, id),
+                    // No explicit dims: infer from shape.
+                    // outer_dim valid range is [1, 2] (1 = MLA fused, 2 = standard K/V split).
+                    // If the candidate dimension exceeds 2 the tensor has no explicit K/V axis
+                    // (e.g. MLA models produce [n_blocks, page_size, latent_dim]) — fall back to
+                    // outer_dim=1 and compute inner_dim from all dims after n_blocks.
+                    _ => {
+                        let candidate = if outer_contiguous { shape[0] } else { shape[1] };
+                        if candidate <= 2 {
+                            // Standard layout: outer_dim is encoded in the shape.
+                            //   outer_contiguous=true:  [outer_dim, n_blocks, page_size, inner_dim]
+                            //   outer_contiguous=false: [n_blocks, outer_dim, page_size, inner_dim]
+                            let inner_dim = shape[2..].iter().product::<usize>() / config.page_size;
+                            (candidate, inner_dim)
+                        } else {
+                            // MLA-style: no explicit K/V split, treat as outer_dim=1.
+                            let dims_start = if outer_contiguous { 2 } else { 1 };
+                            let inner_dim =
+                                shape[dims_start..].iter().product::<usize>() / config.page_size;
+                            (1, inner_dim)
+                        }
+                    }
                 };
 
-                let num_layers = device_tensors.len();
-                let inner_dim = shape[2..].iter().product::<usize>() / config.page_size;
-
                 tracing::info!(
-                    "Inferred layout: num_layers={}, outer_dim={}, outer_contiguous={}, page_size={}, inner_dim={}",
+                    "Layout: num_layers={}, outer_dim={}, outer_contiguous={}, page_size={}, inner_dim={}",
                     num_layers,
                     outer_dim,
                     outer_contiguous,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,6 +263,7 @@ markers = [
     "deploy: marks tests as deployment tests",
     "framework_only: marks standard framework deployment tests (vllm, sglang, trtllm)",
     "framework_with_gaie: marks tests for GAIE (Gateway API Inference Extension) deployment",
+    "mla: marks tests for Multi-Latent Attention (MLA) model validation",
     # Built-in markers
     "skip: skip this test",
     "skipif: skip if condition is true",

--- a/tests/kvbm_integration/engine_config_mla_kvbm.yaml
+++ b/tests/kvbm_integration/engine_config_mla_kvbm.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+backend: pytorch
+cuda_graph_config: null
+kv_cache_config:
+  enable_partial_reuse: false
+  free_gpu_memory_fraction: 0.80
+  max_tokens: 8192
+kv_connector_config:
+  connector_module: kvbm.trtllm_integration.connector
+  connector_scheduler_class: DynamoKVBMConnectorLeader
+  connector_worker_class: DynamoKVBMConnectorWorker

--- a/tests/kvbm_integration/engine_config_mla_kvbm.yaml
+++ b/tests/kvbm_integration/engine_config_mla_kvbm.yaml
@@ -1,13 +1,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# MLA (Multi-Head Latent Attention) test config for KVBM NCCL replicated mode
+# Using DeepSeek-R1-Small-2layers with TP=4 for MLA architecture testing
 backend: pytorch
+tensor_parallel_size: 4
+pipeline_parallel_size: 1
 trust_remote_code: true
+enable_chunked_prefill: true
+max_batch_size: 16
+max_num_tokens: 8192
+max_seq_len: 8192
 cuda_graph_config: null
 kv_cache_config:
   enable_partial_reuse: false
   free_gpu_memory_fraction: 0.80
   max_tokens: 8192
+  enable_block_reuse: true
 kv_connector_config:
   connector_module: kvbm.trtllm_integration.connector
   connector_scheduler_class: DynamoKVBMConnectorLeader

--- a/tests/kvbm_integration/engine_config_mla_kvbm.yaml
+++ b/tests/kvbm_integration/engine_config_mla_kvbm.yaml
@@ -4,7 +4,7 @@
 # MLA (Multi-Head Latent Attention) test config for KVBM NCCL replicated mode
 # Using DeepSeek-R1-Small-2layers with TP=4 for MLA architecture testing
 backend: pytorch
-tensor_parallel_size: 4
+tensor_parallel_size: 2
 pipeline_parallel_size: 1
 trust_remote_code: true
 enable_chunked_prefill: true

--- a/tests/kvbm_integration/engine_config_mla_kvbm.yaml
+++ b/tests/kvbm_integration/engine_config_mla_kvbm.yaml
@@ -17,7 +17,7 @@ kv_cache_config:
   free_gpu_memory_fraction: 0.80
   max_tokens: 8192
   enable_block_reuse: true
-  tokens_per_block: 64
+  tokens_per_block: 32
 kv_connector_config:
   connector_module: kvbm.trtllm_integration.connector
   connector_scheduler_class: DynamoKVBMConnectorLeader

--- a/tests/kvbm_integration/engine_config_mla_kvbm.yaml
+++ b/tests/kvbm_integration/engine_config_mla_kvbm.yaml
@@ -17,6 +17,7 @@ kv_cache_config:
   free_gpu_memory_fraction: 0.80
   max_tokens: 8192
   enable_block_reuse: true
+  tokens_per_block: 64
 kv_connector_config:
   connector_module: kvbm.trtllm_integration.connector
   connector_scheduler_class: DynamoKVBMConnectorLeader

--- a/tests/kvbm_integration/engine_config_mla_kvbm.yaml
+++ b/tests/kvbm_integration/engine_config_mla_kvbm.yaml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 backend: pytorch
+trust_remote_code: true
 cuda_graph_config: null
 kv_cache_config:
   enable_partial_reuse: false

--- a/tests/kvbm_integration/test_mla.py
+++ b/tests/kvbm_integration/test_mla.py
@@ -218,9 +218,11 @@ class MlaDynamoWorkerProcess(ManagedProcess):
         env["DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS"] = '["generate"]'
         # TODO: Replace hardcoded port with allocate_ports() for xdist-safe parallel execution
         env["DYN_SYSTEM_PORT"] = "9345"
-        env["DYN_KVBM_CPU_CACHE_GB"] = "20"
+        env["DYN_KVBM_CPU_CACHE_GB"] = "100"
         env["DYN_KVBM_DISK_CACHE_GB"] = "60"
         env["DYN_KVBM_LEADER_WORKER_INIT_TIMEOUT_SECS"] = "1200"
+        env["DYN_KVBM_TRTLLM_ZMQ_PORT"] = "20081"
+        env["DYN_KVBM_METRICS"] = "true"
         # Enable NCCL MLA mode to exercise the code path.
         # Without MPI, _get_mpi_info() returns (None, None) and the code
         # falls back gracefully to standard per-GPU loading.

--- a/tests/kvbm_integration/test_mla.py
+++ b/tests/kvbm_integration/test_mla.py
@@ -37,8 +37,8 @@ from .common import (
 
 logger = logging.getLogger(__name__)
 
-# MLA model: DeepSeek V2 Lite with Multi-Latent Attention
-MLA_MODEL = "deepseek-ai/DeepSeek-V2-Lite"
+# MLA model: tiny 2-layer DeepSeek R1 with Multi-Latent Attention
+MLA_MODEL = "silence09/DeepSeek-R1-Small-2layers"
 
 # Module availability checks
 HAS_VLLM = check_module_available("vllm")
@@ -307,7 +307,7 @@ def send_mla_completion_request(
 @pytest.mark.trtllm
 @pytest.mark.e2e
 @pytest.mark.pre_merge
-@pytest.mark.gpu_1
+@pytest.mark.gpu_4
 @pytest.mark.mla
 @pytest.mark.model(MLA_MODEL)
 @pytest.mark.skipif(not HAS_TRTLLM, reason="requires tensorrt_llm")

--- a/tests/kvbm_integration/test_mla.py
+++ b/tests/kvbm_integration/test_mla.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+MLA (Multi-Latent Attention) integration tests for KVBM.
+
+These tests validate that MLA models (e.g., DeepSeek R1) work correctly with
+KVBM offload/onboard for both vLLM and TensorRT-LLM backends.
+
+MLA models use a compressed KV cache representation (latent attention), so these
+tests verify that KVBM handles the MLA KV blocks correctly through the full
+offload → cache reset → onboard cycle.
+
+For TensorRT-LLM, the test also exercises the DYN_KVBM_NCCL_MLA_MODE env var
+path, validating graceful fallback when MPI/NCCL is not available.
+"""
+
+import logging
+import os
+import shutil
+
+import pytest
+import requests
+
+from tests.utils.engine_process import FRONTEND_PORT
+from tests.utils.managed_process import DynamoFrontendProcess, ManagedProcess
+from tests.utils.payloads import check_models_api
+
+from .common import llm_server_kvbm  # noqa: F401
+from .common import (
+    DeterminismTester,
+    assert_deterministic,
+    check_module_available,
+    fetch_kvbm_metrics,
+)
+
+logger = logging.getLogger(__name__)
+
+# MLA model: tiny 2-layer DeepSeek R1 with Multi-Latent Attention
+MLA_MODEL = "silence09/DeepSeek-R1-Small-2layers"
+
+# Module availability checks
+HAS_VLLM = check_module_available("vllm")
+HAS_TRTLLM = check_module_available("tensorrt_llm")
+
+# Test configuration
+MAX_TOKENS = 15
+
+# Test prompt
+PROMPT = (
+    "In the heart of Eldoria, an ancient land of boundless magic and mysterious "
+    "creatures, lies the long-forgotten city of Aeloria. Once a beacon of knowledge "
+    "and power, Aeloria was buried beneath the shifting sands of time, lost to the "
+    "world for centuries. You are an intrepid explorer, known for your unparalleled "
+    "curiosity and courage, who has stumbled upon an ancient map hinting at secrets "
+    "that Aeloria holds a secret so profound that it has the potential to reshape the "
+    "very fabric of reality."
+)
+
+
+# =============================================================================
+# Helper functions
+# =============================================================================
+
+
+def print_test_header(title: str) -> None:
+    """Print a formatted test header."""
+    print(f"\n{'=' * 70}")
+    print(title)
+    print("=" * 70)
+
+
+def print_phase(phase_num: int, description: str) -> None:
+    """Print a formatted phase header."""
+    print(f"\n=== Phase {phase_num}: {description} ===")
+
+
+def check_kvbm_metrics_mla(phase_name: str, metrics_port: int) -> dict[str, int]:
+    """Fetch and display KVBM metrics."""
+    print(f"\n--- Checking KVBM metrics after {phase_name} ---")
+    metrics = fetch_kvbm_metrics(port=metrics_port)
+
+    offload_d2h = metrics.get("kvbm_offload_blocks_d2h", 0)
+    onboard_h2d = metrics.get("kvbm_onboard_blocks_h2d", 0)
+
+    print(f"  kvbm_offload_blocks_d2h: {offload_d2h}")
+    print(f"  kvbm_onboard_blocks_h2d: {onboard_h2d}")
+
+    return {
+        "kvbm_offload_blocks_d2h": offload_d2h,
+        "kvbm_onboard_blocks_h2d": onboard_h2d,
+    }
+
+
+def reset_cache(base_url: str) -> None:
+    """Reset the GPU prefix cache."""
+    print("Resetting prefix cache...")
+    try:
+        response = requests.post(f"{base_url}/reset_prefix_cache", timeout=30)
+        response.raise_for_status()
+        print("Cache reset successful")
+    except Exception as e:
+        print(f"Warning: Cache reset failed: {e}")
+
+
+# =============================================================================
+# vLLM MLA Tests
+# =============================================================================
+
+
+@pytest.fixture(scope="function")
+def mla_tester(llm_server_kvbm):  # noqa: F811
+    """Create tester bound to the KVBM-enabled server with MLA model."""
+    return DeterminismTester(
+        base_url=llm_server_kvbm.base_url,
+        model_id=MLA_MODEL,
+        server_type=llm_server_kvbm.server_type,
+    )
+
+
+@pytest.mark.kvbm
+@pytest.mark.e2e
+@pytest.mark.gpu_1
+@pytest.mark.vllm
+@pytest.mark.pre_merge
+@pytest.mark.mla
+@pytest.mark.skipif(not HAS_VLLM, reason="requires vllm")
+@pytest.mark.parametrize(
+    "llm_server_kvbm", [{"model": MLA_MODEL}], indirect=True
+)
+@pytest.mark.timeout(200)
+def test_mla_offload_and_onboard_vllm(mla_tester, llm_server_kvbm):  # noqa: F811
+    """
+    Test KVBM offload/onboard cycle with an MLA (DeepSeek R1) model on vLLM.
+
+    Validates that:
+    - MLA model KV cache blocks are correctly offloaded to CPU
+    - Cache reset clears GPU cache
+    - Re-request triggers onboard from CPU to GPU
+    - Responses are deterministic across the offload/onboard cycle
+    """
+    print_test_header("MLA OFFLOAD AND ONBOARD TEST (vLLM)")
+    print(f"Model: {MLA_MODEL}")
+
+    prompt = PROMPT[:400]
+
+    # Phase 1: Initial request triggers offload
+    print_phase(1, "Initial request (expect offload to CPU)")
+    print(f"Sending request: {prompt[:80]}...")
+
+    response_1 = mla_tester.make_request(prompt, max_tokens=MAX_TOKENS)
+    print(f"Response 1: {response_1}")
+
+    metrics = check_kvbm_metrics_mla("Phase 1", llm_server_kvbm.metrics_port)
+    assert (
+        metrics["kvbm_offload_blocks_d2h"] > 0
+    ), "Phase 1: No blocks offloaded. KVBM may not be triggering offloads for MLA model."
+    assert (
+        metrics["kvbm_onboard_blocks_h2d"] == 0
+    ), f"Phase 1: Expected 0 onboarded blocks, got {metrics['kvbm_onboard_blocks_h2d']}"
+    print(f"Phase 1: {metrics['kvbm_offload_blocks_d2h']} blocks offloaded")
+
+    # Phase 2: Reset GPU cache
+    print_phase(2, "Clean up GPU cache")
+    reset_cache(llm_server_kvbm.base_url)
+
+    # Phase 3: Repeated request triggers onboard
+    print_phase(3, "Re-send same request (expect onboard from CPU)")
+    print(f"Sending same request: {prompt[:80]}...")
+
+    response_2 = mla_tester.make_request(prompt, max_tokens=MAX_TOKENS)
+    print(f"Response 2: {response_2}")
+
+    metrics = check_kvbm_metrics_mla("Phase 3", llm_server_kvbm.metrics_port)
+    assert (
+        metrics["kvbm_onboard_blocks_h2d"] > 0
+    ), "Phase 3: No blocks onboarded. Expected CPU->GPU transfer after cache reset for MLA model."
+    print(f"Phase 3: {metrics['kvbm_onboard_blocks_h2d']} blocks onboarded from CPU")
+
+    # Verify determinism
+    print_test_header("DETERMINISM VERIFICATION")
+    assert_deterministic(
+        response_1,
+        response_2,
+        test_name="MLA Offload/Onboard",
+        label1="Initial response",
+        label2="After cache reset",
+    )
+
+    print("\n=== TEST PASSED ===")
+
+
+# =============================================================================
+# TensorRT-LLM MLA Tests
+# =============================================================================
+
+
+class MlaDynamoWorkerProcess(ManagedProcess):
+    """Process manager for Dynamo worker with TensorRT-LLM backend and MLA model."""
+
+    def __init__(self, request, worker_id: str, engine_config: str):
+        self.worker_id = worker_id
+
+        command = [
+            "python3",
+            "-m",
+            "dynamo.trtllm",
+            "--model",
+            MLA_MODEL,
+            "--served-model-name",
+            MLA_MODEL,
+            "--extra-engine-args",
+            engine_config,
+        ]
+
+        env = os.environ.copy()
+        env["DYN_LOG"] = "debug"
+        env["DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS"] = '["generate"]'
+        # TODO: Replace hardcoded port with allocate_ports() for xdist-safe parallel execution
+        env["DYN_SYSTEM_PORT"] = "9345"
+        env["DYN_KVBM_CPU_CACHE_GB"] = "20"
+        env["DYN_KVBM_DISK_CACHE_GB"] = "60"
+        env["DYN_KVBM_LEADER_WORKER_INIT_TIMEOUT_SECS"] = "1200"
+        # Enable NCCL MLA mode to exercise the code path.
+        # Without MPI, _get_mpi_info() returns (None, None) and the code
+        # falls back gracefully to standard per-GPU loading.
+        env["DYN_KVBM_NCCL_MLA_MODE"] = "true"
+
+        log_dir = f"{request.node.name}_{worker_id}"
+
+        try:
+            shutil.rmtree(log_dir)
+            logger.info(f"Cleaned up existing log directory: {log_dir}")
+        except FileNotFoundError:
+            pass
+
+        super().__init__(
+            command=command,
+            env=env,
+            health_check_urls=[
+                (f"http://localhost:{FRONTEND_PORT}/v1/models", check_models_api),
+                ("http://localhost:9345/health", self.is_ready),
+            ],
+            timeout=300,
+            display_output=True,
+            terminate_all_matching_process_names=False,
+            log_dir=log_dir,
+        )
+
+    def get_pid(self) -> int | None:
+        """Get the PID of the worker process."""
+        return self.proc.pid if hasattr(self, "proc") and self.proc else None
+
+    def is_ready(self, response) -> bool:
+        """Check the health of the worker process."""
+        try:
+            data = response.json()
+            if data.get("status") == "ready":
+                logger.info(
+                    f"{self.__class__.__name__} {{ name: {self.worker_id} }} status is ready"
+                )
+                return True
+            logger.warning(
+                f"{self.__class__.__name__} {{ name: {self.worker_id} }} status is not ready: {data.get('status')}"
+            )
+        except ValueError:
+            logger.warning(
+                f"{self.__class__.__name__} {{ name: {self.worker_id} }} health response is not valid JSON"
+            )
+        return False
+
+
+def send_mla_completion_request(
+    prompt: str, max_tokens: int, timeout: int = 120
+) -> requests.Response:
+    """Send a completion request to the frontend for the MLA model."""
+    payload = {
+        "model": MLA_MODEL,
+        "prompt": prompt,
+        "stream": False,
+        "max_tokens": max_tokens,
+    }
+
+    headers = {"Content-Type": "application/json"}
+
+    logger.info(
+        f"Sending completion request with prompt: '{prompt[:50]}...' and max_tokens: {max_tokens}"
+    )
+
+    try:
+        response = requests.post(
+            "http://localhost:8000/v1/completions",
+            headers=headers,
+            json=payload,
+            timeout=timeout,
+        )
+        return response
+    except requests.exceptions.Timeout:
+        logger.error(f"Request timed out after {timeout} seconds")
+        raise
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Request failed with error: {e}")
+        raise
+
+
+@pytest.mark.kvbm
+@pytest.mark.trtllm
+@pytest.mark.e2e
+@pytest.mark.pre_merge
+@pytest.mark.gpu_1
+@pytest.mark.mla
+@pytest.mark.skipif(not HAS_TRTLLM, reason="requires tensorrt_llm")
+def test_mla_kvbm_trtllm(request, runtime_services):
+    """
+    End-to-end test for TensorRT-LLM worker with MLA model and KVBM enabled.
+
+    Validates that:
+    - MLA model (DeepSeek R1) serves requests successfully with KVBM and TRT-LLM
+    - DYN_KVBM_NCCL_MLA_MODE=true is accepted without error (graceful fallback
+      when MPI/NCCL is not available)
+    - KVBM offloads blocks for the MLA model
+    """
+    logger.info("Starting frontend...")
+    with DynamoFrontendProcess(request):
+        logger.info("Frontend started.")
+
+        engine_config_path = (
+            "tests/kvbm_integration/engine_config_mla_kvbm.yaml"
+        )
+        logger.info(
+            f"Starting MLA worker with DYN_KVBM_NCCL_MLA_MODE=true "
+            f"(model: {MLA_MODEL})..."
+        )
+        with MlaDynamoWorkerProcess(
+            request, "decode", engine_config_path
+        ) as worker:
+            logger.info(f"Worker PID: {worker.get_pid()}")
+
+            response = send_mla_completion_request(PROMPT, 100, timeout=10)
+            assert (
+                response.ok
+            ), f"Expected successful status, got {response.status_code}"
+            logger.info(f"Completion request succeeded: {response.status_code}")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/kvbm_integration/test_mla.py
+++ b/tests/kvbm_integration/test_mla.py
@@ -37,8 +37,8 @@ from .common import (
 
 logger = logging.getLogger(__name__)
 
-# MLA model: tiny 2-layer DeepSeek R1 with Multi-Latent Attention
-MLA_MODEL = "silence09/DeepSeek-R1-Small-2layers"
+# MLA model: DeepSeek V2 Lite with Multi-Latent Attention
+MLA_MODEL = "deepseek-ai/DeepSeek-V2-Lite"
 
 # Module availability checks
 HAS_VLLM = check_module_available("vllm")
@@ -306,15 +306,10 @@ def send_mla_completion_request(
 @pytest.mark.kvbm
 @pytest.mark.trtllm
 @pytest.mark.e2e
-@pytest.mark.nightly
-@pytest.mark.slow
+@pytest.mark.pre_merge
 @pytest.mark.gpu_1
 @pytest.mark.mla
 @pytest.mark.model(MLA_MODEL)
-@pytest.mark.skip(
-    reason="TRT-LLM does not yet support deepseek_v3 architecture "
-    "(silence09/DeepSeek-R1-Small-2layers). Re-enable when TRT-LLM adds MLA model support."
-)
 @pytest.mark.skipif(not HAS_TRTLLM, reason="requires tensorrt_llm")
 def test_mla_kvbm_trtllm(request, runtime_services):
     """

--- a/tests/kvbm_integration/test_mla.py
+++ b/tests/kvbm_integration/test_mla.py
@@ -125,6 +125,7 @@ def mla_tester(llm_server_kvbm):  # noqa: F811
 @pytest.mark.vllm
 @pytest.mark.pre_merge
 @pytest.mark.mla
+@pytest.mark.model(MLA_MODEL)
 @pytest.mark.skipif(not HAS_VLLM, reason="requires vllm")
 @pytest.mark.parametrize("llm_server_kvbm", [{"model": MLA_MODEL}], indirect=True)
 @pytest.mark.timeout(200)
@@ -308,6 +309,7 @@ def send_mla_completion_request(
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
 @pytest.mark.mla
+@pytest.mark.model(MLA_MODEL)
 @pytest.mark.skipif(not HAS_TRTLLM, reason="requires tensorrt_llm")
 def test_mla_kvbm_trtllm(request, runtime_services):
     """

--- a/tests/kvbm_integration/test_mla.py
+++ b/tests/kvbm_integration/test_mla.py
@@ -303,11 +303,31 @@ def send_mla_completion_request(
         raise
 
 
+def _precache_deepseek_remote_code():
+    """Pre-cache the remote code files from deepseek-ai/DeepSeek-R1.
+
+    The silence09/DeepSeek-R1-Small-2layers model's config.json has an auto_map
+    pointing to deepseek-ai/DeepSeek-R1 for configuration_deepseek.py and
+    modeling_deepseek.py. TRT-LLM's executor subprocess needs these files but
+    may not be able to download them in offline/slow-network CI environments.
+    """
+    try:
+        from huggingface_hub import snapshot_download
+
+        snapshot_download(
+            repo_id="deepseek-ai/DeepSeek-R1",
+            allow_patterns=["*.py", "*.json"],
+            ignore_patterns=["*.safetensors", "*.bin", "*.h5", "*.msgpack", "*.ckpt*"],
+        )
+        logger.info("Pre-cached deepseek-ai/DeepSeek-R1 remote code files")
+    except Exception as e:
+        logger.warning(f"Failed to pre-cache DeepSeek-R1 remote code: {e}")
+
+
 @pytest.mark.kvbm
 @pytest.mark.trtllm
 @pytest.mark.e2e
-@pytest.mark.nightly
-@pytest.mark.slow
+@pytest.mark.pre_merge
 @pytest.mark.gpu_4
 @pytest.mark.mla
 @pytest.mark.model(MLA_MODEL)
@@ -322,6 +342,9 @@ def test_mla_kvbm_trtllm(request, runtime_services):
       when MPI/NCCL is not available)
     - KVBM offloads blocks for the MLA model
     """
+    # Pre-cache remote code files that TRT-LLM's executor subprocess needs
+    _precache_deepseek_remote_code()
+
     logger.info("Starting frontend...")
     with DynamoFrontendProcess(request):
         logger.info("Frontend started.")

--- a/tests/kvbm_integration/test_mla.py
+++ b/tests/kvbm_integration/test_mla.py
@@ -306,7 +306,8 @@ def send_mla_completion_request(
 @pytest.mark.kvbm
 @pytest.mark.trtllm
 @pytest.mark.e2e
-@pytest.mark.pre_merge
+@pytest.mark.nightly
+@pytest.mark.slow
 @pytest.mark.gpu_4
 @pytest.mark.mla
 @pytest.mark.model(MLA_MODEL)

--- a/tests/kvbm_integration/test_mla.py
+++ b/tests/kvbm_integration/test_mla.py
@@ -210,7 +210,7 @@ class MlaDynamoWorkerProcess(ManagedProcess):
             "--served-model-name",
             MLA_MODEL,
             "--tensor-parallel-size",
-            "4",
+            "2",
             "--connector",
             "kvbm",
             "--extra-engine-args",
@@ -334,7 +334,7 @@ def _precache_deepseek_remote_code():
 @pytest.mark.trtllm
 @pytest.mark.e2e
 @pytest.mark.pre_merge
-@pytest.mark.gpu_4
+@pytest.mark.gpu_2
 @pytest.mark.mla
 @pytest.mark.model(MLA_MODEL)
 @pytest.mark.skipif(not HAS_TRTLLM, reason="requires tensorrt_llm")

--- a/tests/kvbm_integration/test_mla.py
+++ b/tests/kvbm_integration/test_mla.py
@@ -209,6 +209,10 @@ class MlaDynamoWorkerProcess(ManagedProcess):
             MLA_MODEL,
             "--served-model-name",
             MLA_MODEL,
+            "--tensor-parallel-size",
+            "4",
+            "--connector",
+            "kvbm",
             "--extra-engine-args",
             engine_config,
         ]

--- a/tests/kvbm_integration/test_mla.py
+++ b/tests/kvbm_integration/test_mla.py
@@ -306,10 +306,15 @@ def send_mla_completion_request(
 @pytest.mark.kvbm
 @pytest.mark.trtllm
 @pytest.mark.e2e
-@pytest.mark.pre_merge
+@pytest.mark.nightly
+@pytest.mark.slow
 @pytest.mark.gpu_1
 @pytest.mark.mla
 @pytest.mark.model(MLA_MODEL)
+@pytest.mark.skip(
+    reason="TRT-LLM does not yet support deepseek_v3 architecture "
+    "(silence09/DeepSeek-R1-Small-2layers). Re-enable when TRT-LLM adds MLA model support."
+)
 @pytest.mark.skipif(not HAS_TRTLLM, reason="requires tensorrt_llm")
 def test_mla_kvbm_trtllm(request, runtime_services):
     """

--- a/tests/kvbm_integration/test_mla.py
+++ b/tests/kvbm_integration/test_mla.py
@@ -126,9 +126,7 @@ def mla_tester(llm_server_kvbm):  # noqa: F811
 @pytest.mark.pre_merge
 @pytest.mark.mla
 @pytest.mark.skipif(not HAS_VLLM, reason="requires vllm")
-@pytest.mark.parametrize(
-    "llm_server_kvbm", [{"model": MLA_MODEL}], indirect=True
-)
+@pytest.mark.parametrize("llm_server_kvbm", [{"model": MLA_MODEL}], indirect=True)
 @pytest.mark.timeout(200)
 def test_mla_offload_and_onboard_vllm(mla_tester, llm_server_kvbm):  # noqa: F811
     """
@@ -325,16 +323,12 @@ def test_mla_kvbm_trtllm(request, runtime_services):
     with DynamoFrontendProcess(request):
         logger.info("Frontend started.")
 
-        engine_config_path = (
-            "tests/kvbm_integration/engine_config_mla_kvbm.yaml"
-        )
+        engine_config_path = "tests/kvbm_integration/engine_config_mla_kvbm.yaml"
         logger.info(
             f"Starting MLA worker with DYN_KVBM_NCCL_MLA_MODE=true "
             f"(model: {MLA_MODEL})..."
         )
-        with MlaDynamoWorkerProcess(
-            request, "decode", engine_config_path
-        ) as worker:
+        with MlaDynamoWorkerProcess(request, "decode", engine_config_path) as worker:
             logger.info(f"Worker PID: {worker.get_pid()}")
 
             response = send_mla_completion_request(PROMPT, 100, timeout=10)


### PR DESCRIPTION
## Summary
- Add CI tests validating MLA (Multi-Latent Attention) models work with KVBM offload/onboard
- vLLM test: full offload → cache reset → onboard cycle with determinism verification
- TensorRT-LLM test: exercises `DYN_KVBM_NCCL_MLA_MODE=true` graceful fallback (no MPI/NCCL)
- Uses `silence09/DeepSeek-R1-Small-2layers` (tiny 2-layer DeepSeek R1 MLA model)
- Adds `mla` pytest marker to `pyproject.toml`

> **Note:** TRT-LLM test is temporarily marked `pre_merge` instead of `nightly` for initial validation. Will revert to `nightly` once confirmed passing.

## Test plan
- [ ] vLLM MLA test passes on GPU runner (`test_mla_offload_and_onboard_vllm`)
- [ ] TRT-LLM MLA test passes on GPU runner (`test_mla_kvbm_trtllm`)
- [ ] Revert TRT-LLM marker from `pre_merge` back to `nightly, slow` after verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Multi-Latent Attention (MLA) model support.
  * Enhanced KV cache configuration with improved validation.

* **Tests**
  * Added comprehensive MLA integration tests for vLLM and TensorRT-LLM backends.
  * Validates cache behavior and response consistency for MLA models.
  * New pytest marker for organizing MLA-specific tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->