### PR TITLE
Add XPU post-merge CI pipeline for Intel GPU

### DIFF
--- a/.github/actions/pytest-xpu/action.yml
+++ b/.github/actions/pytest-xpu/action.yml
@@ -1,0 +1,242 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Pytest (XPU)'
+description: |
+  Run pytest inside an XPU runtime container. This is the Intel GPU
+  counterpart to .github/actions/pytest, which targets NVIDIA GPUs via
+  --gpus all. The two actions are intentionally kept separate during the
+  initial XPU CI rollout so that this contribution is purely additive.
+  A follow-up PR can unify them once the XPU pipeline is stable.
+
+  This action does NOT bind-mount the host's test-results directory into
+  the test container. Instead, pytest writes results inside the container
+  and we extract them with `docker cp` afterward. This avoids permission
+  issues when the container's non-root user (e.g. 'dynamo') cannot write
+  to a host-owned mount, and works in both standard and Docker-in-Docker
+  runner setups.
+
+inputs:
+  image_tag:
+    description: 'Container image tag to run tests in'
+    required: true
+  pytest_marks:
+    description: 'Pytest -m marker expression'
+    required: true
+  test_suite_name:
+    description: 'Test suite name (used in artifact names)'
+    required: false
+    default: 'vllm-xpu'
+  test_type:
+    description: 'Test type label (e.g. pre_merge_cpu, pre_merge_gpu_1)'
+    required: false
+    default: 'pre_merge'
+  parallel_mode:
+    description: 'Parallelization mode: auto (use all cores), none/0 (sequential), or a number of workers'
+    required: false
+    default: 'auto'
+  hf_token:
+    description: 'HuggingFace token (passed into container as HF_TOKEN)'
+    required: false
+  docker_device_flags:
+    description: 'docker run flags from setup-xpu (e.g. --device /dev/dri -v /dev/dri:/dev/dri)'
+    required: false
+    default: ''
+  docker_group_flags:
+    description: 'docker run --group-add flags from setup-xpu'
+    required: false
+    default: ''
+  docker_env_flags:
+    description: 'docker run -e flags from setup-xpu (e.g. UR_ADAPTERS_FORCE_LOAD)'
+    required: false
+    default: ''
+  pytest_ignore:
+    description: |
+      Space-separated list of pytest --ignore=PATH arguments. Use this to
+      skip test files (or whole directories) that fail at collection time
+      due to known upstream issues (e.g. version mismatches between
+      ai-dynamo and vllm in the built image).
+    required: false
+    default: ''
+  pytest_deselect:
+    description: |
+      Space-separated list of pytest --deselect=NODEID arguments. Use this
+      to skip individual tests within a file when --ignore would be too
+      broad. Each entry must be a full pytest node ID, e.g.
+      "components/src/dynamo/vllm/tests/test_vllm_unit.py::test_foo".
+    required: false
+    default: ''
+  dynamo_compat_wheels_path:
+    description: |
+      Host path to a directory containing ai-dynamo and ai-dynamo-runtime
+      wheel files that are compatible with the vllm version in the XPU
+      image. When set, the action replaces the installed ai-dynamo
+      packages with these wheels before running tests. This is a
+      workaround for the ai-dynamo 1.0.0 / vllm 0.17.1+xpu version
+      mismatch (MultiModalUUIDDict import error).
+      Leave empty to skip the downgrade (use the image's default).
+    required: false
+    default: ''
+  hf_cache_path:
+    description: |
+      Host path to a pre-populated HuggingFace model cache directory.
+      When set, this is mounted read-only into the container at
+      /home/dynamo/.cache/huggingface/hub so that tests can load models
+      without downloading from huggingface.co. The path must exist on
+      the HOST (not inside the runner container) and contain models in
+      HF hub cache layout (models--ORG--NAME/snapshots/...).
+      Leave empty to skip the mount (tests that need models will error).
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run pytest in XPU container
+      shell: bash
+      env:
+        CONTAINER_ID: test_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}_pytest
+        PYTEST_XML_FILE: pytest_test_report.xml
+        HF_TOKEN: ${{ inputs.hf_token }}
+      run: |
+        set +e
+
+        mkdir -p test-results
+
+        # Determine parallelization based on parallel_mode input
+        case "${{ inputs.parallel_mode }}" in
+          "auto")
+            PARALLEL_OPTS="-n auto"
+            ;;
+          "none"|"0")
+            PARALLEL_OPTS="-n 0"
+            ;;
+          *)
+            PARALLEL_OPTS="-n ${{ inputs.parallel_mode }}"
+            ;;
+        esac
+
+        # Build --ignore and --deselect arguments
+        IGNORE_ARGS=""
+        for p in ${{ inputs.pytest_ignore }}; do
+          IGNORE_ARGS="${IGNORE_ARGS} --ignore=${p}"
+        done
+        DESELECT_ARGS=""
+        for n in ${{ inputs.pytest_deselect }}; do
+          DESELECT_ARGS="${DESELECT_ARGS} --deselect=${n}"
+        done
+
+        PYTEST_CMD="mkdir -p /workspace/test-results /workspace/test-results/allure-results && pytest ${PARALLEL_OPTS} --dist=loadscope --continue-on-collection-errors -v --tb=short --basetemp=/tmp/pytest_temp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${PYTEST_XML_FILE} --alluredir=/workspace/test-results/allure-results --durations=10 ${IGNORE_ARGS} ${DESELECT_ARGS} -m \"${{ inputs.pytest_marks }}\""
+
+        echo "Pytest command: ${PYTEST_CMD}"
+
+        DOCKER_ENV_FLAGS=()
+        if [[ -n "${HF_TOKEN:-}" ]]; then
+          DOCKER_ENV_FLAGS+=(--env "HF_TOKEN=${HF_TOKEN}")
+        fi
+        DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_FRAMEWORK=vllm")
+        DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_PLATFORM=xpu")
+        DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_TYPE=${{ inputs.test_type }}")
+        DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_WORKFLOW=${GITHUB_WORKFLOW}")
+        DOCKER_ENV_FLAGS+=(--env "VLLM_TARGET_DEVICE=xpu")
+
+        # Build optional HF cache mount. When a cache is provided, also set
+        # HF_HUB_OFFLINE=1 so that huggingface_hub never tries to reach the
+        # HF API (which times out behind corporate proxies). The tests will
+        # load models exclusively from the mounted cache.
+        HF_CACHE_MOUNT=""
+        HF_OFFLINE_FLAG=""
+        if [[ -n "${{ inputs.hf_cache_path }}" ]]; then
+          HF_CACHE_MOUNT="-v ${{ inputs.hf_cache_path }}:/home/dynamo/.cache/huggingface/hub"
+          HF_OFFLINE_FLAG="-e HF_HUB_OFFLINE=1"
+          echo "Mounting HF cache from ${{ inputs.hf_cache_path }} (offline mode)"
+        fi
+
+        # Build optional dynamo compat wheels mount and pre-install command.
+        # When ai-dynamo in the image is incompatible with vllm-xpu, we
+        # replace it at container startup before running tests.
+        WHEELS_MOUNT=""
+        WHEELS_INSTALL=""
+        if [[ -n "${{ inputs.dynamo_compat_wheels_path }}" ]]; then
+          WHEELS_MOUNT="-v ${{ inputs.dynamo_compat_wheels_path }}:/dynamo-wheels:ro"
+          WHEELS_INSTALL="source /opt/dynamo/venv/bin/activate 2>/dev/null; uv pip uninstall ai-dynamo ai-dynamo-runtime 2>/dev/null; rm -rf /opt/dynamo/venv/lib/python3.12/site-packages/dynamo /opt/dynamo/venv/lib/python3.12/site-packages/ai_dynamo*; uv pip install --no-deps /dynamo-wheels/ai_dynamo_runtime-*.whl /dynamo-wheels/ai_dynamo-*.whl 2>&1 | tail -3; "
+          echo "Mounting dynamo compat wheels from ${{ inputs.dynamo_compat_wheels_path }}"
+        fi
+
+        # Run WITHOUT --rm so we can docker cp results out after pytest exits.
+        docker rm -f "${CONTAINER_ID}" 2>/dev/null || true
+        docker run \
+          ${{ inputs.docker_device_flags }} \
+          ${{ inputs.docker_group_flags }} \
+          ${{ inputs.docker_env_flags }} \
+          ${HF_CACHE_MOUNT} \
+          ${HF_OFFLINE_FLAG} \
+          ${WHEELS_MOUNT} \
+          --shm-size=200m \
+          --ulimit memlock=-1 \
+          --ulimit stack=67108864 \
+          -w /workspace \
+          --network host \
+          "${DOCKER_ENV_FLAGS[@]}" \
+          --name "${CONTAINER_ID}" \
+          ${{ inputs.image_tag }} \
+          sh -c "umask 0022 && ${WHEELS_INSTALL}${PYTEST_CMD}"
+
+        TEST_EXIT_CODE=$?
+        # pytest exit code 5 = "no tests collected". This is not a failure —
+        # it means the marker/ignore combination yielded zero matching tests.
+        # Treat it as success so the pipeline stays green.
+        if [ "${TEST_EXIT_CODE}" -eq 5 ]; then
+          echo "No tests were selected for this marker — treating as success"
+          TEST_EXIT_CODE=0
+        fi
+        echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> "${GITHUB_ENV}"
+        echo "Tests completed with exit code: ${TEST_EXIT_CODE}"
+
+        # Extract results from the (now-stopped) container, then remove it.
+        docker cp "${CONTAINER_ID}:/workspace/test-results/." test-results/ 2>&1 || \
+          echo "WARNING: failed to docker cp test-results out of container"
+        docker rm -f "${CONTAINER_ID}" 2>/dev/null || true
+
+        ls -la test-results/ || true
+        exit 0
+
+    - name: Process test results
+      shell: bash
+      run: |
+        STR_TEST_TYPE=$(echo "${{ inputs.test_type }}" | tr ', ' '_')
+        echo "STR_TEST_TYPE=${STR_TEST_TYPE}" >> "${GITHUB_ENV}"
+
+        JUNIT_FILE="test-results/pytest_test_report.xml"
+        if [[ -f "${JUNIT_FILE}" ]]; then
+          TOTAL_TESTS=$(grep -o 'tests="[0-9]*"' "${JUNIT_FILE}" | grep -o '[0-9]*' | head -1 || echo "0")
+          FAILED_TESTS=$(grep -o 'failures="[0-9]*"' "${JUNIT_FILE}" | grep -o '[0-9]*' | head -1 || echo "0")
+          ERROR_TESTS=$(grep -o 'errors="[0-9]*"' "${JUNIT_FILE}" | grep -o '[0-9]*' | head -1 || echo "0")
+          echo "${TOTAL_TESTS} tests completed (${FAILED_TESTS} failed, ${ERROR_TESTS} errors)"
+
+          JUNIT_NAME="pytest_test_report_${{ inputs.test_suite_name }}_${STR_TEST_TYPE}_xpu_${{ github.run_id }}.xml"
+          mv "${JUNIT_FILE}" "test-results/${JUNIT_NAME}"
+          echo "Renamed XML file to: ${JUNIT_NAME}"
+        else
+          echo "WARNING: JUnit XML file not found"
+          FAILED_TESTS=1
+        fi
+
+        exit ${TEST_EXIT_CODE}
+
+    - name: Upload test results
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      if: always()
+      with:
+        name: test-results-${{ inputs.test_suite_name }}-${{ env.STR_TEST_TYPE }}-xpu-${{ github.run_id }}
+        path: test-results/pytest_test_report_${{ inputs.test_suite_name }}_${{ env.STR_TEST_TYPE }}_xpu_${{ github.run_id }}.xml
+        retention-days: 7
+
+    - name: Upload allure results
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      if: always()
+      with:
+        name: allure-results-vllm-xpu-${{ env.STR_TEST_TYPE }}-${{ github.run_id }}
+        path: test-results/allure-results/
+        retention-days: 7
+        if-no-files-found: ignore

--- a/.github/actions/setup-xpu/action.yml
+++ b/.github/actions/setup-xpu/action.yml
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Setup XPU runner'
+description: |
+  Detect Intel GPUs (XPU) on the runner and emit the docker flags needed
+  to pass them through into a container. Distinguishes consumer Arc GPUs
+  (which need the V1 Level Zero UR adapter) from data center GPUs (which
+  use the default V2 adapter).
+
+  This action does NOT install drivers or modify the host. It only
+  inspects /sys/class/drm and /dev/dri to derive the runtime flags.
+
+inputs:
+  min_gpus:
+    description: 'Minimum number of XPUs required for this job'
+    required: false
+    default: '1'
+
+outputs:
+  xpu_count:
+    description: 'Number of Intel GPU render devices detected'
+    value: ${{ steps.detect.outputs.xpu_count }}
+  gpu_class:
+    description: 'GPU class: arc-consumer or data-center'
+    value: ${{ steps.detect.outputs.gpu_class }}
+  gpu_name:
+    description: 'Detected GPU name (best-effort)'
+    value: ${{ steps.detect.outputs.gpu_name }}
+  docker_device_flags:
+    description: 'docker run flags to expose /dev/dri (e.g. --device /dev/dri -v /dev/dri:/dev/dri)'
+    value: ${{ steps.detect.outputs.docker_device_flags }}
+  docker_group_flags:
+    description: 'docker run --group-add flags for render device GIDs'
+    value: ${{ steps.detect.outputs.docker_group_flags }}
+  docker_env_flags:
+    description: 'docker run -e flags (e.g. UR_ADAPTERS_FORCE_LOAD for consumer Arc)'
+    value: ${{ steps.detect.outputs.docker_env_flags }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Detect Intel GPUs
+      id: detect
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        echo "=== /dev/dri ==="
+        ls -la /dev/dri/ 2>/dev/null || { echo "ERROR: /dev/dri not present"; exit 1; }
+
+        # Count Intel GPU render devices via sysfs (no xpu-smi/lspci dependency)
+        XPU_COUNT=0
+        GPU_NAME=""
+        DEVICE_ID=""
+        for card in /sys/class/drm/card*/device; do
+          [ -f "${card}/vendor" ] || continue
+          VENDOR=$(cat "${card}/vendor" 2>/dev/null || echo "")
+          if [ "${VENDOR}" = "0x8086" ]; then
+            XPU_COUNT=$((XPU_COUNT + 1))
+            if [ -z "${DEVICE_ID}" ]; then
+              DEVICE_ID=$(cat "${card}/device" 2>/dev/null || echo "")
+            fi
+          fi
+        done
+
+        echo "Detected ${XPU_COUNT} Intel GPU(s) (PCI device ID: ${DEVICE_ID:-unknown})"
+
+        if [ "${XPU_COUNT}" -lt "${{ inputs.min_gpus }}" ]; then
+          echo "ERROR: Job requires ${{ inputs.min_gpus }} XPU(s), found ${XPU_COUNT}"
+          exit 1
+        fi
+
+        # Best-effort name resolution: prefer xpu-smi if available, otherwise
+        # fall back to PCI device ID. Used only for human-readable logs.
+        if command -v xpu-smi >/dev/null 2>&1; then
+          GPU_NAME=$(xpu-smi discovery 2>/dev/null | grep "Device Name" | head -1 | sed 's/.*: *//' || echo "")
+        fi
+        if [ -z "${GPU_NAME}" ]; then
+          GPU_NAME="Intel GPU PCI ${DEVICE_ID}"
+        fi
+        echo "GPU name: ${GPU_NAME}"
+
+        # Classify GPU. Consumer Arc GPUs need the V1 Level Zero UR adapter
+        # because PyTorch's default V2 adapter fails on these device IDs with
+        # UR_RESULT_ERROR_UNKNOWN. Data center GPUs (e.g. Intel Data Center
+        # GPU Max series) work with the default V2 adapter.
+        #
+        # Known consumer Arc PCI IDs:
+        #   0xe20b — Arc B580 (Battlemage)
+        #   0xe20c — Arc B570 (Battlemage)
+        #   0x5690 — Arc A770 (Alchemist)
+        #   0x5694 — Arc A750 (Alchemist)
+        DOCKER_ENV_FLAGS=""
+        case "${DEVICE_ID}" in
+          0xe20b|0xe20c|0x5690|0x5694|0x56a0|0x56a1)
+            GPU_CLASS="arc-consumer"
+            DOCKER_ENV_FLAGS="-e UR_ADAPTERS_FORCE_LOAD=/opt/dynamo/venv/lib/libur_adapter_level_zero.so"
+            echo "Consumer Arc GPU detected — forcing Level Zero V1 UR adapter"
+            ;;
+          *)
+            GPU_CLASS="data-center"
+            echo "Treating as data center GPU — using default V2 UR adapter"
+            ;;
+        esac
+
+        # Render-device group GIDs. The XPU container runs as a non-root user
+        # ('dynamo') which needs explicit access to /dev/dri/renderD* nodes
+        # via supplementary groups. Without --group-add, both UR adapters
+        # fail to init and report the misleading UR_RESULT_ERROR_UNSUPPORTED_VERSION.
+        DOCKER_GROUP_FLAGS=""
+        SEEN_GIDS=""
+        for r in /dev/dri/renderD*; do
+          [ -e "${r}" ] || continue
+          GID=$(stat -c '%g' "${r}")
+          case " ${SEEN_GIDS} " in
+            *" ${GID} "*) ;;  # already added
+            *)
+              DOCKER_GROUP_FLAGS="${DOCKER_GROUP_FLAGS} --group-add ${GID}"
+              SEEN_GIDS="${SEEN_GIDS} ${GID}"
+              ;;
+          esac
+        done
+
+        DOCKER_DEVICE_FLAGS="--device /dev/dri -v /dev/dri:/dev/dri"
+
+        echo "xpu_count=${XPU_COUNT}" >> "${GITHUB_OUTPUT}"
+        echo "gpu_class=${GPU_CLASS}" >> "${GITHUB_OUTPUT}"
+        echo "gpu_name=${GPU_NAME}" >> "${GITHUB_OUTPUT}"
+        echo "docker_device_flags=${DOCKER_DEVICE_FLAGS}" >> "${GITHUB_OUTPUT}"
+        echo "docker_group_flags=${DOCKER_GROUP_FLAGS}" >> "${GITHUB_OUTPUT}"
+        echo "docker_env_flags=${DOCKER_ENV_FLAGS}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/xpu-post-merge-ci.yml
+++ b/.github/workflows/xpu-post-merge-ci.yml
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: XPU Post-Merge CI Pipeline
+
+# Runs on every merge to main. Uses broader test markers than xpu-pr.yml:
+# - PR workflow: "pre_merge and vllm and gpu_N"
+# - Post-merge:  "(pre_merge or post_merge) and vllm and gpu_N"
+#
+# This catches regressions in tests marked post_merge-only (heavier tests
+# that are too slow for every PR but should run on every merge to main).
+#
+# NOTE: when upstreaming, switch to:
+#   on:
+#     push:
+#       branches: [main, 'release/*.*.*']
+on:
+  push:
+    branches:
+      - main
+      - 'xpu-ci-*'
+  workflow_dispatch:
+
+concurrency:
+  group: xpu-post-merge-${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  XPU_RUNTIME_IMAGE: dynamo-vllm-xpu:${{ github.sha }}
+  XPU_TEST_IMAGE: dynamo-vllm-xpu-test:${{ github.sha }}
+
+  # Host path to pre-populated HuggingFace model cache.
+  XPU_HF_CACHE_PATH: /mnt/weka/data/llm-d-models-pv/hub
+
+  # Test files/directories to skip. Same list as xpu-pr.yml — see
+  # that file for detailed comments on each entry.
+  XPU_PYTEST_IGNORE: >-
+    components/src/dynamo/vllm/tests/multimodal_utils
+    components/src/dynamo/vllm/tests/test_vllm_chat_message_utils.py
+    components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py
+    components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
+    components/src/dynamo/vllm/tests/test_vllm_video_handler.py
+    components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+    components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+    tests/serve
+    tests/kvbm_integration
+    tests/test_predownload_models.py
+    tests/frontend/test_vllm_prepost_integration.py
+    tests/mm_router
+    tests/router
+    tests/fault_tolerance
+    tests/frontend/test_vllm.py
+
+  XPU_PYTEST_DESELECT: >-
+    components/src/dynamo/vllm/tests/test_vllm_unit.py::test_headless_namespace_has_required_fields
+    components/src/dynamo/vllm/tests/test_vllm_unit.py::TestVllmOmniOptionalDependency::test_dynamo_vllm_main_importable_without_vllm_omni
+
+jobs:
+  # ============================================================================
+  # BUILD
+  # ============================================================================
+  vllm-xpu-build:
+    name: vllm-xpu Build
+    runs-on: [self-hosted, xpu]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        with:
+          lfs: true
+
+      - name: Generate XPU Dockerfile
+        shell: bash
+        run: |
+          python3 container/render.py \
+            --framework vllm \
+            --device xpu \
+            --target runtime \
+            --platform linux/amd64 \
+            --output-short-filename \
+            --show-result
+
+      - name: Build XPU runtime image
+        shell: bash
+        run: |
+          docker build \
+            --progress=plain \
+            --build-arg DYNAMO_COMMIT_SHA=${{ github.sha }} \
+            --build-arg http_proxy=${http_proxy:-} \
+            --build-arg https_proxy=${https_proxy:-} \
+            --build-arg HTTP_PROXY=${HTTP_PROXY:-} \
+            --build-arg HTTPS_PROXY=${HTTPS_PROXY:-} \
+            --build-arg no_proxy=${no_proxy:-} \
+            -f container/rendered.Dockerfile \
+            -t ${{ env.XPU_RUNTIME_IMAGE }} \
+            .
+
+      - name: Build XPU test image
+        shell: bash
+        run: |
+          if [ -f container/Dockerfile.test ]; then
+            docker build \
+              --progress=plain \
+              --build-arg BASE_IMAGE=${{ env.XPU_RUNTIME_IMAGE }} \
+              --build-arg http_proxy=${http_proxy:-} \
+              --build-arg https_proxy=${https_proxy:-} \
+              --build-arg HTTP_PROXY=${HTTP_PROXY:-} \
+              --build-arg HTTPS_PROXY=${HTTPS_PROXY:-} \
+              --build-arg no_proxy=${no_proxy:-} \
+              -f container/Dockerfile.test \
+              -t ${{ env.XPU_TEST_IMAGE }} \
+              .
+          else
+            docker tag ${{ env.XPU_RUNTIME_IMAGE }} ${{ env.XPU_TEST_IMAGE }}
+          fi
+
+  # ============================================================================
+  # SANITY CHECK
+  # ============================================================================
+  vllm-xpu-sanity:
+    name: vllm-xpu Sanity
+    needs: [vllm-xpu-build]
+    runs-on: [self-hosted, xpu]
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+
+      - name: Setup XPU runtime flags
+        id: setup-xpu
+        uses: ./.github/actions/setup-xpu
+
+      - name: Run sanity_check.py
+        shell: bash
+        run: |
+          docker run --rm \
+            ${{ steps.setup-xpu.outputs.docker_device_flags }} \
+            ${{ steps.setup-xpu.outputs.docker_group_flags }} \
+            ${{ steps.setup-xpu.outputs.docker_env_flags }} \
+            ${{ env.XPU_RUNTIME_IMAGE }} \
+            python /workspace/deploy/sanity_check.py --runtime-check --no-gpu-check
+
+      - name: XPU smoke test
+        shell: bash
+        run: |
+          docker run --rm \
+            ${{ steps.setup-xpu.outputs.docker_device_flags }} \
+            ${{ steps.setup-xpu.outputs.docker_group_flags }} \
+            ${{ steps.setup-xpu.outputs.docker_env_flags }} \
+            ${{ env.XPU_RUNTIME_IMAGE }} \
+            python3 -c "
+          import torch
+          print('PyTorch:', torch.__version__)
+          print('XPU available:', torch.xpu.is_available())
+          print('XPU devices:', torch.xpu.device_count())
+          assert torch.xpu.is_available(), 'XPU not available!'
+          t = torch.randn(2, 3).to('xpu')
+          print('Tensor on XPU:', t.device)
+          print('PASS')
+          "
+
+  # ============================================================================
+  # CPU-ONLY TESTS — post_merge markers included
+  # ============================================================================
+  vllm-xpu-cpu-tests:
+    name: vllm-xpu CPU Tests
+    needs: [vllm-xpu-build]
+    runs-on: [self-hosted, xpu]
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+
+      - name: Setup XPU runtime flags
+        id: setup-xpu
+        uses: ./.github/actions/setup-xpu
+
+      - name: Run CPU-only tests (pre_merge + post_merge)
+        uses: ./.github/actions/pytest-xpu
+        with:
+          image_tag: ${{ env.XPU_TEST_IMAGE }}
+          pytest_marks: '(pre_merge or post_merge) and vllm and gpu_0'
+          test_suite_name: vllm-xpu
+          test_type: post_merge_cpu
+          parallel_mode: 'auto'
+          hf_token: ${{ secrets.HF_TOKEN }}
+          docker_device_flags: ${{ steps.setup-xpu.outputs.docker_device_flags }}
+          docker_group_flags: ${{ steps.setup-xpu.outputs.docker_group_flags }}
+          docker_env_flags: ${{ steps.setup-xpu.outputs.docker_env_flags }}
+          pytest_ignore: ${{ env.XPU_PYTEST_IGNORE }}
+          pytest_deselect: ${{ env.XPU_PYTEST_DESELECT }}
+          hf_cache_path: ${{ env.XPU_HF_CACHE_PATH }}
+
+  # ============================================================================
+  # SINGLE-GPU TESTS — post_merge markers included
+  # ============================================================================
+  vllm-xpu-gpu-tests:
+    name: vllm-xpu Single-GPU Tests
+    needs: [vllm-xpu-build, vllm-xpu-sanity]
+    runs-on: [self-hosted, xpu]
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+
+      - name: Setup XPU runtime flags
+        id: setup-xpu
+        uses: ./.github/actions/setup-xpu
+        with:
+          min_gpus: '1'
+
+      - name: Run single-GPU tests (pre_merge + post_merge)
+        uses: ./.github/actions/pytest-xpu
+        with:
+          image_tag: ${{ env.XPU_TEST_IMAGE }}
+          pytest_marks: '(pre_merge or post_merge) and vllm and gpu_1'
+          test_suite_name: vllm-xpu
+          test_type: post_merge_gpu_1
+          parallel_mode: 'none'
+          hf_token: ${{ secrets.HF_TOKEN }}
+          docker_device_flags: ${{ steps.setup-xpu.outputs.docker_device_flags }}
+          docker_group_flags: ${{ steps.setup-xpu.outputs.docker_group_flags }}
+          docker_env_flags: ${{ steps.setup-xpu.outputs.docker_env_flags }}
+          pytest_ignore: ${{ env.XPU_PYTEST_IGNORE }}
+          pytest_deselect: ${{ env.XPU_PYTEST_DESELECT }}
+          hf_cache_path: ${{ env.XPU_HF_CACHE_PATH }}
+
+  # ============================================================================
+  # MULTI-GPU TESTS — post_merge markers included
+  # ============================================================================
+  # TODO: when 4-XPU runners are available, change min_gpus to 4 and the
+  #       marker to '(pre_merge or post_merge) and vllm and (gpu_2 or gpu_4)'
+  vllm-xpu-multi-gpu-tests:
+    name: vllm-xpu Multi-GPU Tests
+    needs: [vllm-xpu-build, vllm-xpu-sanity]
+    runs-on: [self-hosted, xpu, multi-gpu]
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+
+      - name: Setup XPU runtime flags
+        id: setup-xpu
+        uses: ./.github/actions/setup-xpu
+        with:
+          min_gpus: '2'
+
+      - name: Run multi-GPU tests (pre_merge + post_merge)
+        uses: ./.github/actions/pytest-xpu
+        with:
+          image_tag: ${{ env.XPU_TEST_IMAGE }}
+          pytest_marks: '(pre_merge or post_merge) and vllm and gpu_2'
+          test_suite_name: vllm-xpu
+          test_type: post_merge_gpu_2
+          parallel_mode: 'none'
+          hf_token: ${{ secrets.HF_TOKEN }}
+          docker_device_flags: ${{ steps.setup-xpu.outputs.docker_device_flags }}
+          docker_group_flags: ${{ steps.setup-xpu.outputs.docker_group_flags }}
+          docker_env_flags: ${{ steps.setup-xpu.outputs.docker_env_flags }}
+          pytest_ignore: ${{ env.XPU_PYTEST_IGNORE }}
+          pytest_deselect: ${{ env.XPU_PYTEST_DESELECT }}
+          hf_cache_path: ${{ env.XPU_HF_CACHE_PATH }}
+
+  # ============================================================================
+  # STATUS CHECK
+  # ============================================================================
+  xpu-post-merge-status:
+    name: XPU Post-Merge Status
+    runs-on: ubuntu-latest
+    needs:
+      - vllm-xpu-build
+      - vllm-xpu-sanity
+      - vllm-xpu-cpu-tests
+      - vllm-xpu-gpu-tests
+      - vllm-xpu-multi-gpu-tests
+    if: always()
+    steps:
+      - name: Aggregate job results
+        run: |
+          echo '${{ toJson(needs) }}' | jq -e 'to_entries | map(.value.result) | all(. as $r | ["success", "skipped"] | any($r == .))'


### PR DESCRIPTION
## Summary
- Add XPU post-merge CI workflow for Intel GPU validation after merges to main

## New files
| File | Purpose |
|------|---------|
| `.github/workflows/xpu-post-merge-ci.yml` | Post-merge validation: build → sanity → cpu → gpu_1 → gpu_2 |
| `.github/actions/setup-xpu/action.yml` | Intel GPU detection + docker runtime flags (shared with PR workflow) |
| `.github/actions/pytest-xpu/action.yml` | XPU-aware pytest runner with docker cp result extraction (shared with PR workflow) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added continuous integration support for XPU environments with automated hardware detection and testing capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->