### PR TITLE
docs: add GLM-5 NVFP4 recipe to recipes README

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -65,6 +65,7 @@ These recipes are under active development and may require additional setup step
 
 | Model | Framework | Mode | GPUs | Deployment | Notes |
 |-------|-----------|------|------|------------|-------|
+| **[GLM-5-NVFP4](glm-5-nvfp4/sglang/disagg/)** | SGLang | Disagg Prefill/Decode | 20x GB200 | ✅ | NVFP4, EAGLE speculative decoding, TP16 decode + TP4 prefill. Requires [custom container build](glm-5-nvfp4/). |
 | **[nvidia/Kimi-K2.5-NVFP4](kimi-k2.5/trtllm/agg/nvidia/)** | TensorRT-LLM | Aggregated | 8x B200 | ✅ | Text only — MoE model, TP8×EP8, reasoning + tool calling. Requires [container patch](kimi-k2.5/trtllm/agg/nvidia/patch/). Vision input not yet functional with the patch. |
 
 ## Recipe Structure


### PR DESCRIPTION
## Summary
- Add GLM-5 NVFP4 disaggregated serving recipe to the Experimental Recipes table in `recipes/README.md`
- Recipe was merged in #7780 but was not listed in the README

## Test plan
- [ ] Verify markdown table renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new experimental recipe configuration entry for SGLang deployment featuring disaggregated prefill/decode architecture with speculative decoding support. A custom container build is required for this configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->