### PR TITLE
fix(metrics): skip output token histogram for zero-output requests

### DIFF
--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -1416,11 +1416,17 @@ impl Drop for ResponseMetricCollector {
                 .observe(avg_detokenize_latency_ms);
         }
 
-        // Publish final OSL when the collector is dropped
-        self.metrics
-            .output_sequence_length
-            .with_label_values(&[&self.model])
-            .observe(self.osl as f64);
+        // Publish final OSL when the collector is dropped, but only for
+        // requests that actually produced output tokens. Recording zero for
+        // failed/cancelled requests would corrupt histogram averages (sum/count)
+        // and percentiles. Failures are already tracked by requests_total with
+        // status and error_type labels.
+        if self.osl > 0 {
+            self.metrics
+                .output_sequence_length
+                .with_label_values(&[&self.model])
+                .observe(self.osl as f64);
+        }
 
         // Record request summary on the enclosing span.
         // InflightGuard::Drop and on_response logs will inherit these.

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -151,9 +151,15 @@ impl RequestGuard {
             tracker.record_finish();
             tracker.record_osl(self.cumulative_osl);
         }
-        self.request_metrics
-            .output_sequence_tokens
-            .observe(self.cumulative_osl as f64);
+        // Only record output sequence length for requests that actually
+        // produced output tokens. Recording zero for failed/cancelled requests
+        // would corrupt histogram averages (sum/count) and percentiles.
+        // Failures are already tracked by requests_total.
+        if self.cumulative_osl > 0 {
+            self.request_metrics
+                .output_sequence_tokens
+                .observe(self.cumulative_osl as f64);
+        }
         self.request_metrics.requests_total.inc();
     }
 }

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -6,6 +6,7 @@ use async_stream::stream;
 use dynamo_llm::{
     http::service::{metrics::Endpoint, service_v2::HttpService},
     model_card::ModelDeploymentCard,
+    preprocessor::LLMMetricAnnotation,
     protocols::{
         Annotated,
         openai::chat_completions::{
@@ -50,10 +51,32 @@ impl
             // Simulate some processing time
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
-            // Generate 5 response chunks
+            // Generate 5 response chunks with LLMMetricAnnotation so that
+            // output_sequence_tokens is properly recorded (the histogram only
+            // records when osl > 0, which requires the annotation to be present).
             for i in 0..5 {
                 let output = generator.create_choice(i, Some(format!("Mock response {i}")), None, None, None);
-                yield Annotated::from_data(output);
+                let mut annotated = Annotated::from_data(output);
+                let metrics = LLMMetricAnnotation {
+                    input_tokens: 5,
+                    output_tokens: (i + 1) as usize,
+                    chunk_tokens: 1,
+                    cached_tokens: None,
+                    prefill_worker_id: None,
+                    prefill_dp_rank: None,
+                    prefill_worker_type: None,
+                    decode_worker_id: None,
+                    decode_dp_rank: None,
+                    decode_worker_type: None,
+                    tokenize_latency: None,
+                    detokenize_total_latency: None,
+                    detokenize_count: None,
+                };
+                if let Ok(ann) = metrics.to_annotation::<NvCreateChatCompletionStreamResponse>() {
+                    annotated.event = ann.event;
+                    annotated.comment = ann.comment;
+                }
+                yield annotated;
             }
         };
 


### PR DESCRIPTION
## Summary
- Skip recording `output_sequence_tokens` histogram for requests that produce zero output tokens (failures/cancellations)
- Fixes both the frontend-level (`dynamo_frontend_output_sequence_tokens`) and router-level (`dynamo_component_router_output_sequence_tokens`) histograms
- Prevents histogram corruption that skews `sum/count` averages and percentile calculations used in Grafana dashboards

## Details

The `output_sequence_tokens` histogram is recorded when a response collector or request guard is dropped. Previously, this was unconditional -- even for requests that failed or were cancelled before producing any output tokens, a value of `0` was recorded.

This corrupts the histogram in two ways:
1. **Average (sum/count)**: Every failed request adds 1 to count without adding to sum, artificially lowering the reported average output sequence length
2. **Percentiles**: Zero values accumulate in the lowest bucket, making p50/p90/p99 unreliable

The fix guards the `.observe()` call with `if osl > 0` in two locations:
- `ResponseMetricCollector::Drop` in `lib/llm/src/http/service/metrics.rs` (frontend histogram)
- `RequestGuard::record_metrics()` in `lib/llm/src/kv_router/push_router.rs` (router histogram)

No observability is lost because:
- Failed/cancelled requests are already tracked by `requests_total` with `status` and `error_type` labels
- The `requests_total` counter in `RequestGuard` continues to be incremented unconditionally
- Legitimate zero-output completions are theoretically possible but not meaningful for output length distribution analysis

## Test plan
- [ ] Verify `cargo check` passes (no Rust toolchain available in this environment; change is a minimal conditional guard around existing code)
- [ ] Verify existing `http_metrics` integration tests still pass (`cargo test -p dynamo-llm --test http_metrics`)
- [ ] Confirm Grafana dashboard queries (`dynamo_frontend_output_sequence_tokens_sum / dynamo_frontend_output_sequence_tokens_count`) are not broken by the change (they improve, as zeros no longer dilute the average)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of request metrics collection by preventing zero-value samples from failed or cancelled requests from being recorded, ensuring metrics and derived statistics better reflect actual system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->