### PR TITLE
fix(profiler): use final TRT-LLM paged KV cache log entry for max tokens

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_trtllm_kv_cache_log_parsing.py
+++ b/components/src/dynamo/profiler/tests/unit/test_trtllm_kv_cache_log_parsing.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for TRT-LLM KV-cache token parsing from runtime logs."""
+
+import pytest
+
+from dynamo.profiler.utils.config_modifiers.trtllm import TrtllmConfigModifier
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.planner,
+    pytest.mark.parallel,
+]
+
+
+def test_get_kv_cache_size_uses_last_matching_log_entry(tmp_path) -> None:
+    """Parser returns the last paged-KV token value when multiple entries exist."""
+    log_path = tmp_path / "dynamo.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "random startup line",
+                "[TensorRT-LLM][INFO] [MemUsageChange] Allocated 12.50 GiB for max tokens in paged KV cache (65536).",
+                "intermediate line",
+                "[TensorRT-LLM][INFO] [MemUsageChange] Allocated 43.87 GiB for max tokens in paged KV cache (229984).",
+            ]
+        )
+    )
+
+    parsed = TrtllmConfigModifier.get_kv_cache_size_from_dynamo_log(str(log_path))
+
+    assert parsed == 229984
+
+
+def test_get_kv_cache_size_falls_back_when_missing(tmp_path) -> None:
+    """Parser returns default fallback when no paged-KV line is present."""
+    log_path = tmp_path / "dynamo.log"
+    log_path.write_text("startup\nhealthcheck ok\n")
+
+    parsed = TrtllmConfigModifier.get_kv_cache_size_from_dynamo_log(str(log_path))
+
+    assert parsed == 100000

--- a/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
@@ -275,6 +275,21 @@ class TrtllmConfigModifier(BaseConfigModifier):
     def get_kv_cache_size_from_dynamo_log(
         cls, dynamo_log_fn: str, attention_dp_size: int = 1
     ) -> int:
+        """Return TRT-LLM paged KV cache token capacity parsed from Dynamo logs.
+
+        TRT-LLM may emit multiple memory allocation lines for paged KV cache
+        during startup. This parser scans the full file and returns the token
+        value from the last matching entry, which reflects the effective
+        configured capacity.
+
+        Args:
+            dynamo_log_fn: Path to the Dynamo runtime log file.
+            attention_dp_size: Unused for TRT-LLM; included for interface parity.
+
+        Returns:
+            Parsed max token count for paged KV cache, or ``100000`` when no
+            matching log entry is found.
+        """
         # TRT-LLM log parsing for KV cache size
         # Format: [TensorRT-LLM][INFO] [MemUsageChange] Allocated XX GiB for max tokens in paged KV cache (XXXXXX).
         max_tokens: int | None = None

--- a/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
@@ -277,6 +277,7 @@ class TrtllmConfigModifier(BaseConfigModifier):
     ) -> int:
         # TRT-LLM log parsing for KV cache size
         # Format: [TensorRT-LLM][INFO] [MemUsageChange] Allocated XX GiB for max tokens in paged KV cache (XXXXXX).
+        max_tokens: int | None = None
         try:
             with open(dynamo_log_fn, "r") as f:
                 for line in f:
@@ -289,12 +290,12 @@ class TrtllmConfigModifier(BaseConfigModifier):
                         match = re.search(r"paged KV cache \((\d+)\)", line)
                         if match:
                             max_tokens = int(match.group(1))
-                            logger.info(
-                                f"Found TRT-LLM KV cache max tokens: {max_tokens}"
-                            )
-                            return max_tokens
         except Exception as e:
             logger.warning(f"Failed to parse KV cache size from log file. Error: {e}")
+
+        if max_tokens is not None:
+            logger.info(f"Found TRT-LLM KV cache max tokens: {max_tokens}")
+            return max_tokens
 
         # Return a reasonable default if we couldn't find the KV cache size in logs
         logger.warning(


### PR DESCRIPTION
#### Overview:

Fixes incorrect TRT-LLM KV cache token parsing in profiler log handling.  
The profiler previously used the first matching `paged KV cache (...)` log entry, which can be an intermediate allocation value. This PR updates behavior to use the final matching value from the log.

#### Details:

- Updated `get_kv_cache_size_from_dynamo_log` in `components/src/dynamo/profiler/utils/config_modifiers/trtllm.py`:
  - removed early return on first match
  - scan full log and keep the latest matched token count
  - preserve existing fallback behavior (`100000`) if no match is found
- Added regression tests in `components/src/dynamo/profiler/tests/unit/test_trtllm_kv_cache_log_parsing.py`:
  - verifies last matching TRT-LLM KV cache log entry is used
  - verifies fallback path when no matching log line exists

#### Where should the reviewer start?

1. `components/src/dynamo/profiler/utils/config_modifiers/trtllm.py`  
   - `get_kv_cache_size_from_dynamo_log` (core bug fix)
2. `components/src/dynamo/profiler/tests/unit/test_trtllm_kv_cache_log_parsing.py`  
   - regression coverage for multi-match and fallback behavior

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes GitHub issue: #6905

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new unit test module validating KV cache log parsing behavior with multiple allocation entries and fallback scenarios.

* **Bug Fixes**
  * Improved KV cache max tokens extraction from TensorRT-LLM runtime logs to use the last matching entry and handle missing entries with explicit fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->