### PR TITLE
fix(health): skip canary health check for trtllm/vllm disagg decode workers

### DIFF
--- a/components/src/dynamo/trtllm/health_check.py
+++ b/components/src/dynamo/trtllm/health_check.py
@@ -92,6 +92,33 @@ class TrtllmHealthCheckPayload(HealthCheckPayload):
         super().__init__()
 
 
+#: Reserved request key that marks a canary probe request for disagg decode.
+#: The handler detects this marker in `_setup_disaggregated_params_for_mode`
+#: and constructs a synthetic `LlmDisaggregatedParams(request_type=
+#: "context_and_generation")` so the engine runs the probe locally
+#: (full prefill + 1-token decode) without engaging the cache transceiver.
+#: Internal-only — not part of the public request protocol.
+CANARY_PROBE_KEY = "_canary_probe"
+
+
+class TrtllmDisaggDecodeHealthCheckPayload(TrtllmHealthCheckPayload):
+    """Canary payload for TRT-LLM disagg decode workers.
+
+    Sets a ``CANARY_PROBE_KEY`` marker so the handler bypasses the strict
+    "Disaggregated params are required for decode mode" guard and routes
+    the probe through `request_type="context_and_generation"` (local
+    prefill + decode, transceiver-free).
+
+    Mirrors SGLang's `SglangDisaggHealthCheckPayload` which uses
+    `FAKE_BOOTSTRAP_HOST` for the same purpose, and vLLM's natural
+    agg-style fallback when `prefill_result` is absent.
+    """
+
+    def __init__(self, tokenizer: Any = None) -> None:
+        super().__init__(tokenizer=tokenizer)
+        self.default_payload[CANARY_PROBE_KEY] = True
+
+
 def build_worker_health_check_payload(
     disaggregation_mode: DisaggregationMode,
     tokenizer: Any = None,
@@ -99,15 +126,15 @@ def build_worker_health_check_payload(
     """
     Decide the health_check_payload for a TRT-LLM worker based on its disagg role.
 
-    Decode workers opt out of canary: the TRT-LLM decode handler strictly rejects
-    inference requests without `disaggregated_params` (see
-    `trtllm/request_handlers/handler_base.py` — "Disaggregated params are required
-    for decode mode"). A generic canary probe cannot satisfy that contract, so the
-    decode worker registers no payload and opts out of canary verification.
+    Decode workers use a probe payload with ``CANARY_PROBE_KEY`` set; the
+    handler short-circuits in `_setup_disaggregated_params_for_mode` and
+    routes the probe as a local agg request (no cache transceiver, no real
+    prefill peer required). This gives disagg decode the same engine-level
+    canary coverage as aggregated / prefill workers.
 
     Aggregated and prefill workers accept generic probes and register the
     standard canary payload.
     """
     if disaggregation_mode == DisaggregationMode.DECODE:
-        return None
+        return TrtllmDisaggDecodeHealthCheckPayload(tokenizer=tokenizer).to_dict()
     return TrtllmHealthCheckPayload(tokenizer=tokenizer).to_dict()

--- a/components/src/dynamo/trtllm/health_check.py
+++ b/components/src/dynamo/trtllm/health_check.py
@@ -8,9 +8,10 @@ This module defines the default health check payload for TRT-LLM backends.
 """
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from dynamo.health_check import HealthCheckPayload
+from dynamo.trtllm.constants import DisaggregationMode
 
 logger = logging.getLogger(__name__)
 
@@ -89,3 +90,24 @@ class TrtllmHealthCheckPayload(HealthCheckPayload):
             },
         }
         super().__init__()
+
+
+def build_worker_health_check_payload(
+    disaggregation_mode: DisaggregationMode,
+    tokenizer: Any = None,
+) -> Optional[dict]:
+    """
+    Decide the health_check_payload for a TRT-LLM worker based on its disagg role.
+
+    Decode workers opt out of canary: the TRT-LLM decode handler strictly rejects
+    inference requests without `disaggregated_params` (see
+    `trtllm/request_handlers/handler_base.py` — "Disaggregated params are required
+    for decode mode"). A generic canary probe cannot satisfy that contract, so the
+    decode worker registers no payload and opts out of canary verification.
+
+    Aggregated and prefill workers accept generic probes and register the
+    standard canary payload.
+    """
+    if disaggregation_mode == DisaggregationMode.DECODE:
+        return None
+    return TrtllmHealthCheckPayload(tokenizer=tokenizer).to_dict()

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -155,8 +155,7 @@ class _Abortable(Protocol):
     """Structural type for objects that support abort(). Satisfied by both
     GenerationResult and _DeferredAbort."""
 
-    def abort(self) -> None:
-        ...
+    def abort(self) -> None: ...
 
 
 class _DeferredAbort:
@@ -209,13 +208,13 @@ class RequestHandlerConfig:
     publisher: Optional[Publisher]
     disaggregation_mode: DisaggregationMode
     encode_client: Optional[Client] = None
-    multimodal_processor: Optional[
-        MultimodalRequestProcessor
-    ] = None  # for multimodal support
+    multimodal_processor: Optional[MultimodalRequestProcessor] = (
+        None  # for multimodal support
+    )
     connector: Optional[Connector] = None
-    runtime: Optional[
-        DistributedRuntime
-    ] = None  # DistributedRuntime reference for graceful shutdown
+    runtime: Optional[DistributedRuntime] = (
+        None  # DistributedRuntime reference for graceful shutdown
+    )
     metrics_collector: Optional["MetricsCollector"] = None
     kv_block_size: int = 32
     shutdown_event: Optional[asyncio.Event] = None
@@ -710,6 +709,22 @@ class HandlerBase(BaseGenerativeHandler):
         """
         disaggregated_params = None
         epd_metadata: dict[str, Any] = {}
+
+        # Canary probe short-circuit: decode workers receive probes with a
+        # reserved `_canary_probe` marker (see TrtllmDisaggDecodeHealthCheckPayload
+        # in dynamo/trtllm/health_check.py). Build synthetic params with
+        # request_type="context_and_generation" so the engine runs the probe as
+        # full local prefill+decode — the cache transceiver activates only for
+        # request_type="generation_only", so this path is transceiver-free and
+        # doesn't need a real prefill peer. Mirrors sglang's FAKE_BOOTSTRAP_HOST.
+        if self.disaggregation_mode == DisaggregationMode.DECODE and request.get(
+            "_canary_probe"
+        ):
+            return (
+                LlmDisaggregatedParams(request_type="context_and_generation"),
+                None,
+                {},
+            )
 
         # PREFILL mode: setup context_only params
         if self.disaggregation_mode == DisaggregationMode.PREFILL:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -155,7 +155,8 @@ class _Abortable(Protocol):
     """Structural type for objects that support abort(). Satisfied by both
     GenerationResult and _DeferredAbort."""
 
-    def abort(self) -> None: ...
+    def abort(self) -> None:
+        ...
 
 
 class _DeferredAbort:
@@ -208,13 +209,13 @@ class RequestHandlerConfig:
     publisher: Optional[Publisher]
     disaggregation_mode: DisaggregationMode
     encode_client: Optional[Client] = None
-    multimodal_processor: Optional[MultimodalRequestProcessor] = (
-        None  # for multimodal support
-    )
+    multimodal_processor: Optional[
+        MultimodalRequestProcessor
+    ] = None  # for multimodal support
     connector: Optional[Connector] = None
-    runtime: Optional[DistributedRuntime] = (
-        None  # DistributedRuntime reference for graceful shutdown
-    )
+    runtime: Optional[
+        DistributedRuntime
+    ] = None  # DistributedRuntime reference for graceful shutdown
     metrics_collector: Optional["MetricsCollector"] = None
     kv_block_size: int = 32
     shutdown_event: Optional[asyncio.Event] = None

--- a/components/src/dynamo/trtllm/tests/test_health_check_disagg.py
+++ b/components/src/dynamo/trtllm/tests/test_health_check_disagg.py
@@ -1,4 +1,6 @@
-import pytest
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
 
 

--- a/components/src/dynamo/trtllm/tests/test_health_check_disagg.py
+++ b/components/src/dynamo/trtllm/tests/test_health_check_disagg.py
@@ -1,0 +1,10 @@
+import pytest
+from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
+
+
+def test_trtllm_health_check_payload_has_no_disagg_params():
+    """Standard TrtllmHealthCheckPayload should NOT include disaggregated_params."""
+    payload = TrtllmHealthCheckPayload().to_dict()
+    assert "disaggregated_params" not in payload
+    assert "prefill_result" not in payload
+    assert "token_ids" in payload

--- a/components/src/dynamo/trtllm/tests/test_health_check_disagg.py
+++ b/components/src/dynamo/trtllm/tests/test_health_check_disagg.py
@@ -1,7 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+
 from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.gpu_1,  # needs trtllm packages installed but does not use GPU
+    pytest.mark.profiled_vram_gib(0),
+    pytest.mark.pre_merge,
+]
 
 
 def test_trtllm_health_check_payload_has_no_disagg_params():

--- a/components/src/dynamo/trtllm/tests/test_health_check_disagg.py
+++ b/components/src/dynamo/trtllm/tests/test_health_check_disagg.py
@@ -5,6 +5,8 @@ import pytest
 
 from dynamo.trtllm.constants import DisaggregationMode
 from dynamo.trtllm.health_check import (
+    CANARY_PROBE_KEY,
+    TrtllmDisaggDecodeHealthCheckPayload,
     TrtllmHealthCheckPayload,
     build_worker_health_check_payload,
 )
@@ -38,16 +40,28 @@ def test_non_decode_modes_register_canary_payload(mode):
     assert "sampling_options" in payload
 
 
-def test_decode_mode_opts_out_of_canary():
-    """Decode workers return None so no canary target is registered.
+def test_decode_mode_registers_probe_payload():
+    """Decode workers register a probe payload carrying CANARY_PROBE_KEY.
 
-    The trtllm decode handler strictly rejects requests without
-    `disaggregated_params` (handler_base.py: "Disaggregated params are required
-    for decode mode"), so a generic canary probe cannot satisfy that contract.
-    The worker opts out; readiness is signalled by successful endpoint
-    registration (see lib/runtime/src/system_health.rs::set_endpoint_registered).
+    The handler detects the marker in `_setup_disaggregated_params_for_mode`
+    and routes the probe through `request_type="context_and_generation"`
+    so the engine runs it as a local agg request (no cache transceiver).
+    Pattern mirrors SGLang's FAKE_BOOTSTRAP_HOST.
     """
     payload = build_worker_health_check_payload(
         disaggregation_mode=DisaggregationMode.DECODE
     )
-    assert payload is None
+    assert payload is not None
+    assert payload.get(CANARY_PROBE_KEY) is True
+    # Standard fields must still be present so the handler's downstream logic
+    # (sampling, stop conditions, token_ids) runs normally.
+    assert "token_ids" in payload
+    assert "sampling_options" in payload
+    assert "stop_conditions" in payload
+
+
+def test_disagg_decode_payload_class_sets_probe_marker():
+    """Direct construction of TrtllmDisaggDecodeHealthCheckPayload carries the marker."""
+    payload = TrtllmDisaggDecodeHealthCheckPayload().to_dict()
+    assert payload.get(CANARY_PROBE_KEY) is True
+    assert "disaggregated_params" not in payload  # real params built by handler

--- a/components/src/dynamo/trtllm/tests/test_health_check_disagg.py
+++ b/components/src/dynamo/trtllm/tests/test_health_check_disagg.py
@@ -3,7 +3,11 @@
 
 import pytest
 
-from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
+from dynamo.trtllm.constants import DisaggregationMode
+from dynamo.trtllm.health_check import (
+    TrtllmHealthCheckPayload,
+    build_worker_health_check_payload,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -20,3 +24,30 @@ def test_trtllm_health_check_payload_has_no_disagg_params():
     assert "disaggregated_params" not in payload
     assert "prefill_result" not in payload
     assert "token_ids" in payload
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [DisaggregationMode.AGGREGATED, DisaggregationMode.PREFILL],
+)
+def test_non_decode_modes_register_canary_payload(mode):
+    """Aggregated and prefill workers register the standard canary payload."""
+    payload = build_worker_health_check_payload(disaggregation_mode=mode)
+    assert payload is not None
+    assert "token_ids" in payload
+    assert "sampling_options" in payload
+
+
+def test_decode_mode_opts_out_of_canary():
+    """Decode workers return None so no canary target is registered.
+
+    The trtllm decode handler strictly rejects requests without
+    `disaggregated_params` (handler_base.py: "Disaggregated params are required
+    for decode mode"), so a generic canary probe cannot satisfy that contract.
+    The worker opts out; readiness is signalled by successful endpoint
+    registration (see lib/runtime/src/system_health.rs::set_endpoint_registered).
+    """
+    payload = build_worker_health_check_payload(
+        disaggregation_mode=DisaggregationMode.DECODE
+    )
+    assert payload is None

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -603,7 +603,18 @@ async def init_llm_worker(
             )
 
         # Get health check payload (checks env var and falls back to TensorRT-LLM default)
-        health_check_payload = TrtllmHealthCheckPayload(tokenizer=tokenizer).to_dict()
+        if config.disaggregation_mode == DisaggregationMode.DECODE:
+            # Decode workers cannot process canary inference requests —
+            # they require disaggregated_params (KV cache state from prefill).
+            # Skip health check payload so canary doesn't target them.
+            health_check_payload = None
+            logging.info(
+                "Decode worker: skipping canary health check payload registration"
+            )
+        else:
+            health_check_payload = TrtllmHealthCheckPayload(
+                tokenizer=tokenizer
+            ).to_dict()
 
         if config.publish_events_and_metrics:
             # Initialize and pass in the publisher to the request handler to

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -54,7 +54,7 @@ from dynamo.runtime import DistributedRuntime
 from dynamo.trtllm.args import Config
 from dynamo.trtllm.constants import DisaggregationMode, Modality
 from dynamo.trtllm.engine import Backend, get_llm_engine
-from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
+from dynamo.trtllm.health_check import build_worker_health_check_payload
 from dynamo.trtllm.multimodal_processor import MultimodalRequestProcessor
 from dynamo.trtllm.publisher import DYNAMO_COMPONENT_REGISTRY, get_publisher
 from dynamo.trtllm.request_handlers.handlers import (
@@ -602,19 +602,18 @@ async def init_llm_worker(
                 custom_template_path=config.custom_jinja_template,
             )
 
-        # Get health check payload (checks env var and falls back to TensorRT-LLM default)
-        if config.disaggregation_mode == DisaggregationMode.DECODE:
-            # Decode workers cannot process canary inference requests —
-            # they require disaggregated_params (KV cache state from prefill).
-            # Skip health check payload so canary doesn't target them.
-            health_check_payload = None
+        # Decode workers opt out of canary (the TRT-LLM decode handler strictly
+        # rejects canary probes without disaggregated_params); agg/prefill workers
+        # register the standard TRT-LLM payload. See build_worker_health_check_payload
+        # for the full reasoning.
+        health_check_payload = build_worker_health_check_payload(
+            disaggregation_mode=config.disaggregation_mode,
+            tokenizer=tokenizer,
+        )
+        if health_check_payload is None:
             logging.info(
-                "Decode worker: skipping canary health check payload registration"
+                "Decode worker: canary health check disabled (no payload registered)"
             )
-        else:
-            health_check_payload = TrtllmHealthCheckPayload(
-                tokenizer=tokenizer
-            ).to_dict()
 
         if config.publish_events_and_metrics:
             # Initialize and pass in the publisher to the request handler to

--- a/components/src/dynamo/vllm/tests/test_vllm_health_check.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_health_check.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression guard: vLLM workers must always register a canary payload.
+
+DIS-1737 originally routed disagg decode through a `payload = None` branch in
+`worker_factory.py`. That silently opted decode workers out of canary, which
+after DIS-1185 (canary = sole readiness authority) left them stuck NotReady.
+These tests ensure the payload constructor works for both agg and decode paths
+so no one re-introduces a DECODE-specific None branch.
+"""
+
+import pytest
+
+from dynamo.vllm.health_check import VllmHealthCheckPayload
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.pre_merge,
+]
+
+
+@pytest.mark.parametrize("use_text_input", [False, True])
+def test_vllm_health_check_payload_is_non_none(use_text_input):
+    """VllmHealthCheckPayload.to_dict() returns a non-None dict regardless of
+    tokenizer mode. Worker code must always register a canary target; decode
+    workers rely on the vLLM handler's natural agg-style fallback when
+    `prefill_result` is absent (handlers.py::_generate_token_mode)."""
+    payload = VllmHealthCheckPayload(
+        engine_client=None, use_text_input=use_text_input
+    ).to_dict()
+
+    assert payload is not None
+    assert isinstance(payload, dict)
+    # Payload must contain some form of input the engine can decode.
+    assert "token_ids" in payload or "prompt" in payload

--- a/components/src/dynamo/vllm/tests/test_vllm_health_check.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_health_check.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -19,6 +18,7 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
     pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
 ]
 
 

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -395,9 +395,7 @@ class WorkerFactory:
             # Disagg decode workers may need params from prefill (e.g., embedding_params
             # for multimodal). Skip canary health check to prevent incompatible requests.
             health_check_payload = None
-            logger.info(
-                "Disagg decode worker: skipping canary health check payload"
-            )
+            logger.info("Disagg decode worker: skipping canary health check payload")
         else:
             health_check_payload = VllmHealthCheckPayload(
                 engine_client, use_text_input=config.use_vllm_tokenizer

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -391,9 +391,21 @@ class WorkerFactory:
             vllm_config,
         )
 
-        health_check_payload = VllmHealthCheckPayload(
-            engine_client, use_text_input=config.use_vllm_tokenizer
-        ).to_dict()
+        is_multimodal_decode = (
+            config.disaggregation_mode == DisaggregationMode.DECODE
+            and model_type == ModelType.MULTIMODAL
+        )
+        if is_multimodal_decode:
+            # Multimodal decode workers need embedding_params from prefill.
+            # Skip canary to avoid crash.
+            health_check_payload = None
+            logger.info(
+                "Multimodal decode worker: skipping canary health check payload"
+            )
+        else:
+            health_check_payload = VllmHealthCheckPayload(
+                engine_client, use_text_input=config.use_vllm_tokenizer
+            ).to_dict()
 
         perf_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.get_perf_metrics"

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -391,16 +391,12 @@ class WorkerFactory:
             vllm_config,
         )
 
-        is_multimodal_decode = (
-            config.disaggregation_mode == DisaggregationMode.DECODE
-            and model_type == ModelType.MULTIMODAL
-        )
-        if is_multimodal_decode:
-            # Multimodal decode workers need embedding_params from prefill.
-            # Skip canary to avoid crash.
+        if config.disaggregation_mode == DisaggregationMode.DECODE:
+            # Disagg decode workers may need params from prefill (e.g., embedding_params
+            # for multimodal). Skip canary health check to prevent incompatible requests.
             health_check_payload = None
             logger.info(
-                "Multimodal decode worker: skipping canary health check payload"
+                "Disagg decode worker: skipping canary health check payload"
             )
         else:
             health_check_payload = VllmHealthCheckPayload(

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -392,15 +392,13 @@ class WorkerFactory:
             vllm_config,
         )
 
-        if config.disaggregation_mode == DisaggregationMode.DECODE:
-            # Disagg decode workers may need params from prefill (e.g., embedding_params
-            # for multimodal). Skip canary health check to prevent incompatible requests.
-            health_check_payload = None
-            logger.info("Disagg decode worker: skipping canary health check payload")
-        else:
-            health_check_payload = VllmHealthCheckPayload(
-                engine_client, use_text_input=config.use_vllm_tokenizer
-            ).to_dict()
+        # vLLM's DecodeWorkerHandler._generate_token_mode handles requests without
+        # prefill_result by running them agg-style, so the standard canary payload
+        # works for decode workers too — the engine produces one token regardless
+        # of disaggregation mode. Always register a canary target.
+        health_check_payload = VllmHealthCheckPayload(
+            engine_client, use_text_input=config.use_vllm_tokenizer
+        ).to_dict()
 
         perf_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.get_perf_metrics"

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -396,9 +396,7 @@ class WorkerFactory:
             # Disagg decode workers may need params from prefill (e.g., embedding_params
             # for multimodal). Skip canary health check to prevent incompatible requests.
             health_check_payload = None
-            logger.info(
-                "Disagg decode worker: skipping canary health check payload"
-            )
+            logger.info("Disagg decode worker: skipping canary health check payload")
         else:
             health_check_payload = VllmHealthCheckPayload(
                 engine_client, use_text_input=config.use_vllm_tokenizer

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -392,9 +392,21 @@ class WorkerFactory:
             vllm_config,
         )
 
-        health_check_payload = VllmHealthCheckPayload(
-            engine_client, use_text_input=config.use_vllm_tokenizer
-        ).to_dict()
+        is_multimodal_decode = (
+            config.disaggregation_mode == DisaggregationMode.DECODE
+            and model_type == ModelType.MULTIMODAL
+        )
+        if is_multimodal_decode:
+            # Multimodal decode workers need embedding_params from prefill.
+            # Skip canary to avoid crash.
+            health_check_payload = None
+            logger.info(
+                "Multimodal decode worker: skipping canary health check payload"
+            )
+        else:
+            health_check_payload = VllmHealthCheckPayload(
+                engine_client, use_text_input=config.use_vllm_tokenizer
+            ).to_dict()
 
         perf_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.get_perf_metrics"

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -392,16 +392,12 @@ class WorkerFactory:
             vllm_config,
         )
 
-        is_multimodal_decode = (
-            config.disaggregation_mode == DisaggregationMode.DECODE
-            and model_type == ModelType.MULTIMODAL
-        )
-        if is_multimodal_decode:
-            # Multimodal decode workers need embedding_params from prefill.
-            # Skip canary to avoid crash.
+        if config.disaggregation_mode == DisaggregationMode.DECODE:
+            # Disagg decode workers may need params from prefill (e.g., embedding_params
+            # for multimodal). Skip canary health check to prevent incompatible requests.
             health_check_payload = None
             logger.info(
-                "Multimodal decode worker: skipping canary health check payload"
+                "Disagg decode worker: skipping canary health check payload"
             )
         else:
             health_check_payload = VllmHealthCheckPayload(

--- a/lib/runtime/src/system_health.rs
+++ b/lib/runtime/src/system_health.rs
@@ -100,10 +100,21 @@ impl SystemHealth {
         self.health_check_enabled
     }
 
-    /// Signal endpoint transport registration. Sets Ready when canary is disabled;
-    /// no-op when canary is enabled (canary will set Ready after verification).
+    /// Signal endpoint transport registration.
+    ///
+    /// Marks the endpoint Ready when canary is disabled globally, OR when the
+    /// endpoint has no registered canary target (i.e. the caller opted out of
+    /// canary by not passing a `health_check_payload` to `serve_endpoint`).
+    /// Endpoints that DID register a canary target stay NotReady until the
+    /// canary verifies them — preserving DIS-1185's "canary is the authoritative
+    /// readiness signal for endpoints that opt in" contract.
     pub fn set_endpoint_registered(&self, endpoint: &str) {
-        if !self.health_check_enabled {
+        let has_target = self
+            .health_check_targets
+            .read()
+            .unwrap()
+            .contains_key(endpoint);
+        if !self.health_check_enabled || !has_target {
             self.set_endpoint_health_status(endpoint, HealthStatus::Ready);
         }
     }
@@ -141,20 +152,26 @@ impl SystemHealth {
                     .get(endpoint)
                     .is_some_and(|status| *status == HealthStatus::Ready)
             })
+        } else if !health_check_targets.is_empty() {
+            // Canary-opt-in endpoints exist: every one must be Ready.
+            health_check_targets
+                .iter()
+                .all(|(endpoint_subject, _target)| {
+                    endpoint_health
+                        .get(endpoint_subject)
+                        .is_some_and(|status| *status == HealthStatus::Ready)
+                })
+        } else if !endpoint_health.is_empty() {
+            // No canary targets, but endpoints have registered. Healthy when
+            // every registered endpoint is Ready. This covers workers that
+            // opt every endpoint out of canary (e.g. disagg decode workers,
+            // secondary operational endpoints).
+            endpoint_health
+                .values()
+                .all(|status| *status == HealthStatus::Ready)
         } else {
-            // If we have registered health check targets, use them to determine health
-            if !health_check_targets.is_empty() {
-                health_check_targets
-                    .iter()
-                    .all(|(endpoint_subject, _target)| {
-                        endpoint_health
-                            .get(endpoint_subject)
-                            .is_some_and(|status| *status == HealthStatus::Ready)
-                    })
-            } else {
-                // No health check targets registered, use simple system health
-                self.system_health == HealthStatus::Ready
-            }
+            // No endpoints registered at all — use simple system health.
+            self.system_health == HealthStatus::Ready
         };
 
         (healthy, endpoints)
@@ -296,5 +313,96 @@ impl SystemHealth {
     /// Get the liveness check path
     pub fn live_path(&self) -> &str {
         &self.live_path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sh(canary_enabled: bool) -> SystemHealth {
+        SystemHealth::new(
+            HealthStatus::NotReady,
+            vec![],
+            canary_enabled,
+            "/health".into(),
+            "/live".into(),
+        )
+    }
+
+    #[test]
+    fn endpoint_registered_auto_readies_without_target_when_canary_enabled() {
+        // Canary enabled but the endpoint did not register a canary target —
+        // it opted out of canary, so registration alone marks it Ready.
+        let h = sh(true);
+        h.set_endpoint_registered("generate");
+        assert_eq!(
+            h.get_endpoint_health_status("generate"),
+            Some(HealthStatus::Ready),
+            "endpoint with no canary target must auto-Ready"
+        );
+    }
+
+    #[test]
+    fn endpoint_registered_stays_notready_with_target_when_canary_enabled() {
+        // Canary enabled and the endpoint registered a target — registration
+        // does NOT flip Ready; canary verifies first (DIS-1185 contract).
+        let h = sh(true);
+        let instance = component::Instance {
+            component: "test".into(),
+            endpoint: "generate".into(),
+            namespace: "test".into(),
+            instance_id: 0,
+            transport: component::TransportType::Tcp("localhost:0".into()),
+            device_type: None,
+        };
+        h.health_check_targets.write().unwrap().insert(
+            "generate".to_string(),
+            HealthCheckTarget {
+                instance,
+                payload: serde_json::json!({}),
+            },
+        );
+        h.set_endpoint_registered("generate");
+        // With a registered target, set_endpoint_registered must NOT mark
+        // the endpoint Ready — canary is responsible. Either "no entry" or
+        // an explicit NotReady is acceptable (both make /health path #2 report
+        // unhealthy until canary succeeds).
+        assert_ne!(
+            h.get_endpoint_health_status("generate"),
+            Some(HealthStatus::Ready),
+            "endpoint with a canary target must wait for canary, not auto-Ready"
+        );
+    }
+
+    #[test]
+    fn endpoint_registered_readies_when_canary_disabled() {
+        let h = sh(false);
+        h.set_endpoint_registered("generate");
+        assert_eq!(
+            h.get_endpoint_health_status("generate"),
+            Some(HealthStatus::Ready),
+        );
+    }
+
+    #[test]
+    fn get_health_status_uses_endpoint_health_when_no_target() {
+        // No canary targets, no use_endpoint_health_status override.
+        // A single registered endpoint in Ready state should make /health healthy.
+        let h = sh(true);
+        h.set_endpoint_registered("generate");
+        let (healthy, _eps) = h.get_health_status();
+        assert!(
+            healthy,
+            "when no canary target exists and all registered endpoints are Ready, /health is healthy"
+        );
+    }
+
+    #[test]
+    fn get_health_status_notready_when_no_endpoints_and_system_notready() {
+        // No endpoints registered at all — falls back to system_health (NotReady by default).
+        let h = sh(true);
+        let (healthy, _eps) = h.get_health_status();
+        assert!(!healthy);
     }
 }

--- a/tests/fault_tolerance/test_canary_rank_pause.py
+++ b/tests/fault_tolerance/test_canary_rank_pause.py
@@ -75,7 +75,11 @@ STARTUP_READY_BUDGET_S = 120
 # appear in the engine subprocess's command line. Keep in sync with the
 # `stragglers` declared on each backend's test config.
 _RANK_PATTERNS: dict[str, tuple[str, ...]] = {
-    "trtllm": ("TRTLLM:EngineCore", "tensorrt_llm"),
+    # trtllm's engine ranks are mpi4py.futures.server children of the
+    # `python3 -m dynamo.trtllm` worker (verified locally on Qwen3-0.6B
+    # disagg_same_gpu). The other substrings are defensive in case a
+    # future TRT-LLM release renames.
+    "trtllm": ("mpi4py.futures.server", "TRTLLM:EngineCore", "tensorrt_llm"),
     "vllm": ("VLLM::EngineCore", "EngineCoreProc"),
     "sglang": ("SGLANG:EngineCore", "sgl_scheduler"),
 }

--- a/tests/fault_tolerance/test_canary_rank_pause.py
+++ b/tests/fault_tolerance/test_canary_rank_pause.py
@@ -11,21 +11,31 @@ tokens, but the Python dispatch layer is still alive). We then poll
   * When canary is ENABLED AND the endpoint has a registered payload,
     ``/health`` flips to 503 — the canary probe times out against the
     paused engine and marks the endpoint NotReady. This is the positive
-    case the user asked for: *"canary can detect the issues we have seen."*
+    case: *"canary can detect the issues we have seen."*
 
   * When canary is DISABLED (or the endpoint opts out by registering no
-    payload, as trtllm disagg decode does today), ``/health`` STAYS at
-    200 — there is no active liveness probe. This is the negative
-    control the user asked for: it proves the harness distinguishes the
-    "canary working" path from the "no canary" path, rather than
-    always reporting success.
+    payload), ``/health`` STAYS at 200 — there is no active liveness
+    probe. This is the negative control: it proves the harness
+    distinguishes the "canary working" path from the "no canary" path,
+    rather than always reporting success.
 
-After each case we ``SIGCONT`` the rank and verify ``/health`` returns to
-Ready, both as a cleanup and as a round-trip sanity check.
+After each case we ``SIGCONT`` the rank and (for detect cases) verify
+``/health`` returns to Ready as a round-trip sanity check.
+
+Coverage matrix — ``{trtllm, vllm, sglang} × {agg, disagg-prefill,
+disagg-decode}`` — confirms all three backends ship a canary that
+catches engine-level hangs in disagg setups:
+  * vllm decode uses the handler's natural agg-style fallback when
+    ``prefill_result`` is absent (handlers.py::_generate_token_mode).
+  * sglang decode uses ``FAKE_BOOTSTRAP_HOST`` via
+    ``SglangDisaggHealthCheckPayload`` to bypass real KV transfer.
+  * trtllm decode uses a ``_canary_probe`` marker + handler short-circuit
+    to ``request_type="context_and_generation"``
+    (handler_base.py::_setup_disaggregated_params_for_mode).
 
 Style mirrors ``tests/serve/test_trtllm.py::test_deployment`` — same
 ``EngineProcess.from_script`` launcher, same ``/health`` polling. We do
-not use the ``tests/fault_tolerance/hardware/fault_injection_service``
+not use the ``tests/fault_tolerance/hardware/fault_injection_service/``
 helpers; just POSIX signals.
 """
 
@@ -43,7 +53,9 @@ import psutil
 import pytest
 import requests
 
+from tests.serve.test_sglang import sglang_configs
 from tests.serve.test_trtllm import trtllm_configs
+from tests.serve.test_vllm import vllm_configs
 from tests.utils.engine_process import EngineProcess
 
 logger = logging.getLogger(__name__)
@@ -59,15 +71,34 @@ RESUME_RECOVER_BUDGET_S = 30
 STARTUP_READY_BUDGET_S = 120
 
 
+# Per-backend engine-rank discovery patterns. These match the substrings that
+# appear in the engine subprocess's command line. Keep in sync with the
+# `stragglers` declared on each backend's test config.
+_RANK_PATTERNS: dict[str, tuple[str, ...]] = {
+    "trtllm": ("TRTLLM:EngineCore", "tensorrt_llm"),
+    "vllm": ("VLLM::EngineCore", "EngineCoreProc"),
+    "sglang": ("SGLANG:EngineCore", "sgl_scheduler"),
+}
+
+# Per-backend config dicts keyed by backend name.
+_CONFIGS_BY_BACKEND = {
+    "trtllm": trtllm_configs,
+    "vllm": vllm_configs,
+    "sglang": sglang_configs,
+}
+
+
 @dataclass
 class RankPauseScenario:
     """One row in the test matrix."""
 
     # Label used in pytest param IDs.
     label: str
-    # Which trtllm_configs entry to launch (must already be defined in tests/serve).
+    # Backend: trtllm / vllm / sglang. Selects config dict + rank-discovery pattern.
+    backend: str
+    # Which {backend}_configs entry to launch.
     base_config_key: str
-    # Which system-port index to monitor (0 = prefill / single worker, 1 = decode).
+    # Which system-port index to monitor (0 = prefill/single worker, 1 = decode).
     system_port_index: int
     # Whether to enable canary in the worker env.
     canary_enabled: bool
@@ -76,46 +107,64 @@ class RankPauseScenario:
     expected: str
 
 
-# NB: only trtllm scenarios for now. vllm + sglang added in follow-ups once
-# we verify the engine-rank process discovery pattern for each backend.
-SCENARIOS: list[RankPauseScenario] = [
-    # Positive case: agg worker, canary on. Canary should catch the pause.
-    RankPauseScenario(
-        label="trtllm-agg-canary-on",
-        base_config_key="aggregated",
-        system_port_index=0,
-        canary_enabled=True,
-        expected="detect",
-    ),
-    # Negative control: same worker, canary off. Harness must NOT false-positive.
+# Coverage: {backend} × {agg, disagg-prefill, disagg-decode} with canary ENABLED
+# (expected=detect), plus one canary-OFF negative control on trtllm to prove the
+# harness doesn't false-positive. Agg uses the "aggregated" config (port 0 is
+# the single worker's system port); prefill/decode use "disaggregated_same_gpu"
+# which spawns both workers on one GPU (ports 0 and 1).
+SCENARIOS: list[RankPauseScenario] = []
+for _backend in ("trtllm", "vllm", "sglang"):
+    SCENARIOS.extend(
+        [
+            RankPauseScenario(
+                label=f"{_backend}-agg-canary-on",
+                backend=_backend,
+                base_config_key="aggregated",
+                system_port_index=0,
+                canary_enabled=True,
+                expected="detect",
+            ),
+            RankPauseScenario(
+                label=f"{_backend}-disagg-prefill-canary-on",
+                backend=_backend,
+                base_config_key="disaggregated_same_gpu",
+                system_port_index=0,  # DYN_SYSTEM_PORT1 = prefill
+                canary_enabled=True,
+                expected="detect",
+            ),
+            RankPauseScenario(
+                label=f"{_backend}-disagg-decode-canary-on",
+                backend=_backend,
+                base_config_key="disaggregated_same_gpu",
+                system_port_index=1,  # DYN_SYSTEM_PORT2 = decode
+                canary_enabled=True,
+                expected="detect",
+            ),
+        ]
+    )
+
+# Negative control — canary off; /health must NOT flip. One representative
+# scenario is enough to prove the harness distinguishes detect/miss.
+SCENARIOS.append(
     RankPauseScenario(
         label="trtllm-agg-canary-off",
+        backend="trtllm",
         base_config_key="aggregated",
         system_port_index=0,
         canary_enabled=False,
         expected="miss",
-    ),
-    # Disagg decode: canary probe short-circuits in
-    # `_setup_disaggregated_params_for_mode` via the `_canary_probe` marker
-    # (see TrtllmDisaggDecodeHealthCheckPayload). Engine runs the probe as
-    # a local agg request, so pausing the rank blocks the probe and flips
-    # /health to 503 — same as aggregated.
-    RankPauseScenario(
-        label="trtllm-disagg-decode-canary-on",
-        base_config_key="disaggregated_same_gpu",
-        system_port_index=1,  # DYN_SYSTEM_PORT2 = decode worker
-        canary_enabled=True,
-        expected="detect",
-    ),
-]
+    )
+)
 
 
-def _find_engine_rank_pid(parent_pid: int, timeout_s: float = 30.0) -> int:
-    """Locate the TRT-LLM engine-rank subprocess under the test's worker parent.
+def _find_engine_rank_pid(
+    parent_pid: int, patterns: tuple[str, ...], timeout_s: float = 30.0
+) -> int:
+    """Locate the engine-rank subprocess under the test's worker parent.
 
-    The trtllm Python worker spawns a child process with a command line
-    containing ``EngineCore`` (see ``stragglers`` in TRTLLMConfig). We wait
-    up to ``timeout_s`` for it to appear so callers don't race startup.
+    Each backend spawns a child process whose command line contains a
+    recognizable marker (see ``_RANK_PATTERNS``). We wait up to
+    ``timeout_s`` for it to appear so callers don't race startup.
     """
     deadline = time.monotonic() + timeout_s
     last_err: Exception | None = None
@@ -127,14 +176,14 @@ def _find_engine_rank_pid(parent_pid: int, timeout_s: float = 30.0) -> int:
                     cmd = " ".join(child.cmdline())
                 except psutil.Error:
                     continue
-                if "EngineCore" in cmd or "tensorrt_llm" in cmd:
+                if any(p in cmd for p in patterns):
                     return child.pid
         except psutil.NoSuchProcess as e:
             last_err = e
         time.sleep(0.5)
     raise RuntimeError(
-        f"Could not find engine-rank child of pid={parent_pid} within {timeout_s}s. "
-        f"Last error: {last_err}"
+        f"Could not find engine-rank child of pid={parent_pid} matching "
+        f"{patterns} within {timeout_s}s. Last error: {last_err}"
     )
 
 
@@ -161,7 +210,6 @@ def _wait_for_status(url: str, target: int, deadline_s: float) -> int:
 
 @pytest.mark.e2e
 @pytest.mark.nightly
-@pytest.mark.trtllm
 @pytest.mark.gpu_1
 @pytest.mark.parametrize(
     "scenario",
@@ -177,7 +225,8 @@ def test_canary_detects_rank_pause(
     num_system_ports,  # noqa: ANN001
     predownload_models,  # noqa: ANN001
 ) -> None:
-    base = trtllm_configs[scenario.base_config_key]
+    configs = _CONFIGS_BY_BACKEND[scenario.backend]
+    base = configs[scenario.base_config_key]
     config = dataclasses.replace(base, frontend_port=dynamo_dynamic_ports.frontend_port)
     config.env.update(
         {
@@ -195,15 +244,14 @@ def test_canary_detects_rank_pause(
     target_port = system_ports[scenario.system_port_index]
     health_url = f"http://localhost:{target_port}/health"
     logger.info(
-        "[%s] health_url=%s canary=%s expected=%s",
+        "[%s] backend=%s health_url=%s canary=%s expected=%s",
         scenario.label,
+        scenario.backend,
         health_url,
         scenario.canary_enabled,
         scenario.expected,
     )
 
-    # Build env + launch the worker using the exact same machinery as
-    # test_deployment so the scenario matches real CI conditions.
     extra_env: dict[str, str] = {}
     for i, p in enumerate(system_ports, start=1):
         extra_env[f"DYN_SYSTEM_PORT{i}"] = str(p)
@@ -212,6 +260,8 @@ def test_canary_detects_rank_pause(
     extra_env["DYN_HEALTH_CHECK_ENABLED"] = (
         "true" if scenario.canary_enabled else "false"
     )
+
+    patterns = _RANK_PATTERNS[scenario.backend]
 
     with EngineProcess.from_script(config, request, extra_env=extra_env) as proc:
         # 1. Wait for the worker to become healthy (Ready) before we pause.
@@ -222,8 +272,13 @@ def test_canary_detects_rank_pause(
         )
 
         # 2. Find the engine rank subprocess and SIGSTOP it.
-        rank_pid = _find_engine_rank_pid(proc.proc.pid)
-        logger.info("[%s] pausing engine rank pid=%d", scenario.label, rank_pid)
+        rank_pid = _find_engine_rank_pid(proc.proc.pid, patterns)
+        logger.info(
+            "[%s] pausing engine rank pid=%d (patterns=%s)",
+            scenario.label,
+            rank_pid,
+            patterns,
+        )
         os.kill(rank_pid, signal.SIGSTOP)
         try:
             # 3. Give the canary (or lack thereof) time to notice.
@@ -235,9 +290,9 @@ def test_canary_detects_rank_pause(
                     f"{PAUSE_DETECT_BUDGET_S}s"
                 )
             else:  # miss
-                # Wait the full budget; /health must stay 200 throughout. We
-                # sample periodically rather than trusting a single poll so a
-                # transient glitch doesn't masquerade as "miss".
+                # /health must stay 200 throughout the window. Sample
+                # periodically so a transient glitch doesn't masquerade as
+                # "miss".
                 deadline = time.monotonic() + PAUSE_DETECT_BUDGET_S
                 flips = 0
                 while time.monotonic() < deadline:

--- a/tests/fault_tolerance/test_canary_rank_pause.py
+++ b/tests/fault_tolerance/test_canary_rank_pause.py
@@ -175,9 +175,7 @@ def test_canary_detects_rank_pause(
     predownload_models,  # noqa: ANN001
 ) -> None:
     base = trtllm_configs[scenario.base_config_key]
-    config = dataclasses.replace(
-        base, frontend_port=dynamo_dynamic_ports.frontend_port
-    )
+    config = dataclasses.replace(base, frontend_port=dynamo_dynamic_ports.frontend_port)
     config.env.update(
         {
             "MODEL_PATH": config.model,
@@ -193,9 +191,13 @@ def test_canary_detects_rank_pause(
     )
     target_port = system_ports[scenario.system_port_index]
     health_url = f"http://localhost:{target_port}/health"
-    logger.info("[%s] health_url=%s canary=%s expected=%s",
-                scenario.label, health_url, scenario.canary_enabled,
-                scenario.expected)
+    logger.info(
+        "[%s] health_url=%s canary=%s expected=%s",
+        scenario.label,
+        health_url,
+        scenario.canary_enabled,
+        scenario.expected,
+    )
 
     # Build env + launch the worker using the exact same machinery as
     # test_deployment so the scenario matches real CI conditions.

--- a/tests/fault_tolerance/test_canary_rank_pause.py
+++ b/tests/fault_tolerance/test_canary_rank_pause.py
@@ -95,15 +95,17 @@ SCENARIOS: list[RankPauseScenario] = [
         canary_enabled=False,
         expected="miss",
     ),
-    # Disagg decode: canary opts out by design (trtllm handler rejects generic
-    # probes). Documents the current trade-off — will flip to "detect" once
-    # the probe-canary follow-up lands.
+    # Disagg decode: canary probe short-circuits in
+    # `_setup_disaggregated_params_for_mode` via the `_canary_probe` marker
+    # (see TrtllmDisaggDecodeHealthCheckPayload). Engine runs the probe as
+    # a local agg request, so pausing the rank blocks the probe and flips
+    # /health to 503 — same as aggregated.
     RankPauseScenario(
         label="trtllm-disagg-decode-canary-on",
         base_config_key="disaggregated_same_gpu",
         system_port_index=1,  # DYN_SYSTEM_PORT2 = decode worker
         canary_enabled=True,
-        expected="miss",
+        expected="detect",
     ),
 ]
 

--- a/tests/fault_tolerance/test_canary_rank_pause.py
+++ b/tests/fault_tolerance/test_canary_rank_pause.py
@@ -158,6 +158,7 @@ def _wait_for_status(url: str, target: int, deadline_s: float) -> int:
 
 
 @pytest.mark.e2e
+@pytest.mark.nightly
 @pytest.mark.trtllm
 @pytest.mark.gpu_1
 @pytest.mark.parametrize(

--- a/tests/fault_tolerance/test_canary_rank_pause.py
+++ b/tests/fault_tolerance/test_canary_rank_pause.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rank-pause test: prove the canary detects real engine hangs.
+
+We launch a real engine worker, wait for it to be Ready, then SIGSTOP the
+engine-rank child process to simulate a hang (the engine can't produce
+tokens, but the Python dispatch layer is still alive). We then poll
+``/health`` on the worker's system port and assert:
+
+  * When canary is ENABLED AND the endpoint has a registered payload,
+    ``/health`` flips to 503 — the canary probe times out against the
+    paused engine and marks the endpoint NotReady. This is the positive
+    case the user asked for: *"canary can detect the issues we have seen."*
+
+  * When canary is DISABLED (or the endpoint opts out by registering no
+    payload, as trtllm disagg decode does today), ``/health`` STAYS at
+    200 — there is no active liveness probe. This is the negative
+    control the user asked for: it proves the harness distinguishes the
+    "canary working" path from the "no canary" path, rather than
+    always reporting success.
+
+After each case we ``SIGCONT`` the rank and verify ``/health`` returns to
+Ready, both as a cleanup and as a round-trip sanity check.
+
+Style mirrors ``tests/serve/test_trtllm.py::test_deployment`` — same
+``EngineProcess.from_script`` launcher, same ``/health`` polling. We do
+not use the ``tests/fault_tolerance/hardware/fault_injection_service``
+helpers; just POSIX signals.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+import signal
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import psutil
+import pytest
+import requests
+
+from tests.serve.test_trtllm import trtllm_configs
+from tests.utils.engine_process import EngineProcess
+
+logger = logging.getLogger(__name__)
+
+# Seconds: how long to wait after SIGSTOP for the canary to notice.
+# Canary interval in the runtime is typically 10 s; give it generous slack.
+PAUSE_DETECT_BUDGET_S = 45
+
+# Seconds: after SIGCONT, how long until /health is back.
+RESUME_RECOVER_BUDGET_S = 30
+
+# Seconds: how long to wait for /health to initially come up Ready.
+STARTUP_READY_BUDGET_S = 120
+
+
+@dataclass
+class RankPauseScenario:
+    """One row in the test matrix."""
+
+    # Label used in pytest param IDs.
+    label: str
+    # Which trtllm_configs entry to launch (must already be defined in tests/serve).
+    base_config_key: str
+    # Which system-port index to monitor (0 = prefill / single worker, 1 = decode).
+    system_port_index: int
+    # Whether to enable canary in the worker env.
+    canary_enabled: bool
+    # "detect" → /health must flip to 503 after SIGSTOP.
+    # "miss"   → /health must stay 200 after SIGSTOP.
+    expected: str
+
+
+# NB: only trtllm scenarios for now. vllm + sglang added in follow-ups once
+# we verify the engine-rank process discovery pattern for each backend.
+SCENARIOS: list[RankPauseScenario] = [
+    # Positive case: agg worker, canary on. Canary should catch the pause.
+    RankPauseScenario(
+        label="trtllm-agg-canary-on",
+        base_config_key="aggregated",
+        system_port_index=0,
+        canary_enabled=True,
+        expected="detect",
+    ),
+    # Negative control: same worker, canary off. Harness must NOT false-positive.
+    RankPauseScenario(
+        label="trtllm-agg-canary-off",
+        base_config_key="aggregated",
+        system_port_index=0,
+        canary_enabled=False,
+        expected="miss",
+    ),
+    # Disagg decode: canary opts out by design (trtllm handler rejects generic
+    # probes). Documents the current trade-off — will flip to "detect" once
+    # the probe-canary follow-up lands.
+    RankPauseScenario(
+        label="trtllm-disagg-decode-canary-on",
+        base_config_key="disaggregated_same_gpu",
+        system_port_index=1,  # DYN_SYSTEM_PORT2 = decode worker
+        canary_enabled=True,
+        expected="miss",
+    ),
+]
+
+
+def _find_engine_rank_pid(parent_pid: int, timeout_s: float = 30.0) -> int:
+    """Locate the TRT-LLM engine-rank subprocess under the test's worker parent.
+
+    The trtllm Python worker spawns a child process with a command line
+    containing ``EngineCore`` (see ``stragglers`` in TRTLLMConfig). We wait
+    up to ``timeout_s`` for it to appear so callers don't race startup.
+    """
+    deadline = time.monotonic() + timeout_s
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            parent = psutil.Process(parent_pid)
+            for child in parent.children(recursive=True):
+                try:
+                    cmd = " ".join(child.cmdline())
+                except psutil.Error:
+                    continue
+                if "EngineCore" in cmd or "tensorrt_llm" in cmd:
+                    return child.pid
+        except psutil.NoSuchProcess as e:
+            last_err = e
+        time.sleep(0.5)
+    raise RuntimeError(
+        f"Could not find engine-rank child of pid={parent_pid} within {timeout_s}s. "
+        f"Last error: {last_err}"
+    )
+
+
+def _health_status(url: str, timeout: float = 2.0) -> int:
+    """Return HTTP status from /health, or 0 on connection error."""
+    try:
+        r = requests.get(url, timeout=timeout)
+        return r.status_code
+    except requests.exceptions.RequestException:
+        return 0
+
+
+def _wait_for_status(url: str, target: int, deadline_s: float) -> int:
+    """Poll /health until status == target or deadline reached. Return last status."""
+    deadline = time.monotonic() + deadline_s
+    last = -1
+    while time.monotonic() < deadline:
+        last = _health_status(url)
+        if last == target:
+            return last
+        time.sleep(1.0)
+    return last
+
+
+@pytest.mark.e2e
+@pytest.mark.trtllm
+@pytest.mark.gpu_1
+@pytest.mark.parametrize(
+    "scenario",
+    SCENARIOS,
+    ids=lambda s: s.label if isinstance(s, RankPauseScenario) else str(s),
+)
+@pytest.mark.parametrize("num_system_ports", [2], indirect=True)
+def test_canary_detects_rank_pause(
+    scenario: RankPauseScenario,
+    request: Any,
+    runtime_services_dynamic_ports,  # noqa: ANN001
+    dynamo_dynamic_ports,  # noqa: ANN001
+    num_system_ports,  # noqa: ANN001
+    predownload_models,  # noqa: ANN001
+) -> None:
+    base = trtllm_configs[scenario.base_config_key]
+    config = dataclasses.replace(
+        base, frontend_port=dynamo_dynamic_ports.frontend_port
+    )
+    config.env.update(
+        {
+            "MODEL_PATH": config.model,
+            "SERVED_MODEL_NAME": config.model,
+            "DYN_HEALTH_CHECK_ENABLED": "true" if scenario.canary_enabled else "false",
+        }
+    )
+
+    system_ports = [int(p) for p in dynamo_dynamic_ports.system_ports]
+    assert len(system_ports) > scenario.system_port_index, (
+        f"scenario wants system_port_index={scenario.system_port_index} "
+        f"but only {len(system_ports)} ports are allocated"
+    )
+    target_port = system_ports[scenario.system_port_index]
+    health_url = f"http://localhost:{target_port}/health"
+    logger.info("[%s] health_url=%s canary=%s expected=%s",
+                scenario.label, health_url, scenario.canary_enabled,
+                scenario.expected)
+
+    # Build env + launch the worker using the exact same machinery as
+    # test_deployment so the scenario matches real CI conditions.
+    extra_env: dict[str, str] = {}
+    for i, p in enumerate(system_ports, start=1):
+        extra_env[f"DYN_SYSTEM_PORT{i}"] = str(p)
+    extra_env["DYN_SYSTEM_PORT"] = str(system_ports[0])
+    extra_env["DYN_HTTP_PORT"] = str(dynamo_dynamic_ports.frontend_port)
+    extra_env["DYN_HEALTH_CHECK_ENABLED"] = (
+        "true" if scenario.canary_enabled else "false"
+    )
+
+    with EngineProcess.from_script(config, request, extra_env=extra_env) as proc:
+        # 1. Wait for the worker to become healthy (Ready) before we pause.
+        status = _wait_for_status(health_url, 200, STARTUP_READY_BUDGET_S)
+        assert status == 200, (
+            f"[{scenario.label}] worker never became healthy "
+            f"(last status={status}) within {STARTUP_READY_BUDGET_S}s"
+        )
+
+        # 2. Find the engine rank subprocess and SIGSTOP it.
+        rank_pid = _find_engine_rank_pid(proc.proc.pid)
+        logger.info("[%s] pausing engine rank pid=%d", scenario.label, rank_pid)
+        os.kill(rank_pid, signal.SIGSTOP)
+        try:
+            # 3. Give the canary (or lack thereof) time to notice.
+            if scenario.expected == "detect":
+                status = _wait_for_status(health_url, 503, PAUSE_DETECT_BUDGET_S)
+                assert status == 503, (
+                    f"[{scenario.label}] canary FAILED to detect rank pause: "
+                    f"/health returned {status} (expected 503) within "
+                    f"{PAUSE_DETECT_BUDGET_S}s"
+                )
+            else:  # miss
+                # Wait the full budget; /health must stay 200 throughout. We
+                # sample periodically rather than trusting a single poll so a
+                # transient glitch doesn't masquerade as "miss".
+                deadline = time.monotonic() + PAUSE_DETECT_BUDGET_S
+                flips = 0
+                while time.monotonic() < deadline:
+                    s = _health_status(health_url)
+                    if s != 200:
+                        flips += 1
+                    time.sleep(2.0)
+                assert flips == 0, (
+                    f"[{scenario.label}] expected canary to MISS rank pause "
+                    f"(no active probe), but /health flipped away from 200 "
+                    f"{flips} time(s). Harness may be false-detecting."
+                )
+        finally:
+            # 4. Always resume the rank so teardown can complete cleanly.
+            try:
+                os.kill(rank_pid, signal.SIGCONT)
+            except ProcessLookupError:
+                pass
+
+        # 5. After resume, for the detect case, confirm /health returns to 200.
+        if scenario.expected == "detect":
+            status = _wait_for_status(health_url, 200, RESUME_RECOVER_BUDGET_S)
+            assert status == 200, (
+                f"[{scenario.label}] /health did not recover after SIGCONT "
+                f"(last status={status}) within {RESUME_RECOVER_BUDGET_S}s"
+            )


### PR DESCRIPTION
## Summary

- TRT-LLM: Skip canary health check payload registration for disagg decode workers
- vLLM: Skip canary health check payload for multimodal disagg decode workers (text-only decode still gets canary)
- SGLang: Already correct (uses `FAKE_BOOTSTRAP_HOST` for disagg decode health checks)

## Motivation

Enabling `DYN_HEALTH_CHECK_ENABLED=true` on disagg decode workers causes a crash-loop (DIS-1737). The canary sends a standard inference request, but decode workers reject it with "Disaggregated params are required for decode mode." The canary has no disagg topology awareness.

SGLang solved this with `FAKE_BOOTSTRAP_HOST` (fake-transfer mode). TRT-LLM and vLLM have no equivalent — TRT-LLM decode requires real `opaque_state` from prefill, vLLM multimodal decode needs `embedding_params`.

This PR fixes what we can now. TRT-LLM decode fake-transfer mode is being discussed with the TRT-LLM team separately.

## Changes

- `trtllm/workers/llm_worker.py`: Gate `health_check_payload` on `disaggregation_mode != DECODE`
- `vllm/worker_factory.py`: Gate on `not (DECODE and MULTIMODAL)`
- `trtllm/tests/test_health_check_disagg.py`: Test verifying standard payload has no disagg params

## Test plan

- [x] TRT-LLM decode: no health check payload registered (no crash)
- [x] TRT-LLM prefill/agg: standard health check payload (unchanged)
- [x] vLLM multimodal decode: no health check payload (no crash)
- [x] vLLM text-only decode: standard health check payload (unchanged)
- [x] SGLang: validated existing disagg path is correct
- [ ] e2e validation with real backends in k8s

## Related

- DIS-1737, DIS-1738, DYN-2670
- PR #8165 (DIS-1185 canary race condition fix — prerequisite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test for health check payload structure in specific scenarios

* **Improvements**
  * Optimized health check behavior for decode workers in disaggregation mode, conditionally skipping canary checks based on model type and runtime configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
