### PR TITLE
feat(test): add generalized multimodal model coverage framework

### DIFF
--- a/tests/serve/multimodal_profiles/__init__.py
+++ b/tests/serve/multimodal_profiles/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -40,10 +40,12 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             "e_pd": TopologyConfig(
                 marks=[pytest.mark.pre_merge],
                 timeout_s=340,
+                single_gpu=True,
             ),
             "epd": TopologyConfig(
                 marks=[pytest.mark.pre_merge],
                 timeout_s=300,
+                single_gpu=True,
             ),
         },
         request_payloads=[make_image_payload(["green"])],
@@ -61,6 +63,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 marks=[pytest.mark.pre_merge],
                 timeout_s=600,
                 delayed_start=60,
+                single_gpu=True,
             ),
         },
         request_payloads=[make_video_payload(["red", "static", "still"])],

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.utils.multimodal import (
+    MultimodalModelProfile,
+    TopologyConfig,
+    make_audio_payload,
+    make_image_payload,
+    make_video_payload,
+)
+
+WORKSPACE_DIR = str(Path(__file__).resolve().parents[3])
+
+VLLM_TOPOLOGY_SCRIPTS: dict[str, str] = {
+    "agg": "agg_multimodal.sh",
+    "e_pd": "disagg_multimodal_e_pd.sh",
+    "epd": "disagg_multimodal_epd.sh",
+    "p_d": "disagg_multimodal_p_d.sh",
+    "audio_agg": "audio_agg.sh",
+    "audio_disagg": "audio_disagg.sh",
+}
+
+_AUDIO_DIR = os.path.join(WORKSPACE_DIR, "examples/multimodal")
+
+VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
+    MultimodalModelProfile(
+        name="Qwen/Qwen3-VL-2B-Instruct",
+        short_name="qwen3-vl-2b",
+        topologies={
+            "agg": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=220,
+                profiled_vram_gib=9.6,
+            ),
+            "e_pd": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=340,
+            ),
+            "epd": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=300,
+            ),
+        },
+        request_payloads=[make_image_payload(["green"])],
+    ),
+    MultimodalModelProfile(
+        name="Qwen/Qwen3-VL-2B-Instruct",
+        short_name="qwen3-vl-2b-video",
+        topologies={
+            "agg": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=600,
+                delayed_start=60,
+            ),
+            "epd": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=600,
+                delayed_start=60,
+            ),
+        },
+        request_payloads=[make_video_payload(["red", "static", "still"])],
+    ),
+    MultimodalModelProfile(
+        name="Qwen/Qwen2.5-VL-7B-Instruct",
+        short_name="qwen2.5-vl-7b",
+        topologies={
+            "agg": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=360,
+                profiled_vram_gib=19.9,
+                requested_vllm_kv_cache_bytes=922_354_000,
+            ),
+        },
+        request_payloads=[make_image_payload(["purple"])],
+    ),
+    MultimodalModelProfile(
+        name="Qwen/Qwen2-Audio-7B-Instruct",
+        short_name="qwen2-audio-7b",
+        topologies={
+            "audio_agg": TopologyConfig(
+                marks=[pytest.mark.nightly],
+                timeout_s=600,
+                directory=_AUDIO_DIR,
+            ),
+            "audio_disagg": TopologyConfig(
+                marks=[pytest.mark.nightly],
+                timeout_s=600,
+                directory=_AUDIO_DIR,
+                gpu_marker="gpu_4",
+            ),
+        },
+        gpu_marker="gpu_2",
+        request_payloads=[make_audio_payload(["Hester", "Pynne"])],
+    ),
+    MultimodalModelProfile(
+        name="google/gemma-3-4b-it",
+        short_name="gemma3-4b",
+        topologies={
+            "agg": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=300,
+                profiled_vram_gib=12.0,
+            ),
+        },
+        request_payloads=[make_image_payload(["green"])],
+        extra_vllm_args=["--dtype", "bfloat16"],
+        gated=True,
+    ),
+]

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from pathlib import Path
 
 import pytest
 
+from dynamo.common.utils.paths import WORKSPACE_DIR
 from tests.utils.multimodal import (
     MultimodalModelProfile,
     TopologyConfig,
@@ -13,8 +13,6 @@ from tests.utils.multimodal import (
     make_image_payload,
     make_video_payload,
 )
-
-WORKSPACE_DIR = str(Path(__file__).resolve().parents[3])
 
 VLLM_TOPOLOGY_SCRIPTS: dict[str, str] = {
     "agg": "agg_multimodal.sh",

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -45,6 +45,11 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 timeout_s=300,
                 single_gpu=True,
             ),
+            "p_d": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=300,
+                single_gpu=True,
+            ),
         },
         request_payloads=[make_image_payload(["green"])],
     ),

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -18,9 +18,13 @@ from tests.serve.common import (
 )
 from tests.serve.conftest import MULTIMODAL_IMG_URL, get_multimodal_test_image_bytes
 from tests.serve.lora_utils import MinioLoraConfig
+from tests.serve.multimodal_profiles.vllm import (
+    VLLM_MULTIMODAL_PROFILES,
+    VLLM_TOPOLOGY_SCRIPTS,
+)
 from tests.utils.constants import DefaultPort
 from tests.utils.engine_process import EngineConfig
-from tests.utils.multimodal import MULTIMODAL_MODEL_PROFILES, make_multimodal_configs
+from tests.utils.multimodal import make_multimodal_configs
 from tests.utils.payload_builder import (
     cached_tokens_chat_payload,
     chat_payload,
@@ -590,8 +594,10 @@ vllm_configs = {
 }
 
 # Merge generated multimodal configs
-for _profile in MULTIMODAL_MODEL_PROFILES:
-    vllm_configs.update(make_multimodal_configs(_profile, VLLMConfig, vllm_dir))
+for _profile in VLLM_MULTIMODAL_PROFILES:
+    vllm_configs.update(
+        make_multimodal_configs(_profile, VLLMConfig, vllm_dir, VLLM_TOPOLOGY_SCRIPTS)
+    )
 
 
 @pytest.fixture(params=params_with_model_mark(vllm_configs))

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -8,7 +8,7 @@ import os
 import random
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 import pytest
 
@@ -21,6 +21,7 @@ from tests.serve.conftest import MULTIMODAL_IMG_URL, get_multimodal_test_image_b
 from tests.serve.lora_utils import MinioLoraConfig
 from tests.utils.constants import DefaultPort
 from tests.utils.engine_process import EngineConfig
+from tests.utils.multimodal import MULTIMODAL_MODEL_PROFILES, make_multimodal_configs
 from tests.utils.payload_builder import (
     cached_tokens_chat_payload,
     chat_payload,
@@ -30,11 +31,7 @@ from tests.utils.payload_builder import (
     completion_payload_with_logprobs,
     metric_payload_default,
 )
-from tests.utils.payloads import (
-    ChatPayload,
-    LoraTestChatPayload,
-    ToolCallingChatPayload,
-)
+from tests.utils.payloads import LoraTestChatPayload, ToolCallingChatPayload
 
 logger = logging.getLogger(__name__)
 
@@ -59,149 +56,6 @@ LOCAL_VIDEO_TEST_PATH = Path(
     WORKSPACE_DIR, "lib/llm/tests/data/media/240p_10.mp4"
 ).resolve()
 LOCAL_VIDEO_TEST_URI = LOCAL_VIDEO_TEST_PATH.as_uri()
-
-
-# ---------------------------------------------------------------------------
-# Multimodal model profile framework
-# ---------------------------------------------------------------------------
-# Generated config keys use the "mm_" prefix. Do not use this prefix for
-# hand-written configs to avoid collisions.
-
-
-@dataclass
-class MultimodalModelProfile:
-    """Describes a multimodal model's test-relevant properties.
-
-    Each profile generates one VLLMConfig per topology in supported_topologies
-    via make_multimodal_configs().
-    """
-
-    name: str  # HuggingFace model ID
-    short_name: str  # kebab-case slug for config key (e.g. "qwen3-vl-2b")
-    supported_topologies: list[str]  # ordered list: ["agg"] for Phase 1
-    image_expected_response: list[str]  # OR-substring keywords (any match = pass)
-    gpu_marker: str  # "gpu_1" or "gpu_2"
-    timeout_s: int  # pytest timeout in seconds
-    extra_vllm_args: list[str] = field(default_factory=list)
-    marks: list[Any] = field(default_factory=list)
-    profiled_vram_gib: Optional[float] = None
-    requested_vllm_kv_cache_bytes: Optional[int] = None
-    gated: bool = False  # if True, skip unless DYN_HF_GATED_MODELS_ENABLED=1
-
-
-TOPOLOGY_SCRIPTS: dict[str, str] = {
-    "agg": "agg_multimodal.sh",
-    "e_pd": "disagg_multimodal_e_pd.sh",
-    "epd": "disagg_multimodal_epd.sh",
-    "p_d": "disagg_multimodal_p_d.sh",
-}
-
-
-def _make_image_payload(expected_response: list[str]) -> ChatPayload:
-    """Standard multimodal image test payload.
-
-    Uses the shared test image (MULTIMODAL_IMG_URL) with a color-identification
-    prompt. Response validation uses case-insensitive OR-substring matching:
-    the check passes if ANY keyword in expected_response appears in the response.
-    """
-    return chat_payload(
-        [
-            {
-                "type": "text",
-                "text": "What colors are in the following image? "
-                "Respond only with the colors.",
-            },
-            {
-                "type": "image_url",
-                "image_url": {"url": MULTIMODAL_IMG_URL},
-            },
-        ],
-        repeat_count=1,
-        expected_response=expected_response,
-        temperature=0.0,
-        max_tokens=100,
-    )
-
-
-def make_multimodal_configs(
-    profile: MultimodalModelProfile,
-) -> dict[str, VLLMConfig]:
-    """Generate VLLMConfig entries for each topology in profile.supported_topologies."""
-    configs: dict[str, VLLMConfig] = {}
-    for topology in profile.supported_topologies:
-        script_name = TOPOLOGY_SCRIPTS[topology]  # KeyError if invalid
-        script_args = ["--model", profile.name] + profile.extra_vllm_args
-        if topology != "agg":
-            script_args.append("--single-gpu")
-
-        marks: list[Any] = [
-            getattr(pytest.mark, profile.gpu_marker),
-            pytest.mark.timeout(profile.timeout_s),
-            pytest.mark.post_merge,
-        ]
-        if profile.profiled_vram_gib is not None:
-            marks.append(pytest.mark.profiled_vram_gib(profile.profiled_vram_gib))
-        if profile.requested_vllm_kv_cache_bytes is not None:
-            marks.append(
-                pytest.mark.requested_vllm_kv_cache_bytes(
-                    profile.requested_vllm_kv_cache_bytes
-                )
-            )
-        if profile.gated:
-            marks.append(
-                pytest.mark.skipif(
-                    not os.environ.get("DYN_HF_GATED_MODELS_ENABLED"),
-                    reason=(
-                        f"{profile.name} is gated; set DYN_HF_GATED_MODELS_ENABLED=1 "
-                        "with an HF_TOKEN that has accepted the license"
-                    ),
-                )
-            )
-        marks.extend(profile.marks)
-
-        key = f"mm_{topology}_{profile.short_name}"
-        configs[key] = VLLMConfig(
-            name=key,
-            directory=vllm_dir,
-            script_name=script_name,
-            model=profile.name,
-            script_args=script_args,
-            marks=marks,
-            request_payloads=[_make_image_payload(profile.image_expected_response)],
-        )
-    return configs
-
-
-# ---------------------------------------------------------------------------
-# Multimodal model profiles — add new models here
-# ---------------------------------------------------------------------------
-MULTIMODAL_MODEL_PROFILES: list[MultimodalModelProfile] = [
-    MultimodalModelProfile(
-        name="Qwen/Qwen3-VL-2B-Instruct",
-        short_name="qwen3-vl-2b",
-        supported_topologies=["agg"],
-        image_expected_response=["green"],
-        gpu_marker="gpu_1",
-        timeout_s=220,
-        profiled_vram_gib=9.6,
-    ),
-    MultimodalModelProfile(
-        name="google/gemma-3-4b-it",
-        short_name="gemma3-4b",
-        supported_topologies=["agg"],
-        image_expected_response=["green"],
-        gpu_marker="gpu_1",
-        timeout_s=300,
-        extra_vllm_args=["--dtype", "bfloat16"],
-        gated=True,
-        profiled_vram_gib=12.0,
-    ),
-]
-
-# Generate and merge multimodal configs into the main config dict (populated below)
-_generated_mm_configs: dict[str, VLLMConfig] = {}
-for _profile in MULTIMODAL_MODEL_PROFILES:
-    _generated_mm_configs.update(make_multimodal_configs(_profile))
 
 
 # vLLM test configurations
@@ -474,44 +328,6 @@ vllm_configs = {
             completion_payload_default(),
         ],
     ),
-    # NOTE: Pack all workers on 1 GPU for lower CI resource requirements
-    # NOTE: disagg_multimodal_e_pd.sh uses explicit --gpu-memory-utilization via
-    # DYN_ENCODE_GPU_MEM / DYN_PD_GPU_MEM env vars in single-GPU mode.
-    # PD worker honors build_vllm_gpu_mem_args for parallel execution.
-    "multimodal_e_pd_qwen": VLLMConfig(
-        name="multimodal_e_pd_qwen",
-        directory=vllm_dir,
-        script_name="disagg_multimodal_e_pd.sh",
-        marks=[
-            pytest.mark.gpu_1,
-            # No profiled_vram_gib / requested_vllm_kv_cache_bytes: single-GPU mode
-            # uses hardcoded fractions (encode=0.1, PD=0.7) that scale with GPU size.
-            pytest.mark.timeout(340),  # ~5x observed 68.4s; 2B model loads slower on CI
-            pytest.mark.pre_merge,
-        ],
-        model="Qwen/Qwen3-VL-2B-Instruct",
-        script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct", "--single-gpu"],
-        request_payloads=[
-            chat_payload(
-                [
-                    {
-                        "type": "text",
-                        "text": "What colors are in the following image? Respond only with the colors.",
-                    },
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": MULTIMODAL_IMG_URL},
-                    },
-                ],
-                repeat_count=1,
-                # With proper prompt templating, the model actually only returns "green",
-                # verified behavior with native vLLM.
-                expected_response=["green"],
-                temperature=0.0,
-                max_tokens=100,
-            )
-        ],
-    ),
     "multimodal_agg_frontend_decoding": VLLMConfig(
         name="multimodal_agg_frontend_decoding",
         directory=vllm_dir,
@@ -550,117 +366,6 @@ vllm_configs = {
                 temperature=0.0,
                 max_tokens=100,
             )
-        ],
-    ),
-    # NOTE: Pack all workers on 1 GPU for lower CI resource requirements.
-    # NOTE: disagg_multimodal_epd.sh uses --kv-cache-memory-bytes=512MB for P/D
-    # workers. Per vLLM CacheConfig, kv_cache_memory_bytes (when not-None) ignores
-    # gpu_memory_utilization (ref: https://docs.vllm.ai/en/stable/api/vllm/config/cache/),
-    # so KV cache overrides have no effect. Regardless of GPU_MEM
-    # fractions (0.1/0.4/0.4), the 3 workers combined consistently use ~17.6 GiB
-    # total on this GPU.
-    # NOTE: disagg_multimodal_epd.sh uses explicit --gpu-memory-utilization via
-    # DYN_ENCODE_GPU_MEM / DYN_PREFILL_GPU_MEM / DYN_DECODE_GPU_MEM env vars.
-    # P/D workers honor build_vllm_gpu_mem_args for parallel execution.
-    "multimodal_disagg_qwen": VLLMConfig(
-        name="multimodal_disagg_qwen",
-        directory=vllm_dir,
-        script_name="disagg_multimodal_epd.sh",
-        marks=[
-            pytest.mark.gpu_1,
-            # No profiled_vram_gib / requested_vllm_kv_cache_bytes: single-GPU mode
-            # uses hardcoded fractions via DYN_*_GPU_MEM that scale with GPU size.
-            pytest.mark.pre_merge,
-        ],
-        model="Qwen/Qwen3-VL-2B-Instruct",
-        script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct", "--single-gpu"],
-        timeout=300,
-        request_payloads=[
-            chat_payload(
-                [
-                    {
-                        "type": "text",
-                        "text": "What colors are in the following image? Respond only with the colors.",
-                    },
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": MULTIMODAL_IMG_URL},
-                    },
-                ],
-                repeat_count=1,
-                expected_response=["green"],
-                temperature=0.0,
-                max_tokens=100,
-            )
-        ],
-    ),
-    # P/D multimodal (no encoder): prefill loads images via PIL,
-    # computes grid_thw for decode using smart_resize.
-    "multimodal_p_d_qwen": VLLMConfig(
-        name="multimodal_p_d_qwen",
-        directory=vllm_dir,
-        script_name="disagg_multimodal_p_d.sh",
-        marks=[
-            pytest.mark.gpu_1,
-            pytest.mark.pre_merge,
-        ],
-        model="Qwen/Qwen3-VL-2B-Instruct",
-        script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct", "--single-gpu"],
-        timeout=300,
-        request_payloads=[
-            chat_payload(
-                [
-                    {
-                        "type": "text",
-                        "text": "What colors are in the following image? Respond only with the colors.",
-                    },
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": MULTIMODAL_IMG_URL},
-                    },
-                ],
-                repeat_count=1,
-                expected_response=["green"],
-                temperature=0.0,
-                max_tokens=100,
-            )
-        ],
-    ),
-    "multimodal_agg_qwen": VLLMConfig(
-        name="multimodal_agg_qwen",
-        directory=vllm_dir,
-        script_name="agg_multimodal.sh",
-        marks=[
-            pytest.mark.gpu_1,
-            pytest.mark.profiled_vram_gib(19.9),  # actual profiled peak with kv-bytes
-            pytest.mark.requested_vllm_kv_cache_bytes(
-                922_354_000
-            ),  # KV cache cap (2x safety over min=461_176_832)
-            pytest.mark.timeout(
-                360
-            ),  # ~7x observed 50.0s; 7B model loads ~48s on CI (A10G/L4)
-            pytest.mark.post_merge,
-        ],
-        model="Qwen/Qwen2.5-VL-7B-Instruct",
-        script_args=["--model", "Qwen/Qwen2.5-VL-7B-Instruct"],
-        delayed_start=0,
-        timeout=360,
-        request_payloads=[
-            chat_payload(
-                [
-                    {
-                        "type": "text",
-                        "text": "What colors are in the following image? Respond only with the colors.",
-                    },
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": MULTIMODAL_IMG_URL},
-                    },
-                ],
-                repeat_count=1,
-                expected_response=["purple"],
-                max_tokens=100,
-            ),
         ],
     ),
     "multimodal_agg_llava": VLLMConfig(
@@ -1009,7 +714,8 @@ vllm_configs = {
 }
 
 # Merge generated multimodal configs
-vllm_configs.update(_generated_mm_configs)
+for _profile in MULTIMODAL_MODEL_PROFILES:
+    vllm_configs.update(make_multimodal_configs(_profile, VLLMConfig, vllm_dir))
 
 
 @pytest.fixture(params=params_with_model_mark(vllm_configs))

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -56,6 +56,12 @@ vllm_dir = os.environ.get("VLLM_DIR") or os.path.join(
     WORKSPACE_DIR, "examples/backends/vllm"
 )
 
+# Generated multimodal configs from profile definitions
+_mm_configs: dict[str, VLLMConfig] = {}
+for _profile in VLLM_MULTIMODAL_PROFILES:
+    _mm_configs.update(
+        make_multimodal_configs(_profile, VLLMConfig, vllm_dir, VLLM_TOPOLOGY_SCRIPTS)
+    )
 
 # vLLM test configurations
 # NOTE: pytest.mark.gpu_1 tests take ~5.5 minutes total to run sequentially (with models pre-cached)
@@ -64,6 +70,7 @@ vllm_dir = os.environ.get("VLLM_DIR") or os.path.join(
 # A future collector/launcher can sum profiled_vram_gib values to decide how many tests fit
 # concurrently without exceeding available VRAM.
 vllm_configs = {
+    **_mm_configs,
     "aggregated": VLLMConfig(
         name="aggregated",
         directory=vllm_dir,
@@ -592,12 +599,6 @@ vllm_configs = {
         ],
     ),
 }
-
-# Merge generated multimodal configs
-for _profile in VLLM_MULTIMODAL_PROFILES:
-    vllm_configs.update(
-        make_multimodal_configs(_profile, VLLMConfig, vllm_dir, VLLM_TOPOLOGY_SCRIPTS)
-    )
 
 
 @pytest.fixture(params=params_with_model_mark(vllm_configs))

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -7,7 +7,6 @@ import logging
 import os
 import random
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Optional
 
 import pytest
@@ -52,10 +51,6 @@ class VLLMConfig(EngineConfig):
 vllm_dir = os.environ.get("VLLM_DIR") or os.path.join(
     WORKSPACE_DIR, "examples/backends/vllm"
 )
-LOCAL_VIDEO_TEST_PATH = Path(
-    WORKSPACE_DIR, "lib/llm/tests/data/media/240p_10.mp4"
-).resolve()
-LOCAL_VIDEO_TEST_URI = LOCAL_VIDEO_TEST_PATH.as_uri()
 
 
 # vLLM test configurations
@@ -410,125 +405,6 @@ vllm_configs = {
                 repeat_count=1,
                 expected_response=[],  # Just validate no error
             ),
-        ],
-    ),
-    # Video multimodal tests for CI use the canonical aggregated multimodal launcher.
-    "multimodal_video_agg": VLLMConfig(
-        name="multimodal_video_agg",
-        directory=vllm_dir,
-        script_name="agg_multimodal.sh",
-        marks=[
-            pytest.mark.gpu_1,
-            pytest.mark.pre_merge,
-        ],  # TODO: profile to get max_vram and timeout
-        model="Qwen/Qwen3-VL-2B-Instruct",
-        delayed_start=60,  # Video models require longer loading time
-        script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct"],
-        timeout=600,  # 10 minutes for video processing overhead
-        request_payloads=[
-            chat_payload(
-                [
-                    {"type": "text", "text": "Describe the video in detail"},
-                    {
-                        "type": "video_url",
-                        "video_url": {"url": LOCAL_VIDEO_TEST_URI},
-                    },
-                ],
-                repeat_count=1,
-                expected_response=["red", "static", "still"],
-                temperature=0.0,
-                max_tokens=100,
-            )
-        ],
-    ),
-    "multimodal_video_disagg": VLLMConfig(
-        name="multimodal_video_disagg",
-        directory=vllm_dir,
-        script_name="disagg_multimodal_epd.sh",
-        marks=[
-            pytest.mark.gpu_1,
-            pytest.mark.pre_merge,
-        ],  # TODO: profile to get max_vram and timeout
-        model="Qwen/Qwen3-VL-2B-Instruct",
-        delayed_start=60,  # Video models require longer loading time
-        script_args=["--model", "Qwen/Qwen3-VL-2B-Instruct", "--single-gpu"],
-        timeout=600,  # 10 minutes for video processing overhead
-        request_payloads=[
-            chat_payload(
-                [
-                    {"type": "text", "text": "Describe the video in detail"},
-                    {
-                        "type": "video_url",
-                        "video_url": {"url": LOCAL_VIDEO_TEST_URI},
-                    },
-                ],
-                repeat_count=1,
-                expected_response=["red", "static", "still"],
-                temperature=0.0,
-                max_tokens=100,
-            )
-        ],
-    ),
-    # Audio multimodal tests for nightly CI pipeline
-    # These tests validate audio inference capabilities with Qwen2-Audio model
-    "multimodal_audio_agg": VLLMConfig(
-        name="multimodal_audio_agg",
-        directory=os.path.join(WORKSPACE_DIR, "examples/multimodal"),
-        script_name="audio_agg.sh",
-        marks=[
-            pytest.mark.gpu_2,  # encode worker loads Qwen2Audio on GPU (~19 GiB)
-            pytest.mark.nightly,
-            pytest.mark.timeout(600),
-        ],
-        model="Qwen/Qwen2-Audio-7B-Instruct",
-        delayed_start=0,
-        script_args=["--model", "Qwen/Qwen2-Audio-7B-Instruct"],
-        request_payloads=[
-            chat_payload(
-                [
-                    {"type": "text", "text": "What is recited in the audio?"},
-                    {
-                        "type": "audio_url",
-                        "audio_url": {
-                            "url": "https://raw.githubusercontent.com/yuekaizhang/Triton-ASR-Client/main/datasets/mini_en/wav/1221-135766-0002.wav"
-                        },
-                    },
-                ],
-                repeat_count=1,
-                expected_response=["Hester", "Pynne"],
-                temperature=0.0,
-                max_tokens=100,
-            )
-        ],
-    ),
-    "multimodal_audio_disagg": VLLMConfig(
-        name="multimodal_audio_disagg",
-        directory=os.path.join(WORKSPACE_DIR, "examples/multimodal"),
-        script_name="audio_disagg.sh",
-        marks=[
-            pytest.mark.gpu_4,  # needs 3 GPUs (encode loads Qwen2Audio ~19 GiB + prefill + decode)
-            pytest.mark.nightly,
-            pytest.mark.timeout(600),
-        ],
-        model="Qwen/Qwen2-Audio-7B-Instruct",
-        delayed_start=0,
-        script_args=["--model", "Qwen/Qwen2-Audio-7B-Instruct"],
-        request_payloads=[
-            chat_payload(
-                [
-                    {"type": "text", "text": "What is recited in the audio?"},
-                    {
-                        "type": "audio_url",
-                        "audio_url": {
-                            "url": "https://raw.githubusercontent.com/yuekaizhang/Triton-ASR-Client/main/datasets/mini_en/wav/1221-135766-0002.wav"
-                        },
-                    },
-                ],
-                repeat_count=1,
-                expected_response=["Hester", "Pynne"],
-                temperature=0.0,
-                max_tokens=100,
-            )
         ],
     ),
     "aggregated_toolcalling": VLLMConfig(

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -8,7 +8,7 @@ import os
 import random
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -30,7 +30,11 @@ from tests.utils.payload_builder import (
     completion_payload_with_logprobs,
     metric_payload_default,
 )
-from tests.utils.payloads import LoraTestChatPayload, ToolCallingChatPayload
+from tests.utils.payloads import (
+    ChatPayload,
+    LoraTestChatPayload,
+    ToolCallingChatPayload,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +59,149 @@ LOCAL_VIDEO_TEST_PATH = Path(
     WORKSPACE_DIR, "lib/llm/tests/data/media/240p_10.mp4"
 ).resolve()
 LOCAL_VIDEO_TEST_URI = LOCAL_VIDEO_TEST_PATH.as_uri()
+
+
+# ---------------------------------------------------------------------------
+# Multimodal model profile framework
+# ---------------------------------------------------------------------------
+# Generated config keys use the "mm_" prefix. Do not use this prefix for
+# hand-written configs to avoid collisions.
+
+
+@dataclass
+class MultimodalModelProfile:
+    """Describes a multimodal model's test-relevant properties.
+
+    Each profile generates one VLLMConfig per topology in supported_topologies
+    via make_multimodal_configs().
+    """
+
+    name: str  # HuggingFace model ID
+    short_name: str  # kebab-case slug for config key (e.g. "qwen3-vl-2b")
+    supported_topologies: list[str]  # ordered list: ["agg"] for Phase 1
+    image_expected_response: list[str]  # OR-substring keywords (any match = pass)
+    gpu_marker: str  # "gpu_1" or "gpu_2"
+    timeout_s: int  # pytest timeout in seconds
+    extra_vllm_args: list[str] = field(default_factory=list)
+    marks: list[Any] = field(default_factory=list)
+    profiled_vram_gib: Optional[float] = None
+    requested_vllm_kv_cache_bytes: Optional[int] = None
+    gated: bool = False  # if True, skip unless DYN_HF_GATED_MODELS_ENABLED=1
+
+
+TOPOLOGY_SCRIPTS: dict[str, str] = {
+    "agg": "agg_multimodal.sh",
+    "e_pd": "disagg_multimodal_e_pd.sh",
+    "epd": "disagg_multimodal_epd.sh",
+    "p_d": "disagg_multimodal_p_d.sh",
+}
+
+
+def _make_image_payload(expected_response: list[str]) -> ChatPayload:
+    """Standard multimodal image test payload.
+
+    Uses the shared test image (MULTIMODAL_IMG_URL) with a color-identification
+    prompt. Response validation uses case-insensitive OR-substring matching:
+    the check passes if ANY keyword in expected_response appears in the response.
+    """
+    return chat_payload(
+        [
+            {
+                "type": "text",
+                "text": "What colors are in the following image? "
+                "Respond only with the colors.",
+            },
+            {
+                "type": "image_url",
+                "image_url": {"url": MULTIMODAL_IMG_URL},
+            },
+        ],
+        repeat_count=1,
+        expected_response=expected_response,
+        temperature=0.0,
+        max_tokens=100,
+    )
+
+
+def make_multimodal_configs(
+    profile: MultimodalModelProfile,
+) -> dict[str, VLLMConfig]:
+    """Generate VLLMConfig entries for each topology in profile.supported_topologies."""
+    configs: dict[str, VLLMConfig] = {}
+    for topology in profile.supported_topologies:
+        script_name = TOPOLOGY_SCRIPTS[topology]  # KeyError if invalid
+        script_args = ["--model", profile.name] + profile.extra_vllm_args
+        if topology != "agg":
+            script_args.append("--single-gpu")
+
+        marks: list[Any] = [
+            getattr(pytest.mark, profile.gpu_marker),
+            pytest.mark.timeout(profile.timeout_s),
+            pytest.mark.post_merge,
+        ]
+        if profile.profiled_vram_gib is not None:
+            marks.append(pytest.mark.profiled_vram_gib(profile.profiled_vram_gib))
+        if profile.requested_vllm_kv_cache_bytes is not None:
+            marks.append(
+                pytest.mark.requested_vllm_kv_cache_bytes(
+                    profile.requested_vllm_kv_cache_bytes
+                )
+            )
+        if profile.gated:
+            marks.append(
+                pytest.mark.skipif(
+                    not os.environ.get("DYN_HF_GATED_MODELS_ENABLED"),
+                    reason=(
+                        f"{profile.name} is gated; set DYN_HF_GATED_MODELS_ENABLED=1 "
+                        "with an HF_TOKEN that has accepted the license"
+                    ),
+                )
+            )
+        marks.extend(profile.marks)
+
+        key = f"mm_{topology}_{profile.short_name}"
+        configs[key] = VLLMConfig(
+            name=key,
+            directory=vllm_dir,
+            script_name=script_name,
+            model=profile.name,
+            script_args=script_args,
+            marks=marks,
+            request_payloads=[_make_image_payload(profile.image_expected_response)],
+        )
+    return configs
+
+
+# ---------------------------------------------------------------------------
+# Multimodal model profiles — add new models here
+# ---------------------------------------------------------------------------
+MULTIMODAL_MODEL_PROFILES: list[MultimodalModelProfile] = [
+    MultimodalModelProfile(
+        name="Qwen/Qwen3-VL-2B-Instruct",
+        short_name="qwen3-vl-2b",
+        supported_topologies=["agg"],
+        image_expected_response=["green"],
+        gpu_marker="gpu_1",
+        timeout_s=220,
+        profiled_vram_gib=9.6,
+    ),
+    MultimodalModelProfile(
+        name="google/gemma-3-4b-it",
+        short_name="gemma3-4b",
+        supported_topologies=["agg"],
+        image_expected_response=["green"],
+        gpu_marker="gpu_1",
+        timeout_s=300,
+        extra_vllm_args=["--dtype", "bfloat16"],
+        gated=True,
+        profiled_vram_gib=12.0,
+    ),
+]
+
+# Generate and merge multimodal configs into the main config dict (populated below)
+_generated_mm_configs: dict[str, VLLMConfig] = {}
+for _profile in MULTIMODAL_MODEL_PROFILES:
+    _generated_mm_configs.update(make_multimodal_configs(_profile))
 
 
 # vLLM test configurations
@@ -860,6 +1007,9 @@ vllm_configs = {
         ],
     ),
 }
+
+# Merge generated multimodal configs
+vllm_configs.update(_generated_mm_configs)
 
 
 @pytest.fixture(params=params_with_model_mark(vllm_configs))

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -8,12 +8,11 @@ from typing import Any, Optional, Type
 
 import pytest
 
+from dynamo.common.utils.paths import WORKSPACE_DIR
 from tests.serve.conftest import MULTIMODAL_IMG_URL
 from tests.utils.engine_process import EngineConfig
 from tests.utils.payload_builder import chat_payload
 from tests.utils.payloads import BasePayload, ChatPayload
-
-WORKSPACE_DIR = str(Path(__file__).resolve().parents[2])
 
 LOCAL_VIDEO_TEST_PATH = Path(
     WORKSPACE_DIR, "lib/llm/tests/data/media/240p_10.mp4"

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -3,6 +3,7 @@
 
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Optional, Type
 
 import pytest
@@ -10,52 +11,42 @@ import pytest
 from tests.serve.conftest import MULTIMODAL_IMG_URL
 from tests.utils.engine_process import EngineConfig
 from tests.utils.payload_builder import chat_payload
-from tests.utils.payloads import ChatPayload
+from tests.utils.payloads import BasePayload, ChatPayload
+
+WORKSPACE_DIR = str(Path(__file__).resolve().parents[2])
+
+LOCAL_VIDEO_TEST_PATH = Path(
+    WORKSPACE_DIR, "lib/llm/tests/data/media/240p_10.mp4"
+).resolve()
+LOCAL_VIDEO_TEST_URI = LOCAL_VIDEO_TEST_PATH.as_uri()
+
+AUDIO_TEST_URL = (
+    "https://raw.githubusercontent.com/yuekaizhang/Triton-ASR-Client"
+    "/main/datasets/mini_en/wav/1221-135766-0002.wav"
+)
 
 
-@dataclass
-class TopologyConfig:
-    """Per-topology overrides for marks, timeout, and VRAM profiling."""
-
-    marks: list[Any] = field(default_factory=list)
-    timeout_s: int = 300
-    profiled_vram_gib: Optional[float] = None
-    requested_vllm_kv_cache_bytes: Optional[int] = None
-
-
-@dataclass
-class MultimodalModelProfile:
-    """Describes a multimodal model's test-relevant properties.
-
-    Each profile generates one config per topology in ``topologies``
-    via :func:`make_multimodal_configs`.
-    """
-
-    name: str  # HuggingFace model ID
-    short_name: str  # kebab-case slug for config key (e.g. "qwen3-vl-2b")
-    topologies: dict[str, TopologyConfig]
-    image_expected_response: list[str]  # OR-substring keywords (any match = pass)
-    gpu_marker: str = "gpu_1"
-    extra_vllm_args: list[str] = field(default_factory=list)
-    marks: list[Any] = field(default_factory=list)  # shared across all topologies
-    gated: bool = False  # if True, skip unless DYN_HF_GATED_MODELS_ENABLED=1
-
+# ---------------------------------------------------------------------------
+# Topology scripts
+# ---------------------------------------------------------------------------
 
 TOPOLOGY_SCRIPTS: dict[str, str] = {
     "agg": "agg_multimodal.sh",
     "e_pd": "disagg_multimodal_e_pd.sh",
     "epd": "disagg_multimodal_epd.sh",
     "p_d": "disagg_multimodal_p_d.sh",
+    "audio_agg": "audio_agg.sh",
+    "audio_disagg": "audio_disagg.sh",
 }
 
 
-def make_image_payload(expected_response: list[str]) -> ChatPayload:
-    """Standard multimodal image test payload.
+# ---------------------------------------------------------------------------
+# Payload factories
+# ---------------------------------------------------------------------------
 
-    Uses the shared test image (MULTIMODAL_IMG_URL) with a color-identification
-    prompt. Response validation uses case-insensitive OR-substring matching:
-    the check passes if ANY keyword in expected_response appears in the response.
-    """
+
+def make_image_payload(expected_response: list[str]) -> ChatPayload:
+    """Standard image color-identification payload using MULTIMODAL_IMG_URL."""
     return chat_payload(
         [
             {
@@ -75,6 +66,81 @@ def make_image_payload(expected_response: list[str]) -> ChatPayload:
     )
 
 
+def make_video_payload(expected_response: list[str]) -> ChatPayload:
+    """Standard video description payload using the local test video."""
+    return chat_payload(
+        [
+            {"type": "text", "text": "Describe the video in detail"},
+            {
+                "type": "video_url",
+                "video_url": {"url": LOCAL_VIDEO_TEST_URI},
+            },
+        ],
+        repeat_count=1,
+        expected_response=expected_response,
+        temperature=0.0,
+        max_tokens=100,
+    )
+
+
+def make_audio_payload(expected_response: list[str]) -> ChatPayload:
+    """Standard audio transcription payload using the remote test WAV."""
+    return chat_payload(
+        [
+            {"type": "text", "text": "What is recited in the audio?"},
+            {
+                "type": "audio_url",
+                "audio_url": {"url": AUDIO_TEST_URL},
+            },
+        ],
+        repeat_count=1,
+        expected_response=expected_response,
+        temperature=0.0,
+        max_tokens=100,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TopologyConfig:
+    """Per-topology overrides for marks, timeout, and VRAM profiling."""
+
+    marks: list[Any] = field(default_factory=list)
+    timeout_s: int = 300
+    profiled_vram_gib: Optional[float] = None
+    requested_vllm_kv_cache_bytes: Optional[int] = None
+    delayed_start: int = 0
+    directory: Optional[str] = None  # override profile-level directory
+    gpu_marker: Optional[str] = None  # override profile-level gpu_marker
+
+
+@dataclass
+class MultimodalModelProfile:
+    """Describes a multimodal model's test-relevant properties.
+
+    Each profile generates one config per topology in ``topologies``
+    via :func:`make_multimodal_configs`.
+    """
+
+    name: str  # HuggingFace model ID
+    short_name: str  # kebab-case slug for config key
+    topologies: dict[str, TopologyConfig]
+    request_payloads: list[BasePayload]
+    gpu_marker: str = "gpu_1"
+    extra_vllm_args: list[str] = field(default_factory=list)
+    marks: list[Any] = field(default_factory=list)  # shared across all topologies
+    gated: bool = False  # if True, skip unless DYN_HF_GATED_MODELS_ENABLED=1
+
+
+# ---------------------------------------------------------------------------
+# Config generator
+# ---------------------------------------------------------------------------
+
+
 def make_multimodal_configs(
     profile: MultimodalModelProfile,
     config_cls: Type[EngineConfig],
@@ -87,17 +153,18 @@ def make_multimodal_configs(
     config_cls:
         The concrete config class to instantiate (e.g. ``VLLMConfig``).
     directory:
-        Base directory passed as ``directory`` to the config constructor.
+        Default directory; overridden by ``TopologyConfig.directory`` if set.
     """
     configs: dict[str, EngineConfig] = {}
     for topology, topo_cfg in profile.topologies.items():
-        script_name = TOPOLOGY_SCRIPTS[topology]  # KeyError if invalid
+        script_name = TOPOLOGY_SCRIPTS[topology]
         script_args = ["--model", profile.name] + profile.extra_vllm_args
-        if topology != "agg":
+        if topology not in ("agg", "audio_agg"):
             script_args.append("--single-gpu")
 
+        gpu = topo_cfg.gpu_marker or profile.gpu_marker
         marks: list[Any] = [
-            getattr(pytest.mark, profile.gpu_marker),
+            getattr(pytest.mark, gpu),
             pytest.mark.timeout(topo_cfg.timeout_s),
         ]
         marks.extend(topo_cfg.marks)
@@ -124,12 +191,13 @@ def make_multimodal_configs(
         key = f"mm_{topology}_{profile.short_name}"
         configs[key] = config_cls(
             name=key,
-            directory=directory,
+            directory=topo_cfg.directory or directory,
             script_name=script_name,
             model=profile.name,
             script_args=script_args,
             marks=marks,
-            request_payloads=[make_image_payload(profile.image_expected_response)],
+            delayed_start=topo_cfg.delayed_start,
+            request_payloads=profile.request_payloads,
         )
     return configs
 
@@ -140,8 +208,9 @@ def make_multimodal_configs(
 # Generated config keys use the "mm_" prefix. Do not use this prefix for
 # hand-written configs to avoid collisions.
 
+_AUDIO_DIR = os.path.join(WORKSPACE_DIR, "examples/multimodal")
+
 MULTIMODAL_MODEL_PROFILES: list[MultimodalModelProfile] = [
-    # Replaces: multimodal_e_pd_qwen, multimodal_disagg_qwen, mm_agg_qwen3-vl-2b
     MultimodalModelProfile(
         name="Qwen/Qwen3-VL-2B-Instruct",
         short_name="qwen3-vl-2b",
@@ -160,9 +229,25 @@ MULTIMODAL_MODEL_PROFILES: list[MultimodalModelProfile] = [
                 timeout_s=300,
             ),
         },
-        image_expected_response=["green"],
+        request_payloads=[make_image_payload(["green"])],
     ),
-    # Replaces: multimodal_agg_qwen (Qwen2.5-VL-7B)
+    MultimodalModelProfile(
+        name="Qwen/Qwen3-VL-2B-Instruct",
+        short_name="qwen3-vl-2b-video",
+        topologies={
+            "agg": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=600,
+                delayed_start=60,
+            ),
+            "epd": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=600,
+                delayed_start=60,
+            ),
+        },
+        request_payloads=[make_video_payload(["red", "static", "still"])],
+    ),
     MultimodalModelProfile(
         name="Qwen/Qwen2.5-VL-7B-Instruct",
         short_name="qwen2.5-vl-7b",
@@ -174,9 +259,27 @@ MULTIMODAL_MODEL_PROFILES: list[MultimodalModelProfile] = [
                 requested_vllm_kv_cache_bytes=922_354_000,
             ),
         },
-        image_expected_response=["purple"],
+        request_payloads=[make_image_payload(["purple"])],
     ),
-    # New model coverage
+    MultimodalModelProfile(
+        name="Qwen/Qwen2-Audio-7B-Instruct",
+        short_name="qwen2-audio-7b",
+        topologies={
+            "audio_agg": TopologyConfig(
+                marks=[pytest.mark.nightly],
+                timeout_s=600,
+                directory=_AUDIO_DIR,
+            ),
+            "audio_disagg": TopologyConfig(
+                marks=[pytest.mark.nightly],
+                timeout_s=600,
+                directory=_AUDIO_DIR,
+                gpu_marker="gpu_4",
+            ),
+        },
+        gpu_marker="gpu_2",
+        request_payloads=[make_audio_payload(["Hester", "Pynne"])],
+    ),
     MultimodalModelProfile(
         name="google/gemma-3-4b-it",
         short_name="gemma3-4b",
@@ -187,7 +290,7 @@ MULTIMODAL_MODEL_PROFILES: list[MultimodalModelProfile] = [
                 profiled_vram_gib=12.0,
             ),
         },
-        image_expected_response=["green"],
+        request_payloads=[make_image_payload(["green"])],
         extra_vllm_args=["--dtype", "bfloat16"],
         gated=True,
     ),

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional, Type
+
+import pytest
+
+from tests.serve.conftest import MULTIMODAL_IMG_URL
+from tests.utils.engine_process import EngineConfig
+from tests.utils.payload_builder import chat_payload
+from tests.utils.payloads import ChatPayload
+
+
+@dataclass
+class TopologyConfig:
+    """Per-topology overrides for marks, timeout, and VRAM profiling."""
+
+    marks: list[Any] = field(default_factory=list)
+    timeout_s: int = 300
+    profiled_vram_gib: Optional[float] = None
+    requested_vllm_kv_cache_bytes: Optional[int] = None
+
+
+@dataclass
+class MultimodalModelProfile:
+    """Describes a multimodal model's test-relevant properties.
+
+    Each profile generates one config per topology in ``topologies``
+    via :func:`make_multimodal_configs`.
+    """
+
+    name: str  # HuggingFace model ID
+    short_name: str  # kebab-case slug for config key (e.g. "qwen3-vl-2b")
+    topologies: dict[str, TopologyConfig]
+    image_expected_response: list[str]  # OR-substring keywords (any match = pass)
+    gpu_marker: str = "gpu_1"
+    extra_vllm_args: list[str] = field(default_factory=list)
+    marks: list[Any] = field(default_factory=list)  # shared across all topologies
+    gated: bool = False  # if True, skip unless DYN_HF_GATED_MODELS_ENABLED=1
+
+
+TOPOLOGY_SCRIPTS: dict[str, str] = {
+    "agg": "agg_multimodal.sh",
+    "e_pd": "disagg_multimodal_e_pd.sh",
+    "epd": "disagg_multimodal_epd.sh",
+    "p_d": "disagg_multimodal_p_d.sh",
+}
+
+
+def make_image_payload(expected_response: list[str]) -> ChatPayload:
+    """Standard multimodal image test payload.
+
+    Uses the shared test image (MULTIMODAL_IMG_URL) with a color-identification
+    prompt. Response validation uses case-insensitive OR-substring matching:
+    the check passes if ANY keyword in expected_response appears in the response.
+    """
+    return chat_payload(
+        [
+            {
+                "type": "text",
+                "text": "What colors are in the following image? "
+                "Respond only with the colors.",
+            },
+            {
+                "type": "image_url",
+                "image_url": {"url": MULTIMODAL_IMG_URL},
+            },
+        ],
+        repeat_count=1,
+        expected_response=expected_response,
+        temperature=0.0,
+        max_tokens=100,
+    )
+
+
+def make_multimodal_configs(
+    profile: MultimodalModelProfile,
+    config_cls: Type[EngineConfig],
+    directory: str,
+) -> dict[str, EngineConfig]:
+    """Generate config entries for each topology in *profile*.
+
+    Parameters
+    ----------
+    config_cls:
+        The concrete config class to instantiate (e.g. ``VLLMConfig``).
+    directory:
+        Base directory passed as ``directory`` to the config constructor.
+    """
+    configs: dict[str, EngineConfig] = {}
+    for topology, topo_cfg in profile.topologies.items():
+        script_name = TOPOLOGY_SCRIPTS[topology]  # KeyError if invalid
+        script_args = ["--model", profile.name] + profile.extra_vllm_args
+        if topology != "agg":
+            script_args.append("--single-gpu")
+
+        marks: list[Any] = [
+            getattr(pytest.mark, profile.gpu_marker),
+            pytest.mark.timeout(topo_cfg.timeout_s),
+        ]
+        marks.extend(topo_cfg.marks)
+        if topo_cfg.profiled_vram_gib is not None:
+            marks.append(pytest.mark.profiled_vram_gib(topo_cfg.profiled_vram_gib))
+        if topo_cfg.requested_vllm_kv_cache_bytes is not None:
+            marks.append(
+                pytest.mark.requested_vllm_kv_cache_bytes(
+                    topo_cfg.requested_vllm_kv_cache_bytes
+                )
+            )
+        if profile.gated:
+            marks.append(
+                pytest.mark.skipif(
+                    not os.environ.get("DYN_HF_GATED_MODELS_ENABLED"),
+                    reason=(
+                        f"{profile.name} is gated; set DYN_HF_GATED_MODELS_ENABLED=1 "
+                        "with an HF_TOKEN that has accepted the license"
+                    ),
+                )
+            )
+        marks.extend(profile.marks)
+
+        key = f"mm_{topology}_{profile.short_name}"
+        configs[key] = config_cls(
+            name=key,
+            directory=directory,
+            script_name=script_name,
+            model=profile.name,
+            script_args=script_args,
+            marks=marks,
+            request_payloads=[make_image_payload(profile.image_expected_response)],
+        )
+    return configs
+
+
+# ---------------------------------------------------------------------------
+# Multimodal model profiles — add new models here
+# ---------------------------------------------------------------------------
+# Generated config keys use the "mm_" prefix. Do not use this prefix for
+# hand-written configs to avoid collisions.
+
+MULTIMODAL_MODEL_PROFILES: list[MultimodalModelProfile] = [
+    # Replaces: multimodal_e_pd_qwen, multimodal_disagg_qwen, mm_agg_qwen3-vl-2b
+    MultimodalModelProfile(
+        name="Qwen/Qwen3-VL-2B-Instruct",
+        short_name="qwen3-vl-2b",
+        topologies={
+            "agg": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=220,
+                profiled_vram_gib=9.6,
+            ),
+            "e_pd": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=340,
+            ),
+            "epd": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=300,
+            ),
+        },
+        image_expected_response=["green"],
+    ),
+    # Replaces: multimodal_agg_qwen (Qwen2.5-VL-7B)
+    MultimodalModelProfile(
+        name="Qwen/Qwen2.5-VL-7B-Instruct",
+        short_name="qwen2.5-vl-7b",
+        topologies={
+            "agg": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=360,
+                profiled_vram_gib=19.9,
+                requested_vllm_kv_cache_bytes=922_354_000,
+            ),
+        },
+        image_expected_response=["purple"],
+    ),
+    # New model coverage
+    MultimodalModelProfile(
+        name="google/gemma-3-4b-it",
+        short_name="gemma3-4b",
+        topologies={
+            "agg": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=300,
+                profiled_vram_gib=12.0,
+            ),
+        },
+        image_expected_response=["green"],
+        extra_vllm_args=["--dtype", "bfloat16"],
+        gated=True,
+    ),
+]

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -102,6 +102,7 @@ class TopologyConfig:
     delayed_start: int = 0
     directory: Optional[str] = None  # override profile-level directory
     gpu_marker: Optional[str] = None  # override profile-level gpu_marker
+    single_gpu: bool = False  # append --single-gpu to script_args
 
 
 @dataclass
@@ -148,7 +149,7 @@ def make_multimodal_configs(
     for topology, topo_cfg in profile.topologies.items():
         script_name = topology_scripts[topology]
         script_args = ["--model", profile.name] + profile.extra_vllm_args
-        if not topology.endswith("agg"):
+        if topo_cfg.single_gpu:
             script_args.append("--single-gpu")
 
         gpu = topo_cfg.gpu_marker or profile.gpu_marker

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -27,20 +27,6 @@ AUDIO_TEST_URL = (
 
 
 # ---------------------------------------------------------------------------
-# Topology scripts
-# ---------------------------------------------------------------------------
-
-TOPOLOGY_SCRIPTS: dict[str, str] = {
-    "agg": "agg_multimodal.sh",
-    "e_pd": "disagg_multimodal_e_pd.sh",
-    "epd": "disagg_multimodal_epd.sh",
-    "p_d": "disagg_multimodal_p_d.sh",
-    "audio_agg": "audio_agg.sh",
-    "audio_disagg": "audio_disagg.sh",
-}
-
-
-# ---------------------------------------------------------------------------
 # Payload factories
 # ---------------------------------------------------------------------------
 
@@ -145,6 +131,7 @@ def make_multimodal_configs(
     profile: MultimodalModelProfile,
     config_cls: Type[EngineConfig],
     directory: str,
+    topology_scripts: dict[str, str],
 ) -> dict[str, EngineConfig]:
     """Generate config entries for each topology in *profile*.
 
@@ -154,12 +141,14 @@ def make_multimodal_configs(
         The concrete config class to instantiate (e.g. ``VLLMConfig``).
     directory:
         Default directory; overridden by ``TopologyConfig.directory`` if set.
+    topology_scripts:
+        Mapping from topology key to shell script filename.
     """
     configs: dict[str, EngineConfig] = {}
     for topology, topo_cfg in profile.topologies.items():
-        script_name = TOPOLOGY_SCRIPTS[topology]
+        script_name = topology_scripts[topology]
         script_args = ["--model", profile.name] + profile.extra_vllm_args
-        if topology not in ("agg", "audio_agg"):
+        if not topology.endswith("agg"):
             script_args.append("--single-gpu")
 
         gpu = topo_cfg.gpu_marker or profile.gpu_marker
@@ -200,98 +189,3 @@ def make_multimodal_configs(
             request_payloads=profile.request_payloads,
         )
     return configs
-
-
-# ---------------------------------------------------------------------------
-# Multimodal model profiles — add new models here
-# ---------------------------------------------------------------------------
-# Generated config keys use the "mm_" prefix. Do not use this prefix for
-# hand-written configs to avoid collisions.
-
-_AUDIO_DIR = os.path.join(WORKSPACE_DIR, "examples/multimodal")
-
-MULTIMODAL_MODEL_PROFILES: list[MultimodalModelProfile] = [
-    MultimodalModelProfile(
-        name="Qwen/Qwen3-VL-2B-Instruct",
-        short_name="qwen3-vl-2b",
-        topologies={
-            "agg": TopologyConfig(
-                marks=[pytest.mark.post_merge],
-                timeout_s=220,
-                profiled_vram_gib=9.6,
-            ),
-            "e_pd": TopologyConfig(
-                marks=[pytest.mark.pre_merge],
-                timeout_s=340,
-            ),
-            "epd": TopologyConfig(
-                marks=[pytest.mark.pre_merge],
-                timeout_s=300,
-            ),
-        },
-        request_payloads=[make_image_payload(["green"])],
-    ),
-    MultimodalModelProfile(
-        name="Qwen/Qwen3-VL-2B-Instruct",
-        short_name="qwen3-vl-2b-video",
-        topologies={
-            "agg": TopologyConfig(
-                marks=[pytest.mark.pre_merge],
-                timeout_s=600,
-                delayed_start=60,
-            ),
-            "epd": TopologyConfig(
-                marks=[pytest.mark.pre_merge],
-                timeout_s=600,
-                delayed_start=60,
-            ),
-        },
-        request_payloads=[make_video_payload(["red", "static", "still"])],
-    ),
-    MultimodalModelProfile(
-        name="Qwen/Qwen2.5-VL-7B-Instruct",
-        short_name="qwen2.5-vl-7b",
-        topologies={
-            "agg": TopologyConfig(
-                marks=[pytest.mark.post_merge],
-                timeout_s=360,
-                profiled_vram_gib=19.9,
-                requested_vllm_kv_cache_bytes=922_354_000,
-            ),
-        },
-        request_payloads=[make_image_payload(["purple"])],
-    ),
-    MultimodalModelProfile(
-        name="Qwen/Qwen2-Audio-7B-Instruct",
-        short_name="qwen2-audio-7b",
-        topologies={
-            "audio_agg": TopologyConfig(
-                marks=[pytest.mark.nightly],
-                timeout_s=600,
-                directory=_AUDIO_DIR,
-            ),
-            "audio_disagg": TopologyConfig(
-                marks=[pytest.mark.nightly],
-                timeout_s=600,
-                directory=_AUDIO_DIR,
-                gpu_marker="gpu_4",
-            ),
-        },
-        gpu_marker="gpu_2",
-        request_payloads=[make_audio_payload(["Hester", "Pynne"])],
-    ),
-    MultimodalModelProfile(
-        name="google/gemma-3-4b-it",
-        short_name="gemma3-4b",
-        topologies={
-            "agg": TopologyConfig(
-                marks=[pytest.mark.post_merge],
-                timeout_s=300,
-                profiled_vram_gib=12.0,
-            ),
-        },
-        request_payloads=[make_image_payload(["green"])],
-        extra_vllm_args=["--dtype", "bfloat16"],
-        gated=True,
-    ),
-]


### PR DESCRIPTION
## Summary

basically, we 
- moved the existing 4 image->text, 2 audio->text, 2 video->text tests
- added another image->text model

details --

- Add `MultimodalModelProfile` dataclass and `make_multimodal_configs()` generator to `test_vllm.py` that makes adding new multimodal models to the e2e test suite trivial
- Phase 1 covers `agg` topology with two models: `Qwen/Qwen3-VL-2B-Instruct` and `google/gemma-3-4b-it` (gated, skipped when `DYN_HF_GATED_MODELS_ENABLED` is not set)
- Generated configs (`mm_agg_qwen3-vl-2b`, `mm_agg_gemma3-4b`) are structurally identical to hand-written ones — no changes to production code, shell scripts, or existing configs

## Design
Adding a new model is now just adding a `MultimodalModelProfile` entry:
```python
MultimodalModelProfile(
    name="google/gemma-3-4b-it",
    short_name="gemma3-4b",
    supported_topologies=["agg"],
    image_expected_response=["green"],
    gpu_marker="gpu_1",
    timeout_s=300,
    extra_vllm_args=["--dtype", "bfloat16"],
    gated=True,
    profiled_vram_gib=12.0,
)
```

Key interface decisions:
- `supported_topologies` is an ordered `list[str]` (stable test ordering, source of truth for which topologies get generated)
- `gated=True` generates a `skipif` based on `DYN_HF_GATED_MODELS_ENABLED` env var (no network calls at collection time)
- `profiled_vram_gib` / `requested_vllm_kv_cache_bytes` are optional — generate resource marks when set
- `TOPOLOGY_SCRIPTS` maps topology names to existing shell scripts (all 4 multimodal launchers registered for Phase 2 expansion)

## Onboarding Gate Results

| Model | Response | Deterministic | Load (cached) | First Inference |
|-------|----------|--------------|---------------|-----------------|
| Qwen/Qwen3-VL-2B-Instruct | `green` | 5/5 ✓ | 18.7s | 6.7s |
| google/gemma-3-4b-it | `Green` | 5/5 ✓ | ~30s | 13.7s |

Both match `["green"]` via case-insensitive OR-substring validation.

## Test plan
- Verify pytest collection succeeds with 2 new generated configs (`mm_agg_qwen3-vl-2b`, `mm_agg_gemma3-4b`)
- Verify both configs have `post_merge` and `gpu_1` markers
- Verify Gemma test is skipped when `DYN_HF_GATED_MODELS_ENABLED` is not set
- Run `mm_agg_qwen3-vl-2b` in post_merge CI to validate e2e through dynamo serve
- Run `mm_agg_gemma3-4b` in post_merge CI with `DYN_HF_GATED_MODELS_ENABLED=1` and accepted Gemma license

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored multimodal test configurations to use generated profiles instead of hardcoded entries for better maintainability and coverage.
  * Added test utility functions for generating multimodal payloads (image, video, audio).
  * Introduced vLLM multimodal test profiles with support for multiple topology configurations.

* **Chores**
  * Added SPDX license header to test module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->