### PR TITLE
ci: Enforce 6GB RAM limit on pytest

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -151,6 +151,7 @@ runs:
           --cpus=${NUM_CPUS} \
           --shm-size=200m \
           --network host \
+          --memory=6g \
           "${DOCKER_ENV_FLAGS[@]}" \
           --name ${{ env.CONTAINER_ID }}_pytest \
           -v "${TEST_RESULTS_DIR}:/workspace/test-results" \


### PR DESCRIPTION
#### Overview:

In order to avoid resource exhaustion via DinD, enforce an OOM kill limit of 6GB on containers running `pytest`. This does not affect GPU memory usage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pytest testing infrastructure to enforce Docker memory resource limits during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->