### PR TITLE
fix(kvbm): handle typed KvCacheConnectorConfig in consolidator check

### DIFF
--- a/lib/bindings/kvbm/python/kvbm/trtllm_integration/consolidator_config.py
+++ b/lib/bindings/kvbm/python/kvbm/trtllm_integration/consolidator_config.py
@@ -48,19 +48,23 @@ def should_enable_consolidator(arg_map) -> bool:
         )
         return False
 
-    # Check if KVBM connector is enabled
-    if not isinstance(arg_map, dict):
-        logger.warning("KV Event Consolidator is not enabled: arg_map is not a dict")
-        return False
-
-    kv_connector_config = arg_map.get("kv_connector_config", {})
-    if not isinstance(kv_connector_config, dict):
+    # Check if KVBM connector is enabled by extracting connector_module
+    # from kv_connector_config (works whether arg_map holds raw dicts or typed objects)
+    kv_connector_config = (
+        arg_map.get("kv_connector_config") if isinstance(arg_map, dict) else None
+    )
+    if kv_connector_config is None:
         logger.warning(
-            "KV Event Consolidator is not enabled: kv_connector_config is not a dict"
+            "KV Event Consolidator is not enabled: no kv_connector_config found"
         )
         return False
 
-    connector_module = kv_connector_config.get("connector_module", "")
+    if isinstance(kv_connector_config, dict):
+        connector_module = kv_connector_config.get("connector_module", "")
+    else:
+        # Access directly so AttributeError surfaces if the contract changes
+        connector_module = kv_connector_config.connector_module or ""
+
     has_kvbm_connector = "kvbm.trtllm_integration.connector" in connector_module
 
     if not has_kvbm_connector:

--- a/tests/kvbm_integration/test_consolidator_config_unit.py
+++ b/tests/kvbm_integration/test_consolidator_config_unit.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for consolidator_config.should_enable_consolidator.
+
+Covers both raw dict and typed object paths for kv_connector_config,
+and asserts that the production code path (build_kv_connector_config)
+produces a type that the consolidator check handles correctly.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+kvbm = pytest.importorskip("kvbm", reason="kvbm package not installed")
+from kvbm.trtllm_integration.consolidator_config import (  # noqa: E402
+    should_enable_consolidator,
+)
+
+KVBM_MODULE = "kvbm.trtllm_integration.connector"
+
+
+@pytest.mark.unit
+@pytest.mark.pre_merge
+@pytest.mark.kvbm
+@pytest.mark.gpu_0
+class TestShouldEnableConsolidatorDict:
+    """Tests that only need kvbm (no GPU, no trtllm)."""
+
+    def test_dict_config_with_kvbm(self):
+        """Raw dict path (--extra-engine-args YAML, used in tests)."""
+        arg_map = {"kv_connector_config": {"connector_module": KVBM_MODULE}}
+        assert should_enable_consolidator(arg_map) is True
+
+    def test_non_kvbm_connector(self):
+        arg_map = {"kv_connector_config": {"connector_module": "other.connector"}}
+        assert should_enable_consolidator(arg_map) is False
+
+    def test_no_connector_config(self):
+        assert should_enable_consolidator({"backend": "pytorch"}) is False
+
+    def test_env_var_disables(self):
+        arg_map = {"kv_connector_config": {"connector_module": KVBM_MODULE}}
+        with patch.dict(
+            os.environ, {"DYN_KVBM_KV_EVENTS_ENABLE_CONSOLIDATOR": "false"}
+        ):
+            assert should_enable_consolidator(arg_map) is False
+
+
+@pytest.mark.unit
+@pytest.mark.pre_merge
+@pytest.mark.kvbm
+@pytest.mark.trtllm
+@pytest.mark.gpu_1
+class TestShouldEnableConsolidatorTyped:
+    """Tests that need trtllm (requires GPU for import)."""
+
+    def test_typed_config_with_kvbm(self):
+        """Typed object path (DYN_CONNECTOR=kvbm, used in production)."""
+        from tensorrt_llm.llmapi.llm_args import KvCacheConnectorConfig
+
+        config = KvCacheConnectorConfig(
+            connector_module=KVBM_MODULE,
+            connector_scheduler_class="DynamoKVBMConnectorLeader",
+            connector_worker_class="DynamoKVBMConnectorWorker",
+        )
+        arg_map = {"kv_connector_config": config}
+        assert should_enable_consolidator(arg_map) is True
+
+    def test_production_build_kv_connector_config(self):
+        """Assert build_kv_connector_config output works with consolidator check.
+
+        This is the key regression test: if llm_worker.py changes the type
+        returned by build_kv_connector_config, this test will catch it.
+        """
+        from dynamo.trtllm.workers.llm_worker import build_kv_connector_config
+
+        class FakeConfig:
+            connector = ("kvbm",)
+
+        config = build_kv_connector_config(FakeConfig())
+        assert config is not None
+        assert hasattr(config, "connector_module")
+        assert KVBM_MODULE in config.connector_module
+
+        # The consolidator check must work with this exact object
+        arg_map = {"kv_connector_config": config}
+        assert should_enable_consolidator(arg_map) is True


### PR DESCRIPTION
## Summary
Fix `should_enable_consolidator` in `consolidator_config.py` to handle typed `KvCacheConnectorConfig` objects, not just raw dicts.

## Problem
Since PR #6063 (Feb 2026), `llm_worker.py` constructs `kv_connector_config` as a `KvCacheConnectorConfig` Pydantic model when `DYN_CONNECTOR=kvbm` is set. The consolidator's `should_enable_consolidator` only checked `isinstance(kv_connector_config, dict)`, so it silently returned `False` with the warning:

```
KV Event Consolidator is not enabled: kv_connector_config is not a dict
```

This means the **consolidator has been broken for TRT-LLM in production since February 2026** (~2 months). Tests pass because they construct the config as a raw dict via `--extra-engine-args` YAML, bypassing `llm_worker.py`'s typed construction path.

## Fix
Add `hasattr` fallback to also check typed config objects for `connector_module` attribute.

## Test gap
The existing `test_consolidator_router_e2e.py` test passes `kv_connector_config` as a raw dict in the YAML file (line 79-83). It should also test the production path where `DYN_CONNECTOR=kvbm` constructs a `KvCacheConnectorConfig` object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration validation to support multiple input format types and improve system robustness when handling various configuration sources.

* **Tests**
  * Added comprehensive test suite validating configuration behavior across multiple scenarios, including edge cases, different connector types, environment variable overrides, and optional dependency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->