### PR TITLE
docs(kubernetes): remove decode-mode omission note

### DIFF
--- a/docs/kubernetes/inference-gateway.md
+++ b/docs/kubernetes/inference-gateway.md
@@ -243,7 +243,6 @@ KV-aware routing uses live KV cache block events from workers so the EPP can rou
    - **vLLM:** Pass `--enable-prefix-caching` and `--kv-events-config '{"enable_kv_cache_events":true}'`.
    - **SGLang:** Pass `--kv-events-config` with the appropriate endpoint.
    - **TRT-LLM:** Pass `--publish-events-and-metrics`.
-   - **Disaggregated vLLM (prefill/decode separation):** Do **not** pass `--disaggregation-mode decode` on decode workers — this flag hardcodes KV event publishing to off. Instead, omit the flag (defaults to aggregated mode) so decode workers also publish their cache state.
 2. **EPP — leave `DYN_USE_KV_EVENTS` at its default (`true`).** The EPP subscribes to worker KV events via event plane (NATS/ZMQ) and uses them for prefix-overlap scoring.
 3. **Block size — must be consistent.** The `--block-size` on all workers must match `DYN_KV_CACHE_BLOCK_SIZE` on the EPP (default: 128). Mismatched block sizes cause incorrect block hash computation.
 


### PR DESCRIPTION
Remove the inference-gateway note that told users to omit `--disaggregation-mode decode` for disaggregated vLLM.

Why:
- In the built-in disaggregated vLLM path, decode-stage routing already forces overlap scoring off, so decode KV events are not on the critical path for normal live decode routing.
- Keeping that note nudged users toward enabling decode-side KV event publishing as a workaround, which creates its own failure modes.
- If there is no active consumer, JetStream can keep queueing the backlog and drive memory growth.
- ZMQ can run into the same kind of issue when publisher-side buffers are configured large enough to absorb sustained event buildup.

In practice, that turned the note into an operational footgun without helping the standard decode routing path.