### PR TITLE
fix: ensure flashinfer_cubin directory is group-writable for non-root containers (#7849)

### DIFF
--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -228,6 +228,7 @@ COPY --chmod=775 --chown=dynamo:0 --from=framework ${SITE_PACKAGES}/vllm_omni ${
 COPY --chmod=775 --chown=dynamo:0 --from=framework ${SITE_PACKAGES}/triton ${SITE_PACKAGES}/triton
 {% if device == "cuda" %}
 COPY --chmod=775 --chown=dynamo:0 --from=framework ${SITE_PACKAGES}/flashinfer_cubin ${SITE_PACKAGES}/flashinfer_cubin
+RUN chmod -R 775 ${SITE_PACKAGES}/flashinfer_cubin
 {% endif %}
 # Remaining packages and venv structure (bin/, include/, share/, etc.)
 COPY --chmod=775 --chown=dynamo:0 --from=framework \


### PR DESCRIPTION
## Problem
Non-root users in OpenShift containers cannot write to `flashinfer_cubin` directory at runtime because `COPY --chmod=775` only affects file permissions, not the directory itself.

## Solution
Add explicit `chmod -R 775` after COPY to ensure the directory and all contents are group-writable.

## Files Changed
- `container/templates/vllm_runtime.Dockerfile`: Add chmod -R 775 for flashinfer_cubin

## Impact
- Enables non-root container deployments (OpenShift compatibility)
- No behavioral change for existing deployments
- Single-line fix with zero risk

Fixes #7849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved permission issues for CUDA runtime components in container builds to ensure proper accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->