### PR TITLE
fix: add missing framework markers to KVBM nightly tests

### DIFF
--- a/tests/kvbm_integration/test_consolidator_router_e2e.py
+++ b/tests/kvbm_integration/test_consolidator_router_e2e.py
@@ -43,6 +43,8 @@ if HAS_TRTLLM:
 # Test markers
 pytestmark = [
     pytest.mark.kvbm,
+    pytest.mark.vllm,
+    pytest.mark.trtllm,
     pytest.mark.e2e,
     pytest.mark.slow,
     pytest.mark.gpu_1,

--- a/tests/kvbm_integration/test_determinism_agg.py
+++ b/tests/kvbm_integration/test_determinism_agg.py
@@ -58,8 +58,10 @@ _CACHE_RESET_TIMEOUT = 2 * (_KVBM_MAX_ITERATIONS * 4 + 50)
 _CONCURRENT_TIMEOUT = 2 * ((_KVBM_NUM_ITERATIONS - 1) * _KVBM_REQUEST_DELAY + 150)
 
 # Test markers to align with repository conventions
-# Todo: enable the rest when kvbm is built in the ci
 pytestmark = [
+    pytest.mark.kvbm,
+    pytest.mark.vllm,
+    pytest.mark.trtllm,
     pytest.mark.e2e,
     pytest.mark.slow,
     pytest.mark.gpu_1,


### PR DESCRIPTION
## Summary
- `test_determinism_agg.py` and `test_consolidator_router_e2e.py` were silently dropped from the nightly pipeline because they lacked `vllm`/`trtllm` framework markers
- The nightly CI selects tests by `framework AND gpu_tier` (e.g. `vllm and gpu_1`), so tests without framework markers were never collected
- Added `kvbm`, `vllm`, and `trtllm` markers to both files, matching the pattern already used by `test_determinism_disagg.py`

## Test plan
- [ ] Trigger nightly CI workflow run to verify KVBM tests are now collected in both vllm and trtllm pipelines
- [ ] Confirm `test_determinism_agg` and `test_consolidator_router_e2e` appear in test results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test categorization markers to improve test suite organization and execution control for integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->