### PR TITLE
chore: update trtllm version to v1.3.0rc11 

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pandas",
     "pydantic>=2",
     "tabulate",
-    # Satisfies vLLM 0.11.0 (>=4.55.2), vLLM 0.11.2 (>=4.56.0,<5), TRT-LLM 1.3.0rc9 (==4.57.1), SGLang 0.5.8 (==4.57.1)
+    # Satisfies vLLM 0.11.0 (>=4.55.2), vLLM 0.11.2 (>=4.56.0,<5), TRT-LLM 1.3.0rc11 (==4.57.3), SGLang 0.5.8 (==4.57.1)
     "transformers>=4.56.0",
 ]
 

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -22,7 +22,7 @@ from tensorrt_llm.llmapi import (
     SchedulerConfig,
 )
 from tensorrt_llm.llmapi.llm import SamplingParams
-from tensorrt_llm.llmapi.llm_args import KvCacheConnectorConfig
+from tensorrt_llm.llmapi.llm_args import TOKENIZER_ALIASES, KvCacheConnectorConfig
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_options
 from tensorrt_llm.llmapi.tokenizer import tokenizer_factory
 from tensorrt_llm.metrics import MetricsCollector
@@ -293,7 +293,27 @@ async def init_llm_worker(
     engine_args = arg_map
 
     # Populate default sampling params from the model
-    tokenizer = tokenizer_factory(arg_map["model"])
+    custom_tokenizer = arg_map.get("custom_tokenizer")
+    if custom_tokenizer:
+        from importlib import import_module
+
+        try:
+            tokenizer_path = TOKENIZER_ALIASES.get(custom_tokenizer, custom_tokenizer)
+            module_path, class_name = tokenizer_path.rsplit(".", 1)
+            tokenizer_class = getattr(import_module(module_path), class_name)
+            tokenizer = tokenizer_class.from_pretrained(
+                arg_map["model"],
+                trust_remote_code=arg_map.get("trust_remote_code", False),
+            )
+        except (ValueError, ImportError, AttributeError) as e:
+            raise ValueError(
+                f"Failed to load custom tokenizer '{custom_tokenizer}': {e}. "
+                "Expected format: 'module.path.ClassName' or a recognized alias in TensorRT-LLM LLM API."
+            ) from e
+    else:
+        tokenizer = tokenizer_factory(
+            arg_map["model"], trust_remote_code=arg_map.get("trust_remote_code", False)
+        )
     default_sampling_params = SamplingParams()
 
     # Enable perf metrics so prompt_tokens_details can be returned

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -22,7 +22,7 @@ from tensorrt_llm.llmapi import (
     SchedulerConfig,
 )
 from tensorrt_llm.llmapi.llm import SamplingParams
-from tensorrt_llm.llmapi.llm_args import TOKENIZER_ALIASES, KvCacheConnectorConfig
+from tensorrt_llm.llmapi.llm_args import KvCacheConnectorConfig
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_options
 from tensorrt_llm.llmapi.tokenizer import tokenizer_factory
 from tensorrt_llm.metrics import MetricsCollector
@@ -293,27 +293,7 @@ async def init_llm_worker(
     engine_args = arg_map
 
     # Populate default sampling params from the model
-    custom_tokenizer = arg_map.get("custom_tokenizer")
-    if custom_tokenizer:
-        from importlib import import_module
-
-        try:
-            tokenizer_path = TOKENIZER_ALIASES.get(custom_tokenizer, custom_tokenizer)
-            module_path, class_name = tokenizer_path.rsplit(".", 1)
-            tokenizer_class = getattr(import_module(module_path), class_name)
-            tokenizer = tokenizer_class.from_pretrained(
-                arg_map["model"],
-                trust_remote_code=arg_map.get("trust_remote_code", False),
-            )
-        except (ValueError, ImportError, AttributeError) as e:
-            raise ValueError(
-                f"Failed to load custom tokenizer '{custom_tokenizer}': {e}. "
-                "Expected format: 'module.path.ClassName' or a recognized alias in TensorRT-LLM LLM API."
-            ) from e
-    else:
-        tokenizer = tokenizer_factory(
-            arg_map["model"], trust_remote_code=arg_map.get("trust_remote_code", False)
-        )
+    tokenizer = tokenizer_factory(arg_map["model"])
     default_sampling_params = SamplingParams()
 
     # Enable perf metrics so prompt_tokens_details can be returned

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -94,8 +94,8 @@ trtllm:
   cuda13.1:
     base_image: nvcr.io/nvidia/pytorch
     runtime_image: nvcr.io/nvidia/cuda-dl-base
-    base_image_tag: 25.12-py3
-    runtime_image_tag: 25.12-cuda13.1-runtime-ubuntu24.04
+    base_image_tag: 26.02-py3
+    runtime_image_tag: 26.02-cuda13.1-runtime-ubuntu24.04
   nixl_ref: 0.10.1
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "false"
@@ -103,19 +103,19 @@ trtllm:
   python_version: "3.12"
   index_url: https://pypi.nvidia.com/
   pip_wheel_dir: /tmp/trtllm_wheel/
-  pip_wheel: tensorrt-llm==1.3.0rc9
+  pip_wheel: tensorrt-llm==1.3.0rc11
   trtllm_wheel_image: nvcr.io/nvidia/tensorrt-llm/release:${TENSORRTLLM_PIP_WHEEL#*==}
 
-  github_trtllm_commit: v1.3.0rc9
-  torch_version: 2.10.0a0+b4e4ee81d3.nv25.12
-  torch_tensorrt_version: 2.10.0a0
-  torchvision_version: 0.25.0a0+ca221243
-  torchao_ver: 0.15.0+git01374eb5
+  github_trtllm_commit: v1.3.0rc11
+  torch_version: 2.11.0a0+eb65b36914.nv26.2
+  torch_tensorrt_version: 2.11.0a0
+  torchvision_version: 0.25.0a0+1e53952f.nv26.2.44259020
+  torchao_ver: 0.16.0+gita89eaab2
   torchdata_ver: 0.11.0
-  torchtitan_ver: 0.2.0
+  torchtitan_ver: 0.2.1+git9f211ec1
   jinja2_version: 3.1.6
   sympy_version: 1.14.0
-  pytorch_triton_ver: 3.5.1+gitbfeb0668.nv25.12
-  flash_attn_version: 2.7.4.post1+25.12
-  flashinfer_python_ver: 0.6.1
+  pytorch_triton_ver: 3.6.0+git9844da95.nv26.2
+  flash_attn_version: 2.7.4.post1+nv26.2.44259020
+  flashinfer_python_ver: 0.6.6
   has_trtllm_context: "0"

--- a/container/deps/requirements.common.txt
+++ b/container/deps/requirements.common.txt
@@ -28,7 +28,7 @@ tensorboard>=2.19.0,<2.21.0
 tensorboardX==2.6.2.2
 # Transformers version constraint for container builds
 # - vLLM 0.11.0: >=4.55.2, vLLM 0.11.2: >=4.56.0,<5
-# - TensorRT-LLM 1.3.0rc9: ==4.57.1
+# - TensorRT-LLM 1.3.0rc11: ==4.57.3
 # - SGLang 0.5.8: ==4.57.1
 # Using >=4.56.0 to satisfy all frameworks
 transformers>=4.56.0

--- a/container/templates/trtllm_framework.Dockerfile
+++ b/container/templates/trtllm_framework.Dockerfile
@@ -133,7 +133,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         # Install from local wheel directory in build context
         WHEEL_FILE="$(find /trtllm_wheel -name "*.whl" | head -n 1)"; \
         if [ -n "$WHEEL_FILE" ]; then \
-            uv pip install "$WHEEL_FILE" triton==3.5.1; \
+            uv pip install "$WHEEL_FILE"; \
         else \
             echo "No wheel file found in /trtllm_wheel directory."; \
             exit 1; \
@@ -141,19 +141,18 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     elif [ -n "$(find /trtllm_wheel_image -name "*.whl" | head -n 1)" ]; then \
         # Install from wheel embedded in the TRTLLM release image
         WHEEL_FILE="$(find /trtllm_wheel_image -name "*.whl" | head -n 1)"; \
-        uv pip install "$WHEEL_FILE" triton==3.5.1; \
+        uv pip install "$WHEEL_FILE"; \
     else \
         # Install TensorRT-LLM wheel from the provided index URL, allow dependencies from PyPI
         # TRTLLM 1.2.0rc6.post2 has issues installing from pypi with uv, installing from direct wheel link works best
-        # explicitly installing triton 3.5.1 as trtllm only lists triton as dependency on x64_64 for some reason
         if echo "${TENSORRTLLM_PIP_WHEEL}" | grep -q '^tensorrt-llm=='; then \
             TRTLLM_VERSION=$(echo "${TENSORRTLLM_PIP_WHEEL}" | sed -E 's/tensorrt-llm==([0-9a-zA-Z.+-]+).*/\1/'); \
             PYTHON_TAG="cp$(echo ${PYTHON_VERSION} | tr -d '.')"; \
             ARCH_ALT=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "aarch64"); \
             DIRECT_URL="https://pypi.nvidia.com/tensorrt-llm/tensorrt_llm-${TRTLLM_VERSION}-${PYTHON_TAG}-${PYTHON_TAG}-linux_${ARCH_ALT}.whl"; \
-            uv pip install --index-strategy=unsafe-best-match --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${DIRECT_URL}" triton==3.5.1; \
+            uv pip install --index-strategy=unsafe-best-match --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${DIRECT_URL}"; \
         else \
-            uv pip install --index-strategy=unsafe-best-match --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}" triton==3.5.1; \
+            uv pip install --index-strategy=unsafe-best-match --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}"; \
         fi; \
     fi && \
     # Run TensorRT installer that ships with the TRTLLM wheel

--- a/container/templates/trtllm_framework.Dockerfile
+++ b/container/templates/trtllm_framework.Dockerfile
@@ -7,12 +7,7 @@
 # Copy artifacts from NGC PyTorch image
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS pytorch_base
 
-# Empty fallback for TRTLLM wheel image copy
-FROM alpine:3.20 AS trtllm_wheel_image_empty
-RUN mkdir -p /app/tensorrt_llm
-
 # Resolve TRTLLM wheel image (can be a stage name or a registry image)
-FROM ${TRTLLM_WHEEL_IMAGE} AS trtllm_wheel_image
 
 ##################################################
 ########## Framework Builder Stage ##############
@@ -106,7 +101,6 @@ ARG GITHUB_TRTLLM_COMMIT
 # Copy only wheel files and commit info from trtllm_wheel stage from build_context
 COPY --from=trtllm_wheel / /trtllm_wheel/
 {%- endif %}
-COPY --from=trtllm_wheel_image /app/tensorrt_llm /trtllm_wheel_image/
 
 # Cache uv downloads; uv handles its own locking for this cache.
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -138,10 +132,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
             echo "No wheel file found in /trtllm_wheel directory."; \
             exit 1; \
         fi; \
-    elif [ -n "$(find /trtllm_wheel_image -name "*.whl" | head -n 1)" ]; then \
-        # Install from wheel embedded in the TRTLLM release image
-        WHEEL_FILE="$(find /trtllm_wheel_image -name "*.whl" | head -n 1)"; \
-        uv pip install "$WHEEL_FILE"; \
     else \
         # Install TensorRT-LLM wheel from the provided index URL, allow dependencies from PyPI
         # TRTLLM 1.2.0rc6.post2 has issues installing from pypi with uv, installing from direct wheel link works best

--- a/container/templates/trtllm_framework.Dockerfile
+++ b/container/templates/trtllm_framework.Dockerfile
@@ -7,7 +7,12 @@
 # Copy artifacts from NGC PyTorch image
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS pytorch_base
 
+# Empty fallback for TRTLLM wheel image copy
+FROM alpine:3.20 AS trtllm_wheel_image_empty
+RUN mkdir -p /app/tensorrt_llm
+
 # Resolve TRTLLM wheel image (can be a stage name or a registry image)
+FROM ${TRTLLM_WHEEL_IMAGE} AS trtllm_wheel_image
 
 ##################################################
 ########## Framework Builder Stage ##############
@@ -101,6 +106,7 @@ ARG GITHUB_TRTLLM_COMMIT
 # Copy only wheel files and commit info from trtllm_wheel stage from build_context
 COPY --from=trtllm_wheel / /trtllm_wheel/
 {%- endif %}
+COPY --from=trtllm_wheel_image /app/tensorrt_llm /trtllm_wheel_image/
 
 # Cache uv downloads; uv handles its own locking for this cache.
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -132,6 +138,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
             echo "No wheel file found in /trtllm_wheel directory."; \
             exit 1; \
         fi; \
+    elif [ -n "$(find /trtllm_wheel_image -name "*.whl" | head -n 1)" ]; then \
+        # Install from wheel embedded in the TRTLLM release image
+        WHEEL_FILE="$(find /trtllm_wheel_image -name "*.whl" | head -n 1)"; \
+        uv pip install "$WHEEL_FILE"; \
     else \
         # Install TensorRT-LLM wheel from the provided index URL, allow dependencies from PyPI
         # TRTLLM 1.2.0rc6.post2 has issues installing from pypi with uv, installing from direct wheel link works best

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -29,7 +29,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.9` | `1.3.0rc9` | `0.19.0` | `0.10.1` |
+| **main (ToT)** | `0.5.9` | `1.3.0rc11` | `0.19.0` | `0.10.1` |
 | **v1.1.0-dev.1** *(experimental)* | `0.5.9` | `1.3.0rc5.post1` | `0.17.1` | `0.10.1` |
 | **v1.0.1** | `0.5.9` | `1.3.0rc5.post1` | `0.16.0` | `0.10.1` |
 | **v1.0.0** | `0.5.9` | `1.3.0rc5.post1` | `0.16.0` | `0.10.1` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 [project.optional-dependencies]
 trtllm =[
     "uvloop",
-    "tensorrt-llm==1.3.0rc9",
+    "tensorrt-llm==1.3.0rc11",
 ]
 
 vllm = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,8 @@ filterwarnings = [
     "ignore:Triton is not supported on current platform.*:UserWarning",
     # torch.jit.script_method deprecation from torch.utils.mkldnn
     "ignore:.*torch\\.jit\\.script_method.*is deprecated.*:DeprecationWarning",
+    # torch.jit.script deprecation from modelopt.torch.quantization
+    "ignore:`torch.jit.script` is deprecated:DeprecationWarning",
     # nvidia-modelopt warning about transformers version (transitive dep from TRT-LLM)
     "ignore:transformers version .* is incompatible with nvidia-modelopt.*:UserWarning",
     # SGLang quantization warnings on CPU-only runners


### PR DESCRIPTION
#### Overview:

Update TRT-LLM to v1.3.0rc11 because it includes multiple GLM-5 model fixes. We need the GLM-5 benchmark for the Semianalysis submission.

#### Details:

1. Update TRT-LLM to v1.3.0rc11 for the SA submission for the GLM-5 model.
2. seems the triton dependency issue is no longer with arm64 pip wheel, remove it from the pip install command

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable custom tokenizers in LLM worker initialization.

* **Chores**
  * Updated TensorRT-LLM to version 1.3.0rc11.
  * Updated container images to `26.02` base with aligned dependency versions (PyTorch, TensorRT, flash-attention, and others).
  * Removed explicit Triton version pinning from container build logic.
  * Updated support matrix documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->