### PR TITLE
fix: inherit request IDs in child spans + preserve span in InflightGuard [DIS-1643]

### DIFF
--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -284,6 +284,7 @@ pub struct InflightGuard {
     error_type: ErrorType,
     timer: Instant,
     request_id: String,
+    span: tracing::Span,
 }
 
 /// Requests will be logged by the type of endpoint hit
@@ -996,6 +997,7 @@ impl InflightGuard {
             error_type: ErrorType::Internal,
             timer,
             request_id,
+            span: tracing::Span::current(),
         }
     }
 
@@ -1031,6 +1033,7 @@ impl InflightGuard {
 
 impl Drop for InflightGuard {
     fn drop(&mut self) {
+        let _enter = self.span.enter();
         let duration = self.timer.elapsed().as_secs_f64();
         self.metrics.dec_inflight_gauge(&self.model);
         self.metrics.inc_request_counter(

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -804,6 +804,12 @@ where
                     trace_id = Some(parent_tracing_context.trace_id.clone());
                     parent_id = Some(parent_tracing_context.span_id.clone());
                     tracestate = parent_tracing_context.tracestate.clone();
+                    if x_request_id.is_none() {
+                        x_request_id = parent_tracing_context.x_request_id.clone();
+                    }
+                    if request_id.is_none() {
+                        request_id = parent_tracing_context.request_id.clone();
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
Two fixes for request ID propagation:

1. **DistributedTraceIdLayer**: Inherit `x_request_id` and `request_id` from parent span context when the child span doesn't set them. Without this, `inject_trace_headers_into_map` (called from child spans like `completions_single`) couldn't include `x-request-id` in transport headers, so workers never received it.

2. **InflightGuard**: Capture `Span::current()` at creation and `enter()` it in `Drop`. For streaming responses, the `http-request` span closes when response headers are sent, but `InflightGuard` drops later when the stream ends. Without the stored span, the "request completed" log lost all span context (trace_id, x_request_id, model, etc.).

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` passes (pre-existing preprocessor flake only)
- [x] E2e: `x_request_id` now appears in worker JSONL logs
- [x] E2e: cancellation "request completed" ERROR log now has full span context
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)