### PR TITLE
docs(vllm-omni): note transformers>=5.0 requirement for GLM-Image

### DIFF
--- a/docs/backends/vllm/vllm-omni.md
+++ b/docs/backends/vllm/vllm-omni.md
@@ -372,6 +372,8 @@ sequenceDiagram
 
 GLM-Image is a 2-stage text-to-image model with an AR stage (generates prior token IDs) and a DiT stage (diffusion denoising + VAE decode). The built-in vLLM-Omni stage config already assigns each stage to a separate GPU.
 
+> **Known issue:** GLM-Image requires `transformers>=5.0` to recognize the `glm_image` architecture. Older versions fail at model config creation with `The checkpoint you are trying to load has model type 'glm_image' but Transformers does not recognize this architecture`.
+
 ```bash
 bash examples/backends/vllm/launch/disagg_omni_glm_image.sh
 ```


### PR DESCRIPTION
## Summary

Cherry-pick of #8287 into `release/1.1.0`.

GLM-Image (`zai-org/GLM-Image`) requires `transformers>=5.0` to recognize the `glm_image` architecture. On older transformers, Stage 0 (AR) fails during model config creation with:

```
Value error, The checkpoint you are trying to load has model type `glm_image`
but Transformers does not recognize this architecture.
```

This is a known upstream dependency issue until the bundled `transformers` in the 1.1.0 vLLM runtime image is upgraded. This PR adds a user-facing known-issue note so anyone hitting the error on the 1.1.0 release knows the fix.

## Changes

- Cherry-picks `b0f7d8a5112` from `main` onto `release/1.1.0`.
- Adds a "Known issue" callout under the **Quick Start: GLM-Image** section in `docs/backends/vllm/vllm-omni.md` stating the `transformers>=5.0` requirement.

## Related

- Original PR: #8287
- Linear: DYN-2712

## Test plan

- [x] Clean cherry-pick (no conflicts)
- [x] Signed-off commit
- [ ] Docs site preview on release branch looks correct (reviewer to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)