### PR TITLE
feat(kvbm): build kvbm wheel with nccl feature for CUDA containers

### DIFF
--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -584,7 +584,9 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     source ${VIRTUAL_ENV}/bin/activate && \
     if [ "$ENABLE_KVBM" = "true" ]; then \
         cd /opt/dynamo/lib/bindings/kvbm && \
-        maturin build --release --out target/wheels && \
+        KVBM_FEATURES=""; \
+        if [ "$DEVICE" = "cuda" ]; then KVBM_FEATURES="--features nccl"; fi && \
+        maturin build --release ${KVBM_FEATURES} --out target/wheels && \
         if [ "$DEVICE" = "cuda" ]; then \
             auditwheel repair \
                 --exclude libnixl.so \


### PR DESCRIPTION
## Summary
Add `--features nccl` to the `maturin build` command in the wheel builder Dockerfile for CUDA device builds.

## Problem
PR #7015 (April 6) added the `nccl` cargo feature to kvbm for MLA NCCL broadcast mode (`DYN_KVBM_NCCL_MLA_MODE=true`), but the Dockerfile was never updated to include `--features nccl` in the build. The feature has never been compiled into any CI container.

When `DYN_KVBM_NCCL_MLA_MODE=true` is set:
- Rank 0 logs: `kvbm was not built with the 'nccl' feature`
- Ranks 1-3 enter the NCCL broadcast path and **hang indefinitely**
- The KVBM leader/worker ZMQ handshake times out

## Fix
Conditionally add `--features nccl` to `maturin build` when `DEVICE=cuda`. The nccl feature chain (`kvbm/nccl` → `dynamo-llm/nccl` → `cudarc/nccl`) links against `libnccl.so` which is already present in the `cuda-dl-base` image. No new dependencies needed.

## Test plan
- [x] Verified `libnccl.so` is in `cuda-dl-base` image
- [x] Verified `cudarc/nccl` only needs `libnccl.so` at link time
- [ ] CI build with nccl feature enabled (needs this PR merged to test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KVBM builds now support NCCL for CUDA deployments
  * Consolidator configuration now supports both dictionary and typed object formats

* **Tests**
  * Added unit tests for consolidator configuration validation across multiple input scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->