### PR TITLE
fix(mocker): avoid planner deps on default startup

### DIFF
--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -55,14 +55,14 @@ def resolve_planner_profile_data(
     Raises:
         FileNotFoundError: If path doesn't contain valid profile data in any supported format.
     """
+    if planner_profile_data is None:
+        return ProfileDataResult(npz_path=None, tmpdir=None)
+
     from .utils.planner_profiler_perf_data_converter import (
         convert_profile_results_to_npz,
         is_mocker_format_npz,
         is_profile_results_dir,
     )
-
-    if planner_profile_data is None:
-        return ProfileDataResult(npz_path=None, tmpdir=None)
 
     # Case 1: Already a mocker-format NPZ file
     if is_mocker_format_npz(planner_profile_data):

--- a/components/src/dynamo/mocker/tests/unit/test_args.py
+++ b/components/src/dynamo/mocker/tests/unit/test_args.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from dynamo.mocker.args import resolve_planner_profile_data
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.parallel,
+    pytest.mark.unit,
+]
+
+
+def test_resolve_planner_profile_data_none_does_not_require_planner_deps():
+    result = resolve_planner_profile_data(None)
+
+    assert result.npz_path is None


### PR DESCRIPTION
Avoid importing planner conversion code when --planner-profile-data is unset so normal mocker startup does not require planner-only dependencies like pmdarima. Adds a focused regression test for the None path in resolve_planner_profile_data().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized profile data resolution with improved early-return logic for null inputs.

* **Tests**
  * Added unit test coverage to verify profile data resolution behavior with missing inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->