### PR TITLE
feat(vllm): support Kimi K2.5/K2.6 multimodal vision chunks

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -311,20 +311,55 @@ def _compute_mm_uuids(
     preimage), ensuring consistent hashing across the MM Router, vLLM
     handler, and Rust KV publisher.
     """
-    if not multi_modal_data or "image" not in multi_modal_data:
+    if not multi_modal_data:
         return None
-    images = multi_modal_data["image"]
-    # [gluo FIXME] Dict being returned when the mm data has been processed,
-    # in this case, we skip computing mm_uuids for now until we better understand
-    # what info should be hash on.
-    if isinstance(images, dict):
+    if "image" in multi_modal_data:
+        images = multi_modal_data["image"]
+        # [gluo FIXME] Dict being returned when the mm data has been processed,
+        # in this case, we skip computing mm_uuids for now until we better understand
+        # what info should be hash on.
+        if isinstance(images, dict):
+            return None
+        if not isinstance(images, list):
+            images = [images]
+        if not images:
+            return None
+        uuids = compute_mm_uuids_from_images(images)
+        return {"image": uuids}
+
+    if "vision_chunk" not in multi_modal_data:
         return None
-    if not isinstance(images, list):
-        images = [images]
+
+    vision_chunks = multi_modal_data["vision_chunk"]
+    if not isinstance(vision_chunks, list):
+        vision_chunks = [vision_chunks]
+
+    images = []
+    for item in vision_chunks:
+        if not isinstance(item, dict):
+            logger.debug(
+                "Skipping mm_uuid computation: invalid vision_chunk item type %s",
+                type(item).__name__,
+            )
+            return None
+        if item.get("type") != "image":
+            logger.debug(
+                "Skipping mm_uuid computation: unsupported vision_chunk type %r",
+                item.get("type"),
+            )
+            return None
+        image = item.get("image")
+        if image is None:
+            logger.debug(
+                "Skipping mm_uuid computation: vision_chunk item missing image"
+            )
+            return None
+        images.append(image)
+
     if not images:
         return None
-    uuids = compute_mm_uuids_from_images(images)
-    return {"image": uuids}
+
+    return {"vision_chunk": compute_mm_uuids_from_images(images)}
 
 
 # Helpers for nvext response fields requested through `nvext.extra_fields`.
@@ -2061,37 +2096,50 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         mm_map = request["multi_modal_data"]
 
         vllm_mm_data = {}
+        uses_raw_vision_chunk = (
+            self._use_unified_vision_chunk
+            or resolve_model_family(self.config.model) is ModelFamily.KIMI_K2
+        )
 
         # [gluo NOTE] If embedding loader is configured, fetch image embeddings first.
         # Still continue below so mixed image+video requests can attach `video`.
         if self.embedding_loader is not None:
-            # [gluo FIXME] couldn't simply pass 'mm_map.get(IMAGE_URL_KEY, [])' like below
-            # as currently the encode worker is using 'ImageLoader.load_image()' which doesn't
-            # support 'Decoded' variant. Need to update the encode worker to unify handling
-            image_urls = []
-            supported = True
-            for item in mm_map.get(IMAGE_URL_KEY, []):
-                if isinstance(item, dict) and "Url" in item:
-                    image_urls.append(item["Url"])
-                elif isinstance(item, dict) and "Decoded" in item:
-                    supported = False
-            if supported:
-                vllm_mm_data = await self.embedding_loader.load_multimodal_embeddings(
-                    image_urls, request_id, model=self.config.model, context=context
-                )
+            if uses_raw_vision_chunk:
                 logger.debug(
-                    f"Fetched multimodal embeddings for {len(vllm_mm_data)} items"
+                    "Skipping embedding loader because this model expects "
+                    "raw vision_chunk inputs instead of image embeddings."
                 )
+            else:
+                # [gluo FIXME] couldn't simply pass 'mm_map.get(IMAGE_URL_KEY, [])' like below
+                # as currently the encode worker is using 'ImageLoader.load_image()' which doesn't
+                # support 'Decoded' variant. Need to update the encode worker to unify handling
+                image_urls = []
+                supported = True
+                for item in mm_map.get(IMAGE_URL_KEY, []):
+                    if isinstance(item, dict) and "Url" in item:
+                        image_urls.append(item["Url"])
+                    elif isinstance(item, dict) and "Decoded" in item:
+                        supported = False
+                if supported:
+                    vllm_mm_data = (
+                        await self.embedding_loader.load_multimodal_embeddings(
+                            image_urls,
+                            request_id,
+                            model=self.config.model,
+                            context=context,
+                        )
+                    )
+                    logger.debug(
+                        f"Fetched multimodal embeddings for {len(vllm_mm_data)} items"
+                    )
 
         image_mm_items = mm_map.get(IMAGE_URL_KEY, [])
-        # Kimi-K2.5 (and any model with `use_unified_vision_chunk=True`)
+        # Kimi K2.x (and any model with `use_unified_vision_chunk=True`)
         # consumes images under the `vision_chunk` modality, not `image`,
         # and expects each item to be a `VisionChunkImage` TypedDict.
         # See chat_utils.use_unified_vision_chunk_modality for the
         # upstream rename + wrap path.
-        image_modality_key = (
-            "vision_chunk" if self._use_unified_vision_chunk else "image"
-        )
+        image_modality_key = "vision_chunk" if uses_raw_vision_chunk else "image"
         if image_modality_key not in vllm_mm_data and image_mm_items:
             with _nvtx.annotate("mm_backend:image_download", color="green"):
                 images = await self.image_loader.load_image_batch(
@@ -2099,7 +2147,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 )
 
             if images:
-                if self._use_unified_vision_chunk:
+                if uses_raw_vision_chunk:
                     # `VisionChunkImage` is a TypedDict — a plain dict
                     # with `type`/`image`/`uuid` keys is structurally
                     # equivalent. uuid=None matches vLLM's chat_utils

--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -34,16 +34,17 @@ VLLM_ENCODER = int(os.getenv("VLLM_ENCODER", 1))
 
 
 class ModelFamily(str, Enum):
-    """Multimodal model families dynamo's encoder pipeline knows how to dispatch."""
+    """Multimodal model families with Dynamo-specific handling."""
 
     QWEN_VL = "qwen-vl"
     LLAVA = "llava"
+    KIMI_K2 = "kimi-k2"
 
 
-# Per-family registries used by `resolve_model_family`. The encoder reaches
-# into vLLM internals (`model.visual` for Qwen, `vision_tower` +
+# Per-family registries used by `resolve_model_family`. Encoder-backed
+# families reach into vLLM internals (`model.visual` for Qwen, `vision_tower` +
 # `multi_modal_projector` for LLaVA) whose attribute paths vary per family —
-# entries here must correspond to extractor logic in `encode_utils.py`.
+# those entries must correspond to extractor logic in `encode_utils.py`.
 #
 # Architectures are matched verbatim against `config.json` `architectures`.
 _FAMILY_ARCHITECTURES: Dict[ModelFamily, frozenset[str]] = {
@@ -64,6 +65,8 @@ _FAMILY_ARCHITECTURES: Dict[ModelFamily, frozenset[str]] = {
         }
     ),
     ModelFamily.LLAVA: frozenset({"LlavaForConditionalGeneration"}),
+    # Kimi-K2.6 currently uses the same HF/vLLM architecture as Kimi-K2.5.
+    ModelFamily.KIMI_K2: frozenset({"KimiK25ForConditionalGeneration"}),
 }
 
 # Name-stage substring patterns (lowercase). A new size / quantization /
@@ -84,6 +87,7 @@ _FAMILY_NAME_PATTERNS: Dict[ModelFamily, frozenset[str]] = {
         }
     ),
     ModelFamily.LLAVA: frozenset({"llava-1.5-7b-hf"}),
+    ModelFamily.KIMI_K2: frozenset({"kimi-k2.5", "kimi-k2.6"}),
 }
 
 
@@ -210,11 +214,17 @@ def construct_mm_data(
     image_embeds = image_embeds.to(embeddings_dtype)
 
     # Model-specific image handling
-    if resolve_model_family(model) is ModelFamily.QWEN_VL:
+    model_family = resolve_model_family(model)
+    if model_family is ModelFamily.QWEN_VL:
         return _construct_qwen_image_data(image_embeds, image_grid_thw)
-    else:
-        # Default image handling for other models (e.g., LLAVA_1_5_7B)
-        return {"image": image_embeds}
+    if model_family is ModelFamily.KIMI_K2:
+        raise ValueError(
+            "Kimi K2.5/K2.6 expects raw vision_chunk inputs; embedding-based "
+            "multimodal transfer is not supported yet."
+        )
+
+    # Default image handling for other models (e.g., LLAVA_1_5_7B)
+    return {"image": image_embeds}
 
 
 def _construct_qwen_image_data(

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py
@@ -10,6 +10,7 @@ import torch
 
 from dynamo.vllm.multimodal_utils.model import (
     ModelFamily,
+    construct_mm_data,
     construct_qwen_decode_mm_data,
     resolve_model_family,
 )
@@ -19,10 +20,26 @@ pytestmark = [
     pytest.mark.vllm,
     pytest.mark.gpu_0,
     pytest.mark.multimodal,
+    pytest.mark.unit,
 ]
 
 
 class TestMultiModalUtils:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "moonshotai/Kimi-K2.5",
+            "moonshotai/Kimi-K2.6",
+        ],
+    )
+    def test_construct_mm_data_rejects_kimi_embeddings(self, model):
+        with pytest.raises(ValueError, match="raw vision_chunk inputs"):
+            construct_mm_data(
+                model=model,
+                embeddings_dtype=torch.float16,
+                image_embeds=torch.randn(1, 4),
+            )
+
     def test_construct_qwen_decode_mm_data(self):
         max_rounds = int(torch.finfo(torch.float16).max) + 2
         expected_image_grid_thw_tensor = torch.tensor([16, 16])
@@ -75,6 +92,16 @@ class TestResolveModelFamily:
                 "llava-hf/llava-1.5-7b-hf",
                 ModelFamily.LLAVA,
                 id="hf-id-llava",
+            ),
+            pytest.param(
+                "moonshotai/Kimi-K2.5",
+                ModelFamily.KIMI_K2,
+                id="hf-id-kimi-k2.5",
+            ),
+            pytest.param(
+                "moonshotai/Kimi-K2.6",
+                ModelFamily.KIMI_K2,
+                id="hf-id-kimi-k2.6",
             ),
             pytest.param(
                 "/root/.cache/huggingface/hub/"
@@ -130,6 +157,12 @@ class TestResolveModelFamilyOnDisk:
                 ["Qwen3_5ForConditionalGeneration"],
                 ModelFamily.QWEN_VL,
                 id="metadata-qwen3.5-unified",
+            ),
+            pytest.param(
+                "moonshotai--Kimi-K2.6/v1",
+                ["KimiK25ForConditionalGeneration"],
+                ModelFamily.KIMI_K2,
+                id="metadata-kimi-k2.6",
             ),
         ],
     )

--- a/components/src/dynamo/vllm/tests/test_vllm_handlers_multimodal.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_handlers_multimodal.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from PIL import Image
+
+from dynamo.vllm.handlers import BaseWorkerHandler, _compute_mm_uuids
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.multimodal,
+    pytest.mark.unit,
+]
+
+
+class _TestWorkerHandler(BaseWorkerHandler):
+    async def generate(self, request, context):
+        yield {}
+
+
+def _make_handler(model: str = "test-model") -> _TestWorkerHandler:
+    handler = _TestWorkerHandler.__new__(_TestWorkerHandler)
+    handler.enable_multimodal = True
+    handler.config = SimpleNamespace(model=model)
+    handler.image_loader = SimpleNamespace(load_image_batch=AsyncMock(return_value=[]))
+    handler.video_loader = SimpleNamespace(load_video_batch=AsyncMock(return_value=[]))
+    handler.audio_loader = SimpleNamespace(load_audio_batch=AsyncMock(return_value=[]))
+    handler.embedding_loader = SimpleNamespace(load_multimodal_embeddings=AsyncMock())
+    return handler
+
+
+def test_compute_mm_uuids_supports_kimi_vision_chunk():
+    image = Image.new("RGB", (2, 2), color="blue")
+
+    mm_uuids = _compute_mm_uuids(
+        {
+            "vision_chunk": [
+                {
+                    "type": "image",
+                    "image": image,
+                    "uuid": None,
+                }
+            ]
+        }
+    )
+
+    assert mm_uuids is not None
+    assert "vision_chunk" in mm_uuids
+    assert len(mm_uuids["vision_chunk"]) == 1
+    assert re.fullmatch(r"[0-9a-f]{64}", mm_uuids["vision_chunk"][0])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["moonshotai/Kimi-K2.5", "moonshotai/Kimi-K2.6"])
+async def test_extract_multimodal_data_kimi_uses_raw_vision_chunk_path(model):
+    handler = _make_handler(model=model)
+    fake_image = object()
+    handler.image_loader.load_image_batch = AsyncMock(return_value=[fake_image])
+
+    result = await handler._extract_multimodal_data(
+        {
+            "multi_modal_data": {
+                "image_url": [{"Url": "http://img.png"}],
+            }
+        },
+        "req-1",
+        context=None,
+    )
+
+    handler.image_loader.load_image_batch.assert_awaited_once_with(
+        [{"Url": "http://img.png"}]
+    )
+    handler.embedding_loader.load_multimodal_embeddings.assert_not_awaited()
+    assert result == {
+        "vision_chunk": {"type": "image", "image": fake_image, "uuid": None}
+    }
+
+
+@pytest.mark.asyncio
+async def test_extract_multimodal_data_kimi_preserves_decoded_inputs():
+    handler = _make_handler(model="moonshotai/Kimi-K2.6")
+    decoded_metadata = {"handle": "nixl-1"}
+    fake_image = object()
+    handler.image_loader.load_image_batch = AsyncMock(return_value=[fake_image])
+
+    result = await handler._extract_multimodal_data(
+        {
+            "multi_modal_data": {
+                "image_url": [{"Decoded": decoded_metadata}],
+            }
+        },
+        "req-1",
+        context=None,
+    )
+
+    handler.image_loader.load_image_batch.assert_awaited_once_with(
+        [{"Decoded": decoded_metadata}]
+    )
+    handler.embedding_loader.load_multimodal_embeddings.assert_not_awaited()
+    assert result == {
+        "vision_chunk": {"type": "image", "image": fake_image, "uuid": None}
+    }

--- a/docs/proposals/health-disagg-readiness.md
+++ b/docs/proposals/health-disagg-readiness.md
@@ -2,7 +2,7 @@
 
 **Author:** Jie Hao
 **Date:** 2026-03-24 (updated 2026-05-22)
-**Status:** Approved — See [DEP-0014](https://github.com/ai-dynamo/enhancements/deps/0014-health-endpoint-disagg-readiness.md) and tracking issue [#7787](https://github.com/ai-dynamo/dynamo/issues/7787). PR 1, PR 2a–d landed; PR 3 in progress.
+**Status:** Approved — See tracking issue [#7787](https://github.com/ai-dynamo/dynamo/issues/7787). PR 1, PR 2a–d landed; PR 3 in progress.
 
 ## Problem
 


### PR DESCRIPTION
## Summary
- rebase onto current ai-dynamo/main and remove the old Qwen3.5 detection changes, since Qwen3.5 is already supported upstream
- add Kimi K2.x model-family detection for Kimi-K2.5/Kimi-K2.6 names and local configs using KimiK25ForConditionalGeneration
- reuse Dynamo's upstream use_unified_vision_chunk path so Kimi K2.x VLM image requests bypass embedding transfer and reach vLLM as raw vision_chunk inputs
- compute multimodal UUIDs for vision_chunk image payloads and add debug logging for invalid vision_chunk data
- extend unit coverage for Kimi K2.5/K2.6 family resolution, embedding-transfer rejection, URL/Decoded image handling, and vision_chunk UUID format
- remove a stale DEP hyperlink in docs/proposals/health-disagg-readiness.md that caused lychee to fail on the rebased PR

## Kimi VLM request handling
For moonshotai/Kimi-K2.5 and moonshotai/Kimi-K2.6, Dynamo now skips the multimodal embedding loader and sends loaded images to vLLM under the vision_chunk modality:

```python
{
    "vision_chunk": {"type": "image", "image": image, "uuid": None}
}
```

This matches vLLM's KimiK25 multimodal schema. Kimi-K2.6 also resolves to the same family because its HF config uses KimiK25ForConditionalGeneration.

## EPD status
Kimi K2.5/K2.6 EPD is not enabled in this PR. The current Dynamo EPD multimodal path is embedding-transfer based via the encode-worker pipeline, while vLLM's Kimi K2.x path expects raw vision_chunk inputs. construct_mm_data now raises for Kimi K2.x embedding transfer so unsupported EPD usage fails explicitly instead of silently sending the wrong schema.

## Testing
- python3 -m ruff check components/src/dynamo/vllm/handlers.py components/src/dynamo/vllm/multimodal_utils/model.py components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py components/src/dynamo/vllm/tests/test_vllm_handlers_multimodal.py
- git diff --check upstream/main..HEAD
- rg -n "enhancements/deps/0014-health-endpoint-disagg-readiness|DEP-0014" docs/proposals/health-disagg-readiness.md (no matches)
- pytest components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py components/src/dynamo/vllm/tests/test_vllm_handlers_multimodal.py -q (attempted locally, but the available pytest runs on Python 3.9 and fails during conftest collection on 3.10+ union type syntax before reaching these tests)