### PR TITLE
fix(metrics): widen router overhead histogram buckets

### DIFF
--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -56,10 +56,19 @@ use prometheus::{HistogramOpts, IntGaugeVec, Opts};
 
 use crate::http::service::metrics::generate_log_buckets;
 
-/// Exponential buckets for routing overhead histograms:
-/// from 0.0001 ms (0.1 µs) to ~13.1 ms, factor 2, 18 steps.
+/// Custom buckets for routing overhead histograms (milliseconds).
+///
+/// Covers 0.1 ms to 1000 ms with log-spaced boundaries, providing good
+/// resolution in the typical 0.1-10 ms range while extending high enough
+/// to capture tail latency from async indexer queries and scheduling under load.
+///
+/// Previous config used `exponential_buckets(0.0001, 2.0, 18)` which topped
+/// out at ~13.1 ms, clipping `histogram_quantile()` output for any overhead
+/// beyond that boundary and hiding long-tail behavior.
 fn overhead_buckets() -> Vec<f64> {
-    prometheus::exponential_buckets(0.0001, 2.0, 18).expect("exponential buckets should not fail")
+    vec![
+        0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0,
+    ]
 }
 
 // ---------------------------------------------------------------------------
@@ -590,7 +599,7 @@ dynamo_frontend_router_queue_pending_requests{worker_type=\"decode\"} 5
 
     #[test]
     fn test_routing_overhead_saturating_sub() {
-        let buckets = prometheus::exponential_buckets(0.0001, 2.0, 18).unwrap();
+        let buckets = overhead_buckets();
         let make = |name: &str| {
             prometheus::Histogram::with_opts(
                 prometheus::HistogramOpts::new(name, "test").buckets(buckets.clone()),


### PR DESCRIPTION
## Summary

- Widen `dynamo_router_overhead_*` histogram bucket range from 0.0001-13.1 ms to 0.1-1000 ms to capture realistic routing latency including tail spikes

## Details

The `dynamo_router_overhead_*` histograms (block_hashing, seq_hashing, indexer_find_matches, scheduling, total) used `exponential_buckets(0.0001, 2.0, 18)` which produced 18 buckets maxing out at ~13.1 ms. This caused two problems:

1. **Clipped quantiles**: Once routing overhead exceeded 13.1 ms, `histogram_quantile()` clipped to the top finite bucket boundary, hiding actual tail latency
2. **Wasted resolution**: The bottom 10 of 18 buckets covered 0.0001-0.1024 ms (sub-microsecond), well below meaningful routing measurement resolution

**Old buckets (ms):** 0.0001, 0.0002, 0.0004, 0.0008, 0.0016, 0.0032, 0.0064, 0.0128, 0.0256, 0.0512, 0.1024, 0.2048, 0.4096, 0.8192, 1.6384, 3.2768, 6.5536, 13.1072

**New buckets (ms):** 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0

The new boundaries:
- Start at 0.1 ms (reasonable minimum for routing operations)
- Provide good resolution in the expected 0.1-10 ms range (7 of 13 buckets)
- Extend to 1000 ms to capture tail latency from async indexer queries and scheduling under load
- Use fewer total buckets (13 vs 18), reducing per-metric memory and scrape overhead

The test that previously hardcoded `exponential_buckets(0.0001, 2.0, 18)` now calls the shared `overhead_buckets()` function.

## Test plan

- [ ] Verify `cargo test -p dynamo-llm -- kv_router::metrics` passes (tests use `overhead_buckets()`)
- [ ] Verify `cargo check -p dynamo-llm` compiles cleanly
- [ ] Deploy to a test environment and confirm the new bucket boundaries appear in `/metrics` output
- [ ] Confirm `histogram_quantile(0.99, ...)` on `dynamo_router_overhead_total_ms` no longer clips at 13.1 ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved routing-overhead metrics collection with updated histogram bucket boundaries for more precise performance monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->