### PR TITLE
feat(tests): add pytest markers to tests not picked up by CI

### DIFF
--- a/components/src/dynamo/common/tests/memory/test_multimodal_embedding_cache_manager.py
+++ b/components/src/dynamo/common/tests/memory/test_multimodal_embedding_cache_manager.py
@@ -11,6 +11,13 @@ from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
 )
 
+# Total runtime ~0.67s — no need for parallel marker.
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+]
+
 
 class TestMultimodalEmbeddingCacheManagerBasicOperations:
     """Tests for basic get/set operations."""

--- a/components/src/dynamo/common/tests/multimodal/test_async_encoder_cache.py
+++ b/components/src/dynamo/common/tests/multimodal/test_async_encoder_cache.py
@@ -14,6 +14,13 @@ from dynamo.common.memory.multimodal_embedding_cache_manager import (
 )
 from dynamo.common.multimodal.async_encoder_cache import AsyncEncoderCache
 
+# Total runtime ~0.75s — no need for parallel marker.
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+]
+
 
 class TestAsyncEncoderCacheBasicOperations:
     """Tests for basic operations."""

--- a/components/src/dynamo/common/tests/multimodal/test_embedding_transfer.py
+++ b/components/src/dynamo/common/tests/multimodal/test_embedding_transfer.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for AsyncEncoderCache."""
+"""Unit tests for embedding transfer (local, NIXL write, NIXL read, ring buffer)."""
 
 import asyncio
 import logging
@@ -22,6 +22,14 @@ from dynamo.common.multimodal.embedding_transfer import (
 )
 
 logger = logging.getLogger(__name__)
+
+# GPU tier is set per-class/per-test below (gpu_0 for local/ring buffer, gpu_1
+# for NIXL which requires CUDA).  Total runtime ~1.6s for gpu_0 subset — no
+# need for parallel marker.
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+]
 
 EMBEDDING_SIZE = 8 * 1024
 

--- a/components/src/dynamo/common/utils/tests/test_inject_reasoning_content.py
+++ b/components/src/dynamo/common/utils/tests/test_inject_reasoning_content.py
@@ -10,7 +10,16 @@ to <think> blocks in the content field before chat template rendering.
 
 import copy
 
+import pytest
+
 from dynamo.common.utils.input_params import _inject_reasoning_content
+
+# Total runtime ~0.04s — no need for parallel marker.
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+]
 
 
 class TestInjectReasoningContent:

--- a/components/src/dynamo/common/utils/tests/test_label_injecting_collector.py
+++ b/components/src/dynamo/common/utils/tests/test_label_injecting_collector.py
@@ -11,6 +11,13 @@ modifying the source metrics.
 import pytest
 from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, Summary
 
+# Total runtime ~0.05s — no need for parallel marker.
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+]
+
 
 class TestLabelInjectingCollector:
     """Test suite for LabelInjectingCollector"""

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_api.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_api.py
@@ -10,6 +10,16 @@ upgrades that break our integration surface are caught immediately.
 import inspect
 import pickle
 
+import pytest
+
+# Total runtime ~0.08s — no need for parallel marker.
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_1,
+    pytest.mark.pre_merge,
+]
+
 # ---------------------------------------------------------------------------
 # Import tests -- verify all required modules and symbols exist
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -29,6 +29,14 @@ from dynamo.frontend.sglang_processor import (
 )
 from dynamo.frontend.utils import PreprocessError, random_call_id, random_uuid
 
+# Needs sglang packages (gpu_1 container).  No need for parallel marker.
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_1,
+    pytest.mark.pre_merge,
+]
+
 MODEL = "Qwen/Qwen3-0.6B"
 
 

--- a/components/src/dynamo/frontend/tests/test_sglang_tool_calls.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_tool_calls.py
@@ -20,6 +20,14 @@ from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 
 from dynamo.frontend.sglang_prepost import SglangStreamingPostProcessor
 
+# Needs sglang packages (gpu_1 container).  No need for parallel marker.
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_1,
+    pytest.mark.pre_merge,
+]
+
 MODEL = "Qwen/Qwen3-0.6B"
 
 

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -12,6 +12,14 @@ from transformers import AutoTokenizer
 
 from dynamo.frontend.prepost import _prepare_request
 
+# Needs vllm packages (gpu_1 container).  No need for parallel marker.
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_1,
+    pytest.mark.pre_merge,
+]
+
 MODEL = "Qwen/Qwen3-0.6B"
 
 TOOL_REQUEST = {

--- a/components/src/dynamo/trtllm/tests/test_dynamic_flags.py
+++ b/components/src/dynamo/trtllm/tests/test_dynamic_flags.py
@@ -7,6 +7,14 @@ import pytest
 
 from dynamo.trtllm.dynamic_flags import infer_type, parse_dynamic_flags, set_nested
 
+# Total runtime ~0.03s — no need for parallel marker.
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
 
 class TestInferType:
     def test_int(self):


### PR DESCRIPTION
#### Overview:

Add pytest markers to 10 test files under components/src/dynamo/ that were silently skipped by CI due to missing markers.

#### Details:

- 5 common/ tests: pre_merge + integration + gpu_0
- 3 sglang frontend tests: pre_merge + unit + gpu_1 + sglang
- 1 vllm frontend test: pre_merge + unit + gpu_1 + vllm
- 1 trtllm test: pre_merge + unit + gpu_0 + trtllm
- test_embedding_transfer uses per-class gpu_0/gpu_1 (local vs NIXL)
- Fast tests (<1s) omit parallel marker
- Skipped test_trtllm_additional_metrics (pre-existing test failure)

#### Where should the reviewer start?

components/src/dynamo/common/tests/multimodal/test_embedding_transfer.py — only file with mixed per-class GPU markers

#### Related Issues:

/coderabbit profile chill