### PR TITLE
ci: Move TRTLLM Fault Tolerance tests from post-merge back to nightly

### DIFF
--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -196,7 +196,7 @@ class DynamoWorkerProcess(ManagedProcess):
 
 
 @pytest.mark.timeout(290)  # 3x average
-@pytest.mark.post_merge
+@pytest.mark.nightly
 def test_request_migration_trtllm_aggregated(
     request,
     runtime_services_dynamic_ports,
@@ -405,7 +405,7 @@ def test_request_migration_trtllm_kv_transfer(
 
 
 @pytest.mark.timeout(350)  # 3x average
-@pytest.mark.post_merge
+@pytest.mark.nightly
 def test_request_migration_trtllm_decode(
     request,
     runtime_services_dynamic_ports,


### PR DESCRIPTION
#### Overview:
TRTLLM FT tests taking long time and should be in nightly instead of post-merge. These tests now are causing timeouts of trtllm test jobs in post-merge
```
tests/fault_tolerance/migration/test_trtllm.py::test_request_migration_trtllm_aggregated 45 min
tests/fault_tolerance/migration/test_trtllm.py::test_request_migration_trtllm_decode 56 min
```
#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
