### PR TITLE
fix(vllm): remap image/video → vision_chunk for use_unified_vision_chunk models

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1253,6 +1253,27 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     f"Extracted {len(audios)} audio item(s) for multimodal processing"
                 )
 
+        # Some models (e.g. Kimi-K2.5) set `use_unified_vision_chunk = True` in
+        # their HF config.  vLLM's chat_utils.py remaps "image"/"video" →
+        # "vision_chunk" when it processes OpenAI chat requests, but Dynamo
+        # bypasses that path and feeds multi-modal data directly to the engine.
+        # Without the remap, vLLM's validate_num_items() looks up "image" in
+        # get_supported_mm_limits() which only contains "vision_chunk" → 0,
+        # raising "At most 0 image(s) may be provided in one prompt".
+        hf_config = self.engine_client.vllm_config.model_config.hf_config
+        if getattr(hf_config, "use_unified_vision_chunk", False):
+            vision_chunks = []
+            if "image" in vllm_mm_data:
+                imgs = vllm_mm_data.pop("image")
+                vision_chunks += imgs if isinstance(imgs, list) else [imgs]
+            if "video" in vllm_mm_data:
+                vids = vllm_mm_data.pop("video")
+                vision_chunks += vids if isinstance(vids, list) else [vids]
+            if vision_chunks:
+                vllm_mm_data["vision_chunk"] = (
+                    vision_chunks[0] if len(vision_chunks) == 1 else vision_chunks
+                )
+
         return vllm_mm_data if vllm_mm_data else None
 
     def _build_prompt_from_request(


### PR DESCRIPTION
## Summary

Models like `nvidia/Kimi-K2.5-NVFP4` set `use_unified_vision_chunk = True` in their HuggingFace `config.json`. When vLLM processes an OpenAI `/v1/chat/completions` request natively it remaps `"image"` and `"video"` modality keys to `"vision_chunk"` inside `chat_utils.py` before the request reaches the engine. Dynamo's multimodal path bypasses `chat_utils` entirely, so that remapping never happens.

### Root cause

In `components/src/dynamo/vllm/handlers.py`, `_extract_multimodal_data()` loads images/videos and stores them as `vllm_mm_data["image"]` / `vllm_mm_data["video"]`, then passes this dict directly to the engine. For a model where `use_unified_vision_chunk = True`:

- `kimi_k25.get_supported_mm_limits()` declares `{"vision_chunk": None}` — **not** `"image"`
- vLLM's `validate_num_items()` looks up `supported_mm_limits.get("image", 0)` → `0`
- Result: `ValueError: At most 0 image(s) may be provided in one prompt`

This error occurs regardless of `--limit-mm-per-prompt` because the model limit is 0; user limits can only cap, not raise, a zero model limit.

### Fix

After all media is loaded in `_extract_multimodal_data`, check `hf_config.use_unified_vision_chunk` and merge accumulated `"image"`/`"video"` items into a single `"vision_chunk"` list before returning — mirroring the logic in `vllm/entrypoints/chat_utils.py`:

```python
hf_config = self.engine_client.vllm_config.model_config.hf_config
if getattr(hf_config, "use_unified_vision_chunk", False):
    vision_chunks = []
    if "image" in vllm_mm_data:
        imgs = vllm_mm_data.pop("image")
        vision_chunks += imgs if isinstance(imgs, list) else [imgs]
    if "video" in vllm_mm_data:
        vids = vllm_mm_data.pop("video")
        vision_chunks += vids if isinstance(vids, list) else [vids]
    if vision_chunks:
        vllm_mm_data["vision_chunk"] = (
            vision_chunks[0] if len(vision_chunks) == 1 else vision_chunks
        )
```

### Affected models

Any model whose `config.json` contains `"use_unified_vision_chunk": true` — currently includes at least `nvidia/Kimi-K2.5-NVFP4`. The fix is a no-op for all other models (the `getattr` guard returns `False`).

### Reproducer

```bash
# With vllm-runtime:1.0.1 (vLLM 0.16.x) or 1.1.0-dev.1 (vLLM 0.17.x):
curl https://<dynamo-endpoint>/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "nvidia/kimi-k2.5-nvfp4",
    "messages": [{
      "role": "user",
      "content": [
        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}},
        {"type": "text", "text": "Describe this image"}
      ]
    }]
  }'
# → 500: ValueError: At most 0 image(s) may be provided in one prompt
```

## Test plan

- [ ] Deploy `nvidia/Kimi-K2.5-NVFP4` with the patched runtime; confirm image inputs succeed end-to-end
- [ ] Confirm text-only requests to a non-vision model are unaffected (the `getattr` guard is `False`)
- [ ] Confirm existing multimodal models without `use_unified_vision_chunk` (e.g. LLaVA) continue to work with `vllm_mm_data["image"]` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced multimodal data handling to support unified vision chunk representation. Image and video inputs are now properly aggregated and reformatted based on model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->