### PR TITLE
checkpoint: add operator-managed GMS checkpoint/restore support

### DIFF
--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocheckpoints.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocheckpoints.yaml
@@ -67,6 +67,11 @@ spec:
             spec:
               description: DynamoCheckpointSpec defines the desired state of DynamoCheckpoint
               properties:
+                gms:
+                  description: |-
+                    GMS enables GMS sidecars for checkpoint creation and restore when this
+                    checkpoint is referenced by operator-managed workloads.
+                  type: boolean
                 identity:
                   description: Identity defines the inputs that determine checkpoint equivalence
                   properties:

--- a/deploy/operator/api/v1alpha1/dynamocheckpoint_types.go
+++ b/deploy/operator/api/v1alpha1/dynamocheckpoint_types.go
@@ -124,6 +124,11 @@ type DynamoCheckpointSpec struct {
 	// +kubebuilder:validation:Required
 	Identity DynamoCheckpointIdentity `json:"identity"`
 
+	// GMS enables GMS sidecars for checkpoint creation and restore when this
+	// checkpoint is referenced by operator-managed workloads.
+	// +optional
+	GMS bool `json:"gms,omitempty"`
+
 	// Job defines the configuration for the checkpoint creation Job
 	// +kubebuilder:validation:Required
 	Job DynamoCheckpointJobConfig `json:"job"`

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocheckpoints.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocheckpoints.yaml
@@ -67,6 +67,11 @@ spec:
             spec:
               description: DynamoCheckpointSpec defines the desired state of DynamoCheckpoint
               properties:
+                gms:
+                  description: |-
+                    GMS enables GMS sidecars for checkpoint creation and restore when this
+                    checkpoint is referenced by operator-managed workloads.
+                  type: boolean
                 identity:
                   description: Identity defines the inputs that determine checkpoint equivalence
                   properties:

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -235,6 +235,32 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Nil(t, podSpec.Containers[1].Args)
 	})
 
+	t.Run("ready gms checkpoint injects restore sidecars and loader mount", func(t *testing.T) {
+		podSpec := testPodSpec()
+		info := &CheckpointInfo{Enabled: true, Ready: true, Hash: testHash, GMS: true}
+		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
+
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info))
+		require.NotNil(t, findContainer(podSpec, GMSWeightsServerContainer))
+		require.NotNil(t, findContainer(podSpec, GMSKVCacheServerContainer))
+		loader := findContainer(podSpec, GMSLoaderContainer)
+		require.NotNil(t, loader)
+
+		mounts := map[string]string{}
+		for _, mount := range loader.VolumeMounts {
+			mounts[mount.Name] = mount.MountPath
+		}
+		assert.Equal(t, "/checkpoints", mounts[snapshotprotocol.CheckpointVolumeName])
+		assert.Equal(t, GMSControlDir, mounts[GMSControlVolumeName])
+		assert.Equal(t, GMSSocketDir, mounts[GMSSocketsVolumeName])
+
+		env := map[string]string{}
+		for _, item := range loader.Env {
+			env[item.Name] = item.Value
+		}
+		assert.Equal(t, "/checkpoints/"+testHash+"/versions/1", env["GMS_CHECKPOINT_DIR"])
+	})
+
 	t.Run("error cases", func(t *testing.T) {
 		for _, tc := range []struct {
 			name    string

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -325,6 +325,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 
 	t.Run("ready gms checkpoint injects restore sidecars and loader mount", func(t *testing.T) {
 		podSpec := testPodSpec()
+		podSpec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu"}}
 		info := &CheckpointInfo{Enabled: true, Ready: true, Hash: testHash, GMS: true}
 		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
 
@@ -346,7 +347,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		for _, item := range loader.Env {
 			env[item.Name] = item.Value
 		}
-		assert.Equal(t, "/checkpoints/"+testHash+"/versions/1", env["GMS_CHECKPOINT_DIR"])
+		assert.Equal(t, "/checkpoints/"+testHash+"/gms/versions/1", env["GMS_CHECKPOINT_DIR"])
 	})
 
 	t.Run("error cases", func(t *testing.T) {

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -277,7 +277,7 @@ func TestResolveCheckpointForService(t *testing.T) {
 		require.NoError(t, err)
 		ckpt := &nvidiacomv1alpha1.DynamoCheckpoint{
 			ObjectMeta: metav1.ObjectMeta{Name: hash, Namespace: testNamespace},
-			Spec:       nvidiacomv1alpha1.DynamoCheckpointSpec{Identity: testIdentity()},
+			Spec:       nvidiacomv1alpha1.DynamoCheckpointSpec{Identity: testIdentity(), GMS: true},
 			Status: nvidiacomv1alpha1.DynamoCheckpointStatus{
 				Phase:        nvidiacomv1alpha1.DynamoCheckpointPhaseReady,
 				IdentityHash: hash,
@@ -294,6 +294,7 @@ func TestResolveCheckpointForService(t *testing.T) {
 		assert.True(t, info.Ready)
 		assert.Equal(t, hash, info.Hash)
 		assert.Equal(t, hash, info.CheckpointName)
+		assert.True(t, info.GMS)
 	})
 
 	t.Run("checkpointRef resolves not-ready CR", func(t *testing.T) {

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -182,6 +182,50 @@ func TestCreateOrGetAutoCheckpointSetsDefaultArtifactVersion(t *testing.T) {
 
 // --- InjectCheckpointIntoPodSpec tests ---
 
+func TestEnsurePodInfoVolumeMergesExistingDownwardAPIItems(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Volumes: []corev1.Volume{{
+			Name: consts.PodInfoVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				DownwardAPI: &corev1.DownwardAPIVolumeSource{
+					Items: []corev1.DownwardAPIVolumeFile{
+						{
+							Path:     "pod_name",
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+						},
+						{
+							Path:     "custom",
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels['custom']"},
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	EnsurePodInfoVolume(podSpec)
+
+	require.Len(t, podSpec.Volumes, 1)
+	require.NotNil(t, podSpec.Volumes[0].DownwardAPI)
+
+	fields := map[string]string{}
+	for _, item := range podSpec.Volumes[0].DownwardAPI.Items {
+		if item.FieldRef != nil {
+			fields[item.Path] = item.FieldRef.FieldPath
+		}
+	}
+
+	assert.Equal(t, consts.PodInfoFieldPodName, fields["pod_name"])
+	assert.Equal(t, consts.PodInfoFieldPodUID, fields["pod_uid"])
+	assert.Equal(t, consts.PodInfoFieldPodNamespace, fields["pod_namespace"])
+	assert.Equal(t, "metadata.labels['custom']", fields["custom"])
+	assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoNamespace+"']", fields[consts.PodInfoFileDynNamespace])
+	assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoWorkerHash+"']", fields[consts.PodInfoFileDynNamespaceWorkerSuffix])
+	assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoComponentType+"']", fields[consts.PodInfoFileDynComponent])
+	assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoGraphDeploymentName+"']", fields[consts.PodInfoFileDynParentDGDName])
+	assert.Equal(t, consts.PodInfoFieldPodNamespace, fields[consts.PodInfoFileDynParentDGDNamespace])
+}
+
 func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 	t.Run("ready checkpoint injects podinfo and overrides command", func(t *testing.T) {
 		podSpec := testPodSpec()

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -218,6 +218,50 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Equal(t, consts.PodInfoMountPath, mountPaths[consts.PodInfoVolumeName])
 	})
 
+	t.Run("ready checkpoint augments existing podinfo volume", func(t *testing.T) {
+		podSpec := testPodSpec()
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+			Name: consts.PodInfoVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				DownwardAPI: &corev1.DownwardAPIVolumeSource{
+					Items: []corev1.DownwardAPIVolumeFile{
+						{Path: "pod_name", FieldRef: &corev1.ObjectFieldSelector{FieldPath: consts.PodInfoFieldPodName}},
+						{Path: "pod_uid", FieldRef: &corev1.ObjectFieldSelector{FieldPath: consts.PodInfoFieldPodUID}},
+						{Path: "pod_namespace", FieldRef: &corev1.ObjectFieldSelector{FieldPath: consts.PodInfoFieldPodNamespace}},
+					},
+				},
+			},
+		})
+		info := &CheckpointInfo{Enabled: true, Ready: true, Identity: ptr.To(testIdentity())}
+		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info))
+
+		var podInfoVolume *corev1.Volume
+		for i := range podSpec.Volumes {
+			if podSpec.Volumes[i].Name == consts.PodInfoVolumeName {
+				podInfoVolume = &podSpec.Volumes[i]
+				break
+			}
+		}
+		require.NotNil(t, podInfoVolume)
+		require.NotNil(t, podInfoVolume.DownwardAPI)
+
+		fields := map[string]string{}
+		for _, item := range podInfoVolume.DownwardAPI.Items {
+			if item.FieldRef != nil {
+				fields[item.Path] = item.FieldRef.FieldPath
+			}
+		}
+		assert.Equal(t, consts.PodInfoFieldPodName, fields["pod_name"])
+		assert.Equal(t, consts.PodInfoFieldPodUID, fields["pod_uid"])
+		assert.Equal(t, consts.PodInfoFieldPodNamespace, fields["pod_namespace"])
+		assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoNamespace+"']", fields[consts.PodInfoFileDynNamespace])
+		assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoWorkerHash+"']", fields[consts.PodInfoFileDynNamespaceWorkerSuffix])
+		assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoComponentType+"']", fields[consts.PodInfoFileDynComponent])
+		assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoGraphDeploymentName+"']", fields[consts.PodInfoFileDynParentDGDName])
+		assert.Equal(t, consts.PodInfoFieldPodNamespace, fields[consts.PodInfoFileDynParentDGDNamespace])
+	})
+
 	t.Run("ready checkpoint targets the container named main", func(t *testing.T) {
 		podSpec := &corev1.PodSpec{
 			Containers: []corev1.Container{

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -1,0 +1,378 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package checkpoint
+
+import (
+	"context"
+	"fmt"
+
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	GMSInitContainerName      = "gms-init"
+	GMSWeightsServerContainer = "gms-server"
+	GMSKVCacheServerContainer = "gms-kv-cache"
+	GMSLoaderContainer        = "gms-loader"
+	GMSSaverContainer         = "gms-saver"
+	GMSSocketsVolumeName      = "gms-sockets"
+	GMSControlVolumeName      = "gms-control"
+	GMSSocketDir              = "/var/run/nvidia-gms"
+	GMSControlDir             = "/tmp/gms-control"
+)
+
+const gmsInitCommand = `
+import os
+from pathlib import Path
+
+for path in (os.environ["GMS_SOCKET_DIR"], os.environ["GMS_CONTROL_DIR"]):
+    Path(path).mkdir(parents=True, exist_ok=True)
+`
+
+const gmsServerCommand = `
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+
+
+def devices():
+    result = []
+    for name in os.listdir("/dev"):
+        match = re.fullmatch(r"nvidia(\d+)", name)
+        if match is None:
+            continue
+        result.append(int(match.group(1)))
+    return sorted(result)
+
+
+processes = [
+    subprocess.Popen([
+        "gpu-memory-service",
+        "--device",
+        str(device),
+        "--tag",
+        os.environ["GMS_SERVER_TAG"],
+    ])
+    for device in devices()
+]
+
+if not processes:
+    raise SystemExit("no nvidia devices found")
+
+
+def shutdown(*_args):
+    for process in processes:
+        if process.poll() is None:
+            process.terminate()
+
+
+signal.signal(signal.SIGTERM, shutdown)
+signal.signal(signal.SIGINT, shutdown)
+
+while True:
+    running = False
+    for process in processes:
+        code = process.poll()
+        if code is None:
+            running = True
+            continue
+        shutdown()
+        sys.exit(code)
+    if not running:
+        sys.exit(0)
+    time.sleep(1)
+`
+
+const gmsSaveCommand = `
+import os
+import re
+import subprocess
+import time
+
+from gpu_memory_service.common.utils import get_socket_path
+
+
+def devices():
+    result = []
+    for name in os.listdir("/dev"):
+        match = re.fullmatch(r"nvidia(\d+)", name)
+        if match is None:
+            continue
+        result.append(int(match.group(1)))
+    return sorted(result)
+
+
+for device in devices():
+    socket_path = get_socket_path(device, "weights")
+    while not os.path.exists(socket_path):
+        time.sleep(1)
+    output_dir = os.path.join(os.environ["GMS_CHECKPOINT_DIR"], "gms", f"device-{device}")
+    subprocess.run([
+        "python3",
+        "-m",
+        "gpu_memory_service.cli.storage_runner",
+        "save",
+        "--output-dir",
+        output_dir,
+        "--device",
+        str(device),
+    ], check=True)
+`
+
+const gmsLoadCommand = `
+import os
+import re
+import subprocess
+import time
+
+from gpu_memory_service.common.utils import get_socket_path
+
+
+def devices():
+    result = []
+    for name in os.listdir("/dev"):
+        match = re.fullmatch(r"nvidia(\d+)", name)
+        if match is None:
+            continue
+        result.append(int(match.group(1)))
+    return sorted(result)
+
+
+for device in devices():
+    socket_path = get_socket_path(device, "weights")
+    while not os.path.exists(socket_path):
+        time.sleep(1)
+    input_dir = os.path.join(os.environ["GMS_CHECKPOINT_DIR"], "gms", f"device-{device}")
+    subprocess.run([
+        "python3",
+        "-m",
+        "gpu_memory_service.cli.storage_runner",
+        "load",
+        "--input-dir",
+        input_dir,
+        "--device",
+        str(device),
+    ], check=True)
+
+while True:
+    time.sleep(3600)
+`
+
+func ResolveGMSCheckpointStorage(
+	ctx context.Context,
+	reader ctrlclient.Reader,
+	namespace string,
+	checkpointID string,
+	artifactVersion string,
+) (snapshotprotocol.Storage, error) {
+	if reader == nil {
+		return snapshotprotocol.Storage{}, fmt.Errorf("checkpoint client is required")
+	}
+
+	daemonSets := &appsv1.DaemonSetList{}
+	if err := reader.List(
+		ctx,
+		daemonSets,
+		ctrlclient.InNamespace(namespace),
+		ctrlclient.MatchingLabels{snapshotprotocol.SnapshotAgentLabelKey: snapshotprotocol.SnapshotAgentLabelValue},
+	); err != nil {
+		return snapshotprotocol.Storage{}, fmt.Errorf("list snapshot-agent daemonsets in %s: %w", namespace, err)
+	}
+
+	storage, err := snapshotprotocol.DiscoverStorageFromDaemonSets(namespace, daemonSets.Items)
+	if err != nil {
+		return snapshotprotocol.Storage{}, err
+	}
+	return snapshotprotocol.ResolveCheckpointStorage(checkpointID, artifactVersion, storage)
+}
+
+func EnsureGMSRestoreSidecars(podSpec *corev1.PodSpec, mainContainer *corev1.Container) {
+	if podSpec == nil || mainContainer == nil {
+		return
+	}
+
+	ensureGMSSharedVolumes(podSpec)
+	applyGMSSocketEnv(mainContainer)
+	ensureVolumeMount(mainContainer, corev1.VolumeMount{Name: GMSSocketsVolumeName, MountPath: GMSSocketDir})
+	ensureInitContainer(podSpec, mainContainer.Image)
+	ensureGMSContainer(podSpec, gmsServerContainer(mainContainer.Image, GMSWeightsServerContainer, "weights"))
+	ensureGMSContainer(podSpec, gmsServerContainer(mainContainer.Image, GMSKVCacheServerContainer, "kv_cache"))
+	ensureGMSContainer(podSpec, gmsHelperContainer(mainContainer.Image, GMSLoaderContainer, gmsLoadCommand))
+}
+
+func EnsureGMSRestoreHelperMounts(podSpec *corev1.PodSpec, storage snapshotprotocol.Storage) {
+	loader := findContainer(podSpec, GMSLoaderContainer)
+	if loader == nil {
+		return
+	}
+	ensureCheckpointVolume(podSpec, storage.PVCName)
+	ensureVolumeMount(loader, corev1.VolumeMount{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath})
+	setEnv(loader, "GMS_CHECKPOINT_DIR", storage.Location)
+}
+
+func EnsureGMSCheckpointJobSidecars(
+	podSpec *corev1.PodSpec,
+	mainContainer *corev1.Container,
+	storage snapshotprotocol.Storage,
+) error {
+	if podSpec == nil || mainContainer == nil {
+		return nil
+	}
+	if storage.PVCName == "" || storage.BasePath == "" || storage.Location == "" {
+		return fmt.Errorf("gms checkpoint jobs require resolved checkpoint storage")
+	}
+
+	ensureGMSSharedVolumes(podSpec)
+	applyGMSSocketEnv(mainContainer)
+	ensureVolumeMount(mainContainer, corev1.VolumeMount{Name: GMSSocketsVolumeName, MountPath: GMSSocketDir})
+	ensureInitContainer(podSpec, mainContainer.Image)
+	ensureGMSContainer(podSpec, gmsServerContainer(mainContainer.Image, GMSWeightsServerContainer, "weights"))
+	ensureGMSContainer(podSpec, gmsServerContainer(mainContainer.Image, GMSKVCacheServerContainer, "kv_cache"))
+
+	saver := gmsHelperContainer(mainContainer.Image, GMSSaverContainer, gmsSaveCommand)
+	ensureCheckpointVolume(podSpec, storage.PVCName)
+	ensureVolumeMount(&saver, corev1.VolumeMount{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath})
+	setEnv(&saver, "GMS_CHECKPOINT_DIR", storage.Location)
+	ensureGMSContainer(podSpec, saver)
+	return nil
+}
+
+func gmsServerContainer(image string, name string, tag string) corev1.Container {
+	container := corev1.Container{
+		Name:    name,
+		Image:   image,
+		Command: []string{"python3", "-c", gmsServerCommand},
+		Env: []corev1.EnvVar{
+			{Name: "GMS_SERVER_TAG", Value: tag},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: GMSSocketsVolumeName, MountPath: GMSSocketDir},
+			{Name: GMSControlVolumeName, MountPath: GMSControlDir},
+		},
+	}
+	applyGMSSocketEnv(&container)
+	return container
+}
+
+func gmsHelperContainer(image string, name string, script string) corev1.Container {
+	container := corev1.Container{
+		Name:    name,
+		Image:   image,
+		Command: []string{"python3", "-c", script},
+		Env: []corev1.EnvVar{
+			{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}}},
+			{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: GMSSocketsVolumeName, MountPath: GMSSocketDir},
+			{Name: GMSControlVolumeName, MountPath: GMSControlDir},
+		},
+	}
+	applyGMSSocketEnv(&container)
+	return container
+}
+
+func ensureGMSSharedVolumes(podSpec *corev1.PodSpec) {
+	ensureVolume(podSpec, corev1.Volume{Name: GMSSocketsVolumeName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}})
+	ensureVolume(podSpec, corev1.Volume{Name: GMSControlVolumeName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}})
+}
+
+func ensureInitContainer(podSpec *corev1.PodSpec, image string) {
+	for i := range podSpec.InitContainers {
+		if podSpec.InitContainers[i].Name == GMSInitContainerName {
+			return
+		}
+	}
+	container := corev1.Container{
+		Name:    GMSInitContainerName,
+		Image:   image,
+		Command: []string{"python3", "-c", gmsInitCommand},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: GMSSocketsVolumeName, MountPath: GMSSocketDir},
+			{Name: GMSControlVolumeName, MountPath: GMSControlDir},
+		},
+	}
+	applyGMSSocketEnv(&container)
+	podSpec.InitContainers = append(podSpec.InitContainers, container)
+}
+
+func applyGMSSocketEnv(container *corev1.Container) {
+	setEnv(container, "TMPDIR", GMSSocketDir)
+	setEnv(container, "GMS_SOCKET_DIR", GMSSocketDir)
+	setEnv(container, "GMS_CONTROL_DIR", GMSControlDir)
+}
+
+func ensureCheckpointVolume(podSpec *corev1.PodSpec, pvcName string) {
+	if pvcName == "" {
+		return
+	}
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name == snapshotprotocol.CheckpointVolumeName {
+			return
+		}
+	}
+	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+		Name: snapshotprotocol.CheckpointVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+		},
+	})
+}
+
+func ensureVolume(podSpec *corev1.PodSpec, volume corev1.Volume) {
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name == volume.Name {
+			return
+		}
+	}
+	podSpec.Volumes = append(podSpec.Volumes, volume)
+}
+
+func ensureVolumeMount(container *corev1.Container, mount corev1.VolumeMount) {
+	for i := range container.VolumeMounts {
+		if container.VolumeMounts[i].Name == mount.Name && container.VolumeMounts[i].MountPath == mount.MountPath {
+			return
+		}
+	}
+	container.VolumeMounts = append(container.VolumeMounts, mount)
+}
+
+func setEnv(container *corev1.Container, name string, value string) {
+	for i := range container.Env {
+		if container.Env[i].Name != name {
+			continue
+		}
+		container.Env[i].Value = value
+		container.Env[i].ValueFrom = nil
+		return
+	}
+	container.Env = append(container.Env, corev1.EnvVar{Name: name, Value: value})
+}
+
+func ensureGMSContainer(podSpec *corev1.PodSpec, container corev1.Container) {
+	if findContainer(podSpec, container.Name) != nil {
+		return
+	}
+	podSpec.Containers = append(podSpec.Containers, container)
+}
+
+func findContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {
+	if podSpec == nil {
+		return nil
+	}
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == name {
+			return &podSpec.Containers[i]
+		}
+	}
+	return nil
+}

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -92,12 +92,30 @@ while True:
 `
 
 const gmsSaveCommand = `
+import json
 import os
+import ssl
 import subprocess
 import time
+import urllib.request
 
 import pynvml
 from gpu_memory_service.common.utils import get_socket_path
+
+
+SERVICE_TOKEN = open(
+    "/var/run/secrets/kubernetes.io/serviceaccount/token",
+    encoding="utf-8",
+).read().strip()
+SERVICE_CA = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+POD_API_URL = (
+    "https://"
+    + os.environ["KUBERNETES_SERVICE_HOST"]
+    + ":"
+    + os.environ.get("KUBERNETES_SERVICE_PORT_HTTPS", "443")
+    + f"/api/v1/namespaces/{os.environ['POD_NAMESPACE']}/pods/{os.environ['POD_NAME']}"
+)
+SSL_CONTEXT = ssl.create_default_context(cafile=SERVICE_CA)
 
 
 def devices():
@@ -108,11 +126,33 @@ def devices():
         pynvml.nvmlShutdown()
 
 
-device_ids = devices()
-if not device_ids:
-    raise SystemExit("no nvidia devices found")
+def checkpoint_pod_ready():
+    request = urllib.request.Request(
+        POD_API_URL,
+        headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
+    )
+    with urllib.request.urlopen(request, context=SSL_CONTEXT, timeout=5) as response:
+        pod = json.load(response)
+    status = pod.get("status") or {}
+    if str(status.get("phase", "")).strip() != "Running":
+        return False
+    for condition in status.get("conditions") or []:
+        if condition.get("type") == "Ready" and str(condition.get("status", "")).strip() == "True":
+            return True
+    return False
 
-for device in device_ids:
+
+print("Waiting for checkpoint pod Ready=True before GMS save", flush=True)
+while True:
+    try:
+        if checkpoint_pod_ready():
+            break
+    except Exception:
+        pass
+    time.sleep(1)
+print("Checkpoint pod is Ready; starting GMS save", flush=True)
+
+for device in devices():
     socket_path = get_socket_path(device, "weights")
     while not os.path.exists(socket_path):
         time.sleep(1)

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -8,6 +8,7 @@ package checkpoint
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	appsv1 "k8s.io/api/apps/v1"
@@ -45,6 +46,9 @@ import time
 import pynvml
 
 
+STOP_FILE = os.path.join(os.environ["GMS_CONTROL_DIR"], "checkpoint-done")
+
+
 def devices():
     pynvml.nvmlInit()
     try:
@@ -78,11 +82,16 @@ signal.signal(signal.SIGTERM, shutdown)
 signal.signal(signal.SIGINT, shutdown)
 
 while True:
+    stop_requested = os.path.exists(STOP_FILE)
+    if stop_requested:
+        shutdown()
     running = False
     for process in processes:
         code = process.poll()
         if code is None:
             running = True
+            continue
+        if stop_requested:
             continue
         shutdown()
         sys.exit(code)
@@ -98,6 +107,7 @@ import ssl
 import subprocess
 import time
 import urllib.request
+from pathlib import Path
 
 import pynvml
 from gpu_memory_service.common.utils import get_socket_path
@@ -116,6 +126,7 @@ POD_API_URL = (
     + f"/api/v1/namespaces/{os.environ['POD_NAMESPACE']}/pods/{os.environ['POD_NAME']}"
 )
 SSL_CONTEXT = ssl.create_default_context(cafile=SERVICE_CA)
+STOP_FILE = Path(os.environ["GMS_CONTROL_DIR"]) / "checkpoint-done"
 
 
 def devices():
@@ -126,13 +137,16 @@ def devices():
         pynvml.nvmlShutdown()
 
 
-def checkpoint_pod_ready():
+def checkpoint_pod():
     request = urllib.request.Request(
         POD_API_URL,
         headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
     )
     with urllib.request.urlopen(request, context=SSL_CONTEXT, timeout=5) as response:
-        pod = json.load(response)
+        return json.load(response)
+
+
+def checkpoint_pod_ready(pod):
     status = pod.get("status") or {}
     if str(status.get("phase", "")).strip() != "Running":
         return False
@@ -142,31 +156,50 @@ def checkpoint_pod_ready():
     return False
 
 
+def main_terminated(pod):
+    status = pod.get("status") or {}
+    for container in status.get("containerStatuses") or []:
+        if container.get("name") != "main":
+            continue
+        return bool((container.get("state") or {}).get("terminated"))
+    return False
+
+
 print("Waiting for checkpoint pod Ready=True before GMS save", flush=True)
 while True:
     try:
-        if checkpoint_pod_ready():
-            break
+        pod = checkpoint_pod()
     except Exception:
-        pass
+        time.sleep(1)
+        continue
+    if checkpoint_pod_ready(pod):
+        break
+    if main_terminated(pod):
+        raise SystemExit("main container terminated before GMS save could start")
     time.sleep(1)
 print("Checkpoint pod is Ready; starting GMS save", flush=True)
 
-for device in devices():
-    socket_path = get_socket_path(device, "weights")
-    while not os.path.exists(socket_path):
-        time.sleep(1)
-    output_dir = os.path.join(os.environ["GMS_CHECKPOINT_DIR"], "gms", f"device-{device}")
-    subprocess.run([
-        "python3",
-        "-m",
-        "gpu_memory_service.cli.storage_runner",
-        "save",
-        "--output-dir",
-        output_dir,
-        "--device",
-        str(device),
-    ], check=True)
+try:
+    device_ids = devices()
+    if not device_ids:
+        raise SystemExit("no nvidia devices found")
+    for device in device_ids:
+        socket_path = get_socket_path(device, "weights")
+        while not os.path.exists(socket_path):
+            time.sleep(1)
+        output_dir = os.path.join(os.environ["GMS_CHECKPOINT_DIR"], "gms", f"device-{device}")
+        subprocess.run([
+            "python3",
+            "-m",
+            "gpu_memory_service.cli.storage_runner",
+            "save",
+            "--output-dir",
+            output_dir,
+            "--device",
+            str(device),
+        ], check=True)
+finally:
+    STOP_FILE.write_text("done", encoding="utf-8")
 `
 
 const gmsLoadCommand = `
@@ -247,9 +280,18 @@ func EnsureGMSRestoreSidecars(podSpec *corev1.PodSpec, mainContainer *corev1.Con
 	applyGMSSocketEnv(mainContainer)
 	ensureVolumeMount(mainContainer, corev1.VolumeMount{Name: GMSSocketsVolumeName, MountPath: GMSSocketDir})
 	ensureInitContainer(podSpec, mainContainer.Image)
-	ensureGMSContainer(podSpec, gmsServerContainer(mainContainer.Image, GMSWeightsServerContainer, "weights"))
-	ensureGMSContainer(podSpec, gmsServerContainer(mainContainer.Image, GMSKVCacheServerContainer, "kv_cache"))
-	ensureGMSContainer(podSpec, gmsHelperContainer(mainContainer.Image, GMSLoaderContainer, gmsLoadCommand))
+
+	weightsServer := gmsServerContainer(mainContainer.Image, GMSWeightsServerContainer, "weights")
+	copyGMSDeviceClaims(mainContainer, &weightsServer)
+	ensureGMSContainer(podSpec, weightsServer)
+
+	kvCacheServer := gmsServerContainer(mainContainer.Image, GMSKVCacheServerContainer, "kv_cache")
+	copyGMSDeviceClaims(mainContainer, &kvCacheServer)
+	ensureGMSContainer(podSpec, kvCacheServer)
+
+	loader := gmsHelperContainer(mainContainer.Image, GMSLoaderContainer, gmsLoadCommand)
+	copyGMSDeviceClaims(mainContainer, &loader)
+	ensureGMSContainer(podSpec, loader)
 }
 
 func EnsureGMSRestoreHelperMounts(podSpec *corev1.PodSpec, storage snapshotprotocol.Storage) {
@@ -259,7 +301,7 @@ func EnsureGMSRestoreHelperMounts(podSpec *corev1.PodSpec, storage snapshotproto
 	}
 	ensureCheckpointVolume(podSpec, storage.PVCName)
 	ensureVolumeMount(loader, corev1.VolumeMount{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath})
-	setEnv(loader, "GMS_CHECKPOINT_DIR", storage.Location)
+	setEnv(loader, "GMS_CHECKPOINT_DIR", resolveGMSArtifactDir(storage))
 }
 
 func EnsureGMSCheckpointJobSidecars(
@@ -270,6 +312,9 @@ func EnsureGMSCheckpointJobSidecars(
 	if podSpec == nil || mainContainer == nil {
 		return nil
 	}
+	if len(mainContainer.Resources.Claims) == 0 {
+		return fmt.Errorf("gms sidecars require main container resource claims")
+	}
 	if storage.PVCName == "" || storage.BasePath == "" || storage.Location == "" {
 		return fmt.Errorf("gms checkpoint jobs require resolved checkpoint storage")
 	}
@@ -278,15 +323,28 @@ func EnsureGMSCheckpointJobSidecars(
 	applyGMSSocketEnv(mainContainer)
 	ensureVolumeMount(mainContainer, corev1.VolumeMount{Name: GMSSocketsVolumeName, MountPath: GMSSocketDir})
 	ensureInitContainer(podSpec, mainContainer.Image)
-	ensureGMSContainer(podSpec, gmsServerContainer(mainContainer.Image, GMSWeightsServerContainer, "weights"))
-	ensureGMSContainer(podSpec, gmsServerContainer(mainContainer.Image, GMSKVCacheServerContainer, "kv_cache"))
+
+	weightsServer := gmsServerContainer(mainContainer.Image, GMSWeightsServerContainer, "weights")
+	copyGMSDeviceClaims(mainContainer, &weightsServer)
+	ensureGMSContainer(podSpec, weightsServer)
+
+	kvCacheServer := gmsServerContainer(mainContainer.Image, GMSKVCacheServerContainer, "kv_cache")
+	copyGMSDeviceClaims(mainContainer, &kvCacheServer)
+	ensureGMSContainer(podSpec, kvCacheServer)
 
 	saver := gmsHelperContainer(mainContainer.Image, GMSSaverContainer, gmsSaveCommand)
+	copyGMSDeviceClaims(mainContainer, &saver)
 	ensureCheckpointVolume(podSpec, storage.PVCName)
 	ensureVolumeMount(&saver, corev1.VolumeMount{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath})
-	setEnv(&saver, "GMS_CHECKPOINT_DIR", storage.Location)
+	setEnv(&saver, "GMS_CHECKPOINT_DIR", resolveGMSArtifactDir(storage))
 	ensureGMSContainer(podSpec, saver)
 	return nil
+}
+
+func resolveGMSArtifactDir(storage snapshotprotocol.Storage) string {
+	checkpointRoot := filepath.Dir(filepath.Dir(storage.Location))
+	artifactVersion := filepath.Base(storage.Location)
+	return filepath.Join(checkpointRoot, "gms", "versions", artifactVersion)
 }
 
 func gmsServerContainer(image string, name string, tag string) corev1.Container {
@@ -352,6 +410,13 @@ func applyGMSSocketEnv(container *corev1.Container) {
 	setEnv(container, "TMPDIR", GMSSocketDir)
 	setEnv(container, "GMS_SOCKET_DIR", GMSSocketDir)
 	setEnv(container, "GMS_CONTROL_DIR", GMSControlDir)
+}
+
+func copyGMSDeviceClaims(mainContainer *corev1.Container, container *corev1.Container) {
+	if mainContainer == nil || container == nil || len(mainContainer.Resources.Claims) == 0 {
+		return
+	}
+	container.Resources.Claims = append([]corev1.ResourceClaim{}, mainContainer.Resources.Claims...)
 }
 
 func ensureCheckpointVolume(podSpec *corev1.PodSpec, pvcName string) {

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -36,22 +36,20 @@ for path in (os.environ["GMS_SOCKET_DIR"], os.environ["GMS_CONTROL_DIR"]):
 `
 
 const gmsServerCommand = `
-import os
-import re
 import signal
 import subprocess
 import sys
 import time
 
+import pynvml
+
 
 def devices():
-    result = []
-    for name in os.listdir("/dev"):
-        match = re.fullmatch(r"nvidia(\d+)", name)
-        if match is None:
-            continue
-        result.append(int(match.group(1)))
-    return sorted(result)
+    pynvml.nvmlInit()
+    try:
+        return list(range(pynvml.nvmlDeviceGetCount()))
+    finally:
+        pynvml.nvmlShutdown()
 
 
 processes = [
@@ -94,21 +92,19 @@ while True:
 
 const gmsSaveCommand = `
 import os
-import re
 import subprocess
 import time
 
+import pynvml
 from gpu_memory_service.common.utils import get_socket_path
 
 
 def devices():
-    result = []
-    for name in os.listdir("/dev"):
-        match = re.fullmatch(r"nvidia(\d+)", name)
-        if match is None:
-            continue
-        result.append(int(match.group(1)))
-    return sorted(result)
+    pynvml.nvmlInit()
+    try:
+        return list(range(pynvml.nvmlDeviceGetCount()))
+    finally:
+        pynvml.nvmlShutdown()
 
 
 for device in devices():
@@ -130,21 +126,19 @@ for device in devices():
 
 const gmsLoadCommand = `
 import os
-import re
 import subprocess
 import time
 
+import pynvml
 from gpu_memory_service.common.utils import get_socket_path
 
 
 def devices():
-    result = []
-    for name in os.listdir("/dev"):
-        match = re.fullmatch(r"nvidia(\d+)", name)
-        if match is None:
-            continue
-        result.append(int(match.group(1)))
-    return sorted(result)
+    pynvml.nvmlInit()
+    try:
+        return list(range(pynvml.nvmlDeviceGetCount()))
+    finally:
+        pynvml.nvmlShutdown()
 
 
 for device in devices():

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -36,6 +36,7 @@ for path in (os.environ["GMS_SOCKET_DIR"], os.environ["GMS_CONTROL_DIR"]):
 `
 
 const gmsServerCommand = `
+import os
 import signal
 import subprocess
 import sys
@@ -107,7 +108,11 @@ def devices():
         pynvml.nvmlShutdown()
 
 
-for device in devices():
+device_ids = devices()
+if not device_ids:
+    raise SystemExit("no nvidia devices found")
+
+for device in device_ids:
     socket_path = get_socket_path(device, "weights")
     while not os.path.exists(socket_path):
         time.sleep(1)
@@ -141,7 +146,11 @@ def devices():
         pynvml.nvmlShutdown()
 
 
-for device in devices():
+device_ids = devices()
+if not device_ids:
+    raise SystemExit("no nvidia devices found")
+
+for device in device_ids:
     socket_path = get_socket_path(device, "weights")
     while not os.path.exists(socket_path):
         time.sleep(1)

--- a/deploy/operator/internal/checkpoint/podinfo.go
+++ b/deploy/operator/internal/checkpoint/podinfo.go
@@ -9,69 +9,98 @@ import (
 )
 
 func EnsurePodInfoVolume(podSpec *corev1.PodSpec) {
-	for _, volume := range podSpec.Volumes {
-		if volume.Name == commonconsts.PodInfoVolumeName {
-			return
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name != commonconsts.PodInfoVolumeName {
+			continue
 		}
+		if podSpec.Volumes[i].DownwardAPI == nil {
+			podSpec.Volumes[i].VolumeSource.DownwardAPI = &corev1.DownwardAPIVolumeSource{}
+		}
+		ensurePodInfoItems(podSpec.Volumes[i].DownwardAPI)
+		return
 	}
 
 	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 		Name: commonconsts.PodInfoVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			DownwardAPI: &corev1.DownwardAPIVolumeSource{
-				Items: []corev1.DownwardAPIVolumeFile{
-					{
-						Path: "pod_name",
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodName,
-						},
-					},
-					{
-						Path: "pod_uid",
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodUID,
-						},
-					},
-					{
-						Path: "pod_namespace",
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodNamespace,
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynNamespace,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoNamespace + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynNamespaceWorkerSuffix,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoWorkerHash + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynComponent,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoComponentType + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynParentDGDName,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoGraphDeploymentName + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynParentDGDNamespace,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodNamespace,
-						},
-					},
-				},
+				Items: podInfoItems(),
 			},
 		},
 	})
+}
+
+func ensurePodInfoItems(source *corev1.DownwardAPIVolumeSource) {
+	if source == nil {
+		return
+	}
+
+	pathToIndex := make(map[string]int, len(source.Items))
+	for i := range source.Items {
+		pathToIndex[source.Items[i].Path] = i
+	}
+
+	for _, item := range podInfoItems() {
+		if idx, ok := pathToIndex[item.Path]; ok {
+			source.Items[idx] = item
+			continue
+		}
+		source.Items = append(source.Items, item)
+		pathToIndex[item.Path] = len(source.Items) - 1
+	}
+}
+
+func podInfoItems() []corev1.DownwardAPIVolumeFile {
+	return []corev1.DownwardAPIVolumeFile{
+		{
+			Path: "pod_name",
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: commonconsts.PodInfoFieldPodName,
+			},
+		},
+		{
+			Path: "pod_uid",
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: commonconsts.PodInfoFieldPodUID,
+			},
+		},
+		{
+			Path: "pod_namespace",
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: commonconsts.PodInfoFieldPodNamespace,
+			},
+		},
+		{
+			Path: commonconsts.PodInfoFileDynNamespace,
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoNamespace + "']",
+			},
+		},
+		{
+			Path: commonconsts.PodInfoFileDynNamespaceWorkerSuffix,
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoWorkerHash + "']",
+			},
+		},
+		{
+			Path: commonconsts.PodInfoFileDynComponent,
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoComponentType + "']",
+			},
+		},
+		{
+			Path: commonconsts.PodInfoFileDynParentDGDName,
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoGraphDeploymentName + "']",
+			},
+		},
+		{
+			Path: commonconsts.PodInfoFileDynParentDGDNamespace,
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: commonconsts.PodInfoFieldPodNamespace,
+			},
+		},
+	}
 }
 
 func EnsurePodInfoMount(container *corev1.Container) {

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -93,6 +93,9 @@ func InjectCheckpointIntoPodSpec(
 	}
 
 	if info.GMS {
+		if len(mainContainer.Resources.Claims) == 0 {
+			return fmt.Errorf("gms sidecars require main container resource claims")
+		}
 		storage, err := ResolveGMSCheckpointStorage(
 			ctx,
 			reader,

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -92,6 +92,21 @@ func InjectCheckpointIntoPodSpec(
 		return err
 	}
 
+	if info.GMS {
+		storage, err := ResolveGMSCheckpointStorage(
+			ctx,
+			reader,
+			namespace,
+			info.Hash,
+			info.ArtifactVersion,
+		)
+		if err != nil {
+			return err
+		}
+		EnsureGMSRestoreSidecars(podSpec, mainContainer)
+		EnsureGMSRestoreHelperMounts(podSpec, storage)
+	}
+
 	EnsurePodInfoVolume(podSpec)
 	EnsurePodInfoMount(mainContainer)
 	return nil

--- a/deploy/operator/internal/checkpoint/resolve.go
+++ b/deploy/operator/internal/checkpoint/resolve.go
@@ -35,6 +35,7 @@ type CheckpointInfo struct {
 	ArtifactVersion string
 	CheckpointName  string
 	Ready           bool
+	GMS             bool
 }
 
 func checkpointInfoFromObject(ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (*CheckpointInfo, error) {
@@ -51,6 +52,7 @@ func checkpointInfoFromObject(ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (*Checkp
 		ArtifactVersion: checkpointArtifactVersion(ckpt),
 		CheckpointName:  ckpt.Name,
 		Ready:           ckpt.Status.Phase == nvidiacomv1alpha1.DynamoCheckpointPhaseReady,
+		GMS:             ckpt.Spec.GMS,
 	}, nil
 }
 

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
@@ -16,6 +17,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func buildCheckpointWorkerDefaultEnv(
@@ -48,6 +50,8 @@ func buildCheckpointWorkerDefaultEnv(
 }
 
 func buildCheckpointJob(
+	ctx context.Context,
+	reader ctrlclient.Reader,
 	config *configv1alpha1.OperatorConfiguration,
 	ckpt *nvidiacomv1alpha1.DynamoCheckpoint,
 	jobName string,
@@ -100,6 +104,22 @@ func buildCheckpointJob(
 	mainContainer.StartupProbe = nil
 	checkpoint.EnsurePodInfoMount(mainContainer)
 	dynamo.ApplySharedMemoryVolumeAndMount(&podTemplate.Spec, mainContainer, ckpt.Spec.Job.SharedMemory)
+
+	if ckpt.Spec.GMS {
+		storage, err := checkpoint.ResolveGMSCheckpointStorage(
+			ctx,
+			reader,
+			ckpt.Namespace,
+			hash,
+			ckpt.Annotations[snapshotprotocol.CheckpointArtifactVersionAnnotation],
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err := checkpoint.EnsureGMSCheckpointJobSidecars(&podTemplate.Spec, mainContainer, storage); err != nil {
+			return nil, err
+		}
+	}
 
 	activeDeadlineSeconds := ckpt.Spec.Job.ActiveDeadlineSeconds
 	if activeDeadlineSeconds == nil {

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -197,7 +197,7 @@ func (r *CheckpointReconciler) handlePending(ctx context.Context, ckpt *nvidiaco
 
 	// Use SyncResource to create/update the checkpoint Job
 	modified, _, err := commonController.SyncResource(ctx, r, ckpt, func(ctx context.Context) (*batchv1.Job, bool, error) {
-		job, err := buildCheckpointJob(r.Config, ckpt, jobName)
+		job, err := buildCheckpointJob(ctx, r.Client, r.Config, ckpt, jobName)
 		return job, false, err
 	})
 	if err != nil {

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -29,6 +29,7 @@ import (
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -65,6 +66,7 @@ var defaultCheckpointJobName = snapshotprotocol.GetCheckpointJobName(testHash, s
 func checkpointTestScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	_ = nvidiacomv1alpha1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
 	_ = corev1.AddToScheme(s)
 	_ = batchv1.AddToScheme(s)
 	_ = coordinationv1.AddToScheme(s)
@@ -130,6 +132,39 @@ func makeCheckpointLease(name string, renewTime time.Time, durationSeconds int32
 	}
 }
 
+func testSnapshotAgentDaemonSet() *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snapshot-agent",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				snapshotprotocol.SnapshotAgentLabelKey: snapshotprotocol.SnapshotAgentLabelValue,
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: snapshotprotocol.SnapshotAgentContainerName,
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "checkpoints",
+							MountPath: "/checkpoints",
+						}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "checkpoints",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "snapshot-pvc",
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
 func requireCheckpointContainer(t *testing.T, containers []corev1.Container, name string) *corev1.Container {
 	t.Helper()
 	for i := range containers {
@@ -150,7 +185,7 @@ func TestBuildCheckpointJob(t *testing.T) {
 	}
 
 	r := makeCheckpointReconciler(s, ckpt)
-	job, err := buildCheckpointJob(r.Config, ckpt, defaultCheckpointJobName)
+	job, err := buildCheckpointJob(context.Background(), nil, r.Config, ckpt, defaultCheckpointJobName)
 	require.NoError(t, err)
 	podSpec := job.Spec.Template.Spec
 	main := podSpec.Containers[0]
@@ -247,7 +282,7 @@ func TestBuildCheckpointJob(t *testing.T) {
 	backoff := int32(5)
 	ckpt.Spec.Job.ActiveDeadlineSeconds = &deadline
 	ckpt.Spec.Job.BackoffLimit = &backoff //nolint:staticcheck // Compatibility test: deprecated field must remain ignored by checkpoint Jobs.
-	job, err = buildCheckpointJob(r.Config, ckpt, defaultCheckpointJobName)
+	job, err = buildCheckpointJob(context.Background(), nil, r.Config, ckpt, defaultCheckpointJobName)
 	require.NoError(t, err)
 	assert.Equal(t, int64(7200), *job.Spec.ActiveDeadlineSeconds)
 	assert.Equal(t, int32(0), *job.Spec.BackoffLimit)
@@ -258,7 +293,7 @@ func TestBuildCheckpointJob(t *testing.T) {
 			corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("2"),
 		},
 	}
-	job, err = buildCheckpointJob(r.Config, ckpt, defaultCheckpointJobName)
+	job, err = buildCheckpointJob(context.Background(), nil, r.Config, ckpt, defaultCheckpointJobName)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"cuda-checkpoint"}, job.Spec.Template.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"--launch-job", "python3", "-m", "dynamo.vllm"}, job.Spec.Template.Spec.Containers[0].Args)
@@ -288,7 +323,7 @@ func TestBuildCheckpointJobTargetsMainContainerWhenSidecarIsFirst(t *testing.T) 
 	}
 
 	r := makeCheckpointReconciler(s, ckpt)
-	job, err := buildCheckpointJob(r.Config, ckpt, defaultCheckpointJobName)
+	job, err := buildCheckpointJob(context.Background(), nil, r.Config, ckpt, defaultCheckpointJobName)
 	require.NoError(t, err)
 
 	main := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, consts.MainContainerName)
@@ -317,6 +352,79 @@ func TestBuildCheckpointJobTargetsMainContainerWhenSidecarIsFirst(t *testing.T) 
 	}
 }
 
+func TestBuildCheckpointJobAddsGMSSidecars(t *testing.T) {
+	s := checkpointTestScheme()
+	ckpt := makeTestCheckpoint(nvidiacomv1alpha1.DynamoCheckpointPhasePending)
+	ckpt.Spec.GMS = true
+	snapshotAgentDaemonSet := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snapshot-agent",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				snapshotprotocol.SnapshotAgentLabelKey: snapshotprotocol.SnapshotAgentLabelValue,
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: snapshotprotocol.SnapshotAgentContainerName,
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      snapshotprotocol.SnapshotAgentVolumeName,
+							MountPath: "/checkpoints",
+						}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: snapshotprotocol.SnapshotAgentVolumeName,
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "snapshot-pvc",
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	reader := fake.NewClientBuilder().WithScheme(s).WithObjects(snapshotAgentDaemonSet).Build()
+
+	r := makeCheckpointReconciler(s, ckpt)
+	job, err := buildCheckpointJob(context.Background(), reader, r.Config, ckpt, defaultCheckpointJobName)
+	require.NoError(t, err)
+
+	main := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, consts.MainContainerName)
+	requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, checkpoint.GMSWeightsServerContainer)
+	requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, checkpoint.GMSKVCacheServerContainer)
+	saver := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, checkpoint.GMSSaverContainer)
+	requireCheckpointContainer(t, job.Spec.Template.Spec.InitContainers, checkpoint.GMSInitContainerName)
+
+	volNames := map[string]bool{}
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		volNames[v.Name] = true
+	}
+	assert.True(t, volNames[checkpoint.GMSSocketsVolumeName])
+	assert.True(t, volNames[checkpoint.GMSControlVolumeName])
+	assert.True(t, volNames[snapshotprotocol.CheckpointVolumeName])
+
+	mainMounts := map[string]string{}
+	for _, m := range main.VolumeMounts {
+		mainMounts[m.Name] = m.MountPath
+	}
+	assert.Equal(t, checkpoint.GMSSocketDir, mainMounts[checkpoint.GMSSocketsVolumeName])
+
+	saverMounts := map[string]string{}
+	for _, m := range saver.VolumeMounts {
+		saverMounts[m.Name] = m.MountPath
+	}
+	assert.Equal(t, "/checkpoints", saverMounts[snapshotprotocol.CheckpointVolumeName])
+
+	saverEnv := map[string]string{}
+	for _, env := range saver.Env {
+		saverEnv[env.Name] = env.Value
+	}
+	assert.Equal(t, "/checkpoints/"+testHash+"/versions/1", saverEnv["GMS_CHECKPOINT_DIR"])
+}
+
 func TestBuildCheckpointJobInjectsStandardEnvVars(t *testing.T) {
 	s := checkpointTestScheme()
 	ckpt := makeTestCheckpoint(nvidiacomv1alpha1.DynamoCheckpointPhasePending)
@@ -336,7 +444,7 @@ func TestBuildCheckpointJobInjectsStandardEnvVars(t *testing.T) {
 
 	customShmSize := resource.MustParse("16Gi")
 	ckpt.Spec.Job.SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{Size: customShmSize}
-	job, err := buildCheckpointJob(r.Config, ckpt, defaultCheckpointJobName)
+	job, err := buildCheckpointJob(context.Background(), nil, r.Config, ckpt, defaultCheckpointJobName)
 	require.NoError(t, err)
 	foundCustomShmVolume := false
 	for _, v := range job.Spec.Template.Spec.Volumes {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+	"github.com/stretchr/testify/require"
 	istioNetworking "istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1373,6 +1374,57 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		}
 		if got := podTemplateSpec.Labels[snapshotprotocol.CheckpointIDLabel]; got != checkpointName {
 			t.Fatalf("expected %s to be checkpoint id, got %q", snapshotprotocol.CheckpointIDLabel, got)
+		}
+	})
+
+	t.Run("ready gms checkpoint injects gms restore sidecars", func(t *testing.T) {
+		identity := v1alpha1.DynamoCheckpointIdentity{Model: "test-model", BackendFramework: "vllm"}
+		checkpointName, err := checkpoint.ComputeIdentityHash(identity)
+		if err != nil {
+			t.Fatalf("ComputeIdentityHash failed: %v", err)
+		}
+		dcd := makeDCD(checkpointName)
+		ckpt := &v1alpha1.DynamoCheckpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      checkpointName,
+				Namespace: "default",
+			},
+			Spec: v1alpha1.DynamoCheckpointSpec{Identity: identity, GMS: true},
+			Status: v1alpha1.DynamoCheckpointStatus{
+				Phase: v1alpha1.DynamoCheckpointPhaseReady,
+			},
+		}
+
+		r := makeReconciler(dcd, ckpt)
+		podTemplateSpec, err := r.generatePodTemplateSpec(
+			context.Background(),
+			generateResourceOption{dynamoComponentDeployment: dcd},
+			dynamo.RoleMain,
+		)
+		if err != nil {
+			t.Fatalf("generatePodTemplateSpec failed: %v", err)
+		}
+
+		find := func(name string) *corev1.Container {
+			for i := range podTemplateSpec.Spec.Containers {
+				if podTemplateSpec.Spec.Containers[i].Name == name {
+					return &podTemplateSpec.Spec.Containers[i]
+				}
+			}
+			return nil
+		}
+
+		require.NotNil(t, find(checkpoint.GMSWeightsServerContainer))
+		require.NotNil(t, find(checkpoint.GMSKVCacheServerContainer))
+		loader := find(checkpoint.GMSLoaderContainer)
+		require.NotNil(t, loader)
+
+		mounts := map[string]string{}
+		for _, mount := range loader.VolumeMounts {
+			mounts[mount.Name] = mount.MountPath
+		}
+		if got := mounts[snapshotprotocol.CheckpointVolumeName]; got != "/checkpoints" {
+			t.Fatalf("expected gms loader checkpoint mount at /checkpoints, got %q", got)
 		}
 	})
 

--- a/lib/gpu_memory_service/cli/__init__.py
+++ b/lib/gpu_memory_service/cli/__init__.py
@@ -4,7 +4,13 @@
 """CLI for GPU Memory Service."""
 
 from gpu_memory_service.cli.args import Config, parse_args
-from gpu_memory_service.cli.runner import main
+
+
+def main():
+    from gpu_memory_service.cli.runner import main as runner_main
+
+    return runner_main()
+
 
 __all__ = [
     "Config",

--- a/lib/gpu_memory_service/cli/storage_runner.py
+++ b/lib/gpu_memory_service/cli/storage_runner.py
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GMS Storage Client CLI.
+
+Provides two subcommands for saving and loading GPU Memory Service state:
+
+* ``save`` – connect to a running GMS server in RO mode and write every
+              allocation plus all metadata to a sharded binary directory.
+* ``load`` – connect to a running GMS server in RW mode, read tensor data
+              from a saved directory, and commit the state so readers can
+              acquire the RO lock.
+
+Usage examples::
+
+    # Save GMS state to disk
+    gms-storage-client save --output-dir /mnt/nvme/save --device 0
+
+    # Load a previous save back into a fresh GMS server
+    gms-storage-client load --input-dir /mnt/nvme/save --device 0
+"""
+
+import argparse
+import logging
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _configure_logging(verbose: bool) -> None:
+    if verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+        logging.getLogger("gpu_memory_service").setLevel(logging.DEBUG)
+
+
+def _resolve_socket(device: int, socket_path) -> str:
+    if socket_path is not None:
+        return socket_path
+    from gpu_memory_service.common.utils import get_socket_path
+
+    return get_socket_path(device)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand implementations
+# ---------------------------------------------------------------------------
+
+
+def _run_save(args) -> None:
+    """Execute the save subcommand."""
+    from gpu_memory_service.client.gms_storage_client import GMSStorageClient
+
+    _configure_logging(args.verbose)
+    socket_path = _resolve_socket(args.device, args.socket_path)
+
+    logger.info(
+        "Saving GMS state: device=%s, socket=%s, output_dir=%s, save_workers=%s",
+        args.device,
+        socket_path,
+        args.output_dir,
+        args.save_workers,
+    )
+
+    client = GMSStorageClient(
+        args.output_dir,
+        socket_path=socket_path,
+        device=args.device,
+        timeout_ms=args.timeout_ms,
+        shard_size_bytes=args.shard_size_bytes,
+    )
+
+    manifest = client.save(max_workers=args.save_workers)
+    shard_count = len({a.tensor_file for a in manifest.allocations})
+
+    logger.info(
+        "Save complete: %s allocations written to %s (%s shards)",
+        len(manifest.allocations),
+        args.output_dir,
+        shard_count,
+    )
+    logger.info("Layout hash: %s", manifest.layout_hash)
+
+
+def _run_load(args) -> None:
+    """Execute the load subcommand."""
+    from gpu_memory_service.client.gms_storage_client import GMSStorageClient
+
+    _configure_logging(args.verbose)
+    socket_path = _resolve_socket(args.device, args.socket_path)
+
+    logger.info(
+        "Loading GMS state: device=%s, socket=%s, input_dir=%s, clear_existing=%s",
+        args.device,
+        socket_path,
+        args.input_dir,
+        not args.no_clear,
+    )
+
+    client = GMSStorageClient(
+        socket_path=socket_path,
+        device=args.device,
+        timeout_ms=args.timeout_ms,
+    )
+
+    id_map = client.load_to_gms(
+        args.input_dir,
+        max_workers=args.workers,
+        clear_existing=not args.no_clear,
+    )
+
+    logger.info("Load complete: %s allocations committed to GMS", len(id_map))
+    for old_id, new_id in id_map.items():
+        logger.info("  %s → %s", old_id, new_id)
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+_SHARD_SIZE_DEFAULT = 4 * 1024**3  # 4 GiB
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gms-storage-client",
+        description="Save and load GPU Memory Service state to/from disk.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="subcommand")
+
+    # -- save ---------------------------------------------------------------
+    save_p = subparsers.add_parser(
+        "save",
+        help="Save GMS state to a sharded binary directory.",
+        description=(
+            "Connect to a running GMS server in RO mode and export every "
+            "allocation plus all metadata to a compact sharded binary format."
+        ),
+    )
+    save_p.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory to write into (created if absent).",
+    )
+    save_p.add_argument(
+        "--device",
+        type=int,
+        default=0,
+        help="CUDA device index (default: 0).",
+    )
+    save_p.add_argument(
+        "--socket-path",
+        type=str,
+        default=None,
+        help="GMS Unix socket path. Default uses GPU UUID-based path.",
+    )
+    save_p.add_argument(
+        "--timeout-ms",
+        type=int,
+        default=None,
+        help="Timeout in milliseconds for acquiring the RO lock.",
+    )
+    save_p.add_argument(
+        "--shard-size-bytes",
+        type=int,
+        default=_SHARD_SIZE_DEFAULT,
+        help=(
+            f"Soft upper bound per shard file in bytes "
+            f"(default: {_SHARD_SIZE_DEFAULT // 1024**3} GiB).  "
+            "Decrease to increase parallelism on save/load; increase to "
+            "reduce file count."
+        ),
+    )
+    save_p.add_argument(
+        "--save-workers",
+        type=int,
+        default=4,
+        help="Thread pool size for parallel shard writes (default: 4).",
+    )
+    save_p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging.",
+    )
+
+    # -- load ---------------------------------------------------------------
+    load_p = subparsers.add_parser(
+        "load",
+        help="Load a saved GMS state back into a running GMS server.",
+        description=(
+            "Connect to a running GMS server in RW mode, read tensor data "
+            "from a saved directory (reading each shard file sequentially), "
+            "and commit the state so readers can acquire the RO lock."
+        ),
+    )
+    load_p.add_argument(
+        "--input-dir",
+        required=True,
+        help="Directory previously created by the save subcommand.",
+    )
+    load_p.add_argument(
+        "--device",
+        type=int,
+        default=0,
+        help="CUDA device index (default: 0).",
+    )
+    load_p.add_argument(
+        "--socket-path",
+        type=str,
+        default=None,
+        help="GMS Unix socket path. Default uses GPU UUID-based path.",
+    )
+    load_p.add_argument(
+        "--timeout-ms",
+        type=int,
+        default=None,
+        help="Timeout in milliseconds for acquiring the RW lock.",
+    )
+    load_p.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        help="Thread pool size for parallel shard reads (default: 4).",
+    )
+    load_p.add_argument(
+        "--no-clear",
+        action="store_true",
+        default=False,
+        help=(
+            "Do not clear existing GMS allocations before loading. "
+            "Default behaviour clears the server to produce an exact replica."
+        ),
+    )
+    load_p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging.",
+    )
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Entry point for the GMS Storage Client CLI."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.subcommand is None:
+        parser.print_help()
+        sys.exit(1)
+
+    if args.subcommand == "save":
+        _run_save(args)
+    elif args.subcommand == "load":
+        _run_load(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/gpu_memory_service/client/_gms_storage_disk.py
+++ b/lib/gpu_memory_service/client/_gms_storage_disk.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import base64
+import errno
+import json
+import os
+import queue
+import threading
+from collections import defaultdict
+from concurrent.futures import CancelledError
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    import torch
+
+from gpu_memory_service.client._gms_storage_model import AllocationEntry, SaveManifest
+
+
+class ShardWriter:
+    """Packs allocation bytes sequentially into large binary shard files.
+
+    This is a single-threaded utility for streaming writes.  The parallel save
+    path in GMSStorageClient._write_shards assigns allocations to shards via
+    plan_shard_layout and writes each shard file concurrently, so it does not
+    use ShardWriter directly.  ShardWriter is kept as a public utility for
+    callers that want a simple sequential writer.
+    """
+
+    def __init__(self, shards_dir: str, shard_size_bytes: int = 4 * 1024**3) -> None:
+        self._shards_dir = shards_dir
+        self._shard_size = shard_size_bytes
+        self._shard_idx = -1
+        self._current_offset = 0
+        self._current_file: Optional[Any] = None
+        self._current_rel_path: str = ""
+        os.makedirs(shards_dir, exist_ok=True)
+
+    def _roll_shard(self) -> None:
+        if self._current_file is not None:
+            self._current_file.close()
+        self._shard_idx += 1
+        filename = f"shard_{self._shard_idx:04d}.bin"
+        abs_path = os.path.join(self._shards_dir, filename)
+        self._current_file = open(abs_path, "wb")
+        self._current_rel_path = os.path.join("shards", filename)
+        self._current_offset = 0
+
+    def write(self, tensor: torch.Tensor) -> Tuple[str, int]:
+        cpu = tensor.cpu() if hasattr(tensor, "is_cuda") and tensor.is_cuda else tensor
+        if hasattr(cpu, "is_contiguous") and not cpu.is_contiguous():
+            cpu = cpu.contiguous()
+        arr = cpu.numpy()
+        size = arr.nbytes
+        if self._current_file is None or (
+            self._current_offset > 0 and self._current_offset + size > self._shard_size
+        ):
+            self._roll_shard()
+
+        offset = self._current_offset
+        arr.tofile(self._current_file)
+        self._current_offset += size
+        return self._current_rel_path, offset
+
+    def close(self) -> None:
+        if self._current_file is not None:
+            self._current_file.close()
+            self._current_file = None
+
+    def __enter__(self) -> "ShardWriter":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+
+def read_shard_sequential(
+    abs_path: str,
+    sorted_entries: List[AllocationEntry],
+    device: int,
+    *,
+    pin_memory: bool = False,
+    os_module=os,
+    np_module=None,
+    torch_module=None,
+    logger=None,
+) -> Dict[str, torch.Tensor]:
+    """Read one shard file front-to-back without seeking."""
+    if np_module is None or torch_module is None:
+        raise RuntimeError("numpy and torch modules are required to read shards")
+
+    result: Dict[str, torch.Tensor] = {}
+    device_str = f"cuda:{device}" if device >= 0 else "cpu"
+
+    if abs_path.endswith(".pt"):
+        if len(sorted_entries) != 1:
+            raise RuntimeError(
+                f"Expected exactly 1 entry for legacy .pt file, got "
+                f"{len(sorted_entries)}: {abs_path}"
+            )
+        entry = sorted_entries[0]
+        result[entry.allocation_id] = torch_module.load(
+            abs_path,
+            weights_only=True,
+            map_location=device_str,
+        )
+        return result
+
+    odirect_flag = getattr(os_module, "O_DIRECT", None)
+    if odirect_flag is not None:
+        fd: Optional[int] = None
+        done = 0
+        try:
+            total_size = sum(entry.aligned_size for entry in sorted_entries)
+            if pin_memory and torch_module.cuda.is_available():
+                shard_t = torch_module.empty(
+                    total_size,
+                    dtype=torch_module.uint8,
+                    pin_memory=True,
+                )
+                arr = shard_t.numpy()
+            else:
+                shard_t = None
+                arr = np_module.empty(total_size, dtype=np_module.uint8)
+
+            fd = os_module.open(abs_path, os_module.O_RDONLY | odirect_flag)
+            try:
+                mv = memoryview(arr)
+                try:
+                    while done < total_size:
+                        read = os_module.readv(fd, [mv[done:]])
+                        if read == 0:
+                            raise RuntimeError(
+                                f"Unexpected EOF in O_DIRECT read from {abs_path}: "
+                                f"got {done} of {total_size} bytes"
+                            )
+                        done += read
+                finally:
+                    mv.release()
+            finally:
+                os_module.close(fd)
+
+            offset = 0
+            for entry in sorted_entries:
+                size = entry.aligned_size
+                if shard_t is not None:
+                    tensor = shard_t[offset : offset + size]
+                else:
+                    tensor = torch_module.from_numpy(arr[offset : offset + size])
+                if device >= 0:
+                    tensor = tensor.to(device_str)
+                result[entry.allocation_id] = tensor
+                offset += size
+            return result
+        except OSError as exc:
+            fallback_errnos = {errno.EINVAL, errno.EOPNOTSUPP}
+            if fd is not None and exc.errno not in fallback_errnos:
+                raise
+            result.clear()
+            if logger is not None:
+                if fd is None:
+                    logger.debug(
+                        "O_DIRECT unsupported on %s (errno %s); using buffered reads",
+                        abs_path,
+                        exc.errno,
+                    )
+                else:
+                    logger.debug(
+                        "O_DIRECT read on %s hit EINVAL after %d/%d bytes; using buffered reads",
+                        abs_path,
+                        done,
+                        total_size,
+                    )
+
+    if sorted_entries and sorted_entries[0].tensor_offset != 0:
+        raise RuntimeError(
+            f"Buffered shard read requires entries starting at offset 0, "
+            f"got {sorted_entries[0].tensor_offset} in {abs_path}"
+        )
+    with open(abs_path, "rb") as handle:
+        for entry in sorted_entries:
+            raw = handle.read(entry.aligned_size)
+            if len(raw) != entry.aligned_size:
+                raise RuntimeError(
+                    f"Short read from {abs_path} at offset {entry.tensor_offset}: "
+                    f"expected {entry.aligned_size} bytes, got {len(raw)}"
+                )
+            arr = np_module.frombuffer(raw, dtype=np_module.uint8).copy()
+            tensor = torch_module.from_numpy(arr)
+            if device >= 0:
+                tensor = tensor.to(device_str)
+            result[entry.allocation_id] = tensor
+    return result
+
+
+def decode_metadata(raw_meta: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    return {
+        key: {
+            "allocation_id": entry["allocation_id"],
+            "offset_bytes": int(entry["offset_bytes"]),
+            "value": base64.b64decode(entry["value"]),
+        }
+        for key, entry in raw_meta.items()
+    }
+
+
+def group_entries_by_shard(
+    allocations: List[AllocationEntry],
+) -> Dict[str, List[AllocationEntry]]:
+    groups: Dict[str, List[AllocationEntry]] = defaultdict(list)
+    for entry in allocations:
+        groups[entry.tensor_file].append(entry)
+    for entries in groups.values():
+        entries.sort(key=lambda entry: entry.tensor_offset)
+    return dict(groups)
+
+
+def plan_shard_layout(
+    allocations_info: List[Dict[str, Any]],
+    shard_size_bytes: int,
+) -> List[Tuple[int, int]]:
+    result: List[Tuple[int, int]] = []
+    shard_idx = -1
+    current_offset = 0
+    started = False
+    for alloc in allocations_info:
+        size = int(alloc["aligned_size"])
+        if not started or (
+            current_offset > 0 and current_offset + size > shard_size_bytes
+        ):
+            shard_idx += 1
+            current_offset = 0
+            started = True
+        result.append((shard_idx, current_offset))
+        current_offset += size
+    return result
+
+
+def read_shard_to_queue(
+    abs_path: str,
+    sorted_entries: List[AllocationEntry],
+    work_q: queue.Queue[Optional[Tuple[AllocationEntry, torch.Tensor]]],
+    *,
+    pin_memory: bool,
+    read_shard,
+    cancel_event: Optional[threading.Event] = None,
+) -> int:
+    shard_result = read_shard(
+        abs_path,
+        sorted_entries,
+        -1,
+        pin_memory=pin_memory,
+    )
+    for entry in sorted_entries:
+        while True:
+            if cancel_event is not None and cancel_event.is_set():
+                raise CancelledError(f"shard read cancelled: {abs_path}")
+            try:
+                work_q.put((entry, shard_result[entry.allocation_id]), timeout=0.1)
+                break
+            except queue.Full:
+                if cancel_event is not None and cancel_event.is_set():
+                    raise CancelledError(f"shard read cancelled: {abs_path}")
+    return len(sorted_entries)
+
+
+def load_manifest_and_metadata(
+    input_dir: str,
+) -> Tuple[SaveManifest, Dict[str, Dict[str, Any]]]:
+    manifest_path = os.path.join(input_dir, "manifest.json")
+    with open(manifest_path, encoding="utf-8") as handle:
+        manifest = SaveManifest.from_dict(json.load(handle))
+
+    metadata_path = os.path.join(input_dir, "gms_metadata.json")
+    raw_meta: Dict[str, Any] = {}
+    if os.path.exists(metadata_path):
+        with open(metadata_path, encoding="utf-8") as handle:
+            raw_meta = json.load(handle)
+
+    return manifest, decode_metadata(raw_meta)

--- a/lib/gpu_memory_service/client/_gms_storage_model.py
+++ b/lib/gpu_memory_service/client/_gms_storage_model.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List
+
+CURRENT_VERSION = "1.0"
+
+
+@dataclass(frozen=True)
+class AllocationEntry:
+    """Immutable record of one dumped allocation."""
+
+    allocation_id: str
+    size: int
+    aligned_size: int
+    tag: str
+    tensor_file: str
+    tensor_offset: int = 0
+
+
+@dataclass
+class SaveManifest:
+    """Manifest for a GMS dump directory."""
+
+    version: str
+    timestamp: float
+    layout_hash: str
+    device: int
+    allocations: List[AllocationEntry] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "timestamp": self.timestamp,
+            "layout_hash": self.layout_hash,
+            "device": self.device,
+            "allocations": [asdict(a) for a in self.allocations],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "SaveManifest":
+        version = payload["version"]
+        if version != CURRENT_VERSION:
+            raise ValueError(
+                f"Unsupported manifest version {version!r} "
+                f"(expected {CURRENT_VERSION!r})"
+            )
+        allocations = [
+            AllocationEntry(
+                allocation_id=entry["allocation_id"],
+                size=entry["size"],
+                aligned_size=entry["aligned_size"],
+                tag=entry["tag"],
+                tensor_file=entry["tensor_file"],
+                tensor_offset=entry.get("tensor_offset", 0),
+            )
+            for entry in payload.get("allocations", [])
+        ]
+        return cls(
+            version=payload["version"],
+            timestamp=payload["timestamp"],
+            layout_hash=payload["layout_hash"],
+            device=payload["device"],
+            allocations=allocations,
+        )

--- a/lib/gpu_memory_service/client/_gms_storage_restore.py
+++ b/lib/gpu_memory_service/client/_gms_storage_restore.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import queue
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    import torch
+
+from gpu_memory_service.client._gms_storage_model import AllocationEntry
+
+WORK_QUEUE_DEPTH_MULTIPLIER = 2
+
+
+@dataclass
+class RestorePipelineContext:
+    """Mutable state shared across disk, copy, and Phase A restore stages."""
+
+    worker_count: int
+    use_streams: bool
+    device: int
+    work_q: queue.Queue[Optional[Tuple[AllocationEntry, torch.Tensor]]]
+    va_events: Dict[str, threading.Event]
+    streams: List[torch.cuda.Stream]
+    cancel_event: threading.Event = field(default_factory=threading.Event)
+    vas: Dict[str, int] = field(default_factory=dict)
+    staged_srcs: List[torch.Tensor] = field(default_factory=list)
+    copy_errors: List[BaseException] = field(default_factory=list)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    @classmethod
+    def build(
+        cls,
+        allocations: List[AllocationEntry],
+        worker_count: int,
+        *,
+        device: int,
+        use_streams: bool,
+        torch_module,
+    ) -> "RestorePipelineContext":
+        streams = (
+            [torch_module.cuda.Stream(device=device) for _ in range(worker_count)]
+            if use_streams
+            else []
+        )
+        return cls(
+            worker_count=worker_count,
+            use_streams=use_streams,
+            device=device,
+            work_q=queue.Queue(maxsize=worker_count * WORK_QUEUE_DEPTH_MULTIPLIER),
+            va_events={entry.allocation_id: threading.Event() for entry in allocations},
+            streams=streams,
+        )
+
+
+@dataclass
+class RestorePipelineResources:
+    """Live restore pipeline resources that must be torn down together."""
+
+    ctx: RestorePipelineContext
+    disk_pool: ThreadPoolExecutor
+    disk_futures: Dict[Future[int], str]
+    copy_threads: List[threading.Thread]
+    active: bool = True

--- a/lib/gpu_memory_service/client/gms_storage_client.py
+++ b/lib/gpu_memory_service/client/gms_storage_client.py
@@ -102,6 +102,18 @@ def _group_entries_by_shard(
     return _group_entries_by_shard_impl(allocations)
 
 
+def _allocation_record(alloc: Any) -> Dict[str, Any]:
+    if isinstance(alloc, dict):
+        return alloc
+    return {
+        "allocation_id": str(alloc.allocation_id),
+        "size": int(alloc.size),
+        "aligned_size": int(alloc.aligned_size),
+        "tag": str(alloc.tag),
+        "layout_slot": int(alloc.layout_slot),
+    }
+
+
 def _plan_shard_layout(
     allocations_info: List[Dict[str, Any]],
     shard_size_bytes: int,
@@ -168,7 +180,9 @@ class GMSStorageClient:
                 raise RuntimeError(
                     "GMS server has no committed weights; nothing to dump"
                 )
-            allocations_info = mm.list_handles()
+            allocations_info = [
+                _allocation_record(alloc) for alloc in mm.list_handles()
+            ]
             va_list = self._import_source_mappings(mm, allocations_info)
             entries = self._write_shards(
                 shards_dir,

--- a/lib/gpu_memory_service/client/gms_storage_client.py
+++ b/lib/gpu_memory_service/client/gms_storage_client.py
@@ -1,0 +1,617 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GMS storage client: save GMS state to disk and load it back."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import queue
+import threading
+import time
+from collections import defaultdict
+from concurrent.futures import CancelledError, Future, ThreadPoolExecutor, as_completed
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+from gpu_memory_service.client._gms_storage_disk import (  # noqa: F401  re-exported for external callers
+    ShardWriter as _ShardWriter,
+)
+from gpu_memory_service.client._gms_storage_disk import (
+    decode_metadata as _decode_metadata_impl,
+)
+from gpu_memory_service.client._gms_storage_disk import (
+    group_entries_by_shard as _group_entries_by_shard_impl,
+)
+from gpu_memory_service.client._gms_storage_disk import (
+    load_manifest_and_metadata as _load_manifest_and_metadata_impl,
+)
+from gpu_memory_service.client._gms_storage_disk import (
+    plan_shard_layout as _plan_shard_layout_impl,
+)
+from gpu_memory_service.client._gms_storage_disk import (
+    read_shard_sequential as _read_shard_sequential_impl,
+)
+from gpu_memory_service.client._gms_storage_disk import (
+    read_shard_to_queue as _read_shard_to_queue_impl,
+)
+from gpu_memory_service.client._gms_storage_model import (
+    CURRENT_VERSION as _CURRENT_VERSION,
+)
+from gpu_memory_service.client._gms_storage_model import AllocationEntry, SaveManifest
+from gpu_memory_service.client._gms_storage_restore import (
+    RestorePipelineContext as _RestorePipelineContext,
+)
+from gpu_memory_service.client._gms_storage_restore import (
+    RestorePipelineResources as _RestorePipelineResources,
+)
+
+logger = logging.getLogger(__name__)
+
+try:
+    from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
+    from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
+    from gpu_memory_service.common.locks import RequestedLockType
+
+    _GMS_IMPORTS_AVAILABLE = True
+except ImportError:
+    _GMS_IMPORTS_AVAILABLE = False
+    GMSClientMemoryManager = None  # type: ignore[assignment,misc]
+    _tensor_from_pointer = None  # type: ignore[assignment]
+    RequestedLockType = None  # type: ignore[assignment]
+
+try:
+    import torch
+
+    _TORCH_AVAILABLE = True
+except ImportError:
+    _TORCH_AVAILABLE = False
+    torch = None  # type: ignore[assignment]
+
+
+def _read_shard_sequential(
+    abs_path: str,
+    sorted_entries: List[AllocationEntry],
+    device: int,
+    pin_memory: bool = False,
+) -> Dict[str, "torch.Tensor"]:
+    """Facade wrapper kept for test patchability and backwards compatibility."""
+    return _read_shard_sequential_impl(
+        abs_path,
+        sorted_entries,
+        device,
+        pin_memory=pin_memory,
+        os_module=os,
+        np_module=np,
+        torch_module=torch,
+        logger=logger,
+    )
+
+
+def _decode_metadata(raw_meta: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    # Re-exported for external callers (e.g. multi_ssd_bench.py).
+    return _decode_metadata_impl(raw_meta)
+
+
+def _group_entries_by_shard(
+    allocations: List[AllocationEntry],
+) -> Dict[str, List[AllocationEntry]]:
+    return _group_entries_by_shard_impl(allocations)
+
+
+def _plan_shard_layout(
+    allocations_info: List[Dict[str, Any]],
+    shard_size_bytes: int,
+) -> List[Tuple[int, int]]:
+    return _plan_shard_layout_impl(allocations_info, shard_size_bytes)
+
+
+def _read_shard_to_queue(
+    abs_path: str,
+    sorted_entries: List[AllocationEntry],
+    work_q: "queue.Queue[Optional[Tuple[AllocationEntry, 'torch.Tensor']]]",
+    *,
+    pin_memory: bool,
+    cancel_event: Optional[threading.Event] = None,
+) -> int:
+    return _read_shard_to_queue_impl(
+        abs_path,
+        sorted_entries,
+        work_q,
+        pin_memory=pin_memory,
+        read_shard=_read_shard_sequential,
+        cancel_event=cancel_event,
+    )
+
+
+def _load_manifest_and_metadata(
+    input_dir: str,
+) -> Tuple[SaveManifest, Dict[str, Dict[str, Any]]]:
+    return _load_manifest_and_metadata_impl(input_dir)
+
+
+class GMSStorageClient:
+    """Dump and restore GMS state to/from disk."""
+
+    def __init__(
+        self,
+        output_dir: Optional[str] = None,
+        socket_path: Optional[str] = None,
+        device: int = 0,
+        *,
+        timeout_ms: Optional[int] = None,
+        shard_size_bytes: int = 4 * 1024**3,
+    ) -> None:
+        self.output_dir = output_dir
+        self.device = device
+        self._timeout_ms = timeout_ms
+        self._shard_size = shard_size_bytes
+
+        if socket_path is None:
+            from gpu_memory_service.common.utils import get_socket_path
+
+            socket_path = get_socket_path(device)
+        self._socket_path = socket_path
+
+    def save(self, max_workers: int = 4) -> SaveManifest:
+        """Connect to GMS in RO mode and save all allocations + metadata to disk."""
+        self._validate_save_request()
+        output_dir, shards_dir = self._prepare_output_dir()
+
+        with GMSClientMemoryManager(self._socket_path, device=self.device) as mm:
+            mm.connect(RequestedLockType.RO, timeout_ms=self._timeout_ms)
+            layout_hash = mm.get_memory_layout_hash()
+            if not layout_hash:
+                raise RuntimeError(
+                    "GMS server has no committed weights; nothing to dump"
+                )
+            allocations_info = mm.list_handles()
+            va_list = self._import_source_mappings(mm, allocations_info)
+            entries = self._write_shards(
+                shards_dir,
+                allocations_info,
+                va_list,
+                max_workers=max_workers,
+            )
+            metadata = self._save_metadata(mm)
+
+        self._write_json(os.path.join(output_dir, "gms_metadata.json"), metadata)
+        manifest = SaveManifest(
+            version=_CURRENT_VERSION,
+            timestamp=time.time(),
+            layout_hash=layout_hash,
+            device=self.device,
+            allocations=entries,
+        )
+        self._write_json(os.path.join(output_dir, "manifest.json"), manifest.to_dict())
+        logger.info("Wrote manifest with %d allocations", len(entries))
+        return manifest
+
+    def _validate_save_request(self) -> None:
+        if not _GMS_IMPORTS_AVAILABLE:
+            raise RuntimeError(
+                "GMS client imports unavailable (missing cuda-python or torch)"
+            )
+        if self.output_dir is None:
+            raise ValueError(
+                "output_dir must be set to call save(); pass it to GMSStorageClient()"
+            )
+
+    def _prepare_output_dir(self) -> Tuple[str, str]:
+        assert self.output_dir is not None
+        os.makedirs(self.output_dir, exist_ok=True)
+        shards_dir = os.path.join(self.output_dir, "shards")
+        os.makedirs(shards_dir, exist_ok=True)
+        for name in os.listdir(shards_dir):
+            if name.startswith("shard_") and name.endswith(".bin"):
+                os.unlink(os.path.join(shards_dir, name))
+        return self.output_dir, shards_dir
+
+    def _import_source_mappings(
+        self,
+        mm: Any,
+        allocations_info: List[Dict[str, Any]],
+    ) -> List[int]:
+        va_list = [
+            mm.create_mapping(allocation_id=alloc["allocation_id"])
+            for alloc in allocations_info
+        ]
+        logger.info("Phase A complete: imported %d allocation VAs", len(va_list))
+        return va_list
+
+    def _write_shards(
+        self,
+        shards_dir: str,
+        allocations_info: List[Dict[str, Any]],
+        va_list: List[int],
+        *,
+        max_workers: int,
+    ) -> List[AllocationEntry]:
+        layout = _plan_shard_layout(allocations_info, self._shard_size)
+        shard_groups: Dict[int, List[Tuple[int, int]]] = defaultdict(list)
+        for index, (shard_idx, byte_offset) in enumerate(layout):
+            shard_groups[shard_idx].append((index, byte_offset))
+
+        entries: List[Optional[AllocationEntry]] = [None] * len(allocations_info)
+
+        def _write_one_shard(
+            shard_idx: int, alloc_pairs: List[Tuple[int, int]]
+        ) -> None:
+            filename = f"shard_{shard_idx:04d}.bin"
+            abs_path = os.path.join(shards_dir, filename)
+            rel_path = os.path.join("shards", filename)
+            with open(abs_path, "wb") as handle:
+                for index, byte_offset in alloc_pairs:
+                    alloc = allocations_info[index]
+                    aligned_size = int(alloc["aligned_size"])
+                    tensor = _tensor_from_pointer(
+                        va_list[index],
+                        [aligned_size],
+                        [1],
+                        torch.uint8,
+                        self.device,
+                    )
+                    tensor.cpu().numpy().tofile(handle)
+                    entries[index] = AllocationEntry(
+                        allocation_id=alloc["allocation_id"],
+                        size=int(alloc["size"]),
+                        aligned_size=aligned_size,
+                        tag=str(alloc.get("tag", "default")),
+                        tensor_file=rel_path,
+                        tensor_offset=byte_offset,
+                    )
+
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {
+                pool.submit(_write_one_shard, shard_idx, alloc_pairs): shard_idx
+                for shard_idx, alloc_pairs in shard_groups.items()
+            }
+            for future in as_completed(futures):
+                future.result()
+
+        missing = sum(1 for entry in entries if entry is None)
+        if missing:
+            raise RuntimeError(
+                f"BUG: {missing} allocation(s) missing after shard writers completed"
+            )
+        logger.info("Phase B complete: wrote %d shards", len(shard_groups))
+        return [entry for entry in entries if entry is not None]
+
+    def _write_json(self, path: str, payload: Dict[str, Any]) -> None:
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+
+    def _run_restore_copy_worker(
+        self,
+        ctx: _RestorePipelineContext,
+        stream_idx: int,
+    ) -> None:
+        while True:
+            try:
+                item = ctx.work_q.get(timeout=0.1)
+            except queue.Empty:
+                if ctx.cancel_event.is_set():
+                    return
+                continue
+            if item is None:
+                return
+
+            entry, src = item
+            try:
+                while not ctx.va_events[entry.allocation_id].wait(timeout=0.1):
+                    if ctx.cancel_event.is_set():
+                        return
+                dst = _tensor_from_pointer(
+                    ctx.vas[entry.allocation_id],
+                    [entry.aligned_size],
+                    [1],
+                    torch.uint8,
+                    self.device,
+                )
+                if ctx.streams:
+                    with torch.cuda.stream(ctx.streams[stream_idx]):
+                        dst.copy_(src, non_blocking=src.is_pinned())
+                else:
+                    dst.copy_(src)
+                if ctx.use_streams and src.is_pinned():
+                    with ctx.lock:
+                        ctx.staged_srcs.append(src)
+            except Exception as exc:  # noqa: BLE001
+                with ctx.lock:
+                    ctx.copy_errors.append(exc)
+
+    def _start_restore_copy_threads(
+        self,
+        ctx: _RestorePipelineContext,
+    ) -> List[threading.Thread]:
+        threads = [
+            threading.Thread(
+                target=self._run_restore_copy_worker,
+                args=(ctx, index),
+                daemon=True,
+            )
+            for index in range(ctx.worker_count)
+        ]
+        for thread in threads:
+            thread.start()
+        return threads
+
+    def _prepare_restore_pipeline(
+        self,
+        manifest: SaveManifest,
+        groups: Dict[str, List[AllocationEntry]],
+        worker_count: int,
+        input_dir: str,
+    ) -> _RestorePipelineResources:
+        ctx = _RestorePipelineContext.build(
+            manifest.allocations,
+            worker_count,
+            device=self.device,
+            use_streams=_TORCH_AVAILABLE and torch.cuda.is_available(),
+            torch_module=torch,
+        )
+        copy_threads = self._start_restore_copy_threads(ctx)
+        disk_pool = ThreadPoolExecutor(max_workers=worker_count)
+        disk_futures = {
+            disk_pool.submit(
+                _read_shard_to_queue,
+                os.path.join(input_dir, rel_path),
+                sorted_entries,
+                ctx.work_q,
+                pin_memory=ctx.use_streams,
+                cancel_event=ctx.cancel_event,
+            ): rel_path
+            for rel_path, sorted_entries in groups.items()
+        }
+        return _RestorePipelineResources(
+            ctx=ctx,
+            disk_pool=disk_pool,
+            disk_futures=disk_futures,
+            copy_threads=copy_threads,
+        )
+
+    def _allocate_restore_mappings(
+        self,
+        mm: Any,
+        manifest: SaveManifest,
+        ctx: _RestorePipelineContext,
+    ) -> Dict[str, str]:
+        id_map: Dict[str, str] = {}
+        for entry in manifest.allocations:
+            old_id = entry.allocation_id
+            va = mm.create_mapping(size=entry.size, tag=entry.tag)
+            id_map[old_id] = mm.get_allocation_id(va)
+            ctx.vas[old_id] = va
+            ctx.va_events[old_id].set()
+        logger.info(
+            "Phase A complete: allocated %d GMS VAs; waiting for disk/copy pipeline",
+            len(ctx.vas),
+        )
+        return id_map
+
+    def _await_disk_reads(self, disk_futures: Dict[Future[int], str]) -> None:
+        for future in as_completed(disk_futures):
+            rel_path = disk_futures[future]
+            try:
+                future.result()
+            except CancelledError:
+                pass
+            except Exception as exc:
+                raise RuntimeError(f"Failed to load shard {rel_path}: {exc}") from exc
+
+    def _stop_restore_copy_threads(
+        self,
+        ctx: _RestorePipelineContext,
+        threads: List[threading.Thread],
+        *,
+        drain_queue: bool = False,
+    ) -> None:
+        if drain_queue:
+            self._drain_restore_queue(ctx)
+        for _ in threads:
+            if drain_queue:
+                # Cancel path: workers may have exited, so drain to make room.
+                while True:
+                    try:
+                        ctx.work_q.put(None, timeout=0.1)
+                        break
+                    except queue.Full:
+                        self._drain_restore_queue(ctx)
+            else:
+                # Normal path: disk reads are done and workers are alive; block
+                # until a slot opens rather than spinning with a timeout.
+                ctx.work_q.put(None)
+        for thread in threads:
+            thread.join()
+
+    def _drain_restore_queue(self, ctx: _RestorePipelineContext) -> None:
+        while True:
+            try:
+                ctx.work_q.get_nowait()
+            except queue.Empty:
+                return
+
+    def _cancel_restore_pipeline(self, ctx: _RestorePipelineContext) -> None:
+        ctx.cancel_event.set()
+        for event in ctx.va_events.values():
+            event.set()
+        self._drain_restore_queue(ctx)
+
+    def _finalize_restore_pipeline(self, ctx: _RestorePipelineContext) -> None:
+        if ctx.use_streams:
+            torch.cuda.synchronize(device=self.device)
+            ctx.staged_srcs.clear()
+        if ctx.copy_errors:
+            raise RuntimeError(
+                f"Failed to copy restored data to GMS: {ctx.copy_errors[0]}"
+            )
+
+    def _drain_restore_pipeline(self, resources: _RestorePipelineResources) -> None:
+        disk_error: Optional[BaseException] = None
+        finalize_error: Optional[BaseException] = None
+        drain_queue = False
+        try:
+            self._await_disk_reads(resources.disk_futures)
+        except Exception as exc:
+            disk_error = exc
+            self._cancel_restore_pipeline(resources.ctx)
+            drain_queue = True
+            resources.disk_pool.shutdown(wait=True, cancel_futures=True)
+        else:
+            resources.disk_pool.shutdown(wait=True)
+        try:
+            self._stop_restore_copy_threads(
+                resources.ctx,
+                resources.copy_threads,
+                drain_queue=drain_queue,
+            )
+        finally:
+            resources.active = False
+            try:
+                self._finalize_restore_pipeline(resources.ctx)
+            except Exception as exc:  # noqa: BLE001
+                finalize_error = exc
+        if disk_error is not None:
+            raise disk_error
+        if finalize_error is not None:
+            raise finalize_error
+
+    def _shutdown_restore_pipeline(
+        self,
+        resources: _RestorePipelineResources,
+    ) -> None:
+        if not resources.active:
+            return
+        self._cancel_restore_pipeline(resources.ctx)
+        resources.disk_pool.shutdown(wait=True, cancel_futures=True)
+        self._stop_restore_copy_threads(
+            resources.ctx,
+            resources.copy_threads,
+            drain_queue=True,
+        )
+        resources.active = False
+        # Synchronize async copies to prevent use-after-free of staged pinned
+        # buffers, but suppress copy errors — the caller already has an error
+        # to propagate and we must not mask it.
+        try:
+            self._finalize_restore_pipeline(resources.ctx)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def load_to_gms(
+        self,
+        input_dir: str,
+        *,
+        max_workers: int = 4,
+        clear_existing: bool = True,
+    ) -> Dict[str, str]:
+        if not _GMS_IMPORTS_AVAILABLE:
+            raise RuntimeError(
+                "GMS client imports unavailable (missing cuda-python or torch)"
+            )
+
+        manifest, saved_metadata = _load_manifest_and_metadata(input_dir)
+        groups = _group_entries_by_shard(manifest.allocations)
+        worker_count = max(1, min(max_workers, len(groups) or 1))
+
+        with GMSClientMemoryManager(self._socket_path, device=self.device) as mm:
+            mm.connect(RequestedLockType.RW, timeout_ms=self._timeout_ms)
+            if clear_existing:
+                logger.info("RW connect cleared any previously committed GMS state")
+
+            resources = self._prepare_restore_pipeline(
+                manifest,
+                groups,
+                worker_count,
+                input_dir,
+            )
+            try:
+                id_map = self._allocate_restore_mappings(mm, manifest, resources.ctx)
+                self._drain_restore_pipeline(resources)
+            except Exception:
+                self._shutdown_restore_pipeline(resources)
+                raise
+
+            logger.info(
+                "Phase B complete: streamed %d allocations to GMS memory",
+                len(manifest.allocations),
+            )
+            self._restore_metadata(mm, saved_metadata, id_map)
+            if not mm.commit():
+                raise RuntimeError("GMS commit failed after restore")
+
+        logger.info(
+            "load_to_gms complete: %d allocations, %d metadata keys",
+            len(id_map),
+            len(saved_metadata),
+        )
+        return id_map
+
+    def _restore_metadata(
+        self,
+        mm: Any,
+        saved_metadata: Dict[str, Dict[str, Any]],
+        id_map: Dict[str, str],
+    ) -> None:
+        for key, meta in saved_metadata.items():
+            old_alloc_id = meta["allocation_id"]
+            new_alloc_id = id_map.get(old_alloc_id, old_alloc_id)
+            ok = mm.metadata_put(key, new_alloc_id, meta["offset_bytes"], meta["value"])
+            if not ok:
+                raise RuntimeError(f"Failed to write metadata key={key!r}")
+            logger.debug("Restored metadata key=%s -> alloc=%s", key, new_alloc_id)
+        logger.info("Restored %d metadata keys; committing", len(saved_metadata))
+
+    @staticmethod
+    def load_tensors(
+        input_dir: str,
+        device: int = 0,
+        *,
+        max_workers: int = 4,
+    ) -> Tuple[Dict[str, "torch.Tensor"], Dict[str, Dict[str, Any]]]:
+        if not _TORCH_AVAILABLE:
+            raise RuntimeError("PyTorch is required for load_tensors()")
+
+        manifest, metadata = _load_manifest_and_metadata(input_dir)
+        groups = _group_entries_by_shard(manifest.allocations)
+        tensors: Dict[str, "torch.Tensor"] = {}
+
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {
+                pool.submit(
+                    _read_shard_sequential,
+                    os.path.join(input_dir, rel_path),
+                    sorted_entries,
+                    device,
+                ): rel_path
+                for rel_path, sorted_entries in groups.items()
+            }
+            for future in as_completed(futures):
+                rel_path = futures[future]
+                try:
+                    tensors.update(future.result())
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Failed to load shard {rel_path}: {exc}"
+                    ) from exc
+
+        logger.info("Loaded %d allocations from %s", len(tensors), input_dir)
+        return tensors, metadata
+
+    def _save_metadata(self, mm: Any) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        for key in mm.metadata_list():
+            got = mm.metadata_get(key)
+            if got is None:
+                logger.warning("Metadata key disappeared during dump: %s", key)
+                continue
+            allocation_id, offset_bytes, value = got
+            result[key] = {
+                "allocation_id": str(allocation_id),
+                "offset_bytes": int(offset_bytes),
+                "value": base64.b64encode(value).decode("ascii"),
+            }
+        return result

--- a/lib/gpu_memory_service/common/cuda_utils.py
+++ b/lib/gpu_memory_service/common/cuda_utils.py
@@ -174,6 +174,11 @@ def cuda_synchronize() -> None:
 def cuda_set_current_device(device: int) -> None:
     global _primary_context_release_registered
 
+    # Fresh helper processes (for example gms-storage-client save/load) may be
+    # the first CUDA users in the container. cuDevicePrimaryCtxRetain requires
+    # the driver to be initialized first.
+    cuda_ensure_initialized()
+
     ctx = _primary_contexts.get(device)
     if ctx is None:
         result, ctx = cuda.cuDevicePrimaryCtxRetain(device)

--- a/lib/gpu_memory_service/common/cuda_utils.py
+++ b/lib/gpu_memory_service/common/cuda_utils.py
@@ -52,6 +52,8 @@ def cumem_get_allocation_granularity(device: int) -> int:
     Returns:
         Allocation granularity in bytes (typically 2 MiB)
     """
+    cuda_ensure_initialized()
+
     prop = cuda.CUmemAllocationProp()
     prop.type = cuda.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
     prop.location.type = cuda.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE

--- a/lib/gpu_memory_service/common/utils.py
+++ b/lib/gpu_memory_service/common/utils.py
@@ -38,4 +38,5 @@ def get_socket_path(device: int, tag: str = "weights") -> str:
         uuid = pynvml.nvmlDeviceGetUUID(handle)
     finally:
         pynvml.nvmlShutdown()
-    return os.path.join(tempfile.gettempdir(), f"gms_{uuid}_{tag}.sock")
+    socket_dir = os.environ.get("GMS_SOCKET_DIR") or tempfile.gettempdir()
+    return os.path.join(socket_dir, f"gms_{uuid}_{tag}.sock")

--- a/lib/gpu_memory_service/pyproject.toml
+++ b/lib/gpu_memory_service/pyproject.toml
@@ -36,6 +36,7 @@ keywords = ["llm", "genai", "inference", "nvidia", "gpu", "memory", "dynamo"]
 
 [project.scripts]
 gpu-memory-service = "gpu_memory_service.cli.runner:main"
+gms-storage-client = "gpu_memory_service.cli.storage_runner:main"
 
 [project.optional-dependencies]
 test = [

--- a/lib/gpu_memory_service/setup.py
+++ b/lib/gpu_memory_service/setup.py
@@ -98,6 +98,12 @@ setup(
     package_data={
         "gpu_memory_service.client.torch.extensions": ["*.cpp"],
     },
+    entry_points={
+        "console_scripts": [
+            "gpu-memory-service=gpu_memory_service.cli.runner:main",
+            "gms-storage-client=gpu_memory_service.cli.storage_runner:main",
+        ]
+    },
     ext_modules=_create_ext_modules(),
     cmdclass={"build_ext": BuildExtension},
 )

--- a/lib/gpu_memory_service/tests/test_gms_storage_smoke.py
+++ b/lib/gpu_memory_service/tests/test_gms_storage_smoke.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import json
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from gpu_memory_service.cli.storage_runner import _build_parser
+from gpu_memory_service.client._gms_storage_disk import load_manifest_and_metadata
+from gpu_memory_service.client._gms_storage_model import AllocationEntry, SaveManifest
+from gpu_memory_service.common import cuda_utils
+
+
+class GMSStorageSmokeTest(unittest.TestCase):
+    def test_manifest_round_trip(self) -> None:
+        manifest = SaveManifest(
+            version="1.0",
+            timestamp=123.0,
+            layout_hash="abc",
+            device=2,
+            allocations=[
+                AllocationEntry(
+                    allocation_id="alloc-1",
+                    size=16,
+                    aligned_size=32,
+                    tag="weights",
+                    tensor_file="shards/shard_0000.bin",
+                    tensor_offset=64,
+                )
+            ],
+        )
+
+        restored = SaveManifest.from_dict(manifest.to_dict())
+
+        self.assertEqual(restored.version, "1.0")
+        self.assertEqual(restored.layout_hash, "abc")
+        self.assertEqual(restored.device, 2)
+        self.assertEqual(len(restored.allocations), 1)
+        self.assertEqual(restored.allocations[0].tensor_offset, 64)
+
+    def test_load_manifest_and_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = {
+                "version": "1.0",
+                "timestamp": 1.0,
+                "layout_hash": "layout",
+                "device": 0,
+                "allocations": [
+                    {
+                        "allocation_id": "alloc-1",
+                        "size": 4,
+                        "aligned_size": 8,
+                        "tag": "weights",
+                        "tensor_file": "shards/shard_0000.bin",
+                        "tensor_offset": 0,
+                    }
+                ],
+            }
+            metadata = {
+                "tensor-key": {
+                    "allocation_id": "alloc-1",
+                    "offset_bytes": 0,
+                    "value": base64.b64encode(b"payload").decode("ascii"),
+                }
+            }
+            (root / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            (root / "gms_metadata.json").write_text(
+                json.dumps(metadata),
+                encoding="utf-8",
+            )
+
+            loaded_manifest, loaded_metadata = load_manifest_and_metadata(tmpdir)
+
+            self.assertEqual(loaded_manifest.layout_hash, "layout")
+            self.assertEqual(loaded_manifest.allocations[0].allocation_id, "alloc-1")
+            self.assertEqual(loaded_metadata["tensor-key"]["value"], b"payload")
+
+    def test_cli_parser_builds_save_and_load_commands(self) -> None:
+        parser = _build_parser()
+
+        save_args = parser.parse_args(["save", "--output-dir", "/tmp/out"])
+        load_args = parser.parse_args(["load", "--input-dir", "/tmp/in"])
+
+        self.assertEqual(save_args.subcommand, "save")
+        self.assertEqual(save_args.device, 0)
+        self.assertEqual(load_args.subcommand, "load")
+        self.assertEqual(load_args.workers, 4)
+
+    def test_cuda_set_current_device_initializes_before_retain(self) -> None:
+        calls: list[object] = []
+        fake_cuda = types.SimpleNamespace(
+            CUresult=types.SimpleNamespace(CUDA_SUCCESS=0),
+            cuInit=lambda flags: calls.append("cuInit") or (0,),
+            cuDevicePrimaryCtxRetain=lambda device: calls.append(
+                ("retain", device)
+            ) or (0, f"ctx-{device}"),
+            cuCtxSetCurrent=lambda ctx: calls.append(("set", ctx)) or (0,),
+            cuDevicePrimaryCtxRelease=lambda device: (0,),
+        )
+
+        with mock.patch.object(cuda_utils, "cuda", fake_cuda):
+            with mock.patch.object(cuda_utils, "_primary_contexts", {}):
+                with mock.patch.object(
+                    cuda_utils,
+                    "_primary_context_release_registered",
+                    False,
+                ):
+                    cuda_utils.cuda_set_current_device(3)
+
+        self.assertEqual(calls[0], "cuInit")
+        self.assertEqual(calls[1], ("retain", 3))
+        self.assertEqual(calls[2], ("set", "ctx-3"))
+
+    def test_cumem_get_allocation_granularity_initializes_first(self) -> None:
+        calls: list[object] = []
+
+        class _Prop:
+            def __init__(self) -> None:
+                self.type = None
+                self.location = types.SimpleNamespace(type=None, id=None)
+                self.requestedHandleTypes = None
+
+        fake_cuda = types.SimpleNamespace(
+            CUresult=types.SimpleNamespace(CUDA_SUCCESS=0),
+            CUmemAllocationProp=_Prop,
+            CUmemAllocationType=types.SimpleNamespace(
+                CU_MEM_ALLOCATION_TYPE_PINNED=1
+            ),
+            CUmemLocationType=types.SimpleNamespace(
+                CU_MEM_LOCATION_TYPE_DEVICE=2
+            ),
+            CUmemAllocationHandleType=types.SimpleNamespace(
+                CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR=3
+            ),
+            CUmemAllocationGranularity_flags=types.SimpleNamespace(
+                CU_MEM_ALLOC_GRANULARITY_MINIMUM=4
+            ),
+            cuInit=lambda flags: calls.append("cuInit") or (0,),
+            cuMemGetAllocationGranularity=lambda prop, flag: calls.append(
+                ("granularity", prop.location.id, flag)
+            ) or (0, 2097152),
+        )
+
+        with mock.patch.object(cuda_utils, "cuda", fake_cuda):
+            granularity = cuda_utils.cumem_get_allocation_granularity(5)
+
+        self.assertEqual(granularity, 2097152)
+        self.assertEqual(calls[0], "cuInit")
+        self.assertEqual(calls[1], ("granularity", 5, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add operator-managed GMS checkpoint/restore support through `DynamoCheckpoint` and checkpoint-backed restore pods
- inject GMS sidecars for checkpoint and restore, including shared DRA claim wiring for sidecars
- add the GMS storage runtime and fix save/load issues around CUDA init, visible GPU selection, socket path resolution, and allocation response handling
- preserve restore pod `/etc/podinfo` projection and wait for checkpoint pod readiness before starting `gms-saver`

## Validation
- `go test ./deploy/operator/internal/checkpoint -run 'TestInjectCheckpointIntoPodSpec|TestResolveCheckpointForService'`
- `go test ./deploy/operator/internal/controller -run 'TestBuildCheckpointJobAddsGMSSidecars'`
- `go build ./deploy/operator/cmd/main.go`
- `PYTHONPATH=lib python3 -m unittest gpu_memory_service.tests.test_gms_storage_smoke`
- manual nscale validation of checkpoint and restore with GMS sidecars
- end-to-end checkpoint/restore is operational; small deterministic prompt differences appear model-behavior-related rather than restore corruption


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU Memory Service (GMS) support for checkpoint creation and restore operations via optional `spec.gms` field in checkpoint configurations.
  * Introduced `gms-storage-client` command-line utility for saving and loading GPU memory allocations to/from disk.
  * Added environment variable configuration (`GMS_SOCKET_DIR`) for customizable socket paths.

* **Bug Fixes**
  * Fixed export handle caching to avoid redundant operations.
  * Improved multi-container pod handling with explicit "main" container targeting.

* **Documentation**
  * Updated GMS protocol documentation with FD caching behavior and commit/abort semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->