### PR TITLE
fix(sglang): make prefill warmup failure fatal

### DIFF
--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -99,6 +99,21 @@ except ImportError:
             return f"tcp://{self.host}:{self.port}"
 
 
+try:
+    from sglang.srt.sampling.sampling_params import SamplingParams  # noqa: F401
+except ImportError:
+    # Fallback for sglang <= 0.5.x where SamplingParams may be at a different path.
+    # Remove when min supported version has sglang.srt.sampling.sampling_params.
+    try:
+        from sglang.srt.sampling_params import (  # type: ignore[no-redef]  # noqa: F401
+            SamplingParams,
+        )
+    except ImportError:
+        from sglang.srt.managers.io_struct import (  # type: ignore[no-redef]  # noqa: F401
+            SamplingParams,
+        )
+
+
 def enable_disjoint_streaming_output(server_args: Any) -> None:
     """
     Enable SGLang's disjoint streaming output across ServerArgs field renames.
@@ -134,6 +149,7 @@ def enable_disjoint_streaming_output(server_args: Any) -> None:
 
 __all__ = [
     "NetworkAddress",
+    "SamplingParams",
     "enable_disjoint_streaming_output",
     "get_local_ip_auto",
     "get_zmq_socket",

--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -99,23 +99,6 @@ except ImportError:
             return f"tcp://{self.host}:{self.port}"
 
 
-try:
-    from sglang.srt.sampling.sampling_params import SamplingParams  # noqa: F401
-except ImportError:
-    # Fallback for sglang <= 0.5.x where SamplingParams may be at a different path.
-    # Remove when min supported version has sglang.srt.sampling.sampling_params.
-    try:
-        from sglang.srt.sampling_params import (  # type: ignore[no-redef]  # noqa: F401
-            SamplingParams,
-        )
-    except ImportError:
-        # Fallback for sglang <= 0.2.13. Always available via re-export.
-        # Remove when min supported version is 0.2.14+.
-        from sglang.srt.managers.io_struct import (  # type: ignore[no-redef]  # noqa: F401
-            SamplingParams,
-        )
-
-
 def enable_disjoint_streaming_output(server_args: Any) -> None:
     """
     Enable SGLang's disjoint streaming output across ServerArgs field renames.
@@ -151,7 +134,6 @@ def enable_disjoint_streaming_output(server_args: Any) -> None:
 
 __all__ = [
     "NetworkAddress",
-    "SamplingParams",
     "enable_disjoint_streaming_output",
     "get_local_ip_auto",
     "get_zmq_socket",

--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -109,6 +109,8 @@ except ImportError:
             SamplingParams,
         )
     except ImportError:
+        # Fallback for sglang <= 0.2.13. Always available via re-export.
+        # Remove when min supported version is 0.2.14+.
         from sglang.srt.managers.io_struct import (  # type: ignore[no-redef]  # noqa: F401
             SamplingParams,
         )

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -13,7 +13,6 @@ from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
 from dynamo.llm import ModelInput, ModelType
 from dynamo.runtime import DistributedRuntime
-from dynamo.sglang._compat import SamplingParams
 from dynamo.sglang.args import Config
 from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
@@ -34,11 +33,11 @@ async def _warmup_prefill_engine(engine: sgl.Engine, server_args) -> None:
     logging.info("Start of prefill disaggregation warmup ...")
     from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
 
-    sampling_params = SamplingParams(
-        temperature=0.0,
-        max_new_tokens=8,
-        ignore_eos=True,
-    )
+    sampling_params = {
+        "temperature": 0.0,
+        "max_new_tokens": 8,
+        "ignore_eos": True,
+    }
 
     async def _do_warmup():
         results = await engine.async_generate(

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -25,35 +25,36 @@ from dynamo.sglang.request_handlers import DecodeWorkerHandler, PrefillWorkerHan
 
 
 async def _warmup_prefill_engine(engine: sgl.Engine, server_args) -> None:
-    """Perform warmup request for prefill engine to reduce initial TTFT."""
+    """Perform warmup request for prefill engine to reduce initial TTFT.
+
+    Raises on failure so the caller can prevent the worker from registering
+    with a broken engine (silent request drops).
+    """
     logging.info("Start of prefill disaggregation warmup ...")
-    try:
-        from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
+    from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
 
-        sampling_params = {
-            "temperature": 0.0,
-            "max_new_tokens": 8,
-            "ignore_eos": True,
-        }
+    from dynamo.sglang._compat import SamplingParams
 
-        async def _do_warmup():
-            results = await engine.async_generate(
-                input_ids=[0, 1, 2, 3],
-                sampling_params=sampling_params,
-                stream=True,
-                bootstrap_host=FAKE_BOOTSTRAP_HOST,
-                bootstrap_port=server_args.disaggregation_bootstrap_port,
-                bootstrap_room=999999,
-            )
-            async for _ in results:
-                pass
+    sampling_params = SamplingParams(
+        temperature=0.0,
+        max_new_tokens=8,
+        ignore_eos=True,
+    )
 
-        await asyncio.wait_for(_do_warmup(), timeout=1800)
-        logging.info("Prefill warmup completed")
-    except asyncio.TimeoutError:
-        logging.warning("Prefill warmup timed out after 1800s")
-    except Exception as e:
-        logging.warning(f"Prefill warmup failed: {e}")
+    async def _do_warmup():
+        results = await engine.async_generate(
+            input_ids=[0, 1, 2, 3],
+            sampling_params=sampling_params,
+            stream=True,
+            bootstrap_host=FAKE_BOOTSTRAP_HOST,
+            bootstrap_port=server_args.disaggregation_bootstrap_port,
+            bootstrap_room=999999,
+        )
+        async for _ in results:
+            pass
+
+    await asyncio.wait_for(_do_warmup(), timeout=1800)
+    logging.info("Prefill warmup completed")
 
 
 async def init_decode(
@@ -184,7 +185,14 @@ async def init_prefill(
         await handle_non_leader_node(engine, publisher, metrics_task)
         return
 
-    await _warmup_prefill_engine(engine, server_args)
+    try:
+        await _warmup_prefill_engine(engine, server_args)
+    except asyncio.TimeoutError:
+        logging.error("Prefill warmup timed out after 1800s — aborting worker startup")
+        raise RuntimeError("Prefill warmup timed out; worker cannot serve requests")
+    except Exception as e:
+        logging.error(f"Prefill warmup failed: {e} — aborting worker startup")
+        raise RuntimeError(f"Prefill warmup failed: {e}") from e
 
     handler = PrefillWorkerHandler(
         engine, config, publisher, generate_endpoint, shutdown_event

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -13,6 +13,7 @@ from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
 from dynamo.llm import ModelInput, ModelType
 from dynamo.runtime import DistributedRuntime
+from dynamo.sglang._compat import SamplingParams
 from dynamo.sglang.args import Config
 from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
@@ -32,8 +33,6 @@ async def _warmup_prefill_engine(engine: sgl.Engine, server_args) -> None:
     """
     logging.info("Start of prefill disaggregation warmup ...")
     from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
-
-    from dynamo.sglang._compat import SamplingParams
 
     sampling_params = SamplingParams(
         temperature=0.0,
@@ -187,9 +186,11 @@ async def init_prefill(
 
     try:
         await _warmup_prefill_engine(engine, server_args)
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as e:
         logging.error("Prefill warmup timed out after 1800s — aborting worker startup")
-        raise RuntimeError("Prefill warmup timed out; worker cannot serve requests")
+        raise RuntimeError(
+            "Prefill warmup timed out; worker cannot serve requests"
+        ) from e
     except Exception as e:
         logging.error(f"Prefill warmup failed: {e} — aborting worker startup")
         raise RuntimeError(f"Prefill warmup failed: {e}") from e


### PR DESCRIPTION
## Summary
- Make prefill warmup failure fatal to prevent silent request drops in disaggregated deployments

## Context

The `SamplingParams` not-subscriptable root cause was already fixed by PR #7797 (merged to main 2026-04-02, not yet in any release). That PR reverted the warmup `sampling_params` from a `SamplingParams` object back to a plain dict.

However, the warmup function still silently swallows all failures with `logging.warning`, allowing a broken prefill worker to register, pass health checks, and then drop all requests. This causes the cascade described in DYN-2575:
1. Prefill registers but silently drops all requests
2. Decode starves waiting for KV cache
3. NIXL KVReceiver Exception after timeout
4. Client hangs indefinitely

## Changes

- Remove try/except from `_warmup_prefill_engine()` — let exceptions propagate
- Catch at the call site in `init_prefill()` with `logging.error` + `raise RuntimeError`
- Preserves exception chaining (`from e`) for both timeout and general failures

## Test plan
- [x] CI multi-gpu sglang tests pass (disaggregated prefill + decode)
- [x] Single-GPU aggregated test passes locally on sglang-runtime:1.0.0
- [x] Reproduced original bug locally and confirmed fix path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>