### PR TITLE
fix(container): align sglang nixl_ref with PyPI nixl-cu12 1.0.x

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -85,7 +85,7 @@ sglang:
     runtime_image: lmsysorg/sglang
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
     runtime_image_tag: v0.5.10.post1-cu130-runtime
-  nixl_ref: v1.0.0
+  nixl_ref: v1.0.1
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"
   enable_kvbm: "false"

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -85,7 +85,7 @@ sglang:
     runtime_image: lmsysorg/sglang
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
     runtime_image_tag: v0.5.10.post1-cu130-runtime
-  nixl_ref: 0.10.0
+  nixl_ref: v1.0.0
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"
   enable_kvbm: "false"

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -157,6 +157,20 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
         libuuid-devel \
         zlib-devel
 
+# Build hwloc from source — nixl v1.0.x requires it via src/utils/libfabric/meson.build,
+# and the RHEL8 system package is too old (needs >= 2.3).
+ARG HWLOC_VERSION=2.12.0
+RUN HWLOC_SERIES="$(echo "${HWLOC_VERSION}" | cut -d. -f1-2)" && \
+    cd /tmp && \
+    curl --retry 3 -LO "https://download.open-mpi.org/release/hwloc/v${HWLOC_SERIES}/hwloc-${HWLOC_VERSION}.tar.gz" && \
+    tar xf hwloc-${HWLOC_VERSION}.tar.gz && \
+    cd hwloc-${HWLOC_VERSION} && \
+    ./configure --prefix=/usr/local && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig && \
+    rm -rf /tmp/hwloc-*
+
 # Set GCC toolset 14 as the default compiler (CUDA requires GCC <= 14)
 ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH}" \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -152,24 +152,12 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
         librdmacm-devel \
         numactl-devel \
         # Libfabric support
+        hwloc \
+        hwloc-devel \
         libcurl-devel \
         openssl-devel \
         libuuid-devel \
         zlib-devel
-
-# Build hwloc from source — nixl v1.0.x requires it via src/utils/libfabric/meson.build,
-# and the RHEL8 system package is too old (needs >= 2.3).
-ARG HWLOC_VERSION=2.12.0
-RUN HWLOC_SERIES="$(echo "${HWLOC_VERSION}" | cut -d. -f1-2)" && \
-    cd /tmp && \
-    curl --retry 3 -LO "https://download.open-mpi.org/release/hwloc/v${HWLOC_SERIES}/hwloc-${HWLOC_VERSION}.tar.gz" && \
-    tar xf hwloc-${HWLOC_VERSION}.tar.gz && \
-    cd hwloc-${HWLOC_VERSION} && \
-    ./configure --prefix=/usr/local && \
-    make -j$(nproc) && \
-    make install && \
-    ldconfig && \
-    rm -rf /tmp/hwloc-*
 
 # Set GCC toolset 14 as the default compiler (CUDA requires GCC <= 14)
 ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}" \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -152,6 +152,8 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
         librdmacm-devel \
         numactl-devel \
         # Libfabric support
+        hwloc \
+        hwloc-devel \
         libcurl-devel \
         openssl-devel \
         libuuid-devel \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -152,8 +152,6 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
         librdmacm-devel \
         numactl-devel \
         # Libfabric support
-        hwloc \
-        hwloc-devel \
         libcurl-devel \
         openssl-devel \
         libuuid-devel \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -157,19 +157,6 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
         libuuid-devel \
         zlib-devel
 
-# Build hwloc from source (>= 2.3 required by nixl >= v1.0.0 for hwloc_location API)
-ARG HWLOC_VERSION=2.12.0
-RUN HWLOC_SERIES="$(echo "${HWLOC_VERSION}" | cut -d. -f1-2)" && \
-    cd /tmp && \
-    curl --retry 3 -LO "https://download.open-mpi.org/release/hwloc/v${HWLOC_SERIES}/hwloc-${HWLOC_VERSION}.tar.gz" && \
-    tar xf hwloc-${HWLOC_VERSION}.tar.gz && \
-    cd hwloc-${HWLOC_VERSION} && \
-    ./configure --prefix=/usr/local && \
-    make -j$(nproc) && \
-    make install && \
-    ldconfig && \
-    rm -rf /tmp/hwloc-*
-
 # Set GCC toolset 14 as the default compiler (CUDA requires GCC <= 14)
 ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH}" \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -152,12 +152,22 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
         librdmacm-devel \
         numactl-devel \
         # Libfabric support
-        hwloc \
-        hwloc-devel \
         libcurl-devel \
         openssl-devel \
         libuuid-devel \
         zlib-devel
+
+# Build hwloc from source (>= 2.3 required by nixl >= v1.0.0 for hwloc_location API)
+ARG HWLOC_VERSION=2.12.0
+RUN cd /tmp && \
+    curl --retry 3 -LO https://download.open-mpi.org/release/hwloc/v2.12/hwloc-${HWLOC_VERSION}.tar.gz && \
+    tar xf hwloc-${HWLOC_VERSION}.tar.gz && \
+    cd hwloc-${HWLOC_VERSION} && \
+    ./configure --prefix=/usr/local && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig && \
+    rm -rf /tmp/hwloc-*
 
 # Set GCC toolset 14 as the default compiler (CUDA requires GCC <= 14)
 ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}" \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -152,12 +152,24 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
         librdmacm-devel \
         numactl-devel \
         # Libfabric support
-        hwloc \
-        hwloc-devel \
         libcurl-devel \
         openssl-devel \
         libuuid-devel \
         zlib-devel
+
+# Build hwloc >= 2.3 from source (RHEL8 ships 2.2 which lacks hwloc_location API
+# required by nixl v1.0.x libfabric topology code)
+ARG HWLOC_VERSION=2.12.0
+RUN HWLOC_SERIES="$(echo "${HWLOC_VERSION}" | cut -d. -f1-2)" && \
+    cd /tmp && \
+    curl --retry 3 -LO "https://download.open-mpi.org/release/hwloc/v${HWLOC_SERIES}/hwloc-${HWLOC_VERSION}.tar.gz" && \
+    tar xf hwloc-${HWLOC_VERSION}.tar.gz && \
+    cd hwloc-${HWLOC_VERSION} && \
+    ./configure --prefix=/usr/local && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig && \
+    rm -rf /tmp/hwloc-*
 
 # Set GCC toolset 14 as the default compiler (CUDA requires GCC <= 14)
 ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}" \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -159,8 +159,9 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
 
 # Build hwloc from source (>= 2.3 required by nixl >= v1.0.0 for hwloc_location API)
 ARG HWLOC_VERSION=2.12.0
-RUN cd /tmp && \
-    curl --retry 3 -LO https://download.open-mpi.org/release/hwloc/v2.12/hwloc-${HWLOC_VERSION}.tar.gz && \
+RUN HWLOC_SERIES="$(echo "${HWLOC_VERSION}" | cut -d. -f1-2)" && \
+    cd /tmp && \
+    curl --retry 3 -LO "https://download.open-mpi.org/release/hwloc/v${HWLOC_SERIES}/hwloc-${HWLOC_VERSION}.tar.gz" && \
     tar xf hwloc-${HWLOC_VERSION}.tar.gz && \
     cd hwloc-${HWLOC_VERSION} && \
     ./configure --prefix=/usr/local && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ vllm = [
 sglang = [
     "uvloop",
     "sglang[diffusion]==0.5.10.post1",
-    "nixl[cu12]<=0.10.1",
+    "nixl[cu12]>=1.0.0,<2.0.0",
     "cupy-cuda12x>=13.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ vllm = [
 sglang = [
     "uvloop",
     "sglang[diffusion]==0.5.10.post1",
-    "nixl[cu12]>=1.0.0,<2.0.0",
+    "nixl[cu12]>=1.0.0,<1.1.0",
     "cupy-cuda12x>=13.0.0",
 ]
 


### PR DESCRIPTION
#### Overview:

sglang 0.5.10.post1 pulls nixl-cu12 1.0.0 from PyPI, but the container was building the native lib from v0.10.0 — ABI mismatch caused `undefined symbol: prepXferDlist` at runtime.

#### Details:

- Bump sglang `nixl_ref` from `0.10.0` to `v1.0.1` so the container-built libnixl matches what the PyPI wheel expects
- Tighten pyproject.toml constraint to `nixl[cu12]>=1.0.0,<1.1.0` to prevent future ABI drift
- Build hwloc 2.12 from source — nixl v1.0.x libfabric topology code uses `hwloc_location` API (introduced in hwloc 2.3), and RHEL8 only ships 2.2

#### Where should the reviewer start?

`container/context.yaml`, then `pyproject.toml`, then `container/templates/wheel_builder.Dockerfile`

/coderabbit profile chill