### PR TITLE
docs(recipes): fix EPP image references to use published dynamo-front…

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -225,7 +225,7 @@ First, deploy the Dynamo Graph per instructions above.
 
 Then follow [Deploy Inference Gateway Section 2](../deploy/inference-gateway/README.md#2-deploy-inference-gateway) to install GAIE.
 
-Update the containers.epp.image in the deployment file, i.e. llama-3-70b/vllm/agg/gaie/k8s-manifests/epp/deployment.yaml. It should match the release tag and be in the format `nvcr.io/nvidia/ai-dynamo/frontend:<version>` e.g. `nvcr.io/nvidia/ai-dynamo/frontend:0.9.0`
+Update the containers.epp.image in the deployment file, i.e. llama-3-70b/vllm/agg/gaie/k8s-manifests/epp/deployment.yaml. It should match the release tag and be in the format `nvcr.io/nvidia/ai-dynamo/dynamo-frontend:<version>` e.g. `nvcr.io/nvidia/ai-dynamo/dynamo-frontend:0.9.0`
 The recipe assumes you are using Kubernetes discovery backend and sets the `DYN_DISCOVERY_BACKEND` env variable in the epp deployment. If you want to use etcd enable the lines below and remove the DYN_DISCOVERY_BACKEND env var.
 ```bash
 - name: ETCD_ENDPOINTS

--- a/recipes/llama-3-70b/vllm/agg/gaie/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/agg/gaie/deploy.yaml
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/frontend:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:my-tag
           env:
             - name: DYN_KV_CACHE_BLOCK_SIZE
               value: "128"

--- a/recipes/llama-3-70b/vllm/disagg-single-node/gaie/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-single-node/gaie/deploy.yaml
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/frontend:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:my-tag
           env:
             - name: DYN_KV_CACHE_BLOCK_SIZE
               value: "128"
@@ -75,7 +75,7 @@ spec:
       sharedMemory:
         size: 80Gi
       frontendSidecar:
-        image: nvcr.io/nvidia/ai-dynamo/frontend:my-tag
+        image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:my-tag
         args:
           - -m
           - dynamo.frontend
@@ -130,7 +130,7 @@ spec:
       sharedMemory:
         size: 80Gi
       frontendSidecar:
-        image: nvcr.io/nvidia/ai-dynamo/frontend:my-tag
+        image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:my-tag
         args:
           - -m
           - dynamo.frontend


### PR DESCRIPTION
…end image

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Replace `nvcr.io/nvidia/ai-dynamo/frontend` with `nvcr.io/nvidia/ai-dynamo/dynamo-frontend` in GAIE recipe manifests and
documentation. The `dynamo-frontend` is the official artifact that includes the EPP binary and is the correct image for both standard frontend and EPP/GAIE deployments.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment configuration examples to reference the correct container image version.

* **Chores**
  * Updated container image references across deployment configurations for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->