### PR TITLE
fix(operator): prevent DGD deletion thrashing under foreground cascading deletion

### DIFF
--- a/deploy/operator/internal/controller_common/finalizer.go
+++ b/deploy/operator/internal/controller_common/finalizer.go
@@ -60,8 +60,14 @@ func HandleFinalizer[T client.Object](ctx context.Context, obj T, writer client.
 				return false, err
 			}
 			logger.Info("Finalizer removed from object", "resourceVersion", obj.GetResourceVersion())
-			return true, nil
 		}
+		// Object is being deleted — signal the caller to skip reconciliation
+		// regardless of whether we just removed the finalizer or it was already
+		// gone (e.g., removed by a previous reconcile). Without this, controllers
+		// fall through to reconcileResources and recreate children that the
+		// garbage collector is trying to delete, causing an infinite thrash loop
+		// under foreground cascading deletion (the default for ArgoCD).
+		return true, nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
#### Overview:

`HandleFinalizer` returned `(false, nil)` when a deleting object's finalizer was already
removed — identical to the "not being deleted" return value. This caused DGD and DCD
controllers to fall through to `reconcileResources` and recreate children that the garbage
collector was trying to delete, producing an infinite thrash loop under foreground cascading
deletion (the default propagation policy for ArgoCD pruning). GPU resources were locked until
the loop eventually resolved, sometimes taking hours.

#### Details:

- `deploy/operator/internal/controller_common/finalizer.go` — Moved the `return true, nil`
  from inside the `ContainsFinalizer` block to after it, so `HandleFinalizer` always returns
  `(true, nil)` when the object has a non-zero deletion timestamp. This fixes all six
  controllers that call `HandleFinalizer` (DGD, DCD, DGDR, Checkpoint, ScalingAdapter,
  DynamoModel).

#### Where should the reviewer start?

`deploy/operator/internal/controller_common/finalizer.go` — the entire fix is a single
6-line change in this file.

#### E2E Verification:

Reproduced the bug on minikube with the stock release/1.0.1 operator using foreground
cascading deletion (`propagationPolicy: Foreground`). Before the fix: 105 resource
re-creation events and 112 spurious DCD reconciliation events in 60 seconds with the DGD
stuck indefinitely. After the fix: zero re-creation events, zero spurious reconciliations,
clean deletion completing in seconds.

#### Related Issues:

- Closes #8204