### PR TITLE
fix(llm): support reading eos_token_ids from tokenizer_config.json for models like Qwen3.5 with <|im_end|> token

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -93,12 +93,18 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             sampling_opts = request.get("sampling_options", {})
             stop_conditions = request.get("stop_conditions", {})
 
+            # stop_token_ids are passed to the engine so it can stop generation
+            # proactively (matching vLLM/TRT-LLM handlers). Stop strings are NOT
+            # passed — the Rust Decoder handles string-based stop matching.
+            stop_token_ids = stop_conditions.get("stop_token_ids_hidden")
+
             param_mapping = {
                 "temperature": sampling_opts.get("temperature"),
                 "top_p": sampling_opts.get("top_p"),
                 "top_k": sampling_opts.get("top_k"),
                 "max_new_tokens": stop_conditions.get("max_tokens"),
                 "ignore_eos": stop_conditions.get("ignore_eos"),
+                "stop_token_ids": stop_token_ids,
                 **self._get_guided_decoding_params(
                     sampling_opts.get("guided_decoding")
                 ),

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -93,18 +93,12 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             sampling_opts = request.get("sampling_options", {})
             stop_conditions = request.get("stop_conditions", {})
 
-            # stop_token_ids are passed to the engine so it can stop generation
-            # proactively (matching vLLM/TRT-LLM handlers). Stop strings are NOT
-            # passed — the Rust Decoder handles string-based stop matching.
-            stop_token_ids = stop_conditions.get("stop_token_ids_hidden")
-
             param_mapping = {
                 "temperature": sampling_opts.get("temperature"),
                 "top_p": sampling_opts.get("top_p"),
                 "top_k": sampling_opts.get("top_k"),
                 "max_new_tokens": stop_conditions.get("max_tokens"),
                 "ignore_eos": stop_conditions.get("ignore_eos"),
-                "stop_token_ids": stop_token_ids,
                 **self._get_guided_decoding_params(
                     sampling_opts.get("guided_decoding")
                 ),

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -895,7 +895,7 @@ impl HFConfig {
         // 1. generation_config.json;
         // 2. config.json, or text_config field in config.json.
         // https://github.com/huggingface/transformers/issues/25395#issuecomment-1671863257
-        let final_eos_token_ids: Vec<TokenIdType> = {
+        let mut final_eos_token_ids: Vec<TokenIdType> = {
                 // Firstly check the generation_config.json
                 crate::file_json_field::<serde_json::Value>(&gencfg_path, "eos_token_id")
                 .inspect_err(
@@ -952,10 +952,78 @@ impl HFConfig {
                     "missing eos_token_id in config.json and generation_config.json, cannot load"
                 )
             })?;
+        // Also check tokenizer_config.json for the tokenizer's eos_token.
+        // Some models (e.g. Qwen3.5) have text_config.eos_token_id = <|endoftext|>
+        // but the tokenizer's eos_token is <|im_end|> — the token the model actually
+        // emits to end generation. Merge the tokenizer's EOS into the set so both
+        // are recognized as stop tokens.
+        let tokenizer_cfg_path = file_path
+            .parent()
+            .unwrap_or_else(|| Path::new(""))
+            .join("tokenizer_config.json");
+        if let Ok(tokenizer_eos_id) =
+            resolve_eos_token_id_from_tokenizer_config(&tokenizer_cfg_path)
+            && !final_eos_token_ids.contains(&tokenizer_eos_id)
+        {
+            final_eos_token_ids.push(tokenizer_eos_id);
+        }
+
         text_config.final_eos_token_ids = final_eos_token_ids;
 
         Ok(Arc::new(config))
     }
+}
+
+/// Resolve the tokenizer's `eos_token` to a token ID by reading `tokenizer_config.json`.
+///
+/// Reads the `eos_token` field (string) and looks it up in `added_tokens_decoder`
+/// to find the corresponding token ID. This handles models where the tokenizer's
+/// EOS token differs from `config.json`'s `eos_token_id`.
+fn resolve_eos_token_id_from_tokenizer_config(path: &Path) -> anyhow::Result<TokenIdType> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read tokenizer_config.json: {:?}", path))?;
+    let config: serde_json::Value = serde_json::from_str(&contents)
+        .with_context(|| format!("Failed to parse tokenizer_config.json: {:?}", path))?;
+
+    // Get eos_token — can be a plain string or a dict with a "content" field (older HF format)
+    let eos_token_str = match config.get("eos_token") {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(serde_json::Value::Object(obj)) => obj
+            .get("content")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| anyhow::anyhow!("eos_token is an object without 'content' field"))?,
+        _ => anyhow::bail!("eos_token not found or not a string in tokenizer_config.json"),
+    };
+
+    // Look up the token string in added_tokens_decoder to get its ID
+    let added_tokens = config
+        .get("added_tokens_decoder")
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| {
+            anyhow::anyhow!("added_tokens_decoder not found in tokenizer_config.json")
+        })?;
+
+    for (id_str, token_info) in added_tokens {
+        let content = token_info
+            .get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if content == eos_token_str {
+            let token_id: TokenIdType = id_str.parse().with_context(|| {
+                format!(
+                    "Failed to parse token ID '{}' from added_tokens_decoder",
+                    id_str
+                )
+            })?;
+            return Ok(token_id);
+        }
+    }
+
+    anyhow::bail!(
+        "eos_token '{}' not found in added_tokens_decoder",
+        eos_token_str
+    )
 }
 
 impl ModelInfo for HFConfig {
@@ -1169,5 +1237,27 @@ mod tests {
         dynamo_runtime::logging::init();
         let path = "tests/data/sample-models/NVIDIA-Nemotron-Nano-12B-v2-Base/config.json";
         let _ = HFConfig::from_json_file(path).unwrap();
+    }
+
+    /// Qwen3.5 models have text_config.eos_token_id = 248044 (<|endoftext|>) but the
+    /// tokenizer's eos_token is <|im_end|> (248046). The model actually emits <|im_end|>
+    /// to end generation. Verify that both are included in the resolved EOS set.
+    #[test]
+    fn test_config_json_qwen35_eos_from_tokenizer() -> anyhow::Result<()> {
+        let config_file = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/sample-models/mock-qwen3.5-0.8B/config.json");
+        let config = HFConfig::from_json_file(&config_file)?;
+        let eos_token_id_set: HashSet<_> = config.eos_token_ids().iter().cloned().collect();
+        // Must include both: 248044 (<|endoftext|>) from text_config and
+        // 248046 (<|im_end|>) from tokenizer_config.json
+        assert!(
+            eos_token_id_set.contains(&248044),
+            "Should contain text_config eos_token_id (248044 <|endoftext|>)"
+        );
+        assert!(
+            eos_token_id_set.contains(&248046),
+            "Should contain tokenizer eos_token (248046 <|im_end|>)"
+        );
+        Ok(())
     }
 }

--- a/lib/llm/tests/data/sample-models/mock-qwen3.5-0.8B/config.json
+++ b/lib/llm/tests/data/sample-models/mock-qwen3.5-0.8B/config.json
@@ -1,0 +1,11 @@
+{
+  "architectures": ["Qwen3_5MoeForCausalLM"],
+  "model_type": "qwen3_5_moe",
+  "text_config": {
+    "eos_token_id": 248044,
+    "max_position_embeddings": 262144,
+    "num_hidden_layers": 36,
+    "num_attention_heads": 16,
+    "vocab_size": 248064
+  }
+}

--- a/lib/llm/tests/data/sample-models/mock-qwen3.5-0.8B/tokenizer_config.json
+++ b/lib/llm/tests/data/sample-models/mock-qwen3.5-0.8B/tokenizer_config.json
@@ -1,0 +1,21 @@
+{
+  "eos_token": "<|im_end|>",
+  "added_tokens_decoder": {
+    "248044": {
+      "content": "<|endoftext|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "248046": {
+      "content": "<|im_end|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `tokenizer_config.json` as a fallback source for EOS token IDs in the model card loader
- Fixes Qwen3.5 models where `text_config.eos_token_id` is `<|endoftext|>` (248044) but the model actually terminates with `<|im_end|>` (248046)
- The fix is additive — merges the tokenizer's EOS into the existing set without replacing
- Handles both string and dict `eos_token` formats in `tokenizer_config.json`

## Problem

Qwen3.5-0.8B's `config.json` has no top-level `eos_token_id`. The Rust model card loader falls back to `text_config.eos_token_id = 248044` (`<|endoftext|>`), but the model actually emits `<|im_end|>` (248046) to end generation. Since 248046 was never in the EOS set:

1. **Generation runs to `max_tokens`** instead of stopping naturally — most visible with `enable_thinking=true` where the model fills the entire token budget with reasoning
2. **`<|im_end|>` leaks into response content** (e.g. `"4<|im_end|>\n"`) because it's not recognized as a stop token

Standalone SGLang works correctly because it reads `tokenizer.eos_token_id` at runtime.

## Fix

After the existing EOS resolution chain (generation_config.json → config.json → text_config), add a new step that:
1. Reads `eos_token` (string) from `tokenizer_config.json`
2. Resolves it to a token ID via `added_tokens_decoder`
3. Merges it into `final_eos_token_ids` if not already present

Fails gracefully if `tokenizer_config.json` is missing or doesn't contain the expected fields.

## Test plan
- [x] New unit test `test_config_json_qwen35_eos_from_tokenizer` — verifies both 248044 and 248046 are in the EOS set
- [x] All 4 existing `model_card::tests` pass (no regressions)
- [x] `cargo check -p dynamo-llm` compiles clean
- [ ] Deploy dynamo+sglang with Qwen3.5-0.8B, verify `enable_thinking=true` stops naturally
- [ ] Verify `<|im_end|>` no longer leaks into response content

Refs: DYN-2648

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced model configuration parsing to automatically discover and merge End-of-Sequence tokens from both model and tokenizer configuration files, improving support for diverse model architectures with multiple special token definitions.

* **Tests**
  * Added test data and unit tests for models with multiple End-of-Sequence token sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->