### PR TITLE
fix(operator): handle GPU resources in requests, not just limits

### DIFF
--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -593,6 +593,16 @@ func GetResourcesConfig(resources *v1alpha1.Resources) (*corev1.ResourceRequirem
 			}
 			currentResources.Requests[corev1.ResourceMemory] = q
 		}
+		if resources.Requests.GPU != "" {
+			q, err := resource.ParseQuantity(resources.Requests.GPU)
+			if err != nil {
+				return nil, fmt.Errorf("parse requests gpu quantity: %w", err)
+			}
+			if currentResources.Requests == nil {
+				currentResources.Requests = make(corev1.ResourceList)
+			}
+			currentResources.Requests[getGPUResourceName(resources.Requests)] = q
+		}
 		for k, v := range resources.Requests.Custom {
 			q, err := resource.ParseQuantity(v)
 			if err != nil {

--- a/deploy/operator/internal/controller_common/resource_test.go
+++ b/deploy/operator/internal/controller_common/resource_test.go
@@ -646,11 +646,13 @@ func TestCopySpec(t *testing.T) {
 
 func TestGetResourcesConfig(t *testing.T) {
 	tests := []struct {
-		name             string
-		resources        *v1alpha1.Resources
-		expectedGPULimit corev1.ResourceName
-		expectedGPUValue string
-		expectError      bool
+		name               string
+		resources          *v1alpha1.Resources
+		expectedGPULimit   corev1.ResourceName
+		expectedGPUValue   string
+		expectedGPURequest corev1.ResourceName
+		expectedGPUReqVal  string
+		expectError        bool
 	}{
 		{
 			name: "limits.gpu defined with no gpuType",
@@ -675,6 +677,45 @@ func TestGetResourcesConfig(t *testing.T) {
 			expectedGPUValue: "8",
 			expectError:      false,
 		},
+		{
+			name: "requests.gpu defined with no gpuType",
+			resources: &v1alpha1.Resources{
+				Requests: &v1alpha1.ResourceItem{
+					GPU: "4",
+				},
+			},
+			expectedGPURequest: corev1.ResourceName(consts.KubeResourceGPUNvidia),
+			expectedGPUReqVal:  "4",
+			expectError:        false,
+		},
+		{
+			name: "requests.gpu defined with custom gpuType",
+			resources: &v1alpha1.Resources{
+				Requests: &v1alpha1.ResourceItem{
+					GPU:     "8",
+					GPUType: "gpu.custom-type.com/test",
+				},
+			},
+			expectedGPURequest: corev1.ResourceName("gpu.custom-type.com/test"),
+			expectedGPUReqVal:  "8",
+			expectError:        false,
+		},
+		{
+			name: "both limits.gpu and requests.gpu defined",
+			resources: &v1alpha1.Resources{
+				Limits: &v1alpha1.ResourceItem{
+					GPU: "8",
+				},
+				Requests: &v1alpha1.ResourceItem{
+					GPU: "8",
+				},
+			},
+			expectedGPULimit:   corev1.ResourceName(consts.KubeResourceGPUNvidia),
+			expectedGPUValue:   "8",
+			expectedGPURequest: corev1.ResourceName(consts.KubeResourceGPUNvidia),
+			expectedGPUReqVal:  "8",
+			expectError:        false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -690,11 +731,20 @@ func TestGetResourcesConfig(t *testing.T) {
 
 			g.Expect(err).To(gomega.BeNil())
 			g.Expect(result).ToNot(gomega.BeNil())
-			g.Expect(result.Limits).ToNot(gomega.BeNil())
 
-			gpuQuantity, exists := result.Limits[tt.expectedGPULimit]
-			g.Expect(exists).To(gomega.BeTrue(), "GPU resource %s should exist in limits", tt.expectedGPULimit)
-			g.Expect(gpuQuantity.String()).To(gomega.Equal(tt.expectedGPUValue))
+			if tt.expectedGPULimit != "" {
+				g.Expect(result.Limits).ToNot(gomega.BeNil())
+				gpuQuantity, exists := result.Limits[tt.expectedGPULimit]
+				g.Expect(exists).To(gomega.BeTrue(), "GPU resource %s should exist in limits", tt.expectedGPULimit)
+				g.Expect(gpuQuantity.String()).To(gomega.Equal(tt.expectedGPUValue))
+			}
+
+			if tt.expectedGPURequest != "" {
+				g.Expect(result.Requests).ToNot(gomega.BeNil())
+				gpuQuantity, exists := result.Requests[tt.expectedGPURequest]
+				g.Expect(exists).To(gomega.BeTrue(), "GPU resource %s should exist in requests", tt.expectedGPURequest)
+				g.Expect(gpuQuantity.String()).To(gomega.Equal(tt.expectedGPUReqVal))
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- `GetResourcesConfig()` translated the CRD `gpu` field to `nvidia.com/gpu` for **limits** but silently ignored it for **requests**
- Adds the missing GPU handling in the requests section, mirroring the existing limits logic
- Adds test cases covering requests-only, requests with custom gpuType, and both limits+requests

## Context
The `Resources` struct supports both `requests` and `limits` with a `GPU` field, and backend code like `getGPUsPerNode()` reads `requests.GPU`. However, `GetResourcesConfig()` never translated `requests.gpu` into the Kubernetes pod spec's `ResourceRequirements`, making it a no-op.

In practice this was masked by Kubernetes auto-defaulting extended resource requests to match limits, but explicit `requests.gpu` values were silently dropped.

## Test plan
- [x] Existing `TestGetResourcesConfig` limit tests still pass
- [x] New test: `requests.gpu` with default `nvidia.com/gpu` type
- [x] New test: `requests.gpu` with custom `gpuType`
- [x] New test: both `limits.gpu` and `requests.gpu` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configuring GPU resource requests in addition to GPU limits.

* **Tests**
  * Expanded test coverage for GPU resource configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->