### PR TITLE
fix(kv-router): coalesce worker recovery dumps

### DIFF
--- a/lib/kv-router/src/indexer/kv_indexer.rs
+++ b/lib/kv-router/src/indexer/kv_indexer.rs
@@ -378,11 +378,7 @@ impl KvIndexer {
         self.event_tx.clone()
     }
 
-    /// Get a sender for dump requests (snapshot events).
-    ///
-    /// ### Returns
-    ///
-    /// A `mpsc::Sender` for `DumpRequest`s.
+    #[cfg(test)]
     pub fn snapshot_event_sender(&self) -> mpsc::Sender<DumpRequest> {
         self.dump_tx.clone()
     }

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -9,7 +9,6 @@ use std::{
 use async_trait::async_trait;
 use tokio::sync::futures::OwnedNotified;
 use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc};
-use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 use super::{
@@ -20,18 +19,18 @@ use crate::protocols::*;
 
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(test)]
+use tokio::time::Duration;
 
 // -------------------------------------------------
 // Decentralized router: LocalKvIndexer for workers
 // -------------------------------------------------
 
-const RECOVERY_CACHE_TTL: Duration = Duration::from_secs(1);
-
 #[derive(Clone)]
 struct CachedRecoverySnapshot {
     events: Arc<Vec<RouterEvent>>,
+    base_last_event_id: u64,
     last_event_id: u64,
-    last_used_at: Instant,
 }
 
 impl CachedRecoverySnapshot {
@@ -108,29 +107,13 @@ impl RecoverySnapshotCache {
         assess_tail_append_safety: F,
     ) -> CacheReuseDecision
     where
-        F: FnOnce(u64) -> TailAppendSafety,
+        F: FnOnce(&CachedRecoverySnapshot) -> TailAppendSafety,
     {
         let mut cache_state = self.state.lock().await;
-        let now = Instant::now();
-
-        if cache_state
-            .cached
-            .as_ref()
-            .is_some_and(|cached| now.duration_since(cached.last_used_at) > RECOVERY_CACHE_TTL)
-        {
-            cache_state.cached = None;
-        }
 
         if let Some(cached) = cache_state.cached.clone() {
-            match assess_tail_append_safety(cached.last_event_id) {
-                TailAppendSafety::ExactHit => {
-                    let exact = CachedRecoverySnapshot {
-                        last_used_at: now,
-                        ..cached
-                    };
-                    cache_state.cached = Some(exact.clone());
-                    return CacheReuseDecision::ReturnExact(exact);
-                }
+            match assess_tail_append_safety(&cached) {
+                TailAppendSafety::ExactHit => return CacheReuseDecision::ReturnExact(cached),
                 TailAppendSafety::Safe {
                     last_event_id,
                     tail,
@@ -140,8 +123,8 @@ impl RecoverySnapshotCache {
                     let shared_events = Arc::new(events);
                     cache_state.cached = Some(CachedRecoverySnapshot {
                         events: shared_events.clone(),
+                        base_last_event_id: cached.base_last_event_id,
                         last_event_id,
-                        last_used_at: now,
                     });
                     return CacheReuseDecision::ReturnExtended(WorkerKvQueryResponse::TreeDump {
                         events: shared_events.as_ref().clone(),
@@ -222,7 +205,7 @@ pub struct LocalKvIndexer {
     indexer: KvIndexer,
     /// Circular buffer of recent events
     pub(super) event_buffer: Mutex<VecDeque<RouterEvent>>,
-    /// Coordinates single-flight tree dumps and the short-lived cached snapshot.
+    /// Coordinates single-flight tree dumps and the cached recovery snapshot.
     /// This stays separate from `event_buffer` so dump wait/build state can be
     /// managed on the async path without holding the buffer lock across `.await`.
     recovery_cache: Arc<RecoverySnapshotCache>,
@@ -432,7 +415,7 @@ impl LocalKvIndexer {
                 .decide_reuse_or_build(
                     fallback_last_event_id,
                     self.current_buffer_last_event_id(),
-                    |cached_last_event_id| self.assess_tail_append_safety(cached_last_event_id),
+                    |cached| self.assess_tail_append_safety(cached),
                 )
                 .await;
 
@@ -465,10 +448,11 @@ impl LocalKvIndexer {
         }
     }
 
-    fn assess_tail_append_safety(&self, cached_last_event_id: u64) -> TailAppendSafety {
+    fn assess_tail_append_safety(&self, cached: &CachedRecoverySnapshot) -> TailAppendSafety {
+        let append_budget = self.recovery_cache_append_budget();
         let buffer = self.event_buffer.lock().unwrap();
         let Some(first_buffered) = buffer.front().map(|event| event.event.event_id) else {
-            return if cached_last_event_id == 0 {
+            return if cached.last_event_id == 0 {
                 TailAppendSafety::ExactHit
             } else {
                 TailAppendSafety::Invalidate
@@ -476,11 +460,16 @@ impl LocalKvIndexer {
         };
         let last_buffered = buffer.back().unwrap().event.event_id;
 
-        if last_buffered <= cached_last_event_id {
+        if last_buffered <= cached.last_event_id {
             return TailAppendSafety::ExactHit;
         }
 
-        let next_event_id = cached_last_event_id.saturating_add(1);
+        let appended_since_base = last_buffered.saturating_sub(cached.base_last_event_id);
+        if appended_since_base > append_budget {
+            return TailAppendSafety::Invalidate;
+        }
+
+        let next_event_id = cached.last_event_id.saturating_add(1);
         if next_event_id < first_buffered {
             return TailAppendSafety::Invalidate;
         }
@@ -507,6 +496,10 @@ impl LocalKvIndexer {
             last_event_id: last_buffered,
             tail,
         }
+    }
+
+    fn recovery_cache_append_budget(&self) -> u64 {
+        (self.max_buffer_size / 2) as u64
     }
 
     fn current_buffer_last_event_id(&self) -> Option<u64> {
@@ -553,8 +546,8 @@ impl LocalKvIndexer {
                 },
                 snapshot: Some(CachedRecoverySnapshot {
                     events: Arc::new(events),
+                    base_last_event_id: last_event_id,
                     last_event_id,
-                    last_used_at: Instant::now(),
                 }),
             },
             Err(error) => {

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -212,12 +212,6 @@ impl RecoverySnapshotCache {
         cache_state.generation = cache_state.generation.saturating_add(1);
         cache_state.cached = None;
     }
-
-    fn try_clear_cached(&self) {
-        if let Ok(mut cache_state) = self.state.try_lock() {
-            cache_state.cached = None;
-        }
-    }
 }
 
 /// A thin wrapper around KvIndexer that buffers recent events
@@ -260,7 +254,7 @@ impl LocalKvIndexer {
         }
     }
 
-    /// Get all buffered events (oldest first).
+    /// Test-only helper to inspect the buffered events (oldest first).
     pub fn get_all_events_in_buffer(&self) -> Vec<RouterEvent> {
         let buffer = self.event_buffer.lock().unwrap();
         buffer.iter().cloned().collect()
@@ -271,11 +265,14 @@ impl LocalKvIndexer {
     /// ### Arguments
     ///
     /// * `start_id` - Starting event ID (inclusive). If `None`, dumps entire tree.
-    /// * `end_id` - Ending event ID (inclusive). If `None`, returns up to newest available.
+    /// * `end_id` - Ending event ID (inclusive). Used for validation and
+    ///   `TooNew` responses; successful buffer-backed responses may still
+    ///   return through the newest buffered event.
     ///
     /// ### Returns
     ///
-    /// - `Events`: Buffered events with original IDs (when range is within buffer)
+    /// - `Events`: Buffered events with original IDs from `start_id` through the
+    ///   current buffered tail, plus the buffered `last_event_id`
     /// - `TreeDump`: Full tree dump with synthetic IDs and the worker's latest real event ID (when range is too old or unspecified)
     /// - `TooNew`: Error when requested range is newer than available data
     /// - `InvalidRange`: Error when end_id < start_id
@@ -349,14 +346,7 @@ impl LocalKvIndexer {
         result
     }
 
-    /// Clear the event buffer.
-    pub fn clear_buffer(&self) {
-        let mut buffer = self.event_buffer.lock().unwrap();
-        buffer.clear();
-        self.recovery_cache.try_clear_cached();
-    }
-
-    /// Get the current buffer size.
+    /// Test-only helper to inspect the current buffer size.
     pub fn buffer_len(&self) -> usize {
         let buffer = self.event_buffer.lock().unwrap();
         buffer.len()
@@ -427,21 +417,12 @@ impl LocalKvIndexer {
             Ok(idx) => idx,
             Err(insertion_point) => insertion_point,
         };
-        let clamped_end_id = end_id.min(last_buffered);
-        let end_idx =
-            match buffer.binary_search_by_key(&clamped_end_id, |event| event.event.event_id) {
-                Ok(idx) => idx + 1,
-                Err(insertion_point) => insertion_point,
-            };
+        let events = buffer.iter().skip(start_idx).cloned().collect();
 
-        let events = buffer
-            .iter()
-            .skip(start_idx)
-            .take(end_idx.saturating_sub(start_idx))
-            .cloned()
-            .collect();
-
-        DumpPlan::Immediate(WorkerKvQueryResponse::Events(events))
+        DumpPlan::Immediate(WorkerKvQueryResponse::Events {
+            events,
+            last_event_id: last_buffered,
+        })
     }
 
     async fn get_cached_or_fresh_dump(&self, fallback_last_event_id: u64) -> WorkerKvQueryResponse {
@@ -605,7 +586,7 @@ impl LocalKvIndexer {
         self.indexer.event_sender()
     }
 
-    /// Get a sender for dump requests (snapshot events).
+    /// Test-only helper to send dump requests directly to the underlying indexer.
     pub fn snapshot_event_sender(&self) -> mpsc::Sender<DumpRequest> {
         self.indexer.snapshot_event_sender()
     }
@@ -618,11 +599,6 @@ impl LocalKvIndexer {
     /// Get a sender for get workers requests.
     pub fn get_workers_sender(&self) -> mpsc::Sender<GetWorkersRequest> {
         self.indexer.get_workers_sender()
-    }
-
-    /// Get the KV block size.
-    pub fn block_size(&self) -> u32 {
-        self.indexer.block_size()
     }
 }
 

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use tokio::sync::futures::OwnedNotified;
 use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc};
 use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
@@ -63,7 +64,7 @@ enum DumpPlan {
 enum CacheReuseDecision {
     ReturnExact(CachedRecoverySnapshot),
     ReturnExtended(WorkerKvQueryResponse),
-    WaitForBuilder(Arc<Notify>),
+    WaitForBuilder(OwnedNotified),
     BuildFresh {
         build: InFlightRecoveryBuild,
         last_event_id: u64,
@@ -325,7 +326,7 @@ impl LocalKvIndexer {
             match decision {
                 CacheReuseDecision::ReturnExact(snapshot) => return snapshot.into_response(),
                 CacheReuseDecision::ReturnExtended(response) => return response,
-                CacheReuseDecision::WaitForBuilder(notify) => notify.notified().await,
+                CacheReuseDecision::WaitForBuilder(waiter) => waiter.await,
                 CacheReuseDecision::BuildFresh {
                     build,
                     last_event_id,
@@ -389,13 +390,14 @@ impl LocalKvIndexer {
                 } => {
                     let mut events = cached.events.as_ref().clone();
                     events.extend(tail);
+                    let shared_events = Arc::new(events);
                     cache_state.cached = Some(CachedRecoverySnapshot {
-                        events: Arc::new(events.clone()),
+                        events: shared_events.clone(),
                         last_event_id,
                         last_used_at: now,
                     });
                     return CacheReuseDecision::ReturnExtended(WorkerKvQueryResponse::TreeDump {
-                        events,
+                        events: shared_events.as_ref().clone(),
                         last_event_id,
                     });
                 }
@@ -406,7 +408,7 @@ impl LocalKvIndexer {
         }
 
         if let Some(build) = cache_state.building.clone() {
-            return CacheReuseDecision::WaitForBuilder(build.notify);
+            return CacheReuseDecision::WaitForBuilder(build.notify.notified_owned());
         }
 
         let build = InFlightRecoveryBuild {

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -56,6 +56,10 @@ struct RecoveryCacheState {
     building: Option<InFlightRecoveryBuild>,
 }
 
+struct RecoverySnapshotCache {
+    state: AsyncMutex<RecoveryCacheState>,
+}
+
 enum DumpPlan {
     Immediate(WorkerKvQueryResponse),
     RequiresDump { last_event_id: u64 },
@@ -90,6 +94,132 @@ struct FreshDumpOutput {
     snapshot: Option<CachedRecoverySnapshot>,
 }
 
+impl RecoverySnapshotCache {
+    fn new() -> Self {
+        Self {
+            state: AsyncMutex::new(RecoveryCacheState::default()),
+        }
+    }
+
+    async fn decide_reuse_or_build<F>(
+        &self,
+        fallback_last_event_id: u64,
+        current_last_event_id: Option<u64>,
+        assess_tail_append_safety: F,
+    ) -> CacheReuseDecision
+    where
+        F: FnOnce(u64) -> TailAppendSafety,
+    {
+        let mut cache_state = self.state.lock().await;
+        let now = Instant::now();
+
+        if cache_state
+            .cached
+            .as_ref()
+            .is_some_and(|cached| now.duration_since(cached.last_used_at) > RECOVERY_CACHE_TTL)
+        {
+            cache_state.cached = None;
+        }
+
+        if let Some(cached) = cache_state.cached.clone() {
+            match assess_tail_append_safety(cached.last_event_id) {
+                TailAppendSafety::ExactHit => {
+                    let exact = CachedRecoverySnapshot {
+                        last_used_at: now,
+                        ..cached
+                    };
+                    cache_state.cached = Some(exact.clone());
+                    return CacheReuseDecision::ReturnExact(exact);
+                }
+                TailAppendSafety::Safe {
+                    last_event_id,
+                    tail,
+                } => {
+                    let mut events = cached.events.as_ref().clone();
+                    events.extend(tail);
+                    let shared_events = Arc::new(events);
+                    cache_state.cached = Some(CachedRecoverySnapshot {
+                        events: shared_events.clone(),
+                        last_event_id,
+                        last_used_at: now,
+                    });
+                    return CacheReuseDecision::ReturnExtended(WorkerKvQueryResponse::TreeDump {
+                        events: shared_events.as_ref().clone(),
+                        last_event_id,
+                    });
+                }
+                TailAppendSafety::Invalidate => {
+                    cache_state.cached = None;
+                }
+            }
+        }
+
+        if let Some(build) = cache_state.building.clone() {
+            return CacheReuseDecision::WaitForBuilder(build.notify.notified_owned());
+        }
+
+        let build = InFlightRecoveryBuild {
+            generation: cache_state.generation,
+            notify: Arc::new(Notify::new()),
+        };
+        let last_event_id = current_last_event_id.unwrap_or(fallback_last_event_id);
+        cache_state.building = Some(build.clone());
+        CacheReuseDecision::BuildFresh {
+            build,
+            last_event_id,
+        }
+    }
+
+    async fn finish_build(
+        &self,
+        build: &InFlightRecoveryBuild,
+        build_output: FreshDumpOutput,
+    ) -> BuildTaskResult {
+        let mut cache_state = self.state.lock().await;
+        let is_current_build = cache_state
+            .building
+            .as_ref()
+            .is_some_and(|inflight| inflight.generation == build.generation);
+        let generation_matches = cache_state.generation == build.generation;
+
+        if is_current_build {
+            cache_state.building = None;
+        }
+
+        if !is_current_build || !generation_matches {
+            return BuildTaskResult::StaleGeneration;
+        }
+
+        if let Some(snapshot) = build_output.snapshot {
+            cache_state.cached = Some(snapshot);
+        }
+        BuildTaskResult::Response(build_output.response)
+    }
+
+    async fn clear_build_if_current(&self, generation: u64) {
+        let mut cache_state = self.state.lock().await;
+        if cache_state
+            .building
+            .as_ref()
+            .is_some_and(|inflight| inflight.generation == generation)
+        {
+            cache_state.building = None;
+        }
+    }
+
+    async fn invalidate(&self) {
+        let mut cache_state = self.state.lock().await;
+        cache_state.generation = cache_state.generation.saturating_add(1);
+        cache_state.cached = None;
+    }
+
+    fn try_clear_cached(&self) {
+        if let Ok(mut cache_state) = self.state.try_lock() {
+            cache_state.cached = None;
+        }
+    }
+}
+
 /// A thin wrapper around KvIndexer that buffers recent events
 /// (e.g. which may be queued by router upon startup)
 ///
@@ -101,7 +231,7 @@ pub struct LocalKvIndexer {
     /// Coordinates single-flight tree dumps and the short-lived cached snapshot.
     /// This stays separate from `event_buffer` so dump wait/build state can be
     /// managed on the async path without holding the buffer lock across `.await`.
-    recovery_cache: Arc<AsyncMutex<RecoveryCacheState>>,
+    recovery_cache: Arc<RecoverySnapshotCache>,
     /// Maximum number of events to keep in buffer
     max_buffer_size: usize, // Router sets this to WORKER_KV_INDEXER_BUFFER_SIZE
     #[cfg(test)]
@@ -121,7 +251,7 @@ impl LocalKvIndexer {
         Self {
             indexer: KvIndexer::new(token, kv_block_size, metrics),
             event_buffer: Mutex::new(VecDeque::with_capacity(max_buffer_size)),
-            recovery_cache: Arc::new(AsyncMutex::new(RecoveryCacheState::default())),
+            recovery_cache: Arc::new(RecoverySnapshotCache::new()),
             max_buffer_size,
             #[cfg(test)]
             dump_build_count: AtomicUsize::new(0),
@@ -212,7 +342,7 @@ impl LocalKvIndexer {
             let should_invalidate = matches!(event.event.data, KvCacheEventData::Cleared);
             let detected_gap = self.record_event(event);
             if should_invalidate || detected_gap {
-                self.invalidate_recovery_cache().await;
+                self.recovery_cache.invalidate().await;
             }
         }
 
@@ -223,9 +353,7 @@ impl LocalKvIndexer {
     pub fn clear_buffer(&self) {
         let mut buffer = self.event_buffer.lock().unwrap();
         buffer.clear();
-        if let Ok(mut cache_state) = self.recovery_cache.try_lock() {
-            cache_state.cached = None;
-        }
+        self.recovery_cache.try_clear_cached();
     }
 
     /// Get the current buffer size.
@@ -318,10 +446,14 @@ impl LocalKvIndexer {
 
     async fn get_cached_or_fresh_dump(&self, fallback_last_event_id: u64) -> WorkerKvQueryResponse {
         loop {
-            let decision = {
-                let mut cache_state = self.recovery_cache.lock().await;
-                self.try_reuse_cached_dump(&mut cache_state, fallback_last_event_id)
-            };
+            let decision = self
+                .recovery_cache
+                .decide_reuse_or_build(
+                    fallback_last_event_id,
+                    self.current_buffer_last_event_id(),
+                    |cached_last_event_id| self.assess_tail_append_safety(cached_last_event_id),
+                )
+                .await;
 
             match decision {
                 CacheReuseDecision::ReturnExact(snapshot) => return snapshot.into_response(),
@@ -339,15 +471,7 @@ impl LocalKvIndexer {
                         Ok(BuildTaskResult::StaleGeneration) => continue,
                         Err(error) => {
                             tracing::warn!("Recovery cache build task failed: {error}");
-                            let mut cache_state = self.recovery_cache.lock().await;
-                            if cache_state
-                                .building
-                                .as_ref()
-                                .is_some_and(|inflight| inflight.generation == generation)
-                            {
-                                cache_state.building = None;
-                            }
-                            drop(cache_state);
+                            self.recovery_cache.clear_build_if_current(generation).await;
                             notify.notify_waiters();
                             return WorkerKvQueryResponse::TreeDump {
                                 events: Vec::new(),
@@ -357,71 +481,6 @@ impl LocalKvIndexer {
                     }
                 }
             }
-        }
-    }
-
-    fn try_reuse_cached_dump(
-        &self,
-        cache_state: &mut RecoveryCacheState,
-        fallback_last_event_id: u64,
-    ) -> CacheReuseDecision {
-        let now = Instant::now();
-        if cache_state
-            .cached
-            .as_ref()
-            .is_some_and(|cached| now.duration_since(cached.last_used_at) > RECOVERY_CACHE_TTL)
-        {
-            cache_state.cached = None;
-        }
-
-        if let Some(cached) = cache_state.cached.clone() {
-            match self.assess_tail_append_safety(cached.last_event_id) {
-                TailAppendSafety::ExactHit => {
-                    let exact = CachedRecoverySnapshot {
-                        last_used_at: now,
-                        ..cached
-                    };
-                    cache_state.cached = Some(exact.clone());
-                    return CacheReuseDecision::ReturnExact(exact);
-                }
-                TailAppendSafety::Safe {
-                    last_event_id,
-                    tail,
-                } => {
-                    let mut events = cached.events.as_ref().clone();
-                    events.extend(tail);
-                    let shared_events = Arc::new(events);
-                    cache_state.cached = Some(CachedRecoverySnapshot {
-                        events: shared_events.clone(),
-                        last_event_id,
-                        last_used_at: now,
-                    });
-                    return CacheReuseDecision::ReturnExtended(WorkerKvQueryResponse::TreeDump {
-                        events: shared_events.as_ref().clone(),
-                        last_event_id,
-                    });
-                }
-                TailAppendSafety::Invalidate => {
-                    cache_state.cached = None;
-                }
-            }
-        }
-
-        if let Some(build) = cache_state.building.clone() {
-            return CacheReuseDecision::WaitForBuilder(build.notify.notified_owned());
-        }
-
-        let build = InFlightRecoveryBuild {
-            generation: cache_state.generation,
-            notify: Arc::new(Notify::new()),
-        };
-        let last_event_id = self
-            .current_buffer_last_event_id()
-            .unwrap_or(fallback_last_event_id);
-        cache_state.building = Some(build.clone());
-        CacheReuseDecision::BuildFresh {
-            build,
-            last_event_id,
         }
     }
 
@@ -497,27 +556,7 @@ impl LocalKvIndexer {
 
             let build_output = Self::build_fresh_dump(indexer, last_event_id).await;
             let notify = build.notify.clone();
-            let result = {
-                let mut cache_state = recovery_cache.lock().await;
-                let is_current_build = cache_state
-                    .building
-                    .as_ref()
-                    .is_some_and(|inflight| inflight.generation == build.generation);
-                let generation_matches = cache_state.generation == build.generation;
-
-                if is_current_build {
-                    cache_state.building = None;
-                }
-
-                if !is_current_build || !generation_matches {
-                    BuildTaskResult::StaleGeneration
-                } else {
-                    if let Some(snapshot) = build_output.snapshot {
-                        cache_state.cached = Some(snapshot);
-                    }
-                    BuildTaskResult::Response(build_output.response)
-                }
-            };
+            let result = recovery_cache.finish_build(&build, build_output).await;
 
             notify.notify_waiters();
             result
@@ -548,12 +587,6 @@ impl LocalKvIndexer {
                 }
             }
         }
-    }
-
-    async fn invalidate_recovery_cache(&self) {
-        let mut cache_state = self.recovery_cache.lock().await;
-        cache_state.generation = cache_state.generation.saturating_add(1);
-        cache_state.cached = None;
     }
 
     #[cfg(test)]

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -12,11 +12,13 @@ use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    DumpRequest, GetWorkersRequest, KvIndexer, KvIndexerInterface, KvIndexerMetrics, KvRouterError,
+    GetWorkersRequest, KvIndexer, KvIndexerInterface, KvIndexerMetrics, KvRouterError,
     WorkerKvQueryResponse,
 };
 use crate::protocols::*;
 
+#[cfg(test)]
+use super::DumpRequest;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(test)]
@@ -237,7 +239,7 @@ impl LocalKvIndexer {
         }
     }
 
-    /// Test-only helper to inspect the buffered events (oldest first).
+    #[cfg(test)]
     pub fn get_all_events_in_buffer(&self) -> Vec<RouterEvent> {
         let buffer = self.event_buffer.lock().unwrap();
         buffer.iter().cloned().collect()
@@ -329,7 +331,7 @@ impl LocalKvIndexer {
         result
     }
 
-    /// Test-only helper to inspect the current buffer size.
+    #[cfg(test)]
     pub fn buffer_len(&self) -> usize {
         let buffer = self.event_buffer.lock().unwrap();
         buffer.len()
@@ -579,7 +581,7 @@ impl LocalKvIndexer {
         self.indexer.event_sender()
     }
 
-    /// Test-only helper to send dump requests directly to the underlying indexer.
+    #[cfg(test)]
     pub fn snapshot_event_sender(&self) -> mpsc::Sender<DumpRequest> {
         self.indexer.snapshot_event_sender()
     }
@@ -623,6 +625,10 @@ impl KvIndexerInterface for LocalKvIndexer {
 
     async fn remove_worker(&self, worker: WorkerId) {
         let _ = self.indexer.remove_worker_sender().send(worker).await;
+    }
+
+    async fn remove_worker_dp_rank(&self, worker: WorkerId, dp_rank: DpRank) {
+        KvIndexerInterface::remove_worker_dp_rank(&self.indexer, worker, dp_rank).await;
     }
 
     fn shutdown(&self) {

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -7,7 +7,8 @@ use std::{
 };
 
 use async_trait::async_trait;
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc};
+use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 use super::{
@@ -16,9 +17,77 @@ use super::{
 };
 use crate::protocols::*;
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 // -------------------------------------------------
 // Decentralized router: LocalKvIndexer for workers
 // -------------------------------------------------
+
+const RECOVERY_CACHE_TTL: Duration = Duration::from_secs(1);
+
+#[derive(Clone)]
+struct CachedRecoverySnapshot {
+    events: Arc<Vec<RouterEvent>>,
+    last_event_id: u64,
+    last_used_at: Instant,
+}
+
+impl CachedRecoverySnapshot {
+    fn into_response(self) -> WorkerKvQueryResponse {
+        WorkerKvQueryResponse::TreeDump {
+            events: self.events.as_ref().clone(),
+            last_event_id: self.last_event_id,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct InFlightRecoveryBuild {
+    generation: u64,
+    notify: Arc<Notify>,
+}
+
+#[derive(Default)]
+struct RecoveryCacheState {
+    generation: u64,
+    cached: Option<CachedRecoverySnapshot>,
+    building: Option<InFlightRecoveryBuild>,
+}
+
+enum DumpPlan {
+    Immediate(WorkerKvQueryResponse),
+    RequiresDump { last_event_id: u64 },
+}
+
+enum CacheReuseDecision {
+    ReturnExact(CachedRecoverySnapshot),
+    ReturnExtended(WorkerKvQueryResponse),
+    WaitForBuilder(Arc<Notify>),
+    BuildFresh {
+        build: InFlightRecoveryBuild,
+        last_event_id: u64,
+    },
+}
+
+enum TailAppendSafety {
+    ExactHit,
+    Safe {
+        last_event_id: u64,
+        tail: Vec<RouterEvent>,
+    },
+    Invalidate,
+}
+
+enum BuildTaskResult {
+    Response(WorkerKvQueryResponse),
+    StaleGeneration,
+}
+
+struct FreshDumpOutput {
+    response: WorkerKvQueryResponse,
+    snapshot: Option<CachedRecoverySnapshot>,
+}
 
 /// A thin wrapper around KvIndexer that buffers recent events
 /// (e.g. which may be queued by router upon startup)
@@ -28,8 +97,16 @@ pub struct LocalKvIndexer {
     indexer: KvIndexer,
     /// Circular buffer of recent events
     pub(super) event_buffer: Mutex<VecDeque<RouterEvent>>,
+    /// Coordinates single-flight tree dumps and the short-lived cached snapshot.
+    /// This stays separate from `event_buffer` so dump wait/build state can be
+    /// managed on the async path without holding the buffer lock across `.await`.
+    recovery_cache: Arc<AsyncMutex<RecoveryCacheState>>,
     /// Maximum number of events to keep in buffer
     max_buffer_size: usize, // Router sets this to WORKER_KV_INDEXER_BUFFER_SIZE
+    #[cfg(test)]
+    dump_build_count: AtomicUsize,
+    #[cfg(test)]
+    dump_build_delay: Mutex<Option<Duration>>,
 }
 
 impl LocalKvIndexer {
@@ -43,7 +120,12 @@ impl LocalKvIndexer {
         Self {
             indexer: KvIndexer::new(token, kv_block_size, metrics),
             event_buffer: Mutex::new(VecDeque::with_capacity(max_buffer_size)),
+            recovery_cache: Arc::new(AsyncMutex::new(RecoveryCacheState::default())),
             max_buffer_size,
+            #[cfg(test)]
+            dump_build_count: AtomicUsize::new(0),
+            #[cfg(test)]
+            dump_build_delay: Mutex::new(None),
         }
     }
 
@@ -51,15 +133,6 @@ impl LocalKvIndexer {
     pub fn get_all_events_in_buffer(&self) -> Vec<RouterEvent> {
         let buffer = self.event_buffer.lock().unwrap();
         buffer.iter().cloned().collect()
-    }
-
-    /// Build a tree dump response with the given `last_event_id`.
-    async fn tree_dump_response(&self, last_event_id: u64) -> WorkerKvQueryResponse {
-        let events = self.dump_events().await.unwrap_or_default();
-        WorkerKvQueryResponse::TreeDump {
-            events,
-            last_event_id,
-        }
     }
 
     /// Query events by ID range, returning events in `[start_id, end_id]` (both inclusive).
@@ -80,103 +153,24 @@ impl LocalKvIndexer {
         start_id: Option<u64>,
         end_id: Option<u64>,
     ) -> WorkerKvQueryResponse {
-        // Validate range if both specified
-        if let (Some(s), Some(e)) = (start_id, end_id)
-            && e < s
-        {
-            tracing::warn!(start_id = s, end_id = e, "Invalid range: end_id < start_id");
-            return WorkerKvQueryResponse::InvalidRange {
-                start_id: s,
-                end_id: e,
-            };
-        }
-
-        // Get buffer state
-        let (first_id, last_id) = {
-            let buffer = self.event_buffer.lock().unwrap();
-            if buffer.is_empty() {
-                (None, None)
-            } else {
-                (
-                    Some(buffer.front().unwrap().event.event_id),
-                    Some(buffer.back().unwrap().event.event_id),
-                )
+        match self.classify_query(start_id, end_id) {
+            DumpPlan::Immediate(response) => response,
+            DumpPlan::RequiresDump { last_event_id } => {
+                self.get_cached_or_fresh_dump(last_event_id).await
             }
-        };
-
-        // If no start_id specified, dump entire tree
-        if start_id.is_none() {
-            tracing::debug!("No start_id specified, dumping entire tree");
-            return self.tree_dump_response(last_id.unwrap_or(0)).await;
         }
-
-        let start_id = start_id.unwrap();
-        let end_id = end_id.unwrap_or_else(|| last_id.unwrap_or(start_id));
-
-        // Check for empty buffer
-        let Some(first_buffered) = first_id else {
-            tracing::debug!("Buffer empty, dumping entire tree");
-            return self.tree_dump_response(0).await;
-        };
-        let last_buffered = last_id.unwrap();
-
-        // Check if request is too new
-        if start_id > last_buffered {
-            tracing::warn!(
-                start_id,
-                last_buffered,
-                "Requested start_id is newer than buffer"
-            );
-            return WorkerKvQueryResponse::TooNew {
-                requested_start: Some(start_id),
-                requested_end: Some(end_id),
-                newest_available: last_buffered,
-            };
-        }
-
-        // Check if start_id is too old (before buffer) -> tree dump
-        if start_id < first_buffered {
-            tracing::info!(
-                start_id,
-                first_buffered,
-                "Requested start_id is older than buffer, dumping entire tree"
-            );
-            return self.tree_dump_response(last_buffered).await;
-        }
-
-        // Serve from buffer
-        let buffer = self.event_buffer.lock().unwrap();
-
-        let start_idx = match buffer.binary_search_by_key(&start_id, |e| e.event.event_id) {
-            Ok(idx) => idx,
-            Err(insertion_point) => insertion_point,
-        };
-
-        // Clamp end_id to buffer bounds
-        let clamped_end_id = end_id.min(last_buffered);
-        let end_idx = match buffer.binary_search_by_key(&clamped_end_id, |e| e.event.event_id) {
-            Ok(idx) => idx + 1, // Include the matched element
-            Err(insertion_point) => insertion_point,
-        };
-
-        let events: Vec<RouterEvent> = buffer
-            .iter()
-            .skip(start_idx)
-            .take(end_idx.saturating_sub(start_idx))
-            .cloned()
-            .collect();
-
-        WorkerKvQueryResponse::Events(events)
     }
 
     /// Record an event in the buffer
-    fn record_event(&self, event: RouterEvent) {
+    fn record_event(&self, event: RouterEvent) -> bool {
         let mut buffer = self.event_buffer.lock().unwrap();
+        let mut detected_gap = false;
 
         // Check that event id is consecutive to last one
         if let Some(last_event) = buffer.back()
             && event.event.event_id != last_event.event.event_id + 1
         {
+            detected_gap = true;
             let expected = last_event.event.event_id + 1;
             tracing::error!(
                 worker_id = event.worker_id,
@@ -198,6 +192,8 @@ impl LocalKvIndexer {
         while buffer.len() > self.max_buffer_size {
             buffer.pop_front();
         }
+
+        detected_gap
     }
 
     /// Apply event with buffering.
@@ -212,7 +208,11 @@ impl LocalKvIndexer {
             .await
             .map_err(|_| KvRouterError::IndexerOffline);
         if result.is_ok() {
-            self.record_event(event);
+            let should_invalidate = matches!(event.event.data, KvCacheEventData::Cleared);
+            let detected_gap = self.record_event(event);
+            if should_invalidate || detected_gap {
+                self.invalidate_recovery_cache().await;
+            }
         }
 
         result
@@ -222,12 +222,346 @@ impl LocalKvIndexer {
     pub fn clear_buffer(&self) {
         let mut buffer = self.event_buffer.lock().unwrap();
         buffer.clear();
+        if let Ok(mut cache_state) = self.recovery_cache.try_lock() {
+            cache_state.cached = None;
+        }
     }
 
     /// Get the current buffer size.
     pub fn buffer_len(&self) -> usize {
         let buffer = self.event_buffer.lock().unwrap();
         buffer.len()
+    }
+
+    fn classify_query(&self, start_id: Option<u64>, end_id: Option<u64>) -> DumpPlan {
+        if let (Some(s), Some(e)) = (start_id, end_id)
+            && e < s
+        {
+            tracing::warn!(start_id = s, end_id = e, "Invalid range: end_id < start_id");
+            return DumpPlan::Immediate(WorkerKvQueryResponse::InvalidRange {
+                start_id: s,
+                end_id: e,
+            });
+        }
+
+        let buffer = self.event_buffer.lock().unwrap();
+        let (first_id, last_id) = if buffer.is_empty() {
+            (None, None)
+        } else {
+            (
+                Some(buffer.front().unwrap().event.event_id),
+                Some(buffer.back().unwrap().event.event_id),
+            )
+        };
+
+        if start_id.is_none() {
+            tracing::debug!("No start_id specified, dumping entire tree");
+            return DumpPlan::RequiresDump {
+                last_event_id: last_id.unwrap_or(0),
+            };
+        }
+
+        let start_id = start_id.expect("checked above");
+        let end_id = end_id.unwrap_or_else(|| last_id.unwrap_or(start_id));
+
+        let Some(first_buffered) = first_id else {
+            tracing::debug!("Buffer empty, dumping entire tree");
+            return DumpPlan::RequiresDump { last_event_id: 0 };
+        };
+        let last_buffered = last_id.expect("buffer non-empty");
+
+        if start_id > last_buffered {
+            tracing::warn!(
+                start_id,
+                last_buffered,
+                "Requested start_id is newer than buffer"
+            );
+            return DumpPlan::Immediate(WorkerKvQueryResponse::TooNew {
+                requested_start: Some(start_id),
+                requested_end: Some(end_id),
+                newest_available: last_buffered,
+            });
+        }
+
+        if start_id < first_buffered {
+            tracing::info!(
+                start_id,
+                first_buffered,
+                "Requested start_id is older than buffer, dumping entire tree"
+            );
+            return DumpPlan::RequiresDump {
+                last_event_id: last_buffered,
+            };
+        }
+
+        let start_idx = match buffer.binary_search_by_key(&start_id, |event| event.event.event_id) {
+            Ok(idx) => idx,
+            Err(insertion_point) => insertion_point,
+        };
+        let clamped_end_id = end_id.min(last_buffered);
+        let end_idx =
+            match buffer.binary_search_by_key(&clamped_end_id, |event| event.event.event_id) {
+                Ok(idx) => idx + 1,
+                Err(insertion_point) => insertion_point,
+            };
+
+        let events = buffer
+            .iter()
+            .skip(start_idx)
+            .take(end_idx.saturating_sub(start_idx))
+            .cloned()
+            .collect();
+
+        DumpPlan::Immediate(WorkerKvQueryResponse::Events(events))
+    }
+
+    async fn get_cached_or_fresh_dump(&self, fallback_last_event_id: u64) -> WorkerKvQueryResponse {
+        loop {
+            let decision = {
+                let mut cache_state = self.recovery_cache.lock().await;
+                self.try_reuse_cached_dump(&mut cache_state, fallback_last_event_id)
+            };
+
+            match decision {
+                CacheReuseDecision::ReturnExact(snapshot) => return snapshot.into_response(),
+                CacheReuseDecision::ReturnExtended(response) => return response,
+                CacheReuseDecision::WaitForBuilder(notify) => notify.notified().await,
+                CacheReuseDecision::BuildFresh {
+                    build,
+                    last_event_id,
+                } => {
+                    let notify = build.notify.clone();
+                    let generation = build.generation;
+                    let build_handle = self.spawn_dump_build(build, last_event_id);
+                    match build_handle.await {
+                        Ok(BuildTaskResult::Response(response)) => return response,
+                        Ok(BuildTaskResult::StaleGeneration) => continue,
+                        Err(error) => {
+                            tracing::warn!("Recovery cache build task failed: {error}");
+                            let mut cache_state = self.recovery_cache.lock().await;
+                            if cache_state
+                                .building
+                                .as_ref()
+                                .is_some_and(|inflight| inflight.generation == generation)
+                            {
+                                cache_state.building = None;
+                            }
+                            drop(cache_state);
+                            notify.notify_waiters();
+                            return WorkerKvQueryResponse::TreeDump {
+                                events: Vec::new(),
+                                last_event_id,
+                            };
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn try_reuse_cached_dump(
+        &self,
+        cache_state: &mut RecoveryCacheState,
+        fallback_last_event_id: u64,
+    ) -> CacheReuseDecision {
+        let now = Instant::now();
+        if cache_state
+            .cached
+            .as_ref()
+            .is_some_and(|cached| now.duration_since(cached.last_used_at) > RECOVERY_CACHE_TTL)
+        {
+            cache_state.cached = None;
+        }
+
+        if let Some(cached) = cache_state.cached.clone() {
+            match self.assess_tail_append_safety(cached.last_event_id) {
+                TailAppendSafety::ExactHit => {
+                    let exact = CachedRecoverySnapshot {
+                        last_used_at: now,
+                        ..cached
+                    };
+                    cache_state.cached = Some(exact.clone());
+                    return CacheReuseDecision::ReturnExact(exact);
+                }
+                TailAppendSafety::Safe {
+                    last_event_id,
+                    tail,
+                } => {
+                    let mut events = cached.events.as_ref().clone();
+                    events.extend(tail);
+                    cache_state.cached = Some(CachedRecoverySnapshot {
+                        events: Arc::new(events.clone()),
+                        last_event_id,
+                        last_used_at: now,
+                    });
+                    return CacheReuseDecision::ReturnExtended(WorkerKvQueryResponse::TreeDump {
+                        events,
+                        last_event_id,
+                    });
+                }
+                TailAppendSafety::Invalidate => {
+                    cache_state.cached = None;
+                }
+            }
+        }
+
+        if let Some(build) = cache_state.building.clone() {
+            return CacheReuseDecision::WaitForBuilder(build.notify);
+        }
+
+        let build = InFlightRecoveryBuild {
+            generation: cache_state.generation,
+            notify: Arc::new(Notify::new()),
+        };
+        let last_event_id = self
+            .current_buffer_last_event_id()
+            .unwrap_or(fallback_last_event_id);
+        cache_state.building = Some(build.clone());
+        CacheReuseDecision::BuildFresh {
+            build,
+            last_event_id,
+        }
+    }
+
+    fn assess_tail_append_safety(&self, cached_last_event_id: u64) -> TailAppendSafety {
+        let buffer = self.event_buffer.lock().unwrap();
+        let Some(first_buffered) = buffer.front().map(|event| event.event.event_id) else {
+            return if cached_last_event_id == 0 {
+                TailAppendSafety::ExactHit
+            } else {
+                TailAppendSafety::Invalidate
+            };
+        };
+        let last_buffered = buffer.back().unwrap().event.event_id;
+
+        if last_buffered <= cached_last_event_id {
+            return TailAppendSafety::ExactHit;
+        }
+
+        let next_event_id = cached_last_event_id.saturating_add(1);
+        if next_event_id < first_buffered {
+            return TailAppendSafety::Invalidate;
+        }
+
+        let start_idx =
+            match buffer.binary_search_by_key(&next_event_id, |event| event.event.event_id) {
+                Ok(idx) => idx,
+                Err(insertion_point) => insertion_point,
+            };
+
+        let mut tail = Vec::with_capacity(buffer.len().saturating_sub(start_idx));
+        for event in buffer.iter().skip(start_idx) {
+            match event.event.data {
+                KvCacheEventData::Stored(_) | KvCacheEventData::Removed(_) => {
+                    tail.push(event.clone());
+                }
+                _ => {
+                    return TailAppendSafety::Invalidate;
+                }
+            }
+        }
+
+        TailAppendSafety::Safe {
+            last_event_id: last_buffered,
+            tail,
+        }
+    }
+
+    fn current_buffer_last_event_id(&self) -> Option<u64> {
+        self.event_buffer
+            .lock()
+            .unwrap()
+            .back()
+            .map(|event| event.event.event_id)
+    }
+
+    fn spawn_dump_build(
+        &self,
+        build: InFlightRecoveryBuild,
+        last_event_id: u64,
+    ) -> tokio::task::JoinHandle<BuildTaskResult> {
+        let indexer = self.indexer.clone();
+        let recovery_cache = self.recovery_cache.clone();
+        #[cfg(test)]
+        let build_delay = *self.dump_build_delay.lock().unwrap();
+        #[cfg(test)]
+        self.dump_build_count.fetch_add(1, Ordering::Relaxed);
+
+        tokio::spawn(async move {
+            #[cfg(test)]
+            if let Some(delay) = build_delay {
+                tokio::time::sleep(delay).await;
+            }
+
+            let build_output = Self::build_fresh_dump(indexer, last_event_id).await;
+            let notify = build.notify.clone();
+            let result = {
+                let mut cache_state = recovery_cache.lock().await;
+                let is_current_build = cache_state
+                    .building
+                    .as_ref()
+                    .is_some_and(|inflight| inflight.generation == build.generation);
+                let generation_matches = cache_state.generation == build.generation;
+
+                if is_current_build {
+                    cache_state.building = None;
+                }
+
+                if !is_current_build || !generation_matches {
+                    BuildTaskResult::StaleGeneration
+                } else {
+                    if let Some(snapshot) = build_output.snapshot {
+                        cache_state.cached = Some(snapshot);
+                    }
+                    BuildTaskResult::Response(build_output.response)
+                }
+            };
+
+            notify.notify_waiters();
+            result
+        })
+    }
+
+    async fn build_fresh_dump(indexer: KvIndexer, last_event_id: u64) -> FreshDumpOutput {
+        match indexer.dump_events().await {
+            Ok(events) => FreshDumpOutput {
+                response: WorkerKvQueryResponse::TreeDump {
+                    events: events.clone(),
+                    last_event_id,
+                },
+                snapshot: Some(CachedRecoverySnapshot {
+                    events: Arc::new(events),
+                    last_event_id,
+                    last_used_at: Instant::now(),
+                }),
+            },
+            Err(error) => {
+                tracing::warn!("Failed to build recovery dump: {error}");
+                FreshDumpOutput {
+                    response: WorkerKvQueryResponse::TreeDump {
+                        events: Vec::new(),
+                        last_event_id,
+                    },
+                    snapshot: None,
+                }
+            }
+        }
+    }
+
+    async fn invalidate_recovery_cache(&self) {
+        let mut cache_state = self.recovery_cache.lock().await;
+        cache_state.generation = cache_state.generation.saturating_add(1);
+        cache_state.cached = None;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn dump_build_count(&self) -> usize {
+        self.dump_build_count.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_dump_build_delay(&self, delay: Option<Duration>) {
+        *self.dump_build_delay.lock().unwrap() = delay;
     }
 
     // Delegation methods to underlying KvIndexer

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -2094,6 +2094,52 @@ mod local_indexer_tests {
     use super::*;
     use rstest_reuse::apply;
 
+    fn make_local_store_event(event_id: u64, block_hash: u64) -> RouterEvent {
+        RouterEvent::new(
+            0,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: None,
+                    blocks: vec![KvCacheStoredBlockData {
+                        block_hash: ExternalSequenceBlockHash(block_hash),
+                        tokens_hash: LocalBlockHash(block_hash),
+                        mm_extra_info: None,
+                    }],
+                }),
+                dp_rank: 0,
+            },
+        )
+    }
+
+    fn make_local_remove_event(event_id: u64, block_hashes: &[u64]) -> RouterEvent {
+        RouterEvent::new(
+            0,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Removed(KvCacheRemoveData {
+                    block_hashes: block_hashes
+                        .iter()
+                        .copied()
+                        .map(ExternalSequenceBlockHash)
+                        .collect(),
+                }),
+                dp_rank: 0,
+            },
+        )
+    }
+
+    fn make_local_clear_event(event_id: u64) -> RouterEvent {
+        RouterEvent::new(
+            0,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Cleared,
+                dp_rank: 0,
+            },
+        )
+    }
+
     #[tokio::test]
     async fn test_local_indexer_slice_within_range() {
         let indexer = make_local_indexer_with_events(&[1, 2, 3, 4, 5]);
@@ -2395,6 +2441,220 @@ mod local_indexer_tests {
             }
             other => panic!("Expected TreeDump, got: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_local_indexer_coalesces_concurrent_tree_dumps() {
+        let indexer = Arc::new(LocalKvIndexer::new(
+            CancellationToken::new(),
+            4,
+            Arc::new(KvIndexerMetrics::new_unregistered()),
+            5,
+        ));
+        indexer.set_dump_build_delay(Some(Duration::from_millis(50)));
+
+        let first = {
+            let indexer = indexer.clone();
+            tokio::spawn(async move { indexer.get_events_in_id_range(None, None).await })
+        };
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let second = {
+            let indexer = indexer.clone();
+            tokio::spawn(async move { indexer.get_events_in_id_range(None, None).await })
+        };
+
+        let first = first.await.unwrap();
+        let second = second.await.unwrap();
+
+        assert!(matches!(first, WorkerKvQueryResponse::TreeDump { .. }));
+        assert!(matches!(second, WorkerKvQueryResponse::TreeDump { .. }));
+        assert_eq!(indexer.dump_build_count(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_local_indexer_reuses_cached_tree_dump_within_ttl() {
+        let indexer = LocalKvIndexer::new(
+            CancellationToken::new(),
+            4,
+            Arc::new(KvIndexerMetrics::new_unregistered()),
+            5,
+        );
+        indexer
+            .apply_event_with_buffer(make_local_store_event(1, 101))
+            .await
+            .unwrap();
+        indexer.flush().await;
+
+        let first = indexer.get_events_in_id_range(None, None).await;
+        let second = indexer.get_events_in_id_range(None, None).await;
+
+        assert!(matches!(first, WorkerKvQueryResponse::TreeDump { .. }));
+        assert!(matches!(second, WorkerKvQueryResponse::TreeDump { .. }));
+        assert_eq!(indexer.dump_build_count(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_local_indexer_expires_cached_tree_dump_lazily() {
+        let indexer = LocalKvIndexer::new(
+            CancellationToken::new(),
+            4,
+            Arc::new(KvIndexerMetrics::new_unregistered()),
+            5,
+        );
+        indexer
+            .apply_event_with_buffer(make_local_store_event(1, 101))
+            .await
+            .unwrap();
+        indexer.flush().await;
+
+        let _ = indexer.get_events_in_id_range(None, None).await;
+        assert_eq!(indexer.dump_build_count(), 1);
+
+        time::advance(Duration::from_secs(2)).await;
+        let _ = indexer.get_events_in_id_range(None, None).await;
+        assert_eq!(indexer.dump_build_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_local_indexer_appends_safe_tail_to_cached_dump() {
+        let indexer = LocalKvIndexer::new(
+            CancellationToken::new(),
+            4,
+            Arc::new(KvIndexerMetrics::new_unregistered()),
+            5,
+        );
+        indexer
+            .apply_event_with_buffer(make_local_store_event(1, 101))
+            .await
+            .unwrap();
+        indexer.flush().await;
+
+        let first = indexer.get_events_in_id_range(None, None).await;
+        assert!(matches!(first, WorkerKvQueryResponse::TreeDump { .. }));
+        assert_eq!(indexer.dump_build_count(), 1);
+
+        indexer
+            .apply_event_with_buffer(make_local_remove_event(2, &[101]))
+            .await
+            .unwrap();
+
+        match indexer.get_events_in_id_range(None, None).await {
+            WorkerKvQueryResponse::TreeDump {
+                events,
+                last_event_id,
+            } => {
+                assert_eq!(last_event_id, 2);
+                assert!(events.iter().any(|event| event.event.event_id == 2));
+                assert!(
+                    events
+                        .iter()
+                        .any(|event| matches!(event.event.data, KvCacheEventData::Removed(_)))
+                );
+            }
+            other => panic!("Expected TreeDump, got: {other:?}"),
+        }
+        assert_eq!(indexer.dump_build_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_local_indexer_invalidates_cache_on_clear() {
+        let indexer = LocalKvIndexer::new(
+            CancellationToken::new(),
+            4,
+            Arc::new(KvIndexerMetrics::new_unregistered()),
+            5,
+        );
+        indexer
+            .apply_event_with_buffer(make_local_store_event(1, 101))
+            .await
+            .unwrap();
+        indexer.flush().await;
+
+        let _ = indexer.get_events_in_id_range(None, None).await;
+        assert_eq!(indexer.dump_build_count(), 1);
+
+        indexer
+            .apply_event_with_buffer(make_local_clear_event(2))
+            .await
+            .unwrap();
+
+        let _ = indexer.get_events_in_id_range(None, None).await;
+        assert_eq!(indexer.dump_build_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_local_indexer_invalidates_cache_on_event_gap() {
+        let indexer = LocalKvIndexer::new(
+            CancellationToken::new(),
+            4,
+            Arc::new(KvIndexerMetrics::new_unregistered()),
+            5,
+        );
+        indexer
+            .apply_event_with_buffer(make_local_store_event(1, 101))
+            .await
+            .unwrap();
+        indexer.flush().await;
+
+        let _ = indexer.get_events_in_id_range(None, None).await;
+        assert_eq!(indexer.dump_build_count(), 1);
+
+        indexer
+            .apply_event_with_buffer(make_local_store_event(3, 303))
+            .await
+            .unwrap();
+
+        let _ = indexer.get_events_in_id_range(None, None).await;
+        assert_eq!(indexer.dump_build_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_local_indexer_invalidates_cache_on_missing_tail_coverage() {
+        let indexer = LocalKvIndexer::new(
+            CancellationToken::new(),
+            4,
+            Arc::new(KvIndexerMetrics::new_unregistered()),
+            1,
+        );
+        indexer
+            .apply_event_with_buffer(make_local_store_event(1, 101))
+            .await
+            .unwrap();
+        indexer.flush().await;
+
+        let _ = indexer.get_events_in_id_range(None, None).await;
+        assert_eq!(indexer.dump_build_count(), 1);
+
+        indexer
+            .apply_event_with_buffer(make_local_store_event(2, 202))
+            .await
+            .unwrap();
+        indexer
+            .apply_event_with_buffer(make_local_store_event(3, 303))
+            .await
+            .unwrap();
+
+        let _ = indexer.get_events_in_id_range(None, None).await;
+        assert_eq!(indexer.dump_build_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_local_indexer_failed_dump_is_not_cached() {
+        let indexer = LocalKvIndexer::new(
+            CancellationToken::new(),
+            4,
+            Arc::new(KvIndexerMetrics::new_unregistered()),
+            5,
+        );
+
+        let dump_tx = indexer.snapshot_event_sender();
+        indexer.shutdown();
+        dump_tx.closed().await;
+
+        let _ = indexer.get_events_in_id_range(None, None).await;
+        let _ = indexer.get_events_in_id_range(None, None).await;
+
+        assert_eq!(indexer.dump_build_count(), 2);
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -2485,6 +2485,49 @@ mod local_indexer_tests {
     }
 
     #[tokio::test]
+    async fn test_local_indexer_remove_worker_dp_rank_only_clears_target_rank() {
+        let local_indexer = LocalKvIndexer::new(
+            CancellationToken::new(),
+            4,
+            Arc::new(KvIndexerMetrics::new_unregistered()),
+            5,
+        );
+
+        local_indexer
+            .apply_event_with_buffer(make_store_event_with_dp_rank(7, &[101], 0))
+            .await
+            .unwrap();
+        local_indexer
+            .apply_event_with_buffer(make_store_event_with_dp_rank(7, &[202], 1))
+            .await
+            .unwrap();
+        local_indexer.flush().await;
+
+        local_indexer.remove_worker_dp_rank(7, 0).await;
+        local_indexer.flush().await;
+
+        let events = local_indexer.dump_events().await.unwrap();
+        let mut rank0 = events
+            .iter()
+            .filter(|event| event.worker_id == 7 && event.event.dp_rank == 0)
+            .collect::<Vec<_>>();
+        let mut rank1 = events
+            .iter()
+            .filter(|event| event.worker_id == 7 && event.event.dp_rank == 1)
+            .collect::<Vec<_>>();
+        rank0.sort_by_key(|event| event.event.event_id);
+        rank1.sort_by_key(|event| event.event.event_id);
+
+        assert!(rank0.is_empty());
+        assert_eq!(rank1.len(), 1);
+        assert!(matches!(
+            &rank1[0].event.data,
+            KvCacheEventData::Stored(data)
+                if data.blocks.first().map(|block| block.block_hash.0) == Some(202)
+        ));
+    }
+
+    #[tokio::test]
     async fn test_local_indexer_coalesces_concurrent_tree_dumps() {
         let indexer = Arc::new(LocalKvIndexer::new(
             CancellationToken::new(),

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -2513,7 +2513,7 @@ mod local_indexer_tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_local_indexer_reuses_cached_tree_dump_within_ttl() {
+    async fn test_local_indexer_reuses_cached_tree_dump_without_time_expiry() {
         let indexer = LocalKvIndexer::new(
             CancellationToken::new(),
             4,
@@ -2527,6 +2527,7 @@ mod local_indexer_tests {
         indexer.flush().await;
 
         let first = indexer.get_events_in_id_range(None, None).await;
+        time::advance(Duration::from_secs(60)).await;
         let second = indexer.get_events_in_id_range(None, None).await;
 
         assert!(matches!(first, WorkerKvQueryResponse::TreeDump { .. }));
@@ -2534,8 +2535,8 @@ mod local_indexer_tests {
         assert_eq!(indexer.dump_build_count(), 1);
     }
 
-    #[tokio::test(start_paused = true)]
-    async fn test_local_indexer_expires_cached_tree_dump_lazily() {
+    #[tokio::test]
+    async fn test_local_indexer_rebuilds_when_cumulative_append_budget_exceeded() {
         let indexer = LocalKvIndexer::new(
             CancellationToken::new(),
             4,
@@ -2551,7 +2552,24 @@ mod local_indexer_tests {
         let _ = indexer.get_events_in_id_range(None, None).await;
         assert_eq!(indexer.dump_build_count(), 1);
 
-        time::advance(Duration::from_secs(2)).await;
+        indexer
+            .apply_event_with_buffer(make_local_store_event(2, 202))
+            .await
+            .unwrap();
+        let _ = indexer.get_events_in_id_range(None, None).await;
+        assert_eq!(indexer.dump_build_count(), 1);
+
+        indexer
+            .apply_event_with_buffer(make_local_store_event(3, 303))
+            .await
+            .unwrap();
+        let _ = indexer.get_events_in_id_range(None, None).await;
+        assert_eq!(indexer.dump_build_count(), 1);
+
+        indexer
+            .apply_event_with_buffer(make_local_store_event(4, 404))
+            .await
+            .unwrap();
         let _ = indexer.get_events_in_id_range(None, None).await;
         assert_eq!(indexer.dump_build_count(), 2);
     }

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -2147,9 +2147,17 @@ mod local_indexer_tests {
         // Helper to extract events from response
         let extract_events = |resp: WorkerKvQueryResponse| -> Vec<RouterEvent> {
             match resp {
-                WorkerKvQueryResponse::Events(e) => e,
+                WorkerKvQueryResponse::Events { events: e, .. } => e,
                 WorkerKvQueryResponse::TreeDump { events: e, .. } => e,
                 _ => panic!("Unexpected response type"),
+            }
+        };
+
+        let extract_last_event_id = |resp: &WorkerKvQueryResponse| -> Option<u64> {
+            match resp {
+                WorkerKvQueryResponse::Events { last_event_id, .. } => Some(*last_event_id),
+                WorkerKvQueryResponse::TreeDump { last_event_id, .. } => Some(*last_event_id),
+                _ => None,
             }
         };
 
@@ -2158,22 +2166,25 @@ mod local_indexer_tests {
         };
 
         // Test get_events_in_id_range (buffer queries)
-        // Range is [start, end] inclusive
+        // Buffer hits now return the contiguous suffix through the buffered tail.
         let result = indexer.get_events_in_id_range(Some(2), Some(4)).await;
-        let ids = get_ids(extract_events(result));
-        assert_eq!(ids, vec![2, 3, 4]); // inclusive range [2, 4]
+        let ids = get_ids(extract_events(result.clone()));
+        assert_eq!(ids, vec![2, 3, 4, 5]);
+        assert_eq!(extract_last_event_id(&result), Some(5));
 
         let result = indexer.get_events_in_id_range(Some(2), Some(6)).await;
-        let ids = get_ids(extract_events(result));
+        let ids = get_ids(extract_events(result.clone()));
         assert_eq!(ids, vec![2, 3, 4, 5]); // clamp end to buffer max
+        assert_eq!(extract_last_event_id(&result), Some(5));
 
         // start_id=0 is before buffer (first is 1), so should trigger tree dump
         let result = indexer.get_events_in_id_range(Some(0), Some(4)).await;
         assert!(matches!(result, WorkerKvQueryResponse::TreeDump { .. }));
 
         let result = indexer.get_events_in_id_range(Some(3), Some(3)).await;
-        let ids = get_ids(extract_events(result));
-        assert_eq!(ids, vec![3]); // single element when start == end
+        let ids = get_ids(extract_events(result.clone()));
+        assert_eq!(ids, vec![3, 4, 5]);
+        assert_eq!(extract_last_event_id(&result), Some(5));
 
         // Invalid range: end < start
         let result = indexer.get_events_in_id_range(Some(5), Some(2)).await;
@@ -2222,9 +2233,17 @@ mod local_indexer_tests {
 
         let extract_events = |resp: WorkerKvQueryResponse| -> Vec<RouterEvent> {
             match resp {
-                WorkerKvQueryResponse::Events(e) => e,
+                WorkerKvQueryResponse::Events { events: e, .. } => e,
                 WorkerKvQueryResponse::TreeDump { events: e, .. } => e,
                 _ => panic!("Unexpected response type: {:?}", resp),
+            }
+        };
+
+        let extract_last_event_id = |resp: &WorkerKvQueryResponse| -> Option<u64> {
+            match resp {
+                WorkerKvQueryResponse::Events { last_event_id, .. } => Some(*last_event_id),
+                WorkerKvQueryResponse::TreeDump { last_event_id, .. } => Some(*last_event_id),
+                _ => None,
             }
         };
 
@@ -2238,10 +2257,25 @@ mod local_indexer_tests {
 
         // Buffer path tests
         let result = indexer.get_events_in_id_range(Some(11), None).await;
-        assert_eq!(get_ids(extract_events(result)), vec![11, 12, 13, 14]);
+        assert_eq!(
+            get_ids(extract_events(result.clone())),
+            vec![11, 12, 13, 14]
+        );
+        assert_eq!(extract_last_event_id(&result), Some(14));
 
         let result = indexer.get_events_in_id_range(Some(10), Some(14)).await;
-        assert_eq!(get_ids(extract_events(result)), vec![10, 11, 12, 13, 14]);
+        assert_eq!(
+            get_ids(extract_events(result.clone())),
+            vec![10, 11, 12, 13, 14]
+        );
+        assert_eq!(extract_last_event_id(&result), Some(14));
+
+        let result = indexer.get_events_in_id_range(Some(11), Some(12)).await;
+        assert_eq!(
+            get_ids(extract_events(result.clone())),
+            vec![11, 12, 13, 14]
+        );
+        assert_eq!(extract_last_event_id(&result), Some(14));
 
         // Tree dump path tests
         let result = indexer.get_events_in_id_range(None, None).await;
@@ -2386,16 +2420,23 @@ mod local_indexer_tests {
         assert_eq!(buffered_events[0].worker_id, worker_id);
 
         // Test serialization round-trip
-        let response = WorkerKvQueryResponse::Events(buffered_events);
+        let response = WorkerKvQueryResponse::Events {
+            events: buffered_events,
+            last_event_id: 1,
+        };
         let serialized = serde_json::to_vec(&response).unwrap();
         let deserialized: WorkerKvQueryResponse = serde_json::from_slice(&serialized).unwrap();
 
-        let events = match deserialized {
-            WorkerKvQueryResponse::Events(e) => e,
+        let (events, last_event_id) = match deserialized {
+            WorkerKvQueryResponse::Events {
+                events,
+                last_event_id,
+            } => (events, last_event_id),
             _ => panic!("Expected Events variant"),
         };
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].worker_id, worker_id);
+        assert_eq!(last_event_id, 1);
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -47,15 +47,23 @@ pub struct WorkerKvQueryRequest {
 
     /// Start event ID (inclusive). If `None`, dumps entire tree.
     pub start_event_id: Option<u64>,
-    /// End event ID (inclusive). If `None`, returns up to newest available.
+    /// End event ID (inclusive). Used for validation and `TooNew` responses.
+    /// Successful buffer-backed recovery may still return through the current
+    /// newest buffered event.
     pub end_event_id: Option<u64>,
 }
 
 /// Response from a worker's local KV indexer.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum WorkerKvQueryResponse {
-    /// Events served from the circular buffer (with original event IDs)
-    Events(Vec<RouterEvent>),
+    /// Events served from the circular buffer (with original event IDs),
+    /// always covering the requested `start_event_id` through the current
+    /// buffered tail. `last_event_id` is taken from the same buffer snapshot
+    /// and should be used as the recovery watermark after applying the batch.
+    Events {
+        events: Vec<RouterEvent>,
+        last_event_id: u64,
+    },
     /// Full tree dump (with synthetic 0-indexed event IDs).
     /// Includes `last_event_id`: the newest real event ID in the worker's buffer
     /// at the time of the dump, so the caller can set its tracking cursor correctly.

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -11,7 +11,8 @@ use dynamo_kv_router::{
     config::KvRouterConfig,
     indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics, KvRouterError},
     protocols::{
-        LocalBlockHash, OverlapScores, RouterEvent, TokensWithHashes, WorkerId, WorkerWithDpRank,
+        DpRank, LocalBlockHash, OverlapScores, RouterEvent, TokensWithHashes, WorkerId,
+        WorkerWithDpRank,
     },
 };
 use dynamo_runtime::{component::Component, traits::DistributedRuntimeProvider};
@@ -202,6 +203,18 @@ impl Indexer {
             }
             Self::Concurrent(tpi) => {
                 KvIndexerInterface::remove_worker(tpi.as_ref(), worker_id).await;
+            }
+            Self::Remote(_) | Self::None => {}
+        }
+    }
+
+    pub(crate) async fn remove_worker_dp_rank(&self, worker_id: WorkerId, dp_rank: DpRank) {
+        match self {
+            Self::KvIndexer(indexer) => {
+                KvIndexerInterface::remove_worker_dp_rank(indexer, worker_id, dp_rank).await;
+            }
+            Self::Concurrent(tpi) => {
+                KvIndexerInterface::remove_worker_dp_rank(tpi.as_ref(), worker_id, dp_rank).await;
             }
             Self::Remote(_) | Self::None => {}
         }

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -1125,6 +1125,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_initial_restore_tree_dump_with_safe_tail_advances_cursor() {
+        let (client, transport, kv_indexer) = make_test_client("initial-restore-safe-tail").await;
+        let key = (1, 0);
+
+        transport.push_action(
+            key,
+            MockQueryAction {
+                started: None,
+                release: None,
+                response: Ok(WorkerKvQueryResponse::TreeDump {
+                    events: vec![make_store_event(1, 0, 0), make_store_event(1, 0, 11)],
+                    last_event_id: 11,
+                }),
+            },
+        );
+
+        client.handle_discovered_worker(1, 0).await;
+        wait_for(|| {
+            rank_state_matches(&client, key, |state| {
+                state.last_applied_id() == Some(11) && !state.recovery_inflight
+            })
+        })
+        .await;
+
+        kv_indexer.flush().await;
+        let events = kv_indexer.dump_events().await.unwrap();
+        assert_eq!(stored_block_hashes(&events), vec![0, 11]);
+        assert_eq!(transport.call_count(), 1);
+    }
+
+    #[tokio::test]
     async fn test_live_event_for_other_worker_is_not_blocked_by_inflight_recovery() {
         let (client, transport, kv_indexer) = make_test_client("live-concurrency").await;
 

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -352,6 +352,18 @@ impl WorkerQueryClient {
         self.indexer.apply_event(event).await;
     }
 
+    async fn apply_tree_dump_replace_locked(
+        &self,
+        worker_id: WorkerId,
+        dp_rank: DpRank,
+        events: Vec<RouterEvent>,
+    ) {
+        self.indexer.remove_worker_dp_rank(worker_id, dp_rank).await;
+        for event in events {
+            self.indexer.apply_event(event).await;
+        }
+    }
+
     pub(crate) async fn handle_live_event(self: &Arc<Self>, event: RouterEvent) {
         let worker_id = event.worker_id;
         let dp_rank = event.event.dp_rank;
@@ -522,9 +534,8 @@ impl WorkerQueryClient {
                     events.len(),
                     last_event_id
                 );
-                for event in events {
-                    self.indexer.apply_event(event).await;
-                }
+                self.apply_tree_dump_replace_locked(key.0, key.1, events)
+                    .await;
                 new_cursor = new_cursor.advance_to(last_event_id);
                 successful_response = true;
             }
@@ -893,6 +904,25 @@ mod tests {
         hashes
     }
 
+    fn stored_block_hashes_for(
+        events: &[RouterEvent],
+        worker_id: WorkerId,
+        dp_rank: DpRank,
+    ) -> Vec<u64> {
+        let mut hashes = events
+            .iter()
+            .filter(|event| event.worker_id == worker_id && event.event.dp_rank == dp_rank)
+            .filter_map(|event| match &event.event.data {
+                KvCacheEventData::Stored(data) => {
+                    data.blocks.first().map(|block| block.block_hash.0)
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        hashes.sort_unstable();
+        hashes
+    }
+
     async fn wait_for<F>(mut check: F)
     where
         F: FnMut() -> bool,
@@ -1163,6 +1193,110 @@ mod tests {
         let events = kv_indexer.dump_events().await.unwrap();
         assert_eq!(stored_block_hashes(&events), vec![0, 11]);
         assert_eq!(transport.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_tree_dump_replaces_stale_state_for_recovered_rank() {
+        let (client, transport, kv_indexer) = make_test_client("tree-dump-replaces-rank").await;
+        let key = (1, 0);
+
+        kv_indexer.apply_event(make_store_event(1, 0, 90)).await;
+        kv_indexer.apply_event(make_store_event(1, 0, 91)).await;
+        kv_indexer.flush().await;
+
+        transport.push_action(
+            key,
+            MockQueryAction {
+                started: None,
+                release: None,
+                response: Ok(WorkerKvQueryResponse::TreeDump {
+                    events: vec![make_store_event(1, 0, 11)],
+                    last_event_id: 11,
+                }),
+            },
+        );
+
+        client.handle_discovered_worker(1, 0).await;
+        wait_for(|| {
+            rank_state_matches(&client, key, |state| {
+                state.last_applied_id() == Some(11) && !state.recovery_inflight
+            })
+        })
+        .await;
+
+        kv_indexer.flush().await;
+        let events = kv_indexer.dump_events().await.unwrap();
+        assert_eq!(stored_block_hashes_for(&events, 1, 0), vec![11]);
+    }
+
+    #[tokio::test]
+    async fn test_tree_dump_recovery_does_not_clear_other_dp_ranks() {
+        let (client, transport, kv_indexer) = make_test_client("tree-dump-preserves-sibling").await;
+        let key = (1, 0);
+
+        kv_indexer.apply_event(make_store_event(1, 0, 90)).await;
+        kv_indexer.apply_event(make_store_event(1, 1, 77)).await;
+        kv_indexer.flush().await;
+
+        transport.push_action(
+            key,
+            MockQueryAction {
+                started: None,
+                release: None,
+                response: Ok(WorkerKvQueryResponse::TreeDump {
+                    events: vec![make_store_event(1, 0, 11)],
+                    last_event_id: 11,
+                }),
+            },
+        );
+
+        client.handle_discovered_worker(1, 0).await;
+        wait_for(|| {
+            rank_state_matches(&client, key, |state| {
+                state.last_applied_id() == Some(11) && !state.recovery_inflight
+            })
+        })
+        .await;
+
+        kv_indexer.flush().await;
+        let events = kv_indexer.dump_events().await.unwrap();
+        assert_eq!(stored_block_hashes_for(&events, 1, 0), vec![11]);
+        assert_eq!(stored_block_hashes_for(&events, 1, 1), vec![77]);
+    }
+
+    #[tokio::test]
+    async fn test_empty_tree_dump_clears_only_recovered_rank() {
+        let (client, transport, kv_indexer) = make_test_client("tree-dump-empty-clears-rank").await;
+        let key = (1, 0);
+
+        kv_indexer.apply_event(make_store_event(1, 0, 90)).await;
+        kv_indexer.apply_event(make_store_event(1, 1, 77)).await;
+        kv_indexer.flush().await;
+
+        transport.push_action(
+            key,
+            MockQueryAction {
+                started: None,
+                release: None,
+                response: Ok(WorkerKvQueryResponse::TreeDump {
+                    events: vec![],
+                    last_event_id: 11,
+                }),
+            },
+        );
+
+        client.handle_discovered_worker(1, 0).await;
+        wait_for(|| {
+            rank_state_matches(&client, key, |state| {
+                state.last_applied_id() == Some(11) && !state.recovery_inflight
+            })
+        })
+        .await;
+
+        kv_indexer.flush().await;
+        let events = kv_indexer.dump_events().await.unwrap();
+        assert!(stored_block_hashes_for(&events, 1, 0).is_empty());
+        assert_eq!(stored_block_hashes_for(&events, 1, 1), vec![77]);
     }
 
     #[tokio::test]

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -486,7 +486,10 @@ impl WorkerQueryClient {
         let mut saw_clear = false;
 
         match result {
-            Ok(WorkerKvQueryResponse::Events(events)) => {
+            Ok(WorkerKvQueryResponse::Events {
+                events,
+                last_event_id,
+            }) => {
                 tracing::debug!(
                     "Got {count} buffered events from worker {} dp_rank {}",
                     key.0,
@@ -505,6 +508,7 @@ impl WorkerQueryClient {
                     self.indexer.apply_event(event).await;
                     new_cursor = new_cursor.advance_to(event_id);
                 }
+                new_cursor = new_cursor.advance_to(last_event_id);
                 successful_response = true;
             }
             Ok(WorkerKvQueryResponse::TreeDump {
@@ -958,9 +962,13 @@ mod tests {
             .expect("response stream should yield one item");
 
         match response {
-            WorkerKvQueryResponse::Events(events) => {
+            WorkerKvQueryResponse::Events {
+                events,
+                last_event_id,
+            } => {
                 assert_eq!(events.len(), 1);
                 assert_eq!(events[0].event.event_id, 1);
+                assert_eq!(last_event_id, 1);
             }
             other => panic!("Unexpected response: {other:?}"),
         }
@@ -1022,9 +1030,10 @@ mod tests {
             MockQueryAction {
                 started: Some(first_started.clone()),
                 release: Some(first_release.clone()),
-                response: Ok(WorkerKvQueryResponse::Events(
-                    (11..=15).map(|id| make_store_event(1, 0, id)).collect(),
-                )),
+                response: Ok(WorkerKvQueryResponse::Events {
+                    events: (11..=15).map(|id| make_store_event(1, 0, id)).collect(),
+                    last_event_id: 15,
+                }),
             },
         );
         transport.push_action(
@@ -1032,9 +1041,10 @@ mod tests {
             MockQueryAction {
                 started: None,
                 release: None,
-                response: Ok(WorkerKvQueryResponse::Events(
-                    (16..=18).map(|id| make_store_event(1, 0, id)).collect(),
-                )),
+                response: Ok(WorkerKvQueryResponse::Events {
+                    events: (16..=18).map(|id| make_store_event(1, 0, id)).collect(),
+                    last_event_id: 18,
+                }),
             },
         );
 
@@ -1085,10 +1095,10 @@ mod tests {
             MockQueryAction {
                 started: None,
                 release: None,
-                response: Ok(WorkerKvQueryResponse::Events(vec![
-                    make_store_event(1, 0, 12),
-                    make_store_event(1, 0, 13),
-                ])),
+                response: Ok(WorkerKvQueryResponse::Events {
+                    events: vec![make_store_event(1, 0, 12), make_store_event(1, 0, 13)],
+                    last_event_id: 13,
+                }),
             },
         );
 
@@ -1179,11 +1189,14 @@ mod tests {
             MockQueryAction {
                 started: Some(started.clone()),
                 release: Some(release.clone()),
-                response: Ok(WorkerKvQueryResponse::Events(vec![
-                    make_store_event(1, 0, 11),
-                    make_store_event(1, 0, 12),
-                    make_store_event(1, 0, 13),
-                ])),
+                response: Ok(WorkerKvQueryResponse::Events {
+                    events: vec![
+                        make_store_event(1, 0, 11),
+                        make_store_event(1, 0, 12),
+                        make_store_event(1, 0, 13),
+                    ],
+                    last_event_id: 13,
+                }),
             },
         );
 
@@ -1224,10 +1237,10 @@ mod tests {
             MockQueryAction {
                 started: Some(started.clone()),
                 release: Some(release.clone()),
-                response: Ok(WorkerKvQueryResponse::Events(vec![
-                    make_store_event(1, 0, 11),
-                    make_store_event(1, 0, 12),
-                ])),
+                response: Ok(WorkerKvQueryResponse::Events {
+                    events: vec![make_store_event(1, 0, 11), make_store_event(1, 0, 12)],
+                    last_event_id: 12,
+                }),
             },
         );
 
@@ -1262,11 +1275,14 @@ mod tests {
             MockQueryAction {
                 started: Some(started.clone()),
                 release: Some(release.clone()),
-                response: Ok(WorkerKvQueryResponse::Events(vec![
-                    make_store_event(1, 0, 11),
-                    make_store_event(1, 0, 12),
-                    make_store_event(1, 0, 13),
-                ])),
+                response: Ok(WorkerKvQueryResponse::Events {
+                    events: vec![
+                        make_store_event(1, 0, 11),
+                        make_store_event(1, 0, 12),
+                        make_store_event(1, 0, 13),
+                    ],
+                    last_event_id: 13,
+                }),
             },
         );
         client.handle_live_event(make_store_event(1, 0, 13)).await;
@@ -1316,11 +1332,14 @@ mod tests {
             MockQueryAction {
                 started: None,
                 release: None,
-                response: Ok(WorkerKvQueryResponse::Events(vec![
-                    make_store_event(1, 0, 11),
-                    make_clear_event(1, 0, 12),
-                    make_store_event(1, 0, 13),
-                ])),
+                response: Ok(WorkerKvQueryResponse::Events {
+                    events: vec![
+                        make_store_event(1, 0, 11),
+                        make_clear_event(1, 0, 12),
+                        make_store_event(1, 0, 13),
+                    ],
+                    last_event_id: 13,
+                }),
             },
         );
 

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -502,7 +502,9 @@ mod tests_startup_helpers {
     use super::*;
     use crate::utils::zmq::{bind_pub_socket, send_multipart};
     use bytes::Bytes;
-    use dynamo_kv_router::indexer::{GetWorkersRequest, KvIndexer, KvIndexerInterface};
+    use dynamo_kv_router::indexer::{
+        GetWorkersRequest, KvIndexer, KvIndexerInterface, WorkerKvQueryResponse,
+    };
     use dynamo_kv_router::protocols::{ExternalSequenceBlockHash, LocalBlockHash};
     use std::sync::{Arc, Mutex};
 
@@ -1152,8 +1154,12 @@ mod tests_startup_helpers {
         );
 
         // assert: Worker's local indexer buffered event
-        let buffered = local_indexer_1.get_all_events_in_buffer();
-        assert_eq!(buffered.len(), 1, "Local indexer should buffer 1 event");
+        match local_indexer_1.get_events_in_id_range(Some(1), None).await {
+            WorkerKvQueryResponse::Events { events, .. } => {
+                assert_eq!(events.len(), 1, "Local indexer should buffer 1 event");
+            }
+            other => panic!("Expected buffered events, got {other:?}"),
+        }
 
         // === STEP 2 & 3: Simulate Outage - Stop forwarding to router ===
         let event_2 = KvCacheEvent {
@@ -1192,12 +1198,16 @@ mod tests_startup_helpers {
         }
 
         // assert: Worker's local indexer has both events
-        let buffered = local_indexer_1.get_all_events_in_buffer();
-        assert_eq!(
-            buffered.len(),
-            2,
-            "Local indexer should have both events during outage"
-        );
+        match local_indexer_1.get_events_in_id_range(Some(1), None).await {
+            WorkerKvQueryResponse::Events { events, .. } => {
+                assert_eq!(
+                    events.len(),
+                    2,
+                    "Local indexer should have both events during outage"
+                );
+            }
+            other => panic!("Expected buffered events, got {other:?}"),
+        }
 
         // assert: Router DOESN'T have event_2
         let block_hashes_2 = vec![LocalBlockHash(200), LocalBlockHash(202)];

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -1223,7 +1223,7 @@ mod tests_startup_helpers {
             .get_events_in_id_range(Some(last_known_id + 1), None)
             .await;
         let missed_events = match response {
-            dynamo_kv_router::indexer::WorkerKvQueryResponse::Events(e) => e,
+            dynamo_kv_router::indexer::WorkerKvQueryResponse::Events { events: e, .. } => e,
             dynamo_kv_router::indexer::WorkerKvQueryResponse::TreeDump { events: e, .. } => e,
             dynamo_kv_router::indexer::WorkerKvQueryResponse::Error(message) => {
                 panic!("Unexpected error response: {message}")


### PR DESCRIPTION
This PR improves worker recovery efficiency in two major ways.

## 1. Align buffered recovery with tree-dump semantics
- Buffer-backed recovery responses now return `Events { events, last_event_id }`.
- Once the requested `start_id` is covered by the local circular buffer, the worker returns the contiguous suffix from that `start_id` through the current buffered tail, rather than slicing exactly to the requested `end_id`.
- The buffered `events` and `last_event_id` are derived from the same buffer snapshot, so the router can apply the batch and then advance to the outer recovery watermark, similar to `TreeDump`.
- This removes the extra end-bound binary search on the worker and makes buffered recovery batches more efficient and more uniform with snapshot recovery.

## 2. Add append-only tree-dump reuse on the worker
- `LocalKvIndexer` now keeps a recovery snapshot cache for dump-heavy requests.
- Concurrent dump-needed callers coalesce behind a single in-flight build instead of repeatedly walking the tree.
- Later callers can either reuse the exact cached dump or extend it with a safe buffered tail (`Stored` / `Removed`) and return one `TreeDump { events, last_event_id }` without rebuilding from scratch.
- There is no time-based TTL anymore. Exact reuse stays valid until the cache is invalidated by events or by the append budget.
- Append reuse is bounded by cumulative event distance from the base snapshot: once the cached dump has been extended by more than half the circular buffer, the worker rebuilds from the tree instead of extending it indefinitely.
- Cache reuse remains conservative: it invalidates on `Cleared`, event-id gaps, or missing buffered tail coverage.

## Flow

```mermaid
flowchart TD
    Q["Recovery query enters LocalKvIndexer"] --> C{"Immediate buffer response?"}
    C -- "Yes" --> R1["Return Events { events, last_event_id } / TooNew / InvalidRange"]
    C -- "No, dump required" --> L["Lock RecoverySnapshotCache state"]
    L --> H{"Cached snapshot available?"}
    H -- "No" --> B["Start single-flight dump build"]
    H -- "Yes" --> T{"Can reuse cache?"}
    T -- "Exact hit" --> R2["Return cached TreeDump"]
    T -- "Safe tail within append budget" --> A["Append tail, refresh cache, return TreeDump"]
    T -- "Invalidated or budget exceeded" --> B
    H -- "Builder exists" --> W["Wait for in-flight build, then retry cache lookup"]
    B --> J["Builder awaits dump result"]
    W --> L
    J --> S{"Build succeeded?"}
    S -- "Yes" --> P["Publish cache, notify waiters, return TreeDump"]
    S -- "No" --> F["Do not cache failure, notify waiters, return fallback/error"]
```
