### PR TITLE
chore: update mx client to pre-release version v0.3.0-rc.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5046,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-client"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=756bee33c1698c208930ca23a1b511ddd1fc2146#756bee33c1698c208930ca23a1b511ddd1fc2146"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=fb549152b78a9087a1dfb47e4808a84ba26db804#fb549152b78a9087a1dfb47e4808a84ba26db804"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -5067,7 +5067,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-common"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=756bee33c1698c208930ca23a1b511ddd1fc2146#756bee33c1698c208930ca23a1b511ddd1fc2146"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=fb549152b78a9087a1dfb47e4808a84ba26db804#fb549152b78a9087a1dfb47e4808a84ba26db804"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5045,9 +5045,8 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-client"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9929c605e135347ccda5e0e7ff0627217f23189915a5c3971265ce490a14abf"
+version = "0.3.0"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=8b4b274997f4afa79864f36ea8c50598d01e0315#8b4b274997f4afa79864f36ea8c50598d01e0315"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -5067,9 +5066,8 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4997c93ac4b3ded7a999eff0b770aea2448d808ce7f020729e6af11e4c08fe67"
+version = "0.3.0"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=8b4b274997f4afa79864f36ea8c50598d01e0315#8b4b274997f4afa79864f36ea8c50598d01e0315"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5046,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-client"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=7c4853a61111dca83f457485f244cadeeda33651#7c4853a61111dca83f457485f244cadeeda33651"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=756bee33c1698c208930ca23a1b511ddd1fc2146#756bee33c1698c208930ca23a1b511ddd1fc2146"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -5067,7 +5067,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-common"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=7c4853a61111dca83f457485f244cadeeda33651#7c4853a61111dca83f457485f244cadeeda33651"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=756bee33c1698c208930ca23a1b511ddd1fc2146#756bee33c1698c208930ca23a1b511ddd1fc2146"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5046,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-client"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=8b4b274997f4afa79864f36ea8c50598d01e0315#8b4b274997f4afa79864f36ea8c50598d01e0315"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad#f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -5067,7 +5067,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-common"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=8b4b274997f4afa79864f36ea8c50598d01e0315#8b4b274997f4afa79864f36ea8c50598d01e0315"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad#f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5046,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-client"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad#f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=7c4853a61111dca83f457485f244cadeeda33651#7c4853a61111dca83f457485f244cadeeda33651"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -5067,7 +5067,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-common"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad#f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=7c4853a61111dca83f457485f244cadeeda33651#7c4853a61111dca83f457485f244cadeeda33651"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,8 @@ hf-hub = { version = "0.4.2", default-features = false, features = [
 ] }
 
 # ModelExpress for model downloading
-modelexpress-client = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "756bee33c1698c208930ca23a1b511ddd1fc2146" }
-modelexpress-common = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "756bee33c1698c208930ca23a1b511ddd1fc2146" }
+modelexpress-client = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "fb549152b78a9087a1dfb47e4808a84ba26db804" }
+modelexpress-common = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "fb549152b78a9087a1dfb47e4808a84ba26db804" }
 
 humantime = { version = "2.2.0" }
 indexmap = { version = "2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,8 @@ hf-hub = { version = "0.4.2", default-features = false, features = [
 ] }
 
 # ModelExpress for model downloading
-modelexpress-client = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "8b4b274997f4afa79864f36ea8c50598d01e0315" }
-modelexpress-common = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "8b4b274997f4afa79864f36ea8c50598d01e0315" }
+modelexpress-client = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad" }
+modelexpress-common = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad" }
 
 humantime = { version = "2.2.0" }
 indexmap = { version = "2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,8 @@ hf-hub = { version = "0.4.2", default-features = false, features = [
 ] }
 
 # ModelExpress for model downloading
-modelexpress-client = { version = "0.2.0" }
-modelexpress-common = { version = "0.2.0" }
+modelexpress-client = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "8b4b274997f4afa79864f36ea8c50598d01e0315" }
+modelexpress-common = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "8b4b274997f4afa79864f36ea8c50598d01e0315" }
 
 humantime = { version = "2.2.0" }
 indexmap = { version = "2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,8 @@ hf-hub = { version = "0.4.2", default-features = false, features = [
 ] }
 
 # ModelExpress for model downloading
-modelexpress-client = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "7c4853a61111dca83f457485f244cadeeda33651" }
-modelexpress-common = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "7c4853a61111dca83f457485f244cadeeda33651" }
+modelexpress-client = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "756bee33c1698c208930ca23a1b511ddd1fc2146" }
+modelexpress-common = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "756bee33c1698c208930ca23a1b511ddd1fc2146" }
 
 humantime = { version = "2.2.0" }
 indexmap = { version = "2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,8 @@ hf-hub = { version = "0.4.2", default-features = false, features = [
 ] }
 
 # ModelExpress for model downloading
-modelexpress-client = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad" }
-modelexpress-common = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad" }
+modelexpress-client = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "7c4853a61111dca83f457485f244cadeeda33651" }
+modelexpress-common = { git = "https://github.com/ai-dynamo/modelexpress.git", rev = "7c4853a61111dca83f457485f244cadeeda33651" }
 
 humantime = { version = "2.2.0" }
 indexmap = { version = "2" }

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -72,7 +72,7 @@ vllm:
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"
   enable_modelexpress_p2p: "true"
-  modelexpress_ref: "756bee33c1698c208930ca23a1b511ddd1fc2146"
+  modelexpress_ref: "fb549152b78a9087a1dfb47e4808a84ba26db804"
 
 sglang:
   cuda12.9:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -72,7 +72,7 @@ vllm:
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"
   enable_modelexpress_p2p: "true"
-  modelexpress_ref: "7c4853a61111dca83f457485f244cadeeda33651"
+  modelexpress_ref: "756bee33c1698c208930ca23a1b511ddd1fc2146"
 
 sglang:
   cuda12.9:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -72,7 +72,7 @@ vllm:
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"
   enable_modelexpress_p2p: "false"
-  modelexpress_ref: "f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
+  modelexpress_ref: "7c4853a61111dca83f457485f244cadeeda33651"
 
 sglang:
   cuda12.9:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -72,7 +72,7 @@ vllm:
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"
   enable_modelexpress_p2p: "false"
-  modelexpress_ref: "8b4b274997f4afa79864f36ea8c50598d01e0315"
+  modelexpress_ref: "f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
 
 sglang:
   cuda12.9:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -72,7 +72,7 @@ vllm:
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"
   enable_modelexpress_p2p: "false"
-  modelexpress_ref: "3d73992ce6c10e52ddc54f7f12af35d27e173f15"
+  modelexpress_ref: "8b4b274997f4afa79864f36ea8c50598d01e0315"
 
 sglang:
   cuda12.9:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -71,7 +71,7 @@ vllm:
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"
-  enable_modelexpress_p2p: "false"
+  enable_modelexpress_p2p: "true"
   modelexpress_ref: "7c4853a61111dca83f457485f244cadeeda33651"
 
 sglang:

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -3640,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-client"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=756bee33c1698c208930ca23a1b511ddd1fc2146#756bee33c1698c208930ca23a1b511ddd1fc2146"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=fb549152b78a9087a1dfb47e4808a84ba26db804#fb549152b78a9087a1dfb47e4808a84ba26db804"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-common"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=756bee33c1698c208930ca23a1b511ddd1fc2146#756bee33c1698c208930ca23a1b511ddd1fc2146"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=fb549152b78a9087a1dfb47e4808a84ba26db804#fb549152b78a9087a1dfb47e4808a84ba26db804"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -3640,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-client"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=7c4853a61111dca83f457485f244cadeeda33651#7c4853a61111dca83f457485f244cadeeda33651"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=756bee33c1698c208930ca23a1b511ddd1fc2146#756bee33c1698c208930ca23a1b511ddd1fc2146"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-common"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=7c4853a61111dca83f457485f244cadeeda33651#7c4853a61111dca83f457485f244cadeeda33651"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=756bee33c1698c208930ca23a1b511ddd1fc2146#756bee33c1698c208930ca23a1b511ddd1fc2146"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -3640,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-client"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=8b4b274997f4afa79864f36ea8c50598d01e0315#8b4b274997f4afa79864f36ea8c50598d01e0315"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad#f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-common"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=8b4b274997f4afa79864f36ea8c50598d01e0315#8b4b274997f4afa79864f36ea8c50598d01e0315"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad#f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -3639,12 +3639,11 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-client"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9929c605e135347ccda5e0e7ff0627217f23189915a5c3971265ce490a14abf"
+version = "0.3.0"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=8b4b274997f4afa79864f36ea8c50598d01e0315#8b4b274997f4afa79864f36ea8c50598d01e0315"
 dependencies = [
  "anyhow",
- "clap",
+ "clap 4.6.0",
  "colored",
  "futures",
  "modelexpress-common",
@@ -3661,14 +3660,13 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4997c93ac4b3ded7a999eff0b770aea2448d808ce7f020729e6af11e4c08fe67"
+version = "0.3.0"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=8b4b274997f4afa79864f36ea8c50598d01e0315#8b4b274997f4afa79864f36ea8c50598d01e0315"
 dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "clap",
+ "clap 4.6.0",
  "config",
  "hf-hub",
  "jiff",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -3640,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-client"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad#f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=7c4853a61111dca83f457485f244cadeeda33651#7c4853a61111dca83f457485f244cadeeda33651"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-common"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad#f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=7c4853a61111dca83f457485f244cadeeda33651#7c4853a61111dca83f457485f244cadeeda33651"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-client"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=756bee33c1698c208930ca23a1b511ddd1fc2146#756bee33c1698c208930ca23a1b511ddd1fc2146"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=fb549152b78a9087a1dfb47e4808a84ba26db804#fb549152b78a9087a1dfb47e4808a84ba26db804"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-common"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=756bee33c1698c208930ca23a1b511ddd1fc2146#756bee33c1698c208930ca23a1b511ddd1fc2146"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=fb549152b78a9087a1dfb47e4808a84ba26db804#fb549152b78a9087a1dfb47e4808a84ba26db804"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -3699,12 +3699,11 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-client"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9929c605e135347ccda5e0e7ff0627217f23189915a5c3971265ce490a14abf"
+version = "0.3.0"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=8b4b274997f4afa79864f36ea8c50598d01e0315#8b4b274997f4afa79864f36ea8c50598d01e0315"
 dependencies = [
  "anyhow",
- "clap",
+ "clap 4.6.0",
  "colored",
  "futures",
  "modelexpress-common",
@@ -3721,14 +3720,13 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4997c93ac4b3ded7a999eff0b770aea2448d808ce7f020729e6af11e4c08fe67"
+version = "0.3.0"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=8b4b274997f4afa79864f36ea8c50598d01e0315#8b4b274997f4afa79864f36ea8c50598d01e0315"
 dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "clap",
+ "clap 4.6.0",
  "config",
  "hf-hub",
  "jiff",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-client"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=8b4b274997f4afa79864f36ea8c50598d01e0315#8b4b274997f4afa79864f36ea8c50598d01e0315"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad#f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-common"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=8b4b274997f4afa79864f36ea8c50598d01e0315#8b4b274997f4afa79864f36ea8c50598d01e0315"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad#f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-client"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad#f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=7c4853a61111dca83f457485f244cadeeda33651#7c4853a61111dca83f457485f244cadeeda33651"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-common"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad#f74c8869acc49e2265a7c0c0f6cbcb9da5d6a6ad"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=7c4853a61111dca83f457485f244cadeeda33651#7c4853a61111dca83f457485f244cadeeda33651"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-client"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=7c4853a61111dca83f457485f244cadeeda33651#7c4853a61111dca83f457485f244cadeeda33651"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=756bee33c1698c208930ca23a1b511ddd1fc2146#756bee33c1698c208930ca23a1b511ddd1fc2146"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "modelexpress-common"
 version = "0.3.0"
-source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=7c4853a61111dca83f457485f244cadeeda33651#7c4853a61111dca83f457485f244cadeeda33651"
+source = "git+https://github.com/ai-dynamo/modelexpress.git?rev=756bee33c1698c208930ca23a1b511ddd1fc2146#756bee33c1698c208930ca23a1b511ddd1fc2146"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -112,7 +112,10 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
             {
                 Ok(()) => {
                     tracing::info!("Server download succeeded for model: {model_name}");
-                    match client.get_model_path(&model_name, MxModelProvider::HuggingFace).await {
+                    match client
+                        .get_model_path(&model_name, MxModelProvider::HuggingFace)
+                        .await
+                    {
                         Ok(path) => Ok(path),
                         Err(e) => {
                             tracing::warn!(

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -112,7 +112,7 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
             {
                 Ok(()) => {
                     tracing::info!("Server download succeeded for model: {model_name}");
-                    match client.get_model_path(&model_name).await {
+                    match client.get_model_path(&model_name, MxModelProvider::HuggingFace).await {
                         Ok(path) => Ok(path),
                         Err(e) => {
                             tracing::warn!(


### PR DESCRIPTION
#### Overview:

Bump the ModelExpress client version for Dynamo to the latest 0.3.0.

#### Details:

⚠️ Do not merge!
Currently using a prerelease pinned to a git commit which will break crate publication.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to OPS-4325


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to pinned versions for improved consistency and reliability across build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->