### PR TITLE
fix: add retry backoff to migration to survive iptables reload during scale-up

### DIFF
--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use anyhow::{Error, Result};
 use futures::{stream, stream::StreamExt};
+use std::time::Duration;
 
 use crate::{
     http::service::metrics::Metrics, model_card::ModelDeploymentCard, preprocessor::BackendOutput,
@@ -31,10 +32,18 @@ fn is_migratable(err: &(dyn StdError + 'static)) -> bool {
     error::match_error_chain(err, MIGRATABLE, NON_MIGRATABLE)
 }
 
+/// Backoff between migration retry attempts.
+///
+/// When kube-proxy reloads iptables during k8s scale-up, all workers' TCP
+/// connections are RST'd simultaneously for ~1-2s. Without backoff, migration
+/// exhausts its retry limit before iptables finishes reloading.
+const MIGRATION_RETRY_BACKOFF: Duration = Duration::from_secs(2);
+
 pub struct Migration {
     migration_limit: u32,
     model_name: Arc<String>,
     metrics: Arc<Metrics>,
+    retry_backoff: Duration,
 }
 
 impl Migration {
@@ -44,6 +53,7 @@ impl Migration {
             migration_limit,
             model_name: Arc::new(model_name),
             metrics,
+            retry_backoff: MIGRATION_RETRY_BACKOFF,
         })
     }
 
@@ -80,6 +90,7 @@ impl
             self.migration_limit,
             self.model_name.clone(),
             self.metrics.clone(),
+            self.retry_backoff,
         )
         .await?;
         let response_stream = stream::unfold(retry_manager, move |mut retry_manager| async move {
@@ -101,6 +112,7 @@ struct RetryManager {
     retries_left: u32,
     model_name: Arc<String>,
     metrics: Arc<Metrics>,
+    retry_backoff: Duration,
 }
 
 impl RetryManager {
@@ -111,6 +123,7 @@ impl RetryManager {
         retries_left: u32,
         model_name: Arc<String>,
         metrics: Arc<Metrics>,
+        retry_backoff: Duration,
     ) -> Result<Self> {
         let mut slf = Self {
             context,
@@ -120,6 +133,7 @@ impl RetryManager {
             retries_left: retries_left + 1, // +1 to account for the initial attempt
             model_name,
             metrics,
+            retry_backoff,
         };
         slf.new_stream().await?;
         Ok(slf)
@@ -156,8 +170,25 @@ impl RetryManager {
 
     async fn new_stream(&mut self) -> Result<()> {
         let mut response_stream: Option<Result<ManyOut<Annotated<BackendOutput>>>> = None;
+        let mut attempt: u32 = 0;
         while self.retries_left > 0 {
             self.retries_left -= 1;
+
+            // Sleep before retries (not the initial attempt) to let transient network
+            // disruptions resolve. The primary case is kube-proxy iptables reload during
+            // k8s scale-up: all workers' TCP connections are RST'd simultaneously for
+            // ~1-2s. Without backoff, migration exhausts retries before iptables finishes
+            // reloading. See also STREAM_RETRY_BACKOFF in etcd/lease.rs (same event).
+            if attempt > 0 && !self.retry_backoff.is_zero() {
+                tracing::debug!(
+                    attempt,
+                    backoff_ms = self.retry_backoff.as_millis(),
+                    "Migration retry backoff before next worker attempt"
+                );
+                tokio::time::sleep(self.retry_backoff).await;
+            }
+            attempt += 1;
+
             let request = Context::with_id(self.request.clone(), self.context.id().to_string());
             self.context.link_child(request.context());
             if self.context.is_stopped() || self.context.is_killed() {
@@ -562,6 +593,7 @@ mod tests {
             0,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            Duration::ZERO, // no backoff in tests
         )
         .await
         .expect("Failed to build RetryManager");
@@ -612,6 +644,7 @@ mod tests {
             3,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            Duration::ZERO, // no backoff in tests
         )
         .await
         .expect("Failed to build RetryManager");
@@ -663,6 +696,7 @@ mod tests {
             3,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            Duration::ZERO, // no backoff in tests
         )
         .await
         .expect("Failed to build RetryManager");
@@ -715,6 +749,7 @@ mod tests {
             3,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            Duration::ZERO, // no backoff in tests
         )
         .await;
 
@@ -754,6 +789,7 @@ mod tests {
             3,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            Duration::ZERO, // no backoff in tests
         ) // 3 retries
         .await
         .expect("Failed to build RetryManager");
@@ -812,6 +848,7 @@ mod tests {
             3,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            Duration::ZERO, // no backoff in tests
         ) // 3 retries
         .await
         .expect("Failed to build RetryManager");
@@ -875,6 +912,7 @@ mod tests {
             3,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            Duration::ZERO, // no backoff in tests
         )
         .await;
 


### PR DESCRIPTION
## Problem

During k8s scale-up, kube-proxy bulk-reloads iptables NAT rules, RST-ing all existing TCP connections simultaneously for ~1-2s. Migration's \`new_stream()\` retried immediately on each worker failure — with all workers' connections down at once, it exhausted \`migration_limit\` in under 2 seconds (before iptables finished reloading), returning "Migration limit exhausted" to the client.

## Fix

Add a 2-second backoff between retry attempts in \`new_stream()\` (not before the initial attempt). On the first worker failure, migration waits 2s before trying the next worker — iptables reload completes in that window and the next attempt succeeds.

The backoff is injected via \`Migration.retry_backoff\` (default: 2s in production, \`Duration::ZERO\` in tests) so existing unit tests remain fast. The sleep is skipped entirely when \`retry_backoff.is_zero()\`.

\`MIGRATION_RETRY_BACKOFF=2s\` matches \`STREAM_RETRY_BACKOFF\` in \`etcd/lease.rs\`, which fixes the same iptables reload event for etcd keepalive streams.

## Changes

- \`lib/llm/src/migration.rs\`: add \`MIGRATION_RETRY_BACKOFF\` constant (2s), \`retry_backoff\` field on \`Migration\` and \`RetryManager\`, sleep logic in \`new_stream()\` before each retry (attempt > 0 only), \`Duration::ZERO\` injected in all test callsites

## Test plan

- [x] Existing unit tests pass with \`Duration::ZERO\` backoff (no test slowdown)
- [x] \`cargo check -p dynamo-llm\` passes
- [x] \`pre-commit\` passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration retry behavior with configurable backoff delays (2 seconds) between retry attempts, preventing rapid successive retries and enhancing system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->