### PR TITLE
fix(health): gate health check payload registration on DYN_HEALTH_CHECK_ENABLED

### DIFF
--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -113,11 +113,11 @@ async def init_decode(
     if config.serving_mode == DisaggregationMode.DECODE:
         health_check_payload = SglangDisaggHealthCheckPayload(
             engine, use_text_input=dynamo_args.use_sglang_tokenizer
-        ).to_dict()
+        ).to_dict_if_enabled()
     else:
         health_check_payload = SglangHealthCheckPayload(
             engine, use_text_input=dynamo_args.use_sglang_tokenizer
-        ).to_dict()
+        ).to_dict_if_enabled()
 
     logging.info(f"Registering model with endpoint types: {dynamo_args.endpoint_types}")
     if dynamo_args.custom_jinja_template and "chat" not in dynamo_args.endpoint_types:
@@ -246,7 +246,7 @@ async def init_prefill(
     )
     handler.register_engine_routes(runtime)
 
-    health_check_payload = SglangPrefillHealthCheckPayload(engine).to_dict()
+    health_check_payload = SglangPrefillHealthCheckPayload(engine).to_dict_if_enabled()
 
     ready_event = asyncio.Event()
 

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -546,7 +546,9 @@ async def init_llm_worker(
             )
 
         # Get health check payload (checks env var and falls back to TensorRT-LLM default)
-        health_check_payload = TrtllmHealthCheckPayload(tokenizer=tokenizer).to_dict()
+        health_check_payload = TrtllmHealthCheckPayload(
+            tokenizer=tokenizer
+        ).to_dict_if_enabled()
 
         if config.publish_events_and_metrics:
             # Initialize and pass in the publisher to the request handler to

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -393,7 +393,7 @@ class WorkerFactory:
 
         health_check_payload = VllmHealthCheckPayload(
             engine_client, use_text_input=config.use_vllm_tokenizer
-        ).to_dict()
+        ).to_dict_if_enabled()
 
         perf_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.get_perf_metrics"
@@ -599,7 +599,7 @@ class WorkerFactory:
 
         health_check_payload = VllmPrefillHealthCheckPayload(
             engine_client, use_text_input=config.use_vllm_tokenizer
-        ).to_dict()
+        ).to_dict_if_enabled()
 
         prefill_metrics_labels = [
             (

--- a/lib/bindings/python/src/dynamo/health_check.py
+++ b/lib/bindings/python/src/dynamo/health_check.py
@@ -94,22 +94,31 @@ class HealthCheckPayload:
 
         self._payload = None
 
-    def to_dict(self) -> Optional[Dict[str, Any]]:
+    def to_dict(self) -> Dict[str, Any]:
         """
-        Get the health check payload as a dictionary, or None if canary is disabled.
+        Get the health check payload as a dictionary.
 
-        Returns None if DYN_HEALTH_CHECK_ENABLED is not 'true' — this means
-        no health check target will be registered, and the transport layer
-        will set the endpoint to Ready on registration (default behavior).
-
-        When canary is enabled, returns the environment override if
-        DYN_HEALTH_CHECK_PAYLOAD is set, otherwise returns the default payload.
+        Returns the environment override if DYN_HEALTH_CHECK_PAYLOAD is set,
+        otherwise returns the default payload.
         """
-        if not is_health_check_enabled():
-            return None
         if self._payload is None:
             self._payload = load_health_check_from_env() or self.default_payload
         return self._payload
+
+    def to_dict_if_enabled(self) -> Optional[Dict[str, Any]]:
+        """
+        Get the payload only if canary health checks are enabled.
+
+        Returns None if DYN_HEALTH_CHECK_ENABLED is not 'true', meaning
+        no health check target will be registered and the transport layer
+        will set the endpoint to Ready on registration (default behavior).
+
+        Use this when passing to serve_endpoint(health_check_payload=...).
+        Use to_dict() directly when you need the payload regardless of config.
+        """
+        if not is_health_check_enabled():
+            return None
+        return self.to_dict()
 
     def __repr__(self) -> str:
         """Return a string representation of the health check payload."""

--- a/lib/bindings/python/src/dynamo/health_check.py
+++ b/lib/bindings/python/src/dynamo/health_check.py
@@ -15,7 +15,16 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["HealthCheckPayload", "load_health_check_from_env"]
+__all__ = [
+    "HealthCheckPayload",
+    "load_health_check_from_env",
+    "is_health_check_enabled",
+]
+
+
+def is_health_check_enabled() -> bool:
+    """Check if active canary health checks are enabled via DYN_HEALTH_CHECK_ENABLED."""
+    return os.environ.get("DYN_HEALTH_CHECK_ENABLED", "").lower() == "true"
 
 
 def load_health_check_from_env(
@@ -85,15 +94,20 @@ class HealthCheckPayload:
 
         self._payload = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> Optional[Dict[str, Any]]:
         """
-        Get the health check payload as a dictionary.
+        Get the health check payload as a dictionary, or None if canary is disabled.
 
-        Returns the environment override if DYN_HEALTH_CHECK_PAYLOAD is set,
-        otherwise returns the default payload.
+        Returns None if DYN_HEALTH_CHECK_ENABLED is not 'true' — this means
+        no health check target will be registered, and the transport layer
+        will set the endpoint to Ready on registration (default behavior).
+
+        When canary is enabled, returns the environment override if
+        DYN_HEALTH_CHECK_PAYLOAD is set, otherwise returns the default payload.
         """
+        if not is_health_check_enabled():
+            return None
         if self._payload is None:
-            # Check for environment override
             self._payload = load_health_check_from_env() or self.default_payload
         return self._payload
 

--- a/lib/runtime/src/pipeline/network/ingress/http_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/http_endpoint.rs
@@ -96,10 +96,16 @@ impl SharedHttpServer {
         let subject_clone = subject.clone();
         self.handlers.insert(subject, handler);
 
-        // THEN set health status to Ready (after handler is registered and ready)
-        system_health
+        // Only set Ready if no health check target is registered for this endpoint.
+        if system_health
             .lock()
-            .set_endpoint_health_status(&endpoint_name, HealthStatus::Ready);
+            .get_health_check_target(&endpoint_name)
+            .is_none()
+        {
+            system_health
+                .lock()
+                .set_endpoint_health_status(&endpoint_name, HealthStatus::Ready);
+        }
 
         tracing::debug!("Registered endpoint handler for subject: {subject_clone}");
         Ok(())

--- a/lib/runtime/src/pipeline/network/ingress/push_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_endpoint.rs
@@ -50,9 +50,17 @@ impl PushEndpoint {
         let endpoint_name_local: Arc<String> = Arc::from(endpoint_name);
         let namespace_local: Arc<String> = Arc::from(namespace);
 
-        system_health
+        // Only set Ready if no health check target is registered for this endpoint.
+        // If a target exists, the canary health check is the authority on readiness.
+        if system_health
             .lock()
-            .set_endpoint_health_status(endpoint_name_local.as_str(), HealthStatus::Ready);
+            .get_health_check_target(endpoint_name_local.as_str())
+            .is_none()
+        {
+            system_health
+                .lock()
+                .set_endpoint_health_status(endpoint_name_local.as_str(), HealthStatus::Ready);
+        }
 
         loop {
             let req = tokio::select! {

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -330,10 +330,16 @@ impl SharedTcpServer {
         // Insert handler FIRST to ensure it's ready to receive requests
         self.handlers.insert(endpoint_path, handler);
 
-        // THEN set health status to Ready (after handler is registered and ready)
-        system_health
+        // Only set Ready if no health check target is registered for this endpoint.
+        if system_health
             .lock()
-            .set_endpoint_health_status(&endpoint_name, crate::HealthStatus::Ready);
+            .get_health_check_target(&endpoint_name)
+            .is_none()
+        {
+            system_health
+                .lock()
+                .set_endpoint_health_status(&endpoint_name, crate::HealthStatus::Ready);
+        }
 
         tracing::info!(
             "Registered endpoint '{fqn_endpoint}' with shared TCP server on {}",


### PR DESCRIPTION
## Summary

- Python `HealthCheckPayload.to_dict()` returns `None` when `DYN_HEALTH_CHECK_ENABLED` is not `true`
- Rust transport endpoints check per-endpoint `get_health_check_target()` — no target means transport sets Ready (default behavior)
- Replaces global `health_check_enabled` flag with per-endpoint data-driven behavior

## Motivation

Alternative approach to PR #8165. Instead of a global flag on `SystemHealth`, the decision is driven by whether a health check payload was actually registered:

- **Canary disabled** (default): `to_dict()` returns None → no payload passed to `serve_endpoint` → no health check target registered → transport sets Ready → existing behavior
- **Canary enabled**: `to_dict()` returns payload → target registered → transport skips Ready → canary is sole authority

This is backward compatible and eliminates the need for Rust-side config awareness of `DYN_HEALTH_CHECK_ENABLED`.

## Changes

- `lib/bindings/python/src/dynamo/health_check.py`: `to_dict()` returns None when canary disabled, add `is_health_check_enabled()` helper
- `push_endpoint.rs`, `http_endpoint.rs`, `shared_tcp_endpoint.rs`: Gate eager Ready on `get_health_check_target().is_none()`

## Test plan

- [ ] `cargo check` — passes
- [ ] pre-commit (black/isort) — passes
- [ ] With `DYN_HEALTH_CHECK_ENABLED=false`: backends register no payload → transport Ready → existing behavior
- [ ] With `DYN_HEALTH_CHECK_ENABLED=true`: backends register payload → canary governs readiness
- [ ] CI tests that don't set the env var continue to pass (no payload → transport Ready)

## Related

- PR #8165 (DIS-1185 — global flag approach, can be superseded by this)
- PR #8215 (DIS-1737 — disagg decode skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health check monitoring can now be selectively enabled or disabled through environment variable configuration, providing deployment flexibility.

* **Bug Fixes**
  * HTTP, push, and TCP endpoints with registered health checks now correctly observe their health check state and wait for completion before transitioning to ready status, instead of unconditionally marking as ready upon initialization or registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->