### PR TITLE
fix(discovery): address concurrency edge cases in handle_put lifecycle

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -276,7 +276,6 @@ impl ModelWatcher {
                     // await the in-flight put before attempting cleanup.
                     let instance_key = mcid.to_path();
                     let watcher = Arc::clone(&self);
-                    let key_for_cleanup = instance_key.clone();
                     let handle = tokio::spawn(async move {
                         match watcher.handle_put(&mcid, &mut card).await {
                             Ok(()) => {
@@ -296,12 +295,13 @@ impl ModelWatcher {
                                 );
                             }
                         }
-                        // Remove ourselves from pending_puts once complete
-                        watcher.pending_puts.remove(&key_for_cleanup);
+                        // Note: we intentionally do NOT remove from pending_puts here.
+                        // Only the watch loop (on duplicate events) and handle_delete
+                        // manage pending_puts, avoiding a race where a completed task's
+                        // cleanup could remove a newer task's entry.
                     });
                     // If a duplicate Added event arrives while the first task is still
-                    // in-flight, abort the old task to prevent its cleanup from
-                    // removing the new task's handle from pending_puts.
+                    // in-flight, abort the old task to cancel redundant work.
                     if let Some((_, old_handle)) = self.pending_puts.remove(&instance_key) {
                         old_handle.abort();
                     }
@@ -355,7 +355,15 @@ impl ModelWatcher {
             tracing::debug!(key = %key, "awaiting in-flight handle_put before delete");
             // Ignore join errors (panic in the spawned task) — we still proceed
             // with cleanup since the put may have partially registered the model.
-            let _ = handle.await;
+            match tokio::time::timeout(Duration::from_secs(60), handle).await {
+                Ok(_) => {}
+                Err(_) => {
+                    tracing::warn!(
+                        key = %key,
+                        "Timed out waiting for in-flight handle_put, proceeding with delete"
+                    );
+                }
+            }
         }
         let card = match self.manager.remove_model_card(&key) {
             Some(card) => card,
@@ -508,6 +516,17 @@ impl ModelWatcher {
         while self.registering_worker_sets.contains(registration_key) && attempts < 300 {
             tokio::time::sleep(Duration::from_millis(100)).await;
             attempts += 1;
+        }
+
+        // If we timed out and the other task is still running, bail out rather
+        // than proceeding with concurrent pipeline construction.
+        if self.registering_worker_sets.contains(registration_key) {
+            tracing::warn!(
+                model_name = card.name(),
+                namespace = namespace,
+                "Timed out waiting for concurrent registration to complete, skipping"
+            );
+            return Ok(false);
         }
 
         // Validate checksum against the registered model

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -351,16 +351,20 @@ impl ModelWatcher {
         // to complete before we attempt cleanup. Without this, a Removed event
         // arriving while handle_put is still downloading HF config would fail
         // to find the model card, leaving a stale registration.
-        if let Some((_, handle)) = self.pending_puts.remove(&key) {
+        if let Some((_, mut handle)) = self.pending_puts.remove(&key) {
             tracing::debug!(key = %key, "awaiting in-flight handle_put before delete");
             // Ignore join errors (panic in the spawned task) — we still proceed
             // with cleanup since the put may have partially registered the model.
-            match tokio::time::timeout(Duration::from_secs(60), handle).await {
+            match tokio::time::timeout(Duration::from_secs(60), &mut handle).await {
                 Ok(_) => {}
                 Err(_) => {
+                    // Abort the timed-out task so it cannot register the model
+                    // after we proceed with deletion.
+                    handle.abort();
+                    let _ = handle.await;
                     tracing::warn!(
                         key = %key,
-                        "Timed out waiting for in-flight handle_put, proceeding with delete"
+                        "Timed out waiting for in-flight handle_put, aborted and proceeding with delete"
                     );
                 }
             }
@@ -455,6 +459,16 @@ impl ModelWatcher {
         if let Some(model) = self.manager.get_model(&model_name)
             && model.has_worker_set(&ws_key)
         {
+            if !model.is_checksum_compatible(&ws_key, card.mdcsum()) {
+                tracing::error!(
+                    model_name = card.name(),
+                    namespace = namespace,
+                    new_checksum = card.mdcsum(),
+                    "Checksum for new worker does not match existing WorkerSet's checksum. \
+                     Drain all old workers in this namespace before deploying a new version."
+                );
+                return Ok(());
+            }
             self.manager
                 .save_model_card(&mcid.to_path(), card.clone())?;
             tracing::debug!(
@@ -551,13 +565,24 @@ impl ModelWatcher {
             .get_model(model_name)
             .is_none_or(|m| !m.has_worker_set(ws_key))
         {
+            // Only the first waiter to re-insert the key should proceed with
+            // registration. Other waiters return false to avoid concurrent builds.
+            if !self
+                .registering_worker_sets
+                .insert(registration_key.to_string())
+            {
+                tracing::debug!(
+                    model_name = card.name(),
+                    namespace = namespace,
+                    "Another waiter won the re-registration race, skipping"
+                );
+                return Ok(false);
+            }
             tracing::warn!(
                 model_name = card.name(),
                 namespace = namespace,
                 "Concurrent registration produced no WorkerSet, retrying"
             );
-            self.registering_worker_sets
-                .insert(registration_key.to_string());
             return Ok(true);
         }
 

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -302,6 +302,13 @@ impl ModelWatcher {
                     });
                     // If a duplicate Added event arrives while the first task is still
                     // in-flight, abort the old task to cancel redundant work.
+                    //
+                    // `instance_key` is `mcid.to_path()` = "{ns}/{component}/{endpoint}/{instance_id:x}",
+                    // so this is keyed per-worker-instance, NOT per-model. Two different workers
+                    // registering the same model produce two different keys and run independently.
+                    // The only case that hits this branch is the etcd watch replaying the same
+                    // worker's Added event (reconnect or re-sync) — where cancelling the earlier
+                    // redundant task is exactly what we want.
                     if let Some((_, old_handle)) = self.pending_puts.remove(&instance_key) {
                         old_handle.abort();
                     }

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -474,7 +474,9 @@ impl ModelWatcher {
                     "Checksum for new worker does not match existing WorkerSet's checksum. \
                      Drain all old workers in this namespace before deploying a new version."
                 );
-                return Ok(());
+                return Err(anyhow::anyhow!(
+                    "Checksum mismatch for worker in namespace {namespace}"
+                ));
             }
             self.manager
                 .save_model_card(&mcid.to_path(), card.clone())?;

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -535,6 +535,9 @@ impl ModelWatcher {
         // If we timed out and the other task is still running, bail out rather
         // than proceeding with concurrent pipeline construction.
         if self.registering_worker_sets.contains(registration_key) {
+            // Save the model card so handle_delete can find it for cleanup.
+            self.manager
+                .save_model_card(&mcid.to_path(), card.clone())?;
             tracing::warn!(
                 model_name = card.name(),
                 namespace = namespace,
@@ -571,6 +574,9 @@ impl ModelWatcher {
                 .registering_worker_sets
                 .insert(registration_key.to_string())
             {
+                // Save the model card so handle_delete can find it for cleanup.
+                self.manager
+                    .save_model_card(&mcid.to_path(), card.clone())?;
                 tracing::debug!(
                     model_name = card.name(),
                     namespace = namespace,


### PR DESCRIPTION
## Summary

Follow-up to #7931 — addresses three concurrency edge cases identified during independent review of the concurrent `handle_put` design.

- **Abort-cleanup race**: Completed tasks no longer self-remove from `pending_puts`, preventing a race where a finished task's cleanup could delete a newer task's handle
- **Poll timeout guard**: `recover_concurrent_registration` now returns early if the 30s wait expires while the other task is still running, instead of proceeding with concurrent pipeline construction
- **Delete timeout**: `handle_delete` wraps the pending-put await with a 60s timeout to avoid blocking the watch loop indefinitely

## Test plan

- [ ] CI green (clippy, tests, builds)
- [ ] Manual review of all three interleavings described in commit message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model discovery now processes multiple configurations concurrently, improving responsiveness when downloading model configs.

* **Bug Fixes**
  * Enhanced handling of duplicate discovery events to prevent redundant processing and resource conflicts.
  * Improved concurrent registration recovery with automatic retry logic and checksum validation.
  * Added safeguards to ensure proper cleanup of registration state, even during failures.

* **Performance**
  * Increased storage watch event channel capacity for improved throughput in high-volume monitoring scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
