### PR TITLE
feat(multimodal): set vLLM enable mm embeds when dynamo enable multimodal is set

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -234,6 +234,16 @@ def update_engine_config_with_dynamo(
     if _uses_nixl_connector(engine_config):
         ensure_side_channel_host()
 
+    # Disagg requires enable_mm_embeds set for Qwen multi-modal models
+    # to receive pre-computed image_embeds.
+    if dynamo_config.enable_multimodal:
+        if hasattr(engine_config, "enable_mm_embeds"):
+            engine_config.enable_mm_embeds = True
+            logger.debug(
+                "--enable-multimodal is set: auto-enabling vLLM "
+                "enable_mm_embeds for multimodal embedding support"
+            )
+
     defaults = {
         # vLLM 0.13+ renamed 'task' to 'runner'
         "runner": "generate",


### PR DESCRIPTION
#### Overview:

When `--enable-multimodal` is set, automatically enable vLLM's enable_mm_embeds engine config option. For Qwen VL in disagg mode, the decode worker receives pre-computed image_embeds from prefill (e.g. via construct_qwen_decode_mm_data), which vLLM rejects unless enable_mm_embeds is True. Also follows vllm multimodal [doc](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-vllm.md) which mentions the two flags are analgous

#### Details:

Check to see if enable multi modal flag is present and override vLLM config with enable mm embeds true

#### Where should the reviewer start?

components/src/dynamo/vllm/args.py
