### PR TITLE
checkpoint: operator-managed GMS checkpoint/restore support

### DIFF
--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocheckpoints.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocheckpoints.yaml
@@ -67,6 +67,18 @@ spec:
             spec:
               description: DynamoCheckpointSpec defines the desired state of DynamoCheckpoint
               properties:
+                gpuMemoryService:
+                  description: |-
+                    GPUMemoryService enables checkpoint-time GPU Memory Service wiring.
+                    It is intentionally outside spec.identity, so it does not affect the
+                    checkpoint identity hash or deduplication.
+                  properties:
+                    enabled:
+                      description: Enabled activates GPU Memory Service for this workload or checkpoint.
+                      type: boolean
+                  required:
+                    - enabled
+                  type: object
                 identity:
                   description: Identity defines the inputs that determine checkpoint equivalence
                   properties:

--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocomponentdeployments.yaml
@@ -687,7 +687,7 @@ spec:
                       type: boolean
                     identity:
                       description: |-
-                        Identity defines the checkpoint identity for hash computation
+                        Identity defines the checkpoint identity for hash computation.
                         Used when Mode is Auto or when looking up existing checkpoints
                         Required when checkpointRef is not specified
                       properties:
@@ -10733,9 +10733,7 @@ spec:
                     When enabled, a GMS sidecar is injected and GPU access is managed via DRA.
                   properties:
                     enabled:
-                      description: |-
-                        Enabled activates the GMS sidecar. GPU resources on the main container
-                        are replaced with a DRA ResourceClaim for shared GPU access.
+                      description: Enabled activates GPU Memory Service for this workload or checkpoint.
                       type: boolean
                   required:
                     - enabled

--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeployments.yaml
@@ -910,7 +910,7 @@ spec:
                             type: boolean
                           identity:
                             description: |-
-                              Identity defines the checkpoint identity for hash computation
+                              Identity defines the checkpoint identity for hash computation.
                               Used when Mode is Auto or when looking up existing checkpoints
                               Required when checkpointRef is not specified
                             properties:
@@ -10956,9 +10956,7 @@ spec:
                           When enabled, a GMS sidecar is injected and GPU access is managed via DRA.
                         properties:
                           enabled:
-                            description: |-
-                              Enabled activates the GMS sidecar. GPU resources on the main container
-                              are replaced with a DRA ResourceClaim for shared GPU access.
+                            description: Enabled activates GPU Memory Service for this workload or checkpoint.
                             type: boolean
                         required:
                           - enabled

--- a/deploy/operator/api/v1alpha1/common.go
+++ b/deploy/operator/api/v1alpha1/common.go
@@ -155,13 +155,9 @@ func (e ExtraPodSpec) MarshalJSON() ([]byte, error) {
 	return json.Marshal(aux)
 }
 
-// GPUMemoryServiceSpec configures the GPU Memory Service (GMS) sidecar for a worker component.
-// When enabled, the operator injects a GMS sidecar that provides shared GPU memory access
-// via DRA (Dynamic Resource Allocation). The sidecar runs two GMS processes per GPU
-// (weights + kv_cache) and communicates with the main container over UDS sockets.
+// GPUMemoryServiceSpec configures GPU Memory Service sidecars.
 type GPUMemoryServiceSpec struct {
-	// Enabled activates the GMS sidecar. GPU resources on the main container
-	// are replaced with a DRA ResourceClaim for shared GPU access.
+	// Enabled activates GPU Memory Service for this workload or checkpoint.
 	Enabled bool `json:"enabled"`
 }
 
@@ -208,7 +204,7 @@ type ServiceCheckpointConfig struct {
 	// +optional
 	CheckpointRef *string `json:"checkpointRef,omitempty"`
 
-	// Identity defines the checkpoint identity for hash computation
+	// Identity defines the checkpoint identity for hash computation.
 	// Used when Mode is Auto or when looking up existing checkpoints
 	// Required when checkpointRef is not specified
 	// +optional

--- a/deploy/operator/api/v1alpha1/dynamocheckpoint_types.go
+++ b/deploy/operator/api/v1alpha1/dynamocheckpoint_types.go
@@ -124,6 +124,12 @@ type DynamoCheckpointSpec struct {
 	// +kubebuilder:validation:Required
 	Identity DynamoCheckpointIdentity `json:"identity"`
 
+	// GPUMemoryService enables checkpoint-time GPU Memory Service wiring.
+	// It is intentionally outside spec.identity, so it does not affect the
+	// checkpoint identity hash or deduplication.
+	// +optional
+	GPUMemoryService *GPUMemoryServiceSpec `json:"gpuMemoryService,omitempty"`
+
 	// Job defines the configuration for the checkpoint creation Job
 	// +kubebuilder:validation:Required
 	Job DynamoCheckpointJobConfig `json:"job"`

--- a/deploy/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/deploy/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -340,6 +340,11 @@ func (in *DynamoCheckpointList) DeepCopyObject() runtime.Object {
 func (in *DynamoCheckpointSpec) DeepCopyInto(out *DynamoCheckpointSpec) {
 	*out = *in
 	in.Identity.DeepCopyInto(&out.Identity)
+	if in.GPUMemoryService != nil {
+		in, out := &in.GPUMemoryService, &out.GPUMemoryService
+		*out = new(GPUMemoryServiceSpec)
+		**out = **in
+	}
 	in.Job.DeepCopyInto(&out.Job)
 }
 

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocheckpoints.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocheckpoints.yaml
@@ -67,6 +67,18 @@ spec:
             spec:
               description: DynamoCheckpointSpec defines the desired state of DynamoCheckpoint
               properties:
+                gpuMemoryService:
+                  description: |-
+                    GPUMemoryService enables checkpoint-time GPU Memory Service wiring.
+                    It is intentionally outside spec.identity, so it does not affect the
+                    checkpoint identity hash or deduplication.
+                  properties:
+                    enabled:
+                      description: Enabled activates GPU Memory Service for this workload or checkpoint.
+                      type: boolean
+                  required:
+                    - enabled
+                  type: object
                 identity:
                   description: Identity defines the inputs that determine checkpoint equivalence
                   properties:

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
@@ -687,7 +687,7 @@ spec:
                       type: boolean
                     identity:
                       description: |-
-                        Identity defines the checkpoint identity for hash computation
+                        Identity defines the checkpoint identity for hash computation.
                         Used when Mode is Auto or when looking up existing checkpoints
                         Required when checkpointRef is not specified
                       properties:
@@ -10733,9 +10733,7 @@ spec:
                     When enabled, a GMS sidecar is injected and GPU access is managed via DRA.
                   properties:
                     enabled:
-                      description: |-
-                        Enabled activates the GMS sidecar. GPU resources on the main container
-                        are replaced with a DRA ResourceClaim for shared GPU access.
+                      description: Enabled activates GPU Memory Service for this workload or checkpoint.
                       type: boolean
                   required:
                     - enabled

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -910,7 +910,7 @@ spec:
                             type: boolean
                           identity:
                             description: |-
-                              Identity defines the checkpoint identity for hash computation
+                              Identity defines the checkpoint identity for hash computation.
                               Used when Mode is Auto or when looking up existing checkpoints
                               Required when checkpointRef is not specified
                             properties:
@@ -10956,9 +10956,7 @@ spec:
                           When enabled, a GMS sidecar is injected and GPU access is managed via DRA.
                         properties:
                           enabled:
-                            description: |-
-                              Enabled activates the GMS sidecar. GPU resources on the main container
-                              are replaced with a DRA ResourceClaim for shared GPU access.
+                            description: Enabled activates GPU Memory Service for this workload or checkpoint.
                             type: boolean
                         required:
                           - enabled

--- a/deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml
+++ b/deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml
@@ -27,6 +27,10 @@ spec:
     dtype: "bfloat16"
     maxModelLen: 2048
 
+  # Optional: enable GMS-specific checkpoint capture and restore helpers.
+  # gpuMemoryService:
+  #   enabled: true
+
   # Job configuration for checkpoint creation
   job:
     activeDeadlineSeconds: 3600

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -23,6 +23,7 @@ import (
 
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	gmsruntime "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,6 +46,10 @@ func testIdentity() nvidiacomv1alpha1.DynamoCheckpointIdentity {
 		Model:            "meta-llama/Llama-2-7b-hf",
 		BackendFramework: "vllm",
 	}
+}
+
+func testGPUMemoryService() *nvidiacomv1alpha1.GPUMemoryServiceSpec {
+	return &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true}
 }
 
 func testPodSpec() *corev1.PodSpec {
@@ -182,6 +187,50 @@ func TestCreateOrGetAutoCheckpointSetsDefaultArtifactVersion(t *testing.T) {
 
 // --- InjectCheckpointIntoPodSpec tests ---
 
+func TestEnsurePodInfoVolumeMergesExistingDownwardAPIItems(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Volumes: []corev1.Volume{{
+			Name: consts.PodInfoVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				DownwardAPI: &corev1.DownwardAPIVolumeSource{
+					Items: []corev1.DownwardAPIVolumeFile{
+						{
+							Path:     "pod_name",
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+						},
+						{
+							Path:     "custom",
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels['custom']"},
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	EnsurePodInfoVolume(podSpec)
+
+	require.Len(t, podSpec.Volumes, 1)
+	require.NotNil(t, podSpec.Volumes[0].DownwardAPI)
+
+	fields := map[string]string{}
+	for _, item := range podSpec.Volumes[0].DownwardAPI.Items {
+		if item.FieldRef != nil {
+			fields[item.Path] = item.FieldRef.FieldPath
+		}
+	}
+
+	assert.Equal(t, consts.PodInfoFieldPodName, fields["pod_name"])
+	assert.Equal(t, consts.PodInfoFieldPodUID, fields["pod_uid"])
+	assert.Equal(t, consts.PodInfoFieldPodNamespace, fields["pod_namespace"])
+	assert.Equal(t, "metadata.labels['custom']", fields["custom"])
+	assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoNamespace+"']", fields[consts.PodInfoFileDynNamespace])
+	assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoWorkerHash+"']", fields[consts.PodInfoFileDynNamespaceWorkerSuffix])
+	assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoComponentType+"']", fields[consts.PodInfoFileDynComponent])
+	assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoGraphDeploymentName+"']", fields[consts.PodInfoFileDynParentDGDName])
+	assert.Equal(t, consts.PodInfoFieldPodNamespace, fields[consts.PodInfoFileDynParentDGDNamespace])
+}
+
 func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 	t.Run("ready checkpoint injects podinfo and overrides command", func(t *testing.T) {
 		podSpec := testPodSpec()
@@ -218,6 +267,50 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Equal(t, consts.PodInfoMountPath, mountPaths[consts.PodInfoVolumeName])
 	})
 
+	t.Run("ready checkpoint augments existing podinfo volume", func(t *testing.T) {
+		podSpec := testPodSpec()
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+			Name: consts.PodInfoVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				DownwardAPI: &corev1.DownwardAPIVolumeSource{
+					Items: []corev1.DownwardAPIVolumeFile{
+						{Path: "pod_name", FieldRef: &corev1.ObjectFieldSelector{FieldPath: consts.PodInfoFieldPodName}},
+						{Path: "pod_uid", FieldRef: &corev1.ObjectFieldSelector{FieldPath: consts.PodInfoFieldPodUID}},
+						{Path: "pod_namespace", FieldRef: &corev1.ObjectFieldSelector{FieldPath: consts.PodInfoFieldPodNamespace}},
+					},
+				},
+			},
+		})
+		info := &CheckpointInfo{Enabled: true, Ready: true, Identity: ptr.To(testIdentity())}
+		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info))
+
+		var podInfoVolume *corev1.Volume
+		for i := range podSpec.Volumes {
+			if podSpec.Volumes[i].Name == consts.PodInfoVolumeName {
+				podInfoVolume = &podSpec.Volumes[i]
+				break
+			}
+		}
+		require.NotNil(t, podInfoVolume)
+		require.NotNil(t, podInfoVolume.DownwardAPI)
+
+		fields := map[string]string{}
+		for _, item := range podInfoVolume.DownwardAPI.Items {
+			if item.FieldRef != nil {
+				fields[item.Path] = item.FieldRef.FieldPath
+			}
+		}
+		assert.Equal(t, consts.PodInfoFieldPodName, fields["pod_name"])
+		assert.Equal(t, consts.PodInfoFieldPodUID, fields["pod_uid"])
+		assert.Equal(t, consts.PodInfoFieldPodNamespace, fields["pod_namespace"])
+		assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoNamespace+"']", fields[consts.PodInfoFileDynNamespace])
+		assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoWorkerHash+"']", fields[consts.PodInfoFileDynNamespaceWorkerSuffix])
+		assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoComponentType+"']", fields[consts.PodInfoFileDynComponent])
+		assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoGraphDeploymentName+"']", fields[consts.PodInfoFileDynParentDGDName])
+		assert.Equal(t, consts.PodInfoFieldPodNamespace, fields[consts.PodInfoFileDynParentDGDNamespace])
+	})
+
 	t.Run("ready checkpoint targets the container named main", func(t *testing.T) {
 		podSpec := &corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -233,6 +326,34 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Equal(t, []string{"run"}, podSpec.Containers[0].Args)
 		assert.Equal(t, []string{"sleep", "infinity"}, podSpec.Containers[1].Command)
 		assert.Nil(t, podSpec.Containers[1].Args)
+	})
+
+	t.Run("ready gms checkpoint injects restore sidecars and loader mount", func(t *testing.T) {
+		podSpec := testPodSpec()
+		podSpec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu"}}
+		info := &CheckpointInfo{Enabled: true, Ready: true, Hash: testHash, GPUMemoryService: testGPUMemoryService()}
+		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
+
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info))
+		gmsServer := findContainer(podSpec, gmsruntime.ServerContainerName)
+		require.NotNil(t, gmsServer)
+		loader := findContainer(podSpec, GMSLoaderContainer)
+		require.NotNil(t, loader)
+
+		mounts := map[string]string{}
+		for _, mount := range loader.VolumeMounts {
+			mounts[mount.Name] = mount.MountPath
+		}
+		assert.Equal(t, "/checkpoints", mounts[snapshotprotocol.CheckpointVolumeName])
+		assert.Equal(t, gmsruntime.SharedMountPath, mounts[gmsruntime.SharedVolumeName])
+
+		env := map[string]string{}
+		for _, item := range loader.Env {
+			env[item.Name] = item.Value
+		}
+		assert.Equal(t, "/checkpoints/"+testHash+"/gms/versions/1", env["GMS_CHECKPOINT_DIR"])
+		assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.gms_server_sidecar"}, gmsServer.Command)
+		assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.gms_checkpoint_loader"}, loader.Command)
 	})
 
 	t.Run("error cases", func(t *testing.T) {
@@ -277,7 +398,10 @@ func TestResolveCheckpointForService(t *testing.T) {
 		require.NoError(t, err)
 		ckpt := &nvidiacomv1alpha1.DynamoCheckpoint{
 			ObjectMeta: metav1.ObjectMeta{Name: hash, Namespace: testNamespace},
-			Spec:       nvidiacomv1alpha1.DynamoCheckpointSpec{Identity: testIdentity()},
+			Spec: nvidiacomv1alpha1.DynamoCheckpointSpec{
+				Identity:         testIdentity(),
+				GPUMemoryService: testGPUMemoryService(),
+			},
 			Status: nvidiacomv1alpha1.DynamoCheckpointStatus{
 				Phase:        nvidiacomv1alpha1.DynamoCheckpointPhaseReady,
 				IdentityHash: hash,
@@ -294,6 +418,8 @@ func TestResolveCheckpointForService(t *testing.T) {
 		assert.True(t, info.Ready)
 		assert.Equal(t, hash, info.Hash)
 		assert.Equal(t, hash, info.CheckpointName)
+		require.NotNil(t, info.GPUMemoryService)
+		assert.True(t, info.GPUMemoryService.Enabled)
 	})
 
 	t.Run("checkpointRef resolves not-ready CR", func(t *testing.T) {

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -1,0 +1,243 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package checkpoint
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	gmsruntime "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	GMSLoaderContainer = "gms-loader"
+	GMSSaverContainer  = "gms-saver"
+
+	gmsCheckpointLoaderModule = "gpu_memory_service.cli.gms_checkpoint_loader"
+	gmsCheckpointSaverModule  = "gpu_memory_service.cli.gms_checkpoint_saver"
+)
+
+func ResolveGMSCheckpointStorage(
+	ctx context.Context,
+	reader ctrlclient.Reader,
+	namespace string,
+	checkpointID string,
+	artifactVersion string,
+) (snapshotprotocol.Storage, error) {
+	if reader == nil {
+		return snapshotprotocol.Storage{}, fmt.Errorf("checkpoint client is required")
+	}
+
+	daemonSets := &appsv1.DaemonSetList{}
+	if err := reader.List(
+		ctx,
+		daemonSets,
+		ctrlclient.InNamespace(namespace),
+		ctrlclient.MatchingLabels{snapshotprotocol.SnapshotAgentLabelKey: snapshotprotocol.SnapshotAgentLabelValue},
+	); err != nil {
+		return snapshotprotocol.Storage{}, fmt.Errorf("list snapshot-agent daemonsets in %s: %w", namespace, err)
+	}
+
+	storage, err := snapshotprotocol.DiscoverStorageFromDaemonSets(namespace, daemonSets.Items)
+	if err != nil {
+		return snapshotprotocol.Storage{}, err
+	}
+	return snapshotprotocol.ResolveCheckpointStorage(checkpointID, artifactVersion, storage)
+}
+
+// EnsureGMSRestoreSidecars adds the GMS server sidecar and loader container
+// for a restore pod. Uses the shared runtime helper for server/volume setup.
+func EnsureGMSRestoreSidecars(podSpec *corev1.PodSpec, mainContainer *corev1.Container) {
+	if podSpec == nil || mainContainer == nil {
+		return
+	}
+
+	gmsruntime.EnsureServerSidecar(podSpec, mainContainer)
+
+	loader := gmsCheckpointLoaderContainer(mainContainer.Image)
+	copyGMSDeviceClaims(mainContainer, &loader)
+	ensureGMSContainer(podSpec, loader)
+}
+
+// EnsureGMSRestoreHelperMounts adds the checkpoint storage volume and mount
+// to the GMS loader container and sets GMS_CHECKPOINT_DIR.
+func EnsureGMSRestoreHelperMounts(podSpec *corev1.PodSpec, storage snapshotprotocol.Storage) {
+	loader := findContainer(podSpec, GMSLoaderContainer)
+	if loader == nil {
+		return
+	}
+	ensureCheckpointVolume(podSpec, storage.PVCName)
+	ensureVolumeMount(loader, corev1.VolumeMount{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath})
+	setEnv(loader, "GMS_CHECKPOINT_DIR", resolveGMSArtifactDir(storage))
+}
+
+// EnsureGMSCheckpointJobSidecars adds the GMS server sidecar, saver container,
+// and checkpoint control volume for a checkpoint job pod.
+func EnsureGMSCheckpointJobSidecars(
+	podSpec *corev1.PodSpec,
+	mainContainer *corev1.Container,
+	storage snapshotprotocol.Storage,
+) error {
+	if podSpec == nil || mainContainer == nil {
+		return nil
+	}
+	if len(mainContainer.Resources.Claims) == 0 {
+		return fmt.Errorf("gms sidecars require main container resource claims")
+	}
+	if storage.PVCName == "" || storage.BasePath == "" || storage.Location == "" {
+		return fmt.Errorf("gms checkpoint jobs require resolved checkpoint storage")
+	}
+
+	gmsruntime.EnsureServerSidecar(podSpec, mainContainer)
+	ensureGMSCheckpointControl(podSpec)
+
+	saver := gmsCheckpointSaverContainer(mainContainer.Image)
+	copyGMSDeviceClaims(mainContainer, &saver)
+	ensureCheckpointVolume(podSpec, storage.PVCName)
+	ensureVolumeMount(&saver, corev1.VolumeMount{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath})
+	setEnv(&saver, "GMS_CHECKPOINT_DIR", resolveGMSArtifactDir(storage))
+	ensureGMSContainer(podSpec, saver)
+	return nil
+}
+
+func resolveGMSArtifactDir(storage snapshotprotocol.Storage) string {
+	checkpointRoot := filepath.Dir(filepath.Dir(storage.Location))
+	artifactVersion := filepath.Base(storage.Location)
+	return filepath.Join(checkpointRoot, "gms", "versions", artifactVersion)
+}
+
+func gmsCheckpointLoaderContainer(image string) corev1.Container {
+	container := corev1.Container{
+		Name:    GMSLoaderContainer,
+		Image:   image,
+		Command: []string{"python3", "-m", gmsCheckpointLoaderModule},
+		Env: []corev1.EnvVar{
+			{Name: "TMPDIR", Value: gmsruntime.SharedMountPath},
+			{Name: "GMS_SOCKET_DIR", Value: gmsruntime.SharedMountPath},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: gmsruntime.SharedVolumeName, MountPath: gmsruntime.SharedMountPath},
+		},
+	}
+	return container
+}
+
+func gmsCheckpointSaverContainer(image string) corev1.Container {
+	container := corev1.Container{
+		Name:    GMSSaverContainer,
+		Image:   image,
+		Command: []string{"python3", "-m", gmsCheckpointSaverModule},
+		Env: []corev1.EnvVar{
+			{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}}},
+			{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
+			{Name: "TMPDIR", Value: gmsruntime.SharedMountPath},
+			{Name: "GMS_SOCKET_DIR", Value: gmsruntime.SharedMountPath},
+			{Name: "GMS_CONTROL_DIR", Value: gmsruntime.ControlDir},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: gmsruntime.SharedVolumeName, MountPath: gmsruntime.SharedMountPath},
+			{Name: gmsruntime.ControlVolumeName, MountPath: gmsruntime.ControlDir},
+		},
+	}
+	return container
+}
+
+// ensureGMSCheckpointControl adds the control volume and injects
+// GMS_CONTROL_DIR into the GMS server container for checkpoint coordination.
+func ensureGMSCheckpointControl(podSpec *corev1.PodSpec) {
+	ensureVolume(podSpec, corev1.Volume{
+		Name:         gmsruntime.ControlVolumeName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	})
+	server := gmsruntime.FindServerContainer(podSpec)
+	if server != nil {
+		ensureVolumeMount(server, corev1.VolumeMount{Name: gmsruntime.ControlVolumeName, MountPath: gmsruntime.ControlDir})
+		setEnv(server, "GMS_CONTROL_DIR", gmsruntime.ControlDir)
+	}
+}
+
+func copyGMSDeviceClaims(mainContainer *corev1.Container, container *corev1.Container) {
+	if mainContainer == nil || container == nil || len(mainContainer.Resources.Claims) == 0 {
+		return
+	}
+	container.Resources.Claims = append([]corev1.ResourceClaim{}, mainContainer.Resources.Claims...)
+}
+
+func ensureCheckpointVolume(podSpec *corev1.PodSpec, pvcName string) {
+	if pvcName == "" {
+		return
+	}
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name == snapshotprotocol.CheckpointVolumeName {
+			return
+		}
+	}
+	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+		Name: snapshotprotocol.CheckpointVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+		},
+	})
+}
+
+func ensureVolume(podSpec *corev1.PodSpec, volume corev1.Volume) {
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name == volume.Name {
+			return
+		}
+	}
+	podSpec.Volumes = append(podSpec.Volumes, volume)
+}
+
+func ensureVolumeMount(container *corev1.Container, mount corev1.VolumeMount) {
+	for i := range container.VolumeMounts {
+		if container.VolumeMounts[i].Name == mount.Name && container.VolumeMounts[i].MountPath == mount.MountPath {
+			return
+		}
+	}
+	container.VolumeMounts = append(container.VolumeMounts, mount)
+}
+
+func setEnv(container *corev1.Container, name string, value string) {
+	for i := range container.Env {
+		if container.Env[i].Name != name {
+			continue
+		}
+		container.Env[i].Value = value
+		container.Env[i].ValueFrom = nil
+		return
+	}
+	container.Env = append(container.Env, corev1.EnvVar{Name: name, Value: value})
+}
+
+func ensureGMSContainer(podSpec *corev1.PodSpec, container corev1.Container) {
+	if findContainer(podSpec, container.Name) != nil {
+		return
+	}
+	podSpec.Containers = append(podSpec.Containers, container)
+}
+
+func findContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {
+	if podSpec == nil {
+		return nil
+	}
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == name {
+			return &podSpec.Containers[i]
+		}
+	}
+	for i := range podSpec.InitContainers {
+		if podSpec.InitContainers[i].Name == name {
+			return &podSpec.InitContainers[i]
+		}
+	}
+	return nil
+}

--- a/deploy/operator/internal/checkpoint/hash_test.go
+++ b/deploy/operator/internal/checkpoint/hash_test.go
@@ -24,7 +24,7 @@ func TestComputeIdentityHash(t *testing.T) {
 				BackendFramework: "vllm",
 			},
 			expectError:  false,
-			expectedHash: "96429b2725761a09", // Known hash for this specific identity
+			expectedHash: "96429b2725761a09",
 		},
 		{
 			name: "identity with all fields produces deterministic hash",
@@ -41,7 +41,7 @@ func TestComputeIdentityHash(t *testing.T) {
 				},
 			},
 			expectError:  false,
-			expectedHash: "f4ba65bccbb8e4fb", // Known hash for this specific identity
+			expectedHash: "f4ba65bccbb8e4fb",
 		},
 		{
 			name: "same identity produces same hash",

--- a/deploy/operator/internal/checkpoint/podinfo.go
+++ b/deploy/operator/internal/checkpoint/podinfo.go
@@ -9,69 +9,98 @@ import (
 )
 
 func EnsurePodInfoVolume(podSpec *corev1.PodSpec) {
-	for _, volume := range podSpec.Volumes {
-		if volume.Name == commonconsts.PodInfoVolumeName {
-			return
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name != commonconsts.PodInfoVolumeName {
+			continue
 		}
+		if podSpec.Volumes[i].DownwardAPI == nil {
+			podSpec.Volumes[i].VolumeSource.DownwardAPI = &corev1.DownwardAPIVolumeSource{}
+		}
+		ensurePodInfoItems(podSpec.Volumes[i].DownwardAPI)
+		return
 	}
 
 	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 		Name: commonconsts.PodInfoVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			DownwardAPI: &corev1.DownwardAPIVolumeSource{
-				Items: []corev1.DownwardAPIVolumeFile{
-					{
-						Path: "pod_name",
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodName,
-						},
-					},
-					{
-						Path: "pod_uid",
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodUID,
-						},
-					},
-					{
-						Path: "pod_namespace",
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodNamespace,
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynNamespace,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoNamespace + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynNamespaceWorkerSuffix,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoWorkerHash + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynComponent,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoComponentType + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynParentDGDName,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoGraphDeploymentName + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynParentDGDNamespace,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodNamespace,
-						},
-					},
-				},
+				Items: podInfoItems(),
 			},
 		},
 	})
+}
+
+func ensurePodInfoItems(source *corev1.DownwardAPIVolumeSource) {
+	if source == nil {
+		return
+	}
+
+	pathToIndex := make(map[string]int, len(source.Items))
+	for i := range source.Items {
+		pathToIndex[source.Items[i].Path] = i
+	}
+
+	for _, item := range podInfoItems() {
+		if idx, ok := pathToIndex[item.Path]; ok {
+			source.Items[idx] = item
+			continue
+		}
+		source.Items = append(source.Items, item)
+		pathToIndex[item.Path] = len(source.Items) - 1
+	}
+}
+
+func podInfoItems() []corev1.DownwardAPIVolumeFile {
+	return []corev1.DownwardAPIVolumeFile{
+		{
+			Path: "pod_name",
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: commonconsts.PodInfoFieldPodName,
+			},
+		},
+		{
+			Path: "pod_uid",
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: commonconsts.PodInfoFieldPodUID,
+			},
+		},
+		{
+			Path: "pod_namespace",
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: commonconsts.PodInfoFieldPodNamespace,
+			},
+		},
+		{
+			Path: commonconsts.PodInfoFileDynNamespace,
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoNamespace + "']",
+			},
+		},
+		{
+			Path: commonconsts.PodInfoFileDynNamespaceWorkerSuffix,
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoWorkerHash + "']",
+			},
+		},
+		{
+			Path: commonconsts.PodInfoFileDynComponent,
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoComponentType + "']",
+			},
+		},
+		{
+			Path: commonconsts.PodInfoFileDynParentDGDName,
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoGraphDeploymentName + "']",
+			},
+		},
+		{
+			Path: commonconsts.PodInfoFileDynParentDGDNamespace,
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: commonconsts.PodInfoFieldPodNamespace,
+			},
+		},
+	}
 }
 
 func EnsurePodInfoMount(container *corev1.Container) {

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -92,6 +92,24 @@ func InjectCheckpointIntoPodSpec(
 		return err
 	}
 
+	if info.GPUMemoryService != nil && info.GPUMemoryService.Enabled {
+		if len(mainContainer.Resources.Claims) == 0 {
+			return fmt.Errorf("gms sidecars require main container resource claims")
+		}
+		storage, err := ResolveGMSCheckpointStorage(
+			ctx,
+			reader,
+			namespace,
+			info.Hash,
+			info.ArtifactVersion,
+		)
+		if err != nil {
+			return err
+		}
+		EnsureGMSRestoreSidecars(podSpec, mainContainer)
+		EnsureGMSRestoreHelperMounts(podSpec, storage)
+	}
+
 	EnsurePodInfoVolume(podSpec)
 	EnsurePodInfoMount(mainContainer)
 	return nil

--- a/deploy/operator/internal/checkpoint/resolve.go
+++ b/deploy/operator/internal/checkpoint/resolve.go
@@ -28,13 +28,14 @@ import (
 )
 
 type CheckpointInfo struct {
-	Enabled         bool
-	Exists          bool
-	Identity        *nvidiacomv1alpha1.DynamoCheckpointIdentity
-	Hash            string
-	ArtifactVersion string
-	CheckpointName  string
-	Ready           bool
+	Enabled          bool
+	Exists           bool
+	Identity         *nvidiacomv1alpha1.DynamoCheckpointIdentity
+	GPUMemoryService *nvidiacomv1alpha1.GPUMemoryServiceSpec
+	Hash             string
+	ArtifactVersion  string
+	CheckpointName   string
+	Ready            bool
 }
 
 func checkpointInfoFromObject(ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (*CheckpointInfo, error) {
@@ -44,13 +45,14 @@ func checkpointInfoFromObject(ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (*Checkp
 	}
 
 	return &CheckpointInfo{
-		Enabled:         true,
-		Exists:          true,
-		Identity:        &ckpt.Spec.Identity,
-		Hash:            hash,
-		ArtifactVersion: checkpointArtifactVersion(ckpt),
-		CheckpointName:  ckpt.Name,
-		Ready:           ckpt.Status.Phase == nvidiacomv1alpha1.DynamoCheckpointPhaseReady,
+		Enabled:          true,
+		Exists:           true,
+		Identity:         &ckpt.Spec.Identity,
+		GPUMemoryService: ckpt.Spec.GPUMemoryService,
+		Hash:             hash,
+		ArtifactVersion:  checkpointArtifactVersion(ckpt),
+		CheckpointName:   ckpt.Name,
+		Ready:            ckpt.Status.Phase == nvidiacomv1alpha1.DynamoCheckpointPhaseReady,
 	}, nil
 }
 

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
@@ -16,6 +17,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func buildCheckpointWorkerDefaultEnv(
@@ -48,6 +50,8 @@ func buildCheckpointWorkerDefaultEnv(
 }
 
 func buildCheckpointJob(
+	ctx context.Context,
+	reader ctrlclient.Reader,
 	config *configv1alpha1.OperatorConfiguration,
 	ckpt *nvidiacomv1alpha1.DynamoCheckpoint,
 	jobName string,
@@ -74,30 +78,47 @@ func buildCheckpointJob(
 
 	checkpoint.EnsurePodInfoVolume(&podTemplate.Spec)
 
-	if len(podTemplate.Spec.Containers) > 0 {
-		mainContainer := &podTemplate.Spec.Containers[0]
-		mainContainer.Env = dynamo.MergeEnvs(
-			buildCheckpointWorkerDefaultEnv(ckpt, podTemplate),
-			mainContainer.Env,
-		)
-		dynamo.AddStandardEnvVars(mainContainer, config)
-		mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{
-			Name:  consts.EnvReadyForCheckpointFile,
-			Value: config.Checkpoint.ReadyForCheckpointFilePath,
-		})
-		mainContainer.ReadinessProbe = &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{"cat", config.Checkpoint.ReadyForCheckpointFilePath},
-				},
+	mainContainer, err := snapshotprotocol.ResolveCheckpointWorkerContainer(&podTemplate.Spec)
+	if err != nil {
+		return nil, err
+	}
+	mainContainer.Env = dynamo.MergeEnvs(
+		buildCheckpointWorkerDefaultEnv(ckpt, podTemplate),
+		mainContainer.Env,
+	)
+	dynamo.AddStandardEnvVars(mainContainer, config)
+	mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{
+		Name:  consts.EnvReadyForCheckpointFile,
+		Value: config.Checkpoint.ReadyForCheckpointFilePath,
+	})
+	mainContainer.ReadinessProbe = &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"cat", config.Checkpoint.ReadyForCheckpointFilePath},
 			},
-			InitialDelaySeconds: 15,
-			PeriodSeconds:       2,
+		},
+		InitialDelaySeconds: 15,
+		PeriodSeconds:       2,
+	}
+	mainContainer.LivenessProbe = nil
+	mainContainer.StartupProbe = nil
+	checkpoint.EnsurePodInfoMount(mainContainer)
+	dynamo.ApplySharedMemoryVolumeAndMount(&podTemplate.Spec, mainContainer, ckpt.Spec.Job.SharedMemory)
+
+	if ckpt.Spec.GPUMemoryService != nil && ckpt.Spec.GPUMemoryService.Enabled {
+		storage, err := checkpoint.ResolveGMSCheckpointStorage(
+			ctx,
+			reader,
+			ckpt.Namespace,
+			hash,
+			ckpt.Annotations[snapshotprotocol.CheckpointArtifactVersionAnnotation],
+		)
+		if err != nil {
+			return nil, err
 		}
-		mainContainer.LivenessProbe = nil
-		mainContainer.StartupProbe = nil
-		checkpoint.EnsurePodInfoMount(mainContainer)
-		dynamo.ApplySharedMemoryVolumeAndMount(&podTemplate.Spec, mainContainer, ckpt.Spec.Job.SharedMemory)
+		if err := checkpoint.EnsureGMSCheckpointJobSidecars(&podTemplate.Spec, mainContainer, storage); err != nil {
+			return nil, err
+		}
 	}
 
 	activeDeadlineSeconds := ckpt.Spec.Job.ActiveDeadlineSeconds
@@ -107,10 +128,8 @@ func buildCheckpointJob(
 	}
 
 	wrapLaunchJob := false
-	if len(podTemplate.Spec.Containers) != 0 {
-		if gpus, ok := podTemplate.Spec.Containers[0].Resources.Limits[corev1.ResourceName(consts.KubeResourceGPUNvidia)]; ok {
-			wrapLaunchJob = gpus.Cmp(*resource.NewQuantity(1, resource.DecimalSI)) > 0
-		}
+	if gpus, ok := mainContainer.Resources.Limits[corev1.ResourceName(consts.KubeResourceGPUNvidia)]; ok {
+		wrapLaunchJob = gpus.Cmp(*resource.NewQuantity(1, resource.DecimalSI)) > 0
 	}
 	ttlSecondsAfterFinish := snapshotprotocol.DefaultCheckpointJobTTLSeconds
 

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -197,7 +197,7 @@ func (r *CheckpointReconciler) handlePending(ctx context.Context, ckpt *nvidiaco
 
 	// Use SyncResource to create/update the checkpoint Job
 	modified, _, err := commonController.SyncResource(ctx, r, ckpt, func(ctx context.Context) (*batchv1.Job, bool, error) {
-		job, err := buildCheckpointJob(r.Config, ckpt, jobName)
+		job, err := buildCheckpointJob(ctx, r.Client, r.Config, ckpt, jobName)
 		return job, false, err
 	})
 	if err != nil {

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -25,10 +25,12 @@ import (
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	gmsruntime "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -65,6 +67,7 @@ var defaultCheckpointJobName = snapshotprotocol.GetCheckpointJobName(testHash, s
 func checkpointTestScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	_ = nvidiacomv1alpha1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
 	_ = corev1.AddToScheme(s)
 	_ = batchv1.AddToScheme(s)
 	_ = coordinationv1.AddToScheme(s)
@@ -130,6 +133,50 @@ func makeCheckpointLease(name string, renewTime time.Time, durationSeconds int32
 	}
 }
 
+func testSnapshotAgentDaemonSet() *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snapshot-agent",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				snapshotprotocol.SnapshotAgentLabelKey: snapshotprotocol.SnapshotAgentLabelValue,
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: snapshotprotocol.SnapshotAgentContainerName,
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "checkpoints",
+							MountPath: "/checkpoints",
+						}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "checkpoints",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "snapshot-pvc",
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+func requireCheckpointContainer(t *testing.T, containers []corev1.Container, name string) *corev1.Container {
+	t.Helper()
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	t.Fatalf("container %q not found", name)
+	return nil
+}
+
 func TestBuildCheckpointJob(t *testing.T) {
 	s := checkpointTestScheme()
 	ckpt := makeTestCheckpoint(nvidiacomv1alpha1.DynamoCheckpointPhasePending)
@@ -139,7 +186,7 @@ func TestBuildCheckpointJob(t *testing.T) {
 	}
 
 	r := makeCheckpointReconciler(s, ckpt)
-	job, err := buildCheckpointJob(r.Config, ckpt, defaultCheckpointJobName)
+	job, err := buildCheckpointJob(context.Background(), nil, r.Config, ckpt, defaultCheckpointJobName)
 	require.NoError(t, err)
 	podSpec := job.Spec.Template.Spec
 	main := podSpec.Containers[0]
@@ -236,7 +283,7 @@ func TestBuildCheckpointJob(t *testing.T) {
 	backoff := int32(5)
 	ckpt.Spec.Job.ActiveDeadlineSeconds = &deadline
 	ckpt.Spec.Job.BackoffLimit = &backoff //nolint:staticcheck // Compatibility test: deprecated field must remain ignored by checkpoint Jobs.
-	job, err = buildCheckpointJob(r.Config, ckpt, defaultCheckpointJobName)
+	job, err = buildCheckpointJob(context.Background(), nil, r.Config, ckpt, defaultCheckpointJobName)
 	require.NoError(t, err)
 	assert.Equal(t, int64(7200), *job.Spec.ActiveDeadlineSeconds)
 	assert.Equal(t, int32(0), *job.Spec.BackoffLimit)
@@ -247,10 +294,140 @@ func TestBuildCheckpointJob(t *testing.T) {
 			corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("2"),
 		},
 	}
-	job, err = buildCheckpointJob(r.Config, ckpt, defaultCheckpointJobName)
+	job, err = buildCheckpointJob(context.Background(), nil, r.Config, ckpt, defaultCheckpointJobName)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"cuda-checkpoint"}, job.Spec.Template.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"--launch-job", "python3", "-m", "dynamo.vllm"}, job.Spec.Template.Spec.Containers[0].Args)
+}
+
+func TestBuildCheckpointJobTargetsMainContainerWhenSidecarIsFirst(t *testing.T) {
+	s := checkpointTestScheme()
+	ckpt := makeTestCheckpoint(nvidiacomv1alpha1.DynamoCheckpointPhasePending)
+	ckpt.Spec.Job.PodTemplateSpec.Spec.Containers = []corev1.Container{
+		{
+			Name:    "sidecar",
+			Image:   "sidecar:latest",
+			Command: []string{"sleep"},
+			Args:    []string{"infinity"},
+		},
+		{
+			Name:    consts.MainContainerName,
+			Image:   "test-image:latest",
+			Command: []string{"python3", "-m", "dynamo.vllm"},
+			Env:     []corev1.EnvVar{{Name: "HF_TOKEN", Value: "secret"}},
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceName(consts.KubeResourceGPUNvidia): resource.MustParse("2"),
+				},
+			},
+		},
+	}
+
+	r := makeCheckpointReconciler(s, ckpt)
+	job, err := buildCheckpointJob(context.Background(), nil, r.Config, ckpt, defaultCheckpointJobName)
+	require.NoError(t, err)
+
+	main := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, consts.MainContainerName)
+	assert.Equal(t, []string{"cuda-checkpoint"}, main.Command)
+	assert.Equal(t, []string{"--launch-job", "python3", "-m", "dynamo.vllm"}, main.Args)
+	require.NotNil(t, main.ReadinessProbe)
+	assert.Equal(t, []string{"cat", "/tmp/ready-for-checkpoint"}, main.ReadinessProbe.Exec.Command)
+	assert.Nil(t, main.LivenessProbe)
+	assert.Nil(t, main.StartupProbe)
+
+	mainEnv := map[string]string{}
+	for _, env := range main.Env {
+		mainEnv[env.Name] = env.Value
+	}
+	assert.Equal(t, "/tmp/ready-for-checkpoint", mainEnv[consts.EnvReadyForCheckpointFile])
+	assert.Equal(t, "secret", mainEnv["HF_TOKEN"])
+
+	sidecar := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, "sidecar")
+	assert.Equal(t, []string{"sleep"}, sidecar.Command)
+	assert.Equal(t, []string{"infinity"}, sidecar.Args)
+	assert.Nil(t, sidecar.ReadinessProbe)
+	assert.Nil(t, sidecar.LivenessProbe)
+	assert.Nil(t, sidecar.StartupProbe)
+	for _, env := range sidecar.Env {
+		assert.NotEqual(t, consts.EnvReadyForCheckpointFile, env.Name)
+	}
+}
+
+func TestBuildCheckpointJobAddsGMSSidecars(t *testing.T) {
+	s := checkpointTestScheme()
+	ckpt := makeTestCheckpoint(nvidiacomv1alpha1.DynamoCheckpointPhasePending)
+	ckpt.Spec.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true}
+	ckpt.Spec.Job.PodTemplateSpec.Spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu"}}
+	snapshotAgentDaemonSet := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snapshot-agent",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				snapshotprotocol.SnapshotAgentLabelKey: snapshotprotocol.SnapshotAgentLabelValue,
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: snapshotprotocol.SnapshotAgentContainerName,
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      snapshotprotocol.SnapshotAgentVolumeName,
+							MountPath: "/checkpoints",
+						}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: snapshotprotocol.SnapshotAgentVolumeName,
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "snapshot-pvc",
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	reader := fake.NewClientBuilder().WithScheme(s).WithObjects(snapshotAgentDaemonSet).Build()
+
+	r := makeCheckpointReconciler(s, ckpt)
+	job, err := buildCheckpointJob(context.Background(), reader, r.Config, ckpt, defaultCheckpointJobName)
+	require.NoError(t, err)
+
+	main := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, consts.MainContainerName)
+	weightsServer := requireCheckpointContainer(t, job.Spec.Template.Spec.InitContainers, gmsruntime.ServerContainerName)
+	saver := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, checkpoint.GMSSaverContainer)
+
+	volNames := map[string]bool{}
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		volNames[v.Name] = true
+	}
+	assert.True(t, volNames[gmsruntime.SharedVolumeName])
+	assert.True(t, volNames[gmsruntime.ControlVolumeName])
+	assert.True(t, volNames[snapshotprotocol.CheckpointVolumeName])
+
+	mainMounts := map[string]string{}
+	for _, m := range main.VolumeMounts {
+		mainMounts[m.Name] = m.MountPath
+	}
+	assert.Equal(t, gmsruntime.SharedMountPath, mainMounts[gmsruntime.SharedVolumeName])
+
+	assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.gms_server_sidecar"}, weightsServer.Command)
+	assert.Equal(t, corev1.ContainerRestartPolicyAlways, *weightsServer.RestartPolicy)
+	require.NotNil(t, weightsServer.StartupProbe)
+	assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.gms_checkpoint_saver"}, saver.Command)
+
+	saverMounts := map[string]string{}
+	for _, m := range saver.VolumeMounts {
+		saverMounts[m.Name] = m.MountPath
+	}
+	assert.Equal(t, "/checkpoints", saverMounts[snapshotprotocol.CheckpointVolumeName])
+
+	saverEnv := map[string]string{}
+	for _, env := range saver.Env {
+		saverEnv[env.Name] = env.Value
+	}
+	assert.Equal(t, "/checkpoints/"+testHash+"/gms/versions/1", saverEnv["GMS_CHECKPOINT_DIR"])
 }
 
 func TestBuildCheckpointJobInjectsStandardEnvVars(t *testing.T) {
@@ -272,7 +449,7 @@ func TestBuildCheckpointJobInjectsStandardEnvVars(t *testing.T) {
 
 	customShmSize := resource.MustParse("16Gi")
 	ckpt.Spec.Job.SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{Size: customShmSize}
-	job, err := buildCheckpointJob(r.Config, ckpt, defaultCheckpointJobName)
+	job, err := buildCheckpointJob(context.Background(), nil, r.Config, ckpt, defaultCheckpointJobName)
 	require.NoError(t, err)
 	foundCustomShmVolume := false
 	for _, v := range job.Spec.Template.Spec.Volumes {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -26,6 +26,7 @@ import (
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	gmsruntime "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
@@ -33,6 +34,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+	"github.com/stretchr/testify/require"
 	istioNetworking "istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1373,6 +1375,128 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		}
 		if got := podTemplateSpec.Labels[snapshotprotocol.CheckpointIDLabel]; got != checkpointName {
 			t.Fatalf("expected %s to be checkpoint id, got %q", snapshotprotocol.CheckpointIDLabel, got)
+		}
+	})
+
+	t.Run("ready gms checkpoint injects gms restore sidecars", func(t *testing.T) {
+		identity := v1alpha1.DynamoCheckpointIdentity{Model: "test-model", BackendFramework: "vllm"}
+		checkpointName, err := checkpoint.ComputeIdentityHash(identity)
+		if err != nil {
+			t.Fatalf("ComputeIdentityHash failed: %v", err)
+		}
+		dcd := makeDCD(checkpointName)
+		dcd.Spec.ExtraPodSpec.MainContainer.Resources.Claims = []corev1.ResourceClaim{{Name: "gpu"}}
+		ckpt := &v1alpha1.DynamoCheckpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      checkpointName,
+				Namespace: "default",
+			},
+			Spec: v1alpha1.DynamoCheckpointSpec{
+				Identity:         identity,
+				GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{Enabled: true},
+			},
+			Status: v1alpha1.DynamoCheckpointStatus{
+				Phase: v1alpha1.DynamoCheckpointPhaseReady,
+			},
+		}
+
+		r := makeReconciler(dcd, ckpt)
+		podTemplateSpec, err := r.generatePodTemplateSpec(
+			context.Background(),
+			generateResourceOption{dynamoComponentDeployment: dcd},
+			dynamo.RoleMain,
+		)
+		if err != nil {
+			t.Fatalf("generatePodTemplateSpec failed: %v", err)
+		}
+
+		find := func(name string) *corev1.Container {
+			for i := range podTemplateSpec.Spec.Containers {
+				if podTemplateSpec.Spec.Containers[i].Name == name {
+					return &podTemplateSpec.Spec.Containers[i]
+				}
+			}
+			for i := range podTemplateSpec.Spec.InitContainers {
+				if podTemplateSpec.Spec.InitContainers[i].Name == name {
+					return &podTemplateSpec.Spec.InitContainers[i]
+				}
+			}
+			return nil
+		}
+
+		gmsServer := find(gmsruntime.ServerContainerName)
+		require.NotNil(t, gmsServer)
+		loader := find(checkpoint.GMSLoaderContainer)
+		require.NotNil(t, loader)
+
+		mounts := map[string]string{}
+		for _, mount := range loader.VolumeMounts {
+			mounts[mount.Name] = mount.MountPath
+		}
+		if got := mounts[snapshotprotocol.CheckpointVolumeName]; got != "/checkpoints" {
+			t.Fatalf("expected gms loader checkpoint mount at /checkpoints, got %q", got)
+		}
+		if got := gmsServer.Command; len(got) != 3 || got[0] != "python3" || got[1] != "-m" || got[2] != "gpu_memory_service.cli.gms_server_sidecar" {
+			t.Fatalf("expected weights server to run python module, got %#v", got)
+		}
+		if gmsServer.RestartPolicy == nil || *gmsServer.RestartPolicy != corev1.ContainerRestartPolicyAlways {
+			t.Fatalf("expected weights server to be a restartable init container, got %#v", gmsServer.RestartPolicy)
+		}
+		if gmsServer.StartupProbe == nil {
+			t.Fatalf("expected weights server startup probe")
+		}
+		if got := loader.Command; len(got) != 3 || got[0] != "python3" || got[1] != "-m" || got[2] != "gpu_memory_service.cli.gms_checkpoint_loader" {
+			t.Fatalf("expected loader to run python module, got %#v", got)
+		}
+	})
+
+	t.Run("ready checkpoint rewrites only main when extra sidecars are present", func(t *testing.T) {
+		identity := v1alpha1.DynamoCheckpointIdentity{Model: "test-model", BackendFramework: "vllm"}
+		checkpointName, err := checkpoint.ComputeIdentityHash(identity)
+		if err != nil {
+			t.Fatalf("ComputeIdentityHash failed: %v", err)
+		}
+		dcd := makeDCD(checkpointName)
+		dcd.Spec.ExtraPodSpec.PodSpec = &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    "gms-loader",
+				Image:   "sidecar:latest",
+				Command: []string{"python3"},
+				Args:    []string{"-m", "sidecar"},
+			}},
+		}
+		ckpt := &v1alpha1.DynamoCheckpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      checkpointName,
+				Namespace: "default",
+			},
+			Spec: v1alpha1.DynamoCheckpointSpec{Identity: identity},
+			Status: v1alpha1.DynamoCheckpointStatus{
+				Phase: v1alpha1.DynamoCheckpointPhaseReady,
+			},
+		}
+
+		r := makeReconciler(dcd, ckpt)
+		podTemplateSpec, err := r.generatePodTemplateSpec(
+			context.Background(),
+			generateResourceOption{dynamoComponentDeployment: dcd},
+			dynamo.RoleMain,
+		)
+		if err != nil {
+			t.Fatalf("generatePodTemplateSpec failed: %v", err)
+		}
+
+		if got := podTemplateSpec.Spec.Containers[0]; got.Name != "gms-loader" || len(got.Command) != 1 || got.Command[0] != "python3" {
+			t.Fatalf("expected sidecar container to remain unchanged, got %#v", got)
+		}
+		if got := podTemplateSpec.Spec.Containers[1]; got.Name != commonconsts.MainContainerName || len(got.Command) != 2 || got.Command[0] != "sleep" || got.Command[1] != "infinity" {
+			t.Fatalf("expected main container to be rewritten for restore, got %#v", got)
+		}
+		if podTemplateSpec.Spec.Containers[1].Args != nil {
+			t.Fatalf("expected main container args to be cleared, got %#v", podTemplateSpec.Spec.Containers[1].Args)
+		}
+		if got := podTemplateSpec.Labels[snapshotprotocol.RestoreTargetLabel]; got != commonconsts.KubeLabelValueTrue {
+			t.Fatalf("expected %s label to be true, got %q", snapshotprotocol.RestoreTargetLabel, got)
 		}
 	})
 

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -1380,18 +1380,7 @@ func (r *DynamoGraphDeploymentReconciler) createCheckpointCR(
 		return nil, fmt.Errorf("checkpoint identity is required for Auto mode")
 	}
 
-	identity := component.Checkpoint.Identity
-
-	checkpointIdentity := nvidiacomv1alpha1.DynamoCheckpointIdentity{
-		Model:                identity.Model,
-		BackendFramework:     identity.BackendFramework,
-		DynamoVersion:        identity.DynamoVersion,
-		TensorParallelSize:   identity.TensorParallelSize,
-		PipelineParallelSize: identity.PipelineParallelSize,
-		Dtype:                identity.Dtype,
-		MaxModelLen:          identity.MaxModelLen,
-		ExtraParameters:      identity.ExtraParameters,
-	}
+	checkpointIdentity := *component.Checkpoint.Identity.DeepCopy()
 
 	// Capture config is not part of the checkpoint identity. Once a checkpoint object exists for a
 	// hash, later reconcilers must reuse it instead of racing to overwrite the capture pod template.
@@ -1399,7 +1388,7 @@ func (r *DynamoGraphDeploymentReconciler) createCheckpointCR(
 		dynamoDeployment,
 		component,
 		serviceName,
-		identity.BackendFramework,
+		checkpointIdentity.BackendFramework,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build checkpoint job pod template: %w", err)

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -542,6 +542,91 @@ func TestDynamoGraphDeploymentReconciler_reconcileCheckpoints_checkpointRefSkips
 	}
 }
 
+func TestDynamoGraphDeploymentReconciler_reconcileCheckpoints_checkpointRefUsesReadyReferencedCR(t *testing.T) {
+	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("Failed to add v1alpha1 to scheme: %v", err)
+	}
+
+	ctx := context.Background()
+	identity := v1alpha1.DynamoCheckpointIdentity{
+		Model:            "meta-llama/Llama-2-7b-hf",
+		BackendFramework: "vllm",
+	}
+	hash, err := checkpoint.ComputeIdentityHash(identity)
+	if err != nil {
+		t.Fatalf("Failed to compute checkpoint hash: %v", err)
+	}
+
+	referenced := &v1alpha1.DynamoCheckpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "friendly-checkpoint",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.DynamoCheckpointSpec{
+			Identity: identity,
+		},
+		Status: v1alpha1.DynamoCheckpointStatus{
+			Phase:        v1alpha1.DynamoCheckpointPhaseReady,
+			IdentityHash: hash,
+		},
+	}
+
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithObjects(referenced).
+			WithStatusSubresource(referenced).
+			Build(),
+		Config:   &configv1alpha1.OperatorConfiguration{},
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	ref := "friendly-checkpoint"
+	dgd := &v1alpha1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.DynamoGraphDeploymentSpec{
+			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: string(commonconsts.ComponentTypeWorker),
+					Checkpoint: &v1alpha1.ServiceCheckpointConfig{
+						Enabled:       true,
+						Mode:          v1alpha1.CheckpointModeAuto,
+						CheckpointRef: &ref,
+					},
+				},
+			},
+		},
+	}
+
+	checkpointStatuses, checkpointInfos, err := reconciler.reconcileCheckpoints(ctx, dgd)
+	if err != nil {
+		t.Fatalf("reconcileCheckpoints() error = %v", err)
+	}
+
+	info, ok := checkpointInfos["worker"]
+	if !ok {
+		t.Fatalf("expected checkpoint info for worker service")
+	}
+	if !info.Ready {
+		t.Fatalf("expected referenced checkpoint to be ready")
+	}
+	if !info.Exists {
+		t.Fatalf("expected referenced checkpoint to exist")
+	}
+	if info.Hash != hash {
+		t.Fatalf("checkpoint hash = %s, want %s", info.Hash, hash)
+	}
+	if checkpointStatuses["worker"].CheckpointName != "friendly-checkpoint" {
+		t.Fatalf("checkpoint status name = %s, want friendly-checkpoint", checkpointStatuses["worker"].CheckpointName)
+	}
+	if !checkpointStatuses["worker"].Ready {
+		t.Fatalf("expected checkpoint status to be ready")
+	}
+}
+
 func TestDynamoGraphDeploymentReconciler_reconcileCheckpoints_autoModeWaitsForExistingCreatingCheckpoint(t *testing.T) {
 	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		t.Fatalf("Failed to add v1alpha1 to scheme: %v", err)

--- a/deploy/operator/internal/dynamo/gms.go
+++ b/deploy/operator/internal/dynamo/gms.go
@@ -13,18 +13,15 @@ import (
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	gmsruntime "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	gmsSharedVolumeName    = "gms-shared"
-	gmsSharedMountPath     = "/shared"
-	gmsDRAClaimName        = "shared-gpu"
 	defaultDeviceClassName = "gpu.nvidia.com"
 )
 
@@ -64,47 +61,52 @@ func getDeviceClassName(component *v1alpha1.DynamoComponentDeploymentSharedSpec)
 	return defaultDeviceClassName
 }
 
-// applyGPUMemoryService transforms a pod spec to include a GMS sidecar with
-// DRA shared GPU access. The main container's GPU resources are replaced with
-// a DRA ResourceClaim, and a GMS init container is added.
+// resolveMainContainer finds the container named "main" in the pod spec.
+// Falls back to Containers[0] if there is exactly one container.
+func resolveMainContainer(podSpec *corev1.PodSpec) (*corev1.Container, error) {
+	if len(podSpec.Containers) == 0 {
+		return nil, fmt.Errorf("pod spec must have at least one container for GPU memory service")
+	}
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == commonconsts.MainContainerName {
+			return &podSpec.Containers[i], nil
+		}
+	}
+	if len(podSpec.Containers) == 1 {
+		return &podSpec.Containers[0], nil
+	}
+	return nil, fmt.Errorf("pod spec has %d containers but none named %q", len(podSpec.Containers), commonconsts.MainContainerName)
+}
+
+// applyGPUMemoryService transforms a pod spec to include GMS server sidecars
+// with DRA shared GPU access. The main container's GPU resources are replaced
+// with a DRA ResourceClaim.
 func applyGPUMemoryService(
 	podSpec *corev1.PodSpec,
 	component *v1alpha1.DynamoComponentDeploymentSharedSpec,
 	parentName string,
 	serviceName string,
 ) error {
-	if len(podSpec.Containers) == 0 {
-		return fmt.Errorf("pod spec must have at least one container for GPU memory service")
-	}
-
 	gpuCount, err := getGPUCount(component)
 	if err != nil {
 		return err
 	}
+	_ = gpuCount // GPU count is used for DRA claim template; sidecar discovers devices via pynvml
 
-	mainContainer := &podSpec.Containers[0]
+	mainContainer, err := resolveMainContainer(podSpec)
+	if err != nil {
+		return err
+	}
 
 	// Replace GPU resources with DRA claim on main container
 	removeGPUResources(mainContainer)
 	mainContainer.Resources.Claims = append(mainContainer.Resources.Claims, corev1.ResourceClaim{
-		Name: gmsDRAClaimName,
+		Name: gmsruntime.DRAClaimName,
 	})
 
-	// Add shared volume mount and TMPDIR to main container
-	mainContainer.VolumeMounts = append(mainContainer.VolumeMounts, corev1.VolumeMount{
-		Name:      gmsSharedVolumeName,
-		MountPath: gmsSharedMountPath,
-	})
-	mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{
-		Name: "TMPDIR", Value: gmsSharedMountPath,
-	})
-
-	// Add GMS sidecar
-	gmsSidecar := buildGMSSidecar(mainContainer.Image, gpuCount)
-	podSpec.InitContainers = append(podSpec.InitContainers, gmsSidecar)
-
-	// Add shared volume
-	podSpec.Volumes = append(podSpec.Volumes, gmsSharedVolume())
+	// Add GMS server sidecar, shared volume, and socket env vars.
+	// The sidecar gets DRA claims copied from main automatically.
+	gmsruntime.EnsureServerSidecar(podSpec, mainContainer)
 
 	// DRA replaces normal GPU scheduling, so the default GPU toleration that
 	// kubelet/device-plugin would add is lost. Re-add it explicitly.
@@ -117,7 +119,7 @@ func applyGPUMemoryService(
 	// Add pod-level DRA resource claim referencing the ResourceClaimTemplate
 	claimTemplateName := GMSResourceClaimTemplateName(parentName, serviceName)
 	podSpec.ResourceClaims = append(podSpec.ResourceClaims, corev1.PodResourceClaim{
-		Name:                      gmsDRAClaimName,
+		Name:                      gmsruntime.DRAClaimName,
 		ResourceClaimTemplateName: &claimTemplateName,
 	})
 
@@ -130,87 +132,6 @@ func removeGPUResources(container *corev1.Container) {
 	gpuResource := corev1.ResourceName(commonconsts.KubeResourceGPUNvidia)
 	delete(container.Resources.Limits, gpuResource)
 	delete(container.Resources.Requests, gpuResource)
-}
-
-// buildGMSSidecar creates the GMS weight server as a sidecar init container
-// (restartPolicy: Always). kubelet starts it before regular containers and
-// keeps it running for the pod's lifetime.
-//
-// Each GPU gets two GMS subprocesses (weights + kv_cache) via a bash wrapper
-// that forwards signals and exits if any child dies. TMPDIR is set so
-// UUID-based sockets land in the shared volume.
-func buildGMSSidecar(image string, gpuCount int) corev1.Container {
-	return corev1.Container{
-		Name:          "gms-weights",
-		Image:         image,
-		Command:       []string{"bash", "-c"},
-		Args:          []string{gmsWrapperScript(gpuCount)},
-		RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
-		Env: []corev1.EnvVar{
-			{Name: "TMPDIR", Value: gmsSharedMountPath},
-		},
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      gmsSharedVolumeName,
-				MountPath: gmsSharedMountPath,
-			},
-		},
-		StartupProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				Exec: &corev1.ExecAction{
-					Command: gmsReadyCheckCommand(gpuCount),
-				},
-			},
-			PeriodSeconds:    2,
-			FailureThreshold: 150, // 2s * 150 = 5 min
-		},
-		Resources: corev1.ResourceRequirements{
-			Claims: []corev1.ResourceClaim{
-				{Name: gmsDRAClaimName},
-			},
-		},
-	}
-}
-
-// gmsWrapperScript generates a bash script that launches two GMS subprocesses
-// per GPU device (one for weights, one for kv_cache), waits for any to exit,
-// then tears down the process group.
-func gmsWrapperScript(gpuCount int) string {
-	devList := make([]string, gpuCount)
-	for i := range gpuCount {
-		devList[i] = strconv.Itoa(i)
-	}
-	return fmt.Sprintf(
-		`cleanup() { kill -- -$$ 2>/dev/null; exit 1; }
-trap cleanup SIGTERM SIGINT
-for dev in %s; do
-  python3 -m gpu_memory_service --device "$dev" --tag weights &
-  echo "Started GMS device=$dev tag=weights pid=$!"
-  python3 -m gpu_memory_service --device "$dev" --tag kv_cache &
-  echo "Started GMS device=$dev tag=kv_cache pid=$!"
-done
-wait -n
-echo "A GMS subprocess exited, shutting down"
-cleanup`, strings.Join(devList, " "))
-}
-
-// gmsReadyCheckCommand returns the exec probe command that verifies the
-// expected number of GMS UDS sockets exist on the shared volume.
-// With 2-tag GMS (weights + kv_cache), there are 2 sockets per GPU.
-func gmsReadyCheckCommand(gpuCount int) []string {
-	return []string{
-		"sh", "-c",
-		fmt.Sprintf("test $(ls %s/gms_*.sock 2>/dev/null | wc -l) -ge %d", gmsSharedMountPath, gpuCount*2),
-	}
-}
-
-func gmsSharedVolume() corev1.Volume {
-	return corev1.Volume{
-		Name: gmsSharedVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	}
 }
 
 // GMSResourceClaimTemplateName returns the deterministic name for the

--- a/deploy/operator/internal/dynamo/gms_test.go
+++ b/deploy/operator/internal/dynamo/gms_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	gmsruntime "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -81,20 +82,21 @@ func TestApplyGPUMemoryService_MainContainerTransformed(t *testing.T) {
 
 	// Should have DRA claim
 	require.Len(t, main.Resources.Claims, 1)
-	assert.Equal(t, gmsDRAClaimName, main.Resources.Claims[0].Name)
+	assert.Equal(t, gmsruntime.DRAClaimName, main.Resources.Claims[0].Name)
 
 	// Should have shared volume mount
 	var hasSharedMount bool
 	for _, vm := range main.VolumeMounts {
-		if vm.Name == gmsSharedVolumeName && vm.MountPath == gmsSharedMountPath {
+		if vm.Name == gmsruntime.SharedVolumeName && vm.MountPath == gmsruntime.SharedMountPath {
 			hasSharedMount = true
 		}
 	}
 	assert.True(t, hasSharedMount, "main container should have gms-shared volume mount")
 
-	// Should have TMPDIR
+	// Should have TMPDIR and GMS_SOCKET_DIR
 	envMap := envToMap(main.Env)
-	assert.Equal(t, gmsSharedMountPath, envMap["TMPDIR"])
+	assert.Equal(t, gmsruntime.SharedMountPath, envMap["TMPDIR"])
+	assert.Equal(t, gmsruntime.SharedMountPath, envMap["GMS_SOCKET_DIR"])
 }
 
 func TestApplyGPUMemoryService_GMSSidecarInjected(t *testing.T) {
@@ -104,20 +106,19 @@ func TestApplyGPUMemoryService_GMSSidecarInjected(t *testing.T) {
 
 	require.Len(t, ps.InitContainers, 1)
 	gms := ps.InitContainers[0]
-	assert.Equal(t, "gms-weights", gms.Name)
+	assert.Equal(t, gmsruntime.ServerContainerName, gms.Name)
 	assert.Equal(t, "test-image:latest", gms.Image)
-	assert.Equal(t, []string{"bash", "-c"}, gms.Command)
-	assert.Contains(t, gms.Args[0], "gpu_memory_service --device")
+	assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.gms_server_sidecar"}, gms.Command)
 	assert.NotNil(t, gms.RestartPolicy)
 	assert.Equal(t, corev1.ContainerRestartPolicyAlways, *gms.RestartPolicy)
 
-	// GMS sidecar should have DRA claim
+	// GMS sidecar should have DRA claim copied from main
 	require.Len(t, gms.Resources.Claims, 1)
-	assert.Equal(t, gmsDRAClaimName, gms.Resources.Claims[0].Name)
+	assert.Equal(t, gmsruntime.DRAClaimName, gms.Resources.Claims[0].Name)
 
 	// GMS sidecar should have TMPDIR
 	gmsEnv := envToMap(gms.Env)
-	assert.Equal(t, gmsSharedMountPath, gmsEnv["TMPDIR"])
+	assert.Equal(t, gmsruntime.SharedMountPath, gmsEnv["TMPDIR"])
 }
 
 func TestApplyGPUMemoryService_SharedVolume(t *testing.T) {
@@ -127,7 +128,7 @@ func TestApplyGPUMemoryService_SharedVolume(t *testing.T) {
 
 	var found bool
 	for _, v := range ps.Volumes {
-		if v.Name == gmsSharedVolumeName {
+		if v.Name == gmsruntime.SharedVolumeName {
 			assert.NotNil(t, v.EmptyDir)
 			found = true
 		}
@@ -156,7 +157,7 @@ func TestApplyGPUMemoryService_DRAResourceClaim(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, ps.ResourceClaims, 1)
-	assert.Equal(t, gmsDRAClaimName, ps.ResourceClaims[0].Name)
+	assert.Equal(t, gmsruntime.DRAClaimName, ps.ResourceClaims[0].Name)
 	assert.Equal(t, "myapp-worker-gpu", *ps.ResourceClaims[0].ResourceClaimTemplateName)
 }
 
@@ -176,35 +177,29 @@ func TestApplyGPUMemoryService_SingleContainer(t *testing.T) {
 	err := applyGPUMemoryService(&ps, gmsComponent(2), "myapp", "Worker")
 	require.NoError(t, err)
 
-	// Should still have exactly 1 regular container (no duplication)
 	assert.Len(t, ps.Containers, 1)
 	assert.Equal(t, "main", ps.Containers[0].Name)
 }
 
-// --- GMS sidecar helpers ---
+func TestApplyGPUMemoryService_ResolvesMainByName(t *testing.T) {
+	ps := gmsBasePodSpec()
+	// Prepend a sidecar so main is NOT Containers[0]
+	sidecar := corev1.Container{Name: "sidecar", Image: "sidecar:latest"}
+	ps.Containers = append([]corev1.Container{sidecar}, ps.Containers...)
+	require.Equal(t, "sidecar", ps.Containers[0].Name)
 
-func TestGmsWrapperScript_TwoTagsPerDevice(t *testing.T) {
-	script := gmsWrapperScript(3)
-	assert.Contains(t, script, "for dev in 0 1 2")
-	assert.Contains(t, script, "--tag weights")
-	assert.Contains(t, script, "--tag kv_cache")
-	assert.Contains(t, script, "trap cleanup SIGTERM SIGINT")
-	assert.Contains(t, script, "wait -n")
-}
+	err := applyGPUMemoryService(&ps, gmsComponent(2), "myapp", "Worker")
+	require.NoError(t, err)
 
-func TestGmsReadyCheckCommand_TwoSocketsPerGPU(t *testing.T) {
-	cmd := gmsReadyCheckCommand(2)
-	assert.Equal(t, "sh", cmd[0])
-	assert.Equal(t, "-c", cmd[1])
-	assert.Contains(t, cmd[2], "gms_*.sock")
-	// 2 GPUs * 2 tags = 4 sockets
-	assert.Contains(t, cmd[2], "-ge 4")
-}
+	// Sidecar should be untouched
+	assert.Equal(t, "sidecar", ps.Containers[0].Name)
+	assert.Empty(t, ps.Containers[0].Resources.Claims)
 
-func TestGmsReadyCheckCommand_SingleGPU(t *testing.T) {
-	cmd := gmsReadyCheckCommand(1)
-	// 1 GPU * 2 tags = 2 sockets
-	assert.Contains(t, cmd[2], "-ge 2")
+	// Main should have DRA claim
+	main := ps.Containers[1]
+	assert.Equal(t, "main", main.Name)
+	require.Len(t, main.Resources.Claims, 1)
+	assert.Equal(t, gmsruntime.DRAClaimName, main.Resources.Claims[0].Name)
 }
 
 // --- GenerateGMSResourceClaimTemplate ---

--- a/deploy/operator/internal/gms/runtime.go
+++ b/deploy/operator/internal/gms/runtime.go
@@ -1,0 +1,150 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package gms
+
+import (
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	// ServerContainerName is the name of the GMS server init sidecar.
+	ServerContainerName = "gms-server"
+
+	// SharedVolumeName is the emptyDir volume shared between the GMS server
+	// sidecar and the main workload container for UDS sockets.
+	SharedVolumeName = "gms-shared"
+
+	// SharedMountPath is the mount path for the shared GMS socket directory.
+	SharedMountPath = "/shared"
+
+	// DRAClaimName is the pod-level DRA ResourceClaim name used by both the
+	// main container and GMS sidecars.
+	DRAClaimName = "shared-gpu"
+
+	// ControlVolumeName is the checkpoint-specific control volume name.
+	ControlVolumeName = "gms-control"
+
+	// ControlDir is the mount path for the checkpoint control volume.
+	ControlDir = "/tmp/gms-control"
+
+	readyFile = "gms-ready"
+
+	serverSidecarModule = "gpu_memory_service.cli.gms_server_sidecar"
+)
+
+// EnsureServerSidecar adds the GMS server init sidecar, shared volume, and
+// socket env vars to a pod spec. It copies DRA claims from mainContainer so
+// the sidecar shares GPU access.
+//
+// This is the single owner of GMS server/socket topology. Both the steady-state
+// operator path (dynamo/gms.go) and the checkpoint path (checkpoint/gms.go)
+// call this instead of building their own server containers.
+func EnsureServerSidecar(podSpec *corev1.PodSpec, mainContainer *corev1.Container) {
+	if podSpec == nil || mainContainer == nil {
+		return
+	}
+
+	ensureVolume(podSpec, corev1.Volume{
+		Name:         SharedVolumeName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	})
+	ensureVolumeMount(mainContainer, corev1.VolumeMount{Name: SharedVolumeName, MountPath: SharedMountPath})
+	setEnv(mainContainer, "TMPDIR", SharedMountPath)
+	setEnv(mainContainer, "GMS_SOCKET_DIR", SharedMountPath)
+
+	sidecar := serverContainer(mainContainer.Image)
+	copyDeviceClaims(mainContainer, &sidecar)
+	ensureInitContainer(podSpec, sidecar)
+}
+
+// FindServerContainer returns a pointer to the GMS server init container, or
+// nil if not present. Checkpoint code uses this to layer control-dir env/mounts
+// onto the runtime-owned server container.
+func FindServerContainer(podSpec *corev1.PodSpec) *corev1.Container {
+	if podSpec == nil {
+		return nil
+	}
+	for i := range podSpec.InitContainers {
+		if podSpec.InitContainers[i].Name == ServerContainerName {
+			return &podSpec.InitContainers[i]
+		}
+	}
+	return nil
+}
+
+func serverContainer(image string) corev1.Container {
+	return corev1.Container{
+		Name:          ServerContainerName,
+		Image:         image,
+		Command:       []string{"python3", "-m", serverSidecarModule},
+		RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
+		StartupProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"test", "-f", filepath.Join(SharedMountPath, readyFile)},
+				},
+			},
+			PeriodSeconds:    2,
+			FailureThreshold: 150, // 2s * 150 = 5 min
+		},
+		Env: []corev1.EnvVar{
+			{Name: "TMPDIR", Value: SharedMountPath},
+			{Name: "GMS_SOCKET_DIR", Value: SharedMountPath},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: SharedVolumeName, MountPath: SharedMountPath},
+		},
+	}
+}
+
+func copyDeviceClaims(src *corev1.Container, dst *corev1.Container) {
+	if src == nil || dst == nil || len(src.Resources.Claims) == 0 {
+		return
+	}
+	dst.Resources.Claims = append(dst.Resources.Claims, src.Resources.Claims...)
+}
+
+func ensureInitContainer(podSpec *corev1.PodSpec, container corev1.Container) {
+	for i := range podSpec.InitContainers {
+		if podSpec.InitContainers[i].Name == container.Name {
+			return
+		}
+	}
+	podSpec.InitContainers = append(podSpec.InitContainers, container)
+}
+
+func ensureVolume(podSpec *corev1.PodSpec, volume corev1.Volume) {
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name == volume.Name {
+			return
+		}
+	}
+	podSpec.Volumes = append(podSpec.Volumes, volume)
+}
+
+func ensureVolumeMount(container *corev1.Container, mount corev1.VolumeMount) {
+	for i := range container.VolumeMounts {
+		if container.VolumeMounts[i].Name == mount.Name && container.VolumeMounts[i].MountPath == mount.MountPath {
+			return
+		}
+	}
+	container.VolumeMounts = append(container.VolumeMounts, mount)
+}
+
+func setEnv(container *corev1.Container, name string, value string) {
+	for i := range container.Env {
+		if container.Env[i].Name != name {
+			continue
+		}
+		container.Env[i].Value = value
+		container.Env[i].ValueFrom = nil
+		return
+	}
+	container.Env = append(container.Env, corev1.EnvVar{Name: name, Value: value})
+}

--- a/deploy/operator/internal/gms/runtime_test.go
+++ b/deploy/operator/internal/gms/runtime_test.go
@@ -1,0 +1,112 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package gms
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestEnsureServerSidecar(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:  "main",
+			Image: "test-image:latest",
+			Resources: corev1.ResourceRequirements{
+				Claims: []corev1.ResourceClaim{{Name: DRAClaimName}},
+			},
+		}},
+	}
+
+	EnsureServerSidecar(podSpec, &podSpec.Containers[0])
+
+	require.Len(t, podSpec.Containers, 1)
+	require.Len(t, podSpec.InitContainers, 1)
+
+	main := &podSpec.Containers[0]
+	server := &podSpec.InitContainers[0]
+
+	assert.Equal(t, ServerContainerName, server.Name)
+	assert.Equal(t, []string{"python3", "-m", serverSidecarModule}, server.Command)
+	assert.Equal(t, SharedMountPath, envValue(t, main, "TMPDIR"))
+	assert.Equal(t, SharedMountPath, envValue(t, main, "GMS_SOCKET_DIR"))
+	assert.Equal(t, SharedMountPath, envValue(t, server, "TMPDIR"))
+	assert.Equal(t, SharedMountPath, envValue(t, server, "GMS_SOCKET_DIR"))
+
+	assert.Equal(t, corev1.ContainerRestartPolicyAlways, *server.RestartPolicy)
+	require.NotNil(t, server.StartupProbe)
+	assert.Equal(t, []string{"test", "-f", filepath.Join(SharedMountPath, readyFile)},
+		server.StartupProbe.Exec.Command)
+
+	// DRA claim copied from main
+	assert.Len(t, server.Resources.Claims, 1)
+	assert.Equal(t, DRAClaimName, server.Resources.Claims[0].Name)
+}
+
+func TestEnsureServerSidecarDoesNotAddCheckpointControl(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "main", Image: "test:latest"}},
+	}
+
+	EnsureServerSidecar(podSpec, &podSpec.Containers[0])
+
+	for _, volume := range podSpec.Volumes {
+		if volume.Name == ControlVolumeName {
+			t.Fatal("runtime shaping should not add checkpoint control volume")
+		}
+	}
+	server := FindServerContainer(podSpec)
+	require.NotNil(t, server)
+	for _, env := range server.Env {
+		if env.Name == "GMS_CONTROL_DIR" {
+			t.Fatal("server should not have checkpoint control env")
+		}
+	}
+}
+
+func TestEnsureServerSidecarIdempotent(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "main", Image: "test:latest"}},
+	}
+
+	EnsureServerSidecar(podSpec, &podSpec.Containers[0])
+	EnsureServerSidecar(podSpec, &podSpec.Containers[0])
+
+	assert.Len(t, podSpec.InitContainers, 1)
+	volumeCount := 0
+	for _, v := range podSpec.Volumes {
+		if v.Name == SharedVolumeName {
+			volumeCount++
+		}
+	}
+	assert.Equal(t, 1, volumeCount)
+}
+
+func TestFindServerContainer(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "main", Image: "test:latest"}},
+	}
+	assert.Nil(t, FindServerContainer(podSpec))
+
+	EnsureServerSidecar(podSpec, &podSpec.Containers[0])
+	assert.NotNil(t, FindServerContainer(podSpec))
+	assert.Equal(t, ServerContainerName, FindServerContainer(podSpec).Name)
+}
+
+func envValue(t *testing.T, container *corev1.Container, name string) string {
+	t.Helper()
+	for _, env := range container.Env {
+		if env.Name == name {
+			return env.Value
+		}
+	}
+	t.Fatalf("env %s not found", name)
+	return ""
+}

--- a/deploy/snapshot/cmd/snapshotctl/kube.go
+++ b/deploy/snapshot/cmd/snapshotctl/kube.go
@@ -95,14 +95,30 @@ func loadPod(manifestPath string) (*corev1.Pod, error) {
 	if kind := strings.TrimSpace(pod.Kind); kind != "" && kind != "Pod" {
 		return nil, fmt.Errorf("manifest %s is kind %q, expected Pod", manifestPath, kind)
 	}
-	if len(pod.Spec.Containers) != 1 {
+	if len(pod.Spec.Containers) == 0 {
 		return nil, fmt.Errorf(
-			"manifest %s has %d containers; snapshotctl requires exactly one worker container",
+			"manifest %s has no worker containers; snapshotctl requires at least one worker container",
 			manifestPath,
-			len(pod.Spec.Containers),
 		)
 	}
-	if strings.TrimSpace(pod.Spec.Containers[0].Image) == "" {
+	workerContainer := &pod.Spec.Containers[0]
+	if len(pod.Spec.Containers) > 1 {
+		workerContainer = nil
+		for index := range pod.Spec.Containers {
+			if pod.Spec.Containers[index].Name == "main" {
+				workerContainer = &pod.Spec.Containers[index]
+				break
+			}
+		}
+		if workerContainer == nil {
+			return nil, fmt.Errorf(
+				"manifest %s has %d containers; snapshotctl requires a worker container named main",
+				manifestPath,
+				len(pod.Spec.Containers),
+			)
+		}
+	}
+	if strings.TrimSpace(workerContainer.Image) == "" {
 		return nil, fmt.Errorf("manifest %s: worker container image is required", manifestPath)
 	}
 	if strings.TrimSpace(pod.Name) == "" {

--- a/deploy/snapshot/protocol/checkpoint.go
+++ b/deploy/snapshot/protocol/checkpoint.go
@@ -56,15 +56,16 @@ func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOpt
 		EnsureLocalhostSeccompProfile(&podTemplate.Spec, opts.SeccompProfile)
 	}
 	if opts.WrapLaunchJob {
-		if len(podTemplate.Spec.Containers) == 0 {
-			return nil, fmt.Errorf("checkpoint job requires one worker container")
+		container, err := ResolveCheckpointWorkerContainer(&podTemplate.Spec)
+		if err != nil {
+			return nil, err
 		}
-		if len(podTemplate.Spec.Containers[0].Command) == 0 {
+		if len(container.Command) == 0 {
 			return nil, fmt.Errorf("checkpoint job requires container.command when cuda-checkpoint launch-job wrapping is enabled")
 		}
-		podTemplate.Spec.Containers[0].Command, podTemplate.Spec.Containers[0].Args = wrapWithCudaCheckpointLaunchJob(
-			podTemplate.Spec.Containers[0].Command,
-			podTemplate.Spec.Containers[0].Args,
+		container.Command, container.Args = wrapWithCudaCheckpointLaunchJob(
+			container.Command,
+			container.Args,
 		)
 	}
 

--- a/deploy/snapshot/protocol/checkpoint_container.go
+++ b/deploy/snapshot/protocol/checkpoint_container.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package protocol
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const checkpointWorkerContainerName = "main"
+
+func ResolveCheckpointWorkerContainer(podSpec *corev1.PodSpec) (*corev1.Container, error) {
+	if podSpec == nil || len(podSpec.Containers) == 0 {
+		return nil, fmt.Errorf("checkpoint job requires at least one container")
+	}
+	if len(podSpec.Containers) == 1 {
+		return &podSpec.Containers[0], nil
+	}
+
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == checkpointWorkerContainerName {
+			return &podSpec.Containers[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("checkpoint job requires a container named %q when multiple containers are present", checkpointWorkerContainerName)
+}

--- a/deploy/snapshot/protocol/checkpoint_job_test.go
+++ b/deploy/snapshot/protocol/checkpoint_job_test.go
@@ -11,6 +11,17 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+func requireCheckpointContainer(t *testing.T, containers []corev1.Container, name string) *corev1.Container {
+	t.Helper()
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	t.Fatalf("container %q not found", name)
+	return nil
+}
+
 func TestNewCheckpointJob(t *testing.T) {
 	job, err := NewCheckpointJob(&corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -84,6 +95,97 @@ func TestNewCheckpointJob(t *testing.T) {
 	}
 	if job.Spec.TTLSecondsAfterFinished == nil || *job.Spec.TTLSecondsAfterFinished != 300 {
 		t.Fatalf("unexpected ttlSecondsAfterFinished: %#v", job.Spec.TTLSecondsAfterFinished)
+	}
+}
+
+func TestNewCheckpointJobPrefersContainerNamedMain(t *testing.T) {
+	job, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "sidecar", Command: []string{"sleep"}, Args: []string{"infinity"}},
+				{Name: "main", Command: []string{"python3", "-m", "dynamo.vllm"}, Args: []string{"--model", "Qwen"}},
+			},
+		},
+	}, CheckpointJobOptions{
+		Namespace:             "test-ns",
+		CheckpointID:          "hash",
+		ArtifactVersion:       "2",
+		Name:                  "test-job",
+		TTLSecondsAfterFinish: ptr.To(int32(300)),
+		WrapLaunchJob:         true,
+	})
+	if err != nil {
+		t.Fatalf("expected checkpoint job, got error: %v", err)
+	}
+
+	main := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, "main")
+	if len(main.Command) != 1 || main.Command[0] != "cuda-checkpoint" {
+		t.Fatalf("expected main container to be wrapped, got %#v", main.Command)
+	}
+	expectedArgs := []string{"--launch-job", "python3", "-m", "dynamo.vllm", "--model", "Qwen"}
+	if len(main.Args) != len(expectedArgs) {
+		t.Fatalf("expected launch-job args %#v, got %#v", expectedArgs, main.Args)
+	}
+	for i := range expectedArgs {
+		if main.Args[i] != expectedArgs[i] {
+			t.Fatalf("expected launch-job args %#v, got %#v", expectedArgs, main.Args)
+		}
+	}
+
+	sidecar := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, "sidecar")
+	if len(sidecar.Command) != 1 || sidecar.Command[0] != "sleep" {
+		t.Fatalf("expected sidecar command to remain unchanged, got %#v", sidecar.Command)
+	}
+	if len(sidecar.Args) != 1 || sidecar.Args[0] != "infinity" {
+		t.Fatalf("expected sidecar args to remain unchanged, got %#v", sidecar.Args)
+	}
+}
+
+func TestNewCheckpointJobAllowsSingleNonMainContainer(t *testing.T) {
+	job, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    "worker",
+				Command: []string{"python3", "-m", "dynamo.vllm"},
+				Args:    []string{"--model", "Qwen"},
+			}},
+		},
+	}, CheckpointJobOptions{
+		Namespace:             "test-ns",
+		CheckpointID:          "hash",
+		ArtifactVersion:       "2",
+		Name:                  "test-job",
+		TTLSecondsAfterFinish: ptr.To(int32(300)),
+		WrapLaunchJob:         true,
+	})
+	if err != nil {
+		t.Fatalf("expected checkpoint job, got error: %v", err)
+	}
+
+	container := &job.Spec.Template.Spec.Containers[0]
+	if len(container.Command) != 1 || container.Command[0] != "cuda-checkpoint" {
+		t.Fatalf("expected single container to be wrapped, got %#v", container.Command)
+	}
+}
+
+func TestNewCheckpointJobRejectsMultiContainerPodWithoutMain(t *testing.T) {
+	_, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "sidecar", Command: []string{"sleep"}, Args: []string{"infinity"}},
+				{Name: "worker", Command: []string{"python3", "-m", "dynamo.vllm"}},
+			},
+		},
+	}, CheckpointJobOptions{
+		Namespace:             "test-ns",
+		CheckpointID:          "hash",
+		ArtifactVersion:       "2",
+		Name:                  "test-job",
+		TTLSecondsAfterFinish: ptr.To(int32(300)),
+		WrapLaunchJob:         true,
+	})
+	if err == nil || err.Error() != "checkpoint job requires a container named \"main\" when multiple containers are present" {
+		t.Fatalf("expected missing main container error, got %v", err)
 	}
 }
 

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -39,10 +39,26 @@ func NewRestorePod(pod *corev1.Pod, opts PodOptions) *corev1.Pod {
 		pod.Annotations = map[string]string{}
 	}
 	ApplyRestoreTargetMetadata(pod.Labels, pod.Annotations, true, opts.CheckpointID, opts.ArtifactVersion)
-	PrepareRestorePodSpec(&pod.Spec, &pod.Spec.Containers[0], opts.Storage, opts.SeccompProfile, true)
+	container := resolveWorkerContainer(&pod.Spec)
+	PrepareRestorePodSpec(&pod.Spec, container, opts.Storage, opts.SeccompProfile, true)
 	pod.Namespace = opts.Namespace
 	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
 	return pod
+}
+
+func resolveWorkerContainer(podSpec *corev1.PodSpec) *corev1.Container {
+	if podSpec == nil {
+		return nil
+	}
+	if len(podSpec.Containers) == 1 {
+		return &podSpec.Containers[0]
+	}
+	for index := range podSpec.Containers {
+		if podSpec.Containers[index].Name == "main" {
+			return &podSpec.Containers[index]
+		}
+	}
+	return nil
 }
 
 func PrepareRestorePodSpec(
@@ -92,10 +108,10 @@ func ValidateRestorePodSpec(
 	if podSpec == nil {
 		return fmt.Errorf("pod spec is nil")
 	}
-	if len(podSpec.Containers) != 1 {
-		return fmt.Errorf("restore target must have exactly one container, got %d", len(podSpec.Containers))
+	container := resolveWorkerContainer(podSpec)
+	if container == nil {
+		return fmt.Errorf("restore target must include a worker container named main")
 	}
-	container := &podSpec.Containers[0]
 	if storage.PVCName != "" {
 		hasVolume := false
 		for _, volume := range podSpec.Volumes {

--- a/deploy/snapshot/protocol/restore_test.go
+++ b/deploy/snapshot/protocol/restore_test.go
@@ -187,6 +187,38 @@ func TestPrepareRestorePodSpecSynthesizesStartupProbeFromLiveness(t *testing.T) 
 	}
 }
 
+func TestNewRestorePodTargetsMainContainerWhenSidecarsPresent(t *testing.T) {
+	restorePod := NewRestorePod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "sidecar", Image: "sidecar:latest", Command: []string{"sidecar"}, Args: []string{"run"}},
+				{Name: "main", Image: "test:latest", Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}},
+			},
+		},
+	}, PodOptions{
+		Namespace:       "test-ns",
+		CheckpointID:    "hash",
+		ArtifactVersion: "2",
+		Storage: Storage{
+			Type:     StorageTypePVC,
+			PVCName:  "snapshot-pvc",
+			BasePath: "/checkpoints",
+		},
+		SeccompProfile: DefaultSeccompLocalhostProfile,
+	})
+
+	if got := restorePod.Spec.Containers[0].Command; len(got) != 1 || got[0] != "sidecar" {
+		t.Fatalf("expected sidecar command to remain unchanged, got %#v", got)
+	}
+	if got := restorePod.Spec.Containers[1].Command; len(got) != 2 || got[0] != "sleep" || got[1] != "infinity" {
+		t.Fatalf("expected main container placeholder command, got %#v", got)
+	}
+	if restorePod.Spec.Containers[1].Args != nil {
+		t.Fatalf("expected main container args to be cleared: %#v", restorePod.Spec.Containers[1].Args)
+	}
+}
+
 func TestPrepareRestorePodSpecSynthesizesStartupProbeFromReadiness(t *testing.T) {
 	podSpec := corev1.PodSpec{}
 	readinessProbe := &corev1.Probe{
@@ -279,7 +311,7 @@ func TestValidateRestorePodSpec(t *testing.T) {
 	}
 }
 
-func TestValidateRestorePodSpecRequiresExactlyOneContainer(t *testing.T) {
+func TestValidateRestorePodSpecRequiresMainContainerWhenMultiContainer(t *testing.T) {
 	profile := DefaultSeccompLocalhostProfile
 	podSpec := &corev1.PodSpec{
 		SecurityContext: &corev1.PodSecurityContext{
@@ -314,8 +346,48 @@ func TestValidateRestorePodSpecRequiresExactlyOneContainer(t *testing.T) {
 		BasePath: "/checkpoints",
 	}
 
-	if err := ValidateRestorePodSpec(podSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "restore target must have exactly one container, got 2" {
-		t.Fatalf("expected multi-container restore target to be rejected, got %v", err)
+	if err := ValidateRestorePodSpec(podSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "restore target must include a worker container named main" {
+		t.Fatalf("expected multi-container restore target without main to be rejected, got %v", err)
+	}
+}
+
+func TestValidateRestorePodSpecAllowsMainContainerWithSidecars(t *testing.T) {
+	profile := DefaultSeccompLocalhostProfile
+	podSpec := &corev1.PodSpec{
+		SecurityContext: &corev1.PodSecurityContext{
+			SeccompProfile: &corev1.SeccompProfile{
+				Type:             corev1.SeccompProfileTypeLocalhost,
+				LocalhostProfile: &profile,
+			},
+		},
+		Volumes: []corev1.Volume{{
+			Name: CheckpointVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "snapshot-pvc",
+				},
+			},
+		}},
+		Containers: []corev1.Container{
+			{Name: "sidecar"},
+			{
+				Name: "main",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      CheckpointVolumeName,
+					MountPath: "/checkpoints",
+				}},
+			},
+		},
+	}
+
+	storage := Storage{
+		Type:     StorageTypePVC,
+		PVCName:  "snapshot-pvc",
+		BasePath: "/checkpoints",
+	}
+
+	if err := ValidateRestorePodSpec(podSpec, storage, DefaultSeccompLocalhostProfile); err != nil {
+		t.Fatalf("expected main container with sidecars to validate, got %v", err)
 	}
 }
 

--- a/docs/kubernetes/snapshot.md
+++ b/docs/kubernetes/snapshot.md
@@ -142,6 +142,16 @@ spec:
             ...
 ```
 
+If this checkpoint should capture and restore GPU Memory Service helpers, set:
+
+```yaml
+spec:
+  gpuMemoryService:
+    enabled: true
+```
+
+`spec.gpuMemoryService` is outside `spec.identity`, so it does not change the checkpoint identity hash.
+
 For a full working example, see [deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml).
 
 Apply it:
@@ -261,6 +271,8 @@ spec:
           ...
         ...
 ```
+
+Auto mode only hashes `checkpoint.identity`. If you need GMS-specific checkpoint behavior, configure it on the `DynamoCheckpoint` object with `spec.gpuMemoryService.enabled`.
 
 Useful inspection commands:
 

--- a/lib/gpu_memory_service/cli/__init__.py
+++ b/lib/gpu_memory_service/cli/__init__.py
@@ -4,7 +4,13 @@
 """CLI for GPU Memory Service."""
 
 from gpu_memory_service.cli.args import Config, parse_args
-from gpu_memory_service.cli.runner import main
+
+
+def main():
+    from gpu_memory_service.cli.runner import main as runner_main
+
+    return runner_main()
+
 
 __all__ = [
     "Config",

--- a/lib/gpu_memory_service/cli/gms_checkpoint_loader.py
+++ b/lib/gpu_memory_service/cli/gms_checkpoint_loader.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+from gpu_memory_service.cli.gms_sidecar_common import (
+    checkpoint_device_dir,
+    list_devices,
+    wait_for_weights_socket,
+)
+from gpu_memory_service.client.gms_storage_client import GMSStorageClient
+from gpu_memory_service.common.utils import get_socket_path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    checkpoint_dir = os.environ["GMS_CHECKPOINT_DIR"]
+    for device in list_devices():
+        wait_for_weights_socket(device)
+        input_dir = checkpoint_device_dir(checkpoint_dir, device)
+        logger.info("Loading GMS checkpoint: device=%d input_dir=%s", device, input_dir)
+        client = GMSStorageClient(
+            socket_path=get_socket_path(device),
+            device=device,
+        )
+        client.load_to_gms(
+            input_dir,
+            max_workers=4,
+            clear_existing=True,
+        )
+
+    while True:
+        time.sleep(3600)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/gpu_memory_service/cli/gms_checkpoint_saver.py
+++ b/lib/gpu_memory_service/cli/gms_checkpoint_saver.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import ssl
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from gpu_memory_service.cli.gms_sidecar_common import (
+    checkpoint_device_dir,
+    list_devices,
+    wait_for_weights_socket,
+)
+from gpu_memory_service.client.gms_storage_client import GMSStorageClient
+from gpu_memory_service.common.utils import get_socket_path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+_SERVICE_ACCOUNT_TOKEN = Path(
+    "/var/run/secrets/kubernetes.io/serviceaccount/token"
+)
+_SERVICE_ACCOUNT_CA = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+
+def checkpoint_pod_ready(pod: dict[str, Any]) -> bool:
+    status = pod.get("status") or {}
+    if str(status.get("phase", "")).strip() != "Running":
+        return False
+    for condition in status.get("conditions") or []:
+        if condition.get("type") == "Ready" and str(
+            condition.get("status", "")
+        ).strip() == "True":
+            return True
+    return False
+
+
+def main_terminated(pod: dict[str, Any]) -> bool:
+    status = pod.get("status") or {}
+    for container in status.get("containerStatuses") or []:
+        if container.get("name") != "main":
+            continue
+        return bool((container.get("state") or {}).get("terminated"))
+    return False
+
+
+def main() -> None:
+    service_token = _SERVICE_ACCOUNT_TOKEN.read_text(encoding="utf-8").strip()
+    ssl_context = ssl.create_default_context(cafile=_SERVICE_ACCOUNT_CA)
+    pod_api_url = (
+        "https://"
+        + os.environ["KUBERNETES_SERVICE_HOST"]
+        + ":"
+        + os.environ.get("KUBERNETES_SERVICE_PORT_HTTPS", "443")
+        + f"/api/v1/namespaces/{os.environ['POD_NAMESPACE']}/pods/{os.environ['POD_NAME']}"
+    )
+    checkpoint_dir = os.environ["GMS_CHECKPOINT_DIR"]
+
+    def checkpoint_pod() -> dict[str, Any]:
+        request = urllib.request.Request(
+            pod_api_url,
+            headers={"Authorization": f"Bearer {service_token}"},
+        )
+        with urllib.request.urlopen(
+            request,
+            context=ssl_context,
+            timeout=5,
+        ) as response:
+            return json.load(response)
+
+    logger.info("Waiting for checkpoint pod Ready=True before GMS save")
+    while True:
+        try:
+            pod = checkpoint_pod()
+        except Exception:
+            time.sleep(1)
+            continue
+
+        if checkpoint_pod_ready(pod):
+            break
+        if main_terminated(pod):
+            raise SystemExit("main container terminated before GMS save could start")
+        time.sleep(1)
+
+    logger.info("Checkpoint pod is Ready; starting GMS save")
+    try:
+        for device in list_devices():
+            wait_for_weights_socket(device)
+            output_dir = checkpoint_device_dir(checkpoint_dir, device)
+            logger.info(
+                "Saving GMS checkpoint: device=%d output_dir=%s",
+                device,
+                output_dir,
+            )
+            client = GMSStorageClient(
+                output_dir,
+                socket_path=get_socket_path(device),
+                device=device,
+            )
+            client.save(max_workers=4)
+    finally:
+        (Path(os.environ["GMS_CONTROL_DIR"]) / "checkpoint-done").write_text(
+            "done",
+            encoding="utf-8",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/gpu_memory_service/cli/gms_server_sidecar.py
+++ b/lib/gpu_memory_service/cli/gms_server_sidecar.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GMS server sidecar entry point.
+
+Launches two GMS server processes per GPU (one for weights, one for kv_cache).
+Writes a ready file once all expected UDS sockets are present. Monitors an
+optional checkpoint stop file and shuts down cleanly when it appears.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+
+from gpu_memory_service.common.utils import get_socket_path
+
+from gpu_memory_service.cli.gms_sidecar_common import (
+    list_devices,
+    optional_checkpoint_stop_file,
+    ready_file_path,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+_TAGS = ("weights", "kv_cache")
+
+
+def main() -> None:
+    ready_file = ready_file_path()
+    ready_file.unlink(missing_ok=True)
+
+    devices = list_devices()
+    processes = []
+    for device in devices:
+        for tag in _TAGS:
+            proc = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "gpu_memory_service",
+                    "--device",
+                    str(device),
+                    "--tag",
+                    tag,
+                ]
+            )
+            logger.info("Started GMS device=%d tag=%s pid=%d", device, tag, proc.pid)
+            processes.append(proc)
+
+    def shutdown() -> None:
+        for process in processes:
+            if process.poll() is None:
+                process.terminate()
+
+    def terminate(*_args) -> None:
+        shutdown()
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGTERM, terminate)
+    signal.signal(signal.SIGINT, terminate)
+
+    stop_file = optional_checkpoint_stop_file()
+    ready_written = False
+    while True:
+        stop_requested = stop_file is not None and stop_file.exists()
+        if stop_requested:
+            logger.info("checkpoint stop requested; shutting down GMS servers")
+            shutdown()
+
+        if not ready_written:
+            sockets_ready = all(
+                os.path.exists(get_socket_path(device, tag))
+                for device in devices
+                for tag in _TAGS
+            )
+            if sockets_ready:
+                ready_file.write_text("ready", encoding="utf-8")
+                ready_written = True
+
+        running = False
+        for process in processes:
+            exit_code = process.poll()
+            if exit_code is None:
+                running = True
+                continue
+            if stop_requested:
+                continue
+            shutdown()
+            raise SystemExit(exit_code)
+
+        if not running and not stop_requested:
+            return
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/gpu_memory_service/cli/gms_sidecar_common.py
+++ b/lib/gpu_memory_service/cli/gms_sidecar_common.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from gpu_memory_service.common.utils import get_socket_path
+
+_WEIGHTS_TAG = "weights"
+_READY_FILE = "gms-ready"
+
+
+def ready_file_path() -> Path:
+    """Return the path of the GMS server ready sentinel file."""
+    return Path(os.environ.get("GMS_SOCKET_DIR", "/tmp")) / _READY_FILE
+
+
+def list_devices() -> list[int]:
+    import pynvml
+
+    pynvml.nvmlInit()
+    try:
+        count = pynvml.nvmlDeviceGetCount()
+    finally:
+        pynvml.nvmlShutdown()
+
+    if count == 0:
+        raise SystemExit("no nvidia devices found")
+    return list(range(count))
+
+
+def checkpoint_device_dir(root: str, device: int) -> str:
+    return os.path.join(root, f"device-{device}")
+
+
+def wait_for_socket(device: int, tag: str) -> None:
+    socket_path = get_socket_path(device, tag)
+    while not os.path.exists(socket_path):
+        time.sleep(1)
+
+
+def wait_for_weights_socket(device: int) -> None:
+    wait_for_socket(device, _WEIGHTS_TAG)
+
+
+def optional_checkpoint_stop_file() -> Path | None:
+    control_dir = os.environ.get("GMS_CONTROL_DIR")
+    if not control_dir:
+        return None
+    return Path(control_dir) / "checkpoint-done"

--- a/lib/gpu_memory_service/cli/storage_runner.py
+++ b/lib/gpu_memory_service/cli/storage_runner.py
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GMS Storage Client CLI.
+
+Provides two subcommands for saving and loading GPU Memory Service state:
+
+* ``save`` – connect to a running GMS server in RO mode and write every
+              allocation plus all metadata to a sharded binary directory.
+* ``load`` – connect to a running GMS server in RW mode, read tensor data
+              from a saved directory, and commit the state so readers can
+              acquire the RO lock.
+
+Usage examples::
+
+    # Save GMS state to disk
+    gms-storage-client save --output-dir /mnt/nvme/save --device 0
+
+    # Load a previous save back into a fresh GMS server
+    gms-storage-client load --input-dir /mnt/nvme/save --device 0
+"""
+
+import argparse
+import logging
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _configure_logging(verbose: bool) -> None:
+    if verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+        logging.getLogger("gpu_memory_service").setLevel(logging.DEBUG)
+
+
+def _resolve_socket(device: int, socket_path) -> str:
+    if socket_path is not None:
+        return socket_path
+    from gpu_memory_service.common.utils import get_socket_path
+
+    return get_socket_path(device)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand implementations
+# ---------------------------------------------------------------------------
+
+
+def _run_save(args) -> None:
+    """Execute the save subcommand."""
+    from gpu_memory_service.client.gms_storage_client import GMSStorageClient
+
+    _configure_logging(args.verbose)
+    socket_path = _resolve_socket(args.device, args.socket_path)
+
+    logger.info(
+        "Saving GMS state: device=%s, socket=%s, output_dir=%s, save_workers=%s",
+        args.device,
+        socket_path,
+        args.output_dir,
+        args.save_workers,
+    )
+
+    client = GMSStorageClient(
+        args.output_dir,
+        socket_path=socket_path,
+        device=args.device,
+        timeout_ms=args.timeout_ms,
+        shard_size_bytes=args.shard_size_bytes,
+    )
+
+    manifest = client.save(max_workers=args.save_workers)
+    shard_count = len({a.tensor_file for a in manifest.allocations})
+
+    logger.info(
+        "Save complete: %s allocations written to %s (%s shards)",
+        len(manifest.allocations),
+        args.output_dir,
+        shard_count,
+    )
+    logger.info("Layout hash: %s", manifest.layout_hash)
+
+
+def _run_load(args) -> None:
+    """Execute the load subcommand."""
+    from gpu_memory_service.client.gms_storage_client import GMSStorageClient
+
+    _configure_logging(args.verbose)
+    socket_path = _resolve_socket(args.device, args.socket_path)
+
+    logger.info(
+        "Loading GMS state: device=%s, socket=%s, input_dir=%s, clear_existing=%s",
+        args.device,
+        socket_path,
+        args.input_dir,
+        not args.no_clear,
+    )
+
+    client = GMSStorageClient(
+        socket_path=socket_path,
+        device=args.device,
+        timeout_ms=args.timeout_ms,
+    )
+
+    id_map = client.load_to_gms(
+        args.input_dir,
+        max_workers=args.workers,
+        clear_existing=not args.no_clear,
+    )
+
+    logger.info("Load complete: %s allocations committed to GMS", len(id_map))
+    for old_id, new_id in id_map.items():
+        logger.info("  %s → %s", old_id, new_id)
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+_SHARD_SIZE_DEFAULT = 4 * 1024**3  # 4 GiB
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gms-storage-client",
+        description="Save and load GPU Memory Service state to/from disk.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="subcommand")
+
+    # -- save ---------------------------------------------------------------
+    save_p = subparsers.add_parser(
+        "save",
+        help="Save GMS state to a sharded binary directory.",
+        description=(
+            "Connect to a running GMS server in RO mode and export every "
+            "allocation plus all metadata to a compact sharded binary format."
+        ),
+    )
+    save_p.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory to write into (created if absent).",
+    )
+    save_p.add_argument(
+        "--device",
+        type=int,
+        default=0,
+        help="CUDA device index (default: 0).",
+    )
+    save_p.add_argument(
+        "--socket-path",
+        type=str,
+        default=None,
+        help="GMS Unix socket path. Default uses GPU UUID-based path.",
+    )
+    save_p.add_argument(
+        "--timeout-ms",
+        type=int,
+        default=None,
+        help="Timeout in milliseconds for acquiring the RO lock.",
+    )
+    save_p.add_argument(
+        "--shard-size-bytes",
+        type=int,
+        default=_SHARD_SIZE_DEFAULT,
+        help=(
+            f"Soft upper bound per shard file in bytes "
+            f"(default: {_SHARD_SIZE_DEFAULT // 1024**3} GiB).  "
+            "Decrease to increase parallelism on save/load; increase to "
+            "reduce file count."
+        ),
+    )
+    save_p.add_argument(
+        "--save-workers",
+        type=int,
+        default=4,
+        help="Thread pool size for parallel shard writes (default: 4).",
+    )
+    save_p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging.",
+    )
+
+    # -- load ---------------------------------------------------------------
+    load_p = subparsers.add_parser(
+        "load",
+        help="Load a saved GMS state back into a running GMS server.",
+        description=(
+            "Connect to a running GMS server in RW mode, read tensor data "
+            "from a saved directory (reading each shard file sequentially), "
+            "and commit the state so readers can acquire the RO lock."
+        ),
+    )
+    load_p.add_argument(
+        "--input-dir",
+        required=True,
+        help="Directory previously created by the save subcommand.",
+    )
+    load_p.add_argument(
+        "--device",
+        type=int,
+        default=0,
+        help="CUDA device index (default: 0).",
+    )
+    load_p.add_argument(
+        "--socket-path",
+        type=str,
+        default=None,
+        help="GMS Unix socket path. Default uses GPU UUID-based path.",
+    )
+    load_p.add_argument(
+        "--timeout-ms",
+        type=int,
+        default=None,
+        help="Timeout in milliseconds for acquiring the RW lock.",
+    )
+    load_p.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        help="Thread pool size for parallel shard reads (default: 4).",
+    )
+    load_p.add_argument(
+        "--no-clear",
+        action="store_true",
+        default=False,
+        help=(
+            "Do not clear existing GMS allocations before loading. "
+            "Default behaviour clears the server to produce an exact replica."
+        ),
+    )
+    load_p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging.",
+    )
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Entry point for the GMS Storage Client CLI."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.subcommand is None:
+        parser.print_help()
+        sys.exit(1)
+
+    if args.subcommand == "save":
+        _run_save(args)
+    elif args.subcommand == "load":
+        _run_load(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/gpu_memory_service/client/_gms_storage_disk.py
+++ b/lib/gpu_memory_service/client/_gms_storage_disk.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import base64
+import errno
+import json
+import os
+import queue
+import threading
+from collections import defaultdict
+from concurrent.futures import CancelledError
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    import torch
+
+from gpu_memory_service.client._gms_storage_model import AllocationEntry, SaveManifest
+
+
+class ShardWriter:
+    """Packs allocation bytes sequentially into large binary shard files.
+
+    This is a single-threaded utility for streaming writes.  The parallel save
+    path in GMSStorageClient._write_shards assigns allocations to shards via
+    plan_shard_layout and writes each shard file concurrently, so it does not
+    use ShardWriter directly.  ShardWriter is kept as a public utility for
+    callers that want a simple sequential writer.
+    """
+
+    def __init__(self, shards_dir: str, shard_size_bytes: int = 4 * 1024**3) -> None:
+        self._shards_dir = shards_dir
+        self._shard_size = shard_size_bytes
+        self._shard_idx = -1
+        self._current_offset = 0
+        self._current_file: Optional[Any] = None
+        self._current_rel_path: str = ""
+        os.makedirs(shards_dir, exist_ok=True)
+
+    def _roll_shard(self) -> None:
+        if self._current_file is not None:
+            self._current_file.close()
+        self._shard_idx += 1
+        filename = f"shard_{self._shard_idx:04d}.bin"
+        abs_path = os.path.join(self._shards_dir, filename)
+        self._current_file = open(abs_path, "wb")
+        self._current_rel_path = os.path.join("shards", filename)
+        self._current_offset = 0
+
+    def write(self, tensor: torch.Tensor) -> Tuple[str, int]:
+        cpu = tensor.cpu() if hasattr(tensor, "is_cuda") and tensor.is_cuda else tensor
+        if hasattr(cpu, "is_contiguous") and not cpu.is_contiguous():
+            cpu = cpu.contiguous()
+        arr = cpu.numpy()
+        size = arr.nbytes
+        if self._current_file is None or (
+            self._current_offset > 0 and self._current_offset + size > self._shard_size
+        ):
+            self._roll_shard()
+
+        offset = self._current_offset
+        arr.tofile(self._current_file)
+        self._current_offset += size
+        return self._current_rel_path, offset
+
+    def close(self) -> None:
+        if self._current_file is not None:
+            self._current_file.close()
+            self._current_file = None
+
+    def __enter__(self) -> "ShardWriter":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+
+def read_shard_sequential(
+    abs_path: str,
+    sorted_entries: List[AllocationEntry],
+    device: int,
+    *,
+    pin_memory: bool = False,
+    os_module=os,
+    np_module=None,
+    torch_module=None,
+    logger=None,
+) -> Dict[str, torch.Tensor]:
+    """Read one shard file front-to-back without seeking."""
+    if np_module is None or torch_module is None:
+        raise RuntimeError("numpy and torch modules are required to read shards")
+
+    result: Dict[str, torch.Tensor] = {}
+    device_str = f"cuda:{device}" if device >= 0 else "cpu"
+
+    if abs_path.endswith(".pt"):
+        if len(sorted_entries) != 1:
+            raise RuntimeError(
+                f"Expected exactly 1 entry for legacy .pt file, got "
+                f"{len(sorted_entries)}: {abs_path}"
+            )
+        entry = sorted_entries[0]
+        result[entry.allocation_id] = torch_module.load(
+            abs_path,
+            weights_only=True,
+            map_location=device_str,
+        )
+        return result
+
+    odirect_flag = getattr(os_module, "O_DIRECT", None)
+    if odirect_flag is not None:
+        fd: Optional[int] = None
+        done = 0
+        try:
+            total_size = sum(entry.aligned_size for entry in sorted_entries)
+            if pin_memory and torch_module.cuda.is_available():
+                shard_t = torch_module.empty(
+                    total_size,
+                    dtype=torch_module.uint8,
+                    pin_memory=True,
+                )
+                arr = shard_t.numpy()
+            else:
+                shard_t = None
+                arr = np_module.empty(total_size, dtype=np_module.uint8)
+
+            fd = os_module.open(abs_path, os_module.O_RDONLY | odirect_flag)
+            try:
+                mv = memoryview(arr)
+                try:
+                    while done < total_size:
+                        read = os_module.readv(fd, [mv[done:]])
+                        if read == 0:
+                            raise RuntimeError(
+                                f"Unexpected EOF in O_DIRECT read from {abs_path}: "
+                                f"got {done} of {total_size} bytes"
+                            )
+                        done += read
+                finally:
+                    mv.release()
+            finally:
+                os_module.close(fd)
+
+            offset = 0
+            for entry in sorted_entries:
+                size = entry.aligned_size
+                if shard_t is not None:
+                    tensor = shard_t[offset : offset + size]
+                else:
+                    tensor = torch_module.from_numpy(arr[offset : offset + size])
+                if device >= 0:
+                    tensor = tensor.to(device_str)
+                result[entry.allocation_id] = tensor
+                offset += size
+            return result
+        except OSError as exc:
+            fallback_errnos = {errno.EINVAL, errno.EOPNOTSUPP}
+            if fd is not None and exc.errno not in fallback_errnos:
+                raise
+            result.clear()
+            if logger is not None:
+                if fd is None:
+                    logger.debug(
+                        "O_DIRECT unsupported on %s (errno %s); using buffered reads",
+                        abs_path,
+                        exc.errno,
+                    )
+                else:
+                    logger.debug(
+                        "O_DIRECT read on %s hit EINVAL after %d/%d bytes; using buffered reads",
+                        abs_path,
+                        done,
+                        total_size,
+                    )
+
+    if sorted_entries and sorted_entries[0].tensor_offset != 0:
+        raise RuntimeError(
+            f"Buffered shard read requires entries starting at offset 0, "
+            f"got {sorted_entries[0].tensor_offset} in {abs_path}"
+        )
+    with open(abs_path, "rb") as handle:
+        for entry in sorted_entries:
+            raw = handle.read(entry.aligned_size)
+            if len(raw) != entry.aligned_size:
+                raise RuntimeError(
+                    f"Short read from {abs_path} at offset {entry.tensor_offset}: "
+                    f"expected {entry.aligned_size} bytes, got {len(raw)}"
+                )
+            arr = np_module.frombuffer(raw, dtype=np_module.uint8).copy()
+            tensor = torch_module.from_numpy(arr)
+            if device >= 0:
+                tensor = tensor.to(device_str)
+            result[entry.allocation_id] = tensor
+    return result
+
+
+def decode_metadata(raw_meta: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    return {
+        key: {
+            "allocation_id": entry["allocation_id"],
+            "offset_bytes": int(entry["offset_bytes"]),
+            "value": base64.b64decode(entry["value"]),
+        }
+        for key, entry in raw_meta.items()
+    }
+
+
+def group_entries_by_shard(
+    allocations: List[AllocationEntry],
+) -> Dict[str, List[AllocationEntry]]:
+    groups: Dict[str, List[AllocationEntry]] = defaultdict(list)
+    for entry in allocations:
+        groups[entry.tensor_file].append(entry)
+    for entries in groups.values():
+        entries.sort(key=lambda entry: entry.tensor_offset)
+    return dict(groups)
+
+
+def plan_shard_layout(
+    allocations_info: List[Dict[str, Any]],
+    shard_size_bytes: int,
+) -> List[Tuple[int, int]]:
+    result: List[Tuple[int, int]] = []
+    shard_idx = -1
+    current_offset = 0
+    started = False
+    for alloc in allocations_info:
+        size = int(alloc["aligned_size"])
+        if not started or (
+            current_offset > 0 and current_offset + size > shard_size_bytes
+        ):
+            shard_idx += 1
+            current_offset = 0
+            started = True
+        result.append((shard_idx, current_offset))
+        current_offset += size
+    return result
+
+
+def read_shard_to_queue(
+    abs_path: str,
+    sorted_entries: List[AllocationEntry],
+    work_q: queue.Queue[Optional[Tuple[AllocationEntry, torch.Tensor]]],
+    *,
+    pin_memory: bool,
+    read_shard,
+    cancel_event: Optional[threading.Event] = None,
+) -> int:
+    shard_result = read_shard(
+        abs_path,
+        sorted_entries,
+        -1,
+        pin_memory=pin_memory,
+    )
+    for entry in sorted_entries:
+        while True:
+            if cancel_event is not None and cancel_event.is_set():
+                raise CancelledError(f"shard read cancelled: {abs_path}")
+            try:
+                work_q.put((entry, shard_result[entry.allocation_id]), timeout=0.1)
+                break
+            except queue.Full:
+                if cancel_event is not None and cancel_event.is_set():
+                    raise CancelledError(f"shard read cancelled: {abs_path}")
+    return len(sorted_entries)
+
+
+def load_manifest_and_metadata(
+    input_dir: str,
+) -> Tuple[SaveManifest, Dict[str, Dict[str, Any]]]:
+    manifest_path = os.path.join(input_dir, "manifest.json")
+    with open(manifest_path, encoding="utf-8") as handle:
+        manifest = SaveManifest.from_dict(json.load(handle))
+
+    metadata_path = os.path.join(input_dir, "gms_metadata.json")
+    raw_meta: Dict[str, Any] = {}
+    if os.path.exists(metadata_path):
+        with open(metadata_path, encoding="utf-8") as handle:
+            raw_meta = json.load(handle)
+
+    return manifest, decode_metadata(raw_meta)

--- a/lib/gpu_memory_service/client/_gms_storage_model.py
+++ b/lib/gpu_memory_service/client/_gms_storage_model.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List
+
+CURRENT_VERSION = "1.0"
+
+
+@dataclass(frozen=True)
+class AllocationEntry:
+    """Immutable record of one dumped allocation."""
+
+    allocation_id: str
+    size: int
+    aligned_size: int
+    tag: str
+    tensor_file: str
+    tensor_offset: int = 0
+
+
+@dataclass
+class SaveManifest:
+    """Manifest for a GMS dump directory."""
+
+    version: str
+    timestamp: float
+    layout_hash: str
+    device: int
+    allocations: List[AllocationEntry] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "timestamp": self.timestamp,
+            "layout_hash": self.layout_hash,
+            "device": self.device,
+            "allocations": [asdict(a) for a in self.allocations],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "SaveManifest":
+        version = payload["version"]
+        if version != CURRENT_VERSION:
+            raise ValueError(
+                f"Unsupported manifest version {version!r} "
+                f"(expected {CURRENT_VERSION!r})"
+            )
+        allocations = [
+            AllocationEntry(
+                allocation_id=entry["allocation_id"],
+                size=entry["size"],
+                aligned_size=entry["aligned_size"],
+                tag=entry["tag"],
+                tensor_file=entry["tensor_file"],
+                tensor_offset=entry.get("tensor_offset", 0),
+            )
+            for entry in payload.get("allocations", [])
+        ]
+        return cls(
+            version=payload["version"],
+            timestamp=payload["timestamp"],
+            layout_hash=payload["layout_hash"],
+            device=payload["device"],
+            allocations=allocations,
+        )

--- a/lib/gpu_memory_service/client/_gms_storage_restore.py
+++ b/lib/gpu_memory_service/client/_gms_storage_restore.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import queue
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    import torch
+
+from gpu_memory_service.client._gms_storage_model import AllocationEntry
+
+WORK_QUEUE_DEPTH_MULTIPLIER = 2
+
+
+@dataclass
+class RestorePipelineContext:
+    """Mutable state shared across disk, copy, and Phase A restore stages."""
+
+    worker_count: int
+    use_streams: bool
+    device: int
+    work_q: queue.Queue[Optional[Tuple[AllocationEntry, torch.Tensor]]]
+    va_events: Dict[str, threading.Event]
+    streams: List[torch.cuda.Stream]
+    cancel_event: threading.Event = field(default_factory=threading.Event)
+    vas: Dict[str, int] = field(default_factory=dict)
+    staged_srcs: List[torch.Tensor] = field(default_factory=list)
+    copy_errors: List[BaseException] = field(default_factory=list)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    @classmethod
+    def build(
+        cls,
+        allocations: List[AllocationEntry],
+        worker_count: int,
+        *,
+        device: int,
+        use_streams: bool,
+        torch_module,
+    ) -> "RestorePipelineContext":
+        streams = (
+            [torch_module.cuda.Stream(device=device) for _ in range(worker_count)]
+            if use_streams
+            else []
+        )
+        return cls(
+            worker_count=worker_count,
+            use_streams=use_streams,
+            device=device,
+            work_q=queue.Queue(maxsize=worker_count * WORK_QUEUE_DEPTH_MULTIPLIER),
+            va_events={entry.allocation_id: threading.Event() for entry in allocations},
+            streams=streams,
+        )
+
+
+@dataclass
+class RestorePipelineResources:
+    """Live restore pipeline resources that must be torn down together."""
+
+    ctx: RestorePipelineContext
+    disk_pool: ThreadPoolExecutor
+    disk_futures: Dict[Future[int], str]
+    copy_threads: List[threading.Thread]
+    active: bool = True

--- a/lib/gpu_memory_service/client/gms_storage_client.py
+++ b/lib/gpu_memory_service/client/gms_storage_client.py
@@ -1,0 +1,631 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GMS storage client: save GMS state to disk and load it back."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import queue
+import threading
+import time
+from collections import defaultdict
+from concurrent.futures import CancelledError, Future, ThreadPoolExecutor, as_completed
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+from gpu_memory_service.client._gms_storage_disk import (  # noqa: F401  re-exported for external callers
+    ShardWriter as _ShardWriter,
+)
+from gpu_memory_service.client._gms_storage_disk import (
+    decode_metadata as _decode_metadata_impl,
+)
+from gpu_memory_service.client._gms_storage_disk import (
+    group_entries_by_shard as _group_entries_by_shard_impl,
+)
+from gpu_memory_service.client._gms_storage_disk import (
+    load_manifest_and_metadata as _load_manifest_and_metadata_impl,
+)
+from gpu_memory_service.client._gms_storage_disk import (
+    plan_shard_layout as _plan_shard_layout_impl,
+)
+from gpu_memory_service.client._gms_storage_disk import (
+    read_shard_sequential as _read_shard_sequential_impl,
+)
+from gpu_memory_service.client._gms_storage_disk import (
+    read_shard_to_queue as _read_shard_to_queue_impl,
+)
+from gpu_memory_service.client._gms_storage_model import (
+    CURRENT_VERSION as _CURRENT_VERSION,
+)
+from gpu_memory_service.client._gms_storage_model import AllocationEntry, SaveManifest
+from gpu_memory_service.client._gms_storage_restore import (
+    RestorePipelineContext as _RestorePipelineContext,
+)
+from gpu_memory_service.client._gms_storage_restore import (
+    RestorePipelineResources as _RestorePipelineResources,
+)
+
+logger = logging.getLogger(__name__)
+
+try:
+    from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
+    from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
+    from gpu_memory_service.common.locks import RequestedLockType
+
+    _GMS_IMPORTS_AVAILABLE = True
+except ImportError:
+    _GMS_IMPORTS_AVAILABLE = False
+    GMSClientMemoryManager = None  # type: ignore[assignment,misc]
+    _tensor_from_pointer = None  # type: ignore[assignment]
+    RequestedLockType = None  # type: ignore[assignment]
+
+try:
+    import torch
+
+    _TORCH_AVAILABLE = True
+except ImportError:
+    _TORCH_AVAILABLE = False
+    torch = None  # type: ignore[assignment]
+
+
+def _read_shard_sequential(
+    abs_path: str,
+    sorted_entries: List[AllocationEntry],
+    device: int,
+    pin_memory: bool = False,
+) -> Dict[str, "torch.Tensor"]:
+    """Facade wrapper kept for test patchability and backwards compatibility."""
+    return _read_shard_sequential_impl(
+        abs_path,
+        sorted_entries,
+        device,
+        pin_memory=pin_memory,
+        os_module=os,
+        np_module=np,
+        torch_module=torch,
+        logger=logger,
+    )
+
+
+def _decode_metadata(raw_meta: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    # Re-exported for external callers (e.g. multi_ssd_bench.py).
+    return _decode_metadata_impl(raw_meta)
+
+
+def _group_entries_by_shard(
+    allocations: List[AllocationEntry],
+) -> Dict[str, List[AllocationEntry]]:
+    return _group_entries_by_shard_impl(allocations)
+
+
+def _allocation_record(alloc: Any) -> Dict[str, Any]:
+    if isinstance(alloc, dict):
+        return alloc
+    return {
+        "allocation_id": str(alloc.allocation_id),
+        "size": int(alloc.size),
+        "aligned_size": int(alloc.aligned_size),
+        "tag": str(alloc.tag),
+        "layout_slot": int(alloc.layout_slot),
+    }
+
+
+def _plan_shard_layout(
+    allocations_info: List[Dict[str, Any]],
+    shard_size_bytes: int,
+) -> List[Tuple[int, int]]:
+    return _plan_shard_layout_impl(allocations_info, shard_size_bytes)
+
+
+def _read_shard_to_queue(
+    abs_path: str,
+    sorted_entries: List[AllocationEntry],
+    work_q: "queue.Queue[Optional[Tuple[AllocationEntry, 'torch.Tensor']]]",
+    *,
+    pin_memory: bool,
+    cancel_event: Optional[threading.Event] = None,
+) -> int:
+    return _read_shard_to_queue_impl(
+        abs_path,
+        sorted_entries,
+        work_q,
+        pin_memory=pin_memory,
+        read_shard=_read_shard_sequential,
+        cancel_event=cancel_event,
+    )
+
+
+def _load_manifest_and_metadata(
+    input_dir: str,
+) -> Tuple[SaveManifest, Dict[str, Dict[str, Any]]]:
+    return _load_manifest_and_metadata_impl(input_dir)
+
+
+class GMSStorageClient:
+    """Dump and restore GMS state to/from disk."""
+
+    def __init__(
+        self,
+        output_dir: Optional[str] = None,
+        socket_path: Optional[str] = None,
+        device: int = 0,
+        *,
+        timeout_ms: Optional[int] = None,
+        shard_size_bytes: int = 4 * 1024**3,
+    ) -> None:
+        self.output_dir = output_dir
+        self.device = device
+        self._timeout_ms = timeout_ms
+        self._shard_size = shard_size_bytes
+
+        if socket_path is None:
+            from gpu_memory_service.common.utils import get_socket_path
+
+            socket_path = get_socket_path(device)
+        self._socket_path = socket_path
+
+    def save(self, max_workers: int = 4) -> SaveManifest:
+        """Connect to GMS in RO mode and save all allocations + metadata to disk."""
+        self._validate_save_request()
+        output_dir, shards_dir = self._prepare_output_dir()
+
+        with GMSClientMemoryManager(self._socket_path, device=self.device) as mm:
+            mm.connect(RequestedLockType.RO, timeout_ms=self._timeout_ms)
+            layout_hash = mm.get_memory_layout_hash()
+            if not layout_hash:
+                raise RuntimeError(
+                    "GMS server has no committed weights; nothing to dump"
+                )
+            allocations_info = [
+                _allocation_record(alloc) for alloc in mm.list_handles()
+            ]
+            va_list = self._import_source_mappings(mm, allocations_info)
+            entries = self._write_shards(
+                shards_dir,
+                allocations_info,
+                va_list,
+                max_workers=max_workers,
+            )
+            metadata = self._save_metadata(mm)
+
+        self._write_json(os.path.join(output_dir, "gms_metadata.json"), metadata)
+        manifest = SaveManifest(
+            version=_CURRENT_VERSION,
+            timestamp=time.time(),
+            layout_hash=layout_hash,
+            device=self.device,
+            allocations=entries,
+        )
+        self._write_json(os.path.join(output_dir, "manifest.json"), manifest.to_dict())
+        logger.info("Wrote manifest with %d allocations", len(entries))
+        return manifest
+
+    def _validate_save_request(self) -> None:
+        if not _GMS_IMPORTS_AVAILABLE:
+            raise RuntimeError(
+                "GMS client imports unavailable (missing cuda-python or torch)"
+            )
+        if self.output_dir is None:
+            raise ValueError(
+                "output_dir must be set to call save(); pass it to GMSStorageClient()"
+            )
+
+    def _prepare_output_dir(self) -> Tuple[str, str]:
+        assert self.output_dir is not None
+        os.makedirs(self.output_dir, exist_ok=True)
+        shards_dir = os.path.join(self.output_dir, "shards")
+        os.makedirs(shards_dir, exist_ok=True)
+        for name in os.listdir(shards_dir):
+            if name.startswith("shard_") and name.endswith(".bin"):
+                os.unlink(os.path.join(shards_dir, name))
+        return self.output_dir, shards_dir
+
+    def _import_source_mappings(
+        self,
+        mm: Any,
+        allocations_info: List[Dict[str, Any]],
+    ) -> List[int]:
+        va_list = [
+            mm.create_mapping(allocation_id=alloc["allocation_id"])
+            for alloc in allocations_info
+        ]
+        logger.info("Phase A complete: imported %d allocation VAs", len(va_list))
+        return va_list
+
+    def _write_shards(
+        self,
+        shards_dir: str,
+        allocations_info: List[Dict[str, Any]],
+        va_list: List[int],
+        *,
+        max_workers: int,
+    ) -> List[AllocationEntry]:
+        layout = _plan_shard_layout(allocations_info, self._shard_size)
+        shard_groups: Dict[int, List[Tuple[int, int]]] = defaultdict(list)
+        for index, (shard_idx, byte_offset) in enumerate(layout):
+            shard_groups[shard_idx].append((index, byte_offset))
+
+        entries: List[Optional[AllocationEntry]] = [None] * len(allocations_info)
+
+        def _write_one_shard(
+            shard_idx: int, alloc_pairs: List[Tuple[int, int]]
+        ) -> None:
+            filename = f"shard_{shard_idx:04d}.bin"
+            abs_path = os.path.join(shards_dir, filename)
+            rel_path = os.path.join("shards", filename)
+            with open(abs_path, "wb") as handle:
+                for index, byte_offset in alloc_pairs:
+                    alloc = allocations_info[index]
+                    aligned_size = int(alloc["aligned_size"])
+                    tensor = _tensor_from_pointer(
+                        va_list[index],
+                        [aligned_size],
+                        [1],
+                        torch.uint8,
+                        self.device,
+                    )
+                    tensor.cpu().numpy().tofile(handle)
+                    entries[index] = AllocationEntry(
+                        allocation_id=alloc["allocation_id"],
+                        size=int(alloc["size"]),
+                        aligned_size=aligned_size,
+                        tag=str(alloc.get("tag", "default")),
+                        tensor_file=rel_path,
+                        tensor_offset=byte_offset,
+                    )
+
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {
+                pool.submit(_write_one_shard, shard_idx, alloc_pairs): shard_idx
+                for shard_idx, alloc_pairs in shard_groups.items()
+            }
+            for future in as_completed(futures):
+                future.result()
+
+        missing = sum(1 for entry in entries if entry is None)
+        if missing:
+            raise RuntimeError(
+                f"BUG: {missing} allocation(s) missing after shard writers completed"
+            )
+        logger.info("Phase B complete: wrote %d shards", len(shard_groups))
+        return [entry for entry in entries if entry is not None]
+
+    def _write_json(self, path: str, payload: Dict[str, Any]) -> None:
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+
+    def _run_restore_copy_worker(
+        self,
+        ctx: _RestorePipelineContext,
+        stream_idx: int,
+    ) -> None:
+        while True:
+            try:
+                item = ctx.work_q.get(timeout=0.1)
+            except queue.Empty:
+                if ctx.cancel_event.is_set():
+                    return
+                continue
+            if item is None:
+                return
+
+            entry, src = item
+            try:
+                while not ctx.va_events[entry.allocation_id].wait(timeout=0.1):
+                    if ctx.cancel_event.is_set():
+                        return
+                dst = _tensor_from_pointer(
+                    ctx.vas[entry.allocation_id],
+                    [entry.aligned_size],
+                    [1],
+                    torch.uint8,
+                    self.device,
+                )
+                if ctx.streams:
+                    with torch.cuda.stream(ctx.streams[stream_idx]):
+                        dst.copy_(src, non_blocking=src.is_pinned())
+                else:
+                    dst.copy_(src)
+                if ctx.use_streams and src.is_pinned():
+                    with ctx.lock:
+                        ctx.staged_srcs.append(src)
+            except Exception as exc:  # noqa: BLE001
+                with ctx.lock:
+                    ctx.copy_errors.append(exc)
+
+    def _start_restore_copy_threads(
+        self,
+        ctx: _RestorePipelineContext,
+    ) -> List[threading.Thread]:
+        threads = [
+            threading.Thread(
+                target=self._run_restore_copy_worker,
+                args=(ctx, index),
+                daemon=True,
+            )
+            for index in range(ctx.worker_count)
+        ]
+        for thread in threads:
+            thread.start()
+        return threads
+
+    def _prepare_restore_pipeline(
+        self,
+        manifest: SaveManifest,
+        groups: Dict[str, List[AllocationEntry]],
+        worker_count: int,
+        input_dir: str,
+    ) -> _RestorePipelineResources:
+        ctx = _RestorePipelineContext.build(
+            manifest.allocations,
+            worker_count,
+            device=self.device,
+            use_streams=_TORCH_AVAILABLE and torch.cuda.is_available(),
+            torch_module=torch,
+        )
+        copy_threads = self._start_restore_copy_threads(ctx)
+        disk_pool = ThreadPoolExecutor(max_workers=worker_count)
+        disk_futures = {
+            disk_pool.submit(
+                _read_shard_to_queue,
+                os.path.join(input_dir, rel_path),
+                sorted_entries,
+                ctx.work_q,
+                pin_memory=ctx.use_streams,
+                cancel_event=ctx.cancel_event,
+            ): rel_path
+            for rel_path, sorted_entries in groups.items()
+        }
+        return _RestorePipelineResources(
+            ctx=ctx,
+            disk_pool=disk_pool,
+            disk_futures=disk_futures,
+            copy_threads=copy_threads,
+        )
+
+    def _allocate_restore_mappings(
+        self,
+        mm: Any,
+        manifest: SaveManifest,
+        ctx: _RestorePipelineContext,
+    ) -> Dict[str, str]:
+        id_map: Dict[str, str] = {}
+        for entry in manifest.allocations:
+            old_id = entry.allocation_id
+            va = mm.create_mapping(size=entry.size, tag=entry.tag)
+            id_map[old_id] = mm.get_allocation_id(va)
+            ctx.vas[old_id] = va
+            ctx.va_events[old_id].set()
+        logger.info(
+            "Phase A complete: allocated %d GMS VAs; waiting for disk/copy pipeline",
+            len(ctx.vas),
+        )
+        return id_map
+
+    def _await_disk_reads(self, disk_futures: Dict[Future[int], str]) -> None:
+        for future in as_completed(disk_futures):
+            rel_path = disk_futures[future]
+            try:
+                future.result()
+            except CancelledError:
+                pass
+            except Exception as exc:
+                raise RuntimeError(f"Failed to load shard {rel_path}: {exc}") from exc
+
+    def _stop_restore_copy_threads(
+        self,
+        ctx: _RestorePipelineContext,
+        threads: List[threading.Thread],
+        *,
+        drain_queue: bool = False,
+    ) -> None:
+        if drain_queue:
+            self._drain_restore_queue(ctx)
+        for _ in threads:
+            if drain_queue:
+                # Cancel path: workers may have exited, so drain to make room.
+                while True:
+                    try:
+                        ctx.work_q.put(None, timeout=0.1)
+                        break
+                    except queue.Full:
+                        self._drain_restore_queue(ctx)
+            else:
+                # Normal path: disk reads are done and workers are alive; block
+                # until a slot opens rather than spinning with a timeout.
+                ctx.work_q.put(None)
+        for thread in threads:
+            thread.join()
+
+    def _drain_restore_queue(self, ctx: _RestorePipelineContext) -> None:
+        while True:
+            try:
+                ctx.work_q.get_nowait()
+            except queue.Empty:
+                return
+
+    def _cancel_restore_pipeline(self, ctx: _RestorePipelineContext) -> None:
+        ctx.cancel_event.set()
+        for event in ctx.va_events.values():
+            event.set()
+        self._drain_restore_queue(ctx)
+
+    def _finalize_restore_pipeline(self, ctx: _RestorePipelineContext) -> None:
+        if ctx.use_streams:
+            torch.cuda.synchronize(device=self.device)
+            ctx.staged_srcs.clear()
+        if ctx.copy_errors:
+            raise RuntimeError(
+                f"Failed to copy restored data to GMS: {ctx.copy_errors[0]}"
+            )
+
+    def _drain_restore_pipeline(self, resources: _RestorePipelineResources) -> None:
+        disk_error: Optional[BaseException] = None
+        finalize_error: Optional[BaseException] = None
+        drain_queue = False
+        try:
+            self._await_disk_reads(resources.disk_futures)
+        except Exception as exc:
+            disk_error = exc
+            self._cancel_restore_pipeline(resources.ctx)
+            drain_queue = True
+            resources.disk_pool.shutdown(wait=True, cancel_futures=True)
+        else:
+            resources.disk_pool.shutdown(wait=True)
+        try:
+            self._stop_restore_copy_threads(
+                resources.ctx,
+                resources.copy_threads,
+                drain_queue=drain_queue,
+            )
+        finally:
+            resources.active = False
+            try:
+                self._finalize_restore_pipeline(resources.ctx)
+            except Exception as exc:  # noqa: BLE001
+                finalize_error = exc
+        if disk_error is not None:
+            raise disk_error
+        if finalize_error is not None:
+            raise finalize_error
+
+    def _shutdown_restore_pipeline(
+        self,
+        resources: _RestorePipelineResources,
+    ) -> None:
+        if not resources.active:
+            return
+        self._cancel_restore_pipeline(resources.ctx)
+        resources.disk_pool.shutdown(wait=True, cancel_futures=True)
+        self._stop_restore_copy_threads(
+            resources.ctx,
+            resources.copy_threads,
+            drain_queue=True,
+        )
+        resources.active = False
+        # Synchronize async copies to prevent use-after-free of staged pinned
+        # buffers, but suppress copy errors — the caller already has an error
+        # to propagate and we must not mask it.
+        try:
+            self._finalize_restore_pipeline(resources.ctx)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def load_to_gms(
+        self,
+        input_dir: str,
+        *,
+        max_workers: int = 4,
+        clear_existing: bool = True,
+    ) -> Dict[str, str]:
+        if not _GMS_IMPORTS_AVAILABLE:
+            raise RuntimeError(
+                "GMS client imports unavailable (missing cuda-python or torch)"
+            )
+
+        manifest, saved_metadata = _load_manifest_and_metadata(input_dir)
+        groups = _group_entries_by_shard(manifest.allocations)
+        worker_count = max(1, min(max_workers, len(groups) or 1))
+
+        with GMSClientMemoryManager(self._socket_path, device=self.device) as mm:
+            mm.connect(RequestedLockType.RW, timeout_ms=self._timeout_ms)
+            if clear_existing:
+                logger.info("RW connect cleared any previously committed GMS state")
+
+            resources = self._prepare_restore_pipeline(
+                manifest,
+                groups,
+                worker_count,
+                input_dir,
+            )
+            try:
+                id_map = self._allocate_restore_mappings(mm, manifest, resources.ctx)
+                self._drain_restore_pipeline(resources)
+            except Exception:
+                self._shutdown_restore_pipeline(resources)
+                raise
+
+            logger.info(
+                "Phase B complete: streamed %d allocations to GMS memory",
+                len(manifest.allocations),
+            )
+            self._restore_metadata(mm, saved_metadata, id_map)
+            if not mm.commit():
+                raise RuntimeError("GMS commit failed after restore")
+
+        logger.info(
+            "load_to_gms complete: %d allocations, %d metadata keys",
+            len(id_map),
+            len(saved_metadata),
+        )
+        return id_map
+
+    def _restore_metadata(
+        self,
+        mm: Any,
+        saved_metadata: Dict[str, Dict[str, Any]],
+        id_map: Dict[str, str],
+    ) -> None:
+        for key, meta in saved_metadata.items():
+            old_alloc_id = meta["allocation_id"]
+            new_alloc_id = id_map.get(old_alloc_id, old_alloc_id)
+            ok = mm.metadata_put(key, new_alloc_id, meta["offset_bytes"], meta["value"])
+            if not ok:
+                raise RuntimeError(f"Failed to write metadata key={key!r}")
+            logger.debug("Restored metadata key=%s -> alloc=%s", key, new_alloc_id)
+        logger.info("Restored %d metadata keys; committing", len(saved_metadata))
+
+    @staticmethod
+    def load_tensors(
+        input_dir: str,
+        device: int = 0,
+        *,
+        max_workers: int = 4,
+    ) -> Tuple[Dict[str, "torch.Tensor"], Dict[str, Dict[str, Any]]]:
+        if not _TORCH_AVAILABLE:
+            raise RuntimeError("PyTorch is required for load_tensors()")
+
+        manifest, metadata = _load_manifest_and_metadata(input_dir)
+        groups = _group_entries_by_shard(manifest.allocations)
+        tensors: Dict[str, "torch.Tensor"] = {}
+
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {
+                pool.submit(
+                    _read_shard_sequential,
+                    os.path.join(input_dir, rel_path),
+                    sorted_entries,
+                    device,
+                ): rel_path
+                for rel_path, sorted_entries in groups.items()
+            }
+            for future in as_completed(futures):
+                rel_path = futures[future]
+                try:
+                    tensors.update(future.result())
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Failed to load shard {rel_path}: {exc}"
+                    ) from exc
+
+        logger.info("Loaded %d allocations from %s", len(tensors), input_dir)
+        return tensors, metadata
+
+    def _save_metadata(self, mm: Any) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        for key in mm.metadata_list():
+            got = mm.metadata_get(key)
+            if got is None:
+                logger.warning("Metadata key disappeared during dump: %s", key)
+                continue
+            allocation_id, offset_bytes, value = got
+            result[key] = {
+                "allocation_id": str(allocation_id),
+                "offset_bytes": int(offset_bytes),
+                "value": base64.b64encode(value).decode("ascii"),
+            }
+        return result

--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -37,6 +37,7 @@ from typing import Dict, List, Optional
 from gpu_memory_service.client.session import _GMSClientSession
 from gpu_memory_service.common.cuda_utils import (
     align_to_granularity,
+    cuda_ensure_initialized,
     cuda_set_current_device,
     cuda_synchronize,
     cuda_validate_pointer,
@@ -149,6 +150,7 @@ class GMSClientMemoryManager:
         self._va_preserved = False
         self._last_memory_layout_hash: str = ""
 
+        cuda_ensure_initialized()
         cuda_set_current_device(self.device)
         self.granularity = cumem_get_allocation_granularity(device)
 

--- a/lib/gpu_memory_service/common/utils.py
+++ b/lib/gpu_memory_service/common/utils.py
@@ -38,4 +38,5 @@ def get_socket_path(device: int, tag: str = "weights") -> str:
         uuid = pynvml.nvmlDeviceGetUUID(handle)
     finally:
         pynvml.nvmlShutdown()
-    return os.path.join(tempfile.gettempdir(), f"gms_{uuid}_{tag}.sock")
+    socket_dir = os.environ.get("GMS_SOCKET_DIR") or tempfile.gettempdir()
+    return os.path.join(socket_dir, f"gms_{uuid}_{tag}.sock")

--- a/lib/gpu_memory_service/pyproject.toml
+++ b/lib/gpu_memory_service/pyproject.toml
@@ -36,6 +36,7 @@ keywords = ["llm", "genai", "inference", "nvidia", "gpu", "memory", "dynamo"]
 
 [project.scripts]
 gpu-memory-service = "gpu_memory_service.cli.runner:main"
+gms-storage-client = "gpu_memory_service.cli.storage_runner:main"
 
 [project.optional-dependencies]
 test = [

--- a/lib/gpu_memory_service/setup.py
+++ b/lib/gpu_memory_service/setup.py
@@ -98,6 +98,12 @@ setup(
     package_data={
         "gpu_memory_service.client.torch.extensions": ["*.cpp"],
     },
+    entry_points={
+        "console_scripts": [
+            "gpu-memory-service=gpu_memory_service.cli.runner:main",
+            "gms-storage-client=gpu_memory_service.cli.storage_runner:main",
+        ]
+    },
     ext_modules=_create_ext_modules(),
     cmdclass={"build_ext": BuildExtension},
 )

--- a/lib/gpu_memory_service/tests/test_cuda_utils.py
+++ b/lib/gpu_memory_service/tests/test_cuda_utils.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import types
+from unittest import mock
+
+from gpu_memory_service.common import cuda_utils
+
+
+class _Prop:
+    def __init__(self) -> None:
+        self.type = None
+        self.location = types.SimpleNamespace(type=None, id=None)
+        self.requestedHandleTypes = None
+
+
+def test_cuda_set_current_device_does_not_initialize_driver() -> None:
+    calls: list[object] = []
+    fake_cuda = types.SimpleNamespace(
+        CUresult=types.SimpleNamespace(CUDA_SUCCESS=0),
+        cuDevicePrimaryCtxRetain=lambda device: calls.append(("retain", device))
+        or (0, f"ctx-{device}"),
+        cuCtxSetCurrent=lambda ctx: calls.append(("set", ctx)) or (0,),
+        cuDevicePrimaryCtxRelease=lambda device: (0,),
+    )
+
+    with mock.patch.object(cuda_utils, "cuda", fake_cuda):
+        with mock.patch.object(cuda_utils, "_primary_contexts", {}):
+            with mock.patch.object(
+                cuda_utils,
+                "_primary_context_release_registered",
+                False,
+            ):
+                cuda_utils.cuda_set_current_device(3)
+
+    assert calls == [("retain", 3), ("set", "ctx-3")]
+
+
+def test_cumem_get_allocation_granularity_uses_existing_cuda_init() -> None:
+    calls: list[object] = []
+    fake_cuda = types.SimpleNamespace(
+        CUresult=types.SimpleNamespace(CUDA_SUCCESS=0),
+        CUmemAllocationProp=_Prop,
+        CUmemAllocationType=types.SimpleNamespace(CU_MEM_ALLOCATION_TYPE_PINNED=1),
+        CUmemLocationType=types.SimpleNamespace(CU_MEM_LOCATION_TYPE_DEVICE=2),
+        CUmemAllocationHandleType=types.SimpleNamespace(
+            CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR=3
+        ),
+        CUmemAllocationGranularity_flags=types.SimpleNamespace(
+            CU_MEM_ALLOC_GRANULARITY_MINIMUM=4
+        ),
+        cuMemGetAllocationGranularity=lambda prop, flag: calls.append(
+            ("granularity", prop.location.id, flag)
+        )
+        or (0, 2097152),
+    )
+
+    with mock.patch.object(cuda_utils, "cuda", fake_cuda):
+        granularity = cuda_utils.cumem_get_allocation_granularity(5)
+
+    assert granularity == 2097152
+    assert calls == [("granularity", 5, 4)]

--- a/lib/gpu_memory_service/tests/test_gms_server_sidecar.py
+++ b/lib/gpu_memory_service/tests/test_gms_server_sidecar.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def test_ready_file_written_when_sockets_exist(tmp_path):
+    os.environ["GMS_SOCKET_DIR"] = str(tmp_path)
+
+    # Create mock socket files for 1 device, 2 tags
+    for tag in ("weights", "kv_cache"):
+        socket_file = tmp_path / f"gms_GPU-0000_0000_{tag}.sock"
+        socket_file.touch()
+
+    ready_file = tmp_path / "gms-ready"
+    assert not ready_file.exists()
+
+    mock_nvml = MagicMock()
+    mock_nvml.nvmlInit.return_value = None
+    mock_nvml.nvmlShutdown.return_value = None
+    mock_nvml.nvmlDeviceGetCount.return_value = 1
+    mock_nvml.nvmlDeviceGetHandleByIndex.return_value = "handle"
+    mock_nvml.nvmlDeviceGetUUID.return_value = "GPU-0000_0000"
+
+    with (
+        patch.dict("sys.modules", {"pynvml": mock_nvml}),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        proc = mock_popen.return_value
+        proc.poll.return_value = 0  # exit immediately
+
+        # Reimport to pick up patched modules and env
+        import gpu_memory_service.cli.gms_sidecar_common as common_mod
+        import gpu_memory_service.common.utils as utils_mod
+        import gpu_memory_service.cli.gms_server_sidecar as sidecar_mod
+
+        importlib.reload(utils_mod)
+        importlib.reload(common_mod)
+        importlib.reload(sidecar_mod)
+
+        try:
+            sidecar_mod.main()
+        except SystemExit:
+            pass
+
+    assert ready_file.exists()
+
+
+def test_ready_file_path_uses_socket_dir(tmp_path):
+    os.environ["GMS_SOCKET_DIR"] = str(tmp_path)
+
+    import gpu_memory_service.cli.gms_sidecar_common as mod
+    importlib.reload(mod)
+
+    assert mod.ready_file_path() == tmp_path / "gms-ready"

--- a/lib/gpu_memory_service/tests/test_gms_storage_disk.py
+++ b/lib/gpu_memory_service/tests/test_gms_storage_disk.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import json
+from pathlib import Path
+
+from gpu_memory_service.client._gms_storage_disk import load_manifest_and_metadata
+
+
+def test_load_manifest_and_metadata(tmp_path: Path) -> None:
+    manifest = {
+        "version": "1.0",
+        "timestamp": 1.0,
+        "layout_hash": "layout",
+        "device": 0,
+        "allocations": [
+            {
+                "allocation_id": "alloc-1",
+                "size": 4,
+                "aligned_size": 8,
+                "tag": "weights",
+                "tensor_file": "shards/shard_0000.bin",
+                "tensor_offset": 0,
+            }
+        ],
+    }
+    metadata = {
+        "tensor-key": {
+            "allocation_id": "alloc-1",
+            "offset_bytes": 0,
+            "value": base64.b64encode(b"payload").decode("ascii"),
+        }
+    }
+
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    (tmp_path / "gms_metadata.json").write_text(
+        json.dumps(metadata),
+        encoding="utf-8",
+    )
+
+    loaded_manifest, loaded_metadata = load_manifest_and_metadata(str(tmp_path))
+
+    assert loaded_manifest.layout_hash == "layout"
+    assert loaded_manifest.allocations[0].allocation_id == "alloc-1"
+    assert loaded_metadata["tensor-key"]["value"] == b"payload"

--- a/lib/gpu_memory_service/tests/test_gms_storage_model.py
+++ b/lib/gpu_memory_service/tests/test_gms_storage_model.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from gpu_memory_service.client._gms_storage_model import AllocationEntry, SaveManifest
+
+
+def test_manifest_round_trip() -> None:
+    manifest = SaveManifest(
+        version="1.0",
+        timestamp=123.0,
+        layout_hash="abc",
+        device=2,
+        allocations=[
+            AllocationEntry(
+                allocation_id="alloc-1",
+                size=16,
+                aligned_size=32,
+                tag="weights",
+                tensor_file="shards/shard_0000.bin",
+                tensor_offset=64,
+            )
+        ],
+    )
+
+    restored = SaveManifest.from_dict(manifest.to_dict())
+
+    assert restored.version == "1.0"
+    assert restored.layout_hash == "abc"
+    assert restored.device == 2
+    assert len(restored.allocations) == 1
+    assert restored.allocations[0].tensor_offset == 64

--- a/lib/gpu_memory_service/tests/test_memory_manager.py
+++ b/lib/gpu_memory_service/tests/test_memory_manager.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import mock
+
+from gpu_memory_service.client import memory_manager
+
+
+def test_memory_manager_initializes_cuda_before_selecting_device() -> None:
+    calls: list[object] = []
+
+    with mock.patch.object(
+        memory_manager,
+        "cuda_ensure_initialized",
+        side_effect=lambda: calls.append("init"),
+    ):
+        with mock.patch.object(
+            memory_manager,
+            "cuda_set_current_device",
+            side_effect=lambda device: calls.append(("set", device)),
+        ):
+            with mock.patch.object(
+                memory_manager,
+                "cumem_get_allocation_granularity",
+                side_effect=lambda device: calls.append(("granularity", device))
+                or 2097152,
+            ):
+                manager = memory_manager.GMSClientMemoryManager(
+                    "/tmp/gms.sock",
+                    device=3,
+                )
+
+    assert manager.granularity == 2097152
+    assert calls == ["init", ("set", 3), ("granularity", 3)]

--- a/lib/gpu_memory_service/tests/test_storage_runner.py
+++ b/lib/gpu_memory_service/tests/test_storage_runner.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from gpu_memory_service.cli.storage_runner import _build_parser
+
+
+def test_cli_parser_builds_save_and_load_commands() -> None:
+    parser = _build_parser()
+
+    save_args = parser.parse_args(["save", "--output-dir", "/tmp/out"])
+    load_args = parser.parse_args(["load", "--input-dir", "/tmp/in"])
+
+    assert save_args.subcommand == "save"
+    assert save_args.device == 0
+    assert load_args.subcommand == "load"
+    assert load_args.workers == 4


### PR DESCRIPTION
## Summary

> **Depends on #8148** (`gms/operator-v1`) — operator-level GPU Memory Service baseline

Adds checkpoint/restore support for GMS-enabled workloads, building on top of the operator-level GMS baseline from #8148. The operator handles all GMS pod shaping; the snapshot/checkpoint layer adds only checkpoint-specific deltas.

## Architecture

```
internal/gms/runtime.go (shared helper)
  └── EnsureServerSidecar(): socket volume, env, Python server init sidecar
  └── FindServerContainer(): for checkpoint code to layer control env

internal/dynamo/gms.go (steady-state operator, from #8148)
  └── applyGPUMemoryService(): DRA claims, GPU removal, tolerations
  └── calls gmsruntime.EnsureServerSidecar()

internal/checkpoint/gms.go (checkpoint-specific delta only)
  └── EnsureGMSRestoreSidecars(): shared server + loader
  └── EnsureGMSCheckpointJobSidecars(): shared server + saver + control dir
```

## Key changes

### Operator / Runtime
- Shared GMS server helper (`internal/gms/runtime.go`) used by both steady-state and checkpoint paths — no duplicate server injection
- Runtime-owned socket readiness barrier: GMS servers run as restartable init sidecars with `startupProbe`, so kubelet gates main container startup until UDS sockets are ready
- `main` container resolved by name (not `Containers[0]`), safe with user-provided sidecars via `extraPodSpec`
- No `gms-init` container — simplified to shared volumes + Python module entrypoints

### Checkpoint / Restore
- `DynamoCheckpoint` gains `spec.gpuMemoryService.enabled` (outside identity, mirrors DGD/DCD shape from #8148)
- Checkpoint jobs get GMS saver sidecar + control dir wiring
- Restore pods get GMS loader sidecar for pre-populating GPU memory from checkpoint storage
- Loader/saver share DRA device claims from the main container
- Merged `podinfo` downwardAPI volume for restore pod GPU detection

### Python
- Large inline Python strings removed from Go — sidecars invoke `python3 -m gpu_memory_service.cli.<module>`
- New modules: `gms_server_sidecar.py`, `gms_checkpoint_loader.py`, `gms_checkpoint_saver.py`, `gms_sidecar_common.py`
- CUDA initialization moved to client boundary (`GMSClientMemoryManager.__init__`)
- Broad smoke test replaced with targeted unit tests

### Snapshot layer
- Zero GMS awareness — snapshot code has no GMS references

## CRD changes

Additive (non-breaking) — adds `gpuMemoryService` to `DynamoCheckpoint`:
- `DynamoCheckpoint.spec.gpuMemoryService.enabled`
- DGD/DCD `gpuMemoryService` fields come from #8148

## Testing

- Go unit tests pass for `internal/gms`, `internal/checkpoint`, `internal/controller`, and `protocol`
- Python unit tests pass for GMS CLI modules, CUDA utils, memory manager, storage runner, and server sidecar
- CRDs regenerated via `make manifests`
