### PR TITLE
fix(operator): prevent DGD deletion thrashing under foreground cascading deletion

### DIFF
--- a/deploy/operator/internal/controller_common/finalizer.go
+++ b/deploy/operator/internal/controller_common/finalizer.go
@@ -60,8 +60,14 @@ func HandleFinalizer[T client.Object](ctx context.Context, obj T, writer client.
 				return false, err
 			}
 			logger.Info("Finalizer removed from object", "resourceVersion", obj.GetResourceVersion())
-			return true, nil
 		}
+		// Object is being deleted — signal the caller to skip reconciliation
+		// regardless of whether we just removed the finalizer or it was already
+		// gone (e.g., removed by a previous reconcile). Without this, controllers
+		// fall through to reconcileResources and recreate children that the
+		// garbage collector is trying to delete, causing an infinite thrash loop
+		// under foreground cascading deletion (the default for ArgoCD).
+		return true, nil
 	}
 	return false, nil
 }

--- a/deploy/operator/internal/controller_common/finalizer.go
+++ b/deploy/operator/internal/controller_common/finalizer.go
@@ -63,10 +63,7 @@ func HandleFinalizer[T client.Object](ctx context.Context, obj T, writer client.
 		}
 		// Object is being deleted — signal the caller to skip reconciliation
 		// regardless of whether we just removed the finalizer or it was already
-		// gone (e.g., removed by a previous reconcile). Without this, controllers
-		// fall through to reconcileResources and recreate children that the
-		// garbage collector is trying to delete, causing an infinite thrash loop
-		// under foreground cascading deletion (the default for ArgoCD).
+		// gone (e.g., removed by a previous reconcile)
 		return true, nil
 	}
 	return false, nil

--- a/deploy/operator/internal/controller_common/finalizer_test.go
+++ b/deploy/operator/internal/controller_common/finalizer_test.go
@@ -148,6 +148,25 @@ func TestHandleFinalizer(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "deleted object without finalizer - should return true to prevent reconciliation",
+			args: args{
+				ctx: context.Background(),
+				obj: &ObjectMock{
+					GetDeletionTimestampFunc: func() *metav1.Time {
+						return &metav1.Time{Time: time.Now()}
+					},
+					GetFinalizersFunc: func() []string {
+						return []string{}
+					},
+					GetResourceVersionFunc: func() string {
+						return "1"
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
 			name: "non deleted object without finalizer - nominal case",
 			args: args{
 				ctx: context.Background(),

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -12,11 +12,12 @@ import (
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	gmsruntime "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-var failoverLockFile = filepath.Join(gmsSharedMountPath, "failover.lock")
+var failoverLockFile = filepath.Join(gmsruntime.SharedMountPath, "failover.lock")
 
 const (
 	failoverEngineCount = 2

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	gmsruntime "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -35,7 +36,7 @@ func failoverPodSpec() corev1.PodSpec {
 					{Name: "DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS", Value: "true"},
 					{Name: "DYN_HEALTH_CHECK_ENABLED", Value: "true"},
 					{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: "kubernetes"},
-					{Name: "TMPDIR", Value: gmsSharedMountPath},
+					{Name: "TMPDIR", Value: gmsruntime.SharedMountPath},
 				},
 				Ports: []corev1.ContainerPort{
 					{Name: "system", ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
@@ -56,10 +57,10 @@ func failoverPodSpec() corev1.PodSpec {
 					},
 				},
 				Resources: corev1.ResourceRequirements{
-					Claims: []corev1.ResourceClaim{{Name: gmsDRAClaimName}},
+					Claims: []corev1.ResourceClaim{{Name: gmsruntime.DRAClaimName}},
 				},
 				VolumeMounts: []corev1.VolumeMount{
-					{Name: gmsSharedVolumeName, MountPath: gmsSharedMountPath},
+					{Name: gmsruntime.SharedVolumeName, MountPath: gmsruntime.SharedMountPath},
 				},
 			},
 			{
@@ -164,7 +165,7 @@ func TestBuildFailoverPod_PreservesDRAClaim(t *testing.T) {
 	for i := range 2 {
 		engine := ps.Containers[i]
 		require.Len(t, engine.Resources.Claims, 1, "engine-%d should retain DRA claim", i)
-		assert.Equal(t, gmsDRAClaimName, engine.Resources.Claims[0].Name)
+		assert.Equal(t, gmsruntime.DRAClaimName, engine.Resources.Claims[0].Name)
 	}
 }
 


### PR DESCRIPTION
#### Overview:

`HandleFinalizer` returned `(false, nil)` when a deleting object's finalizer was already
removed — identical to the "not being deleted" return value. This caused DGD and DCD
controllers to fall through to `reconcileResources` and recreate children that the garbage
collector was trying to delete, producing an infinite thrash loop under foreground cascading
deletion (the default propagation policy for ArgoCD pruning). GPU resources were locked until
the loop eventually resolved, sometimes taking hours.

#### Details:

- `deploy/operator/internal/controller_common/finalizer.go` — Moved the `return true, nil`
  from inside the `ContainsFinalizer` block to after it, so `HandleFinalizer` always returns
  `(true, nil)` when the object has a non-zero deletion timestamp. This fixes all six
  controllers that call `HandleFinalizer` (DGD, DCD, DGDR, Checkpoint, ScalingAdapter,
  DynamoModel).

#### Where should the reviewer start?

`deploy/operator/internal/controller_common/finalizer.go` — the entire fix is a single
6-line change in this file.

#### E2E Verification:

Reproduced the bug on minikube with the stock release/1.0.1 operator using foreground
cascading deletion (`propagationPolicy: Foreground`). Before the fix: 105 resource
re-creation events and 112 spurious DCD reconciliation events in 60 seconds with the DGD
stuck indefinitely. After the fix: zero re-creation events, zero spurious reconciliations,
clean deletion completing in seconds.

#### Related Issues:

- Closes #8204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource deletion handling to prevent unnecessary reconciliation attempts during the cleanup process, ensuring more reliable and efficient resource teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->