### PR TITLE
feat: adds support to pass local tokenizer path

### DIFF
--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -302,7 +302,7 @@ async def init_llm_worker(
             module_path, class_name = tokenizer_path.rsplit(".", 1)
             tokenizer_class = getattr(import_module(module_path), class_name)
             tokenizer = tokenizer_class.from_pretrained(
-                arg_map["model"],
+                arg_map.get("tokenizer") or arg_map["model"],
                 trust_remote_code=arg_map.get("trust_remote_code", False),
             )
         except (ValueError, ImportError, AttributeError) as e:


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

This is needed because we usually directly pass the model HF name to the --model-path field when we publish Dynamo recipes, but [changes introduced in PR 8079](https://github.com/ai-dynamo/dynamo/pull/8079) cannot accept the model HF name when creating the custom tokenizer.

This PR aims to resolve this issue. With this PR, we can do:

```
python3 -m dynamo.trtllm --model-path z-ai/GLM-5 --trtllm.custom_tokenizer glm_moe_dsa --trtllm.tokenizer <LOCAL MODEL PATH>
```

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tokenizer initialization to prioritize explicit tokenizer configuration when provided, with proper fallback behavior for default cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->