### PR TITLE
[codex] gate nvext response metadata behind extra_fields

### DIFF
--- a/docs/components/frontend/nvext.md
+++ b/docs/components/frontend/nvext.md
@@ -35,7 +35,7 @@ Include `nvext` as a top-level field alongside standard OpenAI-compatible fields
 | `backend_instance_id` | `u64` | `None` | Router | Routes the request to a specific backend instance. |
 | `token_data` | `u32[]` | `None` | Preprocessor | Pre-tokenized prompt tokens. When provided with `backend_instance_id`, tokenization is skipped. |
 | `max_thinking_tokens` | `u32` | `None` | Backend | Maximum thinking tokens allowed (passed through to backends). |
-| `extra_fields` | `string[]` | `None` | Response builder | Fields to include in the response `nvext`. Supported: `"worker_id"`, `"timing"`. |
+| `extra_fields` | `string[]` | `None` | Response builder | Fields to include in the response `nvext`. Supported: `"worker_id"`, `"timing"`, `"routed_experts"`. |
 | `prefill_worker_id` | `u64` | `None` | Router | Routes the request to a specific prefill worker (disaggregated serving). |
 | `decode_worker_id` | `u64` | `None` | Router | Routes the request to a specific decode worker (disaggregated serving). |
 | `agent_hints` | object | `None` | Router | Per-request hints for scheduling and load balancing. See [Agent Hints](#agent-hints). |
@@ -163,6 +163,7 @@ When the client requests response metadata via `extra_fields`, the response incl
 |-------|---------------|-------------|
 | `worker_id` | `extra_fields: ["worker_id"]` | Prefill/decode worker IDs and data parallel ranks that processed the request. |
 | `timing` | `extra_fields: ["timing"]` | Per-request timing information (TTFT, ITL, queue time, etc.). |
+| `routed_experts` | `extra_fields: ["routed_experts"]` | Routed expert capture payload returned by SGLang-backed requests. |
 | `token_ids` | Automatic (GAIE Stage 1) | Tokenized prompt for reuse in Stage 2 query-only mode. |
 
 ### Example response `nvext`

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -10,7 +10,7 @@ use crate::{
         common::{self, timing::RequestTracker},
         openai::{
             convert_backend_top_logprobs,
-            nvext::{NvExtProvider, NvExtResponse, TimingInfo},
+            nvext::{NvExtProvider, NvExtResponse, NvExtResponseFieldSelection, TimingInfo},
             token_to_utf8_bytes,
         },
     },
@@ -51,20 +51,7 @@ impl NvCreateChatCompletionRequest {
     /// # Returns
     /// * [`DeltaGenerator`] configured with model name and response options.
     pub fn response_generator(&self, request_id: String) -> DeltaGenerator {
-        // Enable tracking if:
-        // 1. Client requested timing in extra_fields, OR
-        // 2. query_instance_id annotation is present (needs worker_id tracking for response)
-        let enable_tracking = self
-            .nvext()
-            .map(|nv| {
-                nv.extra_fields
-                    .as_ref()
-                    .is_some_and(|fields| fields.iter().any(|f| f == "timing"))
-                    || nv.annotations.as_ref().is_some_and(|annots| {
-                        annots.iter().any(|a| a.starts_with("query_instance_id"))
-                    })
-            })
-            .unwrap_or(false);
+        let response_fields = NvExtResponseFieldSelection::from_nvext(self.nvext());
 
         let options = DeltaGeneratorOptions {
             enable_usage: self
@@ -81,7 +68,7 @@ impl NvCreateChatCompletionRequest {
                 .unwrap_or(false),
             enable_logprobs: self.inner.logprobs.unwrap_or(false)
                 || self.inner.top_logprobs.unwrap_or(0) > 0,
-            enable_tracking,
+            response_fields,
             runtime_config: ModelRuntimeConfig::default(),
         };
 
@@ -98,8 +85,8 @@ pub struct DeltaGeneratorOptions {
     pub continuous_usage_stats: bool,
     /// Determines whether log probabilities should be included in the response.
     pub enable_logprobs: bool,
-    /// Determines whether request tracking (timing, KV hit rate) should be enabled.
-    pub enable_tracking: bool,
+    /// Determines which nvext response fields may be emitted for this request.
+    pub response_fields: NvExtResponseFieldSelection,
 
     pub runtime_config: ModelRuntimeConfig,
 }
@@ -414,29 +401,48 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
             delta.stop_reason,
         );
 
+        // Record finish for timing/ITL accounting even when timing is not returned to the client.
+        if finish_reason.is_some()
+            && let Some(ref tracker) = self.tracker
+        {
+            tracker.record_finish();
+        }
+
         // Get worker_id info from tracker (set by KvPushRouter based on phase)
-        let worker_id_info = self.tracker.as_ref().and_then(|t| t.get_worker_info());
-
-        let token_ids = delta
-            .disaggregated_params
-            .as_ref()
-            .and_then(|params| params.get("token_ids"))
-            .and_then(|v| serde_json::from_value::<Vec<u32>>(v.clone()).ok());
-        let routed_experts = delta
-            .disaggregated_params
-            .as_ref()
-            .and_then(|params| params.get("routed_experts"))
-            .cloned();
-
-        // Get timing info if this is the final response (has finish_reason)
-        let timing_info: Option<TimingInfo> = if finish_reason.is_some() {
-            self.tracker.as_ref().map(|tracker| {
-                tracker.record_finish();
-                tracker.get_timing_info()
-            })
+        let worker_id_info = if self.options.response_fields.worker_id {
+            self.tracker.as_ref().and_then(|t| t.get_worker_info())
         } else {
             None
         };
+
+        let token_ids = if self.options.response_fields.token_ids {
+            delta
+                .disaggregated_params
+                .as_ref()
+                .and_then(|params| params.get("token_ids"))
+                .and_then(|v| serde_json::from_value::<Vec<u32>>(v.clone()).ok())
+        } else {
+            None
+        };
+        let routed_experts = if self.options.response_fields.routed_experts {
+            delta
+                .disaggregated_params
+                .as_ref()
+                .and_then(|params| params.get("routed_experts"))
+                .cloned()
+        } else {
+            None
+        };
+
+        // Get timing info if this is the final response (has finish_reason)
+        let timing_info: Option<TimingInfo> =
+            if finish_reason.is_some() && self.options.response_fields.timing {
+                self.tracker
+                    .as_ref()
+                    .map(|tracker| tracker.get_timing_info())
+            } else {
+                None
+            };
 
         // Inject nvext if we have worker_id, token_ids, timing, or routed experts.
         if worker_id_info.is_some()
@@ -500,6 +506,8 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocols::common::{self, llm_backend::BackendOutput, timing::WORKER_TYPE_PREFILL};
+    use crate::protocols::openai::DeltaGeneratorExt;
     use dynamo_protocols::types::{
         ChatCompletionRequestMessage, ChatCompletionRequestUserMessage,
         ChatCompletionRequestUserMessageContent, CreateChatCompletionRequest,
@@ -563,5 +571,34 @@ mod tests {
             request.inner.stream_options.is_none(),
             "Streaming request should not have stream_options modified"
         );
+    }
+
+    #[test]
+    fn test_plain_request_without_extra_fields_omits_nvext() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-no-nvext".to_string());
+        let tracker = generator.tracker().expect("tracker");
+        tracker.record_worker(42, Some(0), WORKER_TYPE_PREFILL);
+
+        let response = generator
+            .choice_from_postprocessor(BackendOutput {
+                token_ids: vec![1],
+                tokens: vec![Some("hello".to_string())],
+                text: Some("hello".to_string()),
+                cum_log_probs: None,
+                log_probs: None,
+                top_logprobs: None,
+                finish_reason: Some(common::FinishReason::Stop),
+                stop_reason: None,
+                index: Some(0),
+                completion_usage: None,
+                disaggregated_params: Some(serde_json::json!({
+                    "token_ids": [11, 22, 33],
+                    "routed_experts": {"layer_0": [1, 3]}
+                })),
+            })
+            .expect("choice generation");
+
+        assert!(response.nvext.is_none());
     }
 }

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -9,7 +9,7 @@ use crate::{
         common::{self, timing::RequestTracker},
         openai::{
             convert_backend_top_logprobs,
-            nvext::{NvExtProvider, NvExtResponse, TimingInfo},
+            nvext::{NvExtProvider, NvExtResponse, NvExtResponseFieldSelection, TimingInfo},
         },
     },
     types::TokenIdType,
@@ -45,20 +45,7 @@ impl NvCreateCompletionRequest {
     // put this method on the request
     // inspect the request to extract options
     pub fn response_generator(&self, request_id: String) -> DeltaGenerator {
-        // Enable tracking if:
-        // 1. Client requested timing in extra_fields, OR
-        // 2. query_instance_id annotation is present (needs worker_id tracking for response)
-        let enable_tracking = self
-            .nvext()
-            .map(|nv| {
-                nv.extra_fields
-                    .as_ref()
-                    .is_some_and(|fields| fields.iter().any(|f| f == "timing"))
-                    || nv.annotations.as_ref().is_some_and(|annots| {
-                        annots.iter().any(|a| a.starts_with("query_instance_id"))
-                    })
-            })
-            .unwrap_or(false);
+        let response_fields = NvExtResponseFieldSelection::from_nvext(self.nvext());
 
         let options = DeltaGeneratorOptions {
             enable_usage: self
@@ -74,7 +61,7 @@ impl NvCreateCompletionRequest {
                 .map(|opts| opts.continuous_usage_stats)
                 .unwrap_or(false),
             enable_logprobs: self.inner.logprobs.unwrap_or(0) > 0,
-            enable_tracking,
+            response_fields,
         };
 
         DeltaGenerator::new(self.inner.model.clone(), options, request_id)
@@ -86,7 +73,7 @@ pub struct DeltaGeneratorOptions {
     pub enable_usage: bool,
     pub continuous_usage_stats: bool,
     pub enable_logprobs: bool,
-    pub enable_tracking: bool,
+    pub response_fields: NvExtResponseFieldSelection,
 }
 
 pub struct DeltaGenerator {
@@ -308,29 +295,47 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
         let index = delta.index.unwrap_or(0);
         let mut response = self.create_choice(index, delta.text.clone(), finish_reason, logprobs);
 
+        // Record finish for timing/ITL accounting even when timing is not returned to the client.
+        if finish_reason.is_some()
+            && let Some(ref tracker) = self.tracker
+        {
+            tracker.record_finish();
+        }
+
         // Get worker_id info from tracker (set by KvPushRouter based on phase)
-        let worker_id_info = self.tracker.as_ref().and_then(|t| t.get_worker_info());
-
-        let token_ids = delta
-            .disaggregated_params
-            .as_ref()
-            .and_then(|params| params.get("token_ids"))
-            .and_then(|v| serde_json::from_value::<Vec<u32>>(v.clone()).ok());
-        let routed_experts = delta
-            .disaggregated_params
-            .as_ref()
-            .and_then(|params| params.get("routed_experts"))
-            .cloned();
-
-        // Get timing info if this is the final response (has finish_reason)
-        let timing_info: Option<TimingInfo> = if finish_reason.is_some() {
-            self.tracker.as_ref().map(|tracker| {
-                tracker.record_finish();
-                tracker.get_timing_info()
-            })
+        let worker_id_info = if self.options.response_fields.worker_id {
+            self.tracker.as_ref().and_then(|t| t.get_worker_info())
         } else {
             None
         };
+        let token_ids = if self.options.response_fields.token_ids {
+            delta
+                .disaggregated_params
+                .as_ref()
+                .and_then(|params| params.get("token_ids"))
+                .and_then(|v| serde_json::from_value::<Vec<u32>>(v.clone()).ok())
+        } else {
+            None
+        };
+        let routed_experts = if self.options.response_fields.routed_experts {
+            delta
+                .disaggregated_params
+                .as_ref()
+                .and_then(|params| params.get("routed_experts"))
+                .cloned()
+        } else {
+            None
+        };
+
+        // Get timing info if this is the final response (has finish_reason)
+        let timing_info: Option<TimingInfo> =
+            if finish_reason.is_some() && self.options.response_fields.timing {
+                self.tracker
+                    .as_ref()
+                    .map(|tracker| tracker.get_timing_info())
+            } else {
+                None
+            };
 
         // Inject nvext if we have worker_id, token_ids, timing, or routed experts.
         if worker_id_info.is_some()
@@ -388,5 +393,58 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
 
     fn tracker(&self) -> Option<std::sync::Arc<crate::protocols::common::timing::RequestTracker>> {
         self.tracker.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::common::{self, llm_backend::BackendOutput, timing::WORKER_TYPE_PREFILL};
+    use crate::protocols::openai::DeltaGeneratorExt;
+    use dynamo_protocols::types::{CreateCompletionRequestArgs, Prompt};
+
+    fn create_test_request() -> NvCreateCompletionRequest {
+        let inner = CreateCompletionRequestArgs::default()
+            .model("test-model")
+            .prompt(Prompt::String("test".to_string()))
+            .build()
+            .expect("completion request");
+
+        NvCreateCompletionRequest {
+            inner,
+            common: Default::default(),
+            nvext: None,
+            metadata: None,
+            unsupported_fields: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_plain_request_without_extra_fields_omits_nvext() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-no-nvext".to_string());
+        let tracker = generator.tracker().expect("tracker");
+        tracker.record_worker(42, Some(0), WORKER_TYPE_PREFILL);
+
+        let response = generator
+            .choice_from_postprocessor(BackendOutput {
+                token_ids: vec![1],
+                tokens: vec![Some("hello".to_string())],
+                text: Some("hello".to_string()),
+                cum_log_probs: None,
+                log_probs: None,
+                top_logprobs: None,
+                finish_reason: Some(common::FinishReason::Stop),
+                stop_reason: None,
+                index: Some(0),
+                completion_usage: None,
+                disaggregated_params: Some(serde_json::json!({
+                    "token_ids": [11, 22, 33],
+                    "routed_experts": {"layer_0": [1, 3]}
+                })),
+            })
+            .expect("choice generation");
+
+        assert!(response.nvext.is_none());
     }
 }

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -116,6 +116,43 @@ pub struct NvExtResponse {
     pub routed_experts: Option<serde_json::Value>,
 }
 
+/// Response nvext fields requested for a given request.
+///
+/// The OpenAI-compatible API should only include `nvext` response fields when the
+/// client explicitly opts in via `nvext.extra_fields`, except for the GAIE
+/// `query_instance_id` flow which automatically returns `worker_id` and `token_ids`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct NvExtResponseFieldSelection {
+    pub worker_id: bool,
+    pub timing: bool,
+    pub token_ids: bool,
+    pub routed_experts: bool,
+}
+
+impl NvExtResponseFieldSelection {
+    pub fn from_nvext(nvext: Option<&NvExt>) -> Self {
+        let query_instance_id = nvext.is_some_and(NvExt::has_query_instance_id_annotation);
+        let has_extra_field = |field_name: &str| {
+            nvext.is_some_and(|ext| {
+                ext.extra_fields
+                    .as_ref()
+                    .is_some_and(|fields| fields.iter().any(|field| field == field_name))
+            })
+        };
+
+        Self {
+            worker_id: has_extra_field("worker_id") || query_instance_id,
+            timing: has_extra_field("timing"),
+            token_ids: query_instance_id,
+            routed_experts: has_extra_field("routed_experts"),
+        }
+    }
+
+    pub fn any(&self) -> bool {
+        self.worker_id || self.timing || self.token_ids || self.routed_experts
+    }
+}
+
 /// NVIDIA LLM extensions to the OpenAI API
 #[derive(ToSchema, Serialize, Deserialize, Builder, Validate, Debug, Clone)]
 #[validate(schema(function = "validate_nv_ext"))]
@@ -285,6 +322,14 @@ impl NvExt {
     pub fn builder() -> NvExtBuilder {
         NvExtBuilder::default()
     }
+
+    pub fn has_query_instance_id_annotation(&self) -> bool {
+        self.annotations.as_ref().is_some_and(|annotations| {
+            annotations
+                .iter()
+                .any(|annotation| annotation.starts_with("query_instance_id"))
+        })
+    }
 }
 
 fn validate_nv_ext(_nv_ext: &NvExt) -> Result<(), ValidationError> {
@@ -421,5 +466,43 @@ mod tests {
         assert_eq!(result.prefill_worker_id, Some(456));
         assert_eq!(result.dp_rank, Some(3));
         assert_eq!(result.prefill_dp_rank, Some(5));
+    }
+
+    #[test]
+    fn test_nvext_response_field_selection_defaults_to_none() {
+        let selection = NvExtResponseFieldSelection::from_nvext(None);
+
+        assert_eq!(selection, NvExtResponseFieldSelection::default());
+        assert!(!selection.any());
+    }
+
+    #[test]
+    fn test_nvext_response_field_selection_respects_extra_fields() {
+        let nvext = NvExt::builder()
+            .extra_fields(vec!["worker_id".to_string(), "routed_experts".to_string()])
+            .build()
+            .unwrap();
+
+        let selection = NvExtResponseFieldSelection::from_nvext(Some(&nvext));
+
+        assert!(selection.worker_id);
+        assert!(!selection.timing);
+        assert!(!selection.token_ids);
+        assert!(selection.routed_experts);
+    }
+
+    #[test]
+    fn test_nvext_response_field_selection_query_instance_id_exception() {
+        let nvext = NvExt::builder()
+            .annotations(vec!["query_instance_id:".to_string()])
+            .build()
+            .unwrap();
+
+        let selection = NvExtResponseFieldSelection::from_nvext(Some(&nvext));
+
+        assert!(selection.worker_id);
+        assert!(!selection.timing);
+        assert!(selection.token_ids);
+        assert!(!selection.routed_experts);
     }
 }


### PR DESCRIPTION
## Summary

- restore opt-in gating for `nvext` response fields in OpenAI-compatible chat/completions responses
- keep `RequestTracker` always enabled so internal per-worker metrics still work
- add a small doc clarification for `routed_experts`
- add one smoke test in each delta generator to cover the default no-`extra_fields` path

## Root Cause

The February 4, 2026 per-worker metrics change made request tracking unconditional in the chat/completions delta generators. Response shaping still emitted `nvext` whenever tracker-backed metadata was present, so plain OpenAI-compatible requests could leak `worker_id` and `timing` data by default.

## What Changed

- introduced a shared `NvExtResponseFieldSelection` helper to compute which response fields are allowed for a request
- gated `worker_id`, `timing`, `routed_experts`, and `token_ids` independently from tracker existence
- preserved the `query_instance_id` exception for `worker_id` and `token_ids`
- left `record_finish()` unconditional so timing/ITL accounting and Prometheus metrics do not regress

## Impact

- plain `/v1/chat/completions` and `/v1/completions` requests no longer return `nvext` by default
- `nvext.worker_id`, `nvext.timing`, and `nvext.routed_experts` remain opt-in via `nvext.extra_fields`
- `query_instance_id` behavior is preserved

Closes #8249.

## Validation

- `cargo check -p dynamo-llm --no-default-features --lib --tests`