### PR TITLE
fix: Only read prompt embeds from request if globally enabled

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1352,7 +1352,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
         if "prompt_embeds" in request and request["prompt_embeds"]:
             if not self.config.engine_args.enable_prompt_embeds:
-                msg = "Operator must set `--enable-prompt-embeds` to allow `prompt_embeds` in request."
+                msg = (
+                    "Set `--enable-prompt-embeds` to allow `prompt_embeds` in request."
+                )
                 logger.error(
                     f"Rejected prompt_embeds for {log_prefix.lower().strip() or 'request'} "
                     f"{request_id}: {msg}"

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1351,12 +1351,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         embedding_sequence_length = None
 
         if "prompt_embeds" in request and request["prompt_embeds"]:
-            if not getattr(
-                getattr(self.config, "engine_args", None),
-                "enable_prompt_embeds",
-                False,
-            ):
-                msg = "You must set `--enable-prompt-embeds` to input `prompt_embeds`."
+            if not self.config.engine_args.enable_prompt_embeds:
+                msg = "Operator must set `--enable-prompt-embeds` to allow `prompt_embeds` in request."
                 logger.error(
                     f"Rejected prompt_embeds for {log_prefix.lower().strip() or 'request'} "
                     f"{request_id}: {msg}"

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1351,6 +1351,24 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         embedding_sequence_length = None
 
         if "prompt_embeds" in request and request["prompt_embeds"]:
+            if not getattr(
+                getattr(self.config, "engine_args", None),
+                "enable_prompt_embeds",
+                False,
+            ):
+                msg = "You must set `--enable-prompt-embeds` to input `prompt_embeds`."
+                logger.error(
+                    f"Rejected prompt_embeds for {log_prefix.lower().strip() or 'request'} "
+                    f"{request_id}: {msg}"
+                )
+                return (
+                    None,
+                    None,
+                    {
+                        "finish_reason": f"error: Invalid prompt_embeds: {msg}",
+                        "token_ids": [],
+                    },
+                )
             try:
                 (
                     prompt,


### PR DESCRIPTION
Most deployments don't enable this.

Related to #8228 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Added validation to ensure the prompt embeddings feature can only be used when explicitly enabled in the configuration. Requests providing prompt embeddings will now be properly rejected with a descriptive error message when the feature flag is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->