### PR TITLE
fix(discovery): send ModelUpdate::Added after add_worker_set completes

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -665,10 +665,6 @@ impl ModelWatcher {
         self.manager
             .save_model_card(&mcid.to_path(), card.clone())?;
 
-        if let Some(tx) = &self.model_update_tx {
-            tx.send(ModelUpdate::Added(card.clone())).await.ok();
-        }
-
         let checksum = card.mdcsum();
         let namespace = mcid.namespace.clone();
         let ws_key = worker_set_key(&namespace, card.model_type);
@@ -1024,6 +1020,10 @@ impl ModelWatcher {
             self.manager
                 .add_worker_set(card.name(), &ws_key, worker_set);
 
+            if let Some(tx) = &self.model_update_tx {
+                tx.send(ModelUpdate::Added(card.clone())).await.ok();
+            }
+
             // Note: activate_prefill_router is keyed by deployment namespace (not ws_key)
             // because it coordinates between decode and prefill WorkerSets that share
             // the same deployment namespace but have different ws_keys ("ns" vs "ns:prefill").
@@ -1057,6 +1057,10 @@ impl ModelWatcher {
         // Add the completed WorkerSet to the Model
         self.manager
             .add_worker_set(card.name(), &ws_key, worker_set);
+
+        if let Some(tx) = &self.model_update_tx {
+            tx.send(ModelUpdate::Added(card.clone())).await.ok();
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- `ModelUpdate::Added` was sent before pipeline construction, enabling HTTP endpoints before a serving pipeline existed
- Requests arriving in this window would fail with "model not found"
- Moved the notification to after `add_worker_set` in both the prefill early-return path and the normal path
- Consumers (`update_http_endpoints`, `update_model_metrics`) only read the card, not the WorkerSet, so the reordering is safe

## Test plan

- [ ] CI green
- [ ] Manual review of the two placement sites (prefill path and normal path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model registration timing to ensure models are properly available after worker set initialization is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
