### PR TITLE
fix: add worker dump throtteling

### DIFF
--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -169,6 +169,28 @@ impl LocalKvIndexer {
         WorkerKvQueryResponse::Events(events)
     }
 
+    /// Check if a query can likely be served from the buffer (fast path).
+    /// Returns true if:
+    /// - start_id is Some (not a full dump request)
+    /// - buffer is not empty
+    /// - start_id is within or after the buffer range
+    ///
+    /// Note: This is a heuristic - the buffer state may change between this check
+    /// and the actual query, so a tree dump may still occur even if this returns true.
+    pub fn likely_served_from_buffer(&self, start_id: Option<u64>) -> bool {
+        if start_id.is_none() {
+            return false;
+        }
+
+        let buffer = self.event_buffer.lock().unwrap();
+        if buffer.is_empty() {
+            return false;
+        }
+
+        let first_buffered = buffer.front().unwrap().event.event_id;
+        start_id.unwrap() >= first_buffered
+    }
+
     /// Record an event in the buffer
     fn record_event(&self, event: RouterEvent) {
         let mut buffer = self.event_buffer.lock().unwrap();

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -10,7 +10,6 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use dynamo_runtime::component::Component;
 use dynamo_runtime::discovery::{DiscoveryEvent, DiscoveryInstance, DiscoveryQuery};
-use dynamo_runtime::metrics::MetricsHierarchy;
 use dynamo_runtime::pipeline::{
     AsyncEngine, AsyncEngineContextProvider, ManyOut, PushRouter, ResponseStream, RouterMode,
     SingleIn, network::Ingress,
@@ -22,7 +21,6 @@ use futures::StreamExt;
 use tokio::sync::{Mutex, Semaphore};
 
 use super::Indexer;
-use crate::kv_router::metrics::WorkerQueryMetrics;
 use crate::kv_router::worker_kv_indexer_query_endpoint;
 use dynamo_kv_router::{
     indexer::{LocalKvIndexer, WorkerKvQueryRequest, WorkerKvQueryResponse},
@@ -649,20 +647,10 @@ pub(crate) async fn start_worker_kv_query_endpoint(
     dp_rank: DpRank,
     local_indexer: Arc<LocalKvIndexer>,
 ) {
-    // Register metrics for this worker
-    if let Err(e) = WorkerQueryMetrics::register(
-        &component.get_metrics_registry().get_prometheus_registry(),
-        worker_id,
-    ) {
-        tracing::warn!("Failed to register worker query metrics: {e}");
-    }
-    let metrics = WorkerQueryMetrics::get();
-
     let engine = Arc::new(WorkerKvQueryEngine {
         worker_id,
         local_indexer,
         processing_semaphore: Semaphore::new(1),
-        metrics,
     });
 
     let ingress = match Ingress::for_engine(engine) {
@@ -700,8 +688,6 @@ struct WorkerKvQueryEngine {
     /// Semaphore limiting concurrent recovery request processing to 1.
     /// Prevents multiple routers from overwhelming the worker with heavy tree dump operations.
     processing_semaphore: Semaphore,
-    /// Optional metrics for tracking semaphore wait time and query duration.
-    metrics: Option<Arc<WorkerQueryMetrics>>,
 }
 
 #[async_trait]
@@ -730,11 +716,6 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
                 Box::pin(stream::iter(vec![response])),
                 ctx.context(),
             ));
-        }
-
-        // Track total queries
-        if let Some(metrics) = &self.metrics {
-            metrics.increment_queries();
         }
 
         // Acquire semaphore permit before processing - only one request at a time.
@@ -1001,7 +982,6 @@ mod tests {
             worker_id,
             local_indexer,
             processing_semaphore: Semaphore::new(1),
-            metrics: None,
         };
 
         let request = WorkerKvQueryRequest {

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -735,7 +735,7 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
                 _ = futures::future::select(engine_ctx.stopped(), engine_ctx.killed()) => {
                     tracing::warn!("Worker<>Router KV query request cancelled while waiting for semaphore");
                     return Ok(ResponseStream::new(
-                        // this response will be dropped on the router side since the request was cancelled, 
+                        // this response will be dropped on the router side since the request was cancelled,
                         // but we return it here to satisfy the function signature and provide some context in logs if it does get processed for some reason.
                         Box::pin(stream::iter(vec![WorkerKvQueryResponse::Error(
                             "Request cancelled by client".to_string(),

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -742,17 +742,8 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
             result = self.processing_semaphore.acquire() => {
                 result.map_err(|_| anyhow::anyhow!("Worker KV query semaphore closed"))?
             }
-            _ = engine_ctx.stopped() => {
-                tracing::debug!("Worker KV query request stopped while waiting for semaphore");
-                return Ok(ResponseStream::new(
-                    Box::pin(stream::iter(vec![WorkerKvQueryResponse::Error(
-                        "Request cancelled".to_string(),
-                    )])),
-                    ctx.context(),
-                ));
-            }
-            _ = engine_ctx.killed() => {
-                tracing::debug!("Worker KV query request killed while waiting for semaphore");
+            _ = futures::future::select(engine_ctx.stopped(), engine_ctx.killed()) => {
+                tracing::debug!("Worker KV query request cancelled while waiting for semaphore");
                 return Ok(ResponseStream::new(
                     Box::pin(stream::iter(vec![WorkerKvQueryResponse::Error(
                         "Request cancelled".to_string(),

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -718,30 +718,44 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
             ));
         }
 
-        // Acquire semaphore permit before processing - only one request at a time.
-        // This prevents multiple heavy tree dump operations from running concurrently
-        // and overwhelming the worker's indexing capacity.
-        // Handle cancellation (stopped or killed) while waiting for the semaphore.
-        let engine_ctx = ctx.context();
-        let _permit = tokio::select! {
-            result = self.processing_semaphore.acquire() => {
-                result.map_err(|_| anyhow::anyhow!("Worker KV query semaphore closed"))?
-            }
-            _ = futures::future::select(engine_ctx.stopped(), engine_ctx.killed()) => {
-                // this should rarely happen, as routers typically do not give up their request.
-                tracing::warn!("Worker<>Router KV query request cancelled while waiting for semaphore");
-                return Ok(ResponseStream::new(
-                    Box::pin(stream::iter(vec![WorkerKvQueryResponse::Error(
-                        "Request cancelled by client".to_string(),
-                    )])),
-                    ctx.context(),
-                ));
-            }
+        // Check if this request can likely be served from buffer (fast path).
+        // If not, acquire semaphore for tree dump (heavy operation).
+        let likely_buffer_read = self
+            .local_indexer
+            .likely_served_from_buffer(request.start_event_id);
+
+        // Slow query logging only for potential tree dumps
+        let _slow_query_guard = if !likely_buffer_read {
+            Some(SlowQueryGuard::spawn(self.worker_id))
+        } else {
+            None
         };
 
-        // Process the query with slow operation logging
-        // RAII guard ensures the logger is aborted even if request is cancelled
-        let _slow_query_guard = SlowQueryGuard::spawn(self.worker_id);
+        let _maybe_permit = if !likely_buffer_read {
+            // Acquire semaphore permit before processing tree dump.
+            // This prevents multiple heavy tree dump operations from running concurrently
+            // and overwhelming the worker's indexing capacity.
+            // Handle cancellation (stopped or killed) while waiting for the semaphore.
+            let engine_ctx = ctx.context();
+            let permit = tokio::select! {
+                result = self.processing_semaphore.acquire() => {
+                    result.map_err(|_| anyhow::anyhow!("Worker KV query semaphore closed"))?
+                }
+                _ = futures::future::select(engine_ctx.stopped(), engine_ctx.killed()) => {
+                    tracing::warn!("Worker<>Router KV query request cancelled while waiting for semaphore");
+                    return Ok(ResponseStream::new(
+                        Box::pin(stream::iter(vec![WorkerKvQueryResponse::Error(
+                            "Request cancelled by client".to_string(),
+                        )])),
+                        ctx.context(),
+                    ));
+                }
+            };
+            Some(permit)
+        } else {
+            // Fast buffer read - no semaphore needed
+            None
+        };
 
         let response = self
             .local_indexer

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -740,8 +740,27 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
         };
 
         // Process the query with slow operation logging
-        let worker_id = self.worker_id;
-        let slow_query_handle = tokio::spawn(async move {
+        // RAII guard ensures the logger is aborted even if request is cancelled
+        let _slow_query_guard = SlowQueryGuard::spawn(self.worker_id);
+
+        let response = self
+            .local_indexer
+            .get_events_in_id_range(request.start_event_id, request.end_event_id)
+            .await;
+
+        Ok(ResponseStream::new(
+            Box::pin(stream::iter(vec![response])),
+            ctx.context(),
+        ))
+    }
+}
+
+/// RAII guard that aborts a slow query logger task on drop.
+struct SlowQueryGuard(tokio::task::JoinHandle<()>);
+
+impl SlowQueryGuard {
+    fn spawn(worker_id: u64) -> Self {
+        Self(tokio::spawn(async move {
             let mut elapsed_secs = 0u64;
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
@@ -752,19 +771,13 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
                     "Worker KV query still running - possible slow tree dump",
                 );
             }
-        });
+        }))
+    }
+}
 
-        let response = self
-            .local_indexer
-            .get_events_in_id_range(request.start_event_id, request.end_event_id)
-            .await;
-
-        slow_query_handle.abort();
-
-        Ok(ResponseStream::new(
-            Box::pin(stream::iter(vec![response])),
-            ctx.context(),
-        ))
+impl Drop for SlowQueryGuard {
+    fn drop(&mut self) {
+        self.0.abort();
     }
 }
 

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -756,35 +756,27 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
         };
 
         // Process the query with slow operation logging
-        let slow_query_token = tokio_util::sync::CancellationToken::new();
-        {
-            let token = slow_query_token.clone();
-            let worker_id = self.worker_id;
-            tokio::spawn(async move {
-                let mut elapsed_secs = 0u64;
-                loop {
-                    tokio::select! {
-                        _ = token.cancelled() => break,
-                        _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
-                            elapsed_secs += 5;
-                            tracing::warn!(
-                                worker_id,
-                                elapsed_secs,
-                                "Worker KV query still running after {}s - possible slow tree dump",
-                                elapsed_secs
-                            );
-                        }
-                    }
-                }
-            });
-        }
+        let worker_id = self.worker_id;
+        let slow_query_handle = tokio::spawn(async move {
+            let mut elapsed_secs = 0u64;
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                elapsed_secs += 5;
+                tracing::warn!(
+                    worker_id,
+                    elapsed_secs,
+                    "Worker KV query still running after {}s - possible slow tree dump",
+                    elapsed_secs
+                );
+            }
+        });
 
         let response = self
             .local_indexer
             .get_events_in_id_range(request.start_event_id, request.end_event_id)
             .await;
 
-        slow_query_token.cancel();
+        slow_query_handle.abort();
 
         Ok(ResponseStream::new(
             Box::pin(stream::iter(vec![response])),

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -765,8 +765,7 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
                 tracing::warn!(
                     worker_id,
                     elapsed_secs,
-                    "Worker KV query still running after {}s - possible slow tree dump",
-                    elapsed_secs
+                    "Worker KV query still running - possible slow tree dump",
                 );
             }
         });

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use dynamo_runtime::component::Component;
 use dynamo_runtime::discovery::{DiscoveryEvent, DiscoveryInstance, DiscoveryQuery};
+use dynamo_runtime::metrics::MetricsHierarchy;
 use dynamo_runtime::pipeline::{
     AsyncEngine, AsyncEngineContextProvider, ManyOut, PushRouter, ResponseStream, RouterMode,
     SingleIn, network::Ingress,
@@ -649,7 +650,7 @@ pub(crate) async fn start_worker_kv_query_endpoint(
     local_indexer: Arc<LocalKvIndexer>,
 ) {
     // Register metrics for this worker
-    if let Err(e) = WorkerQueryMetrics::register(component.drt().prometheus_registry(), worker_id) {
+    if let Err(e) = WorkerQueryMetrics::register(&component.get_metrics_registry().get_prometheus_registry(), worker_id) {
         tracing::warn!("Failed to register worker query metrics: {e}");
     }
     let metrics = WorkerQueryMetrics::get();
@@ -743,20 +744,47 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
                 result.map_err(|_| anyhow::anyhow!("Worker KV query semaphore closed"))?
             }
             _ = futures::future::select(engine_ctx.stopped(), engine_ctx.killed()) => {
-                tracing::debug!("Worker KV query request cancelled while waiting for semaphore");
+                // this should rarely happen, as routers typically do not give up their request.
+                tracing::warn!("Worker<>Router KV query request cancelled while waiting for semaphore");
                 return Ok(ResponseStream::new(
                     Box::pin(stream::iter(vec![WorkerKvQueryResponse::Error(
-                        "Request cancelled".to_string(),
+                        "Request cancelled by client".to_string(),
                     )])),
                     ctx.context(),
                 ));
             }
         };
 
+        // Process the query with slow operation logging
+        let slow_query_token = tokio_util::sync::CancellationToken::new();
+        {
+            let token = slow_query_token.clone();
+            let worker_id = self.worker_id;
+            tokio::spawn(async move {
+                let mut elapsed_secs = 0u64;
+                loop {
+                    tokio::select! {
+                        _ = token.cancelled() => break,
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+                            elapsed_secs += 5;
+                            tracing::warn!(
+                                worker_id,
+                                elapsed_secs,
+                                "Worker KV query still running after {}s - possible slow tree dump",
+                                elapsed_secs
+                            );
+                        }
+                    }
+                }
+            });
+        }
+
         let response = self
             .local_indexer
             .get_events_in_id_range(request.start_event_id, request.end_event_id)
             .await;
+
+        slow_query_token.cancel();
 
         Ok(ResponseStream::new(
             Box::pin(stream::iter(vec![response])),

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -727,8 +727,6 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
         let _maybe_permit = if !likely_buffer_read {
             // Acquire semaphore permit before processing tree dump.
             // This prevents multiple heavy tree dump operations from running concurrently
-            // and overwhelming the worker's indexing capacity.
-            // Handle cancellation (stopped or killed) while waiting for the semaphore.
             let engine_ctx = ctx.context();
             let permit = tokio::select! {
                 result = self.processing_semaphore.acquire() => {
@@ -737,6 +735,8 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
                 _ = futures::future::select(engine_ctx.stopped(), engine_ctx.killed()) => {
                     tracing::warn!("Worker<>Router KV query request cancelled while waiting for semaphore");
                     return Ok(ResponseStream::new(
+                        // this response will be dropped on the router side since the request was cancelled, 
+                        // but we return it here to satisfy the function signature and provide some context in logs if it does get processed for some reason.
                         Box::pin(stream::iter(vec![WorkerKvQueryResponse::Error(
                             "Request cancelled by client".to_string(),
                         )])),

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -724,13 +724,6 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
             .local_indexer
             .likely_served_from_buffer(request.start_event_id);
 
-        // Slow query logging only for potential tree dumps
-        let _slow_query_guard = if !likely_buffer_read {
-            Some(SlowQueryGuard::spawn(self.worker_id))
-        } else {
-            None
-        };
-
         let _maybe_permit = if !likely_buffer_read {
             // Acquire semaphore permit before processing tree dump.
             // This prevents multiple heavy tree dump operations from running concurrently
@@ -754,6 +747,14 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
             Some(permit)
         } else {
             // Fast buffer read - no semaphore needed
+            None
+        };
+
+        // Start slow-query logging only once the request is actively executing the slow path.
+        // Queued requests waiting on the semaphore should remain silent.
+        let _slow_query_guard = if !likely_buffer_read {
+            Some(SlowQueryGuard::spawn(self.worker_id))
+        } else {
             None
         };
 

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -978,6 +978,8 @@ mod tests {
         let engine = WorkerKvQueryEngine {
             worker_id,
             local_indexer,
+            processing_semaphore: Semaphore::new(1),
+            metrics: None,
         };
 
         let request = WorkerKvQueryRequest {

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -650,6 +650,8 @@ pub(crate) async fn start_worker_kv_query_endpoint(
     let engine = Arc::new(WorkerKvQueryEngine {
         worker_id,
         local_indexer,
+        // only queue 1 request at a time, to not have consecu
+        processing_semaphore: Semaphore::new(1),
     });
 
     let ingress = match Ingress::for_engine(engine) {
@@ -684,6 +686,9 @@ pub(crate) async fn start_worker_kv_query_endpoint(
 struct WorkerKvQueryEngine {
     worker_id: u64,
     local_indexer: Arc<LocalKvIndexer>,
+    /// Semaphore limiting concurrent recovery request processing to 1.
+    /// Prevents multiple routers from overwhelming the worker with heavy tree dump operations.
+    processing_semaphore: Semaphore,
 }
 
 #[async_trait]
@@ -713,6 +718,35 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
                 ctx.context(),
             ));
         }
+
+        // Acquire semaphore permit before processing - only one request at a time.
+        // This prevents multiple heavy tree dump operations from running concurrently
+        // and overwhelming the worker's indexing capacity.
+        // Handle cancellation (stopped or killed) while waiting for the semaphore.
+        let engine_ctx = ctx.context();
+        let _permit = tokio::select! {
+            result = self.processing_semaphore.acquire() => {
+                result.map_err(|_| anyhow::anyhow!("Worker KV query semaphore closed"))?
+            }
+            _ = engine_ctx.stopped() => {
+                tracing::debug!("Worker KV query request stopped while waiting for semaphore");
+                return Ok(ResponseStream::new(
+                    Box::pin(stream::iter(vec![WorkerKvQueryResponse::Error(
+                        "Request cancelled".to_string(),
+                    )])),
+                    ctx.context(),
+                ));
+            }
+            _ = engine_ctx.killed() => {
+                tracing::debug!("Worker KV query request killed while waiting for semaphore");
+                return Ok(ResponseStream::new(
+                    Box::pin(stream::iter(vec![WorkerKvQueryResponse::Error(
+                        "Request cancelled".to_string(),
+                    )])),
+                    ctx.context(),
+                ));
+            }
+        };
 
         let response = self
             .local_indexer

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -650,7 +650,10 @@ pub(crate) async fn start_worker_kv_query_endpoint(
     local_indexer: Arc<LocalKvIndexer>,
 ) {
     // Register metrics for this worker
-    if let Err(e) = WorkerQueryMetrics::register(&component.get_metrics_registry().get_prometheus_registry(), worker_id) {
+    if let Err(e) = WorkerQueryMetrics::register(
+        &component.get_metrics_registry().get_prometheus_registry(),
+        worker_id,
+    ) {
         tracing::warn!("Failed to register worker query metrics: {e}");
     }
     let metrics = WorkerQueryMetrics::get();

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -21,6 +21,7 @@ use futures::StreamExt;
 use tokio::sync::{Mutex, Semaphore};
 
 use super::Indexer;
+use crate::kv_router::metrics::WorkerQueryMetrics;
 use crate::kv_router::worker_kv_indexer_query_endpoint;
 use dynamo_kv_router::{
     indexer::{LocalKvIndexer, WorkerKvQueryRequest, WorkerKvQueryResponse},
@@ -647,11 +648,17 @@ pub(crate) async fn start_worker_kv_query_endpoint(
     dp_rank: DpRank,
     local_indexer: Arc<LocalKvIndexer>,
 ) {
+    // Register metrics for this worker
+    if let Err(e) = WorkerQueryMetrics::register(component.drt().prometheus_registry(), worker_id) {
+        tracing::warn!("Failed to register worker query metrics: {e}");
+    }
+    let metrics = WorkerQueryMetrics::get();
+
     let engine = Arc::new(WorkerKvQueryEngine {
         worker_id,
         local_indexer,
-        // only queue 1 request at a time, to not have consecu
         processing_semaphore: Semaphore::new(1),
+        metrics,
     });
 
     let ingress = match Ingress::for_engine(engine) {
@@ -689,6 +696,8 @@ struct WorkerKvQueryEngine {
     /// Semaphore limiting concurrent recovery request processing to 1.
     /// Prevents multiple routers from overwhelming the worker with heavy tree dump operations.
     processing_semaphore: Semaphore,
+    /// Optional metrics for tracking semaphore wait time and query duration.
+    metrics: Option<Arc<WorkerQueryMetrics>>,
 }
 
 #[async_trait]
@@ -717,6 +726,11 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
                 Box::pin(stream::iter(vec![response])),
                 ctx.context(),
             ));
+        }
+
+        // Track total queries
+        if let Some(metrics) = &self.metrics {
+            metrics.increment_queries();
         }
 
         // Acquire semaphore permit before processing - only one request at a time.

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -42,10 +42,10 @@ use std::sync::{Arc, LazyLock, OnceLock};
 use std::time::Duration;
 
 use dynamo_runtime::component::Component;
-use dynamo_runtime::metrics::MetricsHierarchy;
 use dynamo_runtime::metrics::prometheus_names::{
     frontend_service, labels, name_prefix, router, router_request, routing_overhead,
 };
+use dynamo_runtime::metrics::MetricsHierarchy;
 
 /// Build a router metric name: `"router_" + frontend_service_suffix`.
 fn router_metric(suffix: &str) -> String {
@@ -451,6 +451,50 @@ impl RemoteIndexerMetrics {
 
     pub fn increment_write_failures(&self) {
         self.write_failures_total.inc();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worker query metrics (simple counter)
+// ---------------------------------------------------------------------------
+
+/// Metrics for worker-side KV query operations.
+pub struct WorkerQueryMetrics {
+    pub queries_total: prometheus::IntCounter,
+}
+
+static WORKER_QUERY_METRICS: OnceLock<Arc<WorkerQueryMetrics>> = OnceLock::new();
+
+impl WorkerQueryMetrics {
+    pub fn get() -> Option<Arc<Self>> {
+        WORKER_QUERY_METRICS.get().cloned()
+    }
+
+    pub fn register(
+        registry: &prometheus::Registry,
+        worker_id: u64,
+    ) -> Result<(), prometheus::Error> {
+        let m = WORKER_QUERY_METRICS.get_or_init(|| {
+            let worker_id_str = worker_id.to_string();
+
+            let queries_total = prometheus::IntCounter::with_opts(
+                Opts::new(
+                    "dynamo_worker_query_requests_total",
+                    "Total number of KV query requests received",
+                )
+                .const_label("worker_id", &worker_id_str),
+            )
+            .expect("failed to create queries_total counter");
+
+            Arc::new(Self { queries_total })
+        });
+
+        registry.register(Box::new(m.queries_total.clone()))?;
+        Ok(())
+    }
+
+    pub fn increment_queries(&self) {
+        self.queries_total.inc();
     }
 }
 

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -42,10 +42,10 @@ use std::sync::{Arc, LazyLock, OnceLock};
 use std::time::Duration;
 
 use dynamo_runtime::component::Component;
+use dynamo_runtime::metrics::MetricsHierarchy;
 use dynamo_runtime::metrics::prometheus_names::{
     frontend_service, labels, name_prefix, router, router_request, routing_overhead,
 };
-use dynamo_runtime::metrics::MetricsHierarchy;
 
 /// Build a router metric name: `"router_" + frontend_service_suffix`.
 fn router_metric(suffix: &str) -> String {

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -454,50 +454,6 @@ impl RemoteIndexerMetrics {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Worker query metrics (simple counter)
-// ---------------------------------------------------------------------------
-
-/// Metrics for worker-side KV query operations.
-pub struct WorkerQueryMetrics {
-    pub queries_total: prometheus::IntCounter,
-}
-
-static WORKER_QUERY_METRICS: OnceLock<Arc<WorkerQueryMetrics>> = OnceLock::new();
-
-impl WorkerQueryMetrics {
-    pub fn get() -> Option<Arc<Self>> {
-        WORKER_QUERY_METRICS.get().cloned()
-    }
-
-    pub fn register(
-        registry: &prometheus::Registry,
-        worker_id: u64,
-    ) -> Result<(), prometheus::Error> {
-        let m = WORKER_QUERY_METRICS.get_or_init(|| {
-            let worker_id_str = worker_id.to_string();
-
-            let queries_total = prometheus::IntCounter::with_opts(
-                Opts::new(
-                    "dynamo_worker_query_requests_total",
-                    "Total number of KV query requests received",
-                )
-                .const_label("worker_id", &worker_id_str),
-            )
-            .expect("failed to create queries_total counter");
-
-            Arc::new(Self { queries_total })
-        });
-
-        registry.register(Box::new(m.queries_total.clone()))?;
-        Ok(())
-    }
-
-    pub fn increment_queries(&self) {
-        self.queries_total.inc();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Signed-off-by: michaelfeil <63565275+michaelfeil@users.noreply.github.com>

# Worker KV Query Semaphore

## Problem

Multiple routers starting simultaneously could overwhelm a worker with concurrent KV indexer recovery requests (tree dumps). Each tree dump serializes the entire radix tree into memory, which is CPU-intensive and could cause the worker to fall behind on indexing. This could be amplified on retry pattern. We found this issue on pure code review, and have decided to not try out the feature yet, and stabilize the snapshot pattern on 1.0 first, before trying to migrate. In summary, we want to be mindful how many "recovery" requests we are queuing in a row, and want to give the local indexer enough time, to e.g. process events up to the latest. Ultimately, tree dump can take multiple seconds, and we would like to perform it on most up to date data. Potentially, there is a issue with aggressive 200ms timeout and retry pattern, leaving many attempts behind. One issue is that the router could have issue consuming the payload and retry more often. Retry might only happen in flaky networking conditions of the worker. 

I think there are no practical downsides to this from performance perspective.  
I am  mostly contributing it since we saw a few of races in snapshotting. (e.g. when snapshotting process to nats took longer than the interval, it would fall behind snapshotting), and would like to find possible error scenarios upfront. 

## Solution

Added a semaphore (permit=1) to `WorkerKvQueryEngine` in `lib/llm/src/kv_router/indexer/worker_query.rs`:

```rust
struct WorkerKvQueryEngine {
    worker_id: u64,
    local_indexer: Arc<LocalKvIndexer>,
    processing_semaphore: Semaphore,  // 1 permit
    metrics: Option<Arc<WorkerQueryMetrics>>,
}
```

## Behavior

- Only one recovery request processes at a time
- Requests wait in queue via `semaphore.acquire()`
- Cancellation handled via `tokio::select!` on `stopped()` and `killed()`
- Semaphore held during `get_events_in_id_range()` (includes tree dump)

## Metrics

Added `WorkerQueryMetrics` in `lib/llm/src/kv_router/metrics.rs`, just a counter. Should be extended in case we get issues on this route, but this would signal any issues in deployment for now on global level.


#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fast-path heuristic to serve buffered queries more quickly.

* **Bug Fixes / Performance**
  * Capped concurrent heavy query handling to improve stability under load.
  * Improved shutdown behavior so in-flight slow queries are aborted or return errors promptly.
  * Added periodic slow-query warnings to aid operational visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->