### PR TITLE
fix: recovery etc order, full recovery, thundering herd on same worker ids in same order.

### DIFF
--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -18,6 +18,7 @@ use dynamo_runtime::protocols::maybe_error::MaybeError;
 use dynamo_runtime::stream;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
 use futures::StreamExt;
+use rand::Rng;
 use tokio::sync::{Mutex, Semaphore};
 
 use super::Indexer;
@@ -447,6 +448,13 @@ impl WorkerQueryClient {
         let client = self.clone();
 
         tokio::spawn(async move {
+            // Add small random jitter to permute semaphore acquisition order load when multiple routers
+            // start simultaneously, and etcd order is deterministic.
+            let jitter_ms = rand::rng().random_range(0..100u64);
+            if jitter_ms > 0 {
+                tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
+            }
+
             let Ok(_permit) = client.recovery_semaphore.clone().acquire_owned().await else {
                 return;
             };

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -448,12 +448,12 @@ impl WorkerQueryClient {
         let client = self.clone();
 
         tokio::spawn(async move {
-            // Add jitter only for full-restore (start_event_id is None).
+            // Add jitter only for full-restore (start_event_id is None)
             // to permute semaphore acquisition order and reduce thundering herd risk on initial discovery.
             // This distributes load when multiple routers start simultaneously.
             if start_event_id.is_none() {
-                let jitter_ms = rand::rng().random_range(0..10u64);
-                tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
+                let jitter_us = rand::rng().random_range(0..3000u64);
+                tokio::time::sleep(Duration::from_micros(jitter_us)).await;
             }
 
             let Ok(_permit) = client.recovery_semaphore.clone().acquire_owned().await else {

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -448,10 +448,11 @@ impl WorkerQueryClient {
         let client = self.clone();
 
         tokio::spawn(async move {
-            // Add small random jitter to permute semaphore acquisition order load when multiple routers
-            // start simultaneously, and etcd order is deterministic.
-            let jitter_ms = rand::rng().random_range(0..100u64);
-            if jitter_ms > 0 {
+            // Add jitter only for full-restore (start_event_id is None).
+            // to permute semaphore acquisition order and reduce thundering herd risk on initial discovery.
+            // This distributes load when multiple routers start simultaneously.
+            if start_event_id.is_none() {
+                let jitter_ms = rand::rng().random_range(0..10u64);
                 tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
             }
 


### PR DESCRIPTION
Signed-off-by: michaelfeil <63565275+michaelfeil@users.noreply.github.com>

#### Overview:

On startup of 2 or more routers, all routers would request in the same order. This is conceptually not a good idea. Ideally, we would shuffle the order of the worker pods on recovery. (NIT, this could be also 1 router crashlooping, imaging it OOMs due to bug or memory request, and repeatedly requests from the same 16 workers). Seems like a no-brainer to randomize the order here. 

Best way would be to delay the entry by some ms. Since its spawn -> sleep_rng -> acquire semaphore, this is only relevant for the first 16 tasks, and will have no practical impact on recovery time. 

Edit: not performed on small gap recovery.


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced small randomized startup delays for full-restore recovery tasks to reduce contention when many recovery processes start at once.
  * No other recovery behavior changed—fetching, retry/backoff, cursor updates, and subsequent recovery spawning remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->