### PR TITLE
fix(runtime): clean up orphaned sinks entry when Frontend.generate() fails

### DIFF
--- a/lib/runtime/src/pipeline/nodes/sources/base.rs
+++ b/lib/runtime/src/pipeline/nodes/sources/base.rs
@@ -59,11 +59,17 @@ impl<In: PipelineIO, Out: PipelineIO + AsyncEngineContextProvider> Sink<Out> for
 impl<In: PipelineIO + Sync, Out: PipelineIO> AsyncEngine<In, Out, Error> for Frontend<In, Out> {
     async fn generate(&self, request: In) -> Result<Out, Error> {
         let (tx, rx) = oneshot::channel::<Out>();
+        let id = request.id().to_string();
         {
             let mut sinks = self.sinks.lock().unwrap();
-            sinks.insert(request.id().to_string(), tx);
+            sinks.insert(id.clone(), tx);
         }
-        self.on_next(request, private::Token {}).await?;
+        if let Err(e) = self.on_next(request, private::Token {}).await {
+            // Clean up the orphaned sender to prevent unbounded HashMap growth
+            let mut sinks = self.sinks.lock().unwrap();
+            sinks.remove(&id);
+            return Err(e);
+        }
         Ok(rx.await.map_err(|_| PipelineError::DetachedStreamSender)?)
     }
 }

--- a/lib/runtime/src/pipeline/nodes/sources/base.rs
+++ b/lib/runtime/src/pipeline/nodes/sources/base.rs
@@ -100,4 +100,41 @@ mod tests {
             _ => panic!("Expected NoEdge error"),
         }
     }
+
+    #[tokio::test]
+    async fn test_generate_failure_cleans_up_sinks() {
+        // When generate() fails because on_next() errors (no edge linked),
+        // the oneshot sender should be removed from the sinks HashMap.
+        // Otherwise orphaned entries accumulate as a memory leak.
+        let source = Frontend::<SingleIn<()>, ManyOut<()>>::default();
+
+        // generate() should fail with NoEdge
+        let err = source.generate(().into()).await.unwrap_err();
+        assert!(err.downcast_ref::<PipelineError>().is_some());
+
+        // The sinks HashMap should be empty — the orphaned sender must be cleaned up
+        let sinks = source.sinks.lock().unwrap();
+        assert!(
+            sinks.is_empty(),
+            "sinks HashMap should be empty after generate() failure, but has {} entries",
+            sinks.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_repeated_generate_failures_do_not_accumulate() {
+        // Repeated generate() failures should not cause the sinks HashMap to grow.
+        let source = Frontend::<SingleIn<()>, ManyOut<()>>::default();
+
+        for _ in 0..100 {
+            let _ = source.generate(().into()).await;
+        }
+
+        let sinks = source.sinks.lock().unwrap();
+        assert!(
+            sinks.is_empty(),
+            "sinks HashMap should be empty after 100 failed generate() calls, but has {} entries",
+            sinks.len()
+        );
+    }
 }


### PR DESCRIPTION
#### Overview:

Fix a memory leak where `Frontend::generate()` leaves orphaned oneshot senders in the `sinks` HashMap when the downstream `on_next()` call fails.

#### Details:

`Frontend::generate()` creates a oneshot channel and inserts the sender into the `sinks` HashMap (keyed by request ID) before forwarding the request downstream via `on_next()`. If `on_next()` returns an error (e.g., `PipelineError::NoEdge`), the `?` operator propagates the error but the sender is never removed from the HashMap. The receiver is dropped when the function returns.

Each failed `generate()` call leaks one HashMap entry. There is no cleanup path, periodic GC, or TTL — under sustained failures the HashMap grows without bound. In a long-running inference server, this can cause significant memory pressure.

**Fix:** Capture the request ID before insertion, and on the `on_next()` error path, remove the entry from the HashMap before returning the error.

#### Where should the reviewer start?

- `lib/runtime/src/pipeline/nodes/sources/base.rs` — the `generate()` method on `Frontend` (lines 60-74), and the two new tests at the end of the file.

#### How this was found:

This bug was identified by distilling an [Allium](https://github.com/juxt/allium) specification from the pipeline runtime code ([full spec](https://gist.github.com/oliverholworthy/db16623853e226dd6cf6570ea9b218fb)). The spec models the request lifecycle through the `Frontend` entity, and the `IssueRequest` / `DeliverResponse` rules made the HashMap insert/remove contract explicit — revealing that the error path of `generate()` was missing the corresponding removal. Part of an exploration into whether spec-driven development with Allium can surface real bugs by distilling specifications from existing code and checking where the implementation diverges from the derived spec.

#### Related Issues:

- Relates to: pipeline Frontend resource cleanup