### PR TITLE
fix(gms): replace gms_read_only with gms_lock_mode

### DIFF
--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -480,8 +480,7 @@ def setup_vllm_engine(
             logger.info(
                 "[Shadow] Enabled shadow mode: will skip KV cache allocation at startup"
             )
-            # ENGINE_ID=0 writes weights, all others import (RO).
-            # Prevents deadlock during TP>1 failover.
+            # Normalize gms_lock_mode so missing config becomes "auto".
             configure_gms_lock_mode(engine_args)
             validate_cudagraph_mode(engine_args)
 

--- a/lib/gpu_memory_service/README.md
+++ b/lib/gpu_memory_service/README.md
@@ -359,9 +359,9 @@ sequenceDiagram
     end
 ```
 
-### Auto-Mode (RW_OR_RO)
+### Auto-Mode (AUTO)
 
-The `RW_OR_RO` mode automatically selects writer or reader based on server state, simplifying multi-worker deployments.
+The `AUTO` mode automatically selects writer or reader based on server state, simplifying multi-worker deployments.
 
 ```mermaid
 sequenceDiagram
@@ -372,8 +372,8 @@ sequenceDiagram
     Note over P,S: Auto-mode: try RW only when no committed layout exists
 
     P->>C: mgr = GMSClientMemoryManager(socket_path, device=0)
-    P->>C: mgr.connect(RW_OR_RO)
-    C->>S: HandshakeRequest(lock_type=RW_OR_RO)
+    P->>C: mgr.connect(AUTO)
+    C->>S: HandshakeRequest(lock_type=AUTO)
 
     alt No committed weights AND no RW holder
         S->>S: Grant RW lock
@@ -529,9 +529,9 @@ GMS provides pre-built integrations for vLLM and SGLang. Enable GMS by passing `
 When `--load-format gms` is set:
 
 1. **A GMS server must already be running** for the target GPU device. The engine connects to it via a Unix socket derived from the GPU UUID.
-2. The engine uses `RW_OR_RO` mode by default: if no committed layout exists and no writer holds the lock, the first process gets RW and loads weights from disk. Otherwise clients wait for a committed layout and then get RO to import published weights.
+2. The engine uses `AUTO` mode by default: if no committed layout exists and no writer holds the lock, the first process gets RW and loads weights from disk. Otherwise clients wait for a committed layout and then get RO to import published weights.
 3. Both weights and KV cache are managed by GMS, but they use separate tags:
-   - `weights`: publish/import flow (`RW_OR_RO`, then `RO` after commit)
+   - `weights`: publish/import flow (`AUTO`, then `RO` after commit)
    - `kv_cache`: separate RW-only tag for mutable KV-cache memory
 
 #### vLLM
@@ -550,7 +550,7 @@ The integration uses a custom worker class (`GMSWorker`) that:
 - Registers a custom model loader (`GMSModelLoader`) for the `gms` load format
 - Patches `torch.cuda.empty_cache` to avoid releasing GMS-managed memory
 - Uses two GMS tags on the GPU:
-  - `weights`: normal publish/import flow (`RW_OR_RO`, then `RO` after commit)
+  - `weights`: normal publish/import flow (`AUTO`, then `RO` after commit)
   - `kv_cache`: separate RW-only tag for mutable KV-cache memory
 - Routes both weight and KV-cache allocation through a `CUDAPluggableAllocator` backed by the appropriate GMS tag
 
@@ -588,10 +588,10 @@ This enables a shadow engine to release its GPU memory, let a primary engine use
 
 ### Configuration via `model_loader_extra_config`
 
-To force read-only mode (import only, never load from disk), pass `gms_read_only` via the framework's `--model-loader-extra-config` flag:
+To control the weights lock mode, pass `gms_lock_mode` via the framework's `--model-loader-extra-config` flag:
 
 ```bash
---model-loader-extra-config '{"gms_read_only": true}'
+--model-loader-extra-config '{"gms_lock_mode": "ro"}'
 ```
 
-This forces `RO` lock mode instead of the default `RW_OR_RO` auto-detection. The engine will only import existing committed weights and fail if none are available.
+Supported values are `"auto"` (default), `"rw"`, and `"ro"`. `"auto"` picks RW for the first loader when no committed layout exists, then RO for later loaders. `"ro"` forces import-only mode and fails if no committed weights are available.

--- a/lib/gpu_memory_service/common/locks.py
+++ b/lib/gpu_memory_service/common/locks.py
@@ -7,7 +7,7 @@ from enum import Enum
 class RequestedLockType(str, Enum):
     RW = "rw"
     RO = "ro"
-    RW_OR_RO = "rw_or_ro"
+    AUTO = "auto"
 
 
 class GrantedLockType(str, Enum):

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -21,14 +21,33 @@ GMS_TAGS = ("weights", "kv_cache")
 
 
 def get_gms_lock_mode(extra_config: dict):
-    """Resolve GMS lock mode from model_loader_extra_config.
+    """Resolve GMS lock mode from model_loader_extra_config."""
+    if "gms_read_only" in extra_config:
+        raise ValueError(
+            "gms_read_only was removed. Use gms_lock_mode with one of: rw, ro, auto."
+        )
 
-    Returns RO if gms_read_only=True, otherwise RW_OR_RO (default).
-    """
-    if extra_config.get("gms_read_only", False):
-        logger.info("[GMS] gms_read_only=True, forcing RO mode")
-        return RequestedLockType.RO
-    return RequestedLockType.RW_OR_RO
+    raw_mode = extra_config.get("gms_lock_mode")
+    if raw_mode is None:
+        logger.info("[GMS] gms_lock_mode not set, defaulting to auto")
+        return RequestedLockType.AUTO
+
+    if isinstance(raw_mode, RequestedLockType):
+        return raw_mode
+    if not isinstance(raw_mode, str):
+        raise ValueError(
+            f"gms_lock_mode must be one of: rw, ro, auto; got {type(raw_mode).__name__}"
+        )
+
+    try:
+        mode = RequestedLockType(raw_mode.strip().lower())
+    except ValueError as exc:
+        raise ValueError(
+            f"gms_lock_mode must be one of: rw, ro, auto; got {raw_mode!r}"
+        ) from exc
+
+    logger.info("[GMS] gms_lock_mode=%s", mode.value)
+    return mode
 
 
 def strip_gms_model_loader_config(load_config, load_format: str):

--- a/lib/gpu_memory_service/integrations/sglang/memory_saver.py
+++ b/lib/gpu_memory_service/integrations/sglang/memory_saver.py
@@ -69,7 +69,7 @@ class GMSMemorySaverImpl:
     ):
         self._device = torch.device("cuda", device_index)
         self.imported_weights_bytes = 0
-        requested_mode = mode or RequestedLockType.RW_OR_RO
+        requested_mode = mode or RequestedLockType.AUTO
         self.allocators = {
             tag: get_or_create_gms_client_memory_manager(
                 get_socket_path(device_index, tag),

--- a/lib/gpu_memory_service/integrations/sglang/model_loader.py
+++ b/lib/gpu_memory_service/integrations/sglang/model_loader.py
@@ -4,7 +4,7 @@
 """SGLang model loader for GPU Memory Service integration.
 
 Provides a model loader that loads weights via GMS for cross-process sharing.
-The loader uses RW_OR_RO mode: first process loads from disk (RW), subsequent
+The loader uses AUTO mode: first process loads from disk (RW), subsequent
 processes import from GMS metadata (RO).
 
 Usage:

--- a/lib/gpu_memory_service/integrations/sglang/patches.py
+++ b/lib/gpu_memory_service/integrations/sglang/patches.py
@@ -68,7 +68,7 @@ def patch_torch_memory_saver() -> None:
             # Get device from torch.cuda.current_device() (already set by SGLang)
             device_index = torch.cuda.current_device()
 
-            # Read lock mode set by setup_gms() (defaults to RW_OR_RO)
+            # Read lock mode set by setup_gms() (defaults to AUTO)
             gms_impl = GMSMemorySaverImpl(
                 device_index=device_index,
                 mode=gms_sglang._gms_lock_mode,

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -4,7 +4,7 @@
 """vLLM model loader for GPU Memory Service integration.
 
 Provides a model loader that loads weights via GMS for cross-process sharing.
-The loader uses RW_OR_RO mode: first process loads from disk (RW), subsequent
+The loader uses AUTO mode: first process loads from disk (RW), subsequent
 processes import from GMS metadata (RO).
 """
 

--- a/lib/gpu_memory_service/integrations/vllm/utils.py
+++ b/lib/gpu_memory_service/integrations/vllm/utils.py
@@ -3,8 +3,11 @@
 
 """Shadow mode utilities for GMS vLLM integration."""
 
+import json
 import logging
 import os
+
+from gpu_memory_service.integrations.common.utils import get_gms_lock_mode
 
 logger = logging.getLogger(__name__)
 
@@ -43,32 +46,10 @@ def validate_cudagraph_mode(engine_args) -> None:
 
 
 def configure_gms_lock_mode(engine_args) -> None:
-    """Set gms_read_only in model_loader_extra_config based on ENGINE_ID.
-
-    In a failover setup with TP>1, only ENGINE_ID="0" loads weights from
-    disk (RW_OR_RO). All other engines import from GMS (RO). This avoids
-    deadlock: if multiple engines tried to acquire RW locks across TP ranks
-    simultaneously, they could block each other indefinitely.
-
-    Raises if user-specified gms_read_only conflicts with ENGINE_ID.
-    """
-    engine_id = os.environ.get("ENGINE_ID", "0")
+    """Normalize model_loader_extra_config for GMS lock-mode handling."""
     extra = engine_args.model_loader_extra_config or {}
-    user_read_only = extra.get("gms_read_only", None)
+    if isinstance(extra, str):
+        extra = json.loads(extra) if extra else {}
 
-    if engine_id == "0":
-        if user_read_only:
-            raise ValueError(
-                "ENGINE_ID=0 is the primary writer but "
-                "gms_read_only=True was explicitly set. "
-                "The primary engine must be able to write weights."
-            )
-    else:
-        if user_read_only is not None and not user_read_only:
-            raise ValueError(
-                f"ENGINE_ID={engine_id} requires gms_read_only=True, "
-                f"but gms_read_only=False was explicitly set."
-            )
-        extra["gms_read_only"] = True
-
+    extra["gms_lock_mode"] = get_gms_lock_mode(extra).value
     engine_args.model_loader_extra_config = extra

--- a/lib/gpu_memory_service/server/session.py
+++ b/lib/gpu_memory_service/server/session.py
@@ -106,7 +106,7 @@ class GMSSessionManager:
             self._waiting_writers
         )
 
-    def _can_grant_rw_or_ro(self) -> bool:
+    def _can_resolve_auto_request(self) -> bool:
         if self._can_grant_ro():
             return True
         return self._can_grant_rw() and not self._locking.committed
@@ -148,13 +148,16 @@ class GMSSessionManager:
                     return None
             return GrantedLockType.RO
 
+        if mode != RequestedLockType.AUTO:
+            raise ValueError(f"Unsupported lock mode {mode!r}")
+
         async with self._condition:
             if self._can_grant_rw() and not self._locking.committed:
                 self._reserved_rw_session_id = session_id
                 return GrantedLockType.RW
             try:
                 await asyncio.wait_for(
-                    self._condition.wait_for(self._can_grant_rw_or_ro),
+                    self._condition.wait_for(self._can_resolve_auto_request),
                     timeout=timeout,
                 )
             except asyncio.TimeoutError:

--- a/tests/gms/common/test_gms_client_session.py
+++ b/tests/gms/common/test_gms_client_session.py
@@ -80,7 +80,7 @@ def test_client_session_records_granted_lock_and_committed(monkeypatch):
         ),
     )
 
-    session = _GMSClientSession("/tmp/gms-test.sock", RequestedLockType.RW_OR_RO, None)
+    session = _GMSClientSession("/tmp/gms-test.sock", RequestedLockType.AUTO, None)
 
     assert session.committed
     assert session.lock_type == GrantedLockType.RO
@@ -98,7 +98,7 @@ def test_client_session_requires_granted_lock_type(monkeypatch):
     )
 
     with pytest.raises(RuntimeError, match="granted_lock_type"):
-        _GMSClientSession("/tmp/gms-test.sock", RequestedLockType.RW_OR_RO, None)
+        _GMSClientSession("/tmp/gms-test.sock", RequestedLockType.AUTO, None)
 
     assert closed["value"]
 

--- a/tests/gms/common/test_gms_lock_mode_config.py
+++ b/tests/gms/common/test_gms_lock_mode_config.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from gpu_memory_service.common.locks import RequestedLockType
+from gpu_memory_service.integrations.common.utils import get_gms_lock_mode
+from gpu_memory_service.integrations.vllm.utils import configure_gms_lock_mode
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.none,
+    pytest.mark.gpu_0,
+]
+
+
+def test_get_gms_lock_mode_defaults_to_auto():
+    assert get_gms_lock_mode({}) == RequestedLockType.AUTO
+
+
+@pytest.mark.parametrize(
+    ("raw_mode", "expected"),
+    [
+        ("rw", RequestedLockType.RW),
+        ("RO", RequestedLockType.RO),
+        (RequestedLockType.AUTO, RequestedLockType.AUTO),
+    ],
+)
+def test_get_gms_lock_mode_parses_supported_values(raw_mode, expected):
+    assert get_gms_lock_mode({"gms_lock_mode": raw_mode}) == expected
+
+
+def test_get_gms_lock_mode_rejects_removed_gms_read_only_flag():
+    with pytest.raises(ValueError, match="gms_read_only was removed"):
+        get_gms_lock_mode({"gms_read_only": True})
+
+
+def test_get_gms_lock_mode_rejects_invalid_value():
+    with pytest.raises(ValueError, match="rw, ro, auto"):
+        get_gms_lock_mode({"gms_lock_mode": "reader"})
+
+
+@pytest.mark.parametrize(
+    ("extra_config", "expected_mode"),
+    [
+        (None, "auto"),
+        ({}, "auto"),
+        ({"gms_lock_mode": "auto"}, "auto"),
+        ({"gms_lock_mode": "rw"}, "rw"),
+        ({"gms_lock_mode": "ro"}, "ro"),
+        ('{"gms_lock_mode": "rw"}', "rw"),
+        ('{"gms_lock_mode": "ro"}', "ro"),
+    ],
+)
+def test_configure_gms_lock_mode_preserves_explicit_mode_and_defaults_to_auto(
+    extra_config, expected_mode
+):
+    engine_args = SimpleNamespace(model_loader_extra_config=extra_config)
+
+    configure_gms_lock_mode(engine_args)
+
+    assert engine_args.model_loader_extra_config["gms_lock_mode"] == expected_mode
+
+
+def test_configure_gms_lock_mode_rejects_removed_gms_read_only_flag():
+    engine_args = SimpleNamespace(model_loader_extra_config={"gms_read_only": True})
+
+    with pytest.raises(ValueError, match="gms_read_only was removed"):
+        configure_gms_lock_mode(engine_args)

--- a/tests/gms/common/test_gms_runtime_flows.py
+++ b/tests/gms/common/test_gms_runtime_flows.py
@@ -226,16 +226,16 @@ def test_rw_disconnect_aborts_layout_and_next_writer_starts_clean(real_gms):
         next_writer.close()
 
 
-def test_rw_or_ro_grants_rw_from_empty_and_ro_from_committed(real_gms):
+def test_auto_grants_rw_from_empty_and_ro_from_committed(real_gms):
     server, socket_path = real_gms
 
-    session = _GMSClientSession(socket_path, RequestedLockType.RW_OR_RO, 100)
+    session = _GMSClientSession(socket_path, RequestedLockType.AUTO, 100)
     assert session.lock_type == GrantedLockType.RW
     session.commit()
 
     _wait_for_server_state(server, ServerState.COMMITTED)
 
-    session = _GMSClientSession(socket_path, RequestedLockType.RW_OR_RO, 100)
+    session = _GMSClientSession(socket_path, RequestedLockType.AUTO, 100)
     try:
         assert session.lock_type == GrantedLockType.RO
         assert session.committed
@@ -388,7 +388,7 @@ def test_waiting_writer_blocks_new_readers_until_last_reader_disconnects(real_gm
         waiting_writer.close()
 
 
-def test_rw_or_ro_times_out_while_writer_waits_behind_reader(real_gms):
+def test_auto_times_out_while_writer_waits_behind_reader(real_gms):
     server, socket_path = real_gms
 
     writer = _GMSClientSession(socket_path, RequestedLockType.RW, None)
@@ -412,7 +412,7 @@ def test_rw_or_ro_times_out_while_writer_waits_behind_reader(real_gms):
     _wait_for_waiting_writers(server, 1)
 
     with pytest.raises(TimeoutError, match="Timeout waiting for lock"):
-        _GMSClientSession(socket_path, RequestedLockType.RW_OR_RO, 100)
+        _GMSClientSession(socket_path, RequestedLockType.AUTO, 100)
 
     reader.close()
     thread.join(timeout=2)

--- a/tests/gms/common/test_gms_server_transport_failures.py
+++ b/tests/gms/common/test_gms_server_transport_failures.py
@@ -386,7 +386,7 @@ async def test_reader_waiter_wakes_when_waiting_writer_times_out():
 
 
 @pytest.mark.asyncio
-async def test_rw_or_ro_waiter_becomes_rw_after_writer_abort():
+async def test_auto_waiter_becomes_rw_after_writer_abort():
     sessions = GMSSessionManager()
 
     writer_mode = await sessions.acquire_lock(
@@ -407,7 +407,7 @@ async def test_rw_or_ro_waiter_becomes_rw_after_writer_abort():
 
     waiter = asyncio.create_task(
         sessions.acquire_lock(
-            RequestedLockType.RW_OR_RO,
+            RequestedLockType.AUTO,
             timeout_ms=200,
             session_id="waiter_1",
         )

--- a/tests/gms/harness/sglang.py
+++ b/tests/gms/harness/sglang.py
@@ -30,7 +30,7 @@ class SGLangWithGMSProcess(ManagedProcess):
         sglang_port: int,
         frontend_port: int,
         *,
-        read_only_weights: bool = False,
+        weights_lock_mode: str | None = None,
     ):
         self.engine_id = engine_id
         self.system_port = system_port
@@ -52,11 +52,11 @@ class SGLangWithGMSProcess(ManagedProcess):
             "--port",
             str(sglang_port),
         ]
-        if read_only_weights:
+        if weights_lock_mode is not None:
             command.extend(
                 [
                     "--model-loader-extra-config",
-                    '{"gms_read_only": true}',
+                    f'{{"gms_lock_mode": "{weights_lock_mode}"}}',
                 ]
             )
         super().__init__(

--- a/tests/gms/harness/vllm.py
+++ b/tests/gms/harness/vllm.py
@@ -31,7 +31,7 @@ class VLLMWithGMSProcess(ManagedProcess):
         nixl_port: int,
         frontend_port: int,
         *,
-        read_only_weights: bool = False,
+        weights_lock_mode: str | None = None,
     ):
         self.engine_id = engine_id
         self.system_port = system_port
@@ -62,11 +62,11 @@ class VLLMWithGMSProcess(ManagedProcess):
             "--kv-events-config",
             kv_events_cfg,
         ]
-        if read_only_weights:
+        if weights_lock_mode is not None:
             command.extend(
                 [
                     "--model-loader-extra-config",
-                    json.dumps({"gms_read_only": True}),
+                    json.dumps({"gms_lock_mode": weights_lock_mode}),
                 ]
             )
         super().__init__(

--- a/tests/gms/integration/test_external_weight_mgr.py
+++ b/tests/gms/integration/test_external_weight_mgr.py
@@ -256,7 +256,7 @@ def test_external_weight_mgr_vllm(
             ports["shadow_kv_event"],
             ports["shadow_nixl"],
             ports["frontend"],
-            read_only_weights=True,
+            weights_lock_mode="ro",
         ),
     )
 
@@ -284,6 +284,6 @@ def test_external_weight_mgr_sglang(
             ports["shadow_system"],
             ports["shadow_sglang"],
             ports["frontend"],
-            read_only_weights=True,
+            weights_lock_mode="ro",
         ),
     )


### PR DESCRIPTION
## Summary
- replace `gms_read_only` with `gms_lock_mode` across the GMS integrations, harnesses, tests, and README
- rename `RequestedLockType.RW_OR_RO` to `RequestedLockType.AUTO` and update the server-side auto-request helper naming
- default missing `gms_lock_mode` to `auto` and add focused config parsing coverage

## Testing
- `PYTHONPATH=/home/schwinns/gms-lock-mode/lib /home/schwinns/dynamo-gms-nightly-fixes/.venv/bin/python -m pytest -o cache_dir=/tmp/pytest-cache tests/gms/common/test_gms_lock_mode_config.py tests/gms/common/test_gms_client_session.py tests/gms/common/test_gms_runtime_flows.py tests/gms/common/test_gms_server_transport_failures.py`