### PR TITLE
fix(sglang): use served_model_name for video/image model registration

### DIFF
--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -274,7 +274,9 @@ async def register_image_diffusion_model(
         by default. When output_modalities is provided, the ModelType is derived
         from the given modality names instead.
     """
-    model_name = getattr(server_args, "served_model_name", None) or server_args.model_path
+    model_name = (
+        getattr(server_args, "served_model_name", None) or server_args.model_path
+    )
 
     model_type = ModelType.Images
     if output_modalities:
@@ -328,7 +330,9 @@ async def register_video_generation_model(
     Note:
         Video generation models use ModelInput.Text (text prompts) and ModelType.Videos.
     """
-    model_name = getattr(server_args, "served_model_name", None) or server_args.model_path
+    model_name = (
+        getattr(server_args, "served_model_name", None) or server_args.model_path
+    )
 
     try:
         await register_model(

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -274,8 +274,7 @@ async def register_image_diffusion_model(
         by default. When output_modalities is provided, the ModelType is derived
         from the given modality names instead.
     """
-    # Use model_path as the model name (diffusion workers don't have served_model_name)
-    model_name = server_args.model_path
+    model_name = getattr(server_args, "served_model_name", None) or server_args.model_path
 
     model_type = ModelType.Images
     if output_modalities:
@@ -297,7 +296,7 @@ async def register_image_diffusion_model(
             ModelInput.Text,
             model_type,
             endpoint,
-            model_name,
+            server_args.model_path,
             model_name,
         )
         logging.info(f"Successfully registered diffusion model: {model_name}")
@@ -329,15 +328,14 @@ async def register_video_generation_model(
     Note:
         Video generation models use ModelInput.Text (text prompts) and ModelType.Videos.
     """
-    # Use model_path as the model name (video workers don't have served_model_name)
-    model_name = server_args.model_path
+    model_name = getattr(server_args, "served_model_name", None) or server_args.model_path
 
     try:
         await register_model(
             ModelInput.Text,
             ModelType.Videos,
             endpoint,
-            model_name,
+            server_args.model_path,
             model_name,
         )
         logging.info(f"Successfully registered video generation model: {model_name}")


### PR DESCRIPTION
#### Overview:

Fix `--served-model-name` being ignored for video and image generation worker registration with the Dynamo frontend. Currently only the text/LLM SGLang worker passes `served_model_name` to `register_model`; video and image workers always register under `model_path`, causing "Model not found" 404 errors when clients use the served name.

#### Details:

In `register.py`, both `register_video_generation_model` and `register_image_diffusion_model` hardcode `model_name = server_args.model_path` and pass it as both `source_path` and `served_name` to `register_model`. The `server_args.served_model_name` attribute is set by `args.py` (line 353) but never used at registration.

This change:
- Uses `getattr(server_args, "served_model_name", None) or server_args.model_path` as the served name (falls back to `model_path` when not specified)
- Passes `server_args.model_path` as the source path (first arg) and the resolved served name as the second arg
- Aligns video/image registration with the text worker pattern (line 58)

When `--served-model-name` is not provided, behavior is unchanged (defaults to `model_path`).

#### Where should the reviewer start?

- `components/src/dynamo/sglang/register.py` -- the only file changed. Compare the video/image `register_model` calls with the text worker call at line 58 which already correctly passes `server_args.served_model_name`.

#### Related Issues:

- Fixes GitHub issue: #8034

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved model registration handling for image diffusion and video generation models to better utilize custom model identifiers when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->