### PR TITLE
chore(ci): add xpu label to PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -94,6 +94,12 @@ documentation:
           - '**/*.md'
           - '**/*.rst'
 
+xpu:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/xpu/**'
+          - '**/*xpu*'
+
 multimodal:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Add labeler rules to automatically apply the `xpu` label when PRs touch files in xpu directories or with xpu in the filename.


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated labeling rules for infrastructure-related pull requests to improve workflow organization and overall code contribution tracking across the project. This enhancement makes it easier to categorize, filter, and manage development activities, supporting better project coordination and helping the team maintain an organized and efficient development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->