### PR TITLE
feat: Support Data Parallel / Expert Parallelism vLLM example on XPU

### DIFF
--- a/examples/backends/vllm/launch/xpu/dep_xpu.sh
+++ b/examples/backends/vllm/launch/xpu/dep_xpu.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+# Common configuration
+MODEL="Qwen/Qwen3-30B-A3B"
+BLOCK_SIZE=64
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../../common/launch_utils.sh"
+
+print_launch_banner "Launching Data Parallel / Expert Parallelism (4 XPUs)" "$MODEL" "$HTTP_PORT"
+
+# run ingress
+python -m dynamo.frontend --router-mode kv &
+
+# Data Parallel Attention / Expert Parallelism
+# Routing to DP workers managed by Dynamo
+# Qwen3-30B-A3B is a small MoE model that fits on smaller GPUs
+VLLM_NIXL_SIDE_CHANNEL_PORT=20096 \
+ZE_AFFINITY_MASK=0,1,2,3 \
+CCL_ZE_IPC_EXCHANGE=sockets \
+python3 -m dynamo.vllm \
+    --model "$MODEL" \
+    --block-size $BLOCK_SIZE \
+    --max_model_len 25.6k \
+    --data-parallel-hybrid-lb \
+    --data-parallel-size 4 \
+    --data-parallel-size-local 4 \
+    --data-parallel-start-rank 0 \
+    --enable-expert-parallel \
+    --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
+
+echo "All workers starting. (press Ctrl+C to stop)..."
+# Exit on first worker failure; kill 0 in the EXIT trap tears down the rest
+wait_any_exit


### PR DESCRIPTION
#### Overview:

Add an XPU launch script example for Data Parallel / Expert Parallelism (DEP) with vLLM, enabling Intel GPU users to run MoE models with distributed expert parallelism across multiple XPUs.

#### Details:

This PR adds `examples/backends/vllm/launch/xpu/dep_xpu.sh`, adapted from the CUDA-based `examples/backends/vllm/launch/dep.sh`, with the following XPU-specific changes:

- `CUDA_VISIBLE_DEVICES` → `ZE_AFFINITY_MASK=0,1,2,3` for Intel GPU device selection
- Added `--block-size 64` (required for XPU vLLM backend)
- Added `CCL_ZE_IPC_EXCHANGE=sockets` to work around pidfd_getfd permission issues in containerized environments  where oneCCL needs cross-process FD sharing for collective communications
- Removed `--enforce-eager` (not used in XPU scripts)
- Placed in `launch/xpu/` subdirectory consistent with other XPU examples

#### Where should the reviewer start?

- `examples/backends/vllm/launch/xpu/dep_xpu.sh` — compare against `examples/backends/vllm/launch/dep.sh` for the CUDA→XPU mapping

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added Intel XPU deployment launcher supporting multi-process distributed model inference and serving infrastructure
- Enables efficient execution of large models with intelligent load balancing, advanced parallelism features, and automatic request routing
- Includes comprehensive worker orchestration, process coordination, lifecycle management with health monitoring, and robust error handling with graceful shutdown for production deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->