### PR TITLE
fix(operator): handle spec-less resources (ConfigMaps, Secrets, etc.) in SyncResource

### DIFF
--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -226,6 +226,19 @@ var kubeEnvelopeFields = map[string]bool{
 	"status":     true,
 }
 
+// nonEnvelopeFields returns all top-level fields from an unstructured map
+// except the Kubernetes envelope (apiVersion, kind, metadata, status).
+func nonEnvelopeFields(obj map[string]interface{}) map[string]interface{} {
+	content := make(map[string]interface{}, len(obj))
+	for k, v := range obj {
+		if kubeEnvelopeFields[k] {
+			continue
+		}
+		content[k] = v
+	}
+	return content
+}
+
 // getContentFields returns all content fields from an unstructured object,
 // i.e. everything except the Kubernetes envelope (apiVersion, kind, metadata, status).
 // For resources with a "spec" field, it returns the spec directly for
@@ -236,13 +249,7 @@ func getContentFields(u *unstructured.Unstructured) (any, bool) {
 		return spec, true
 	}
 
-	content := make(map[string]interface{})
-	for k, v := range u.Object {
-		if kubeEnvelopeFields[k] {
-			continue
-		}
-		content[k] = v
-	}
+	content := nonEnvelopeFields(u.Object)
 	if len(content) == 0 {
 		return nil, false
 	}
@@ -254,29 +261,26 @@ func CopySpec(source, destination client.Object) error {
 	if err != nil {
 		return err
 	}
-	srcU := &unstructured.Unstructured{Object: sourceMap}
+	sourceUnstructured := &unstructured.Unstructured{Object: sourceMap}
 
 	destMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(destination)
 	if err != nil {
 		return err
 	}
-	dstU := &unstructured.Unstructured{Object: destMap}
+	destUnstructured := &unstructured.Unstructured{Object: destMap}
 
-	if spec, found, err := unstructured.NestedFieldCopy(srcU.Object, "spec"); err == nil && found {
-		if err := unstructured.SetNestedField(dstU.Object, spec, "spec"); err != nil {
+	if spec, found, err := unstructured.NestedFieldCopy(sourceUnstructured.Object, "spec"); err == nil && found {
+		if err := unstructured.SetNestedField(destUnstructured.Object, spec, "spec"); err != nil {
 			return err
 		}
-		return runtime.DefaultUnstructuredConverter.FromUnstructured(dstU.Object, destination)
+		return runtime.DefaultUnstructuredConverter.FromUnstructured(destUnstructured.Object, destination)
 	}
 
-	for k, v := range srcU.Object {
-		if kubeEnvelopeFields[k] {
-			continue
-		}
-		dstU.Object[k] = v
+	for k, v := range nonEnvelopeFields(sourceUnstructured.Object) {
+		destUnstructured.Object[k] = v
 	}
 
-	return runtime.DefaultUnstructuredConverter.FromUnstructured(dstU.Object, destination)
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(destUnstructured.Object, destination)
 }
 
 func getSpec(obj client.Object) (any, error) {
@@ -284,9 +288,9 @@ func getSpec(obj client.Object) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	u := &unstructured.Unstructured{Object: sourceMap}
+	sourceUnstructured := &unstructured.Unstructured{Object: sourceMap}
 
-	content, found := getContentFields(u)
+	content, found := getContentFields(sourceUnstructured)
 	if !found {
 		return nil, nil
 	}

--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -215,56 +215,82 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 }
 
 // CopySpec copies only the Spec field from source to destination using Unstructured
+
+// kubeEnvelopeFields are standard top-level Kubernetes fields that don't
+// represent the resource's desired state. Everything else (spec, data,
+// rules, roleRef, subjects, etc.) is considered content.
+var kubeEnvelopeFields = map[string]bool{
+	"apiVersion": true,
+	"kind":       true,
+	"metadata":   true,
+	"status":     true,
+}
+
+// getContentFields returns all content fields from an unstructured object,
+// i.e. everything except the Kubernetes envelope (apiVersion, kind, metadata, status).
+// For resources with a "spec" field, it returns the spec directly for
+// backward-compatible hashing. For spec-less resources (ConfigMaps, Secrets,
+// Roles, etc.), it returns a map of all content fields.
+func getContentFields(u *unstructured.Unstructured) (any, bool) {
+	if spec, found, err := unstructured.NestedFieldCopy(u.Object, "spec"); err == nil && found {
+		return spec, true
+	}
+
+	content := make(map[string]interface{})
+	for k, v := range u.Object {
+		if kubeEnvelopeFields[k] {
+			continue
+		}
+		content[k] = v
+	}
+	if len(content) == 0 {
+		return nil, false
+	}
+	return content, true
+}
+
 func CopySpec(source, destination client.Object) error {
-	// Convert source to unstructured
 	sourceMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(source)
 	if err != nil {
 		return err
 	}
-	sourceUnstructured := &unstructured.Unstructured{Object: sourceMap}
+	srcU := &unstructured.Unstructured{Object: sourceMap}
 
-	// Convert destination to unstructured
 	destMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(destination)
 	if err != nil {
 		return err
 	}
-	destUnstructured := &unstructured.Unstructured{Object: destMap}
+	dstU := &unstructured.Unstructured{Object: destMap}
 
-	// Extract only the spec from source
-	sourceSpec, found, err := unstructured.NestedFieldCopy(sourceUnstructured.Object, "spec")
-	if err != nil {
-		return err
-	}
-	if !found {
-		return fmt.Errorf("spec not found in source object")
+	if spec, found, err := unstructured.NestedFieldCopy(srcU.Object, "spec"); err == nil && found {
+		if err := unstructured.SetNestedField(dstU.Object, spec, "spec"); err != nil {
+			return err
+		}
+		return runtime.DefaultUnstructuredConverter.FromUnstructured(dstU.Object, destination)
 	}
 
-	// Set the spec in the destination
-	err = unstructured.SetNestedField(destUnstructured.Object, sourceSpec, "spec")
-	if err != nil {
-		return err
+	for k, v := range srcU.Object {
+		if kubeEnvelopeFields[k] {
+			continue
+		}
+		dstU.Object[k] = v
 	}
 
-	// Convert back to the original object
-	return runtime.DefaultUnstructuredConverter.FromUnstructured(destUnstructured.Object, destination)
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(dstU.Object, destination)
 }
 
 func getSpec(obj client.Object) (any, error) {
-	// Convert source to unstructured
 	sourceMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
 		return nil, err
 	}
-	sourceUnstructured := &unstructured.Unstructured{Object: sourceMap}
-	// Extract only the spec from source
-	spec, found, err := unstructured.NestedFieldCopy(sourceUnstructured.Object, "spec")
-	if err != nil {
-		return nil, err
-	}
+	u := &unstructured.Unstructured{Object: sourceMap}
+
+	content, found := getContentFields(u)
 	if !found {
 		return nil, nil
 	}
-	return spec, nil
+	return content, nil
 }
 
 // SpecChangeResult contains the result of spec change detection

--- a/deploy/operator/internal/controller_common/resource_test.go
+++ b/deploy/operator/internal/controller_common/resource_test.go
@@ -770,3 +770,116 @@ func TestAppendUniqueImagePullSecrets(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSpecChangeResult_ConfigMap(t *testing.T) {
+	baseHash := func(t *testing.T, obj client.Object) string {
+		t.Helper()
+		h, err := GetSpecHash(obj)
+		if err != nil {
+			t.Fatalf("GetSpecHash: %v", err)
+		}
+		return h
+	}
+
+	baseCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "ns"},
+		Data:       map[string]string{"script.py": "print('v1')"},
+	}
+
+	tests := []struct {
+		name        string
+		current     client.Object
+		desired     client.Object
+		needsUpdate bool
+	}{
+		{
+			name: "same ConfigMap data does not need update",
+			current: func() client.Object {
+				cm := baseCM.DeepCopy()
+				cm.Annotations = map[string]string{
+					NvidiaAnnotationHashKey:       baseHash(t, baseCM),
+					NvidiaAnnotationGenerationKey: "1",
+				}
+				cm.Generation = 1
+				return cm
+			}(),
+			desired: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "ns"},
+				Data:       map[string]string{"script.py": "print('v1')"},
+			},
+			needsUpdate: false,
+		},
+		{
+			name: "changed ConfigMap data needs update",
+			current: func() client.Object {
+				cm := baseCM.DeepCopy()
+				cm.Annotations = map[string]string{
+					NvidiaAnnotationHashKey:       baseHash(t, baseCM),
+					NvidiaAnnotationGenerationKey: "1",
+				}
+				cm.Generation = 1
+				return cm
+			}(),
+			desired: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "ns"},
+				Data:       map[string]string{"script.py": "print('v2')"},
+			},
+			needsUpdate: true,
+		},
+		{
+			name: "metadata-only change does not need update",
+			current: func() client.Object {
+				cm := baseCM.DeepCopy()
+				cm.Annotations = map[string]string{
+					NvidiaAnnotationHashKey:       baseHash(t, baseCM),
+					NvidiaAnnotationGenerationKey: "1",
+				}
+				cm.Generation = 1
+				return cm
+			}(),
+			desired: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "different-name", Namespace: "ns", Labels: map[string]string{"foo": "bar"}},
+				Data:       map[string]string{"script.py": "print('v1')"},
+			},
+			needsUpdate: false,
+		},
+		{
+			name: "added key needs update",
+			current: func() client.Object {
+				cm := baseCM.DeepCopy()
+				cm.Annotations = map[string]string{
+					NvidiaAnnotationHashKey:       baseHash(t, baseCM),
+					NvidiaAnnotationGenerationKey: "1",
+				}
+				cm.Generation = 1
+				return cm
+			}(),
+			desired: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "ns"},
+				Data:       map[string]string{"script.py": "print('v1')", "extra.py": "pass"},
+			},
+			needsUpdate: true,
+		},
+		{
+			name: "no hash annotation needs update (pre-upgrade resource)",
+			current: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "ns"},
+				Data:       map[string]string{"script.py": "print('v1')"},
+			},
+			desired: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "ns"},
+				Data:       map[string]string{"script.py": "print('v1')"},
+			},
+			needsUpdate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			result, err := GetSpecChangeResult(tt.current, tt.desired)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(result.NeedsUpdate).To(gomega.Equal(tt.needsUpdate))
+		})
+	}
+}


### PR DESCRIPTION
- SyncResource, CopySpec, and getSpec only looked at .spec when hashing and comparing resources. Kubernetes types like ConfigMaps, Secrets, Roles, and ClusterRoles store their desired state in other top-level fields (data, rules, roleRef, subjects, etc.), so changes to those resources were silently ignored after initial creation.
- Introduce getContentFields() which returns .spec when present (preserving backward-compatible hashing) or falls back to all non-envelope fields (apiVersion, kind, metadata, status excluded) for spec-less resources.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced support for Kubernetes resources without spec fields, enabling proper change detection and hashing.
  * Improved handling of spec-less resource types like ConfigMaps in the operator.

* **Tests**
  * Added comprehensive test coverage for ConfigMap scenarios, including change detection, metadata updates, and pre-upgrade resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->