### PR TITLE
fix(planner): avoid hang in wait_for_scaling_completion when no decision pending

### DIFF
--- a/lib/bindings/python/rust/planner.rs
+++ b/lib/bindings/python/rust/planner.rs
@@ -254,6 +254,17 @@ impl VirtualConnectorCoordinator {
                 ));
             };
             for _ in 0..inner.max_retries {
+                // If no scaling decision has been made yet, return immediately
+                // rather than waiting for a scaled_decision_id that will never
+                // appear (the client only writes it after handling a decision).
+                let current = load(&inner.decision_id);
+                if current == NONE_SENTINEL {
+                    tracing::info!(
+                        decision_id = current,
+                        "No scaling decision pending, skipping wait"
+                    );
+                    return Ok(());
+                }
                 match kv_cache.get("scaled_decision_id").await {
                     None => {
                         tokio::time::sleep(inner.check_interval).await;
@@ -261,8 +272,7 @@ impl VirtualConnectorCoordinator {
                     Some(scaled_decision_id_bytes) => {
                         match String::from_utf8_lossy(&scaled_decision_id_bytes).parse::<usize>() {
                             Ok(scaled_decision_id) => {
-                                let current = load(&inner.decision_id);
-                                if scaled_decision_id >= current || current == NONE_SENTINEL {
+                                if scaled_decision_id >= current {
                                     tracing::info!(
                                         decision_id = current,
                                         "Scaling decision completed"


### PR DESCRIPTION
## Summary

- Fix `wait_for_scaling_completion` hanging for up to `max_retries * check_interval` when no scaling decision has been made yet (`decision_id == NONE_SENTINEL`)
- Add early return at the top of the retry loop when `decision_id` is `NONE_SENTINEL` since there is nothing to wait for (the client only writes `scaled_decision_id` after handling a decision)
- Simplify the comparison in the `Some` arm from `scaled_decision_id >= current || current == NONE_SENTINEL` to `scaled_decision_id >= current`, since the `NONE_SENTINEL` case is now handled before entering the match

## Bug scenario

1. `decision_id` is `NONE_SENTINEL` (no scaling decision has been made)
2. `wait_for_scaling_completion` is called
3. `kv_cache.get("scaled_decision_id")` returns `None` (no previous completion exists)
4. The code sleeps and retries `max_retries` times, eventually timing out with a warning
5. This wastes time and blocks the planner loop unnecessarily

The early return is correct because when `decision_id` is `NONE_SENTINEL`, no decision has been issued to the client, so `scaled_decision_id` will never appear in etcd. Waiting is futile.

## Test plan

- [x] Added 8 unit tests covering the decision ID sentinel logic, comparison semantics, and state transitions
- [x] `cargo check` passes
- [x] `cargo test --lib planner::tests` passes (all 8 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized scaling completion detection with early-exit logic for faster responsiveness.

* **Tests**
  * Added unit tests for scaling decision handling to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->