### PR TITLE
fix: add IPC_LOCK capability to disagg deploy examples

### DIFF
--- a/examples/backends/sglang/deploy/disagg.yaml
+++ b/examples/backends/sglang/deploy/disagg.yaml
@@ -23,6 +23,10 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
           command:
@@ -58,6 +62,10 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
           command:

--- a/examples/backends/trtllm/deploy/disagg.yaml
+++ b/examples/backends/trtllm/deploy/disagg.yaml
@@ -23,6 +23,10 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
           image: my-registry/tensorrtllm-runtime:my-tag
           workingDir: /workspace/
           command:
@@ -48,6 +52,10 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
           image: my-registry/tensorrtllm-runtime:my-tag
           workingDir: /workspace/
           command:

--- a/examples/backends/vllm/deploy/disagg.yaml
+++ b/examples/backends/vllm/deploy/disagg.yaml
@@ -27,6 +27,10 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
           command:
@@ -52,6 +56,10 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
           command:

--- a/examples/backends/vllm/deploy/disagg_router.yaml
+++ b/examples/backends/vllm/deploy/disagg_router.yaml
@@ -29,6 +29,10 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
           command:
@@ -53,6 +57,10 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
           command:


### PR DESCRIPTION
## Summary
- Adds `securityContext.capabilities.add: [IPC_LOCK]` to all worker `mainContainer` specs in disagg deploy YAMLs
- Covers vllm, sglang, and trtllm backends
- NIXL requires IPC_LOCK for inter-pod KV transfer; without it workers crash with `NIXL_ERR_BACKEND`

Based on the YAML changes from #8143.

## Test plan
- [ ] Deploy tests pass for `disagg` and `disagg_router` profiles (vllm, sglang, trtllm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations across sglang, trtllm, and vllm backends to enable memory locking capabilities for both prefill and decode worker containers, improving resource management and operational system stability.
  * Applied matching memory locking capability enhancements to vllm router deployment configuration to ensure consistent security and resource settings across all deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->