### PR TITLE
fix(pre-commit): always stub extension modules in pytest-marker-report hook

### DIFF
--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -322,8 +322,6 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocols::OverlapScores;
-    use crate::test_utils::SimpleWorkerConfig;
 
     #[test]
     fn test_softmax_sample_single_key() {
@@ -432,66 +430,5 @@ mod tests {
 
         let result = softmax_sample_with_sample(&logits, temperature, sample);
         assert_eq!(result, entries[target_idx]);
-    }
-
-    fn request_without_prefill_for_worker(
-        worker_with_prefill: WorkerWithDpRank,
-        prefill_tokens: usize,
-        track_prefill_tokens: bool,
-    ) -> SchedulingRequest {
-        let mut request = SchedulingRequest {
-            maybe_request_id: None,
-            token_seq: None,
-            isl_tokens: 64,
-            overlaps: OverlapScores::new(),
-            decode_blocks: FxHashMap::default(),
-            prefill_tokens: FxHashMap::default(),
-            track_prefill_tokens,
-            router_config_override: None,
-            update_states: false,
-            lora_name: None,
-            priority_jump: 0.0,
-            expected_output_tokens: None,
-            pinned_worker: None,
-            allowed_worker_ids: None,
-            resp_tx: None,
-        };
-        request
-            .prefill_tokens
-            .insert(worker_with_prefill, prefill_tokens);
-        request
-    }
-
-    #[test]
-    fn test_select_worker_missing_prefill_tokens_falls_back_to_zero_when_untracked() {
-        let worker_with_prefill = WorkerWithDpRank::from_worker_id(1);
-        let worker_without_prefill = WorkerWithDpRank::from_worker_id(2);
-        let workers = HashMap::from([
-            (1, SimpleWorkerConfig::default()),
-            (2, SimpleWorkerConfig::default()),
-        ]);
-        let request = request_without_prefill_for_worker(worker_with_prefill, 32, false);
-        let selector = DefaultWorkerSelector::new(None, "prefill");
-
-        let result = selector.select_worker(&workers, &request, 16).unwrap();
-
-        assert_eq!(result.worker, worker_without_prefill);
-    }
-
-    #[test]
-    fn test_select_worker_missing_prefill_tokens_falls_back_to_isl_when_tracked() {
-        let worker_with_prefill = WorkerWithDpRank::from_worker_id(1);
-        let worker_without_prefill = WorkerWithDpRank::from_worker_id(2);
-        let workers = HashMap::from([
-            (1, SimpleWorkerConfig::default()),
-            (2, SimpleWorkerConfig::default()),
-        ]);
-        let request = request_without_prefill_for_worker(worker_with_prefill, 32, true);
-        let selector = DefaultWorkerSelector::new(None, "prefill");
-
-        let result = selector.select_worker(&workers, &request, 16).unwrap();
-
-        assert_eq!(result.worker, worker_with_prefill);
-        assert_ne!(result.worker, worker_without_prefill);
     }
 }

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -322,6 +322,8 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocols::OverlapScores;
+    use crate::test_utils::SimpleWorkerConfig;
 
     #[test]
     fn test_softmax_sample_single_key() {
@@ -430,5 +432,66 @@ mod tests {
 
         let result = softmax_sample_with_sample(&logits, temperature, sample);
         assert_eq!(result, entries[target_idx]);
+    }
+
+    fn request_without_prefill_for_worker(
+        worker_with_prefill: WorkerWithDpRank,
+        prefill_tokens: usize,
+        track_prefill_tokens: bool,
+    ) -> SchedulingRequest {
+        let mut request = SchedulingRequest {
+            maybe_request_id: None,
+            token_seq: None,
+            isl_tokens: 64,
+            overlaps: OverlapScores::new(),
+            decode_blocks: FxHashMap::default(),
+            prefill_tokens: FxHashMap::default(),
+            track_prefill_tokens,
+            router_config_override: None,
+            update_states: false,
+            lora_name: None,
+            priority_jump: 0.0,
+            expected_output_tokens: None,
+            pinned_worker: None,
+            allowed_worker_ids: None,
+            resp_tx: None,
+        };
+        request
+            .prefill_tokens
+            .insert(worker_with_prefill, prefill_tokens);
+        request
+    }
+
+    #[test]
+    fn test_select_worker_missing_prefill_tokens_falls_back_to_zero_when_untracked() {
+        let worker_with_prefill = WorkerWithDpRank::from_worker_id(1);
+        let worker_without_prefill = WorkerWithDpRank::from_worker_id(2);
+        let workers = HashMap::from([
+            (1, SimpleWorkerConfig::default()),
+            (2, SimpleWorkerConfig::default()),
+        ]);
+        let request = request_without_prefill_for_worker(worker_with_prefill, 32, false);
+        let selector = DefaultWorkerSelector::new(None, "prefill");
+
+        let result = selector.select_worker(&workers, &request, 16).unwrap();
+
+        assert_eq!(result.worker, worker_without_prefill);
+    }
+
+    #[test]
+    fn test_select_worker_missing_prefill_tokens_falls_back_to_isl_when_tracked() {
+        let worker_with_prefill = WorkerWithDpRank::from_worker_id(1);
+        let worker_without_prefill = WorkerWithDpRank::from_worker_id(2);
+        let workers = HashMap::from([
+            (1, SimpleWorkerConfig::default()),
+            (2, SimpleWorkerConfig::default()),
+        ]);
+        let request = request_without_prefill_for_worker(worker_with_prefill, 32, true);
+        let selector = DefaultWorkerSelector::new(None, "prefill");
+
+        let result = selector.select_worker(&workers, &request, 16).unwrap();
+
+        assert_eq!(result.worker, worker_with_prefill);
+        assert_ne!(result.worker, worker_without_prefill);
     }
 }

--- a/tests/report_pytest_markers.py
+++ b/tests/report_pytest_markers.py
@@ -206,8 +206,16 @@ class DependencyStubber:
         return stub
 
     def ensure_available(self, module_name: str) -> ModuleType:
-        """Ensure a module is available, stubbing it if not installed."""
-        if module_name in sys.modules:
+        """Ensure a module is available as a stub for test collection.
+
+        Always installs a stub for ``module_name`` so that even partially-built
+        native extensions (e.g. a stale ``dynamo._core`` ``.so`` that is
+        importable but is missing freshly-added symbols) do not cause
+        ``ImportError`` during collection.  Parent packages already present in
+        ``sys.modules`` are left untouched.
+        """
+        # If we already stubbed this exact module, return the existing stub.
+        if module_name in self.stubbed:
             return sys.modules[module_name]
 
         parts = module_name.split(".")
@@ -216,12 +224,17 @@ class DependencyStubber:
         )
 
         if not parent_stubbed:
+            # Attempt the real import solely to populate parent packages (e.g.
+            # the ``dynamo`` namespace package) with their real implementations.
+            # We intentionally do *not* return here: even a successful import
+            # may produce a stale module that is missing newly-added symbols, so
+            # we always fall through and replace it with a stub below.
             try:
-                return importlib.import_module(module_name)
+                importlib.import_module(module_name)
             except (ImportError, AttributeError):
                 pass
 
-        # Create parent packages if needed
+        # Create parent packages if needed (skip any already in sys.modules).
         for i in range(1, len(parts)):
             sub = ".".join(parts[:i])
             if sub not in sys.modules:
@@ -230,7 +243,8 @@ class DependencyStubber:
                 sys.modules[sub] = pkg
                 self.stubbed.add(sub)
 
-        # Create stub module with proper attributes
+        # Always install a stub for the leaf module, overriding any real
+        # (possibly stale) module that may have been loaded above.
         stub = self._create_module_stub(module_name)
         sys.modules[module_name] = stub
         self.stubbed.add(module_name)

--- a/tests/report_pytest_markers.py
+++ b/tests/report_pytest_markers.py
@@ -205,6 +205,17 @@ class DependencyStubber:
         stub.__package__ = name.rsplit(".", 1)[0] if "." in name else name
         return stub
 
+    def _bind_to_parent(self, module_name: str) -> None:
+        """Expose sys.modules[module_name] as an attribute on its parent package."""
+        if "." not in module_name:
+            return
+
+        parent_name, child_name = module_name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        child = sys.modules.get(module_name)
+        if parent is not None and child is not None:
+            setattr(parent, child_name, child)
+
     def ensure_available(self, module_name: str) -> ModuleType:
         """Ensure a module is available as a stub for test collection.
 
@@ -242,13 +253,53 @@ class DependencyStubber:
                 pkg.__path__ = []
                 sys.modules[sub] = pkg
                 self.stubbed.add(sub)
+            self._bind_to_parent(sub)
 
         # Always install a stub for the leaf module, overriding any real
         # (possibly stale) module that may have been loaded above.
         stub = self._create_module_stub(module_name)
         sys.modules[module_name] = stub
         self.stubbed.add(module_name)
+        self._bind_to_parent(module_name)
         return stub
+
+
+def test_dependency_stubber_rebinds_replaced_child_on_existing_parent():
+    parent_name = "_marker_report_stub_parent"
+    child_name = f"{parent_name}.child"
+    parent = ModuleType(parent_name)
+    stale_child = ModuleType(child_name)
+    parent.child = stale_child
+    sys.modules[parent_name] = parent
+    sys.modules[child_name] = stale_child
+
+    try:
+        stub = DependencyStubber().ensure_available(child_name)
+
+        assert sys.modules[child_name] is stub
+        assert parent.child is stub
+        assert parent.child is not stale_child
+    finally:
+        sys.modules.pop(child_name, None)
+        sys.modules.pop(parent_name, None)
+
+
+def test_dependency_stubber_binds_created_intermediate_packages():
+    root_name = "_marker_report_created_parent"
+    mid_name = f"{root_name}.mid"
+    leaf_name = f"{mid_name}.leaf"
+
+    try:
+        stub = DependencyStubber().ensure_available(leaf_name)
+
+        root = sys.modules[root_name]
+        mid = sys.modules[mid_name]
+        assert root.mid is mid
+        assert mid.leaf is stub
+    finally:
+        sys.modules.pop(leaf_name, None)
+        sys.modules.pop(mid_name, None)
+        sys.modules.pop(root_name, None)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- Fixes `pytest-marker-report` pre-commit hook failing with `ImportError: cannot import name 'AicPerfConfig' from 'dynamo._core'` on dev machines with a stale native extension binary
- `DependencyStubber.ensure_available` previously returned the real module when `importlib.import_module` succeeded, allowing a stale `.abi3.so` (importable but missing freshly-added symbols) to bypass stubbing
- Fix: always fall through to install a `MagicMock` stub for the leaf module; the real import attempt is kept only to populate parent namespace packages (e.g. `dynamo`) correctly

## Root cause

`dynamo._core` is listed in `STUB_MODULES` and should always be replaced with a `MagicMock` during collection.  A stale binary (built before `AicPerfConfig` was added in #7866) loads successfully, so `ensure_available` returned the real module.  Subsequent `from dynamo._core import AicPerfConfig` then failed with `ImportError`, blocking commits unless `--no-verify` was used.

## Test plan

- [ ] Run `python tests/report_pytest_markers.py` with a stale `dynamo._core.abi3.so` (or without any built binary) — collection should succeed
- [ ] Run `python tests/report_pytest_markers.py` with an up-to-date built binary — collection should still succeed
- [ ] Verify pre-commit hook passes: `pre-commit run pytest-marker-report --all-files`

Fixes #8047

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated router queue threshold parameter documentation to clarify behavior when threshold is set to zero, indicating maximum queueing sensitivity for token activation.

* **Configuration**
  * Adjusted default router queue threshold value and relaxed validation semantics to permit zero values, enabling enhanced configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->