### PR TITLE
fix(llm): restore zeromq for kv-event sidecars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,6 +2074,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -2354,7 +2380,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.8.4",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",
  "dynamo-runtime",
@@ -2406,7 +2432,7 @@ dependencies = [
  "clap 4.6.0",
  "criterion 0.3.6",
  "cudarc",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",
  "dialoguer",
@@ -2479,6 +2505,7 @@ dependencies = [
  "validator",
  "video-rs",
  "xxhash-rust",
+ "zeromq",
 ]
 
 [[package]]
@@ -2504,7 +2531,7 @@ name = "dynamo-mocker"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",
  "dynamo-kv-router",
@@ -2581,7 +2608,7 @@ dependencies = [
  "console-subscriber",
  "criterion 0.5.1",
  "cudarc",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",
  "dynamo-config",
@@ -2643,7 +2670,7 @@ version = "1.0.0"
 dependencies = [
  "bs58",
  "bytemuck",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "serde",
  "thiserror 2.0.18",
@@ -4493,7 +4520,7 @@ dependencies = [
  "clap 4.6.0",
  "crossbeam-queue",
  "cudarc",
- "dashmap",
+ "dashmap 6.1.0",
  "derive_builder",
  "dynamo-memory",
  "figment",
@@ -8584,6 +8611,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "pin-project-lite",
@@ -9442,7 +9470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2504e857f1ed52ad96ce73792a724be880ba75f3579a27050395e81d38cb42d0"
 dependencies = [
  "anyhow",
- "dashmap",
+ "dashmap 6.1.0",
  "futures",
  "parking_lot",
  "serde",
@@ -9462,7 +9490,7 @@ dependencies = [
  "anyhow",
  "bs58",
  "bytes",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",
  "flume 0.12.0",
@@ -9501,7 +9529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7bcce33f5710d87e33e1eacc5472300cbe6acdfb5f2cd6929c12f2e4908ef38"
 dependencies = [
  "bytes",
- "dashmap",
+ "dashmap 6.1.0",
  "flume 0.12.0",
  "futures",
  "rmp-serde",
@@ -9519,7 +9547,7 @@ checksum = "d1eac77f329b0c3dba1b36114c969e0a7d680bb4a6436720754bef14a24fedde"
 dependencies = [
  "anyhow",
  "bytes",
- "dashmap",
+ "dashmap 6.1.0",
  "futures",
  "serde",
  "serde_json",
@@ -9537,7 +9565,7 @@ checksum = "cd6dc0d71f73c6f369302bb94b05341a807a5693f6c321fc208d9c9a974d918a"
 dependencies = [
  "anyhow",
  "bytes",
- "dashmap",
+ "dashmap 6.1.0",
  "derive_builder",
  "flume 0.12.0",
  "futures",
@@ -9568,7 +9596,7 @@ dependencies = [
  "axum 0.8.4",
  "bs58",
  "bytes",
- "dashmap",
+ "dashmap 6.1.0",
  "flume 0.12.0",
  "futures",
  "http 1.4.0",
@@ -10392,6 +10420,33 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zeromq"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a4528179201f6eecf211961a7d3276faa61554c82651ecc66387f68fc3004bd"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "crossbeam-queue",
+ "dashmap 5.5.3",
+ "futures-channel",
+ "futures-io",
+ "futures-task",
+ "futures-util",
+ "log",
+ "num-traits",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.5",
+ "regex",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "uuid",
+]
 
 [[package]]
 name = "zeromq-src"

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -290,6 +290,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1264,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -1510,7 +1536,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",
  "dynamo-runtime",
@@ -1553,7 +1579,7 @@ dependencies = [
  "bytes",
  "chrono",
  "cudarc",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",
  "dialoguer",
@@ -1615,6 +1641,7 @@ dependencies = [
  "uuid",
  "validator",
  "xxhash-rust",
+ "zeromq",
 ]
 
 [[package]]
@@ -1638,7 +1665,7 @@ name = "dynamo-mocker"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",
  "dynamo-kv-router",
@@ -1707,7 +1734,7 @@ dependencies = [
  "blake3",
  "bytes",
  "chrono",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",
  "dynamo-config",
@@ -1764,7 +1791,7 @@ version = "1.0.0"
 dependencies = [
  "bs58",
  "bytemuck",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "serde",
  "thiserror 2.0.18",
@@ -2325,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -2363,7 +2390,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2409,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -2809,12 +2836,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -4599,7 +4626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4610,7 +4637,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -5948,7 +5975,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -6027,7 +6054,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -6054,7 +6081,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -6650,6 +6677,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "pin-project-lite",
@@ -6727,7 +6755,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -6870,7 +6898,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -7266,7 +7294,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -7494,7 +7522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7520,7 +7548,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -7946,7 +7974,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -7977,7 +8005,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -7996,7 +8024,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -8118,6 +8146,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
+name = "zeromq"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a4528179201f6eecf211961a7d3276faa61554c82651ecc66387f68fc3004bd"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "crossbeam-queue",
+ "dashmap 5.5.3",
+ "futures-channel",
+ "futures-io",
+ "futures-task",
+ "futures-util",
+ "log",
+ "num-traits",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.5",
+ "regex",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "uuid",
+]
+
+[[package]]
 name = "zeromq-src"
 version = "0.2.6+4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8171,7 +8226,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "memchr",
  "thiserror 2.0.18",
  "zopfli",
@@ -8186,7 +8241,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "memchr",
  "zopfli",
 ]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -290,6 +290,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1282,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -1519,7 +1545,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",
  "dynamo-runtime",
@@ -1565,7 +1591,7 @@ dependencies = [
  "bytes",
  "chrono",
  "cudarc",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",
  "dialoguer",
@@ -1630,6 +1656,7 @@ dependencies = [
  "validator",
  "video-rs",
  "xxhash-rust",
+ "zeromq",
 ]
 
 [[package]]
@@ -1653,7 +1680,7 @@ name = "dynamo-mocker"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",
  "dynamo-kv-router",
@@ -1714,7 +1741,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
- "dashmap",
+ "dashmap 6.1.0",
  "dynamo-kv-router",
  "dynamo-llm",
  "dynamo-mocker",
@@ -1754,7 +1781,7 @@ dependencies = [
  "bytes",
  "chrono",
  "cudarc",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "derive_builder",
  "dynamo-config",
@@ -1811,7 +1838,7 @@ version = "1.0.0"
 dependencies = [
  "bs58",
  "bytemuck",
- "dashmap",
+ "dashmap 6.1.0",
  "derive-getters",
  "serde",
  "thiserror 2.0.18",
@@ -2397,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -2435,7 +2462,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2481,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -2881,12 +2908,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -4659,7 +4686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4670,7 +4697,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -6018,7 +6045,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -6097,7 +6124,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -6124,7 +6151,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -6720,6 +6747,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "pin-project-lite",
@@ -6797,7 +6825,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -6940,7 +6968,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -7336,7 +7364,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -7581,7 +7609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7607,7 +7635,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -8033,7 +8061,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -8064,7 +8092,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -8083,7 +8111,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -8205,6 +8233,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
+name = "zeromq"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a4528179201f6eecf211961a7d3276faa61554c82651ecc66387f68fc3004bd"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "crossbeam-queue",
+ "dashmap 5.5.3",
+ "futures-channel",
+ "futures-io",
+ "futures-task",
+ "futures-util",
+ "log",
+ "num-traits",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.5",
+ "regex",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "uuid",
+]
+
+[[package]]
 name = "zeromq-src"
 version = "0.2.6+4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8258,7 +8313,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "memchr",
  "thiserror 2.0.18",
  "zopfli",
@@ -8273,7 +8328,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "memchr",
  "zopfli",
 ]

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -169,6 +169,7 @@ tokio-rayon = {version = "2" }
 ndarray = { version = "0.16" }
 
 # Publishers
+zeromq = "0.4.1"
 rmp-serde = "1.3"
 
 [dev-dependencies]

--- a/lib/llm/src/block_manager/kv_consolidator/publisher.rs
+++ b/lib/llm/src/block_manager/kv_consolidator/publisher.rs
@@ -14,9 +14,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
+use zeromq::{PubSocket, Socket, SocketSend};
 
 use super::tracker::{CacheStatusTracker, ConsolidatedEvent};
-use crate::utils::zmq::{bind_pub_socket, send_multipart};
 
 /// Event batch structure matching vLLM's format (array_like=True)
 /// Format: [timestamp, [events], data_parallel_rank]
@@ -183,7 +183,9 @@ impl KvEventConsolidatorPublisher {
         tracing::info!("Starting consolidated event publisher on {}", endpoint);
 
         // Create ZMQ PUB socket and bind
-        let socket = bind_pub_socket(&endpoint)
+        let mut socket = PubSocket::new();
+        socket
+            .bind(&endpoint)
             .await
             .with_context(|| format!("Failed to bind publisher to {}", endpoint))?;
 
@@ -256,9 +258,15 @@ impl KvEventConsolidatorPublisher {
                 Bytes::from(seq_bytes.to_vec()),
                 Bytes::from(payload),
             ];
-            let frames = frames.into_iter().map(|frame| frame.to_vec()).collect();
+            let msg = match zeromq::ZmqMessage::try_from(frames) {
+                Ok(message) => message,
+                Err(error) => {
+                    tracing::error!("Failed to create multipart ZMQ message: {:?}", error);
+                    continue;
+                }
+            };
 
-            if let Err(e) = send_multipart(&socket, frames).await {
+            if let Err(e) = socket.send(msg).await {
                 tracing::error!("Failed to send consolidated events: {}", e);
             } else {
                 tracing::debug!(

--- a/lib/llm/src/block_manager/kv_consolidator/subscriber.rs
+++ b/lib/llm/src/block_manager/kv_consolidator/subscriber.rs
@@ -6,18 +6,17 @@
 //! This is a simplified subscriber that deserializes raw vLLM/TensorRT-LLM events.
 
 use anyhow::{Context, Result};
-use futures::StreamExt;
 use rmp_serde::Deserializer;
 use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+use zeromq::{Socket, SocketRecv, SubSocket};
 
 use dynamo_kv_router::zmq_wire::RawKvEvent;
 
 use super::tracker::{CacheStatusTracker, EventSource, StorageTier};
-use crate::utils::zmq::{connect_sub_socket, multipart_message};
 
 /// Event batch received from vLLM/TensorRT-LLM (array format)
 /// Format: [timestamp, [events], data_parallel_rank]
@@ -74,10 +73,15 @@ async fn run_listener_loop(
         endpoint
     );
 
-    let socket = connect_sub_socket(&endpoint, None)
+    let mut socket = SubSocket::new();
+    socket
+        .connect(&endpoint)
         .await
         .with_context(|| format!("Failed to connect to ZMQ endpoint {endpoint}"))?;
-    let mut socket = socket;
+    socket
+        .subscribe("")
+        .await
+        .context("Failed to subscribe to ZMQ topics")?;
 
     tracing::info!(
         "KV event consolidator ZMQ listener successfully connected to {}",
@@ -93,19 +97,18 @@ async fn run_listener_loop(
                 break;
             }
 
-            msg_result = socket.next() => {
-                let frames = match msg_result {
-                    Some(Ok(frames)) => multipart_message(frames),
-                    Some(Err(error)) => {
-                        tracing::error!("Error receiving ZMQ message: {error}");
-                        break;
-                    }
-                    None => break,
+            msg_result = socket.recv() => {
+                let Ok(msg) = msg_result else {
+                    tracing::warn!("Error receiving ZMQ message: {:?}", msg_result.unwrap_err());
+                    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                    continue;
                 };
 
                 // Parse multipart message: supports both formats
                 // - 2 frames: [topic, payload]
                 // - 3 frames: [topic, sequence, payload]
+                let frames: Vec<Vec<u8>> = msg.into_vec().into_iter().map(|frame| frame.to_vec()).collect();
+
                 let payload = match frames.len() {
                     2 => &frames[1],  // [topic, payload]
                     3 => &frames[2],  // [topic, sequence, payload]

--- a/lib/llm/src/fpm_publisher.rs
+++ b/lib/llm/src/fpm_publisher.rs
@@ -11,17 +11,85 @@
 //! [`crate::kv_router::publisher::KvEventPublisher`], but is much simpler:
 //! no event transformation, no batching, no local indexer — just raw byte relay.
 
+use std::time::Duration;
+
 use anyhow::Result;
-use futures::StreamExt;
 use tokio_util::sync::CancellationToken;
+use zeromq::{Socket, SocketRecv, SubSocket};
 
-use dynamo_runtime::component::Component;
-use dynamo_runtime::traits::DistributedRuntimeProvider;
-use dynamo_runtime::transports::event_plane::EventPublisher;
-
-use crate::utils::zmq::{connect_sub_socket, multipart_message};
+use dynamo_runtime::{
+    component::Component, traits::DistributedRuntimeProvider,
+    transports::event_plane::EventPublisher,
+};
 
 const FPM_TOPIC: &str = "forward-pass-metrics";
+const MAX_CONSECUTIVE_ERRORS: u32 = 10;
+const INITIAL_SETUP_BACKOFF_MS: u64 = 10;
+const MAX_SETUP_BACKOFF_MS: u64 = 5000;
+const MAX_SETUP_BACKOFF_EXPONENT: u32 = 8;
+
+fn calculate_setup_backoff_ms(consecutive_errors: u32) -> u64 {
+    std::cmp::min(
+        INITIAL_SETUP_BACKOFF_MS * 2_u64.pow(consecutive_errors.min(MAX_SETUP_BACKOFF_EXPONENT)),
+        MAX_SETUP_BACKOFF_MS,
+    )
+}
+
+async fn connect_sub_socket_with_retry(
+    endpoint: &str,
+    cancellation_token: &CancellationToken,
+    log_prefix: &str,
+) -> Option<SubSocket> {
+    let mut consecutive_errors = 0u32;
+
+    loop {
+        if cancellation_token.is_cancelled() {
+            tracing::debug!("{log_prefix}: cancelled before connecting to {endpoint}");
+            return None;
+        }
+
+        let mut socket = SubSocket::new();
+
+        match socket.subscribe("").await {
+            Ok(()) => {}
+            Err(error) => {
+                consecutive_errors += 1;
+                let backoff_ms = calculate_setup_backoff_ms(consecutive_errors);
+                tracing::warn!(
+                    error = %error,
+                    consecutive_errors = consecutive_errors,
+                    backoff_ms = backoff_ms,
+                    "{log_prefix}: failed to subscribe on ZMQ socket during setup, retrying"
+                );
+                tokio::select! {
+                    biased;
+                    _ = cancellation_token.cancelled() => return None,
+                    _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => {}
+                }
+                continue;
+            }
+        }
+
+        match socket.connect(endpoint).await {
+            Ok(()) => return Some(socket),
+            Err(error) => {
+                consecutive_errors += 1;
+                let backoff_ms = calculate_setup_backoff_ms(consecutive_errors);
+                tracing::warn!(
+                    error = %error,
+                    consecutive_errors = consecutive_errors,
+                    backoff_ms = backoff_ms,
+                    "{log_prefix}: failed to connect ZMQ SUB during setup, retrying"
+                );
+                tokio::select! {
+                    biased;
+                    _ = cancellation_token.cancelled() => return None,
+                    _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => {}
+                }
+            }
+        }
+    }
+}
 
 /// A relay that bridges ForwardPassMetrics from a local raw ZMQ PUB socket
 /// to the Dynamo event plane.
@@ -60,15 +128,14 @@ impl FpmEventRelay {
         publisher: EventPublisher,
         cancel: CancellationToken,
     ) {
-        let socket = match connect_sub_socket(&zmq_endpoint, None).await {
-            Ok(socket) => socket,
-            Err(error) => {
-                tracing::error!(endpoint = %zmq_endpoint, error = %error, "FPM relay: failed to connect");
-                return;
-            }
+        let Some(mut socket) =
+            connect_sub_socket_with_retry(&zmq_endpoint, &cancel, "FPM relay").await
+        else {
+            return;
         };
-        let mut socket = socket;
         tracing::info!("FPM relay: connected to {zmq_endpoint}");
+
+        let mut consecutive_errors: u32 = 0;
 
         loop {
             tokio::select! {
@@ -77,10 +144,12 @@ impl FpmEventRelay {
                     tracing::info!("FPM relay: shutting down");
                     break;
                 }
-                result = socket.next() => {
+                result = socket.recv() => {
                     match result {
-                        Some(Ok(frames)) => {
-                            let mut frames = multipart_message(frames);
+                        Ok(msg) => {
+                            consecutive_errors = 0;
+                            let mut frames: Vec<Vec<u8>> =
+                                msg.into_vec().into_iter().map(|frame| frame.to_vec()).collect();
                             // ZMQ multipart: [topic, seq, payload]
                             if frames.len() == 3 {
                                 let payload = frames.swap_remove(2);
@@ -91,16 +160,19 @@ impl FpmEventRelay {
                                 tracing::warn!(
                                     "FPM relay: unexpected ZMQ frame count: expected 3, got {}",
                                     frames.len()
-                            );
+                                );
                             }
                         }
-                        Some(Err(e)) => {
-                            tracing::error!("FPM relay: ZMQ recv failed: {e}");
-                            break;
-                        }
-                        None => {
-                            tracing::error!("FPM relay: ZMQ stream ended");
-                            break;
+                        Err(error) => {
+                            consecutive_errors += 1;
+                            tracing::warn!(
+                                "FPM relay: ZMQ recv error ({consecutive_errors}/{MAX_CONSECUTIVE_ERRORS}): {error}"
+                            );
+                            if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                                tracing::error!("FPM relay: too many consecutive errors, exiting");
+                                break;
+                            }
+                            tokio::time::sleep(Duration::from_millis(100)).await;
                         }
                     }
                 }

--- a/lib/llm/src/kv_router/publisher/zmq_listener.rs
+++ b/lib/llm/src/kv_router/publisher/zmq_listener.rs
@@ -8,16 +8,83 @@ use std::time::Duration;
 use rmp_serde as rmps;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
+use zeromq::{Socket, SocketRecv, SubSocket};
 
 use dynamo_kv_router::protocols::*;
 use dynamo_kv_router::zmq_wire::*;
-
-use crate::utils::zmq::{connect_sub_socket_with_retry, recv_multipart};
 
 const INITIAL_BACKOFF_MS: u64 = 10;
 const MAX_BACKOFF_MS: u64 = 5000;
 const MAX_CONSECUTIVE_ERRORS: u32 = 10;
 const MAX_BACKOFF_EXPONENT: u32 = 8;
+const INITIAL_SETUP_BACKOFF_MS: u64 = 10;
+const MAX_SETUP_BACKOFF_MS: u64 = 5000;
+const MAX_SETUP_BACKOFF_EXPONENT: u32 = 8;
+
+fn calculate_setup_backoff_ms(consecutive_errors: u32) -> u64 {
+    std::cmp::min(
+        INITIAL_SETUP_BACKOFF_MS * 2_u64.pow(consecutive_errors.min(MAX_SETUP_BACKOFF_EXPONENT)),
+        MAX_SETUP_BACKOFF_MS,
+    )
+}
+
+async fn connect_sub_socket_with_retry(
+    endpoint: &str,
+    topic: Option<&str>,
+    cancellation_token: &CancellationToken,
+    log_prefix: &str,
+) -> Option<SubSocket> {
+    let mut consecutive_errors = 0u32;
+    let topic = topic.unwrap_or("");
+
+    loop {
+        if cancellation_token.is_cancelled() {
+            tracing::debug!("{log_prefix}: cancelled before connecting to {endpoint}");
+            return None;
+        }
+
+        let mut socket = SubSocket::new();
+
+        match socket.subscribe(topic).await {
+            Ok(()) => {}
+            Err(error) => {
+                consecutive_errors += 1;
+                let backoff_ms = calculate_setup_backoff_ms(consecutive_errors);
+                tracing::warn!(
+                    error = %error,
+                    consecutive_errors = consecutive_errors,
+                    backoff_ms = backoff_ms,
+                    "{log_prefix}: failed to subscribe on ZMQ socket during setup, retrying"
+                );
+                tokio::select! {
+                    biased;
+                    _ = cancellation_token.cancelled() => return None,
+                    _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => {}
+                }
+                continue;
+            }
+        }
+
+        match socket.connect(endpoint).await {
+            Ok(()) => return Some(socket),
+            Err(error) => {
+                consecutive_errors += 1;
+                let backoff_ms = calculate_setup_backoff_ms(consecutive_errors);
+                tracing::warn!(
+                    error = %error,
+                    consecutive_errors = consecutive_errors,
+                    backoff_ms = backoff_ms,
+                    "{log_prefix}: failed to connect ZMQ SUB during setup, retrying"
+                );
+                tokio::select! {
+                    biased;
+                    _ = cancellation_token.cancelled() => return None,
+                    _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => {}
+                }
+            }
+        }
+    }
+}
 
 fn calculate_backoff_ms(consecutive_errors: u32) -> u64 {
     std::cmp::min(
@@ -67,39 +134,38 @@ pub(super) async fn start_zmq_listener(
                 break 'main;
             }
 
-            msg_result = recv_multipart(&mut socket) => {
-                let mut frames = match msg_result {
-                    Ok(frames) => {
-                        consecutive_errors = 0;
-                        frames
-                    }
-                    Err(error) => {
-                        consecutive_errors += 1;
+            msg_result = socket.recv() => {
+                let Ok(msg) = msg_result else {
+                    let error = msg_result.unwrap_err();
+                    consecutive_errors += 1;
 
-                        if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
-                            tracing::error!(
-                                endpoint = %zmq_endpoint,
-                                error = %error,
-                                consecutive_errors = consecutive_errors,
-                                "Too many consecutive ZMQ errors, terminating listener"
-                            );
-                            exit_reason = "too many consecutive errors";
-                            break 'main;
-                        }
-
-                        let backoff_ms = calculate_backoff_ms(consecutive_errors);
-                        tracing::warn!(
+                    if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                        tracing::error!(
                             endpoint = %zmq_endpoint,
                             error = %error,
                             consecutive_errors = consecutive_errors,
-                            backoff_ms = backoff_ms,
-                            "Error reading from ZMQ socket, applying exponential backoff"
+                            "Too many consecutive ZMQ errors, terminating listener"
                         );
-
-                        tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
-                        continue;
+                        exit_reason = "too many consecutive errors";
+                        break 'main;
                     }
+
+                    let backoff_ms = calculate_backoff_ms(consecutive_errors);
+                    tracing::warn!(
+                        endpoint = %zmq_endpoint,
+                        error = %error,
+                        consecutive_errors = consecutive_errors,
+                        backoff_ms = backoff_ms,
+                        "Error reading from ZMQ socket, applying exponential backoff"
+                    );
+
+                    tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                    continue;
                 };
+                consecutive_errors = 0;
+
+                let mut frames: Vec<Vec<u8>> =
+                    msg.into_vec().into_iter().map(|frame| frame.to_vec()).collect();
 
                 if frames.len() != 3 {
                     tracing::warn!(

--- a/lib/llm/src/kv_router/publisher/zmq_listener.rs
+++ b/lib/llm/src/kv_router/publisher/zmq_listener.rs
@@ -3,8 +3,8 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::time::Duration;
 
-use futures::StreamExt;
 use rmp_serde as rmps;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -12,7 +12,19 @@ use tokio_util::sync::CancellationToken;
 use dynamo_kv_router::protocols::*;
 use dynamo_kv_router::zmq_wire::*;
 
-use crate::utils::zmq::{connect_sub_socket, multipart_message};
+use crate::utils::zmq::{connect_sub_socket_with_retry, recv_multipart};
+
+const INITIAL_BACKOFF_MS: u64 = 10;
+const MAX_BACKOFF_MS: u64 = 5000;
+const MAX_CONSECUTIVE_ERRORS: u32 = 10;
+const MAX_BACKOFF_EXPONENT: u32 = 8;
+
+fn calculate_backoff_ms(consecutive_errors: u32) -> u64 {
+    std::cmp::min(
+        INITIAL_BACKOFF_MS * 2_u64.pow(consecutive_errors.min(MAX_BACKOFF_EXPONENT)),
+        MAX_BACKOFF_MS,
+    )
+}
 
 pub(super) async fn start_zmq_listener(
     zmq_endpoint: String,
@@ -30,40 +42,64 @@ pub(super) async fn start_zmq_listener(
     );
 
     let warning_count = Arc::new(AtomicU32::new(0));
-    let socket = match connect_sub_socket(&zmq_endpoint, Some(&zmq_topic)).await {
-        Ok(socket) => socket,
-        Err(error) => {
-            tracing::error!(endpoint = %zmq_endpoint, topic = %zmq_topic, error = %error, "ZMQ listener failed to connect");
-            return;
-        }
-    };
-    let mut socket = socket;
-
-    if cancellation_token.is_cancelled() {
+    let Some(mut socket) = connect_sub_socket_with_retry(
+        &zmq_endpoint,
+        Some(&zmq_topic),
+        &cancellation_token,
+        "ZMQ listener",
+    )
+    .await
+    else {
         return;
-    }
+    };
 
+    let mut consecutive_errors = 0u32;
     let mut messages_processed = 0u64;
-
-    let exit_reason = 'main: loop {
+    #[expect(unused_assignments)]
+    let mut exit_reason = "unknown";
+    'main: loop {
         tokio::select! {
             biased;
 
             _ = cancellation_token.cancelled() => {
                 tracing::debug!("ZMQ listener received cancellation signal");
-                break 'main String::from("cancellation token cancelled");
+                exit_reason = "cancellation token cancelled";
+                break 'main;
             }
 
-            msg_result = socket.next() => {
-                let frames = match msg_result {
-                    Some(Ok(frames)) => multipart_message(frames),
-                    Some(Err(error)) => {
-                        tracing::error!(endpoint = %zmq_endpoint, error = %error, "ZMQ listener recv failed");
-                        break 'main format!("ZMQ recv failed: {error}");
+            msg_result = recv_multipart(&mut socket) => {
+                let mut frames = match msg_result {
+                    Ok(frames) => {
+                        consecutive_errors = 0;
+                        frames
                     }
-                    None => break 'main String::from("ZMQ stream ended"),
+                    Err(error) => {
+                        consecutive_errors += 1;
+
+                        if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                            tracing::error!(
+                                endpoint = %zmq_endpoint,
+                                error = %error,
+                                consecutive_errors = consecutive_errors,
+                                "Too many consecutive ZMQ errors, terminating listener"
+                            );
+                            exit_reason = "too many consecutive errors";
+                            break 'main;
+                        }
+
+                        let backoff_ms = calculate_backoff_ms(consecutive_errors);
+                        tracing::warn!(
+                            endpoint = %zmq_endpoint,
+                            error = %error,
+                            consecutive_errors = consecutive_errors,
+                            backoff_ms = backoff_ms,
+                            "Error reading from ZMQ socket, applying exponential backoff"
+                        );
+
+                        tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                        continue;
+                    }
                 };
-                let mut frames = frames;
 
                 if frames.len() != 3 {
                     tracing::warn!(
@@ -109,13 +145,14 @@ pub(super) async fn start_zmq_listener(
                         convert_event(raw_event, event_id, kv_block_size, worker, &warning_count);
                     if tx.send(event).is_err() {
                         tracing::warn!("Failed to send message to channel - receiver dropped");
-                        break 'main String::from("channel receiver dropped");
+                        exit_reason = "channel receiver dropped";
+                        break 'main;
                     }
                     messages_processed += 1;
                 }
             }
         }
-    };
+    }
 
     tracing::debug!(
         "ZMQ listener exiting, reason: {}, messages processed: {}",

--- a/lib/llm/src/utils/zmq.rs
+++ b/lib/llm/src/utils/zmq.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
+use std::time::Duration;
 
-use anyhow::Result;
-use futures::SinkExt;
+use anyhow::{Result, anyhow};
+use futures::{SinkExt, StreamExt};
 use tmq::{
     Context, Multipart, SocketBuilder,
     publish::{Publish, publish},
@@ -12,6 +13,7 @@ use tmq::{
     subscribe::{Subscribe, subscribe},
 };
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 
 pub(crate) type MultipartMessage = Vec<Vec<u8>>;
 pub(crate) type SharedPubSocket = Arc<Mutex<Publish>>;
@@ -23,6 +25,16 @@ const ZMQ_RECONNECT_IVL_MS: i32 = 100;
 const ZMQ_RECONNECT_IVL_MAX_MS: i32 = 5000;
 const ZMQ_TCP_KEEPALIVE: i32 = 1;
 const ZMQ_LINGER_MS: i32 = 0;
+const INITIAL_SETUP_BACKOFF_MS: u64 = 10;
+const MAX_SETUP_BACKOFF_MS: u64 = 5000;
+const MAX_SETUP_BACKOFF_EXPONENT: u32 = 8;
+
+fn calculate_setup_backoff_ms(consecutive_errors: u32) -> u64 {
+    std::cmp::min(
+        INITIAL_SETUP_BACKOFF_MS * 2_u64.pow(consecutive_errors.min(MAX_SETUP_BACKOFF_EXPONENT)),
+        MAX_SETUP_BACKOFF_MS,
+    )
+}
 
 fn configure_common_builder<T>(builder: SocketBuilder<T>) -> SocketBuilder<T>
 where
@@ -64,6 +76,41 @@ pub(crate) async fn connect_sub_socket(endpoint: &str, topic: Option<&str>) -> R
     Ok(socket)
 }
 
+pub(crate) async fn connect_sub_socket_with_retry(
+    endpoint: &str,
+    topic: Option<&str>,
+    cancellation_token: &CancellationToken,
+    log_prefix: &str,
+) -> Option<SubSocket> {
+    let mut consecutive_errors = 0u32;
+
+    loop {
+        if cancellation_token.is_cancelled() {
+            tracing::debug!("{log_prefix}: cancelled before connecting to {endpoint}");
+            return None;
+        }
+
+        match connect_sub_socket(endpoint, topic).await {
+            Ok(socket) => return Some(socket),
+            Err(error) => {
+                consecutive_errors += 1;
+                let backoff_ms = calculate_setup_backoff_ms(consecutive_errors);
+                tracing::warn!(
+                    error = %error,
+                    consecutive_errors = consecutive_errors,
+                    backoff_ms = backoff_ms,
+                    "{log_prefix}: failed to connect ZMQ SUB during setup, retrying"
+                );
+                tokio::select! {
+                    biased;
+                    _ = cancellation_token.cancelled() => return None,
+                    _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => {}
+                }
+            }
+        }
+    }
+}
+
 pub(crate) async fn bind_pub_socket(endpoint: &str) -> Result<SharedPubSocket> {
     let ctx = Context::new();
     let socket = configure_send_builder(publish(&ctx)).bind(endpoint)?;
@@ -78,6 +125,17 @@ pub(crate) async fn bind_router_socket(endpoint: &str) -> Result<Router> {
 
 pub(crate) fn multipart_message(multipart: Multipart) -> MultipartMessage {
     multipart.into_iter().map(|frame| frame.to_vec()).collect()
+}
+
+pub(crate) async fn recv_multipart<S>(socket: &mut S) -> Result<MultipartMessage>
+where
+    S: futures::Stream<Item = std::result::Result<Multipart, tmq::TmqError>> + Unpin,
+{
+    match socket.next().await {
+        Some(Ok(multipart)) => Ok(multipart_message(multipart)),
+        Some(Err(error)) => Err(error.into()),
+        None => Err(anyhow!("ZMQ stream ended")),
+    }
 }
 
 pub(crate) async fn send_multipart<S>(

--- a/lib/llm/src/utils/zmq.rs
+++ b/lib/llm/src/utils/zmq.rs
@@ -2,22 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
-use std::time::Duration;
 
-use anyhow::{Result, anyhow};
-use futures::{SinkExt, StreamExt};
+use anyhow::Result;
+use futures::SinkExt;
 use tmq::{
     Context, Multipart, SocketBuilder,
     publish::{Publish, publish},
     router::{Router, router},
-    subscribe::{Subscribe, subscribe},
 };
 use tokio::sync::Mutex;
-use tokio_util::sync::CancellationToken;
 
 pub(crate) type MultipartMessage = Vec<Vec<u8>>;
 pub(crate) type SharedPubSocket = Arc<Mutex<Publish>>;
-pub(crate) type SubSocket = Subscribe;
 
 const ZMQ_RCVTIMEOUT_MS: i32 = 100;
 const ZMQ_SNDTIMEOUT_MS: i32 = 0;
@@ -25,16 +21,6 @@ const ZMQ_RECONNECT_IVL_MS: i32 = 100;
 const ZMQ_RECONNECT_IVL_MAX_MS: i32 = 5000;
 const ZMQ_TCP_KEEPALIVE: i32 = 1;
 const ZMQ_LINGER_MS: i32 = 0;
-const INITIAL_SETUP_BACKOFF_MS: u64 = 10;
-const MAX_SETUP_BACKOFF_MS: u64 = 5000;
-const MAX_SETUP_BACKOFF_EXPONENT: u32 = 8;
-
-fn calculate_setup_backoff_ms(consecutive_errors: u32) -> u64 {
-    std::cmp::min(
-        INITIAL_SETUP_BACKOFF_MS * 2_u64.pow(consecutive_errors.min(MAX_SETUP_BACKOFF_EXPONENT)),
-        MAX_SETUP_BACKOFF_MS,
-    )
-}
 
 fn configure_common_builder<T>(builder: SocketBuilder<T>) -> SocketBuilder<T>
 where
@@ -68,49 +54,6 @@ where
     configure_common_builder(builder).set_sndtimeo(ZMQ_SNDTIMEOUT_MS)
 }
 
-pub(crate) async fn connect_sub_socket(endpoint: &str, topic: Option<&str>) -> Result<SubSocket> {
-    let ctx = Context::new();
-    let socket = configure_receive_builder(subscribe(&ctx))
-        .connect(endpoint)?
-        .subscribe(topic.unwrap_or("").as_bytes())?;
-    Ok(socket)
-}
-
-pub(crate) async fn connect_sub_socket_with_retry(
-    endpoint: &str,
-    topic: Option<&str>,
-    cancellation_token: &CancellationToken,
-    log_prefix: &str,
-) -> Option<SubSocket> {
-    let mut consecutive_errors = 0u32;
-
-    loop {
-        if cancellation_token.is_cancelled() {
-            tracing::debug!("{log_prefix}: cancelled before connecting to {endpoint}");
-            return None;
-        }
-
-        match connect_sub_socket(endpoint, topic).await {
-            Ok(socket) => return Some(socket),
-            Err(error) => {
-                consecutive_errors += 1;
-                let backoff_ms = calculate_setup_backoff_ms(consecutive_errors);
-                tracing::warn!(
-                    error = %error,
-                    consecutive_errors = consecutive_errors,
-                    backoff_ms = backoff_ms,
-                    "{log_prefix}: failed to connect ZMQ SUB during setup, retrying"
-                );
-                tokio::select! {
-                    biased;
-                    _ = cancellation_token.cancelled() => return None,
-                    _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => {}
-                }
-            }
-        }
-    }
-}
-
 pub(crate) async fn bind_pub_socket(endpoint: &str) -> Result<SharedPubSocket> {
     let ctx = Context::new();
     let socket = configure_send_builder(publish(&ctx)).bind(endpoint)?;
@@ -125,17 +68,6 @@ pub(crate) async fn bind_router_socket(endpoint: &str) -> Result<Router> {
 
 pub(crate) fn multipart_message(multipart: Multipart) -> MultipartMessage {
     multipart.into_iter().map(|frame| frame.to_vec()).collect()
-}
-
-pub(crate) async fn recv_multipart<S>(socket: &mut S) -> Result<MultipartMessage>
-where
-    S: futures::Stream<Item = std::result::Result<Multipart, tmq::TmqError>> + Unpin,
-{
-    match socket.next().await {
-        Some(Ok(multipart)) => Ok(multipart_message(multipart)),
-        Some(Err(error)) => Err(error.into()),
-        None => Err(anyhow!("ZMQ stream ended")),
-    }
 }
 
 pub(crate) async fn send_multipart<S>(

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -226,6 +226,14 @@ async fn handle_reader(
     let mut framed_reader = framed_reader;
     let mut alive_tx = alive_tx;
     let mut cancellation_counted = false;
+    let mut count_cancellation = || {
+        if let Some(counter) = &cancellation_counter
+            && !cancellation_counted
+        {
+            counter.inc();
+            cancellation_counted = true;
+        }
+    };
     loop {
         tokio::select! {
             msg = framed_reader.next() => {
@@ -235,50 +243,43 @@ async fn handle_reader(
                            (Some(bytes), None) => {
                                 let msg = match serde_json::from_slice::<ControlMessage>(bytes) {
                                     Ok(msg) => msg,
-                                    Err(_) => {
-                                        // TODO(#171) - address fatal errors
-                                        panic!("fatal error - invalid control message detected");
+                                    Err(error) => {
+                                        tracing::warn!(error = %error, "invalid control message detected on response stream");
+                                        break;
                                     }
                                 };
 
                                 match msg {
                                     ControlMessage::Stop => {
-                                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
-                                            counter.inc();
-                                            cancellation_counted = true;
-                                        }
+                                        count_cancellation();
                                         context.stop();
                                     }
                                     ControlMessage::Kill => {
-                                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
-                                            counter.inc();
-                                            cancellation_counted = true;
-                                        }
+                                        count_cancellation();
                                         context.kill();
                                     }
                                     ControlMessage::Sentinel => {
-                                        // TODO(#171) - address fatal errors
-                                        panic!("received a sentinel message; this should never happen");
+                                        tracing::warn!("unexpected sentinel message received on response stream");
+                                        break;
                                     }
                                 }
                            }
                            _ => {
-                                panic!("received a non-control message; this should never happen");
+                                tracing::warn!("received a non-control message on response stream");
+                                break;
                            }
                         }
                     }
-                    Some(Err(e)) => {
-                        // TODO(#171) - address fatal errors
-                        // in this case the binary representation of the message is invalid
-                        panic!("fatal error - failed to decode message from stream; invalid line protocol: {e:?}");
+                    Some(Err(error)) => {
+                        tracing::warn!(error = ?error, "failed to decode message from stream; closing response reader");
+                        count_cancellation();
+                        break;
                     }
                     None => {
                         tracing::debug!("tcp stream closed by server");
                         // If no Stop/Kill was received, this is a cancellation where frontend
                         // dropped the connection
-                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
-                            counter.inc();
-                        }
+                        count_cancellation();
                         break;
                     }
                 }
@@ -356,7 +357,7 @@ mod tests {
     use bytes::Bytes;
     use futures::StreamExt;
     use std::sync::Arc;
-    use tokio::io::AsyncReadExt;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
     use tokio::sync::{mpsc, oneshot};
     use tokio_util::codec::FramedRead;
@@ -778,6 +779,38 @@ mod tests {
         TwoPartMessage::from_header(Bytes::from(msg_bytes))
     }
 
+    async fn run_reader_with_truncated_frame() -> Result<(), tokio::task::JoinError> {
+        let ReaderHarness {
+            framed_server,
+            framed_reader,
+            alive_tx,
+            alive_rx: _alive_rx,
+            controller,
+        } = reader_harness().await;
+
+        let reader_handle =
+            tokio::spawn(
+                async move { handle_reader(framed_reader, controller, alive_tx, None).await },
+            );
+
+        let encoded = TwoPartCodec::default()
+            .encode_message(TwoPartMessage::from_parts(
+                Bytes::from_static(b"header"),
+                Bytes::from_static(b"body"),
+            ))
+            .unwrap();
+        let truncated = &encoded[..encoded.len() - 1];
+
+        let mut server_write = framed_server.into_inner();
+        server_write.write_all(truncated).await.unwrap();
+        server_write.shutdown().await.unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), reader_handle)
+            .await
+            .expect("handle_reader should finish after truncated frame")
+            .map(|_| ())
+    }
+
     /// Test that handle_reader handles Stop control message by calling context.stop()
     #[tokio::test]
     async fn test_handle_reader_stop_control_message() {
@@ -908,6 +941,17 @@ mod tests {
         );
     }
 
+    /// Test that handle_reader exits cleanly when the peer closes mid-frame.
+    #[tokio::test]
+    async fn test_handle_reader_exits_on_truncated_frame() {
+        let result = run_reader_with_truncated_frame().await;
+
+        assert!(
+            result.is_ok(),
+            "handle_reader should not panic on truncated frame: {result:?}"
+        );
+    }
+
     /// Test that handle_reader handles multiple control messages in sequence
     #[tokio::test]
     async fn test_handle_reader_multiple_control_messages() {
@@ -986,5 +1030,19 @@ mod tests {
             controller.is_killed(),
             "Controller should be killed after receiving Kill message"
         );
+    }
+
+    /// Short stress test to ensure repeated truncated frames do not take down Tokio workers.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_handle_reader_many_truncated_frames() {
+        let tasks = (0..32).map(|_| tokio::spawn(run_reader_with_truncated_frame()));
+
+        for task in futures::future::join_all(tasks).await {
+            let join_result = task.expect("outer test task should not panic");
+            assert!(
+                join_result.is_ok(),
+                "handle_reader should not panic on truncated frame: {join_result:?}"
+            );
+        }
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -226,14 +226,6 @@ async fn handle_reader(
     let mut framed_reader = framed_reader;
     let mut alive_tx = alive_tx;
     let mut cancellation_counted = false;
-    let mut count_cancellation = || {
-        if let Some(counter) = &cancellation_counter
-            && !cancellation_counted
-        {
-            counter.inc();
-            cancellation_counted = true;
-        }
-    };
     loop {
         tokio::select! {
             msg = framed_reader.next() => {
@@ -243,43 +235,50 @@ async fn handle_reader(
                            (Some(bytes), None) => {
                                 let msg = match serde_json::from_slice::<ControlMessage>(bytes) {
                                     Ok(msg) => msg,
-                                    Err(error) => {
-                                        tracing::warn!(error = %error, "invalid control message detected on response stream");
-                                        break;
+                                    Err(_) => {
+                                        // TODO(#171) - address fatal errors
+                                        panic!("fatal error - invalid control message detected");
                                     }
                                 };
 
                                 match msg {
                                     ControlMessage::Stop => {
-                                        count_cancellation();
+                                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
+                                            counter.inc();
+                                            cancellation_counted = true;
+                                        }
                                         context.stop();
                                     }
                                     ControlMessage::Kill => {
-                                        count_cancellation();
+                                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
+                                            counter.inc();
+                                            cancellation_counted = true;
+                                        }
                                         context.kill();
                                     }
                                     ControlMessage::Sentinel => {
-                                        tracing::warn!("unexpected sentinel message received on response stream");
-                                        break;
+                                        // TODO(#171) - address fatal errors
+                                        panic!("received a sentinel message; this should never happen");
                                     }
                                 }
                            }
                            _ => {
-                                tracing::warn!("received a non-control message on response stream");
-                                break;
+                                panic!("received a non-control message; this should never happen");
                            }
                         }
                     }
-                    Some(Err(error)) => {
-                        tracing::warn!(error = ?error, "failed to decode message from stream; closing response reader");
-                        count_cancellation();
-                        break;
+                    Some(Err(e)) => {
+                        // TODO(#171) - address fatal errors
+                        // in this case the binary representation of the message is invalid
+                        panic!("fatal error - failed to decode message from stream; invalid line protocol: {e:?}");
                     }
                     None => {
                         tracing::debug!("tcp stream closed by server");
                         // If no Stop/Kill was received, this is a cancellation where frontend
                         // dropped the connection
-                        count_cancellation();
+                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
+                            counter.inc();
+                        }
                         break;
                     }
                 }
@@ -357,7 +356,7 @@ mod tests {
     use bytes::Bytes;
     use futures::StreamExt;
     use std::sync::Arc;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::io::AsyncReadExt;
     use tokio::net::TcpStream;
     use tokio::sync::{mpsc, oneshot};
     use tokio_util::codec::FramedRead;
@@ -779,38 +778,6 @@ mod tests {
         TwoPartMessage::from_header(Bytes::from(msg_bytes))
     }
 
-    async fn run_reader_with_truncated_frame() -> Result<(), tokio::task::JoinError> {
-        let ReaderHarness {
-            framed_server,
-            framed_reader,
-            alive_tx,
-            alive_rx: _alive_rx,
-            controller,
-        } = reader_harness().await;
-
-        let reader_handle =
-            tokio::spawn(
-                async move { handle_reader(framed_reader, controller, alive_tx, None).await },
-            );
-
-        let encoded = TwoPartCodec::default()
-            .encode_message(TwoPartMessage::from_parts(
-                Bytes::from_static(b"header"),
-                Bytes::from_static(b"body"),
-            ))
-            .unwrap();
-        let truncated = &encoded[..encoded.len() - 1];
-
-        let mut server_write = framed_server.into_inner();
-        server_write.write_all(truncated).await.unwrap();
-        server_write.shutdown().await.unwrap();
-
-        tokio::time::timeout(std::time::Duration::from_secs(1), reader_handle)
-            .await
-            .expect("handle_reader should finish after truncated frame")
-            .map(|_| ())
-    }
-
     /// Test that handle_reader handles Stop control message by calling context.stop()
     #[tokio::test]
     async fn test_handle_reader_stop_control_message() {
@@ -941,17 +908,6 @@ mod tests {
         );
     }
 
-    /// Test that handle_reader exits cleanly when the peer closes mid-frame.
-    #[tokio::test]
-    async fn test_handle_reader_exits_on_truncated_frame() {
-        let result = run_reader_with_truncated_frame().await;
-
-        assert!(
-            result.is_ok(),
-            "handle_reader should not panic on truncated frame: {result:?}"
-        );
-    }
-
     /// Test that handle_reader handles multiple control messages in sequence
     #[tokio::test]
     async fn test_handle_reader_multiple_control_messages() {
@@ -1030,19 +986,5 @@ mod tests {
             controller.is_killed(),
             "Controller should be killed after receiving Kill message"
         );
-    }
-
-    /// Short stress test to ensure repeated truncated frames do not take down Tokio workers.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn test_handle_reader_many_truncated_frames() {
-        let tasks = (0..32).map(|_| tokio::spawn(run_reader_with_truncated_frame()));
-
-        for task in futures::future::join_all(tasks).await {
-            let join_result = task.expect("outer test task should not panic");
-            assert!(
-                join_result.is_ok(),
-                "handle_reader should not panic on truncated frame: {join_result:?}"
-            );
-        }
     }
 }


### PR DESCRIPTION
This PR turns the branch into a first-stage transport rollback for `#7871`.

The important constraint is that I am not reverting whole files back to `main`; I am restoring the pre-`#7871` transport shape for the `lib/llm` ZMQ sidecars while keeping later cleanup/refactor work where it does not change behavior.

Scope of the rollback on this branch:
- `lib/llm/src/kv_router/publisher/zmq_listener.rs`
- `lib/llm/src/fpm_publisher.rs`
- `lib/llm/src/block_manager/kv_consolidator/subscriber.rs`
- `lib/llm/src/block_manager/kv_consolidator/publisher.rs`
- `lib/llm/Cargo.toml` and `Cargo.lock` to add `zeromq` back for those paths
- `lib/llm/src/utils/zmq.rs` trimmed back to the still-used `tmq` helper surface

Not rolled back here:
- `lib/llm/src/mocker.rs` still uses the shared `tmq` helper
- runtime request plane remains TCP
- runtime event-plane ZMQ backend remains `tmq`
- KVBM distributed block-manager ZMQ remains `tmq`
- standalone indexer remains on its raw `zmq` + `AsyncFd` path

Why this slice:
- DEP still runs `--router-mode kv`
- workers still emit KV events over raw ZMQ via `--kv-events-config ... "publisher":"zmq"`
- request/response is still TCP, so the highest-signal first rollback is the `lib/llm` ZMQ sidecar layer rather than the runtime request plane

## Package Matrix

The topology is mostly the same across all three snapshots; the important difference is which package is driving each node.

| Subsystem | Before `#7871` | After `#7871` | This PR |
| --- | --- | --- | --- |
| Main request/response plane | TCP | TCP | TCP |
| Runtime event plane default backend | NATS | NATS | NATS |
| Runtime event-plane ZMQ backend | raw `zmq` crate | `tmq` | `tmq` |
| Worker KV listener | `zeromq` | `tmq` helper | `zeromq` |
| FPM relay | `zeromq` | `tmq` helper | `zeromq` |
| Consolidator subscriber | `zeromq` | `tmq` helper | `zeromq` |
| Consolidator publisher | `zeromq` | `tmq` helper | `zeromq` |
| Mocker PUB/ROUTER path | `zeromq` | `tmq` helper | `tmq` helper |
| KVBM distributed block-manager ZMQ | `tmq` | `tmq` | `tmq` |

## Transport Shape

### Before `#7871`
```mermaid
flowchart LR
    classDef zeromq fill:#dcfce7,stroke:#16a34a,color:#111827
    classDef tmq fill:#ffedd5,stroke:#ea580c,color:#111827
    classDef rawzmq fill:#dbeafe,stroke:#2563eb,color:#111827
    classDef nats fill:#ede9fe,stroke:#7c3aed,color:#111827
    classDef tcp fill:#f3f4f6,stroke:#6b7280,color:#111827
    classDef neutral fill:#fefce8,stroke:#a16207,color:#111827

    C1["Client / SA-Bench"] --> F1["Frontend KV router"]
    F1 --> T1["Request / response plane<br/>pkg: TCP"]
    T1 --> W1["Workers"]

    W1 --> K1["Worker KV listener<br/>pkg: zeromq"]
    K1 --> P1["KvEventPublisher<br/>pkg: lib/llm logic"]
    W1 --> FPM1["FPM relay<br/>pkg: zeromq"]
    CP1["Consolidator publisher<br/>pkg: zeromq"] --> CS1["Consolidator subscriber<br/>pkg: zeromq"]
    M1["Mocker PUB/ROUTER<br/>pkg: zeromq"]

    P1 --> EPA1["Runtime event-plane API"]
    FPM1 --> EPA1
    EPA1 --> N1["Default backend<br/>pkg: NATS"]
    EPA1 -. if ZMQ enabled .-> Z1["Optional ZMQ backend<br/>pkg: raw zmq crate"]

    class K1,FPM1,CP1,CS1,M1 zeromq
    class Z1 rawzmq
    class N1 nats
    class T1 tcp
    class P1,EPA1 neutral
```

### After `#7871`
```mermaid
flowchart LR
    classDef zeromq fill:#dcfce7,stroke:#16a34a,color:#111827
    classDef tmq fill:#ffedd5,stroke:#ea580c,color:#111827
    classDef rawzmq fill:#dbeafe,stroke:#2563eb,color:#111827
    classDef nats fill:#ede9fe,stroke:#7c3aed,color:#111827
    classDef tcp fill:#f3f4f6,stroke:#6b7280,color:#111827
    classDef neutral fill:#fefce8,stroke:#a16207,color:#111827

    C2["Client / SA-Bench"] --> F2["Frontend KV router"]
    F2 --> T2["Request / response plane<br/>pkg: TCP"]
    T2 --> W2["Workers"]

    W2 --> K2["Worker KV listener<br/>pkg: tmq helper"]
    K2 --> P2["KvEventPublisher<br/>pkg: lib/llm logic"]
    W2 --> FPM2["FPM relay<br/>pkg: tmq helper"]
    CP2["Consolidator publisher<br/>pkg: tmq helper"] --> CS2["Consolidator subscriber<br/>pkg: tmq helper"]
    M2["Mocker PUB/ROUTER<br/>pkg: tmq helper"]

    P2 --> EPA2["Runtime event-plane API"]
    FPM2 --> EPA2
    EPA2 --> N2["Default backend<br/>pkg: NATS"]
    EPA2 -. if ZMQ enabled .-> Z2["Optional ZMQ backend<br/>pkg: tmq"]

    class K2,FPM2,CP2,CS2,M2,Z2 tmq
    class N2 nats
    class T2 tcp
    class P2,EPA2 neutral
```

### This PR
```mermaid
flowchart LR
    classDef zeromq fill:#dcfce7,stroke:#16a34a,color:#111827
    classDef tmq fill:#ffedd5,stroke:#ea580c,color:#111827
    classDef rawzmq fill:#dbeafe,stroke:#2563eb,color:#111827
    classDef nats fill:#ede9fe,stroke:#7c3aed,color:#111827
    classDef tcp fill:#f3f4f6,stroke:#6b7280,color:#111827
    classDef neutral fill:#fefce8,stroke:#a16207,color:#111827

    C3["Client / SA-Bench"] --> F3["Frontend KV router"]
    F3 --> T3["Request / response plane<br/>pkg: TCP"]
    T3 --> W3["Workers"]

    W3 --> K3["Worker KV listener<br/>pkg: zeromq"]
    K3 --> P3["KvEventPublisher<br/>pkg: lib/llm logic"]
    W3 --> FPM3["FPM relay<br/>pkg: zeromq"]
    CP3["Consolidator publisher<br/>pkg: zeromq"] --> CS3["Consolidator subscriber<br/>pkg: zeromq"]
    M3["Mocker PUB/ROUTER<br/>pkg: tmq helper"]

    P3 --> EPA3["Runtime event-plane API"]
    FPM3 --> EPA3
    EPA3 --> N3["Default backend<br/>pkg: NATS"]
    EPA3 -. if ZMQ enabled .-> Z3["Optional ZMQ backend<br/>pkg: tmq"]

    class K3,FPM3,CP3,CS3 zeromq
    class M3,Z3 tmq
    class N3 nats
    class T3 tcp
    class P3,EPA3 neutral
```

## Verification
- `cargo check -p dynamo-llm --no-default-features --lib`
- `cargo check -p dynamo-llm --no-default-features --tests`
- `(cd lib/llm && cargo clippy --no-default-features -- -D warnings && cargo fmt)`
- `cargo metadata --locked --no-deps` passed in the workspace root, `lib/bindings/kvbm`, and `lib/bindings/python`
