### PR TITLE
fix(responses): merge same-turn items into one assistant message

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import socket
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from vllm.distributed.kv_events import KVEventsConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
@@ -47,7 +47,7 @@ class Config(DynamoRuntimeConfig, DynamoVllmConfig):
 
     # mirror vLLM
     model: str
-    served_model_name: Optional[str] = None
+    served_model_name: Optional[str | List[str]] = None
 
     # rest vLLM args
     engine_args: AsyncEngineArgs
@@ -144,14 +144,6 @@ def update_dynamo_config_with_engine(
     dynamo_config: Config, engine_config: AsyncEngineArgs
 ) -> None:
     """Update dynamo_config fields from engine_config and worker flags."""
-
-    if getattr(engine_config, "served_model_name", None) is not None:
-        served = engine_config.served_model_name
-        if len(served) > 1:
-            raise ValueError("We do not support multiple model names.")
-        dynamo_config.served_model_name = served[0]
-    else:
-        dynamo_config.served_model_name = None
 
     # Capture user-provided --endpoint before defaults overwrite it
     user_endpoint = dynamo_config.endpoint
@@ -612,3 +604,13 @@ def ensure_side_channel_host():
     host_ip = get_host_ip()
     os.environ["VLLM_NIXL_SIDE_CHANNEL_HOST"] = host_ip
     logger.info("Set VLLM_NIXL_SIDE_CHANNEL_HOST to %s (auto-detected)", host_ip)
+
+
+def get_served_model_name(model: str, served_model_name: str | List[str] | None) -> str:
+    """Extract the primary model name from served_model_name."""
+
+    if not served_model_name:
+        return model
+    if isinstance(served_model_name, list):
+        return served_model_name[0]
+    return served_model_name

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -118,8 +118,12 @@ async def worker() -> None:
 
     # Name the model. Use either the full path (vllm and sglang do the same),
     # or the HF name (e.g. "Qwen/Qwen3-0.6B"), depending on cmd line params.
+    # Normalize served_model_name to a list for consistent handling downstream.
     if not config.served_model_name:
-        config.served_model_name = config.engine_args.served_model_name = config.model
+        config.served_model_name = [config.model]
+    elif isinstance(config.served_model_name, str):
+        config.served_model_name = [config.served_model_name]
+    config.engine_args.served_model_name = config.served_model_name
 
     # Download the model if necessary using modelexpress.
     # We want it on disk before we start vllm to avoid downloading from HuggingFace.
@@ -444,9 +448,11 @@ def setup_vllm_engine(
 
     # Construct Prometheus gauges AFTER setup_multiprocess_prometheus() so Gauge objects
     # see the correct ValueClass (multiprocess vs in-memory).
+    # Use the primary name (first element) for metrics labeling.
+    primary_name = config.served_model_name[0] if config.served_model_name else ""
     component_gauges = LLMBackendMetrics(
         registry=DYNAMO_COMPONENT_REGISTRY,
-        model_name=config.served_model_name or "",
+        model_name=primary_name,
         component_name=config.component or "",
     )
 
@@ -585,7 +591,9 @@ def setup_vllm_engine(
     # Record model load time
     component_gauges.set_model_load_time(load_time)
 
-    logger.info(f"VllmWorker for {config.served_model_name} has been initialized")
+    logger.info(
+        f"VllmWorker for {config.engine_args.served_model_name} has been initialized"
+    )
 
     # update block_size in vllm_config based on final engine cache info for later use
     runtime_values = get_engine_cache_info(engine_client)
@@ -680,18 +688,30 @@ async def register_vllm_model(
         media_fetcher.timeout_ms(30000)
         media_fetcher.allow_direct_port(True)
 
+    # Extract primary name and aliases from served_model_name list
+    # First element is the primary name, rest are aliases
+    primary_name = (
+        config.served_model_name[0] if config.served_model_name else config.model
+    )
+    model_aliases = (
+        config.served_model_name[1:]
+        if config.served_model_name and len(config.served_model_name) > 1
+        else None
+    )
+
     await register_model(
         model_input,
         model_type,
         generate_endpoint,
         config.model,
-        config.served_model_name,
+        primary_name,
         context_length=vllm_config.model_config.max_model_len,
         kv_cache_block_size=runtime_values["block_size"],
         runtime_config=runtime_config,
         custom_template_path=config.custom_jinja_template,
         media_decoder=media_decoder,
         media_fetcher=media_fetcher,
+        model_aliases=model_aliases,
     )
 
 

--- a/components/src/dynamo/vllm/omni/args.py
+++ b/components/src/dynamo/vllm/omni/args.py
@@ -6,7 +6,7 @@
 import argparse
 import dataclasses
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from vllm_omni.engine.arg_utils import OmniEngineArgs
 
@@ -324,7 +324,7 @@ class OmniConfig(DynamoRuntimeConfig):
     endpoint: Optional[str] = None
 
     model: str
-    served_model_name: Optional[str] = None
+    served_model_name: Optional[str | List[str]] = None
     engine_args: OmniEngineArgs
 
     stage_configs_path: Optional[str] = None
@@ -425,11 +425,14 @@ def parse_omni_args() -> OmniConfig:
 
     engine_args = OmniEngineArgs.from_cli_args(vllm_args)
 
+    # Normalize served_model_name to list
+    # vLLM accepts str | list[str] | None, we normalize to list[str] | None
     if getattr(engine_args, "served_model_name", None) is not None:
         served = engine_args.served_model_name
-        if len(served) > 1:
-            raise ValueError("We do not support multiple model names.")
-        config.served_model_name = served[0]
+        if isinstance(served, str):
+            config.served_model_name = [served]
+        else:
+            config.served_model_name = served
 
     config.engine_args = engine_args
     config.validate()

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -37,6 +37,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --vllm-ref)
             VLLM_REF="$2"
+            VLLM_VER="${VLLM_REF#v}"
             shift 2
             ;;
         --max-jobs)

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -263,7 +263,7 @@ fn lora_name_to_id(lora_name: &str) -> i32 {
 /// For LoRA mode, both `lora_name` and `base_model_path` must be provided together.
 /// Providing only one of them will result in an error.
 #[pyfunction]
-#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None, router_mode=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None))]
+#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None, router_mode=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None, model_aliases=None))]
 #[allow(clippy::too_many_arguments)]
 fn register_model<'p>(
     py: Python<'p>,
@@ -282,6 +282,7 @@ fn register_model<'p>(
     media_fetcher: Option<MediaFetcher>,
     lora_name: Option<&str>,
     base_model_path: Option<&str>,
+    model_aliases: Option<Vec<String>>,
 ) -> PyResult<Bound<'p, PyAny>> {
     // Validate Prefill model type requirements
     if model_type.inner == llm_rs::model_type::ModelType::Prefill
@@ -357,6 +358,7 @@ fn register_model<'p>(
             card.model_type = model_type_obj;
             card.model_input = model_input;
             card.user_data = user_data_json;
+            card.set_aliases(model_aliases.unwrap_or_default());
 
             if let Some(cfg) = runtime_config {
                 card.runtime_config = cfg.inner;
@@ -394,6 +396,7 @@ fn register_model<'p>(
             .source_path(source_path.clone().into())
             // --served_model_name
             .model_name(model_name.clone())
+            .model_aliases(model_aliases.unwrap_or_default())
             .context_length(context_length)
             .kv_cache_block_size(kv_cache_block_size)
             .router_config(Some(router_config))

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -12,6 +12,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Sequence,
     Tuple,
 )
 
@@ -1441,6 +1442,7 @@ async def register_model(
     media_fetcher: Optional[MediaFetcher] = None,
     lora_name: Optional[str] = None,
     base_model_path: Optional[str] = None,
+    model_aliases: Optional[Sequence[str]] = None,
 ) -> None:
     """
     Attach the model at path to the given endpoint, and advertise it as model_type.

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -44,6 +44,22 @@ impl Model {
         &self.name
     }
 
+    /// Check if a given name matches this model's display name or any of its aliases.
+    /// Aliases are stored in the ModelDeploymentCard within each WorkerSet.
+    pub fn matches_name(&self, name: &str) -> bool {
+        // Fast path: exact match on display name
+        if self.name == name {
+            return true;
+        }
+        // Check aliases in all WorkerSets
+        for entry in self.worker_sets.iter() {
+            if entry.value().card().matches_name(name) {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Add a WorkerSet to this model.
     pub fn add_worker_set(&self, namespace: String, worker_set: Arc<WorkerSet>) {
         tracing::info!(

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -132,13 +132,13 @@ impl ModelManager {
                     existing_model: name.to_string(),
                 });
             }
-            if let Some(existing_model) = self.alias_to_model.get(name) {
-                if existing_model.value() != new_model_name {
-                    return Err(ModelManagerError::AliasConflict {
-                        alias: name.to_string(),
-                        existing_model: existing_model.clone(),
-                    });
-                }
+            if let Some(existing_model) = self.alias_to_model.get(name)
+                && existing_model.value() != new_model_name
+            {
+                return Err(ModelManagerError::AliasConflict {
+                    alias: name.to_string(),
+                    existing_model: existing_model.clone(),
+                });
             }
         }
         Ok(())
@@ -159,10 +159,10 @@ impl ModelManager {
         if let Some(model) = self.models.get(name) {
             return Some((name.to_string(), model.clone()));
         }
-        if let Some(model_name) = self.alias_to_model.get(name) {
-            if let Some(model) = self.models.get(model_name.value()) {
-                return Some((model_name.clone(), model.clone()));
-            }
+        if let Some(model_name) = self.alias_to_model.get(name)
+            && let Some(model) = self.models.get(model_name.value())
+        {
+            return Some((model_name.clone(), model.clone()));
         }
         None
     }

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -51,6 +51,12 @@ pub enum ModelManagerError {
 
     #[error("Model already exists: {0}")]
     ModelAlreadyExists(String),
+
+    #[error("Alias '{alias}' is already registered to model '{existing_model}'")]
+    AliasConflict {
+        alias: String,
+        existing_model: String,
+    },
 }
 
 /// Central manager for model engines, routing, and configuration.
@@ -62,6 +68,10 @@ pub enum ModelManagerError {
 pub struct ModelManager {
     /// Model name → Model (which contains WorkerSets with engines)
     models: DashMap<String, Arc<Model>>,
+
+    /// Alias → model name mapping for O(1) alias resolution
+    /// Key: alias name, Value: primary model name (display_name)
+    alias_to_model: DashMap<String, String>,
 
     /// Per-instance model cards, keyed by instance path. Used for cleanup on worker removal.
     cards: DashMap<String, ModelDeploymentCard>,
@@ -83,6 +93,7 @@ impl ModelManager {
     pub fn new() -> Self {
         Self {
             models: DashMap::new(),
+            alias_to_model: DashMap::new(),
             cards: DashMap::new(),
             prefill_router_activators: DashMap::new(),
             runtime_configs: DashMap::new(),
@@ -106,14 +117,64 @@ impl ModelManager {
             .map(|entry| entry.value().clone())
     }
 
+    /// Check if any of the provided names conflict with existing models.
+    /// Returns Ok(()) if no conflicts, or Err with the first conflict found.
+    /// Uses O(1) lookups via the models map and alias index.
+    pub fn check_name_conflicts(
+        &self,
+        new_model_name: &str,
+        aliases: &[String],
+    ) -> Result<(), ModelManagerError> {
+        for name in std::iter::once(new_model_name).chain(aliases.iter().map(String::as_str)) {
+            if self.models.contains_key(name) && name != new_model_name {
+                return Err(ModelManagerError::AliasConflict {
+                    alias: name.to_string(),
+                    existing_model: name.to_string(),
+                });
+            }
+            if let Some(existing_model) = self.alias_to_model.get(name) {
+                if existing_model.value() != new_model_name {
+                    return Err(ModelManagerError::AliasConflict {
+                        alias: name.to_string(),
+                        existing_model: existing_model.clone(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Register aliases for a model in the alias index.
+    /// Should be called after conflict check passes.
+    fn register_aliases(&self, model_name: &str, aliases: &[String]) {
+        for alias in aliases {
+            self.alias_to_model
+                .insert(alias.clone(), model_name.to_string());
+        }
+    }
+
+    /// Resolve a model name (which could be display_name or alias) to the actual model.
+    /// Returns the model name (for lookup in self.models) and the Model.
+    pub fn resolve_model(&self, name: &str) -> Option<(String, Arc<Model>)> {
+        if let Some(model) = self.models.get(name) {
+            return Some((name.to_string(), model.clone()));
+        }
+        if let Some(model_name) = self.alias_to_model.get(name) {
+            if let Some(model) = self.models.get(model_name.value()) {
+                return Some((model_name.clone(), model.clone()));
+            }
+        }
+        None
+    }
+
     /// Remove a Model if it has no remaining WorkerSets.
     /// Uses atomic remove_if to avoid TOCTOU race between checking is_empty and removing.
     pub fn remove_model_if_empty(&self, model_name: &str) {
-        if self
+        if let Some((_, _)) = self
             .models
             .remove_if(model_name, |_, model| model.is_empty())
-            .is_some()
         {
+            self.alias_to_model.retain(|_, v| v != model_name);
             tracing::info!(model_name, "Removed empty model from manager");
         }
     }
@@ -142,6 +203,9 @@ impl ModelManager {
     /// Save a ModelDeploymentCard from an instance's key so we can fetch it later when the key is
     /// deleted.
     pub fn save_model_card(&self, key: &str, card: ModelDeploymentCard) -> anyhow::Result<()> {
+        if !card.aliases.is_empty() {
+            self.register_aliases(card.name(), &card.aliases);
+        }
         self.cards.insert(key.to_string(), card);
         Ok(())
     }
@@ -155,14 +219,14 @@ impl ModelManager {
 
     /// Check if a decode model (chat or completions) is registered
     pub fn has_decode_model(&self, model: &str) -> bool {
-        self.models
-            .get(model)
-            .is_some_and(|m| m.has_decode_engine())
+        self.resolve_model(model)
+            .is_some_and(|(_, m)| m.has_decode_engine())
     }
 
     /// Check if a prefill model is registered
     pub fn has_prefill_model(&self, model: &str) -> bool {
-        self.models.get(model).is_some_and(|m| m.has_prefill())
+        self.resolve_model(model)
+            .is_some_and(|(_, m)| m.has_prefill())
     }
 
     /// Check if any model (decode or prefill) is registered.
@@ -238,9 +302,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIEmbeddingsStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_embeddings_engine()
     }
 
@@ -248,9 +312,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAICompletionsStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_completions_engine()
     }
 
@@ -258,9 +322,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIChatCompletionsStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_chat_engine()
     }
 
@@ -268,9 +332,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<TensorStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_tensor_engine()
     }
 
@@ -278,9 +342,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIImagesStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_images_engine()
     }
 
@@ -288,9 +352,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIVideosStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_videos_engine()
     }
 
@@ -298,9 +362,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIAudiosStreamingEngine, ModelManagerError> {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_audios_engine()
     }
 
@@ -316,9 +380,9 @@ impl ModelManager {
         ),
         ModelManagerError,
     > {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_chat_engine_with_parsing()
     }
 
@@ -332,9 +396,9 @@ impl ModelManager {
         ),
         ModelManagerError,
     > {
-        self.models
-            .get(model)
+        self.resolve_model(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .1
             .get_completions_engine_with_parsing()
     }
 

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -559,6 +559,10 @@ impl ModelWatcher {
     ) -> anyhow::Result<()> {
         card.download_config().await?;
 
+        self.manager
+            .check_name_conflicts(card.name(), &card.aliases)
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+
         let component = self
             .drt
             .namespace(&mcid.namespace)?

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -37,6 +37,7 @@ pub struct LocalModelBuilder {
     model_path: Option<PathBuf>,
     source_path: Option<PathBuf>,
     model_name: Option<String>,
+    model_aliases: Vec<String>,
     endpoint_id: Option<EndpointId>,
     context_length: Option<u32>,
     template_file: Option<PathBuf>,
@@ -72,6 +73,7 @@ impl Default for LocalModelBuilder {
             model_path: Default::default(),
             source_path: Default::default(),
             model_name: Default::default(),
+            model_aliases: Default::default(),
             endpoint_id: Default::default(),
             context_length: Default::default(),
             template_file: Default::default(),
@@ -108,6 +110,11 @@ impl LocalModelBuilder {
 
     pub fn model_name(&mut self, model_name: Option<String>) -> &mut Self {
         self.model_name = model_name;
+        self
+    }
+
+    pub fn model_aliases(&mut self, aliases: Vec<String>) -> &mut Self {
+        self.model_aliases = aliases;
         self
     }
 
@@ -245,6 +252,7 @@ impl LocalModelBuilder {
             let mut card = ModelDeploymentCard::with_name_only(
                 self.model_name.as_deref().unwrap_or(DEFAULT_NAME),
             );
+            card.set_aliases(self.model_aliases.clone());
             card.kv_cache_block_size = self.kv_cache_block_size;
             card.migration_limit = self.migration_limit;
             card.user_data = self.user_data.take();
@@ -292,6 +300,7 @@ impl LocalModelBuilder {
         // This matches what vllm and sglang do.
         let alt = card.source_path().to_string();
         card.set_name(self.model_name.as_deref().unwrap_or(&alt));
+        card.set_aliases(self.model_aliases.clone());
 
         card.kv_cache_block_size = self.kv_cache_block_size;
 

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -208,6 +208,12 @@ pub struct ModelDeploymentCard {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_path: Option<String>,
 
+    /// Alternative names for this model.
+    /// Allows the same model to be addressed by multiple names.
+    /// Corresponds to additional names in vllm's `--served-model-name`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
+
     /// Model information
     pub model_info: Option<ModelInfoType>,
 
@@ -377,6 +383,13 @@ impl ModelDeploymentCard {
                 bytes_to_hash.extend(self.context_length.to_be_bytes());
                 bytes_to_hash.extend(self.kv_cache_block_size.to_be_bytes());
 
+                // Include aliases in checksum (sorted for determinism)
+                let mut sorted_aliases = self.aliases.clone();
+                sorted_aliases.sort();
+                for alias in sorted_aliases {
+                    bytes_to_hash.extend(alias.as_bytes());
+                }
+
                 // TODO: Do we want any of user_data or runtime_config?
 
                 blake3::hash(&bytes_to_hash).to_string()
@@ -486,6 +499,26 @@ impl ModelDeploymentCard {
     pub fn set_name(&mut self, name: &str) {
         self.display_name = name.to_string();
         self.slug = Slug::from_string(name);
+    }
+
+    /// Check if a given name matches this model's display_name or any alias.
+    pub fn matches_name(&self, name: &str) -> bool {
+        if self.display_name == name {
+            return true;
+        }
+        self.aliases.iter().any(|alias| alias == name)
+    }
+
+    /// Returns all names this model can be addressed by (display_name + aliases).
+    pub fn all_names(&self) -> Vec<&str> {
+        let mut names = vec![self.display_name.as_str()];
+        names.extend(self.aliases.iter().map(|s| s.as_str()));
+        names
+    }
+
+    /// Set alternative names for this model.
+    pub fn set_aliases(&mut self, aliases: Vec<String>) {
+        self.aliases = aliases;
     }
 
     pub fn source_path(&self) -> &str {
@@ -743,6 +776,7 @@ impl ModelDeploymentCard {
             slug: Slug::from_string(&display_name),
             display_name,
             source_path: None,
+            aliases: Default::default(),
             model_info,
             tokenizer,
             gen_config,

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -227,6 +227,32 @@ fn convert_input_content_to_text(content: &[InputContent]) -> String {
         .join("")
 }
 
+/// Append `text` to an existing assistant message, preserving any previously
+/// attached tool_calls. Used to fold consecutive Responses API items that
+/// belong to the same assistant turn into a single ChatCompletion message.
+fn append_assistant_text(prev: &mut ChatCompletionRequestAssistantMessage, text: &str) {
+    if text.is_empty() && prev.content.is_some() {
+        return;
+    }
+    match prev.content.take() {
+        Some(ChatCompletionRequestAssistantMessageContent::Text(existing)) => {
+            let mut combined = existing;
+            combined.push_str(text);
+            prev.content = Some(ChatCompletionRequestAssistantMessageContent::Text(combined));
+        }
+        Some(other) => {
+            // Array-form content is not produced by this converter; preserve it
+            // as-is rather than silently dropping structured parts.
+            prev.content = Some(other);
+        }
+        None => {
+            prev.content = Some(ChatCompletionRequestAssistantMessageContent::Text(
+                text.to_string(),
+            ));
+        }
+    }
+}
+
 /// Convert InputParam::Items to a Vec of ChatCompletionRequestMessages.
 fn convert_input_items_to_messages(
     items: &[InputItem],
@@ -263,7 +289,13 @@ fn convert_input_items_to_messages(
                         messages.push(chat_msg);
                     }
                     MessageItem::Output(out_msg) => {
-                        // Previous assistant output message -> assistant message
+                        // Previous assistant output message -> assistant message.
+                        // Merge into the trailing assistant message (if any) so that a
+                        // single Responses API turn that emits both text and tool calls
+                        // collapses to one ChatCompletion assistant message. This keeps
+                        // the subsequent tool-role message adjacent to the assistant
+                        // message that owns its tool_calls, which is required by the
+                        // tool-aware chat templates (e.g. minimax_m2).
                         let text = out_msg
                             .content
                             .iter()
@@ -273,43 +305,62 @@ fn convert_input_items_to_messages(
                             })
                             .collect::<Vec<_>>()
                             .join("");
+                        if let Some(ChatCompletionRequestMessage::Assistant(prev)) =
+                            messages.last_mut()
+                        {
+                            append_assistant_text(prev, &text);
+                        } else {
+                            messages.push(ChatCompletionRequestMessage::Assistant(
+                                ChatCompletionRequestAssistantMessage {
+                                    content: Some(
+                                        ChatCompletionRequestAssistantMessageContent::Text(text),
+                                    ),
+                                    reasoning_content: None,
+                                    refusal: None,
+                                    name: None,
+                                    audio: None,
+                                    tool_calls: None,
+                                    #[allow(deprecated)]
+                                    function_call: None,
+                                },
+                            ));
+                        }
+                    }
+                },
+                Item::FunctionCall(fc) => {
+                    // A function call from a previous assistant turn -> assistant
+                    // message with tool_calls. Merge into the trailing assistant
+                    // message (if any) so the tool_calls stay attached to the same
+                    // assistant turn that (optionally) produced text alongside them.
+                    let new_call = ChatCompletionMessageToolCall {
+                        id: fc.call_id.clone(),
+                        r#type: FunctionType::Function,
+                        function: dynamo_protocols::types::FunctionCall {
+                            name: fc.name.clone(),
+                            arguments: fc.arguments.clone(),
+                        },
+                    };
+                    if let Some(ChatCompletionRequestMessage::Assistant(prev)) =
+                        messages.last_mut()
+                    {
+                        match &mut prev.tool_calls {
+                            Some(calls) => calls.push(new_call),
+                            None => prev.tool_calls = Some(vec![new_call]),
+                        }
+                    } else {
                         messages.push(ChatCompletionRequestMessage::Assistant(
                             ChatCompletionRequestAssistantMessage {
-                                content: Some(ChatCompletionRequestAssistantMessageContent::Text(
-                                    text,
-                                )),
+                                content: None,
                                 reasoning_content: None,
                                 refusal: None,
                                 name: None,
                                 audio: None,
-                                tool_calls: None,
+                                tool_calls: Some(vec![new_call]),
                                 #[allow(deprecated)]
                                 function_call: None,
                             },
                         ));
                     }
-                },
-                Item::FunctionCall(fc) => {
-                    // A function call from a previous assistant turn -> assistant message with tool_calls
-                    messages.push(ChatCompletionRequestMessage::Assistant(
-                        ChatCompletionRequestAssistantMessage {
-                            content: None,
-                            reasoning_content: None,
-                            refusal: None,
-                            name: None,
-                            audio: None,
-                            tool_calls: Some(vec![ChatCompletionMessageToolCall {
-                                id: fc.call_id.clone(),
-                                r#type: FunctionType::Function,
-                                function: dynamo_protocols::types::FunctionCall {
-                                    name: fc.name.clone(),
-                                    arguments: fc.arguments.clone(),
-                                },
-                            }]),
-                            #[allow(deprecated)]
-                            function_call: None,
-                        },
-                    ));
                 }
                 Item::FunctionCallOutput(fco) => {
                     // The output of a function call -> tool message
@@ -1262,6 +1313,226 @@ mod tests {
             }
             _ => panic!("Expected FunctionCall output"),
         }
+    }
+
+    // Regression: the Responses API may interleave a `function_call` item and
+    // an assistant `output_text` message that belong to the *same* assistant
+    // turn (e.g. Codex + minimax_m2 where the reasoning parser emits a short
+    // text segment alongside tool calls). These must collapse to a single
+    // assistant ChatCompletion message that carries both `content` and
+    // `tool_calls`; otherwise the following `function_call_output` is lifted
+    // as a tool-role message whose preceding assistant message lacks
+    // `tool_calls`, and tool-aware chat templates reject the sequence with
+    // "Message has tool role, but there was no previous assistant message
+    // with a tool call!"
+    #[test]
+    fn test_function_call_then_output_text_then_output_merges_to_one_turn() {
+        let req = NvCreateResponse {
+            inner: CreateResponse {
+                input: InputParam::Items(vec![
+                    InputItem::Item(Item::Message(MessageItem::Input(InputMessage {
+                        content: vec![InputContent::InputText(InputTextContent {
+                            text: "Call say with x=hi".into(),
+                        })],
+                        role: InputRole::User,
+                        status: None,
+                    }))),
+                    InputItem::Item(Item::FunctionCall(FunctionToolCall {
+                        arguments: r#"{"x":"hi"}"#.into(),
+                        call_id: "call_minimal".into(),
+                        namespace: None,
+                        name: "say".into(),
+                        id: None,
+                        status: None,
+                    })),
+                    InputItem::Item(Item::Message(MessageItem::Output(OutputMessage {
+                        id: "msg_1".into(),
+                        role: AssistantRole::Assistant,
+                        status: OutputStatus::Completed,
+                        phase: None,
+                        content: vec![OutputMessageContent::OutputText(OutputTextContent {
+                            text: "\n\n\n".into(),
+                            annotations: vec![],
+                            logprobs: None,
+                        })],
+                    }))),
+                    InputItem::Item(Item::FunctionCallOutput(FunctionCallOutputItemParam {
+                        call_id: "call_minimal".into(),
+                        output: FunctionCallOutput::Text("hi".into()),
+                        id: None,
+                        status: None,
+                    })),
+                ]),
+                model: Some("test-model".into()),
+                ..Default::default()
+            },
+            nvext: None,
+        };
+
+        let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
+        let messages = &chat_req.inner.messages;
+
+        assert_eq!(
+            messages.len(),
+            3,
+            "function_call + assistant output_text must collapse to one assistant message"
+        );
+        assert!(matches!(messages[0], ChatCompletionRequestMessage::User(_)));
+
+        let assistant = match &messages[1] {
+            ChatCompletionRequestMessage::Assistant(m) => m,
+            other => panic!("expected assistant at index 1, got {other:?}"),
+        };
+        let tool_calls = assistant
+            .tool_calls
+            .as_ref()
+            .expect("assistant message must carry tool_calls so the template can match them to the following tool result");
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].id, "call_minimal");
+        assert_eq!(tool_calls[0].function.name, "say");
+        match &assistant.content {
+            Some(ChatCompletionRequestAssistantMessageContent::Text(t)) => {
+                assert_eq!(t, "\n\n\n");
+            }
+            other => panic!("expected assistant text content, got {other:?}"),
+        }
+
+        match &messages[2] {
+            ChatCompletionRequestMessage::Tool(tool) => {
+                assert_eq!(tool.tool_call_id, "call_minimal");
+            }
+            other => panic!("expected tool message at index 2, got {other:?}"),
+        }
+    }
+
+    // Same-turn merge also works in the opposite order (text item emitted
+    // before the function_call): Responses API items from one assistant turn
+    // should always collapse into a single ChatCompletion assistant message.
+    #[test]
+    fn test_output_text_then_function_call_then_output_merges_to_one_turn() {
+        let req = NvCreateResponse {
+            inner: CreateResponse {
+                input: InputParam::Items(vec![
+                    InputItem::Item(Item::Message(MessageItem::Input(InputMessage {
+                        content: vec![InputContent::InputText(InputTextContent {
+                            text: "What's the weather?".into(),
+                        })],
+                        role: InputRole::User,
+                        status: None,
+                    }))),
+                    InputItem::Item(Item::Message(MessageItem::Output(OutputMessage {
+                        id: "msg_1".into(),
+                        role: AssistantRole::Assistant,
+                        status: OutputStatus::Completed,
+                        phase: None,
+                        content: vec![OutputMessageContent::OutputText(OutputTextContent {
+                            text: "Let me check.".into(),
+                            annotations: vec![],
+                            logprobs: None,
+                        })],
+                    }))),
+                    InputItem::Item(Item::FunctionCall(FunctionToolCall {
+                        arguments: r#"{"location":"SF"}"#.into(),
+                        call_id: "call_abc".into(),
+                        namespace: None,
+                        name: "get_weather".into(),
+                        id: None,
+                        status: None,
+                    })),
+                    InputItem::Item(Item::FunctionCallOutput(FunctionCallOutputItemParam {
+                        call_id: "call_abc".into(),
+                        output: FunctionCallOutput::Text(r#"{"temp":"72F"}"#.into()),
+                        id: None,
+                        status: None,
+                    })),
+                ]),
+                model: Some("test-model".into()),
+                ..Default::default()
+            },
+            nvext: None,
+        };
+
+        let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
+        let messages = &chat_req.inner.messages;
+
+        assert_eq!(messages.len(), 3);
+        let assistant = match &messages[1] {
+            ChatCompletionRequestMessage::Assistant(m) => m,
+            _ => panic!("expected assistant at index 1"),
+        };
+        match &assistant.content {
+            Some(ChatCompletionRequestAssistantMessageContent::Text(t)) => {
+                assert_eq!(t, "Let me check.");
+            }
+            _ => panic!("expected preserved text content"),
+        }
+        let tool_calls = assistant.tool_calls.as_ref().expect("tool_calls preserved");
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].id, "call_abc");
+    }
+
+    // Multiple function_calls emitted in a single assistant turn must attach
+    // to the same assistant message so subsequent tool results can pair off.
+    #[test]
+    fn test_multiple_function_calls_merge_into_single_assistant_message() {
+        let req = NvCreateResponse {
+            inner: CreateResponse {
+                input: InputParam::Items(vec![
+                    InputItem::Item(Item::Message(MessageItem::Input(InputMessage {
+                        content: vec![InputContent::InputText(InputTextContent {
+                            text: "Parallel calls please".into(),
+                        })],
+                        role: InputRole::User,
+                        status: None,
+                    }))),
+                    InputItem::Item(Item::FunctionCall(FunctionToolCall {
+                        arguments: r#"{"x":"a"}"#.into(),
+                        call_id: "call_1".into(),
+                        namespace: None,
+                        name: "say".into(),
+                        id: None,
+                        status: None,
+                    })),
+                    InputItem::Item(Item::FunctionCall(FunctionToolCall {
+                        arguments: r#"{"x":"b"}"#.into(),
+                        call_id: "call_2".into(),
+                        namespace: None,
+                        name: "say".into(),
+                        id: None,
+                        status: None,
+                    })),
+                    InputItem::Item(Item::FunctionCallOutput(FunctionCallOutputItemParam {
+                        call_id: "call_1".into(),
+                        output: FunctionCallOutput::Text("a".into()),
+                        id: None,
+                        status: None,
+                    })),
+                    InputItem::Item(Item::FunctionCallOutput(FunctionCallOutputItemParam {
+                        call_id: "call_2".into(),
+                        output: FunctionCallOutput::Text("b".into()),
+                        id: None,
+                        status: None,
+                    })),
+                ]),
+                model: Some("test-model".into()),
+                ..Default::default()
+            },
+            nvext: None,
+        };
+
+        let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
+        let messages = &chat_req.inner.messages;
+        assert_eq!(messages.len(), 4);
+        let assistant = match &messages[1] {
+            ChatCompletionRequestMessage::Assistant(m) => m,
+            _ => panic!("expected one merged assistant message"),
+        };
+        let tool_calls = assistant.tool_calls.as_ref().expect("tool_calls preserved");
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[0].id, "call_1");
+        assert_eq!(tool_calls[1].id, "call_2");
+        assert!(matches!(messages[2], ChatCompletionRequestMessage::Tool(_)));
+        assert!(matches!(messages[3], ChatCompletionRequestMessage::Tool(_)));
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -231,7 +231,7 @@ fn convert_input_content_to_text(content: &[InputContent]) -> String {
 /// attached tool_calls. Used to fold consecutive Responses API items that
 /// belong to the same assistant turn into a single ChatCompletion message.
 fn append_assistant_text(prev: &mut ChatCompletionRequestAssistantMessage, text: &str) {
-    if text.is_empty() && prev.content.is_some() {
+    if text.is_empty() {
         return;
     }
     match prev.content.take() {

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -340,8 +340,7 @@ fn convert_input_items_to_messages(
                             arguments: fc.arguments.clone(),
                         },
                     };
-                    if let Some(ChatCompletionRequestMessage::Assistant(prev)) =
-                        messages.last_mut()
+                    if let Some(ChatCompletionRequestMessage::Assistant(prev)) = messages.last_mut()
                     {
                         match &mut prev.tool_calls {
                             Some(calls) => calls.push(new_call),

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -268,9 +268,14 @@ async fn handle_reader(
                         }
                     }
                     Some(Err(e)) => {
-                        // TODO(#171) - address fatal errors
-                        // in this case the binary representation of the message is invalid
-                        panic!("fatal error - failed to decode message from stream; invalid line protocol: {e:?}");
+                        // TCP RST from peer (e.g. server crash) or a protocol decode
+                        // error — both mean the stream is unrecoverable.  Break so
+                        // only this connection is torn down; other requests are not
+                        // affected.
+                        tracing::warn!(
+                            "tcp stream read error, closing connection: {e:?}"
+                        );
+                        break;
                     }
                     None => {
                         tracing::debug!("tcp stream closed by server");

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -566,8 +566,14 @@ async fn tcp_listener(
                                         break;
                                     }
                                     Err(e) => {
-                                        // TODO(#171) - address fatal errors
-                                        panic!("{:?}", e);
+                                        // Malformed control message — kill the
+                                        // connection so only this stream is torn
+                                        // down.
+                                        tracing::warn!(
+                                            "malformed control message, closing connection: {e:?}"
+                                        );
+                                        control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                                        break;
                                     }
                                 }
                             }
@@ -579,9 +585,15 @@ async fn tcp_listener(
                                     break;
                                 };
                         }
-                        Some(Err(_)) => {
-                            // TODO(#171) - address fatal errors
-                            panic!("invalid message issued over socket; this should never happen");
+                        Some(Err(e)) => {
+                            // TCP RST or decode error from worker side — the
+                            // connection is broken.  Kill the request context and
+                            // break so only this stream is affected.
+                            tracing::warn!(
+                                "tcp stream read error from worker, closing connection: {e:?}"
+                            );
+                            control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                            break;
                         }
                         None => {
                             // this is allowed but we try to avoid it


### PR DESCRIPTION
## Summary

Fixes a production regression in Dynamo's Responses API that breaks Codex + `nvidia/minimaxai/minimax-m2.5` (`--dyn-reasoning-parser minimax_append_think --dyn-tool-call-parser minimax_m2`):

```
Failed to apply prompt template: invalid operation:
Message has tool role, but there was no previous assistant message
with a tool call! (in tool_use:129)
```

### Root cause

`convert_input_items_to_messages` in `lib/llm/src/protocols/openai/responses/mod.rs` pushed a separate ChatCompletion message for every Responses API `InputItem`. A single assistant turn that emits both a `function_call` **and** a short `output_text` (the `minimax_append_think` reasoning parser does exactly this) therefore produced:

1. `Assistant { content: None, tool_calls: Some([...]) }`
2. `Assistant { content: Some("..."), tool_calls: None }` ← wipes tool-call context
3. `Tool { tool_call_id: ... }`

The tool-aware chat templates (minimax_m2 among others) require the Tool message to be immediately preceded by an Assistant message carrying the matching `tool_calls`, so they reject the sequence.

### Fix

Merge `MessageItem::Output` and `Item::FunctionCall` into the trailing assistant message when there is one, so a single Responses-API assistant turn collapses into a single ChatCompletion assistant message carrying both `content` and `tool_calls`. The following `function_call_output → Tool` message is then adjacent to an assistant that owns its `tool_calls`, and the template accepts it.

### Minimal repro

```json
{
  "model": "nvidia/minimaxai/minimax-m2.5",
  "stream": false,
  "tools": [{"type":"function","name":"say","parameters":{"type":"object","properties":{"x":{"type":"string"}},"required":["x"],"additionalProperties":false}}],
  "input": [
    {"type":"message","role":"user","content":[{"type":"input_text","text":"Call say with x=hi"}]},
    {"type":"function_call","call_id":"call_minimal","name":"say","arguments":"{\"x\":\"hi\"}"},
    {"type":"message","role":"assistant","content":[{"type":"output_text","text":"\n\n\n"}]},
    {"type":"function_call_output","call_id":"call_minimal","output":"hi"}
  ]
}
```

Before: 500 with the template error above. After: the same request converts to a single `Assistant{content:"\n\n\n", tool_calls:[say]}` followed by `Tool`, and the template renders cleanly.

## How we tested

### 1. Unit tests pass with the fix

```
$ cargo +1.93.1 test --package dynamo-llm --lib responses::tests
test result: ok. 38 passed; 0 failed; 0 ignored; 0 measured; 853 filtered out
```

38/38 = 35 pre-existing `responses::tests` + 3 new regression tests (below). No existing test changes behavior.

### 2. Three new regression tests (in `lib/llm/src/protocols/openai/responses/mod.rs`)

- **`test_function_call_then_output_text_then_output_merges_to_one_turn`** — exact bytes from the minimal repro above. Asserts the 4 input items collapse to 3 ChatCompletion messages (User → Assistant{content, tool_calls} → Tool), and that the assistant message carries both the `"\n\n\n"` text and the `say` tool call.
- **`test_output_text_then_function_call_then_output_merges_to_one_turn`** — reverse item order inside one assistant turn (text first, then `function_call`). Same merge guarantee — proves the fix isn't position-sensitive.
- **`test_multiple_function_calls_merge_into_single_assistant_message`** — two `function_call` items in one turn followed by two `function_call_output`s. Asserts both tool_calls attach to the *same* assistant message so each downstream Tool message pairs off against the correct assistant turn.

### 3. Cross-check: the tests actually detect the regression

Methodology: revert the fix in-place (keeping the new tests), run the three new tests, confirm they fail, then restore the fix and confirm they pass again.

```
$ cargo +1.93.1 test --package dynamo-llm --lib responses::tests::test_function_call_then_output_text
test protocols::openai::responses::tests::test_function_call_then_output_text_then_output_merges_to_one_turn ... FAILED
  assertion `left == right` failed: function_call + assistant output_text must collapse to one assistant message
    left: 4
   right: 3

$ cargo +1.93.1 test --package dynamo-llm --lib responses::tests::test_output_text_then_function_call
test protocols::openai::responses::tests::test_output_text_then_function_call_then_output_merges_to_one_turn ... FAILED
  assertion `left == right` failed
    left: 4
   right: 3

$ cargo +1.93.1 test --package dynamo-llm --lib responses::tests::test_multiple_function_calls_merge
test protocols::openai::responses::tests::test_multiple_function_calls_merge_into_single_assistant_message ... FAILED
  assertion `left == right` failed
    left: 5
   right: 4
```

All three fail with the expected messages-count mismatch (one extra `Assistant` message that the fix is supposed to collapse away). After restoring the fix, all three pass again. This confirms the tests exercise the faulty code path rather than just asserting properties the code happened to already satisfy.

### 4. Why no live-GPU replay (unchecked box)

The bug is entirely in the Responses-API → ChatCompletion message converter, which is pure Rust running in the frontend preprocessor *before* any prompt-template rendering, tokenization, or GPU work. The regression tests feed `convert_input_items_to_messages` the exact `InputItem` sequence from the minimal repro curl and assert that the resulting `Vec<ChatCompletionRequestMessage>` satisfies the template's invariant (every `Tool` message is immediately preceded by an `Assistant` that owns the matching `tool_calls`). Once that invariant holds, the prompt-template rendering — and everything downstream — cannot produce the `"Message has tool role, but there was no previous assistant message with a tool call!"` error. The unit tests cover exactly the same code path a live request would hit through that function; a GPU replay wouldn't probe any code the unit tests miss.

Skipped for practical reasons: `minimax-m2.5` is a ~230B MoE and won't fit on the 2×A6000 (96 GB) available here.

## Test plan

- [x] `cargo +1.93.1 test --package dynamo-llm --lib responses::tests` — 38/38 pass.
- [x] Three new regression tests fail without the fix (cross-checked), pass with the fix.
- [ ] End-to-end replay against live `minimax-m2.5` — not run; rationale in §4 above. Happy to run this on a machine that can host the weights if a reviewer prefers.

cc @ishandhanani @benjaminklieger @brianwestphal @vasilisvagias @kylekranen
