### PR TITLE
fix(kvbm): query NCCL version at runtime instead of hardcoding

### DIFF
--- a/lib/llm/src/block_manager/distributed/nccl_bootstrap.rs
+++ b/lib/llm/src/block_manager/distributed/nccl_bootstrap.rs
@@ -14,7 +14,7 @@
 use anyhow::{Context, Result};
 use cudarc::nccl::sys::{
     ncclComm_t, ncclCommDestroy, ncclCommInitRankConfig, ncclConfig_t, ncclGetUniqueId,
-    ncclResult_t, ncclUniqueId,
+    ncclGetVersion, ncclResult_t, ncclUniqueId,
 };
 
 /// Check NCCL result and convert to anyhow::Result
@@ -162,6 +162,16 @@ impl NcclBootstrap {
         // We have to manually create it the same way the NCCL C++ macros do.
         let mut config: ncclConfig_t;
 
+        // Query runtime NCCL version instead of hardcoding — avoids
+        // ncclInvalidUsage when the container's NCCL version doesn't match.
+        let nccl_version = {
+            let mut v: std::ffi::c_int = 0;
+            let result = unsafe { ncclGetVersion(&mut v) };
+            check_nccl_result(result, "ncclGetVersion")?;
+            tracing::debug!("NCCL runtime version: {v}");
+            v as std::ffi::c_uint
+        };
+
         let max_ctas = std::env::var("DYN_KVBM_NCCL_MAX_CTAS")
             .ok()
             .and_then(|val| val.parse::<i32>().ok())
@@ -170,7 +180,7 @@ impl NcclBootstrap {
         config = ncclConfig_t {
             size: std::mem::size_of::<ncclConfig_t>(),
             magic: 0xcafebeef, // Required Magic Number
-            version: 22800, // NOTE: This needs to be updated whenever we update the NCCL version.
+            version: nccl_version,
             blocking: 1,
             cgaClusterSize: i32::MIN,
             minCTAs: 1,


### PR DESCRIPTION
## Summary
Replace hardcoded `version: 22800` in `ncclConfig_t` with a runtime `ncclGetVersion()` call.

## Problem
`nccl_bootstrap.rs` hardcodes the NCCL config version to `22800` (NCCL 2.28.0). The current `cuda-dl-base` containers ship **NCCL 2.29.2** (version `22902`). `ncclCommInitRankConfig` rejects the config struct with `ncclInvalidUsage` because the version field doesn't match the runtime library.

This completely breaks `DYN_KVBM_NCCL_MLA_MODE=true` — rank 0 fails at comm init, ranks 1-3 hang in MPI bcast, and the ZMQ leader/worker handshake times out.

Verified on Lyris GB200 (aarch64):
```bash
srun --container-image=<trtllm-runtime-kvbm-nccl.sqsh> bash -c \
  "python3 -c \"import ctypes; nccl=ctypes.CDLL('libnccl.so.2'); v=ctypes.c_int(); nccl.ncclGetVersion(ctypes.byref(v)); print(v.value)\""
# Output: 22902  (NCCL 2.29.2)
```

## Fix
Query `ncclGetVersion()` at runtime and use the result for the config struct. One line change, forward-compatible with any NCCL version.

## Test plan
- [ ] CI build passes (Rust compilation with nccl feature)
- [ ] KVBM NCCL MLA mode initializes successfully on TRT-LLM TP4 (needs GPU CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved runtime library version detection to automatically identify and adapt to the actual installed version, ensuring proper compatibility across different environments instead of relying on hardcoded values.
  * Enhanced diagnostic logging during system initialization to report the detected library version for better troubleshooting and system monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->