### PR TITLE
feat(trtllm): ModelExpress P2P weight transfer with auto-detect source/target

### DIFF
--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -184,6 +184,14 @@ class DynamoTrtllmArgGroup(ArgGroup):
         )
         add_argument(
             g,
+            flag_name="--model-express-url",
+            env_var="MODEL_EXPRESS_URL",
+            default=None,
+            help="ModelExpress P2P server URL (e.g., modelexpress-server:8001). "
+            "When set, auto-detects source/target role based on existing sources.",
+        )
+        add_argument(
+            g,
             flag_name="--disaggregation-mode",
             env_var="DYN_TRTLLM_DISAGGREGATION_MODE",
             default=DisaggregationMode.AGGREGATED.value,
@@ -501,6 +509,8 @@ class DynamoTrtllmConfig(ConfigBase):
     load_format: str
     model_loader_extra_config: str
     guided_decoding_backend: Optional[str] = None
+
+    model_express_url: Optional[str] = None
 
     disaggregation_mode: DisaggregationMode
     modality: Modality

--- a/components/src/dynamo/trtllm/engine.py
+++ b/components/src/dynamo/trtllm/engine.py
@@ -3,6 +3,7 @@
 
 import enum
 import logging
+import os
 import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -34,6 +35,7 @@ class TensorRTLLMEngine:
         self,
         engine_args: dict[str, Any],
         disaggregation_mode: Optional[DisaggregationMode] = None,
+        model_express_url: Optional[str] = None,
     ) -> None:
         self._llm: Optional[LLM] = None
         self.disaggregation_mode = (
@@ -58,6 +60,7 @@ class TensorRTLLMEngine:
             )
 
         self.engine_args = engine_args
+        self._model_express_url = model_express_url
 
     @property
     def encoder_available(self) -> bool:
@@ -66,6 +69,14 @@ class TensorRTLLMEngine:
 
     async def initialize(self) -> None:
         if not self._llm:
+            if self._model_express_url:
+                self.engine_args["checkpoint_format"] = "MX"
+                os.environ.setdefault("MODEL_EXPRESS_URL", self._model_express_url)
+                logger.info(
+                    "ModelExpress P2P enabled: checkpoint_format=MX, server=%s",
+                    self._model_express_url,
+                )
+
             if self.disaggregation_mode == DisaggregationMode.ENCODE:
                 # Initialize the multimodal encoder for full EPD
                 # Prefill/decode workers initialize the standard TRT-LLM `LLM` from `engine_args`
@@ -170,6 +181,7 @@ async def get_llm_engine(
     engine_args: dict[str, Any],
     disaggregation_mode: Optional[DisaggregationMode] = None,
     component_gauges: Any = None,
+    model_express_url: Optional[str] = None,
 ) -> AsyncGenerator[TensorRTLLMEngine, None]:
     """Get TensorRT-LLM engine instance with load time tracking.
 
@@ -177,11 +189,11 @@ async def get_llm_engine(
         engine_args: Engine configuration arguments.
         disaggregation_mode: Optional disaggregation mode configuration.
         component_gauges: Optional LLMBackendGauges instance for recording load time.
+        model_express_url: Optional ModelExpress P2P server URL for RDMA weight transfer.
     """
-    # Time engine initialization
     start_time = time.time()
 
-    engine = TensorRTLLMEngine(engine_args, disaggregation_mode)
+    engine = TensorRTLLMEngine(engine_args, disaggregation_mode, model_express_url)
     try:
         await engine.initialize()
         load_time = time.time() - start_time

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -458,6 +458,7 @@ async def init_llm_worker(
         engine_args,
         config.disaggregation_mode,
         component_gauges=component_gauges,
+        model_express_url=config.model_express_url,
     ) as engine:
         # Expose engine to the drain callback installed by main.py (#7319).
         # The callback uses this to poll active request count during shutdown.
@@ -585,7 +586,7 @@ async def init_llm_worker(
         logging.debug("DYNAMO_COMPONENT_REGISTRY callback registered successfully")
 
         # publisher will be set later if publishing is enabled.
-        handler_config = RequestHandlerConfig(
+        handler_kwargs = dict(
             engine=engine,
             default_sampling_params=default_sampling_params,
             publisher=None,
@@ -594,7 +595,7 @@ async def init_llm_worker(
             multimodal_processor=multimodal_processor,
             generate_endpoint=endpoint,
             connector=connector,
-            runtime=runtime,  # Pass runtime for graceful shutdown
+            runtime=runtime,
             metrics_collector=metrics_collector,
             kv_block_size=config.kv_block_size,
             shutdown_event=shutdown_event,
@@ -603,6 +604,7 @@ async def init_llm_worker(
             max_seq_len=config.max_seq_len,
             disagg_machine_id=int(endpoint.connection_id()) % 1021,
         )
+        handler_config = RequestHandlerConfig(**handler_kwargs)
 
         media_decoder = None
         media_fetcher = None

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -101,6 +101,8 @@ trtllm:
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"
+  enable_modelexpress_p2p: "false"
+  modelexpress_ref: "3d73992ce6c10e52ddc54f7f12af35d27e173f15"
   python_version: "3.12"
   index_url: https://pypi.nvidia.com/
   pip_wheel_dir: /tmp/trtllm_wheel/

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -111,6 +111,8 @@ ARG MODELEXPRESS_REF={{ context.vllm.modelexpress_ref }}
 
 {% if framework == "trtllm" %}
 # TensorRT-LLM specific configuration
+ARG ENABLE_MODELEXPRESS_P2P={{ context.trtllm.enable_modelexpress_p2p }}
+ARG MODELEXPRESS_REF={{ context.trtllm.modelexpress_ref }}
 ARG HAS_TRTLLM_CONTEXT={{ context.trtllm.has_trtllm_context }}
 ARG TENSORRTLLM_PIP_WHEEL={{ context.trtllm.pip_wheel }}
 ARG TENSORRTLLM_INDEX_URL={{ context.trtllm.index_url }}

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -273,6 +273,16 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
         if [ -n "$GMS_WHEEL" ]; then uv pip install "$GMS_WHEEL"; fi; \
     fi
 
+# Optional: ModelExpress P2P weight transfer support
+ARG ENABLE_MODELEXPRESS_P2P
+ARG MODELEXPRESS_REF
+RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+    if [ "${ENABLE_MODELEXPRESS_P2P}" = "true" ]; then \
+        echo "Installing ModelExpress P2P support..."; \
+        export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
+        uv pip install "modelexpress @ git+https://github.com/ai-dynamo/modelexpress.git@${MODELEXPRESS_REF}#subdirectory=modelexpress_client/python"; \
+    fi
+
 # Install runtime dependencies (common + benchmarks).
 # Test and dev dependencies are NOT installed here — they go in the test and dev images.
 # --no-cache is intentional: mixed indexes (PyPI + PyTorch CUDA wheels) risk serving stale/wrong-variant cached wheels

--- a/recipes/deepseek-v3.2/README.md
+++ b/recipes/deepseek-v3.2/README.md
@@ -1,0 +1,49 @@
+# DeepSeek-V3.2 Recipes
+
+Deployment recipes for **DeepSeek-V3.2** using TensorRT-LLM with Dynamo's KV-aware routing and ModelExpress P2P weight transfer for fast scale-up.
+
+## Available Configurations
+
+| Configuration | Modality | Deploy Config | Notes |
+|---------------|----------|---------------|-------|
+| **dep8x2 disaggregated** | Text | [`trtllm/disagg/dep8x2/deploy.yaml`](trtllm/disagg/dep8x2/deploy.yaml) | TP=8 prefill + TP=8 decode (8 GPUs each, 2-node multinode each), ModelExpress P2P enabled for sub-second weight loading on subsequent replica scale-up. |
+
+## A note on the missing `model-cache/`
+
+This recipe deviates from the standard structure documented in [`recipes/CONTRIBUTING.md`](../CONTRIBUTING.md) — there's no `model-cache/` directory. That's intentional:
+
+DeepSeek-V3.2 is ~685 GB on disk; downloading it into a per-deployment cache PVC every time is the bottleneck this recipe is specifically designed to bypass. The deployment uses ModelExpress P2P (`--model-express-url modelexpress-server:8001`) so:
+
+- The **first replica** loads the model from a shared `shared-model-cache` PVC (provisioned out-of-band by the operator) and publishes its weights via NIXL RDMA.
+- **Every subsequent replica** auto-detects the existing source and pulls weights via RDMA in ~2 seconds per rank instead of pulling from disk.
+
+For clusters that need the standard model-cache flow (no MX server available), use a sibling DeepSeek recipe such as [`recipes/deepseek-r1/`](../deepseek-r1/) or [`recipes/deepseek-v32-fp4/`](../deepseek-v32-fp4/) which include `model-cache/` with `model-cache.yaml` and `model-download.yaml`.
+
+`run.sh` only validates that `<model>/<framework>/<deployment>/deploy.yaml` exists, so this recipe runs cleanly without `model-cache/`.
+
+## Prerequisites
+
+1. **Dynamo platform** installed (etcd + NATS, the DGD operator, optionally HPA + DGDSA controllers).
+2. **GB200 cluster** with at least 4 nodes (the dep8x2 deployment uses 2 nodes for prefill + 2 for decode; aggregated configs would need fewer).
+3. **HuggingFace token** with access to `deepseek-ai/DeepSeek-V3.2`.
+4. **`shared-model-cache` PVC** populated with the model in HF cache layout (downloaded once, out-of-band — for example via a one-shot Job).
+5. **ComputeDomain** sized for the deployment's `replicas × multinode.nodeCount` nodes (IMEX channels via DRA on GB200).
+6. **ModelExpress server + Redis** reachable in the namespace. A reference deployment is at [`ai-dynamo/modelexpress`](https://github.com/ai-dynamo/modelexpress) (`examples/p2p_transfer_k8s/client/trtllm/mx-infra-decode.yaml`).
+7. **`tensorrtllm-runtime` image at TRT-LLM 1.3.0rc15+** (carrying [PR #13531](https://github.com/NVIDIA/TensorRT-LLM/pull/13531) — `MXCheckpointLoader`) plus `pip install modelexpress` (or use the equivalent NVIDIA-built image once available).
+
+## Quick Deploy
+
+```bash
+kubectl -n <namespace> apply -f trtllm/disagg/dep8x2/deploy.yaml
+```
+
+After all 8 source ranks publish to MX, scale the prefill or decode component up; the new replicas auto-detect the source and complete weight loading in ~5 minutes (vs ~22 minutes for the cold-load source).
+
+## Companion PRs
+
+| PR | Repo | Status | Notes |
+|----|------|--------|-------|
+| [#13531](https://github.com/NVIDIA/TensorRT-LLM/pull/13531) | TRT-LLM | **Merged 2026-05-06** | `MXCheckpointLoader`, `checkpoint_format="MX"` |
+| [#202](https://github.com/ai-dynamo/modelexpress/pull/202) | ModelExpress | **Merged** | `MxLiveWeightLoader`, `publish_model_params` |
+| [#267](https://github.com/ai-dynamo/modelexpress/pull/267) | ModelExpress | **Merged** | `MX_POOL_REG` allocation-based registration |
+| [#8037](https://github.com/ai-dynamo/dynamo/pull/8037) | Dynamo | This PR | `--model-express-url` engine integration with auto-detect source/target |

--- a/recipes/deepseek-v3.2/trtllm/disagg/dep8x2/deploy.yaml
+++ b/recipes/deepseek-v3.2/trtllm/disagg/dep8x2/deploy.yaml
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSeek-V3.2 DEP8x2 Disaggregated Prefill/Decode with P2P Weight Transfer
+#
+# Architecture:
+#   - ModelExpress Server: CPU-only metadata coordinator
+#   - MX Source: Loads FP4 weights, shards for EP8, serves via NIXL/RDMA
+#   - Prefill: 2 nodes x 8 GPUs (DEP8x2), receives weights via P2P
+#   - Decode: 2 nodes x 8 GPUs (DEP8x2), receives weights via P2P
+#
+# Prerequisites:
+#   1. ModelExpress server deployed (see modelexpress-server.yaml)
+#   2. MX source loaded with DeepSeek-V3.2 FP4 weights
+#   3. RDMA/InfiniBand connectivity between nodes
+#
+# Usage:
+#   kubectl apply -f deploy.yaml -n <namespace>
+
+# ConfigMap for prefill engine configuration (DEP8)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prefill-config-dep8x2
+data:
+  prefill_config.yaml: |
+    max_batch_size: 4
+    max_num_tokens: 4608
+    max_seq_len: 8192
+    tensor_parallel_size: 1
+    moe_expert_parallel_size: 8
+    enable_attention_dp: true
+    pipeline_parallel_size: 1
+    disable_overlap_scheduler: true
+    print_iter_log: true
+    kv_cache_config:
+      enable_block_reuse: false
+      free_gpu_memory_fraction: 0.85
+      dtype: fp8
+    cache_transceiver_config:
+      max_tokens_in_buffer: 4608
+      backend: DEFAULT
+---
+
+# ConfigMap for decode engine configuration (DEP8)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: decode-config-dep8x2
+data:
+  decode_config.yaml: |
+    tensor_parallel_size: 1
+    moe_expert_parallel_size: 8
+    enable_attention_dp: true
+    pipeline_parallel_size: 1
+    max_batch_size: 256
+    max_num_tokens: 256
+    max_seq_len: 8448
+    cuda_graph_config:
+      enable_padding: true
+      batch_sizes:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+      - 64
+      - 128
+      - 256
+    print_iter_log: true
+    disable_overlap_scheduler: false
+    kv_cache_config:
+      enable_block_reuse: false
+      free_gpu_memory_fraction: 0.7
+      dtype: fp8
+    cache_transceiver_config:
+      max_tokens_in_buffer: 4608
+      backend: DEFAULT
+---
+
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: dsv32-dep8x2-compute-domain
+spec:
+  numNodes: 5
+  channel:
+    resourceClaimTemplate:
+      name: dsv32-dep8x2-channel
+---
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: dsv32-dep8x2-disagg
+spec:
+  envs:
+    - name: NCCL_MNNVL_ENABLE
+      value: "1"
+    - name: NCCL_CUMEM_ENABLE
+      value: "1"
+    - name: TLLM_LOG_LEVEL
+      value: "info"
+    - name: TRTLLM_MOE_ENABLE_ALLTOALL_WITHOUT_ALLGATHER
+      value: "1"
+    - name: TRTLLM_ENABLE_PDL
+      value: "1"
+  backendFramework: trtllm
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
+          args:
+          - |
+            python3 -m dynamo.frontend --http-port 8000
+          command:
+          - /bin/sh
+          - -c
+    prefill:
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      multinode:
+        nodeCount: 2
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /model-cache
+      sharedMemory:
+        size: 800Gi
+      resources:
+        requests:
+          cpu: "130"
+          memory: "850Gi"
+        limits:
+          cpu: "130"
+          memory: "850Gi"
+          gpu: "8"
+        claims:
+          - name: compute-domain-channel
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
+          workingDir: /workspace/components/backends/trtllm
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 9090
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 600
+          volumeMounts:
+            - name: prefill-config-volume
+              mountPath: /config
+          command:
+          - /bin/sh
+          - -c
+          args:
+          - >-
+            python3 -m dynamo.trtllm
+            --model deepseek-ai/DeepSeek-V3.2
+            --served-model-name deepseek-ai/DeepSeek-V3.2
+            --model-express-url modelexpress-server:8001
+            --extra-engine-args /config/prefill_config.yaml
+            --disaggregation-mode prefill
+        resourceClaims:
+          - name: compute-domain-channel
+            resourceClaimTemplateName: dsv32-dep8x2-channel
+        volumes:
+          - name: prefill-config-volume
+            configMap:
+              name: prefill-config-dep8x2
+    decode:
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      multinode:
+        nodeCount: 2
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /model-cache
+      sharedMemory:
+        size: 800Gi
+      resources:
+        requests:
+          cpu: "130"
+          memory: "850Gi"
+        limits:
+          cpu: "130"
+          memory: "850Gi"
+          gpu: "8"
+        claims:
+          - name: compute-domain-channel
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
+          workingDir: /workspace/components/backends/trtllm
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 9090
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 600
+          volumeMounts:
+            - name: decode-config-volume
+              mountPath: /config
+          command:
+          - /bin/sh
+          - -c
+          args:
+          - >-
+            python3 -m dynamo.trtllm
+            --model deepseek-ai/DeepSeek-V3.2
+            --served-model-name deepseek-ai/DeepSeek-V3.2
+            --model-express-url modelexpress-server:8001
+            --extra-engine-args /config/decode_config.yaml
+            --disaggregation-mode decode
+        resourceClaims:
+          - name: compute-domain-channel
+            resourceClaimTemplateName: dsv32-dep8x2-channel
+        volumes:
+          - name: decode-config-volume
+            configMap:
+              name: decode-config-dep8x2


### PR DESCRIPTION
## Summary

Add ModelExpress P2P weight transfer support to the Dynamo TRT-LLM engine. When `--model-express-url` is provided, the engine automatically detects whether to act as source or target by probing the MX server for existing sources — no explicit role flag needed.

### How auto-detect works

1. Engine calls `_has_existing_sources()` which probes the MX server via `list_sources()`
2. **Sources found** → target mode: configures `LoadFormat.PRESHARDED` + `MxLiveCheckpointLoader` for RDMA receive
3. **No sources** → source mode: sets `MODEL_EXPRESS_URL` env var, workers auto-publish via `publish_from_worker()` after disk load

### Changes

**`components/src/dynamo/trtllm/backend_args.py`**:
- Add `--model-express-url` argument (MX server gRPC address)

**`components/src/dynamo/trtllm/engine.py`**:
- `_has_existing_sources()`: Probe MX server for existing source workers
- `_setup_modelexpress_loader()`: Configure PRESHARDED checkpoint loader for target mode
- Auto-detect in `initialize()`: probe → target or source mode

**`components/src/dynamo/trtllm/workers/llm_worker.py`**:
- Pass `model_express_url` from backend args to engine constructor

### Validated

Kimi K2.5 (TP=8, 2 nodes) on GCP GB200 — 90.75 GB/rank transferred at 365-509 Gbps, end-to-end disaggregated inference verified.

### Dependencies

- **ModelExpress** [PR #202](https://github.com/ai-dynamo/modelexpress/pull/202) (merged): `MxClient`, `MxLiveCheckpointLoader`, `publish_from_worker`
- **TensorRT-LLM** [PR #12898](https://github.com/NVIDIA/TensorRT-LLM/pull/12898): `LoadFormat.PRESHARDED`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
