### PR TITLE
fix(tcp): replace panic with warn+break on stream read errors

### DIFF
--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -268,9 +268,14 @@ async fn handle_reader(
                         }
                     }
                     Some(Err(e)) => {
-                        // TODO(#171) - address fatal errors
-                        // in this case the binary representation of the message is invalid
-                        panic!("fatal error - failed to decode message from stream; invalid line protocol: {e:?}");
+                        // TCP RST from peer (e.g. server crash) or a protocol decode
+                        // error — both mean the stream is unrecoverable.  Break so
+                        // only this connection is torn down; other requests are not
+                        // affected.
+                        tracing::warn!(
+                            "tcp stream read error, closing connection: {e:?}"
+                        );
+                        break;
                     }
                     None => {
                         tracing::debug!("tcp stream closed by server");

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -271,13 +271,17 @@ async fn handle_reader(
                         // TCP RST from peer (e.g. server crash) or a protocol decode
                         // error — both mean the stream is unrecoverable.  Break so
                         // only this connection is torn down; other requests are not
-                        // affected.
+                        // affected. `context.kill()` preserves the downstream signal
+                        // the old `panic!` used to deliver via `JoinError::Panic`:
+                        // without it, the engine keeps processing requests whose
+                        // responses can no longer be delivered.
                         tracing::warn!(
                             "tcp stream read error, closing connection: {e:?}"
                         );
                         if let Some(counter) = &cancellation_counter && !cancellation_counted {
                             counter.inc();
                         }
+                        context.kill();
                         break;
                     }
                     None => {
@@ -364,7 +368,7 @@ mod tests {
     use bytes::Bytes;
     use futures::StreamExt;
     use std::sync::Arc;
-    use tokio::io::AsyncReadExt;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
     use tokio::sync::{mpsc, oneshot};
     use tokio_util::codec::FramedRead;
@@ -993,6 +997,40 @@ mod tests {
         assert!(
             controller.is_killed(),
             "Controller should be killed after receiving Kill message"
+        );
+    }
+
+    /// Test that handle_reader calls context.kill() on a TCP stream read error,
+    /// preserving the downstream signal the original `panic!` delivered via
+    /// `JoinError::Panic`.
+    #[tokio::test]
+    async fn test_handle_reader_kills_context_on_read_error() {
+        let ReaderHarness {
+            framed_server,
+            framed_reader,
+            alive_tx,
+            alive_rx: _alive_rx,
+            controller,
+        } = reader_harness().await;
+
+        let controller_clone = controller.clone();
+        let reader_handle = tokio::spawn(async move {
+            handle_reader(framed_reader, controller_clone, alive_tx, None).await
+        });
+
+        // Bypass the codec and write a partial TwoPartCodec header (codec needs
+        // >=24 bytes), then close. FramedRead's default decode_eof with a
+        // non-empty buffer at EOF returns Err, driving handle_reader into the
+        // read-error arm that this test covers.
+        let mut raw_writer = framed_server.into_inner();
+        raw_writer.write_all(&[0u8; 8]).await.unwrap();
+        raw_writer.shutdown().await.unwrap();
+
+        let _ = reader_handle.await.unwrap();
+
+        assert!(
+            controller.is_killed(),
+            "Controller should be killed after TCP stream read error"
         );
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -275,6 +275,9 @@ async fn handle_reader(
                         tracing::warn!(
                             "tcp stream read error, closing connection: {e:?}"
                         );
+                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
+                            counter.inc();
+                        }
                         break;
                     }
                     None => {

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -832,10 +832,10 @@ mod tests {
             handle_writer(framed_writer, bytes_rx, alive_rx, writer_context).await
         });
 
-        // Bypass the codec and write a partial TwoPartCodec header. EOF with
-        // buffered bytes drives the client reader into Some(Err(_)).
-        server.write_all(&[0u8; 8]).await.unwrap();
-        server.shutdown().await.unwrap();
+        // Bypass the codec and write a complete but invalid TwoPartCodec
+        // header. This drives the client reader into Some(Err(_)) without
+        // closing the server side of the socket.
+        server.write_all(&[0xFF; 24]).await.unwrap();
 
         let monitor_context: Arc<dyn AsyncEngineContext> = controller.clone();
         let result = tokio::time::timeout(

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -144,51 +144,14 @@ impl TcpClient {
 
         let subject = info.subject.clone();
         tokio::spawn(async move {
-            // await both tasks
-            let (reader, writer) = tokio::join!(reader_task, writer_task);
-
-            match (reader, writer) {
-                (Ok(reader), Ok(writer)) => {
-                    let reader = reader.into_inner();
-
-                    let writer = match writer {
-                        Ok(writer) => writer.into_inner(),
-                        Err(e) => {
-                            tracing::error!("failed to join writer task: {:?}", e);
-                            return Err(e);
-                        }
-                    };
-
-                    let stream = reader.unsplit(writer);
-                    wait_for_server_shutdown(stream, monitor_context).await?;
-
-                    Ok(())
-                }
-                (Err(reader_err), Ok(_)) => {
-                    tracing::error!(
-                        "reader task failed to join (peer_port: {peer_port:?}, subject: {subject}): {reader_err:?}"
-                    );
-                    anyhow::bail!(
-                        "reader task failed to join (peer_port: {peer_port:?}, subject: {subject}): {reader_err:?}"
-                    );
-                }
-                (Ok(_), Err(writer_err)) => {
-                    tracing::error!(
-                        "writer task failed to join (peer_port: {peer_port:?}, subject: {subject}): {writer_err:?}"
-                    );
-                    anyhow::bail!(
-                        "writer task failed to join (peer_port: {peer_port:?}, subject: {subject}): {writer_err:?}"
-                    );
-                }
-                (Err(reader_err), Err(writer_err)) => {
-                    tracing::error!(
-                        "both reader and writer tasks failed to join (peer_port: {peer_port:?}, subject: {subject}) - reader: {reader_err:?}, writer: {writer_err:?}"
-                    );
-                    anyhow::bail!(
-                        "both reader and writer tasks failed to join (peer_port: {peer_port:?}, subject: {subject}) - reader: {reader_err:?}, writer: {writer_err:?}"
-                    );
-                }
-            }
+            wait_for_connection_tasks(
+                reader_task,
+                writer_task,
+                monitor_context,
+                peer_port,
+                subject,
+            )
+            .await
         });
 
         // set up the prologue for the stream
@@ -202,6 +165,58 @@ impl TcpClient {
         };
 
         Ok(stream_sender)
+    }
+}
+
+async fn wait_for_connection_tasks(
+    reader_task: tokio::task::JoinHandle<FramedRead<ReadHalf<TcpStream>, TwoPartCodec>>,
+    writer_task: tokio::task::JoinHandle<Result<FramedWrite<WriteHalf<TcpStream>, TwoPartCodec>>>,
+    context: Arc<dyn AsyncEngineContext>,
+    peer_port: Option<u16>,
+    subject: String,
+) -> Result<()> {
+    // await both tasks
+    let (reader, writer) = tokio::join!(reader_task, writer_task);
+
+    match (reader, writer) {
+        (Ok(reader), Ok(writer)) => {
+            let reader = reader.into_inner();
+
+            let writer = match writer {
+                Ok(writer) => writer.into_inner(),
+                Err(e) => {
+                    tracing::error!("failed to join writer task: {:?}", e);
+                    return Err(e);
+                }
+            };
+
+            let stream = reader.unsplit(writer);
+            wait_for_server_shutdown(stream, context).await
+        }
+        (Err(reader_err), Ok(_)) => {
+            tracing::error!(
+                "reader task failed to join (peer_port: {peer_port:?}, subject: {subject}): {reader_err:?}"
+            );
+            anyhow::bail!(
+                "reader task failed to join (peer_port: {peer_port:?}, subject: {subject}): {reader_err:?}"
+            );
+        }
+        (Ok(_), Err(writer_err)) => {
+            tracing::error!(
+                "writer task failed to join (peer_port: {peer_port:?}, subject: {subject}): {writer_err:?}"
+            );
+            anyhow::bail!(
+                "writer task failed to join (peer_port: {peer_port:?}, subject: {subject}): {writer_err:?}"
+            );
+        }
+        (Err(reader_err), Err(writer_err)) => {
+            tracing::error!(
+                "both reader and writer tasks failed to join (peer_port: {peer_port:?}, subject: {subject}) - reader: {reader_err:?}, writer: {writer_err:?}"
+            );
+            anyhow::bail!(
+                "both reader and writer tasks failed to join (peer_port: {peer_port:?}, subject: {subject}) - reader: {reader_err:?}, writer: {writer_err:?}"
+            );
+        }
     }
 }
 
@@ -792,6 +807,57 @@ mod tests {
         assert!(
             result.unwrap().is_ok(),
             "killed context shutdown should succeed"
+        );
+    }
+
+    /// Test the actual reader/writer monitor path used by create_response_stream:
+    /// a read decode error kills the context, the writer exits without a
+    /// sentinel, and the monitor returns promptly instead of waiting for FIN.
+    #[tokio::test]
+    async fn test_connection_monitor_skips_fin_wait_after_read_error_kills_context() {
+        let (client, mut server) = create_tcp_pair().await;
+        let (read_half, write_half) = tokio::io::split(client);
+        let framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
+        let framed_writer = FramedWrite::new(write_half, TwoPartCodec::default());
+        let (_bytes_tx, bytes_rx) = mpsc::channel(64);
+        let (alive_tx, alive_rx) = oneshot::channel::<()>();
+        let controller = Arc::new(Controller::default());
+
+        let reader_context = controller.clone();
+        let reader_task = tokio::spawn(async move {
+            handle_reader(framed_reader, reader_context, alive_tx, None).await
+        });
+        let writer_context = controller.clone();
+        let writer_task = tokio::spawn(async move {
+            handle_writer(framed_writer, bytes_rx, alive_rx, writer_context).await
+        });
+
+        // Bypass the codec and write a partial TwoPartCodec header. EOF with
+        // buffered bytes drives the client reader into Some(Err(_)).
+        server.write_all(&[0u8; 8]).await.unwrap();
+        server.shutdown().await.unwrap();
+
+        let monitor_context: Arc<dyn AsyncEngineContext> = controller.clone();
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            wait_for_connection_tasks(
+                reader_task,
+                writer_task,
+                monitor_context,
+                None,
+                "test-subject".to_string(),
+            ),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "connection monitor should not wait for the FIN deadline after read error"
+        );
+        assert!(result.unwrap().is_ok(), "connection monitor should succeed");
+        assert!(
+            controller.is_killed(),
+            "read error should kill the stream context"
         );
     }
 

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -133,8 +133,14 @@ impl TcpClient {
         let (bytes_tx, bytes_rx) = tokio::sync::mpsc::channel(64);
 
         // forwards the bytes send from this stream to the transport layer; hold the alive_rx half of the oneshot channel
-
-        let writer_task = tokio::spawn(handle_writer(framed_writer, bytes_rx, alive_rx, context));
+        let writer_context = context.clone();
+        let monitor_context = context.clone();
+        let writer_task = tokio::spawn(handle_writer(
+            framed_writer,
+            bytes_rx,
+            alive_rx,
+            writer_context,
+        ));
 
         let subject = info.subject.clone();
         tokio::spawn(async move {
@@ -153,26 +159,8 @@ impl TcpClient {
                         }
                     };
 
-                    let mut stream = reader.unsplit(writer);
-
-                    // await the tcp server to shutdown the socket connection
-                    // set a timeout for the server shutdown
-                    let mut buf = vec![0u8; 1024];
-                    let deadline = Instant::now() + Duration::from_secs(10);
-                    loop {
-                        let n = time::timeout_at(deadline, stream.read(&mut buf))
-                            .await
-                            .inspect_err(|_| {
-                                tracing::debug!("server did not close socket within the deadline");
-                            })?
-                            .inspect_err(|e| {
-                                tracing::debug!("failed to read from stream: {:?}", e);
-                            })?;
-                        if n == 0 {
-                            // Server has closed (FIN)
-                            break;
-                        }
-                    }
+                    let stream = reader.unsplit(writer);
+                    wait_for_server_shutdown(stream, monitor_context).await?;
 
                     Ok(())
                 }
@@ -215,6 +203,37 @@ impl TcpClient {
 
         Ok(stream_sender)
     }
+}
+
+async fn wait_for_server_shutdown(
+    mut stream: TcpStream,
+    context: Arc<dyn AsyncEngineContext>,
+) -> Result<()> {
+    if context.is_killed() {
+        tracing::debug!("stream context killed; skipping server FIN wait");
+        return Ok(());
+    }
+
+    // Await the tcp server to shutdown the socket connection, bounded by a
+    // timeout so normal sentinel shutdown cannot hang indefinitely.
+    let mut buf = vec![0u8; 1024];
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let n = time::timeout_at(deadline, stream.read(&mut buf))
+            .await
+            .inspect_err(|_| {
+                tracing::debug!("server did not close socket within the deadline");
+            })?
+            .inspect_err(|e| {
+                tracing::debug!("failed to read from stream: {:?}", e);
+            })?;
+        if n == 0 {
+            // Server has closed (FIN)
+            break;
+        }
+    }
+
+    Ok(())
 }
 
 async fn handle_reader(
@@ -753,6 +772,27 @@ mod tests {
 
         let sentinel = recv_msg(&mut reader).await;
         assert_sentinel_message(sentinel);
+    }
+
+    /// Test that killed contexts do not wait for the server FIN deadline.
+    #[tokio::test]
+    async fn test_wait_for_server_shutdown_skips_killed_context() {
+        let (client, _server) = create_tcp_pair().await;
+        let controller = Arc::new(Controller::default());
+        controller.kill();
+
+        let context: Arc<dyn AsyncEngineContext> = controller;
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            wait_for_server_shutdown(client, context),
+        )
+        .await;
+
+        assert!(result.is_ok(), "killed context should not wait for FIN");
+        assert!(
+            result.unwrap().is_ok(),
+            "killed context shutdown should succeed"
+        );
     }
 
     // ==================== handle_reader tests ====================

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -134,7 +134,6 @@ impl TcpClient {
 
         // forwards the bytes send from this stream to the transport layer; hold the alive_rx half of the oneshot channel
         let writer_context = context.clone();
-        let monitor_context = context.clone();
         let writer_task = tokio::spawn(handle_writer(
             framed_writer,
             bytes_rx,
@@ -143,6 +142,7 @@ impl TcpClient {
         ));
 
         let subject = info.subject.clone();
+        let monitor_context = context;
         // Spawn the connection monitor; errors are already logged inside
         // wait_for_connection_tasks, so the Result is intentionally dropped.
         tokio::spawn(async move {
@@ -177,7 +177,6 @@ async fn wait_for_connection_tasks(
     peer_port: Option<u16>,
     subject: String,
 ) -> Result<()> {
-    // await both tasks
     let (reader, writer) = tokio::join!(reader_task, writer_task);
 
     match (reader, writer) {
@@ -274,7 +273,8 @@ async fn handle_reader(
 ) -> FramedRead<tokio::io::ReadHalf<tokio::net::TcpStream>, TwoPartCodec> {
     let mut framed_reader = framed_reader;
     let mut alive_tx = alive_tx;
-    let mut cancellation_counted = false;
+    // Set on every cancellation arm; counted once after the loop.
+    let mut cancellation_seen = false;
     loop {
         tokio::select! {
             msg = framed_reader.next() => {
@@ -289,36 +289,32 @@ async fn handle_reader(
                                             err = ?e,
                                             "invalid control message, closing connection"
                                         );
-                                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
-                                            counter.inc();
-                                        }
+                                        cancellation_seen = true;
                                         context.kill();
                                         break;
                                     }
                                 };
 
+                                // Stop/Kill intentionally do not `break`: the
+                                // reader keeps running so a later Kill can
+                                // upgrade an earlier Stop (and vice versa).
+                                // The loop still exits promptly via the
+                                // `alive_tx.closed()` arm once `handle_writer`
+                                // reacts to `context.stop()` / `context.kill()`.
                                 match msg {
                                     ControlMessage::Stop => {
-                                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
-                                            counter.inc();
-                                            cancellation_counted = true;
-                                        }
+                                        cancellation_seen = true;
                                         context.stop();
                                     }
                                     ControlMessage::Kill => {
-                                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
-                                            counter.inc();
-                                            cancellation_counted = true;
-                                        }
+                                        cancellation_seen = true;
                                         context.kill();
                                     }
                                     ControlMessage::Sentinel => {
                                         tracing::warn!(
                                             "unexpected sentinel on client reader, closing connection"
                                         );
-                                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
-                                            counter.inc();
-                                        }
+                                        cancellation_seen = true;
                                         context.kill();
                                         break;
                                     }
@@ -328,9 +324,7 @@ async fn handle_reader(
                                 tracing::warn!(
                                     "unexpected non-control message on client reader, closing connection"
                                 );
-                                if let Some(counter) = &cancellation_counter && !cancellation_counted {
-                                    counter.inc();
-                                }
+                                cancellation_seen = true;
                                 context.kill();
                                 break;
                            }
@@ -340,19 +334,13 @@ async fn handle_reader(
                         // Kill the engine context so the producer stops
                         // generating responses that can no longer be delivered.
                         tracing::warn!(err = ?e, "tcp stream read error, closing connection");
-                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
-                            counter.inc();
-                        }
+                        cancellation_seen = true;
                         context.kill();
                         break;
                     }
                     None => {
                         tracing::debug!("tcp stream closed by server");
-                        // If no Stop/Kill was received, this is a cancellation where frontend
-                        // dropped the connection
-                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
-                            counter.inc();
-                        }
+                        cancellation_seen = true;
                         break;
                     }
                 }
@@ -360,6 +348,11 @@ async fn handle_reader(
             _ = alive_tx.closed() => {
                 break;
             }
+        }
+    }
+    if cancellation_seen {
+        if let Some(counter) = &cancellation_counter {
+            counter.inc();
         }
     }
     framed_reader
@@ -817,46 +810,27 @@ mod tests {
         assert_sentinel_message(sentinel);
     }
 
-    /// Test that killed contexts do not wait for the server FIN deadline.
+    /// Killed or stopped contexts skip the server FIN deadline.
     #[tokio::test]
-    async fn test_wait_for_server_shutdown_skips_killed_context() {
-        let (client, _server) = create_tcp_pair().await;
-        let controller = Arc::new(Controller::default());
-        controller.kill();
+    async fn test_wait_for_server_shutdown_skips_terminal_context() {
+        for action in [Controller::kill as fn(&Controller), Controller::stop] {
+            let (client, _server) = create_tcp_pair().await;
+            let controller = Arc::new(Controller::default());
+            action(&controller);
 
-        let context: Arc<dyn AsyncEngineContext> = controller;
-        let result = tokio::time::timeout(
-            std::time::Duration::from_millis(50),
-            wait_for_server_shutdown(client, context),
-        )
-        .await;
+            let context: Arc<dyn AsyncEngineContext> = controller;
+            let result = tokio::time::timeout(
+                std::time::Duration::from_millis(50),
+                wait_for_server_shutdown(client, context),
+            )
+            .await;
 
-        assert!(result.is_ok(), "killed context should not wait for FIN");
-        assert!(
-            result.unwrap().is_ok(),
-            "killed context shutdown should succeed"
-        );
-    }
-
-    /// Mirror of test_wait_for_server_shutdown_skips_killed_context for stop.
-    #[tokio::test]
-    async fn test_wait_for_server_shutdown_skips_stopped_context() {
-        let (client, _server) = create_tcp_pair().await;
-        let controller = Arc::new(Controller::default());
-        controller.stop();
-
-        let context: Arc<dyn AsyncEngineContext> = controller;
-        let result = tokio::time::timeout(
-            std::time::Duration::from_millis(50),
-            wait_for_server_shutdown(client, context),
-        )
-        .await;
-
-        assert!(result.is_ok(), "stopped context should not wait for FIN");
-        assert!(
-            result.unwrap().is_ok(),
-            "stopped context shutdown should succeed"
-        );
+            assert!(result.is_ok(), "terminal context should not wait for FIN");
+            assert!(
+                result.unwrap().is_ok(),
+                "terminal context shutdown should succeed"
+            );
+        }
     }
 
     /// Read error in the connection monitor kills the context and skips the FIN wait.
@@ -1153,40 +1127,7 @@ mod tests {
         );
     }
 
-    /// Read error in handle_reader kills the context.
-    #[tokio::test]
-    async fn test_handle_reader_kills_context_on_read_error() {
-        let ReaderHarness {
-            framed_server,
-            framed_reader,
-            alive_tx,
-            alive_rx: _alive_rx,
-            controller,
-        } = reader_harness().await;
-
-        let controller_clone = controller.clone();
-        let reader_handle = tokio::spawn(async move {
-            handle_reader(framed_reader, controller_clone, alive_tx, None).await
-        });
-
-        // Bypass the codec and write a partial TwoPartCodec header (codec needs
-        // >=24 bytes), then close. FramedRead's default decode_eof with a
-        // non-empty buffer at EOF returns Err, driving handle_reader into the
-        // read-error arm that this test covers.
-        let mut raw_writer = framed_server.into_inner();
-        raw_writer.write_all(&[0u8; 8]).await.unwrap();
-        raw_writer.shutdown().await.unwrap();
-
-        let _ = reader_handle.await.unwrap();
-
-        assert!(
-            controller.is_killed(),
-            "Controller should be killed after TCP stream read error"
-        );
-    }
-
-    /// Read errors are counted as cancellations, matching the clean-close
-    /// accounting path.
+    /// Read errors kill the context and are counted as cancellations.
     #[tokio::test]
     async fn test_handle_reader_increments_cancellation_counter_on_read_error() {
         let ReaderHarness {
@@ -1228,56 +1169,6 @@ mod tests {
             cancellation_counter.get(),
             1,
             "read-error close should increment cancellation metric once"
-        );
-    }
-
-    /// Real TCP RST via SO_LINGER=0 + drop; complements the partial-frame
-    /// variant. Linux-only — abortive-close semantics aren't portable.
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn test_handle_reader_handles_tcp_rst() {
-        let (client, server) = create_tcp_pair().await;
-        let (read_half, _write_half) = tokio::io::split(client);
-        let framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
-        let (alive_tx, _alive_rx) = oneshot::channel::<()>();
-        let controller = Arc::new(Controller::default());
-
-        // SO_LINGER=0 → on close(), kernel sends RST instead of FIN.
-        server
-            .set_linger(Some(std::time::Duration::ZERO))
-            .expect("set_linger should succeed on a connected socket");
-
-        let cancellation_counter =
-            IntCounter::new("tcp_client_reader_rst_test", "RST-path counter").unwrap();
-        let counter_clone = cancellation_counter.clone();
-        let controller_clone = controller.clone();
-
-        let reader_handle = tokio::spawn(async move {
-            handle_reader(
-                framed_reader,
-                controller_clone,
-                alive_tx,
-                Some(counter_clone),
-            )
-            .await
-        });
-
-        // Dropping the server socket while linger=0 emits a TCP RST.
-        drop(server);
-
-        let join = tokio::time::timeout(std::time::Duration::from_secs(2), reader_handle)
-            .await
-            .expect("handle_reader should complete promptly after RST");
-        join.expect("handle_reader must NOT panic on TCP RST");
-
-        assert!(
-            controller.is_killed(),
-            "controller should be killed after RST"
-        );
-        assert_eq!(
-            cancellation_counter.get(),
-            1,
-            "RST close should increment cancellation metric once"
         );
     }
 

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -269,9 +269,15 @@ async fn handle_reader(
                            (Some(bytes), None) => {
                                 let msg = match serde_json::from_slice::<ControlMessage>(bytes) {
                                     Ok(msg) => msg,
-                                    Err(_) => {
-                                        // TODO(#171) - address fatal errors
-                                        panic!("fatal error - invalid control message detected");
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            "invalid control message, closing connection: {e:?}"
+                                        );
+                                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
+                                            counter.inc();
+                                        }
+                                        context.kill();
+                                        break;
                                     }
                                 };
 
@@ -291,13 +297,26 @@ async fn handle_reader(
                                         context.kill();
                                     }
                                     ControlMessage::Sentinel => {
-                                        // TODO(#171) - address fatal errors
-                                        panic!("received a sentinel message; this should never happen");
+                                        tracing::warn!(
+                                            "unexpected sentinel on client reader, closing connection"
+                                        );
+                                        if let Some(counter) = &cancellation_counter && !cancellation_counted {
+                                            counter.inc();
+                                        }
+                                        context.kill();
+                                        break;
                                     }
                                 }
                            }
                            _ => {
-                                panic!("received a non-control message; this should never happen");
+                                tracing::warn!(
+                                    "unexpected non-control message on client reader, closing connection"
+                                );
+                                if let Some(counter) = &cancellation_counter && !cancellation_counted {
+                                    counter.inc();
+                                }
+                                context.kill();
+                                break;
                            }
                         }
                     }
@@ -810,9 +829,7 @@ mod tests {
         );
     }
 
-    /// Test the actual reader/writer monitor path used by create_response_stream:
-    /// a read decode error kills the context, the writer exits without a
-    /// sentinel, and the monitor returns promptly instead of waiting for FIN.
+    /// Read error in the connection monitor kills the context and skips the FIN wait.
     #[tokio::test]
     async fn test_connection_monitor_skips_fin_wait_after_read_error_kills_context() {
         let (client, mut server) = create_tcp_pair().await;
@@ -1106,9 +1123,7 @@ mod tests {
         );
     }
 
-    /// Test that handle_reader calls context.kill() on a TCP stream read error,
-    /// preserving the downstream signal the original `panic!` delivered via
-    /// `JoinError::Panic`.
+    /// Read error in handle_reader kills the context.
     #[tokio::test]
     async fn test_handle_reader_kills_context_on_read_error() {
         let ReaderHarness {

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -255,7 +255,7 @@ async fn wait_for_server_shutdown(
                 tracing::debug!("server did not close socket within the deadline");
             })?
             .inspect_err(|e| {
-                tracing::debug!("failed to read from stream: {:?}", e);
+                tracing::debug!(err = ?e, "failed to read from stream");
             })?;
         if n == 0 {
             // Server has closed (FIN)
@@ -838,10 +838,7 @@ mod tests {
         );
     }
 
-    /// Stopped contexts also skip the FIN wait. `handle_writer` suppresses
-    /// the closing sentinel on both `killed` and `stopped`, so the server
-    /// has nothing to react to in either case and the read loop would
-    /// otherwise sit idle until the 10s deadline.
+    /// Mirror of test_wait_for_server_shutdown_skips_killed_context for stop.
     #[tokio::test]
     async fn test_wait_for_server_shutdown_skips_stopped_context() {
         let (client, _server) = create_tcp_pair().await;
@@ -1234,12 +1231,8 @@ mod tests {
         );
     }
 
-    /// Real TCP-RST integration test: configures the peer socket with
-    /// SO_LINGER=0 and drops it, forcing the kernel to send RST instead
-    /// of FIN. This produces a `Some(Err(ConnectionReset))` from the
-    /// codec — the canonical "worker crashed mid-stream" trigger.
-    /// Linux-only because abortive-close semantics are reliable there;
-    /// other platforms may interpret SO_LINGER=0 differently.
+    /// Real TCP RST via SO_LINGER=0 + drop; complements the partial-frame
+    /// variant. Linux-only — abortive-close semantics aren't portable.
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn test_handle_reader_handles_tcp_rst() {

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -143,15 +143,17 @@ impl TcpClient {
         ));
 
         let subject = info.subject.clone();
+        // Spawn the connection monitor; errors are already logged inside
+        // wait_for_connection_tasks, so the Result is intentionally dropped.
         tokio::spawn(async move {
-            wait_for_connection_tasks(
+            let _ = wait_for_connection_tasks(
                 reader_task,
                 writer_task,
                 monitor_context,
                 peer_port,
                 subject,
             )
-            .await
+            .await;
         });
 
         // set up the prologue for the stream
@@ -284,7 +286,8 @@ async fn handle_reader(
                                     Ok(msg) => msg,
                                     Err(e) => {
                                         tracing::warn!(
-                                            "invalid control message, closing connection: {e:?}"
+                                            err = ?e,
+                                            "invalid control message, closing connection"
                                         );
                                         if let Some(counter) = &cancellation_counter && !cancellation_counted {
                                             counter.inc();
@@ -334,13 +337,9 @@ async fn handle_reader(
                         }
                     }
                     Some(Err(e)) => {
-                        // TCP RST from peer or a protocol decode error — the stream
-                        // is unrecoverable. Kill the engine context so the producer
-                        // stops generating responses that can no longer be delivered,
-                        // then break so only this connection is torn down.
-                        tracing::warn!(
-                            "tcp stream read error, closing connection: {e:?}"
-                        );
+                        // Kill the engine context so the producer stops
+                        // generating responses that can no longer be delivered.
+                        tracing::warn!(err = ?e, "tcp stream read error, closing connection");
                         if let Some(counter) = &cancellation_counter && !cancellation_counted {
                             counter.inc();
                         }
@@ -1289,10 +1288,12 @@ mod tests {
         );
     }
 
-    /// Undecodable control header from the server must not panic.
-    /// Covers `serde_json::from_slice::<ControlMessage>` Err arm.
-    #[tokio::test]
-    async fn test_handle_reader_kills_on_invalid_control_message() {
+    /// Drives `handle_reader` against a single message and returns the
+    /// controller + cancellation counter for assertions.
+    async fn run_reader_with(
+        msg: TwoPartMessage,
+        counter_name: &str,
+    ) -> (Arc<Controller>, IntCounter) {
         let ReaderHarness {
             mut framed_server,
             framed_reader,
@@ -1300,10 +1301,9 @@ mod tests {
             alive_rx: _alive_rx,
             controller,
         } = reader_harness().await;
-        let cancellation_counter =
-            IntCounter::new("tcp_client_reader_invalid_control_test", "test counter").unwrap();
+        let counter = IntCounter::new(counter_name, "test counter").unwrap();
 
-        let counter_clone = cancellation_counter.clone();
+        let counter_clone = counter.clone();
         let controller_clone = controller.clone();
         let reader_handle = tokio::spawn(async move {
             handle_reader(
@@ -1315,113 +1315,42 @@ mod tests {
             .await
         });
 
-        framed_server
-            .send(TwoPartMessage::from_header(Bytes::from_static(
-                b"this is not a valid control message",
-            )))
-            .await
-            .unwrap();
-
+        framed_server.send(msg).await.unwrap();
         let _ = reader_handle.await.unwrap();
 
-        assert!(
-            controller.is_killed(),
-            "invalid control message should kill the stream context"
-        );
-        assert_eq!(
-            cancellation_counter.get(),
-            1,
-            "invalid control message should be counted once"
-        );
+        (controller, counter)
     }
 
-    /// Sentinel from server is a protocol violation (Sentinel is
-    /// client→server). Must not panic the worker.
+    /// Each protocol-violating message variant must kill only this stream
+    /// (controller killed, cancellation counted once) and never panic the
+    /// worker. Covers the three non-read-error panic arms in `handle_reader`:
+    /// undecodable control bytes, server-sent Sentinel, and non-control
+    /// (data-only) messages.
     #[tokio::test]
-    async fn test_handle_reader_kills_on_sentinel_from_server() {
-        let ReaderHarness {
-            mut framed_server,
-            framed_reader,
-            alive_tx,
-            alive_rx: _alive_rx,
-            controller,
-        } = reader_harness().await;
-        let cancellation_counter =
-            IntCounter::new("tcp_client_reader_sentinel_test", "test counter").unwrap();
+    async fn test_handle_reader_kills_on_protocol_violations() {
+        let cases: Vec<(&str, TwoPartMessage)> = vec![
+            (
+                "invalid control bytes",
+                TwoPartMessage::from_header(Bytes::from_static(b"not a valid control message")),
+            ),
+            (
+                "sentinel from server",
+                control_message(&ControlMessage::Sentinel),
+            ),
+            (
+                "non-control (data-only)",
+                TwoPartMessage::from_data(Bytes::from_static(b"unexpected payload")),
+            ),
+        ];
 
-        let counter_clone = cancellation_counter.clone();
-        let controller_clone = controller.clone();
-        let reader_handle = tokio::spawn(async move {
-            handle_reader(
-                framed_reader,
-                controller_clone,
-                alive_tx,
-                Some(counter_clone),
-            )
-            .await
-        });
-
-        framed_server
-            .send(control_message(&ControlMessage::Sentinel))
-            .await
-            .unwrap();
-
-        let _ = reader_handle.await.unwrap();
-
-        assert!(
-            controller.is_killed(),
-            "Sentinel from server should kill the stream context"
-        );
-        assert_eq!(
-            cancellation_counter.get(),
-            1,
-            "Sentinel-from-server should be counted once"
-        );
-    }
-
-    /// Non-control message (data attached, header missing, etc.) from
-    /// the server must not panic. Covers the catch-all `_` arm.
-    #[tokio::test]
-    async fn test_handle_reader_kills_on_non_control_message() {
-        let ReaderHarness {
-            mut framed_server,
-            framed_reader,
-            alive_tx,
-            alive_rx: _alive_rx,
-            controller,
-        } = reader_harness().await;
-        let cancellation_counter =
-            IntCounter::new("tcp_client_reader_non_control_test", "test counter").unwrap();
-
-        let counter_clone = cancellation_counter.clone();
-        let controller_clone = controller.clone();
-        let reader_handle = tokio::spawn(async move {
-            handle_reader(
-                framed_reader,
-                controller_clone,
-                alive_tx,
-                Some(counter_clone),
-            )
-            .await
-        });
-
-        framed_server
-            .send(TwoPartMessage::from_data(Bytes::from_static(
-                b"unexpected payload",
-            )))
-            .await
-            .unwrap();
-
-        let _ = reader_handle.await.unwrap();
-
-        assert!(
-            controller.is_killed(),
-            "non-control message from server should kill the stream context"
-        );
-        assert_eq!(
-            cancellation_counter.get(),
-            1,
-            "non-control message should be counted once"
-        );
+        for (i, (label, msg)) in cases.into_iter().enumerate() {
+            let counter_name = format!("tcp_client_reader_protocol_violation_test_{i}");
+            let (controller, counter) = run_reader_with(msg, &counter_name).await;
+            assert!(
+                controller.is_killed(),
+                "{label}: should kill stream context"
+            );
+            assert_eq!(counter.get(), 1, "{label}: should be counted once");
+        }
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -350,10 +350,8 @@ async fn handle_reader(
             }
         }
     }
-    if cancellation_seen {
-        if let Some(counter) = &cancellation_counter {
-            counter.inc();
-        }
+    if cancellation_seen && let Some(counter) = &cancellation_counter {
+        counter.inc();
     }
     framed_reader
 }

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -185,7 +185,12 @@ async fn wait_for_connection_tasks(
             let writer = match writer {
                 Ok(writer) => writer.into_inner(),
                 Err(e) => {
-                    tracing::error!("failed to join writer task: {:?}", e);
+                    tracing::error!(
+                        subject = %subject,
+                        peer_port = ?peer_port,
+                        err = ?e,
+                        "writer task returned error"
+                    );
                     return Err(e);
                 }
             };
@@ -195,27 +200,32 @@ async fn wait_for_connection_tasks(
         }
         (Err(reader_err), Ok(_)) => {
             tracing::error!(
-                "reader task failed to join (peer_port: {peer_port:?}, subject: {subject}): {reader_err:?}"
+                subject = %subject,
+                peer_port = ?peer_port,
+                err = ?reader_err,
+                "reader task failed to join"
             );
-            anyhow::bail!(
-                "reader task failed to join (peer_port: {peer_port:?}, subject: {subject}): {reader_err:?}"
-            );
+            Err(reader_err.into())
         }
         (Ok(_), Err(writer_err)) => {
             tracing::error!(
-                "writer task failed to join (peer_port: {peer_port:?}, subject: {subject}): {writer_err:?}"
+                subject = %subject,
+                peer_port = ?peer_port,
+                err = ?writer_err,
+                "writer task failed to join"
             );
-            anyhow::bail!(
-                "writer task failed to join (peer_port: {peer_port:?}, subject: {subject}): {writer_err:?}"
-            );
+            Err(writer_err.into())
         }
         (Err(reader_err), Err(writer_err)) => {
             tracing::error!(
-                "both reader and writer tasks failed to join (peer_port: {peer_port:?}, subject: {subject}) - reader: {reader_err:?}, writer: {writer_err:?}"
+                subject = %subject,
+                peer_port = ?peer_port,
+                reader_err = ?reader_err,
+                writer_err = ?writer_err,
+                "both reader and writer tasks failed to join"
             );
-            anyhow::bail!(
-                "both reader and writer tasks failed to join (peer_port: {peer_port:?}, subject: {subject}) - reader: {reader_err:?}, writer: {writer_err:?}"
-            );
+            // Surface the reader error; the writer error is captured above.
+            Err(reader_err.into())
         }
     }
 }
@@ -224,14 +234,17 @@ async fn wait_for_server_shutdown(
     mut stream: TcpStream,
     context: Arc<dyn AsyncEngineContext>,
 ) -> Result<()> {
-    if context.is_killed() {
-        tracing::debug!("stream context killed; skipping server FIN wait");
+    // `handle_writer` skips the closing sentinel on both `killed` and
+    // `stopped`, so the server has nothing to react to in either case;
+    // sitting in the read loop until the 10 s deadline would be dead time.
+    if context.is_killed() || context.is_stopped() {
+        tracing::debug!("stream context killed or stopped; skipping server FIN wait");
         return Ok(());
     }
 
     // Await the tcp server to shutdown the socket connection, bounded by a
     // timeout so normal sentinel shutdown cannot hang indefinitely.
-    let mut buf = vec![0u8; 1024];
+    let mut buf = [0u8; 1024];
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         let n = time::timeout_at(deadline, stream.read(&mut buf))
@@ -321,13 +334,10 @@ async fn handle_reader(
                         }
                     }
                     Some(Err(e)) => {
-                        // TCP RST from peer (e.g. server crash) or a protocol decode
-                        // error — both mean the stream is unrecoverable.  Break so
-                        // only this connection is torn down; other requests are not
-                        // affected. `context.kill()` preserves the downstream signal
-                        // the old `panic!` used to deliver via `JoinError::Panic`:
-                        // without it, the engine keeps processing requests whose
-                        // responses can no longer be delivered.
+                        // TCP RST from peer or a protocol decode error — the stream
+                        // is unrecoverable. Kill the engine context so the producer
+                        // stops generating responses that can no longer be delivered,
+                        // then break so only this connection is torn down.
                         tracing::warn!(
                             "tcp stream read error, closing connection: {e:?}"
                         );
@@ -829,6 +839,30 @@ mod tests {
         );
     }
 
+    /// Stopped contexts also skip the FIN wait. `handle_writer` suppresses
+    /// the closing sentinel on both `killed` and `stopped`, so the server
+    /// has nothing to react to in either case and the read loop would
+    /// otherwise sit idle until the 10s deadline.
+    #[tokio::test]
+    async fn test_wait_for_server_shutdown_skips_stopped_context() {
+        let (client, _server) = create_tcp_pair().await;
+        let controller = Arc::new(Controller::default());
+        controller.stop();
+
+        let context: Arc<dyn AsyncEngineContext> = controller;
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            wait_for_server_shutdown(client, context),
+        )
+        .await;
+
+        assert!(result.is_ok(), "stopped context should not wait for FIN");
+        assert!(
+            result.unwrap().is_ok(),
+            "stopped context shutdown should succeed"
+        );
+    }
+
     /// Read error in the connection monitor kills the context and skips the FIN wait.
     #[tokio::test]
     async fn test_connection_monitor_skips_fin_wait_after_read_error_kills_context() {
@@ -1152,6 +1186,242 @@ mod tests {
         assert!(
             controller.is_killed(),
             "Controller should be killed after TCP stream read error"
+        );
+    }
+
+    /// Read errors are counted as cancellations, matching the clean-close
+    /// accounting path.
+    #[tokio::test]
+    async fn test_handle_reader_increments_cancellation_counter_on_read_error() {
+        let ReaderHarness {
+            framed_server,
+            framed_reader,
+            alive_tx,
+            alive_rx: _alive_rx,
+            controller,
+        } = reader_harness().await;
+        let cancellation_counter = IntCounter::new(
+            "tcp_client_reader_read_error_cancellations_test",
+            "test cancellation counter",
+        )
+        .unwrap();
+
+        let counter_clone = cancellation_counter.clone();
+        let controller_clone = controller.clone();
+        let reader_handle = tokio::spawn(async move {
+            handle_reader(
+                framed_reader,
+                controller_clone,
+                alive_tx,
+                Some(counter_clone),
+            )
+            .await
+        });
+
+        let mut raw_writer = framed_server.into_inner();
+        raw_writer.write_all(&[0u8; 8]).await.unwrap();
+        raw_writer.shutdown().await.unwrap();
+
+        let _ = reader_handle.await.unwrap();
+
+        assert!(
+            controller.is_killed(),
+            "Controller should be killed after TCP stream read error"
+        );
+        assert_eq!(
+            cancellation_counter.get(),
+            1,
+            "read-error close should increment cancellation metric once"
+        );
+    }
+
+    /// Real TCP-RST integration test: configures the peer socket with
+    /// SO_LINGER=0 and drops it, forcing the kernel to send RST instead
+    /// of FIN. This produces a `Some(Err(ConnectionReset))` from the
+    /// codec — the canonical "worker crashed mid-stream" trigger.
+    /// Linux-only because abortive-close semantics are reliable there;
+    /// other platforms may interpret SO_LINGER=0 differently.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn test_handle_reader_handles_tcp_rst() {
+        let (client, server) = create_tcp_pair().await;
+        let (read_half, _write_half) = tokio::io::split(client);
+        let framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
+        let (alive_tx, _alive_rx) = oneshot::channel::<()>();
+        let controller = Arc::new(Controller::default());
+
+        // SO_LINGER=0 → on close(), kernel sends RST instead of FIN.
+        server
+            .set_linger(Some(std::time::Duration::ZERO))
+            .expect("set_linger should succeed on a connected socket");
+
+        let cancellation_counter =
+            IntCounter::new("tcp_client_reader_rst_test", "RST-path counter").unwrap();
+        let counter_clone = cancellation_counter.clone();
+        let controller_clone = controller.clone();
+
+        let reader_handle = tokio::spawn(async move {
+            handle_reader(
+                framed_reader,
+                controller_clone,
+                alive_tx,
+                Some(counter_clone),
+            )
+            .await
+        });
+
+        // Dropping the server socket while linger=0 emits a TCP RST.
+        drop(server);
+
+        let join = tokio::time::timeout(std::time::Duration::from_secs(2), reader_handle)
+            .await
+            .expect("handle_reader should complete promptly after RST");
+        join.expect("handle_reader must NOT panic on TCP RST");
+
+        assert!(
+            controller.is_killed(),
+            "controller should be killed after RST"
+        );
+        assert_eq!(
+            cancellation_counter.get(),
+            1,
+            "RST close should increment cancellation metric once"
+        );
+    }
+
+    /// Undecodable control header from the server must not panic.
+    /// Covers `serde_json::from_slice::<ControlMessage>` Err arm.
+    #[tokio::test]
+    async fn test_handle_reader_kills_on_invalid_control_message() {
+        let ReaderHarness {
+            mut framed_server,
+            framed_reader,
+            alive_tx,
+            alive_rx: _alive_rx,
+            controller,
+        } = reader_harness().await;
+        let cancellation_counter =
+            IntCounter::new("tcp_client_reader_invalid_control_test", "test counter").unwrap();
+
+        let counter_clone = cancellation_counter.clone();
+        let controller_clone = controller.clone();
+        let reader_handle = tokio::spawn(async move {
+            handle_reader(
+                framed_reader,
+                controller_clone,
+                alive_tx,
+                Some(counter_clone),
+            )
+            .await
+        });
+
+        framed_server
+            .send(TwoPartMessage::from_header(Bytes::from_static(
+                b"this is not a valid control message",
+            )))
+            .await
+            .unwrap();
+
+        let _ = reader_handle.await.unwrap();
+
+        assert!(
+            controller.is_killed(),
+            "invalid control message should kill the stream context"
+        );
+        assert_eq!(
+            cancellation_counter.get(),
+            1,
+            "invalid control message should be counted once"
+        );
+    }
+
+    /// Sentinel from server is a protocol violation (Sentinel is
+    /// client→server). Must not panic the worker.
+    #[tokio::test]
+    async fn test_handle_reader_kills_on_sentinel_from_server() {
+        let ReaderHarness {
+            mut framed_server,
+            framed_reader,
+            alive_tx,
+            alive_rx: _alive_rx,
+            controller,
+        } = reader_harness().await;
+        let cancellation_counter =
+            IntCounter::new("tcp_client_reader_sentinel_test", "test counter").unwrap();
+
+        let counter_clone = cancellation_counter.clone();
+        let controller_clone = controller.clone();
+        let reader_handle = tokio::spawn(async move {
+            handle_reader(
+                framed_reader,
+                controller_clone,
+                alive_tx,
+                Some(counter_clone),
+            )
+            .await
+        });
+
+        framed_server
+            .send(control_message(&ControlMessage::Sentinel))
+            .await
+            .unwrap();
+
+        let _ = reader_handle.await.unwrap();
+
+        assert!(
+            controller.is_killed(),
+            "Sentinel from server should kill the stream context"
+        );
+        assert_eq!(
+            cancellation_counter.get(),
+            1,
+            "Sentinel-from-server should be counted once"
+        );
+    }
+
+    /// Non-control message (data attached, header missing, etc.) from
+    /// the server must not panic. Covers the catch-all `_` arm.
+    #[tokio::test]
+    async fn test_handle_reader_kills_on_non_control_message() {
+        let ReaderHarness {
+            mut framed_server,
+            framed_reader,
+            alive_tx,
+            alive_rx: _alive_rx,
+            controller,
+        } = reader_harness().await;
+        let cancellation_counter =
+            IntCounter::new("tcp_client_reader_non_control_test", "test counter").unwrap();
+
+        let counter_clone = cancellation_counter.clone();
+        let controller_clone = controller.clone();
+        let reader_handle = tokio::spawn(async move {
+            handle_reader(
+                framed_reader,
+                controller_clone,
+                alive_tx,
+                Some(counter_clone),
+            )
+            .await
+        });
+
+        framed_server
+            .send(TwoPartMessage::from_data(Bytes::from_static(
+                b"unexpected payload",
+            )))
+            .await
+            .unwrap();
+
+        let _ = reader_handle.await.unwrap();
+
+        assert!(
+            controller.is_killed(),
+            "non-control message from server should kill the stream context"
+        );
+        assert_eq!(
+            cancellation_counter.get(),
+            1,
+            "non-control message should be counted once"
         );
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -566,8 +566,14 @@ async fn tcp_listener(
                                         break;
                                     }
                                     Err(e) => {
-                                        // TODO(#171) - address fatal errors
-                                        panic!("{:?}", e);
+                                        // Malformed control message — kill the
+                                        // connection so only this stream is torn
+                                        // down.
+                                        tracing::warn!(
+                                            "malformed control message, closing connection: {e:?}"
+                                        );
+                                        control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                                        break;
                                     }
                                 }
                             }
@@ -579,9 +585,15 @@ async fn tcp_listener(
                                     break;
                                 };
                         }
-                        Some(Err(_)) => {
-                            // TODO(#171) - address fatal errors
-                            panic!("invalid message issued over socket; this should never happen");
+                        Some(Err(e)) => {
+                            // TCP RST or decode error from worker side — the
+                            // connection is broken.  Kill the request context and
+                            // break so only this stream is affected.
+                            tracing::warn!(
+                                "tcp stream read error from worker, closing connection: {e:?}"
+                            );
+                            control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                            break;
                         }
                         None => {
                             // this is allowed but we try to avoid it

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use core::panic;
 use socket2::{Domain, SockAddr, Socket, Type};
 use std::{
     collections::{HashMap, HashSet},

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -702,8 +702,14 @@ async fn tcp_listener(
                                         break;
                                     }
                                     Err(e) => {
-                                        // TODO(#171) - address fatal errors
-                                        panic!("{:?}", e);
+                                        // Malformed control message — kill the
+                                        // connection so only this stream is torn
+                                        // down.
+                                        tracing::warn!(
+                                            "malformed control message, closing connection: {e:?}"
+                                        );
+                                        control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                                        break;
                                     }
                                 }
                             }
@@ -715,9 +721,15 @@ async fn tcp_listener(
                                     break;
                                 };
                         }
-                        Some(Err(_)) => {
-                            // TODO(#171) - address fatal errors
-                            panic!("invalid message issued over socket; this should never happen");
+                        Some(Err(e)) => {
+                            // TCP RST or decode error from worker side — the
+                            // connection is broken.  Kill the request context and
+                            // break so only this stream is affected.
+                            tracing::warn!(
+                                "tcp stream read error from worker, closing connection: {e:?}"
+                            );
+                            control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                            break;
                         }
                         None => {
                             // this is allowed but we try to avoid it

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -604,7 +604,13 @@ async fn tcp_listener(
                 prologue
             }
             _ => {
-                panic!("Expected HeaderOnly ControlMessage; internally logic error")
+                // Worker sent a non-HeaderOnly frame in the prologue slot
+                // (protocol violation, version skew, corruption). Notify the
+                // requester so the generate call chain fails cleanly, then
+                // return Err so the connection task ends without panicking.
+                let msg = "malformed prologue: expected HeaderOnly ControlMessage".to_string();
+                let _ = connection.send(Err(msg.clone()));
+                return Err(error!("{msg}"));
             }
         };
 
@@ -697,7 +703,18 @@ async fn tcp_listener(
                                 match process_control_message(header) {
                                     Ok(ControlAction::Continue) => {}
                                     Ok(ControlAction::Shutdown) => {
-                                        assert!(data.is_empty(), "received sentinel message with data; this should never happen");
+                                        if !data.is_empty() {
+                                            // Client sent Sentinel with a data
+                                            // payload (protocol violation). Kill
+                                            // this stream rather than panic the
+                                            // process via assert!.
+                                            tracing::warn!(
+                                                data_len = data.len(),
+                                                "client sent Sentinel with data (protocol violation); killing stream"
+                                            );
+                                            control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                                            break;
+                                        }
                                         tracing::trace!("received sentinel message; shutting down");
                                         break;
                                     }
@@ -1391,5 +1408,217 @@ mod tests {
             "Different namespace/component must not be tombstoned"
         );
         assert_eq!(server.cancel_instance_streams(&id_b).await, 1);
+    }
+
+    // ===== peer-controlled-bytes panic-replacement coverage =====
+    //
+    // The four tests below stand up a real registered response stream
+    // (handshake + prologue) and feed it bytes that previously triggered
+    // panic!()/assert!() in process_response_stream/network_receive_handler.
+    // Each test asserts the worker (a) does NOT panic and (b) tears down
+    // only the affected stream via ControlMessage::Kill.
+
+    use tokio::io::{AsyncWriteExt, ReadHalf, WriteHalf};
+    use tokio::net::TcpStream;
+
+    type TestFramedRead = FramedRead<ReadHalf<TcpStream>, TwoPartCodec>;
+    type TestFramedWrite = FramedWrite<WriteHalf<TcpStream>, TwoPartCodec>;
+    type TestResponseStream = (TestFramedRead, TestFramedWrite, StreamReceiver);
+
+    /// Stand up a TcpStreamServer, register a response stream, connect a
+    /// client, drive the handshake + prologue, and return the client-side
+    /// framed reader/writer along with the receiver.
+    async fn open_registered_response_stream() -> TestResponseStream {
+        let options = ServerOptions::builder().port(0).build().unwrap();
+        let server = TcpStreamServer::new_with_resolver(options, FailingIpResolver)
+            .await
+            .unwrap();
+        let context = Context::new(());
+        let stream_options = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(false)
+            .enable_response_stream(true)
+            .build()
+            .unwrap();
+        let pending_connection = server.register(stream_options).await;
+        let registered_stream = pending_connection.recv_stream.unwrap();
+        let (connection_info, stream_provider) = registered_stream.into_parts();
+        let tcp_info: TcpStreamConnectionInfo = connection_info.try_into().unwrap();
+
+        let stream = TcpStream::connect(&tcp_info.address).await.unwrap();
+        let (read_half, write_half) = tokio::io::split(stream);
+        let framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
+        let mut framed_writer = FramedWrite::new(write_half, TwoPartCodec::default());
+
+        let handshake = CallHomeHandshake {
+            subject: tcp_info.subject,
+            stream_type: StreamType::Response,
+        };
+        framed_writer
+            .send(TwoPartMessage::from_header(
+                serde_json::to_vec(&handshake).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        framed_writer
+            .send(TwoPartMessage::from_header(
+                serde_json::to_vec(&ResponseStreamPrologue { error: None })
+                    .unwrap()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+
+        // SAFETY (test-only): each `.expect` below describes a condition that
+        // can only fail if the test harness itself is broken; in production,
+        // a connected localhost socket always drives all three layers
+        // (timeout → stream_provider → response stream registration) to a
+        // non-error outcome. A panic in the test thread is the desired
+        // failure mode here.
+        let receiver = tokio::time::timeout(std::time::Duration::from_secs(1), stream_provider)
+            .await
+            .expect("server should establish response stream within timeout")
+            .expect("stream provider should not be dropped")
+            .expect("response stream should be accepted");
+
+        (framed_reader, framed_writer, receiver)
+    }
+
+    async fn recv_control_message(framed_reader: &mut TestFramedRead) -> ControlMessage {
+        // SAFETY (test-only): a misbehaving server (closing early, sending
+        // garbage, or sending data alongside a control header) is exactly the
+        // kind of harness failure we want surfaced as a test panic.
+        let message = tokio::time::timeout(std::time::Duration::from_secs(1), framed_reader.next())
+            .await
+            .expect("server should send a control message within timeout")
+            .expect("server should not close before sending control")
+            .expect("control message should decode");
+        let (header, data) = message.optional_parts();
+        assert!(data.is_none(), "control message should not contain data");
+        serde_json::from_slice(header.expect("control header missing").as_ref()).unwrap()
+    }
+
+    /// Sending an unexpected control message (Stop or Kill from the data
+    /// direction) is a protocol violation. The server's
+    /// network_receive_handler must reply with ControlMessage::Kill on
+    /// that stream alone, not panic.
+    #[tokio::test]
+    async fn test_tcp_stream_server_sends_kill_on_unexpected_control_message() {
+        let (mut framed_reader, mut framed_writer, _receiver) =
+            open_registered_response_stream().await;
+
+        framed_writer
+            .send(TwoPartMessage::from_header(
+                serde_json::to_vec(&ControlMessage::Stop).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            recv_control_message(&mut framed_reader).await,
+            ControlMessage::Kill,
+            "unexpected control message should kill only this stream"
+        );
+    }
+
+    /// A framing/decode error from the worker side is unrecoverable for
+    /// this stream but must not panic the worker. Server should send Kill
+    /// and tear down only this connection.
+    #[tokio::test]
+    async fn test_tcp_stream_server_sends_kill_on_read_error() {
+        let (mut framed_reader, framed_writer, _receiver) = open_registered_response_stream().await;
+
+        let mut raw_writer = framed_writer.into_inner();
+        raw_writer.write_all(&[0u8; 8]).await.unwrap();
+        raw_writer.shutdown().await.unwrap();
+
+        assert_eq!(
+            recv_control_message(&mut framed_reader).await,
+            ControlMessage::Kill,
+            "framing read error should kill only this stream"
+        );
+    }
+
+    /// Sentinel is supposed to be header-only. A misbehaving client that
+    /// attaches a data payload must not panic the worker via assert!().
+    #[tokio::test]
+    async fn test_tcp_stream_server_sends_kill_on_sentinel_with_data() {
+        let (mut framed_reader, mut framed_writer, _receiver) =
+            open_registered_response_stream().await;
+
+        let header = serde_json::to_vec(&ControlMessage::Sentinel)
+            .unwrap()
+            .into();
+        framed_writer
+            .send(TwoPartMessage::from_parts(
+                header,
+                Bytes::from_static(b"unexpected payload"),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            recv_control_message(&mut framed_reader).await,
+            ControlMessage::Kill,
+            "Sentinel with data should kill only this stream"
+        );
+    }
+
+    /// The prologue must be a HeaderOnly frame. A non-HeaderOnly prologue
+    /// (data-only or mixed) must surface as Err to the requester rather
+    /// than panic the worker.
+    #[tokio::test]
+    async fn test_tcp_stream_server_returns_error_on_invalid_prologue() {
+        let options = ServerOptions::builder().port(0).build().unwrap();
+        let server = TcpStreamServer::new_with_resolver(options, FailingIpResolver)
+            .await
+            .unwrap();
+        let context = Context::new(());
+        let stream_options = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(false)
+            .enable_response_stream(true)
+            .build()
+            .unwrap();
+        let pending_connection = server.register(stream_options).await;
+        let registered_stream = pending_connection.recv_stream.unwrap();
+        let (connection_info, stream_provider) = registered_stream.into_parts();
+        let tcp_info: TcpStreamConnectionInfo = connection_info.try_into().unwrap();
+
+        let stream = TcpStream::connect(&tcp_info.address).await.unwrap();
+        let (_read_half, write_half) = tokio::io::split(stream);
+        let mut framed_writer = FramedWrite::new(write_half, TwoPartCodec::default());
+
+        let handshake = CallHomeHandshake {
+            subject: tcp_info.subject,
+            stream_type: StreamType::Response,
+        };
+        framed_writer
+            .send(TwoPartMessage::from_header(
+                serde_json::to_vec(&handshake).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        // Send a data-only frame in the prologue slot.
+        framed_writer
+            .send(TwoPartMessage::from_data(Bytes::from_static(
+                b"not a prologue",
+            )))
+            .await
+            .unwrap();
+
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(1), stream_provider)
+            .await
+            .expect("stream provider should resolve quickly")
+            .expect("stream provider channel should not be dropped");
+        // StreamReceiver doesn't impl Debug, so we can't use `.expect_err`.
+        match outcome {
+            Err(err) => assert!(
+                err.contains("malformed prologue"),
+                "expected malformed-prologue error, got: {err}"
+            ),
+            Ok(_) => std::panic!("invalid prologue should produce an error, but got Ok"),
+        }
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -677,20 +677,20 @@ async fn tcp_listener(
 
                 _ = response_tx.closed() => {
                     tracing::trace!("response channel closed before the client finished writing data");
-                    control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                    let _ = control_tx.send(ControlMessage::Kill).await;
                     break;
                 }
 
                 _ = context.killed() => {
                     tracing::trace!("context kill signal received; shutting down");
-                    control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                    let _ = control_tx.send(ControlMessage::Kill).await;
                     break;
                 }
 
                 _ = context.stopped(), if can_stop => {
                     tracing::trace!("context stop signal received; shutting down");
                     can_stop = false;
-                    control_tx.send(ControlMessage::Stop).await.expect("the control channel should not be closed");
+                    let _ = control_tx.send(ControlMessage::Stop).await;
                 }
 
                 msg = framed_reader.next() => {
@@ -704,28 +704,24 @@ async fn tcp_listener(
                                     Ok(ControlAction::Continue) => {}
                                     Ok(ControlAction::Shutdown) => {
                                         if !data.is_empty() {
-                                            // Client sent Sentinel with a data
-                                            // payload (protocol violation). Kill
-                                            // this stream rather than panic the
-                                            // process via assert!.
+                                            // Sentinel-with-data is a protocol
+                                            // violation; kill this stream, don't
+                                            // assert!() the process down.
                                             tracing::warn!(
                                                 data_len = data.len(),
                                                 "client sent Sentinel with data (protocol violation); killing stream"
                                             );
-                                            control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                                            let _ = control_tx.send(ControlMessage::Kill).await;
                                             break;
                                         }
                                         tracing::trace!("received sentinel message; shutting down");
                                         break;
                                     }
                                     Err(e) => {
-                                        // Malformed control message — kill the
-                                        // connection so only this stream is torn
-                                        // down.
-                                        tracing::warn!(
-                                            "malformed control message, closing connection: {e:?}"
-                                        );
-                                        control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                                        // Malformed control message — kill only
+                                        // this stream.
+                                        tracing::warn!(err = ?e, "malformed control message, closing connection");
+                                        let _ = control_tx.send(ControlMessage::Kill).await;
                                         break;
                                     }
                                 }
@@ -733,19 +729,16 @@ async fn tcp_listener(
 
                             if !data.is_empty()
                                 && let Err(err) = response_tx.send(data).await {
-                                    tracing::debug!("forwarding body/data message to response channel failed: {err}");
-                                    control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                                    tracing::debug!(?err, "forwarding body/data to response channel failed");
+                                    let _ = control_tx.send(ControlMessage::Kill).await;
                                     break;
                                 };
                         }
                         Some(Err(e)) => {
-                            // TCP RST or decode error from worker side — the
-                            // connection is broken.  Kill the request context and
-                            // break so only this stream is affected.
-                            tracing::warn!(
-                                "tcp stream read error from worker, closing connection: {e:?}"
-                            );
-                            control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                            // TCP RST or decode error from worker — kill only
+                            // this stream.
+                            tracing::warn!(err = ?e, "tcp stream read error from worker, closing connection");
+                            let _ = control_tx.send(ControlMessage::Kill).await;
                             break;
                         }
                         None => {

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -608,9 +608,9 @@ async fn tcp_listener(
                 // (protocol violation, version skew, corruption). Notify the
                 // requester so the generate call chain fails cleanly, then
                 // return Err so the connection task ends without panicking.
-                let msg = "malformed prologue: expected HeaderOnly ControlMessage".to_string();
-                let _ = connection.send(Err(msg.clone()));
-                return Err(error!("{msg}"));
+                let msg = "malformed prologue: expected HeaderOnly ControlMessage";
+                let _ = connection.send(Err(msg.to_string()));
+                return Err(error!(msg));
             }
         };
 
@@ -1606,7 +1606,7 @@ mod tests {
                 err.contains("malformed prologue"),
                 "expected malformed-prologue error, got: {err}"
             ),
-            Ok(_) => std::panic!("invalid prologue should produce an error, but got Ok"),
+            Ok(_) => panic!("invalid prologue should produce an error, but got Ok"),
         }
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -765,18 +765,27 @@ async fn tcp_listener(
         let mut control_rx = control_rx;
 
         while let Some(control_msg) = control_rx.recv().await {
-            assert_ne!(
-                control_msg,
-                ControlMessage::Sentinel,
-                "received sentinel message; this should never happen"
-            );
-            let bytes =
-                serde_json::to_vec(&control_msg).expect("failed to serialize control message");
+            // Sentinel is a worker→frontend message; receiving one here means
+            // a producer is buggy. Skip rather than asserting — a stream-level
+            // bug must not panic the worker.
+            if matches!(control_msg, ControlMessage::Sentinel) {
+                tracing::warn!("received sentinel on send-side control channel; dropping");
+                continue;
+            }
+            let bytes = match serde_json::to_vec(&control_msg) {
+                Ok(b) => b,
+                Err(e) => {
+                    // Closed enum of small variants; serialization shouldn't
+                    // fail. If it ever does, log and skip rather than panic.
+                    tracing::warn!(err = ?e, ?control_msg, "failed to serialize control message");
+                    continue;
+                }
+            };
             let message = TwoPartMessage::from_header(bytes.into());
             match socket_tx.send(message).await {
-                Ok(_) => tracing::debug!("issued control message {control_msg:?} to sender"),
-                Err(_) => {
-                    tracing::debug!("failed to send control message {control_msg:?} to sender")
+                Ok(_) => tracing::debug!(?control_msg, "issued control message"),
+                Err(e) => {
+                    tracing::debug!(err = ?e, ?control_msg, "failed to send control message")
                 }
             }
         }
@@ -805,10 +814,10 @@ fn process_control_message(message: Bytes) -> Result<ControlAction> {
             Ok(ControlAction::Shutdown)
         }
         ControlMessage::Kill | ControlMessage::Stop => {
-            // TODO(#171) - address fatal errors
-            anyhow::bail!(
-                "fatal error - unexpected control message received - this should never happen"
-            );
+            // Worker→frontend control direction only carries Sentinel. Kill/Stop
+            // here is a protocol violation; the caller turns this Err into a
+            // stream-local Kill rather than a process-fatal event.
+            anyhow::bail!("unexpected control message on response stream");
         }
     }
 }
@@ -818,6 +827,8 @@ mod tests {
     use super::*;
     use crate::engine::AsyncEngineContextProvider;
     use crate::pipeline::Context;
+    use tokio::io::{AsyncWriteExt, ReadHalf, WriteHalf};
+    use tokio::net::TcpStream;
 
     // Mock resolver that always fails to simulate the fallback scenario
     struct FailingIpResolver;
@@ -1403,17 +1414,6 @@ mod tests {
         assert_eq!(server.cancel_instance_streams(&id_b).await, 1);
     }
 
-    // ===== peer-controlled-bytes panic-replacement coverage =====
-    //
-    // The four tests below stand up a real registered response stream
-    // (handshake + prologue) and feed it bytes that previously triggered
-    // panic!()/assert!() in process_response_stream/network_receive_handler.
-    // Each test asserts the worker (a) does NOT panic and (b) tears down
-    // only the affected stream via ControlMessage::Kill.
-
-    use tokio::io::{AsyncWriteExt, ReadHalf, WriteHalf};
-    use tokio::net::TcpStream;
-
     type TestFramedRead = FramedRead<ReadHalf<TcpStream>, TwoPartCodec>;
     type TestFramedWrite = FramedWrite<WriteHalf<TcpStream>, TwoPartCodec>;
     type TestResponseStream = (TestFramedRead, TestFramedWrite, StreamReceiver);
@@ -1462,12 +1462,8 @@ mod tests {
             .await
             .unwrap();
 
-        // SAFETY (test-only): each `.expect` below describes a condition that
-        // can only fail if the test harness itself is broken; in production,
-        // a connected localhost socket always drives all three layers
-        // (timeout → stream_provider → response stream registration) to a
-        // non-error outcome. A panic in the test thread is the desired
-        // failure mode here.
+        // SAFETY (test-only): healthy localhost handshake always resolves all
+        // three layers; a panic here means the harness is broken.
         let receiver = tokio::time::timeout(std::time::Duration::from_secs(1), stream_provider)
             .await
             .expect("server should establish response stream within timeout")
@@ -1478,9 +1474,8 @@ mod tests {
     }
 
     async fn recv_control_message(framed_reader: &mut TestFramedRead) -> ControlMessage {
-        // SAFETY (test-only): a misbehaving server (closing early, sending
-        // garbage, or sending data alongside a control header) is exactly the
-        // kind of harness failure we want surfaced as a test panic.
+        // SAFETY (test-only): a misbehaving server in any of these layers is
+        // exactly the harness failure we want surfaced as a test panic.
         let message = tokio::time::timeout(std::time::Duration::from_secs(1), framed_reader.next())
             .await
             .expect("server should send a control message within timeout")

--- a/tests/fault_tolerance/cancellation/test_sglang.py
+++ b/tests/fault_tolerance/cancellation/test_sglang.py
@@ -287,7 +287,7 @@ def test_request_cancellation_sglang_aggregated(
                 # Verify frontend log has kill message
                 _, frontend_log_offset = poll_for_pattern(
                     process=frontend,
-                    pattern="issued control message Kill to sender",
+                    pattern="issued control message control_msg=Kill",
                     log_offset=frontend_log_offset,
                 )
 
@@ -403,7 +403,7 @@ def test_request_cancellation_sglang_decode_cancel(
                 # Verify frontend log has kill message
                 _, frontend_log_offset = poll_for_pattern(
                     process=frontend,
-                    pattern="issued control message Kill to sender",
+                    pattern="issued control message control_msg=Kill",
                 )
 
                 logger.info(

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -243,7 +243,7 @@ def test_request_cancellation_trtllm_aggregated(
                 # Verify frontend log has kill message
                 _, frontend_log_offset = poll_for_pattern(
                     process=frontend,
-                    pattern="issued control message Kill to sender",
+                    pattern="issued control message control_msg=Kill",
                     log_offset=frontend_log_offset,
                 )
 
@@ -338,7 +338,7 @@ def test_request_cancellation_trtllm_decode_cancel(
                 # Verify frontend log has kill message
                 _, frontend_log_offset = poll_for_pattern(
                     process=frontend,
-                    pattern="issued control message Kill to sender",
+                    pattern="issued control message control_msg=Kill",
                 )
 
                 logger.info(
@@ -431,7 +431,7 @@ def test_request_cancellation_trtllm_prefill_cancel(
                 # Verify frontend log has kill message
                 _, frontend_log_offset = poll_for_pattern(
                     process=frontend,
-                    pattern="issued control message Kill to sender",
+                    pattern="issued control message control_msg=Kill",
                 )
 
                 # Verify decode worker never received the request
@@ -549,7 +549,7 @@ def test_request_cancellation_trtllm_kv_transfer_cancel(
                 # Verify frontend log has kill message
                 _, frontend_log_offset = poll_for_pattern(
                     process=frontend,
-                    pattern="issued control message Kill to sender",
+                    pattern="issued control message control_msg=Kill",
                 )
 
                 logger.info(

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -278,7 +278,7 @@ def test_request_cancellation_vllm_aggregated(
                 # Verify frontend log has kill message
                 _, frontend_log_offset = poll_for_pattern(
                     process=frontend,
-                    pattern="issued control message Kill to sender",
+                    pattern="issued control message control_msg=Kill",
                     log_offset=frontend_log_offset,
                 )
 
@@ -371,7 +371,7 @@ def test_request_cancellation_vllm_decode_cancel(
                 # Verify frontend log has kill message
                 _, frontend_log_offset = poll_for_pattern(
                     process=frontend,
-                    pattern="issued control message Kill to sender",
+                    pattern="issued control message control_msg=Kill",
                 )
 
                 logger.info(
@@ -464,7 +464,7 @@ def test_request_cancellation_vllm_prefill_cancel(
                 # Verify frontend log has kill message
                 _, frontend_log_offset = poll_for_pattern(
                     process=frontend,
-                    pattern="issued control message Kill to sender",
+                    pattern="issued control message control_msg=Kill",
                 )
 
                 # Verify decode worker never received the request


### PR DESCRIPTION
## Summary

Under high concurrency (issue #8039, observed with SGLang DEP4 at concurrency=4096), TCP stream read errors (`ECONNRESET` / `Connection reset by peer`) caused `panic!` calls in the TCP client and server read loops. Each panic aborted a Tokio task — 13–130 per failing run — stranding requests with no response path.

**Root cause** of the hang was separately fixed by PR #8181 (push-router scheduler-slot cleanup gap). This PR addresses the **secondary failure mode**: the panics that cascaded from the initial connection resets.

### Changes

**`tcp/client.rs`** (`handle_reader`)
- `Some(Err(e))` branch: replace `panic!` with `tracing::warn! + break`.
- Connection reset from the push-router side no longer kills the worker's response-streaming Tokio task.

**`tcp/server.rs`** (`network_receive_handler`)
- `Some(Err(e))` branch: replace `panic!` with `tracing::warn! + ControlMessage::Kill + break`.
- TCP RST or decode error from the worker side no longer panics the push-router's per-connection receive handler.
- `process_control_message` error path: same pattern — warn + Kill + break instead of `panic!`.

Both sides already handle `None` (clean peer close) with a `break`, so this aligns the error path with that existing pattern.

## Test plan
- [ ] `cargo check -p dynamo-runtime` passes (verified locally)
- [ ] Existing `cargo test -p dynamo-runtime` passes
- [ ] High-concurrency SGLang DEP4 benchmark no longer shows TCP worker panics (needs cluster test)

Supersedes PR #7858 (same client-side fix plus server-side fix).
Closes #8039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP network error handling to gracefully close individual connections on decode or protocol failures, with warning logs for troubleshooting, instead of crashing the entire process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
