### PR TITLE
fix(runtime): prevent controller state regression from killed to stopped

### DIFF
--- a/lib/runtime/src/pipeline/context.rs
+++ b/lib/runtime/src/pipeline/context.rs
@@ -387,7 +387,14 @@ impl AsyncEngineContext for Controller {
             child.stop_generating();
         }
 
-        let _ = self.tx.send(State::Stopped);
+        // Do not regress from Killed to Stopped — Killed is terminal
+        self.tx.send_if_modified(|state| {
+            if *state == State::Killed {
+                return false;
+            }
+            *state = State::Stopped;
+            true
+        });
     }
 
     fn stop(&self) {
@@ -403,7 +410,14 @@ impl AsyncEngineContext for Controller {
             child.stop();
         }
 
-        let _ = self.tx.send(State::Stopped);
+        // Do not regress from Killed to Stopped — Killed is terminal
+        self.tx.send_if_modified(|state| {
+            if *state == State::Killed {
+                return false;
+            }
+            *state = State::Stopped;
+            true
+        });
     }
 
     fn kill(&self) {

--- a/lib/runtime/src/pipeline/context.rs
+++ b/lib/runtime/src/pipeline/context.rs
@@ -514,4 +514,50 @@ mod tests {
 
         assert_eq!(ctx.current.message, "Processed length: 5");
     }
+
+    #[test]
+    fn test_kill_is_terminal() {
+        // Once a controller is killed, stop_generating/stop must not
+        // regress its state back to Stopped.
+        let controller = Controller::default();
+
+        controller.kill();
+        assert!(controller.is_killed());
+
+        // This should not regress from Killed to Stopped
+        controller.stop_generating();
+        assert!(
+            controller.is_killed(),
+            "stop_generating() after kill() should not regress state from Killed to Stopped"
+        );
+
+        // Same for stop()
+        controller.stop();
+        assert!(
+            controller.is_killed(),
+            "stop() after kill() should not regress state from Killed to Stopped"
+        );
+    }
+
+    #[test]
+    fn test_kill_child_not_regressed_by_parent_stop() {
+        // If a child is killed independently, a parent's stop_generating()
+        // must not regress the child back to Stopped.
+        let parent = Controller::default();
+        let child = Arc::new(Controller::default());
+
+        parent.link_child(child.clone());
+
+        // Child is killed independently
+        child.kill();
+        assert!(child.is_killed());
+
+        // Parent stops — should not regress the killed child
+        parent.stop_generating();
+        assert!(parent.is_stopped());
+        assert!(
+            child.is_killed(),
+            "parent stop_generating() should not regress a killed child back to Stopped"
+        );
+    }
 }


### PR DESCRIPTION
#### Overview:

Fix a bug where `stop_generating()` and `stop()` on a pipeline `Controller` could regress the state from `Killed` back to `Stopped`, violating the terminal semantics of the killed state.

#### Details:

The `Controller` state machine has three states: `Live`, `Stopped`, `Killed`. `Killed` is intended to be terminal — once a controller is killed, `is_killed()` should always return `true`.

However, both `stop_generating()` and `stop()` unconditionally called `self.tx.send(State::Stopped)`, which overwrites whatever value is currently in the `tokio::sync::watch` channel. If a controller (or a child controller) was already killed, calling `stop_generating()` would regress the state from `Killed` to `Stopped`, causing `is_killed()` to return `false`.

This can happen in practice when:
1. A parent calls `kill()`, setting all children to `Killed`
2. An error path (e.g., `Frontend::on_data` receiving a detached response) calls `ctx.stop_generating()` on a child controller
3. The child's state regresses from `Killed` to `Stopped`
4. Downstream code checking `is_killed()` to decide whether to terminate immediately vs drain a stream makes the wrong decision

**Fix:** Replace `self.tx.send(State::Stopped)` with `self.tx.send_if_modified()` in both methods. This atomically checks the current state and only writes `Stopped` if the state is not already `Killed`.

#### Where should the reviewer start?

- `lib/runtime/src/pipeline/context.rs` — the `stop_generating()` and `stop()` methods on `Controller` (lines 390-397 and 413-420), and the two new tests at the end of the file.

#### How this was found:

This bug was identified by distilling an [Allium](https://github.com/juxt/allium) specification from the pipeline runtime code ([full spec](https://gist.github.com/oliverholworthy/db16623853e226dd6cf6570ea9b218fb)). The spec's transition graph declares `Killed` as a terminal state, and the Allium tend agent flagged that the `StopGenerating` and `Stop` rules needed guards (`if child.state = live:`) to avoid producing an invalid `killed -> stopped` transition — guards that were missing from the code. Part of an exploration into whether spec-driven development with Allium can surface real bugs by distilling specifications from existing code and checking where the implementation diverges from the derived spec.

#### Related Issues:

- Relates to: pipeline controller lifecycle correctness