### PR TITLE
fix(tests): respect CUDA_VISIBLE_DEVICES in GMS GPU probe

### DIFF
--- a/tests/gpu_memory_service/common/runtime.py
+++ b/tests/gpu_memory_service/common/runtime.py
@@ -27,6 +27,18 @@ logger = logging.getLogger(__name__)
 
 
 def get_gpu_memory_used(device: int = 0) -> int:
+    visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible_devices:
+        selected_devices = [part.strip() for part in visible_devices.split(",")]
+        if 0 <= device < len(selected_devices):
+            try:
+                device = int(selected_devices[device])
+            except ValueError:
+                logger.debug(
+                    "Unable to map CUDA_VISIBLE_DEVICES=%s to an NVML index",
+                    visible_devices,
+                )
+
     pynvml.nvmlInit()
     try:
         handle = pynvml.nvmlDeviceGetHandleByIndex(device)


### PR DESCRIPTION
#### Overview:

Fix false nightly GMS shadow failover failures when the cross-component test harness runs under `CUDA_VISIBLE_DEVICES` on a nonzero physical GPU.

#### Details:

- Update `tests/gpu_memory_service/common/runtime.py::get_gpu_memory_used()` to map the logical test device through `CUDA_VISIBLE_DEVICES` before querying NVML.
- This keeps the quiesce/resume memory assertions pointed at the engine's actual GPU instead of always sampling physical GPU `0`.
- Scope is limited to the cross-component GMS test harness. There are no engine or GMS runtime behavior changes in this PR.
- Per-test time estimates for this area after the fix:
  - `test_gms_shadow_engine_failover_vllm`: about `80s`
  - `test_gms_shadow_engine_failover_sglang`: about `110s`

Validation:
- `uvx pre-commit run --files tests/gpu_memory_service/common/runtime.py`
- `CUDA_VISIBLE_DEVICES=0 ... test_gms_shadow_engine_failover_vllm` passed in `80.05s`
- `CUDA_VISIBLE_DEVICES=1 ... test_gms_shadow_engine_failover_sglang` passed in `109.86s`

#### Where should the reviewer start?

`tests/gpu_memory_service/common/runtime.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to nightly GMS shadow failover CI failures on nonzero CUDA-visible devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GPU memory usage detection to correctly handle scenarios where `CUDA_VISIBLE_DEVICES` environment variable is configured, ensuring accurate device indexing and memory reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->