### PR TITLE
feat(kv-router): add dedup filter for duplicate vLLM KV block events

### DIFF
--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -50,7 +50,10 @@ impl EventDedupFilter {
     /// Filter a remove event. Retains only block hashes whose refcount
     /// decrements to 0 (removing them from the map). Returns `None` if
     /// no hashes survive filtering.
-    pub(super) fn filter_remove(&mut self, mut data: KvCacheRemoveData) -> Option<KvCacheRemoveData> {
+    pub(super) fn filter_remove(
+        &mut self,
+        mut data: KvCacheRemoveData,
+    ) -> Option<KvCacheRemoveData> {
         data.block_hashes.retain(|hash| {
             match self.refcounts.entry(*hash) {
                 Entry::Occupied(mut entry) => {
@@ -148,21 +151,21 @@ impl BatchingState {
         }
         let dp_rank = self.last_dp_rank;
         let mut emitted = false;
-        if let Some(data) = self.pending_removed.take() {
-            if let Some(filtered) = dedup.filter_remove(data) {
-                emit(
-                    publisher,
-                    local_indexer,
-                    worker_id,
-                    KvCacheEvent {
-                        event_id: self.next_publish_id,
-                        data: KvCacheEventData::Removed(filtered),
-                        dp_rank,
-                    },
-                )
-                .await;
-                emitted = true;
-            }
+        if let Some(data) = self.pending_removed.take()
+            && let Some(filtered) = dedup.filter_remove(data)
+        {
+            emit(
+                publisher,
+                local_indexer,
+                worker_id,
+                KvCacheEvent {
+                    event_id: self.next_publish_id,
+                    data: KvCacheEventData::Removed(filtered),
+                    dp_rank,
+                },
+            )
+            .await;
+            emitted = true;
         }
         if let Some(data) = self.pending_stored.take() {
             dedup.track_store(&data);

--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -24,38 +24,44 @@ use super::{DEFAULT_MAX_BATCH_BLOCKS, kv_publisher_metrics};
 /// Reference-counting filter that deduplicates KV cache events.
 ///
 /// vLLM can emit multiple store/remove events for the same block hash.
-/// This filter tracks a refcount per `ExternalSequenceBlockHash`:
-/// - **Store**: always passes through; increments refcount.
+/// Refcounts are tracked **per DP rank** because identical block hashes
+/// on different ranks represent independent blocks.
+///
+/// - **Store**: always passes through; increments refcount for the rank.
 /// - **Remove**: only passes through when refcount decrements to 0.
-/// - **Cleared**: resets all refcounts.
+/// - **Cleared**: resets refcounts for the affected rank only.
 pub(super) struct EventDedupFilter {
-    refcounts: HashMap<ExternalSequenceBlockHash, usize>,
+    /// Per-dp-rank refcounts.
+    per_rank: HashMap<u32, HashMap<ExternalSequenceBlockHash, usize>>,
 }
 
 impl EventDedupFilter {
     pub(super) fn new() -> Self {
         Self {
-            refcounts: HashMap::new(),
+            per_rank: HashMap::new(),
         }
     }
 
-    /// Track a store event. Increments refcount for each block hash.
-    /// Stores always pass through — this only updates bookkeeping.
-    pub(super) fn track_store(&mut self, data: &KvCacheStoreData) {
+    /// Track a store event. Increments refcount for each block hash on the
+    /// given DP rank. Stores always pass through — this only updates bookkeeping.
+    pub(super) fn track_store(&mut self, dp_rank: u32, data: &KvCacheStoreData) {
+        let refcounts = self.per_rank.entry(dp_rank).or_default();
         for block in &data.blocks {
-            *self.refcounts.entry(block.block_hash).or_insert(0) += 1;
+            *refcounts.entry(block.block_hash).or_insert(0) += 1;
         }
     }
 
-    /// Filter a remove event. Retains only block hashes whose refcount
-    /// decrements to 0 (removing them from the map). Returns `None` if
-    /// no hashes survive filtering.
+    /// Filter a remove event. Retains only block hashes whose refcount on the
+    /// given DP rank decrements to 0 (removing them from the map). Returns
+    /// `None` if no hashes survive filtering.
     pub(super) fn filter_remove(
         &mut self,
+        dp_rank: u32,
         mut data: KvCacheRemoveData,
     ) -> Option<KvCacheRemoveData> {
+        let refcounts = self.per_rank.entry(dp_rank).or_default();
         data.block_hashes.retain(|hash| {
-            match self.refcounts.entry(*hash) {
+            match refcounts.entry(*hash) {
                 Entry::Occupied(mut entry) => {
                     *entry.get_mut() -= 1;
                     if *entry.get() == 0 {
@@ -77,9 +83,11 @@ impl EventDedupFilter {
         }
     }
 
-    /// Clear all refcounts (used on Cleared events).
+    /// Clear refcounts for all DP ranks. A `Cleared` event from any rank
+    /// causes the indexer to wipe all blocks for the entire worker, so we
+    /// must reset all ranks' refcounts to stay consistent.
     pub(super) fn clear(&mut self) {
-        self.refcounts.clear();
+        self.per_rank.clear();
     }
 }
 
@@ -152,7 +160,7 @@ impl BatchingState {
         let dp_rank = self.last_dp_rank;
         let mut emitted = false;
         if let Some(data) = self.pending_removed.take()
-            && let Some(filtered) = dedup.filter_remove(data)
+            && let Some(filtered) = dedup.filter_remove(dp_rank, data)
         {
             emit(
                 publisher,
@@ -168,7 +176,7 @@ impl BatchingState {
             emitted = true;
         }
         if let Some(data) = self.pending_stored.take() {
-            dedup.track_store(&data);
+            dedup.track_store(dp_rank, &data);
             emit(
                 publisher,
                 local_indexer,

--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use dashmap::DashMap;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -28,19 +29,19 @@ use super::{DEFAULT_MAX_BATCH_BLOCKS, kv_publisher_metrics};
 /// - **Remove**: only passes through when refcount decrements to 0.
 /// - **Cleared**: resets all refcounts.
 pub(super) struct EventDedupFilter {
-    refcounts: DashMap<ExternalSequenceBlockHash, usize>,
+    refcounts: HashMap<ExternalSequenceBlockHash, usize>,
 }
 
 impl EventDedupFilter {
     pub(super) fn new() -> Self {
         Self {
-            refcounts: DashMap::new(),
+            refcounts: HashMap::new(),
         }
     }
 
     /// Track a store event. Increments refcount for each block hash.
     /// Stores always pass through — this only updates bookkeeping.
-    pub(super) fn track_store(&self, data: &KvCacheStoreData) {
+    pub(super) fn track_store(&mut self, data: &KvCacheStoreData) {
         for block in &data.blocks {
             *self.refcounts.entry(block.block_hash).or_insert(0) += 1;
         }
@@ -49,20 +50,19 @@ impl EventDedupFilter {
     /// Filter a remove event. Retains only block hashes whose refcount
     /// decrements to 0 (removing them from the map). Returns `None` if
     /// no hashes survive filtering.
-    pub(super) fn filter_remove(&self, mut data: KvCacheRemoveData) -> Option<KvCacheRemoveData> {
+    pub(super) fn filter_remove(&mut self, mut data: KvCacheRemoveData) -> Option<KvCacheRemoveData> {
         data.block_hashes.retain(|hash| {
             match self.refcounts.entry(*hash) {
-                dashmap::mapref::entry::Entry::Occupied(mut entry) => {
-                    let count = entry.get_mut();
-                    *count -= 1;
-                    if *count == 0 {
+                Entry::Occupied(mut entry) => {
+                    *entry.get_mut() -= 1;
+                    if *entry.get() == 0 {
                         entry.remove();
                         true // refcount hit 0 → pass through
                     } else {
                         false // still has references → filter out
                     }
                 }
-                dashmap::mapref::entry::Entry::Vacant(_) => {
+                Entry::Vacant(_) => {
                     true // not tracked → pass through defensively
                 }
             }
@@ -75,7 +75,7 @@ impl EventDedupFilter {
     }
 
     /// Clear all refcounts (used on Cleared events).
-    pub(super) fn clear(&self) {
+    pub(super) fn clear(&mut self) {
         self.refcounts.clear();
     }
 }
@@ -141,7 +141,7 @@ impl BatchingState {
         publisher: &P,
         local_indexer: &Option<Arc<LocalKvIndexer>>,
         worker_id: u64,
-        dedup: &EventDedupFilter,
+        dedup: &mut EventDedupFilter,
     ) {
         if !self.has_pending() {
             return;
@@ -229,20 +229,20 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
     max_batch_blocks: usize,
 ) {
     let mut batching_state = BatchingState::new();
-    let dedup = EventDedupFilter::new();
+    let mut dedup = EventDedupFilter::new();
     let mut last_raw_input_id: Option<u64> = None;
 
     loop {
         tokio::select! {
             _ = cancellation_token.cancelled() => {
                 tracing::info!("KV Event source received cancellation signal");
-                batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
+                batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
                 break;
             }
             event = rx.recv() => {
                 let Some(placement_event) = event else {
                     tracing::debug!("Event processor channel closed.");
-                    batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
+                    batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
                     break;
                 };
 
@@ -293,7 +293,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                 match event.data {
                     KvCacheEventData::Removed(data) => {
                         if batching_state.pending_stored.is_some() || dp_rank_changed {
-                            batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
+                            batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
                         }
                         match &mut batching_state.pending_removed {
                             Some(pending) => pending.block_hashes.extend(data.block_hashes),
@@ -309,7 +309,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                                 data.parent_hash != p.blocks.last().map(|b| b.block_hash)
                             });
                         if should_flush {
-                            batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
+                            batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
                         }
                         match &mut batching_state.pending_stored {
                             Some(pending) => pending.blocks.extend(data.blocks),
@@ -319,7 +319,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                         }
                     }
                     KvCacheEventData::Cleared => {
-                        batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
+                        batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
                         dedup.clear();
                         emit(
                             &publisher,
@@ -342,7 +342,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                     && (timeout_ms.is_none_or(|ms| batching_state.is_timeout_elapsed(ms))
                         || batching_state.pending_block_count() > max_batch_blocks)
                 {
-                    batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
+                    batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
                 }
             }
             _ = tokio::time::sleep(
@@ -350,7 +350,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                     .map(|ms| batching_state.remaining_timeout(ms))
                     .unwrap_or(Duration::from_secs(3600))
             ), if timeout_ms.is_some() && batching_state.has_pending() => {
-                batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
+                batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
             }
         }
     }

--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use dashmap::DashMap;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -18,6 +19,66 @@ use dynamo_runtime::transports::nats::NatsQueue;
 use crate::kv_router::KV_EVENT_SUBJECT;
 
 use super::{DEFAULT_MAX_BATCH_BLOCKS, kv_publisher_metrics};
+
+/// Reference-counting filter that deduplicates KV cache events.
+///
+/// vLLM can emit multiple store/remove events for the same block hash.
+/// This filter tracks a refcount per `ExternalSequenceBlockHash`:
+/// - **Store**: always passes through; increments refcount.
+/// - **Remove**: only passes through when refcount decrements to 0.
+/// - **Cleared**: resets all refcounts.
+pub(super) struct EventDedupFilter {
+    refcounts: DashMap<ExternalSequenceBlockHash, usize>,
+}
+
+impl EventDedupFilter {
+    pub(super) fn new() -> Self {
+        Self {
+            refcounts: DashMap::new(),
+        }
+    }
+
+    /// Track a store event. Increments refcount for each block hash.
+    /// Stores always pass through — this only updates bookkeeping.
+    pub(super) fn track_store(&self, data: &KvCacheStoreData) {
+        for block in &data.blocks {
+            *self.refcounts.entry(block.block_hash).or_insert(0) += 1;
+        }
+    }
+
+    /// Filter a remove event. Retains only block hashes whose refcount
+    /// decrements to 0 (removing them from the map). Returns `None` if
+    /// no hashes survive filtering.
+    pub(super) fn filter_remove(&self, mut data: KvCacheRemoveData) -> Option<KvCacheRemoveData> {
+        data.block_hashes.retain(|hash| {
+            match self.refcounts.entry(*hash) {
+                dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                    let count = entry.get_mut();
+                    *count -= 1;
+                    if *count == 0 {
+                        entry.remove();
+                        true // refcount hit 0 → pass through
+                    } else {
+                        false // still has references → filter out
+                    }
+                }
+                dashmap::mapref::entry::Entry::Vacant(_) => {
+                    true // not tracked → pass through defensively
+                }
+            }
+        });
+        if data.block_hashes.is_empty() {
+            None
+        } else {
+            Some(data)
+        }
+    }
+
+    /// Clear all refcounts (used on Cleared events).
+    pub(super) fn clear(&self) {
+        self.refcounts.clear();
+    }
+}
 
 /// Accumulator for in-flight KV cache events that will be merged into a single
 /// [`RouterEvent`] before being forwarded to the event sink.
@@ -80,39 +141,47 @@ impl BatchingState {
         publisher: &P,
         local_indexer: &Option<Arc<LocalKvIndexer>>,
         worker_id: u64,
+        dedup: &EventDedupFilter,
     ) {
         if !self.has_pending() {
             return;
         }
-        let id = self.next_publish_id;
         let dp_rank = self.last_dp_rank;
+        let mut emitted = false;
         if let Some(data) = self.pending_removed.take() {
-            emit(
-                publisher,
-                local_indexer,
-                worker_id,
-                KvCacheEvent {
-                    event_id: id,
-                    data: KvCacheEventData::Removed(data),
-                    dp_rank,
-                },
-            )
-            .await;
+            if let Some(filtered) = dedup.filter_remove(data) {
+                emit(
+                    publisher,
+                    local_indexer,
+                    worker_id,
+                    KvCacheEvent {
+                        event_id: self.next_publish_id,
+                        data: KvCacheEventData::Removed(filtered),
+                        dp_rank,
+                    },
+                )
+                .await;
+                emitted = true;
+            }
         }
         if let Some(data) = self.pending_stored.take() {
+            dedup.track_store(&data);
             emit(
                 publisher,
                 local_indexer,
                 worker_id,
                 KvCacheEvent {
-                    event_id: id,
+                    event_id: self.next_publish_id,
                     data: KvCacheEventData::Stored(data),
                     dp_rank,
                 },
             )
             .await;
+            emitted = true;
         }
-        self.next_publish_id += 1;
+        if emitted {
+            self.next_publish_id += 1;
+        }
         self.record_flush_time();
     }
 }
@@ -160,19 +229,20 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
     max_batch_blocks: usize,
 ) {
     let mut batching_state = BatchingState::new();
+    let dedup = EventDedupFilter::new();
     let mut last_raw_input_id: Option<u64> = None;
 
     loop {
         tokio::select! {
             _ = cancellation_token.cancelled() => {
                 tracing::info!("KV Event source received cancellation signal");
-                batching_state.flush(&publisher, &local_indexer, worker_id).await;
+                batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
                 break;
             }
             event = rx.recv() => {
                 let Some(placement_event) = event else {
                     tracing::debug!("Event processor channel closed.");
-                    batching_state.flush(&publisher, &local_indexer, worker_id).await;
+                    batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
                     break;
                 };
 
@@ -223,7 +293,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                 match event.data {
                     KvCacheEventData::Removed(data) => {
                         if batching_state.pending_stored.is_some() || dp_rank_changed {
-                            batching_state.flush(&publisher, &local_indexer, worker_id).await;
+                            batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
                         }
                         match &mut batching_state.pending_removed {
                             Some(pending) => pending.block_hashes.extend(data.block_hashes),
@@ -239,7 +309,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                                 data.parent_hash != p.blocks.last().map(|b| b.block_hash)
                             });
                         if should_flush {
-                            batching_state.flush(&publisher, &local_indexer, worker_id).await;
+                            batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
                         }
                         match &mut batching_state.pending_stored {
                             Some(pending) => pending.blocks.extend(data.blocks),
@@ -249,7 +319,8 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                         }
                     }
                     KvCacheEventData::Cleared => {
-                        batching_state.flush(&publisher, &local_indexer, worker_id).await;
+                        batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
+                        dedup.clear();
                         emit(
                             &publisher,
                             &local_indexer,
@@ -271,7 +342,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                     && (timeout_ms.is_none_or(|ms| batching_state.is_timeout_elapsed(ms))
                         || batching_state.pending_block_count() > max_batch_blocks)
                 {
-                    batching_state.flush(&publisher, &local_indexer, worker_id).await;
+                    batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
                 }
             }
             _ = tokio::time::sleep(
@@ -279,7 +350,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                     .map(|ms| batching_state.remaining_timeout(ms))
                     .unwrap_or(Duration::from_secs(3600))
             ), if timeout_ms.is_some() && batching_state.has_pending() => {
-                batching_state.flush(&publisher, &local_indexer, worker_id).await;
+                batching_state.flush(&publisher, &local_indexer, worker_id, &dedup).await;
             }
         }
     }

--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -29,7 +29,7 @@ use super::{DEFAULT_MAX_BATCH_BLOCKS, kv_publisher_metrics};
 ///
 /// - **Store**: always passes through; increments refcount for the rank.
 /// - **Remove**: only passes through when refcount decrements to 0.
-/// - **Cleared**: resets refcounts for the affected rank only.
+/// - **Cleared**: resets refcounts for all ranks.
 pub(super) struct EventDedupFilter {
     /// Per-dp-rank refcounts.
     per_rank: HashMap<u32, HashMap<ExternalSequenceBlockHash, usize>>,

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -34,7 +34,7 @@ mod worker_metrics;
 mod zmq_listener;
 
 #[cfg(test)]
-use event_processor::{BatchingState, run_event_processor_loop};
+use event_processor::{BatchingState, EventDedupFilter, run_event_processor_loop};
 use event_processor::{
     EventPlanePublisher, start_event_processor, start_event_processor_jetstream,
 };

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -1292,7 +1292,7 @@ mod test_event_dedup_filter {
 
     #[test]
     fn stores_track_refcounts_for_removes() {
-        let filter = EventDedupFilter::new();
+        let mut filter = EventDedupFilter::new();
         let data = store_data(&[1, 2, 3]);
 
         // Store same hashes twice — refcount should be 2
@@ -1311,7 +1311,7 @@ mod test_event_dedup_filter {
 
     #[test]
     fn duplicate_removes_are_filtered() {
-        let filter = EventDedupFilter::new();
+        let mut filter = EventDedupFilter::new();
 
         // Store same hash twice
         filter.track_store(&store_data(&[1]));
@@ -1329,7 +1329,7 @@ mod test_event_dedup_filter {
 
     #[test]
     fn store_remove_store_cycle() {
-        let filter = EventDedupFilter::new();
+        let mut filter = EventDedupFilter::new();
 
         // Store hash 1
         filter.track_store(&store_data(&[1]));
@@ -1348,7 +1348,7 @@ mod test_event_dedup_filter {
 
     #[test]
     fn clear_resets_state() {
-        let filter = EventDedupFilter::new();
+        let mut filter = EventDedupFilter::new();
 
         // Store 3 blocks, then store them again (refcount 2 each)
         filter.track_store(&store_data(&[1, 2, 3]));
@@ -1363,7 +1363,7 @@ mod test_event_dedup_filter {
 
     #[test]
     fn mixed_blocks_in_single_remove() {
-        let filter = EventDedupFilter::new();
+        let mut filter = EventDedupFilter::new();
 
         // Hash 1: stored twice (refcount 2)
         filter.track_store(&store_data(&[1]));

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -1296,15 +1296,15 @@ mod test_event_dedup_filter {
         let data = store_data(&[1, 2, 3]);
 
         // Store same hashes twice — refcount should be 2
-        filter.track_store(&data);
-        filter.track_store(&data);
+        filter.track_store(0, &data);
+        filter.track_store(0, &data);
 
         // First remove — refcounts 2→1, all filtered out
-        let result = filter.filter_remove(remove_data(&[1, 2, 3]));
+        let result = filter.filter_remove(0, remove_data(&[1, 2, 3]));
         assert!(result.is_none());
 
         // Second remove — refcounts 1→0, all pass through
-        let result = filter.filter_remove(remove_data(&[1, 2, 3]));
+        let result = filter.filter_remove(0, remove_data(&[1, 2, 3]));
         assert!(result.is_some());
         assert_eq!(result.unwrap().block_hashes.len(), 3);
     }
@@ -1314,15 +1314,15 @@ mod test_event_dedup_filter {
         let mut filter = EventDedupFilter::new();
 
         // Store same hash twice
-        filter.track_store(&store_data(&[1]));
-        filter.track_store(&store_data(&[1]));
+        filter.track_store(0, &store_data(&[1]));
+        filter.track_store(0, &store_data(&[1]));
 
         // First remove — refcount 2→1, filtered out
-        let result = filter.filter_remove(remove_data(&[1]));
+        let result = filter.filter_remove(0, remove_data(&[1]));
         assert!(result.is_none());
 
         // Second remove — refcount 1→0, passes through
-        let result = filter.filter_remove(remove_data(&[1]));
+        let result = filter.filter_remove(0, remove_data(&[1]));
         assert!(result.is_some());
         assert_eq!(result.unwrap().block_hashes.len(), 1);
     }
@@ -1332,32 +1332,39 @@ mod test_event_dedup_filter {
         let mut filter = EventDedupFilter::new();
 
         // Store hash 1
-        filter.track_store(&store_data(&[1]));
+        filter.track_store(0, &store_data(&[1]));
 
         // Remove hash 1 — refcount 1→0, passes through
-        let result = filter.filter_remove(remove_data(&[1]));
+        let result = filter.filter_remove(0, remove_data(&[1]));
         assert!(result.is_some());
 
         // Store hash 1 again — refcount starts fresh at 1
-        filter.track_store(&store_data(&[1]));
+        filter.track_store(0, &store_data(&[1]));
 
         // Remove again — refcount 1→0, passes through
-        let result = filter.filter_remove(remove_data(&[1]));
+        let result = filter.filter_remove(0, remove_data(&[1]));
         assert!(result.is_some());
     }
 
     #[test]
-    fn clear_resets_state() {
+    fn clear_resets_all_ranks() {
         let mut filter = EventDedupFilter::new();
 
-        // Store 3 blocks, then store them again (refcount 2 each)
-        filter.track_store(&store_data(&[1, 2, 3]));
-        filter.track_store(&store_data(&[1, 2, 3]));
+        // Store on rank 0 and rank 1
+        filter.track_store(0, &store_data(&[1, 2]));
+        filter.track_store(0, &store_data(&[1, 2]));
+        filter.track_store(1, &store_data(&[1, 2]));
+        filter.track_store(1, &store_data(&[1, 2]));
 
+        // Clear wipes all ranks (matches indexer semantics where Cleared
+        // from any rank removes all blocks for the entire worker).
         filter.clear();
 
-        // Remove after clear — hashes not in map, passes through defensively
-        let result = filter.filter_remove(remove_data(&[1]));
+        // Both ranks pass through defensively after clear
+        let result = filter.filter_remove(0, remove_data(&[1]));
+        assert!(result.is_some());
+
+        let result = filter.filter_remove(1, remove_data(&[1]));
         assert!(result.is_some());
     }
 
@@ -1366,22 +1373,44 @@ mod test_event_dedup_filter {
         let mut filter = EventDedupFilter::new();
 
         // Hash 1: stored twice (refcount 2)
-        filter.track_store(&store_data(&[1]));
-        filter.track_store(&store_data(&[1]));
+        filter.track_store(0, &store_data(&[1]));
+        filter.track_store(0, &store_data(&[1]));
 
         // Hash 2: stored once (refcount 1)
-        filter.track_store(&store_data(&[2]));
+        filter.track_store(0, &store_data(&[2]));
 
         // Hash 3: stored twice (refcount 2)
-        filter.track_store(&store_data(&[3]));
-        filter.track_store(&store_data(&[3]));
+        filter.track_store(0, &store_data(&[3]));
+        filter.track_store(0, &store_data(&[3]));
 
         // Remove all three — only hash 2 (refcount 1→0) passes through
-        let result = filter.filter_remove(remove_data(&[1, 2, 3]));
+        let result = filter.filter_remove(0, remove_data(&[1, 2, 3]));
         assert!(result.is_some());
         let result = result.unwrap();
         assert_eq!(result.block_hashes.len(), 1);
         assert_eq!(result.block_hashes[0], ExternalSequenceBlockHash(2));
+    }
+
+    #[test]
+    fn same_hash_on_different_ranks_are_independent() {
+        let mut filter = EventDedupFilter::new();
+
+        // Store hash 1 on rank 0 (twice) and rank 1 (once)
+        filter.track_store(0, &store_data(&[1]));
+        filter.track_store(0, &store_data(&[1]));
+        filter.track_store(1, &store_data(&[1]));
+
+        // Remove hash 1 on rank 1 — refcount 1→0, passes through
+        let result = filter.filter_remove(1, remove_data(&[1]));
+        assert!(result.is_some());
+
+        // Remove hash 1 on rank 0 — refcount 2→1, filtered out
+        let result = filter.filter_remove(0, remove_data(&[1]));
+        assert!(result.is_none());
+
+        // Remove hash 1 on rank 0 again — refcount 1→0, passes through
+        let result = filter.filter_remove(0, remove_data(&[1]));
+        assert!(result.is_some());
     }
 }
 

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -1263,6 +1263,128 @@ mod tests_startup_helpers {
     }
 }
 
+#[cfg(test)]
+mod test_event_dedup_filter {
+    use super::*;
+
+    fn store_data(hashes: &[u64]) -> KvCacheStoreData {
+        KvCacheStoreData {
+            parent_hash: None,
+            blocks: hashes
+                .iter()
+                .map(|&h| KvCacheStoredBlockData {
+                    block_hash: ExternalSequenceBlockHash(h),
+                    tokens_hash: LocalBlockHash(h * 10),
+                    mm_extra_info: None,
+                })
+                .collect(),
+        }
+    }
+
+    fn remove_data(hashes: &[u64]) -> KvCacheRemoveData {
+        KvCacheRemoveData {
+            block_hashes: hashes
+                .iter()
+                .map(|&h| ExternalSequenceBlockHash(h))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn stores_track_refcounts_for_removes() {
+        let filter = EventDedupFilter::new();
+        let data = store_data(&[1, 2, 3]);
+
+        // Store same hashes twice — refcount should be 2
+        filter.track_store(&data);
+        filter.track_store(&data);
+
+        // First remove — refcounts 2→1, all filtered out
+        let result = filter.filter_remove(remove_data(&[1, 2, 3]));
+        assert!(result.is_none());
+
+        // Second remove — refcounts 1→0, all pass through
+        let result = filter.filter_remove(remove_data(&[1, 2, 3]));
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().block_hashes.len(), 3);
+    }
+
+    #[test]
+    fn duplicate_removes_are_filtered() {
+        let filter = EventDedupFilter::new();
+
+        // Store same hash twice
+        filter.track_store(&store_data(&[1]));
+        filter.track_store(&store_data(&[1]));
+
+        // First remove — refcount 2→1, filtered out
+        let result = filter.filter_remove(remove_data(&[1]));
+        assert!(result.is_none());
+
+        // Second remove — refcount 1→0, passes through
+        let result = filter.filter_remove(remove_data(&[1]));
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().block_hashes.len(), 1);
+    }
+
+    #[test]
+    fn store_remove_store_cycle() {
+        let filter = EventDedupFilter::new();
+
+        // Store hash 1
+        filter.track_store(&store_data(&[1]));
+
+        // Remove hash 1 — refcount 1→0, passes through
+        let result = filter.filter_remove(remove_data(&[1]));
+        assert!(result.is_some());
+
+        // Store hash 1 again — refcount starts fresh at 1
+        filter.track_store(&store_data(&[1]));
+
+        // Remove again — refcount 1→0, passes through
+        let result = filter.filter_remove(remove_data(&[1]));
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn clear_resets_state() {
+        let filter = EventDedupFilter::new();
+
+        // Store 3 blocks, then store them again (refcount 2 each)
+        filter.track_store(&store_data(&[1, 2, 3]));
+        filter.track_store(&store_data(&[1, 2, 3]));
+
+        filter.clear();
+
+        // Remove after clear — hashes not in map, passes through defensively
+        let result = filter.filter_remove(remove_data(&[1]));
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn mixed_blocks_in_single_remove() {
+        let filter = EventDedupFilter::new();
+
+        // Hash 1: stored twice (refcount 2)
+        filter.track_store(&store_data(&[1]));
+        filter.track_store(&store_data(&[1]));
+
+        // Hash 2: stored once (refcount 1)
+        filter.track_store(&store_data(&[2]));
+
+        // Hash 3: stored twice (refcount 2)
+        filter.track_store(&store_data(&[3]));
+        filter.track_store(&store_data(&[3]));
+
+        // Remove all three — only hash 2 (refcount 1→0) passes through
+        let result = filter.filter_remove(remove_data(&[1, 2, 3]));
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.block_hashes.len(), 1);
+        assert_eq!(result.block_hashes[0], ExternalSequenceBlockHash(2));
+    }
+}
+
 #[cfg(all(test, feature = "integration"))]
 mod test_integration_publisher {
     use super::*;


### PR DESCRIPTION
## Summary
- vLLM can emit multiple store/remove events for the same `ExternalSequenceBlockHash` without deduplication
- Adds `EventDedupFilter` with a `DashMap<ExternalSequenceBlockHash, usize>` refcount map in the event processor, sitting in front of the local indexer and event publisher
- Stores always pass through (incrementing refcount); removes only pass through when refcount decrements to 0
- Event IDs only increment when an event is actually emitted, preventing non-consecutive ID errors in the `LocalKvIndexer` buffer

## Test plan
- [x] 5 new unit tests for `EventDedupFilter` (refcount tracking, duplicate remove filtering, store-remove-store cycles, clear resets, mixed blocks)
- [x] All 52 existing publisher tests pass unchanged
- [x] Manual verification with vLLM workload that previously produced duplicate events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved deduplication logic for KV cache events to prevent redundant cache removal operations.

* **Tests**
  * Added comprehensive test suite validating deduplication behavior across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->