### PR TITLE
fix(kvbm-physical): return errors for unsupported System<->Device transfers

### DIFF
--- a/lib/kvbm-physical/src/transfer/strategy.rs
+++ b/lib/kvbm-physical/src/transfer/strategy.rs
@@ -464,9 +464,8 @@ mod tests {
     fn test_device_to_remote_without_rdma() {
         let caps = default_caps(); // GPU RDMA disabled
         // Device → Remote should use bounce buffer
-        let plan =
-            select_direct_strategy(StorageKind::Device(0), StorageKind::System, true, &caps)
-                .unwrap();
+        let plan = select_direct_strategy(StorageKind::Device(0), StorageKind::System, true, &caps)
+            .unwrap();
         match plan {
             TransferPlan::TwoHop {
                 first,
@@ -496,9 +495,8 @@ mod tests {
     fn test_disk_to_remote() {
         let caps = default_caps();
         // Disk → Remote always uses bounce buffer
-        let plan =
-            select_direct_strategy(StorageKind::Disk(42), StorageKind::System, true, &caps)
-                .unwrap();
+        let plan = select_direct_strategy(StorageKind::Disk(42), StorageKind::System, true, &caps)
+            .unwrap();
         match plan {
             TransferPlan::TwoHop {
                 first,

--- a/lib/kvbm-physical/src/transfer/strategy.rs
+++ b/lib/kvbm-physical/src/transfer/strategy.rs
@@ -288,19 +288,19 @@ mod tests {
     fn test_host_to_host_transfers() {
         let caps = default_caps();
         assert_eq!(
-            select_direct_strategy(StorageKind::System, StorageKind::System, false, &caps),
+            select_direct_strategy(StorageKind::System, StorageKind::System, false, &caps).unwrap(),
             TransferPlan::Direct(TransferStrategy::Memcpy)
         );
         assert_eq!(
-            select_direct_strategy(StorageKind::System, StorageKind::Pinned, false, &caps),
+            select_direct_strategy(StorageKind::System, StorageKind::Pinned, false, &caps).unwrap(),
             TransferPlan::Direct(TransferStrategy::Memcpy)
         );
         assert_eq!(
-            select_direct_strategy(StorageKind::Pinned, StorageKind::System, false, &caps),
+            select_direct_strategy(StorageKind::Pinned, StorageKind::System, false, &caps).unwrap(),
             TransferPlan::Direct(TransferStrategy::Memcpy)
         );
         assert_eq!(
-            select_direct_strategy(StorageKind::Pinned, StorageKind::Pinned, false, &caps),
+            select_direct_strategy(StorageKind::Pinned, StorageKind::Pinned, false, &caps).unwrap(),
             TransferPlan::Direct(TransferStrategy::Memcpy)
         );
     }
@@ -308,12 +308,14 @@ mod tests {
     #[test]
     fn test_host_to_device_transfers() {
         let caps = default_caps();
-        let err = select_direct_strategy(StorageKind::System, StorageKind::Device(0), false, &caps)
-            .unwrap_err();
+        let _err =
+            select_direct_strategy(StorageKind::System, StorageKind::Device(0), false, &caps)
+                .unwrap_err();
 
         // Pinned to device should be async
         assert_eq!(
-            select_direct_strategy(StorageKind::Pinned, StorageKind::Device(0), false, &caps),
+            select_direct_strategy(StorageKind::Pinned, StorageKind::Device(0), false, &caps)
+                .unwrap(),
             TransferPlan::Direct(TransferStrategy::CudaAsyncH2D)
         );
     }
@@ -321,12 +323,14 @@ mod tests {
     #[test]
     fn test_device_to_host_transfers() {
         let caps = default_caps();
-        let err = select_direct_strategy(StorageKind::Device(0), StorageKind::System, false, &caps)
-            .unwrap_err();
+        let _err =
+            select_direct_strategy(StorageKind::Device(0), StorageKind::System, false, &caps)
+                .unwrap_err();
 
         // Device to pinned should be async
         assert_eq!(
-            select_direct_strategy(StorageKind::Device(0), StorageKind::Pinned, false, &caps),
+            select_direct_strategy(StorageKind::Device(0), StorageKind::Pinned, false, &caps)
+                .unwrap(),
             TransferPlan::Direct(TransferStrategy::CudaAsyncD2H)
         );
     }
@@ -335,11 +339,13 @@ mod tests {
     fn test_device_to_device_transfers() {
         let caps = default_caps();
         assert_eq!(
-            select_direct_strategy(StorageKind::Device(0), StorageKind::Device(1), false, &caps),
+            select_direct_strategy(StorageKind::Device(0), StorageKind::Device(1), false, &caps)
+                .unwrap(),
             TransferPlan::Direct(TransferStrategy::CudaAsyncD2D)
         );
         assert_eq!(
-            select_direct_strategy(StorageKind::Device(3), StorageKind::Device(3), false, &caps),
+            select_direct_strategy(StorageKind::Device(3), StorageKind::Device(3), false, &caps)
+                .unwrap(),
             TransferPlan::Direct(TransferStrategy::CudaAsyncD2D)
         );
     }
@@ -349,11 +355,13 @@ mod tests {
         let caps = default_caps();
         // Disk to host - direct NIXL
         assert_eq!(
-            select_direct_strategy(StorageKind::Disk(42), StorageKind::System, false, &caps),
+            select_direct_strategy(StorageKind::Disk(42), StorageKind::System, false, &caps)
+                .unwrap(),
             TransferPlan::Direct(TransferStrategy::NixlReadFlipped)
         );
         assert_eq!(
-            select_direct_strategy(StorageKind::Disk(42), StorageKind::Pinned, false, &caps),
+            select_direct_strategy(StorageKind::Disk(42), StorageKind::Pinned, false, &caps)
+                .unwrap(),
             TransferPlan::Direct(TransferStrategy::NixlReadFlipped)
         );
     }
@@ -363,11 +371,13 @@ mod tests {
         let caps = default_caps();
         // Host to disk - direct NIXL
         assert_eq!(
-            select_direct_strategy(StorageKind::System, StorageKind::Disk(42), false, &caps),
+            select_direct_strategy(StorageKind::System, StorageKind::Disk(42), false, &caps)
+                .unwrap(),
             TransferPlan::Direct(TransferStrategy::NixlWrite)
         );
         assert_eq!(
-            select_direct_strategy(StorageKind::Pinned, StorageKind::Disk(42), false, &caps),
+            select_direct_strategy(StorageKind::Pinned, StorageKind::Disk(42), false, &caps)
+                .unwrap(),
             TransferPlan::Direct(TransferStrategy::NixlWrite)
         );
     }
@@ -377,7 +387,8 @@ mod tests {
         let caps = default_caps(); // GDS disabled
         // Device → Disk should use bounce buffer
         let plan =
-            select_direct_strategy(StorageKind::Device(0), StorageKind::Disk(42), false, &caps);
+            select_direct_strategy(StorageKind::Device(0), StorageKind::Disk(42), false, &caps)
+                .unwrap();
         match plan {
             TransferPlan::TwoHop {
                 first,
@@ -397,7 +408,8 @@ mod tests {
         let caps = default_caps(); // GDS disabled
         // Disk → Device should use bounce buffer
         let plan =
-            select_direct_strategy(StorageKind::Disk(42), StorageKind::Device(0), false, &caps);
+            select_direct_strategy(StorageKind::Disk(42), StorageKind::Device(0), false, &caps)
+                .unwrap();
         match plan {
             TransferPlan::TwoHop {
                 first,
@@ -417,7 +429,8 @@ mod tests {
         let caps = TransferCapabilities::default().with_gds(true);
         // Device → Disk should be direct with GDS
         assert_eq!(
-            select_direct_strategy(StorageKind::Device(0), StorageKind::Disk(42), false, &caps),
+            select_direct_strategy(StorageKind::Device(0), StorageKind::Disk(42), false, &caps)
+                .unwrap(),
             TransferPlan::Direct(TransferStrategy::NixlWrite)
         );
     }
@@ -427,7 +440,8 @@ mod tests {
         let caps = TransferCapabilities::default().with_gds(true);
         // Disk → Device should be direct with GDS
         assert_eq!(
-            select_direct_strategy(StorageKind::Disk(42), StorageKind::Device(0), false, &caps),
+            select_direct_strategy(StorageKind::Disk(42), StorageKind::Device(0), false, &caps)
+                .unwrap(),
             TransferPlan::Direct(TransferStrategy::NixlRead)
         );
     }
@@ -437,11 +451,11 @@ mod tests {
         let caps = default_caps();
         // Host → Remote - always direct
         assert_eq!(
-            select_direct_strategy(StorageKind::System, StorageKind::System, true, &caps),
+            select_direct_strategy(StorageKind::System, StorageKind::System, true, &caps).unwrap(),
             TransferPlan::Direct(TransferStrategy::NixlWrite)
         );
         assert_eq!(
-            select_direct_strategy(StorageKind::Pinned, StorageKind::Pinned, true, &caps),
+            select_direct_strategy(StorageKind::Pinned, StorageKind::Pinned, true, &caps).unwrap(),
             TransferPlan::Direct(TransferStrategy::NixlWrite)
         );
     }
@@ -450,7 +464,9 @@ mod tests {
     fn test_device_to_remote_without_rdma() {
         let caps = default_caps(); // GPU RDMA disabled
         // Device → Remote should use bounce buffer
-        let plan = select_direct_strategy(StorageKind::Device(0), StorageKind::System, true, &caps);
+        let plan =
+            select_direct_strategy(StorageKind::Device(0), StorageKind::System, true, &caps)
+                .unwrap();
         match plan {
             TransferPlan::TwoHop {
                 first,
@@ -470,7 +486,8 @@ mod tests {
         let caps = TransferCapabilities::default().with_gpu_rdma(true);
         // Device → Remote should be direct with GPU RDMA
         assert_eq!(
-            select_direct_strategy(StorageKind::Device(0), StorageKind::Device(0), true, &caps),
+            select_direct_strategy(StorageKind::Device(0), StorageKind::Device(0), true, &caps)
+                .unwrap(),
             TransferPlan::Direct(TransferStrategy::NixlWrite)
         );
     }
@@ -479,7 +496,9 @@ mod tests {
     fn test_disk_to_remote() {
         let caps = default_caps();
         // Disk → Remote always uses bounce buffer
-        let plan = select_direct_strategy(StorageKind::Disk(42), StorageKind::System, true, &caps);
+        let plan =
+            select_direct_strategy(StorageKind::Disk(42), StorageKind::System, true, &caps)
+                .unwrap();
         match plan {
             TransferPlan::TwoHop {
                 first,

--- a/lib/kvbm-physical/src/transfer/strategy.rs
+++ b/lib/kvbm-physical/src/transfer/strategy.rs
@@ -95,7 +95,7 @@ pub(crate) fn select_strategy(
             dst.location(),
             false,
             ctx.capabilities(),
-        ));
+        )?);
     }
 
     select_remote_strategy_v2(
@@ -146,7 +146,7 @@ fn select_direct_strategy(
 
     // Handle remote destination
     if dst_is_remote {
-        return select_remote_strategy(src, capabilities);
+        return Ok(select_remote_strategy(src, capabilities));
     }
 
     // Local-to-local transfers

--- a/lib/kvbm-physical/src/transfer/strategy.rs
+++ b/lib/kvbm-physical/src/transfer/strategy.rs
@@ -90,12 +90,7 @@ pub(crate) fn select_strategy(
     }
 
     if is_src_local && is_dst_local {
-        return select_direct_strategy(
-            src.location(),
-            dst.location(),
-            false,
-            ctx.capabilities(),
-        );
+        return select_direct_strategy(src.location(), dst.location(), false, ctx.capabilities());
     }
 
     select_remote_strategy_v2(

--- a/lib/kvbm-physical/src/transfer/strategy.rs
+++ b/lib/kvbm-physical/src/transfer/strategy.rs
@@ -140,7 +140,7 @@ fn select_direct_strategy(
     dst: StorageKind,
     dst_is_remote: bool,
     capabilities: &TransferCapabilities,
-) -> TransferPlan {
+) -> anyhow::Result<TransferPlan> {
     use StorageKind::*;
     use TransferStrategy::*;
 
@@ -153,57 +153,61 @@ fn select_direct_strategy(
     match (src, dst) {
         // Host ↔ Host - direct memcpy
         (System, System) | (System, Pinned) | (Pinned, System) | (Pinned, Pinned) => {
-            TransferPlan::Direct(Memcpy)
+            Ok(TransferPlan::Direct(Memcpy))
         }
 
         // Host → Device - direct CUDA
-        (System, Device(_)) => panic!("System to Device transfers are not supported"),
-        (Pinned, Device(_)) => TransferPlan::Direct(CudaAsyncH2D),
+        (System, Device(_)) => Err(anyhow::anyhow!(
+            "System to Device transfers are not supported; use Pinned memory for CUDA transfers."
+        )),
+        (Pinned, Device(_)) => Ok(TransferPlan::Direct(CudaAsyncH2D)),
 
         // Device → Host - direct CUDA
-        (Device(_), System) => panic!("Device to System transfers are not supported"),
-        (Device(_), Pinned) => TransferPlan::Direct(CudaAsyncD2H),
+        (Device(_), System) => Err(anyhow::anyhow!(
+            "Device to System transfers are not supported; use Pinned memory for CUDA transfers."
+        )),
+        (Device(_), Pinned) => Ok(TransferPlan::Direct(CudaAsyncD2H)),
 
         // Device ↔ Device - direct CUDA
-        (Device(_), Device(_)) => TransferPlan::Direct(CudaAsyncD2D),
+        (Device(_), Device(_)) => Ok(TransferPlan::Direct(CudaAsyncD2D)),
 
         // Host ↔ Disk - direct NIXL
-        (System, Disk(_)) | (Pinned, Disk(_)) => TransferPlan::Direct(NixlWrite),
-        (Disk(_), System) | (Disk(_), Pinned) => TransferPlan::Direct(NixlReadFlipped),
+        (System, Disk(_)) | (Pinned, Disk(_)) => Ok(TransferPlan::Direct(NixlWrite)),
+        (Disk(_), System) | (Disk(_), Pinned) => Ok(TransferPlan::Direct(NixlReadFlipped)),
 
         // Disk ↔ Disk - NIXL doesn't seem to support direct transfers here.
         // Leaving this as two-hop for now.
-        (Disk(_), Disk(_)) => TransferPlan::TwoHop {
+        (Disk(_), Disk(_)) => Ok(TransferPlan::TwoHop {
             first: NixlReadFlipped,
             bounce_location: Pinned,
             second: NixlWrite,
-        },
+        }),
 
         // Device ↔ Disk - check GDS capability
         (Device(_), Disk(_)) => {
             if capabilities.allows_device_disk_direct() {
                 // Direct GDS transfer
-                TransferPlan::Direct(NixlWrite)
+                Ok(TransferPlan::Direct(NixlWrite))
             } else {
                 // Stage through host: Device → Pinned → Disk
-                TransferPlan::TwoHop {
+                Ok(TransferPlan::TwoHop {
                     first: CudaAsyncD2H,
                     bounce_location: Pinned,
                     second: NixlWrite,
-                }
+                })
             }
         }
         (Disk(_), Device(_)) => {
             if capabilities.allows_device_disk_direct() {
                 // Direct GDS transfer
-                TransferPlan::Direct(NixlRead)
+                Ok(TransferPlan::Direct(NixlRead))
             } else {
                 // Stage through host: Disk → Pinned → Device
-                TransferPlan::TwoHop {
+                Ok(TransferPlan::TwoHop {
                     first: NixlReadFlipped,
                     bounce_location: Pinned,
                     second: CudaAsyncH2D,
-                }
+                })
             }
         }
     }
@@ -309,11 +313,8 @@ mod tests {
     #[test]
     fn test_host_to_device_transfers() {
         let caps = default_caps();
-        // // System (unpinned) to device should be blocking
-        // assert_eq!(
-        //     select_direct_strategy(StorageKind::System, StorageKind::Device(0), false, &caps),
-        //     TransferPlan::Direct(TransferStrategy::CudaBlockingH2D)
-        // );
+        let err = select_direct_strategy(StorageKind::System, StorageKind::Device(0), false, &caps)
+            .unwrap_err();
 
         // Pinned to device should be async
         assert_eq!(
@@ -325,11 +326,8 @@ mod tests {
     #[test]
     fn test_device_to_host_transfers() {
         let caps = default_caps();
-        //    // Device to system should be blocking
-        //     assert_eq!(
-        //         select_direct_strategy(StorageKind::Device(0), StorageKind::System, false, &caps),
-        //         TransferPlan::Direct(TransferStrategy::CudaBlockingD2H)
-        //     );
+        let err = select_direct_strategy(StorageKind::Device(0), StorageKind::System, false, &caps)
+            .unwrap_err();
 
         // Device to pinned should be async
         assert_eq!(

--- a/lib/kvbm-physical/src/transfer/strategy.rs
+++ b/lib/kvbm-physical/src/transfer/strategy.rs
@@ -90,12 +90,12 @@ pub(crate) fn select_strategy(
     }
 
     if is_src_local && is_dst_local {
-        return Ok(select_direct_strategy(
+        return select_direct_strategy(
             src.location(),
             dst.location(),
             false,
             ctx.capabilities(),
-        )?);
+        );
     }
 
     select_remote_strategy_v2(

--- a/lib/kvbm-physical/src/transfer/tests/local_transfers.rs
+++ b/lib/kvbm-physical/src/transfer/tests/local_transfers.rs
@@ -173,6 +173,39 @@ async fn test_p2p(
 
 #[rstest]
 #[tokio::test]
+#[case(StorageKind::System, StorageKind::Device(0))]
+#[case(StorageKind::Device(0), StorageKind::System)]
+async fn test_unsupported_system_device_transfer_returns_error(
+    #[case] src_kind: StorageKind,
+    #[case] dst_kind: StorageKind,
+) -> Result<()> {
+    use crate::transfer::executor::TransferOptionsInternal;
+
+    let agent = build_agent_for_kinds(&[src_kind, dst_kind])?;
+    let src = build_layout(agent.clone(), LayoutType::FC, src_kind, 2);
+    let dst = build_layout(agent.clone(), LayoutType::FC, dst_kind, 2);
+    let src_blocks = vec![0];
+    let dst_blocks = vec![0];
+    let ctx = create_transfer_context(agent, None).unwrap();
+
+    let err = execute_transfer(
+        &src,
+        &dst,
+        &src_blocks,
+        &dst_blocks,
+        TransferOptionsInternal::default(),
+        ctx.context(),
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("use Pinned memory"),
+        "unexpected error: {err}"
+    );
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_roundtrip(
     #[values(LayoutType::FC, LayoutType::LW)] src_layout: LayoutType,
     #[values(StorageKind::System, StorageKind::Pinned, StorageKind::Device(0))]

--- a/lib/kvbm-physical/src/transfer/tests/local_transfers.rs
+++ b/lib/kvbm-physical/src/transfer/tests/local_transfers.rs
@@ -9,7 +9,6 @@
 //! - Different transfer strategies (Memcpy, CUDA H2D/D2H)
 
 use super::*;
-use crate::transfer::TransferCapabilities;
 use crate::transfer::executor::TransferOptionsInternal;
 use crate::transfer::executor::execute_transfer;
 use crate::transfer::{can_use_whole_block_transfer, validate_layout_compatibility};
@@ -188,15 +187,17 @@ async fn test_unsupported_system_device_transfer_returns_error(
     let dst_blocks = vec![0];
     let ctx = create_transfer_context(agent, None).unwrap();
 
-    let err = execute_transfer(
+    let err = match execute_transfer(
         &src,
         &dst,
         &src_blocks,
         &dst_blocks,
         TransferOptionsInternal::default(),
         ctx.context(),
-    )
-    .unwrap_err();
+    ) {
+        Ok(_) => anyhow::bail!("expected transfer to fail for System <-> Device"),
+        Err(err) => err,
+    };
     assert!(
         err.to_string().contains("use Pinned memory"),
         "unexpected error: {err}"


### PR DESCRIPTION
#### Overview:

This PR makes unsupported System <-> Device transfers in **kvbm-physical** fail with explicit errors instead of panic, and adds tests to lock in that behavior.

#### Details:

- Changed `lib/kvbm-physical/src/transfer/strategy.rs` so unsupported System -> Device and Device -> System paths return **anyhow::Error** with a clear message directing callers to use Pinned memory.
- Updated `select_direct_strategy(...)` to return **anyhow::Result<TransferPlan>** so unsupported local transfer paths are handled consistently with the rest of the strategy layer.
- Replaced the old commented-out blocking-transfer expectations in unit tests with negative tests that assert the new error behavior.
- Added an integration test in `lib/kvbm-physical/src/transfer/tests/local_transfers.rs` covering both unsupported System -> Device and Device -> System transfer attempts.

#### Where should the reviewer start?

- `lib/kvbm-physical/src/transfer/strategy.rs` 
- `lib/kvbm-physical/src/transfer/tests/local_transfers.rs` 

#### Related Issues: 

- closes GitHub issue: #6490 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for unsupported data transfer operations. Previously problematic transfers could crash; now they fail gracefully with clear error messages guiding users to use pinned memory when needed.

* **Tests**
  * Added test coverage for error scenarios in unsupported transfer paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->