### PR TITLE
chore(runtime): add velo peer discovery plumbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,6 +1986,7 @@ dependencies = [
  "utoipa-swagger-ui",
  "uuid",
  "validator",
+ "velo-messenger",
  "video-rs",
  "xxhash-rust",
 ]
@@ -2155,6 +2156,8 @@ dependencies = [
  "url",
  "uuid",
  "validator",
+ "velo-messenger",
+ "velo-transports 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xxhash-rust",
 ]
 
@@ -2599,6 +2602,17 @@ checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
  "tokio",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix 1.1.4",
+ "tokio",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3964,7 +3978,7 @@ dependencies = [
  "tracing",
  "uuid",
  "validator",
- "velo-events",
+ "velo-events 0.1.0",
 ]
 
 [[package]]
@@ -4305,6 +4319,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4598,7 +4621,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
 ]
 
@@ -4612,6 +4635,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -5758,7 +5782,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -5778,7 +5802,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8667,6 +8691,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "velo-common"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2824d7667c4ee992dfc58c30799518f504d39c91f1e83962d55cb8c44cfb67"
+dependencies = [
+ "bytes",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "velo-discovery"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41107947fe3d15972c56815e42fd2485ca4ba58a5a69ec1a6fd61c00966f8734"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "bytes",
+ "fs4",
+ "futures",
+ "parking_lot",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "velo-common 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "velo-events"
 version = "0.1.0"
 dependencies = [
@@ -8680,6 +8742,65 @@ dependencies = [
  "tracing",
  "uuid",
  "xxhash-rust",
+]
+
+[[package]]
+name = "velo-events"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2504e857f1ed52ad96ce73792a724be880ba75f3579a27050395e81d38cb42d0"
+dependencies = [
+ "anyhow",
+ "dashmap 6.1.0",
+ "futures",
+ "parking_lot",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "velo-messenger"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8ea47ab39a82ef9101024452a3c605bcf5c0acad82c76afcf48a17c0450cf"
+dependencies = [
+ "anyhow",
+ "bs58",
+ "bytes",
+ "dashmap 6.1.0",
+ "derive-getters",
+ "derive_builder",
+ "flume",
+ "futures",
+ "lru 0.12.5",
+ "parking_lot",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "velo-common 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "velo-discovery",
+ "velo-events 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "velo-observability",
+ "velo-transports 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "velo-observability"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57813414b19b0f845744fcf158ed4b87afe4f5c59ee99d58872c8e5d5534d61b"
+dependencies = [
+ "prometheus",
+ "tracing",
 ]
 
 [[package]]
@@ -8715,7 +8836,45 @@ dependencies = [
  "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
- "velo-common",
+ "velo-common 0.1.0",
+]
+
+[[package]]
+name = "velo-transports"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5a348cc2fe13fc560824f170d3bdc3d10ec3a11802bb32489a59f49eb12409"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "axum 0.8.4",
+ "bs58",
+ "bytes",
+ "dashmap 6.1.0",
+ "flume",
+ "futures",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "nix 0.30.1",
+ "parking_lot",
+ "prost 0.13.5",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
+ "tower 0.5.3",
+ "tracing",
+ "velo-common 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "velo-observability",
 ]
 
 [[package]]

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -168,6 +168,7 @@ ndarray = { version = "0.16" }
 
 # Publishers
 rmp-serde = "1.3"
+upstream-velo-messenger = { package = "velo-messenger", version = "0.1.0" }
 
 [dev-dependencies]
 approx = "0.5"

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -260,7 +260,9 @@ impl ModelWatcher {
                     // Extract ModelCardInstanceId from the removal event
                     let model_card_instance_id = match &id {
                         DiscoveryInstanceId::Model(mcid) => mcid,
-                        DiscoveryInstanceId::Endpoint(_) | DiscoveryInstanceId::EventChannel(_) => {
+                        DiscoveryInstanceId::Endpoint(_)
+                        | DiscoveryInstanceId::VeloPeer(_)
+                        | DiscoveryInstanceId::EventChannel(_) => {
                             tracing::error!(
                                 "Unexpected discovery instance type in removal (expected Model)"
                             );

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -9,16 +9,15 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use dashmap::DashMap;
 use dynamo_runtime::component::Component;
-use dynamo_runtime::discovery::{DiscoveryEvent, DiscoveryInstance, DiscoveryQuery};
-use dynamo_runtime::pipeline::{
-    AsyncEngine, AsyncEngineContextProvider, ManyOut, PushRouter, ResponseStream, RouterMode,
-    SingleIn, network::Ingress,
+use dynamo_runtime::discovery::{
+    DiscoveredVeloMessenger, DiscoveryEvent, DiscoveryInstance, DiscoveryQuery,
+    build_default_messenger, register_local_component_peer,
 };
 use dynamo_runtime::protocols::maybe_error::MaybeError;
-use dynamo_runtime::stream;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
 use futures::StreamExt;
 use tokio::sync::{Mutex, Semaphore};
+use upstream_velo_messenger::{Handler, TypedContext};
 
 use super::Indexer;
 use crate::kv_router::worker_kv_indexer_query_endpoint;
@@ -35,6 +34,7 @@ const RECOVERY_CONCURRENCY_LIMIT: usize = 16;
 
 /// Prefix for worker KV indexer query endpoint names.
 const QUERY_ENDPOINT_PREFIX: &str = "worker_kv_indexer_query_dp";
+const VELO_WORKER_KV_QUERY_HANDLER: &str = "worker_kv_indexer_query";
 
 type RecoveryKey = (WorkerId, DpRank);
 
@@ -81,40 +81,39 @@ trait WorkerQueryTransport: Send + Sync {
     ) -> Result<WorkerKvQueryResponse>;
 }
 
-struct RuntimeWorkerQueryTransport {
-    component: Component,
-    routers: DashMap<DpRank, Arc<PushRouter<WorkerKvQueryRequest, WorkerKvQueryResponse>>>,
+struct VeloWorkerQueryTransport {
+    discovered: DiscoveredVeloMessenger,
 }
 
-impl RuntimeWorkerQueryTransport {
-    fn new(component: Component) -> Self {
-        Self {
-            component,
-            routers: DashMap::new(),
-        }
+impl VeloWorkerQueryTransport {
+    async fn new(component: Component) -> Result<Self> {
+        Ok(Self {
+            discovered: DiscoveredVeloMessenger::new(component).await?,
+        })
     }
 
-    async fn get_router_for_dp_rank(
+    async fn send_query_request(
         &self,
+        worker_id: WorkerId,
         dp_rank: DpRank,
-    ) -> Result<Arc<PushRouter<WorkerKvQueryRequest, WorkerKvQueryResponse>>> {
-        if let Some(router) = self.routers.get(&dp_rank) {
-            return Ok(router.clone());
-        }
-
-        let endpoint_name = worker_kv_indexer_query_endpoint(dp_rank);
-        let endpoint = self.component.endpoint(&endpoint_name);
-        let client = endpoint.client().await?;
-        let router = Arc::new(
-            PushRouter::from_client_no_fault_detection(client, RouterMode::RoundRobin).await?,
-        );
-
-        Ok(self.routers.entry(dp_rank).or_insert(router).clone())
+        target_instance_id: upstream_velo_messenger::InstanceId,
+        request: WorkerKvQueryRequest,
+    ) -> Result<WorkerKvQueryResponse> {
+        self.discovered
+            .messenger()
+            .typed_unary::<WorkerKvQueryResponse>(VELO_WORKER_KV_QUERY_HANDLER)?
+            .instance(target_instance_id)
+            .payload(request)?
+            .send()
+            .await
+            .with_context(|| {
+                format!("Failed to send worker KV query over Velo to worker {worker_id} dp_rank {dp_rank}")
+            })
     }
 }
 
 #[async_trait]
-impl WorkerQueryTransport for RuntimeWorkerQueryTransport {
+impl WorkerQueryTransport for VeloWorkerQueryTransport {
     async fn query_worker(
         &self,
         worker_id: WorkerId,
@@ -122,24 +121,30 @@ impl WorkerQueryTransport for RuntimeWorkerQueryTransport {
         start_event_id: Option<u64>,
         end_event_id: Option<u64>,
     ) -> Result<WorkerKvQueryResponse> {
-        let router = self.get_router_for_dp_rank(dp_rank).await?;
-
         let request = WorkerKvQueryRequest {
             worker_id,
             start_event_id,
             end_event_id,
         };
-        let mut stream = router
-            .direct(SingleIn::new(request), worker_id)
-            .await
-            .with_context(|| {
-                format!("Failed to send worker KV query to worker {worker_id} dp_rank {dp_rank}")
-            })?;
 
-        let response = stream
-            .next()
+        let peer_info = self.discovered.resolve_peer_info(worker_id).await?;
+        let response = match self
+            .send_query_request(worker_id, dp_rank, peer_info.instance_id(), request.clone())
             .await
-            .context("Worker KV query returned an empty response stream")?;
+        {
+            Ok(response) => response,
+            Err(first_error) => {
+                self.discovered.invalidate_peer_info(worker_id);
+                let peer_info = self.discovered.resolve_peer_info(worker_id).await?;
+                self.send_query_request(worker_id, dp_rank, peer_info.instance_id(), request)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "Worker KV query retry after refreshing peer info failed for worker {worker_id} dp_rank {dp_rank}; initial error: {first_error}"
+                        )
+                    })?
+            }
+        };
 
         if let Some(err) = response.err() {
             return Err(err).context("Worker KV query response error");
@@ -189,7 +194,7 @@ impl WorkerQueryClient {
     /// recovers each `(worker_id, dp_rank)` as it appears, and sends worker removal
     /// events when all dp_ranks for a worker disappear.
     pub async fn spawn(component: Component, indexer: Indexer) -> Result<Arc<Self>> {
-        let transport = Arc::new(RuntimeWorkerQueryTransport::new(component.clone()));
+        let transport = Arc::new(VeloWorkerQueryTransport::new(component.clone()).await?);
         let client = Self::new(component.clone(), indexer, transport);
 
         let client_bg = client.clone();
@@ -637,26 +642,68 @@ impl WorkerQueryClient {
 }
 
 // ============================================================================
-// Worker-side endpoint registration (unchanged)
+// Worker-side endpoint registration
 // ============================================================================
 
-/// Worker-side endpoint registration for Router -> LocalKvIndexer query service
+async fn query_local_indexer(
+    worker_id: WorkerId,
+    local_indexer: Arc<LocalKvIndexer>,
+    request: WorkerKvQueryRequest,
+) -> WorkerKvQueryResponse {
+    tracing::debug!(
+        "Received query request for worker {}: {:?}",
+        worker_id,
+        request
+    );
+
+    if request.worker_id != worker_id {
+        return WorkerKvQueryResponse::Error(format!(
+            "worker KV query worker_id mismatch: request.worker_id={} this.worker_id={worker_id}",
+            request.worker_id,
+        ));
+    }
+
+    local_indexer
+        .get_events_in_id_range(request.start_event_id, request.end_event_id)
+        .await
+}
+
+async fn build_worker_query_messenger(
+    worker_id: WorkerId,
+    local_indexer: Arc<LocalKvIndexer>,
+) -> Result<Arc<upstream_velo_messenger::Messenger>> {
+    let messenger = build_default_messenger().await?;
+
+    let handler = Handler::typed_unary_async(
+        VELO_WORKER_KV_QUERY_HANDLER,
+        move |ctx: TypedContext<WorkerKvQueryRequest>| {
+            let local_indexer = local_indexer.clone();
+            async move { Ok(query_local_indexer(worker_id, local_indexer, ctx.input).await) }
+        },
+    )
+    .build();
+    messenger
+        .register_handler(handler)
+        .context("Failed to register worker-query Velo handler")?;
+
+    Ok(messenger)
+}
+
+/// Worker-side endpoint registration for Router -> LocalKvIndexer query service.
+///
+/// The runtime endpoint is registered only for service discovery / dp-rank
+/// presence. The query itself is served over Velo typed-unary messaging.
 pub(crate) async fn start_worker_kv_query_endpoint(
     component: Component,
     worker_id: u64,
     dp_rank: DpRank,
     local_indexer: Arc<LocalKvIndexer>,
 ) {
-    let engine = Arc::new(WorkerKvQueryEngine {
-        worker_id,
-        local_indexer,
-    });
-
-    let ingress = match Ingress::for_engine(engine) {
-        Ok(ingress) => ingress,
+    let messenger = match build_worker_query_messenger(worker_id, local_indexer).await {
+        Ok(messenger) => messenger,
         Err(e) => {
             tracing::error!(
-                "Failed to build WorkerKvQuery endpoint handler for worker {worker_id} dp_rank {dp_rank}: {e}"
+                "Failed to start worker-query Velo server for worker {worker_id} dp_rank {dp_rank}: {e}"
             );
             return;
         }
@@ -664,65 +711,24 @@ pub(crate) async fn start_worker_kv_query_endpoint(
 
     let endpoint_name = worker_kv_indexer_query_endpoint(dp_rank);
     tracing::info!(
-        "WorkerKvQuery endpoint starting for worker {worker_id} dp_rank {dp_rank} on endpoint '{endpoint_name}'"
+        "Registering worker-query discovery endpoint for worker {worker_id} dp_rank {dp_rank} on endpoint '{endpoint_name}'"
     );
 
     if let Err(e) = component
         .endpoint(&endpoint_name)
-        .endpoint_builder()
-        .handler(ingress)
-        .graceful_shutdown(true)
-        .start()
+        .register_endpoint_instance()
         .await
     {
         tracing::error!(
-            "WorkerKvQuery endpoint failed for worker {worker_id} dp_rank {dp_rank}: {e}"
+            "Worker-query discovery endpoint registration failed for worker {worker_id} dp_rank {dp_rank}: {e}"
         );
+        return;
     }
-}
 
-struct WorkerKvQueryEngine {
-    worker_id: u64,
-    local_indexer: Arc<LocalKvIndexer>,
-}
-
-#[async_trait]
-impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>, anyhow::Error>
-    for WorkerKvQueryEngine
-{
-    async fn generate(
-        &self,
-        request: SingleIn<WorkerKvQueryRequest>,
-    ) -> anyhow::Result<ManyOut<WorkerKvQueryResponse>> {
-        let (request, ctx) = request.into_parts();
-
-        tracing::debug!(
-            "Received query request for worker {}: {:?}",
-            self.worker_id,
-            request
+    if let Err(e) = register_local_component_peer(&component, &messenger.peer_info()).await {
+        tracing::error!(
+            "Worker-query Velo peer registration failed for worker {worker_id} dp_rank {dp_rank}: {e}"
         );
-
-        if request.worker_id != self.worker_id {
-            let error_message = format!(
-                "WorkerKvQueryEngine::generate worker_id mismatch: request.worker_id={} this.worker_id={}",
-                request.worker_id, self.worker_id
-            );
-            let response = WorkerKvQueryResponse::Error(error_message);
-            return Ok(ResponseStream::new(
-                Box::pin(stream::iter(vec![response])),
-                ctx.context(),
-            ));
-        }
-
-        let response = self
-            .local_indexer
-            .get_events_in_id_range(request.start_event_id, request.end_event_id)
-            .await;
-
-        Ok(ResponseStream::new(
-            Box::pin(stream::iter(vec![response])),
-            ctx.context(),
-        ))
     }
 }
 
@@ -917,7 +923,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_worker_kv_query_engine_returns_buffered_events() {
+    async fn test_worker_local_kv_query_returns_buffered_events() {
         let worker_id = 7u64;
         let token = CancellationToken::new();
         let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
@@ -936,27 +942,13 @@ mod tests {
             .await
             .expect("apply_event_with_buffer should succeed");
 
-        let engine = WorkerKvQueryEngine {
-            worker_id,
-            local_indexer,
-        };
-
         let request = WorkerKvQueryRequest {
             worker_id,
             start_event_id: Some(1),
             end_event_id: Some(1),
         };
 
-        let mut stream = engine
-            .generate(SingleIn::new(request))
-            .await
-            .expect("generate should succeed");
-
-        let response = stream
-            .next()
-            .await
-            .expect("response stream should yield one item");
-
+        let response = query_local_indexer(worker_id, local_indexer, request).await;
         match response {
             WorkerKvQueryResponse::Events(events) => {
                 assert_eq!(events.len(), 1);

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -87,6 +87,8 @@ rayon = { version = "1.10" }
 regex = { version = "1" }
 socket2 = { version = "0.5.8" }
 tokio-rayon = { version = "2.1" }
+upstream-velo-messenger = { package = "velo-messenger", version = "0.1.0" }
+upstream-velo-transports = { package = "velo-transports", version = "0.1.0" }
 
 # Kubernetes discovery backend
 kube = { version = "2.0.1", default-features = false, features = ["runtime", "derive", "client", "rustls-tls", "aws-lc-rs"] }

--- a/lib/runtime/src/discovery/kube.rs
+++ b/lib/runtime/src/discovery/kube.rs
@@ -117,6 +117,19 @@ impl Discovery for KubeDiscoveryClient {
                 );
                 metadata.register_endpoint(instance.clone())?;
             }
+            DiscoveryInstance::VeloPeer {
+                namespace,
+                component,
+                ..
+            } => {
+                tracing::info!(
+                    "Registering Velo peer: namespace={}, component={}, instance_id={:x}",
+                    namespace,
+                    component,
+                    instance_id
+                );
+                metadata.register_velo_peer(instance.clone())?;
+            }
             DiscoveryInstance::Model {
                 namespace,
                 component,
@@ -188,6 +201,19 @@ impl Discovery for KubeDiscoveryClient {
                     instance_id
                 );
                 metadata.unregister_endpoint(&instance)?;
+            }
+            DiscoveryInstance::VeloPeer {
+                namespace,
+                component,
+                ..
+            } => {
+                tracing::info!(
+                    "Unregistering Velo peer: namespace={}, component={}, instance_id={:x}",
+                    namespace,
+                    component,
+                    instance_id
+                );
+                metadata.unregister_velo_peer(&instance)?;
             }
             DiscoveryInstance::Model {
                 namespace,

--- a/lib/runtime/src/discovery/kv_store.rs
+++ b/lib/runtime/src/discovery/kv_store.rs
@@ -12,11 +12,12 @@ use tokio_util::sync::CancellationToken;
 use super::{
     Discovery, DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, DiscoveryQuery,
     DiscoverySpec, DiscoveryStream, EndpointInstanceId, EventChannelInstanceId,
-    ModelCardInstanceId,
+    ModelCardInstanceId, VeloPeerInstanceId,
 };
 use crate::storage::kv;
 
 const INSTANCES_BUCKET: &str = "v1/instances";
+const VELO_PEERS_BUCKET: &str = "v1/velo_peers";
 const MODELS_BUCKET: &str = "v1/mdc";
 const EVENT_CHANNELS_BUCKET: &str = "v1/event_channels";
 
@@ -42,6 +43,11 @@ impl KVStoreDiscovery {
     /// Build the key path for a model (relative to bucket, not absolute)
     fn model_key(namespace: &str, component: &str, endpoint: &str, instance_id: u64) -> String {
         format!("{}/{}/{}/{:x}", namespace, component, endpoint, instance_id)
+    }
+
+    /// Build the key path for a Velo peer (relative to bucket, not absolute)
+    fn velo_peer_key(namespace: &str, component: &str, instance_id: u64) -> String {
+        format!("{}/{}/{:x}", namespace, component, instance_id)
     }
 
     /// Build the key path for an event channel relative to bucket, not absolute)
@@ -76,6 +82,16 @@ impl KVStoreDiscovery {
                     "{}/{}/{}/{}",
                     INSTANCES_BUCKET, namespace, component, endpoint
                 )
+            }
+            DiscoveryQuery::AllVeloPeers => VELO_PEERS_BUCKET.to_string(),
+            DiscoveryQuery::NamespacedVeloPeers { namespace } => {
+                format!("{}/{}", VELO_PEERS_BUCKET, namespace)
+            }
+            DiscoveryQuery::ComponentVeloPeers {
+                namespace,
+                component,
+            } => {
+                format!("{}/{}/{}", VELO_PEERS_BUCKET, namespace, component)
             }
             DiscoveryQuery::AllModels => MODELS_BUCKET.to_string(),
             DiscoveryQuery::NamespacedModels { namespace } => {
@@ -177,6 +193,22 @@ impl Discovery for KVStoreDiscovery {
                     key
                 );
                 (INSTANCES_BUCKET, key)
+            }
+            DiscoveryInstance::VeloPeer {
+                namespace,
+                component,
+                instance_id,
+                ..
+            } => {
+                let key = Self::velo_peer_key(namespace, component, *instance_id);
+                tracing::debug!(
+                    "KVStoreDiscovery::register: Registering Velo peer instance_id={}, namespace={}, component={}, key={}",
+                    instance_id,
+                    namespace,
+                    component,
+                    key
+                );
+                (VELO_PEERS_BUCKET, key)
             }
             DiscoveryInstance::Model {
                 namespace,
@@ -297,6 +329,22 @@ impl Discovery for KVStoreDiscovery {
                 );
                 (INSTANCES_BUCKET, key)
             }
+            DiscoveryInstance::VeloPeer {
+                namespace,
+                component,
+                instance_id,
+                ..
+            } => {
+                let key = Self::velo_peer_key(namespace, component, *instance_id);
+                tracing::debug!(
+                    "Unregistering Velo peer instance_id={}, namespace={}, component={}, key={}",
+                    instance_id,
+                    namespace,
+                    component,
+                    key
+                );
+                (VELO_PEERS_BUCKET, key)
+            }
             DiscoveryInstance::Model {
                 namespace,
                 component,
@@ -377,6 +425,8 @@ impl Discovery for KVStoreDiscovery {
         let prefix = Self::query_prefix(&query);
         let bucket_name = if prefix.starts_with(INSTANCES_BUCKET) {
             INSTANCES_BUCKET
+        } else if prefix.starts_with(VELO_PEERS_BUCKET) {
+            VELO_PEERS_BUCKET
         } else if prefix.starts_with(EVENT_CHANNELS_BUCKET) {
             EVENT_CHANNELS_BUCKET
         } else {
@@ -428,6 +478,8 @@ impl Discovery for KVStoreDiscovery {
         let prefix = Self::query_prefix(&query);
         let bucket_name = if prefix.starts_with(INSTANCES_BUCKET) {
             INSTANCES_BUCKET
+        } else if prefix.starts_with(VELO_PEERS_BUCKET) {
+            VELO_PEERS_BUCKET
         } else if prefix.starts_with(EVENT_CHANNELS_BUCKET) {
             EVENT_CHANNELS_BUCKET
         } else {
@@ -495,9 +547,7 @@ impl Discovery for KVStoreDiscovery {
                         let relative_key = Self::strip_bucket_prefix(key_str, bucket_name);
                         let key_parts: Vec<&str> = relative_key.split('/').collect();
 
-                        // EventChannels need 4 parts (namespace/component/topic/instance_id)
-                        // Endpoints/Models need at least 4 parts
-                        let min_parts = 4;
+                        let min_parts = if bucket_name == VELO_PEERS_BUCKET { 3 } else { 4 };
                         if key_parts.len() < min_parts {
                             tracing::warn!(
                                 key = %key_str,
@@ -513,7 +563,7 @@ impl Discovery for KVStoreDiscovery {
                         let namespace = key_parts[0].to_string();
                         let component = key_parts[1].to_string();
 
-                        // Handle EventChannel (4 parts: namespace/component/topic/instance_id) vs Endpoints/Models
+                        // Handle VeloPeer (3 parts), EventChannel (4 parts) vs Endpoints/Models
                         let id = if bucket_name == EVENT_CHANNELS_BUCKET {
                             // EventChannel keys: namespace/component/topic/{instance_id:x}
                             let topic = key_parts[2].to_string();
@@ -533,6 +583,26 @@ impl Discovery for KVStoreDiscovery {
                                         error = %e,
                                         instance_id_hex = %instance_id_hex,
                                         "Failed to parse event channel instance_id hex"
+                                    );
+                                    continue;
+                                }
+                            }
+                        } else if bucket_name == VELO_PEERS_BUCKET {
+                            let instance_id_hex = key_parts[2];
+                            match u64::from_str_radix(instance_id_hex, 16) {
+                                Ok(instance_id) => {
+                                    DiscoveryInstanceId::VeloPeer(VeloPeerInstanceId {
+                                        namespace,
+                                        component,
+                                        instance_id,
+                                    })
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key_str,
+                                        error = %e,
+                                        instance_id_hex = %instance_id_hex,
+                                        "Failed to parse Velo peer instance_id hex"
                                     );
                                     continue;
                                 }

--- a/lib/runtime/src/discovery/metadata.rs
+++ b/lib/runtime/src/discovery/metadata.rs
@@ -36,6 +36,9 @@ pub struct DiscoveryMetadata {
     /// Registered endpoint instances (key: path string from EndpointInstanceId::to_path())
     #[serde(default, deserialize_with = "deserialize_null_default")]
     endpoints: HashMap<String, DiscoveryInstance>,
+    /// Registered Velo peer instances (key: path string from VeloPeerInstanceId::to_path())
+    #[serde(default, deserialize_with = "deserialize_null_default")]
+    velo_peers: HashMap<String, DiscoveryInstance>,
     /// Registered model card instances (key: path string from ModelCardInstanceId::to_path())
     #[serde(default, deserialize_with = "deserialize_null_default")]
     model_cards: HashMap<String, DiscoveryInstance>,
@@ -49,6 +52,7 @@ impl DiscoveryMetadata {
     pub fn new() -> Self {
         Self {
             endpoints: HashMap::new(),
+            velo_peers: HashMap::new(),
             model_cards: HashMap::new(),
             event_channels: HashMap::new(),
         }
@@ -60,6 +64,9 @@ impl DiscoveryMetadata {
             DiscoveryInstanceId::Endpoint(key) => {
                 self.endpoints.insert(key.to_path(), instance);
                 Ok(())
+            }
+            DiscoveryInstanceId::VeloPeer(_) => {
+                anyhow::bail!("Cannot register VeloPeer instance as endpoint")
             }
             DiscoveryInstanceId::Model(_) => {
                 anyhow::bail!("Cannot register non-endpoint instance as endpoint")
@@ -80,8 +87,30 @@ impl DiscoveryMetadata {
             DiscoveryInstanceId::Endpoint(_) => {
                 anyhow::bail!("Cannot register non-model-card instance as model card")
             }
+            DiscoveryInstanceId::VeloPeer(_) => {
+                anyhow::bail!("Cannot register VeloPeer instance as model card")
+            }
             DiscoveryInstanceId::EventChannel(_) => {
                 anyhow::bail!("Cannot register EventChannel instance as model card")
+            }
+        }
+    }
+
+    /// Register a Velo peer instance
+    pub fn register_velo_peer(&mut self, instance: DiscoveryInstance) -> Result<()> {
+        match instance.id() {
+            DiscoveryInstanceId::VeloPeer(key) => {
+                self.velo_peers.insert(key.to_path(), instance);
+                Ok(())
+            }
+            DiscoveryInstanceId::Endpoint(_) => {
+                anyhow::bail!("Cannot register Endpoint instance as VeloPeer")
+            }
+            DiscoveryInstanceId::Model(_) => {
+                anyhow::bail!("Cannot register Model instance as VeloPeer")
+            }
+            DiscoveryInstanceId::EventChannel(_) => {
+                anyhow::bail!("Cannot register EventChannel instance as VeloPeer")
             }
         }
     }
@@ -92,6 +121,9 @@ impl DiscoveryMetadata {
             DiscoveryInstanceId::Endpoint(key) => {
                 self.endpoints.remove(&key.to_path());
                 Ok(())
+            }
+            DiscoveryInstanceId::VeloPeer(_) => {
+                anyhow::bail!("Cannot unregister VeloPeer instance as endpoint")
             }
             DiscoveryInstanceId::Model(_) => {
                 anyhow::bail!("Cannot unregister non-endpoint instance as endpoint")
@@ -112,8 +144,30 @@ impl DiscoveryMetadata {
             DiscoveryInstanceId::Endpoint(_) => {
                 anyhow::bail!("Cannot unregister non-model-card instance as model card")
             }
+            DiscoveryInstanceId::VeloPeer(_) => {
+                anyhow::bail!("Cannot unregister VeloPeer instance as model card")
+            }
             DiscoveryInstanceId::EventChannel(_) => {
                 anyhow::bail!("Cannot unregister EventChannel instance as model card")
+            }
+        }
+    }
+
+    /// Unregister a Velo peer instance
+    pub fn unregister_velo_peer(&mut self, instance: &DiscoveryInstance) -> Result<()> {
+        match instance.id() {
+            DiscoveryInstanceId::VeloPeer(key) => {
+                self.velo_peers.remove(&key.to_path());
+                Ok(())
+            }
+            DiscoveryInstanceId::Endpoint(_) => {
+                anyhow::bail!("Cannot unregister Endpoint instance as VeloPeer")
+            }
+            DiscoveryInstanceId::Model(_) => {
+                anyhow::bail!("Cannot unregister Model instance as VeloPeer")
+            }
+            DiscoveryInstanceId::EventChannel(_) => {
+                anyhow::bail!("Cannot unregister EventChannel instance as VeloPeer")
             }
         }
     }
@@ -127,6 +181,9 @@ impl DiscoveryMetadata {
             }
             DiscoveryInstanceId::Endpoint(_) => {
                 anyhow::bail!("Cannot register Endpoint instance as event channel")
+            }
+            DiscoveryInstanceId::VeloPeer(_) => {
+                anyhow::bail!("Cannot register VeloPeer instance as event channel")
             }
             DiscoveryInstanceId::Model(_) => {
                 anyhow::bail!("Cannot register Model instance as event channel")
@@ -144,6 +201,9 @@ impl DiscoveryMetadata {
             DiscoveryInstanceId::Endpoint(_) => {
                 anyhow::bail!("Cannot unregister Endpoint instance as event channel")
             }
+            DiscoveryInstanceId::VeloPeer(_) => {
+                anyhow::bail!("Cannot unregister VeloPeer instance as event channel")
+            }
             DiscoveryInstanceId::Model(_) => {
                 anyhow::bail!("Cannot unregister Model instance as event channel")
             }
@@ -153,6 +213,11 @@ impl DiscoveryMetadata {
     /// Get all registered endpoints
     pub fn get_all_endpoints(&self) -> Vec<DiscoveryInstance> {
         self.endpoints.values().cloned().collect()
+    }
+
+    /// Get all registered Velo peers
+    pub fn get_all_velo_peers(&self) -> Vec<DiscoveryInstance> {
+        self.velo_peers.values().cloned().collect()
     }
 
     /// Get all registered model cards
@@ -169,6 +234,7 @@ impl DiscoveryMetadata {
     pub fn get_all(&self) -> Vec<DiscoveryInstance> {
         self.endpoints
             .values()
+            .chain(self.velo_peers.values())
             .chain(self.model_cards.values())
             .chain(self.event_channels.values())
             .cloned()
@@ -182,6 +248,10 @@ impl DiscoveryMetadata {
             | DiscoveryQuery::NamespacedEndpoints { .. }
             | DiscoveryQuery::ComponentEndpoints { .. }
             | DiscoveryQuery::Endpoint { .. } => self.get_all_endpoints(),
+
+            DiscoveryQuery::AllVeloPeers
+            | DiscoveryQuery::NamespacedVeloPeers { .. }
+            | DiscoveryQuery::ComponentVeloPeers { .. } => self.get_all_velo_peers(),
 
             DiscoveryQuery::AllModels
             | DiscoveryQuery::NamespacedModels { .. }
@@ -243,6 +313,31 @@ fn filter_instances(
                         && &i.component == component
                         && &i.endpoint == endpoint
                 }
+                _ => false,
+            })
+            .collect(),
+
+        DiscoveryQuery::AllVeloPeers => instances,
+
+        DiscoveryQuery::NamespacedVeloPeers { namespace } => instances
+            .into_iter()
+            .filter(|inst| match inst {
+                DiscoveryInstance::VeloPeer { namespace: ns, .. } => ns == namespace,
+                _ => false,
+            })
+            .collect(),
+
+        DiscoveryQuery::ComponentVeloPeers {
+            namespace,
+            component,
+        } => instances
+            .into_iter()
+            .filter(|inst| match inst {
+                DiscoveryInstance::VeloPeer {
+                    namespace: ns,
+                    component: comp,
+                    ..
+                } => ns == namespace && comp == component,
                 _ => false,
             })
             .collect(),

--- a/lib/runtime/src/discovery/mock.rs
+++ b/lib/runtime/src/discovery/mock.rs
@@ -72,6 +72,26 @@ fn matches_query(instance: &DiscoveryInstance, query: &DiscoveryQuery) -> bool {
                 && &inst.endpoint == endpoint
         }
 
+        // VeloPeer matching
+        (DiscoveryInstance::VeloPeer { .. }, DiscoveryQuery::AllVeloPeers) => true,
+        (
+            DiscoveryInstance::VeloPeer {
+                namespace: inst_ns, ..
+            },
+            DiscoveryQuery::NamespacedVeloPeers { namespace },
+        ) => inst_ns == namespace,
+        (
+            DiscoveryInstance::VeloPeer {
+                namespace: inst_ns,
+                component: inst_comp,
+                ..
+            },
+            DiscoveryQuery::ComponentVeloPeers {
+                namespace,
+                component,
+            },
+        ) => inst_ns == namespace && inst_comp == component,
+
         // Model matching
         (DiscoveryInstance::Model { .. }, DiscoveryQuery::AllModels) => true,
         (
@@ -124,6 +144,21 @@ fn matches_query(instance: &DiscoveryInstance, query: &DiscoveryQuery) -> bool {
         (
             DiscoveryInstance::Endpoint(_),
             DiscoveryQuery::AllModels
+            | DiscoveryQuery::AllVeloPeers
+            | DiscoveryQuery::NamespacedModels { .. }
+            | DiscoveryQuery::NamespacedVeloPeers { .. }
+            | DiscoveryQuery::ComponentModels { .. }
+            | DiscoveryQuery::ComponentVeloPeers { .. }
+            | DiscoveryQuery::EndpointModels { .. }
+            | DiscoveryQuery::EventChannels(_),
+        ) => false,
+        (
+            DiscoveryInstance::VeloPeer { .. },
+            DiscoveryQuery::AllEndpoints
+            | DiscoveryQuery::NamespacedEndpoints { .. }
+            | DiscoveryQuery::ComponentEndpoints { .. }
+            | DiscoveryQuery::Endpoint { .. }
+            | DiscoveryQuery::AllModels
             | DiscoveryQuery::NamespacedModels { .. }
             | DiscoveryQuery::ComponentModels { .. }
             | DiscoveryQuery::EndpointModels { .. }
@@ -135,6 +170,9 @@ fn matches_query(instance: &DiscoveryInstance, query: &DiscoveryQuery) -> bool {
             | DiscoveryQuery::NamespacedEndpoints { .. }
             | DiscoveryQuery::ComponentEndpoints { .. }
             | DiscoveryQuery::Endpoint { .. }
+            | DiscoveryQuery::AllVeloPeers
+            | DiscoveryQuery::NamespacedVeloPeers { .. }
+            | DiscoveryQuery::ComponentVeloPeers { .. }
             | DiscoveryQuery::EventChannels(_),
         ) => false,
         (
@@ -143,6 +181,9 @@ fn matches_query(instance: &DiscoveryInstance, query: &DiscoveryQuery) -> bool {
             | DiscoveryQuery::NamespacedEndpoints { .. }
             | DiscoveryQuery::ComponentEndpoints { .. }
             | DiscoveryQuery::Endpoint { .. }
+            | DiscoveryQuery::AllVeloPeers
+            | DiscoveryQuery::NamespacedVeloPeers { .. }
+            | DiscoveryQuery::ComponentVeloPeers { .. }
             | DiscoveryQuery::AllModels
             | DiscoveryQuery::NamespacedModels { .. }
             | DiscoveryQuery::ComponentModels { .. }
@@ -328,6 +369,7 @@ mod tests {
         // Remove first instance
         registry.instances.lock().unwrap().retain(|i| match i {
             DiscoveryInstance::Endpoint(inst) => inst.instance_id != 1,
+            DiscoveryInstance::VeloPeer { instance_id, .. } => *instance_id != 1,
             DiscoveryInstance::Model { instance_id, .. } => *instance_id != 1,
             DiscoveryInstance::EventChannel { instance_id, .. } => *instance_id != 1,
         });

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -10,6 +10,10 @@ use tokio_util::sync::CancellationToken;
 
 mod metadata;
 pub use metadata::{DiscoveryMetadata, MetadataSnapshot};
+mod velo_peers;
+pub use velo_peers::{
+    DiscoveredVeloMessenger, build_default_messenger, register_local_component_peer,
+};
 
 mod mock;
 pub use mock::{MockDiscovery, SharedMockRegistry};
@@ -204,6 +208,17 @@ pub enum DiscoveryQuery {
         component: String,
         endpoint: String,
     },
+    /// Query all Velo peer records in the system
+    AllVeloPeers,
+    /// Query all Velo peer records in a specific namespace
+    NamespacedVeloPeers {
+        namespace: String,
+    },
+    /// Query all Velo peer records for a namespace/component
+    ComponentVeloPeers {
+        namespace: String,
+        component: String,
+    },
     AllModels,
     NamespacedModels {
         namespace: String,
@@ -299,6 +314,13 @@ pub enum DiscoverySpec {
         /// Transport type and routing information
         transport: TransportType,
     },
+    /// Velo peer transport metadata for a component instance
+    VeloPeer {
+        namespace: String,
+        component: String,
+        /// Serialized Velo PeerInfo as JSON to avoid lib/runtime depending on Velo types
+        peer_json: serde_json::Value,
+    },
     Model {
         namespace: String,
         component: String,
@@ -324,6 +346,18 @@ pub enum DiscoverySpec {
 }
 
 impl DiscoverySpec {
+    /// Creates a Velo peer discovery spec from a serializable type.
+    pub fn from_velo_peer<T>(namespace: String, component: String, peer: &T) -> Result<Self>
+    where
+        T: Serialize,
+    {
+        Ok(Self::VeloPeer {
+            namespace,
+            component,
+            peer_json: serde_json::to_value(peer)?,
+        })
+    }
+
     /// Creates a Model discovery spec from a serializable type
     /// The card will be serialized to JSON to avoid cross-crate dependencies
     pub fn from_model<T>(
@@ -375,6 +409,16 @@ impl DiscoverySpec {
                 instance_id,
                 transport,
             }),
+            Self::VeloPeer {
+                namespace,
+                component,
+                peer_json,
+            } => DiscoveryInstance::VeloPeer {
+                namespace,
+                component,
+                instance_id,
+                peer_json,
+            },
             Self::Model {
                 namespace,
                 component,
@@ -412,6 +456,14 @@ impl DiscoverySpec {
 pub enum DiscoveryInstance {
     /// Registered endpoint instance - wraps the component::Instance directly
     Endpoint(crate::component::Instance),
+    /// Registered Velo peer metadata for a component instance
+    VeloPeer {
+        namespace: String,
+        component: String,
+        instance_id: u64,
+        /// Serialized Velo PeerInfo as JSON to avoid lib/runtime depending on Velo types
+        peer_json: serde_json::Value,
+    },
     Model {
         namespace: String,
         component: String,
@@ -441,8 +493,28 @@ impl DiscoveryInstance {
     pub fn instance_id(&self) -> u64 {
         match self {
             Self::Endpoint(inst) => inst.instance_id,
+            Self::VeloPeer { instance_id, .. } => *instance_id,
             Self::Model { instance_id, .. } => *instance_id,
             Self::EventChannel { instance_id, .. } => *instance_id,
+        }
+    }
+
+    /// Deserializes the Velo peer JSON into the specified type T.
+    pub fn deserialize_velo_peer<T>(&self) -> Result<T>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        match self {
+            Self::VeloPeer { peer_json, .. } => Ok(serde_json::from_value(peer_json.clone())?),
+            Self::Endpoint(_) => {
+                anyhow::bail!("Cannot deserialize Velo peer from Endpoint instance")
+            }
+            Self::Model { .. } => {
+                anyhow::bail!("Cannot deserialize Velo peer from Model instance")
+            }
+            Self::EventChannel { .. } => {
+                anyhow::bail!("Cannot deserialize Velo peer from EventChannel instance")
+            }
         }
     }
 
@@ -456,6 +528,9 @@ impl DiscoveryInstance {
             Self::Model { card_json, .. } => Ok(serde_json::from_value(card_json.clone())?),
             Self::Endpoint(_) => {
                 anyhow::bail!("Cannot deserialize model from Endpoint instance")
+            }
+            Self::VeloPeer { .. } => {
+                anyhow::bail!("Cannot deserialize model from VeloPeer instance")
             }
             Self::EventChannel { .. } => {
                 anyhow::bail!("Cannot deserialize model from EventChannel instance")
@@ -472,6 +547,16 @@ impl DiscoveryInstance {
                 component: inst.component.clone(),
                 endpoint: inst.endpoint.clone(),
                 instance_id: inst.instance_id,
+            }),
+            Self::VeloPeer {
+                namespace,
+                component,
+                instance_id,
+                ..
+            } => DiscoveryInstanceId::VeloPeer(VeloPeerInstanceId {
+                namespace: namespace.clone(),
+                component: component.clone(),
+                instance_id: *instance_id,
             }),
             Self::Model {
                 namespace,
@@ -500,6 +585,41 @@ impl DiscoveryInstance {
                 instance_id: *instance_id,
             }),
         }
+    }
+}
+
+/// Unique identifier for a Velo peer instance
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct VeloPeerInstanceId {
+    pub namespace: String,
+    pub component: String,
+    pub instance_id: u64,
+}
+
+impl VeloPeerInstanceId {
+    /// Converts to a path string: `{namespace}/{component}/{instance_id:x}`
+    pub fn to_path(&self) -> String {
+        format!(
+            "{}/{}/{:x}",
+            self.namespace, self.component, self.instance_id
+        )
+    }
+
+    /// Parses from a path string: `{namespace}/{component}/{instance_id:x}`
+    pub fn from_path(path: &str) -> Result<Self> {
+        let parts: Vec<&str> = path.split('/').collect();
+        if parts.len() != 3 {
+            anyhow::bail!(
+                "Invalid VeloPeerInstanceId path: expected 3 parts, got {}",
+                parts.len()
+            );
+        }
+        Ok(Self {
+            namespace: parts[0].to_string(),
+            component: parts[1].to_string(),
+            instance_id: u64::from_str_radix(parts[2], 16)
+                .map_err(|e| anyhow::anyhow!("Invalid instance_id hex: {}", e))?,
+        })
     }
 }
 
@@ -629,6 +749,7 @@ impl ModelCardInstanceId {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum DiscoveryInstanceId {
     Endpoint(EndpointInstanceId),
+    VeloPeer(VeloPeerInstanceId),
     Model(ModelCardInstanceId),
     EventChannel(EventChannelInstanceId),
 }
@@ -638,6 +759,7 @@ impl DiscoveryInstanceId {
     pub fn instance_id(&self) -> u64 {
         match self {
             Self::Endpoint(eid) => eid.instance_id,
+            Self::VeloPeer(vid) => vid.instance_id,
             Self::Model(mid) => mid.instance_id,
             Self::EventChannel(ecid) => ecid.instance_id,
         }
@@ -647,8 +769,19 @@ impl DiscoveryInstanceId {
     pub fn extract_endpoint_id(&self) -> Result<&EndpointInstanceId> {
         match self {
             Self::Endpoint(eid) => Ok(eid),
+            Self::VeloPeer(_) => anyhow::bail!("Expected Endpoint variant, got VeloPeer"),
             Self::Model(_) => anyhow::bail!("Expected Endpoint variant, got Model"),
             Self::EventChannel(_) => anyhow::bail!("Expected Endpoint variant, got EventChannel"),
+        }
+    }
+
+    /// Extracts the VeloPeerInstanceId, returning an error if this is not a VeloPeer variant.
+    pub fn extract_velo_peer_id(&self) -> Result<&VeloPeerInstanceId> {
+        match self {
+            Self::VeloPeer(vid) => Ok(vid),
+            Self::Endpoint(_) => anyhow::bail!("Expected VeloPeer variant, got Endpoint"),
+            Self::Model(_) => anyhow::bail!("Expected VeloPeer variant, got Model"),
+            Self::EventChannel(_) => anyhow::bail!("Expected VeloPeer variant, got EventChannel"),
         }
     }
 
@@ -657,6 +790,7 @@ impl DiscoveryInstanceId {
         match self {
             Self::Model(mid) => Ok(mid),
             Self::Endpoint(_) => anyhow::bail!("Expected Model variant, got Endpoint"),
+            Self::VeloPeer(_) => anyhow::bail!("Expected Model variant, got VeloPeer"),
             Self::EventChannel(_) => anyhow::bail!("Expected Model variant, got EventChannel"),
         }
     }
@@ -666,6 +800,7 @@ impl DiscoveryInstanceId {
         match self {
             Self::EventChannel(ecid) => Ok(ecid),
             Self::Endpoint(_) => anyhow::bail!("Expected EventChannel variant, got Endpoint"),
+            Self::VeloPeer(_) => anyhow::bail!("Expected EventChannel variant, got VeloPeer"),
             Self::Model(_) => anyhow::bail!("Expected EventChannel variant, got Model"),
         }
     }

--- a/lib/runtime/src/discovery/velo_peers.rs
+++ b/lib/runtime/src/discovery/velo_peers.rs
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use dashmap::DashMap;
+use upstream_velo_messenger::{Messenger, PeerInfo};
+use upstream_velo_transports::tcp::TcpTransportBuilder;
+
+use crate::component::Component;
+use crate::traits::DistributedRuntimeProvider;
+
+use super::{DiscoveryQuery, DiscoverySpec};
+
+pub async fn build_default_messenger() -> Result<Arc<Messenger>> {
+    let transport = Arc::new(
+        TcpTransportBuilder::new()
+            .build()
+            .context("Failed to build Velo TCP transport")?,
+    );
+
+    Messenger::builder()
+        .add_transport(transport)
+        .build()
+        .await
+        .context("Failed to build Velo messenger")
+}
+
+pub async fn register_local_component_peer(
+    component: &Component,
+    peer_info: &PeerInfo,
+) -> Result<()> {
+    let spec = DiscoverySpec::from_velo_peer(
+        component.namespace().name(),
+        component.name().to_string(),
+        peer_info,
+    )?;
+
+    component
+        .drt()
+        .discovery()
+        .register(spec)
+        .await
+        .context("Failed to register Velo peer in discovery")?;
+
+    Ok(())
+}
+
+pub struct DiscoveredVeloMessenger {
+    component: Component,
+    peer_info_cache: DashMap<u64, PeerInfo>,
+    messenger: Arc<Messenger>,
+}
+
+impl DiscoveredVeloMessenger {
+    pub async fn new(component: Component) -> Result<Self> {
+        Ok(Self {
+            component,
+            peer_info_cache: DashMap::new(),
+            messenger: build_default_messenger().await?,
+        })
+    }
+
+    pub fn messenger(&self) -> &Arc<Messenger> {
+        &self.messenger
+    }
+
+    pub fn invalidate_peer_info(&self, instance_id: u64) {
+        self.peer_info_cache.remove(&instance_id);
+    }
+
+    pub async fn resolve_peer_info(&self, instance_id: u64) -> Result<PeerInfo> {
+        if let Some(peer_info) = self.peer_info_cache.get(&instance_id) {
+            return Ok(peer_info.clone());
+        }
+
+        let peers = self
+            .component
+            .drt()
+            .discovery()
+            .list(DiscoveryQuery::ComponentVeloPeers {
+                namespace: self.component.namespace().name(),
+                component: self.component.name().to_string(),
+            })
+            .await
+            .context("Failed to list discovered Velo peers")?;
+
+        let Some(peer_instance) = peers
+            .into_iter()
+            .find(|peer| peer.instance_id() == instance_id)
+        else {
+            anyhow::bail!("No discovered Velo peer for runtime instance {instance_id}");
+        };
+
+        let peer_info = peer_instance
+            .deserialize_velo_peer::<PeerInfo>()
+            .with_context(|| {
+                format!(
+                    "Failed to deserialize Velo peer metadata for runtime instance {instance_id}"
+                )
+            })?;
+
+        self.messenger
+            .register_peer(peer_info.clone())
+            .context("Failed to register discovered Velo peer")?;
+        self.peer_info_cache.insert(instance_id, peer_info.clone());
+
+        Ok(peer_info)
+    }
+}


### PR DESCRIPTION
## Summary
- add first-class Velo peer records to runtime discovery
- move the shared Velo messenger/peer resolution helper into dynamo-runtime
- switch worker-query recovery to resolve peers through runtime discovery

## Status
DO NOT MERGE.

Known regression: worker-query recovery currently loses dp-rank specificity on multi-rank workers, so a recovery request can resolve the wrong local indexer.