### PR TITLE
fix(discovery): add missing Audios model type to is_model_type_list_empty

### DIFF
--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -218,6 +218,14 @@ impl ModelManager {
             .collect()
     }
 
+    pub fn list_audios_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_audios_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     pub fn list_videos_models(&self) -> Vec<String> {
         self.models
             .iter()

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1061,6 +1061,7 @@ mod tests {
         assert!(is_model_type_list_empty(&mm, ModelType::Completions));
         assert!(is_model_type_list_empty(&mm, ModelType::Embedding));
         assert!(is_model_type_list_empty(&mm, ModelType::Images));
+        assert!(is_model_type_list_empty(&mm, ModelType::Audios));
         assert!(is_model_type_list_empty(&mm, ModelType::Videos));
         assert!(is_model_type_list_empty(&mm, ModelType::TensorBased));
         assert!(is_model_type_list_empty(&mm, ModelType::Prefill));
@@ -1078,6 +1079,7 @@ mod tests {
         assert!(is_model_type_list_empty(&mm, ModelType::Completions));
         assert!(is_model_type_list_empty(&mm, ModelType::Embedding));
         assert!(is_model_type_list_empty(&mm, ModelType::Images));
+        assert!(is_model_type_list_empty(&mm, ModelType::Audios));
         assert!(is_model_type_list_empty(&mm, ModelType::Videos));
         assert!(is_model_type_list_empty(&mm, ModelType::TensorBased));
     }

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -108,6 +108,8 @@ fn is_model_type_list_empty(manager: &ModelManager, model_type: ModelType) -> bo
         manager.list_embeddings_models().is_empty()
     } else if model_type == ModelType::Images {
         manager.list_images_models().is_empty()
+    } else if model_type == ModelType::Audios {
+        manager.list_audios_models().is_empty()
     } else if model_type == ModelType::Videos {
         manager.list_videos_models().is_empty()
     } else if model_type == ModelType::TensorBased {


### PR DESCRIPTION
## Summary

- `is_model_type_list_empty` handled every `ModelType` variant except `Audios`, which fell through to the `else` branch returning `true` (always empty)
- This caused `handle_delete` to emit spurious `ModelUpdate::Removed` for audio models even when other audio workers still existed
- Added `list_audios_models()` to `ModelManager` following the existing pattern, and the `Audios` arm to the if-else chain
- Added `ModelType::Audios` to both existing test assertions

## Test plan

- [ ] CI green (rust-tests will exercise the new test assertions)
- [ ] `test_is_model_type_list_empty_on_empty_manager` now covers Audios
- [ ] `test_is_model_type_list_empty_prefill_present` now asserts Audios is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio model enumeration and discovery mechanisms, enabling the system to automatically identify and list all available audio models for seamless integration with audio processing workflows and related operations.

* **Tests**
  * Enhanced unit test coverage with comprehensive validation of audio model availability detection, covering edge cases including empty and populated model manager scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->