### PR TITLE
feat(vllm): add multiple served model names support

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import socket
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from vllm.distributed.kv_events import KVEventsConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
@@ -47,7 +47,7 @@ class Config(DynamoRuntimeConfig, DynamoVllmConfig):
 
     # mirror vLLM
     model: str
-    served_model_name: Optional[str] = None
+    served_model_name: Optional[str | List[str]] = None
 
     # rest vLLM args
     engine_args: AsyncEngineArgs
@@ -144,14 +144,6 @@ def update_dynamo_config_with_engine(
     dynamo_config: Config, engine_config: AsyncEngineArgs
 ) -> None:
     """Update dynamo_config fields from engine_config and worker flags."""
-
-    if getattr(engine_config, "served_model_name", None) is not None:
-        served = engine_config.served_model_name
-        if len(served) > 1:
-            raise ValueError("We do not support multiple model names.")
-        dynamo_config.served_model_name = served[0]
-    else:
-        dynamo_config.served_model_name = None
 
     # Capture user-provided --endpoint before defaults overwrite it
     user_endpoint = dynamo_config.endpoint
@@ -612,3 +604,13 @@ def ensure_side_channel_host():
     host_ip = get_host_ip()
     os.environ["VLLM_NIXL_SIDE_CHANNEL_HOST"] = host_ip
     logger.info("Set VLLM_NIXL_SIDE_CHANNEL_HOST to %s (auto-detected)", host_ip)
+
+
+def get_served_model_name(model: str, served_model_name: str | List[str] | None) -> str:
+    """Extract the primary model name from served_model_name."""
+
+    if not served_model_name:
+        return model
+    if isinstance(served_model_name, list):
+        return served_model_name[0]
+    return served_model_name

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -27,7 +27,7 @@ from dynamo.common.backend.engine import (
 )
 from dynamo.common.backend.worker import WorkerConfig
 from dynamo.llm import ModelInput
-from dynamo.vllm.args import parse_args
+from dynamo.vllm.args import get_served_model_name, parse_args
 
 from .handlers import build_sampling_params
 
@@ -58,7 +58,9 @@ class VllmLLMEngine(LLMEngine):
         worker_config = WorkerConfig.from_runtime_config(
             config,
             model_name=config.model,
-            served_model_name=config.served_model_name,
+            served_model_name=get_served_model_name(
+                config.model, config.served_model_name
+            ),
             model_input=ModelInput.Tokens,
         )
         return engine, worker_config

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -118,8 +118,12 @@ async def worker() -> None:
 
     # Name the model. Use either the full path (vllm and sglang do the same),
     # or the HF name (e.g. "Qwen/Qwen3-0.6B"), depending on cmd line params.
+    # Normalize served_model_name to a list for consistent handling downstream.
     if not config.served_model_name:
-        config.served_model_name = config.engine_args.served_model_name = config.model
+        config.served_model_name = [config.model]
+    elif isinstance(config.served_model_name, str):
+        config.served_model_name = [config.served_model_name]
+    config.engine_args.served_model_name = config.served_model_name
 
     # Download the model if necessary using modelexpress.
     # We want it on disk before we start vllm to avoid downloading from HuggingFace.
@@ -444,9 +448,11 @@ def setup_vllm_engine(
 
     # Construct Prometheus gauges AFTER setup_multiprocess_prometheus() so Gauge objects
     # see the correct ValueClass (multiprocess vs in-memory).
+    # Use the primary name (first element) for metrics labeling.
+    primary_name = config.served_model_name[0] if config.served_model_name else ""
     component_gauges = LLMBackendMetrics(
         registry=DYNAMO_COMPONENT_REGISTRY,
-        model_name=config.served_model_name or "",
+        model_name=primary_name,
         component_name=config.component or "",
     )
 
@@ -585,7 +591,9 @@ def setup_vllm_engine(
     # Record model load time
     component_gauges.set_model_load_time(load_time)
 
-    logger.info(f"VllmWorker for {config.served_model_name} has been initialized")
+    logger.info(
+        f"VllmWorker for {config.engine_args.served_model_name} has been initialized"
+    )
 
     # update block_size in vllm_config based on final engine cache info for later use
     runtime_values = get_engine_cache_info(engine_client)
@@ -680,18 +688,30 @@ async def register_vllm_model(
         media_fetcher.timeout_ms(30000)
         media_fetcher.allow_direct_port(True)
 
+    # Extract primary name and aliases from served_model_name list
+    # First element is the primary name, rest are aliases
+    primary_name = (
+        config.served_model_name[0] if config.served_model_name else config.model
+    )
+    model_aliases = (
+        config.served_model_name[1:]
+        if config.served_model_name and len(config.served_model_name) > 1
+        else None
+    )
+
     await register_model(
         model_input,
         model_type,
         generate_endpoint,
         config.model,
-        config.served_model_name,
+        primary_name,
         context_length=vllm_config.model_config.max_model_len,
         kv_cache_block_size=runtime_values["block_size"],
         runtime_config=runtime_config,
         custom_template_path=config.custom_jinja_template,
         media_decoder=media_decoder,
         media_fetcher=media_fetcher,
+        model_aliases=model_aliases,
     )
 
 

--- a/components/src/dynamo/vllm/omni/args.py
+++ b/components/src/dynamo/vllm/omni/args.py
@@ -6,7 +6,7 @@
 import argparse
 import dataclasses
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from vllm_omni.engine.arg_utils import OmniEngineArgs
 
@@ -324,7 +324,7 @@ class OmniConfig(DynamoRuntimeConfig):
     endpoint: Optional[str] = None
 
     model: str
-    served_model_name: Optional[str] = None
+    served_model_name: Optional[str | List[str]] = None
     engine_args: OmniEngineArgs
 
     stage_configs_path: Optional[str] = None
@@ -425,11 +425,14 @@ def parse_omni_args() -> OmniConfig:
 
     engine_args = OmniEngineArgs.from_cli_args(vllm_args)
 
+    # Normalize served_model_name to list
+    # vLLM accepts str | list[str] | None, we normalize to list[str] | None
     if getattr(engine_args, "served_model_name", None) is not None:
         served = engine_args.served_model_name
-        if len(served) > 1:
-            raise ValueError("We do not support multiple model names.")
-        config.served_model_name = served[0]
+        if isinstance(served, str):
+            config.served_model_name = [served]
+        else:
+            config.served_model_name = served
 
     config.engine_args = engine_args
     config.validate()

--- a/components/src/dynamo/vllm/omni/base_handler.py
+++ b/components/src/dynamo/vllm/omni/base_handler.py
@@ -163,7 +163,9 @@ class BaseOmniHandler(BaseWorkerHandler[Dict[str, Any], Dict[str, Any]]):
         if request_type == RequestType.AUDIO_GENERATION:
             return NvAudioSpeechResponse(
                 id=request_id,
-                model=get_served_model_name(self.config.model, self.config.served_model_name),
+                model=get_served_model_name(
+                    self.config.model, self.config.served_model_name
+                ),
                 status="failed",
                 created=int(time.time()),
                 error=error_message,

--- a/components/src/dynamo/vllm/omni/base_handler.py
+++ b/components/src/dynamo/vllm/omni/base_handler.py
@@ -20,6 +20,7 @@ except ImportError:
 from dynamo._core import Context
 from dynamo.common.protocols.audio_protocol import NvAudioSpeechResponse
 from dynamo.common.utils.output_modalities import RequestType
+from dynamo.vllm.args import get_served_model_name
 from dynamo.vllm.handlers import BaseWorkerHandler, build_sampling_params
 
 logger = logging.getLogger(__name__)
@@ -162,7 +163,7 @@ class BaseOmniHandler(BaseWorkerHandler[Dict[str, Any], Dict[str, Any]]):
         if request_type == RequestType.AUDIO_GENERATION:
             return NvAudioSpeechResponse(
                 id=request_id,
-                model=self.config.served_model_name or self.config.model,
+                model=get_served_model_name(self.config.model, self.config.served_model_name),
                 status="failed",
                 created=int(time.time()),
                 error=error_message,

--- a/components/src/dynamo/vllm/omni/main.py
+++ b/components/src/dynamo/vllm/omni/main.py
@@ -18,6 +18,7 @@ from dynamo.common.utils.runtime import create_runtime
 from dynamo.llm import ModelInput, ModelType, fetch_model, register_model
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
+from dynamo.vllm.args import get_served_model_name
 from dynamo.vllm.health_check import VllmOmniHealthCheckPayload
 from dynamo.vllm.main import setup_metrics_collection
 from dynamo.vllm.omni.stage_router import init_omni_stage_router
@@ -84,12 +85,13 @@ async def init_omni(
     if "audio" in config.output_modalities:
         dummy_tokenizer_paths = ensure_dummy_tokenizer_for_tts(config.model)
 
+    primary_name = get_served_model_name(config.model, config.served_model_name)
     await register_model(
         ModelInput.Text,
         model_type,
         generate_endpoint,
         config.model,
-        config.served_model_name,
+        primary_name,
         kv_cache_block_size=config.engine_args.block_size,
     )
 
@@ -109,11 +111,11 @@ async def init_omni(
             metrics_labels=[
                 (
                     prometheus_names.labels.MODEL,
-                    config.served_model_name or config.model,
+                    primary_name,
                 ),
                 (
                     prometheus_names.labels.MODEL_NAME,
-                    config.served_model_name or config.model,
+                    primary_name,
                 ),
             ],
             health_check_payload=health_check_payload,

--- a/components/src/dynamo/vllm/omni/stage_router.py
+++ b/components/src/dynamo/vllm/omni/stage_router.py
@@ -19,6 +19,7 @@ from dynamo.common.utils.output_modalities import (
 )
 from dynamo.llm import ModelInput, register_model
 from dynamo.runtime import DistributedRuntime
+from dynamo.vllm.args import get_served_model_name
 from dynamo.vllm.main import setup_metrics_collection
 from dynamo.vllm.omni.args import OmniConfig
 from dynamo.vllm.omni.output_formatter import OutputFormatter
@@ -45,7 +46,7 @@ class OmniStageRouter:
             get_fs(config.media_output_fs_url) if config.media_output_fs_url else None
         )
         self._formatter = OutputFormatter(
-            model_name=config.served_model_name or config.model,
+            model_name=get_served_model_name(config.model, config.served_model_name),
             media_fs=media_fs,
             media_http_url=config.media_output_http_url,
             default_fps=config.default_video_fps,
@@ -183,12 +184,13 @@ async def init_omni_stage_router(
     if model_type is None:
         model_type = _resolve_model_type(final_output_type)
 
+    primary_name = get_served_model_name(config.model, config.served_model_name)
     await register_model(
         ModelInput.Text,
         model_type,
         generate_endpoint,
         config.model,
-        config.served_model_name,
+        primary_name,
     )
     logger.info("OmniStageRouter registered at '%s'", generate_endpoint)
 
@@ -199,11 +201,11 @@ async def init_omni_stage_router(
             metrics_labels=[
                 (
                     prometheus_names.labels.MODEL,
-                    config.served_model_name or config.model,
+                    primary_name,
                 ),
                 (
                     prometheus_names.labels.MODEL_NAME,
-                    config.served_model_name or config.model,
+                    primary_name,
                 ),
             ],
         )

--- a/components/src/dynamo/vllm/omni/stage_worker.py
+++ b/components/src/dynamo/vllm/omni/stage_worker.py
@@ -20,6 +20,7 @@ from vllm_omni.entrypoints.utils import load_stage_configs_from_yaml
 from dynamo import prometheus_names
 from dynamo.llm import ModelType
 from dynamo.runtime import DistributedRuntime
+from dynamo.vllm.args import get_served_model_name
 from dynamo.vllm.health_check import VllmOmniHealthCheckPayload
 from dynamo.vllm.main import setup_metrics_collection
 from dynamo.vllm.omni.args import OmniConfig
@@ -322,11 +323,11 @@ async def init_omni_stage(
             metrics_labels=[
                 (
                     prometheus_names.labels.MODEL,
-                    config.served_model_name or config.model,
+                    get_served_model_name(config.model, config.served_model_name),
                 ),
                 (
                     prometheus_names.labels.MODEL_NAME,
-                    config.served_model_name or config.model,
+                    get_served_model_name(config.model, config.served_model_name),
                 ),
             ],
             health_check_payload=health_check_payload,

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -24,7 +24,7 @@ from dynamo.common.utils.prometheus import (
 from dynamo.llm import ModelInput, ModelType
 from dynamo.runtime import DistributedRuntime
 
-from .args import Config
+from .args import Config, get_served_model_name
 from .constants import DisaggregationMode
 from .handlers import DecodeWorkerHandler, PrefillWorkerHandler, get_dp_range_for_worker
 from .health_check import VllmHealthCheckPayload, VllmPrefillHealthCheckPayload
@@ -326,7 +326,7 @@ class WorkerFactory:
             register_embedding_cache_metrics(
                 endpoint=generate_endpoint,
                 cache=embedding_cache,
-                model_name=config.served_model_name or config.model,
+                model_name=get_served_model_name(config.model, config.served_model_name),
                 component_name=config.component,
             )
 
@@ -406,11 +406,11 @@ class WorkerFactory:
             model_metrics_labels = [
                 (
                     prometheus_names.labels.MODEL,
-                    config.served_model_name or config.model,
+                    get_served_model_name(config.model, config.served_model_name),
                 ),
                 (
                     prometheus_names.labels.MODEL_NAME,
-                    config.served_model_name or config.model,
+                    get_served_model_name(config.model, config.served_model_name),
                 ),
             ]
 
@@ -560,7 +560,7 @@ class WorkerFactory:
             register_embedding_cache_metrics(
                 endpoint=generate_endpoint,
                 cache=embedding_cache,
-                model_name=config.served_model_name or config.model,
+                model_name=get_served_model_name(config.model, config.served_model_name),
                 component_name=config.component,
             )
 
@@ -604,11 +604,11 @@ class WorkerFactory:
         prefill_metrics_labels = [
             (
                 prometheus_names.labels.MODEL,
-                config.served_model_name or config.model,
+                get_served_model_name(config.model, config.served_model_name),
             ),
             (
                 prometheus_names.labels.MODEL_NAME,
-                config.served_model_name or config.model,
+                get_served_model_name(config.model, config.served_model_name),
             ),
         ]
 

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -326,7 +326,9 @@ class WorkerFactory:
             register_embedding_cache_metrics(
                 endpoint=generate_endpoint,
                 cache=embedding_cache,
-                model_name=get_served_model_name(config.model, config.served_model_name),
+                model_name=get_served_model_name(
+                    config.model, config.served_model_name
+                ),
                 component_name=config.component,
             )
 
@@ -560,7 +562,9 @@ class WorkerFactory:
             register_embedding_cache_metrics(
                 endpoint=generate_endpoint,
                 cache=embedding_cache,
-                model_name=get_served_model_name(config.model, config.served_model_name),
+                model_name=get_served_model_name(
+                    config.model, config.served_model_name
+                ),
                 component_name=config.component,
             )
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -263,7 +263,7 @@ fn lora_name_to_id(lora_name: &str) -> i32 {
 /// For LoRA mode, both `lora_name` and `base_model_path` must be provided together.
 /// Providing only one of them will result in an error.
 #[pyfunction]
-#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None, router_mode=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None))]
+#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None, router_mode=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None, model_aliases=None))]
 #[allow(clippy::too_many_arguments)]
 fn register_model<'p>(
     py: Python<'p>,
@@ -282,6 +282,7 @@ fn register_model<'p>(
     media_fetcher: Option<MediaFetcher>,
     lora_name: Option<&str>,
     base_model_path: Option<&str>,
+    model_aliases: Option<Vec<String>>,
 ) -> PyResult<Bound<'p, PyAny>> {
     // Validate Prefill model type requirements
     if model_type.inner == llm_rs::model_type::ModelType::Prefill
@@ -357,6 +358,7 @@ fn register_model<'p>(
             card.model_type = model_type_obj;
             card.model_input = model_input;
             card.user_data = user_data_json;
+            card.set_aliases(model_aliases.unwrap_or_default());
 
             if let Some(cfg) = runtime_config {
                 card.runtime_config = cfg.inner;
@@ -394,6 +396,7 @@ fn register_model<'p>(
             .source_path(source_path.clone().into())
             // --served_model_name
             .model_name(model_name.clone())
+            .model_aliases(model_aliases.unwrap_or_default())
             .context_length(context_length)
             .kv_cache_block_size(kv_cache_block_size)
             .router_config(Some(router_config))

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -12,6 +12,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Sequence,
     Tuple,
 )
 
@@ -1441,6 +1442,7 @@ async def register_model(
     media_fetcher: Optional[MediaFetcher] = None,
     lora_name: Optional[str] = None,
     base_model_path: Optional[str] = None,
+    model_aliases: Optional[Sequence[str]] = None,
 ) -> None:
     """
     Attach the model at path to the given endpoint, and advertise it as model_type.

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -44,6 +44,22 @@ impl Model {
         &self.name
     }
 
+    /// Check if a given name matches this model's display name or any of its aliases.
+    /// Aliases are stored in the ModelDeploymentCard within each WorkerSet.
+    pub fn matches_name(&self, name: &str) -> bool {
+        // Fast path: exact match on display name
+        if self.name == name {
+            return true;
+        }
+        // Check aliases in all WorkerSets
+        for entry in self.worker_sets.iter() {
+            if entry.value().card().matches_name(name) {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Add a WorkerSet to this model.
     pub fn add_worker_set(&self, namespace: String, worker_set: Arc<WorkerSet>) {
         tracing::info!(

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -46,6 +46,12 @@ impl Model {
 
     /// Check if a given name matches this model's display name or any of its aliases.
     /// Aliases are stored in the ModelDeploymentCard within each WorkerSet.
+    ///
+    /// Note: aliases are intentionally model-global — if *any* WorkerSet advertises an
+    /// alias, the model matches that name. Routing still picks a concrete WorkerSet via
+    /// the usual per-namespace logic, so this does not change request placement. Conflicts
+    /// are prevented upstream by `ModelManager::check_name_conflicts`, which rejects the
+    /// same alias pointing at two different display names across the manager.
     pub fn matches_name(&self, name: &str) -> bool {
         // Fast path: exact match on display name
         if self.name == name {

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -202,8 +202,12 @@ impl ModelManager {
 
     /// Save a ModelDeploymentCard from an instance's key so we can fetch it later when the key is
     /// deleted.
+    ///
+    /// Enforces alias-conflict invariants internally so callers can't bypass the check by skipping
+    /// a prior `check_name_conflicts` call.
     pub fn save_model_card(&self, key: &str, card: ModelDeploymentCard) -> anyhow::Result<()> {
         if !card.aliases.is_empty() {
+            self.check_name_conflicts(card.name(), &card.aliases)?;
             self.register_aliases(card.name(), &card.aliases);
         }
         self.cards.insert(key.to_string(), card);
@@ -579,7 +583,11 @@ impl ModelManager {
     /// Remove a model entirely (all its WorkerSets).
     /// Returns the removed Model, or None if not found.
     pub fn remove_model(&self, model: &str) -> Option<Arc<Model>> {
-        self.models.remove(model).map(|(_, m)| m)
+        let removed = self.models.remove(model).map(|(_, m)| m);
+        if removed.is_some() {
+            self.alias_to_model.retain(|_, v| v != model);
+        }
+        removed
     }
 
     // Per-type remove methods for in-process models (used by Python bindings).

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -132,13 +132,13 @@ impl ModelManager {
                     existing_model: name.to_string(),
                 });
             }
-            if let Some(existing_model) = self.alias_to_model.get(name) {
-                if existing_model.value() != new_model_name {
-                    return Err(ModelManagerError::AliasConflict {
-                        alias: name.to_string(),
-                        existing_model: existing_model.clone(),
-                    });
-                }
+            if let Some(existing_model) = self.alias_to_model.get(name)
+                && existing_model.value() != new_model_name
+            {
+                return Err(ModelManagerError::AliasConflict {
+                    alias: name.to_string(),
+                    existing_model: existing_model.clone(),
+                });
             }
         }
         Ok(())
@@ -159,10 +159,10 @@ impl ModelManager {
         if let Some(model) = self.models.get(name) {
             return Some((name.to_string(), model.clone()));
         }
-        if let Some(model_name) = self.alias_to_model.get(name) {
-            if let Some(model) = self.models.get(model_name.value()) {
-                return Some((model_name.clone(), model.clone()));
-            }
+        if let Some(model_name) = self.alias_to_model.get(name)
+            && let Some(model) = self.models.get(model_name.value())
+        {
+            return Some((model_name.clone(), model.clone()));
         }
         None
     }

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -51,6 +51,12 @@ pub enum ModelManagerError {
 
     #[error("Model already exists: {0}")]
     ModelAlreadyExists(String),
+
+    #[error("Alias '{alias}' is already registered to model '{existing_model}'")]
+    AliasConflict {
+        alias: String,
+        existing_model: String,
+    },
 }
 
 /// Central manager for model engines, routing, and configuration.
@@ -62,6 +68,10 @@ pub enum ModelManagerError {
 pub struct ModelManager {
     /// Model name → Model (which contains WorkerSets with engines)
     models: DashMap<String, Arc<Model>>,
+
+    /// Alias → model name mapping for O(1) alias resolution
+    /// Key: alias name, Value: primary model name (display_name)
+    alias_to_model: DashMap<String, String>,
 
     /// Per-instance model cards, keyed by instance path. Used for cleanup on worker removal.
     cards: DashMap<String, ModelDeploymentCard>,
@@ -83,6 +93,7 @@ impl ModelManager {
     pub fn new() -> Self {
         Self {
             models: DashMap::new(),
+            alias_to_model: DashMap::new(),
             cards: DashMap::new(),
             prefill_router_activators: DashMap::new(),
             runtime_configs: DashMap::new(),
@@ -106,14 +117,64 @@ impl ModelManager {
             .map(|entry| entry.value().clone())
     }
 
+    /// Check if any of the provided names conflict with existing models.
+    /// Returns Ok(()) if no conflicts, or Err with the first conflict found.
+    /// Uses O(1) lookups via the models map and alias index.
+    pub fn check_name_conflicts(
+        &self,
+        new_model_name: &str,
+        aliases: &[String],
+    ) -> Result<(), ModelManagerError> {
+        for name in std::iter::once(new_model_name).chain(aliases.iter().map(String::as_str)) {
+            if self.models.contains_key(name) && name != new_model_name {
+                return Err(ModelManagerError::AliasConflict {
+                    alias: name.to_string(),
+                    existing_model: name.to_string(),
+                });
+            }
+            if let Some(existing_model) = self.alias_to_model.get(name) {
+                if existing_model.value() != new_model_name {
+                    return Err(ModelManagerError::AliasConflict {
+                        alias: name.to_string(),
+                        existing_model: existing_model.clone(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Register aliases for a model in the alias index.
+    /// Should be called after conflict check passes.
+    fn register_aliases(&self, model_name: &str, aliases: &[String]) {
+        for alias in aliases {
+            self.alias_to_model
+                .insert(alias.clone(), model_name.to_string());
+        }
+    }
+
+    /// Resolve a model name (which could be display_name or alias) to the actual model.
+    /// Returns the model name (for lookup in self.models) and the Model.
+    pub fn resolve_model(&self, name: &str) -> Option<(String, Arc<Model>)> {
+        if let Some(model) = self.models.get(name) {
+            return Some((name.to_string(), model.clone()));
+        }
+        if let Some(model_name) = self.alias_to_model.get(name) {
+            if let Some(model) = self.models.get(model_name.value()) {
+                return Some((model_name.clone(), model.clone()));
+            }
+        }
+        None
+    }
+
     /// Remove a Model if it has no remaining WorkerSets.
     /// Uses atomic remove_if to avoid TOCTOU race between checking is_empty and removing.
     pub fn remove_model_if_empty(&self, model_name: &str) {
-        if self
+        if let Some((_, _)) = self
             .models
             .remove_if(model_name, |_, model| model.is_empty())
-            .is_some()
         {
+            self.alias_to_model.retain(|_, v| v != model_name);
             tracing::info!(model_name, "Removed empty model from manager");
         }
     }
@@ -142,6 +203,9 @@ impl ModelManager {
     /// Save a ModelDeploymentCard from an instance's key so we can fetch it later when the key is
     /// deleted.
     pub fn save_model_card(&self, key: &str, card: ModelDeploymentCard) -> anyhow::Result<()> {
+        if !card.aliases.is_empty() {
+            self.register_aliases(card.name(), &card.aliases);
+        }
         self.cards.insert(key.to_string(), card);
         Ok(())
     }
@@ -155,14 +219,14 @@ impl ModelManager {
 
     /// Check if a decode model (chat or completions) is registered
     pub fn has_decode_model(&self, model: &str) -> bool {
-        self.models
-            .get(model)
-            .is_some_and(|m| m.has_decode_engine())
+        self.resolve_model(model)
+            .is_some_and(|(_, m)| m.has_decode_engine())
     }
 
     /// Check if a prefill model is registered
     pub fn has_prefill_model(&self, model: &str) -> bool {
-        self.models.get(model).is_some_and(|m| m.has_prefill())
+        self.resolve_model(model)
+            .is_some_and(|(_, m)| m.has_prefill())
     }
 
     /// Check if any model (decode or prefill) is registered.
@@ -238,9 +302,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIEmbeddingsStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_embeddings_engine()
     }
 
@@ -248,9 +312,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAICompletionsStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_completions_engine()
     }
 
@@ -258,9 +322,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIChatCompletionsStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_chat_engine()
     }
 
@@ -268,9 +332,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<TensorStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_tensor_engine()
     }
 
@@ -278,9 +342,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIImagesStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_images_engine()
     }
 
@@ -288,9 +352,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIVideosStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_videos_engine()
     }
 
@@ -298,9 +362,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIAudiosStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_audios_engine()
     }
 
@@ -316,9 +380,9 @@ impl ModelManager {
         ),
         ModelManagerError,
     > {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_chat_engine_with_parsing()
     }
 
@@ -332,9 +396,9 @@ impl ModelManager {
         ),
         ModelManagerError,
     > {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_completions_engine_with_parsing()
     }
 

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -560,8 +560,7 @@ impl ModelWatcher {
         card.download_config().await?;
 
         self.manager
-            .check_name_conflicts(card.name(), &card.aliases)
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+            .check_name_conflicts(card.name(), &card.aliases)?;
 
         let component = self
             .drt

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -559,6 +559,10 @@ impl ModelWatcher {
     ) -> anyhow::Result<()> {
         card.download_config().await?;
 
+        self.manager
+            .check_name_conflicts(card.name(), &card.aliases)
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+
         let component = self
             .drt
             .namespace(&mcid.namespace)?

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -37,6 +37,7 @@ pub struct LocalModelBuilder {
     model_path: Option<PathBuf>,
     source_path: Option<PathBuf>,
     model_name: Option<String>,
+    model_aliases: Vec<String>,
     endpoint_id: Option<EndpointId>,
     context_length: Option<u32>,
     template_file: Option<PathBuf>,
@@ -72,6 +73,7 @@ impl Default for LocalModelBuilder {
             model_path: Default::default(),
             source_path: Default::default(),
             model_name: Default::default(),
+            model_aliases: Default::default(),
             endpoint_id: Default::default(),
             context_length: Default::default(),
             template_file: Default::default(),
@@ -108,6 +110,11 @@ impl LocalModelBuilder {
 
     pub fn model_name(&mut self, model_name: Option<String>) -> &mut Self {
         self.model_name = model_name;
+        self
+    }
+
+    pub fn model_aliases(&mut self, aliases: Vec<String>) -> &mut Self {
+        self.model_aliases = aliases;
         self
     }
 
@@ -245,6 +252,7 @@ impl LocalModelBuilder {
             let mut card = ModelDeploymentCard::with_name_only(
                 self.model_name.as_deref().unwrap_or(DEFAULT_NAME),
             );
+            card.set_aliases(self.model_aliases.clone());
             card.kv_cache_block_size = self.kv_cache_block_size;
             card.migration_limit = self.migration_limit;
             card.user_data = self.user_data.take();
@@ -292,6 +300,7 @@ impl LocalModelBuilder {
         // This matches what vllm and sglang do.
         let alt = card.source_path().to_string();
         card.set_name(self.model_name.as_deref().unwrap_or(&alt));
+        card.set_aliases(self.model_aliases.clone());
 
         card.kv_cache_block_size = self.kv_cache_block_size;
 

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -208,6 +208,12 @@ pub struct ModelDeploymentCard {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_path: Option<String>,
 
+    /// Alternative names for this model.
+    /// Allows the same model to be addressed by multiple names.
+    /// Corresponds to additional names in vllm's `--served-model-name`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
+
     /// Model information
     pub model_info: Option<ModelInfoType>,
 
@@ -377,6 +383,13 @@ impl ModelDeploymentCard {
                 bytes_to_hash.extend(self.context_length.to_be_bytes());
                 bytes_to_hash.extend(self.kv_cache_block_size.to_be_bytes());
 
+                // Include aliases in checksum (sorted for determinism)
+                let mut sorted_aliases = self.aliases.clone();
+                sorted_aliases.sort();
+                for alias in sorted_aliases {
+                    bytes_to_hash.extend(alias.as_bytes());
+                }
+
                 // TODO: Do we want any of user_data or runtime_config?
 
                 blake3::hash(&bytes_to_hash).to_string()
@@ -486,6 +499,26 @@ impl ModelDeploymentCard {
     pub fn set_name(&mut self, name: &str) {
         self.display_name = name.to_string();
         self.slug = Slug::from_string(name);
+    }
+
+    /// Check if a given name matches this model's display_name or any alias.
+    pub fn matches_name(&self, name: &str) -> bool {
+        if self.display_name == name {
+            return true;
+        }
+        self.aliases.iter().any(|alias| alias == name)
+    }
+
+    /// Returns all names this model can be addressed by (display_name + aliases).
+    pub fn all_names(&self) -> Vec<&str> {
+        let mut names = vec![self.display_name.as_str()];
+        names.extend(self.aliases.iter().map(|s| s.as_str()));
+        names
+    }
+
+    /// Set alternative names for this model.
+    pub fn set_aliases(&mut self, aliases: Vec<String>) {
+        self.aliases = aliases;
     }
 
     pub fn source_path(&self) -> &str {
@@ -743,6 +776,7 @@ impl ModelDeploymentCard {
             slug: Slug::from_string(&display_name),
             display_name,
             source_path: None,
+            aliases: Default::default(),
             model_info,
             tokenizer,
             gen_config,

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -517,8 +517,11 @@ impl ModelDeploymentCard {
     }
 
     /// Set alternative names for this model.
+    ///
+    /// Also invalidates the cached checksum, since `mdcsum()` incorporates aliases into its hash.
     pub fn set_aliases(&mut self, aliases: Vec<String>) {
         self.aliases = aliases;
+        self.checksum = std::sync::OnceLock::new();
     }
 
     pub fn source_path(&self) -> &str {


### PR DESCRIPTION
## Summary

Implements support for multiple served model names in the vLLM backend (fixes #8038), matching vLLM's native `--served-model-name` capability. This enables model upgrade scenarios where the same model must respond to multiple names for backward compatibility.

## Details

**Rust layer**:
- Added `aliases` field to `ModelDeploymentCard` with `matches_name()` and `all_names()` methods
- Added `alias_to_model: DashMap<String, String>` secondary index to `ModelManager` for O(1) alias resolution
- Added `resolve_model()` method that checks both primary name and alias index
- Updated all hot-path engine accessors (`get_chat_completions_engine`, etc.) to use `resolve_model()`
- Added `AliasConflict` error variant for duplicate alias detection at registration time
- Alias cleanup in `remove_model_if_empty()` via `retain()`

**Python bindings**:
- Added `model_aliases` parameter to `register_model()` function

**vLLM component**:
- Changed `served_model_name` type from `Optional[str]` to `Optional[str | List[str]]`
- Normalization in `worker()` converts to list early
- Removed the artificial single-name restriction from `update_dynamo_config_with_engine()`
- Added `get_served_model_name()` utility function

**Behavior**:
- First name in `--served-model-name` list becomes the primary model name
- Subsequent names become aliases that route to the same model
- Backward compatible: single-name registrations work unchanged
- O(1) alias lookups on the request hot path
- Fail-fast on duplicate aliases with clear error message

**Example usage**:
```bash
python -m dynamo.vllm --model Qwen/Qwen3.5-0.8B --served-model-name Qwen3-0.6B Qwen3.5-0.8B
```
Both names will route to the same model.

## Test plan

- [ ] Single served model name still works as before
- [ ] Multiple `--served-model-name` values register aliases correctly
- [ ] Requests to alias names are routed to the primary model
- [ ] Duplicate alias registration returns a clear `AliasConflict` error
- [ ] Model removal cleans up aliases from the index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for model aliases—models can now be accessed by alternative names.
  * Enhanced multi-model serving configuration with improved flexibility for handling multiple served model names.

* **Bug Fixes**
  * Improved error handling for network connectivity issues to prevent system crashes; errors now gracefully terminate individual connections.

* **Chores**
  * Fixed version handling in the installation process for custom references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->