### PR TITLE
fix(sglang): pass stop_token_ids to engine for proactive EOS detection

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -93,9 +93,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             sampling_opts = request.get("sampling_options", {})
             stop_conditions = request.get("stop_conditions", {})
 
-            # stop_token_ids are passed to the engine so it can stop generation
-            # proactively (matching vLLM/TRT-LLM handlers). Stop strings are NOT
-            # passed — the Rust Decoder handles string-based stop matching.
             stop_token_ids = stop_conditions.get("stop_token_ids_hidden")
 
             param_mapping = {

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -93,7 +93,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             sampling_opts = request.get("sampling_options", {})
             stop_conditions = request.get("stop_conditions", {})
 
-            stop_token_ids = stop_conditions.get("stop_token_ids_hidden")
+            _hidden = stop_conditions.get("stop_token_ids_hidden") or []
+            _plain = stop_conditions.get("stop_token_ids") or []
+            _merged = list(set(_hidden).union(_plain))
+            stop_token_ids = _merged if _merged else None
 
             param_mapping = {
                 "temperature": sampling_opts.get("temperature"),

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -93,12 +93,18 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             sampling_opts = request.get("sampling_options", {})
             stop_conditions = request.get("stop_conditions", {})
 
+            # stop_token_ids are passed to the engine so it can stop generation
+            # proactively (matching vLLM/TRT-LLM handlers). Stop strings are NOT
+            # passed — the Rust Decoder handles string-based stop matching.
+            stop_token_ids = stop_conditions.get("stop_token_ids_hidden")
+
             param_mapping = {
                 "temperature": sampling_opts.get("temperature"),
                 "top_p": sampling_opts.get("top_p"),
                 "top_k": sampling_opts.get("top_k"),
                 "max_new_tokens": stop_conditions.get("max_tokens"),
                 "ignore_eos": stop_conditions.get("ignore_eos"),
+                "stop_token_ids": stop_token_ids,
                 **self._get_guided_decoding_params(
                     sampling_opts.get("guided_decoding")
                 ),


### PR DESCRIPTION
## Summary
- Forward `stop_token_ids_hidden` from the Rust frontend's preprocessed request to the SGLang engine's sampling parameters
- Brings the SGLang decode handler into parity with the vLLM and TRT-LLM handlers, which already pass stop token IDs to their engines

## Problem

The SGLang decode handler's `_build_sampling_params()` was not forwarding `stop_token_ids_hidden` (EOS token IDs) to the engine. With `skip_tokenizer_init=True` (the default), the SGLang scheduler has `self.tokenizer = None`, so its tokenizer-based EOS check is skipped - but it will still check stop_token_ids from request sampling params: https://github.com/sgl-project/sglang/blob/b4a1d8fd714d39ef11bec6fc444443254ed04b3f/python/sglang/srt/managers/schedule_batch.py#L1107-L1108

In practice this isn't a big problem because the Rust-side Decoder in `backend.rs` does enforce stop tokens client-side as a safety net, but without engine-side enforcement, the engine can waste compute generating tokens past EOS until the Rust Decoder catches up and cancels

## Fix

Add `stop_token_ids` to the `param_mapping` dict, sourced from `stop_conditions["stop_token_ids_hidden"]`. Stop strings are intentionally NOT passed — the Rust Decoder handles string-based stop matching.

**Before:**
```python
param_mapping = {
    "temperature": ..., "top_p": ..., "top_k": ...,
    "max_new_tokens": stop_conditions.get("max_tokens"),
    "ignore_eos": stop_conditions.get("ignore_eos"),
}
```

**After:**
```python
param_mapping = {
    "temperature": ..., "top_p": ..., "top_k": ...,
    "max_new_tokens": stop_conditions.get("max_tokens"),
    "ignore_eos": stop_conditions.get("ignore_eos"),
    "stop_token_ids": stop_token_ids,
}
```

This matches the existing pattern in both:
- **vLLM handler** (`handlers.py:219-225`): merges `stop_token_ids_hidden` into `sampling_params.stop_token_ids`
- **TRT-LLM handler** (`handler_base.py:848-851`): same pattern

Refs: DYN-2649

🤖 Generated with [Claude Code](https://claude.com/claude-code)