### PR TITLE
feat: address MR comments from TRTLLM/GMS integration

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -70,6 +70,7 @@ class TRTLLMEngineQuiesceController:
     def __init__(self, engine: TensorRTLLMEngine):
         self._engine = engine
         self._is_quiesced = False
+        self._wakeup_rpc_name: str | None = None
 
     @property
     def is_quiesced(self) -> bool:
@@ -107,13 +108,23 @@ class TRTLLMEngineQuiesceController:
                 "TRT-LLM does not expose _collective_rpc; skipping %s", method
             )
             return
-        try:
+
+        if method != "wakeup":
             rpc(method, args=(rpc_tags,), kwargs={}, non_block=False)
-        except Exception:
-            if method != "wakeup":
-                raise
-            # Some TRT-LLM versions use "wake_up" instead of "wakeup"
-            rpc("wake_up", args=(rpc_tags,), kwargs={}, non_block=False)
+            return
+
+        # Probe and cache the correct wakeup method name on the first call.
+        # Some TRT-LLM versions use "wake_up" instead of "wakeup".
+        if self._wakeup_rpc_name is None:
+            try:
+                rpc("wakeup", args=(rpc_tags,), kwargs={}, non_block=False)
+                self._wakeup_rpc_name = "wakeup"
+                return
+            except Exception as e:
+                logger.debug("'wakeup' RPC failed (%s); falling back to 'wake_up'", e)
+                self._wakeup_rpc_name = "wake_up"
+
+        rpc(self._wakeup_rpc_name, args=(rpc_tags,), kwargs={}, non_block=False)
 
     @staticmethod
     def _release_gms_weights() -> None:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -70,7 +70,6 @@ class TRTLLMEngineQuiesceController:
     def __init__(self, engine: TensorRTLLMEngine):
         self._engine = engine
         self._is_quiesced = False
-        self._wakeup_rpc_name: str | None = None
 
     @property
     def is_quiesced(self) -> bool:
@@ -109,29 +108,7 @@ class TRTLLMEngineQuiesceController:
             )
             return
 
-        if method != "wakeup":
-            rpc(method, args=(rpc_tags,), kwargs={}, non_block=False)
-            return
-
-        # Probe and cache the correct wakeup method name on the first call.
-        # Some TRT-LLM versions use "wake_up" instead of "wakeup".
-        # Only cache a name after it succeeds; transient failures leave _wakeup_rpc_name
-        # as None so the probe retries on the next call.
-        if self._wakeup_rpc_name is None:
-            try:
-                rpc("wakeup", args=(rpc_tags,), kwargs={}, non_block=False)
-                self._wakeup_rpc_name = "wakeup"
-                return
-            except Exception as wakeup_exc:
-                try:
-                    rpc("wake_up", args=(rpc_tags,), kwargs={}, non_block=False)
-                except Exception:
-                    raise wakeup_exc
-                logger.debug("'wakeup' RPC unavailable; using 'wake_up'")
-                self._wakeup_rpc_name = "wake_up"
-                return
-
-        rpc(self._wakeup_rpc_name, args=(rpc_tags,), kwargs={}, non_block=False)
+        rpc(method, args=(rpc_tags,), kwargs={}, non_block=False)
 
     @staticmethod
     def _release_gms_weights() -> None:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -115,14 +115,21 @@ class TRTLLMEngineQuiesceController:
 
         # Probe and cache the correct wakeup method name on the first call.
         # Some TRT-LLM versions use "wake_up" instead of "wakeup".
+        # Only cache a name after it succeeds; transient failures leave _wakeup_rpc_name
+        # as None so the probe retries on the next call.
         if self._wakeup_rpc_name is None:
             try:
                 rpc("wakeup", args=(rpc_tags,), kwargs={}, non_block=False)
                 self._wakeup_rpc_name = "wakeup"
                 return
-            except Exception as e:
-                logger.debug("'wakeup' RPC failed (%s); falling back to 'wake_up'", e)
+            except Exception as wakeup_exc:
+                try:
+                    rpc("wake_up", args=(rpc_tags,), kwargs={}, non_block=False)
+                except Exception:
+                    raise wakeup_exc
+                logger.debug("'wakeup' RPC unavailable; using 'wake_up'")
                 self._wakeup_rpc_name = "wake_up"
+                return
 
         rpc(self._wakeup_rpc_name, args=(rpc_tags,), kwargs={}, non_block=False)
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
@@ -20,7 +20,10 @@ if not torch.cuda.is_available():
         allow_module_level=True,
     )
 
-from dynamo.trtllm.request_handlers.handler_base import HandlerBase
+from dynamo.trtllm.request_handlers.handler_base import (
+    HandlerBase,
+    TRTLLMEngineQuiesceController,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -206,3 +209,61 @@ async def test_generate_locally_rejected_when_sleeping():
 
     assert len(chunks) == 1
     assert "error" in str(chunks[0].get("finish_reason", ""))
+
+
+# ---------------------------------------------------------------------------
+# TRTLLMEngineQuiesceController._collective_rpc wakeup probe-and-cache
+# ---------------------------------------------------------------------------
+
+
+def _make_controller(rpc_side_effects: dict) -> TRTLLMEngineQuiesceController:
+    """Create a controller with a mock engine whose _collective_rpc raises per method."""
+    engine = MagicMock()
+
+    def _rpc(method, **_kwargs):
+        exc = rpc_side_effects.get(method)
+        if exc is not None:
+            raise exc
+
+    engine.llm._collective_rpc = MagicMock(side_effect=_rpc)
+    ctrl = TRTLLMEngineQuiesceController(engine)
+    return ctrl
+
+
+def test_wakeup_probe_caches_wakeup_on_success():
+    ctrl = _make_controller({})
+    ctrl._collective_rpc("wakeup", ["kv_cache"])
+    assert ctrl._wakeup_rpc_name == "wakeup"
+    ctrl._collective_rpc("wakeup", ["kv_cache"])
+    # Second call should use cached name, no re-probing: rpc called exactly twice total
+    assert ctrl._engine.llm._collective_rpc.call_count == 2
+
+
+def test_wakeup_probe_falls_back_to_wake_up():
+    ctrl = _make_controller({"wakeup": AttributeError("no such method")})
+    ctrl._collective_rpc("wakeup", ["kv_cache"])
+    assert ctrl._wakeup_rpc_name == "wake_up"
+    ctrl._collective_rpc("wakeup", ["kv_cache"])
+    # Second call reuses "wake_up" directly; 3 rpc calls total (probe-wakeup, probe-wake_up, cached)
+    assert ctrl._engine.llm._collective_rpc.call_count == 3
+
+
+def test_wakeup_transient_failure_does_not_cache_wrong_name():
+    transient = RuntimeError("network error")
+    ctrl = _make_controller(
+        {"wakeup": transient, "wake_up": RuntimeError("also failed")}
+    )
+    with pytest.raises(RuntimeError, match="network error"):
+        ctrl._collective_rpc("wakeup", ["kv_cache"])
+    # Name must remain None so the probe retries on the next call
+    assert ctrl._wakeup_rpc_name is None
+
+
+def test_wakeup_cached_name_not_reprobed():
+    ctrl = _make_controller({})
+    ctrl._wakeup_rpc_name = "wakeup"
+    ctrl._collective_rpc("wakeup", ["kv_cache"])
+    # Cached path skips the probe entirely; rpc called exactly once
+    ctrl._engine.llm._collective_rpc.assert_called_once_with(
+        "wakeup", args=(["kv_cache"],), kwargs={}, non_block=False
+    )

--- a/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
@@ -53,10 +53,17 @@ def _make_handler() -> _ConcreteHandler:
     handler._no_inflight_requests = asyncio.Event()
     handler._no_inflight_requests.set()
     handler._reject_new_requests = False
-    # Mock the quiesce controller that release/resume delegate to
+    # Mock the quiesce controller that release/resume delegate to.
+    # quiesce side_effect mirrors the real implementation;
+    # tests don't need to manually update state after a release call.
     handler._quiesce_controller = MagicMock()
     handler._quiesce_controller.is_quiesced = False
-    handler._quiesce_controller.quiesce = AsyncMock(return_value=True)
+
+    async def _quiesce(tags=None):
+        handler._quiesce_controller.is_quiesced = True
+        return True
+
+    handler._quiesce_controller.quiesce = AsyncMock(side_effect=_quiesce)
     handler._quiesce_controller.resume = AsyncMock(return_value=True)
     handler._quiesce_controller.mark_resumed = MagicMock()
     return handler
@@ -164,9 +171,6 @@ async def test_release_and_resume_round_trip():
     handler = _make_handler()
     release = await handler.release_memory_occupation({})
     assert release["status"] == "ok"
-
-    # After release, controller reports quiesced
-    handler._quiesce_controller.is_quiesced = True
 
     resume = await handler.resume_memory_occupation({})
     assert resume["status"] == "ok"

--- a/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
@@ -20,10 +20,7 @@ if not torch.cuda.is_available():
         allow_module_level=True,
     )
 
-from dynamo.trtllm.request_handlers.handler_base import (
-    HandlerBase,
-    TRTLLMEngineQuiesceController,
-)
+from dynamo.trtllm.request_handlers.handler_base import HandlerBase
 
 pytestmark = [
     pytest.mark.unit,
@@ -209,61 +206,3 @@ async def test_generate_locally_rejected_when_sleeping():
 
     assert len(chunks) == 1
     assert "error" in str(chunks[0].get("finish_reason", ""))
-
-
-# ---------------------------------------------------------------------------
-# TRTLLMEngineQuiesceController._collective_rpc wakeup probe-and-cache
-# ---------------------------------------------------------------------------
-
-
-def _make_controller(rpc_side_effects: dict) -> TRTLLMEngineQuiesceController:
-    """Create a controller with a mock engine whose _collective_rpc raises per method."""
-    engine = MagicMock()
-
-    def _rpc(method, **_kwargs):
-        exc = rpc_side_effects.get(method)
-        if exc is not None:
-            raise exc
-
-    engine.llm._collective_rpc = MagicMock(side_effect=_rpc)
-    ctrl = TRTLLMEngineQuiesceController(engine)
-    return ctrl
-
-
-def test_wakeup_probe_caches_wakeup_on_success():
-    ctrl = _make_controller({})
-    ctrl._collective_rpc("wakeup", ["kv_cache"])
-    assert ctrl._wakeup_rpc_name == "wakeup"
-    ctrl._collective_rpc("wakeup", ["kv_cache"])
-    # Second call should use cached name, no re-probing: rpc called exactly twice total
-    assert ctrl._engine.llm._collective_rpc.call_count == 2
-
-
-def test_wakeup_probe_falls_back_to_wake_up():
-    ctrl = _make_controller({"wakeup": AttributeError("no such method")})
-    ctrl._collective_rpc("wakeup", ["kv_cache"])
-    assert ctrl._wakeup_rpc_name == "wake_up"
-    ctrl._collective_rpc("wakeup", ["kv_cache"])
-    # Second call reuses "wake_up" directly; 3 rpc calls total (probe-wakeup, probe-wake_up, cached)
-    assert ctrl._engine.llm._collective_rpc.call_count == 3
-
-
-def test_wakeup_transient_failure_does_not_cache_wrong_name():
-    transient = RuntimeError("network error")
-    ctrl = _make_controller(
-        {"wakeup": transient, "wake_up": RuntimeError("also failed")}
-    )
-    with pytest.raises(RuntimeError, match="network error"):
-        ctrl._collective_rpc("wakeup", ["kv_cache"])
-    # Name must remain None so the probe retries on the next call
-    assert ctrl._wakeup_rpc_name is None
-
-
-def test_wakeup_cached_name_not_reprobed():
-    ctrl = _make_controller({})
-    ctrl._wakeup_rpc_name = "wakeup"
-    ctrl._collective_rpc("wakeup", ["kv_cache"])
-    # Cached path skips the probe entirely; rpc called exactly once
-    ctrl._engine.llm._collective_rpc.assert_called_once_with(
-        "wakeup", args=(["kv_cache"],), kwargs={}, non_block=False
-    )


### PR DESCRIPTION
#### Overview:

- keep original exceptions from `wakeup` call
- all subsequent wakeup calls go directly to the cached name with no extra RPC
- in the tests: give `quiesce` mock a side effect that mirrors the real implementation

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RPC method name detection and caching for wake operations. The system now automatically identifies the correct method name on first invocation and reuses it for subsequent calls, enhancing reliability and reducing compatibility issues during system wake and resume operations.

* **Tests**
  * Updated test mocks to more accurately reflect real quiesce controller state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
