### PR TITLE
fix: return offloaded blocks synchronously to prevent disk cache misses

### DIFF
--- a/lib/llm/src/block_manager/offload/pending.rs
+++ b/lib/llm/src/block_manager/offload/pending.rs
@@ -40,7 +40,7 @@ use crate::block_manager::block::{
     locality::LocalityProvider,
     transfer::{TransferContext, WriteTo, WriteToStrategy},
 };
-use crate::block_manager::pool::{BlockPool, BlockPoolError};
+use crate::block_manager::pool::{BlockPool, BlockPoolError, OwnedBlock};
 use crate::block_manager::storage::{Local, Storage};
 
 use anyhow::Result;
@@ -107,6 +107,18 @@ impl<Source: Storage, Target: Storage, Locality: LocalityProvider, Metadata: Blo
             completion_indicator
                 .send(Ok(blocks))
                 .map_err(|_| BlockPoolError::ProgressEngineShutdown)?;
+        } else {
+            // Offload path: no caller is waiting for these blocks.
+            // Return them to the pool through the priority channel so they
+            // land in the inactive pool's lookup_map synchronously -- before
+            // any subsequent match_sequence_hashes can run.  Dropping them
+            // would send them through the async return_tx channel, which
+            // races with lookups and causes disk cache misses.
+            for block in blocks {
+                target_pool
+                    .try_return_block(OwnedBlock::Immutable(block))
+                    .await?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
After an offload transfer completes, register_blocks() adds the block to the pool hash table and returns ImmutableBlocks. When no caller is waiting (completion_indicator is None, i.e. the offload path), these blocks were simply dropped, sending them back to the pool through the async return_tx channel.

This creates a race: match_sequence_hashes can find the block in the hash table (inserted by register_blocks) but fail to retrieve it because the async return hasn't completed yet -- the block hasn't landed in the inactive pool's lookup_map. This causes disk cache misses on blocks that should be available.

Fix by explicitly returning blocks via try_return_block (the priority channel) which updates the lookup_map synchronously before any subsequent match_sequence_hashes can run.

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed block resource handling in the offload path to ensure blocks are properly returned to the resource pool instead of being implicitly dropped, improving resource cleanup and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->