### PR TITLE
fix(metrics): split overload error_type into throttled and unavailable

### DIFF
--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -363,8 +363,10 @@ pub enum ErrorType {
     Validation,
     /// Model or resource not found (404)
     NotFound,
-    /// Service overloaded, too many requests (503)
-    Overload,
+    /// Too many requests / rate-limited (429)
+    Throttled,
+    /// Service unavailable (503)
+    Unavailable,
     /// Request cancelled by client or timeout
     Cancelled,
     /// Backend accepted the request but stopped responding (response inactivity timeout)
@@ -1124,7 +1126,8 @@ impl Drop for InflightGuard {
                     ErrorType::Internal => "internal server error during processing",
                     ErrorType::Validation => "invalid request parameters",
                     ErrorType::NotFound => "model or resource not found",
-                    ErrorType::Overload => "service overloaded or rate limited",
+                    ErrorType::Throttled => "rate limited (too many requests)",
+                    ErrorType::Unavailable => "service unavailable",
                     ErrorType::NotImplemented => "requested feature not implemented",
                     ErrorType::None => "unknown error",
                 };
@@ -1217,7 +1220,8 @@ impl ErrorType {
             ErrorType::None => frontend_service::error_type::NONE,
             ErrorType::Validation => frontend_service::error_type::VALIDATION,
             ErrorType::NotFound => frontend_service::error_type::NOT_FOUND,
-            ErrorType::Overload => frontend_service::error_type::OVERLOAD,
+            ErrorType::Throttled => frontend_service::error_type::THROTTLED,
+            ErrorType::Unavailable => frontend_service::error_type::UNAVAILABLE,
             ErrorType::Cancelled => frontend_service::error_type::CANCELLED,
             ErrorType::ResponseTimeout => frontend_service::error_type::RESPONSE_TIMEOUT,
             ErrorType::Internal => frontend_service::error_type::INTERNAL,
@@ -2245,7 +2249,8 @@ mod tests {
         assert_eq!(ErrorType::None.as_str(), "");
         assert_eq!(ErrorType::Validation.as_str(), "validation");
         assert_eq!(ErrorType::NotFound.as_str(), "not_found");
-        assert_eq!(ErrorType::Overload.as_str(), "overload");
+        assert_eq!(ErrorType::Throttled.as_str(), "throttled");
+        assert_eq!(ErrorType::Unavailable.as_str(), "unavailable");
         assert_eq!(ErrorType::Cancelled.as_str(), "cancelled");
         assert_eq!(ErrorType::ResponseTimeout.as_str(), "response_timeout");
         assert_eq!(ErrorType::Internal.as_str(), "internal");
@@ -2355,7 +2360,8 @@ mod tests {
         let error_types = vec![
             ErrorType::Validation,
             ErrorType::NotFound,
-            ErrorType::Overload,
+            ErrorType::Throttled,
+            ErrorType::Unavailable,
             ErrorType::Cancelled,
             ErrorType::ResponseTimeout,
             ErrorType::Internal,

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -111,8 +111,8 @@ fn classify_error_for_metrics(code: StatusCode, message: &str) -> ErrorType {
         }
         StatusCode::NOT_FOUND => ErrorType::NotFound, // 404
         StatusCode::NOT_IMPLEMENTED => ErrorType::NotImplemented, // 501
-        StatusCode::TOO_MANY_REQUESTS => ErrorType::Overload, // 429
-        StatusCode::SERVICE_UNAVAILABLE => ErrorType::Overload, // 503
+        StatusCode::TOO_MANY_REQUESTS => ErrorType::Throttled, // 429
+        StatusCode::SERVICE_UNAVAILABLE => ErrorType::Unavailable, // 503
         StatusCode::INTERNAL_SERVER_ERROR => ErrorType::Internal, // 500
         _ if code.is_client_error() => ErrorType::Validation, // other 4xx
         _ => ErrorType::Internal,                     // everything else
@@ -3229,11 +3229,11 @@ mod tests {
         );
         assert_eq!(
             classify_error_for_metrics(StatusCode::TOO_MANY_REQUESTS, "Rate limit exceeded"),
-            ErrorType::Overload
+            ErrorType::Throttled
         );
         assert_eq!(
             classify_error_for_metrics(StatusCode::SERVICE_UNAVAILABLE, "Overloaded"),
-            ErrorType::Overload
+            ErrorType::Unavailable
         );
         assert_eq!(
             classify_error_for_metrics(StatusCode::INTERNAL_SERVER_ERROR, "Panic"),

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -322,8 +322,11 @@ pub mod frontend_service {
         /// Model or resource not found (404)
         pub const NOT_FOUND: &str = "not_found";
 
-        /// Service overloaded, too many requests (503)
-        pub const OVERLOAD: &str = "overload";
+        /// Too many requests / rate-limited (429)
+        pub const THROTTLED: &str = "throttled";
+
+        /// Service unavailable (503)
+        pub const UNAVAILABLE: &str = "unavailable";
 
         /// Request cancelled by client or timeout
         pub const CANCELLED: &str = "cancelled";


### PR DESCRIPTION
## Summary
- Split the conflated `overload` metric label into two distinct labels: `throttled` (HTTP 429) and `unavailable` (HTTP 503)
- Enables operators to distinguish rate-limiting from service unavailability in dashboards and alerts

## Details

The frontend HTTP service previously mapped both HTTP 429 (Too Many Requests) and HTTP 503 (Service Unavailable) to a single `overload` error_type label in Prometheus metrics. These represent fundamentally different failure modes:

- **429 / `throttled`**: The server is actively rate-limiting. The client should back off and retry after the indicated delay.
- **503 / `unavailable`**: The service itself is down or unable to handle requests (e.g., all workers busy). This may indicate a more serious infrastructure issue.

### Files changed
- `lib/runtime/src/metrics/prometheus_names.rs` — replaced `OVERLOAD` constant with `THROTTLED` and `UNAVAILABLE`
- `lib/llm/src/http/service/metrics.rs` — split `ErrorType::Overload` enum variant into `Throttled` and `Unavailable`, updated `as_str()` mapping and error detail strings
- `lib/llm/src/http/service/openai.rs` — updated `classify_error_for_metrics()` to map 429 → `Throttled` and 503 → `Unavailable`

### Breaking change note
This is a metrics label value change. Any existing Prometheus queries, dashboards, or alerts filtering on `error_type="overload"` will need to be updated to use `error_type="throttled"` and/or `error_type="unavailable"`. No external configs referencing this label were found in the repository.

## Test plan
- [x] `cargo check` passes for `dynamo-llm` and `dynamo-runtime`
- [x] All affected unit tests pass (`test_classify_error_for_metrics_status_codes`, `test_error_type_as_str`, `test_all_error_types_recorded_correctly`)
- [x] No remaining references to `ErrorType::Overload` or `error_type::OVERLOAD` in the codebase
- [ ] Verify in a staging environment that metrics emit `error_type="throttled"` for 429 responses and `error_type="unavailable"` for 503 responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error classification to differentiate between rate-limited requests (HTTP 429) and service unavailability (HTTP 503), replacing the previous generic overload categorization.
  * Improved metrics tracking and error reporting for better service health monitoring and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->