### PR TITLE
fix(frontend): classify cancelled requests as 499 instead of 500

### DIFF
--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -289,6 +289,16 @@ async fn anthropic_messages(
                 .metrics_clone()
                 .inc_rejection(&model, super::metrics::Endpoint::AnthropicMessages);
         }
+        // Check for cancelled request (client disconnected before response was sent)
+        if super::metrics::request_was_cancelled(e.as_ref()) {
+            inflight_guard.mark_error(super::metrics::ErrorType::Cancelled);
+            return anthropic_error(
+                StatusCode::from_u16(499).unwrap(),
+                "request_cancelled",
+                &format!("Request cancelled: {}", e),
+            );
+        }
+        inflight_guard.mark_error(super::metrics::ErrorType::Internal);
         anthropic_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "api_error",

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -36,6 +36,13 @@ pub fn request_was_rejected(err: &(dyn std::error::Error + 'static)) -> bool {
     dynamo_runtime::error::match_error_chain(err, REJECTION, NON_REJECTION)
 }
 
+/// Check whether an error chain indicates the request was cancelled.
+pub fn request_was_cancelled(err: &(dyn std::error::Error + 'static)) -> bool {
+    const CANCELLATION: &[DynamoErrorType] = &[DynamoErrorType::Cancelled];
+    const NON_CANCELLATION: &[DynamoErrorType] = &[];
+    dynamo_runtime::error::match_error_chain(err, CANCELLATION, NON_CANCELLATION)
+}
+
 pub use prometheus::Registry;
 
 use super::RouteDoc;

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2566,7 +2566,7 @@ mod tests {
             classify_error_for_metrics(StatusCode::from_u16(499).unwrap(), "cancelled request");
         assert_eq!(
             error_type,
-            super::metrics::ErrorType::Cancelled,
+            ErrorType::Cancelled,
             "HTTP 499 should map to ErrorType::Cancelled in metrics"
         );
     }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -94,6 +94,9 @@ pub(crate) struct ErrorMessage {
 fn map_error_code_to_error_type(code: StatusCode) -> String {
     match code.canonical_reason() {
         Some(reason) => reason.to_string(),
+        // 499 is not IANA-registered (nginx convention for client-closed-request),
+        // so canonical_reason() returns None. Use the de facto standard name.
+        None if code.as_u16() == 499 => "Client Closed Request".to_string(),
         None => "UnknownError".to_string(),
     }
 }
@@ -229,8 +232,8 @@ impl ErrorMessage {
                 code,
                 Json(ErrorMessage {
                     message: err.to_string(),
-                    error_type: "Client Closed Request".to_string(),
-                    code: 499,
+                    error_type: map_error_code_to_error_type(code),
+                    code: code.as_u16(),
                 }),
             );
         }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -223,8 +223,6 @@ impl ErrorMessage {
 
         // Check for Cancelled anywhere in the error chain → HTTP 499 (Client Closed Request)
         if super::metrics::request_was_cancelled(err.as_ref()) {
-            // Use 499 (nginx convention for client-closed-request). This is not a server
-            // error — the client disconnected before we could send a response.
             let code = StatusCode::from_u16(499).unwrap();
             tracing::debug!("Request cancelled before response: {err}");
             return (

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -114,6 +114,7 @@ fn classify_error_for_metrics(code: StatusCode, message: &str) -> ErrorType {
         StatusCode::TOO_MANY_REQUESTS => ErrorType::Overload, // 429
         StatusCode::SERVICE_UNAVAILABLE => ErrorType::Overload, // 503
         StatusCode::INTERNAL_SERVER_ERROR => ErrorType::Internal, // 500
+        _ if code.as_u16() == 499 => ErrorType::Cancelled, // 499 Client Closed Request
         _ if code.is_client_error() => ErrorType::Validation, // other 4xx
         _ => ErrorType::Internal,                     // everything else
     }
@@ -216,6 +217,22 @@ impl ErrorMessage {
                     message: dynamo_err.message().to_string(),
                     error_type: map_error_code_to_error_type(StatusCode::BAD_REQUEST),
                     code: StatusCode::BAD_REQUEST.as_u16(),
+                }),
+            );
+        }
+
+        // Check for Cancelled anywhere in the error chain → HTTP 499 (Client Closed Request)
+        if super::metrics::request_was_cancelled(err.as_ref()) {
+            // Use 499 (nginx convention for client-closed-request). This is not a server
+            // error — the client disconnected before we could send a response.
+            let code = StatusCode::from_u16(499).unwrap();
+            tracing::debug!("Request cancelled before response: {err}");
+            return (
+                code,
+                Json(ErrorMessage {
+                    message: err.to_string(),
+                    error_type: "Client Closed Request".to_string(),
+                    code: 499,
                 }),
             );
         }
@@ -2521,6 +2538,38 @@ mod tests {
         assert_eq!(
             response.1.message,
             "ResourceExhausted: All workers are busy, please retry later"
+        );
+    }
+
+    #[test]
+    fn test_cancelled_error_response_from_anyhow() {
+        use dynamo_runtime::error::{DynamoError, ErrorType};
+
+        let err: anyhow::Error = DynamoError::builder()
+            .error_type(ErrorType::Cancelled)
+            .message("Context id abc-123 is stopped or killed")
+            .build()
+            .into();
+        let response = ErrorMessage::from_anyhow(err, BACKUP_ERROR_MESSAGE);
+        assert_eq!(
+            response.0.as_u16(),
+            499,
+            "Cancelled errors should return HTTP 499"
+        );
+        assert_eq!(response.1.code, 499);
+        assert_eq!(response.1.error_type, "Client Closed Request");
+        assert!(response.1.message.contains("stopped or killed"));
+    }
+
+    #[test]
+    fn test_cancelled_error_metrics_classification() {
+        // HTTP 499 should be classified as Cancelled for metrics
+        let error_type =
+            classify_error_for_metrics(StatusCode::from_u16(499).unwrap(), "cancelled request");
+        assert_eq!(
+            error_type,
+            super::metrics::ErrorType::Cancelled,
+            "HTTP 499 should map to ErrorType::Cancelled in metrics"
         );
     }
 

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -181,10 +181,14 @@ impl RetryManager {
             self.context.link_child(request.context());
             if self.context.is_stopped() || self.context.is_killed() {
                 tracing::debug!("Abort creating new stream after context is stopped or killed");
-                return Err(Error::msg(format!(
-                    "Context id {} is stopped or killed",
-                    self.context.id()
-                )));
+                return Err(DynamoError::builder()
+                    .error_type(ErrorType::Cancelled)
+                    .message(format!(
+                        "Context id {} is stopped or killed",
+                        self.context.id()
+                    ))
+                    .build()
+                    .into());
             }
             response_stream = Some(self.next_generate.generate(request).await);
             if let Some(err) = response_stream.as_ref().unwrap().as_ref().err()
@@ -905,6 +909,15 @@ mod tests {
                 error
                     .to_string()
                     .contains(&format!("Context id {} is stopped or killed", context_id))
+            );
+            // Verify the error is a typed DynamoError with Cancelled type
+            let dynamo_err = error
+                .downcast_ref::<DynamoError>()
+                .expect("Error should be a DynamoError");
+            assert_eq!(
+                dynamo_err.error_type(),
+                ErrorType::Cancelled,
+                "Stopped/killed context should produce a Cancelled error"
             );
         }
 


### PR DESCRIPTION
#### Overview:

Cancelled requests that occur before the HTTP response is sent (e.g., during prefill) are misclassified as HTTP 500 Internal Server Errors. This inflates the `internal` error count in `dynamo_frontend_requests_total{error_type="internal"}` and deflates the `cancelled` count, obscuring the real cancellation rate in dashboards.

The root cause is a gap in the error classification pipeline: the migration layer returns a plain `anyhow::Error` when a context is stopped/killed, and neither the OpenAI nor Anthropic error handlers check for cancellation errors — so they fall through to HTTP 500. The metrics classifier then maps 500 → ErrorType::Internal. Meanwhile, post-stream cancellation detection works correctly via monitor_for_disconnects() and ctx.is_killed() checks.

#### Details:

- **lib/llm/src/migration.rs**: Changed the stopped/killed context check to return a typed DynamoError with ErrorType::Cancelled instead of a plain anyhow::Error. Updated the existing test to verify the error type is Cancelled.
- **lib/llm/src/http/service/metrics.rs**: Added request_was_cancelled() helper function that walks the error chain looking for ErrorType::Cancelled, mirroring the existing request_was_rejected() pattern for ResourceExhausted.
- **lib/llm/src/http/service/openai.rs**: Added a Cancelled check in from_anyhow() returning HTTP 499 (Client Closed Request), and map 499 to ErrorType::Cancelled in classify_error_for_metrics(). Added two new tests covering both the HTTP response and metrics classification.
- **lib/llm/src/http/service/anthropic.rs**: Added request_was_cancelled() check in the engine.generate() error handler to return HTTP 499 with request_cancelled error type. Also explicitly marks the inflight_guard as Cancelled vs Internal (previously relied on default drop behavior for all errors).

#### Where should the reviewer start?

Start with openai.rs — the from_anyhow() change (new cancellation check between InvalidArgument and HttpError) and classify_error_for_metrics() (new 499 mapping) are the core of the fix. Then check anthropic.rs for the parallel fix using the Anthropic error format, and migration.rs for the error type change that feeds into both.