### PR TITLE
fix(container): sync VLLM_VER when --vllm-ref is passed to install_vllm.sh

### DIFF
--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -37,6 +37,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --vllm-ref)
             VLLM_REF="$2"
+            VLLM_VER="${VLLM_REF#v}"
             shift 2
             ;;
         --max-jobs)


### PR DESCRIPTION
## Summary

- When `--vllm-ref` is passed to `container/deps/vllm/install_vllm.sh`, only `VLLM_REF` was updated but `VLLM_VER` (used for wheel URL construction and pip install) remained at its default value
- This caused the wrong vLLM version to be installed regardless of the specified ref
- Fix: derive `VLLM_VER` from `VLLM_REF` by stripping the leading `v` prefix when `--vllm-ref` is specified

Fixes #8029

## Test plan

- [ ] Build container with `--vllm-ref v0.17.1` and confirm vLLM 0.17.1 is installed
- [ ] Verify default (no `--vllm-ref`) still installs the expected default version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version resolution when installing with custom references.
  * Improved TCP network stability by gracefully handling connection failures instead of abrupt termination. The system now logs error details and safely closes individual connections while maintaining overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->