### PR TITLE
fix(test): unskip test_smoke by switching to trtllm attention backend (DYN-2607)

### DIFF
--- a/tests/basic/autodeploy_engine_config.yaml
+++ b/tests/basic/autodeploy_engine_config.yaml
@@ -6,4 +6,5 @@ kv_cache_config:
   enable_partial_reuse: false
   free_gpu_memory_fraction: 0.80
   max_tokens: 8192
-compile_backend: torch-cudagraph
+attn_backend: trtllm
+max_batch_size: 128

--- a/tests/basic/test_autodeploy_backend.py
+++ b/tests/basic/test_autodeploy_backend.py
@@ -166,7 +166,6 @@ def send_completion_request(
         raise
 
 
-@pytest.mark.skip(reason="Nightly CI failure: https://linear.app/nvidia/issue/DYN-2607")
 @pytest.mark.trtllm
 @pytest.mark.e2e
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
Unskip `test_smoke` by switching from FlashInfer (default) to TRT-LLM native attention kernels.

- Replace `compile_backend: torch-cudagraph` with `attn_backend: trtllm` and `max_batch_size: 128`
- Remove `@pytest.mark.skip` to restore nightly CI coverage

## Root Cause
The crash is in **FlashInfer's `BatchPrefillWithKVCachePlan`** — not `compile_backend`. FlashInfer's prefill planner triggers `cudaErrorIllegalAddress` during executor initialization regardless of compile backend (`torch-compile`, `torch-simple`, `torch-cudagraph` all crash). Switching to `attn_backend: trtllm` avoids FlashInfer entirely.

| Config tried | Result |
|---|---|
| flashinfer (default) + any compile_backend | **CRASH**: cudaErrorIllegalAddress in FlashInfer |
| `attn_backend: torch` or `triton` | **OOM**: 160 GiB pre-allocation at default batch size |
| **`attn_backend: trtllm`, `max_batch_size: 128`** | **PASSED** (88s) |

## Test plan
- [x] `test_smoke` passes locally (TRT-LLM rc11, CUDA 13.1, Blackwell)
- [x] pre-commit passes
- [x] CI validation on CI runner GPU by marking the test as premerge to trigger it.
<img width="1516" height="145" alt="Screenshot 2026-04-13 at 3 01 07 PM" src="https://github.com/user-attachments/assets/69a7cfff-420c-48ad-9371-b7e05247f909" />