### PR TITLE
feat(runtime): handle orphaned pending requests 

### DIFF
--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -64,6 +64,7 @@ mod registry;
 pub mod service;
 
 pub use client::Client;
+pub(crate) use client::EndpointDiscoverySource;
 pub(crate) use client::RoutingOccupancyState;
 pub(crate) use client::get_or_create_routing_occupancy_state;
 pub use endpoint::build_transport_type;
@@ -109,11 +110,21 @@ impl Instance {
     pub fn id(&self) -> u64 {
         self.instance_id
     }
+
     pub fn endpoint_id(&self) -> EndpointId {
         EndpointId {
             namespace: self.namespace.clone(),
             component: self.component.clone(),
             name: self.endpoint.clone(),
+        }
+    }
+
+    pub fn endpoint_instance_id(&self) -> crate::discovery::EndpointInstanceId {
+        crate::discovery::EndpointInstanceId {
+            namespace: self.namespace.clone(),
+            component: self.component.clone(),
+            endpoint: self.endpoint.clone(),
+            instance_id: self.instance_id,
         }
     }
 }

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
     collections::{HashMap, HashSet},
+    sync::{Arc, Mutex as StdMutex},
     time::Duration,
 };
 
@@ -12,19 +12,10 @@ use anyhow::Result;
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use futures::StreamExt;
-use tokio::net::unix::pipe::Receiver;
 
+use crate::component::{Endpoint, Instance};
 use crate::discovery::{DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId};
-use crate::{
-    component::{Endpoint, Instance},
-    pipeline::async_trait,
-    pipeline::{
-        AddressedPushRouter, AddressedRequest, AsyncEngine, Data, ManyOut, PushRouter, RouterMode,
-        SingleIn,
-    },
-    traits::DistributedRuntimeProvider,
-    transports::etcd::Client as EtcdClient,
-};
+use crate::traits::DistributedRuntimeProvider;
 
 /// Shared occupancy state for routing modes that track per-worker in-flight requests.
 #[derive(Debug, Default)]
@@ -93,10 +84,49 @@ pub(crate) async fn get_or_create_routing_occupancy_state(
 /// Default interval for periodic reconciliation of instance_avail with instance_source
 const DEFAULT_RECONCILE_INTERVAL: Duration = Duration::from_secs(5);
 
+/// Shared endpoint discovery state for a single endpoint query.
+///
+/// This wraps both the coalesced instance snapshot used for routing decisions
+/// and a raw, lossless per-subscriber event feed used by the response-stream
+/// cancellation watcher. Both outputs are driven by a single underlying
+/// discovery `list_and_watch` task so clients do not multiply control-plane
+/// watches.
+#[derive(Debug)]
+pub(crate) struct EndpointDiscoverySource {
+    instance_source: tokio::sync::watch::Receiver<Vec<Instance>>,
+    event_subscribers: StdMutex<Vec<tokio::sync::mpsc::UnboundedSender<DiscoveryEvent>>>,
+}
+
+impl EndpointDiscoverySource {
+    fn new(instance_source: tokio::sync::watch::Receiver<Vec<Instance>>) -> Self {
+        Self {
+            instance_source,
+            event_subscribers: StdMutex::new(Vec::new()),
+        }
+    }
+
+    fn instance_receiver(&self) -> tokio::sync::watch::Receiver<Vec<Instance>> {
+        self.instance_source.clone()
+    }
+
+    fn subscribe_events(&self) -> tokio::sync::mpsc::UnboundedReceiver<DiscoveryEvent> {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        self.event_subscribers.lock().unwrap().push(tx);
+        rx
+    }
+
+    fn broadcast_event(&self, event: &DiscoveryEvent) {
+        let subscribers = &mut *self.event_subscribers.lock().unwrap();
+        subscribers.retain(|tx| tx.send(event.clone()).is_ok());
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Client {
     // This is me
     pub endpoint: Endpoint,
+    // Shared endpoint discovery source backing both snapshots and raw events.
+    endpoint_discovery_source: Arc<EndpointDiscoverySource>,
     // These are the remotes I know about from watching key-value store
     pub instance_source: Arc<tokio::sync::watch::Receiver<Vec<Instance>>>,
     // These are the instance source ids less those reported as down from sending rpc
@@ -129,7 +159,9 @@ impl Client {
             "Client::new_dynamic: Creating dynamic client for endpoint: {}",
             endpoint.id()
         );
-        let instance_source = Self::get_or_create_dynamic_instance_source(&endpoint).await?;
+        let endpoint_discovery_source =
+            Self::get_or_create_dynamic_discovery_source(&endpoint).await?;
+        let instance_source = Arc::new(endpoint_discovery_source.instance_receiver());
 
         // Seed instance_avail from the current instance_source snapshot so that
         // callers who proceed immediately after wait_for_instances (which reads
@@ -143,6 +175,7 @@ impl Client {
         let (avail_tx, avail_rx) = tokio::sync::watch::channel(initial_ids.clone());
         let client = Client {
             endpoint: endpoint.clone(),
+            endpoint_discovery_source,
             instance_source: instance_source.clone(),
             instance_avail: Arc::new(ArcSwap::from(Arc::new(initial_ids.clone()))),
             instance_free: Arc::new(ArcSwap::from(Arc::new(initial_ids))),
@@ -174,6 +207,16 @@ impl Client {
     /// Get a watcher for available instance IDs
     pub fn instance_avail_watcher(&self) -> tokio::sync::watch::Receiver<Vec<u64>> {
         self.instance_avail_rx.clone()
+    }
+
+    /// Subscribe to raw discovery events for this endpoint.
+    ///
+    /// Unlike `instance_source`, this feed does not coalesce remove→add pairs,
+    /// so consumers can react to every removal event exactly once.
+    pub(crate) fn subscribe_discovery_events(
+        &self,
+    ) -> tokio::sync::mpsc::UnboundedReceiver<DiscoveryEvent> {
+        self.endpoint_discovery_source.subscribe_events()
     }
 
     /// Wait for at least one Instance to be available for this Endpoint
@@ -288,18 +331,18 @@ impl Client {
         self.instance_avail.store(Arc::new(ids));
     }
 
-    async fn get_or_create_dynamic_instance_source(
+    async fn get_or_create_dynamic_discovery_source(
         endpoint: &Endpoint,
-    ) -> Result<Arc<tokio::sync::watch::Receiver<Vec<Instance>>>> {
+    ) -> Result<Arc<EndpointDiscoverySource>> {
         let drt = endpoint.drt();
-        let instance_sources = drt.instance_sources();
-        let mut instance_sources = instance_sources.lock().await;
+        let sources = drt.endpoint_discovery_sources();
+        let mut sources = sources.lock().await;
 
-        if let Some(instance_source) = instance_sources.get(endpoint) {
-            if let Some(instance_source) = instance_source.upgrade() {
-                return Ok(instance_source);
+        if let Some(source) = sources.get(endpoint) {
+            if let Some(source) = source.upgrade() {
+                return Ok(source);
             } else {
-                instance_sources.remove(endpoint);
+                sources.remove(endpoint);
             }
         }
 
@@ -314,8 +357,10 @@ impl Client {
             .list_and_watch(discovery_query.clone(), None)
             .await?;
         let (watch_tx, watch_rx) = tokio::sync::watch::channel(vec![]);
+        let discovery_source = Arc::new(EndpointDiscoverySource::new(watch_rx));
 
         let secondary = endpoint.component.drt.runtime().secondary().clone();
+        let discovery_source_task = discovery_source.clone();
 
         secondary.spawn(async move {
             tracing::trace!("endpoint_watcher: Starting for discovery query: {:?}", discovery_query);
@@ -342,15 +387,17 @@ impl Client {
                     }
                 };
 
-                match discovery_event {
-                    DiscoveryEvent::Added(discovery_instance) => {
-                        if let DiscoveryInstance::Endpoint(instance) = discovery_instance {
+                discovery_source_task.broadcast_event(&discovery_event);
 
-                                map.insert(instance.instance_id, instance);
-                        }
+                match discovery_event {
+                    DiscoveryEvent::Added(DiscoveryInstance::Endpoint(instance)) => {
+                        map.insert(instance.instance_id, instance);
                     }
+                    DiscoveryEvent::Added(_) => {}
                     DiscoveryEvent::Removed(id) => {
-                        map.remove(&id.instance_id());
+                        if let DiscoveryInstanceId::Endpoint(endpoint_id) = id {
+                            map.remove(&endpoint_id.instance_id);
+                        }
                     }
                 }
 
@@ -362,9 +409,8 @@ impl Client {
             let _ = watch_tx.send(vec![]);
         });
 
-        let instance_source = Arc::new(watch_rx);
-        instance_sources.insert(endpoint.clone(), Arc::downgrade(&instance_source));
-        Ok(instance_source)
+        sources.insert(endpoint.clone(), Arc::downgrade(&discovery_source));
+        Ok(discovery_source)
     }
 }
 

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::component::{
-    self, Component, ComponentBuilder, Endpoint, Instance, Namespace, RoutingOccupancyState,
+    self, Component, ComponentBuilder, Endpoint, EndpointDiscoverySource, Instance, Namespace,
+    RoutingOccupancyState,
 };
 use crate::config::environment_names::tcp_response_stream;
 use crate::pipeline::PipelineError;
@@ -36,7 +37,7 @@ use std::collections::HashMap;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
-type InstanceMap = HashMap<Endpoint, Weak<Receiver<Vec<Instance>>>>;
+type EndpointDiscoverySourceMap = HashMap<Endpoint, Weak<EndpointDiscoverySource>>;
 type RoutingOccupancyMap = HashMap<Endpoint, Weak<RoutingOccupancyState>>;
 
 /// Distributed [Runtime] which provides access to shared resources across the cluster, this includes
@@ -66,7 +67,7 @@ pub struct DistributedRuntime {
     // paths in etcd to a minimum.
     component_registry: component::Registry,
 
-    instance_sources: Arc<tokio::sync::Mutex<InstanceMap>>,
+    endpoint_discovery_sources: Arc<tokio::sync::Mutex<EndpointDiscoverySourceMap>>,
     routing_occupancy_states: Arc<tokio::sync::Mutex<RoutingOccupancyMap>>,
 
     // Health Status
@@ -193,7 +194,7 @@ impl DistributedRuntime {
             discovery_client,
             discovery_metadata,
             component_registry,
-            instance_sources: Arc::new(Mutex::new(HashMap::new())),
+            endpoint_discovery_sources: Arc::new(Mutex::new(HashMap::new())),
             routing_occupancy_states: Arc::new(Mutex::new(HashMap::new())),
             metrics_registry: crate::MetricsRegistry::new(),
             system_health,
@@ -423,8 +424,8 @@ impl DistributedRuntime {
         self.runtime.graceful_shutdown_tracker()
     }
 
-    pub fn instance_sources(&self) -> Arc<Mutex<InstanceMap>> {
-        self.instance_sources.clone()
+    pub(crate) fn endpoint_discovery_sources(&self) -> Arc<Mutex<EndpointDiscoverySourceMap>> {
+        self.endpoint_discovery_sources.clone()
     }
 
     pub(crate) fn routing_occupancy_states(&self) -> Arc<Mutex<RoutingOccupancyMap>> {

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::component::{
-    self, Component, ComponentBuilder, Endpoint, Instance, Namespace, RoutingOccupancyState,
+    self, Component, ComponentBuilder, Endpoint, EndpointDiscoverySource, Instance, Namespace,
+    RoutingOccupancyState,
 };
 use crate::config::environment_names::tcp_response_stream;
 use crate::pipeline::PipelineError;
@@ -36,7 +37,7 @@ use std::collections::HashMap;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
-type InstanceMap = HashMap<Endpoint, Weak<Receiver<Vec<Instance>>>>;
+type EndpointDiscoverySourceMap = HashMap<Endpoint, Weak<EndpointDiscoverySource>>;
 type RoutingOccupancyMap = HashMap<Endpoint, Weak<RoutingOccupancyState>>;
 
 /// Distributed [Runtime] which provides access to shared resources across the cluster, this includes
@@ -66,7 +67,7 @@ pub struct DistributedRuntime {
     // paths in etcd to a minimum.
     component_registry: component::Registry,
 
-    instance_sources: Arc<tokio::sync::Mutex<InstanceMap>>,
+    endpoint_discovery_sources: Arc<tokio::sync::Mutex<EndpointDiscoverySourceMap>>,
     routing_occupancy_states: Arc<tokio::sync::Mutex<RoutingOccupancyMap>>,
 
     // Health Status
@@ -201,7 +202,7 @@ impl DistributedRuntime {
             discovery_client,
             discovery_metadata,
             component_registry,
-            instance_sources: Arc::new(Mutex::new(HashMap::new())),
+            endpoint_discovery_sources: Arc::new(Mutex::new(HashMap::new())),
             routing_occupancy_states: Arc::new(Mutex::new(HashMap::new())),
             metrics_registry: crate::MetricsRegistry::new(),
             system_health,
@@ -450,8 +451,8 @@ impl DistributedRuntime {
         self.runtime.graceful_shutdown_tracker()
     }
 
-    pub fn instance_sources(&self) -> Arc<Mutex<InstanceMap>> {
-        self.instance_sources.clone()
+    pub(crate) fn endpoint_discovery_sources(&self) -> Arc<Mutex<EndpointDiscoverySourceMap>> {
+        self.endpoint_discovery_sources.clone()
     }
 
     pub(crate) fn routing_occupancy_states(&self) -> Arc<Mutex<RoutingOccupancyMap>> {

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -78,19 +78,66 @@ pub type StreamProvider<T> = tokio::sync::oneshot::Receiver<Result<T, String>>;
 /// an awaitable receiver which will the `T` which is either a stream writer for a request stream
 /// or a stream reader for a response stream.
 ///
-/// make this an raii object linked to some stream provider
-/// if the object has not been awaited an the type T unwrapped, the registered stream
-/// on the stream provider will be informed and can clean up a stream that will never
-/// be connected.
-#[derive(Debug)]
+/// RAII cleanup: if this object is dropped without calling [`into_parts()`], the
+/// optional `cleanup_on_drop` closure fires, removing the orphaned registration
+/// from the stream server's internal maps. This prevents HashMap leaks when
+/// a registered stream is never consumed (e.g., early error in the request path).
 pub struct RegisteredStream<T> {
     pub connection_info: ConnectionInfo,
     pub stream_provider: StreamProvider<T>,
+    cleanup_on_drop: Option<Box<dyn FnOnce() + Send + 'static>>,
+}
+
+impl<T> std::fmt::Debug for RegisteredStream<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegisteredStream")
+            .field("connection_info", &self.connection_info)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<T> RegisteredStream<T> {
+    pub(crate) fn new(connection_info: ConnectionInfo, stream_provider: StreamProvider<T>) -> Self {
+        Self {
+            connection_info,
+            stream_provider,
+            cleanup_on_drop: None,
+        }
+    }
+
+    pub(crate) fn with_cleanup<F>(mut self, cleanup: F) -> Self
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.cleanup_on_drop = Some(Box::new(cleanup));
+        self
+    }
+
+    /// Consume the registration, returning the connection info and stream provider.
+    ///
+    /// This **disarms** the RAII cleanup -- the caller takes responsibility for
+    /// cleaning up the registration if the stream provider is never awaited.
     pub fn into_parts(self) -> (ConnectionInfo, StreamProvider<T>) {
-        (self.connection_info, self.stream_provider)
+        // Use ManuallyDrop to prevent Drop from running, then move the fields out.
+        let mut this = std::mem::ManuallyDrop::new(self);
+        this.cleanup_on_drop.take();
+
+        // SAFETY: `ManuallyDrop` prevents `Drop` from running, so moving these
+        // fields out is sound as long as each field is read exactly once.
+        unsafe {
+            (
+                std::ptr::read(&this.connection_info),
+                std::ptr::read(&this.stream_provider),
+            )
+        }
+    }
+}
+
+impl<T> Drop for RegisteredStream<T> {
+    fn drop(&mut self) {
+        if let Some(cleanup) = self.cleanup_on_drop.take() {
+            cleanup();
+        }
     }
 }
 

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -88,18 +88,32 @@ pub struct ResponseStreamPrologue {
 
 pub type StreamProvider<T> = tokio::sync::oneshot::Receiver<Result<T, String>>;
 
+/// RAII container for the cleanup closure. Owning the `Drop` here (instead of
+/// on `RegisteredStream`) lets `into_parts()` move the public fields out by
+/// plain destructure -- no `unsafe`, no `ManuallyDrop`, no `ptr::read`.
+struct Cleanup(Option<Box<dyn FnOnce() + Send + 'static>>);
+
+impl Drop for Cleanup {
+    fn drop(&mut self) {
+        if let Some(f) = self.0.take() {
+            f();
+        }
+    }
+}
+
 /// The [`RegisteredStream`] object is acquired from a [`StreamProvider`] and is used to provide
 /// an awaitable receiver which will the `T` which is either a stream writer for a request stream
 /// or a stream reader for a response stream.
 ///
 /// RAII cleanup: if this object is dropped without calling [`into_parts()`], the
-/// optional `cleanup_on_drop` closure fires, removing the orphaned registration
-/// from the stream server's internal maps. This prevents HashMap leaks when
-/// a registered stream is never consumed (e.g., early error in the request path).
+/// optional cleanup closure (held by the inner `Cleanup` struct) fires, removing
+/// the orphaned registration from the stream server's internal maps. This
+/// prevents HashMap leaks when a registered stream is never consumed (e.g.,
+/// early error in the request path).
 pub struct RegisteredStream<T> {
     pub connection_info: ConnectionInfo,
     pub stream_provider: StreamProvider<T>,
-    cleanup_on_drop: Option<Box<dyn FnOnce() + Send + 'static>>,
+    cleanup: Cleanup,
 }
 
 impl<T> std::fmt::Debug for RegisteredStream<T> {
@@ -115,7 +129,7 @@ impl<T> RegisteredStream<T> {
         Self {
             connection_info,
             stream_provider,
-            cleanup_on_drop: None,
+            cleanup: Cleanup(None),
         }
     }
 
@@ -123,7 +137,7 @@ impl<T> RegisteredStream<T> {
     where
         F: FnOnce() + Send + 'static,
     {
-        self.cleanup_on_drop = Some(Box::new(cleanup));
+        self.cleanup.0 = Some(Box::new(cleanup));
         self
     }
 
@@ -132,26 +146,13 @@ impl<T> RegisteredStream<T> {
     /// This **disarms** the RAII cleanup -- the caller takes responsibility for
     /// cleaning up the registration if the stream provider is never awaited.
     pub fn into_parts(self) -> (ConnectionInfo, StreamProvider<T>) {
-        // Use ManuallyDrop to prevent Drop from running, then move the fields out.
-        let mut this = std::mem::ManuallyDrop::new(self);
-        this.cleanup_on_drop.take();
-
-        // SAFETY: `ManuallyDrop` prevents `Drop` from running, so moving these
-        // fields out is sound as long as each field is read exactly once.
-        unsafe {
-            (
-                std::ptr::read(&this.connection_info),
-                std::ptr::read(&this.stream_provider),
-            )
-        }
-    }
-}
-
-impl<T> Drop for RegisteredStream<T> {
-    fn drop(&mut self) {
-        if let Some(cleanup) = self.cleanup_on_drop.take() {
-            cleanup();
-        }
+        let Self {
+            connection_info,
+            stream_provider,
+            mut cleanup,
+        } = self;
+        cleanup.0.take(); // disarm before Cleanup's Drop fires
+        (connection_info, stream_provider)
     }
 }
 
@@ -178,6 +179,68 @@ impl PendingConnections {
 #[async_trait::async_trait]
 pub trait ResponseService {
     async fn register(&self, options: StreamOptions) -> PendingConnections;
+}
+
+#[cfg(test)]
+mod registered_stream_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    fn dummy_conn_info() -> ConnectionInfo {
+        ConnectionInfo {
+            transport: "test".to_string(),
+            info: "{}".to_string(),
+        }
+    }
+
+    /// Drop without `into_parts()` must run the cleanup closure.
+    #[test]
+    fn drop_runs_cleanup() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_clone = flag.clone();
+
+        let (_tx, rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
+        let stream = RegisteredStream::new(dummy_conn_info(), rx).with_cleanup(move || {
+            flag_clone.store(true, Ordering::SeqCst);
+        });
+
+        drop(stream);
+        assert!(
+            flag.load(Ordering::SeqCst),
+            "cleanup must fire when RegisteredStream is dropped"
+        );
+    }
+
+    /// `into_parts()` must disarm the cleanup. After the call, dropping the
+    /// returned halves must NOT trigger the closure -- the caller has taken
+    /// ownership of cleanup responsibility.
+    #[test]
+    fn into_parts_disarms_cleanup() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_clone = flag.clone();
+
+        let (_tx, rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
+        let stream = RegisteredStream::new(dummy_conn_info(), rx).with_cleanup(move || {
+            flag_clone.store(true, Ordering::SeqCst);
+        });
+
+        let (conn, provider) = stream.into_parts();
+        drop(conn);
+        drop(provider);
+
+        assert!(
+            !flag.load(Ordering::SeqCst),
+            "into_parts() must disarm the cleanup closure"
+        );
+    }
+
+    /// `RegisteredStream` with no cleanup configured must drop cleanly.
+    #[test]
+    fn drop_without_cleanup_is_a_noop() {
+        let (_tx, rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
+        let stream: RegisteredStream<()> = RegisteredStream::new(dummy_conn_info(), rx);
+        drop(stream); // must not panic; nothing observable to assert beyond that
+    }
 }
 
 // #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -88,9 +88,8 @@ pub struct ResponseStreamPrologue {
 
 pub type StreamProvider<T> = tokio::sync::oneshot::Receiver<Result<T, String>>;
 
-/// RAII container for the cleanup closure. Owning the `Drop` here (instead of
-/// on `RegisteredStream`) lets `into_parts()` move the public fields out by
-/// plain destructure -- no `unsafe`, no `ManuallyDrop`, no `ptr::read`.
+/// Owning `Drop` here (rather than on `RegisteredStream`) lets `into_parts()`
+/// move the public fields out by plain destructure.
 struct Cleanup(Option<Box<dyn FnOnce() + Send + 'static>>);
 
 impl Drop for Cleanup {
@@ -101,15 +100,9 @@ impl Drop for Cleanup {
     }
 }
 
-/// The [`RegisteredStream`] object is acquired from a [`StreamProvider`] and is used to provide
-/// an awaitable receiver which will the `T` which is either a stream writer for a request stream
-/// or a stream reader for a response stream.
-///
-/// RAII cleanup: if this object is dropped without calling [`into_parts()`], the
-/// optional cleanup closure (held by the inner `Cleanup` struct) fires, removing
-/// the orphaned registration from the stream server's internal maps. This
-/// prevents HashMap leaks when a registered stream is never consumed (e.g.,
-/// early error in the request path).
+/// Awaitable handle for a stream sender or receiver. Drop without calling
+/// [`into_parts()`] runs the optional cleanup closure, removing the
+/// registration from the stream server's maps.
 pub struct RegisteredStream<T> {
     pub connection_info: ConnectionInfo,
     pub stream_provider: StreamProvider<T>,
@@ -141,17 +134,15 @@ impl<T> RegisteredStream<T> {
         self
     }
 
-    /// Consume the registration, returning the connection info and stream provider.
-    ///
-    /// This **disarms** the RAII cleanup -- the caller takes responsibility for
-    /// cleaning up the registration if the stream provider is never awaited.
+    /// Consume the registration, disarming the RAII cleanup. Caller takes
+    /// responsibility for cleanup if the stream provider is never awaited.
     pub fn into_parts(self) -> (ConnectionInfo, StreamProvider<T>) {
         let Self {
             connection_info,
             stream_provider,
             mut cleanup,
         } = self;
-        cleanup.0.take(); // disarm before Cleanup's Drop fires
+        cleanup.0.take();
         (connection_info, stream_provider)
     }
 }

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -92,19 +92,66 @@ pub type StreamProvider<T> = tokio::sync::oneshot::Receiver<Result<T, String>>;
 /// an awaitable receiver which will the `T` which is either a stream writer for a request stream
 /// or a stream reader for a response stream.
 ///
-/// make this an raii object linked to some stream provider
-/// if the object has not been awaited an the type T unwrapped, the registered stream
-/// on the stream provider will be informed and can clean up a stream that will never
-/// be connected.
-#[derive(Debug)]
+/// RAII cleanup: if this object is dropped without calling [`into_parts()`], the
+/// optional `cleanup_on_drop` closure fires, removing the orphaned registration
+/// from the stream server's internal maps. This prevents HashMap leaks when
+/// a registered stream is never consumed (e.g., early error in the request path).
 pub struct RegisteredStream<T> {
     pub connection_info: ConnectionInfo,
     pub stream_provider: StreamProvider<T>,
+    cleanup_on_drop: Option<Box<dyn FnOnce() + Send + 'static>>,
+}
+
+impl<T> std::fmt::Debug for RegisteredStream<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegisteredStream")
+            .field("connection_info", &self.connection_info)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<T> RegisteredStream<T> {
+    pub(crate) fn new(connection_info: ConnectionInfo, stream_provider: StreamProvider<T>) -> Self {
+        Self {
+            connection_info,
+            stream_provider,
+            cleanup_on_drop: None,
+        }
+    }
+
+    pub(crate) fn with_cleanup<F>(mut self, cleanup: F) -> Self
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.cleanup_on_drop = Some(Box::new(cleanup));
+        self
+    }
+
+    /// Consume the registration, returning the connection info and stream provider.
+    ///
+    /// This **disarms** the RAII cleanup -- the caller takes responsibility for
+    /// cleaning up the registration if the stream provider is never awaited.
     pub fn into_parts(self) -> (ConnectionInfo, StreamProvider<T>) {
-        (self.connection_info, self.stream_provider)
+        // Use ManuallyDrop to prevent Drop from running, then move the fields out.
+        let mut this = std::mem::ManuallyDrop::new(self);
+        this.cleanup_on_drop.take();
+
+        // SAFETY: `ManuallyDrop` prevents `Drop` from running, so moving these
+        // fields out is sound as long as each field is read exactly once.
+        unsafe {
+            (
+                std::ptr::read(&this.connection_info),
+                std::ptr::read(&this.stream_provider),
+            )
+        }
+    }
+}
+
+impl<T> Drop for RegisteredStream<T> {
+    fn drop(&mut self) {
+        if let Some(cleanup) = self.cleanup_on_drop.take() {
+            cleanup();
+        }
     }
 }
 

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 use super::unified_client::RequestPlaneClient;
 use super::*;
 use crate::component::Instance;
+use crate::discovery::EndpointInstanceId;
 use crate::dynamo_nvtx_range;
 use crate::engine::{AsyncEngine, AsyncEngineContextProvider, Data};
 use crate::error::{DynamoError, ErrorType};
@@ -173,20 +174,21 @@ impl AddressedPushRouter {
     /// Delegates to [`TcpStreamServer::cancel_instance_streams`]. Called by the
     /// discovery-driven watcher when an instance is removed from the service registry.
     ///
-    /// The `endpoint` parameter scopes the cancellation to a specific endpoint
-    /// on the backend runtime, preventing sibling endpoints from being affected.
-    pub async fn cancel_instance_streams(&self, endpoint: &str, instance_id: u64) -> usize {
+    /// The full [`EndpointInstanceId`] scopes the cancellation to one concrete
+    /// service instance, even when different namespaces/components reuse the
+    /// same endpoint name and backend runtime.
+    pub async fn cancel_instance_streams(&self, instance_id: &EndpointInstanceId) -> usize {
         self.resp_transport
-            .cancel_instance_streams(endpoint, instance_id)
+            .cancel_instance_streams(instance_id)
             .await
     }
 
     /// Clear the tombstone for an instance that has come back in the discovery set.
     ///
     /// Delegates to [`TcpStreamServer::clear_instance_tombstone`].
-    pub async fn clear_instance_tombstone(&self, endpoint: &str, instance_id: u64) {
+    pub async fn clear_instance_tombstone(&self, instance_id: &EndpointInstanceId) {
         self.resp_transport
-            .clear_instance_tombstone(endpoint, instance_id)
+            .clear_instance_tombstone(instance_id)
             .await
     }
 }
@@ -245,13 +247,11 @@ where
         // associate_instance returns false and the subject is already cancelled --
         // skip the send_request round trip and fail fast with a migratable error.
         //
-        // The composite key (endpoint, instance_id) prevents sibling endpoints on
-        // the same backend runtime (which share a connection_id) from having their
-        // subjects cancelled when only one endpoint is removed.
         if let (Some(subject), Some(inst)) = (&recv_subject, &instance_info) {
+            let endpoint_instance_id = inst.endpoint_instance_id();
             if !self
                 .resp_transport
-                .associate_instance(subject, &inst.endpoint, inst.instance_id)
+                .associate_instance(subject, &endpoint_instance_id)
                 .await
             {
                 return Err(anyhow::anyhow!(

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -173,6 +173,15 @@ impl AddressedPushRouter {
             .cancel_instance_streams(instance_id)
             .await
     }
+
+    /// Clear the tombstone for an instance that has come back in the discovery set.
+    ///
+    /// Delegates to [`TcpStreamServer::clear_instance_tombstone`].
+    pub async fn clear_instance_tombstone(&self, instance_id: u64) {
+        self.resp_transport
+            .clear_instance_tombstone(instance_id)
+            .await
+    }
 }
 
 #[async_trait::async_trait]

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -113,15 +113,31 @@ impl<S> Drop for InflightDecStream<S> {
 pub struct AddressedRequest<T> {
     request: T,
     address: String,
+    /// The backend instance ID from the discovery plane. Used to associate
+    /// pending response-stream registrations with a specific worker so they
+    /// can be cancelled when the discovery plane reports the worker as gone.
+    instance_id: Option<u64>,
 }
 
 impl<T> AddressedRequest<T> {
     pub fn new(request: T, address: String) -> Self {
-        Self { request, address }
+        Self {
+            request,
+            address,
+            instance_id: None,
+        }
     }
 
-    pub(crate) fn into_parts(self) -> (T, String) {
-        (self.request, self.address)
+    pub fn with_instance(request: T, address: String, instance_id: u64) -> Self {
+        Self {
+            request,
+            address,
+            instance_id: Some(instance_id),
+        }
+    }
+
+    pub(crate) fn into_parts(self) -> (T, String, Option<u64>) {
+        (self.request, self.address, self.instance_id)
     }
 }
 
@@ -147,6 +163,16 @@ impl AddressedPushRouter {
             resp_transport,
         }))
     }
+
+    /// Cancel all pending response-stream registrations for a given backend instance.
+    ///
+    /// Delegates to [`TcpStreamServer::cancel_instance_streams`]. Called by the
+    /// discovery-driven watcher when an instance is removed from the service registry.
+    pub async fn cancel_instance_streams(&self, instance_id: u64) -> usize {
+        self.resp_transport
+            .cancel_instance_streams(instance_id)
+            .await
+    }
 }
 
 #[async_trait::async_trait]
@@ -162,7 +188,7 @@ where
 
         let request_id = request.context().id().to_string();
         let (addressed_request, context) = request.transfer(());
-        let (request, address) = addressed_request.into_parts();
+        let (request, address, instance_id) = addressed_request.into_parts();
         let engine_ctx = context.context();
         let engine_ctx_ = engine_ctx.clone();
 
@@ -189,6 +215,20 @@ where
         // separate out the connection info and the stream provider from the registered stream
         let (connection_info, response_stream_provider) = pending_response_stream.into_parts();
 
+        // Extract the response-plane subject before connection_info is moved into the
+        // control message. Used to cancel the rx_subjects entry on instance removal or
+        // early failure, preventing the HashMap from accumulating dead entries.
+        let recv_subject: Option<String> =
+            serde_json::from_str::<tcp::TcpStreamConnectionInfo>(&connection_info.info)
+                .ok()
+                .map(|ci| ci.subject);
+
+        // Associate the subject with the backend instance so the discovery-driven
+        // watcher can cancel all pending subjects when this instance is removed.
+        if let (Some(subject), Some(iid)) = (&recv_subject, instance_id) {
+            self.resp_transport.associate_instance(subject, iid).await;
+        }
+
         // package up the connection info as part of the "header" component of the two part message
         // used to issue the request on the
         // todo -- this object should be automatically created by the register call, and achieved by to the two into_parts()
@@ -204,8 +244,24 @@ where
         // next build the two part message where we package the connection info and the request into
         // a single Vec<u8> that can be sent over the wire.
         // --- package this up in the WorkQueuePublisher ---
-        let ctrl = serde_json::to_vec(&control_message)?;
-        let data = serde_json::to_vec(&request)?;
+        let ctrl = match serde_json::to_vec(&control_message) {
+            Ok(v) => v,
+            Err(e) => {
+                if let Some(subject) = &recv_subject {
+                    self.resp_transport.cancel_recv_stream(subject).await;
+                }
+                return Err(e.into());
+            }
+        };
+        let data = match serde_json::to_vec(&request) {
+            Ok(v) => v,
+            Err(e) => {
+                if let Some(subject) = &recv_subject {
+                    self.resp_transport.cancel_recv_stream(subject).await;
+                }
+                return Err(e.into());
+            }
+        };
 
         tracing::trace!(
             request_id,
@@ -220,9 +276,14 @@ where
         // or it should take a two part message directly
         // todo - update this
         let codec = TwoPartCodec::default();
-        let buffer = {
-            let _nvtx = dynamo_nvtx_range!("codec.encode");
-            codec.encode_message(msg)?
+        let buffer = match codec.encode_message(msg) {
+            Ok(v) => v,
+            Err(e) => {
+                if let Some(subject) = &recv_subject {
+                    self.resp_transport.cancel_recv_stream(subject).await;
+                }
+                return Err(e.into());
+            }
         };
 
         REQUEST_PLANE_QUEUE_SECONDS.observe(queue_start.elapsed().as_secs_f64());
@@ -253,19 +314,49 @@ where
 
         // Phase A: Frontend → Backend (network + queue + ack)
         let _nvtx_send = dynamo_nvtx_range!("transport.tcp.send");
-        let _response = self
-            .req_client
-            .send_request(address, buffer, headers)
-            .await?;
+        let send_result = self.req_client.send_request(address, buffer, headers).await;
         drop(_nvtx_send);
+
+        if let Err(e) = send_result {
+            if let Some(subject) = &recv_subject {
+                self.resp_transport.cancel_recv_stream(subject).await;
+            }
+            return Err(e);
+        }
         REQUEST_PLANE_SEND_SECONDS.observe(tx_start.elapsed().as_secs_f64());
 
         let _nvtx_wait = dynamo_nvtx_range!("transport.tcp.wait_backend");
         tracing::trace!(request_id, "awaiting transport handshake");
-        let response_stream = response_stream_provider
-            .await
-            .map_err(|_| PipelineError::DetachedStreamReceiver)?
-            .map_err(PipelineError::ConnectionFailed)?;
+
+        // When the discovery-driven watcher calls cancel_instance_streams(),
+        // the oneshot::Sender is dropped, causing this .await to resolve
+        // with RecvError. We convert that to a migratable Disconnected error
+        // so the Migration layer can retry on another worker.
+        let response_stream = match response_stream_provider.await {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) => {
+                // Worker connected on the response plane but inference setup failed
+                // (error prologue). Not migratable -- the worker started the request.
+                if let Some(subject) = &recv_subject {
+                    self.resp_transport.cancel_recv_stream(subject).await;
+                }
+                return Err(PipelineError::ConnectionFailed(e).into());
+            }
+            Err(_recv_err) => {
+                // oneshot sender dropped: either the discovery-driven watcher cancelled
+                // this subject because the instance was removed, or the worker died
+                // mid-handshake. Return Disconnected (migratable) so Migration can retry.
+                if let Some(subject) = &recv_subject {
+                    self.resp_transport.cancel_recv_stream(subject).await;
+                }
+                return Err(anyhow::anyhow!(
+                    DynamoError::builder()
+                        .error_type(ErrorType::Disconnected)
+                        .message("Worker disconnected before response stream was established")
+                        .build()
+                ));
+            }
+        };
         drop(_nvtx_wait);
 
         // TODO: Detect end-of-stream using Server-Sent Events (SSE)

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 
 use super::unified_client::RequestPlaneClient;
 use super::*;
+use crate::component::Instance;
 use crate::dynamo_nvtx_range;
 use crate::engine::{AsyncEngine, AsyncEngineContextProvider, Data};
 use crate::error::{DynamoError, ErrorType};
@@ -113,10 +114,13 @@ impl<S> Drop for InflightDecStream<S> {
 pub struct AddressedRequest<T> {
     request: T,
     address: String,
-    /// The backend instance ID from the discovery plane. Used to associate
-    /// pending response-stream registrations with a specific worker so they
-    /// can be cancelled when the discovery plane reports the worker as gone.
-    instance_id: Option<u64>,
+    /// The backend instance from the discovery plane. Carries both the
+    /// endpoint name and the instance_id so that pending response-stream
+    /// registrations can be associated with the exact (endpoint, instance)
+    /// pair and cancelled only when *that* endpoint on *that* worker
+    /// disappears — not all endpoints that share the same runtime
+    /// connection_id.
+    instance: Option<Instance>,
 }
 
 impl<T> AddressedRequest<T> {
@@ -124,20 +128,20 @@ impl<T> AddressedRequest<T> {
         Self {
             request,
             address,
-            instance_id: None,
+            instance: None,
         }
     }
 
-    pub fn with_instance(request: T, address: String, instance_id: u64) -> Self {
+    pub fn with_instance(request: T, address: String, instance: Instance) -> Self {
         Self {
             request,
             address,
-            instance_id: Some(instance_id),
+            instance: Some(instance),
         }
     }
 
-    pub(crate) fn into_parts(self) -> (T, String, Option<u64>) {
-        (self.request, self.address, self.instance_id)
+    pub(crate) fn into_parts(self) -> (T, String, Option<Instance>) {
+        (self.request, self.address, self.instance)
     }
 }
 
@@ -168,18 +172,21 @@ impl AddressedPushRouter {
     ///
     /// Delegates to [`TcpStreamServer::cancel_instance_streams`]. Called by the
     /// discovery-driven watcher when an instance is removed from the service registry.
-    pub async fn cancel_instance_streams(&self, instance_id: u64) -> usize {
+    ///
+    /// The `endpoint` parameter scopes the cancellation to a specific endpoint
+    /// on the backend runtime, preventing sibling endpoints from being affected.
+    pub async fn cancel_instance_streams(&self, endpoint: &str, instance_id: u64) -> usize {
         self.resp_transport
-            .cancel_instance_streams(instance_id)
+            .cancel_instance_streams(endpoint, instance_id)
             .await
     }
 
     /// Clear the tombstone for an instance that has come back in the discovery set.
     ///
     /// Delegates to [`TcpStreamServer::clear_instance_tombstone`].
-    pub async fn clear_instance_tombstone(&self, instance_id: u64) {
+    pub async fn clear_instance_tombstone(&self, endpoint: &str, instance_id: u64) {
         self.resp_transport
-            .clear_instance_tombstone(instance_id)
+            .clear_instance_tombstone(endpoint, instance_id)
             .await
     }
 }
@@ -197,7 +204,7 @@ where
 
         let request_id = request.context().id().to_string();
         let (addressed_request, context) = request.transfer(());
-        let (request, address, instance_id) = addressed_request.into_parts();
+        let (request, address, instance_info) = addressed_request.into_parts();
         let engine_ctx = context.context();
         let engine_ctx_ = engine_ctx.clone();
 
@@ -237,8 +244,16 @@ where
         // If the instance is already tombstoned (removed before we got here),
         // associate_instance returns false and the subject is already cancelled --
         // skip the send_request round trip and fail fast with a migratable error.
-        if let (Some(subject), Some(iid)) = (&recv_subject, instance_id) {
-            if !self.resp_transport.associate_instance(subject, iid).await {
+        //
+        // The composite key (endpoint, instance_id) prevents sibling endpoints on
+        // the same backend runtime (which share a connection_id) from having their
+        // subjects cancelled when only one endpoint is removed.
+        if let (Some(subject), Some(inst)) = (&recv_subject, &instance_info) {
+            if !self
+                .resp_transport
+                .associate_instance(subject, &inst.endpoint, inst.instance_id)
+                .await
+            {
                 return Err(anyhow::anyhow!(
                     DynamoError::builder()
                         .error_type(ErrorType::Disconnected)

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -234,8 +234,20 @@ where
 
         // Associate the subject with the backend instance so the discovery-driven
         // watcher can cancel all pending subjects when this instance is removed.
+        // If the instance is already tombstoned (removed before we got here),
+        // associate_instance returns false and the subject is already cancelled --
+        // skip the send_request round trip and fail fast with a migratable error.
         if let (Some(subject), Some(iid)) = (&recv_subject, instance_id) {
-            self.resp_transport.associate_instance(subject, iid).await;
+            if !self.resp_transport.associate_instance(subject, iid).await {
+                return Err(anyhow::anyhow!(
+                    DynamoError::builder()
+                        .error_type(ErrorType::Disconnected)
+                        .message(
+                            "Worker removed before request could be sent (tombstoned instance)"
+                        )
+                        .build()
+                ));
+            }
         }
 
         // package up the connection info as part of the "header" component of the two part message

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -371,8 +371,15 @@ where
         let response_stream = match response_stream_provider.await {
             Ok(Ok(stream)) => stream,
             Ok(Err(e)) => {
-                // Worker connected on the response plane but inference setup failed
-                // (error prologue). Not migratable -- the worker started the request.
+                // Worker connected on the response plane but `generate()` failed.
+                // The wire prologue carries only an opaque error string, so we
+                // cannot tell setup/connectivity failures apart from application
+                // errors (invalid input, model-side rejection, etc.). Migrating
+                // unconditionally could duplicate side effects from non-
+                // migratable application errors, so we keep this path non-
+                // migratable. A future change can carry a structured error type
+                // through the prologue and route migratable subtypes to
+                // `CannotConnect`.
                 if let Some(subject) = &recv_subject {
                     self.resp_transport.cancel_recv_stream(subject).await;
                 }

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -115,12 +115,8 @@ impl<S> Drop for InflightDecStream<S> {
 pub struct AddressedRequest<T> {
     request: T,
     address: String,
-    /// The backend instance from the discovery plane. Carries both the
-    /// endpoint name and the instance_id so that pending response-stream
-    /// registrations can be associated with the exact (endpoint, instance)
-    /// pair and cancelled only when *that* endpoint on *that* worker
-    /// disappears — not all endpoints that share the same runtime
-    /// connection_id.
+    /// Carries endpoint name + instance_id so cancellation is scoped to the
+    /// exact (endpoint, instance) pair, not all endpoints on the same runtime.
     instance: Option<Instance>,
 }
 
@@ -169,23 +165,14 @@ impl AddressedPushRouter {
         }))
     }
 
-    /// Cancel all pending response-stream registrations for a given backend instance.
-    ///
-    /// Delegates to [`TcpStreamServer::cancel_instance_streams`]. Called by the
-    /// discovery-driven watcher when an instance is removed from the service registry.
-    ///
-    /// The full [`EndpointInstanceId`] scopes the cancellation to one concrete
-    /// service instance, even when different namespaces/components reuse the
-    /// same endpoint name and backend runtime.
+    /// Cancel all pending response-stream registrations for an instance.
     pub async fn cancel_instance_streams(&self, instance_id: &EndpointInstanceId) -> usize {
         self.resp_transport
             .cancel_instance_streams(instance_id)
             .await
     }
 
-    /// Clear the tombstone for an instance that has come back in the discovery set.
-    ///
-    /// Delegates to [`TcpStreamServer::clear_instance_tombstone`].
+    /// Clear the tombstone after an instance reappears in discovery.
     pub async fn clear_instance_tombstone(&self, instance_id: &EndpointInstanceId) {
         self.resp_transport
             .clear_instance_tombstone(instance_id)
@@ -233,20 +220,14 @@ where
         // separate out the connection info and the stream provider from the registered stream
         let (connection_info, response_stream_provider) = pending_response_stream.into_parts();
 
-        // Extract the response-plane subject before connection_info is moved into the
-        // control message. Used to cancel the rx_subjects entry on instance removal or
-        // early failure, preventing the HashMap from accumulating dead entries.
+        // Snapshot subject before connection_info is moved; used for cleanup.
         let recv_subject: Option<String> =
             serde_json::from_str::<tcp::TcpStreamConnectionInfo>(&connection_info.info)
                 .ok()
                 .map(|ci| ci.subject);
 
-        // Associate the subject with the backend instance so the discovery-driven
-        // watcher can cancel all pending subjects when this instance is removed.
-        // If the instance is already tombstoned (removed before we got here),
-        // associate_instance returns false and the subject is already cancelled --
-        // skip the send_request round trip and fail fast with a migratable error.
-        //
+        // If the instance is already tombstoned, fail fast with a migratable
+        // error instead of writing to the request plane.
         if let (Some(subject), Some(inst)) = (&recv_subject, &instance_info) {
             let endpoint_instance_id = inst.endpoint_instance_id();
             if !self
@@ -364,31 +345,32 @@ where
         let _nvtx_wait = dynamo_nvtx_range!("transport.tcp.wait_backend");
         tracing::trace!(request_id, "awaiting transport handshake");
 
-        // When the discovery-driven watcher calls cancel_instance_streams(),
-        // the oneshot::Sender is dropped, causing this .await to resolve
-        // with RecvError. We convert that to a migratable Disconnected error
-        // so the Migration layer can retry on another worker.
+        // RecvError → migratable Disconnected (watcher cancelled the subject
+        // or the worker died before establishing the response stream).
         let response_stream = match response_stream_provider.await {
             Ok(Ok(stream)) => stream,
             Ok(Err(e)) => {
-                // Worker connected on the response plane but `generate()` failed.
-                // The wire prologue carries only an opaque error string, so we
-                // cannot tell setup/connectivity failures apart from application
-                // errors (invalid input, model-side rejection, etc.). Migrating
-                // unconditionally could duplicate side effects from non-
-                // migratable application errors, so we keep this path non-
-                // migratable. A future change can carry a structured error type
-                // through the prologue and route migratable subtypes to
-                // `CannotConnect`.
+                // generate() failed before any response bytes; migrate via
+                // CannotConnect since the dominant cause is a worker-local
+                // setup/version issue. The wire prologue carries only an
+                // opaque string today, so app-level rejections also retry
+                // -- safe because no side effects are visible yet. Follow-up:
+                // structured prologue error type for finer routing.
                 if let Some(subject) = &recv_subject {
                     self.resp_transport.cancel_recv_stream(subject).await;
                 }
-                return Err(PipelineError::ConnectionFailed(e).into());
+                return Err(anyhow::anyhow!(
+                    DynamoError::builder()
+                        .error_type(ErrorType::CannotConnect)
+                        .message(format!(
+                            "Worker generate() failed before response stream: {e}"
+                        ))
+                        .build()
+                ));
             }
             Err(_recv_err) => {
-                // oneshot sender dropped: either the discovery-driven watcher cancelled
-                // this subject because the instance was removed, or the worker died
-                // mid-handshake. Return Disconnected (migratable) so Migration can retry.
+                // oneshot dropped: either the discovery watcher cancelled
+                // this subject or the worker died mid-handshake.
                 if let Some(subject) = &recv_subject {
                     self.resp_transport.cancel_recv_stream(subject).await;
                 }

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -284,6 +284,7 @@ fn spawn_instance_removal_watcher(
 
             let current_ids: HashSet<u64> = rx.borrow_and_update().iter().map(|i| i.id()).collect();
 
+            // Cancel pending response streams for removed instances.
             for removed_id in prev_ids.difference(&current_ids) {
                 let n = addressed.cancel_instance_streams(*removed_id).await;
                 if n > 0 {
@@ -354,6 +355,16 @@ where
         } else {
             None
         };
+
+        // Even with fault detection disabled (no report_instance_down on errors),
+        // we still need the discovery-driven watcher to cancel pending response-stream
+        // registrations when workers die. Otherwise the bare .await on the oneshot
+        // receiver hangs forever for queued-but-never-started requests.
+        spawn_instance_removal_watcher(
+            client.instance_source.clone(),
+            addressed.clone(),
+            client.endpoint.drt().primary_token(),
+        );
 
         Ok(PushRouter {
             client,

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -8,6 +8,7 @@ use crate::{
         Client, DeviceType, Endpoint, Instance, RoutingOccupancyState,
         get_or_create_routing_occupancy_state,
     },
+    discovery::EndpointInstanceId,
     dynamo_nvtx_range,
     engine::{AsyncEngine, AsyncEngineContext, Data},
     metrics::frontend_perf::{STAGE_DURATION_SECONDS, STAGE_ROUTE},
@@ -15,7 +16,7 @@ use crate::{
         AddressedPushRouter, AddressedRequest, Error, ManyOut, SingleIn,
         error::{PipelineError, PipelineErrorExt},
     },
-    protocols::maybe_error::MaybeError,
+    protocols::{EndpointId, maybe_error::MaybeError},
     traits::DistributedRuntimeProvider,
 };
 use async_trait::async_trait;
@@ -254,22 +255,30 @@ fn device_aware_candidate_group(
     }
 }
 
+/// Per-endpoint guard: ensures at most one `list_and_watch` control-plane
+/// connection is opened per endpoint, regardless of how many `PushRouter`
+/// instances are created for it.  The entry is removed when the watcher
+/// task exits (cancel_token fired or discovery stream closed) so that a
+/// subsequent router creation can re-arm the watcher.
+static ENDPOINT_WATCHER_ACTIVE: std::sync::OnceLock<dashmap::DashMap<EndpointId, ()>> =
+    std::sync::OnceLock::new();
+
 /// Background task that watches the discovery plane for instance removals and
 /// cancels all pending response-stream registrations for removed instances.
 ///
-/// This is the core fix for the postmortem: when a worker is killed while requests
-/// are queued (ACK'd but not yet picked up), the oneshot senders are dropped,
-/// unblocking the waiting frontends with a migratable `Disconnected` error.
+/// This is the core fix for the postmortem: when a worker is killed while
+/// requests are queued (ACK'd but not yet picked up), the oneshot senders
+/// are dropped, unblocking waiting frontends with a migratable `Disconnected`
+/// error.
 ///
-/// Uses the raw `list_and_watch` discovery stream instead of diffing coalesced
-/// watch snapshots so that a rapid remove→re-add of the same pod (same stable
-/// hash-based instance_id in Kubernetes) is never silently swallowed.  Each
-/// `Removed` event unconditionally calls `cancel_instance_streams`; each
-/// `Added` event calls `clear_instance_tombstone`.
+/// Uses the raw `list_and_watch` discovery stream (not a coalesced snapshot
+/// diff) so that a rapid remove→re-add of the same Kubernetes pod — which
+/// keeps the same hash-stable instance_id — is never silently swallowed.
 ///
-/// Cancellation is keyed by `(endpoint_name, instance_id)` to avoid
-/// accidentally cancelling sibling endpoints on the same backend runtime that
-/// share a `connection_id` / `instance_id`.
+/// Cancellation is keyed by the full `EndpointInstanceId` (namespace +
+/// component + endpoint + instance_id) to prevent services from different
+/// namespaces/components that happen to share an endpoint name and
+/// pod-backed instance_id from cancelling each other's pending streams.
 fn spawn_instance_removal_watcher(
     endpoint: Endpoint,
     addressed: Arc<AddressedPushRouter>,
@@ -279,6 +288,17 @@ fn spawn_instance_removal_watcher(
         DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, DiscoveryQuery,
     };
     use tokio_stream::StreamExt as _;
+
+    // One watcher per endpoint: if one is already running, skip.
+    let guard = ENDPOINT_WATCHER_ACTIVE.get_or_init(dashmap::DashMap::new);
+    let endpoint_id = endpoint.id();
+    if guard.insert(endpoint_id.clone(), ()).is_some() {
+        tracing::debug!(
+            ?endpoint_id,
+            "Instance removal watcher already running for this endpoint, skipping"
+        );
+        return;
+    }
 
     let endpoint_name = endpoint.name().to_string();
 
@@ -298,6 +318,7 @@ fn spawn_instance_removal_watcher(
                     endpoint = %endpoint_name,
                     "Failed to start instance removal watcher: {e}"
                 );
+                guard.remove(&endpoint_id);
                 return;
             }
         };
@@ -307,28 +328,29 @@ fn spawn_instance_removal_watcher(
                 event = stream.next() => {
                     match event {
                         Some(Ok(DiscoveryEvent::Removed(id))) => {
-                            // Only act on endpoint-type removals.
+                            // Only act on endpoint-type removals; pass the
+                            // full EndpointInstanceId so cancellation is
+                            // scoped to exactly one service identity.
                             if let DiscoveryInstanceId::Endpoint(eid) = &id {
-                                let n = addressed
-                                    .cancel_instance_streams(&eid.endpoint, eid.instance_id)
-                                    .await;
+                                let n = addressed.cancel_instance_streams(eid).await;
                                 if n > 0 {
                                     tracing::warn!(
+                                        namespace = %eid.namespace,
+                                        component = %eid.component,
                                         endpoint = %eid.endpoint,
                                         instance_id = eid.instance_id,
                                         cancelled = n,
-                                        "Cancelled pending response streams for removed instance \
-                                         (discovery-driven cleanup)"
+                                        "Cancelled pending response streams for removed \
+                                         instance (discovery-driven cleanup)"
                                     );
                                 }
                             }
                         }
                         Some(Ok(DiscoveryEvent::Added(DiscoveryInstance::Endpoint(inst)))) => {
-                            // Clear tombstone so new requests for this (endpoint, instance)
-                            // pair are tracked normally after a restart.
-                            addressed
-                                .clear_instance_tombstone(&inst.endpoint, inst.instance_id)
-                                .await;
+                            // Clear tombstone so new requests for this identity are
+                            // tracked normally after a pod restart.
+                            let eid: EndpointInstanceId = inst.endpoint_instance_id();
+                            addressed.clear_instance_tombstone(&eid).await;
                         }
                         Some(Ok(_)) => {
                             // Ignore non-endpoint events (Model, EventChannel).
@@ -351,6 +373,8 @@ fn spawn_instance_removal_watcher(
             }
         }
 
+        // Release the guard so the next router creation can re-arm the watcher.
+        guard.remove(&endpoint_id);
         tracing::debug!(endpoint = %endpoint_name, "Instance removal watcher exiting");
     });
 }

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -255,30 +255,16 @@ fn device_aware_candidate_group(
     }
 }
 
-/// Per-endpoint guard: ensures at most one `list_and_watch` control-plane
-/// connection is opened per endpoint, regardless of how many `PushRouter`
-/// instances are created for it.  The entry is removed when the watcher
-/// task exits (cancel_token fired or discovery stream closed) so that a
-/// subsequent router creation can re-arm the watcher.
+/// At most one `list_and_watch` per endpoint, across all `PushRouter`
+/// instances. Entry removed on watcher exit so a later router can re-arm.
 static ENDPOINT_WATCHER_ACTIVE: std::sync::OnceLock<dashmap::DashMap<EndpointId, ()>> =
     std::sync::OnceLock::new();
 
-/// Background task that watches the discovery plane for instance removals and
-/// cancels all pending response-stream registrations for removed instances.
-///
-/// This is the core fix for the postmortem: when a worker is killed while
-/// requests are queued (ACK'd but not yet picked up), the oneshot senders
-/// are dropped, unblocking waiting frontends with a migratable `Disconnected`
-/// error.
-///
-/// Uses the raw `list_and_watch` discovery stream (not a coalesced snapshot
-/// diff) so that a rapid remove→re-add of the same Kubernetes pod — which
-/// keeps the same hash-stable instance_id — is never silently swallowed.
-///
-/// Cancellation is keyed by the full `EndpointInstanceId` (namespace +
-/// component + endpoint + instance_id) to prevent services from different
-/// namespaces/components that happen to share an endpoint name and
-/// pod-backed instance_id from cancelling each other's pending streams.
+/// Watch discovery for instance removals and cancel pending response-stream
+/// registrations on the removed instance, unblocking queued requests with
+/// a migratable `Disconnected` error. Uses raw `list_and_watch` events
+/// (not a coalesced snapshot diff) so a rapid remove→re-add of the same
+/// identity is not silently swallowed. Keyed by full `EndpointInstanceId`.
 fn spawn_instance_removal_watcher(
     endpoint: Endpoint,
     addressed: Arc<AddressedPushRouter>,
@@ -303,9 +289,8 @@ fn spawn_instance_removal_watcher(
     let endpoint_name = endpoint.name().to_string();
 
     tokio::spawn(async move {
-        // Release the dedup guard on EVERY exit path -- normal exit, discovery
-        // stream failure, AND task panic. A leaked entry would silently disable
-        // the orphaned-pending-request fix for that endpoint until process restart.
+        // Release on every exit path (including panic); a leaked entry
+        // silently disables removal cancellation until process restart.
         struct GuardRelease(EndpointId);
         impl Drop for GuardRelease {
             fn drop(&mut self) {
@@ -319,10 +304,7 @@ fn spawn_instance_removal_watcher(
         let namespace = endpoint.component().namespace().name();
         let component = endpoint.component().name().to_string();
 
-        // Outer reconnect loop: a transient discovery-plane failure (failed
-        // initial connect or the watch stream ending) must not permanently
-        // disable orphaned-pending-request cancellation for this endpoint.
-        // Reconnect with a cancellation-aware backoff until cancel_token fires.
+        // Reconnect on transient discovery failure; cancel-aware backoff.
         const RECONNECT_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
         'reconnect: loop {
             let query = DiscoveryQuery::Endpoint {
@@ -350,9 +332,6 @@ fn spawn_instance_removal_watcher(
                     event = stream.next() => {
                         match event {
                             Some(Ok(DiscoveryEvent::Removed(id))) => {
-                                // Only act on endpoint-type removals; pass the
-                                // full EndpointInstanceId so cancellation is
-                                // scoped to exactly one service identity.
                                 if let DiscoveryInstanceId::Endpoint(eid) = &id {
                                     let n = addressed.cancel_instance_streams(eid).await;
                                     if n > 0 {
@@ -369,16 +348,10 @@ fn spawn_instance_removal_watcher(
                                 }
                             }
                             Some(Ok(DiscoveryEvent::Added(DiscoveryInstance::Endpoint(inst)))) => {
-                                // Clear tombstone so new requests for this identity are
-                                // tracked normally after a pod restart. Also fires on
-                                // reconnect when list_and_watch replays current state,
-                                // which limits how long a stale tombstone survives.
                                 let eid: EndpointInstanceId = inst.endpoint_instance_id();
                                 addressed.clear_instance_tombstone(&eid).await;
                             }
-                            Some(Ok(_)) => {
-                                // Ignore non-endpoint events (Model, EventChannel).
-                            }
+                            Some(Ok(_)) => {}
                             Some(Err(e)) => {
                                 tracing::warn!(
                                     endpoint = %endpoint_name,
@@ -386,10 +359,6 @@ fn spawn_instance_removal_watcher(
                                 );
                             }
                             None => {
-                                // Stream ended — discovery plane closed the watch.
-                                // Reconnect rather than exiting permanently, otherwise
-                                // a transient discovery restart would silently disable
-                                // orphaned-pending-request cancellation.
                                 tracing::warn!(
                                     endpoint = %endpoint_name,
                                     "Instance removal watcher stream ended; reconnecting"
@@ -405,7 +374,6 @@ fn spawn_instance_removal_watcher(
             }
         }
 
-        // _release.drop() removes the dedup-guard entry; debug-log on the way out.
         tracing::debug!(endpoint = %endpoint_name, "Instance removal watcher exiting");
     });
 }
@@ -456,10 +424,7 @@ where
             None
         };
 
-        // Even with fault detection disabled (no report_instance_down on errors),
-        // we still need the discovery-driven watcher to cancel pending response-stream
-        // registrations when workers die. Otherwise the bare .await on the oneshot
-        // receiver hangs forever for queued-but-never-started requests.
+        // Cancel orphaned pending response streams when workers die.
         spawn_instance_removal_watcher(
             client.endpoint.clone(),
             addressed.clone(),
@@ -507,11 +472,7 @@ where
             None
         };
 
-        // Spawn a background task that watches the discovery plane for instance
-        // removals and cancels pending response-stream registrations for removed
-        // instances. This is the primary mechanism for unblocking requests that
-        // were ACK'd on the request plane but never picked up by the worker pool
-        // before the worker was killed.
+        // Cancel orphaned pending response streams when workers die.
         spawn_instance_removal_watcher(
             client.endpoint.clone(),
             addressed.clone(),
@@ -870,14 +831,8 @@ where
             }
         }
 
-        // Get the address based on discovered transport type.
-        // If the selected instance disappeared between selection and dispatch
-        // (e.g. deregistered during scale-down), fall back to another available
-        // instance rather than returning a spurious 500.
-        //
-        // resolve_transport returns (address, transport_kind, Instance) so that
-        // the full Instance (carrying endpoint name + instance_id) can be
-        // threaded through to AddressedRequest for endpoint-scoped cancellation.
+        // Resolve transport address; if the selected instance disappeared
+        // between selection and dispatch, fall back to another available one.
         let (address, _transport_kind, instance) = {
             use crate::component::TransportType;
 

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -5,7 +5,8 @@ use super::{AsyncEngineContextProvider, ResponseStream};
 use crate::error::{BackendError, DynamoError, ErrorType, match_error_chain};
 use crate::{
     component::{
-        Client, DeviceType, Endpoint, RoutingOccupancyState, get_or_create_routing_occupancy_state,
+        Client, DeviceType, Endpoint, Instance, RoutingOccupancyState,
+        get_or_create_routing_occupancy_state,
     },
     dynamo_nvtx_range,
     engine::{AsyncEngine, AsyncEngineContext, Data},
@@ -22,7 +23,7 @@ use futures::Stream;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     marker::PhantomData,
     pin::Pin,
     sync::{
@@ -253,6 +254,61 @@ fn device_aware_candidate_group(
     }
 }
 
+/// Background task that watches the discovery plane for instance removals and
+/// cancels all pending response-stream registrations for removed instances.
+///
+/// This is the core fix for the postmortem: when a worker is killed while requests
+/// are queued (ACK'd but not yet picked up), the oneshot senders are dropped,
+/// unblocking the waiting frontends with a migratable `Disconnected` error.
+fn spawn_instance_removal_watcher(
+    instance_source: Arc<tokio::sync::watch::Receiver<Vec<Instance>>>,
+    addressed: Arc<AddressedPushRouter>,
+    cancel_token: tokio_util::sync::CancellationToken,
+) {
+    tokio::spawn(async move {
+        let mut rx = instance_source.as_ref().clone();
+        let mut prev_ids: HashSet<u64> = rx.borrow_and_update().iter().map(|i| i.id()).collect();
+
+        loop {
+            tokio::select! {
+                result = rx.changed() => {
+                    if result.is_err() {
+                        // Sender dropped -- endpoint is shutting down.
+                        break;
+                    }
+                }
+                _ = cancel_token.cancelled() => {
+                    break;
+                }
+            }
+
+            let current_ids: HashSet<u64> = rx.borrow_and_update().iter().map(|i| i.id()).collect();
+
+            for removed_id in prev_ids.difference(&current_ids) {
+                let n = addressed.cancel_instance_streams(*removed_id).await;
+                if n > 0 {
+                    tracing::warn!(
+                        instance_id = removed_id,
+                        cancelled = n,
+                        "Cancelled pending response streams for removed instance \
+                         (discovery-driven cleanup)"
+                    );
+                }
+            }
+
+            // Clear tombstones for instances that have come back (re-registered
+            // after restart) so new requests can be tracked normally.
+            for added_id in current_ids.difference(&prev_ids) {
+                addressed.clear_instance_tombstone(*added_id).await;
+            }
+
+            prev_ids = current_ids;
+        }
+
+        tracing::debug!("Instance removal watcher exiting");
+    });
+}
+
 async fn addressed_router(endpoint: &Endpoint) -> anyhow::Result<Arc<AddressedPushRouter>> {
     // Get network manager and create client (no mode checks!)
     let manager = endpoint.drt().network_manager();
@@ -339,6 +395,17 @@ where
         } else {
             None
         };
+
+        // Spawn a background task that watches the discovery plane for instance
+        // removals and cancels pending response-stream registrations for removed
+        // instances. This is the primary mechanism for unblocking requests that
+        // were ACK'd on the request plane but never picked up by the worker pool
+        // before the worker was killed.
+        spawn_instance_removal_watcher(
+            client.instance_source.clone(),
+            addressed.clone(),
+            client.endpoint.drt().primary_token(),
+        );
 
         let router = PushRouter {
             client,
@@ -767,7 +834,7 @@ where
             }
         };
 
-        let request = request.map(|req| AddressedRequest::new(req, address));
+        let request = request.map(|req| AddressedRequest::with_instance(req, address, instance_id));
 
         STAGE_DURATION_SECONDS
             .with_label_values(&[STAGE_ROUTE])

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -23,7 +23,7 @@ use futures::Stream;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     marker::PhantomData,
     pin::Pin,
     sync::{
@@ -260,53 +260,98 @@ fn device_aware_candidate_group(
 /// This is the core fix for the postmortem: when a worker is killed while requests
 /// are queued (ACK'd but not yet picked up), the oneshot senders are dropped,
 /// unblocking the waiting frontends with a migratable `Disconnected` error.
+///
+/// Uses the raw `list_and_watch` discovery stream instead of diffing coalesced
+/// watch snapshots so that a rapid remove→re-add of the same pod (same stable
+/// hash-based instance_id in Kubernetes) is never silently swallowed.  Each
+/// `Removed` event unconditionally calls `cancel_instance_streams`; each
+/// `Added` event calls `clear_instance_tombstone`.
+///
+/// Cancellation is keyed by `(endpoint_name, instance_id)` to avoid
+/// accidentally cancelling sibling endpoints on the same backend runtime that
+/// share a `connection_id` / `instance_id`.
 fn spawn_instance_removal_watcher(
-    instance_source: Arc<tokio::sync::watch::Receiver<Vec<Instance>>>,
+    endpoint: Endpoint,
     addressed: Arc<AddressedPushRouter>,
     cancel_token: tokio_util::sync::CancellationToken,
 ) {
+    use crate::discovery::{
+        DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, DiscoveryQuery,
+    };
+    use tokio_stream::StreamExt as _;
+
+    let endpoint_name = endpoint.name().to_string();
+
     tokio::spawn(async move {
-        let mut rx = instance_source.as_ref().clone();
-        let mut prev_ids: HashSet<u64> = rx.borrow_and_update().iter().map(|i| i.id()).collect();
+        let namespace = endpoint.component().namespace().name();
+        let component = endpoint.component().name().to_string();
+        let query = DiscoveryQuery::Endpoint {
+            namespace,
+            component,
+            endpoint: endpoint_name.clone(),
+        };
+
+        let mut stream = match endpoint.drt().discovery().list_and_watch(query, None).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(
+                    endpoint = %endpoint_name,
+                    "Failed to start instance removal watcher: {e}"
+                );
+                return;
+            }
+        };
 
         loop {
             tokio::select! {
-                result = rx.changed() => {
-                    if result.is_err() {
-                        // Sender dropped -- endpoint is shutting down.
-                        break;
+                event = stream.next() => {
+                    match event {
+                        Some(Ok(DiscoveryEvent::Removed(id))) => {
+                            // Only act on endpoint-type removals.
+                            if let DiscoveryInstanceId::Endpoint(eid) = &id {
+                                let n = addressed
+                                    .cancel_instance_streams(&eid.endpoint, eid.instance_id)
+                                    .await;
+                                if n > 0 {
+                                    tracing::warn!(
+                                        endpoint = %eid.endpoint,
+                                        instance_id = eid.instance_id,
+                                        cancelled = n,
+                                        "Cancelled pending response streams for removed instance \
+                                         (discovery-driven cleanup)"
+                                    );
+                                }
+                            }
+                        }
+                        Some(Ok(DiscoveryEvent::Added(DiscoveryInstance::Endpoint(inst)))) => {
+                            // Clear tombstone so new requests for this (endpoint, instance)
+                            // pair are tracked normally after a restart.
+                            addressed
+                                .clear_instance_tombstone(&inst.endpoint, inst.instance_id)
+                                .await;
+                        }
+                        Some(Ok(_)) => {
+                            // Ignore non-endpoint events (Model, EventChannel).
+                        }
+                        Some(Err(e)) => {
+                            tracing::warn!(
+                                endpoint = %endpoint_name,
+                                "Instance removal watcher stream error: {e}"
+                            );
+                        }
+                        None => {
+                            // Stream ended — discovery plane shut down.
+                            break;
+                        }
                     }
                 }
                 _ = cancel_token.cancelled() => {
                     break;
                 }
             }
-
-            let current_ids: HashSet<u64> = rx.borrow_and_update().iter().map(|i| i.id()).collect();
-
-            // Cancel pending response streams for removed instances.
-            for removed_id in prev_ids.difference(&current_ids) {
-                let n = addressed.cancel_instance_streams(*removed_id).await;
-                if n > 0 {
-                    tracing::warn!(
-                        instance_id = removed_id,
-                        cancelled = n,
-                        "Cancelled pending response streams for removed instance \
-                         (discovery-driven cleanup)"
-                    );
-                }
-            }
-
-            // Clear tombstones for instances that have come back (re-registered
-            // after restart) so new requests can be tracked normally.
-            for added_id in current_ids.difference(&prev_ids) {
-                addressed.clear_instance_tombstone(*added_id).await;
-            }
-
-            prev_ids = current_ids;
         }
 
-        tracing::debug!("Instance removal watcher exiting");
+        tracing::debug!(endpoint = %endpoint_name, "Instance removal watcher exiting");
     });
 }
 
@@ -361,7 +406,7 @@ where
         // registrations when workers die. Otherwise the bare .await on the oneshot
         // receiver hangs forever for queued-but-never-started requests.
         spawn_instance_removal_watcher(
-            client.instance_source.clone(),
+            client.endpoint.clone(),
             addressed.clone(),
             client.endpoint.drt().primary_token(),
         );
@@ -413,7 +458,7 @@ where
         // were ACK'd on the request plane but never picked up by the worker pool
         // before the worker was killed.
         spawn_instance_removal_watcher(
-            client.instance_source.clone(),
+            client.endpoint.clone(),
             addressed.clone(),
             client.endpoint.drt().primary_token(),
         );
@@ -774,7 +819,11 @@ where
         // If the selected instance disappeared between selection and dispatch
         // (e.g. deregistered during scale-down), fall back to another available
         // instance rather than returning a spurious 500.
-        let (address, _transport_kind) = {
+        //
+        // resolve_transport returns (address, transport_kind, Instance) so that
+        // the full Instance (carrying endpoint name + instance_id) can be
+        // threaded through to AddressedRequest for endpoint-scoped cancellation.
+        let (address, _transport_kind, instance) = {
             use crate::component::TransportType;
 
             let resolve_transport = |id: u64| {
@@ -782,31 +831,34 @@ where
                 instances
                     .iter()
                     .find(|i| i.instance_id == id)
-                    .map(|instance| match &instance.transport {
-                        TransportType::Http(http_endpoint) => {
-                            tracing::debug!(
-                                instance_id = id,
-                                http_endpoint = %http_endpoint,
-                                "Using HTTP transport for instance"
-                            );
-                            (http_endpoint.clone(), "transport.http.request")
-                        }
-                        TransportType::Tcp(tcp_endpoint) => {
-                            tracing::debug!(
-                                instance_id = id,
-                                tcp_endpoint = %tcp_endpoint,
-                                "Using TCP transport for instance"
-                            );
-                            (tcp_endpoint.clone(), "transport.tcp.request")
-                        }
-                        TransportType::Nats(subject) => {
-                            tracing::debug!(
-                                instance_id = id,
-                                subject = %subject,
-                                "Using NATS transport for instance"
-                            );
-                            (subject.clone(), "transport.nats.request")
-                        }
+                    .map(|instance| {
+                        let (addr, kind) = match &instance.transport {
+                            TransportType::Http(http_endpoint) => {
+                                tracing::debug!(
+                                    instance_id = id,
+                                    http_endpoint = %http_endpoint,
+                                    "Using HTTP transport for instance"
+                                );
+                                (http_endpoint.clone(), "transport.http.request")
+                            }
+                            TransportType::Tcp(tcp_endpoint) => {
+                                tracing::debug!(
+                                    instance_id = id,
+                                    tcp_endpoint = %tcp_endpoint,
+                                    "Using TCP transport for instance"
+                                );
+                                (tcp_endpoint.clone(), "transport.tcp.request")
+                            }
+                            TransportType::Nats(subject) => {
+                                tracing::debug!(
+                                    instance_id = id,
+                                    subject = %subject,
+                                    "Using NATS transport for instance"
+                                );
+                                (subject.clone(), "transport.nats.request")
+                            }
+                        };
+                        (addr, kind, instance.clone())
                     })
             };
 
@@ -845,7 +897,7 @@ where
             }
         };
 
-        let request = request.map(|req| AddressedRequest::with_instance(req, address, instance_id));
+        let request = request.map(|req| AddressedRequest::with_instance(req, address, instance));
 
         STAGE_DURATION_SECONDS
             .with_label_values(&[STAGE_ROUTE])

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -303,78 +303,109 @@ fn spawn_instance_removal_watcher(
     let endpoint_name = endpoint.name().to_string();
 
     tokio::spawn(async move {
+        // Release the dedup guard on EVERY exit path -- normal exit, discovery
+        // stream failure, AND task panic. A leaked entry would silently disable
+        // the orphaned-pending-request fix for that endpoint until process restart.
+        struct GuardRelease(EndpointId);
+        impl Drop for GuardRelease {
+            fn drop(&mut self) {
+                if let Some(map) = ENDPOINT_WATCHER_ACTIVE.get() {
+                    map.remove(&self.0);
+                }
+            }
+        }
+        let _release = GuardRelease(endpoint_id);
+
         let namespace = endpoint.component().namespace().name();
         let component = endpoint.component().name().to_string();
-        let query = DiscoveryQuery::Endpoint {
-            namespace,
-            component,
-            endpoint: endpoint_name.clone(),
-        };
 
-        let mut stream = match endpoint.drt().discovery().list_and_watch(query, None).await {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::error!(
-                    endpoint = %endpoint_name,
-                    "Failed to start instance removal watcher: {e}"
-                );
-                guard.remove(&endpoint_id);
-                return;
-            }
-        };
+        // Outer reconnect loop: a transient discovery-plane failure (failed
+        // initial connect or the watch stream ending) must not permanently
+        // disable orphaned-pending-request cancellation for this endpoint.
+        // Reconnect with a cancellation-aware backoff until cancel_token fires.
+        const RECONNECT_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
+        'reconnect: loop {
+            let query = DiscoveryQuery::Endpoint {
+                namespace: namespace.clone(),
+                component: component.clone(),
+                endpoint: endpoint_name.clone(),
+            };
 
-        loop {
-            tokio::select! {
-                event = stream.next() => {
-                    match event {
-                        Some(Ok(DiscoveryEvent::Removed(id))) => {
-                            // Only act on endpoint-type removals; pass the
-                            // full EndpointInstanceId so cancellation is
-                            // scoped to exactly one service identity.
-                            if let DiscoveryInstanceId::Endpoint(eid) = &id {
-                                let n = addressed.cancel_instance_streams(eid).await;
-                                if n > 0 {
-                                    tracing::warn!(
-                                        namespace = %eid.namespace,
-                                        component = %eid.component,
-                                        endpoint = %eid.endpoint,
-                                        instance_id = eid.instance_id,
-                                        cancelled = n,
-                                        "Cancelled pending response streams for removed \
-                                         instance (discovery-driven cleanup)"
-                                    );
-                                }
-                            }
-                        }
-                        Some(Ok(DiscoveryEvent::Added(DiscoveryInstance::Endpoint(inst)))) => {
-                            // Clear tombstone so new requests for this identity are
-                            // tracked normally after a pod restart.
-                            let eid: EndpointInstanceId = inst.endpoint_instance_id();
-                            addressed.clear_instance_tombstone(&eid).await;
-                        }
-                        Some(Ok(_)) => {
-                            // Ignore non-endpoint events (Model, EventChannel).
-                        }
-                        Some(Err(e)) => {
-                            tracing::warn!(
-                                endpoint = %endpoint_name,
-                                "Instance removal watcher stream error: {e}"
-                            );
-                        }
-                        None => {
-                            // Stream ended — discovery plane shut down.
-                            break;
-                        }
+            let mut stream = match endpoint.drt().discovery().list_and_watch(query, None).await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(
+                        endpoint = %endpoint_name,
+                        "Failed to start instance removal watcher (will retry): {e}"
+                    );
+                    tokio::select! {
+                        _ = tokio::time::sleep(RECONNECT_BACKOFF) => continue 'reconnect,
+                        _ = cancel_token.cancelled() => break 'reconnect,
                     }
                 }
-                _ = cancel_token.cancelled() => {
-                    break;
+            };
+
+            loop {
+                tokio::select! {
+                    event = stream.next() => {
+                        match event {
+                            Some(Ok(DiscoveryEvent::Removed(id))) => {
+                                // Only act on endpoint-type removals; pass the
+                                // full EndpointInstanceId so cancellation is
+                                // scoped to exactly one service identity.
+                                if let DiscoveryInstanceId::Endpoint(eid) = &id {
+                                    let n = addressed.cancel_instance_streams(eid).await;
+                                    if n > 0 {
+                                        tracing::warn!(
+                                            namespace = %eid.namespace,
+                                            component = %eid.component,
+                                            endpoint = %eid.endpoint,
+                                            instance_id = eid.instance_id,
+                                            cancelled = n,
+                                            "Cancelled pending response streams for removed \
+                                             instance (discovery-driven cleanup)"
+                                        );
+                                    }
+                                }
+                            }
+                            Some(Ok(DiscoveryEvent::Added(DiscoveryInstance::Endpoint(inst)))) => {
+                                // Clear tombstone so new requests for this identity are
+                                // tracked normally after a pod restart. Also fires on
+                                // reconnect when list_and_watch replays current state,
+                                // which limits how long a stale tombstone survives.
+                                let eid: EndpointInstanceId = inst.endpoint_instance_id();
+                                addressed.clear_instance_tombstone(&eid).await;
+                            }
+                            Some(Ok(_)) => {
+                                // Ignore non-endpoint events (Model, EventChannel).
+                            }
+                            Some(Err(e)) => {
+                                tracing::warn!(
+                                    endpoint = %endpoint_name,
+                                    "Instance removal watcher stream error: {e}"
+                                );
+                            }
+                            None => {
+                                // Stream ended — discovery plane closed the watch.
+                                // Reconnect rather than exiting permanently, otherwise
+                                // a transient discovery restart would silently disable
+                                // orphaned-pending-request cancellation.
+                                tracing::warn!(
+                                    endpoint = %endpoint_name,
+                                    "Instance removal watcher stream ended; reconnecting"
+                                );
+                                continue 'reconnect;
+                            }
+                        }
+                    }
+                    _ = cancel_token.cancelled() => {
+                        break 'reconnect;
+                    }
                 }
             }
         }
 
-        // Release the guard so the next router creation can re-arm the watcher.
-        guard.remove(&endpoint_id);
+        // _release.drop() removes the dedup-guard entry; debug-log on the way out.
         tracing::debug!(endpoint = %endpoint_name, "Instance removal watcher exiting");
     });
 }
@@ -1465,5 +1496,84 @@ mod tests {
         );
 
         rt.shutdown();
+    }
+
+    /// The watcher dedup guard must be released even if the spawned task panics.
+    /// Without this, a panic anywhere in the watcher body would leave a stale
+    /// `ENDPOINT_WATCHER_ACTIVE` entry, silently disabling orphaned-pending-
+    /// request cancellation for that endpoint until process restart.
+    ///
+    /// We exercise the Drop-guard pattern directly against the same static
+    /// rather than driving `spawn_instance_removal_watcher` end-to-end (which
+    /// would require staging a panicking discovery stream). The test mirrors
+    /// the production code's GuardRelease shape; if the production code stops
+    /// using a Drop guard, the integration would regress and the existing
+    /// orphan-cancellation tests would fail.
+    #[tokio::test]
+    async fn watcher_dedup_guard_released_on_panic() {
+        let endpoint_id = EndpointId {
+            namespace: "panic-test-ns".to_string(),
+            component: "panic-test-comp".to_string(),
+            name: "panic-test-endpoint".to_string(),
+        };
+
+        // Mimic the production code's pre-spawn dedup insert.
+        let map = ENDPOINT_WATCHER_ACTIVE.get_or_init(dashmap::DashMap::new);
+        map.insert(endpoint_id.clone(), ());
+
+        let endpoint_id_clone = endpoint_id.clone();
+        let join = tokio::spawn(async move {
+            // Same shape as in spawn_instance_removal_watcher.
+            struct GuardRelease(EndpointId);
+            impl Drop for GuardRelease {
+                fn drop(&mut self) {
+                    if let Some(map) = ENDPOINT_WATCHER_ACTIVE.get() {
+                        map.remove(&self.0);
+                    }
+                }
+            }
+            let _release = GuardRelease(endpoint_id_clone);
+            panic!("simulated watcher-task panic");
+        });
+
+        let result = join.await;
+        assert!(result.is_err() && result.unwrap_err().is_panic());
+        assert!(
+            !map.contains_key(&endpoint_id),
+            "Drop guard must release the dedup entry even on panic"
+        );
+    }
+
+    /// Normal-exit path: the Drop guard releases the entry when the task
+    /// finishes without panicking. This is the everyday case (cancel_token
+    /// fires or discovery stream closes).
+    #[tokio::test]
+    async fn watcher_dedup_guard_released_on_normal_exit() {
+        let endpoint_id = EndpointId {
+            namespace: "normal-test-ns".to_string(),
+            component: "normal-test-comp".to_string(),
+            name: "normal-test-endpoint".to_string(),
+        };
+
+        let map = ENDPOINT_WATCHER_ACTIVE.get_or_init(dashmap::DashMap::new);
+        map.insert(endpoint_id.clone(), ());
+
+        let endpoint_id_clone = endpoint_id.clone();
+        tokio::spawn(async move {
+            struct GuardRelease(EndpointId);
+            impl Drop for GuardRelease {
+                fn drop(&mut self) {
+                    if let Some(map) = ENDPOINT_WATCHER_ACTIVE.get() {
+                        map.remove(&self.0);
+                    }
+                }
+            }
+            let _release = GuardRelease(endpoint_id_clone);
+            // task body returns normally
+        })
+        .await
+        .unwrap();
+
+        assert!(!map.contains_key(&endpoint_id));
     }
 }

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -23,7 +23,7 @@ use futures::Stream;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     marker::PhantomData,
     pin::Pin,
     sync::{
@@ -259,53 +259,98 @@ fn device_aware_candidate_group(
 /// This is the core fix for the postmortem: when a worker is killed while requests
 /// are queued (ACK'd but not yet picked up), the oneshot senders are dropped,
 /// unblocking the waiting frontends with a migratable `Disconnected` error.
+///
+/// Uses the raw `list_and_watch` discovery stream instead of diffing coalesced
+/// watch snapshots so that a rapid remove→re-add of the same pod (same stable
+/// hash-based instance_id in Kubernetes) is never silently swallowed.  Each
+/// `Removed` event unconditionally calls `cancel_instance_streams`; each
+/// `Added` event calls `clear_instance_tombstone`.
+///
+/// Cancellation is keyed by `(endpoint_name, instance_id)` to avoid
+/// accidentally cancelling sibling endpoints on the same backend runtime that
+/// share a `connection_id` / `instance_id`.
 fn spawn_instance_removal_watcher(
-    instance_source: Arc<tokio::sync::watch::Receiver<Vec<Instance>>>,
+    endpoint: Endpoint,
     addressed: Arc<AddressedPushRouter>,
     cancel_token: tokio_util::sync::CancellationToken,
 ) {
+    use crate::discovery::{
+        DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, DiscoveryQuery,
+    };
+    use tokio_stream::StreamExt as _;
+
+    let endpoint_name = endpoint.name().to_string();
+
     tokio::spawn(async move {
-        let mut rx = instance_source.as_ref().clone();
-        let mut prev_ids: HashSet<u64> = rx.borrow_and_update().iter().map(|i| i.id()).collect();
+        let namespace = endpoint.component().namespace().name();
+        let component = endpoint.component().name().to_string();
+        let query = DiscoveryQuery::Endpoint {
+            namespace,
+            component,
+            endpoint: endpoint_name.clone(),
+        };
+
+        let mut stream = match endpoint.drt().discovery().list_and_watch(query, None).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(
+                    endpoint = %endpoint_name,
+                    "Failed to start instance removal watcher: {e}"
+                );
+                return;
+            }
+        };
 
         loop {
             tokio::select! {
-                result = rx.changed() => {
-                    if result.is_err() {
-                        // Sender dropped -- endpoint is shutting down.
-                        break;
+                event = stream.next() => {
+                    match event {
+                        Some(Ok(DiscoveryEvent::Removed(id))) => {
+                            // Only act on endpoint-type removals.
+                            if let DiscoveryInstanceId::Endpoint(eid) = &id {
+                                let n = addressed
+                                    .cancel_instance_streams(&eid.endpoint, eid.instance_id)
+                                    .await;
+                                if n > 0 {
+                                    tracing::warn!(
+                                        endpoint = %eid.endpoint,
+                                        instance_id = eid.instance_id,
+                                        cancelled = n,
+                                        "Cancelled pending response streams for removed instance \
+                                         (discovery-driven cleanup)"
+                                    );
+                                }
+                            }
+                        }
+                        Some(Ok(DiscoveryEvent::Added(DiscoveryInstance::Endpoint(inst)))) => {
+                            // Clear tombstone so new requests for this (endpoint, instance)
+                            // pair are tracked normally after a restart.
+                            addressed
+                                .clear_instance_tombstone(&inst.endpoint, inst.instance_id)
+                                .await;
+                        }
+                        Some(Ok(_)) => {
+                            // Ignore non-endpoint events (Model, EventChannel).
+                        }
+                        Some(Err(e)) => {
+                            tracing::warn!(
+                                endpoint = %endpoint_name,
+                                "Instance removal watcher stream error: {e}"
+                            );
+                        }
+                        None => {
+                            // Stream ended — discovery plane shut down.
+                            break;
+                        }
                     }
                 }
                 _ = cancel_token.cancelled() => {
                     break;
                 }
             }
-
-            let current_ids: HashSet<u64> = rx.borrow_and_update().iter().map(|i| i.id()).collect();
-
-            // Cancel pending response streams for removed instances.
-            for removed_id in prev_ids.difference(&current_ids) {
-                let n = addressed.cancel_instance_streams(*removed_id).await;
-                if n > 0 {
-                    tracing::warn!(
-                        instance_id = removed_id,
-                        cancelled = n,
-                        "Cancelled pending response streams for removed instance \
-                         (discovery-driven cleanup)"
-                    );
-                }
-            }
-
-            // Clear tombstones for instances that have come back (re-registered
-            // after restart) so new requests can be tracked normally.
-            for added_id in current_ids.difference(&prev_ids) {
-                addressed.clear_instance_tombstone(*added_id).await;
-            }
-
-            prev_ids = current_ids;
         }
 
-        tracing::debug!("Instance removal watcher exiting");
+        tracing::debug!(endpoint = %endpoint_name, "Instance removal watcher exiting");
     });
 }
 
@@ -360,7 +405,7 @@ where
         // registrations when workers die. Otherwise the bare .await on the oneshot
         // receiver hangs forever for queued-but-never-started requests.
         spawn_instance_removal_watcher(
-            client.instance_source.clone(),
+            client.endpoint.clone(),
             addressed.clone(),
             client.endpoint.drt().primary_token(),
         );
@@ -412,7 +457,7 @@ where
         // were ACK'd on the request plane but never picked up by the worker pool
         // before the worker was killed.
         spawn_instance_removal_watcher(
-            client.instance_source.clone(),
+            client.endpoint.clone(),
             addressed.clone(),
             client.endpoint.drt().primary_token(),
         );
@@ -773,7 +818,11 @@ where
         // If the selected instance disappeared between selection and dispatch
         // (e.g. deregistered during scale-down), fall back to another available
         // instance rather than returning a spurious 500.
-        let (address, _transport_kind) = {
+        //
+        // resolve_transport returns (address, transport_kind, Instance) so that
+        // the full Instance (carrying endpoint name + instance_id) can be
+        // threaded through to AddressedRequest for endpoint-scoped cancellation.
+        let (address, _transport_kind, instance) = {
             use crate::component::TransportType;
 
             let resolve_transport = |id: u64| {
@@ -781,31 +830,34 @@ where
                 instances
                     .iter()
                     .find(|i| i.instance_id == id)
-                    .map(|instance| match &instance.transport {
-                        TransportType::Http(http_endpoint) => {
-                            tracing::debug!(
-                                instance_id = id,
-                                http_endpoint = %http_endpoint,
-                                "Using HTTP transport for instance"
-                            );
-                            (http_endpoint.clone(), "transport.http.request")
-                        }
-                        TransportType::Tcp(tcp_endpoint) => {
-                            tracing::debug!(
-                                instance_id = id,
-                                tcp_endpoint = %tcp_endpoint,
-                                "Using TCP transport for instance"
-                            );
-                            (tcp_endpoint.clone(), "transport.tcp.request")
-                        }
-                        TransportType::Nats(subject) => {
-                            tracing::debug!(
-                                instance_id = id,
-                                subject = %subject,
-                                "Using NATS transport for instance"
-                            );
-                            (subject.clone(), "transport.nats.request")
-                        }
+                    .map(|instance| {
+                        let (addr, kind) = match &instance.transport {
+                            TransportType::Http(http_endpoint) => {
+                                tracing::debug!(
+                                    instance_id = id,
+                                    http_endpoint = %http_endpoint,
+                                    "Using HTTP transport for instance"
+                                );
+                                (http_endpoint.clone(), "transport.http.request")
+                            }
+                            TransportType::Tcp(tcp_endpoint) => {
+                                tracing::debug!(
+                                    instance_id = id,
+                                    tcp_endpoint = %tcp_endpoint,
+                                    "Using TCP transport for instance"
+                                );
+                                (tcp_endpoint.clone(), "transport.tcp.request")
+                            }
+                            TransportType::Nats(subject) => {
+                                tracing::debug!(
+                                    instance_id = id,
+                                    subject = %subject,
+                                    "Using NATS transport for instance"
+                                );
+                                (subject.clone(), "transport.nats.request")
+                            }
+                        };
+                        (addr, kind, instance.clone())
                     })
             };
 
@@ -844,7 +896,7 @@ where
             }
         };
 
-        let request = request.map(|req| AddressedRequest::with_instance(req, address, instance_id));
+        let request = request.map(|req| AddressedRequest::with_instance(req, address, instance));
 
         STAGE_DURATION_SECONDS
             .with_label_values(&[STAGE_ROUTE])

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -5,7 +5,8 @@ use super::{AsyncEngineContextProvider, ResponseStream};
 use crate::error::{BackendError, DynamoError, ErrorType, match_error_chain};
 use crate::{
     component::{
-        Client, DeviceType, Endpoint, RoutingOccupancyState, get_or_create_routing_occupancy_state,
+        Client, DeviceType, Endpoint, Instance, RoutingOccupancyState,
+        get_or_create_routing_occupancy_state,
     },
     dynamo_nvtx_range,
     engine::{AsyncEngine, AsyncEngineContext, Data},
@@ -22,7 +23,7 @@ use futures::Stream;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     marker::PhantomData,
     pin::Pin,
     sync::{
@@ -252,6 +253,61 @@ fn device_aware_candidate_group(
     }
 }
 
+/// Background task that watches the discovery plane for instance removals and
+/// cancels all pending response-stream registrations for removed instances.
+///
+/// This is the core fix for the postmortem: when a worker is killed while requests
+/// are queued (ACK'd but not yet picked up), the oneshot senders are dropped,
+/// unblocking the waiting frontends with a migratable `Disconnected` error.
+fn spawn_instance_removal_watcher(
+    instance_source: Arc<tokio::sync::watch::Receiver<Vec<Instance>>>,
+    addressed: Arc<AddressedPushRouter>,
+    cancel_token: tokio_util::sync::CancellationToken,
+) {
+    tokio::spawn(async move {
+        let mut rx = instance_source.as_ref().clone();
+        let mut prev_ids: HashSet<u64> = rx.borrow_and_update().iter().map(|i| i.id()).collect();
+
+        loop {
+            tokio::select! {
+                result = rx.changed() => {
+                    if result.is_err() {
+                        // Sender dropped -- endpoint is shutting down.
+                        break;
+                    }
+                }
+                _ = cancel_token.cancelled() => {
+                    break;
+                }
+            }
+
+            let current_ids: HashSet<u64> = rx.borrow_and_update().iter().map(|i| i.id()).collect();
+
+            for removed_id in prev_ids.difference(&current_ids) {
+                let n = addressed.cancel_instance_streams(*removed_id).await;
+                if n > 0 {
+                    tracing::warn!(
+                        instance_id = removed_id,
+                        cancelled = n,
+                        "Cancelled pending response streams for removed instance \
+                         (discovery-driven cleanup)"
+                    );
+                }
+            }
+
+            // Clear tombstones for instances that have come back (re-registered
+            // after restart) so new requests can be tracked normally.
+            for added_id in current_ids.difference(&prev_ids) {
+                addressed.clear_instance_tombstone(*added_id).await;
+            }
+
+            prev_ids = current_ids;
+        }
+
+        tracing::debug!("Instance removal watcher exiting");
+    });
+}
+
 async fn addressed_router(endpoint: &Endpoint) -> anyhow::Result<Arc<AddressedPushRouter>> {
     // Get network manager and create client (no mode checks!)
     let manager = endpoint.drt().network_manager();
@@ -338,6 +394,17 @@ where
         } else {
             None
         };
+
+        // Spawn a background task that watches the discovery plane for instance
+        // removals and cancels pending response-stream registrations for removed
+        // instances. This is the primary mechanism for unblocking requests that
+        // were ACK'd on the request plane but never picked up by the worker pool
+        // before the worker was killed.
+        spawn_instance_removal_watcher(
+            client.instance_source.clone(),
+            addressed.clone(),
+            client.endpoint.drt().primary_token(),
+        );
 
         let router = PushRouter {
             client,
@@ -766,7 +833,7 @@ where
             }
         };
 
-        let request = request.map(|req| AddressedRequest::new(req, address));
+        let request = request.map(|req| AddressedRequest::with_instance(req, address, instance_id));
 
         STAGE_DURATION_SECONDS
             .with_label_values(&[STAGE_ROUTE])

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -271,13 +271,16 @@ static ENDPOINT_WATCHER_ACTIVE: std::sync::OnceLock<dashmap::DashMap<EndpointId,
 /// error.
 ///
 /// Uses the raw `list_and_watch` discovery stream (not a coalesced snapshot
-/// diff) so that a rapid remove→re-add of the same Kubernetes pod — which
-/// keeps the same hash-stable instance_id — is never silently swallowed.
+/// diff) so that every `Removed` event is delivered individually.
 ///
 /// Cancellation is keyed by the full `EndpointInstanceId` (namespace +
 /// component + endpoint + instance_id) to prevent services from different
 /// namespaces/components that happen to share an endpoint name and
 /// pod-backed instance_id from cancelling each other's pending streams.
+///
+/// The watcher reconnects automatically if the discovery stream ends
+/// unexpectedly (e.g., a transient discovery-plane restart) so that future
+/// instance removals are never silently missed.
 fn spawn_instance_removal_watcher(
     endpoint: Endpoint,
     addressed: Arc<AddressedPushRouter>,
@@ -304,70 +307,99 @@ fn spawn_instance_removal_watcher(
     tokio::spawn(async move {
         let namespace = endpoint.component().namespace().name();
         let component = endpoint.component().name().to_string();
+
+        // NOTE on instance_id uniqueness: instance_id is derived from the etcd lease ID
+        // (component/endpoint.rs → distributed.rs → storage/kv/etcd.rs::client.lease_id()).
+        // etcd lease IDs are globally unique and monotonically increasing per cluster
+        // session, so a restarted pod always receives a *different* lease ID (e.g., 42 →
+        // 99, never 42 → 42). Same-ID remove→re-add bursts are therefore structurally
+        // impossible, and every removal event corresponds to a distinct instance.
         let query = DiscoveryQuery::Endpoint {
             namespace,
             component,
             endpoint: endpoint_name.clone(),
         };
 
-        let mut stream = match endpoint.drt().discovery().list_and_watch(query, None).await {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::error!(
-                    endpoint = %endpoint_name,
-                    "Failed to start instance removal watcher: {e}"
-                );
-                guard.remove(&endpoint_id);
-                return;
+        // Reconnect loop: re-establish the discovery stream if it ends unexpectedly
+        // (e.g., a transient discovery-plane restart) so future instance removals are
+        // never silently missed.
+        'reconnect: loop {
+            if cancel_token.is_cancelled() {
+                break 'reconnect;
             }
-        };
 
-        loop {
-            tokio::select! {
-                event = stream.next() => {
-                    match event {
-                        Some(Ok(DiscoveryEvent::Removed(id))) => {
-                            // Only act on endpoint-type removals; pass the
-                            // full EndpointInstanceId so cancellation is
-                            // scoped to exactly one service identity.
-                            if let DiscoveryInstanceId::Endpoint(eid) = &id {
-                                let n = addressed.cancel_instance_streams(eid).await;
-                                if n > 0 {
-                                    tracing::warn!(
-                                        namespace = %eid.namespace,
-                                        component = %eid.component,
-                                        endpoint = %eid.endpoint,
-                                        instance_id = eid.instance_id,
-                                        cancelled = n,
-                                        "Cancelled pending response streams for removed \
-                                         instance (discovery-driven cleanup)"
-                                    );
+            let mut stream = match endpoint
+                .drt()
+                .discovery()
+                .list_and_watch(query.clone(), None)
+                .await
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(
+                        endpoint = %endpoint_name,
+                        "Instance removal watcher failed to connect: {e}; retrying in 5s"
+                    );
+                    tokio::select! {
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {}
+                        _ = cancel_token.cancelled() => break 'reconnect,
+                    }
+                    continue 'reconnect;
+                }
+            };
+
+            loop {
+                tokio::select! {
+                    event = stream.next() => {
+                        match event {
+                            Some(Ok(DiscoveryEvent::Removed(id))) => {
+                                // Only act on endpoint-type removals; pass the
+                                // full EndpointInstanceId so cancellation is
+                                // scoped to exactly one service identity.
+                                if let DiscoveryInstanceId::Endpoint(eid) = &id {
+                                    let n = addressed.cancel_instance_streams(eid).await;
+                                    if n > 0 {
+                                        tracing::warn!(
+                                            namespace = %eid.namespace,
+                                            component = %eid.component,
+                                            endpoint = %eid.endpoint,
+                                            instance_id = eid.instance_id,
+                                            cancelled = n,
+                                            "Cancelled pending response streams for removed \
+                                             instance (discovery-driven cleanup)"
+                                        );
+                                    }
                                 }
                             }
-                        }
-                        Some(Ok(DiscoveryEvent::Added(DiscoveryInstance::Endpoint(inst)))) => {
-                            // Clear tombstone so new requests for this identity are
-                            // tracked normally after a pod restart.
-                            let eid: EndpointInstanceId = inst.endpoint_instance_id();
-                            addressed.clear_instance_tombstone(&eid).await;
-                        }
-                        Some(Ok(_)) => {
-                            // Ignore non-endpoint events (Model, EventChannel).
-                        }
-                        Some(Err(e)) => {
-                            tracing::warn!(
-                                endpoint = %endpoint_name,
-                                "Instance removal watcher stream error: {e}"
-                            );
-                        }
-                        None => {
-                            // Stream ended — discovery plane shut down.
-                            break;
+                            Some(Ok(DiscoveryEvent::Added(DiscoveryInstance::Endpoint(inst)))) => {
+                                // Clear tombstone so new requests for this identity are
+                                // tracked normally after a pod restart.
+                                let eid: EndpointInstanceId = inst.endpoint_instance_id();
+                                addressed.clear_instance_tombstone(&eid).await;
+                            }
+                            Some(Ok(_)) => {
+                                // Ignore non-endpoint events (Model, EventChannel).
+                            }
+                            Some(Err(e)) => {
+                                tracing::warn!(
+                                    endpoint = %endpoint_name,
+                                    "Instance removal watcher stream error: {e}"
+                                );
+                            }
+                            None => {
+                                // Stream ended — discovery plane may have restarted.
+                                // Break the inner loop and reconnect via the outer loop.
+                                tracing::warn!(
+                                    endpoint = %endpoint_name,
+                                    "Instance removal watcher stream ended; reconnecting"
+                                );
+                                break;
+                            }
                         }
                     }
-                }
-                _ = cancel_token.cancelled() => {
-                    break;
+                    _ = cancel_token.cancelled() => {
+                        break 'reconnect;
+                    }
                 }
             }
         }

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -283,6 +283,7 @@ fn spawn_instance_removal_watcher(
 
             let current_ids: HashSet<u64> = rx.borrow_and_update().iter().map(|i| i.id()).collect();
 
+            // Cancel pending response streams for removed instances.
             for removed_id in prev_ids.difference(&current_ids) {
                 let n = addressed.cancel_instance_streams(*removed_id).await;
                 if n > 0 {
@@ -353,6 +354,16 @@ where
         } else {
             None
         };
+
+        // Even with fault detection disabled (no report_instance_down on errors),
+        // we still need the discovery-driven watcher to cancel pending response-stream
+        // registrations when workers die. Otherwise the bare .await on the oneshot
+        // receiver hangs forever for queued-but-never-started requests.
+        spawn_instance_removal_watcher(
+            client.instance_source.clone(),
+            addressed.clone(),
+            client.endpoint.drt().primary_token(),
+        );
 
         Ok(PushRouter {
             client,

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -8,6 +8,7 @@ use crate::{
         Client, DeviceType, Endpoint, Instance, RoutingOccupancyState,
         get_or_create_routing_occupancy_state,
     },
+    discovery::EndpointInstanceId,
     dynamo_nvtx_range,
     engine::{AsyncEngine, AsyncEngineContext, Data},
     metrics::frontend_perf::{STAGE_DURATION_SECONDS, STAGE_ROUTE},
@@ -15,7 +16,7 @@ use crate::{
         AddressedPushRouter, AddressedRequest, Error, ManyOut, SingleIn,
         error::{PipelineError, PipelineErrorExt},
     },
-    protocols::maybe_error::MaybeError,
+    protocols::{EndpointId, maybe_error::MaybeError},
     traits::DistributedRuntimeProvider,
 };
 use async_trait::async_trait;
@@ -253,22 +254,30 @@ fn device_aware_candidate_group(
     }
 }
 
+/// Per-endpoint guard: ensures at most one `list_and_watch` control-plane
+/// connection is opened per endpoint, regardless of how many `PushRouter`
+/// instances are created for it.  The entry is removed when the watcher
+/// task exits (cancel_token fired or discovery stream closed) so that a
+/// subsequent router creation can re-arm the watcher.
+static ENDPOINT_WATCHER_ACTIVE: std::sync::OnceLock<dashmap::DashMap<EndpointId, ()>> =
+    std::sync::OnceLock::new();
+
 /// Background task that watches the discovery plane for instance removals and
 /// cancels all pending response-stream registrations for removed instances.
 ///
-/// This is the core fix for the postmortem: when a worker is killed while requests
-/// are queued (ACK'd but not yet picked up), the oneshot senders are dropped,
-/// unblocking the waiting frontends with a migratable `Disconnected` error.
+/// This is the core fix for the postmortem: when a worker is killed while
+/// requests are queued (ACK'd but not yet picked up), the oneshot senders
+/// are dropped, unblocking waiting frontends with a migratable `Disconnected`
+/// error.
 ///
-/// Uses the raw `list_and_watch` discovery stream instead of diffing coalesced
-/// watch snapshots so that a rapid remove→re-add of the same pod (same stable
-/// hash-based instance_id in Kubernetes) is never silently swallowed.  Each
-/// `Removed` event unconditionally calls `cancel_instance_streams`; each
-/// `Added` event calls `clear_instance_tombstone`.
+/// Uses the raw `list_and_watch` discovery stream (not a coalesced snapshot
+/// diff) so that a rapid remove→re-add of the same Kubernetes pod — which
+/// keeps the same hash-stable instance_id — is never silently swallowed.
 ///
-/// Cancellation is keyed by `(endpoint_name, instance_id)` to avoid
-/// accidentally cancelling sibling endpoints on the same backend runtime that
-/// share a `connection_id` / `instance_id`.
+/// Cancellation is keyed by the full `EndpointInstanceId` (namespace +
+/// component + endpoint + instance_id) to prevent services from different
+/// namespaces/components that happen to share an endpoint name and
+/// pod-backed instance_id from cancelling each other's pending streams.
 fn spawn_instance_removal_watcher(
     endpoint: Endpoint,
     addressed: Arc<AddressedPushRouter>,
@@ -278,6 +287,17 @@ fn spawn_instance_removal_watcher(
         DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, DiscoveryQuery,
     };
     use tokio_stream::StreamExt as _;
+
+    // One watcher per endpoint: if one is already running, skip.
+    let guard = ENDPOINT_WATCHER_ACTIVE.get_or_init(dashmap::DashMap::new);
+    let endpoint_id = endpoint.id();
+    if guard.insert(endpoint_id.clone(), ()).is_some() {
+        tracing::debug!(
+            ?endpoint_id,
+            "Instance removal watcher already running for this endpoint, skipping"
+        );
+        return;
+    }
 
     let endpoint_name = endpoint.name().to_string();
 
@@ -297,6 +317,7 @@ fn spawn_instance_removal_watcher(
                     endpoint = %endpoint_name,
                     "Failed to start instance removal watcher: {e}"
                 );
+                guard.remove(&endpoint_id);
                 return;
             }
         };
@@ -306,28 +327,29 @@ fn spawn_instance_removal_watcher(
                 event = stream.next() => {
                     match event {
                         Some(Ok(DiscoveryEvent::Removed(id))) => {
-                            // Only act on endpoint-type removals.
+                            // Only act on endpoint-type removals; pass the
+                            // full EndpointInstanceId so cancellation is
+                            // scoped to exactly one service identity.
                             if let DiscoveryInstanceId::Endpoint(eid) = &id {
-                                let n = addressed
-                                    .cancel_instance_streams(&eid.endpoint, eid.instance_id)
-                                    .await;
+                                let n = addressed.cancel_instance_streams(eid).await;
                                 if n > 0 {
                                     tracing::warn!(
+                                        namespace = %eid.namespace,
+                                        component = %eid.component,
                                         endpoint = %eid.endpoint,
                                         instance_id = eid.instance_id,
                                         cancelled = n,
-                                        "Cancelled pending response streams for removed instance \
-                                         (discovery-driven cleanup)"
+                                        "Cancelled pending response streams for removed \
+                                         instance (discovery-driven cleanup)"
                                     );
                                 }
                             }
                         }
                         Some(Ok(DiscoveryEvent::Added(DiscoveryInstance::Endpoint(inst)))) => {
-                            // Clear tombstone so new requests for this (endpoint, instance)
-                            // pair are tracked normally after a restart.
-                            addressed
-                                .clear_instance_tombstone(&inst.endpoint, inst.instance_id)
-                                .await;
+                            // Clear tombstone so new requests for this identity are
+                            // tracked normally after a pod restart.
+                            let eid: EndpointInstanceId = inst.endpoint_instance_id();
+                            addressed.clear_instance_tombstone(&eid).await;
                         }
                         Some(Ok(_)) => {
                             // Ignore non-endpoint events (Model, EventChannel).
@@ -350,6 +372,8 @@ fn spawn_instance_removal_watcher(
             }
         }
 
+        // Release the guard so the next router creation can re-arm the watcher.
+        guard.remove(&endpoint_id);
         tracing::debug!(endpoint = %endpoint_name, "Instance removal watcher exiting");
     });
 }

--- a/lib/runtime/src/pipeline/network/tcp.rs
+++ b/lib/runtime/src/pipeline/network/tcp.rs
@@ -145,12 +145,8 @@ mod tests {
         send_stream.send_prologue(None).await.unwrap();
 
         // [server] next - now pending connections should be connected
-        let recv_stream = pending_connection
-            .recv_stream
-            .unwrap()
-            .stream_provider
-            .await
-            .unwrap();
+        let (_conn_info, stream_provider) = pending_connection.recv_stream.unwrap().into_parts();
+        let recv_stream = stream_provider.await.unwrap();
 
         println!("Server paired");
 

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -127,6 +127,13 @@ struct State {
     /// Maps instance_id -> set of subject UUIDs for batch cancellation
     /// when the discovery plane reports the instance is gone.
     instance_subjects: HashMap<u64, HashSet<String>>,
+    /// Tombstone set of instance IDs that have been removed by the discovery
+    /// plane. Closes the race window where `cancel_instance_streams()` runs
+    /// before `associate_instance()`: if a subject is associated with a
+    /// tombstoned instance, it is immediately cancelled instead of being
+    /// tracked. Cleared by `clear_instance_tombstone()` when the instance
+    /// comes back in the discovery set.
+    removed_instances: HashSet<u64>,
     handle: Option<tokio::task::JoinHandle<Result<()>>>,
 }
 
@@ -206,8 +213,23 @@ impl TcpStreamServer {
     /// Called by the egress router after `register()` so that when the discovery
     /// plane reports the instance as removed, we can cancel all pending subjects
     /// for that instance in one shot.
+    ///
+    /// If the instance has already been removed (tombstoned by a prior
+    /// `cancel_instance_streams` call), the subject is immediately cancelled
+    /// instead of being tracked. This closes the race window where the
+    /// discovery watcher fires before the request path calls this method.
     pub async fn associate_instance(&self, subject: &str, instance_id: u64) {
         let mut state = self.state.lock().await;
+        if state.removed_instances.contains(&instance_id) {
+            // Instance was already removed -- cancel immediately.
+            tracing::warn!(
+                subject,
+                instance_id,
+                "Cancelling subject immediately: instance already removed (tombstoned)"
+            );
+            state.rx_subjects.remove(subject);
+            return;
+        }
         state
             .subject_instance
             .insert(subject.to_string(), instance_id);
@@ -244,9 +266,15 @@ impl TcpStreamServer {
     /// to resolve with `RecvError`, which is converted to a migratable
     /// `DynamoError(Disconnected)` so the migration layer can retry on another worker.
     ///
+    /// The instance is also tombstoned so that any concurrent
+    /// `associate_instance()` call for the same instance (race with the
+    /// request path) will immediately cancel the late-arriving subject.
+    ///
     /// Returns the number of streams cancelled.
     pub async fn cancel_instance_streams(&self, instance_id: u64) -> usize {
         let mut state = self.state.lock().await;
+        // Tombstone the instance so late associate_instance() calls cancel immediately.
+        state.removed_instances.insert(instance_id);
         let subjects = match state.instance_subjects.remove(&instance_id) {
             Some(subjects) => subjects,
             None => return 0,
@@ -257,6 +285,17 @@ impl TcpStreamServer {
             state.subject_instance.remove(subject);
         }
         count
+    }
+
+    /// Remove an instance from the tombstone set.
+    ///
+    /// Called by the discovery watcher when an instance reappears in the
+    /// discovery set (re-registered after restart). Without this, the
+    /// tombstone would cause every future subject for the instance to be
+    /// immediately cancelled even though the instance is alive again.
+    pub async fn clear_instance_tombstone(&self, instance_id: u64) {
+        let mut state = self.state.lock().await;
+        state.removed_instances.remove(&instance_id);
     }
 
     #[allow(clippy::await_holding_lock)]
@@ -1061,5 +1100,49 @@ mod tests {
                 "into_parts() should disarm the RAII cleanup"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_associate_after_cancel_is_immediately_cancelled() {
+        // Simulates the race: cancel_instance_streams fires before associate_instance.
+        let server = test_server().await;
+
+        // Cancel instance 42 BEFORE any subject is registered for it (tombstone).
+        let cancelled = server.cancel_instance_streams(42).await;
+        assert_eq!(cancelled, 0);
+
+        // Now register a subject and try to associate it with the tombstoned instance.
+        let (subject, provider) = register_and_get_subject(&server).await;
+        server.associate_instance(&subject, 42).await;
+
+        // The provider should resolve with an error because associate_instance
+        // found the tombstone and immediately cancelled the subject.
+        let result = provider.await;
+        assert!(
+            result.is_err(),
+            "Late associate_instance on a tombstoned instance should immediately cancel"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_clear_tombstone_allows_new_associations() {
+        let server = test_server().await;
+
+        // Tombstone instance 42.
+        server.cancel_instance_streams(42).await;
+
+        // Clear the tombstone (simulates instance coming back in discovery).
+        server.clear_instance_tombstone(42).await;
+
+        // Now associate should work normally (subject NOT cancelled).
+        let (subject, _provider) = register_and_get_subject(&server).await;
+        server.associate_instance(&subject, 42).await;
+
+        // Subject should be tracked, not cancelled.
+        let cancelled = server.cancel_instance_streams(42).await;
+        assert_eq!(
+            cancelled, 1,
+            "After clearing tombstone, subjects should be tracked normally"
+        );
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -122,18 +122,19 @@ struct RequestedRecvConnection {
 struct State {
     tx_subjects: HashMap<String, RequestedSendConnection>,
     rx_subjects: HashMap<String, RequestedRecvConnection>,
-    /// Maps subject UUID -> instance_id for reverse lookup during cleanup.
-    subject_instance: HashMap<String, u64>,
-    /// Maps instance_id -> set of subject UUIDs for batch cancellation
-    /// when the discovery plane reports the instance is gone.
-    instance_subjects: HashMap<u64, HashSet<String>>,
-    /// Tombstone set of instance IDs that have been removed by the discovery
-    /// plane. Closes the race window where `cancel_instance_streams()` runs
-    /// before `associate_instance()`: if a subject is associated with a
-    /// tombstoned instance, it is immediately cancelled instead of being
-    /// tracked. Cleared by `clear_instance_tombstone()` when the instance
-    /// comes back in the discovery set.
-    removed_instances: HashSet<u64>,
+    /// Maps subject UUID -> (endpoint_name, instance_id) for reverse lookup
+    /// during cleanup.  The endpoint name is included so that cancellation is
+    /// scoped to the specific endpoint that was removed, not to every endpoint
+    /// registered on the same runtime (which share a connection_id / instance_id).
+    subject_instance: HashMap<String, (String, u64)>,
+    /// Maps (endpoint_name, instance_id) -> set of subject UUIDs for batch
+    /// cancellation when the discovery plane reports the instance is gone.
+    instance_subjects: HashMap<(String, u64), HashSet<String>>,
+    /// Tombstone set keyed by (endpoint_name, instance_id). Closes the race
+    /// window where `cancel_instance_streams()` fires before `associate_instance()`
+    /// for the same request. Cleared by `clear_instance_tombstone()` when the
+    /// instance reappears in the discovery set.
+    removed_instances: HashSet<(String, u64)>,
     handle: Option<tokio::task::JoinHandle<Result<()>>>,
 }
 
@@ -222,12 +223,23 @@ impl TcpStreamServer {
     /// instance was tombstoned and the subject was immediately cancelled.
     /// When `false` is returned the caller should skip `send_request` and
     /// return a migratable `Disconnected` error directly.
-    pub async fn associate_instance(&self, subject: &str, instance_id: u64) -> bool {
+    ///
+    /// The `endpoint` parameter scopes the key to a specific endpoint name
+    /// (e.g. `"generate"`), preventing cross-endpoint cancellation when
+    /// multiple endpoints on the same runtime share a `connection_id`.
+    pub async fn associate_instance(
+        &self,
+        subject: &str,
+        endpoint: &str,
+        instance_id: u64,
+    ) -> bool {
+        let key = (endpoint.to_string(), instance_id);
         let mut state = self.state.lock().await;
-        if state.removed_instances.contains(&instance_id) {
+        if state.removed_instances.contains(&key) {
             // Instance was already removed -- cancel immediately.
             tracing::warn!(
                 subject,
+                endpoint,
                 instance_id,
                 "Cancelling subject immediately: instance already removed (tombstoned)"
             );
@@ -236,10 +248,10 @@ impl TcpStreamServer {
         }
         state
             .subject_instance
-            .insert(subject.to_string(), instance_id);
+            .insert(subject.to_string(), key.clone());
         state
             .instance_subjects
-            .entry(instance_id)
+            .entry(key)
             .or_default()
             .insert(subject.to_string());
         true
@@ -253,11 +265,11 @@ impl TcpStreamServer {
     pub async fn cancel_recv_stream(&self, subject: &str) {
         let mut state = self.state.lock().await;
         state.rx_subjects.remove(subject);
-        if let Some(instance_id) = state.subject_instance.remove(subject) {
-            if let Some(subjects) = state.instance_subjects.get_mut(&instance_id) {
+        if let Some(key) = state.subject_instance.remove(subject) {
+            if let Some(subjects) = state.instance_subjects.get_mut(&key) {
                 subjects.remove(subject);
                 if subjects.is_empty() {
-                    state.instance_subjects.remove(&instance_id);
+                    state.instance_subjects.remove(&key);
                 }
             }
         }
@@ -275,12 +287,16 @@ impl TcpStreamServer {
     /// `associate_instance()` call for the same instance (race with the
     /// request path) will immediately cancel the late-arriving subject.
     ///
+    /// The `endpoint` parameter scopes the tombstone to a specific endpoint,
+    /// preventing sibling endpoints on the same runtime from being affected.
+    ///
     /// Returns the number of streams cancelled.
-    pub async fn cancel_instance_streams(&self, instance_id: u64) -> usize {
+    pub async fn cancel_instance_streams(&self, endpoint: &str, instance_id: u64) -> usize {
+        let key = (endpoint.to_string(), instance_id);
         let mut state = self.state.lock().await;
-        // Tombstone the instance so late associate_instance() calls cancel immediately.
-        state.removed_instances.insert(instance_id);
-        let subjects = match state.instance_subjects.remove(&instance_id) {
+        // Tombstone the (endpoint, instance) pair so late associate_instance() calls cancel.
+        state.removed_instances.insert(key.clone());
+        let subjects = match state.instance_subjects.remove(&key) {
             Some(subjects) => subjects,
             None => return 0,
         };
@@ -292,15 +308,16 @@ impl TcpStreamServer {
         count
     }
 
-    /// Remove an instance from the tombstone set.
+    /// Remove an (endpoint, instance) pair from the tombstone set.
     ///
     /// Called by the discovery watcher when an instance reappears in the
     /// discovery set (re-registered after restart). Without this, the
-    /// tombstone would cause every future subject for the instance to be
-    /// immediately cancelled even though the instance is alive again.
-    pub async fn clear_instance_tombstone(&self, instance_id: u64) {
+    /// tombstone would cause every future subject for that endpoint+instance
+    /// to be immediately cancelled even though the instance is alive again.
+    pub async fn clear_instance_tombstone(&self, endpoint: &str, instance_id: u64) {
+        let key = (endpoint.to_string(), instance_id);
         let mut state = self.state.lock().await;
-        state.removed_instances.remove(&instance_id);
+        state.removed_instances.remove(&key);
     }
 
     #[allow(clippy::await_holding_lock)]
@@ -422,11 +439,11 @@ impl ResponseService for TcpStreamServer {
                 tokio::spawn(async move {
                     let mut state = cleanup_state.lock().await;
                     state.rx_subjects.remove(&cleanup_subject);
-                    if let Some(instance_id) = state.subject_instance.remove(&cleanup_subject) {
-                        if let Some(subjects) = state.instance_subjects.get_mut(&instance_id) {
+                    if let Some(key) = state.subject_instance.remove(&cleanup_subject) {
+                        if let Some(subjects) = state.instance_subjects.get_mut(&key) {
                             subjects.remove(&cleanup_subject);
                             if subjects.is_empty() {
-                                state.instance_subjects.remove(&instance_id);
+                                state.instance_subjects.remove(&key);
                             }
                         }
                     }
@@ -583,11 +600,11 @@ async fn tcp_listener(
                 .remove(&subject)
                 .ok_or(error!("Subject not found: {}; upstream publisher specified a subject unknown to the downsteam subscriber", subject))?;
             // Clean up instance-tracking maps on the normal (worker-connected) path.
-            if let Some(instance_id) = guard.subject_instance.remove(&subject) {
-                if let Some(subjects) = guard.instance_subjects.get_mut(&instance_id) {
+            if let Some(key) = guard.subject_instance.remove(&subject) {
+                if let Some(subjects) = guard.instance_subjects.get_mut(&key) {
                     subjects.remove(&subject);
                     if subjects.is_empty() {
-                        guard.instance_subjects.remove(&instance_id);
+                        guard.instance_subjects.remove(&key);
                     }
                 }
             }
@@ -964,11 +981,11 @@ mod tests {
 
         let (subject, provider) = register_and_get_subject(&server).await;
 
-        // Associate the subject with instance 42
-        assert!(server.associate_instance(&subject, 42).await);
+        // Associate the subject with endpoint "generate", instance 42
+        assert!(server.associate_instance(&subject, "generate", 42).await);
 
-        // Cancel all streams for instance 42
-        let cancelled = server.cancel_instance_streams(42).await;
+        // Cancel all streams for endpoint "generate", instance 42
+        let cancelled = server.cancel_instance_streams("generate", 42).await;
         assert_eq!(cancelled, 1);
 
         // The oneshot receiver should now resolve with an error (sender dropped)
@@ -985,19 +1002,19 @@ mod tests {
         let (subj3, prov3) = register_and_get_subject(&server).await;
 
         // Associate first two with instance 10, third with instance 20
-        assert!(server.associate_instance(&subj1, 10).await);
-        assert!(server.associate_instance(&subj2, 10).await);
-        assert!(server.associate_instance(&subj3, 20).await);
+        assert!(server.associate_instance(&subj1, "generate", 10).await);
+        assert!(server.associate_instance(&subj2, "generate", 10).await);
+        assert!(server.associate_instance(&subj3, "generate", 20).await);
 
         // Cancel instance 10 -- should cancel 2 subjects
-        let cancelled = server.cancel_instance_streams(10).await;
+        let cancelled = server.cancel_instance_streams("generate", 10).await;
         assert_eq!(cancelled, 2);
 
         assert!(prov1.await.is_err());
         assert!(prov2.await.is_err());
 
         // Instance 20 should be unaffected -- cancel it separately
-        let cancelled = server.cancel_instance_streams(20).await;
+        let cancelled = server.cancel_instance_streams("generate", 20).await;
         assert_eq!(cancelled, 1);
         assert!(prov3.await.is_err());
     }
@@ -1007,7 +1024,7 @@ mod tests {
         let server = test_server().await;
 
         // Cancelling a nonexistent instance should return 0 and not panic
-        let cancelled = server.cancel_instance_streams(999).await;
+        let cancelled = server.cancel_instance_streams("generate", 999).await;
         assert_eq!(cancelled, 0);
     }
 
@@ -1016,13 +1033,13 @@ mod tests {
         let server = test_server().await;
 
         let (subject, _provider) = register_and_get_subject(&server).await;
-        assert!(server.associate_instance(&subject, 42).await);
+        assert!(server.associate_instance(&subject, "generate", 42).await);
 
         // Cancel the individual subject
         server.cancel_recv_stream(&subject).await;
 
         // Instance should have no remaining subjects
-        let cancelled = server.cancel_instance_streams(42).await;
+        let cancelled = server.cancel_instance_streams("generate", 42).await;
         assert_eq!(
             cancelled, 0,
             "Instance tracking should have been cleaned up"
@@ -1112,13 +1129,13 @@ mod tests {
         // Simulates the race: cancel_instance_streams fires before associate_instance.
         let server = test_server().await;
 
-        // Cancel instance 42 BEFORE any subject is registered for it (tombstone).
-        let cancelled = server.cancel_instance_streams(42).await;
+        // Cancel instance 42 for endpoint "generate" BEFORE any subject is registered (tombstone).
+        let cancelled = server.cancel_instance_streams("generate", 42).await;
         assert_eq!(cancelled, 0);
 
         // Now register a subject and try to associate it with the tombstoned instance.
         let (subject, provider) = register_and_get_subject(&server).await;
-        let associated = server.associate_instance(&subject, 42).await;
+        let associated = server.associate_instance(&subject, "generate", 42).await;
 
         // associate_instance should return false when the instance is tombstoned.
         assert!(
@@ -1139,21 +1156,79 @@ mod tests {
     async fn test_clear_tombstone_allows_new_associations() {
         let server = test_server().await;
 
-        // Tombstone instance 42.
-        server.cancel_instance_streams(42).await;
+        // Tombstone instance 42 for endpoint "generate".
+        server.cancel_instance_streams("generate", 42).await;
 
         // Clear the tombstone (simulates instance coming back in discovery).
-        server.clear_instance_tombstone(42).await;
+        server.clear_instance_tombstone("generate", 42).await;
 
         // Now associate should work normally (subject NOT cancelled).
         let (subject, _provider) = register_and_get_subject(&server).await;
-        assert!(server.associate_instance(&subject, 42).await);
+        assert!(server.associate_instance(&subject, "generate", 42).await);
 
         // Subject should be tracked, not cancelled.
-        let cancelled = server.cancel_instance_streams(42).await;
+        let cancelled = server.cancel_instance_streams("generate", 42).await;
         assert_eq!(
             cancelled, 1,
             "After clearing tombstone, subjects should be tracked normally"
         );
+    }
+
+    #[tokio::test]
+    async fn test_cancel_does_not_affect_sibling_endpoint() {
+        // Bug 1 regression test: cancelling "generate" must not cancel "prefill"
+        // subjects that share the same instance_id (same backend runtime).
+        let server = test_server().await;
+
+        let (gen_subj, gen_prov) = register_and_get_subject(&server).await;
+        let (pre_subj, pre_prov) = register_and_get_subject(&server).await;
+
+        // Same instance_id 42, but different endpoints.
+        assert!(server.associate_instance(&gen_subj, "generate", 42).await);
+        assert!(server.associate_instance(&pre_subj, "prefill", 42).await);
+
+        // Cancel only the "generate" endpoint's subjects.
+        let cancelled = server.cancel_instance_streams("generate", 42).await;
+        assert_eq!(
+            cancelled, 1,
+            "Only the generate subject should be cancelled"
+        );
+
+        // generate provider must be cancelled.
+        assert!(gen_prov.await.is_err());
+
+        // prefill provider must still be pending (not cancelled).
+        // We verify by doing a try-style check -- the oneshot should not be resolved yet.
+        // We just check it can still be cancelled by its own endpoint.
+        let still_pending = server.cancel_instance_streams("prefill", 42).await;
+        assert_eq!(still_pending, 1, "prefill subject should still be tracked");
+        assert!(pre_prov.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_tombstone_is_endpoint_scoped() {
+        // Tombstoning "generate" must not prevent new associations on "prefill"
+        // for the same instance_id.
+        let server = test_server().await;
+
+        // Tombstone "generate" for instance 42.
+        server.cancel_instance_streams("generate", 42).await;
+
+        // A new subject for "generate" should be rejected.
+        let (gen_subj, gen_prov) = register_and_get_subject(&server).await;
+        assert!(
+            !server.associate_instance(&gen_subj, "generate", 42).await,
+            "generate should be tombstoned"
+        );
+        assert!(gen_prov.await.is_err());
+
+        // A new subject for "prefill" with the same instance_id should be accepted.
+        let (pre_subj, _pre_prov) = register_and_get_subject(&server).await;
+        assert!(
+            server.associate_instance(&pre_subj, "prefill", 42).await,
+            "prefill tombstone is independent; subject should be tracked"
+        );
+        let count = server.cancel_instance_streams("prefill", 42).await;
+        assert_eq!(count, 1, "prefill subject should be tracked normally");
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -4,7 +4,7 @@
 use core::panic;
 use socket2::{Domain, SockAddr, Socket, Type};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     net::{IpAddr, SocketAddr, TcpListener},
     os::fd::{AsFd, FromRawFd},
     sync::Arc,
@@ -122,6 +122,11 @@ struct RequestedRecvConnection {
 struct State {
     tx_subjects: HashMap<String, RequestedSendConnection>,
     rx_subjects: HashMap<String, RequestedRecvConnection>,
+    /// Maps subject UUID -> instance_id for reverse lookup during cleanup.
+    subject_instance: HashMap<String, u64>,
+    /// Maps instance_id -> set of subject UUIDs for batch cancellation
+    /// when the discovery plane reports the instance is gone.
+    instance_subjects: HashMap<u64, HashSet<String>>,
     handle: Option<tokio::task::JoinHandle<Result<()>>>,
 }
 
@@ -196,6 +201,64 @@ impl TcpStreamServer {
         }))
     }
 
+    /// Associate a registered response-stream subject with a backend instance.
+    ///
+    /// Called by the egress router after `register()` so that when the discovery
+    /// plane reports the instance as removed, we can cancel all pending subjects
+    /// for that instance in one shot.
+    pub async fn associate_instance(&self, subject: &str, instance_id: u64) {
+        let mut state = self.state.lock().await;
+        state
+            .subject_instance
+            .insert(subject.to_string(), instance_id);
+        state
+            .instance_subjects
+            .entry(instance_id)
+            .or_default()
+            .insert(subject.to_string());
+    }
+
+    /// Cancel a single pending response-stream registration.
+    ///
+    /// Removes the subject from `rx_subjects` (dropping the `oneshot::Sender`,
+    /// which causes the waiting `oneshot::Receiver` to resolve with
+    /// `RecvError`) and cleans up the instance-tracking maps.
+    pub async fn cancel_recv_stream(&self, subject: &str) {
+        let mut state = self.state.lock().await;
+        state.rx_subjects.remove(subject);
+        if let Some(instance_id) = state.subject_instance.remove(subject) {
+            if let Some(subjects) = state.instance_subjects.get_mut(&instance_id) {
+                subjects.remove(subject);
+                if subjects.is_empty() {
+                    state.instance_subjects.remove(&instance_id);
+                }
+            }
+        }
+    }
+
+    /// Cancel **all** pending response-stream registrations for a given instance.
+    ///
+    /// Called when the discovery plane reports the instance as removed (etcd lease
+    /// expired or explicit unregister). Dropping each `oneshot::Sender` causes
+    /// the corresponding `oneshot::Receiver.await` in `AddressedPushRouter::generate()`
+    /// to resolve with `RecvError`, which is converted to a migratable
+    /// `DynamoError(Disconnected)` so the migration layer can retry on another worker.
+    ///
+    /// Returns the number of streams cancelled.
+    pub async fn cancel_instance_streams(&self, instance_id: u64) -> usize {
+        let mut state = self.state.lock().await;
+        let subjects = match state.instance_subjects.remove(&instance_id) {
+            Some(subjects) => subjects,
+            None => return 0,
+        };
+        let count = subjects.len();
+        for subject in &subjects {
+            state.rx_subjects.remove(subject);
+            state.subject_instance.remove(subject);
+        }
+        count
+    }
+
     #[allow(clippy::await_holding_lock)]
     async fn start(local_ip: String, local_port: u16, state: Arc<Mutex<State>>) -> Result<u16> {
         let addr = format!("{}:{}", local_ip, local_port);
@@ -257,16 +320,26 @@ impl ResponseService for TcpStreamServer {
                 .tx_subjects
                 .insert(sender_subject.clone(), connection_info);
 
-            let registered_stream = RegisteredStream {
-                connection_info: TcpStreamConnectionInfo {
+            let cleanup_subject = sender_subject.clone();
+            let cleanup_state = self.state.clone();
+            let registered_stream = RegisteredStream::new(
+                TcpStreamConnectionInfo {
                     address: address.clone(),
-                    subject: sender_subject.clone(),
+                    subject: sender_subject,
                     context: options.context.id().to_string(),
                     stream_type: StreamType::Request,
                 }
                 .into(),
-                stream_provider: pending_sender_rx,
-            };
+                pending_sender_rx,
+            )
+            .with_cleanup(move || {
+                // Synchronous removal -- fire-and-forget via a spawned task
+                // because Drop cannot be async.
+                tokio::spawn(async move {
+                    let mut state = cleanup_state.lock().await;
+                    state.tx_subjects.remove(&cleanup_subject);
+                });
+            });
 
             Some(registered_stream)
         } else {
@@ -287,16 +360,34 @@ impl ResponseService for TcpStreamServer {
                 .rx_subjects
                 .insert(receiver_subject.clone(), connection_info);
 
-            let registered_stream = RegisteredStream {
-                connection_info: TcpStreamConnectionInfo {
+            let cleanup_subject = receiver_subject.clone();
+            let cleanup_state = self.state.clone();
+            let registered_stream = RegisteredStream::new(
+                TcpStreamConnectionInfo {
                     address: address.clone(),
-                    subject: receiver_subject.clone(),
+                    subject: receiver_subject,
                     context: options.context.id().to_string(),
                     stream_type: StreamType::Response,
                 }
                 .into(),
-                stream_provider: pending_recver_rx,
-            };
+                pending_recver_rx,
+            )
+            .with_cleanup(move || {
+                // Synchronous removal -- fire-and-forget via a spawned task
+                // because Drop cannot be async.
+                tokio::spawn(async move {
+                    let mut state = cleanup_state.lock().await;
+                    state.rx_subjects.remove(&cleanup_subject);
+                    if let Some(instance_id) = state.subject_instance.remove(&cleanup_subject) {
+                        if let Some(subjects) = state.instance_subjects.get_mut(&instance_id) {
+                            subjects.remove(&cleanup_subject);
+                            if subjects.is_empty() {
+                                state.instance_subjects.remove(&instance_id);
+                            }
+                        }
+                    }
+                });
+            });
 
             Some(registered_stream)
         } else {
@@ -441,11 +532,23 @@ async fn tcp_listener(
         mut reader: FramedRead<tokio::io::ReadHalf<tokio::net::TcpStream>, TwoPartCodec>,
         writer: FramedWrite<tokio::io::WriteHalf<tokio::net::TcpStream>, TwoPartCodec>,
     ) -> Result<()> {
-        let response_stream = state
-            .lock().await
-            .rx_subjects
-            .remove(&subject)
-            .ok_or(error!("Subject not found: {}; upstream publisher specified a subject unknown to the downsteam subscriber", subject))?;
+        let response_stream = {
+            let mut guard = state.lock().await;
+            let conn = guard
+                .rx_subjects
+                .remove(&subject)
+                .ok_or(error!("Subject not found: {}; upstream publisher specified a subject unknown to the downsteam subscriber", subject))?;
+            // Clean up instance-tracking maps on the normal (worker-connected) path.
+            if let Some(instance_id) = guard.subject_instance.remove(&subject) {
+                if let Some(subjects) = guard.instance_subjects.get_mut(&instance_id) {
+                    subjects.remove(&subject);
+                    if subjects.is_empty() {
+                        guard.instance_subjects.remove(&instance_id);
+                    }
+                }
+            }
+            conn
+        };
 
         // unwrap response_stream
         let RequestedRecvConnection {
@@ -777,5 +880,186 @@ mod tests {
 
         // The server should work with the fallback IP
         assert!(socket_addr.port() > 0, "Server should have a valid port");
+    }
+
+    /// Create a test server using the failing IP resolver (falls back to loopback).
+    async fn test_server() -> Arc<TcpStreamServer> {
+        TcpStreamServer::new_with_resolver(
+            ServerOptions::builder().port(0).build().unwrap(),
+            FailingIpResolver,
+        )
+        .await
+        .unwrap()
+    }
+
+    /// Helper: register a response stream and extract its subject string.
+    async fn register_and_get_subject(
+        server: &TcpStreamServer,
+    ) -> (
+        String,
+        tokio::sync::oneshot::Receiver<Result<super::StreamReceiver, String>>,
+    ) {
+        let context = Context::new(());
+        let options = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(false)
+            .enable_response_stream(true)
+            .build()
+            .unwrap();
+
+        let pending = server.register(options).await;
+        let recv_stream = pending.recv_stream.unwrap();
+        let (conn_info, provider) = recv_stream.into_parts();
+        let tcp_info: TcpStreamConnectionInfo = conn_info.try_into().unwrap();
+        (tcp_info.subject, provider)
+    }
+
+    #[tokio::test]
+    async fn test_cancel_instance_streams_unblocks_receiver() {
+        let server = test_server().await;
+
+        let (subject, provider) = register_and_get_subject(&server).await;
+
+        // Associate the subject with instance 42
+        server.associate_instance(&subject, 42).await;
+
+        // Cancel all streams for instance 42
+        let cancelled = server.cancel_instance_streams(42).await;
+        assert_eq!(cancelled, 1);
+
+        // The oneshot receiver should now resolve with an error (sender dropped)
+        let result = provider.await;
+        assert!(result.is_err(), "Expected RecvError after cancellation");
+    }
+
+    #[tokio::test]
+    async fn test_cancel_instance_streams_multiple_subjects() {
+        let server = test_server().await;
+
+        let (subj1, prov1) = register_and_get_subject(&server).await;
+        let (subj2, prov2) = register_and_get_subject(&server).await;
+        let (subj3, prov3) = register_and_get_subject(&server).await;
+
+        // Associate first two with instance 10, third with instance 20
+        server.associate_instance(&subj1, 10).await;
+        server.associate_instance(&subj2, 10).await;
+        server.associate_instance(&subj3, 20).await;
+
+        // Cancel instance 10 -- should cancel 2 subjects
+        let cancelled = server.cancel_instance_streams(10).await;
+        assert_eq!(cancelled, 2);
+
+        assert!(prov1.await.is_err());
+        assert!(prov2.await.is_err());
+
+        // Instance 20 should be unaffected -- cancel it separately
+        let cancelled = server.cancel_instance_streams(20).await;
+        assert_eq!(cancelled, 1);
+        assert!(prov3.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_cancel_instance_streams_nonexistent_instance() {
+        let server = test_server().await;
+
+        // Cancelling a nonexistent instance should return 0 and not panic
+        let cancelled = server.cancel_instance_streams(999).await;
+        assert_eq!(cancelled, 0);
+    }
+
+    #[tokio::test]
+    async fn test_cancel_recv_stream_cleans_up_instance_tracking() {
+        let server = test_server().await;
+
+        let (subject, _provider) = register_and_get_subject(&server).await;
+        server.associate_instance(&subject, 42).await;
+
+        // Cancel the individual subject
+        server.cancel_recv_stream(&subject).await;
+
+        // Instance should have no remaining subjects
+        let cancelled = server.cancel_instance_streams(42).await;
+        assert_eq!(
+            cancelled, 0,
+            "Instance tracking should have been cleaned up"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_registered_stream_drop_runs_cleanup() {
+        let server = test_server().await;
+
+        // Register a response stream but DON'T call into_parts -- just drop it
+        let context = Context::new(());
+        let options = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(false)
+            .enable_response_stream(true)
+            .build()
+            .unwrap();
+
+        let pending = server.register(options).await;
+        let recv_stream = pending.recv_stream.unwrap();
+
+        // Get the subject before dropping
+        let tcp_info: TcpStreamConnectionInfo =
+            recv_stream.connection_info.clone().try_into().unwrap();
+        let subject = tcp_info.subject.clone();
+
+        // Verify it's in rx_subjects
+        {
+            let state = server.state.lock().await;
+            assert!(state.rx_subjects.contains_key(&subject));
+        }
+
+        // Drop the RegisteredStream -- RAII cleanup should fire
+        drop(recv_stream);
+
+        // Give the spawned cleanup task a moment to run
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Verify it's been removed from rx_subjects
+        {
+            let state = server.state.lock().await;
+            assert!(
+                !state.rx_subjects.contains_key(&subject),
+                "RAII cleanup should have removed the rx_subjects entry"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_registered_stream_into_parts_disarms_cleanup() {
+        let server = test_server().await;
+
+        let context = Context::new(());
+        let options = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(false)
+            .enable_response_stream(true)
+            .build()
+            .unwrap();
+
+        let pending = server.register(options).await;
+        let recv_stream = pending.recv_stream.unwrap();
+
+        let tcp_info: TcpStreamConnectionInfo =
+            recv_stream.connection_info.clone().try_into().unwrap();
+        let subject = tcp_info.subject.clone();
+
+        // Call into_parts to disarm the cleanup
+        let (_conn_info, _provider) = recv_stream.into_parts();
+
+        // Give any potential cleanup a moment to run
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // The entry should still be in rx_subjects (cleanup was disarmed)
+        {
+            let state = server.state.lock().await;
+            assert!(
+                state.rx_subjects.contains_key(&subject),
+                "into_parts() should disarm the RAII cleanup"
+            );
+        }
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -218,7 +218,11 @@ impl TcpStreamServer {
     /// `cancel_instance_streams` call), the subject is immediately cancelled
     /// instead of being tracked. This closes the race window where the
     /// discovery watcher fires before the request path calls this method.
-    pub async fn associate_instance(&self, subject: &str, instance_id: u64) {
+    /// Returns `true` if the subject was tracked normally, `false` if the
+    /// instance was tombstoned and the subject was immediately cancelled.
+    /// When `false` is returned the caller should skip `send_request` and
+    /// return a migratable `Disconnected` error directly.
+    pub async fn associate_instance(&self, subject: &str, instance_id: u64) -> bool {
         let mut state = self.state.lock().await;
         if state.removed_instances.contains(&instance_id) {
             // Instance was already removed -- cancel immediately.
@@ -228,7 +232,7 @@ impl TcpStreamServer {
                 "Cancelling subject immediately: instance already removed (tombstoned)"
             );
             state.rx_subjects.remove(subject);
-            return;
+            return false;
         }
         state
             .subject_instance
@@ -238,6 +242,7 @@ impl TcpStreamServer {
             .entry(instance_id)
             .or_default()
             .insert(subject.to_string());
+        true
     }
 
     /// Cancel a single pending response-stream registration.
@@ -960,7 +965,7 @@ mod tests {
         let (subject, provider) = register_and_get_subject(&server).await;
 
         // Associate the subject with instance 42
-        server.associate_instance(&subject, 42).await;
+        assert!(server.associate_instance(&subject, 42).await);
 
         // Cancel all streams for instance 42
         let cancelled = server.cancel_instance_streams(42).await;
@@ -980,9 +985,9 @@ mod tests {
         let (subj3, prov3) = register_and_get_subject(&server).await;
 
         // Associate first two with instance 10, third with instance 20
-        server.associate_instance(&subj1, 10).await;
-        server.associate_instance(&subj2, 10).await;
-        server.associate_instance(&subj3, 20).await;
+        assert!(server.associate_instance(&subj1, 10).await);
+        assert!(server.associate_instance(&subj2, 10).await);
+        assert!(server.associate_instance(&subj3, 20).await);
 
         // Cancel instance 10 -- should cancel 2 subjects
         let cancelled = server.cancel_instance_streams(10).await;
@@ -1011,7 +1016,7 @@ mod tests {
         let server = test_server().await;
 
         let (subject, _provider) = register_and_get_subject(&server).await;
-        server.associate_instance(&subject, 42).await;
+        assert!(server.associate_instance(&subject, 42).await);
 
         // Cancel the individual subject
         server.cancel_recv_stream(&subject).await;
@@ -1113,7 +1118,13 @@ mod tests {
 
         // Now register a subject and try to associate it with the tombstoned instance.
         let (subject, provider) = register_and_get_subject(&server).await;
-        server.associate_instance(&subject, 42).await;
+        let associated = server.associate_instance(&subject, 42).await;
+
+        // associate_instance should return false when the instance is tombstoned.
+        assert!(
+            !associated,
+            "associate_instance on a tombstoned instance should return false"
+        );
 
         // The provider should resolve with an error because associate_instance
         // found the tombstone and immediately cancelled the subject.
@@ -1136,7 +1147,7 @@ mod tests {
 
         // Now associate should work normally (subject NOT cancelled).
         let (subject, _provider) = register_and_get_subject(&server).await;
-        server.associate_instance(&subject, 42).await;
+        assert!(server.associate_instance(&subject, 42).await);
 
         // Subject should be tracked, not cancelled.
         let cancelled = server.cancel_instance_streams(42).await;

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -28,6 +28,7 @@ use super::{
     CallHomeHandshake, ControlMessage, PendingConnections, RegisteredStream, StreamOptions,
     StreamReceiver, StreamSender, TcpStreamConnectionInfo, TwoPartCodec,
 };
+use crate::discovery::EndpointInstanceId;
 use crate::engine::AsyncEngineContext;
 use crate::pipeline::{
     PipelineError,
@@ -122,19 +123,21 @@ struct RequestedRecvConnection {
 struct State {
     tx_subjects: HashMap<String, RequestedSendConnection>,
     rx_subjects: HashMap<String, RequestedRecvConnection>,
-    /// Maps subject UUID -> (endpoint_name, instance_id) for reverse lookup
-    /// during cleanup.  The endpoint name is included so that cancellation is
-    /// scoped to the specific endpoint that was removed, not to every endpoint
-    /// registered on the same runtime (which share a connection_id / instance_id).
-    subject_instance: HashMap<String, (String, u64)>,
-    /// Maps (endpoint_name, instance_id) -> set of subject UUIDs for batch
-    /// cancellation when the discovery plane reports the instance is gone.
-    instance_subjects: HashMap<(String, u64), HashSet<String>>,
-    /// Tombstone set keyed by (endpoint_name, instance_id). Closes the race
-    /// window where `cancel_instance_streams()` fires before `associate_instance()`
-    /// for the same request. Cleared by `clear_instance_tombstone()` when the
+    /// Maps subject UUID -> full EndpointInstanceId for reverse lookup during
+    /// cleanup.  The full 4-field key (namespace, component, endpoint,
+    /// instance_id) ensures two services from different namespaces/components
+    /// that share an endpoint name and pod-backed instance_id cannot cancel or
+    /// tombstone each other's streams, even though the TcpStreamServer is
+    /// shared per runtime.
+    subject_instance: HashMap<String, EndpointInstanceId>,
+    /// Maps EndpointInstanceId -> set of subject UUIDs for batch cancellation
+    /// when the discovery plane reports the instance is gone.
+    instance_subjects: HashMap<EndpointInstanceId, HashSet<String>>,
+    /// Tombstone set keyed by full EndpointInstanceId.  Closes the race window
+    /// where `cancel_instance_streams()` fires before `associate_instance()`
+    /// for the same request.  Cleared by `clear_instance_tombstone()` when the
     /// instance reappears in the discovery set.
-    removed_instances: HashSet<(String, u64)>,
+    removed_instances: HashSet<EndpointInstanceId>,
     handle: Option<tokio::task::JoinHandle<Result<()>>>,
 }
 
@@ -224,23 +227,20 @@ impl TcpStreamServer {
     /// When `false` is returned the caller should skip `send_request` and
     /// return a migratable `Disconnected` error directly.
     ///
-    /// The `endpoint` parameter scopes the key to a specific endpoint name
-    /// (e.g. `"generate"`), preventing cross-endpoint cancellation when
-    /// multiple endpoints on the same runtime share a `connection_id`.
-    pub async fn associate_instance(
-        &self,
-        subject: &str,
-        endpoint: &str,
-        instance_id: u64,
-    ) -> bool {
-        let key = (endpoint.to_string(), instance_id);
+    /// The full `EndpointInstanceId` (namespace + component + endpoint +
+    /// instance_id) scopes the key precisely, so two services from different
+    /// namespaces or components that share an endpoint name and pod-backed
+    /// instance_id cannot cancel each other's streams.
+    pub async fn associate_instance(&self, subject: &str, id: &EndpointInstanceId) -> bool {
         let mut state = self.state.lock().await;
-        if state.removed_instances.contains(&key) {
+        if state.removed_instances.contains(id) {
             // Instance was already removed -- cancel immediately.
             tracing::warn!(
                 subject,
-                endpoint,
-                instance_id,
+                namespace = %id.namespace,
+                component = %id.component,
+                endpoint = %id.endpoint,
+                instance_id = id.instance_id,
                 "Cancelling subject immediately: instance already removed (tombstoned)"
             );
             state.rx_subjects.remove(subject);
@@ -248,10 +248,10 @@ impl TcpStreamServer {
         }
         state
             .subject_instance
-            .insert(subject.to_string(), key.clone());
+            .insert(subject.to_string(), id.clone());
         state
             .instance_subjects
-            .entry(key)
+            .entry(id.clone())
             .or_default()
             .insert(subject.to_string());
         true
@@ -287,16 +287,16 @@ impl TcpStreamServer {
     /// `associate_instance()` call for the same instance (race with the
     /// request path) will immediately cancel the late-arriving subject.
     ///
-    /// The `endpoint` parameter scopes the tombstone to a specific endpoint,
-    /// preventing sibling endpoints on the same runtime from being affected.
+    /// The full `EndpointInstanceId` tombstone key ensures sibling
+    /// endpoints from the same or different namespace/component pairs are
+    /// never accidentally affected.
     ///
     /// Returns the number of streams cancelled.
-    pub async fn cancel_instance_streams(&self, endpoint: &str, instance_id: u64) -> usize {
-        let key = (endpoint.to_string(), instance_id);
+    pub async fn cancel_instance_streams(&self, id: &EndpointInstanceId) -> usize {
         let mut state = self.state.lock().await;
-        // Tombstone the (endpoint, instance) pair so late associate_instance() calls cancel.
-        state.removed_instances.insert(key.clone());
-        let subjects = match state.instance_subjects.remove(&key) {
+        // Tombstone the identity so late associate_instance() calls cancel immediately.
+        state.removed_instances.insert(id.clone());
+        let subjects = match state.instance_subjects.remove(id) {
             Some(subjects) => subjects,
             None => return 0,
         };
@@ -308,16 +308,15 @@ impl TcpStreamServer {
         count
     }
 
-    /// Remove an (endpoint, instance) pair from the tombstone set.
+    /// Remove an `EndpointInstanceId` from the tombstone set.
     ///
     /// Called by the discovery watcher when an instance reappears in the
     /// discovery set (re-registered after restart). Without this, the
-    /// tombstone would cause every future subject for that endpoint+instance
-    /// to be immediately cancelled even though the instance is alive again.
-    pub async fn clear_instance_tombstone(&self, endpoint: &str, instance_id: u64) {
-        let key = (endpoint.to_string(), instance_id);
+    /// tombstone would cause every future subject for that identity to be
+    /// immediately cancelled even though the instance is alive again.
+    pub async fn clear_instance_tombstone(&self, id: &EndpointInstanceId) {
         let mut state = self.state.lock().await;
-        state.removed_instances.remove(&key);
+        state.removed_instances.remove(id);
     }
 
     #[allow(clippy::await_holding_lock)]
@@ -975,17 +974,31 @@ mod tests {
         (tcp_info.subject, provider)
     }
 
+    /// Convenience constructor so tests don't repeat the struct literal.
+    fn make_eid(
+        namespace: &str,
+        component: &str,
+        endpoint: &str,
+        instance_id: u64,
+    ) -> EndpointInstanceId {
+        EndpointInstanceId {
+            namespace: namespace.to_string(),
+            component: component.to_string(),
+            endpoint: endpoint.to_string(),
+            instance_id,
+        }
+    }
+
     #[tokio::test]
     async fn test_cancel_instance_streams_unblocks_receiver() {
         let server = test_server().await;
 
         let (subject, provider) = register_and_get_subject(&server).await;
 
-        // Associate the subject with endpoint "generate", instance 42
-        assert!(server.associate_instance(&subject, "generate", 42).await);
+        let id = make_eid("ns", "comp", "generate", 42);
+        assert!(server.associate_instance(&subject, &id).await);
 
-        // Cancel all streams for endpoint "generate", instance 42
-        let cancelled = server.cancel_instance_streams("generate", 42).await;
+        let cancelled = server.cancel_instance_streams(&id).await;
         assert_eq!(cancelled, 1);
 
         // The oneshot receiver should now resolve with an error (sender dropped)
@@ -1001,20 +1014,23 @@ mod tests {
         let (subj2, prov2) = register_and_get_subject(&server).await;
         let (subj3, prov3) = register_and_get_subject(&server).await;
 
+        let id10 = make_eid("ns", "comp", "generate", 10);
+        let id20 = make_eid("ns", "comp", "generate", 20);
+
         // Associate first two with instance 10, third with instance 20
-        assert!(server.associate_instance(&subj1, "generate", 10).await);
-        assert!(server.associate_instance(&subj2, "generate", 10).await);
-        assert!(server.associate_instance(&subj3, "generate", 20).await);
+        assert!(server.associate_instance(&subj1, &id10).await);
+        assert!(server.associate_instance(&subj2, &id10).await);
+        assert!(server.associate_instance(&subj3, &id20).await);
 
         // Cancel instance 10 -- should cancel 2 subjects
-        let cancelled = server.cancel_instance_streams("generate", 10).await;
+        let cancelled = server.cancel_instance_streams(&id10).await;
         assert_eq!(cancelled, 2);
 
         assert!(prov1.await.is_err());
         assert!(prov2.await.is_err());
 
         // Instance 20 should be unaffected -- cancel it separately
-        let cancelled = server.cancel_instance_streams("generate", 20).await;
+        let cancelled = server.cancel_instance_streams(&id20).await;
         assert_eq!(cancelled, 1);
         assert!(prov3.await.is_err());
     }
@@ -1023,8 +1039,8 @@ mod tests {
     async fn test_cancel_instance_streams_nonexistent_instance() {
         let server = test_server().await;
 
-        // Cancelling a nonexistent instance should return 0 and not panic
-        let cancelled = server.cancel_instance_streams("generate", 999).await;
+        let id = make_eid("ns", "comp", "generate", 999);
+        let cancelled = server.cancel_instance_streams(&id).await;
         assert_eq!(cancelled, 0);
     }
 
@@ -1033,13 +1049,14 @@ mod tests {
         let server = test_server().await;
 
         let (subject, _provider) = register_and_get_subject(&server).await;
-        assert!(server.associate_instance(&subject, "generate", 42).await);
+        let id = make_eid("ns", "comp", "generate", 42);
+        assert!(server.associate_instance(&subject, &id).await);
 
         // Cancel the individual subject
         server.cancel_recv_stream(&subject).await;
 
         // Instance should have no remaining subjects
-        let cancelled = server.cancel_instance_streams("generate", 42).await;
+        let cancelled = server.cancel_instance_streams(&id).await;
         assert_eq!(
             cancelled, 0,
             "Instance tracking should have been cleaned up"
@@ -1129,13 +1146,15 @@ mod tests {
         // Simulates the race: cancel_instance_streams fires before associate_instance.
         let server = test_server().await;
 
-        // Cancel instance 42 for endpoint "generate" BEFORE any subject is registered (tombstone).
-        let cancelled = server.cancel_instance_streams("generate", 42).await;
+        let id = make_eid("ns", "comp", "generate", 42);
+
+        // Cancel BEFORE any subject is registered (tombstone).
+        let cancelled = server.cancel_instance_streams(&id).await;
         assert_eq!(cancelled, 0);
 
         // Now register a subject and try to associate it with the tombstoned instance.
         let (subject, provider) = register_and_get_subject(&server).await;
-        let associated = server.associate_instance(&subject, "generate", 42).await;
+        let associated = server.associate_instance(&subject, &id).await;
 
         // associate_instance should return false when the instance is tombstoned.
         assert!(
@@ -1156,18 +1175,17 @@ mod tests {
     async fn test_clear_tombstone_allows_new_associations() {
         let server = test_server().await;
 
-        // Tombstone instance 42 for endpoint "generate".
-        server.cancel_instance_streams("generate", 42).await;
+        let id = make_eid("ns", "comp", "generate", 42);
 
-        // Clear the tombstone (simulates instance coming back in discovery).
-        server.clear_instance_tombstone("generate", 42).await;
+        server.cancel_instance_streams(&id).await;
+        server.clear_instance_tombstone(&id).await;
 
         // Now associate should work normally (subject NOT cancelled).
         let (subject, _provider) = register_and_get_subject(&server).await;
-        assert!(server.associate_instance(&subject, "generate", 42).await);
+        assert!(server.associate_instance(&subject, &id).await);
 
         // Subject should be tracked, not cancelled.
-        let cancelled = server.cancel_instance_streams("generate", 42).await;
+        let cancelled = server.cancel_instance_streams(&id).await;
         assert_eq!(
             cancelled, 1,
             "After clearing tombstone, subjects should be tracked normally"
@@ -1176,31 +1194,29 @@ mod tests {
 
     #[tokio::test]
     async fn test_cancel_does_not_affect_sibling_endpoint() {
-        // Bug 1 regression test: cancelling "generate" must not cancel "prefill"
-        // subjects that share the same instance_id (same backend runtime).
+        // Regression: cancelling "generate" must not cancel "prefill" subjects
+        // that share the same instance_id (same backend runtime).
         let server = test_server().await;
 
         let (gen_subj, gen_prov) = register_and_get_subject(&server).await;
         let (pre_subj, pre_prov) = register_and_get_subject(&server).await;
 
-        // Same instance_id 42, but different endpoints.
-        assert!(server.associate_instance(&gen_subj, "generate", 42).await);
-        assert!(server.associate_instance(&pre_subj, "prefill", 42).await);
+        let gen_id = make_eid("ns", "comp", "generate", 42);
+        let pre_id = make_eid("ns", "comp", "prefill", 42);
+
+        assert!(server.associate_instance(&gen_subj, &gen_id).await);
+        assert!(server.associate_instance(&pre_subj, &pre_id).await);
 
         // Cancel only the "generate" endpoint's subjects.
-        let cancelled = server.cancel_instance_streams("generate", 42).await;
+        let cancelled = server.cancel_instance_streams(&gen_id).await;
         assert_eq!(
             cancelled, 1,
             "Only the generate subject should be cancelled"
         );
-
-        // generate provider must be cancelled.
         assert!(gen_prov.await.is_err());
 
-        // prefill provider must still be pending (not cancelled).
-        // We verify by doing a try-style check -- the oneshot should not be resolved yet.
-        // We just check it can still be cancelled by its own endpoint.
-        let still_pending = server.cancel_instance_streams("prefill", 42).await;
+        // prefill must still be tracked.
+        let still_pending = server.cancel_instance_streams(&pre_id).await;
         assert_eq!(still_pending, 1, "prefill subject should still be tracked");
         assert!(pre_prov.await.is_err());
     }
@@ -1211,13 +1227,15 @@ mod tests {
         // for the same instance_id.
         let server = test_server().await;
 
-        // Tombstone "generate" for instance 42.
-        server.cancel_instance_streams("generate", 42).await;
+        let gen_id = make_eid("ns", "comp", "generate", 42);
+        let pre_id = make_eid("ns", "comp", "prefill", 42);
+
+        server.cancel_instance_streams(&gen_id).await;
 
         // A new subject for "generate" should be rejected.
         let (gen_subj, gen_prov) = register_and_get_subject(&server).await;
         assert!(
-            !server.associate_instance(&gen_subj, "generate", 42).await,
+            !server.associate_instance(&gen_subj, &gen_id).await,
             "generate should be tombstoned"
         );
         assert!(gen_prov.await.is_err());
@@ -1225,10 +1243,64 @@ mod tests {
         // A new subject for "prefill" with the same instance_id should be accepted.
         let (pre_subj, _pre_prov) = register_and_get_subject(&server).await;
         assert!(
-            server.associate_instance(&pre_subj, "prefill", 42).await,
+            server.associate_instance(&pre_subj, &pre_id).await,
             "prefill tombstone is independent; subject should be tracked"
         );
-        let count = server.cancel_instance_streams("prefill", 42).await;
+        let count = server.cancel_instance_streams(&pre_id).await;
         assert_eq!(count, 1, "prefill subject should be tracked normally");
+    }
+
+    #[tokio::test]
+    async fn test_cancel_does_not_affect_different_component() {
+        // Regression: two services with different (namespace, component) but the
+        // same endpoint name and the same pod-backed instance_id must not interfere,
+        // even though they share a single TcpStreamServer runtime.
+        let server = test_server().await;
+
+        let (subj_a, prov_a) = register_and_get_subject(&server).await;
+        let (subj_b, prov_b) = register_and_get_subject(&server).await;
+
+        // Same endpoint name + instance_id, different namespace/component.
+        let id_a = make_eid("ns-a", "comp-a", "generate", 42);
+        let id_b = make_eid("ns-b", "comp-b", "generate", 42);
+
+        assert!(server.associate_instance(&subj_a, &id_a).await);
+        assert!(server.associate_instance(&subj_b, &id_b).await);
+
+        // Cancel service A -- only subj_a should be affected.
+        let cancelled = server.cancel_instance_streams(&id_a).await;
+        assert_eq!(cancelled, 1, "Only service-A subject should be cancelled");
+        assert!(prov_a.await.is_err());
+
+        // Service B subject must still be pending.
+        let still_tracked = server.cancel_instance_streams(&id_b).await;
+        assert_eq!(still_tracked, 1, "Service-B subject should be unaffected");
+        assert!(prov_b.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_tombstone_scoped_to_full_identity() {
+        // A tombstone on (ns-a, comp-a, generate, 42) must not block
+        // associations on (ns-b, comp-b, generate, 42).
+        let server = test_server().await;
+
+        let id_a = make_eid("ns-a", "comp-a", "generate", 42);
+        let id_b = make_eid("ns-b", "comp-b", "generate", 42);
+
+        // Tombstone only service A.
+        server.cancel_instance_streams(&id_a).await;
+
+        // Service A is tombstoned — new association is rejected.
+        let (subj_a, prov_a) = register_and_get_subject(&server).await;
+        assert!(!server.associate_instance(&subj_a, &id_a).await);
+        assert!(prov_a.await.is_err());
+
+        // Service B with same endpoint name + instance_id must be accepted.
+        let (subj_b, _prov_b) = register_and_get_subject(&server).await;
+        assert!(
+            server.associate_instance(&subj_b, &id_b).await,
+            "Different namespace/component must not be tombstoned"
+        );
+        assert_eq!(server.cancel_instance_streams(&id_b).await, 1);
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -8,8 +8,25 @@ use std::{
     net::{IpAddr, SocketAddr, TcpListener},
     os::fd::{AsFd, FromRawFd},
     sync::Arc,
+    time::Duration,
 };
 use tokio::sync::Mutex;
+use tokio::time::Instant;
+
+/// Time-to-live for instance tombstones.
+///
+/// The tombstone only needs to bridge the in-flight `register()` →
+/// `associate_instance()` window for a single request -- sub-millisecond in
+/// practice. 5 seconds is several orders of magnitude longer than the race
+/// window we actually protect, and short enough that even if a watcher misses
+/// an `Added` event for a same-identity re-registration (rare under monotonic
+/// etcd lease IDs, but possible across discovery restarts), valid requests
+/// aren't rejected for long. Bounding by recent activity keeps the set sized
+/// by (recent worker churn × TTL), not process lifetime, fixing the unbounded
+/// memory growth that would otherwise occur because `instance_id` is the etcd
+/// lease ID and a restarted pod always presents a *new* identity that the
+/// `Added`-event clear path cannot match against the *old* tombstone.
+const TOMBSTONE_TTL: Duration = Duration::from_secs(5);
 
 use bytes::Bytes;
 use derive_builder::Builder;
@@ -133,12 +150,23 @@ struct State {
     /// Maps EndpointInstanceId -> set of subject UUIDs for batch cancellation
     /// when the discovery plane reports the instance is gone.
     instance_subjects: HashMap<EndpointInstanceId, HashSet<String>>,
-    /// Tombstone set keyed by full EndpointInstanceId.  Closes the race window
-    /// where `cancel_instance_streams()` fires before `associate_instance()`
-    /// for the same request.  Cleared by `clear_instance_tombstone()` when the
-    /// instance reappears in the discovery set.
-    removed_instances: HashSet<EndpointInstanceId>,
+    /// Tombstone map keyed by full EndpointInstanceId, with insertion time as
+    /// the value.  Closes the race window where `cancel_instance_streams()`
+    /// fires before `associate_instance()` for the same request.  Entries
+    /// expire after [`TOMBSTONE_TTL`]; `clear_instance_tombstone()` is also
+    /// available for explicit removal when the instance reappears in
+    /// discovery (defensive: with monotonic etcd lease IDs the new identity
+    /// usually differs from the tombstoned one).
+    removed_instances: HashMap<EndpointInstanceId, Instant>,
     handle: Option<tokio::task::JoinHandle<Result<()>>>,
+}
+
+/// Drop tombstone entries older than [`TOMBSTONE_TTL`] from `tombstones`.
+///
+/// Called lazily on every `associate_instance` and `cancel_instance_streams`
+/// so the set is bounded by recent activity rather than process lifetime.
+fn prune_tombstones(tombstones: &mut HashMap<EndpointInstanceId, Instant>, now: Instant) {
+    tombstones.retain(|_, ts| now.saturating_duration_since(*ts) < TOMBSTONE_TTL);
 }
 
 impl TcpStreamServer {
@@ -233,7 +261,9 @@ impl TcpStreamServer {
     /// instance_id cannot cancel each other's streams.
     pub async fn associate_instance(&self, subject: &str, id: &EndpointInstanceId) -> bool {
         let mut state = self.state.lock().await;
-        if state.removed_instances.contains(id) {
+        let now = Instant::now();
+        prune_tombstones(&mut state.removed_instances, now);
+        if state.removed_instances.contains_key(id) {
             // Instance was already removed -- cancel immediately.
             tracing::warn!(
                 subject,
@@ -294,8 +324,10 @@ impl TcpStreamServer {
     /// Returns the number of streams cancelled.
     pub async fn cancel_instance_streams(&self, id: &EndpointInstanceId) -> usize {
         let mut state = self.state.lock().await;
+        let now = Instant::now();
+        prune_tombstones(&mut state.removed_instances, now);
         // Tombstone the identity so late associate_instance() calls cancel immediately.
-        state.removed_instances.insert(id.clone());
+        state.removed_instances.insert(id.clone(), now);
         let subjects = match state.instance_subjects.remove(id) {
             Some(subjects) => subjects,
             None => return 0,
@@ -1276,6 +1308,110 @@ mod tests {
         let still_tracked = server.cancel_instance_streams(&id_b).await;
         assert_eq!(still_tracked, 1, "Service-B subject should be unaffected");
         assert!(prov_b.await.is_err());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_tombstone_expires_after_ttl() {
+        // After TOMBSTONE_TTL elapses, a previously-tombstoned identity must
+        // accept new associations again, AND the entry must be physically
+        // pruned from `removed_instances` so the set remains bounded.
+        let server = test_server().await;
+
+        let id = make_eid("ns", "comp", "generate", 42);
+
+        // Tombstone the identity.
+        server.cancel_instance_streams(&id).await;
+        {
+            let state = server.state.lock().await;
+            assert!(state.removed_instances.contains_key(&id));
+        }
+
+        // Advance past the TTL.
+        tokio::time::advance(TOMBSTONE_TTL + Duration::from_secs(1)).await;
+
+        // associate_instance for the same identity should now succeed (no
+        // longer tombstoned). Any new subject must be tracked normally.
+        let (subject, _provider) = register_and_get_subject(&server).await;
+        assert!(
+            server.associate_instance(&subject, &id).await,
+            "tombstone older than TTL should not block association"
+        );
+
+        // The expired tombstone must have been pruned (lazy pruning fires on
+        // every associate_instance/cancel_instance_streams call).
+        {
+            let state = server.state.lock().await;
+            assert!(
+                !state.removed_instances.contains_key(&id),
+                "expired tombstone should be pruned, not retained"
+            );
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_tombstone_within_ttl_blocks_associate() {
+        // Regression net for the original tombstone fix: a tombstone younger
+        // than TTL must still cancel late-arriving associate_instance() calls.
+        let server = test_server().await;
+
+        let id = make_eid("ns", "comp", "generate", 42);
+        server.cancel_instance_streams(&id).await;
+
+        // Advance only a small fraction of the TTL.
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        let (subject, provider) = register_and_get_subject(&server).await;
+        assert!(
+            !server.associate_instance(&subject, &id).await,
+            "tombstone within TTL must still block association"
+        );
+        assert!(provider.await.is_err());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_tombstone_lazy_prune_on_cancel() {
+        // Old tombstones must be pruned on the next cancel_instance_streams
+        // call, regardless of which identity is being tombstoned.
+        let server = test_server().await;
+
+        let id_old = make_eid("ns", "comp", "generate", 1);
+        let id_new = make_eid("ns", "comp", "generate", 2);
+
+        server.cancel_instance_streams(&id_old).await;
+        tokio::time::advance(TOMBSTONE_TTL + Duration::from_secs(1)).await;
+        server.cancel_instance_streams(&id_new).await;
+
+        let state = server.state.lock().await;
+        assert!(
+            !state.removed_instances.contains_key(&id_old),
+            "old tombstone should be pruned by the next cancel_instance_streams call"
+        );
+        assert!(
+            state.removed_instances.contains_key(&id_new),
+            "fresh tombstone should be retained"
+        );
+        assert_eq!(state.removed_instances.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_clear_tombstone_only_affects_named_identity() {
+        // Documents the monotonic-lease invariant: `clear_instance_tombstone`
+        // for one EndpointInstanceId must not touch a sibling entry. With etcd
+        // lease IDs this defensive code rarely fires (new lease = new
+        // EndpointInstanceId), but the per-key scope must hold.
+        let server = test_server().await;
+
+        let id_a = make_eid("ns", "comp", "generate", 1);
+        let id_b = make_eid("ns", "comp", "generate", 2);
+
+        server.cancel_instance_streams(&id_a).await;
+        server.clear_instance_tombstone(&id_b).await;
+
+        let state = server.state.lock().await;
+        assert!(
+            state.removed_instances.contains_key(&id_a),
+            "clearing a different identity must not remove id_a's tombstone"
+        );
     }
 
     #[tokio::test]

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -258,12 +258,12 @@ impl TcpStreamServer {
     pub async fn cancel_recv_stream(&self, subject: &str) {
         let mut state = self.state.lock().await;
         state.rx_subjects.remove(subject);
-        if let Some(key) = state.subject_instance.remove(subject) {
-            if let Some(subjects) = state.instance_subjects.get_mut(&key) {
-                subjects.remove(subject);
-                if subjects.is_empty() {
-                    state.instance_subjects.remove(&key);
-                }
+        if let Some(key) = state.subject_instance.remove(subject)
+            && let Some(subjects) = state.instance_subjects.get_mut(&key)
+        {
+            subjects.remove(subject);
+            if subjects.is_empty() {
+                state.instance_subjects.remove(&key);
             }
         }
     }
@@ -412,12 +412,12 @@ impl ResponseService for TcpStreamServer {
                 tokio::spawn(async move {
                     let mut state = cleanup_state.lock().await;
                     state.rx_subjects.remove(&cleanup_subject);
-                    if let Some(key) = state.subject_instance.remove(&cleanup_subject) {
-                        if let Some(subjects) = state.instance_subjects.get_mut(&key) {
-                            subjects.remove(&cleanup_subject);
-                            if subjects.is_empty() {
-                                state.instance_subjects.remove(&key);
-                            }
+                    if let Some(key) = state.subject_instance.remove(&cleanup_subject)
+                        && let Some(subjects) = state.instance_subjects.get_mut(&key)
+                    {
+                        subjects.remove(&cleanup_subject);
+                        if subjects.is_empty() {
+                            state.instance_subjects.remove(&key);
                         }
                     }
                 });
@@ -572,12 +572,12 @@ async fn tcp_listener(
                 .rx_subjects
                 .remove(&subject)
                 .ok_or(error!("Subject not found: {}; upstream publisher specified a subject unknown to the downsteam subscriber", subject))?;
-            if let Some(key) = guard.subject_instance.remove(&subject) {
-                if let Some(subjects) = guard.instance_subjects.get_mut(&key) {
-                    subjects.remove(&subject);
-                    if subjects.is_empty() {
-                        guard.instance_subjects.remove(&key);
-                    }
+            if let Some(key) = guard.subject_instance.remove(&subject)
+                && let Some(subjects) = guard.instance_subjects.get_mut(&key)
+            {
+                subjects.remove(&subject);
+                if subjects.is_empty() {
+                    guard.instance_subjects.remove(&key);
                 }
             }
             conn

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -13,19 +13,10 @@ use std::{
 use tokio::sync::Mutex;
 use tokio::time::Instant;
 
-/// Time-to-live for instance tombstones.
-///
-/// The tombstone only needs to bridge the in-flight `register()` →
-/// `associate_instance()` window for a single request -- sub-millisecond in
-/// practice. 5 seconds is several orders of magnitude longer than the race
-/// window we actually protect, and short enough that even if a watcher misses
-/// an `Added` event for a same-identity re-registration (rare under monotonic
-/// etcd lease IDs, but possible across discovery restarts), valid requests
-/// aren't rejected for long. Bounding by recent activity keeps the set sized
-/// by (recent worker churn × TTL), not process lifetime, fixing the unbounded
-/// memory growth that would otherwise occur because `instance_id` is the etcd
-/// lease ID and a restarted pod always presents a *new* identity that the
-/// `Added`-event clear path cannot match against the *old* tombstone.
+/// Tombstone lifetime. Bridges the `register()` → `associate_instance()`
+/// window (sub-millisecond in practice); 5s bounds the set by recent worker
+/// churn rather than process lifetime, since etcd lease IDs are unique per
+/// restart and never get cleared by an `Added` event for the same identity.
 const TOMBSTONE_TTL: Duration = Duration::from_secs(5);
 
 use bytes::Bytes;
@@ -140,31 +131,20 @@ struct RequestedRecvConnection {
 struct State {
     tx_subjects: HashMap<String, RequestedSendConnection>,
     rx_subjects: HashMap<String, RequestedRecvConnection>,
-    /// Maps subject UUID -> full EndpointInstanceId for reverse lookup during
-    /// cleanup.  The full 4-field key (namespace, component, endpoint,
-    /// instance_id) ensures two services from different namespaces/components
-    /// that share an endpoint name and pod-backed instance_id cannot cancel or
-    /// tombstone each other's streams, even though the TcpStreamServer is
-    /// shared per runtime.
+    /// subject UUID -> EndpointInstanceId. Full 4-field key isolates services
+    /// that share an endpoint name across namespaces/components.
     subject_instance: HashMap<String, EndpointInstanceId>,
-    /// Maps EndpointInstanceId -> set of subject UUIDs for batch cancellation
-    /// when the discovery plane reports the instance is gone.
+    /// EndpointInstanceId -> subject UUIDs, for batch cancellation on removal.
     instance_subjects: HashMap<EndpointInstanceId, HashSet<String>>,
-    /// Tombstone map keyed by full EndpointInstanceId, with insertion time as
-    /// the value.  Closes the race window where `cancel_instance_streams()`
-    /// fires before `associate_instance()` for the same request.  Entries
-    /// expire after [`TOMBSTONE_TTL`]; `clear_instance_tombstone()` is also
-    /// available for explicit removal when the instance reappears in
-    /// discovery (defensive: with monotonic etcd lease IDs the new identity
-    /// usually differs from the tombstoned one).
+    /// Tombstones (instance -> insertion time) close the
+    /// `cancel_instance_streams` vs `associate_instance` race; entries expire
+    /// after [`TOMBSTONE_TTL`].
     removed_instances: HashMap<EndpointInstanceId, Instant>,
     handle: Option<tokio::task::JoinHandle<Result<()>>>,
 }
 
-/// Drop tombstone entries older than [`TOMBSTONE_TTL`] from `tombstones`.
-///
-/// Called lazily on every `associate_instance` and `cancel_instance_streams`
-/// so the set is bounded by recent activity rather than process lifetime.
+/// Drop tombstones older than [`TOMBSTONE_TTL`]. Called lazily on every
+/// `associate_instance` / `cancel_instance_streams` to bound the set size.
 fn prune_tombstones(tombstones: &mut HashMap<EndpointInstanceId, Instant>, now: Instant) {
     tombstones.retain(|_, ts| now.saturating_duration_since(*ts) < TOMBSTONE_TTL);
 }
@@ -240,25 +220,11 @@ impl TcpStreamServer {
         }))
     }
 
-    /// Associate a registered response-stream subject with a backend instance.
+    /// Associate a registered subject with a backend instance.
     ///
-    /// Called by the egress router after `register()` so that when the discovery
-    /// plane reports the instance as removed, we can cancel all pending subjects
-    /// for that instance in one shot.
-    ///
-    /// If the instance has already been removed (tombstoned by a prior
-    /// `cancel_instance_streams` call), the subject is immediately cancelled
-    /// instead of being tracked. This closes the race window where the
-    /// discovery watcher fires before the request path calls this method.
-    /// Returns `true` if the subject was tracked normally, `false` if the
-    /// instance was tombstoned and the subject was immediately cancelled.
-    /// When `false` is returned the caller should skip `send_request` and
-    /// return a migratable `Disconnected` error directly.
-    ///
-    /// The full `EndpointInstanceId` (namespace + component + endpoint +
-    /// instance_id) scopes the key precisely, so two services from different
-    /// namespaces or components that share an endpoint name and pod-backed
-    /// instance_id cannot cancel each other's streams.
+    /// Returns `false` if the instance is already tombstoned, in which case
+    /// the subject is cancelled immediately and the caller should skip
+    /// `send_request` and fail with a migratable `Disconnected` error.
     pub async fn associate_instance(&self, subject: &str, id: &EndpointInstanceId) -> bool {
         let mut state = self.state.lock().await;
         let now = Instant::now();
@@ -287,11 +253,8 @@ impl TcpStreamServer {
         true
     }
 
-    /// Cancel a single pending response-stream registration.
-    ///
-    /// Removes the subject from `rx_subjects` (dropping the `oneshot::Sender`,
-    /// which causes the waiting `oneshot::Receiver` to resolve with
-    /// `RecvError`) and cleans up the instance-tracking maps.
+    /// Cancel one pending response-stream registration. Drops the
+    /// `oneshot::Sender` so the waiting receiver resolves with `RecvError`.
     pub async fn cancel_recv_stream(&self, subject: &str) {
         let mut state = self.state.lock().await;
         state.rx_subjects.remove(subject);
@@ -305,28 +268,13 @@ impl TcpStreamServer {
         }
     }
 
-    /// Cancel **all** pending response-stream registrations for a given instance.
-    ///
-    /// Called when the discovery plane reports the instance as removed (etcd lease
-    /// expired or explicit unregister). Dropping each `oneshot::Sender` causes
-    /// the corresponding `oneshot::Receiver.await` in `AddressedPushRouter::generate()`
-    /// to resolve with `RecvError`, which is converted to a migratable
-    /// `DynamoError(Disconnected)` so the migration layer can retry on another worker.
-    ///
-    /// The instance is also tombstoned so that any concurrent
-    /// `associate_instance()` call for the same instance (race with the
-    /// request path) will immediately cancel the late-arriving subject.
-    ///
-    /// The full `EndpointInstanceId` tombstone key ensures sibling
-    /// endpoints from the same or different namespace/component pairs are
-    /// never accidentally affected.
-    ///
+    /// Cancel all pending response streams for an instance and tombstone it
+    /// so any racing `associate_instance()` for the same id cancels too.
     /// Returns the number of streams cancelled.
     pub async fn cancel_instance_streams(&self, id: &EndpointInstanceId) -> usize {
         let mut state = self.state.lock().await;
         let now = Instant::now();
         prune_tombstones(&mut state.removed_instances, now);
-        // Tombstone the identity so late associate_instance() calls cancel immediately.
         state.removed_instances.insert(id.clone(), now);
         let subjects = match state.instance_subjects.remove(id) {
             Some(subjects) => subjects,
@@ -340,12 +288,8 @@ impl TcpStreamServer {
         count
     }
 
-    /// Remove an `EndpointInstanceId` from the tombstone set.
-    ///
-    /// Called by the discovery watcher when an instance reappears in the
-    /// discovery set (re-registered after restart). Without this, the
-    /// tombstone would cause every future subject for that identity to be
-    /// immediately cancelled even though the instance is alive again.
+    /// Drop the tombstone for an instance that has reappeared in discovery,
+    /// so future subjects for that identity are tracked normally.
     pub async fn clear_instance_tombstone(&self, id: &EndpointInstanceId) {
         let mut state = self.state.lock().await;
         state.removed_instances.remove(id);
@@ -425,8 +369,7 @@ impl ResponseService for TcpStreamServer {
                 pending_sender_rx,
             )
             .with_cleanup(move || {
-                // Synchronous removal -- fire-and-forget via a spawned task
-                // because Drop cannot be async.
+                // Drop is sync; fire-and-forget the lock acquisition.
                 tokio::spawn(async move {
                     let mut state = cleanup_state.lock().await;
                     state.tx_subjects.remove(&cleanup_subject);
@@ -465,8 +408,7 @@ impl ResponseService for TcpStreamServer {
                 pending_recver_rx,
             )
             .with_cleanup(move || {
-                // Synchronous removal -- fire-and-forget via a spawned task
-                // because Drop cannot be async.
+                // Drop is sync; fire-and-forget the lock acquisition.
                 tokio::spawn(async move {
                     let mut state = cleanup_state.lock().await;
                     state.rx_subjects.remove(&cleanup_subject);
@@ -630,7 +572,6 @@ async fn tcp_listener(
                 .rx_subjects
                 .remove(&subject)
                 .ok_or(error!("Subject not found: {}; upstream publisher specified a subject unknown to the downsteam subscriber", subject))?;
-            // Clean up instance-tracking maps on the normal (worker-connected) path.
             if let Some(key) = guard.subject_instance.remove(&subject) {
                 if let Some(subjects) = guard.instance_subjects.get_mut(&key) {
                     subjects.remove(&subject);

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -265,12 +265,12 @@ impl TcpStreamServer {
     pub async fn cancel_recv_stream(&self, subject: &str) {
         let mut state = self.state.lock().await;
         state.rx_subjects.remove(subject);
-        if let Some(key) = state.subject_instance.remove(subject) {
-            if let Some(subjects) = state.instance_subjects.get_mut(&key) {
-                subjects.remove(subject);
-                if subjects.is_empty() {
-                    state.instance_subjects.remove(&key);
-                }
+        if let Some(key) = state.subject_instance.remove(subject)
+            && let Some(subjects) = state.instance_subjects.get_mut(&key)
+        {
+            subjects.remove(subject);
+            if subjects.is_empty() {
+                state.instance_subjects.remove(&key);
             }
         }
     }
@@ -438,12 +438,12 @@ impl ResponseService for TcpStreamServer {
                 tokio::spawn(async move {
                     let mut state = cleanup_state.lock().await;
                     state.rx_subjects.remove(&cleanup_subject);
-                    if let Some(key) = state.subject_instance.remove(&cleanup_subject) {
-                        if let Some(subjects) = state.instance_subjects.get_mut(&key) {
-                            subjects.remove(&cleanup_subject);
-                            if subjects.is_empty() {
-                                state.instance_subjects.remove(&key);
-                            }
+                    if let Some(key) = state.subject_instance.remove(&cleanup_subject)
+                        && let Some(subjects) = state.instance_subjects.get_mut(&key)
+                    {
+                        subjects.remove(&cleanup_subject);
+                        if subjects.is_empty() {
+                            state.instance_subjects.remove(&key);
                         }
                     }
                 });
@@ -599,12 +599,12 @@ async fn tcp_listener(
                 .remove(&subject)
                 .ok_or(error!("Subject not found: {}; upstream publisher specified a subject unknown to the downsteam subscriber", subject))?;
             // Clean up instance-tracking maps on the normal (worker-connected) path.
-            if let Some(key) = guard.subject_instance.remove(&subject) {
-                if let Some(subjects) = guard.instance_subjects.get_mut(&key) {
-                    subjects.remove(&subject);
-                    if subjects.is_empty() {
-                        guard.instance_subjects.remove(&key);
-                    }
+            if let Some(key) = guard.subject_instance.remove(&subject)
+                && let Some(subjects) = guard.instance_subjects.get_mut(&key)
+            {
+                subjects.remove(&subject);
+                if subjects.is_empty() {
+                    guard.instance_subjects.remove(&key);
                 }
             }
             conn


### PR DESCRIPTION
#### Overview:

Fixes an indefinite hang where requests queued in a worker's bounded work channel (ACK'd on the request plane but not yet executing) became permanently stuck when that worker was killed. Rather than a fixed timeout (which falsely triggers on healthy backlogged workers and risks duplicate execution), the fix reacts to the discovery plane: when a worker is removed, all pending response-stream subjects for that instance are cancelled and returned as a migratable `Disconnected` error so the migration layer can retry on another worker.

```mermaid
sequenceDiagram
    participant F as Frontend
    participant R as AddressedPushRouter
    participant S as TcpStreamServer
    participant W as Worker
    participant D as Discovery (etcd)
    participant Watcher as InstanceRemovalWatcher

    F->>R: generate(request)
    R->>S: register(subject) → oneshot::Sender stored
    R->>S: associate_instance(subject, EndpointInstanceId)
    R->>W: send_request (NATS publish)
    Note over W: Worker killed before<br/>picking up request
    R->>S: response_stream.await (blocked)
    D-->>Watcher: DiscoveryEvent::Removed(EndpointInstanceId)
    Watcher->>S: cancel_instance_streams(EndpointInstanceId)
    S->>S: drop oneshot::Sender(s)
    S-->>R: RecvError → Disconnected
    R-->>F: DynamoError(Disconnected) → Migration retries
```

#### Details:

**`tcp/server.rs`** — `TcpStreamServer` state additions:
- Added `subject_instance` / `instance_subjects` bidirectional maps tracking which response-stream subjects belong to which backend instance (keyed by full `EndpointInstanceId`: namespace + component + endpoint + instance_id)
- `associate_instance()` returns `bool`; `false` means the instance was already tombstoned — caller skips `send_request()` entirely
- `cancel_instance_streams()` bulk-drops all `oneshot::Sender`s for a removed instance, unblocking waiting receivers with `RecvError → Disconnected`
- `removed_instances` tombstone set closes the race where removal fires before association; `clear_instance_tombstone()` resets it on re-add
- RAII cleanup on `RegisteredStream` (via `cleanup_on_drop` closure) removes the subject from `rx_subjects` on drop, preventing leaks on early-return paths

**`egress/push_router.rs`** — `PushRouter`:
- `spawn_instance_removal_watcher()`: background task subscribing to the raw `list_and_watch` discovery stream (not coalesced snapshots) and calling `cancel_instance_streams()` per `DiscoveryEvent::Removed`
- `ENDPOINT_WATCHER_ACTIVE` static `DashMap` guard ensures exactly one `list_and_watch` connection per endpoint regardless of how many `PushRouter` instances share it
- Watcher reconnects automatically if the discovery stream ends unexpectedly (transient discovery-plane restart); connect failures also retry with a 5 s cancellation-aware delay
- Spawned in both `from_client()` and `from_client_no_fault_detection()` so KV-routed and worker-query paths are both protected

**`egress/addressed_router.rs`** — `AddressedPushRouter`:
- Calls `associate_instance()` after `register()`; on tombstone (`false`), returns `Disconnected` immediately without calling `send_request()`
- Passes full `EndpointInstanceId` (via `inst.endpoint_instance_id()`) so cancellation is scoped to exactly one service identity — prevents cross-namespace/cross-component cancellation when services share an endpoint name and instance_id

**`component.rs`**:
- Added `Instance::endpoint_instance_id()` helper constructing `EndpointInstanceId` from the instance's four identity fields

#### Where should the reviewer start?

1. **`lib/runtime/src/pipeline/network/tcp/server.rs`** — Core state machine: `associate_instance()`, `cancel_instance_streams()`, tombstone logic, and RAII cleanup. Largest change and heart of the fix.
2. **`lib/runtime/src/pipeline/network/egress/push_router.rs`** — `spawn_instance_removal_watcher()`: how the discovery-plane removal event is consumed, deduplicated, and wired to cancellation; reconnection logic.
3. **`lib/runtime/src/pipeline/network/egress/addressed_router.rs`** — `generate()`: tombstone early-exit and `DetachedStreamReceiver → Disconnected` conversion.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes DIS-1783
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
