### PR TITLE
fix(operator): surface specific failure reason in DGDR Succeeded condition

### DIFF
--- a/deploy/operator/internal/controller/dynamo_model_controller.go
+++ b/deploy/operator/internal/controller/dynamo_model_controller.go
@@ -229,7 +229,7 @@ func (r *DynamoModelReconciler) updateCondition(model *v1alpha1.DynamoModel, con
 		Type:               condType,
 		Status:             status,
 		ObservedGeneration: model.Generation,
-		LastTransitionTime: metav1.Now(),
+
 		Reason:             reason,
 		Message:            message,
 	}

--- a/deploy/operator/internal/controller/dynamo_model_controller.go
+++ b/deploy/operator/internal/controller/dynamo_model_controller.go
@@ -230,8 +230,8 @@ func (r *DynamoModelReconciler) updateCondition(model *v1alpha1.DynamoModel, con
 		Status:             status,
 		ObservedGeneration: model.Generation,
 
-		Reason:             reason,
-		Message:            message,
+		Reason:  reason,
+		Message: message,
 	}
 	meta.SetStatusCondition(&model.Status.Conditions, condition)
 }

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -265,11 +265,10 @@ func (r *CheckpointReconciler) handlePending(ctx context.Context, ckpt *nvidiaco
 	ckpt.Status.CreatedAt = nil
 	ckpt.Status.Message = ""
 	meta.SetStatusCondition(&ckpt.Status.Conditions, metav1.Condition{
-		Type:               string(nvidiacomv1alpha1.DynamoCheckpointConditionJobCreated),
-		Status:             metav1.ConditionTrue,
-		Reason:             "JobCreated",
-		Message:            fmt.Sprintf("Checkpoint job %s created", jobName),
-
+		Type:    string(nvidiacomv1alpha1.DynamoCheckpointConditionJobCreated),
+		Status:  metav1.ConditionTrue,
+		Reason:  "JobCreated",
+		Message: fmt.Sprintf("Checkpoint job %s created", jobName),
 	})
 
 	if err := r.Status().Update(ctx, ckpt); err != nil {
@@ -340,10 +339,10 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 			ckpt.Status.Phase = nvidiacomv1alpha1.DynamoCheckpointPhaseFailed
 			ckpt.Status.Message = "checkpoint job was deleted"
 			meta.SetStatusCondition(&ckpt.Status.Conditions, metav1.Condition{
-				Type:               string(nvidiacomv1alpha1.DynamoCheckpointConditionJobCreated),
-				Status:             metav1.ConditionFalse,
-				Reason:             "JobDeleted",
-				Message:            "Checkpoint job was deleted",
+				Type:    string(nvidiacomv1alpha1.DynamoCheckpointConditionJobCreated),
+				Status:  metav1.ConditionFalse,
+				Reason:  "JobDeleted",
+				Message: "Checkpoint job was deleted",
 			})
 			if err := r.Status().Update(ctx, ckpt); err != nil {
 				return ctrl.Result{}, err
@@ -392,10 +391,10 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 		ckpt.Status.CreatedAt = &now
 		ckpt.Status.Message = ""
 		meta.SetStatusCondition(&ckpt.Status.Conditions, metav1.Condition{
-			Type:               string(nvidiacomv1alpha1.DynamoCheckpointConditionJobCompleted),
-			Status:             metav1.ConditionTrue,
-			Reason:             observation.Reason,
-			Message:            observation.Message,
+			Type:    string(nvidiacomv1alpha1.DynamoCheckpointConditionJobCompleted),
+			Status:  metav1.ConditionTrue,
+			Reason:  observation.Reason,
+			Message: observation.Message,
 		})
 		if err := r.Status().Update(ctx, ckpt); err != nil {
 			return ctrl.Result{}, err
@@ -408,10 +407,10 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 		ckpt.Status.Phase = nvidiacomv1alpha1.DynamoCheckpointPhaseFailed
 		ckpt.Status.Message = observation.Message
 		meta.SetStatusCondition(&ckpt.Status.Conditions, metav1.Condition{
-			Type:               string(nvidiacomv1alpha1.DynamoCheckpointConditionJobCompleted),
-			Status:             metav1.ConditionFalse,
-			Reason:             observation.Reason,
-			Message:            observation.Message,
+			Type:    string(nvidiacomv1alpha1.DynamoCheckpointConditionJobCompleted),
+			Status:  metav1.ConditionFalse,
+			Reason:  observation.Reason,
+			Message: observation.Message,
 		})
 		if err := r.Status().Update(ctx, ckpt); err != nil {
 			return ctrl.Result{}, err

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -269,7 +269,7 @@ func (r *CheckpointReconciler) handlePending(ctx context.Context, ckpt *nvidiaco
 		Status:             metav1.ConditionTrue,
 		Reason:             "JobCreated",
 		Message:            fmt.Sprintf("Checkpoint job %s created", jobName),
-		LastTransitionTime: metav1.Now(),
+
 	})
 
 	if err := r.Status().Update(ctx, ckpt); err != nil {
@@ -344,7 +344,7 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 				Status:             metav1.ConditionFalse,
 				Reason:             "JobDeleted",
 				Message:            "Checkpoint job was deleted",
-				LastTransitionTime: metav1.Now(),
+		
 			})
 			if err := r.Status().Update(ctx, ckpt); err != nil {
 				return ctrl.Result{}, err
@@ -397,7 +397,7 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 			Status:             metav1.ConditionTrue,
 			Reason:             observation.Reason,
 			Message:            observation.Message,
-			LastTransitionTime: metav1.Now(),
+	
 		})
 		if err := r.Status().Update(ctx, ckpt); err != nil {
 			return ctrl.Result{}, err
@@ -414,7 +414,7 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 			Status:             metav1.ConditionFalse,
 			Reason:             observation.Reason,
 			Message:            observation.Message,
-			LastTransitionTime: metav1.Now(),
+	
 		})
 		if err := r.Status().Update(ctx, ckpt); err != nil {
 			return ctrl.Result{}, err

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -344,7 +344,6 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 				Status:             metav1.ConditionFalse,
 				Reason:             "JobDeleted",
 				Message:            "Checkpoint job was deleted",
-		
 			})
 			if err := r.Status().Update(ctx, ckpt); err != nil {
 				return ctrl.Result{}, err
@@ -397,7 +396,6 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 			Status:             metav1.ConditionTrue,
 			Reason:             observation.Reason,
 			Message:            observation.Message,
-	
 		})
 		if err := r.Status().Update(ctx, ckpt); err != nil {
 			return ctrl.Result{}, err
@@ -414,7 +412,6 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 			Status:             metav1.ConditionFalse,
 			Reason:             observation.Reason,
 			Message:            observation.Message,
-	
 		})
 		if err := r.Status().Update(ctx, ckpt); err != nil {
 			return ctrl.Result{}, err

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -149,11 +149,10 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 
 		// Update Ready condition
 		dynamoDeployment.AddStatusCondition(metav1.Condition{
-			Type:               "Ready",
-			Status:             readyStatus,
-			Reason:             string(reason),
-			Message:            string(message),
-
+			Type:    "Ready",
+			Status:  readyStatus,
+			Reason:  string(reason),
+			Message: string(message),
 		})
 
 		// Only set ObservedGeneration when reconciliation succeeded (no error),
@@ -544,11 +543,10 @@ func (r *DynamoGraphDeploymentReconciler) propagateTopologyCondition(ctx context
 	if groveTopoCond == nil {
 		// No topology condition from Grove yet — don't assume healthy.
 		dynamoCond = metav1.Condition{
-			Type:               nvidiacomv1beta1.ConditionTypeTopologyLevelsAvailable,
-			Status:             metav1.ConditionUnknown,
-			Reason:             nvidiacomv1beta1.ConditionReasonTopologyConditionPending,
-			Message:            "Waiting for topology condition from the scheduling framework",
-
+			Type:    nvidiacomv1beta1.ConditionTypeTopologyLevelsAvailable,
+			Status:  metav1.ConditionUnknown,
+			Reason:  nvidiacomv1beta1.ConditionReasonTopologyConditionPending,
+			Message: "Waiting for topology condition from the scheduling framework",
 		}
 	} else if groveTopoCond.Status == metav1.ConditionTrue {
 		// Grove reports topology levels are unavailable.
@@ -557,11 +555,10 @@ func (r *DynamoGraphDeploymentReconciler) propagateTopologyCondition(ctx context
 			reason = nvidiacomv1beta1.ConditionReasonTopologyDefinitionNotFound
 		}
 		dynamoCond = metav1.Condition{
-			Type:               nvidiacomv1beta1.ConditionTypeTopologyLevelsAvailable,
-			Status:             metav1.ConditionFalse,
-			Reason:             reason,
-			Message:            groveTopoCond.Message,
-
+			Type:    nvidiacomv1beta1.ConditionTypeTopologyLevelsAvailable,
+			Status:  metav1.ConditionFalse,
+			Reason:  reason,
+			Message: groveTopoCond.Message,
 		}
 		prev := meta.FindStatusCondition(dgd.Status.Conditions, nvidiacomv1beta1.ConditionTypeTopologyLevelsAvailable)
 		if prev == nil || prev.Status != metav1.ConditionFalse || prev.Reason != reason || prev.Message != groveTopoCond.Message {
@@ -571,11 +568,10 @@ func (r *DynamoGraphDeploymentReconciler) propagateTopologyCondition(ctx context
 	} else {
 		// Grove's TopologyLevelsUnavailable is False → all levels available.
 		dynamoCond = metav1.Condition{
-			Type:               nvidiacomv1beta1.ConditionTypeTopologyLevelsAvailable,
-			Status:             metav1.ConditionTrue,
-			Reason:             nvidiacomv1beta1.ConditionReasonAllTopologyLevelsAvailable,
-			Message:            "All required topology levels are available in the cluster topology",
-
+			Type:    nvidiacomv1beta1.ConditionTypeTopologyLevelsAvailable,
+			Status:  metav1.ConditionTrue,
+			Reason:  nvidiacomv1beta1.ConditionReasonAllTopologyLevelsAvailable,
+			Message: "All required topology levels are available in the cluster topology",
 		}
 	}
 

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -153,7 +153,7 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 			Status:             readyStatus,
 			Reason:             string(reason),
 			Message:            string(message),
-			LastTransitionTime: metav1.Now(),
+
 		})
 
 		// Only set ObservedGeneration when reconciliation succeeded (no error),
@@ -548,7 +548,7 @@ func (r *DynamoGraphDeploymentReconciler) propagateTopologyCondition(ctx context
 			Status:             metav1.ConditionUnknown,
 			Reason:             nvidiacomv1beta1.ConditionReasonTopologyConditionPending,
 			Message:            "Waiting for topology condition from the scheduling framework",
-			LastTransitionTime: metav1.Now(),
+
 		}
 	} else if groveTopoCond.Status == metav1.ConditionTrue {
 		// Grove reports topology levels are unavailable.
@@ -561,7 +561,7 @@ func (r *DynamoGraphDeploymentReconciler) propagateTopologyCondition(ctx context
 			Status:             metav1.ConditionFalse,
 			Reason:             reason,
 			Message:            groveTopoCond.Message,
-			LastTransitionTime: metav1.Now(),
+
 		}
 		prev := meta.FindStatusCondition(dgd.Status.Conditions, nvidiacomv1beta1.ConditionTypeTopologyLevelsAvailable)
 		if prev == nil || prev.Status != metav1.ConditionFalse || prev.Reason != reason || prev.Message != groveTopoCond.Message {
@@ -575,7 +575,7 @@ func (r *DynamoGraphDeploymentReconciler) propagateTopologyCondition(ctx context
 			Status:             metav1.ConditionTrue,
 			Reason:             nvidiacomv1beta1.ConditionReasonAllTopologyLevelsAvailable,
 			Message:            "All required topology levels are available in the cluster topology",
-			LastTransitionTime: metav1.Now(),
+
 		}
 	}
 

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -578,13 +578,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) updateProfilingSubPhase(
 		Reason:             reason,
 		Message:            message,
 	})
-	meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
-		Type:               nvidiacomv1beta1.ConditionTypeSucceeded,
-		Status:             metav1.ConditionFalse,
-		ObservedGeneration: dgdr.Generation,
-		Reason:             reason,
-		Message:            message,
-	})
+	setSucceededCondition(dgdr, nvidiacomv1beta1.DGDRPhaseProfiling)
 
 	return r.Status().Update(ctx, dgdr)
 }
@@ -655,28 +649,10 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleProfilingPhase(ctx contex
 			failureMessage = fmt.Sprintf("profiling failed: %s", profilerError)
 		}
 
-		// Set phase and conditions directly so we can use sub-phase-specific failure
-		// reason on both Profiling and Succeeded conditions. (updatePhaseWithCondition
-		// would hardcode Succeeded reason to generic "Failed".)
-		dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseFailed
-		meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
-			Type:               nvidiacomv1beta1.ConditionTypeSucceeded,
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: dgdr.Generation,
-			Reason:             failureReason,
-			Message:            failureMessage,
-		})
-		dgdr.AddStatusCondition(metav1.Condition{
-			Type:               nvidiacomv1beta1.ConditionTypeProfiling,
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: dgdr.Generation,
-			Reason:             failureReason,
-			Message:            failureMessage,
-		})
-		if err := r.Status().Update(ctx, dgdr); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{Requeue: true}, nil
+		// updatePhaseWithCondition sets Profiling first, then setSucceededCondition
+		// surfaces the failure reason in the aggregate Succeeded condition.
+		return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed,
+			nvidiacomv1beta1.ConditionTypeProfiling, metav1.ConditionFalse, failureReason, failureMessage)
 	}
 
 	if !completed {
@@ -915,7 +891,6 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDGDDeleted(ctx context.Co
 	logger.Info("DGD was deleted by user, transitioning to Failed phase")
 
 	dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseFailed
-	setSucceededCondition(dgdr, nvidiacomv1beta1.DGDRPhaseFailed)
 
 	r.Recorder.Event(dgdr, corev1.EventTypeWarning, nvidiacomv1beta1.EventReasonDeploymentDeleted,
 		fmt.Sprintf(MessageDeploymentDeleted, dgdr.Status.DGDName))
@@ -923,12 +898,14 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDGDDeleted(ctx context.Co
 	dgdr.Status.DGDName = ""
 	dgdr.Status.DeploymentInfo = nil
 
+	// Set the specific condition before the aggregate so setSucceededCondition can surface it.
 	meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
 		Type:    nvidiacomv1beta1.ConditionTypeDeploymentReady,
 		Status:  metav1.ConditionFalse,
 		Reason:  nvidiacomv1beta1.EventReasonDeploymentDeleted,
 		Message: "Deployment was deleted by user. Create a new DGDR to redeploy.",
 	})
+	setSucceededCondition(dgdr, nvidiacomv1beta1.DGDRPhaseFailed)
 
 	return ctrl.Result{}, r.Status().Update(ctx, dgdr)
 }
@@ -1195,6 +1172,21 @@ func (r *DynamoGraphDeploymentRequestReconciler) createAdditionalResources(ctx c
 func (r *DynamoGraphDeploymentRequestReconciler) handleFailedPhase(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("DGDR is in failed phase", "name", dgdr.Name)
+
+	// Re-sync the Succeeded condition so that operator upgrades that improve
+	// failure messages take effect on already-failed DGDRs.
+	setSucceededCondition(dgdr, nvidiacomv1beta1.DGDRPhaseFailed)
+	if err := r.Status().Update(ctx, dgdr); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Re-sync the Succeeded condition so that operator upgrades that improve
+	// failure messages take effect on already-failed DGDRs.
+	if setSucceededCondition(dgdr, nvidiacomv1beta1.DGDRPhaseFailed) {
+		if err := r.Status().Update(ctx, dgdr); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 
 	// Could implement retry logic here if desired
 	return ctrl.Result{}, nil
@@ -2184,7 +2176,8 @@ func updateDeploymentInfo(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, d
 }
 
 // setSucceededCondition sets the aggregate Succeeded condition based on the current phase.
-func setSucceededCondition(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, phase nvidiacomv1beta1.DGDRPhase) {
+// It returns true if the condition was actually changed.
+func setSucceededCondition(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, phase nvidiacomv1beta1.DGDRPhase) bool {
 	var status metav1.ConditionStatus
 	var reason, message string
 
@@ -2201,11 +2194,26 @@ func setSucceededCondition(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, 
 		status, reason, message = metav1.ConditionTrue, "Deployed", "Deployment is healthy"
 	case nvidiacomv1beta1.DGDRPhaseFailed:
 		status, reason, message = metav1.ConditionFalse, "Failed", "DGDR has failed"
+		for _, entry := range []struct {
+			condType string
+			prefix   string
+		}{
+			{nvidiacomv1beta1.ConditionTypeValidation, "Validation failed: "},
+			{nvidiacomv1beta1.ConditionTypeProfiling, "Profiling failed: "},
+			{nvidiacomv1beta1.ConditionTypeSpecGenerated, "Spec generation failed: "},
+			{nvidiacomv1beta1.ConditionTypeDeploymentReady, "Deployment failed: "},
+		} {
+			if c := meta.FindStatusCondition(dgdr.Status.Conditions, entry.condType); c != nil && c.Status == metav1.ConditionFalse && c.Message != "" {
+				reason = c.Reason
+				message = entry.prefix + c.Message
+				break
+			}
+		}
 	default:
 		status, reason, message = metav1.ConditionFalse, "Unknown", "Unknown phase"
 	}
 
-	meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
+	return meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
 		Type:               nvidiacomv1beta1.ConditionTypeSucceeded,
 		Status:             status,
 		ObservedGeneration: dgdr.Generation,
@@ -2237,18 +2245,17 @@ func (r *DynamoGraphDeploymentRequestReconciler) updatePhaseWithCondition(
 	message string,
 ) (ctrl.Result, error) {
 	dgdr.Status.Phase = phase
-	setSucceededCondition(dgdr, phase)
 
-	condition := metav1.Condition{
+	// Set the specific condition first so setSucceededCondition can surface it.
+	dgdr.AddStatusCondition(metav1.Condition{
 		Type:               conditionType,
 		Status:             status,
 		ObservedGeneration: dgdr.Generation,
-		LastTransitionTime: metav1.Now(),
 		Reason:             reason,
 		Message:            message,
-	}
+	})
 
-	dgdr.AddStatusCondition(condition)
+	setSucceededCondition(dgdr, phase)
 
 	if err := r.Status().Update(ctx, dgdr); err != nil {
 		return ctrl.Result{}, err

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -505,6 +505,13 @@ func (r *DynamoGraphDeploymentRequestReconciler) handlePendingPhase(ctx context.
 		// Set observedGeneration to track the spec we're processing
 		dgdr.Status.ObservedGeneration = dgdr.Generation
 
+		dgdr.AddStatusCondition(metav1.Condition{
+			Type:               nvidiacomv1beta1.ConditionTypeValidation,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: dgdr.Generation,
+			Reason:             "ValidationPassed",
+		})
+
 		// Initialize status — next reconcile will discover hardware and create the profiling job.
 		r.Recorder.Event(dgdr, corev1.EventTypeNormal, nvidiacomv1beta1.EventReasonInitialized, MessageInitialized)
 		return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhasePending,

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1182,13 +1182,6 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleFailedPhase(ctx context.C
 
 	// Re-sync the Succeeded condition so that operator upgrades that improve
 	// failure messages take effect on already-failed DGDRs.
-	setSucceededCondition(dgdr, nvidiacomv1beta1.DGDRPhaseFailed)
-	if err := r.Status().Update(ctx, dgdr); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	// Re-sync the Succeeded condition so that operator upgrades that improve
-	// failure messages take effect on already-failed DGDRs.
 	if setSucceededCondition(dgdr, nvidiacomv1beta1.DGDRPhaseFailed) {
 		if err := r.Status().Update(ctx, dgdr); err != nil {
 			return ctrl.Result{}, err


### PR DESCRIPTION
## Summary
- **Fix:** The Succeeded condition always showed generic `reason: Failed, message: "DGDR has failed"` instead of surfacing the actual cause from sub-conditions. Now takes the reason directly from the failing sub-condition (e.g. `reason: SweepingDecodeFailed, message: "Profiling failed: ..."`) and re-syncs on already-failed DGDRs so operator upgrades take effect without delete+recreate.
- **Fix:** Ensure each condition type is written at most once per reconcile and remove redundant explicit `LastTransitionTime: metav1.Now()` — both cause unnecessary status updates that can hot-loop the controller via the self-watch.
- **Fix:** Set `Validation` condition to `True` on successful spec validation so conditions don't disappear from status.
- **Fix:** Guard the re-sync status update in `handleFailedPhase` with the `setSucceededCondition` return value to avoid unconditional writes.

## Test plan
- [x] 57/57 controller tests pass
- [x] Verified on kind: DGDR shows specific failure reason after validation error
