### PR TITLE
fix(ci): move negation patterns after positives in filters.yaml

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -71,10 +71,6 @@ ci: &ci
   - 'container/Dockerfile.test'
 
 core:
-  # Exclude documentation files first, then include patterns override for specific paths
-  - '!**/*.md'
-  - '!**/*.rst'
-  - '!**/*.txt'
   - *ci
   - 'container/render.py'
   - 'container/Dockerfile.template'
@@ -98,6 +94,12 @@ core:
   - '*.py'
   - '*.rs'
   - 'scripts/report_pytest_markers.py'
+  # Negation patterns MUST come after positive patterns — micromatch processes
+  # patterns left-to-right, so negations only filter matches accumulated by
+  # preceding patterns. Placing them first has no effect.
+  - '!**/*.md'
+  - '!**/*.rst'
+  - '!**/*.txt'
 
 operator:
   - *ci
@@ -108,13 +110,13 @@ operator:
   - 'components/src/dynamo/profiler/utils/dgdr_*'
 
 deploy:
-  - '!**/*.md'
-  - '!**/*.rst'
   - *ci
   - 'deploy/helm/**'
   - 'deploy/utils/**'
   - 'deploy/snapshot/**'
   - 'tests/deploy/**'
+  - '!**/*.md'
+  - '!**/*.rst'
 
 planner:
   - 'container/templates/planner.Dockerfile'
@@ -124,33 +126,31 @@ planner:
   - 'components/src/dynamo/global_router/**'
 
 vllm:
-  - '!**/*.md'
-  - '!**/*.rst'
   - 'container/deps/requirements.vllm.txt'
   - 'container/deps/vllm/**'
   - 'examples/backends/vllm/**'
   - 'components/src/dynamo/vllm/**'
   - 'container/templates/vllm_*'
-
-sglang:
   - '!**/*.md'
   - '!**/*.rst'
+
+sglang:
   - 'examples/backends/sglang/**'
   - 'components/src/dynamo/sglang/**'
   - 'container/templates/sglang_*'
-
-trtllm:
   - '!**/*.md'
   - '!**/*.rst'
+
+trtllm:
   - 'container/deps/trtllm/**'
   - 'examples/backends/trtllm/**'
   - 'components/src/dynamo/trtllm/**'
   - 'container/build_trtllm_wheel.sh'
   - 'container/templates/trtllm_*'
-
-frontend:
   - '!**/*.md'
   - '!**/*.rst'
+
+frontend:
   - *ci
   - '.cargo/config.toml'
   - 'lib/**'
@@ -164,6 +164,8 @@ frontend:
   - 'components/src/dynamo/common/**'
   - 'deploy/inference-gateway/**'
   - 'container/templates/frontend.Dockerfile'
+  - '!**/*.md'
+  - '!**/*.rst'
 
 rust:
   - '.github/workflows/pre-merge.yml'


### PR DESCRIPTION
## Summary

- Docs-only PRs (e.g. editing READMEs under `components/`) were triggering full `core`/`frontend`/`deploy` CI builds
- Root cause: `tj-actions/changed-files` uses **micromatch**, which processes glob patterns **left-to-right** — negation patterns (`!**/*.md`) only filter matches accumulated by *preceding* positive patterns
- All 6 filters with negation (`core`, `frontend`, `deploy`, `vllm`, `sglang`, `trtllm`) had them at the **top** of their pattern list, where they had no effect
- Fix: move negation patterns to the **end** of each filter block

## Reproduction

Built a local micromatch test harness against the actual `filters.yaml` and the 23 files from a real docs-only PR:

```
# Before (negation at top — broken)
core:     1 match   (components/src/dynamo/router/README.md leaks through)
frontend: 1 match

# After (negation at bottom — fixed)
core:     0 matches
frontend: 0 matches
docs:     23 matches (correct)
```

Key micromatch behavior:
```js
micromatch([readme], ['!**/*.md', 'src/**'])  // → ['src/README.md']  ← negation ignored
micromatch([readme], ['src/**', '!**/*.md'])  // → []                 ← negation works
```

## Test plan

- [x] Local micromatch reproduction confirms fix
- [ ] CI on this PR should itself demonstrate correct filter behavior (only `docs` and `ci` filters should match)
- [ ] Verify no regression on a code-change PR (`.rs`/`.py` files still trigger `core`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized CI filter configuration to ensure exclusion patterns are evaluated correctly in the filtering pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->