### PR TITLE
fix(nixl): fix iteration_count debug logging in _wait_for_completion_

### DIFF
--- a/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
+++ b/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
@@ -448,20 +448,19 @@ class ActiveOperation(AbstractOperation):
     ) -> None:
         # Loop until the operation is no longer in progress (or "initialized"),
         # yielding control to the event loop to allow other operations to run.
-        start_time = time.monotonic()
-        iteration_count = 0
+        start = time.monotonic()
         sleep_time = min_poll_ms
         while True:
-            if iteration_count % 10 == 0:
+            elapsed = time.monotonic() - start
+            if int(elapsed) % 10 == 0:
                 logger.debug(
-                    f"dynamo.nixl_connect.{self.__class__.__name__}: Waiting for operation {{ kind={self._operation_kind}, remote='{self._remote.name}', duration={time.monotonic() - start_time:.1f}s }}."
+                    f"dynamo.nixl_connect.{self.__class__.__name__}: Waiting for operation {{ kind={self._operation_kind}, remote='{self._remote.name}', duration={elapsed:.1f}s }}."
                 )
             match self.status:
                 # "in progress" or "initialized" means the operation is ongoing.
                 case OperationStatus.INITIALIZED | OperationStatus.IN_PROGRESS:
                     await asyncio.sleep(sleep_time / 1000)
                     sleep_time = min(sleep_time * backoff_factor, max_poll_ms)
-                    iteration_count += 1
                 # Any other state indicates completion or error.
                 case _:
                     return

--- a/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
+++ b/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
@@ -450,7 +450,7 @@ class ActiveOperation(AbstractOperation):
         iteration_count = 0
         sleep_time = min_poll_ms
         while True:
-            if iteration_count & 10 == 0:
+            if iteration_count % 10 == 0:
                 logger.debug(
                     f"dynamo.nixl_connect.{self.__class__.__name__}: Waiting for operation {{ kind={self._operation_kind}, remote='{self._remote.name}', duration={iteration_count / 10}s }}."
                 )
@@ -459,6 +459,7 @@ class ActiveOperation(AbstractOperation):
                 case OperationStatus.INITIALIZED | OperationStatus.IN_PROGRESS:
                     await asyncio.sleep(sleep_time / 1000)
                     sleep_time = min(sleep_time * backoff_factor, max_poll_ms)
+                    iteration_count += 1
                 # Any other state indicates completion or error.
                 case _:
                     return

--- a/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
+++ b/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
@@ -449,12 +449,14 @@ class ActiveOperation(AbstractOperation):
         # Loop until the operation is no longer in progress (or "initialized"),
         # yielding control to the event loop to allow other operations to run.
         start = time.monotonic()
+        next_log_time = start
         sleep_time = min_poll_ms
         while True:
-            elapsed = time.monotonic() - start
-            if int(elapsed) % 10 == 0:
+            now = time.monotonic()
+            if now >= next_log_time:
+                next_log_time = now + 10.0
                 logger.debug(
-                    f"dynamo.nixl_connect.{self.__class__.__name__}: Waiting for operation {{ kind={self._operation_kind}, remote='{self._remote.name}', duration={elapsed:.1f}s }}."
+                    f"dynamo.nixl_connect.{self.__class__.__name__}: Waiting for operation {{ kind={self._operation_kind}, remote='{self._remote.name}', duration={now - start:.1f}s }}."
                 )
             match self.status:
                 # "in progress" or "initialized" means the operation is ongoing.

--- a/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
+++ b/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
@@ -21,6 +21,7 @@ import ctypes
 import logging
 import socket
 import threading
+import time
 import uuid
 import zlib
 from abc import ABC, abstractmethod
@@ -447,12 +448,13 @@ class ActiveOperation(AbstractOperation):
     ) -> None:
         # Loop until the operation is no longer in progress (or "initialized"),
         # yielding control to the event loop to allow other operations to run.
+        start_time = time.monotonic()
         iteration_count = 0
         sleep_time = min_poll_ms
         while True:
             if iteration_count % 10 == 0:
                 logger.debug(
-                    f"dynamo.nixl_connect.{self.__class__.__name__}: Waiting for operation {{ kind={self._operation_kind}, remote='{self._remote.name}', duration={iteration_count / 10}s }}."
+                    f"dynamo.nixl_connect.{self.__class__.__name__}: Waiting for operation {{ kind={self._operation_kind}, remote='{self._remote.name}', duration={time.monotonic() - start_time:.1f}s }}."
                 )
             match self.status:
                 # "in progress" or "initialized" means the operation is ongoing.


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs in `ActiveOperation._wait_for_completion_` (`lib/bindings/python/src/dynamo/nixl_connect/__init__.py`):

1. **`iteration_count` was never incremented** — initialized to 0 but never updated in the loop body, so it stayed 0 forever
2. **`iteration_count & 10` used bitwise AND instead of modulo** — should be `iteration_count % 10` to log every 10th iteration

Combined effect: the debug log fired on **every single poll iteration** with `duration=0.0s`, adding noise to debug logs during NIXL transfers.

## Fix

- Add `iteration_count += 1` at the end of the `IN_PROGRESS` case
- Change `&` to `%` for the modulo check

Found during review of #7933.

## Test plan

- [x] Existing pre-commit hooks pass (isort, black, flake8, ruff, codespell)
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal debug logging timing and iteration counting in active operation monitoring to ensure more precise and consistent cadence tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->