### PR TITLE
feat(mocker): integrate kvbm-engine for vllm G2 offload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,11 @@ dependencies = [
  "derive_builder",
  "dynamo-kv-router",
  "dynamo-tokens",
+ "futures",
  "indicatif 0.18.4",
+ "kvbm-engine",
+ "kvbm-logical",
+ "kvbm-physical",
  "ndarray 0.16.1",
  "ndarray-interp",
  "ndarray-npy",
@@ -2526,6 +2530,7 @@ dependencies = [
  "tracing",
  "uuid",
  "validator",
+ "velo",
 ]
 
 [[package]]

--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -484,6 +484,26 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "using: num_layers * 2 * num_kv_heads * head_dim * dtype_bytes.",
     )
 
+    # ── KVBM G1↔G2 offload ────────────────────────────────────────
+    parser.add_argument(
+        "--num-g2-blocks",
+        type=int,
+        default=0,
+        help="Number of G2 (host-memory) blocks for KVBM offload. 0 = disabled.",
+    )
+    parser.add_argument(
+        "--kvbm-offload-batch-size",
+        type=int,
+        default=32,
+        help="Max blocks per offload batch in the G1→G2 pipeline.",
+    )
+    parser.add_argument(
+        "--kvbm-bandwidth-g1-g2",
+        type=float,
+        default=14.0,
+        help="Simulated G1↔G2 bandwidth in GB/s (default: 14.0, PCIe Gen4 x16).",
+    )
+
     parser.add_argument(
         "--stagger-delay",
         type=float,

--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -95,6 +95,9 @@ def build_mocker_engine_args(args: argparse.Namespace) -> MockEngineArgs:
         reasoning=_parse_reasoning_config(getattr(args, "reasoning", None)),
         sglang=_build_sglang_args(args),
         preemption_mode=getattr(args, "preemption_mode", "lifo"),
+        num_g2_blocks=getattr(args, "num_g2_blocks", 0),
+        kvbm_offload_batch_size=getattr(args, "kvbm_offload_batch_size", 32),
+        kvbm_bandwidth_g1_g2=getattr(args, "kvbm_bandwidth_g1_g2", 14.0),
     )
 
 

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -226,6 +226,9 @@ def test_build_mocker_engine_args_preserves_cli_mapped_fields(tmp_path):
         "zmq_replay_port": None,
         "preemption_mode": "fifo",
         "router_queue_policy": None,
+        "num_g2_blocks": 0,
+        "kvbm_offload_batch_size": 32,
+        "kvbm_bandwidth_g1_g2": 14.0,
         "sglang": {
             "schedule_policy": "lpm",
             "page_size": 128,

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -228,7 +228,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-util",
  "tokio-websockets",
@@ -354,6 +354,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-config"
+version = "1.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26bbf46abc608f2dc61fd6cb3b7b0665497cc259a21520151ed98f8b37d2c79"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +418,384 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f92058d22a46adf53ec57a6a96f34447daf02bff52e8fb956c66bcd5c6ac12"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.123.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c018f22146966fdd493a664f62ee2483dff256b42a08c125ab6a084bde7b77fe"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "lru 0.16.3",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.94.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699da1961a289b23842d88fe2984c6ff68735fdf9bdcbc69ceaeb2491c9bf434"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e3a4cb3b124833eafea9afd1a6cc5f8ddf3efefffc6651ef76a03cbc6b4981"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c4f19655ab0856375e169865c91264de965bd74c407c7f1e403184b1049409"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f6ae9b71597dc5fd115d52849d7a5556ad9265885ad3492ea8d73b93bbc46e"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint 0.5.5",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "p256",
+ "percent-encoding",
+ "ring",
+ "sha2",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cba48474f1d6807384d06fec085b909f5807e16653c5af5c45dfe89539f0b70"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.64.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a764fa7222922f6c0af8eea478b0ef1ba5ce1222af97e01f33ca5e957bd7f3b9"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c0b3e587fbaa5d7f7e870544508af8ce82ea47cd30376e69e1e37c4ac746f79"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4a8a5fe3e4ac7ee871237c340bbce13e982d37543b65700f4419e039f5d78e"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0709f0083aa19b704132684bc26d3c868e06bd428ccc4373b0b55c3e8748a58b"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.9.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.37",
+ "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b3a779093e18cad88bbae08dc4261e1d95018c4c5b9356a52bcae7c0b6e9bb"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f76a580e3d8f8961e5d48763214025a2af65c2fa4cd1fb7f270a0e107a71b0"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd3dfc18c1ce097cf81fced7192731e63809829c6cbf933c1ec47452d08e1aa"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c55e0837e9b8526f49e0b9bfa9ee18ddee70e853f5bc09c5d11ebceddcb0fec"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576b0d6991c9c32bc14fc340582ef148311f924d41815f641a308b5d11e8e7cd"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c50f3cdf47caa8d01f2be4a6663ea02418e892f9bbfd82c7b9a3a37eaccdd3a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,10 +806,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -418,8 +838,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -449,16 +869,16 @@ dependencies = [
  "arc-swap",
  "bytes",
  "fs-err",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -474,6 +894,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +910,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -720,6 +1156,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
 ]
 
 [[package]]
@@ -1033,6 +1479,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc-fast"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+dependencies = [
+ "crc",
+ "digest",
+ "rustversion",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1575,28 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "crypto-common"
@@ -1295,6 +1790,16 @@ checksum = "aafbece59594ed57696a1a69e8bb3ca1683fbc9cdb41d5c02726070b2cd8f19d"
 
 [[package]]
 name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
@@ -1429,6 +1934,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1606,7 +2112,7 @@ dependencies = [
  "reqwest",
  "rmp-serde",
  "rustc-hash 1.1.0",
- "rustls",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "strum",
@@ -1658,7 +2164,11 @@ dependencies = [
  "derive_builder",
  "dynamo-kv-router",
  "dynamo-tokens",
+ "futures",
  "indicatif 0.18.4",
+ "kvbm-engine",
+ "kvbm-logical",
+ "kvbm-physical",
  "ndarray",
  "ndarray-interp",
  "ndarray-npy",
@@ -1673,6 +2183,7 @@ dependencies = [
  "tracing",
  "uuid",
  "validator",
+ "velo",
 ]
 
 [[package]]
@@ -1770,7 +2281,7 @@ dependencies = [
  "libc",
  "local-ip-address",
  "log",
- "lru",
+ "lru 0.12.5",
  "notify",
  "nuid",
  "once_cell",
@@ -1820,12 +2331,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 1.6.4",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1837,7 +2360,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "sha2",
- "signature",
+ "signature 2.2.0",
  "subtle",
 ]
 
@@ -1860,6 +2383,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1959,7 +2502,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8acfe553027cd07fc5fafa81a84f19a7a87eaffaccd2162b6db05e8d6ce98084"
 dependencies = [
- "http",
+ "http 1.4.0",
  "prost 0.14.3",
  "tokio",
  "tokio-stream",
@@ -2087,6 +2630,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "ffmpeg-next"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,7 +2730,7 @@ dependencies = [
  "fastrand",
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2191,6 +2744,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -2209,6 +2768,17 @@ checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
  "tokio",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix 1.1.4",
+ "tokio",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2424,6 +2994,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.13.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2434,7 +3034,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap 2.13.1",
  "slab",
  "tokio",
@@ -2476,7 +3076,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2484,6 +3084,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -2520,7 +3125,7 @@ checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
  "dirs",
  "futures",
- "http",
+ "http 1.4.0",
  "indicatif 0.17.11",
  "libc",
  "log",
@@ -2533,6 +3138,15 @@ dependencies = [
  "tokio",
  "ureq",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -2557,6 +3171,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -2567,12 +3192,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2583,8 +3219,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2608,6 +3244,30 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -2616,9 +3276,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2630,19 +3290,34 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.9.0",
  "hyper-util",
  "log",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.6",
 ]
@@ -2653,7 +3328,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2670,9 +3345,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -3225,18 +3900,18 @@ dependencies = [
  "either",
  "futures",
  "home",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.7",
  "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls",
+ "rustls 0.23.37",
  "secrecy",
  "serde",
  "serde_json",
@@ -3258,7 +3933,7 @@ dependencies = [
  "chrono",
  "derive_more 2.1.1",
  "form_urlencoded",
- "http",
+ "http 1.4.0",
  "json-patch",
  "k8s-openapi",
  "schemars 1.2.1",
@@ -3307,6 +3982,119 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "kvbm-common"
+version = "1.0.0"
+dependencies = [
+ "dynamo-tokens",
+ "serde",
+]
+
+[[package]]
+name = "kvbm-config"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "dynamo-memory",
+ "figment",
+ "nix 0.30.1",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "validator",
+ "velo",
+]
+
+[[package]]
+name = "kvbm-engine"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "aws-config",
+ "aws-sdk-s3",
+ "bytes",
+ "chrono",
+ "crossbeam-queue",
+ "dashmap",
+ "derive_builder",
+ "dynamo-memory",
+ "futures",
+ "kvbm-common",
+ "kvbm-config",
+ "kvbm-logical",
+ "kvbm-physical",
+ "oneshot",
+ "parking_lot",
+ "rayon",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-rayon",
+ "tokio-stream",
+ "tracing",
+ "uuid",
+ "velo",
+]
+
+[[package]]
+name = "kvbm-kernels"
+version = "1.0.0"
+dependencies = [
+ "cudarc",
+]
+
+[[package]]
+name = "kvbm-logical"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "bincode 2.0.1",
+ "bytes",
+ "derive_builder",
+ "dynamo-tokens",
+ "futures",
+ "indexmap 2.13.1",
+ "lru 0.16.3",
+ "parking_lot",
+ "prometheus",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "kvbm-physical"
+version = "1.0.0"
+dependencies = [
+ "aligned-vec",
+ "anyhow",
+ "bincode 2.0.1",
+ "blake3",
+ "cudarc",
+ "derive-getters",
+ "derive_builder",
+ "dynamo-memory",
+ "futures",
+ "kvbm-common",
+ "kvbm-kernels",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "validator",
+ "velo",
 ]
 
 [[package]]
@@ -3447,6 +4235,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3879,6 +4676,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -4242,11 +5040,11 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "futures",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "httparse",
  "humantime",
- "hyper",
+ "hyper 1.9.0",
  "itertools 0.14.0",
  "md-5",
  "parking_lot",
@@ -4388,7 +5186,7 @@ checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 1.4.0",
  "opentelemetry",
  "reqwest",
 ]
@@ -4399,7 +5197,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
- "http",
+ "http 1.4.0",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -4490,6 +5288,23 @@ dependencies = [
  "objc2-ui-kit",
  "serde",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
 ]
 
 [[package]]
@@ -4745,12 +5560,22 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -5207,7 +6032,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.2",
- "rustls",
+ "rustls 0.23.37",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -5227,7 +6052,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.2",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -5490,6 +6315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5507,12 +6338,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
@@ -5521,7 +6352,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
@@ -5529,7 +6360,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -5540,6 +6371,17 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
 ]
 
 [[package]]
@@ -5688,6 +6530,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -5744,6 +6598,16 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -5899,6 +6763,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der 0.6.1",
+ "generic-array",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5979,6 +6867,16 @@ checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float 2.10.1",
  "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -6190,10 +7088,20 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "signature",
+ "signature 2.2.0",
  "zeroize",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6289,13 +7197,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -6680,11 +7604,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -6697,6 +7631,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -6737,13 +7672,13 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "httparse",
  "rand 0.8.5",
  "ring",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "webpki-roots 0.26.11",
 ]
@@ -6830,11 +7765,11 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -6859,11 +7794,11 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -6871,7 +7806,7 @@ dependencies = [
  "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -6961,8 +7896,8 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "mime",
  "pin-project-lite",
@@ -7290,7 +8225,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7311,6 +8246,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf16_iter"
@@ -7438,6 +8379,226 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "velo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0cc874c11ea3d03afd7adf90529bcf3df374039deff65bc02a26e71bb5814b"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "velo-common",
+ "velo-discovery",
+ "velo-events",
+ "velo-messenger",
+ "velo-observability",
+ "velo-queue",
+ "velo-rendezvous",
+ "velo-streaming",
+ "velo-transports",
+]
+
+[[package]]
+name = "velo-common"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2824d7667c4ee992dfc58c30799518f504d39c91f1e83962d55cb8c44cfb67"
+dependencies = [
+ "bytes",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "velo-discovery"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41107947fe3d15972c56815e42fd2485ca4ba58a5a69ec1a6fd61c00966f8734"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "bytes",
+ "fs4",
+ "futures",
+ "parking_lot",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "velo-common",
+]
+
+[[package]]
+name = "velo-events"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2504e857f1ed52ad96ce73792a724be880ba75f3579a27050395e81d38cb42d0"
+dependencies = [
+ "anyhow",
+ "dashmap",
+ "futures",
+ "parking_lot",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "velo-messenger"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8ea47ab39a82ef9101024452a3c605bcf5c0acad82c76afcf48a17c0450cf"
+dependencies = [
+ "anyhow",
+ "bs58",
+ "bytes",
+ "dashmap",
+ "derive-getters",
+ "derive_builder",
+ "flume",
+ "futures",
+ "lru 0.12.5",
+ "parking_lot",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "velo-common",
+ "velo-discovery",
+ "velo-events",
+ "velo-observability",
+ "velo-transports",
+]
+
+[[package]]
+name = "velo-observability"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57813414b19b0f845744fcf158ed4b87afe4f5c59ee99d58872c8e5d5534d61b"
+dependencies = [
+ "prometheus",
+ "tracing",
+]
+
+[[package]]
+name = "velo-queue"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bcce33f5710d87e33e1eacc5472300cbe6acdfb5f2cd6929c12f2e4908ef38"
+dependencies = [
+ "bytes",
+ "dashmap",
+ "flume",
+ "futures",
+ "rmp-serde",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "velo-rendezvous"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1eac77f329b0c3dba1b36114c969e0a7d680bb4a6436720754bef14a24fedde"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "dashmap",
+ "futures",
+ "serde",
+ "serde_json",
+ "tracing",
+ "velo-common",
+ "velo-messenger",
+ "velo-observability",
+]
+
+[[package]]
+name = "velo-streaming"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6dc0d71f73c6f369302bb94b05341a807a5693f6c321fc208d9c9a974d918a"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "dashmap",
+ "derive_builder",
+ "flume",
+ "futures",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tonic-build 0.13.1",
+ "tracing",
+ "uuid",
+ "velo-common",
+ "velo-messenger",
+ "velo-observability",
+ "velo-transports",
+]
+
+[[package]]
+name = "velo-transports"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5a348cc2fe13fc560824f170d3bdc3d10ec3a11802bb32489a59f49eb12409"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "axum",
+ "bs58",
+ "bytes",
+ "dashmap",
+ "flume",
+ "futures",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "nix 0.30.1",
+ "parking_lot",
+ "prost 0.13.5",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
+ "tower",
+ "tracing",
+ "velo-common",
+ "velo-observability",
+]
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7465,6 +8626,12 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -8104,6 +9271,12 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -27,6 +27,7 @@ media-ffmpeg = ["dynamo-llm/media-ffmpeg"]
 kv-indexer = ["dep:clap", "dep:tracing-subscriber"]
 kv-indexer-metrics = ["kv-indexer", "dynamo-kv-router/metrics"]
 nvtx = ["dynamo-runtime/nvtx"]
+mocker-kvbm = ["dynamo-mocker/kvbm"]
 
 [dependencies]
 dynamo-runtime = { path = "../../runtime" }

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -133,7 +133,7 @@ impl MockEngineArgs {
 #[pymethods]
 impl MockEngineArgs {
     #[new]
-    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=16384, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, enable_local_indexer=false, bootstrap_port=None, kv_bytes_per_token=None, kv_transfer_bandwidth=None, reasoning=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None))]
+    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=16384, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, enable_local_indexer=false, bootstrap_port=None, kv_bytes_per_token=None, kv_transfer_bandwidth=None, reasoning=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, num_g2_blocks=0, kvbm_offload_batch_size=32, kvbm_bandwidth_g1_g2=14.0, sglang=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         engine_type: &str,
@@ -166,6 +166,9 @@ impl MockEngineArgs {
         zmq_replay_port: Option<u16>,
         preemption_mode: &str,
         router_queue_policy: Option<&str>,
+        num_g2_blocks: usize,
+        kvbm_offload_batch_size: usize,
+        kvbm_bandwidth_g1_g2: f64,
         sglang: Option<SglangArgs>,
     ) -> PyResult<Self> {
         let engine_type = parse_mocker_engine_type(engine_type)?;
@@ -210,6 +213,9 @@ impl MockEngineArgs {
             .zmq_replay_port(zmq_replay_port)
             .preemption_mode(preemption_mode)
             .router_queue_policy(router_queue_policy)
+            .num_g2_blocks(num_g2_blocks)
+            .kvbm_offload_batch_size(kvbm_offload_batch_size)
+            .kvbm_bandwidth_g1_g2(kvbm_bandwidth_g1_g2)
             .sglang(sglang.map(|config| config.inner()));
 
         if let Some(npz_path) = planner_profile_data {
@@ -290,6 +296,9 @@ impl MockEngineArgs {
             "zmq_replay_port": self.inner.zmq_replay_port,
             "preemption_mode": preemption_mode,
             "router_queue_policy": router_queue_policy,
+            "num_g2_blocks": self.inner.num_g2_blocks,
+            "kvbm_offload_batch_size": self.inner.kvbm_offload_batch_size,
+            "kvbm_bandwidth_g1_g2": self.inner.kvbm_bandwidth_g1_g2,
             "sglang": self.inner.sglang,
         });
         serde_json::to_string_pretty(&payload)

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1309,6 +1309,9 @@ class MockEngineArgs:
         zmq_replay_port: Optional[int] = None,
         preemption_mode: str = "lifo",
         router_queue_policy: Optional[str] = None,
+        num_g2_blocks: int = 0,
+        kvbm_offload_batch_size: int = 32,
+        kvbm_bandwidth_g1_g2: float = 14.0,
         sglang: Optional[SglangArgs] = None,
     ) -> None:
         ...

--- a/lib/mocker/Cargo.toml
+++ b/lib/mocker/Cargo.toml
@@ -12,10 +12,20 @@ homepage.workspace = true
 repository.workspace = true
 readme = "README.md"
 
+[features]
+kvbm = ["dep:kvbm-engine", "dep:kvbm-logical", "dep:kvbm-physical", "dep:velo", "dep:futures"]
+
 [dependencies]
 # repo
 dynamo-kv-router = { workspace = true }
 dynamo-tokens = { workspace = true }
+
+# kvbm multi-tier KV cache offload (optional)
+kvbm-engine = { workspace = true, optional = true }
+kvbm-logical = { workspace = true, optional = true }
+kvbm-physical = { workspace = true, optional = true }
+velo = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
 
 # workspace
 anyhow = { workspace = true }

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -394,6 +394,20 @@ pub struct MockEngineArgs {
     #[builder(default = "None")]
     pub router_queue_policy: Option<RouterQueuePolicy>,
 
+    // ── KVBM G1↔G2 offload ────────────────────────────────────────────
+    /// Number of G2 (host-memory) blocks. Set > 0 to enable KVBM offload.
+    #[builder(default = "0")]
+    pub num_g2_blocks: usize,
+
+    /// Max blocks per offload batch in the G1→G2 pipeline.
+    #[builder(default = "32")]
+    pub kvbm_offload_batch_size: usize,
+
+    /// Simulated G1↔G2 bandwidth in GB/s (PCIe Gen4 x16).
+    #[builder(default = "14.0")]
+    pub kvbm_bandwidth_g1_g2: f64,
+
+    // ── SGLang ──────────────────────────────────────────────────────────
     /// SGLang-specific configuration. Only used when `engine_type == Sglang`.
     #[builder(default = "None")]
     pub sglang: Option<SglangArgs>,
@@ -524,6 +538,9 @@ impl MockEngineArgs {
             "zmq_replay_port",
             "preemption_mode",
             "router_queue_policy",
+            "num_g2_blocks",
+            "kvbm_offload_batch_size",
+            "kvbm_bandwidth_g1_g2",
             "sglang",
             "has_perf_model",
         ]
@@ -692,6 +709,24 @@ impl MockEngineArgs {
         {
             let policy = policy_str.parse().map_err(|e: String| anyhow::anyhow!(e))?;
             builder = builder.router_queue_policy(Some(policy));
+        }
+
+        if let Some(value) = extra_args.get("num_g2_blocks")
+            && let Some(num) = value.as_u64()
+        {
+            builder = builder.num_g2_blocks(num as usize);
+        }
+
+        if let Some(value) = extra_args.get("kvbm_offload_batch_size")
+            && let Some(num) = value.as_u64()
+        {
+            builder = builder.kvbm_offload_batch_size(num as usize);
+        }
+
+        if let Some(value) = extra_args.get("kvbm_bandwidth_g1_g2")
+            && let Some(num) = value.as_f64()
+        {
+            builder = builder.kvbm_bandwidth_g1_g2(num);
         }
 
         if let Some(value) = extra_args.get("sglang")

--- a/lib/mocker/src/kv_manager/kvbm_offload.rs
+++ b/lib/mocker/src/kv_manager/kvbm_offload.rs
@@ -1,0 +1,454 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! KVBM G1↔G2 KV cache offload integration for the mocker.
+//!
+//! [`MockOffloadEngine`] wires up a real `kvbm-engine` [`OffloadEngine`] +
+//! [`InstanceLeader`] in-process (single node, no GPUs).  [`MockWorker`]
+//! replaces `DirectWorker` so that transfers complete with simulated delays
+//! based on configurable bandwidth parameters — no actual data is moved.
+
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+
+use crate::common::utils::sleep_precise;
+
+use dynamo_tokens::PositionalLineageHash;
+use kvbm_engine::{
+    BlockId, G1, G2, InstanceId, LogicalLayoutHandle, SequenceHash,
+    leader::InstanceLeader,
+    object::ObjectBlockOps,
+    offload::{ExternalBlock, OffloadEngine, PipelineBuilder, PresenceFilter, SourceBlocks},
+    worker::{
+        ConnectRemoteResponse, ImportMetadataResponse, LayoutHandle, RemoteDescriptor,
+        SerializedLayout, SerializedLayoutResponse, Worker, WorkerTransfers,
+    },
+};
+use kvbm_logical::blocks::BlockRegistry;
+use kvbm_logical::manager::{BlockManager, FrequencyTrackingCapacity};
+use kvbm_physical::transfer::{TransferCompleteNotification, TransferOptions};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Configuration for the KVBM offload engine used by the mocker.
+pub struct KvbmOffloadConfig {
+    pub num_g2_blocks: usize,
+    pub offload_batch_size: usize,
+    /// KV cache bytes per block.  `None` → transfers complete instantly.
+    pub block_size_bytes: Option<usize>,
+    /// G1↔G2 bandwidth in GB/s (default: 14.0, PCIe Gen4 x16).
+    pub bandwidth_g1_g2_gbps: f64,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Create a local-only Messenger on a random TCP port.
+/// Required by `InstanceLeader` even in single-node mode.
+async fn create_local_messenger() -> Result<Arc<velo::Messenger>> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let transport: Arc<dyn velo::backend::Transport> = Arc::new(
+        velo::backend::tcp::TcpTransportBuilder::new()
+            .from_listener(listener)?
+            .build()?,
+    );
+    let messenger = velo::Messenger::builder()
+        .add_transport(transport)
+        .build()
+        .await?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    Ok(messenger)
+}
+
+fn build_registry() -> BlockRegistry {
+    BlockRegistry::builder()
+        .frequency_tracker(FrequencyTrackingCapacity::Medium.create_tracker())
+        .build()
+}
+
+fn build_block_manager<T: kvbm_logical::blocks::BlockMetadata>(
+    block_count: usize,
+    registry: &BlockRegistry,
+) -> BlockManager<T> {
+    BlockManager::<T>::builder()
+        .block_count(block_count)
+        .block_size(1)
+        .registry(registry.clone())
+        .with_lru_backend()
+        .build()
+        .expect("BlockManager build should not fail with valid config")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MockWorker
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Worker that simulates transfer delays without moving real data.
+/// Returns [`TransferCompleteNotification`] that resolves after a delay
+/// computed from bandwidth parameters and block count.
+struct MockWorker {
+    block_size_bytes: Option<usize>,
+    bandwidth_g1_g2_gbps: f64,
+    event_manager: Arc<velo::EventManager>,
+    runtime_handle: tokio::runtime::Handle,
+}
+
+impl MockWorker {
+    fn new(config: &KvbmOffloadConfig) -> Self {
+        tracing::info!(
+            block_size_bytes = ?config.block_size_bytes,
+            bw_g1_g2 = config.bandwidth_g1_g2_gbps,
+            "MockWorker initialized"
+        );
+        Self {
+            block_size_bytes: config.block_size_bytes,
+            bandwidth_g1_g2_gbps: config.bandwidth_g1_g2_gbps,
+            event_manager: Arc::new(velo::EventManager::local()),
+            runtime_handle: tokio::runtime::Handle::current(),
+        }
+    }
+
+    pub(crate) fn transfer_delay(
+        &self,
+        _src: LogicalLayoutHandle,
+        _dst: LogicalLayoutHandle,
+        num_blocks: usize,
+    ) -> Option<Duration> {
+        let block_bytes = self.block_size_bytes?;
+        let total_bytes = num_blocks * block_bytes;
+        Some(Duration::from_secs_f64(
+            total_bytes as f64 / (self.bandwidth_g1_g2_gbps * 1e9),
+        ))
+    }
+
+    fn delayed_notification(
+        &self,
+        delay: Option<Duration>,
+    ) -> Result<TransferCompleteNotification> {
+        let delay = match delay {
+            Some(d) if !d.is_zero() => d,
+            _ => return Ok(TransferCompleteNotification::completed()),
+        };
+        let event = self.event_manager.new_event()?;
+        let handle = event.handle();
+        let awaiter = self.event_manager.awaiter(handle)?;
+        let em = self.event_manager.clone();
+        self.runtime_handle.spawn(async move {
+            sleep_precise(delay).await;
+            let _ = em.trigger(handle);
+            drop(event);
+        });
+        Ok(TransferCompleteNotification::from_awaiter(awaiter))
+    }
+}
+
+impl WorkerTransfers for MockWorker {
+    fn execute_local_transfer(
+        &self,
+        src: LogicalLayoutHandle,
+        dst: LogicalLayoutHandle,
+        src_block_ids: Arc<[BlockId]>,
+        _dst_block_ids: Arc<[BlockId]>,
+        _options: TransferOptions,
+    ) -> Result<TransferCompleteNotification> {
+        let delay = self.transfer_delay(src, dst, src_block_ids.len());
+        tracing::info!(
+            ?src,
+            ?dst,
+            num_blocks = src_block_ids.len(),
+            delay_us = delay.map(|d| d.as_micros()).unwrap_or(0),
+            "MockWorker: local transfer"
+        );
+        self.delayed_notification(delay)
+    }
+
+    fn execute_remote_onboard(
+        &self,
+        _src: RemoteDescriptor,
+        _dst: LogicalLayoutHandle,
+        _dst_block_ids: Arc<[BlockId]>,
+        _options: TransferOptions,
+    ) -> Result<TransferCompleteNotification> {
+        Ok(TransferCompleteNotification::completed())
+    }
+
+    fn execute_remote_offload(
+        &self,
+        _src: LogicalLayoutHandle,
+        _src_block_ids: Arc<[BlockId]>,
+        _dst: RemoteDescriptor,
+        _options: TransferOptions,
+    ) -> Result<TransferCompleteNotification> {
+        Ok(TransferCompleteNotification::completed())
+    }
+
+    fn connect_remote(
+        &self,
+        _instance_id: InstanceId,
+        _metadata: Vec<SerializedLayout>,
+    ) -> Result<ConnectRemoteResponse> {
+        Ok(ConnectRemoteResponse::ready())
+    }
+
+    fn has_remote_metadata(&self, _instance_id: InstanceId) -> bool {
+        false
+    }
+
+    fn execute_remote_onboard_for_instance(
+        &self,
+        _instance_id: InstanceId,
+        _remote_logical_type: LogicalLayoutHandle,
+        _src_block_ids: Vec<BlockId>,
+        _dst: LogicalLayoutHandle,
+        _dst_block_ids: Arc<[BlockId]>,
+        _options: TransferOptions,
+    ) -> Result<TransferCompleteNotification> {
+        Ok(TransferCompleteNotification::completed())
+    }
+}
+
+impl Worker for MockWorker {
+    fn g1_handle(&self) -> Option<LayoutHandle> {
+        None
+    }
+    fn g2_handle(&self) -> Option<LayoutHandle> {
+        None
+    }
+    fn g3_handle(&self) -> Option<LayoutHandle> {
+        None
+    }
+    fn export_metadata(&self) -> Result<SerializedLayoutResponse> {
+        Ok(SerializedLayoutResponse::ready(
+            SerializedLayout::from_bytes(vec![]),
+        ))
+    }
+    fn import_metadata(&self, _metadata: SerializedLayout) -> Result<ImportMetadataResponse> {
+        Ok(ImportMetadataResponse::ready(vec![]))
+    }
+}
+
+impl ObjectBlockOps for MockWorker {
+    fn has_blocks(
+        &self,
+        keys: Vec<SequenceHash>,
+    ) -> BoxFuture<'static, Vec<(SequenceHash, Option<usize>)>> {
+        Box::pin(async move { keys.into_iter().map(|k| (k, None)).collect() })
+    }
+
+    fn put_blocks(
+        &self,
+        keys: Vec<SequenceHash>,
+        _src_layout: LogicalLayoutHandle,
+        _block_ids: Vec<BlockId>,
+    ) -> BoxFuture<'static, Vec<Result<SequenceHash, SequenceHash>>> {
+        Box::pin(async move { keys.into_iter().map(Err).collect() })
+    }
+
+    fn get_blocks(
+        &self,
+        keys: Vec<SequenceHash>,
+        _dst_layout: LogicalLayoutHandle,
+        _block_ids: Vec<BlockId>,
+    ) -> BoxFuture<'static, Vec<Result<SequenceHash, SequenceHash>>> {
+        Box::pin(async move { keys.into_iter().map(Err).collect() })
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SwapInHandle
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Non-blocking handle for a pending G2→G1 swap-in transfer.
+pub struct SwapInHandle {
+    rx: Option<tokio::sync::oneshot::Receiver<()>>,
+}
+
+impl SwapInHandle {
+    fn completed() -> Self {
+        Self { rx: None }
+    }
+
+    /// Non-blocking check if the transfer has completed.
+    pub fn is_complete(&mut self) -> bool {
+        match &mut self.rx {
+            None => true,
+            Some(rx) => rx.try_recv().is_ok(),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MockOffloadEngine
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// In-process offload engine backed by [`MockWorker`].
+/// Wraps a real kvbm-engine [`OffloadEngine`] so that mocker's G1 evictions
+/// feed into G2 [`BlockManager`] for logical metadata tracking.
+pub struct MockOffloadEngine {
+    offload_engine: OffloadEngine,
+    leader: Arc<InstanceLeader>,
+    worker: Arc<MockWorker>,
+}
+
+impl MockOffloadEngine {
+    pub async fn build(config: &KvbmOffloadConfig) -> Result<Self> {
+        let messenger = create_local_messenger().await?;
+        let registry = Arc::new(build_registry());
+        let g2_manager = Arc::new(build_block_manager::<G2>(config.num_g2_blocks, &registry));
+
+        // InstanceLeader with MockWorker
+        let mock_worker = Arc::new(MockWorker::new(config));
+        let worker_for_leader: Arc<dyn Worker> = mock_worker.clone();
+        let leader = Arc::new(
+            InstanceLeader::builder()
+                .messenger(messenger)
+                .registry((*registry).clone())
+                .g2_manager(g2_manager.clone())
+                .worker(worker_for_leader)
+                .build()?,
+        );
+
+        // OffloadEngine: G1→G2 pipeline with PresenceFilter
+        let g1_to_g2_pipeline = PipelineBuilder::<G1, G2>::new()
+            .policy(Arc::new(PresenceFilter::<G1, G2>::new(registry.clone())))
+            .batch_size(config.offload_batch_size)
+            .build();
+
+        let offload_engine = OffloadEngine::builder(leader.clone())
+            .with_registry(registry)
+            .with_g2_manager(g2_manager)
+            .with_g1_to_g2_pipeline(g1_to_g2_pipeline)
+            .build()?;
+
+        Ok(Self {
+            offload_engine,
+            leader,
+            worker: mock_worker,
+        })
+    }
+
+    /// Enqueue a G1 block eviction for offload to G2.
+    /// `seq_hash` is mocker's `SequenceHash` (u64), wrapped into
+    /// `PositionalLineageHash` for kvbm-engine block identity tracking.
+    pub fn enqueue_g1_eviction(&self, block_id: BlockId, seq_hash: dynamo_tokens::SequenceHash) {
+        let kvbm_hash = PositionalLineageHash::new(seq_hash, None, 0);
+        let block = ExternalBlock::<G1>::new(block_id, kvbm_hash);
+        let blocks: SourceBlocks<G1> = vec![block].into();
+
+        match self.offload_engine.enqueue_g1_to_g2(blocks) {
+            Ok(_handle) => {
+                tracing::debug!(block_id, seq_hash, "KVBM: enqueued G1→G2 offload");
+            }
+            Err(e) => {
+                tracing::warn!("KVBM: G1→G2 offload failed for block {block_id}: {e}");
+            }
+        }
+    }
+
+    /// Start an async G2→G1 swap-in transfer. Returns a [`SwapInHandle`]
+    /// that the scheduler polls on subsequent passes.
+    pub fn start_swap_in(&self, num_blocks: usize) -> SwapInHandle {
+        let delay = self
+            .worker
+            .transfer_delay(LogicalLayoutHandle::G2, LogicalLayoutHandle::G1, num_blocks)
+            .unwrap_or(Duration::ZERO);
+
+        if delay.is_zero() {
+            tracing::debug!(num_blocks, "KVBM: swap-in (instant)");
+            return SwapInHandle::completed();
+        }
+
+        tracing::debug!(
+            num_blocks,
+            delay_us = delay.as_micros(),
+            "KVBM: swap-in started"
+        );
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.worker.runtime_handle.spawn(async move {
+            sleep_precise(delay).await;
+            let _ = tx.send(());
+        });
+        SwapInHandle { rx: Some(rx) }
+    }
+
+    /// Check whether `seq_hash` exists in G2.
+    pub fn find_in_tiers(&self, seq_hash: dynamo_tokens::SequenceHash) -> bool {
+        use kvbm_engine::leader::{FindMatchesOptions, FindMatchesResult, Leader, StagingMode};
+
+        let kvbm_hash = PositionalLineageHash::new(seq_hash, None, 0);
+        let options = FindMatchesOptions {
+            search_remote: false,
+            staging_mode: StagingMode::Hold,
+        };
+        match self.leader.find_matches_with_options(&[kvbm_hash], options) {
+            Ok(FindMatchesResult::Ready(result)) => {
+                let found = result.g2_count() > 0;
+                if found {
+                    tracing::debug!(seq_hash, "KVBM: G2 hit for onboard");
+                }
+                found
+            }
+            Ok(FindMatchesResult::AsyncSession(_)) => false,
+            Err(e) => {
+                tracing::warn!("KVBM: find_matches failed for {seq_hash}: {e}");
+                false
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_g1_eviction_offloads_to_g2() -> Result<()> {
+        let config = KvbmOffloadConfig {
+            num_g2_blocks: 64,
+            offload_batch_size: 8,
+            block_size_bytes: None,
+            bandwidth_g1_g2_gbps: 14.0,
+        };
+        let engine = MockOffloadEngine::build(&config).await?;
+
+        engine.enqueue_g1_eviction(0, 0xdeadbeef_cafebabe);
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_find_in_tiers_after_offload() -> Result<()> {
+        let config = KvbmOffloadConfig {
+            num_g2_blocks: 64,
+            offload_batch_size: 8,
+            block_size_bytes: None,
+            bandwidth_g1_g2_gbps: 14.0,
+        };
+        let engine = MockOffloadEngine::build(&config).await?;
+
+        let seq_hash: dynamo_tokens::SequenceHash = 0xdeadbeef;
+        engine.enqueue_g1_eviction(0, seq_hash);
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        assert!(
+            engine.find_in_tiers(seq_hash),
+            "block should be found in G2"
+        );
+        assert!(
+            !engine.find_in_tiers(0x12345678),
+            "unknown block should not be found"
+        );
+        Ok(())
+    }
+}

--- a/lib/mocker/src/kv_manager/mod.rs
+++ b/lib/mocker/src/kv_manager/mod.rs
@@ -3,6 +3,8 @@
 
 //! Pluggable KV cache block managers.
 
+#[cfg(feature = "kvbm")]
+pub mod kvbm_offload;
 pub mod sglang_backend;
 pub mod vllm_backend;
 

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -45,6 +45,15 @@ use dynamo_kv_router::protocols::{
 use dynamo_tokens::blocks::UniqueBlock;
 use dynamo_tokens::{BlockHash, SequenceHash};
 use rustc_hash::FxHashMap;
+#[cfg(feature = "kvbm")]
+use std::collections::{HashMap, VecDeque};
+#[cfg(feature = "kvbm")]
+use std::sync::Arc;
+
+#[cfg(feature = "kvbm")]
+use crate::kv_manager::kvbm_offload::{MockOffloadEngine, SwapInHandle};
+#[cfg(feature = "kvbm")]
+use kvbm_engine::BlockId;
 
 pub struct KvManager {
     cache: HashCache,
@@ -52,6 +61,18 @@ pub struct KvManager {
     kv_event_publishers: KvEventPublishers,
     dp_rank: u32,
     next_event_id: u64,
+    /// Maps UniqueBlock → physical slot ID for kvbm-engine block tracking.
+    #[cfg(feature = "kvbm")]
+    block_id_map: HashMap<UniqueBlock, BlockId>,
+    /// Free physical slot IDs returned on eviction/destruction.
+    #[cfg(feature = "kvbm")]
+    block_id_pool: VecDeque<BlockId>,
+    #[cfg(feature = "kvbm")]
+    offload_engine: Option<Arc<MockOffloadEngine>>,
+    /// Set by `process()` when a G2 hit starts an async swap-in.
+    /// The scheduler takes this to defer the request (WAITING_FOR_SWAP_IN).
+    #[cfg(feature = "kvbm")]
+    pub swap_in_pending: Option<SwapInHandle>,
 }
 
 impl KvManager {
@@ -78,7 +99,44 @@ impl KvManager {
             kv_event_publishers,
             dp_rank,
             next_event_id: 0,
+            #[cfg(feature = "kvbm")]
+            block_id_map: HashMap::new(),
+            #[cfg(feature = "kvbm")]
+            block_id_pool: (0..max_capacity as BlockId).collect(),
+            #[cfg(feature = "kvbm")]
+            offload_engine: None,
+            #[cfg(feature = "kvbm")]
+            swap_in_pending: None,
         }
+    }
+
+    /// Attach a KVBM offload engine to enable G1→G2→G3 block offloading.
+    #[cfg(feature = "kvbm")]
+    pub fn set_offload_engine(&mut self, engine: Arc<MockOffloadEngine>) {
+        self.offload_engine = Some(engine);
+    }
+
+    /// Allocate a physical slot ID for a newly inserted G1 block.
+    #[cfg(feature = "kvbm")]
+    fn assign_block_id(&mut self, block: &UniqueBlock) {
+        if let Some(id) = self.block_id_pool.pop_front() {
+            self.block_id_map.insert(block.clone(), id);
+        } else {
+            tracing::warn!("block_id_pool exhausted — no slot ID assigned for {block:?}");
+        }
+    }
+
+    /// Release a physical slot ID back to the pool and return (block_id, seq_hash)
+    /// for the evicted block.
+    #[cfg(feature = "kvbm")]
+    fn release_block_id(&mut self, block: &UniqueBlock) -> Option<(BlockId, SequenceHash)> {
+        if let Some(id) = self.block_id_map.remove(block) {
+            self.block_id_pool.push_back(id);
+            if let UniqueBlock::FullBlock(seq_hash) = block {
+                return Some((id, *seq_hash));
+            }
+        }
+        None
     }
 
     /// Converts stored/removed blocks into KvCacheEventData and publishes if sink is available.
@@ -165,13 +223,14 @@ impl KvManager {
                 let mut blocks_stored = Vec::<u64>::new();
                 let mut stored_token_ids: Option<Vec<Vec<u32>>> =
                     token_ids.as_ref().map(|_| Vec::new());
+                #[cfg(feature = "kvbm")]
+                let kvbm_engine = self.offload_engine.clone();
 
                 let mut parent_block: Option<&UniqueBlock> = parent.as_ref();
                 let mut allocated = 0;
                 for (i, hash) in hashes.iter().enumerate() {
                     // First check if it already exists in active blocks
                     if self.cache.contains_active(hash) {
-                        // Block already active, just increment reference count
                         self.cache.increment_ref(hash);
                         parent_block = Some(hash);
                         allocated += 1;
@@ -185,6 +244,50 @@ impl KvManager {
                         continue;
                     }
 
+                    // Check G2 for swap-in.
+                    #[cfg(feature = "kvbm")]
+                    if let Some(ref engine) = kvbm_engine {
+                        if let UniqueBlock::FullBlock(seq_hash) = hash {
+                            if engine.find_in_tiers(*seq_hash) {
+                                // Allocate GPU slot for the swapped-in block.
+                                if self.cache.is_at_capacity() {
+                                    let Some(evicted) = self.cache.evict_inactive() else {
+                                        break;
+                                    };
+                                    if let UniqueBlock::FullBlock(eh) = &evicted {
+                                        self.publish_kv_event(vec![*eh], &[], None, false, None);
+                                    }
+                                    if let Some((bid, sh)) = self.release_block_id(&evicted) {
+                                        engine.enqueue_g1_eviction(bid, sh);
+                                    }
+                                }
+                                self.cache.insert_active(hash.clone(), 1);
+                                self.assign_block_id(hash);
+                                allocated += 1;
+
+                                // Start async swap-in and signal scheduler to defer.
+                                self.swap_in_pending = Some(engine.start_swap_in(1));
+
+                                // Publish blocks stored so far, then return.
+                                let parent_hash = match parent_block {
+                                    None => None,
+                                    Some(UniqueBlock::FullBlock(b)) => Some(*b),
+                                    Some(UniqueBlock::PartialBlock(_)) => {
+                                        panic!("parent block cannot be partial")
+                                    }
+                                };
+                                self.publish_kv_event(
+                                    blocks_stored,
+                                    local_hashes,
+                                    parent_hash,
+                                    true,
+                                    stored_token_ids,
+                                );
+                                return allocated;
+                            }
+                        }
+                    }
+
                     // If at max capacity, evict the oldest entry from inactive blocks
                     if self.cache.is_at_capacity() {
                         let Some(evicted) = self.cache.evict_inactive() else {
@@ -194,14 +297,31 @@ impl KvManager {
                             "Evicting block from inactive pool: {evicted:?}, dp_rank={}",
                             self.dp_rank
                         );
-                        if let UniqueBlock::FullBlock(evicted_full_block) = evicted {
-                            self.publish_kv_event(vec![evicted_full_block], &[], None, false, None);
+                        if let UniqueBlock::FullBlock(evicted_full_block) = &evicted {
+                            self.publish_kv_event(
+                                vec![*evicted_full_block],
+                                &[],
+                                None,
+                                false,
+                                None,
+                            );
+                        }
+                        // Enqueue evicted block for G2 offload if KVBM is enabled.
+                        #[cfg(feature = "kvbm")]
+                        if let Some(ref engine) = kvbm_engine {
+                            if let Some((block_id, seq_hash)) = self.release_block_id(&evicted) {
+                                engine.enqueue_g1_eviction(block_id, seq_hash);
+                            }
                         }
                     }
 
                     // Now insert the new block in active blocks with reference count 1
                     self.cache.insert_active(hash.clone(), 1);
                     allocated += 1;
+                    #[cfg(feature = "kvbm")]
+                    if kvbm_engine.is_some() {
+                        self.assign_block_id(hash);
+                    }
                     // Track blocks for trace/event
                     if let UniqueBlock::FullBlock(stored_full_block) = hash {
                         blocks_stored.push(*stored_full_block);
@@ -228,12 +348,14 @@ impl KvManager {
 
             MoveBlock::Destroy(hashes) => {
                 let mut blocks_destroyed = Vec::<u64>::new();
-                // Process blocks in order (already reversed by caller if needed)
                 for hash in hashes.iter() {
                     self.cache.remove_active(hash).unwrap();
-                    // Track blocks for batch sending
                     if let UniqueBlock::FullBlock(destroyed_full_block) = hash {
                         blocks_destroyed.push(*destroyed_full_block);
+                    }
+                    #[cfg(feature = "kvbm")]
+                    if self.offload_engine.is_some() {
+                        self.release_block_id(hash);
                     }
                 }
 
@@ -278,7 +400,20 @@ impl KvManager {
                 };
 
                 self.cache
-                    .insert_active(hash_block, hash_ref_count.unwrap_or(0) + 1);
+                    .insert_active(hash_block.clone(), hash_ref_count.unwrap_or(0) + 1);
+
+                // Transfer KVBM slot ID: PartialBlock → FullBlock.
+                #[cfg(feature = "kvbm")]
+                if self.offload_engine.is_some() {
+                    if let Some(slot_id) = self.block_id_map.remove(&uuid_block) {
+                        if is_new {
+                            self.block_id_map.insert(hash_block, slot_id);
+                        } else {
+                            // Cache hit: FullBlock already tracked; return slot to pool.
+                            self.block_id_pool.push_back(slot_id);
+                        }
+                    }
+                }
 
                 if is_new {
                     self.publish_kv_event(

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -189,11 +189,21 @@ impl SchedulerState {
     }
 }
 
+/// A request waiting for an async G2→G1 swap-in transfer to complete.
+#[cfg(feature = "kvbm")]
+struct PendingSwapIn {
+    uuid: Uuid,
+    handle: crate::kv_manager::kvbm_offload::SwapInHandle,
+}
+
 pub(crate) struct VllmCore {
     args: MockEngineArgs,
     pub(super) state: SchedulerState,
     pub(super) kv_manager: KvManager,
     kv_event_buffer: Option<CapturedRouterEventBuffer>,
+    /// Requests waiting for G2→G1 swap-in to complete before joining a pass.
+    #[cfg(feature = "kvbm")]
+    pending_swap_ins: Vec<PendingSwapIn>,
 }
 
 impl VllmCore {
@@ -236,6 +246,8 @@ impl VllmCore {
             args,
             state: SchedulerState::default(),
             kv_event_buffer,
+            #[cfg(feature = "kvbm")]
+            pending_swap_ins: Vec::new(),
         }
     }
 
@@ -290,6 +302,19 @@ impl VllmCore {
         now_ms: f64,
         admission_tx: Option<&mpsc::UnboundedSender<AdmissionEvent>>,
     ) -> EnginePassResult {
+        // Poll pending swap-ins: completed transfers promote the request
+        // back to the front of the waiting queue.
+        #[cfg(feature = "kvbm")]
+        self.pending_swap_ins.retain_mut(|pending| {
+            if pending.handle.is_complete() {
+                tracing::debug!(uuid = %pending.uuid, "KVBM: swap-in complete, request re-queued");
+                self.state.prepend_waiting(pending.uuid);
+                false // remove from pending
+            } else {
+                true // keep waiting
+            }
+        });
+
         let requests_before = self.state.requests.len();
         self.state.compact_running();
         let mut token_budget = self.args.max_num_batched_tokens.unwrap_or(usize::MAX);
@@ -483,6 +508,29 @@ impl VllmCore {
                 _ => unreachable!(),
             };
             let allocated = self.kv_manager.process(&signal);
+
+            // If process() started an async swap-in (G2 hit), defer the
+            // request — it won't join this forward pass.
+            #[cfg(feature = "kvbm")]
+            if let Some(handle) = self.kv_manager.swap_in_pending.take() {
+                // Commit what we allocated so far.
+                if let Some(request) = self.state.requests.get_mut(&uuid) {
+                    let prev_blocks = prev_allocated_tokens
+                        .div_ceil(request.sequence.block_size())
+                        .min(request.sequence.unique_blocks().len());
+                    let committed = (prev_blocks + allocated) * request.sequence.block_size();
+                    request
+                        .sequence
+                        .commit_allocation(committed.min(allocation_target));
+                    request.num_computed_tokens = actual_computed_after.min(committed);
+                }
+                // Remove from waiting and park until swap-in completes.
+                self.state.waiting_members.remove(&uuid);
+                self.pending_swap_ins.push(PendingSwapIn { uuid, handle });
+                tracing::debug!(%uuid, "KVBM: request deferred for swap-in");
+                return ScheduleOutcome::Blocked;
+            }
+
             let (_committed_tokens, current_computed_tokens) = {
                 let Some(request) = self.state.requests.get_mut(&uuid) else {
                     return ScheduleOutcome::Blocked;

--- a/lib/mocker/src/scheduler/vllm/live.rs
+++ b/lib/mocker/src/scheduler/vllm/live.rs
@@ -14,6 +14,9 @@ use crate::scheduler::{
     publish_deferred_kv_events,
 };
 
+#[cfg(feature = "kvbm")]
+use crate::kv_manager::kvbm_offload::{KvbmOffloadConfig, MockOffloadEngine};
+
 use super::core::VllmCore;
 
 #[derive(Clone, Default, Debug)]
@@ -112,10 +115,40 @@ impl Scheduler {
         let cancel_token_clone = cancel_token.clone();
         let cancel_guard = Arc::new(CancelGuard(cancel_token));
 
+        // Build KVBM config before moving args into the spawned task.
+        #[cfg(feature = "kvbm")]
+        let kvbm_config = if args.num_g2_blocks > 0 {
+            Some(KvbmOffloadConfig {
+                num_g2_blocks: args.num_g2_blocks,
+                offload_batch_size: args.kvbm_offload_batch_size,
+                block_size_bytes: args.kv_bytes_per_token.map(|bpt| args.block_size * bpt),
+                bandwidth_g1_g2_gbps: args.kvbm_bandwidth_g1_g2,
+            })
+        } else {
+            None
+        };
+
         tokio::spawn(async move {
             let (deferred_kv_events, buffering_publishers) =
                 capture_deferred_kv_publish_sink(kv_event_publishers.raw_enabled());
             let mut core = VllmCore::new_with_sink(args, dp_rank, buffering_publishers);
+
+            #[cfg(feature = "kvbm")]
+            if let Some(config) = kvbm_config {
+                match MockOffloadEngine::build(&config).await {
+                    Ok(engine) => {
+                        tracing::info!(
+                            num_g2 = config.num_g2_blocks,
+                            block_size_bytes = ?config.block_size_bytes,
+                            "KVBM offload engine initialized"
+                        );
+                        core.kv_manager.set_offload_engine(Arc::new(engine));
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to initialize KVBM offload engine: {e}");
+                    }
+                }
+            }
 
             loop {
                 if receive_requests(&mut core, &mut request_rx, &cancel_token_clone)


### PR DESCRIPTION
#### Overview:

Integrate kvbm-engine into the vllm mocker for G1↔G2 KV cache offload/onboard simulation.

#### Details:

**G1→G2 offload**: When vLLM scheduler evicts blocks from G1 inactive pool, they are enqueued into kvbm-engine's offload pipeline. MockWorker simulates PCIe transfer delay based on configurable bandwidth (default 14 GB/s).

**G2→G1 swap-in**: When a prefix-cached block misses in G1 but hits in G2 (via `InstanceLeader::find_matches`), an async swap-in transfer is started. The request is deferred and doesn't join the current pass. On the next scheduler pass, the transfer is polled; if complete, the request is promoted back.

All KVBM code gated behind optional `kvbm` cargo feature flag. 
Python bindings forward it as `mocker-kvbm`.

**CLI usage:**

```bash
maturin develop --features mocker-kvbm
python3 -m dynamo.mocker --model-path <model> --num-g2-blocks 512
```

**Example logs (`DYN_LOG=debug`):**

```
# G1→G2 offload (block evicted from G1, transferred to G2)
DEBUG dynamo_mocker::kv_manager::kvbm_offload: KVBM: enqueued G1→G2 offload block_id=125 seq_hash=13429400773344838530
INFO  kvbm_engine::offload::pipeline: Batch transfer complete blocks=1 src="kvbm_engine::G1" dst="kvbm_engine::G2"

# G2→G1 swap-in (prefix cache hit in G2, async transferred back to G1)
DEBUG dynamo_mocker::kv_manager::kvbm_offload: KVBM: G2 hit for onboard seq_hash=15859598872868864997
DEBUG dynamo_mocker::kv_manager::kvbm_offload: KVBM: swap-in started num_blocks=1 delay_us=37
DEBUG dynamo_mocker::scheduler::vllm::core: KVBM: request deferred for swap-in uuid=864dae4d-857a-43f1-b2ad-2e559fbd3757
DEBUG dynamo_mocker::scheduler::vllm::core: KVBM: swap-in complete, request re-queued uuid=864dae4d-857a-43f1-b2ad-2e559fbd3757
```

**Out of scope (follow-up PRs):**

- `dynamo.replay` integration
- G3/G4 tiers
- SGLang engine support
- Real NIXL transfers

#### Where should the reviewer start?

- `lib/mocker/src/kv_manager/kvbm_offload.rs` — new file, MockWorker, MockOffloadEngine core logic
- `lib/mocker/src/kv_manager/vllm_backend.rs` — KvManager integration (offload on eviction, swap-in on G2 hit)

#### Related Issues:

- Relates to https://github.com/ai-dynamo/dynamo/issues/8190, https://github.com/ai-dynamo/dynamo/issues/6383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KVBM G1↔G2 offload simulation support with three new configuration parameters: `--num-g2-blocks`, `--kvbm-offload-batch-size`, and `--kvbm-bandwidth-g1-g2`.
  * Integrated offload engine to manage key-value cache operations across memory tiers with configurable bandwidth and batch sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->