### PR TITLE
fix(container): Bump EFA installer version to 1.47.0

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -36,7 +36,7 @@ dynamo:
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   ffmpeg_version: "7.1"
-  efa_version: 1.45.1
+  efa_version: 1.47.0
 
 vllm:
   cuda12.9:


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Bump EFA installer version to 1.47.0, minimum recommended version to use NIXL with libfabric.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated EFA software version to 1.47.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->