### PR TITLE
fix(kvbm): set CUDA device per rank before ncclCommInitRank

### DIFF
--- a/lib/bindings/kvbm/python/kvbm/trtllm_integration/connector/kvbm_connector_worker.py
+++ b/lib/bindings/kvbm/python/kvbm/trtllm_integration/connector/kvbm_connector_worker.py
@@ -88,13 +88,16 @@ def _create_kvbm_nccl_comm(rank: int, world_size: int):
 
     logger.info(f"KVBM: Rank {rank} bootstrap world_size={bootstrap.world_size()}")
 
-    # Trust the framework (TRT-LLM / MPI launcher) to have already
-    # set the correct CUDA device for this rank, either via
-    # CUDA_VISIBLE_DEVICES or its own initialization.
-    current_device = torch.cuda.current_device()
+    # TRT-LLM MPI launch exposes all GPUs to each rank but manages device
+    # assignment internally. torch.cuda.current_device() defaults to 0 for
+    # all ranks, which causes ncclCommInitRank to fail (all ranks on same
+    # device). Explicitly set the device to match the MPI rank.
+    device_count = torch.cuda.device_count()
+    device_id = rank % device_count
+    torch.cuda.set_device(device_id)
     logger.info(
-        f"KVBM: Rank {rank} on CUDA device {current_device} "
-        f"(device_count={torch.cuda.device_count()})"
+        f"KVBM: Rank {rank} set to CUDA device {device_id} "
+        f"(device_count={device_count})"
     )
 
     logger.info(f"KVBM: Rank {rank} waiting at MPI barrier " "before ncclCommInitRank")

--- a/lib/bindings/kvbm/python/kvbm/trtllm_integration/connector/kvbm_connector_worker.py
+++ b/lib/bindings/kvbm/python/kvbm/trtllm_integration/connector/kvbm_connector_worker.py
@@ -93,6 +93,10 @@ def _create_kvbm_nccl_comm(rank: int, world_size: int):
     # all ranks, which causes ncclCommInitRank to fail (all ranks on same
     # device). Explicitly set the device to match the MPI rank.
     device_count = torch.cuda.device_count()
+    if device_count <= 0:
+        raise RuntimeError(
+            "KVBM NCCL MLA mode requires at least one visible CUDA device."
+        )
     device_id = rank % device_count
     torch.cuda.set_device(device_id)
     logger.info(


### PR DESCRIPTION
## Summary
Explicitly set `torch.cuda.set_device(rank % device_count)` before calling `ncclCommInitRank` in the KVBM NCCL MLA bootstrap.

## Problem
In TRT-LLM MPI launch (`trtllm-llmapi-launch`), all GPUs are visible to each rank but device assignment is managed internally by TRT-LLM. The KVBM code trusted `torch.cuda.current_device()` to return the correct device, but it defaults to **device 0 for all ranks**.

This causes `ncclCommInitRank` to fail with `ncclInvalidUsage` because all 4 ranks attempt to create a communicator on the same CUDA device (0).

Verified via `NCCL_DEBUG=INFO`:
```
[Rank 2] ncclCommInitRankConfig ... cudaDev 0  <-- should be cudaDev 2
```

## Evidence
Aniket's working test (from Slack thread) showed correct device assignment:
```
KVBM: Rank 0 set to CUDA device 0
KVBM: Rank 1 set to CUDA device 1
KVBM: Rank 2 set to CUDA device 2
KVBM: Rank 3 set to CUDA device 3
```

Our failing runs showed all ranks on device 0:
```
KVBM: Rank 0 on CUDA device 0 (device_count=4)
```

## Fix
Replace the passive `torch.cuda.current_device()` read with an explicit `torch.cuda.set_device(rank % device_count)` call.

## Test plan
- [x] KVBM NCCL MLA mode initializes successfully on TRT-LLM TP4 (Lyris GB200)
- [x] `NCCL_DEBUG=INFO` shows each rank on its own cudaDev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced multi-GPU environment handling by implementing explicit device assignment per process rank, ensuring reliable GPU utilization and stability in distributed computing setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->