### PR TITLE
docs(vllm-omni): note transformers>=5.0 requirement for GLM-Image

### DIFF
--- a/docs/backends/vllm/vllm-omni.md
+++ b/docs/backends/vllm/vllm-omni.md
@@ -372,6 +372,8 @@ sequenceDiagram
 
 GLM-Image is a 2-stage text-to-image model with an AR stage (generates prior token IDs) and a DiT stage (diffusion denoising + VAE decode). The built-in vLLM-Omni stage config already assigns each stage to a separate GPU.
 
+> **Known issue:** GLM-Image requires `transformers>=5.0` to recognize the `glm_image` architecture. Older versions fail at model config creation with `The checkpoint you are trying to load has model type 'glm_image' but Transformers does not recognize this architecture`.
+
 ```bash
 bash examples/backends/vllm/launch/disagg_omni_glm_image.sh
 ```


### PR DESCRIPTION
## Summary

GLM-Image (`zai-org/GLM-Image`) requires `transformers>=5.0` to recognize the `glm_image` architecture. On older transformers, Stage 0 (AR) fails during model config creation with:

```
Value error, The checkpoint you are trying to load has model type `glm_image`
but Transformers does not recognize this architecture.
```

This is a known upstream dependency issue until the bundled `transformers` in the vLLM runtime image is upgraded. Tracking the root fix separately; this PR just adds a user-facing note so anyone hitting the error knows what to do.

## Changes

- Add a "Known issue" callout under the **Quick Start: GLM-Image** section in `docs/backends/vllm/vllm-omni.md` stating the `transformers>=5.0` requirement and the exact error message.

## Related

- Linear: DYN-2712

## Test plan

- [x] Rendered markdown renders the blockquote / inline code correctly
- [ ] Docs site preview looks correct (reviewer to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added known issue guidance for GLM-Image model support, documenting compatibility requirements to prevent model configuration and initialization failures during model loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->