### PR TITLE
fix(trtllm): install pip into runtime venv for NVRTC JIT include discovery

### DIFF
--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -230,11 +230,15 @@ COPY --chmod=775 --chown=dynamo:0 benchmarks/ /workspace/benchmarks/
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 
 {% if target not in ("dev", "local-dev") %}
-# Install dynamo, NIXL, and dynamo-specific dependencies
+# Install dynamo, NIXL, and dynamo-specific dependencies.
+# `pip` is installed into the venv so TRT-LLM's NVRTC JIT can locate this
+# install via `pip show tensorrt_llm` at runtime (required for FMHA kernel
+# JIT compilation on sm_100a, where cubins are not pre-compiled).
 ARG ENABLE_KVBM
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775 \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
     uv pip install \
+      pip \
       /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
       /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
       /opt/dynamo/wheelhouse/nixl/nixl*.whl && \
@@ -252,9 +256,12 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775 \
 {% else %}
 # Dev/local-dev: skip dynamo wheel install (users build from source via cargo build + maturin develop).
 # Install NIXL wheel only (pre-built C++ binary, not buildable from source).
+# `pip` is installed into the venv so TRT-LLM's NVRTC JIT can locate this
+# install via `pip show tensorrt_llm` at runtime (required for FMHA kernel
+# JIT compilation on sm_100a, where cubins are not pre-compiled).
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775 \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
-    uv pip install /opt/dynamo/wheelhouse/nixl/nixl*.whl
+    uv pip install pip /opt/dynamo/wheelhouse/nixl/nixl*.whl
 {% endif %}
 
 # Install gpu_memory_service wheel if enabled (all targets)


### PR DESCRIPTION
## Summary

Install `pip` into the TRT-LLM runtime venv so TRT-LLM's NVRTC JIT path can discover its own install location at runtime.

## Root cause

On Blackwell (sm_100a), TRT-LLM 1.3.0rc11 must JIT-compile `fmhaSm100aKernel_*` via NVRTC because FMHA cubins are only pre-compiled for sm_90 (Hopper). TRT-LLM's JIT wrapper (`cpp/include/tensorrt_llm/deep_gemm/compiler.cuh:151`, `getJitIncludeDirs()`) discovers its install path by shelling out to `pip show tensorrt_llm`. From there it adds `<install>/tensorrt_llm/include` as an NVRTC `-I` option — the path that ships `cuda.h` and the kernel sources.

Dynamo's runtime venv is built with `uv pip install`, which does **not** install `pip` inside the venv. `$PATH` still has `$VIRTUAL_ENV/bin` first, but there is no `pip` binary there, so the subprocess falls through to `/usr/bin/pip` (system Python's pip), which cannot see uv-managed site-packages. `pip show tensorrt_llm` returns "Package(s) not found", `getJitIncludeDirs()` returns empty, and TRT-LLM calls `nvrtcCompileProgram` with zero `-I` options:

```
[E] [CudaRunner.cpp:458]: Failed to preprocess kernel fmhaSm100aKernel_Qkv...PersistentSwapsAbForGen:
    Compilation failed: NVRTC_ERROR_COMPILATION
    fmhaSm100aKernel_...(4): catastrophic error: could not open source file "cuda.h"
    (no directories in search list)
    #include <cuda.h>
```

Hopper is unaffected because the pre-compiled sm_90 cubins skip the JIT path entirely.

## Fix

Add `pip` to the `uv pip install` line in both the runtime and dev/local-dev branches of `container/templates/trtllm_runtime.Dockerfile`. `pip show tensorrt_llm` now resolves to `/opt/dynamo/venv/bin/pip` (installed in the venv), which can see the dist-info — TRT-LLM gets the correct include path and NVRTC JIT succeeds.

## Alternatives considered and rejected

- `CPATH=/usr/local/cuda/include` — NVRTC does not honor GCC's `CPATH`.
- `ln -s /usr/local/cuda/include/cuda.h /usr/include/cuda.h` — NVRTC does not search `/usr/include`; it only uses `-I` options.
- `apt install cuda-cudart-dev-13-1` — redundant; headers are already present. The bug is discovery, not file absence.
- Patching `getJitIncludeDirs()` upstream — correct long-term fix but requires a TRT-LLM release; the pip-in-venv workaround unblocks Dynamo 1.1.0 immediately.

## Test plan

Reproduced and fixed on GB200 (gb200nvl4, NVIDIA GB200 sm_100a, ARM64) using the pre-built CI arm64 image `gitlab-master.nvidia.com:5005/dl/ai-dynamo/dynamo-ci:652d692a...-48651348-trtllm-arm64`:

- [x] Baseline: `trtllm-serve serve Qwen/Qwen3-0.6B --backend pytorch` fails with the NVRTC error above.
- [x] Fix validated inline: `docker exec ... uv pip install pip` → `pip show tensorrt_llm` resolves → `trtllm-serve` starts, `/v1/models` returns `Qwen/Qwen3-0.6B`, `/v1/chat/completions` returns a valid completion, `nvidia-smi` shows 171 GB used by the worker.
- [x] Template change renders without diff drift (verified via `python3 container/render.py --framework=trtllm --target=runtime --cuda-version=13.1 --platform=arm64`).
- [x] Fresh `docker build` from this branch on GB200 produces `dyn-2715-main-fix:latest` (28.5 GB arm64 image). `trtllm-serve serve Qwen/Qwen3-0.6B --backend pytorch` starts clean, `/v1/models` returns the model, `/v1/chat/completions` returns a valid completion, `nvidia-smi` shows 167 GB of GPU memory used by the worker process. Zero NVRTC errors in `/tmp/serve.log`.

Fixes [DYN-2715](https://linear.app/nvidia/issue/DYN-2715).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved runtime environment configuration to ensure proper package discovery and dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->