### PR TITLE
fix(health): use local endpoint registry for canary health checks

### DIFF
--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -144,6 +144,24 @@ impl EndpointConfigBuilder {
 
         // Register health check target in SystemHealth if provided
         if let Some(health_check_payload) = &health_check_payload {
+            // When canary health checks are enabled, the canary calls the engine
+            // via LocalEndpointRegistry. Fail fast if the engine wasn't registered
+            // (caller forgot .register_local_engine() before .start()).
+            if system_health.lock().health_check_enabled()
+                && endpoint
+                    .drt()
+                    .local_endpoint_registry()
+                    .get(&endpoint.name)
+                    .is_none()
+            {
+                anyhow::bail!(
+                    "Endpoint '{}' has a health_check_payload and canary is enabled, \
+                     but no local engine is registered. Call .register_local_engine() \
+                     before .start() so the canary health check can function.",
+                    endpoint.name
+                );
+            }
+
             // Build transport based on request plane mode
             let transport = build_transport_type(&endpoint, &endpoint_id, connection_id).await?;
 

--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -144,9 +144,6 @@ impl EndpointConfigBuilder {
 
         // Register health check target in SystemHealth if provided
         if let Some(health_check_payload) = &health_check_payload {
-            // When canary health checks are enabled, the canary calls the engine
-            // via LocalEndpointRegistry. Fail fast if the engine wasn't registered
-            // (caller forgot .register_local_engine() before .start()).
             if system_health.lock().health_check_enabled()
                 && endpoint
                     .drt()

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::DistributedRuntime;
 use crate::config::HealthStatus;
 use crate::engine::AsyncEngine;
 use crate::pipeline::SingleIn;
-use crate::DistributedRuntime;
 use futures::StreamExt;
 use parking_lot::Mutex;
 use std::collections::HashMap;
@@ -201,7 +201,10 @@ impl HealthCheckManager {
         endpoint_subject: &str,
         payload: &serde_json::Value,
     ) -> anyhow::Result<()> {
-        debug!("Sending health check to {} via local registry", endpoint_subject);
+        debug!(
+            "Sending health check to {} via local registry",
+            endpoint_subject
+        );
 
         // Look up the engine in the local endpoint registry (in-process call only).
         // If not found, the endpoint hasn't finished registering yet — the canary

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -192,11 +192,6 @@ impl HealthCheckManager {
     }
 
     /// Send a health check request via the local endpoint registry (in-process).
-    ///
-    /// This calls the engine directly without going through discovery, routing,
-    /// or network transport. The local registry is populated during
-    /// `EndpointConfigBuilder::start()` via `.register_local_engine()`, using
-    /// the same `endpoint.name` key as health check target registration.
     async fn send_health_check_request(
         &self,
         endpoint_subject: &str,
@@ -207,9 +202,6 @@ impl HealthCheckManager {
             endpoint_subject
         );
 
-        // Look up the engine in the local endpoint registry (in-process call only).
-        // If not found, the endpoint hasn't finished registering yet — the canary
-        // will retry on the next cycle.
         let engine = self
             .drt
             .local_endpoint_registry()
@@ -234,10 +226,7 @@ impl HealthCheckManager {
                 match engine.generate(request).await {
                     Ok(mut response_stream) => {
                         // Get the first response to verify endpoint is alive.
-                        // Check for errors rather than data presence: an Annotated
-                        // item can have data: None without being an error (e.g.,
-                        // annotation/metadata events). Only explicit errors indicate
-                        // an unhealthy endpoint.
+                        // Check for errors
                         let is_healthy = if let Some(response) = response_stream.next().await {
                             if let Some(error) = response.err() {
                                 warn!(
@@ -257,8 +246,8 @@ impl HealthCheckManager {
                             false
                         };
 
-                        // Consume the rest of the stream in the background
                         tokio::spawn(async move {
+                            // We need to consume the rest of the stream to avoid warnings on the frontend.
                             response_stream.for_each(|_| async {}).await;
                         });
 

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -5,6 +5,7 @@ use crate::DistributedRuntime;
 use crate::config::HealthStatus;
 use crate::engine::AsyncEngine;
 use crate::pipeline::SingleIn;
+use crate::protocols::maybe_error::MaybeError;
 use futures::StreamExt;
 use parking_lot::Mutex;
 use std::collections::HashMap;
@@ -232,17 +233,21 @@ impl HealthCheckManager {
                 let request = SingleIn::new(payload);
                 match engine.generate(request).await {
                     Ok(mut response_stream) => {
-                        // Get the first response to verify endpoint is alive
+                        // Get the first response to verify endpoint is alive.
+                        // Check for errors rather than data presence: an Annotated
+                        // item can have data: None without being an error (e.g.,
+                        // annotation/metadata events). Only explicit errors indicate
+                        // an unhealthy endpoint.
                         let is_healthy = if let Some(response) = response_stream.next().await {
-                            if response.data.is_some() {
-                                debug!("Health check successful for {}", endpoint_subject_owned);
-                                true
-                            } else {
+                            if let Some(error) = response.err() {
                                 warn!(
-                                    "Health check got empty response from {}",
-                                    endpoint_subject_owned
+                                    "Health check error response from {}: {:?}",
+                                    endpoint_subject_owned, error
                                 );
                                 false
+                            } else {
+                                debug!("Health check successful for {}", endpoint_subject_owned);
+                                true
                             }
                         } else {
                             warn!(

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -1,21 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::component::{Client, Component, Endpoint, Instance};
 use crate::config::HealthStatus;
-use crate::pipeline::PushRouter;
-use crate::pipeline::{AsyncEngine, Context, ManyOut, SingleIn};
-use crate::protocols::annotated::Annotated;
-use crate::protocols::maybe_error::MaybeError;
-use crate::{DistributedRuntime, SystemHealth};
+use crate::engine::AsyncEngine;
+use crate::pipeline::SingleIn;
+use crate::DistributedRuntime;
 use futures::StreamExt;
 use parking_lot::Mutex;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::task::JoinHandle;
-use tokio::time::{MissedTickBehavior, interval};
 use tracing::{debug, error, info, warn};
 
 /// Configuration for health check behavior
@@ -37,17 +32,10 @@ impl Default for HealthCheckConfig {
     }
 }
 
-// Type alias for the router cache to improve readability
-// Maps endpoint subject -> router and payload
-type RouterCache =
-    Arc<Mutex<HashMap<String, Arc<PushRouter<serde_json::Value, Annotated<serde_json::Value>>>>>>;
-
 /// Health check manager that monitors endpoint health
 pub struct HealthCheckManager {
     drt: DistributedRuntime,
     config: HealthCheckConfig,
-    /// Cache of PushRouters and payloads for each endpoint
-    router_cache: RouterCache,
     /// Track per-endpoint health check tasks
     /// Maps: endpoint_subject -> task_handle
     endpoint_tasks: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
@@ -58,43 +46,8 @@ impl HealthCheckManager {
         Self {
             drt,
             config,
-            router_cache: Arc::new(Mutex::new(HashMap::new())),
             endpoint_tasks: Arc::new(Mutex::new(HashMap::new())),
         }
-    }
-
-    /// Get or create a PushRouter for an endpoint
-    async fn get_or_create_router(
-        &self,
-        cache_key: &str,
-        endpoint: Endpoint,
-    ) -> anyhow::Result<Arc<PushRouter<serde_json::Value, Annotated<serde_json::Value>>>> {
-        let cache_key = cache_key.to_string();
-
-        // Check cache first
-        {
-            let cache = self.router_cache.lock();
-            if let Some(router) = cache.get(&cache_key) {
-                return Ok(router.clone());
-            }
-        }
-
-        // Create a client that discovers instances dynamically for this endpoint
-        let client = Client::new(endpoint).await?;
-
-        // Create PushRouter - it will use direct routing when we call direct()
-        let router: Arc<PushRouter<serde_json::Value, Annotated<serde_json::Value>>> = Arc::new(
-            PushRouter::from_client(
-                client,
-                crate::pipeline::RouterMode::RoundRobin, // Default mode, we'll use direct() explicitly
-            )
-            .await?,
-        );
-
-        // Cache it
-        self.router_cache.lock().insert(cache_key, router.clone());
-
-        Ok(router)
     }
 
     /// Start the health check manager by spawning per-endpoint monitoring tasks
@@ -237,96 +190,56 @@ impl HealthCheckManager {
         Ok(())
     }
 
-    /// Send a health check request through AsyncEngine
+    /// Send a health check request via the local endpoint registry (in-process).
+    ///
+    /// This calls the engine directly without going through discovery, routing,
+    /// or network transport. The local registry is populated during
+    /// `EndpointConfigBuilder::start()` via `.register_local_engine()`, using
+    /// the same `endpoint.name` key as health check target registration.
     async fn send_health_check_request(
         &self,
         endpoint_subject: &str,
         payload: &serde_json::Value,
     ) -> anyhow::Result<()> {
-        let target = self
+        debug!("Sending health check to {} via local registry", endpoint_subject);
+
+        // Look up the engine in the local endpoint registry (in-process call only).
+        // If not found, the endpoint hasn't finished registering yet — the canary
+        // will retry on the next cycle.
+        let engine = self
             .drt
-            .system_health()
-            .lock()
-            .get_health_check_target(endpoint_subject)
+            .local_endpoint_registry()
+            .get(endpoint_subject)
             .ok_or_else(|| {
-                anyhow::anyhow!("No health check target found for {}", endpoint_subject)
-            })?;
-
-        debug!(
-            "Sending health check to {} (instance_id: {})",
-            endpoint_subject, target.instance.instance_id
-        );
-
-        // Create the Endpoint directly from the Instance info
-        let namespace = self.drt.namespace(&target.instance.namespace)?;
-        let component = namespace.component(&target.instance.component)?;
-        let endpoint = component.endpoint(&target.instance.endpoint);
-
-        // Get or create router for this endpoint
-        let router = self
-            .get_or_create_router(endpoint_subject, endpoint)
-            .await?;
-
-        // Wait for watch stream to discover instances before checking
-        // This ensures the router's client has populated its instance list
-        // from etcd before we attempt to send the health check request.
-        // Without this, the first health check can fail due to a race condition
-        // where the watch stream hasn't completed its initial discovery yet.
-        match tokio::time::timeout(
-            Duration::from_secs(10), // 10 second timeout for discovery
-            router.client.wait_for_instances(),
-        )
-        .await
-        {
-            Ok(Ok(instances)) => {
-                debug!(
-                    "Health check for {}: watch stream ready, found {} instance(s)",
-                    endpoint_subject,
-                    instances.len()
-                );
-            }
-            Ok(Err(e)) => {
-                return Err(anyhow::anyhow!(
-                    "Failed to discover instances for {} during health check: {}",
-                    endpoint_subject,
-                    e
-                ));
-            }
-            Err(_) => {
-                return Err(anyhow::anyhow!(
-                    "Timeout waiting for instance discovery for {} during health check",
+                anyhow::anyhow!(
+                    "Endpoint '{}' not found in local registry, engine may still be initializing",
                     endpoint_subject
-                ));
-            }
-        }
-
-        // Create the request context
-        let request: SingleIn<serde_json::Value> = Context::new(payload.clone());
+                )
+            })?;
 
         // Clone what we need for the spawned task
         let system_health = self.drt.system_health().clone();
         let endpoint_subject_owned = endpoint_subject.to_string();
-        let instance_id = target.instance.instance_id;
+        let payload = payload.clone();
         let timeout = self.config.request_timeout;
 
         // Spawn task to send health check and wait for response
         tokio::spawn(async move {
             let result = tokio::time::timeout(timeout, async {
-                // Call direct() on the PushRouter to target specific instance
-                match router.direct(request, instance_id).await {
+                let request = SingleIn::new(payload);
+                match engine.generate(request).await {
                     Ok(mut response_stream) => {
                         // Get the first response to verify endpoint is alive
                         let is_healthy = if let Some(response) = response_stream.next().await {
-                            // Check if response indicates an error
-                            if let Some(error) = response.err() {
-                                warn!(
-                                    "Health check error response from {}: {:?}",
-                                    endpoint_subject_owned, error
-                                );
-                                false
-                            } else {
+                            if response.data.is_some() {
                                 debug!("Health check successful for {}", endpoint_subject_owned);
                                 true
+                            } else {
+                                warn!(
+                                    "Health check got empty response from {}",
+                                    endpoint_subject_owned
+                                );
+                                false
                             }
                         } else {
                             warn!(
@@ -336,8 +249,8 @@ impl HealthCheckManager {
                             false
                         };
 
+                        // Consume the rest of the stream in the background
                         tokio::spawn(async move {
-                            // We need to consume the rest of the stream to avoid warnings on the frontend.
                             response_stream.for_each(|_| async {}).await;
                         });
 


### PR DESCRIPTION
#### Overview:

The canary health check used PushRouter/discovery/direct() to send a test request back to itself through the full distributed pipeline. This was fragile in Kubernetes because it depended on discovery settling (EndpointSlice + DynamoWorkerMetadata CR correlation), and `PushRouter::direct(instance_id)` required an exact instance_id match that broke on pod restarts due to stale data from previous pods. The `wait_for_instances()` call only checked that *any* instance existed — not that the *correct* instance was routable — so the canary would discover a stale pod, then fail with "instance_id not found" when trying to direct-route to itself.

This PR replaces the entire discovery/routing path with a direct in-process call via `LocalEndpointRegistry`, which is already populated during `EndpointConfigBuilder::start()` using the same `endpoint.name` key. This eliminates all discovery timing dependencies and instance_id matching issues.

#### Details:

- `lib/runtime/src/health_check.rs`:
  - Replaced `send_health_check_request()` to use `drt.local_endpoint_registry().get(endpoint_subject)` → `engine.generate()` (same pattern as `call_lora_endpoint` in `system_status_server.rs`)
  - Removed `RouterCache` type alias, `router_cache` field, and `get_or_create_router()` method
  - Removed unused imports: `Client`, `Component`, `Endpoint`, `Instance`, `PushRouter`, `Context`, `ManyOut`, `Annotated`, `MaybeError`, `Serialize`, `Deserialize`, `Instant`, `MissedTickBehavior`, `interval`
  - No changes to the timer/notifier/per-endpoint task lifecycle (`start()`, `spawn_endpoint_health_check_task()`, `spawn_new_endpoint_monitor()`)

#### Where should the reviewer start?

`lib/runtime/src/health_check.rs` — specifically the new `send_health_check_request()` method (line ~240). The old method was ~140 lines of discovery/routing logic; the new one is ~80 lines with a single `local_endpoint_registry.get()` → `engine.generate()` call.

#### Related Issues:

- Relates to [DIS-1185](https://linear.app/nvidia/issue/DIS-1185/race-condition-for-canary-health-check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal health check mechanism by removing router-discovery machinery and updating endpoint resolution to use local registry. No public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->