### PR TITLE
fix(block-manager): propagate NIXL transfer errors in v1 offload path

### DIFF
--- a/lib/llm/src/block_manager/block/data/logical.rs
+++ b/lib/llm/src/block_manager/block/data/logical.rs
@@ -25,7 +25,7 @@ pub trait LogicalResources: Clone + Send + Sync + 'static + std::fmt::Debug {
         sources: &[RB],
         targets: &mut [WB],
         ctx: Arc<TransferContext>,
-    ) -> Result<oneshot::Receiver<()>, TransferError>
+    ) -> Result<oneshot::Receiver<Result<(), TransferError>>, TransferError>
     where
         RB: ReadableBlock + WriteToStrategy<WB> + storage::Local,
         <RB as StorageTypeProvider>::StorageType: NixlDescriptor,

--- a/lib/llm/src/block_manager/block/data/logical/distributed_leader_worker.rs
+++ b/lib/llm/src/block_manager/block/data/logical/distributed_leader_worker.rs
@@ -9,7 +9,7 @@ use dynamo_runtime::utils::task::CriticalTaskExecutionHandle;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
-type TransferRequest = (BlockTransferRequest, oneshot::Sender<()>);
+type TransferRequest = (BlockTransferRequest, oneshot::Sender<Result<(), TransferError>>);
 
 #[derive(Clone)]
 pub struct DistributedLeaderWorkerResources {
@@ -72,7 +72,7 @@ impl DistributedLeaderWorkerResources {
 
                     tokio::spawn(async move {
                         rx.await.unwrap();
-                        let _ = notify_tx.send(());
+                        let _ = notify_tx.send(Ok(()));
                     });
                 }
                 _ = cancel_token.cancelled() => {
@@ -92,7 +92,7 @@ impl LogicalResources for DistributedLeaderWorkerResources {
         targets: &mut [WB],
         // TODO: This transfer context is only ever used in the `Local` locality.
         _ctx: Arc<TransferContext>,
-    ) -> Result<oneshot::Receiver<()>, TransferError>
+    ) -> Result<oneshot::Receiver<Result<(), TransferError>>, TransferError>
     where
         RB: ReadableBlock + WriteToStrategy<WB> + storage::Local,
         <RB as StorageTypeProvider>::StorageType: NixlDescriptor,
@@ -106,7 +106,7 @@ impl LogicalResources for DistributedLeaderWorkerResources {
                 "DistributedLeaderWorkerResources::handle_transfer called with both sources and targets empty, skipping transfer"
             );
             let (tx, rx) = oneshot::channel();
-            tx.send(()).unwrap();
+            tx.send(Ok(())).unwrap();
             return Ok(rx);
         }
 

--- a/lib/llm/src/block_manager/block/data/logical/null.rs
+++ b/lib/llm/src/block_manager/block/data/logical/null.rs
@@ -12,7 +12,7 @@ impl LogicalResources for NullResources {
         _sources: &[RB],
         _targets: &mut [WB],
         _ctx: Arc<TransferContext>,
-    ) -> Result<oneshot::Receiver<()>, TransferError>
+    ) -> Result<oneshot::Receiver<Result<(), TransferError>>, TransferError>
     where
         RB: ReadableBlock + WriteToStrategy<WB> + storage::Local,
         <RB as StorageTypeProvider>::StorageType: NixlDescriptor,

--- a/lib/llm/src/block_manager/block/locality.rs
+++ b/lib/llm/src/block_manager/block/locality.rs
@@ -34,7 +34,7 @@ pub trait LocalityProvider: Send + Sync + 'static + std::fmt::Debug {
         _sources: &[RB],
         _targets: &mut [WB],
         _ctx: Arc<TransferContext>,
-    ) -> Result<oneshot::Receiver<()>, TransferError>
+    ) -> Result<oneshot::Receiver<Result<(), TransferError>>, TransferError>
     where
         RB: ReadableBlock + WriteToStrategy<WB> + storage::Local,
         <RB as StorageTypeProvider>::StorageType: NixlDescriptor,
@@ -54,7 +54,7 @@ impl LocalityProvider for Local {
         sources: &[RB],
         targets: &mut [WB],
         ctx: Arc<TransferContext>,
-    ) -> Result<oneshot::Receiver<()>, TransferError>
+    ) -> Result<oneshot::Receiver<Result<(), TransferError>>, TransferError>
     where
         RB: ReadableBlock + WriteToStrategy<WB> + storage::Local,
         <RB as StorageTypeProvider>::StorageType: NixlDescriptor,
@@ -117,7 +117,7 @@ impl<R: LogicalResources> LocalityProvider for Logical<R> {
         sources: &[RB],
         targets: &mut [WB],
         ctx: Arc<TransferContext>,
-    ) -> Result<oneshot::Receiver<()>, TransferError>
+    ) -> Result<oneshot::Receiver<Result<(), TransferError>>, TransferError>
     where
         RB: ReadableBlock + WriteToStrategy<WB> + storage::Local,
         <RB as StorageTypeProvider>::StorageType: NixlDescriptor,
@@ -131,7 +131,7 @@ impl<R: LogicalResources> LocalityProvider for Logical<R> {
                 "Logical::handle_transfer called with both sources and targets empty, skipping transfer"
             );
             let (tx, rx) = oneshot::channel();
-            tx.send(()).unwrap();
+            tx.send(Ok(())).unwrap();
             return Ok(rx);
         }
 

--- a/lib/llm/src/block_manager/block/transfer.rs
+++ b/lib/llm/src/block_manager/block/transfer.rs
@@ -177,7 +177,7 @@ pub fn handle_local_transfer<RB, WB>(
     sources: &[RB],
     targets: &mut [WB],
     ctx: Arc<TransferContext>,
-) -> Result<oneshot::Receiver<()>, TransferError>
+) -> Result<oneshot::Receiver<Result<(), TransferError>>, TransferError>
 where
     RB: ReadableBlock + WriteToStrategy<WB> + Local,
     WB: WritableBlock,
@@ -190,7 +190,7 @@ where
             "handle_local_transfer called with both sources and targets empty, skipping transfer"
         );
         let (tx, rx) = oneshot::channel();
-        tx.send(()).unwrap();
+        tx.send(Ok(())).unwrap();
         return Ok(rx);
     }
 
@@ -208,7 +208,7 @@ where
                 memcpy::copy_block(src, dst)?;
             }
 
-            tx.send(()).unwrap();
+            tx.send(Ok(())).unwrap();
             Ok(rx)
         }
         TransferStrategy::CudaAsyncH2D
@@ -264,8 +264,8 @@ where
             let transfer_fut = nixl::write_blocks_to(sources, targets, &ctx, transfer_type)?;
 
             ctx.async_rt_handle().spawn(async move {
-                transfer_fut.await;
-                tx.send(()).unwrap();
+                let result = transfer_fut.await;
+                let _ = tx.send(result.map_err(TransferError::Other));
             });
             Ok(rx)
         }
@@ -281,7 +281,7 @@ pub trait WriteTo<Target> {
         &self,
         dst: &mut Vec<Target>,
         ctx: Arc<TransferContext>,
-    ) -> Result<oneshot::Receiver<()>, TransferError>;
+    ) -> Result<oneshot::Receiver<Result<(), TransferError>>, TransferError>;
 }
 
 impl<RB, WB, L: LocalityProvider> WriteTo<WB> for Vec<RB>
@@ -296,7 +296,7 @@ where
         &self,
         dst: &mut Vec<WB>,
         ctx: Arc<TransferContext>,
-    ) -> Result<oneshot::Receiver<()>, TransferError> {
+    ) -> Result<oneshot::Receiver<Result<(), TransferError>>, TransferError> {
         L::handle_transfer(self, dst, ctx)
     }
 }

--- a/lib/llm/src/block_manager/block/transfer/context.rs
+++ b/lib/llm/src/block_manager/block/transfer/context.rs
@@ -181,7 +181,7 @@ pub struct TransferContext {
     // LEGACY: Old pinned buffer pool (still used by TransferResources)
     pinned_buffer_pool: Option<SyncPinnedBufferPool>,
 
-    cuda_event_tx: mpsc::UnboundedSender<(CudaEvent, oneshot::Sender<()>)>,
+    cuda_event_tx: mpsc::UnboundedSender<(CudaEvent, oneshot::Sender<Result<(), TransferError>>)>,
     cuda_event_worker: Option<JoinHandle<()>>,
     cancel_token: CancellationToken,
 }
@@ -194,7 +194,7 @@ impl TransferContext {
         config: Option<PoolConfig>,
     ) -> Result<Self, anyhow::Error> {
         let (cuda_event_tx, cuda_event_rx) =
-            mpsc::unbounded_channel::<(CudaEvent, oneshot::Sender<()>)>();
+            mpsc::unbounded_channel::<(CudaEvent, oneshot::Sender<Result<(), TransferError>>)>();
 
         let cancel_token = CancellationToken::new();
 
@@ -258,7 +258,7 @@ impl TransferContext {
     }
 
     fn setup_cuda_event_worker(
-        mut cuda_event_rx: mpsc::UnboundedReceiver<(CudaEvent, oneshot::Sender<()>)>,
+        mut cuda_event_rx: mpsc::UnboundedReceiver<(CudaEvent, oneshot::Sender<Result<(), TransferError>>)>,
         cancel_token: CancellationToken,
     ) -> JoinHandle<()> {
         std::thread::spawn(move || {
@@ -271,10 +271,16 @@ impl TransferContext {
                 loop {
                     tokio::select! {
                         Some((event, tx)) = cuda_event_rx.recv() => {
-                            if let Err(e) = event.synchronize() {
-                                tracing::error!("Error synchronizing CUDA event: {}", e);
-                            }
-                            let _ = tx.send(());
+                            let result = match event.synchronize() {
+                                Ok(()) => Ok(()),
+                                Err(e) => {
+                                    tracing::error!("Error synchronizing CUDA event: {}", e);
+                                    Err(TransferError::ExecutionError(
+                                        format!("CUDA event synchronization failed: {}", e),
+                                    ))
+                                }
+                            };
+                            let _ = tx.send(result);
                         }
                         _ = cancel_token.cancelled() => {
                             break;
@@ -302,7 +308,7 @@ impl TransferContext {
         self.cuda_mem_pool.as_ref()
     }
 
-    pub fn cuda_event(&self, tx: oneshot::Sender<()>) -> Result<(), TransferError> {
+    pub fn cuda_event(&self, tx: oneshot::Sender<Result<(), TransferError>>) -> Result<(), TransferError> {
         let event = self
             .stream
             .record_event(Some(CUevent_flags::CU_EVENT_BLOCKING_SYNC))

--- a/lib/llm/src/block_manager/block/transfer/nixl.rs
+++ b/lib/llm/src/block_manager/block/transfer/nixl.rs
@@ -78,7 +78,7 @@ pub fn write_blocks_to<Source, Destination>(
     dst: &mut [Destination],
     ctx: &Arc<TransferContext>,
     transfer_type: NixlTransfer,
-) -> Result<Box<dyn Future<Output = ()> + Send + Sync + Unpin>>
+) -> Result<Box<dyn Future<Output = Result<()>> + Send + Sync + Unpin>>
 where
     Source: BlockDataProvider,
     Source::StorageType: NixlDescriptor,
@@ -86,7 +86,7 @@ where
     Destination::StorageType: NixlDescriptor,
 {
     if src.is_empty() || dst.is_empty() {
-        return Ok(Box::new(std::future::ready(())));
+        return Ok(Box::new(std::future::ready(Ok(()))));
     }
     assert_eq!(src.len(), dst.len());
 
@@ -135,18 +135,20 @@ where
 
             loop {
                 match nixl_agent.get_xfer_status(&xfer_req) {
-                    Ok(XferStatus::Success) => break, // Transfer is complete.
+                    Ok(XferStatus::Success) => return Ok(()),
                     Ok(XferStatus::InProgress) => {
                         tokio::time::sleep(std::time::Duration::from_millis(5)).await
-                    } // Transfer is still in progress.
+                    }
                     Err(e) => {
-                        tracing::error!("Error getting transfer status: {}", e);
-                        break;
+                        return Err(anyhow::anyhow!(
+                            "NIXL transfer status check failed: {}",
+                            e
+                        ));
                     }
                 }
             }
         })))
     } else {
-        Ok(Box::new(std::future::ready(())))
+        Ok(Box::new(std::future::ready(Ok(()))))
     }
 }

--- a/lib/llm/src/block_manager/distributed/transfer.rs
+++ b/lib/llm/src/block_manager/distributed/transfer.rs
@@ -16,7 +16,7 @@ use crate::block_manager::{
         Block, BlockDataProvider, BlockDataProviderMut, ReadableBlock, WritableBlock,
         data::local::LocalBlockData,
         locality,
-        transfer::{TransferContext, WriteTo, WriteToStrategy},
+        transfer::{TransferContext, TransferError, WriteTo, WriteToStrategy},
     },
     connector::scheduler::{SchedulingDecision, TransferSchedulerClient},
     offload::max_transfer_batch_size,
@@ -306,7 +306,7 @@ impl BlockTransferHandler {
         source_pool_list: &Option<LocalBlockDataList<Source>>,
         target_pool_list: &Option<LocalBlockDataList<Target>>,
         request: BlockTransferRequest,
-    ) -> Result<tokio::sync::oneshot::Receiver<()>>
+    ) -> Result<tokio::sync::oneshot::Receiver<Result<(), TransferError>>>
     where
         Source: Storage + NixlDescriptor,
         Target: Storage + NixlDescriptor,
@@ -387,7 +387,9 @@ impl BlockTransferHandler {
             }
         }?;
 
-        notify.await?;
+        notify
+            .await
+            .map_err(|_| anyhow::anyhow!("Transfer notification channel dropped"))??;
         Ok(())
     }
 
@@ -459,7 +461,9 @@ impl BlockTransferHandler {
                     return Err(anyhow::anyhow!("Invalid transfer type."));
                 }
             }?;
-            notify.await?;
+            notify
+                .await
+                .map_err(|_| anyhow::anyhow!("Transfer notification channel dropped"))??;
         }
 
         // Broadcast Device blocks if needed (all ranks participate)

--- a/lib/llm/src/block_manager/offload/pending.rs
+++ b/lib/llm/src/block_manager/offload/pending.rs
@@ -292,7 +292,15 @@ where
             .write_to(&mut pending_transfer.targets, self.transfer_ctx.clone())?;
 
         let completion_future = async move {
-            let _ = notify.await;
+            match notify.await {
+                Ok(Ok(())) => {} // transfer succeeded
+                Ok(Err(e)) => {
+                    tracing::error!("Block transfer failed during offload: {e}");
+                }
+                Err(_) => {
+                    tracing::error!("Transfer notification channel dropped unexpectedly");
+                }
+            }
             pending_transfer
         };
 


### PR DESCRIPTION
## Summary

The v1 block manager's `write_blocks_to` returns `Future<Output = ()>`, making it impossible to propagate NIXL/RDMA transfer failures. When a transfer fails during KV cache offload (GPU→CPU→SSD), the error is silently swallowed and the caller proceeds as if it succeeded — corrupted KV blocks can be recalled for attention computation, causing silent inference corruption.

This PR fixes the error propagation chain at four points:

- **`nixl.rs`**: Change return type to `Future<Output = Result<()>>`, return `Err` on `get_xfer_status` failure instead of logging and breaking
- **`transfer.rs`**: Change oneshot channel from `Sender<()>` to `Sender<Result<(), TransferError>>`, update all send sites (Memcpy, CUDA, NIXL)
- **`context.rs`**: Propagate CUDA event synchronization errors through the channel
- **`pending.rs`**: Replace `let _ = notify.await` with explicit error matching and ERROR-level logging
- **`distributed/transfer.rs`**: Unwrap nested `Result` and propagate errors to callers

The v2 block manager and kvbm-physical crate already use the correct pattern (`oneshot::Sender<Result<()>>`). This aligns the v1 offload path with those implementations. The existing `// TODO: Add NIXL specific errors` comment at `transfer.rs:59` anticipated this fix.

## Test plan

- [x] `cargo check -p dynamo-llm --features block-manager` passes (remaining errors are macOS-only platform limitations unrelated to this change)
- [x] All pre-commit hooks pass
- [ ] `cargo test -p dynamo-llm` on Linux CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Transfer operations now properly report and propagate errors that previously went undetected
  * CUDA synchronization failures are now correctly signaled instead of being silently ignored
  * Asynchronous transfers now reliably indicate success or failure upon completion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->