### PR TITLE
perf: avoid cloning content parts in gather_multi_modal_data

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -419,6 +419,8 @@ impl OpenAIPreprocessor {
         let Some(messages) = request.typed_messages() else {
             return Ok(());
         };
+        let has_media_loader = self.media_loader.is_some();
+
         for message in messages.iter() {
             let content_parts = match message {
                 ChatCompletionRequestMessage::User(u) => match &u.content {
@@ -427,37 +429,33 @@ impl OpenAIPreprocessor {
                 },
                 _ => continue,
             };
-            // Iterate over content parts
             for content_part in content_parts.iter() {
-                let type_str = match content_part {
-                    ChatCompletionRequestUserMessageContentPart::ImageUrl(_) => "image_url",
-                    ChatCompletionRequestUserMessageContentPart::VideoUrl(_) => "video_url",
-                    ChatCompletionRequestUserMessageContentPart::AudioUrl(_) => "audio_url",
-                    _ => continue,
-                };
-
-                if self.media_loader.is_some() {
+                if has_media_loader {
+                    let type_str = match content_part {
+                        ChatCompletionRequestUserMessageContentPart::ImageUrl(_) => "image_url",
+                        ChatCompletionRequestUserMessageContentPart::VideoUrl(_) => "video_url",
+                        ChatCompletionRequestUserMessageContentPart::AudioUrl(_) => "audio_url",
+                        _ => continue,
+                    };
                     fetch_tasks.push((type_str.to_string(), content_part));
-                    continue;
+                } else {
+                    let (type_str, url) = match content_part {
+                        ChatCompletionRequestUserMessageContentPart::ImageUrl(p) => {
+                            ("image_url", p.image_url.url.clone())
+                        }
+                        ChatCompletionRequestUserMessageContentPart::VideoUrl(p) => {
+                            ("video_url", p.video_url.url.clone())
+                        }
+                        ChatCompletionRequestUserMessageContentPart::AudioUrl(p) => {
+                            ("audio_url", p.audio_url.url.clone())
+                        }
+                        _ => continue,
+                    };
+                    media_map
+                        .entry(type_str.to_string())
+                        .or_default()
+                        .push(MultimodalData::Url(url));
                 }
-
-                // Fallback: just pass the URL through
-                let url = match content_part {
-                    ChatCompletionRequestUserMessageContentPart::ImageUrl(image_part) => {
-                        image_part.image_url.url.clone()
-                    }
-                    ChatCompletionRequestUserMessageContentPart::VideoUrl(video_part) => {
-                        video_part.video_url.url.clone()
-                    }
-                    ChatCompletionRequestUserMessageContentPart::AudioUrl(audio_part) => {
-                        audio_part.audio_url.url.clone()
-                    }
-                    _ => unreachable!(),
-                };
-                media_map
-                    .entry(type_str.to_string())
-                    .or_default()
-                    .push(MultimodalData::Url(url));
             }
         }
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -413,7 +413,7 @@ impl OpenAIPreprocessor {
         formatted_prompt: Option<String>,
     ) -> Result<()> {
         let mut media_map: MultimodalDataMap = HashMap::new();
-        let mut fetch_tasks: Vec<(String, ChatCompletionRequestUserMessageContentPart)> =
+        let mut fetch_tasks: Vec<(String, &ChatCompletionRequestUserMessageContentPart)> =
             Vec::new();
 
         let Some(messages) = request.typed_messages() else {
@@ -429,27 +429,33 @@ impl OpenAIPreprocessor {
             };
             // Iterate over content parts
             for content_part in content_parts.iter() {
-                let (type_str, url) = match content_part {
-                    ChatCompletionRequestUserMessageContentPart::ImageUrl(image_part) => {
-                        ("image_url".to_string(), image_part.image_url.url.clone())
-                    }
-                    ChatCompletionRequestUserMessageContentPart::VideoUrl(video_part) => {
-                        ("video_url".to_string(), video_part.video_url.url.clone())
-                    }
-                    ChatCompletionRequestUserMessageContentPart::AudioUrl(audio_part) => {
-                        ("audio_url".to_string(), audio_part.audio_url.url.clone())
-                    }
+                let type_str = match content_part {
+                    ChatCompletionRequestUserMessageContentPart::ImageUrl(_) => "image_url",
+                    ChatCompletionRequestUserMessageContentPart::VideoUrl(_) => "video_url",
+                    ChatCompletionRequestUserMessageContentPart::AudioUrl(_) => "audio_url",
                     _ => continue,
                 };
 
                 if self.media_loader.is_some() {
-                    fetch_tasks.push((type_str, content_part.clone()));
+                    fetch_tasks.push((type_str.to_string(), content_part));
                     continue;
                 }
 
-                //Fallback: ust pass the URL through
+                // Fallback: just pass the URL through
+                let url = match content_part {
+                    ChatCompletionRequestUserMessageContentPart::ImageUrl(image_part) => {
+                        image_part.image_url.url.clone()
+                    }
+                    ChatCompletionRequestUserMessageContentPart::VideoUrl(video_part) => {
+                        video_part.video_url.url.clone()
+                    }
+                    ChatCompletionRequestUserMessageContentPart::AudioUrl(audio_part) => {
+                        audio_part.audio_url.url.clone()
+                    }
+                    _ => unreachable!(),
+                };
                 media_map
-                    .entry(type_str)
+                    .entry(type_str.to_string())
                     .or_default()
                     .push(MultimodalData::Url(url));
             }


### PR DESCRIPTION
#### Overview:

-  `gather_multi_modal_data` clones each `ChatCompletionRequestUserMessageContentPart` into `fetch_tasks`, but downstream only borrows it — the owned copy is dropped unused.
-  For base64 data URIs this means a multi-MB deep copy per image on every request.
-  This PR stores `&ContentPart` references instead and restructures the match so the `url.clone()` only runs in the fallback (no-media-loader) branch where it's actually consumed. Main perf wins are on the `--frontend-decoding` part.

#### Details:

- `fetch_tasks: Vec<(String, ContentPart)>` → `Vec<(String, &ContentPart)>`
- Removed `.clone()` — lifetimes are sound since `request` outlives the function
- Deferred URL extraction into the no-loader branch to avoid a wasted clone on the frontend-decoding path

#### Tests:

- [x] Aggregated multimodal (no `--frontend-decoding`) with llava-1.5-7b — image described correctly
- [x] Frontend-decoding multimodal (`--frontend-decoding`) with llava-1.5-7b — identical output, NIXL/RDMA path exercised

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code optimization in the LLM preprocessor module to improve memory efficiency and reduce unnecessary allocations during multi-modal data processing. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->