### PR TITLE
fix(planner): don't block agg decode scaling when max_num_batched_tokens is missing

### DIFF
--- a/components/src/dynamo/planner/core/load_scaling.py
+++ b/components/src/dynamo/planner/core/load_scaling.py
@@ -259,6 +259,9 @@ class LoadScalingMixin:
             desired = p_desired
         elif d_desired is not None and d_desired > num_workers:
             desired = d_desired
+        elif p_desired is None and d_desired is not None and d_desired < num_workers:
+            # Prefill signal unavailable: allow decode-only scale-down.
+            desired = d_desired
         elif (
             p_desired is not None
             and p_desired < num_workers

--- a/components/src/dynamo/planner/core/load_scaling.py
+++ b/components/src/dynamo/planner/core/load_scaling.py
@@ -243,11 +243,12 @@ class LoadScalingMixin:
         d_caps = self._capabilities.decode
         max_tokens = d_caps.max_num_batched_tokens if d_caps else None
         if not max_tokens or max_tokens <= 0:
-            logger.warning("max_num_batched_tokens not available, skipping agg scaling")
-            self._diag_load_reason = "insufficient_data"
-            return None
-
-        p_desired = self._agg_prefill_scaling(fpm_stats, num_workers, max_tokens)
+            logger.warning(
+                "max_num_batched_tokens not available, skipping agg prefill scaling"
+            )
+            p_desired = None
+        else:
+            p_desired = self._agg_prefill_scaling(fpm_stats, num_workers, max_tokens)
         d_desired = self._agg_decode_scaling(fpm_stats, num_workers)
 
         logger.info(


### PR DESCRIPTION
## Summary
- In `_advance_load_agg()`, a missing `max_num_batched_tokens` caused an early return that blocked **both** prefill and decode agg scaling.
- Decode scaling uses ITL regression and does not need `max_num_batched_tokens`, so only prefill scaling should be skipped when the value is unavailable.
- This can happen when a backend (e.g. sglang without explicit `max_prefill_tokens`) does not register the parameter in its MDC.

## Test plan
- [x] All 227 planner unit tests pass
- [ ] Verify agg decode scaling proceeds when `max_num_batched_tokens` is missing in MDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved resilience in load scaling calculations by allowing the system to compute available scaling metrics when token capacity information is missing or invalid, rather than halting early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->