### PR TITLE
feat: functional backend alternative to #8003

### DIFF
--- a/components/src/dynamo/common/backend/__init__.py
+++ b/components/src/dynamo/common/backend/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .serve import EngineConfig, WorkerConfig, run, serve
+
+__all__ = ["EngineConfig", "WorkerConfig", "run", "serve"]

--- a/components/src/dynamo/common/backend/sample_main.py
+++ b/components/src/dynamo/common/backend/sample_main.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sample backend — CPU-only reference implementation.
+
+Usage:
+    python -m dynamo.common.backend.sample_main [--model-name ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections.abc import AsyncGenerator
+
+from dynamo._core import Context
+
+from .serve import EngineConfig, WorkerConfig, run, serve
+
+
+async def sample_main(argv=None):
+    parser = argparse.ArgumentParser(description="Sample Dynamo backend")
+    parser.add_argument("--model-name", default="sample-model")
+    parser.add_argument("--namespace", default="dynamo")
+    parser.add_argument("--component", default="sample")
+    parser.add_argument("--endpoint", default="generate")
+    parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument("--delay", type=float, default=0.01)
+    parser.add_argument("--endpoint-types", default="chat,completions")
+    parser.add_argument("--discovery-backend", default="etcd")
+    parser.add_argument("--request-plane", default="tcp")
+    parser.add_argument("--event-plane", default="nats")
+    args = parser.parse_args(argv)
+
+    async def generate(request: dict, context: Context) -> AsyncGenerator[dict, None]:
+        token_ids = request.get("token_ids", [])
+        prompt_len = len(token_ids)
+        max_new = (
+            request.get("stop_conditions", {}).get("max_tokens") or args.max_tokens
+        )
+
+        for i in range(max_new):
+            if context.is_stopped():
+                yield {
+                    "token_ids": [],
+                    "finish_reason": "cancelled",
+                    "completion_usage": {
+                        "prompt_tokens": prompt_len,
+                        "completion_tokens": i,
+                        "total_tokens": prompt_len + i,
+                    },
+                }
+                return
+            await asyncio.sleep(args.delay)
+            token_id = (i + 1) % 32000
+            out: dict = {"token_ids": [token_id]}
+            if i == max_new - 1:
+                out["finish_reason"] = "length"
+                out["completion_usage"] = {
+                    "prompt_tokens": prompt_len,
+                    "completion_tokens": max_new,
+                    "total_tokens": prompt_len + max_new,
+                }
+            yield out
+
+    await serve(
+        worker_config=WorkerConfig(
+            namespace=args.namespace,
+            component=args.component,
+            endpoint=args.endpoint,
+            model_name=args.model_name,
+            served_model_name=args.model_name,
+            endpoint_types=args.endpoint_types,
+            discovery_backend=args.discovery_backend,
+            request_plane=args.request_plane,
+            event_plane=args.event_plane,
+        ),
+        engine_config=EngineConfig(
+            model=args.model_name,
+            served_model_name=args.model_name,
+            context_length=2048,
+            kv_cache_block_size=16,
+            total_kv_blocks=1000,
+            max_num_seqs=64,
+            max_num_batched_tokens=2048,
+        ),
+        generate=generate,
+    )
+
+
+def main():
+    run(sample_main)
+
+
+if __name__ == "__main__":
+    main()

--- a/components/src/dynamo/common/backend/serve.py
+++ b/components/src/dynamo/common/backend/serve.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Functional backend entry point for Dynamo inference engines.
+
+Instead of inheriting from an ABC, backend authors write an async main
+function that parses args, starts the engine, and calls ``serve()`` with
+callbacks::
+
+    async def my_backend(argv=None):
+        engine = await start_my_engine(argv)
+        await serve(
+            worker_config=...,
+            engine_config=...,
+            generate=engine.generate,
+            cleanup=engine.shutdown,
+        )
+
+    if __name__ == "__main__":
+        run(my_backend)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Optional
+
+from dynamo._core import Context
+from dynamo.common.utils.endpoint_types import parse_endpoint_types
+from dynamo.common.utils.graceful_shutdown import install_signal_handlers
+from dynamo.common.utils.runtime import create_runtime
+from dynamo.llm import ModelInput, ModelRuntimeConfig, register_model
+from dynamo.llm.exceptions import CannotConnect, DynamoException, Unknown
+from dynamo.runtime.logging import configure_dynamo_logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EngineConfig:
+    """Metadata returned after engine startup, used for model registration."""
+
+    model: str
+    served_model_name: Optional[str] = None
+    context_length: Optional[int] = None
+    kv_cache_block_size: Optional[int] = None
+    total_kv_blocks: Optional[int] = None
+    max_num_seqs: Optional[int] = None
+    max_num_batched_tokens: Optional[int] = None
+
+
+@dataclass
+class WorkerConfig:
+    """Runtime connection and model registration parameters."""
+
+    namespace: str
+    component: str = "backend"
+    endpoint: str = "generate"
+    model_name: str = ""
+    served_model_name: Optional[str] = None
+    model_input: ModelInput = field(default_factory=lambda: ModelInput.Tokens)
+    endpoint_types: str = "chat,completions"
+    discovery_backend: str = "etcd"
+    request_plane: str = "tcp"
+    event_plane: str = "nats"
+    use_kv_events: bool = False
+    custom_jinja_template: Optional[str] = None
+    metrics_labels: list = field(default_factory=list)
+
+    @classmethod
+    def from_runtime_config(
+        cls,
+        runtime_cfg,
+        model_name: str,
+        served_model_name: Optional[str] = None,
+        model_input: Optional[ModelInput] = None,
+        **overrides,
+    ) -> WorkerConfig:
+        """Build from any object that carries DynamoRuntimeConfig fields.
+
+        Works with vllm.Config, trtllm.Config (inherit DynamoRuntimeConfig
+        directly) and sglang DynamoConfig (nested in config.dynamo_args).
+        """
+        kwargs = {
+            "namespace": runtime_cfg.namespace,
+            "component": getattr(runtime_cfg, "component", None) or "backend",
+            "endpoint": getattr(runtime_cfg, "endpoint", None) or "generate",
+            "model_name": model_name,
+            "served_model_name": served_model_name,
+            "endpoint_types": getattr(
+                runtime_cfg, "endpoint_types", "chat,completions"
+            ),
+            "discovery_backend": runtime_cfg.discovery_backend,
+            "request_plane": runtime_cfg.request_plane,
+            "event_plane": runtime_cfg.event_plane,
+            "use_kv_events": getattr(runtime_cfg, "use_kv_events", False),
+            "custom_jinja_template": getattr(
+                runtime_cfg, "custom_jinja_template", None
+            ),
+        }
+        if model_input is not None:
+            kwargs["model_input"] = model_input
+        kwargs.update(overrides)
+        return cls(**kwargs)
+
+
+# Callback type aliases
+GenerateFn = Callable[[dict, Context], AsyncGenerator[dict, None]]
+AbortFn = Callable[[Context], Awaitable[None]]
+CleanupFn = Callable[[], Awaitable[None]]
+
+
+async def serve(
+    worker_config: WorkerConfig,
+    engine_config: EngineConfig,
+    generate: GenerateFn,
+    abort: AbortFn | None = None,
+    cleanup: CleanupFn | None = None,
+) -> None:
+    """Start the Dynamo runtime and serve inference requests.
+
+    The caller has already parsed args and started their engine.  This
+    function handles everything else: runtime creation, signal handlers,
+    model registration, request cancellation, and graceful shutdown.
+
+    Args:
+        worker_config: Runtime connection and model registration params.
+        engine_config: Model metadata for registration.
+        generate: Async generator yielding response chunks per request.
+                  Each chunk: ``{"token_ids": [...]}``.
+                  Final chunk must include ``"finish_reason"`` and
+                  ``"completion_usage"``.
+        abort: Called when a request is cancelled.  Optional.
+        cleanup: Called once on shutdown to release engine resources.  Optional.
+    """
+    configure_dynamo_logging()
+    cfg = worker_config
+    shutdown_event = asyncio.Event()
+
+    try:
+        runtime, loop = create_runtime(
+            discovery_backend=cfg.discovery_backend,
+            request_plane=cfg.request_plane,
+            event_plane=cfg.event_plane,
+            use_kv_events=cfg.use_kv_events,
+        )
+    except DynamoException:
+        raise
+    except Exception as exc:
+        raise CannotConnect(f"Failed to create runtime: {exc}") from exc
+
+    endpoint = runtime.endpoint(f"{cfg.namespace}.{cfg.component}.{cfg.endpoint}")
+    install_signal_handlers(loop, runtime, [endpoint], shutdown_event)
+
+    async def _handle_request(
+        request: dict, context: Context
+    ) -> AsyncGenerator[dict, None]:
+        async def _monitor_cancel():
+            await context.async_killed_or_stopped()
+            if abort is not None:
+                try:
+                    await abort(context)
+                except Exception:
+                    logger.debug("Error during request abort", exc_info=True)
+
+        cancel_task = asyncio.create_task(_monitor_cancel())
+        try:
+            async for chunk in generate(request, context):
+                if context.is_stopped():
+                    break
+                yield chunk
+        except DynamoException:
+            raise
+        except Exception as exc:
+            raise Unknown(f"Engine generate failed: {exc}") from exc
+        finally:
+            if not cancel_task.done():
+                cancel_task.cancel()
+                try:
+                    await cancel_task
+                except asyncio.CancelledError:
+                    pass
+
+    try:
+        runtime_config = ModelRuntimeConfig()
+        if engine_config.total_kv_blocks is not None:
+            runtime_config.total_kv_blocks = engine_config.total_kv_blocks
+        if engine_config.max_num_seqs is not None:
+            runtime_config.max_num_seqs = engine_config.max_num_seqs
+        if engine_config.max_num_batched_tokens is not None:
+            runtime_config.max_num_batched_tokens = engine_config.max_num_batched_tokens
+
+        served_name = cfg.served_model_name or cfg.model_name
+        await register_model(
+            cfg.model_input,
+            parse_endpoint_types(cfg.endpoint_types),
+            endpoint,
+            cfg.model_name,
+            served_name,
+            context_length=engine_config.context_length,
+            kv_cache_block_size=engine_config.kv_cache_block_size,
+            runtime_config=runtime_config,
+            custom_template_path=cfg.custom_jinja_template,
+        )
+
+        logger.info(
+            "Serving %s on %s.%s.%s",
+            served_name,
+            cfg.namespace,
+            cfg.component,
+            cfg.endpoint,
+        )
+
+        await endpoint.serve_endpoint(
+            _handle_request,
+            graceful_shutdown=True,
+            metrics_labels=cfg.metrics_labels,
+        )
+    finally:
+        if cleanup is not None:
+            await cleanup()
+        logger.info("Engine cleanup complete")
+
+
+def run(start, argv=None):
+    """Sync entry point.  Calls ``start(argv)`` under uvloop."""
+    import uvloop
+
+    uvloop.run(start(argv))

--- a/components/src/dynamo/sglang/functional_main.py
+++ b/components/src/dynamo/sglang/functional_main.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Functional entry point for the SGLang backend.
+
+Usage:
+    python -m dynamo.sglang.functional_main <sglang args>
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from collections.abc import AsyncGenerator
+from typing import Any, Dict
+
+import sglang as sgl
+
+from dynamo._core import Context
+from dynamo.common.backend.serve import EngineConfig, WorkerConfig, run, serve
+from dynamo.common.utils.input_params import InputParamManager
+from dynamo.llm import ModelInput
+from dynamo.sglang.args import parse_args
+
+logger = logging.getLogger(__name__)
+
+
+async def sglang_main(argv=None):
+    # -- Parse args --
+    config = await parse_args(argv if argv is not None else sys.argv[1:])
+    server_args = config.server_args
+    dynamo_args = config.dynamo_args
+
+    skip_tokenizer_init = server_args.skip_tokenizer_init
+    model_input = ModelInput.Text if not skip_tokenizer_init else ModelInput.Tokens
+
+    worker_config = WorkerConfig.from_runtime_config(
+        dynamo_args,
+        model_name=server_args.model_path,
+        served_model_name=server_args.served_model_name,
+        model_input=model_input,
+    )
+
+    # -- Start engine --
+    engine = sgl.Engine(server_args=server_args)
+
+    tokenizer = engine.tokenizer_manager.tokenizer if not skip_tokenizer_init else None
+    input_param_manager = InputParamManager(tokenizer)
+
+    # -- Helpers --
+    def _build_sampling_params(request: dict) -> dict:
+        if skip_tokenizer_init:
+            sampling_opts = request.get("sampling_options", {})
+            stop_conditions = request.get("stop_conditions", {})
+            param_mapping = {
+                "temperature": sampling_opts.get("temperature"),
+                "top_p": sampling_opts.get("top_p"),
+                "top_k": sampling_opts.get("top_k"),
+                "max_new_tokens": stop_conditions.get("max_tokens"),
+                "ignore_eos": stop_conditions.get("ignore_eos"),
+            }
+        else:
+            param_mapping = {
+                "temperature": request.get("temperature"),
+                "top_p": request.get("top_p"),
+                "top_k": request.get("top_k"),
+                "max_new_tokens": request.get("max_tokens"),
+            }
+        return {k: v for k, v in param_mapping.items() if v is not None}
+
+    def _get_input_param(request: dict) -> dict:
+        request_input = input_param_manager.get_input_param(
+            request, use_tokenizer=not skip_tokenizer_init
+        )
+        return {
+            "prompt" if isinstance(request_input, str) else "input_ids": request_input
+        }
+
+    # -- Callbacks --
+    async def generate(request: dict, context: Context) -> AsyncGenerator[dict, None]:
+        sampling_params = _build_sampling_params(request)
+        input_param = _get_input_param(request)
+
+        stream = await engine.async_generate(
+            **input_param,
+            sampling_params=sampling_params,
+            stream=True,
+            rid=context.trace_id,
+        )
+
+        async for res in stream:
+            out: Dict[str, Any] = {}
+            meta_info = res["meta_info"]
+            finish_reason = meta_info["finish_reason"]
+
+            output_ids = res.get("output_ids", [])
+            if not output_ids and not finish_reason:
+                if context.is_stopped():
+                    prompt_tokens = meta_info.get("prompt_tokens", 0)
+                    completion_tokens = meta_info.get("completion_tokens", 0)
+                    yield {
+                        "token_ids": [],
+                        "finish_reason": "cancelled",
+                        "completion_usage": {
+                            "prompt_tokens": prompt_tokens,
+                            "completion_tokens": completion_tokens,
+                            "total_tokens": prompt_tokens + completion_tokens,
+                        },
+                    }
+                    break
+                continue
+
+            out["token_ids"] = output_ids
+
+            if finish_reason:
+                prompt_tokens = meta_info["prompt_tokens"]
+                completion_tokens = meta_info["completion_tokens"]
+                out["finish_reason"] = finish_reason["type"]
+                out["completion_usage"] = {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                }
+
+            if context.is_stopped():
+                prompt_tokens = meta_info.get("prompt_tokens", 0)
+                completion_tokens = meta_info.get("completion_tokens", 0)
+                yield {
+                    "token_ids": output_ids,
+                    "finish_reason": "cancelled",
+                    "completion_usage": {
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": completion_tokens,
+                        "total_tokens": prompt_tokens + completion_tokens,
+                    },
+                }
+                break
+
+            yield out
+
+    async def abort(context: Context) -> None:
+        rid = context.trace_id
+        if engine is not None and rid is not None:
+            if hasattr(engine, "tokenizer_manager") and engine.tokenizer_manager:
+                engine.tokenizer_manager.abort_request(rid=rid, abort_all=False)
+                logger.debug("Aborted request %s", rid)
+
+    async def cleanup() -> None:
+        if engine is not None:
+            engine.shutdown()
+            logger.info("SGLang engine shutdown")
+
+    # -- Serve --
+    await serve(
+        worker_config=worker_config,
+        engine_config=EngineConfig(
+            model=server_args.model_path,
+            served_model_name=server_args.served_model_name,
+            context_length=server_args.context_length,
+            kv_cache_block_size=server_args.page_size,
+        ),
+        generate=generate,
+        abort=abort,
+        cleanup=cleanup,
+    )
+
+
+def main():
+    run(sglang_main)
+
+
+if __name__ == "__main__":
+    main()

--- a/components/src/dynamo/trtllm/functional_main.py
+++ b/components/src/dynamo/trtllm/functional_main.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Functional entry point for the TensorRT-LLM backend.
+
+Usage:
+    python -m dynamo.trtllm.functional_main <trtllm args>
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from tensorrt_llm.llmapi import KvCacheConfig, SchedulerConfig
+from tensorrt_llm.llmapi.llm import SamplingParams
+from tensorrt_llm.sampling_params import GuidedDecodingParams
+from torch.cuda import device_count
+
+from dynamo._core import Context
+from dynamo.common.backend.serve import EngineConfig, WorkerConfig, run, serve
+from dynamo.llm import ModelInput
+from dynamo.trtllm.args import parse_args
+from dynamo.trtllm.engine import Backend, TensorRTLLMEngine
+
+logger = logging.getLogger(__name__)
+
+
+def _override_sampling_params(
+    sampling_params: SamplingParams, request: dict
+) -> SamplingParams:
+    """Apply request-level sampling overrides to a base SamplingParams."""
+    overrides = {
+        key: value
+        for key, value in request["sampling_options"].items()
+        if value is not None
+    }
+
+    guided_decoding = overrides.pop("guided_decoding", None)
+    if guided_decoding is not None and isinstance(guided_decoding, dict):
+        regex = guided_decoding.get("regex")
+        choice = guided_decoding.get("choice")
+        if choice and not regex:
+            valid_choices = [c for c in choice if c is not None]
+            if valid_choices:
+                regex = "(" + "|".join(re.escape(c) for c in valid_choices) + ")"
+        overrides["guided_decoding"] = GuidedDecodingParams(
+            json=guided_decoding.get("json"),
+            regex=regex,
+            grammar=guided_decoding.get("grammar"),
+            json_object=guided_decoding.get("json_object", False),
+            structural_tag=guided_decoding.get("structural_tag"),
+        )
+
+    return dataclasses.replace(sampling_params, **overrides)
+
+
+async def trtllm_main(argv=None):
+    # -- Parse args --
+    config = parse_args(argv)
+
+    gpus_per_node = config.gpus_per_node or device_count()
+
+    engine_args = {
+        "model": str(config.model),
+        "scheduler_config": SchedulerConfig(),
+        "tensor_parallel_size": config.tensor_parallel_size,
+        "pipeline_parallel_size": config.pipeline_parallel_size,
+        "backend": Backend.PYTORCH,
+        "kv_cache_config": KvCacheConfig(
+            free_gpu_memory_fraction=config.free_gpu_memory_fraction,
+        ),
+        "gpus_per_node": gpus_per_node,
+        "max_num_tokens": config.max_num_tokens,
+        "max_seq_len": config.max_seq_len,
+        "max_beam_width": config.max_beam_width,
+        "max_batch_size": config.max_batch_size,
+    }
+
+    worker_config = WorkerConfig.from_runtime_config(
+        config,
+        model_name=config.model,
+        served_model_name=config.served_model_name,
+        model_input=ModelInput.Tokens,
+    )
+
+    # -- Start engine --
+    trtllm_engine = TensorRTLLMEngine(engine_args)
+    await trtllm_engine.initialize()
+
+    max_seq_len = config.max_seq_len
+    max_batch_size = config.max_batch_size
+    max_num_tokens = config.max_num_tokens
+    kv_block_size = config.kv_block_size
+    default_sampling_params = SamplingParams(detokenize=False)
+    active_requests: dict[str, Any] = {}
+
+    # -- Callbacks --
+    async def generate(request: dict, context: Context) -> AsyncGenerator[dict, None]:
+        token_ids = request.get("token_ids", [])
+        sampling_params = _override_sampling_params(default_sampling_params, request)
+
+        max_tokens = request["stop_conditions"].get("max_tokens")
+        if max_tokens is not None:
+            sampling_params.max_tokens = max_tokens
+        elif max_seq_len is not None:
+            sampling_params.max_tokens = max(1, max_seq_len - len(token_ids))
+
+        ignore_eos = request["stop_conditions"].get("ignore_eos")
+        if ignore_eos:
+            sampling_params.ignore_eos = ignore_eos
+
+        generation_result = trtllm_engine.llm.generate_async(
+            inputs=token_ids,
+            sampling_params=sampling_params,
+            streaming=True,
+        )
+
+        request_id = context.id()
+        if request_id is not None:
+            active_requests[request_id] = generation_result
+
+        try:
+            num_output_tokens_so_far = 0
+            async for res in generation_result:
+                if not res.outputs and not res.finished:
+                    yield {"finish_reason": "error", "token_ids": []}
+                    break
+
+                output = res.outputs[0]
+                next_total = len(output.token_ids)
+                out: dict = {"token_ids": output.token_ids[num_output_tokens_so_far:]}
+
+                if output.finish_reason:
+                    out["finish_reason"] = str(output.finish_reason)
+
+                if out.get("finish_reason") or res.finished:
+                    if not out.get("finish_reason"):
+                        out["finish_reason"] = "unknown"
+                    prompt_tokens = len(token_ids)
+                    out["completion_usage"] = {
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": next_total,
+                        "total_tokens": prompt_tokens + next_total,
+                    }
+
+                yield out
+                num_output_tokens_so_far = next_total
+        finally:
+            if request_id is not None:
+                active_requests.pop(request_id, None)
+
+    async def abort(context: Context) -> None:
+        request_id = context.id()
+        if request_id is not None:
+            generation_result = active_requests.get(request_id)
+            if generation_result is not None:
+                generation_result.abort()
+                logger.debug("Aborted request %s", request_id)
+
+    async def cleanup() -> None:
+        await trtllm_engine.cleanup()
+        logger.info("TensorRT-LLM engine shutdown")
+
+    # -- Serve --
+    await serve(
+        worker_config=worker_config,
+        engine_config=EngineConfig(
+            model=config.model,
+            served_model_name=config.served_model_name,
+            context_length=max_seq_len,
+            kv_cache_block_size=kv_block_size,
+            max_num_seqs=max_batch_size,
+            max_num_batched_tokens=max_num_tokens,
+        ),
+        generate=generate,
+        abort=abort,
+        cleanup=cleanup,
+    )
+
+
+def main():
+    run(trtllm_main)
+
+
+if __name__ == "__main__":
+    main()

--- a/components/src/dynamo/vllm/functional_main.py
+++ b/components/src/dynamo/vllm/functional_main.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Functional entry point for the vLLM backend.
+
+Usage:
+    python -m dynamo.vllm.functional_main <vllm args>
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from collections.abc import AsyncGenerator
+
+from vllm.inputs import TokensPrompt
+from vllm.usage.usage_lib import UsageContext
+from vllm.v1.engine.async_llm import AsyncLLM
+
+from dynamo._core import Context
+from dynamo.common.backend.serve import EngineConfig, WorkerConfig, run, serve
+from dynamo.llm import ModelInput
+from dynamo.vllm.args import parse_args
+
+from .handlers import build_sampling_params
+
+logger = logging.getLogger(__name__)
+
+
+async def vllm_main(argv=None):
+    # -- Parse args --
+    config = parse_args()  # TODO: forward argv when vllm supports it
+    if not config.served_model_name:
+        config.served_model_name = config.engine_args.served_model_name = config.model
+
+    worker_config = WorkerConfig.from_runtime_config(
+        config,
+        model_name=config.model,
+        served_model_name=config.served_model_name,
+        model_input=ModelInput.Tokens,
+    )
+
+    # -- Start engine --
+    os.environ["VLLM_NO_USAGE_STATS"] = "1"
+    os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+    prometheus_temp_dir = None
+    if "PROMETHEUS_MULTIPROC_DIR" not in os.environ:
+        prometheus_temp_dir = tempfile.TemporaryDirectory(prefix="vllm_prometheus_")
+        os.environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_temp_dir.name
+
+    default_sampling_params = (
+        config.engine_args.create_model_config().get_diff_sampling_param()
+    )
+    vllm_config = config.engine_args.create_engine_config(
+        usage_context=UsageContext.OPENAI_API_SERVER
+    )
+    engine_client = AsyncLLM.from_vllm_config(
+        vllm_config=vllm_config,
+        usage_context=UsageContext.OPENAI_API_SERVER,
+    )
+
+    model_max_len = getattr(
+        getattr(vllm_config, "model_config", None), "max_model_len", None
+    )
+    num_gpu_blocks = vllm_config.cache_config.num_gpu_blocks or 0
+    block_size = vllm_config.cache_config.block_size
+
+    # -- Callbacks --
+    async def generate(request: dict, context: Context) -> AsyncGenerator[dict, None]:
+        token_ids = request.get("token_ids", [])
+        prompt = TokensPrompt(prompt_token_ids=token_ids)
+        sampling_params = build_sampling_params(
+            request, default_sampling_params, model_max_len
+        )
+
+        num_so_far = 0
+        async for res in engine_client.generate(prompt, sampling_params, context.id()):
+            if not res.outputs:
+                yield {
+                    "finish_reason": "error: No outputs from vLLM engine",
+                    "token_ids": [],
+                }
+                break
+
+            output = res.outputs[0]
+            next_total = len(output.token_ids)
+            out: dict = {"token_ids": output.token_ids[num_so_far:]}
+
+            if output.finish_reason:
+                out["finish_reason"] = str(output.finish_reason)
+                prompt_tokens = len(res.prompt_token_ids) if res.prompt_token_ids else 0
+                out["completion_usage"] = {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": next_total,
+                    "total_tokens": prompt_tokens + next_total,
+                }
+
+            yield out
+            num_so_far = next_total
+
+    async def abort(context: Context) -> None:
+        request_id = context.id()
+        if engine_client is not None and request_id is not None:
+            await engine_client.abort(request_id)
+            logger.debug("Aborted request %s", request_id)
+
+    async def cleanup() -> None:
+        engine_client.shutdown()
+        if prometheus_temp_dir is not None:
+            prometheus_temp_dir.cleanup()
+        logger.info("vLLM engine shutdown")
+
+    # -- Serve --
+    await serve(
+        worker_config=worker_config,
+        engine_config=EngineConfig(
+            model=config.engine_args.model,
+            served_model_name=config.engine_args.served_model_name,
+            context_length=model_max_len,
+            kv_cache_block_size=block_size,
+            total_kv_blocks=num_gpu_blocks,
+            max_num_seqs=vllm_config.scheduler_config.max_num_seqs,
+            max_num_batched_tokens=vllm_config.scheduler_config.max_num_batched_tokens,
+        ),
+        generate=generate,
+        abort=abort,
+        cleanup=cleanup,
+    )
+
+
+def main():
+    run(vllm_main)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -55,7 +55,7 @@ pub enum FinishReason {
     #[serde(rename = "error")]
     Error(String),
 
-    #[serde(rename = "cancelled")]
+    #[serde(rename = "cancelled", alias = "abort")]
     Cancelled,
 
     #[serde(rename = "content_filter")]
@@ -83,7 +83,7 @@ impl std::str::FromStr for FinishReason {
             "eos" => Ok(FinishReason::EoS),
             "length" => Ok(FinishReason::Length),
             "stop" => Ok(FinishReason::Stop),
-            "cancelled" => Ok(FinishReason::Cancelled),
+            "cancelled" | "abort" => Ok(FinishReason::Cancelled),
             s if s.starts_with("error: ") => Ok(FinishReason::Error(s[7..].to_string())),
             _ => Err(anyhow::anyhow!("Invalid FinishReason variant: '{}'", s)),
         }


### PR DESCRIPTION
## Summary

Alternative approach to #8003's class-based `Worker` / `LLMEngine` ABC hierarchy for unified backends.

**Key idea:** Replace the class hierarchy with a single `serve()` function that takes callbacks. Backend authors write plain async functions — no inheritance, no ABCs, no `super().__init__()` chains.

### What's here

- **`dynamo.common.backend.serve`** — core `serve()` function + `EngineConfig`/`WorkerConfig` dataclasses
- **`dynamo.common.backend.sample_main`** — CPU-only reference backend (no GPU deps)
- **`dynamo.vllm.functional_main`** — vLLM functional entry point
- **`dynamo.sglang.functional_main`** — SGLang functional entry point
- **`dynamo.trtllm.functional_main`** — TRT-LLM functional entry point
- **`lib/llm/src/protocols/common.rs`** — same `abort` alias for `FinishReason::Cancelled` as #8003

### Comparison with #8003's class approach

| Aspect | #8003 (class-based) | This PR (functional) |
|--------|---------------------|---------------------|
| Backend author writes | Subclass of `LLMEngine` ABC | Plain `async def` + callbacks |
| Boilerplate | `__init__`, `from_args`, `init`, `generate`, `abort`, `cleanup` methods | Single `async def main()` calling `serve()` |
| Runtime/signal/registration | Hidden in `Worker` base class | Hidden in `serve()` function |
| State sharing | Instance attributes (`self.*`) | Closures over local variables |
| Testing | Mock the ABC methods | Mock the callbacks |
| Adding a new backend | New class + wire up inheritance | New function + call `serve()` |

### Design rationale

1. **Fewer concepts** — `serve()` is the only thing to learn. No `Worker`, no `LLMEngine`, no `run()` class method chains.
2. **Closures > inheritance** — Backend state (engine handle, tokenizer, active requests) lives as local variables captured by closures. No `self.*` to manage.
3. **Same capabilities** — Handles runtime creation, signal handlers, request cancellation monitoring, model registration, graceful shutdown — same as #8003.
4. **Incremental adoption** — Each backend's `functional_main.py` is independent. Can coexist with existing entry points during migration.

### What's NOT here (same gaps as #8003)

- Disaggregated serving (prefill/decode split)
- Metrics/publisher integration
- Health check payloads
- Multi-node support (node_rank handling)
- Diffusion/embedding/multimodal workers

These are intentionally excluded — this PR targets the same scope as #8003's initial unified backend.

## Test plan

- [ ] Review against #8003 for functional parity
- [ ] Verify sample_main works with local etcd/nats
- [ ] Test vLLM functional_main on a single GPU
- [ ] Test SGLang functional_main on a single GPU
- [ ] Test TRT-LLM functional_main on a single GPU
- [ ] Compare startup/shutdown behavior with existing entry points

🤖 Generated with [Claude Code](https://claude.com/claude-code)