### PR TITLE
fix(ci): move test_multimodal_b64 to gpu_1 and force tool calls in aggregated_toolcalling (DYN-2662)

### DIFF
--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -486,7 +486,7 @@ vllm_configs = {
                             },
                         }
                     ],
-                    "tool_choice": "auto",
+                    "tool_choice": "required",
                     "max_tokens": 1024,
                 },
                 repeat_count=1,
@@ -633,7 +633,7 @@ def test_serve_deployment(
 
 @pytest.mark.vllm
 @pytest.mark.e2e
-@pytest.mark.gpu_2
+@pytest.mark.gpu_1
 @pytest.mark.nightly
 @pytest.mark.model("Qwen/Qwen2.5-VL-7B-Instruct")
 @pytest.mark.timeout(360)  # Match VLLMConfig.timeout for this multimodal deployment
@@ -649,9 +649,10 @@ def test_multimodal_b64(
     This test is separate because it loads the required image at runtime
     (not collection time), ensuring it only fails when actually executed.
 
-    Uses ``@pytest.mark.model`` so nightly multi-GPU jobs (gpu_2 without the
-    gpu_1 multimodal_agg_qwen param) still predownload Qwen2.5-VL-7B before
-    ``HF_HUB_OFFLINE=1``.
+    Runs on gpu_1 alongside other single-GPU multimodal tests that use the
+    same model (mm_agg_qwen2.5-vl-7b).  The ``@pytest.mark.model`` mark is
+    kept as a safety net so the model is predownloaded even if no other
+    gpu_1 config collects this model in a given CI job.
     """
     # Load B64 image at test execution time (uses real PNG even if MULTIMODAL_IMG is LFS pointer)
     b64_img = base64.b64encode(get_multimodal_test_image_bytes()).decode()


### PR DESCRIPTION
## Summary

- **`test_multimodal_b64`**: Move from `gpu_2` to `gpu_1` so it runs in the nightly `gpu_1` job alongside other single-GPU multimodal tests using the same model (`Qwen/Qwen2.5-VL-7B-Instruct`). Previously this test was isolated on `gpu_2` and never ran in `gpu_1` nightly CI.
- **`aggregated_toolcalling`**: Change `tool_choice` from `"auto"` to `"required"` to force `Qwen2.5-VL-7B-Instruct` to always produce tool calls. With `"auto"`, the 7B model was choosing to describe the image in plain text instead of invoking the `describe_image` tool, causing the assertion `Expected model to generate tool calls but none found`.

## Root Cause

The `aggregated_toolcalling` failure was introduced by PR #7964 which switched from `Qwen3-VL-30B` to `Qwen2.5-VL-7B-Instruct` to fit on single-GPU CI runners. The smaller model with `tool_choice: "auto"` does not reliably route multimodal prompts through tool calls — it prefers to answer directly. Using `"required"` is the correct fix since the test's purpose is to validate the tool-calling pipeline, not the model's tool-use decision-making.

## Related Issues

- Fixes [DYN-2662](https://linear.app/nvidia/issue/DYN-2662/fix-nightly-multimodal-test-marker-and-aggregated-toolcalling-failure)
- Follow-up to #7964


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tool-calling configuration to enforce mandatory tool calls.
  * Optimized GPU scheduling for multimodal tests.
  * Updated test documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->