### PR TITLE
docs(mocker): clarify mocker image placeholder

### DIFF
--- a/examples/backends/mocker/deploy/agg.yaml
+++ b/examples/backends/mocker/deploy/agg.yaml
@@ -1,6 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# NOTE: There is no dedicated `mocker-runtime` image. The mocker component
+# (`python3 -m dynamo.mocker`) is bundled into the standard Dynamo backend
+# runtime images published on NGC (e.g. `nvcr.io/nvidia/ai-dynamo/vllm-runtime`,
+# `sglang-runtime`, `tensorrtllm-runtime`). Replace `my-registry/vllm-runtime:my-tag`
+# below with any of those tags, or with your own built image.
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
@@ -12,7 +17,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/mocker-runtime:my-tag
+          image: my-registry/vllm-runtime:my-tag
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -20,7 +25,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/mocker-runtime:my-tag
+          image: my-registry/vllm-runtime:my-tag
           workingDir: /workspace
           command:
           - python3

--- a/examples/backends/mocker/deploy/agg.yaml
+++ b/examples/backends/mocker/deploy/agg.yaml
@@ -4,7 +4,7 @@
 # NOTE: There is no dedicated `mocker-runtime` image. The mocker component
 # (`python3 -m dynamo.mocker`) is bundled into the standard Dynamo backend
 # runtime images published on NGC (e.g. `nvcr.io/nvidia/ai-dynamo/vllm-runtime`,
-# `sglang-runtime`, `tensorrtllm-runtime`). Replace `my-registry/vllm-runtime:my-tag`
+# `sglang-runtime`, `tensorrtllm-runtime`). Replace `my-dynamo-image:my-tag`
 # below with any of those tags, or with your own built image.
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
@@ -17,7 +17,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: my-dynamo-image:my-tag
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -25,7 +25,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: my-dynamo-image:my-tag
           workingDir: /workspace
           command:
           - python3

--- a/examples/backends/mocker/deploy/disagg.yaml
+++ b/examples/backends/mocker/deploy/disagg.yaml
@@ -4,7 +4,7 @@
 # NOTE: There is no dedicated `mocker-runtime` image. The mocker component
 # (`python3 -m dynamo.mocker`) is bundled into the standard Dynamo backend
 # runtime images published on NGC (e.g. `nvcr.io/nvidia/ai-dynamo/vllm-runtime`,
-# `sglang-runtime`, `tensorrtllm-runtime`). Replace `my-registry/vllm-runtime:my-tag`
+# `sglang-runtime`, `tensorrtllm-runtime`). Replace `my-dynamo-image:my-tag`
 # below with any of those tags, or with your own built image.
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
@@ -17,7 +17,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: my-dynamo-image:my-tag
     prefill:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -25,7 +25,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: my-dynamo-image:my-tag
           workingDir: /workspace
           command:
           - python3
@@ -49,7 +49,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: my-dynamo-image:my-tag
           workingDir: /workspace
           command:
           - python3

--- a/examples/backends/mocker/deploy/disagg.yaml
+++ b/examples/backends/mocker/deploy/disagg.yaml
@@ -1,6 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# NOTE: There is no dedicated `mocker-runtime` image. The mocker component
+# (`python3 -m dynamo.mocker`) is bundled into the standard Dynamo backend
+# runtime images published on NGC (e.g. `nvcr.io/nvidia/ai-dynamo/vllm-runtime`,
+# `sglang-runtime`, `tensorrtllm-runtime`). Replace `my-registry/vllm-runtime:my-tag`
+# below with any of those tags, or with your own built image.
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
@@ -12,7 +17,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/mocker-runtime:my-tag
+          image: my-registry/vllm-runtime:my-tag
     prefill:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -20,7 +25,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/mocker-runtime:my-tag
+          image: my-registry/vllm-runtime:my-tag
           workingDir: /workspace
           command:
           - python3
@@ -44,7 +49,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/mocker-runtime:my-tag
+          image: my-registry/vllm-runtime:my-tag
           workingDir: /workspace
           command:
           - python3


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

The image reference `my-registry/mocker-runtime:my-tag` in the mocker deploy YAMLs implies an image that does not exist on NGC (see DGH-719 / GH #7860 — users hit a 401 trying to pull `nvcr.io/nvidia/ai-dynamo/mocker-runtime:1.0.1`). The mocker component (`python3 -m dynamo.mocker`) is actually bundled into the standard Dynamo backend runtime images (vllm-runtime, sglang-runtime, tensorrtllm-runtime).

Change the placeholder to `my-registry/vllm-runtime:my-tag` (matches the default engine-type for mocker) and add a header comment pointing users to the NGC Dynamo runtime images.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes #7860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification notes for deployment configurations explaining that mocker functionality is bundled into standard Dynamo backend runtime images, rather than requiring a dedicated image.

* **Chores**
  * Updated container image references in deployment example configurations to use appropriate Dynamo backend runtime images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->