### PR TITLE
docs(block-manager): clarify storage fallback comment

### DIFF
--- a/lib/llm/src/block_manager/config.rs
+++ b/lib/llm/src/block_manager/config.rs
@@ -106,7 +106,7 @@ pub struct KvManagerLayoutConfig<S: Storage + NixlRegisterableStorage> {
 
     /// Storage for the blocks
     /// If provided, the blocks will be allocated from the provided storage
-    /// Otherwise, the blocks will be allocated from
+    /// Otherwise, the blocks will be allocated from the provided allocator or logical strategy
     #[builder(default)]
     pub storage: Option<Vec<S>>,
 


### PR DESCRIPTION
#### Overview:

Clarify the `KvManagerLayoutConfig::storage` doc comment in the block manager config.
This is a docs-only change and does not affect runtime behavior.

#### Details:

- Fix an incomplete doc comment
- Note that allocation falls back to the allocator or logical strategy when `storage` is not provided

#### Where should the reviewer start?

`lib/llm/src/block_manager/config.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation clarity for block allocation configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->