### PR TITLE
feat: Add vLLM start/stop profile endpoints

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -35,7 +35,6 @@ from dynamo.common.multimodal.embedding_transfer import (
 )
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.common.multimodal.video_loader import VideoLoader
-from dynamo.runtime import DistributedRuntime
 from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.otel_tracing import build_trace_headers
@@ -50,7 +49,7 @@ from dynamo.llm import (
     unregister_model,
 )
 from dynamo.llm.exceptions import EngineShutdown
-from dynamo.runtime import Client
+from dynamo.runtime import Client, DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 
 from .args import Config
@@ -625,7 +624,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 logger.error(f"Failed to wake up engine: {e}")
                 return {"status": "error", "message": str(e)}
 
-    
     async def start_profile(self, body: dict) -> dict:
         """Start profiling on the engine.
 
@@ -645,7 +643,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         """
         await self.engine_client.stop_profile()
         return {"status": "ok", "message": "Profiling stopped"}
-
 
     def register_engine_routes(self, runtime: DistributedRuntime) -> None:
         """Register all engine routes for this handler.

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -49,7 +49,7 @@ from dynamo.llm import (
     unregister_model,
 )
 from dynamo.llm.exceptions import EngineShutdown
-from dynamo.runtime import Client, DistributedRuntime
+from dynamo.runtime import Client
 from dynamo.runtime.logging import configure_dynamo_logging
 
 from .args import Config
@@ -643,18 +643,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         """
         await self.engine_client.stop_profile()
         return {"status": "ok", "message": "Profiling stopped"}
-
-    def register_engine_routes(self, runtime: DistributedRuntime) -> None:
-        """Register all engine routes for this handler.
-
-        Args:
-            runtime: The DistributedRuntime instance to register routes on.
-        """
-        runtime.register_engine_route("start_profile", self.start_profile)
-        runtime.register_engine_route("stop_profile", self.stop_profile)
-        runtime.register_engine_route("sleep", self.sleep)
-        runtime.register_engine_route("wake_up", self.wake_up)
-        runtime.register_engine_route("scale_elastic_ep", self.scale_elastic_ep)
 
     @abstractmethod
     def generate(self, request: RequestT, context: Context) -> AsyncIterator[ResponseT]:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -35,6 +35,7 @@ from dynamo.common.multimodal.embedding_transfer import (
 )
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.common.multimodal.video_loader import VideoLoader
+from dynamo.runtime import DistributedRuntime
 from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.otel_tracing import build_trace_headers
@@ -623,6 +624,40 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             except Exception as e:
                 logger.error(f"Failed to wake up engine: {e}")
                 return {"status": "error", "message": str(e)}
+
+    
+    async def start_profile(self, body: dict) -> dict:
+        """Start profiling on the engine.
+
+        Args:
+            body: Dict with profiling parameters. Supported keys:
+                - profile_prefix (str|None): Optional prefix for profile output files.
+        """
+        profile_prefix = body.get("profile_prefix")
+        await self.engine_client.start_profile(profile_prefix=profile_prefix)
+        return {"status": "ok", "message": "Profiling started"}
+
+    async def stop_profile(self, body: dict) -> dict:
+        """Stop profiling on the engine.
+
+        Args:
+            body: Unused, but required for handler signature.
+        """
+        await self.engine_client.stop_profile()
+        return {"status": "ok", "message": "Profiling stopped"}
+
+
+    def register_engine_routes(self, runtime: DistributedRuntime) -> None:
+        """Register all engine routes for this handler.
+
+        Args:
+            runtime: The DistributedRuntime instance to register routes on.
+        """
+        runtime.register_engine_route("start_profile", self.start_profile)
+        runtime.register_engine_route("stop_profile", self.stop_profile)
+        runtime.register_engine_route("sleep", self.sleep)
+        runtime.register_engine_route("wake_up", self.wake_up)
+        runtime.register_engine_route("scale_elastic_ep", self.scale_elastic_ep)
 
     @abstractmethod
     def generate(self, request: RequestT, context: Context) -> AsyncIterator[ResponseT]:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -635,8 +635,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 - profile_prefix (str|None): Optional prefix for profile output files.
         """
         profile_prefix = body.get("profile_prefix")
-        await self.engine_client.start_profile(profile_prefix=profile_prefix)
-        return {"status": "ok", "message": "Profiling started"}
+        try:
+            await self.engine_client.start_profile(profile_prefix=profile_prefix)
+            return {"status": "ok", "message": "Profiling started"}
+        except Exception as e:
+            logger.error(f"Failed to start profiling: {e}")
+            return {"status": "error", "message": str(e)}
 
     async def stop_profile(self, body: dict) -> dict:
         """Stop profiling on the engine.
@@ -644,8 +648,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         Args:
             body: Unused, but required for handler signature.
         """
-        await self.engine_client.stop_profile()
-        return {"status": "ok", "message": "Profiling stopped"}
+        try:
+            await self.engine_client.stop_profile()
+            return {"status": "ok", "message": "Profiling stopped"}
+        except Exception as e:
+            logger.error(f"Failed to stop profiling: {e}")
+            return {"status": "error", "message": str(e)}
 
     @abstractmethod
     def generate(self, request: RequestT, context: Context) -> AsyncIterator[ResponseT]:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -47,7 +47,7 @@ from dynamo.llm import (
     unregister_model,
 )
 from dynamo.llm.exceptions import EngineShutdown
-from dynamo.runtime import Client, DistributedRuntime
+from dynamo.runtime import Client
 from dynamo.runtime.logging import configure_dynamo_logging
 
 from .args import Config
@@ -646,18 +646,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         """
         await self.engine_client.stop_profile()
         return {"status": "ok", "message": "Profiling stopped"}
-
-    def register_engine_routes(self, runtime: DistributedRuntime) -> None:
-        """Register all engine routes for this handler.
-
-        Args:
-            runtime: The DistributedRuntime instance to register routes on.
-        """
-        runtime.register_engine_route("start_profile", self.start_profile)
-        runtime.register_engine_route("stop_profile", self.stop_profile)
-        runtime.register_engine_route("sleep", self.sleep)
-        runtime.register_engine_route("wake_up", self.wake_up)
-        runtime.register_engine_route("scale_elastic_ep", self.scale_elastic_ep)
 
     @abstractmethod
     def generate(self, request: RequestT, context: Context) -> AsyncIterator[ResponseT]:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -33,6 +33,7 @@ from dynamo.common.multimodal.embedding_transfer import (
 )
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.common.multimodal.video_loader import VideoLoader
+from dynamo.runtime import DistributedRuntime
 from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.otel_tracing import build_trace_headers
@@ -626,6 +627,40 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             except Exception as e:
                 logger.error(f"Failed to wake up engine: {e}")
                 return {"status": "error", "message": str(e)}
+
+    
+    async def start_profile(self, body: dict) -> dict:
+        """Start profiling on the engine.
+
+        Args:
+            body: Dict with profiling parameters. Supported keys:
+                - profile_prefix (str|None): Optional prefix for profile output files.
+        """
+        profile_prefix = body.get("profile_prefix")
+        await self.engine_client.start_profile(profile_prefix=profile_prefix)
+        return {"status": "ok", "message": "Profiling started"}
+
+    async def stop_profile(self, body: dict) -> dict:
+        """Stop profiling on the engine.
+
+        Args:
+            body: Unused, but required for handler signature.
+        """
+        await self.engine_client.stop_profile()
+        return {"status": "ok", "message": "Profiling stopped"}
+
+
+    def register_engine_routes(self, runtime: DistributedRuntime) -> None:
+        """Register all engine routes for this handler.
+
+        Args:
+            runtime: The DistributedRuntime instance to register routes on.
+        """
+        runtime.register_engine_route("start_profile", self.start_profile)
+        runtime.register_engine_route("stop_profile", self.stop_profile)
+        runtime.register_engine_route("sleep", self.sleep)
+        runtime.register_engine_route("wake_up", self.wake_up)
+        runtime.register_engine_route("scale_elastic_ep", self.scale_elastic_ep)
 
     @abstractmethod
     def generate(self, request: RequestT, context: Context) -> AsyncIterator[ResponseT]:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -33,7 +33,6 @@ from dynamo.common.multimodal.embedding_transfer import (
 )
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.common.multimodal.video_loader import VideoLoader
-from dynamo.runtime import DistributedRuntime
 from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.otel_tracing import build_trace_headers
@@ -48,7 +47,7 @@ from dynamo.llm import (
     unregister_model,
 )
 from dynamo.llm.exceptions import EngineShutdown
-from dynamo.runtime import Client
+from dynamo.runtime import Client, DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 
 from .args import Config
@@ -628,7 +627,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 logger.error(f"Failed to wake up engine: {e}")
                 return {"status": "error", "message": str(e)}
 
-    
     async def start_profile(self, body: dict) -> dict:
         """Start profiling on the engine.
 
@@ -648,7 +646,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         """
         await self.engine_client.stop_profile()
         return {"status": "ok", "message": "Profiling stopped"}
-
 
     def register_engine_routes(self, runtime: DistributedRuntime) -> None:
         """Register all engine routes for this handler.

--- a/components/src/dynamo/vllm/tests/test_vllm_profile_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_profile_handlers.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dynamo.vllm.handlers import BaseWorkerHandler
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+class _TestWorkerHandler(BaseWorkerHandler):
+    async def generate(self, request, context):
+        yield {}
+
+
+def _make_handler() -> _TestWorkerHandler:
+    handler = _TestWorkerHandler.__new__(_TestWorkerHandler)
+    handler.engine_client = SimpleNamespace(
+        start_profile=AsyncMock(),
+        stop_profile=AsyncMock(),
+    )
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_start_profile_calls_engine_with_prefix():
+    handler = _make_handler()
+
+    result = await handler.start_profile({"profile_prefix": "prefix"})
+
+    assert result["status"] == "ok"
+    handler.engine_client.start_profile.assert_awaited_once_with(
+        profile_prefix="prefix"
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_profile_without_prefix_passes_none():
+    handler = _make_handler()
+
+    result = await handler.start_profile({})
+
+    assert result["status"] == "ok"
+    handler.engine_client.start_profile.assert_awaited_once_with(profile_prefix=None)
+
+
+@pytest.mark.asyncio
+async def test_stop_profile_calls_engine():
+    handler = _make_handler()
+
+    result = await handler.stop_profile({})
+
+    assert result["status"] == "ok"
+    handler.engine_client.stop_profile.assert_awaited_once_with()

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -330,13 +330,8 @@ class WorkerFactory:
                 component_name=config.component,
             )
 
-        # Register sleep/wake_up engine routes
-        runtime.register_engine_route("sleep", handler.sleep)
-        runtime.register_engine_route("wake_up", handler.wake_up)
-        runtime.register_engine_route("scale_elastic_ep", handler.scale_elastic_ep)
-        logger.info(
-            "Registered engine routes: /engine/sleep, /engine/wake_up, /engine/scale_elastic_ep"
-        )
+        # Register engine routes
+        handler.register_engine_routes(runtime)
 
         # Parse endpoint types from --endpoint-types flag
         model_type = parse_endpoint_types(config.endpoint_types)
@@ -564,14 +559,9 @@ class WorkerFactory:
                 component_name=config.component,
             )
 
-        # Register sleep/wake_up engine routes
-        runtime.register_engine_route("sleep", handler.sleep)
-        runtime.register_engine_route("wake_up", handler.wake_up)
-        runtime.register_engine_route("scale_elastic_ep", handler.scale_elastic_ep)
-        logger.info(
-            "Registered engine routes: /engine/sleep, /engine/wake_up, /engine/scale_elastic_ep"
-        )
-
+        # Register engine routes
+        handler.register_engine_routes(runtime)
+        
         # Wait for self-benchmark to complete before registering.
         bench_cfg = vllm_config.additional_config.get("benchmark")
         if bench_cfg:

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -26,7 +26,12 @@ from dynamo.runtime import DistributedRuntime
 
 from .args import Config
 from .constants import DisaggregationMode
-from .handlers import DecodeWorkerHandler, PrefillWorkerHandler, get_dp_range_for_worker
+from .handlers import (
+    BaseWorkerHandler,
+    DecodeWorkerHandler,
+    PrefillWorkerHandler,
+    get_dp_range_for_worker,
+)
 from .health_check import VllmHealthCheckPayload, VllmPrefillHealthCheckPayload
 from .multimodal_handlers import EncodeWorkerHandler
 from .publisher import StatLoggerFactory
@@ -331,7 +336,7 @@ class WorkerFactory:
             )
 
         # Register engine routes
-        handler.register_engine_routes(runtime)
+        self.register_engine_routes(runtime, handler)
 
         # Parse endpoint types from --endpoint-types flag
         model_type = parse_endpoint_types(config.endpoint_types)
@@ -560,8 +565,8 @@ class WorkerFactory:
             )
 
         # Register engine routes
-        handler.register_engine_routes(runtime)
-        
+        self.register_engine_routes(runtime, handler)
+
         # Wait for self-benchmark to complete before registering.
         bench_cfg = vllm_config.additional_config.get("benchmark")
         if bench_cfg:
@@ -642,3 +647,21 @@ class WorkerFactory:
             logger.info("Connected to encode workers")
             return encode_worker_client
         return None
+
+    def register_engine_routes(
+        self, runtime: DistributedRuntime, handler: BaseWorkerHandler
+    ) -> None:
+        """Register all engine routes for this handler.
+
+        Args:
+            runtime: The DistributedRuntime instance to register routes on.
+        """
+        runtime.register_engine_route("start_profile", handler.start_profile)
+        runtime.register_engine_route("stop_profile", handler.stop_profile)
+        runtime.register_engine_route("sleep", handler.sleep)
+        runtime.register_engine_route("wake_up", handler.wake_up)
+        runtime.register_engine_route("scale_elastic_ep", handler.scale_elastic_ep)
+
+        logger.info(
+            "Registered engine routes: /engine/sleep, /engine/wake_up, /engine/scale_elastic_ep, /engine/start_profile, /engine/stop_profile"
+        )

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -331,13 +331,8 @@ class WorkerFactory:
                 component_name=config.component,
             )
 
-        # Register sleep/wake_up engine routes
-        runtime.register_engine_route("sleep", handler.sleep)
-        runtime.register_engine_route("wake_up", handler.wake_up)
-        runtime.register_engine_route("scale_elastic_ep", handler.scale_elastic_ep)
-        logger.info(
-            "Registered engine routes: /engine/sleep, /engine/wake_up, /engine/scale_elastic_ep"
-        )
+        # Register engine routes
+        handler.register_engine_routes(runtime)
 
         # Parse endpoint types from --endpoint-types flag
         model_type = parse_endpoint_types(config.endpoint_types)
@@ -566,14 +561,9 @@ class WorkerFactory:
                 component_name=config.component,
             )
 
-        # Register sleep/wake_up engine routes
-        runtime.register_engine_route("sleep", handler.sleep)
-        runtime.register_engine_route("wake_up", handler.wake_up)
-        runtime.register_engine_route("scale_elastic_ep", handler.scale_elastic_ep)
-        logger.info(
-            "Registered engine routes: /engine/sleep, /engine/wake_up, /engine/scale_elastic_ep"
-        )
-
+        # Register engine routes
+        handler.register_engine_routes(runtime)
+        
         # Wait for self-benchmark to complete before registering.
         bench_cfg = vllm_config.additional_config.get("benchmark")
         if bench_cfg:

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -26,7 +26,12 @@ from dynamo.runtime import DistributedRuntime
 
 from .args import Config
 from .constants import DisaggregationMode
-from .handlers import DecodeWorkerHandler, PrefillWorkerHandler, get_dp_range_for_worker
+from .handlers import (
+    BaseWorkerHandler,
+    DecodeWorkerHandler,
+    PrefillWorkerHandler,
+    get_dp_range_for_worker,
+)
 from .health_check import VllmHealthCheckPayload, VllmPrefillHealthCheckPayload
 from .multimodal_handlers import EncodeWorkerHandler
 from .publisher import StatLoggerFactory
@@ -332,7 +337,7 @@ class WorkerFactory:
             )
 
         # Register engine routes
-        handler.register_engine_routes(runtime)
+        self.register_engine_routes(runtime, handler)
 
         # Parse endpoint types from --endpoint-types flag
         model_type = parse_endpoint_types(config.endpoint_types)
@@ -562,8 +567,8 @@ class WorkerFactory:
             )
 
         # Register engine routes
-        handler.register_engine_routes(runtime)
-        
+        self.register_engine_routes(runtime, handler)
+
         # Wait for self-benchmark to complete before registering.
         bench_cfg = vllm_config.additional_config.get("benchmark")
         if bench_cfg:
@@ -644,3 +649,21 @@ class WorkerFactory:
             logger.info("Connected to encode workers")
             return encode_worker_client
         return None
+
+    def register_engine_routes(
+        self, runtime: DistributedRuntime, handler: BaseWorkerHandler
+    ) -> None:
+        """Register all engine routes for this handler.
+
+        Args:
+            runtime: The DistributedRuntime instance to register routes on.
+        """
+        runtime.register_engine_route("start_profile", handler.start_profile)
+        runtime.register_engine_route("stop_profile", handler.stop_profile)
+        runtime.register_engine_route("sleep", handler.sleep)
+        runtime.register_engine_route("wake_up", handler.wake_up)
+        runtime.register_engine_route("scale_elastic_ep", handler.scale_elastic_ep)
+
+        logger.info(
+            "Registered engine routes: /engine/sleep, /engine/wake_up, /engine/scale_elastic_ep, /engine/start_profile, /engine/stop_profile"
+        )


### PR DESCRIPTION
**Overview:**
This PR exposes the start/stop profile endpoints for vLLM (as `engine/start_profile` and `engine/stop_profile` respectively) to maintain parity with the SGLang implementation. Also cleaned up route registration in the vLLM handler.

The [semi-analysis bench for srt-slurm](https://github.com/NVIDIA/srt-slurm/blob/main/src/srtctl/benchmarks/scripts/sa-bench/bench.sh) uses these endpoints to collect profiles, and having a unified interface prevents the need for engine-specific profiling logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profiling functionality, enabling engine performance analysis and monitoring during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->