### PR TITLE
chore(operator): bump golangci-lint to v2

### DIFF
--- a/.github/workflows/pr_full_ci_reminder.yaml
+++ b/.github/workflows/pr_full_ci_reminder.yaml
@@ -41,7 +41,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: `👋 Hi ${CONTRIBUTOR}! Thank you for contributing to ${REPOSITORY}.\n\n` +
-                'Just a reminder: The `NVIDIA Test Github Validation` CI runs an essential subset of the testing framework to quickly catch errors.' +
+                'Just a reminder: The `NVIDIA Test Github Validation` CI runs an essential subset of the testing framework to quickly catch errors. ' +
                 'Your PR reviewers may elect to test the changes comprehensively before approving your changes.\n\n' +
                 '🚀'
             })

--- a/deploy/operator/.golangci.yml
+++ b/deploy/operator/.golangci.yml
@@ -13,51 +13,68 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: 2
 run:
-  timeout: 10m
   allow-parallel-runners: true
 
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
-    - path: "pkg/dynamo/*"
-      linters:
-        - lll
-        - nakedret
-    # Intentional internal usage of deprecated namespace-restricted mode fields/packages.
-    # The feature is soft-deprecated (still functional) so internal references are expected.
-    - linters:
-        - staticcheck
-      text: "SA1019:.*deprecated.*namespace"
 linters:
-  disable-all: true
+  default: none
   enable:
     - dupl
     - errcheck
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
     - nakedret
-    - prealloc
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
+
+  exclusions:
+    # don't skip warning about doc comments
+    # don't exclude the default set of lint
+    generated: lax
+    rules:
+      - linters:
+          - lll
+        path: api/*
+      - linters:
+          - dupl
+          - lll
+        path: internal/*
+      - linters:
+          - lll
+          - nakedret
+        path: pkg/dynamo/*
+      # Intentional internal usage of deprecated namespace-restricted mode fields/packages.
+      # The feature is soft-deprecated (still functional) so internal references are expected.
+      - linters:
+          - staticcheck
+        text: SA1019:.*deprecated.*[Nn]amespace
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+formatters:
+  enable:
+    - gofmt
+    - gci
+
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
+
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/deploy/operator/.golangci.yml
+++ b/deploy/operator/.golangci.yml
@@ -13,43 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: "2"
 run:
-  timeout: 10m
   allow-parallel-runners: true
 
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
-    - path: "pkg/dynamo/*"
-      linters:
-        - lll
-        - nakedret
-    # Intentional internal usage of deprecated namespace-restricted mode fields/packages.
-    # The feature is soft-deprecated (still functional) so internal references are expected.
-    - linters:
-        - staticcheck
-      text: "SA1019:.*deprecated.*namespace"
 linters:
-  disable-all: true
+  default: none
   enable:
+    - copyloopvar
     - dupl
     - errcheck
+    - errorlint
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -57,7 +33,57 @@ linters:
     - nakedret
     - prealloc
     - staticcheck
-    - typecheck
+    - testifylint
     - unconvert
     - unparam
     - unused
+
+  exclusions:
+    generated: lax
+    # don't skip warning about doc comments
+    # don't exclude the default set of lint
+    presets: []
+    rules:
+      - linters:
+          - lll
+        path: api/*
+      - linters:
+          - dupl
+          - lll
+        path: internal/*
+      - linters:
+          - lll
+          - nakedret
+        path: pkg/dynamo/*
+      # Intentional internal usage of deprecated namespace-restricted mode fields/packages.
+      # The feature is soft-deprecated (still functional) so internal references are expected.
+      - linters:
+          - staticcheck
+        text: SA1019:.*deprecated.*[Nn]amespace
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+formatters:
+  enable:
+    - gofmt
+    - gci
+
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/ai-dynamo/dynamo)
+    gofmt:
+      rewrite-rules:
+        - pattern: 'interface{}'
+          replacement: 'any'
+
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/deploy/operator/Dockerfile
+++ b/deploy/operator/Dockerfile
@@ -31,11 +31,7 @@ COPY --from=snapshot . /snapshot/
 # Lint stage
 FROM base AS linter
 
-# Install golangci-lint using go install (builds with current Go version)
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
-
-# Run linting
-RUN golangci-lint run --timeout=5m
+RUN make lint fmt
 
 # Test stage
 FROM base AS tester

--- a/deploy/operator/Dockerfile
+++ b/deploy/operator/Dockerfile
@@ -31,11 +31,7 @@ COPY --from=snapshot . /snapshot/
 # Lint stage
 FROM base AS linter
 
-# Install golangci-lint using go install (builds with current Go version)
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
-
-# Run linting
-RUN golangci-lint run --timeout=5m
+RUN make lint
 
 # Test stage
 FROM base AS tester

--- a/deploy/operator/Makefile
+++ b/deploy/operator/Makefile
@@ -137,8 +137,8 @@ generate-pydantic: ## Generate Python Pydantic models from v1beta1 Go types (req
 	@python3 api/scripts/validate_pydantic_models.py
 
 .PHONY: fmt
-fmt: ## Run go fmt against code.
-	go fmt ./...
+fmt: golangci-lint ## Run golangci-lint formatter
+	$(GOLANGCI_LINT) fmt
 
 .PHONY: vet
 vet: ## Run go vet against code.
@@ -378,7 +378,7 @@ YQ_VERSION ?= v4.45.4
 KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.4
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.64.8
+GOLANGCI_LINT_VERSION ?= v2.11.4
 
 ## Tool Binaries
 KUBECTL ?= $(LOCALBIN)/kubectl-$(KUBECTL_VERSION)
@@ -442,7 +442,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)

--- a/deploy/operator/Makefile
+++ b/deploy/operator/Makefile
@@ -137,8 +137,8 @@ generate-pydantic: ## Generate Python Pydantic models from v1beta1 Go types (req
 	@python3 api/scripts/validate_pydantic_models.py
 
 .PHONY: fmt
-fmt: ## Run go fmt against code.
-	go fmt ./...
+fmt: golangci-lint ## Run golangci-lint formatter
+	$(GOLANGCI_LINT) fmt
 
 .PHONY: vet
 vet: ## Run go vet against code.
@@ -154,7 +154,7 @@ test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
+lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix
@@ -378,7 +378,7 @@ YQ_VERSION ?= v4.45.4
 KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.4
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.64.8
+GOLANGCI_LINT_VERSION ?= v2.11.4
 
 ## Tool Binaries
 KUBECTL ?= $(LOCALBIN)/kubectl-$(KUBECTL_VERSION)
@@ -442,7 +442,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)

--- a/deploy/operator/api/config/v1alpha1/groupversion_info.go
+++ b/deploy/operator/api/config/v1alpha1/groupversion_info.go
@@ -52,7 +52,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 // RegisterDefaults adds defaulters functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterDefaults(scheme *runtime.Scheme) error {
-	scheme.AddTypeDefaultingFunc(&OperatorConfiguration{}, func(obj interface{}) {
+	scheme.AddTypeDefaultingFunc(&OperatorConfiguration{}, func(obj any) {
 		SetDefaultsOperatorConfiguration(obj.(*OperatorConfiguration))
 	})
 	return nil

--- a/deploy/operator/api/config/validation/validation.go
+++ b/deploy/operator/api/config/validation/validation.go
@@ -20,8 +20,9 @@ package validation
 import (
 	"net/url"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 )
 
 // ValidateOperatorConfiguration validates an OperatorConfiguration object.

--- a/deploy/operator/api/config/validation/validation.go
+++ b/deploy/operator/api/config/validation/validation.go
@@ -20,8 +20,9 @@ package validation
 import (
 	"net/url"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 )
 
 // ValidateOperatorConfiguration validates an OperatorConfiguration object.
@@ -30,7 +31,7 @@ func ValidateOperatorConfiguration(config *configv1alpha1.OperatorConfiguration)
 		return field.ErrorList{field.Required(field.NewPath(""), "operator configuration is required")}
 	}
 
-	allErrs := field.ErrorList{}
+	allErrs := field.ErrorList{} //nolint:prealloc
 	allErrs = append(allErrs, validateServer(&config.Server, field.NewPath("server"))...)
 	allErrs = append(allErrs, validateLeaderElection(&config.LeaderElection, field.NewPath("leaderElection"))...)
 	allErrs = append(allErrs, validateNamespace(&config.Namespace, field.NewPath("namespace"))...)

--- a/deploy/operator/api/config/validation/validation_test.go
+++ b/deploy/operator/api/config/validation/validation_test.go
@@ -22,8 +22,9 @@ import (
 	"testing"
 	"time"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 )
 
 // validConfig returns a minimal valid OperatorConfiguration for cluster-wide mode.

--- a/deploy/operator/api/v1alpha1/common.go
+++ b/deploy/operator/api/v1alpha1/common.go
@@ -148,7 +148,7 @@ func (e ExtraPodSpec) MarshalJSON() ([]byte, error) {
 	if e.PodSpec != nil {
 		a := PodSpecAlias(*e.PodSpec)
 		aux.PodSpecAlias = &a
-		aux.Containers = e.PodSpec.Containers
+		aux.Containers = e.Containers
 	}
 	aux.MainContainer = e.MainContainer
 

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
@@ -23,10 +23,11 @@ import (
 	"fmt"
 	"strings"
 
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apixv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/apix/config/v1alpha1"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 const (
@@ -339,7 +340,7 @@ func (s *DynamoComponentDeploymentSharedSpec) GetNumberOfNodes() int32 {
 }
 
 func (s *DynamoComponentDeployment) GetParentGraphDeploymentName() string {
-	for _, ownerRef := range s.ObjectMeta.OwnerReferences {
+	for _, ownerRef := range s.OwnerReferences {
 		if ownerRef.Kind == "DynamoGraphDeployment" {
 			return ownerRef.Name
 		}

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
@@ -23,10 +23,11 @@ import (
 	"fmt"
 	"strings"
 
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apixv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/apix/config/v1alpha1"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 const (
@@ -345,7 +346,7 @@ func (s *DynamoComponentDeploymentSharedSpec) GetNumberOfNodes() int32 {
 }
 
 func (s *DynamoComponentDeployment) GetParentGraphDeploymentName() string {
-	for _, ownerRef := range s.ObjectMeta.OwnerReferences {
+	for _, ownerRef := range s.OwnerReferences {
 		if ownerRef.Kind == "DynamoGraphDeployment" {
 			return ownerRef.Name
 		}

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types_test.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types_test.go
@@ -23,11 +23,12 @@ import (
 	"reflect"
 	"testing"
 
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 func TestDynamoComponentDeployment_IsFrontendComponent(t *testing.T) {
@@ -204,8 +205,8 @@ func TestDynamoComponentDeployment_SetDynamoDeploymentConfig(t *testing.T) {
 				Status:     tt.fields.Status,
 			}
 			s.SetDynamoDeploymentConfig(tt.args.config)
-			if !reflect.DeepEqual(s.Spec.DynamoComponentDeploymentSharedSpec.Envs, tt.want) {
-				t.Errorf("DynamoComponentDeployment.SetDynamoDeploymentConfig() = %v, want %v", s.Spec.DynamoComponentDeploymentSharedSpec.Envs, tt.want)
+			if !reflect.DeepEqual(s.Spec.Envs, tt.want) {
+				t.Errorf("DynamoComponentDeployment.SetDynamoDeploymentConfig() = %v, want %v", s.Spec.Envs, tt.want)
 			}
 		})
 	}

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -148,12 +148,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 // Annotation keys used to round-trip v1alpha1 fields that have no v1beta1 equivalent.

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -148,12 +148,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 // Annotation keys used to round-trip v1alpha1 fields that have no v1beta1 equivalent.
@@ -240,7 +241,7 @@ func convertDGDRSpecTo(src *DynamoGraphDeploymentRequestSpec, dst *v1beta1.Dynam
 	}
 
 	if src.ProfilingConfig.Config != nil && src.ProfilingConfig.Config.Raw != nil {
-		var blob map[string]interface{}
+		var blob map[string]any
 		if err := json.Unmarshal(src.ProfilingConfig.Config.Raw, &blob); err != nil {
 			return fmt.Errorf("failed to parse ProfilingConfig.Config: %w", err)
 		}
@@ -272,12 +273,12 @@ func convertDGDRSpecTo(src *DynamoGraphDeploymentRequestSpec, dst *v1beta1.Dynam
 
 // applySLAAndWorkloadFromBlob extracts SLA and Workload fields from the v1alpha1 JSON blob.
 // Both are nested under blob["sla"] in the v1alpha1 schema.
-func applySLAAndWorkloadFromBlob(blob map[string]interface{}, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
+func applySLAAndWorkloadFromBlob(blob map[string]any, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
 	slaRaw, ok := blob["sla"]
 	if !ok {
 		return
 	}
-	slaMap, ok := slaRaw.(map[string]interface{})
+	slaMap, ok := slaRaw.(map[string]any)
 	if !ok {
 		return
 	}
@@ -309,12 +310,12 @@ func applySLAAndWorkloadFromBlob(blob map[string]interface{}, dst *v1beta1.Dynam
 }
 
 // applyModelCacheFromBlob extracts ModelCache from blob["deployment"]["modelCache"].
-func applyModelCacheFromBlob(blob map[string]interface{}, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
+func applyModelCacheFromBlob(blob map[string]any, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
 	deployRaw, ok := blob["deployment"]
 	if !ok {
 		return
 	}
-	deployMap, ok := deployRaw.(map[string]interface{})
+	deployMap, ok := deployRaw.(map[string]any)
 	if !ok {
 		return
 	}
@@ -322,7 +323,7 @@ func applyModelCacheFromBlob(blob map[string]interface{}, dst *v1beta1.DynamoGra
 	if !ok {
 		return
 	}
-	mcMap, ok := mcRaw.(map[string]interface{})
+	mcMap, ok := mcRaw.(map[string]any)
 	if !ok {
 		return
 	}
@@ -420,7 +421,7 @@ func convertDGDRSpecFrom(src *v1beta1.DynamoGraphDeploymentRequestSpec, dst *Dyn
 
 	// Reconstruct the JSON blob: start from the round-trip annotation (preserves unknown
 	// keys), then overwrite with structured v1beta1 fields (structured fields win).
-	var blob map[string]interface{}
+	var blob map[string]any
 	if srcObj.Annotations != nil {
 		if rawBlob, ok := srcObj.Annotations[annDGDRProfilingConfig]; ok && rawBlob != "" {
 			_ = json.Unmarshal([]byte(rawBlob), &blob) // best-effort
@@ -428,19 +429,19 @@ func convertDGDRSpecFrom(src *v1beta1.DynamoGraphDeploymentRequestSpec, dst *Dyn
 	}
 	if src.SLA != nil || src.Workload != nil {
 		if blob == nil {
-			blob = make(map[string]interface{})
+			blob = make(map[string]any)
 		}
 		mergeSLAWorkloadIntoBlob(src, blob)
 	}
 	if src.ModelCache != nil {
 		if blob == nil {
-			blob = make(map[string]interface{})
+			blob = make(map[string]any)
 		}
 		mergeModelCacheIntoBlob(src.ModelCache, blob)
 	}
 	if src.Features != nil && src.Features.Planner != nil {
 		if blob == nil {
-			blob = make(map[string]interface{})
+			blob = make(map[string]any)
 		}
 		mergePlannerIntoBlob(src.Features.Planner, blob)
 	}
@@ -463,10 +464,10 @@ func convertDGDRSpecFrom(src *v1beta1.DynamoGraphDeploymentRequestSpec, dst *Dyn
 
 // mergeSLAWorkloadIntoBlob writes SLA and Workload structured fields back into the JSON blob,
 // overwriting any existing values for those keys.
-func mergeSLAWorkloadIntoBlob(src *v1beta1.DynamoGraphDeploymentRequestSpec, blob map[string]interface{}) {
-	slaMap, _ := blob["sla"].(map[string]interface{})
+func mergeSLAWorkloadIntoBlob(src *v1beta1.DynamoGraphDeploymentRequestSpec, blob map[string]any) {
+	slaMap, _ := blob["sla"].(map[string]any)
 	if slaMap == nil {
-		slaMap = make(map[string]interface{})
+		slaMap = make(map[string]any)
 	}
 	if src.SLA != nil {
 		if src.SLA.TTFT != nil {
@@ -488,12 +489,12 @@ func mergeSLAWorkloadIntoBlob(src *v1beta1.DynamoGraphDeploymentRequestSpec, blo
 }
 
 // mergeModelCacheIntoBlob writes ModelCache structured fields back into blob["deployment"]["modelCache"].
-func mergeModelCacheIntoBlob(mc *v1beta1.ModelCacheSpec, blob map[string]interface{}) {
-	deployMap, _ := blob["deployment"].(map[string]interface{})
+func mergeModelCacheIntoBlob(mc *v1beta1.ModelCacheSpec, blob map[string]any) {
+	deployMap, _ := blob["deployment"].(map[string]any)
 	if deployMap == nil {
-		deployMap = make(map[string]interface{})
+		deployMap = make(map[string]any)
 	}
-	mcMap := make(map[string]interface{})
+	mcMap := make(map[string]any)
 	if mc.PVCName != "" {
 		mcMap["pvcName"] = mc.PVCName
 	}
@@ -511,11 +512,11 @@ func mergeModelCacheIntoBlob(mc *v1beta1.ModelCacheSpec, blob map[string]interfa
 
 // mergePlannerIntoBlob writes the planner RawExtension into blob["planner"].
 // The RawExtension is the full PlannerConfig JSON blob (opaque to Go).
-func mergePlannerIntoBlob(planner *runtime.RawExtension, blob map[string]interface{}) {
+func mergePlannerIntoBlob(planner *runtime.RawExtension, blob map[string]any) {
 	if planner == nil || planner.Raw == nil {
 		return
 	}
-	var plannerMap map[string]interface{}
+	var plannerMap map[string]any
 	if err := json.Unmarshal(planner.Raw, &plannerMap); err != nil || len(plannerMap) == 0 {
 		return
 	}
@@ -523,12 +524,12 @@ func mergePlannerIntoBlob(planner *runtime.RawExtension, blob map[string]interfa
 }
 
 // applyPlannerFromBlob extracts blob["planner"] and populates v1beta1 Features.Planner.
-func applyPlannerFromBlob(blob map[string]interface{}, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
+func applyPlannerFromBlob(blob map[string]any, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
 	plannerRaw, ok := blob["planner"]
 	if !ok {
 		return
 	}
-	plannerMap, ok := plannerRaw.(map[string]interface{})
+	plannerMap, ok := plannerRaw.(map[string]any)
 	if !ok || len(plannerMap) == 0 {
 		return
 	}

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
@@ -23,11 +23,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-
-	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
+	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 // newV1alpha1DGDR builds a fully-populated v1alpha1 DGDR for use in tests.

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
@@ -23,30 +23,30 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-
-	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
+	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 // newV1alpha1DGDR builds a fully-populated v1alpha1 DGDR for use in tests.
 func newV1alpha1DGDR() *DynamoGraphDeploymentRequest {
-	profilingBlob := map[string]interface{}{
-		"sla": map[string]interface{}{
+	profilingBlob := map[string]any{
+		"sla": map[string]any{
 			"ttft": float64(500),
 			"itl":  float64(20),
 			"isl":  float64(2048),
 			"osl":  float64(512),
 		},
-		"deployment": map[string]interface{}{
-			"modelCache": map[string]interface{}{
+		"deployment": map[string]any{
+			"modelCache": map[string]any{
 				"pvcName":        "model-pvc",
 				"modelPathInPvc": "llama-3",
 				"pvcMountPath":   "/data/model",
 			},
 		},
-		"planner": map[string]interface{}{
+		"planner": map[string]any{
 			"enable_load_scaling": false,
 		},
 		"extra_key": "preserved",
@@ -99,8 +99,8 @@ func newV1beta1DGDR() *v1beta1.DynamoGraphDeploymentRequest {
 	isl := int32(1024)
 	osl := int32(256)
 
-	rawDGD, _ := json.Marshal(map[string]interface{}{"apiVersion": "nvidia.com/v1alpha1", "kind": "DynamoGraphDeployment"})
-	rawPlanner, _ := json.Marshal(map[string]interface{}{"enable_load_scaling": false})
+	rawDGD, _ := json.Marshal(map[string]any{"apiVersion": "nvidia.com/v1alpha1", "kind": "DynamoGraphDeployment"})
+	rawPlanner, _ := json.Marshal(map[string]any{"enable_load_scaling": false})
 	autoApplyFalse := false
 
 	return &v1beta1.DynamoGraphDeploymentRequest{
@@ -287,11 +287,11 @@ func TestAlpha1RoundTrip(t *testing.T) {
 	if restored.Spec.ProfilingConfig.Config == nil {
 		t.Fatal("ProfilingConfig.Config is nil after round-trip")
 	}
-	var blob map[string]interface{}
+	var blob map[string]any
 	if err := json.Unmarshal(restored.Spec.ProfilingConfig.Config.Raw, &blob); err != nil {
 		t.Fatalf("failed to unmarshal restored ProfilingConfig.Config: %v", err)
 	}
-	slaMap, _ := blob["sla"].(map[string]interface{})
+	slaMap, _ := blob["sla"].(map[string]any)
 	if slaMap == nil {
 		t.Fatal("sla key missing in restored JSON blob")
 	}
@@ -306,7 +306,7 @@ func TestAlpha1RoundTrip(t *testing.T) {
 		t.Errorf("extra_key: got %v, want %q", blob["extra_key"], "preserved")
 	}
 	// Planner round-trip via applyPlannerFromBlob / mergePlannerIntoBlob
-	plannerMap, _ := blob["planner"].(map[string]interface{})
+	plannerMap, _ := blob["planner"].(map[string]any)
 	if plannerMap == nil {
 		t.Fatal("planner key missing in restored JSON blob")
 	}

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -29,39 +29,40 @@ import (
 	"strings"
 	"time"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-
+	//+kubebuilder:scaffold:imports
+	semver "github.com/Masterminds/semver/v3"
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	istioclientsetscheme "istio.io/client-go/pkg/clientset/versioned/scheme"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/scale"
 	k8sCache "k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsfilters "sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
+	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	lwsscheme "sigs.k8s.io/lws/client-go/clientset/versioned/scheme"
 	volcanoscheme "volcano.sh/apis/pkg/client/clientset/versioned/scheme"
 
-	semver "github.com/Masterminds/semver/v3"
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	configvalidation "github.com/ai-dynamo/dynamo/deploy/operator/api/config/validation"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -79,10 +80,6 @@ import (
 	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 	webhookdefaulting "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/defaulting"
 	webhookvalidation "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/validation"
-	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
-	istioclientsetscheme "istio.io/client-go/pkg/clientset/versioned/scheme"
-	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
-	//+kubebuilder:scaffold:imports
 )
 
 var (

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -29,39 +29,40 @@ import (
 	"strings"
 	"time"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-
+	//+kubebuilder:scaffold:imports
+	semver "github.com/Masterminds/semver/v3"
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	istioclientsetscheme "istio.io/client-go/pkg/clientset/versioned/scheme"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/scale"
 	k8sCache "k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsfilters "sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
+	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	lwsscheme "sigs.k8s.io/lws/client-go/clientset/versioned/scheme"
 	volcanoscheme "volcano.sh/apis/pkg/client/clientset/versioned/scheme"
 
-	semver "github.com/Masterminds/semver/v3"
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	configvalidation "github.com/ai-dynamo/dynamo/deploy/operator/api/config/validation"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -79,10 +80,6 @@ import (
 	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 	webhookdefaulting "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/defaulting"
 	webhookvalidation "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/validation"
-	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
-	istioclientsetscheme "istio.io/client-go/pkg/clientset/versioned/scheme"
-	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
-	//+kubebuilder:scaffold:imports
 )
 
 var (
@@ -479,7 +476,7 @@ func main() {
 	}
 	setupLog.Info("Secret informer cache synced and ready")
 	_, err = secretInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			secret := obj.(*corev1.Secret)
 			if secret.Type == corev1.SecretTypeDockerConfigJson {
 				setupLog.Info("refreshing docker secrets index after secret creation...")
@@ -491,7 +488,7 @@ func main() {
 				}
 			}
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new any) {
 			newSecret := new.(*corev1.Secret)
 			if newSecret.Type == corev1.SecretTypeDockerConfigJson {
 				setupLog.Info("refreshing docker secrets index after secret update...")
@@ -503,7 +500,7 @@ func main() {
 				}
 			}
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			secret := obj.(*corev1.Secret)
 			if secret.Type == corev1.SecretTypeDockerConfigJson {
 				setupLog.Info("refreshing docker secrets index after secret deletion...")

--- a/deploy/operator/go.mod
+++ b/deploy/operator/go.mod
@@ -3,7 +3,6 @@ module github.com/ai-dynamo/dynamo/deploy/operator
 go 1.25.0
 
 require (
-	emperror.dev/errors v0.8.1
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/ai-dynamo/dynamo/deploy/snapshot v0.0.0
 	github.com/ai-dynamo/grove/operator/api v0.1.0-alpha.6

--- a/deploy/operator/go.sum
+++ b/deploy/operator/go.sum
@@ -1,7 +1,5 @@
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
-emperror.dev/errors v0.8.1 h1:UavXZ5cSX/4u9iyvH6aDcuGkVjeexUGJ7Ij7G4VfQT0=
-emperror.dev/errors v0.8.1/go.mod h1:YcRvLPh626Ubn2xqtoprejnA5nFha+TJ+2vew48kWuE=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/ai-dynamo/grove/operator/api v0.1.0-alpha.6 h1:6xspRy93dVsGzwiRebNUhrEnamXUtAGvt5tP50uxkOA=
@@ -189,12 +187,10 @@ go.opentelemetry.io/otel/trace v1.40.0 h1:WA4etStDttCSYuhwvEa8OP8I5EWu24lkOzp+ZY
 go.opentelemetry.io/otel/trace v1.40.0/go.mod h1:zeAhriXecNGP/s2SEG3+Y8X9ujcJOTqQ5RgdEJcawiA=
 go.opentelemetry.io/proto/otlp v1.7.1 h1:gTOMpGDb0WTBOP8JaO72iL3auEZhVmAQg4ipjOVAtj4=
 go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
-go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=

--- a/deploy/operator/internal/cert/cert.go
+++ b/deploy/operator/internal/cert/cert.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"strings"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	"github.com/go-logr/logr"
 	certrotator "github.com/open-policy-agent/cert-controller/pkg/rotator"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -22,6 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 )
 
 const (

--- a/deploy/operator/internal/cert/cert_test.go
+++ b/deploy/operator/internal/cert/cert_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	"github.com/go-logr/logr"
 	certrotator "github.com/open-policy-agent/cert-controller/pkg/rotator"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -24,6 +23,8 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 )
 
 // fakeCertProvisioner captures the rotator config passed to AddRotator and

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"testing"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,6 +31,9 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 const (

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -21,10 +21,6 @@ import (
 	"context"
 	"testing"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -34,6 +30,11 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 const (

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -9,10 +9,11 @@ import (
 	"fmt"
 	"path/filepath"
 
-	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+
+	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 const (

--- a/deploy/operator/internal/checkpoint/hash_test.go
+++ b/deploy/operator/internal/checkpoint/hash_test.go
@@ -3,9 +3,10 @@ package checkpoint
 import (
 	"testing"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 )
 
 func TestComputeIdentityHash(t *testing.T) {

--- a/deploy/operator/internal/checkpoint/podinfo.go
+++ b/deploy/operator/internal/checkpoint/podinfo.go
@@ -4,8 +4,9 @@
 package checkpoint
 
 import (
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 func EnsurePodInfoVolume(podSpec *corev1.PodSpec) {

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -21,10 +21,11 @@ import (
 	"context"
 	"fmt"
 
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 func ApplyRestorePodMetadata(labels map[string]string, annotations map[string]string, checkpointInfo *CheckpointInfo) {

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -21,10 +21,11 @@ import (
 	"context"
 	"fmt"
 
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 func ApplyRestorePodMetadata(labels map[string]string, annotations map[string]string, checkpointInfo *CheckpointInfo) {

--- a/deploy/operator/internal/checkpoint/resolve.go
+++ b/deploy/operator/internal/checkpoint/resolve.go
@@ -21,10 +21,11 @@ import (
 	"context"
 	"fmt"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 )
 
 type CheckpointInfo struct {

--- a/deploy/operator/internal/checkpoint/resolve.go
+++ b/deploy/operator/internal/checkpoint/resolve.go
@@ -21,10 +21,11 @@ import (
 	"context"
 	"fmt"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 type CheckpointInfo struct {

--- a/deploy/operator/internal/checkpoint/resource.go
+++ b/deploy/operator/internal/checkpoint/resource.go
@@ -21,13 +21,14 @@ import (
 	"context"
 	"fmt"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 )
 
 func checkpointIdentityHash(ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (string, error) {

--- a/deploy/operator/internal/checkpoint/resource.go
+++ b/deploy/operator/internal/checkpoint/resource.go
@@ -21,13 +21,14 @@ import (
 	"context"
 	"fmt"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 func checkpointIdentityHash(ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (string, error) {
@@ -158,7 +159,7 @@ func CreateOrGetAutoCheckpoint(
 	existing, err := FindCheckpointByIdentityHash(ctx, c, namespace, hash, ckpt.Name)
 	if err != nil {
 		if deleteErr := c.Delete(ctx, ckpt); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
-			return nil, fmt.Errorf("failed to clean up checkpoint %s after dedupe error: %v (lookup error: %w)", ckpt.Name, deleteErr, err)
+			return nil, fmt.Errorf("failed to clean up checkpoint %s after dedupe error: %w (lookup error: %w)", ckpt.Name, deleteErr, err)
 		}
 		return nil, err
 	}

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -6,16 +6,17 @@ package controller
 import (
 	"fmt"
 
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func buildCheckpointWorkerDefaultEnv(

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -7,6 +7,10 @@ import (
 	"context"
 	"fmt"
 
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
@@ -15,9 +19,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func buildCheckpointWorkerDefaultEnv(

--- a/deploy/operator/internal/controller/common.go
+++ b/deploy/operator/internal/controller/common.go
@@ -18,9 +18,10 @@
 package controller
 
 import (
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 )
 
 func constructPVC(crd metav1.Object, pvcConfig v1alpha1.PVC) *corev1.PersistentVolumeClaim {

--- a/deploy/operator/internal/controller/compute_dgd_name_test.go
+++ b/deploy/operator/internal/controller/compute_dgd_name_test.go
@@ -20,9 +20,10 @@ package controller
 import (
 	"testing"
 
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 func TestComputeDGDName(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamo_model_controller_test.go
+++ b/deploy/operator/internal/controller/dynamo_model_controller_test.go
@@ -21,10 +21,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/modelendpoint"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/modelendpoint"
 )
 
 var _ = Describe("DynamoModel Controller", func() {

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	batchv1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,7 +43,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 // CheckpointReconciler reconciles a DynamoCheckpoint object
@@ -325,7 +325,7 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 			lastRenewal = lease.Spec.AcquireTime
 		}
 		if lastRenewal != nil {
-			checkpointWorkerActive = !now.After(lastRenewal.Time.Add(time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second))
+			checkpointWorkerActive = !now.After(lastRenewal.Add(time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second))
 		}
 	}
 

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -356,7 +356,7 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 			lastRenewal = lease.Spec.AcquireTime
 		}
 		if lastRenewal != nil {
-			checkpointWorkerActive = !now.After(lastRenewal.Time.Add(time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second))
+			checkpointWorkerActive = !now.After(lastRenewal.Add(time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second))
 		}
 	}
 

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -22,10 +22,6 @@ import (
 	"testing"
 	"time"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +38,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 const testNamespace = "default"

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -22,12 +22,6 @@ import (
 	"testing"
 	"time"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -44,6 +38,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 const testNamespace = "default"

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -21,12 +21,12 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
 	"time"
 
-	"emperror.dev/errors"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -568,7 +568,7 @@ func (r *DynamoComponentDeploymentReconciler) generateVolcanoPodGroup(ctx contex
 func (r *DynamoComponentDeploymentReconciler) generateLeaderPodTemplateSpec(ctx context.Context, opt generateResourceOption, kubeName string, labels map[string]string, instanceID int) (*corev1.PodTemplateSpec, error) {
 	leaderPodTemplateSpec, err := r.generatePodTemplateSpec(ctx, opt, dynamo.RoleLeader)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate leader pod template")
+		return nil, fmt.Errorf("failed to generate leader pod template: %w", err)
 	}
 
 	maps.Copy(leaderPodTemplateSpec.Labels, labels)
@@ -586,7 +586,7 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderPodTemplateSpec(ctx 
 	err = checkMainContainer(&leaderPodTemplateSpec.Spec)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "generateLeaderPodTemplateSpec: failed to check main container")
+		return nil, fmt.Errorf("generateLeaderPodTemplateSpec: failed to check main container: %w", err)
 	}
 
 	return leaderPodTemplateSpec, nil
@@ -595,7 +595,7 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderPodTemplateSpec(ctx 
 func checkMainContainer(spec *corev1.PodSpec) error {
 
 	if len(spec.Containers) == 0 {
-		return errors.New("No containers found in pod spec")
+		return errors.New("no containers found in pod spec")
 	}
 
 	mainContainerFound := false
@@ -626,7 +626,7 @@ func checkMainContainer(spec *corev1.PodSpec) error {
 func (r *DynamoComponentDeploymentReconciler) generateWorkerPodTemplateSpec(ctx context.Context, opt generateResourceOption, kubeName string, labels map[string]string, instanceID int) (*corev1.PodTemplateSpec, error) {
 	workerPodTemplateSpec, err := r.generatePodTemplateSpec(ctx, opt, dynamo.RoleWorker)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate worker pod template")
+		return nil, fmt.Errorf("failed to generate worker pod template: %w", err)
 	}
 
 	maps.Copy(workerPodTemplateSpec.Labels, labels)
@@ -644,7 +644,7 @@ func (r *DynamoComponentDeploymentReconciler) generateWorkerPodTemplateSpec(ctx 
 	err = checkMainContainer(&workerPodTemplateSpec.Spec)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "generateWorkerPodTemplateSpec: failed to check LWS worker main container")
+		return nil, fmt.Errorf("generateWorkerPodTemplateSpec: failed to check LWS worker main container: %w", err)
 	}
 
 	if opt.dynamoComponentDeployment.Spec.Resources == nil || opt.dynamoComponentDeployment.Spec.Resources.Limits == nil || opt.dynamoComponentDeployment.Spec.Resources.Limits.GPU == "" {
@@ -692,7 +692,7 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderWorkerSet(ctx contex
 	}
 	leaderPodTemplateSpec, err := r.generateLeaderPodTemplateSpec(ctx, opt, kubeName, leaderPodLabels, instanceID)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "generateLeaderWorkerSet: failed to generate leader pod template")
+		return nil, false, fmt.Errorf("generateLeaderWorkerSet: failed to generate leader pod template: %w", err)
 	}
 
 	workerPodLabels := make(map[string]string)
@@ -701,7 +701,7 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderWorkerSet(ctx contex
 	}
 	workerPodTemplateSpec, err := r.generateWorkerPodTemplateSpec(ctx, opt, kubeName, workerPodLabels, instanceID)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "generateLeaderWorkerSet: failed to generate worker pod template")
+		return nil, false, fmt.Errorf("generateLeaderWorkerSet: failed to generate worker pod template: %w", err)
 	}
 
 	// Each individual LeaderWorkerSet always has exactly 1 replica
@@ -780,7 +780,7 @@ func (r *DynamoComponentDeploymentReconciler) setStatusConditions(ctx context.Co
 	maxRetries := 3
 	for range maxRetries - 1 {
 		if err = r.Get(ctx, req.NamespacedName, dynamoComponentDeployment); err != nil {
-			err = errors.Wrap(err, "Failed to re-fetch DynamoComponentDeployment")
+			err = fmt.Errorf("failed to re-fetch DynamoComponentDeployment: %w", err)
 			return
 		}
 		for _, condition := range conditions {
@@ -797,11 +797,11 @@ func (r *DynamoComponentDeploymentReconciler) setStatusConditions(ctx context.Co
 		}
 	}
 	if err != nil {
-		err = errors.Wrap(err, "Failed to update DynamoComponentDeployment status")
+		err = fmt.Errorf("failed to update DynamoComponentDeployment status: %w", err)
 		return
 	}
 	if err = r.Get(ctx, req.NamespacedName, dynamoComponentDeployment); err != nil {
-		err = errors.Wrap(err, "Failed to re-fetch DynamoComponentDeployment")
+		err = fmt.Errorf("failed to re-fetch DynamoComponentDeployment: %w", err)
 		return
 	}
 	return
@@ -812,7 +812,7 @@ func (r *DynamoComponentDeploymentReconciler) createOrUpdateOrDeleteDeployments(
 		return r.generateDeployment(ctx, opt)
 	})
 	if err != nil {
-		return false, nil, errors.Wrap(err, "create or update deployment")
+		return false, nil, fmt.Errorf("create or update deployment: %w", err)
 	}
 	return modified, depl, nil
 }
@@ -1064,14 +1064,14 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 		opt.dynamoComponentDeployment.Spec.Checkpoint.Enabled {
 		info, err := checkpoint.ResolveCheckpointForService(ctx, r.Client, opt.dynamoComponentDeployment.Namespace, opt.dynamoComponentDeployment.Spec.Checkpoint)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to resolve checkpoint")
+			return nil, fmt.Errorf("failed to resolve checkpoint: %w", err)
 		}
 		checkpointInfo = info
 	}
 
 	podSpec, err := dynamo.GenerateBasePodSpecForController(opt.dynamoComponentDeployment, r.DockerSecretRetriever, r.Config, role, commonconsts.MultinodeDeploymentTypeLWS, checkpointInfo)
 	if err != nil {
-		err = errors.Wrap(err, "failed to generate base pod spec")
+		err = fmt.Errorf("failed to generate base pod spec: %w", err)
 		return nil, err
 	}
 	if r.Config.Checkpoint.Enabled {
@@ -1082,7 +1082,7 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 			podSpec,
 			checkpointInfo,
 		); err != nil {
-			return nil, errors.Wrap(err, "failed to inject checkpoint config")
+			return nil, fmt.Errorf("failed to inject checkpoint config: %w", err)
 		}
 	}
 
@@ -1131,7 +1131,7 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 			commonconsts.KubeLabelDynamoComponentPod: commonconsts.KubeLabelValueTrue,
 		})
 		if err != nil {
-			err = errors.Wrapf(err, "failed to list service accounts in namespace %s", opt.dynamoComponentDeployment.Namespace)
+			err = fmt.Errorf("failed to list service accounts in namespace %s: %w", opt.dynamoComponentDeployment.Namespace, err)
 			return
 		}
 		if len(serviceAccounts.Items) > 0 {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -26,26 +26,17 @@ import (
 	"slices"
 	"time"
 
+	"emperror.dev/errors"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	resourcev1 "k8s.io/api/resource/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"emperror.dev/errors"
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/common"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
-	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
@@ -55,9 +46,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/common"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
 )
 
 const (
@@ -572,15 +571,15 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderPodTemplateSpec(ctx 
 		return nil, errors.Wrap(err, "failed to generate leader pod template")
 	}
 
-	maps.Copy(leaderPodTemplateSpec.ObjectMeta.Labels, labels)
-	leaderPodTemplateSpec.ObjectMeta.Labels["role"] = "leader"
-	leaderPodTemplateSpec.ObjectMeta.Labels["instance-id"] = fmt.Sprintf("%d", instanceID)
-	delete(leaderPodTemplateSpec.ObjectMeta.Labels, commonconsts.KubeLabelDynamoSelector)
+	maps.Copy(leaderPodTemplateSpec.Labels, labels)
+	leaderPodTemplateSpec.Labels["role"] = "leader"
+	leaderPodTemplateSpec.Labels["instance-id"] = fmt.Sprintf("%d", instanceID)
+	delete(leaderPodTemplateSpec.Labels, commonconsts.KubeLabelDynamoSelector)
 
-	if leaderPodTemplateSpec.ObjectMeta.Annotations == nil {
-		leaderPodTemplateSpec.ObjectMeta.Annotations = make(map[string]string)
+	if leaderPodTemplateSpec.Annotations == nil {
+		leaderPodTemplateSpec.Annotations = make(map[string]string)
 	}
-	leaderPodTemplateSpec.ObjectMeta.Annotations["scheduling.k8s.io/group-name"] = kubeName
+	leaderPodTemplateSpec.Annotations["scheduling.k8s.io/group-name"] = kubeName
 
 	leaderPodTemplateSpec.Spec.SchedulerName = SchedulerNameVolcano
 
@@ -630,17 +629,17 @@ func (r *DynamoComponentDeploymentReconciler) generateWorkerPodTemplateSpec(ctx 
 		return nil, errors.Wrap(err, "failed to generate worker pod template")
 	}
 
-	maps.Copy(workerPodTemplateSpec.ObjectMeta.Labels, labels)
-	workerPodTemplateSpec.ObjectMeta.Labels["role"] = "worker"
-	workerPodTemplateSpec.ObjectMeta.Labels["instance-id"] = fmt.Sprintf("%d", instanceID)
-	delete(workerPodTemplateSpec.ObjectMeta.Labels, commonconsts.KubeLabelDynamoSelector)
+	maps.Copy(workerPodTemplateSpec.Labels, labels)
+	workerPodTemplateSpec.Labels["role"] = "worker"
+	workerPodTemplateSpec.Labels["instance-id"] = fmt.Sprintf("%d", instanceID)
+	delete(workerPodTemplateSpec.Labels, commonconsts.KubeLabelDynamoSelector)
 
 	workerPodTemplateSpec.Spec.SchedulerName = SchedulerNameVolcano
 
-	if workerPodTemplateSpec.ObjectMeta.Annotations == nil {
-		workerPodTemplateSpec.ObjectMeta.Annotations = make(map[string]string)
+	if workerPodTemplateSpec.Annotations == nil {
+		workerPodTemplateSpec.Annotations = make(map[string]string)
 	}
-	workerPodTemplateSpec.ObjectMeta.Annotations["scheduling.k8s.io/group-name"] = kubeName
+	workerPodTemplateSpec.Annotations["scheduling.k8s.io/group-name"] = kubeName
 
 	err = checkMainContainer(&workerPodTemplateSpec.Spec)
 
@@ -939,7 +938,6 @@ func (r *DynamoComponentDeploymentReconciler) generateDeployment(ctx context.Con
 		},
 	}
 
-	// nolint: gosimple
 	podTemplateSpec, err := r.generatePodTemplateSpec(ctx, opt, dynamo.RoleMain)
 	if err != nil {
 		return
@@ -1166,7 +1164,7 @@ func (r *DynamoComponentDeploymentReconciler) generateService(opt generateResour
 
 	isK8sDiscovery := commonController.IsK8sDiscoveryEnabled(r.Config.Discovery.Backend, dcd.Spec.Annotations)
 
-	if !(isK8sDiscovery || dcd.IsFrontendComponent()) {
+	if !isK8sDiscovery && !dcd.IsFrontendComponent() {
 		return deleteStub, true, nil
 	}
 

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -26,14 +26,28 @@ import (
 	"slices"
 	"time"
 
+	"emperror.dev/errors"
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	resourcev1 "k8s.io/api/resource/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 
-	"emperror.dev/errors"
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
@@ -44,21 +58,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
-	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
-	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
 const (
@@ -575,15 +574,15 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderPodTemplateSpec(ctx 
 		return nil, errors.Wrap(err, "failed to generate leader pod template")
 	}
 
-	maps.Copy(leaderPodTemplateSpec.ObjectMeta.Labels, labels)
-	leaderPodTemplateSpec.ObjectMeta.Labels["role"] = "leader"
-	leaderPodTemplateSpec.ObjectMeta.Labels["instance-id"] = fmt.Sprintf("%d", instanceID)
-	delete(leaderPodTemplateSpec.ObjectMeta.Labels, commonconsts.KubeLabelDynamoSelector)
+	maps.Copy(leaderPodTemplateSpec.Labels, labels)
+	leaderPodTemplateSpec.Labels["role"] = "leader"
+	leaderPodTemplateSpec.Labels["instance-id"] = fmt.Sprintf("%d", instanceID)
+	delete(leaderPodTemplateSpec.Labels, commonconsts.KubeLabelDynamoSelector)
 
-	if leaderPodTemplateSpec.ObjectMeta.Annotations == nil {
-		leaderPodTemplateSpec.ObjectMeta.Annotations = make(map[string]string)
+	if leaderPodTemplateSpec.Annotations == nil {
+		leaderPodTemplateSpec.Annotations = make(map[string]string)
 	}
-	leaderPodTemplateSpec.ObjectMeta.Annotations["scheduling.k8s.io/group-name"] = kubeName
+	leaderPodTemplateSpec.Annotations["scheduling.k8s.io/group-name"] = kubeName
 
 	leaderPodTemplateSpec.Spec.SchedulerName = SchedulerNameVolcano
 
@@ -633,17 +632,17 @@ func (r *DynamoComponentDeploymentReconciler) generateWorkerPodTemplateSpec(ctx 
 		return nil, errors.Wrap(err, "failed to generate worker pod template")
 	}
 
-	maps.Copy(workerPodTemplateSpec.ObjectMeta.Labels, labels)
-	workerPodTemplateSpec.ObjectMeta.Labels["role"] = "worker"
-	workerPodTemplateSpec.ObjectMeta.Labels["instance-id"] = fmt.Sprintf("%d", instanceID)
-	delete(workerPodTemplateSpec.ObjectMeta.Labels, commonconsts.KubeLabelDynamoSelector)
+	maps.Copy(workerPodTemplateSpec.Labels, labels)
+	workerPodTemplateSpec.Labels["role"] = "worker"
+	workerPodTemplateSpec.Labels["instance-id"] = fmt.Sprintf("%d", instanceID)
+	delete(workerPodTemplateSpec.Labels, commonconsts.KubeLabelDynamoSelector)
 
 	workerPodTemplateSpec.Spec.SchedulerName = SchedulerNameVolcano
 
-	if workerPodTemplateSpec.ObjectMeta.Annotations == nil {
-		workerPodTemplateSpec.ObjectMeta.Annotations = make(map[string]string)
+	if workerPodTemplateSpec.Annotations == nil {
+		workerPodTemplateSpec.Annotations = make(map[string]string)
 	}
-	workerPodTemplateSpec.ObjectMeta.Annotations["scheduling.k8s.io/group-name"] = kubeName
+	workerPodTemplateSpec.Annotations["scheduling.k8s.io/group-name"] = kubeName
 
 	err = checkMainContainer(&workerPodTemplateSpec.Spec)
 
@@ -942,7 +941,6 @@ func (r *DynamoComponentDeploymentReconciler) generateDeployment(ctx context.Con
 		},
 	}
 
-	// nolint: gosimple
 	podTemplateSpec, err := r.generatePodTemplateSpec(ctx, opt, dynamo.RoleMain)
 	if err != nil {
 		return
@@ -1169,7 +1167,7 @@ func (r *DynamoComponentDeploymentReconciler) generateService(opt generateResour
 
 	isK8sDiscovery := commonController.IsK8sDiscoveryEnabled(r.Config.Discovery.Backend, dcd.Spec.Annotations)
 
-	if !(isK8sDiscovery || dcd.IsFrontendComponent()) {
+	if !isK8sDiscovery && !dcd.IsFrontendComponent() {
 		return deleteStub, true, nil
 	}
 

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -21,12 +21,12 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
 	"time"
 
-	"emperror.dev/errors"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -571,7 +571,7 @@ func (r *DynamoComponentDeploymentReconciler) generateVolcanoPodGroup(ctx contex
 func (r *DynamoComponentDeploymentReconciler) generateLeaderPodTemplateSpec(ctx context.Context, opt generateResourceOption, kubeName string, labels map[string]string, instanceID int) (*corev1.PodTemplateSpec, error) {
 	leaderPodTemplateSpec, err := r.generatePodTemplateSpec(ctx, opt, dynamo.RoleLeader)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate leader pod template")
+		return nil, fmt.Errorf("failed to generate leader pod template: %w", err)
 	}
 
 	maps.Copy(leaderPodTemplateSpec.Labels, labels)
@@ -589,7 +589,7 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderPodTemplateSpec(ctx 
 	err = checkMainContainer(&leaderPodTemplateSpec.Spec)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "generateLeaderPodTemplateSpec: failed to check main container")
+		return nil, fmt.Errorf("generateLeaderPodTemplateSpec: failed to check main container: %w", err)
 	}
 
 	return leaderPodTemplateSpec, nil
@@ -598,7 +598,7 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderPodTemplateSpec(ctx 
 func checkMainContainer(spec *corev1.PodSpec) error {
 
 	if len(spec.Containers) == 0 {
-		return errors.New("No containers found in pod spec")
+		return errors.New("no containers found in pod spec")
 	}
 
 	mainContainerFound := false
@@ -629,7 +629,7 @@ func checkMainContainer(spec *corev1.PodSpec) error {
 func (r *DynamoComponentDeploymentReconciler) generateWorkerPodTemplateSpec(ctx context.Context, opt generateResourceOption, kubeName string, labels map[string]string, instanceID int) (*corev1.PodTemplateSpec, error) {
 	workerPodTemplateSpec, err := r.generatePodTemplateSpec(ctx, opt, dynamo.RoleWorker)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate worker pod template")
+		return nil, fmt.Errorf("failed to generate worker pod template: %w", err)
 	}
 
 	maps.Copy(workerPodTemplateSpec.Labels, labels)
@@ -647,7 +647,7 @@ func (r *DynamoComponentDeploymentReconciler) generateWorkerPodTemplateSpec(ctx 
 	err = checkMainContainer(&workerPodTemplateSpec.Spec)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "generateWorkerPodTemplateSpec: failed to check LWS worker main container")
+		return nil, fmt.Errorf("generateWorkerPodTemplateSpec: failed to check LWS worker main container: %w", err)
 	}
 
 	if opt.dynamoComponentDeployment.Spec.Resources == nil || opt.dynamoComponentDeployment.Spec.Resources.Limits == nil || opt.dynamoComponentDeployment.Spec.Resources.Limits.GPU == "" {
@@ -695,7 +695,7 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderWorkerSet(ctx contex
 	}
 	leaderPodTemplateSpec, err := r.generateLeaderPodTemplateSpec(ctx, opt, kubeName, leaderPodLabels, instanceID)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "generateLeaderWorkerSet: failed to generate leader pod template")
+		return nil, false, fmt.Errorf("generateLeaderWorkerSet: failed to generate leader pod template: %w", err)
 	}
 
 	workerPodLabels := make(map[string]string)
@@ -704,7 +704,7 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderWorkerSet(ctx contex
 	}
 	workerPodTemplateSpec, err := r.generateWorkerPodTemplateSpec(ctx, opt, kubeName, workerPodLabels, instanceID)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "generateLeaderWorkerSet: failed to generate worker pod template")
+		return nil, false, fmt.Errorf("generateLeaderWorkerSet: failed to generate worker pod template: %w", err)
 	}
 
 	// Each individual LeaderWorkerSet always has exactly 1 replica
@@ -783,7 +783,7 @@ func (r *DynamoComponentDeploymentReconciler) setStatusConditions(ctx context.Co
 	maxRetries := 3
 	for range maxRetries - 1 {
 		if err = r.Get(ctx, req.NamespacedName, dynamoComponentDeployment); err != nil {
-			err = errors.Wrap(err, "Failed to re-fetch DynamoComponentDeployment")
+			err = fmt.Errorf("failed to re-fetch DynamoComponentDeployment: %w", err)
 			return
 		}
 		for _, condition := range conditions {
@@ -800,11 +800,11 @@ func (r *DynamoComponentDeploymentReconciler) setStatusConditions(ctx context.Co
 		}
 	}
 	if err != nil {
-		err = errors.Wrap(err, "Failed to update DynamoComponentDeployment status")
+		err = fmt.Errorf("failed to update DynamoComponentDeployment status: %w", err)
 		return
 	}
 	if err = r.Get(ctx, req.NamespacedName, dynamoComponentDeployment); err != nil {
-		err = errors.Wrap(err, "Failed to re-fetch DynamoComponentDeployment")
+		err = fmt.Errorf("failed to re-fetch DynamoComponentDeployment: %w", err)
 		return
 	}
 	return
@@ -815,7 +815,7 @@ func (r *DynamoComponentDeploymentReconciler) createOrUpdateOrDeleteDeployments(
 		return r.generateDeployment(ctx, opt)
 	})
 	if err != nil {
-		return false, nil, errors.Wrap(err, "create or update deployment")
+		return false, nil, fmt.Errorf("create or update deployment: %w", err)
 	}
 	return modified, depl, nil
 }
@@ -1067,14 +1067,14 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 		opt.dynamoComponentDeployment.Spec.Checkpoint.Enabled {
 		info, err := checkpoint.ResolveCheckpointForService(ctx, r.Client, opt.dynamoComponentDeployment.Namespace, opt.dynamoComponentDeployment.Spec.Checkpoint)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to resolve checkpoint")
+			return nil, fmt.Errorf("failed to resolve checkpoint: %w", err)
 		}
 		checkpointInfo = info
 	}
 
 	podSpec, err := dynamo.GenerateBasePodSpecForController(opt.dynamoComponentDeployment, r.DockerSecretRetriever, r.Config, role, commonconsts.MultinodeDeploymentTypeLWS, checkpointInfo)
 	if err != nil {
-		err = errors.Wrap(err, "failed to generate base pod spec")
+		err = fmt.Errorf("failed to generate base pod spec: %w", err)
 		return nil, err
 	}
 	if r.Config.Checkpoint.Enabled {
@@ -1085,7 +1085,7 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 			podSpec,
 			checkpointInfo,
 		); err != nil {
-			return nil, errors.Wrap(err, "failed to inject checkpoint config")
+			return nil, fmt.Errorf("failed to inject checkpoint config: %w", err)
 		}
 	}
 
@@ -1134,7 +1134,7 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 			commonconsts.KubeLabelDynamoComponentPod: commonconsts.KubeLabelValueTrue,
 		})
 		if err != nil {
-			err = errors.Wrapf(err, "failed to list service accounts in namespace %s", opt.dynamoComponentDeployment.Namespace)
+			err = fmt.Errorf("failed to list service accounts in namespace %s: %w", opt.dynamoComponentDeployment.Namespace, err)
 			return
 		}
 		if len(serviceAccounts.Items) > 0 {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -23,12 +23,6 @@ import (
 	"context"
 	"testing"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
@@ -49,6 +43,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 )
 
 func TestIsDeploymentReady(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -23,14 +23,6 @@ import (
 	"context"
 	"testing"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
-	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
@@ -51,6 +43,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 func TestIsDeploymentReady(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -25,17 +25,13 @@ import (
 
 	groveconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/secret"
-
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -49,16 +45,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo/epp"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
-	rbacv1 "k8s.io/api/rbac/v1"
-	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/secret"
 )
 
 type Reason string
@@ -376,10 +374,7 @@ func (r *DynamoGraphDeploymentReconciler) isGrovePathway(dgd *nvidiacomv1alpha1.
 	// Orchestrator selection via single boolean annotation: nvidia.com/enable-grove
 	// Unset or not "false": Grove if available; else component mode
 	// "false": component mode (multinode -> LWS; single-node -> standard)
-	enableGrove := true
-	if dgd.Annotations != nil && strings.ToLower(dgd.Annotations[consts.KubeAnnotationEnableGrove]) == consts.KubeLabelValueFalse {
-		enableGrove = false
-	}
+	enableGrove := dgd.Annotations == nil || strings.ToLower(dgd.Annotations[consts.KubeAnnotationEnableGrove]) != consts.KubeLabelValueFalse
 
 	return enableGrove && r.RuntimeConfig.GroveEnabled
 }
@@ -396,7 +391,7 @@ func (r *DynamoGraphDeploymentReconciler) getUpdatedInProgressForGrove(ctx conte
 	logger := log.FromContext(ctx)
 
 	pcs := &grovev1alpha1.PodCliqueSet{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs)
+	err := r.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs)
 	if err != nil {
 		logger.Error(err, "failed to get PodCliqueSet")
 		return inProgress
@@ -444,7 +439,7 @@ func (r *DynamoGraphDeploymentReconciler) propagateTopologyCondition(ctx context
 	logger := log.FromContext(ctx)
 
 	pcs := &grovev1alpha1.PodCliqueSet{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs); err != nil {
 		if errors.IsNotFound(err) {
 			return
 		}
@@ -591,7 +586,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGrovePodCliqueSet(ctx context
 func (r *DynamoGraphDeploymentReconciler) getExistingRestartAnnotationsPCS(ctx context.Context, dgd *nvidiacomv1alpha1.DynamoGraphDeployment) (map[string]string, error) {
 	restartAnnotations := make(map[string]string)
 	pcs := &grovev1alpha1.PodCliqueSet{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs)
+	err := r.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs)
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get PodCliqueSet: %w", err)
 	}
@@ -1227,7 +1222,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcilePVC(ctx context.Context, dyna
 		}
 
 		pvc = constructPVC(dynamoDeployment, pvcConfig)
-		if err := controllerutil.SetControllerReference(dynamoDeployment, pvc, r.Client.Scheme()); err != nil {
+		if err := controllerutil.SetControllerReference(dynamoDeployment, pvc, r.Scheme()); err != nil {
 			logger.Error(err, "Failed to set controller reference for top-level PVC", "pvcName", pvcName)
 			return nil, err
 		}

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -25,17 +25,13 @@ import (
 
 	groveconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/secret"
-
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -49,17 +45,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo/epp"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
-	rbacv1 "k8s.io/api/rbac/v1"
-	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/secret"
 )
 
 type Reason string
@@ -379,10 +377,7 @@ func (r *DynamoGraphDeploymentReconciler) isGrovePathway(dgd *nvidiacomv1alpha1.
 	// Orchestrator selection via single boolean annotation: nvidia.com/enable-grove
 	// Unset or not "false": Grove if available; else component mode
 	// "false": component mode (multinode -> LWS; single-node -> standard)
-	enableGrove := true
-	if dgd.Annotations != nil && strings.ToLower(dgd.Annotations[consts.KubeAnnotationEnableGrove]) == consts.KubeLabelValueFalse {
-		enableGrove = false
-	}
+	enableGrove := dgd.Annotations == nil || strings.ToLower(dgd.Annotations[consts.KubeAnnotationEnableGrove]) != consts.KubeLabelValueFalse
 
 	return enableGrove && r.RuntimeConfig.GroveEnabled
 }
@@ -399,7 +394,7 @@ func (r *DynamoGraphDeploymentReconciler) getUpdatedInProgressForGrove(ctx conte
 	logger := log.FromContext(ctx)
 
 	pcs := &grovev1alpha1.PodCliqueSet{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs)
+	err := r.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs)
 	if err != nil {
 		logger.Error(err, "failed to get PodCliqueSet")
 		return inProgress
@@ -447,7 +442,7 @@ func (r *DynamoGraphDeploymentReconciler) propagateTopologyCondition(ctx context
 	logger := log.FromContext(ctx)
 
 	pcs := &grovev1alpha1.PodCliqueSet{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs); err != nil {
 		if errors.IsNotFound(err) {
 			return
 		}
@@ -594,7 +589,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGrovePodCliqueSet(ctx context
 func (r *DynamoGraphDeploymentReconciler) getExistingRestartAnnotationsPCS(ctx context.Context, dgd *nvidiacomv1alpha1.DynamoGraphDeployment) (map[string]string, error) {
 	restartAnnotations := make(map[string]string)
 	pcs := &grovev1alpha1.PodCliqueSet{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs)
+	err := r.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs)
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get PodCliqueSet: %w", err)
 	}
@@ -1230,7 +1225,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcilePVC(ctx context.Context, dyna
 		}
 
 		pvc = constructPVC(dynamoDeployment, pvcConfig)
-		if err := controllerutil.SetControllerReference(dynamoDeployment, pvc, r.Client.Scheme()); err != nil {
+		if err := controllerutil.SetControllerReference(dynamoDeployment, pvc, r.Scheme()); err != nil {
 			logger.Error(err, "Failed to set controller reference for top-level PVC", "pvcName", pvcName)
 			return nil, err
 		}

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -21,11 +21,6 @@ import (
 	"context"
 	"testing"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	groveconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/onsi/gomega"
@@ -40,6 +35,12 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 )
 
 func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -926,7 +926,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createAdditionalResources(ctx c
 	for {
 		obj := &unstructured.Unstructured{}
 		if err := decoder.Decode(obj); err != nil {
-			if err == io.EOF {
+			if err == io.EOF { //nolint:errorlint
 				break
 			}
 			logger.Error(err, "Failed to decode resource, skipping")
@@ -1779,7 +1779,7 @@ func extractParetoFromWebUIData(data []byte) ([]nvidiacomv1beta1.ParetoConfig, e
 			continue
 		}
 
-		var configObj map[string]interface{}
+		var configObj map[string]any
 		if err := sigsyaml.Unmarshal([]byte(stripYAMLComments(actionYAML)), &configObj); err != nil {
 			continue
 		}
@@ -1860,7 +1860,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) extractResourcesFromYAML(yamlCo
 	for {
 		obj := &unstructured.Unstructured{}
 		if err := decoder.Decode(obj); err != nil {
-			if err == io.EOF {
+			if err == io.EOF { //nolint:errorlint
 				break
 			}
 			// Skip invalid documents and continue

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
@@ -21,11 +21,6 @@ import (
 	"context"
 	"time"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	dgdv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
-	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gpu"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
@@ -36,6 +31,12 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	dgdv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gpu"
 )
 
 const (

--- a/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -31,6 +29,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -31,6 +29,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
@@ -177,8 +178,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Build initial objects
-			var initObjs []client.Object
-			initObjs = append(initObjs, tt.adapter, tt.dgd)
+			initObjs := []client.Object{tt.adapter, tt.dgd}
 
 			// Create fake client with status subresource support
 			fakeClient := fake.NewClientBuilder().

--- a/deploy/operator/internal/controller/enrich_hardware_test.go
+++ b/deploy/operator/internal/controller/enrich_hardware_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"testing"
 
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	gpupkg "github.com/ai-dynamo/dynamo/deploy/operator/internal/gpu"
 )
 

--- a/deploy/operator/internal/controller/profiling_job_overrides_test.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides_test.go
@@ -20,12 +20,13 @@ package controller
 import (
 	"testing"
 
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 func baseJob() *batchv1.Job {

--- a/deploy/operator/internal/controller/suite_test.go
+++ b/deploy/operator/internal/controller/suite_test.go
@@ -26,33 +26,31 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	//+kubebuilder:scaffold:imports
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
-	vcbatchv1alpha1 "volcano.sh/apis/pkg/apis/batch/v1alpha1"
-	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
-
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
+	vcbatchv1alpha1 "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/deploy/operator/internal/controller_common/predicate.go
+++ b/deploy/operator/internal/controller_common/predicate.go
@@ -21,14 +21,15 @@ import (
 	"context"
 	"strings"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 // ExcludedNamespacesInterface defines the interface for checking namespace exclusions

--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -26,8 +26,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -40,6 +38,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 const (

--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -26,8 +26,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -40,6 +38,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 const (
@@ -228,8 +229,8 @@ var kubeEnvelopeFields = map[string]bool{
 
 // nonEnvelopeFields returns all top-level fields from an unstructured map
 // except the Kubernetes envelope (apiVersion, kind, metadata, status).
-func nonEnvelopeFields(obj map[string]interface{}) map[string]interface{} {
-	content := make(map[string]interface{}, len(obj))
+func nonEnvelopeFields(obj map[string]any) map[string]any {
+	content := make(map[string]any, len(obj))
 	for k, v := range obj {
 		if kubeEnvelopeFields[k] {
 			continue
@@ -443,7 +444,7 @@ func GetResourceHash(obj any) (string, error) {
 		return "", err
 	}
 
-	var objData map[string]interface{}
+	var objData map[string]any
 	if err := json.Unmarshal(objMap, &objData); err != nil {
 		return "", err
 	}
@@ -464,10 +465,10 @@ func GetResourceHash(obj any) (string, error) {
 }
 
 // SortKeys recursively sorts the keys of a map to ensure consistent serialization
-func SortKeys(obj interface{}) interface{} {
+func SortKeys(obj any) any {
 	switch obj := obj.(type) {
-	case map[string]interface{}:
-		sortedMap := make(map[string]interface{})
+	case map[string]any:
+		sortedMap := make(map[string]any)
 		keys := make([]string, 0, len(obj))
 		for k := range obj {
 			keys = append(keys, k)
@@ -477,14 +478,14 @@ func SortKeys(obj interface{}) interface{} {
 			sortedMap[k] = SortKeys(obj[k])
 		}
 		return sortedMap
-	case []interface{}:
+	case []any:
 		// Check if the slice contains maps and sort them by the "name" field or the first available field
 		if len(obj) > 0 {
 
-			if _, ok := obj[0].(map[string]interface{}); ok {
+			if _, ok := obj[0].(map[string]any); ok {
 				sort.SliceStable(obj, func(i, j int) bool {
-					iMap, iOk := obj[i].(map[string]interface{})
-					jMap, jOk := obj[j].(map[string]interface{})
+					iMap, iOk := obj[i].(map[string]any)
+					jMap, jOk := obj[j].(map[string]any)
 					if iOk && jOk {
 						// Try to sort by "name" if present
 						iName, iNameOk := iMap["name"].(string)
@@ -513,7 +514,7 @@ func SortKeys(obj interface{}) interface{} {
 }
 
 // Helper function to get the first key of a map (alphabetically sorted)
-func firstKey(m map[string]interface{}) string {
+func firstKey(m map[string]any) string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/deploy/operator/internal/controller_common/resource_test.go
+++ b/deploy/operator/internal/controller_common/resource_test.go
@@ -20,15 +20,15 @@ package controller_common
 import (
 	"testing"
 
+	"github.com/bsm/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/bsm/gomega"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestGetSpecChangeResult(t *testing.T) {

--- a/deploy/operator/internal/controller_common/resource_test.go
+++ b/deploy/operator/internal/controller_common/resource_test.go
@@ -20,15 +20,15 @@ package controller_common
 import (
 	"testing"
 
+	"github.com/bsm/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/bsm/gomega"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestGetSpecChangeResult(t *testing.T) {
@@ -42,39 +42,39 @@ func TestGetSpecChangeResult(t *testing.T) {
 		{
 			name: "no change in hash with deployment spec and env variables",
 			current: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "nim-deployment",
 						"namespace": "default",
 					},
-					"spec": map[string]interface{}{
+					"spec": map[string]any{
 						"replicas": int64(2),
-						"selector": map[string]interface{}{
-							"matchLabels": map[string]interface{}{
+						"selector": map[string]any{
+							"matchLabels": map[string]any{
 								"app": "nim",
 							},
 						},
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
+						"template": map[string]any{
+							"metadata": map[string]any{
+								"labels": map[string]any{
 									"app": "nim",
 								},
 							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
+							"spec": map[string]any{
+								"containers": []any{
+									map[string]any{
 										"name":  "nim",
 										"image": "nim:v0.1.0",
-										"ports": []interface{}{
-											map[string]interface{}{
+										"ports": []any{
+											map[string]any{
 												"containerPort": int64(80),
 											},
 										},
-										"env": []interface{}{
-											map[string]interface{}{"name": "ENV_VAR1", "value": "value1"},
-											map[string]interface{}{"name": "ENV_VAR2", "value": "value2"},
+										"env": []any{
+											map[string]any{"name": "ENV_VAR1", "value": "value1"},
+											map[string]any{"name": "ENV_VAR2", "value": "value2"},
 										},
 									},
 								},
@@ -84,39 +84,39 @@ func TestGetSpecChangeResult(t *testing.T) {
 				},
 			},
 			desired: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "nim-deployment",
 						"namespace": "default",
 					},
-					"spec": map[string]interface{}{
+					"spec": map[string]any{
 						"replicas": int64(2),
-						"selector": map[string]interface{}{
-							"matchLabels": map[string]interface{}{
+						"selector": map[string]any{
+							"matchLabels": map[string]any{
 								"app": "nim",
 							},
 						},
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
+						"template": map[string]any{
+							"metadata": map[string]any{
+								"labels": map[string]any{
 									"app": "nim",
 								},
 							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
+							"spec": map[string]any{
+								"containers": []any{
+									map[string]any{
 										"name":  "nim",
 										"image": "nim:v0.1.0",
-										"ports": []interface{}{
-											map[string]interface{}{
+										"ports": []any{
+											map[string]any{
 												"containerPort": int64(80),
 											},
 										},
-										"env": []interface{}{
-											map[string]interface{}{"name": "ENV_VAR1", "value": "value1"},
-											map[string]interface{}{"name": "ENV_VAR2", "value": "value2"},
+										"env": []any{
+											map[string]any{"name": "ENV_VAR1", "value": "value1"},
+											map[string]any{"name": "ENV_VAR2", "value": "value2"},
 										},
 									},
 								},
@@ -131,39 +131,39 @@ func TestGetSpecChangeResult(t *testing.T) {
 		{
 			name: "no change in hash with deployment spec and env variables, change in order",
 			current: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "nim-deployment",
 						"namespace": "default",
 					},
-					"spec": map[string]interface{}{
+					"spec": map[string]any{
 						"replicas": int64(2),
-						"selector": map[string]interface{}{
-							"matchLabels": map[string]interface{}{
+						"selector": map[string]any{
+							"matchLabels": map[string]any{
 								"app": "nim",
 							},
 						},
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
+						"template": map[string]any{
+							"metadata": map[string]any{
+								"labels": map[string]any{
 									"app": "nim",
 								},
 							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
+							"spec": map[string]any{
+								"containers": []any{
+									map[string]any{
 										"name":  "nim",
 										"image": "nim:v0.1.0",
-										"ports": []interface{}{
-											map[string]interface{}{
+										"ports": []any{
+											map[string]any{
 												"containerPort": int64(80),
 											},
 										},
-										"env": []interface{}{
-											map[string]interface{}{"name": "ENV_VAR1", "value": "value1"},
-											map[string]interface{}{"name": "ENV_VAR2", "value": "value2"},
+										"env": []any{
+											map[string]any{"name": "ENV_VAR1", "value": "value1"},
+											map[string]any{"name": "ENV_VAR2", "value": "value2"},
 										},
 									},
 								},
@@ -173,39 +173,39 @@ func TestGetSpecChangeResult(t *testing.T) {
 				},
 			},
 			desired: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "nim-deployment",
 						"namespace": "default",
 					},
-					"spec": map[string]interface{}{
+					"spec": map[string]any{
 						"replicas": int64(2),
-						"selector": map[string]interface{}{
-							"matchLabels": map[string]interface{}{
+						"selector": map[string]any{
+							"matchLabels": map[string]any{
 								"app": "nim",
 							},
 						},
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
+						"template": map[string]any{
+							"metadata": map[string]any{
+								"labels": map[string]any{
 									"app": "nim",
 								},
 							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
+							"spec": map[string]any{
+								"containers": []any{
+									map[string]any{
 										"name":  "nim",
 										"image": "nim:v0.1.0",
-										"ports": []interface{}{
-											map[string]interface{}{
+										"ports": []any{
+											map[string]any{
 												"containerPort": int64(80),
 											},
 										},
-										"env": []interface{}{
-											map[string]interface{}{"name": "ENV_VAR2", "value": "value2"},
-											map[string]interface{}{"name": "ENV_VAR1", "value": "value1"},
+										"env": []any{
+											map[string]any{"name": "ENV_VAR2", "value": "value2"},
+											map[string]any{"name": "ENV_VAR1", "value": "value1"},
 										},
 									},
 								},
@@ -220,39 +220,39 @@ func TestGetSpecChangeResult(t *testing.T) {
 		{
 			name: "no change in hash with change in metadata and status",
 			current: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "nim-deployment",
 						"namespace": "default",
 					},
-					"spec": map[string]interface{}{
+					"spec": map[string]any{
 						"replicas": int64(2),
-						"selector": map[string]interface{}{
-							"matchLabels": map[string]interface{}{
+						"selector": map[string]any{
+							"matchLabels": map[string]any{
 								"app": "nim",
 							},
 						},
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
+						"template": map[string]any{
+							"metadata": map[string]any{
+								"labels": map[string]any{
 									"app": "nim",
 								},
 							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
+							"spec": map[string]any{
+								"containers": []any{
+									map[string]any{
 										"name":  "nim",
 										"image": "nim:v0.1.0",
-										"ports": []interface{}{
-											map[string]interface{}{
+										"ports": []any{
+											map[string]any{
 												"containerPort": int64(80),
 											},
 										}, // switch order of env
-										"env": []interface{}{
-											map[string]interface{}{"name": "ENV_VAR1", "value": "value1"},
-											map[string]interface{}{"name": "ENV_VAR2", "value": "value2"},
+										"env": []any{
+											map[string]any{"name": "ENV_VAR1", "value": "value1"},
+											map[string]any{"name": "ENV_VAR2", "value": "value2"},
 										},
 									},
 								},
@@ -262,47 +262,47 @@ func TestGetSpecChangeResult(t *testing.T) {
 				},
 			},
 			desired: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "nim-deployment",
 						"namespace": "default",
 						"blah":      "blah",
 					},
-					"spec": map[string]interface{}{
+					"spec": map[string]any{
 						"replicas": int64(2),
-						"selector": map[string]interface{}{
-							"matchLabels": map[string]interface{}{
+						"selector": map[string]any{
+							"matchLabels": map[string]any{
 								"app": "nim",
 							},
 						},
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
+						"template": map[string]any{
+							"metadata": map[string]any{
+								"labels": map[string]any{
 									"app": "nim",
 								},
 							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
+							"spec": map[string]any{
+								"containers": []any{
+									map[string]any{
 										"name":  "nim",
 										"image": "nim:v0.1.0",
-										"ports": []interface{}{
-											map[string]interface{}{
+										"ports": []any{
+											map[string]any{
 												"containerPort": int64(80),
 											},
 										},
-										"env": []interface{}{
-											map[string]interface{}{"name": "ENV_VAR1", "value": "value1"},
-											map[string]interface{}{"name": "ENV_VAR2", "value": "value2"},
+										"env": []any{
+											map[string]any{"name": "ENV_VAR1", "value": "value1"},
+											map[string]any{"name": "ENV_VAR2", "value": "value2"},
 										},
 									},
 								},
 							},
 						},
 					},
-					"status": map[string]interface{}{
+					"status": map[string]any{
 						"ready": true,
 					},
 				},
@@ -313,39 +313,39 @@ func TestGetSpecChangeResult(t *testing.T) {
 		{
 			name: "change in hash with change in value of elements",
 			current: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "nim-deployment",
 						"namespace": "default",
 					},
-					"spec": map[string]interface{}{
+					"spec": map[string]any{
 						"replicas": int64(2),
-						"selector": map[string]interface{}{
-							"matchLabels": map[string]interface{}{
+						"selector": map[string]any{
+							"matchLabels": map[string]any{
 								"app": "nim",
 							},
 						},
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
+						"template": map[string]any{
+							"metadata": map[string]any{
+								"labels": map[string]any{
 									"app": "nim",
 								},
 							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
+							"spec": map[string]any{
+								"containers": []any{
+									map[string]any{
 										"name":  "nim",
 										"image": "nim:v0.1.0",
-										"ports": []interface{}{
-											map[string]interface{}{
+										"ports": []any{
+											map[string]any{
 												"containerPort": int64(80),
 											},
 										},
-										"env": []interface{}{
-											map[string]interface{}{"name": "ENV_VAR1", "value": "value2"},
-											map[string]interface{}{"name": "ENV_VAR2", "value": "value1"},
+										"env": []any{
+											map[string]any{"name": "ENV_VAR1", "value": "value2"},
+											map[string]any{"name": "ENV_VAR2", "value": "value1"},
 										},
 									},
 								},
@@ -355,39 +355,39 @@ func TestGetSpecChangeResult(t *testing.T) {
 				},
 			},
 			desired: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "nim-deployment",
 						"namespace": "default",
 					},
-					"spec": map[string]interface{}{
+					"spec": map[string]any{
 						"replicas": int64(3),
-						"selector": map[string]interface{}{
-							"matchLabels": map[string]interface{}{
+						"selector": map[string]any{
+							"matchLabels": map[string]any{
 								"app": "nim",
 							},
 						},
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
+						"template": map[string]any{
+							"metadata": map[string]any{
+								"labels": map[string]any{
 									"app": "nim",
 								},
 							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
+							"spec": map[string]any{
+								"containers": []any{
+									map[string]any{
 										"name":  "nim",
 										"image": "nim:v0.1.0",
-										"ports": []interface{}{
-											map[string]interface{}{
+										"ports": []any{
+											map[string]any{
 												"containerPort": int64(80),
 											},
 										},
-										"env": []interface{}{
-											map[string]interface{}{"name": "ENV_VAR1", "value": "asdf"},
-											map[string]interface{}{"name": "ENV_VAR2", "value": "jljl"},
+										"env": []any{
+											map[string]any{"name": "ENV_VAR1", "value": "asdf"},
+											map[string]any{"name": "ENV_VAR2", "value": "jljl"},
 										},
 									},
 								},
@@ -529,16 +529,16 @@ func TestGetSpecChangeResult_GenerationTracking(t *testing.T) {
 
 			// Create current resource
 			current := &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":        "test-deployment",
 						"namespace":   "default",
 						"generation":  tt.currentGeneration,
-						"annotations": map[string]interface{}{},
+						"annotations": map[string]any{},
 					},
-					"spec": map[string]interface{}{
+					"spec": map[string]any{
 						"replicas": int64(2),
 					},
 				},
@@ -546,14 +546,14 @@ func TestGetSpecChangeResult_GenerationTracking(t *testing.T) {
 
 			// Create desired resource
 			desired := &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "test-deployment",
 						"namespace": "default",
 					},
-					"spec": map[string]interface{}{
+					"spec": map[string]any{
 						"replicas": tt.desiredReplicas,
 					},
 				},

--- a/deploy/operator/internal/controller_common/scale.go
+++ b/deploy/operator/internal/controller_common/scale.go
@@ -57,7 +57,7 @@ func ScaleResource(ctx context.Context, scaleClient scale.ScalesGetter, gvr sche
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			Namespace:       namespace,
-			ResourceVersion: currentScale.ObjectMeta.ResourceVersion,
+			ResourceVersion: currentScale.ResourceVersion,
 		},
 		Spec: autoscalingv1.ScaleSpec{
 			Replicas: replicas,

--- a/deploy/operator/internal/dra/dra.go
+++ b/deploy/operator/internal/dra/dra.go
@@ -11,14 +11,15 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 const (

--- a/deploy/operator/internal/dra/dra_test.go
+++ b/deploy/operator/internal/dra/dra_test.go
@@ -10,13 +10,14 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 func basePodSpec() corev1.PodSpec {
@@ -125,14 +126,14 @@ func TestResourceClaimTemplateName(t *testing.T) {
 func TestExtractGPUParams(t *testing.T) {
 	count, dc := ExtractGPUParams(nil, nil)
 	assert.Equal(t, 0, count)
-	assert.Equal(t, "", dc)
+	assert.Empty(t, dc)
 
 	count, dc = ExtractGPUParams(
 		&v1alpha1.GPUMemoryServiceSpec{Enabled: true},
 		&v1alpha1.Resources{Limits: &v1alpha1.ResourceItem{GPU: strconv.Itoa(4)}},
 	)
 	assert.Equal(t, 4, count)
-	assert.Equal(t, "", dc)
+	assert.Empty(t, dc)
 
 	count, dc = ExtractGPUParams(
 		&v1alpha1.GPUMemoryServiceSpec{Enabled: true, DeviceClassName: "gpu.intel.com/xe"},

--- a/deploy/operator/internal/dynamo/backend_sglang.go
+++ b/deploy/operator/internal/dynamo/backend_sglang.go
@@ -5,9 +5,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 )
 
 const (

--- a/deploy/operator/internal/dynamo/backend_sglang.go
+++ b/deploy/operator/internal/dynamo/backend_sglang.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 )
 
 const (

--- a/deploy/operator/internal/dynamo/backend_sglang_test.go
+++ b/deploy/operator/internal/dynamo/backend_sglang_test.go
@@ -4,8 +4,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 )
 
 // Mock MultinodeDeployer for testing with no shell interpretation needed

--- a/deploy/operator/internal/dynamo/backend_trtllm.go
+++ b/deploy/operator/internal/dynamo/backend_trtllm.go
@@ -6,11 +6,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 type TRTLLMBackend struct {

--- a/deploy/operator/internal/dynamo/backend_trtllm.go
+++ b/deploy/operator/internal/dynamo/backend_trtllm.go
@@ -6,11 +6,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 type TRTLLMBackend struct {
@@ -118,7 +119,7 @@ func (b *TRTLLMBackend) setupLeaderContainer(container *corev1.Container, number
 	if len(container.Command) > 0 && isPythonCommand(container.Command[0]) {
 		// Direct Python command: combine command + args
 		// Shell-quote each part to handle args with spaces (e.g., JSON in --override-engine-args)
-		var quotedParts []string
+		var quotedParts []string //nolint:prealloc
 		for _, part := range container.Command {
 			quotedParts = append(quotedParts, shellQuoteForBashC(part))
 		}

--- a/deploy/operator/internal/dynamo/backend_trtllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_trtllm_test.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 const (
@@ -461,13 +462,13 @@ func TestTRTLLMBackend_UpdatePodSpec(t *testing.T) {
 				if volume.Name == mpiRunSecretName {
 					hasSSHVolume = true
 					// Verify volume configuration
-					if volume.VolumeSource.Secret == nil {
+					if volume.Secret == nil {
 						t.Errorf("UpdatePodSpec() SSH volume should use Secret volume source")
 					} else {
-						if volume.VolumeSource.Secret.SecretName != mpiRunSecretName {
-							t.Errorf("UpdatePodSpec() SSH volume secret name = %s, want %s", volume.VolumeSource.Secret.SecretName, mpiRunSecretName)
+						if volume.Secret.SecretName != mpiRunSecretName {
+							t.Errorf("UpdatePodSpec() SSH volume secret name = %s, want %s", volume.Secret.SecretName, mpiRunSecretName)
 						}
-						if volume.VolumeSource.Secret.DefaultMode == nil || *volume.VolumeSource.Secret.DefaultMode != 0644 {
+						if volume.Secret.DefaultMode == nil || *volume.Secret.DefaultMode != 0644 {
 							t.Errorf("UpdatePodSpec() SSH volume should have DefaultMode 0644")
 						}
 					}

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -6,12 +6,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/featuregate"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/featuregate"
 )
 
 const (

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -6,12 +6,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/featuregate"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/featuregate"
 )
 
 const (
@@ -264,7 +265,7 @@ func updateVLLMMultinodeArgs(container *corev1.Container, role Role, serviceName
 // getExpandedArgs will expand the containers args in the case where
 // the args are joined together with spaces as an individual string (i.e. "python3 -m dynamo.vllm")
 func getExpandedArgs(container *corev1.Container) []string {
-	expandedArgs := []string{}
+	expandedArgs := []string{} //nolint:prealloc
 	for _, arg := range container.Args {
 		expandedArgs = append(expandedArgs, strings.Fields(arg)...)
 	}

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -6,10 +6,11 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 func TestVLLMBackend_UpdateContainer(t *testing.T) {

--- a/deploy/operator/internal/dynamo/component_common.go
+++ b/deploy/operator/internal/dynamo/component_common.go
@@ -6,12 +6,13 @@
 package dynamo
 
 import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	controller_common "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 )
 
 // ComponentDefaults interface defines how defaults should be provided

--- a/deploy/operator/internal/dynamo/component_epp.go
+++ b/deploy/operator/internal/dynamo/component_epp.go
@@ -8,10 +8,11 @@ package dynamo
 import (
 	"fmt"
 
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo/epp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo/epp"
 )
 
 // EPPDefaults implements ComponentDefaults for EPP (Endpoint Picker Plugin) components

--- a/deploy/operator/internal/dynamo/component_frontend.go
+++ b/deploy/operator/internal/dynamo/component_frontend.go
@@ -8,9 +8,10 @@ package dynamo
 import (
 	"fmt"
 
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 // FrontendDefaults implements ComponentDefaults for Frontend components

--- a/deploy/operator/internal/dynamo/component_planner.go
+++ b/deploy/operator/internal/dynamo/component_planner.go
@@ -8,9 +8,10 @@ package dynamo
 import (
 	"fmt"
 
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 // PlannerDefaults implements ComponentDefaults for Planner components

--- a/deploy/operator/internal/dynamo/component_planner_test.go
+++ b/deploy/operator/internal/dynamo/component_planner_test.go
@@ -9,10 +9,11 @@ import (
 	"fmt"
 	"testing"
 
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 func TestPlannerDefaults_GetBaseContainer(t *testing.T) {

--- a/deploy/operator/internal/dynamo/component_worker.go
+++ b/deploy/operator/internal/dynamo/component_worker.go
@@ -8,9 +8,10 @@ package dynamo
 import (
 	"fmt"
 
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 // WorkerDefaults implements ComponentDefaults for Worker components

--- a/deploy/operator/internal/dynamo/epp/config.go
+++ b/deploy/operator/internal/dynamo/epp/config.go
@@ -9,12 +9,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apixv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/apix/config/v1alpha1"
 	"sigs.k8s.io/yaml"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 const (

--- a/deploy/operator/internal/dynamo/epp/inference_pool.go
+++ b/deploy/operator/internal/dynamo/epp/inference_pool.go
@@ -8,11 +8,12 @@ package epp
 import (
 	"fmt"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 const (

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -10,11 +10,12 @@ import (
 	"path/filepath"
 	"strconv"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	gmsruntime "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var failoverLockFile = filepath.Join(gmsruntime.SharedMountPath, "failover.lock")
@@ -45,9 +46,9 @@ func buildFailoverPod(
 	mainContainer := podSpec.Containers[0]
 	sidecars := podSpec.Containers[1:]
 
-	engines := make([]corev1.Container, failoverEngineCount)
+	engines := make([]corev1.Container, 0, failoverEngineCount+len(sidecars))
 	for i := range failoverEngineCount {
-		engines[i] = buildEngineContainer(mainContainer, i, commonconsts.DynamoSystemPort+i)
+		engines = append(engines, buildEngineContainer(mainContainer, i, commonconsts.DynamoSystemPort+i))
 	}
 
 	podSpec.Containers = append(engines, sidecars...)

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -10,14 +10,15 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 )
 
 // failoverPodSpec returns a pod spec that has already been transformed by

--- a/deploy/operator/internal/dynamo/gms.go
+++ b/deploy/operator/internal/dynamo/gms.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,6 +19,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 const (

--- a/deploy/operator/internal/dynamo/gms_test.go
+++ b/deploy/operator/internal/dynamo/gms_test.go
@@ -10,13 +10,14 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 func gmsComponent(gpuCount int) *v1alpha1.DynamoComponentDeploymentSharedSpec {

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -26,11 +26,16 @@ import (
 	"sort"
 	"strings"
 
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/imdario/mergo"
 	istioNetworking "istio.io/api/networking/v1beta1"
-
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -38,12 +43,6 @@ import (
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
-	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
-	"github.com/imdario/mergo"
-	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
-	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // RestartState holds the restart state for DGD services.
@@ -360,7 +359,7 @@ func generateSingleDCD(
 		if deployment.Spec.ExtraPodSpec.PodSpec == nil {
 			deployment.Spec.ExtraPodSpec.PodSpec = &corev1.PodSpec{}
 		}
-		deployment.Spec.ExtraPodSpec.PodSpec.ServiceAccountName = commonconsts.PlannerServiceAccountName
+		deployment.Spec.ExtraPodSpec.ServiceAccountName = commonconsts.PlannerServiceAccountName
 	}
 
 	if deployment.IsFrontendComponent() && defaultIngressSpec != nil && deployment.Spec.Ingress == nil {
@@ -1136,7 +1135,7 @@ func GenerateBasePodSpec(
 	// Check if user provided their own security context before merging
 	userProvidedSecurityContext := component.ExtraPodSpec != nil &&
 		component.ExtraPodSpec.PodSpec != nil &&
-		component.ExtraPodSpec.PodSpec.SecurityContext != nil
+		component.ExtraPodSpec.SecurityContext != nil
 
 	if component.ExtraPodSpec != nil && component.ExtraPodSpec.PodSpec != nil {
 		// merge extraPodSpec PodSpec with base podspec

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -26,11 +26,16 @@ import (
 	"sort"
 	"strings"
 
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/imdario/mergo"
 	istioNetworking "istio.io/api/networking/v1beta1"
-
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -40,12 +45,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
-	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
-	"github.com/imdario/mergo"
-	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
-	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // RestartState holds the restart state for DGD services.
@@ -362,7 +361,7 @@ func generateSingleDCD(
 		if deployment.Spec.ExtraPodSpec.PodSpec == nil {
 			deployment.Spec.ExtraPodSpec.PodSpec = &corev1.PodSpec{}
 		}
-		deployment.Spec.ExtraPodSpec.PodSpec.ServiceAccountName = commonconsts.PlannerServiceAccountName
+		deployment.Spec.ExtraPodSpec.ServiceAccountName = commonconsts.PlannerServiceAccountName
 	}
 
 	if deployment.IsFrontendComponent() && defaultIngressSpec != nil && deployment.Spec.Ingress == nil {
@@ -1138,7 +1137,7 @@ func GenerateBasePodSpec(
 	// Check if user provided their own security context before merging
 	userProvidedSecurityContext := component.ExtraPodSpec != nil &&
 		component.ExtraPodSpec.PodSpec != nil &&
-		component.ExtraPodSpec.PodSpec.SecurityContext != nil
+		component.ExtraPodSpec.SecurityContext != nil
 
 	if component.ExtraPodSpec != nil && component.ExtraPodSpec.PodSpec != nil {
 		// merge extraPodSpec PodSpec with base podspec

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -26,11 +26,6 @@ import (
 	"testing"
 	"time"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/google/go-cmp/cmp"
@@ -41,6 +36,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ptr "k8s.io/utils/ptr"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 )
 
 func TestGenerateDynamoComponentsDeployments(t *testing.T) {

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -26,12 +26,6 @@ import (
 	"testing"
 	"time"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +35,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ptr "k8s.io/utils/ptr"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 func TestGenerateDynamoComponentsDeployments(t *testing.T) {
@@ -761,13 +762,8 @@ func Test_GetDynamoComponentDeploymentsGlobalNamespace(t *testing.T) {
 	}
 
 	got, err := GenerateDynamoComponentsDeployments(context.Background(), dgd, nil, nil, nil, RollingUpdateContext{})
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	if !assert.Len(t, got, 2) {
-		return
-	}
+	require.NoError(t, err)
+	require.Len(t, got, 2)
 
 	for _, d := range got {
 		switch d.Spec.ComponentType {
@@ -3850,13 +3846,8 @@ func Test_GeneratePodCliqueSetGlobalDynamoNamespace(t *testing.T) {
 	}
 
 	got, err := GenerateGrovePodCliqueSet(context.Background(), dynamoDeployment, &configv1alpha1.OperatorConfiguration{}, &controller_common.RuntimeConfig{}, nil, nil, nil, nil, nil)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	if !assert.Len(t, got.Spec.Template.Cliques, 2) {
-		return
-	}
+	require.NoError(t, err)
+	require.Len(t, got.Spec.Template.Cliques, 2)
 
 	for _, clique := range got.Spec.Template.Cliques {
 		switch clique.Name {
@@ -3883,7 +3874,7 @@ func assertDYNNamespace(t *testing.T, podSpec corev1.PodSpec, expectedNamespace 
 				break
 			}
 		}
-		assert.True(t, foundDYNNamespace, fmt.Sprintf("%s not found in container environment variables", commonconsts.DynamoNamespaceEnvVar))
+		assert.True(t, foundDYNNamespace, "%s not found in container environment variables", commonconsts.DynamoNamespaceEnvVar)
 	}
 }
 
@@ -5370,9 +5361,7 @@ func TestGenerateBasePodSpec_DiscoverBackend(t *testing.T) {
 				"test-service",
 				nil, // No checkpoint info in tests
 			)
-			if !assert.NoError(t, err) {
-				return
-			}
+			require.NoError(t, err)
 			if tt.wantEnvVar != "" {
 				assert.Contains(t, podSpec.Containers[0].Env, corev1.EnvVar{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: tt.wantEnvVar})
 			} else {
@@ -7016,7 +7005,7 @@ func TestGenerateSingleDCD_RollingUpdateContext(t *testing.T) {
 	}
 
 	dcds, err := GenerateDynamoComponentsDeployments(ctx, dgd, nil, &RestartState{}, nil, ruCtx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Worker DCD: hash suffix in name, hash label, replica override
 	prefillDCD := dcds["prefill"]
@@ -7042,7 +7031,7 @@ func TestGenerateSingleDCD_NoRollingUpdate(t *testing.T) {
 	}
 
 	dcds, err := GenerateDynamoComponentsDeployments(context.Background(), dgd, nil, &RestartState{}, nil, RollingUpdateContext{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dcd := dcds["worker"]
 	assert.Equal(t, "my-dgd-worker", dcd.Name)
@@ -7084,7 +7073,7 @@ func TestWorkerDefaults_WorkerHashSuffixEnvVar(t *testing.T) {
 		ComponentType:    commonconsts.ComponentTypeWorker,
 		WorkerHashSuffix: "abc123",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	found := false
 	for _, env := range container.Env {
 		if env.Name == commonconsts.DynamoNamespaceWorkerSuffixEnvVar {
@@ -7099,7 +7088,7 @@ func TestWorkerDefaults_WorkerHashSuffixEnvVar(t *testing.T) {
 		DynamoNamespace: "ns-dgd",
 		ComponentType:   commonconsts.ComponentTypeWorker,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	for _, env := range container2.Env {
 		assert.NotEqual(t, commonconsts.DynamoNamespaceWorkerSuffixEnvVar, env.Name,
 			"DYN_NAMESPACE_WORKER_SUFFIX should not be set when suffix is empty")
@@ -7112,7 +7101,7 @@ func TestFrontendDefaults_NamespacePrefixEnvVar(t *testing.T) {
 		DynamoNamespace: "myns-mydgd",
 		ComponentType:   commonconsts.ComponentTypeFrontend,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	found := false
 	for _, env := range container.Env {
 		if env.Name == commonconsts.DynamoNamespacePrefixEnvVar {
@@ -7246,7 +7235,7 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, tt.wantSidecarCount, len(podSpec.Containers),
+			assert.Len(t, podSpec.Containers, tt.wantSidecarCount,
 				"expected %d containers, got %d", tt.wantSidecarCount, len(podSpec.Containers))
 
 			if tt.wantSidecarCount <= 1 {
@@ -7276,7 +7265,7 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 			}
 
 			if tt.wantSidecarEnvFrom > 0 {
-				assert.Equal(t, tt.wantSidecarEnvFrom, len(sidecar.EnvFrom), "sidecar envFrom count")
+				assert.Len(t, sidecar.EnvFrom, tt.wantSidecarEnvFrom, "sidecar envFrom count")
 				assert.Equal(t, envFromSecret, sidecar.EnvFrom[0].SecretRef.Name, "sidecar envFromSecret name")
 			}
 
@@ -7636,7 +7625,7 @@ func TestGenerateGrovePodCliqueSet_TopologyConstraints(t *testing.T) {
 				nil,
 				nil,
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, pcs)
 
 			// Verify PCS template-level TopologyConstraint
@@ -7648,7 +7637,7 @@ func TestGenerateGrovePodCliqueSet_TopologyConstraints(t *testing.T) {
 			}
 
 			// Verify clique-level TopologyConstraints (exhaustive)
-			assert.Equal(t, len(tt.wantCliqueTC), len(pcs.Spec.Template.Cliques), "clique count mismatch")
+			assert.Len(t, pcs.Spec.Template.Cliques, len(tt.wantCliqueTC), "clique count mismatch")
 			actualCliqueNames := make(map[string]struct{}, len(pcs.Spec.Template.Cliques))
 			for _, clique := range pcs.Spec.Template.Cliques {
 				actualCliqueNames[clique.Name] = struct{}{}
@@ -7671,7 +7660,7 @@ func TestGenerateGrovePodCliqueSet_TopologyConstraints(t *testing.T) {
 			}
 
 			// Verify PCSG-level TopologyConstraints (exhaustive)
-			assert.Equal(t, tt.wantPCSGCount, len(pcs.Spec.Template.PodCliqueScalingGroupConfigs), "PCSG count mismatch")
+			assert.Len(t, pcs.Spec.Template.PodCliqueScalingGroupConfigs, tt.wantPCSGCount, "PCSG count mismatch")
 			actualPCSGNames := make(map[string]struct{}, len(pcs.Spec.Template.PodCliqueScalingGroupConfigs))
 			for _, pcsg := range pcs.Spec.Template.PodCliqueScalingGroupConfigs {
 				actualPCSGNames[pcsg.Name] = struct{}{}

--- a/deploy/operator/internal/dynamo/grove.go
+++ b/deploy/operator/internal/dynamo/grove.go
@@ -8,17 +8,16 @@ import (
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/dynamic"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 type GroveMultinodeDeployer struct {
@@ -56,7 +55,7 @@ func (d *GroveMultinodeDeployer) GetHostNames(serviceName string, numberOfNodes 
 // and returns the service replica statuses for each component.
 // - PodCliques: spec.replicas == status.readyReplicas
 // - PodCliqueScalingGroups: spec.replicas == status.availableReplicas
-func GetComponentReadinessAndServiceReplicaStatuses(ctx context.Context, client client.Client, dgd *nvidiacomv1alpha1.DynamoGraphDeployment) (bool, string, map[string]v1alpha1.ServiceReplicaStatus) {
+func GetComponentReadinessAndServiceReplicaStatuses(ctx context.Context, client client.Client, dgd *v1alpha1.DynamoGraphDeployment) (bool, string, map[string]v1alpha1.ServiceReplicaStatus) {
 	logger := log.FromContext(ctx)
 	var notReadyComponents []string
 

--- a/deploy/operator/internal/dynamo/grove_test.go
+++ b/deploy/operator/internal/dynamo/grove_test.go
@@ -5,9 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	v1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -21,6 +18,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	v1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 )
 
 func TestResolveKaiSchedulerQueueName(t *testing.T) {

--- a/deploy/operator/internal/dynamo/hash_test.go
+++ b/deploy/operator/internal/dynamo/hash_test.go
@@ -20,13 +20,14 @@ package dynamo
 import (
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 func baseDGD(services map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec) *v1alpha1.DynamoGraphDeployment {

--- a/deploy/operator/internal/dynamo/model_service.go
+++ b/deploy/operator/internal/dynamo/model_service.go
@@ -23,14 +23,15 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 )
 
 // ReconcileModelServicesForComponents creates services for components with modelRef

--- a/deploy/operator/internal/featuregate/operator_origin.go
+++ b/deploy/operator/internal/featuregate/operator_origin.go
@@ -19,8 +19,9 @@ package featuregate
 
 import (
 	semver "github.com/Masterminds/semver/v3"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 // OperatorOriginFeatureGate represents a feature gated on the operator version

--- a/deploy/operator/internal/featuregate/operator_origin_test.go
+++ b/deploy/operator/internal/featuregate/operator_origin_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	semver "github.com/Masterminds/semver/v3"
+
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 

--- a/deploy/operator/internal/gms/gms.go
+++ b/deploy/operator/internal/gms/gms.go
@@ -10,9 +10,10 @@ package gms
 import (
 	"path/filepath"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 )
 
 const (

--- a/deploy/operator/internal/gms/gms_test.go
+++ b/deploy/operator/internal/gms/gms_test.go
@@ -9,10 +9,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 )
 
 func TestEnsureServerSidecar(t *testing.T) {

--- a/deploy/operator/internal/gpu/discovery.go
+++ b/deploy/operator/internal/gpu/discovery.go
@@ -31,11 +31,11 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
-
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 const (

--- a/deploy/operator/internal/gpu/discovery.go
+++ b/deploy/operator/internal/gpu/discovery.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 	"time"
 
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
@@ -35,6 +34,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 const (

--- a/deploy/operator/internal/gpu/discovery_test.go
+++ b/deploy/operator/internal/gpu/discovery_test.go
@@ -23,10 +23,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,6 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 // newFakeClient creates a fake Kubernetes client with the given objects
@@ -226,7 +226,7 @@ func TestDiscoverGPUs_NoNodes(t *testing.T) {
 	k8sClient := newFakeClient() // Empty cluster
 
 	gpuInfo, err := DiscoverGPUs(ctx, k8sClient)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, gpuInfo)
 	assert.Contains(t, err.Error(), "no nodes found")
 }
@@ -253,7 +253,7 @@ func TestDiscoverGPUs_NoGPUNodes(t *testing.T) {
 	k8sClient := newFakeClient(cpuNode1, cpuNode2)
 
 	gpuInfo, err := DiscoverGPUs(ctx, k8sClient)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, gpuInfo)
 	assert.Contains(t, err.Error(), "no nodes with NVIDIA GPU Feature Discovery labels found")
 }
@@ -308,13 +308,13 @@ func TestExtractGPUInfoFromNode_MissingLabels(t *testing.T) {
 
 			gpuInfo, err := extractGPUInfoFromNode(node)
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, gpuInfo)
 				if tt.errorMsg != "" {
 					assert.Contains(t, err.Error(), tt.errorMsg)
 				}
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, gpuInfo)
 			}
 		})
@@ -683,33 +683,24 @@ func TestScrapeMetricsEndpoint(t *testing.T) {
 
 	// Prepare a fake HTTP server to simulate Prometheus metrics
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := fmt.Fprintln(w, `# HELP DCGM_FI_DEV_GPU_TEMP GPU temperature`)
-		require.NoError(t, err)
-		_, err = fmt.Fprintln(w, `# TYPE DCGM_FI_DEV_GPU_TEMP gauge`)
-		require.NoError(t, err)
-		_, err = fmt.Fprintln(w, `DCGM_FI_DEV_GPU_TEMP{gpu="0",modelName="NVIDIA A100",Hostname="test-node"} 50`)
-		require.NoError(t, err)
-
-		_, err = fmt.Fprintln(w, `# HELP DCGM_FI_DEV_FB_FREE Framebuffer free`)
-		require.NoError(t, err)
-		_, err = fmt.Fprintln(w, `# TYPE DCGM_FI_DEV_FB_FREE gauge`)
-		require.NoError(t, err)
-		_, err = fmt.Fprintln(w, `DCGM_FI_DEV_FB_FREE{gpu="0",Hostname="test-node"} 10000`)
-		require.NoError(t, err)
-
-		_, err = fmt.Fprintln(w, `# HELP DCGM_FI_DEV_FB_USED Framebuffer used`)
-		require.NoError(t, err)
-		_, err = fmt.Fprintln(w, `# TYPE DCGM_FI_DEV_FB_USED gauge`)
-		require.NoError(t, err)
-		_, err = fmt.Fprintln(w, `DCGM_FI_DEV_FB_USED{gpu="0",Hostname="test-node"} 2000`)
-		require.NoError(t, err)
-
-		_, err = fmt.Fprintln(w, `# HELP DCGM_FI_DEV_FB_RESERVED Framebuffer reserved`)
-		require.NoError(t, err)
-		_, err = fmt.Fprintln(w, `# TYPE DCGM_FI_DEV_FB_RESERVED gauge`)
-		require.NoError(t, err)
-		_, err = fmt.Fprintln(w, `DCGM_FI_DEV_FB_RESERVED{gpu="0",Hostname="test-node"} 500`)
-		require.NoError(t, err)
+		_, err := fmt.Fprintln(w, `
+# HELP DCGM_FI_DEV_GPU_TEMP GPU temperature
+# TYPE DCGM_FI_DEV_GPU_TEMP gauge
+DCGM_FI_DEV_GPU_TEMP{gpu="0",modelName="NVIDIA A100",Hostname="test-node"} 50
+# HELP DCGM_FI_DEV_FB_FREE Framebuffer free
+# TYPE DCGM_FI_DEV_FB_FREE gauge
+DCGM_FI_DEV_FB_FREE{gpu="0",Hostname="test-node"} 10000
+# HELP DCGM_FI_DEV_FB_USED Framebuffer used
+# TYPE DCGM_FI_DEV_FB_USED gauge
+DCGM_FI_DEV_FB_USED{gpu="0",Hostname="test-node"} 2000
+# HELP DCGM_FI_DEV_FB_RESERVED Framebuffer reserved
+# TYPE DCGM_FI_DEV_FB_RESERVED gauge
+DCGM_FI_DEV_FB_RESERVED{gpu="0",Hostname="test-node"} 500
+		`)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+		}
 	}))
 	defer server.Close()
 
@@ -737,7 +728,10 @@ func TestScrapeMetricsEndpoint(t *testing.T) {
 	t.Run("invalid metrics", func(t *testing.T) {
 		invalidServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, err := fmt.Fprintln(w, `not a prometheus format`)
-			require.NoError(t, err)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+			}
 		}))
 		defer invalidServer.Close()
 
@@ -871,9 +865,9 @@ func TestDiscoverGPUsFromDCGM_NoGPUOperator_NoDCGM(t *testing.T) {
 	require.Nil(t, info)
 	require.Error(t, err)
 
-	require.True(
+	require.Contains(
 		t,
-		strings.Contains(err.Error(), "gpu operator is not installed"),
+		err.Error(), "gpu operator is not installed",
 	)
 }
 

--- a/deploy/operator/internal/modelendpoint/lora.go
+++ b/deploy/operator/internal/modelendpoint/lora.go
@@ -34,9 +34,9 @@ func (c *Client) loadLoRA(ctx context.Context, address, modelName, sourceURI str
 	logs := log.FromContext(ctx)
 
 	// Build request body with source object
-	loadReq := map[string]interface{}{
+	loadReq := map[string]any{
 		"lora_name": modelName,
-		"source": map[string]interface{}{
+		"source": map[string]any{
 			"uri": sourceURI,
 		},
 	}

--- a/deploy/operator/internal/modelendpoint/lora_test.go
+++ b/deploy/operator/internal/modelendpoint/lora_test.go
@@ -100,7 +100,7 @@ func TestLoadLoRA_RequestBody(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a test server that captures the request body
-			var capturedBody map[string]interface{}
+			var capturedBody map[string]any
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				body, _ := io.ReadAll(r.Body)
 				_ = json.Unmarshal(body, &capturedBody)
@@ -127,7 +127,7 @@ func TestLoadLoRA_RequestBody(t *testing.T) {
 				t.Errorf("expected lora_name %s, got %v", tt.expectedLoraName, capturedBody["lora_name"])
 			}
 
-			source, ok := capturedBody["source"].(map[string]interface{})
+			source, ok := capturedBody["source"].(map[string]any)
 			if !ok {
 				t.Fatal("expected source to be a map")
 			}

--- a/deploy/operator/internal/namespace_scope/lease_watcher.go
+++ b/deploy/operator/internal/namespace_scope/lease_watcher.go
@@ -102,17 +102,17 @@ func (lw *LeaseWatcher) Start(ctx context.Context) error {
 
 	// Add event handler for namespace scope marker leases
 	_, err := leaseInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			if lease := lw.extractLease(obj); lease != nil {
 				lw.handleLeaseAdd(lease)
 			}
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			if lease := lw.extractLease(newObj); lease != nil {
 				lw.handleLeaseUpdate(lease)
 			}
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if lease := lw.extractLease(obj); lease != nil {
 				lw.handleLeaseDelete(lease)
 			}

--- a/deploy/operator/internal/secret/ssh_key_manager.go
+++ b/deploy/operator/internal/secret/ssh_key_manager.go
@@ -13,7 +13,6 @@ import (
 	"encoding/pem"
 	"fmt"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	"github.com/go-logr/logr"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
@@ -22,6 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 )
 
 const (

--- a/deploy/operator/internal/secret/ssh_key_manager_test.go
+++ b/deploy/operator/internal/secret/ssh_key_manager_test.go
@@ -13,7 +13,6 @@ import (
 	"reflect"
 	"testing"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	"github.com/go-logr/logr"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
@@ -21,6 +20,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 )
 
 const (

--- a/deploy/operator/internal/secrets/docker.go
+++ b/deploy/operator/internal/secrets/docker.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/common"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/common"
 )
 
 type DockerSecretIndexer struct {

--- a/deploy/operator/internal/webhook/common.go
+++ b/deploy/operator/internal/webhook/common.go
@@ -21,12 +21,13 @@ import (
 	"context"
 	"strings"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 var webhookCommonLog = logf.Log.WithName("webhook-common")

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler.go
@@ -21,14 +21,15 @@ import (
 	"context"
 	"fmt"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 const (

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler_test.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler_test.go
@@ -21,12 +21,13 @@ import (
 	"context"
 	"testing"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 // admissionCtx builds a context carrying an admission request for the given operation.

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler.go
@@ -21,12 +21,13 @@ import (
 	"context"
 	"fmt"
 
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 const (

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler_test.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler_test.go
@@ -21,10 +21,11 @@ import (
 	"context"
 	"testing"
 
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 func TestDGDRDefaulter_defaultImageFor(t *testing.T) {

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
@@ -21,8 +21,9 @@ import (
 	"context"
 	"fmt"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 )
 
 // DynamoComponentDeploymentValidator validates DynamoComponentDeployment resources.

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler.go
@@ -21,14 +21,15 @@ import (
 	"context"
 	"fmt"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
-	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
+	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 )
 
 const (

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_test.go
@@ -21,9 +21,10 @@ import (
 	"context"
 	"testing"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 )
 
 func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -25,15 +25,16 @@ import (
 	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 )
 
 const (

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
@@ -21,15 +21,16 @@ import (
 	"context"
 	"fmt"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
-	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
+	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 )
 
 const (

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -23,11 +23,12 @@ import (
 	"strings"
 	"testing"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest.go
@@ -22,8 +22,9 @@ import (
 	"errors"
 	"fmt"
 
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 // DynamoGraphDeploymentRequestValidator validates DynamoGraphDeploymentRequest resources.

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_handler.go
@@ -21,14 +21,15 @@ import (
 	"context"
 	"fmt"
 
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
-	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
+	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 )
 
 const (

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_test.go
@@ -21,8 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 func TestDynamoGraphDeploymentRequestValidator_Validate(t *testing.T) {

--- a/deploy/operator/internal/webhook/validation/dynamomodel.go
+++ b/deploy/operator/internal/webhook/validation/dynamomodel.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"strings"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 )
 
 // DynamoModelValidator validates DynamoModel resources.

--- a/deploy/operator/internal/webhook/validation/dynamomodel_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamomodel_handler.go
@@ -21,14 +21,15 @@ import (
 	"context"
 	"fmt"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
-	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
+	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 )
 
 const (

--- a/deploy/operator/internal/webhook/validation/dynamomodel_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamomodel_test.go
@@ -20,8 +20,9 @@ package validation
 import (
 	"testing"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 )
 
 func TestDynamoModelValidator_Validate(t *testing.T) {

--- a/deploy/operator/internal/webhook/validation/shared.go
+++ b/deploy/operator/internal/webhook/validation/shared.go
@@ -23,12 +23,13 @@ import (
 	"strconv"
 	"strings"
 
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	controllercommon "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo/epp"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // SharedSpecValidator validates DynamoComponentDeploymentSharedSpec fields.
@@ -251,7 +252,7 @@ func (v *SharedSpecValidator) validateFrontendSidecar() error {
 	if v.spec.ExtraPodSpec == nil || v.spec.ExtraPodSpec.PodSpec == nil {
 		return nil
 	}
-	for _, c := range v.spec.ExtraPodSpec.PodSpec.Containers {
+	for _, c := range v.spec.ExtraPodSpec.Containers {
 		if c.Name == consts.FrontendSidecarContainerName {
 			return fmt.Errorf(
 				"%s: cannot inject frontend sidecar: a container named %q already exists in extraPodSpec.containers",

--- a/deploy/operator/internal/webhook/validation/shared.go
+++ b/deploy/operator/internal/webhook/validation/shared.go
@@ -23,12 +23,13 @@ import (
 	"strconv"
 	"strings"
 
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	controllercommon "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo/epp"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // SharedSpecValidator validates DynamoComponentDeploymentSharedSpec fields.
@@ -256,7 +257,7 @@ func (v *SharedSpecValidator) validateFrontendSidecar() error {
 	if v.spec.ExtraPodSpec == nil || v.spec.ExtraPodSpec.PodSpec == nil {
 		return nil
 	}
-	for _, c := range v.spec.ExtraPodSpec.PodSpec.Containers {
+	for _, c := range v.spec.ExtraPodSpec.Containers {
 		if c.Name == consts.FrontendSidecarContainerName {
 			return fmt.Errorf(
 				"%s: cannot inject frontend sidecar: a container named %q already exists in extraPodSpec.containers",

--- a/deploy/operator/internal/webhook/validation/shared_test.go
+++ b/deploy/operator/internal/webhook/validation/shared_test.go
@@ -21,10 +21,11 @@ import (
 	"context"
 	"testing"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
 
 // ptr is a helper function to create a pointer to a string

--- a/deploy/operator/test/utils/utils.go
+++ b/deploy/operator/test/utils/utils.go
@@ -23,7 +23,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
 )
 
 const (
@@ -136,6 +136,6 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }

--- a/deploy/operator/test/utils/utils.go
+++ b/deploy/operator/test/utils/utils.go
@@ -23,7 +23,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
 )
 
 const (
@@ -61,7 +61,7 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 	_, _ = fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return output, fmt.Errorf("%s failed with error: (%v) %s", command, err, string(output))
+		return output, fmt.Errorf("%s failed with error: (%w) %s", command, err, string(output))
 	}
 
 	return output, nil
@@ -136,6 +136,6 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }


### PR DESCRIPTION
#### Overview:

* Upgrade to golangci-lint v2 and migrate the config
* Applies new linting and a new [gci](https://github.com/daixiang0/gci) formatter for deterministic imports
* Remove the emperror.dev/errors dependency as we should be doing wrapping with stdlib

#### Details:

As above.

#### Where should the reviewer start?

_N/A_

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

_N/A_