### PR TITLE
fix(vllm): propagate --model-express-url before first MX connection

### DIFF
--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -101,6 +101,13 @@ def run_dynamo_headless(config: Config) -> None:
 async def worker() -> None:
     config = parse_args()
 
+    # Propagate --model-express-url to env var early, before any MX client code
+    # (Rust hub, Python MxModelLoader) reads it. The Rust fetch_model() and the
+    # MxClientConfig default both fall back to localhost:8001 when this env var
+    # is absent, so it must be set before the first MX connection attempt.
+    if config.model_express_url:
+        os.environ["MODEL_EXPRESS_URL"] = config.model_express_url
+
     dump_config(config.dump_config_to, config)
 
     # Name the model. Use either the full path (vllm and sglang do the same),
@@ -470,9 +477,6 @@ def setup_vllm_engine(
         try:
             from modelexpress import register_modelexpress_loaders
 
-            # Ensure the ModelExpress server URL env var is set for the model loader
-            if config.model_express_url:
-                os.environ["MODEL_EXPRESS_URL"] = config.model_express_url
             register_modelexpress_loaders()
             # Use wrapper worker to ensure loaders are registered in spawned worker processes
             engine_args.worker_cls = "modelexpress.vllm_worker.ModelExpressWorker"


### PR DESCRIPTION
Fixes a regression from #6186 where the --model-express-url CLI argument
was parsed but never exported to MODEL_EXPRESS_URL until setup_vllm_engine(),
which runs after fetch_model(). The Rust hub and Python MxModelLoader both
read the env var, so both silently fell back to localhost:8001 regardless
of the CLI value.

- Move env var export to immediately after parse_args()
- Remove redundant late export from setup_vllm_engine()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved initialization sequence for environment configuration to ensure proper setup timing before loader registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->