### PR TITLE
fix(operator/deploy/tilt): build helm dependencies automatically

### DIFF
--- a/deploy/operator/Tiltfile
+++ b/deploy/operator/Tiltfile
@@ -160,8 +160,8 @@ local_resource(
 # ---------------------------------------------------------------------------
 
 # Ensure Helm repos for non-OCI dependencies are registered.
-local(helm_cmd + ' repo add nats https://nats-io.github.io/k8s/helm/charts/ || true', quiet=True)
-local(helm_cmd + ' repo add bitnami https://charts.bitnami.com/bitnami || true', quiet=True)
+local(helm_cmd + ' repo add --force-update nats https://nats-io.github.io/k8s/helm/charts/', quiet=True)
+local(helm_cmd + ' repo add --force-update bitnami https://charts.bitnami.com/bitnami', quiet=True)
 local(helm_cmd + ' repo update', quiet=True)
 
 # Initial build at load time so render_helm() can succeed.
@@ -171,7 +171,7 @@ local(helm_cmd + ' dependency build ' + HELM_CHART, quiet=True)
 local_resource(
     'helm-dep-build',
     helm_cmd + ' dependency build ' + HELM_CHART,
-    deps=[os.path.join(HELM_CHART, 'components', 'operator')],
+    deps=[os.path.join(HELM_CHART, 'components', 'operator'), os.path.join(HELM_CHART, 'Chart.yaml')],
     labels=['operator'],
 )
 

--- a/deploy/operator/Tiltfile
+++ b/deploy/operator/Tiltfile
@@ -155,6 +155,27 @@ local_resource(
 )
 
 # ---------------------------------------------------------------------------
+# Helm dependencies — fetch remote subcharts and package the local operator
+# subchart (file://components/operator).
+# ---------------------------------------------------------------------------
+
+# Ensure Helm repos for non-OCI dependencies are registered.
+local(helm_cmd + ' repo add nats https://nats-io.github.io/k8s/helm/charts/ || true', quiet=True)
+local(helm_cmd + ' repo add bitnami https://charts.bitnami.com/bitnami || true', quiet=True)
+local(helm_cmd + ' repo update', quiet=True)
+
+# Initial build at load time so render_helm() can succeed.
+local(helm_cmd + ' dependency build ' + HELM_CHART, quiet=True)
+
+# Re-run when the local operator subchart changes.
+local_resource(
+    'helm-dep-build',
+    helm_cmd + ' dependency build ' + HELM_CHART,
+    deps=[os.path.join(HELM_CHART, 'components', 'operator')],
+    labels=['operator'],
+)
+
+# ---------------------------------------------------------------------------
 # Helm template → k8s_yaml
 #
 # Renders the production Helm chart (deploy/helm/charts/platform) with the
@@ -272,7 +293,7 @@ k8s_resource(
     new_name='operator',
     labels=['operator'],
     port_forwards=['8081:8081'],  # health endpoint
-    resource_deps=['crds', 'manager-build'],
+    resource_deps=['crds', 'manager-build', 'helm-dep-build'],
 )
 
 # Group subchart workloads in the Tilt UI


### PR DESCRIPTION
## Summary
- `tilt up` fails on a fresh checkout because `helm template` is called without building chart dependencies first
- Add `helm dependency build` as immediate `local()` call at Tiltfile load time and as `local_resource` that re-triggers when the local operator subchart (`file://components/operator`) changes
- Register non-OCI Helm repos (nats, bitnami) automatically so no manual `helm repo add` is needed

## Test plan
- [ ] `kind create cluster && cd deploy/operator && tilt up` on a fresh checkout (no prior `helm dep build`)
- [ ] Modify a file under `deploy/helm/charts/platform/components/operator/` and verify Tilt re-runs `helm dep build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Helm dependency management in deployment configuration to ensure chart dependencies are properly resolved during deployments. Automatic dependency refresh is now triggered when chart files change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->