### PR TITLE
feat(kvbm-v2): enable KVBM v2 DynamoConnector in PdConnector for disaggregated serving

### DIFF
--- a/lib/bindings/kvbm/python/kvbm/v1/vllm_integration/connector/pd_connector.py
+++ b/lib/bindings/kvbm/python/kvbm/v1/vllm_integration/connector/pd_connector.py
@@ -4,6 +4,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Type
 
 from kvbm.v1.vllm_integration.connector.dynamo_connector import DynamoConnector
+
+try:
+    from kvbm.v2.vllm.schedulers.connector import DynamoConnector as DynamoConnectorV2
+except ImportError:
+    DynamoConnectorV2 = None
+
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorHandshakeMetadata,
     KVConnectorRole,
@@ -78,6 +84,8 @@ class PdConnector(MultiConnector):
 
         # Build allowed types for first connector
         allowed_first_types: list[Type] = [DynamoConnector]
+        if DynamoConnectorV2 is not None:
+            allowed_first_types.append(DynamoConnectorV2)
         if _LMCacheConnectorV1 is not None:
             allowed_first_types.append(_LMCacheConnectorV1)
 

--- a/lib/bindings/kvbm/python/kvbm/v1/vllm_integration/connector/pd_connector.py
+++ b/lib/bindings/kvbm/python/kvbm/v1/vllm_integration/connector/pd_connector.py
@@ -116,8 +116,10 @@ class PdConnector(MultiConnector):
         This is required for NIXL connector to start its handshake listener
         which decode workers connect to for KV transfer coordination.
         """
-        for c in self._connectors:
-            c.set_xfer_handshake_metadata(metadata)
+        # Only pass handshake metadata to the NixlConnector (second connector).
+        # The DynamoConnector (first connector) uses its own Velo peer handshake
+        # and rejects non-VeloPeerMetadata.
+        self._connectors[1].set_xfer_handshake_metadata(metadata)
 
     def get_handshake_metadata(self) -> KVConnectorHandshakeMetadata | None:
         """

--- a/lib/bindings/kvbm/python/kvbm/v1/vllm_integration/connector/pd_connector.py
+++ b/lib/bindings/kvbm/python/kvbm/v1/vllm_integration/connector/pd_connector.py
@@ -59,6 +59,14 @@ class PdConnectorMetadata(MultiKVConnectorMetadata):
     pass
 
 
+@dataclass
+class PdHandshakeMetadata(KVConnectorHandshakeMetadata):
+    """Composite handshake metadata wrapping both child connectors' metadata."""
+
+    dynamo_metadata: Optional[KVConnectorHandshakeMetadata]
+    nixl_metadata: Optional[KVConnectorHandshakeMetadata]
+
+
 class PdConnector(MultiConnector):
     """
     A wrapper for using KV offloading Connectors (e.g. KVBM or LMCache) and NIXL Connector for PD disaggregated serving.
@@ -111,36 +119,48 @@ class PdConnector(MultiConnector):
         self, metadata: dict[int, KVConnectorHandshakeMetadata]
     ) -> None:
         """
-        Propagate handshake metadata to child connectors.
+        Unpack composite handshake metadata and route to each child connector.
 
-        This is required for NIXL connector to start its handshake listener
-        which decode workers connect to for KV transfer coordination.
+        Each worker exports a PdHandshakeMetadata wrapping both the
+        DynamoConnector metadata (VeloPeerMetadata, if v2) and NixlConnector
+        metadata (NixlHandshakePayload). We split them into per-connector
+        dicts and forward only to connectors that produced non-None metadata.
         """
-        # Only pass handshake metadata to the NixlConnector (second connector).
-        # The DynamoConnector (first connector) uses its own Velo peer handshake
-        # and rejects non-VeloPeerMetadata.
-        self._connectors[1].set_xfer_handshake_metadata(metadata)
+        dynamo_meta: dict[int, KVConnectorHandshakeMetadata] = {}
+        nixl_meta: dict[int, KVConnectorHandshakeMetadata] = {}
+
+        for rank, composite in metadata.items():
+            if isinstance(composite, PdHandshakeMetadata):
+                if composite.dynamo_metadata is not None:
+                    dynamo_meta[rank] = composite.dynamo_metadata
+                if composite.nixl_metadata is not None:
+                    nixl_meta[rank] = composite.nixl_metadata
+            else:
+                # Fallback: assume it's NIXL-only metadata (backwards compat)
+                nixl_meta[rank] = composite
+
+        if dynamo_meta:
+            self._connectors[0].set_xfer_handshake_metadata(dynamo_meta)
+        if nixl_meta:
+            self._connectors[1].set_xfer_handshake_metadata(nixl_meta)
 
     def get_handshake_metadata(self) -> KVConnectorHandshakeMetadata | None:
         """
-        Get the KVConnector handshake metadata from the NIXL connector.
+        Collect handshake metadata from both child connectors.
 
-        This metadata is used for out-of-band connector handshake between
-        P/D workers. The NIXL connector (second connector) provides this
-        metadata so decode workers can connect for KV transfer coordination.
-
-        Returns:
-            NixlHandshakePayload from the NIXL connector, or None if not available.
+        Returns a PdHandshakeMetadata wrapping each connector's metadata
+        so that set_xfer_handshake_metadata can route them correctly.
         """
-        # Get handshake metadata from the NIXL connector (second connector)
-        nixl_connector = self._connectors[1]
-        metadata = nixl_connector.get_handshake_metadata()
-        if metadata is not None and not isinstance(metadata, NixlHandshakePayload):
-            raise TypeError(
-                f"Expected NixlHandshakePayload from NIXL connector, "
-                f"got {type(metadata).__name__}"
-            )
-        return metadata
+        dynamo_metadata = self._connectors[0].get_handshake_metadata()
+        nixl_metadata = self._connectors[1].get_handshake_metadata()
+
+        if dynamo_metadata is None and nixl_metadata is None:
+            return None
+
+        return PdHandshakeMetadata(
+            dynamo_metadata=dynamo_metadata,
+            nixl_metadata=nixl_metadata,
+        )
 
     def bind_connector_metadata(self, connector_metadata: PdConnectorMetadata) -> None:
         # Must call super() to set _connector_metadata so has_connector_metadata() returns True


### PR DESCRIPTION
## Summary
- Add v2 `DynamoConnector` to `PdConnector`'s allowed first-connector types so it passes the `isinstance` validation
- Introduce `PdHandshakeMetadata` composite to collect and route handshake metadata from both child connectors — the v2 DynamoConnector's `VeloPeerMetadata` (for Velo peer registration) and NixlConnector's `NixlHandshakePayload` (for RDMA coordination)
- Fixes "Workers not initialized" crash caused by the v2 leader never receiving its `VeloPeerMetadata` through the `set_xfer_handshake_metadata` path

## Test results (Qwen3-8B, TP4, 3 prefill x 1 decode)

| # | Test | Result |
|---|------|--------|
| 1 | Longer reply (max_tokens=300, /no_think) | HTTP 200, 1.7s total, ttft=305ms |
| 2 | Streaming SSE | HTTP 200, chunks flowing with per-chunk nvext.worker_id |
| 3 | KV-reuse (3x identical short prompt) | HTTP 200, ttft 33-39ms |
| 4 | 8 parallel requests | All HTTP 200, 380-412ms total, load spread across all 3 prefill workers |
| 5 | Long prompt (1524 tokens) | HTTP 200, ttft=80.7ms, prefill=73.6ms, exercises NIXL KV transfer |

**Performance at-a-glance:**
- Short prompt TTFT: ~33ms
- 1.5k-token prompt TTFT: ~81ms
- Concurrent 8-request TTFT: 32-65ms (no queueing degradation)
- Decode time/token: ~25ms

**Pod health:** Zero restarts through all 5 test scenarios — PdConnector + KVBM v2 + NIXL path is stable.

## Test plan
- [x] Verify PdConnector accepts v2 DynamoConnector as first child connector
- [x] Verify v2 DynamoConnector leader receives VeloPeerMetadata and initializes workers
- [x] Verify NixlConnector still receives NixlHandshakePayload correctly
- [x] Verify disaggregated serving (prefill/decode) works end-to-end with NIXL KV transfer
- [x] Verify concurrent request handling with load spread across prefill workers