### PR TITLE
fix: improve etcd keepalive resilience under CoreDNS overload

### DIFF
--- a/lib/runtime/src/transports/etcd.rs
+++ b/lib/runtime/src/transports/etcd.rs
@@ -83,7 +83,10 @@ impl Client {
                     })?;
 
                 let lease_id = if config.attach_lease {
-                    create_lease(connector.clone(), 10, token)
+                    // TTL=60s: gives ~10 reconnect attempts (max_backoff=5s) before expiry.
+                    // 10s was too short — a transient CoreDNS overload (~8-30s) during
+                    // simultaneous scale-up of many instances exhausted the deadline in 1-2 tries.
+                    create_lease(connector.clone(), 60, token)
                         .await
                         .with_context(|| {
                             format!(

--- a/lib/runtime/src/transports/etcd.rs
+++ b/lib/runtime/src/transports/etcd.rs
@@ -85,7 +85,7 @@ impl Client {
                 let lease_id = if config.attach_lease {
                     // TTL=60s: gives ~10 reconnect attempts (max_backoff=5s) before expiry.
                     // 10s was too short — a transient CoreDNS overload (~8-30s) during
-                    // simultaneous scale-up of many instances exhausted the deadline in 1-2 tries.
+                    // simultaneous scale-up of many replicas exhausted the deadline in 1-2 tries.
                     create_lease(connector.clone(), 60, token)
                         .await
                         .with_context(|| {

--- a/lib/runtime/src/transports/etcd/lease.rs
+++ b/lib/runtime/src/transports/etcd/lease.rs
@@ -3,6 +3,7 @@
 
 use super::connector::Connector;
 use etcd_client::{LeaseKeepAliveStream, LeaseKeeper};
+use rand::Rng;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
@@ -87,34 +88,94 @@ async fn new_keep_alive_stream(
     deadline: &Instant,
     token: &CancellationToken,
 ) -> anyhow::Result<Option<(LeaseKeeper, LeaseKeepAliveStream)>> {
+    // Background: connector.reconnect() creates a *new lazy tonic channel*
+    // that has not yet resolved DNS. The very next keep_alive() call on that
+    // channel triggers a fresh DNS lookup. Under CoreDNS overload (e.g.
+    // simultaneous scale-up of many replicas) that lookup fails immediately,
+    // causing another reconnect() call — a tight loop that burns through the
+    // lease TTL deadline in seconds.
+    //
+    // Strategy: retry on the existing channel first (its TCP connection is
+    // already established, no DNS needed). Only call reconnect() after
+    // MAX_STREAM_RETRIES consecutive failures, to handle the case where etcd
+    // itself has actually restarted. Exponential backoff + jitter prevents
+    // synchronized DNS storms across replicas.
+    const MAX_STREAM_RETRIES: u32 = 5;
+    // Exponential backoff base: 500ms → 1s → 2s → 4s → 5s (capped).
+    // Mirrors the BackoffState used in connector.reconnect().
+    const INITIAL_BACKOFF: Duration = Duration::from_millis(500);
+    const MAX_BACKOFF: Duration = Duration::from_secs(5);
+
+    let mut consecutive_failures: u32 = 0;
+
     loop {
+        if Instant::now() >= *deadline {
+            anyhow::bail!(
+                "Unable to maintain lease - deadline exceeded while establishing keep-alive stream"
+            );
+        }
+
         let mut lease_client = connector.get_client().lease_client();
         match lease_client.keep_alive(lease_id as i64).await {
             Ok((sender, receiver)) => {
                 tracing::debug!(lease_id, "Established keep-alive stream");
-                return Ok(Some((sender, receiver))); // success
+                return Ok(Some((sender, receiver)));
             }
             Err(e) => {
-                tracing::warn!(lease_id, error = %e, "Failed to establish keep-alive stream");
+                consecutive_failures += 1;
+                tracing::warn!(
+                    lease_id,
+                    error = %e,
+                    attempt = consecutive_failures,
+                    "Failed to establish keep-alive stream"
+                );
 
-                // Try to reconnect with the deadline, but also check for cancellation
-                tokio::select! {
-                    biased;
-
-                    reconnect_result = connector.reconnect(*deadline) => {
-                        match reconnect_result {
-                            Err(e) => return Err(e), // cannot reconnect
-                            _ => continue, // retry
+                if consecutive_failures >= MAX_STREAM_RETRIES {
+                    // Enough retries on the existing channel — etcd may have
+                    // actually moved. Ask the connector for a fresh channel.
+                    tracing::warn!(
+                        lease_id,
+                        "Keep-alive stream failed {} times; reconnecting to etcd",
+                        consecutive_failures
+                    );
+                    consecutive_failures = 0;
+                    tokio::select! {
+                        biased;
+                        reconnect_result = connector.reconnect(*deadline) => {
+                            match reconnect_result {
+                                Err(e) => return Err(e),
+                                _ => continue,
+                            }
+                        }
+                        _ = token.cancelled() => {
+                            tracing::debug!(lease_id, "Cancellation token triggered during reconnection");
+                            return Ok(None);
                         }
                     }
-
-                    _ = token.cancelled() => {
-                        tracing::debug!(lease_id, "Cancellation token triggered during reconnection");
-                        return Ok(None); // cancelled
+                } else {
+                    // Retry on the existing channel with exponential backoff + jitter.
+                    // Jitter spreads retries across replicas to avoid synchronized
+                    // DNS storms when many workers fail at the same time.
+                    let exp_backoff =
+                        INITIAL_BACKOFF.saturating_mul(1u32 << (consecutive_failures - 1).min(3));
+                    let capped = std::cmp::min(exp_backoff, MAX_BACKOFF);
+                    let jitter_ms = rand::rng().random_range(0..=(capped.as_millis() / 2) as u64);
+                    let with_jitter = capped + Duration::from_millis(jitter_ms);
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    let backoff = std::cmp::min(with_jitter, remaining / 2);
+                    tokio::select! {
+                        biased;
+                        _ = token.cancelled() => {
+                            tracing::debug!(lease_id, "Cancellation token triggered during retry backoff");
+                            return Ok(None);
+                        }
+                        _ = tokio::time::sleep(backoff) => {
+                            continue;
+                        }
                     }
                 }
             }
-        };
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

During simultaneous scale-up of many replicas, CoreDNS can become temporarily
overloaded for ~8–30 seconds. etcd keepalive streams fail and leases expire,
causing workers to drop off discovery and requiring manual restarts.

**Two compounding issues:**

1. **TTL too short (10s):** DNS resolution failures during reconnect consumed
   most of the lease window in 1–2 attempts.

2. **Tight reconnect loop + fixed backoff:** `connector.reconnect()` creates a
   new *lazy* tonic channel whose first `keep_alive()` call triggers a DNS
   lookup. Under CoreDNS overload that lookup fails immediately — causing
   another `reconnect()` call. With fixed backoff and no jitter, hundreds of
   replicas retry in lockstep, creating synchronized DNS storms that make the
   overload worse.

## Fix

**`etcd.rs`** — lease TTL 10s → 60s.
Gives ~10 reconnect cycles at max backoff (5s) before expiry, enough to
outlast a transient CoreDNS event.

**`etcd/lease.rs`** — retry on existing channel with exponential backoff + jitter.

On a stream failure, retry on the *current* tonic channel (TCP already
established, no DNS needed) up to `MAX_STREAM_RETRIES=5` times before calling
`connector.reconnect()`. Backoff schedule per attempt:

| Attempt | Base | +Jitter (0–50%) | Range |
|---------|------|-----------------|-------|
| 1 | 500ms | 0–250ms | 500–750ms |
| 2 | 1s | 0–500ms | 1–1.5s |
| 3 | 2s | 0–1s | 2–3s |
| 4 | 4s | 0–2s | 4–6s → capped |
| 5+ | 5s | 0–2.5s | 5–7.5s → capped |

Jitter is random per attempt, spreading replicas that fail simultaneously
across a ±50% window to prevent synchronized DNS bursts. After 5 consecutive
failures, `connector.reconnect()` is called (which already has its own
exponential backoff via `BackoffState`) to handle actual etcd restarts.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Transient CoreDNS blip (<10s) | Lease likely expires | Survives on existing channel |
| Sustained CoreDNS overload (8–30s) | Lease expires in 1–2 attempts | Survives with 60s TTL + spread retries |
| etcd actual restart | Reconnects (tight loop) | Reconnects after 5 retries (connector.reconnect backoff) |
| Many replicas fail simultaneously | Synchronized retry storms | Jitter spreads DNS load |

## Checklist
- [x] `cargo check -p dynamo-runtime` passes
- [x] `pre-commit run` passes on changed files