### PR TITLE
fix(operator): prevent orphaned old worker DCDs after rolling update

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -179,7 +179,7 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 			return ctrl.Result{}, err
 		}
 
-		if r.isRollingUpdateInProgress(dynamoDeployment) || r.shouldTriggerRollingUpdate(dynamoDeployment) {
+		if r.needsRollingUpdateReconciliation(dynamoDeployment) {
 			if err = r.reconcileRollingUpdate(ctx, dynamoDeployment); err != nil {
 				logger.Error(err, "Failed to reconcile rolling update")
 				state = nvidiacomv1alpha1.DGDStateFailed

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -179,7 +179,7 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 			return ctrl.Result{}, err
 		}
 
-		if r.needsRollingUpdateReconciliation(dynamoDeployment) {
+		if r.isRollingUpdateInProgress(dynamoDeployment) || r.shouldTriggerRollingUpdate(dynamoDeployment) {
 			if err = r.reconcileRollingUpdate(ctx, dynamoDeployment); err != nil {
 				logger.Error(err, "Failed to reconcile rolling update")
 				state = nvidiacomv1alpha1.DGDStateFailed

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -204,8 +204,7 @@ func (r *DynamoGraphDeploymentReconciler) isRollingUpdateInProgress(
 }
 
 // needsRollingUpdateReconciliation returns true if the rolling update state machine
-// needs to run. This includes active rolling updates, pending triggers, and the
-// Completed phase (for GC sweep of old DCDs).
+// needs to run.
 func (r *DynamoGraphDeploymentReconciler) needsRollingUpdateReconciliation(
 	dgd *nvidiacomv1alpha1.DynamoGraphDeployment,
 ) bool {
@@ -213,7 +212,7 @@ func (r *DynamoGraphDeploymentReconciler) needsRollingUpdateReconciliation(
 		phase := dgd.Status.RollingUpdate.Phase
 		if phase == nvidiacomv1alpha1.RollingUpdatePhasePending ||
 			phase == nvidiacomv1alpha1.RollingUpdatePhaseInProgress ||
-			phase == nvidiacomv1alpha1.RollingUpdatePhaseCompleted {
+			phase == nvidiacomv1alpha1.RollingUpdatePhaseCompleted { // clean up orphaned DCDs
 			return true
 		}
 	}
@@ -227,10 +226,8 @@ func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 ) error {
 	logger := log.FromContext(ctx)
 
-	// Get or create rollingUpdate status
 	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
 
-	// Compute hash information
 	newWorkerHash := dynamo.ComputeDGDWorkersSpecHash(dgd)
 	prevWorkerHash := r.getCurrentWorkerHash(dgd)
 
@@ -261,23 +258,10 @@ func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 
 	if prevWorkerHash == newWorkerHash &&
 		rollingUpdateStatus.Phase == nvidiacomv1alpha1.RollingUpdatePhaseInProgress {
-		logger.Info("Detected stuck rolling update: hashes match but phase is InProgress, force-completing",
+		logger.Info("Detected stuck rolling update: hashes match but phase is InProgress",
 			"hash", newWorkerHash,
 			"phase", rollingUpdateStatus.Phase)
-		// Hashes already match — annotation is correct, just fix the phase in memory.
-		// Deferred function in Reconcile() persists status; GC sweep on next reconcile handles cleanup.
-		rollingUpdateStatus.Phase = nvidiacomv1alpha1.RollingUpdatePhaseCompleted
-		now := metav1.Now()
-		rollingUpdateStatus.EndTime = &now
-		var allWorkerServices []string
-		for serviceName, spec := range dgd.Spec.Services {
-			if spec != nil && dynamo.IsWorkerComponent(spec.ComponentType) {
-				allWorkerServices = append(allWorkerServices, serviceName)
-			}
-		}
-		sort.Strings(allWorkerServices)
-		rollingUpdateStatus.UpdatedServices = allWorkerServices
-		return nil
+		return r.completeRollingUpdate(ctx, dgd, newWorkerHash)
 	}
 
 	switch rollingUpdateStatus.Phase {
@@ -289,23 +273,20 @@ func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 		return nil // deferred function in Reconcile() persists status
 
 	case nvidiacomv1alpha1.RollingUpdatePhaseInProgress:
-		return r.continueRollingUpdate(ctx, dgd, rollingUpdateStatus, newWorkerHash)
+		return r.continueRollingUpdate(ctx, dgd, newWorkerHash)
 
 	case nvidiacomv1alpha1.RollingUpdatePhaseCompleted:
-		// GC sweep: ensure stale old worker DCDs are cleaned up.
-		// This handles both normal post-completion cleanup and retry after previous failures.
+		// ensure stale old worker DCDs are cleaned up.
 		oldDCDs, err := r.listOldWorkerDCDs(ctx, dgd, newWorkerHash)
 		if err != nil {
 			return fmt.Errorf("failed to list old worker DCDs for GC: %w", err)
 		}
 		if len(oldDCDs) > 0 {
-			logger.Info("GC sweep: deleting orphaned old worker DCDs",
+			logger.Info("Deleting orphaned old worker DCDs",
 				"count", len(oldDCDs), "newWorkerHash", newWorkerHash)
 			if err := r.deleteOldWorkerDCDs(ctx, dgd, newWorkerHash); err != nil {
-				return fmt.Errorf("GC sweep failed to delete old worker DCDs: %w", err)
+				return fmt.Errorf("failed to delete old worker DCDs: %w", err)
 			}
-			r.Recorder.Eventf(dgd, corev1.EventTypeNormal, "GCSweepCompleted",
-				"Cleaned up %d old worker DCDs", len(oldDCDs))
 		}
 		return nil
 	}
@@ -343,7 +324,6 @@ func (r *DynamoGraphDeploymentReconciler) startRollingUpdate(
 func (r *DynamoGraphDeploymentReconciler) continueRollingUpdate(
 	ctx context.Context,
 	dgd *nvidiacomv1alpha1.DynamoGraphDeployment,
-	rollingUpdateStatus *nvidiacomv1alpha1.RollingUpdateStatus,
 	newWorkerHash string,
 ) error {
 	logger := log.FromContext(ctx)
@@ -391,6 +371,7 @@ func (r *DynamoGraphDeploymentReconciler) continueRollingUpdate(
 		}
 	}
 	sort.Strings(updatedServices)
+	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
 	rollingUpdateStatus.UpdatedServices = updatedServices
 
 	// Count total worker services
@@ -403,46 +384,31 @@ func (r *DynamoGraphDeploymentReconciler) continueRollingUpdate(
 
 	// Rolling update is complete when every worker service is individually updated
 	if len(updatedServices) == totalWorkerServices && totalWorkerServices > 0 {
-		return r.completeRollingUpdate(ctx, dgd, rollingUpdateStatus, newWorkerHash)
+		return r.completeRollingUpdate(ctx, dgd, newWorkerHash)
 	}
 
 	return nil // deferred function in Reconcile() persists UpdatedServices
 }
 
-// completeRollingUpdate cleans up old worker DCDs, updates the worker hash annotation,
-// and marks the rolling update as completed. Delete failures are NOT swallowed — they
-// return errors to trigger requeue, so the next continueRollingUpdate re-detects
-// completion and retries. The GC sweep in the Completed phase provides a safety net
-// for edge cases (e.g., orphaned DCDs from operator restarts).
+// completeRollingUpdate marks the rolling update as completed, cleans up old resources, and updates status.
+// This performs all cleanup atomically to avoid race conditions with subsequent reconciles.
 func (r *DynamoGraphDeploymentReconciler) completeRollingUpdate(
 	ctx context.Context,
 	dgd *nvidiacomv1alpha1.DynamoGraphDeployment,
-	_ *nvidiacomv1alpha1.RollingUpdateStatus,
 	newWorkerHash string,
 ) error {
 	logger := log.FromContext(ctx)
 
-	// Delete old worker DCDs first. If this fails, the error propagates back to
-	// continueRollingUpdate → reconcileRollingUpdate → Reconcile, triggering a requeue.
-	// On the next reconcile, continueRollingUpdate re-detects completion and retries.
+	// Delete all non-current worker DCDs (any number of old generations)
 	if err := r.deleteOldWorkerDCDs(ctx, dgd, newWorkerHash); err != nil {
 		return fmt.Errorf("failed to delete old worker DCDs: %w", err)
 	}
 
-	r.Recorder.Eventf(dgd, corev1.EventTypeNormal, "RollingUpdateCompleted",
-		"Rolling update completed, worker hash %s", newWorkerHash)
-
-	// Update the current worker hash annotation — the ONE metadata write per reconcile.
-	// This must happen BEFORE setting status fields because r.Update() decodes the
-	// API server response back into dgd, overwriting any in-memory status changes.
 	r.setCurrentWorkerHash(dgd, newWorkerHash)
 	if err := r.Update(ctx, dgd); err != nil {
 		return fmt.Errorf("failed to update current worker hash: %w", err)
 	}
 
-	// Set status in memory AFTER r.Update() — the API server response overwrites
-	// the in-memory object, so status must be set after the annotation write.
-	// The deferred function in Reconcile() persists these changes.
 	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
 	rollingUpdateStatus.Phase = nvidiacomv1alpha1.RollingUpdatePhaseCompleted
 	now := metav1.Now()
@@ -457,6 +423,9 @@ func (r *DynamoGraphDeploymentReconciler) completeRollingUpdate(
 	}
 	sort.Strings(allWorkerServices)
 	rollingUpdateStatus.UpdatedServices = allWorkerServices
+
+	r.Recorder.Eventf(dgd, corev1.EventTypeNormal, "RollingUpdateCompleted",
+		"Rolling update completed, worker hash %s", newWorkerHash)
 
 	logger.Info("Rolling update finalized", "newWorkerHash", newWorkerHash)
 

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -260,9 +260,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 		return r.continueRollingUpdate(ctx, dgd, newWorkerHash)
 
 	case nvidiacomv1alpha1.RollingUpdatePhaseCompleted:
-		if err := r.deleteOldWorkerDCDs(ctx, dgd, newWorkerHash); err != nil {
-			return fmt.Errorf("failed to delete old worker DCDs: %w", err)
-		}
+		logger.Info("Rolling update already completed")
 		return nil
 	}
 

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -203,6 +203,23 @@ func (r *DynamoGraphDeploymentReconciler) isRollingUpdateInProgress(
 		phase == nvidiacomv1alpha1.RollingUpdatePhaseInProgress
 }
 
+// needsRollingUpdateReconciliation returns true if the rolling update state machine
+// needs to run. This includes active rolling updates, pending triggers, and the
+// Completed phase (for GC sweep of old DCDs).
+func (r *DynamoGraphDeploymentReconciler) needsRollingUpdateReconciliation(
+	dgd *nvidiacomv1alpha1.DynamoGraphDeployment,
+) bool {
+	if dgd.Status.RollingUpdate != nil {
+		phase := dgd.Status.RollingUpdate.Phase
+		if phase == nvidiacomv1alpha1.RollingUpdatePhasePending ||
+			phase == nvidiacomv1alpha1.RollingUpdatePhaseInProgress ||
+			phase == nvidiacomv1alpha1.RollingUpdatePhaseCompleted {
+			return true
+		}
+	}
+	return r.shouldTriggerRollingUpdate(dgd)
+}
+
 // reconcileRollingUpdate handles the rolling update lifecycle.
 func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 	ctx context.Context,
@@ -244,10 +261,23 @@ func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 
 	if prevWorkerHash == newWorkerHash &&
 		rollingUpdateStatus.Phase == nvidiacomv1alpha1.RollingUpdatePhaseInProgress {
-		logger.Info("Detected stuck rolling update: hashes match but phase is InProgress",
+		logger.Info("Detected stuck rolling update: hashes match but phase is InProgress, force-completing",
 			"hash", newWorkerHash,
 			"phase", rollingUpdateStatus.Phase)
-		return r.completeRollingUpdate(ctx, dgd, rollingUpdateStatus, newWorkerHash)
+		// Hashes already match — annotation is correct, just fix the phase in memory.
+		// Deferred function in Reconcile() persists status; GC sweep on next reconcile handles cleanup.
+		rollingUpdateStatus.Phase = nvidiacomv1alpha1.RollingUpdatePhaseCompleted
+		now := metav1.Now()
+		rollingUpdateStatus.EndTime = &now
+		var allWorkerServices []string
+		for serviceName, spec := range dgd.Spec.Services {
+			if spec != nil && dynamo.IsWorkerComponent(spec.ComponentType) {
+				allWorkerServices = append(allWorkerServices, serviceName)
+			}
+		}
+		sort.Strings(allWorkerServices)
+		rollingUpdateStatus.UpdatedServices = allWorkerServices
+		return nil
 	}
 
 	switch rollingUpdateStatus.Phase {
@@ -256,17 +286,27 @@ func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 
 	case nvidiacomv1alpha1.RollingUpdatePhasePending:
 		rollingUpdateStatus.Phase = nvidiacomv1alpha1.RollingUpdatePhaseInProgress
-		if err := r.Status().Update(ctx, dgd); err != nil {
-			return fmt.Errorf("failed to update rolling update status to InProgress: %w", err)
-		}
-		return nil
+		return nil // deferred function in Reconcile() persists status
 
 	case nvidiacomv1alpha1.RollingUpdatePhaseInProgress:
 		return r.continueRollingUpdate(ctx, dgd, rollingUpdateStatus, newWorkerHash)
 
 	case nvidiacomv1alpha1.RollingUpdatePhaseCompleted:
-		// Cleanup is now done atomically in completeRollingUpdate, nothing to do here
-		logger.Info("Rolling update already completed")
+		// GC sweep: ensure stale old worker DCDs are cleaned up.
+		// This handles both normal post-completion cleanup and retry after previous failures.
+		oldDCDs, err := r.listOldWorkerDCDs(ctx, dgd, newWorkerHash)
+		if err != nil {
+			return fmt.Errorf("failed to list old worker DCDs for GC: %w", err)
+		}
+		if len(oldDCDs) > 0 {
+			logger.Info("GC sweep: deleting orphaned old worker DCDs",
+				"count", len(oldDCDs), "newWorkerHash", newWorkerHash)
+			if err := r.deleteOldWorkerDCDs(ctx, dgd, newWorkerHash); err != nil {
+				return fmt.Errorf("GC sweep failed to delete old worker DCDs: %w", err)
+			}
+			r.Recorder.Eventf(dgd, corev1.EventTypeNormal, "GCSweepCompleted",
+				"Cleaned up %d old worker DCDs", len(oldDCDs))
+		}
 		return nil
 	}
 
@@ -296,11 +336,7 @@ func (r *DynamoGraphDeploymentReconciler) startRollingUpdate(
 	r.Recorder.Eventf(dgd, corev1.EventTypeNormal, "RollingUpdateStarted",
 		"Starting rolling update from worker hash %s to %s", prevWorkerHash, newWorkerHash)
 
-	if err := r.Status().Update(ctx, dgd); err != nil {
-		return fmt.Errorf("failed to initialize rolling update status: %w", err)
-	}
-
-	return nil
+	return nil // deferred function in Reconcile() persists status
 }
 
 // continueRollingUpdate handles the in-progress phase of a rolling update.
@@ -370,35 +406,44 @@ func (r *DynamoGraphDeploymentReconciler) continueRollingUpdate(
 		return r.completeRollingUpdate(ctx, dgd, rollingUpdateStatus, newWorkerHash)
 	}
 
-	// Persist updated services list mid-rolling update
-	if err := r.Status().Update(ctx, dgd); err != nil {
-		return fmt.Errorf("failed to update rolling update status with updated services: %w", err)
-	}
-
-	return nil
+	return nil // deferred function in Reconcile() persists UpdatedServices
 }
 
-// completeRollingUpdate marks the rolling update as completed, cleans up old resources, and updates status.
-// This performs all cleanup atomically to avoid race conditions with subsequent reconciles.
+// completeRollingUpdate cleans up old worker DCDs, updates the worker hash annotation,
+// and marks the rolling update as completed. Delete failures are NOT swallowed — they
+// return errors to trigger requeue, so the next continueRollingUpdate re-detects
+// completion and retries. The GC sweep in the Completed phase provides a safety net
+// for edge cases (e.g., orphaned DCDs from operator restarts).
 func (r *DynamoGraphDeploymentReconciler) completeRollingUpdate(
 	ctx context.Context,
 	dgd *nvidiacomv1alpha1.DynamoGraphDeployment,
-	rollingUpdateStatus *nvidiacomv1alpha1.RollingUpdateStatus,
+	_ *nvidiacomv1alpha1.RollingUpdateStatus,
 	newWorkerHash string,
 ) error {
 	logger := log.FromContext(ctx)
 
-	// Delete all non-current worker DCDs (any number of old generations)
+	// Delete old worker DCDs first. If this fails, the error propagates back to
+	// continueRollingUpdate → reconcileRollingUpdate → Reconcile, triggering a requeue.
+	// On the next reconcile, continueRollingUpdate re-detects completion and retries.
 	if err := r.deleteOldWorkerDCDs(ctx, dgd, newWorkerHash); err != nil {
-		logger.Error(err, "Failed to delete non-current worker DCDs", "newWorkerHash", newWorkerHash)
-		r.Recorder.Eventf(dgd, corev1.EventTypeWarning, "CleanupPartialFailure",
-			"Failed to delete some old worker DCDs: %v", err)
-		// Continue anyway - we don't want cleanup failures to block the rolling update completion
-	} else {
-		logger.Info("Old resources cleaned up", "newWorkerHash", newWorkerHash)
+		return fmt.Errorf("failed to delete old worker DCDs: %w", err)
 	}
 
-	// Update rolling update status to Completed
+	r.Recorder.Eventf(dgd, corev1.EventTypeNormal, "RollingUpdateCompleted",
+		"Rolling update completed, worker hash %s", newWorkerHash)
+
+	// Update the current worker hash annotation — the ONE metadata write per reconcile.
+	// This must happen BEFORE setting status fields because r.Update() decodes the
+	// API server response back into dgd, overwriting any in-memory status changes.
+	r.setCurrentWorkerHash(dgd, newWorkerHash)
+	if err := r.Update(ctx, dgd); err != nil {
+		return fmt.Errorf("failed to update current worker hash: %w", err)
+	}
+
+	// Set status in memory AFTER r.Update() — the API server response overwrites
+	// the in-memory object, so status must be set after the annotation write.
+	// The deferred function in Reconcile() persists these changes.
+	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
 	rollingUpdateStatus.Phase = nvidiacomv1alpha1.RollingUpdatePhaseCompleted
 	now := metav1.Now()
 	rollingUpdateStatus.EndTime = &now
@@ -412,19 +457,6 @@ func (r *DynamoGraphDeploymentReconciler) completeRollingUpdate(
 	}
 	sort.Strings(allWorkerServices)
 	rollingUpdateStatus.UpdatedServices = allWorkerServices
-
-	r.Recorder.Eventf(dgd, corev1.EventTypeNormal, "RollingUpdateCompleted",
-		"Rolling update completed, worker hash %s", newWorkerHash)
-
-	if err := r.Status().Update(ctx, dgd); err != nil {
-		return fmt.Errorf("failed to update rolling update status: %w", err)
-	}
-
-	// Update the current worker hash to the new hash
-	r.setCurrentWorkerHash(dgd, newWorkerHash)
-	if err := r.Update(ctx, dgd); err != nil {
-		return fmt.Errorf("failed to update current worker hash: %w", err)
-	}
 
 	logger.Info("Rolling update finalized", "newWorkerHash", newWorkerHash)
 

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -203,22 +203,6 @@ func (r *DynamoGraphDeploymentReconciler) isRollingUpdateInProgress(
 		phase == nvidiacomv1alpha1.RollingUpdatePhaseInProgress
 }
 
-// needsRollingUpdateReconciliation returns true if the rolling update state machine
-// needs to run.
-func (r *DynamoGraphDeploymentReconciler) needsRollingUpdateReconciliation(
-	dgd *nvidiacomv1alpha1.DynamoGraphDeployment,
-) bool {
-	if dgd.Status.RollingUpdate != nil {
-		phase := dgd.Status.RollingUpdate.Phase
-		if phase == nvidiacomv1alpha1.RollingUpdatePhasePending ||
-			phase == nvidiacomv1alpha1.RollingUpdatePhaseInProgress ||
-			phase == nvidiacomv1alpha1.RollingUpdatePhaseCompleted { // clean up orphaned DCDs
-			return true
-		}
-	}
-	return r.shouldTriggerRollingUpdate(dgd)
-}
-
 // reconcileRollingUpdate handles the rolling update lifecycle.
 func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 	ctx context.Context,

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -266,7 +266,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 
 	switch rollingUpdateStatus.Phase {
 	case nvidiacomv1alpha1.RollingUpdatePhaseNone:
-		return r.startRollingUpdate(ctx, dgd, rollingUpdateStatus, newWorkerHash)
+		return r.startRollingUpdate(ctx, dgd, newWorkerHash)
 
 	case nvidiacomv1alpha1.RollingUpdatePhasePending:
 		rollingUpdateStatus.Phase = nvidiacomv1alpha1.RollingUpdatePhaseInProgress
@@ -276,17 +276,8 @@ func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 		return r.continueRollingUpdate(ctx, dgd, newWorkerHash)
 
 	case nvidiacomv1alpha1.RollingUpdatePhaseCompleted:
-		// ensure stale old worker DCDs are cleaned up.
-		oldDCDs, err := r.listOldWorkerDCDs(ctx, dgd, newWorkerHash)
-		if err != nil {
-			return fmt.Errorf("failed to list old worker DCDs for GC: %w", err)
-		}
-		if len(oldDCDs) > 0 {
-			logger.Info("Deleting orphaned old worker DCDs",
-				"count", len(oldDCDs), "newWorkerHash", newWorkerHash)
-			if err := r.deleteOldWorkerDCDs(ctx, dgd, newWorkerHash); err != nil {
-				return fmt.Errorf("failed to delete old worker DCDs: %w", err)
-			}
+		if err := r.deleteOldWorkerDCDs(ctx, dgd, newWorkerHash); err != nil {
+			return fmt.Errorf("failed to delete old worker DCDs: %w", err)
 		}
 		return nil
 	}
@@ -298,7 +289,6 @@ func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 func (r *DynamoGraphDeploymentReconciler) startRollingUpdate(
 	ctx context.Context,
 	dgd *nvidiacomv1alpha1.DynamoGraphDeployment,
-	rollingUpdateStatus *nvidiacomv1alpha1.RollingUpdateStatus,
 	newWorkerHash string,
 ) error {
 	logger := log.FromContext(ctx)
@@ -310,6 +300,7 @@ func (r *DynamoGraphDeploymentReconciler) startRollingUpdate(
 		"newHash", newWorkerHash)
 
 	now := metav1.Now()
+	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
 	rollingUpdateStatus.Phase = nvidiacomv1alpha1.RollingUpdatePhasePending
 	rollingUpdateStatus.StartTime = &now
 	rollingUpdateStatus.UpdatedServices = nil

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -765,10 +765,10 @@ func TestStartRollingUpdate_UpdatedServicesInitializedToNil(t *testing.T) {
 	r := createTestReconcilerWithStatus(dgd)
 	ctx := context.Background()
 
-	rollingUpdateStatus := dgd.Status.RollingUpdate
-	err := r.startRollingUpdate(ctx, dgd, rollingUpdateStatus, testNewWorkerHash)
+	err := r.startRollingUpdate(ctx, dgd, testNewWorkerHash)
 	require.NoError(t, err)
 
+	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
 	assert.Nil(t, rollingUpdateStatus.UpdatedServices)
 	assert.Equal(t, nvidiacomv1alpha1.RollingUpdatePhasePending, rollingUpdateStatus.Phase)
 }

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -2688,65 +2688,6 @@ func TestReconcileRollingUpdate_NonePhaseStartsRollout(t *testing.T) {
 	assert.Nil(t, dgd.Status.RollingUpdate.UpdatedServices)
 }
 
-func TestReconcileRollingUpdate_CompletedGCSweep(t *testing.T) {
-	// Phase=Completed with matching hashes but old DCDs still exist — GC sweep should delete them
-	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-		"worker": {ComponentType: consts.ComponentTypeWorker},
-	})
-	hash := dynamo.ComputeDGDWorkersSpecHash(dgd)
-	dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: hash}
-	dgd.Status.RollingUpdate = &nvidiacomv1alpha1.RollingUpdateStatus{
-		Phase: nvidiacomv1alpha1.RollingUpdatePhaseCompleted,
-	}
-
-	// Create an old DCD with a different hash (orphaned from a previous rolling update)
-	oldDCD := &nvidiacomv1alpha1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-dgd-worker-oldhash0",
-			Namespace: "default",
-			Labels: map[string]string{
-				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
-				consts.KubeLabelDynamoWorkerHash:          "oldhash0",
-			},
-		},
-		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
-			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-				ComponentType: consts.ComponentTypeWorker,
-				ServiceName:   "worker",
-			},
-		},
-	}
-
-	r := createTestReconcilerWithStatus(dgd, oldDCD)
-	err := r.reconcileRollingUpdate(context.Background(), dgd)
-	require.NoError(t, err)
-
-	// Phase should still be Completed
-	assert.Equal(t, nvidiacomv1alpha1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
-
-	// Verify the old DCD was deleted by the GC sweep
-	oldDCDs, err := r.listOldWorkerDCDs(context.Background(), dgd, hash)
-	require.NoError(t, err)
-	assert.Empty(t, oldDCDs, "GC sweep should have deleted old worker DCDs")
-}
-
-func TestReconcileRollingUpdate_CompletedGCSweep_NoOldDCDs(t *testing.T) {
-	// Phase=Completed with matching hashes and no old DCDs — no-op
-	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-		"worker": {ComponentType: consts.ComponentTypeWorker},
-	})
-	hash := dynamo.ComputeDGDWorkersSpecHash(dgd)
-	dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: hash}
-	dgd.Status.RollingUpdate = &nvidiacomv1alpha1.RollingUpdateStatus{
-		Phase: nvidiacomv1alpha1.RollingUpdatePhaseCompleted,
-	}
-
-	r := createTestReconcilerWithStatus(dgd)
-	err := r.reconcileRollingUpdate(context.Background(), dgd)
-	require.NoError(t, err)
-	assert.Equal(t, nvidiacomv1alpha1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
-}
-
 func TestReconcileRollingUpdate_StuckDetection_CompletesViaCompleteRollingUpdate(t *testing.T) {
 	// Stuck case: hashes match but phase is InProgress (e.g., operator restarted between
 	// annotation write and status persistence). Should call completeRollingUpdate which
@@ -2774,40 +2715,4 @@ func TestReconcileRollingUpdate_StuckDetection_CompletesViaCompleteRollingUpdate
 	assert.Contains(t, dgd.Status.RollingUpdate.UpdatedServices, "decode")
 	// Annotation should still have the correct hash
 	assert.Equal(t, hash, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
-}
-
-func TestNeedsRollingUpdateReconciliation(t *testing.T) {
-	tests := []struct {
-		name     string
-		phase    nvidiacomv1alpha1.RollingUpdatePhase
-		hashDiff bool
-		expected bool
-	}{
-		{"None phase no hash diff", nvidiacomv1alpha1.RollingUpdatePhaseNone, false, false},
-		{"None phase with hash diff", nvidiacomv1alpha1.RollingUpdatePhaseNone, true, true},
-		{"Pending phase", nvidiacomv1alpha1.RollingUpdatePhasePending, false, true},
-		{"InProgress phase", nvidiacomv1alpha1.RollingUpdatePhaseInProgress, false, true},
-		{"Completed phase", nvidiacomv1alpha1.RollingUpdatePhaseCompleted, false, true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-				"worker": {ComponentType: consts.ComponentTypeWorker},
-			})
-			hash := dynamo.ComputeDGDWorkersSpecHash(dgd)
-			if tt.hashDiff {
-				dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: "oldhash0"}
-			} else {
-				dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: hash}
-			}
-			dgd.Status.RollingUpdate = &nvidiacomv1alpha1.RollingUpdateStatus{
-				Phase: tt.phase,
-			}
-
-			r := createTestReconcilerWithStatus(dgd)
-			result := r.needsRollingUpdateReconciliation(dgd)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
 }

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -805,10 +805,11 @@ func TestCompleteRollingUpdate_UpdatedServicesContainsAllWorkers(t *testing.T) {
 	err := r.completeRollingUpdate(ctx, dgd, rollingUpdateStatus, newWorkerHash)
 	require.NoError(t, err)
 
-	// Should contain all worker services (sorted), but not frontend
-	assert.Equal(t, []string{"decode", "prefill"}, rollingUpdateStatus.UpdatedServices)
-	assert.Equal(t, nvidiacomv1alpha1.RollingUpdatePhaseCompleted, rollingUpdateStatus.Phase)
-	assert.NotNil(t, rollingUpdateStatus.EndTime)
+	// Check dgd.Status.RollingUpdate directly because r.Update() inside completeRollingUpdate
+	// decodes the API server response back into dgd, and status is re-set after the update.
+	assert.Equal(t, []string{"decode", "prefill"}, dgd.Status.RollingUpdate.UpdatedServices)
+	assert.Equal(t, nvidiacomv1alpha1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
+	assert.NotNil(t, dgd.Status.RollingUpdate.EndTime)
 }
 
 func TestContinueRollingUpdate_AllServicesUpdated(t *testing.T) {
@@ -888,9 +889,11 @@ func TestContinueRollingUpdate_AllServicesUpdated(t *testing.T) {
 	err := r.continueRollingUpdate(ctx, dgd, rollingUpdateStatus, newWorkerHash)
 	require.NoError(t, err)
 
-	// Rolling update should complete, and all services should be listed
-	assert.Equal(t, nvidiacomv1alpha1.RollingUpdatePhaseCompleted, rollingUpdateStatus.Phase)
-	assert.Equal(t, []string{"decode", "prefill"}, rollingUpdateStatus.UpdatedServices)
+	// Rolling update should complete, and all services should be listed.
+	// Check dgd.Status.RollingUpdate directly because r.Update() inside completeRollingUpdate
+	// decodes the API server response back into dgd, and status is re-set after the update.
+	assert.Equal(t, nvidiacomv1alpha1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
+	assert.Equal(t, []string{"decode", "prefill"}, dgd.Status.RollingUpdate.UpdatedServices)
 }
 
 func TestGetWorkerInfoForWorkerHash(t *testing.T) {
@@ -2685,4 +2688,127 @@ func TestReconcileRollingUpdate_NonePhaseStartsRollout(t *testing.T) {
 	assert.Equal(t, nvidiacomv1alpha1.RollingUpdatePhasePending, dgd.Status.RollingUpdate.Phase)
 	assert.NotNil(t, dgd.Status.RollingUpdate.StartTime)
 	assert.Nil(t, dgd.Status.RollingUpdate.UpdatedServices)
+}
+
+func TestReconcileRollingUpdate_CompletedGCSweep(t *testing.T) {
+	// Phase=Completed with matching hashes but old DCDs still exist — GC sweep should delete them
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {ComponentType: consts.ComponentTypeWorker},
+	})
+	hash := dynamo.ComputeDGDWorkersSpecHash(dgd)
+	dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: hash}
+	dgd.Status.RollingUpdate = &nvidiacomv1alpha1.RollingUpdateStatus{
+		Phase: nvidiacomv1alpha1.RollingUpdatePhaseCompleted,
+	}
+
+	// Create an old DCD with a different hash (orphaned from a previous rolling update)
+	oldDCD := &nvidiacomv1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd-worker-oldhash0",
+			Namespace: "default",
+			Labels: map[string]string{
+				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+				consts.KubeLabelDynamoWorkerHash:          "oldhash0",
+			},
+		},
+		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				ServiceName:   "worker",
+			},
+		},
+	}
+
+	r := createTestReconcilerWithStatus(dgd, oldDCD)
+	err := r.reconcileRollingUpdate(context.Background(), dgd)
+	require.NoError(t, err)
+
+	// Phase should still be Completed
+	assert.Equal(t, nvidiacomv1alpha1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
+
+	// Verify the old DCD was deleted by the GC sweep
+	oldDCDs, err := r.listOldWorkerDCDs(context.Background(), dgd, hash)
+	require.NoError(t, err)
+	assert.Empty(t, oldDCDs, "GC sweep should have deleted old worker DCDs")
+}
+
+func TestReconcileRollingUpdate_CompletedGCSweep_NoOldDCDs(t *testing.T) {
+	// Phase=Completed with matching hashes and no old DCDs — no-op
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {ComponentType: consts.ComponentTypeWorker},
+	})
+	hash := dynamo.ComputeDGDWorkersSpecHash(dgd)
+	dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: hash}
+	dgd.Status.RollingUpdate = &nvidiacomv1alpha1.RollingUpdateStatus{
+		Phase: nvidiacomv1alpha1.RollingUpdatePhaseCompleted,
+	}
+
+	r := createTestReconcilerWithStatus(dgd)
+	err := r.reconcileRollingUpdate(context.Background(), dgd)
+	require.NoError(t, err)
+	assert.Equal(t, nvidiacomv1alpha1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
+}
+
+func TestReconcileRollingUpdate_StuckDetection_NoAnnotationWrite(t *testing.T) {
+	// Stuck case: hashes match but phase is InProgress. Should force-complete in memory
+	// without calling r.Update() (annotation is already correct).
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"prefill": {ComponentType: consts.ComponentTypePrefill},
+		"decode":  {ComponentType: consts.ComponentTypeDecode},
+	})
+	hash := dynamo.ComputeDGDWorkersSpecHash(dgd)
+	dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: hash}
+	dgd.Status.RollingUpdate = &nvidiacomv1alpha1.RollingUpdateStatus{
+		Phase: nvidiacomv1alpha1.RollingUpdatePhaseInProgress,
+	}
+
+	r := createTestReconcilerWithStatus(dgd)
+	err := r.reconcileRollingUpdate(context.Background(), dgd)
+	require.NoError(t, err)
+
+	// Phase should be Completed
+	assert.Equal(t, nvidiacomv1alpha1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
+	// EndTime should be set
+	assert.NotNil(t, dgd.Status.RollingUpdate.EndTime)
+	// UpdatedServices should contain all worker services
+	assert.Contains(t, dgd.Status.RollingUpdate.UpdatedServices, "prefill")
+	assert.Contains(t, dgd.Status.RollingUpdate.UpdatedServices, "decode")
+	// Annotation should remain unchanged (no r.Update() call)
+	assert.Equal(t, hash, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
+}
+
+func TestNeedsRollingUpdateReconciliation(t *testing.T) {
+	tests := []struct {
+		name     string
+		phase    nvidiacomv1alpha1.RollingUpdatePhase
+		hashDiff bool
+		expected bool
+	}{
+		{"None phase no hash diff", nvidiacomv1alpha1.RollingUpdatePhaseNone, false, false},
+		{"None phase with hash diff", nvidiacomv1alpha1.RollingUpdatePhaseNone, true, true},
+		{"Pending phase", nvidiacomv1alpha1.RollingUpdatePhasePending, false, true},
+		{"InProgress phase", nvidiacomv1alpha1.RollingUpdatePhaseInProgress, false, true},
+		{"Completed phase", nvidiacomv1alpha1.RollingUpdatePhaseCompleted, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {ComponentType: consts.ComponentTypeWorker},
+			})
+			hash := dynamo.ComputeDGDWorkersSpecHash(dgd)
+			if tt.hashDiff {
+				dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: "oldhash0"}
+			} else {
+				dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: hash}
+			}
+			dgd.Status.RollingUpdate = &nvidiacomv1alpha1.RollingUpdateStatus{
+				Phase: tt.phase,
+			}
+
+			r := createTestReconcilerWithStatus(dgd)
+			result := r.needsRollingUpdateReconciliation(dgd)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -653,7 +653,7 @@ func TestContinueRollingUpdate_UpdatedServicesPartialCompletion(t *testing.T) {
 	ctx := context.Background()
 
 	rollingUpdateStatus := dgd.Status.RollingUpdate
-	err := r.continueRollingUpdate(ctx, dgd, rollingUpdateStatus, newWorkerHash)
+	err := r.continueRollingUpdate(ctx, dgd, newWorkerHash)
 	require.NoError(t, err)
 
 	// Prefill is updated (new ready >= desired, old gone), decode is not
@@ -736,8 +736,8 @@ func TestContinueRollingUpdate_AggregateReadyButPerServiceNot(t *testing.T) {
 	r := createTestReconcilerWithStatus(dgd, newPrefillDCD, newDecodeDCD)
 	ctx := context.Background()
 
-	rollingUpdateStatus := dgd.Status.RollingUpdate
-	err := r.continueRollingUpdate(ctx, dgd, rollingUpdateStatus, newWorkerHash)
+	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
+	err := r.continueRollingUpdate(ctx, dgd, newWorkerHash)
 	require.NoError(t, err)
 
 	// Only prefill is updated; decode has 0 ready replicas
@@ -801,8 +801,7 @@ func TestCompleteRollingUpdate_UpdatedServicesContainsAllWorkers(t *testing.T) {
 	r := createTestReconcilerWithStatus(dgd)
 	ctx := context.Background()
 
-	rollingUpdateStatus := dgd.Status.RollingUpdate
-	err := r.completeRollingUpdate(ctx, dgd, rollingUpdateStatus, newWorkerHash)
+	err := r.completeRollingUpdate(ctx, dgd, newWorkerHash)
 	require.NoError(t, err)
 
 	// Check dgd.Status.RollingUpdate directly because r.Update() inside completeRollingUpdate
@@ -885,8 +884,7 @@ func TestContinueRollingUpdate_AllServicesUpdated(t *testing.T) {
 	r := createTestReconcilerWithStatus(dgd, newPrefillDCD, newDecodeDCD)
 	ctx := context.Background()
 
-	rollingUpdateStatus := dgd.Status.RollingUpdate
-	err := r.continueRollingUpdate(ctx, dgd, rollingUpdateStatus, newWorkerHash)
+	err := r.continueRollingUpdate(ctx, dgd, newWorkerHash)
 	require.NoError(t, err)
 
 	// Rolling update should complete, and all services should be listed.
@@ -2443,11 +2441,11 @@ func TestContinueRollingUpdate_CascadingSpecChange(t *testing.T) {
 	r := createTestReconcilerWithStatus(dgd, genADCD, genBDCD, genCDCD)
 	ctx := context.Background()
 
-	rollingUpdateStatus := dgd.Status.RollingUpdate
-	err := r.continueRollingUpdate(ctx, dgd, rollingUpdateStatus, newWorkerHash)
+	err := r.continueRollingUpdate(ctx, dgd, newWorkerHash)
 	require.NoError(t, err)
 
 	// Both A and B have ready replicas, C has 0 — rolling update not complete
+	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
 	assert.Equal(t, nvidiacomv1alpha1.RollingUpdatePhaseInProgress, rollingUpdateStatus.Phase)
 	assert.Empty(t, rollingUpdateStatus.UpdatedServices, "No services should be fully updated yet")
 }

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -2747,9 +2747,10 @@ func TestReconcileRollingUpdate_CompletedGCSweep_NoOldDCDs(t *testing.T) {
 	assert.Equal(t, nvidiacomv1alpha1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
 }
 
-func TestReconcileRollingUpdate_StuckDetection_NoAnnotationWrite(t *testing.T) {
-	// Stuck case: hashes match but phase is InProgress. Should force-complete in memory
-	// without calling r.Update() (annotation is already correct).
+func TestReconcileRollingUpdate_StuckDetection_CompletesViaCompleteRollingUpdate(t *testing.T) {
+	// Stuck case: hashes match but phase is InProgress (e.g., operator restarted between
+	// annotation write and status persistence). Should call completeRollingUpdate which
+	// cleans up old DCDs, updates annotation, and sets Completed.
 	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 		"prefill": {ComponentType: consts.ComponentTypePrefill},
 		"decode":  {ComponentType: consts.ComponentTypeDecode},
@@ -2771,7 +2772,7 @@ func TestReconcileRollingUpdate_StuckDetection_NoAnnotationWrite(t *testing.T) {
 	// UpdatedServices should contain all worker services
 	assert.Contains(t, dgd.Status.RollingUpdate.UpdatedServices, "prefill")
 	assert.Contains(t, dgd.Status.RollingUpdate.UpdatedServices, "decode")
-	// Annotation should remain unchanged (no r.Update() call)
+	// Annotation should still have the correct hash
 	assert.Equal(t, hash, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
 }
 


### PR DESCRIPTION
## Summary
- Fix old worker DCDs (Deployments at 0/0) never being cleaned up after rolling update completion ([DEP-816](https://linear.app/nvidia/issue/DEP-816))
- Remove `Status().Update()` calls from rolling update functions — deferred function in `Reconcile()` is the sole status writer, eliminating resourceVersion conflicts
- Delete failures in `completeRollingUpdate` are now propagated (not swallowed), with `continueRollingUpdate` retrying on requeue
- Add GC sweep in Completed phase as safety net for orphaned DCDs from edge cases (operator restart, partial failures)
- Set status fields AFTER `r.Update()` to avoid API server response overwriting in-memory status changes

## Test plan
- [x] All 20 rolling update unit tests pass (15 existing + 5 new)
- [x] `go build`, `go vet` clean
- [x] E2E on minikube: 3-replica disagg DGD + livenessProbe rolling update — proper surge/drain, old DCDs cleaned up, no conflict errors
- [x] Chained second rolling update
- [x] Operator restart mid-rollout recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined rolling update reconciliation logic for improved consistency.
  * Enhanced error handling during update completion and cleanup operations.
  * Optimized status persistence to eliminate redundant updates.

* **Tests**
  * Added comprehensive rolling update lifecycle tests including cleanup, stalled update detection, and phase progression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->