### PR TITLE
fix(llm): gate HTTP readiness on initial discovery scan completion (D…

### DIFF
--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -1,7 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::HashSet,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use dashmap::{DashMap, mapref::entry::Entry};
 use dynamo_kv_router::{PrefillLoadEstimator, config::KvRouterConfig, protocols::WorkerId};
@@ -68,6 +74,12 @@ pub struct ModelManager {
 
     /// Per-endpoint runtime config watchers. Keyed by EndpointId (includes namespace).
     runtime_configs: DashMap<EndpointId, RuntimeConfigWatch>,
+
+    /// Set to `true` once the initial discovery scan has completed (or immediately for
+    /// in-process engines that don't use remote discovery).  The HTTP readiness probe
+    /// gates on this flag so that the frontend never becomes Kubernetes-Ready before
+    /// its local model table is fully populated.
+    discovery_ready: AtomicBool,
 }
 
 impl Default for ModelManager {
@@ -83,7 +95,31 @@ impl ModelManager {
             cards: DashMap::new(),
             prefill_router_activators: DashMap::new(),
             runtime_configs: DashMap::new(),
+            // Default to ready so that in-process (non-discovery) engines are immediately
+            // reachable.  Remote-discovery engines call `set_discovery_pending()` before
+            // the HTTP server starts, and `mark_discovery_ready()` when the initial scan
+            // completes.
+            discovery_ready: AtomicBool::new(true),
         }
+    }
+
+    /// Mark that a remote discovery scan is in progress.  The HTTP readiness probe will
+    /// return 503 until `mark_discovery_ready()` is called.
+    pub fn set_discovery_pending(&self) {
+        self.discovery_ready.store(false, Ordering::Release);
+    }
+
+    /// Signal that the initial discovery replay has finished.  Called by `ModelWatcher`
+    /// when it receives `DiscoveryEvent::InitialSyncDone`.
+    pub fn mark_discovery_ready(&self) {
+        self.discovery_ready.store(true, Ordering::Release);
+        tracing::info!("Initial model discovery complete – frontend is ready");
+    }
+
+    /// Returns `true` once the initial discovery scan has completed (or immediately for
+    /// in-process engines).
+    pub fn is_discovery_ready(&self) -> bool {
+        self.discovery_ready.load(Ordering::Acquire)
     }
 
     // -- Model access --

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -287,6 +287,9 @@ impl ModelWatcher {
                         }
                     }
                 }
+                DiscoveryEvent::InitialSyncDone => {
+                    self.manager.mark_discovery_ready();
+                }
             }
         }
     }

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -174,6 +174,11 @@ async fn run_watcher(
     chat_engine_factory: Option<ChatEngineFactoryCallback>,
     prefill_load_estimator: Option<Arc<dyn dynamo_kv_router::PrefillLoadEstimator>>,
 ) -> anyhow::Result<()> {
+    // Mark discovery as pending *before* spawning the watcher task so that the
+    // HTTP server starts in the unready state and Kubernetes never routes traffic
+    // to this replica until the initial model table is fully populated.
+    model_manager.set_discovery_pending();
+
     let mut watch_obj = ModelWatcher::new(
         runtime.clone(),
         model_manager,

--- a/lib/llm/src/http/service/health.rs
+++ b/lib/llm/src/http/service/health.rs
@@ -63,6 +63,16 @@ async fn live_handler(
 async fn health_handler(
     axum::extract::State(state): axum::extract::State<Arc<service_v2::State>>,
 ) -> impl IntoResponse {
+    if !state.is_discovery_ready() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "status": "starting",
+                "message": "Initial model discovery is in progress"
+            })),
+        );
+    }
+
     let instances = match list_all_instances(state.discovery()).await {
         Ok(instances) => instances,
         Err(err) => {

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1794,10 +1794,10 @@ pub fn validate_response_unsupported_fields(
 
 // todo - abstract this to the top level lib.rs to be reused
 // todo - move the service_observer to its own state/arc
-fn check_ready(_state: &Arc<service_v2::State>) -> Result<(), ErrorResponse> {
-    // if state.service_observer.stage() != ServiceStage::Ready {
-    //     return Err(ErrorMessage::service_unavailable());
-    // }
+fn check_ready(state: &Arc<service_v2::State>) -> Result<(), ErrorResponse> {
+    if !state.is_discovery_ready() {
+        return Err(ErrorMessage::_service_unavailable());
+    }
     Ok(())
 }
 

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -161,6 +161,12 @@ impl State {
         self.discovery_client.clone()
     }
 
+    /// Returns `true` once the initial discovery scan has completed (or immediately for
+    /// in-process engines that don't use remote discovery).
+    pub fn is_discovery_ready(&self) -> bool {
+        self.manager.is_discovery_ready()
+    }
+
     /// Check if the service is shutting down
     pub fn is_cancelled(&self) -> bool {
         self.cancel_token.is_cancelled()

--- a/lib/runtime/src/discovery/kube.rs
+++ b/lib/runtime/src/discovery/kube.rs
@@ -327,6 +327,18 @@ impl Discovery for KubeDiscoveryClient {
                 }
             }
 
+            // Signal that all pre-existing instances have been replayed
+            if event_tx
+                .send(Ok(DiscoveryEvent::InitialSyncDone))
+                .is_err()
+            {
+                tracing::debug!(
+                    stream_id = %stream_id,
+                    "Watch receiver dropped before InitialSyncDone"
+                );
+                return;
+            }
+
             // Track known instances by their unique ID
             let mut known: HashSet<DiscoveryInstanceId> = initial.into_keys().collect();
 

--- a/lib/runtime/src/discovery/kv_store.rs
+++ b/lib/runtime/src/discovery/kv_store.rs
@@ -582,6 +582,9 @@ impl Discovery for KVStoreDiscovery {
                         );
                         Some(DiscoveryEvent::Removed(id))
                     }
+                    kv::WatchEvent::InitialSyncDone => {
+                        Some(DiscoveryEvent::InitialSyncDone)
+                    }
                 };
 
                 if let Some(event) = discovery_event {

--- a/lib/runtime/src/discovery/mock.rs
+++ b/lib/runtime/src/discovery/mock.rs
@@ -201,6 +201,7 @@ impl Discovery for MockDiscovery {
 
         let stream = async_stream::stream! {
             let mut known_instances: HashSet<DiscoveryInstanceId> = HashSet::new();
+            let mut initial_sync_done = false;
 
             loop {
                 let current: Vec<_> = {
@@ -226,6 +227,12 @@ impl Discovery for MockDiscovery {
                 for id in known_instances.difference(&current_ids).cloned().collect::<Vec<_>>() {
                     known_instances.remove(&id);
                     yield Ok(DiscoveryEvent::Removed(id));
+                }
+
+                // After the first poll, signal that the initial list is complete
+                if !initial_sync_done {
+                    initial_sync_done = true;
+                    yield Ok(DiscoveryEvent::InitialSyncDone);
                 }
 
                 tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -678,6 +678,9 @@ pub enum DiscoveryEvent {
     Added(DiscoveryInstance),
     /// An instance was removed (identified by its unique ID)
     Removed(DiscoveryInstanceId),
+    /// All pre-existing instances have been replayed; subsequent events are live updates.
+    /// Consumers that gate readiness on discovery convergence should wait for this event.
+    InitialSyncDone,
 }
 
 /// Stream type for discovery events

--- a/lib/runtime/src/discovery/utils.rs
+++ b/lib/runtime/src/discovery/utils.rs
@@ -145,6 +145,9 @@ where
                         break;
                     }
                 }
+                Ok(DiscoveryEvent::InitialSyncDone) => {
+                    // Not relevant for field extraction; ignore.
+                }
                 Err(e) => {
                     tracing::error!(error = %e, "Discovery event stream error in watch_and_extract_field");
                     // Continue processing other events

--- a/lib/runtime/src/storage/kv.rs
+++ b/lib/runtime/src/storage/kv.rs
@@ -109,6 +109,10 @@ impl KeyValue {
 pub enum WatchEvent {
     Put(KeyValue),
     Delete(Key),
+    /// Emitted once after all pre-existing entries have been replayed on a new watch.
+    /// Consumers that need to know when the initial list phase is complete should
+    /// wait for this event before marking themselves ready.
+    InitialSyncDone,
 }
 
 #[async_trait]
@@ -344,6 +348,14 @@ impl Manager {
                 {
                     tracing::error!(bucket_name, %err, "KeyValueStoreManager.watch failed adding existing key to channel");
                 }
+            }
+
+            // Signal that all pre-existing entries have been replayed
+            if let Err(err) = tx
+                .send_timeout(WatchEvent::InitialSyncDone, WATCH_SEND_TIMEOUT)
+                .await
+            {
+                tracing::error!(bucket_name, %err, "KeyValueStoreManager.watch failed sending InitialSyncDone");
             }
 
             // Now block waiting for new entries


### PR DESCRIPTION
…GH-702)

The HTTP frontend was becoming Kubernetes-Ready before its local ModelManager was fully populated, causing random 404s and inconsistent /v1/models across replicas.

Changes:
- Add WatchEvent::InitialSyncDone to the KV store layer, emitted after all pre-existing entries have been replayed in Manager::watch
- Add DiscoveryEvent::InitialSyncDone to the discovery layer; propagated by kv_store, kube, and mock backends
- Add discovery_ready: AtomicBool to ModelManager (defaults true for in-process engines, set to false by run_watcher before the HTTP server starts)
- ModelWatcher::watch handles InitialSyncDone and calls manager.mark_discovery_ready()
- check_ready and health_handler return 503 SERVICE_UNAVAILABLE until discovery_ready is true

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model discovery readiness tracking to provide explicit visibility into service startup state.

* **Bug Fixes**
  * Health check endpoint now returns 503 SERVICE_UNAVAILABLE during initial model discovery, enabling clients to detect the starting state.
  * API endpoints now properly gate requests until model discovery completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->