### PR TITLE
feat(sglang): add video embedding cache support to multimodal EPD

### DIFF
--- a/components/src/dynamo/common/memory/multimodal_embedding_cache_manager.py
+++ b/components/src/dynamo/common/memory/multimodal_embedding_cache_manager.py
@@ -19,7 +19,7 @@ Usage:
 
 import logging
 from collections import OrderedDict
-from typing import NamedTuple, Optional
+from typing import Any, NamedTuple, Optional
 
 import torch
 
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 class CachedEmbedding(NamedTuple):
     tensor: torch.Tensor
     image_grid_thw: list | None = None
+    model_specific_data: dict[str, Any] | None = None
 
 
 class CacheMutation(NamedTuple):

--- a/components/src/dynamo/common/memory/multimodal_embedding_cache_manager.py
+++ b/components/src/dynamo/common/memory/multimodal_embedding_cache_manager.py
@@ -29,7 +29,9 @@ logger = logging.getLogger(__name__)
 class CachedEmbedding(NamedTuple):
     tensor: torch.Tensor
     image_grid_thw: list | None = None
-    model_specific_data: dict[str, Any] | None = None
+    video_grid_thw: list | None = None
+    second_per_grid_ts: Any | None = None
+    video_timestamps: Any | None = None
 
 
 class CacheMutation(NamedTuple):

--- a/components/src/dynamo/common/memory/multimodal_embedding_cache_manager.py
+++ b/components/src/dynamo/common/memory/multimodal_embedding_cache_manager.py
@@ -19,7 +19,7 @@ Usage:
 
 import logging
 from collections import OrderedDict
-from typing import Any, NamedTuple, Optional
+from typing import NamedTuple, Optional
 
 import torch
 
@@ -30,8 +30,8 @@ class CachedEmbedding(NamedTuple):
     tensor: torch.Tensor
     image_grid_thw: list | None = None
     video_grid_thw: list | None = None
-    second_per_grid_ts: Any | None = None
-    video_timestamps: Any | None = None
+    second_per_grid_ts: float | None = None
+    video_timestamps: list[float] | None = None
 
 
 class CacheMutation(NamedTuple):

--- a/components/src/dynamo/common/tests/memory/test_multimodal_embedding_cache_manager.py
+++ b/components/src/dynamo/common/tests/memory/test_multimodal_embedding_cache_manager.py
@@ -35,6 +35,7 @@ class TestMultimodalEmbeddingCacheManagerBasicOperations:
         assert retrieved is not None
         assert torch.equal(retrieved.tensor, tensor)
         assert retrieved.image_grid_thw is None
+        assert retrieved.model_specific_data is None
 
     def test_set_and_get_with_grid(self):
         cache = MultimodalEmbeddingCacheManager(capacity_bytes=1024 * 1024)
@@ -270,20 +271,29 @@ class TestCachedEmbeddingNamedTuple:
     def test_fields(self):
         tensor = torch.randn(4, 4)
         grid = [[1, 2, 3]]
-        entry = CachedEmbedding(tensor=tensor, image_grid_thw=grid)
+        metadata = {"image_grid_thw": grid}
+        entry = CachedEmbedding(
+            tensor=tensor, image_grid_thw=grid, model_specific_data=metadata
+        )
 
         assert torch.equal(entry.tensor, tensor)
         assert entry.image_grid_thw == grid
+        assert entry.model_specific_data == metadata
 
     def test_none_grid(self):
         tensor = torch.randn(4, 4)
         entry = CachedEmbedding(tensor=tensor, image_grid_thw=None)
         assert entry.image_grid_thw is None
+        assert entry.model_specific_data is None
 
     def test_unpacking(self):
         tensor = torch.randn(4, 4)
         grid = [[1, 2, 3]]
-        entry = CachedEmbedding(tensor=tensor, image_grid_thw=grid)
-        t, g = entry
+        metadata = {"image_grid_thw": grid}
+        entry = CachedEmbedding(
+            tensor=tensor, image_grid_thw=grid, model_specific_data=metadata
+        )
+        t, g, m = entry
         assert torch.equal(t, tensor)
         assert g == grid
+        assert m == metadata

--- a/components/src/dynamo/common/tests/memory/test_multimodal_embedding_cache_manager.py
+++ b/components/src/dynamo/common/tests/memory/test_multimodal_embedding_cache_manager.py
@@ -35,7 +35,9 @@ class TestMultimodalEmbeddingCacheManagerBasicOperations:
         assert retrieved is not None
         assert torch.equal(retrieved.tensor, tensor)
         assert retrieved.image_grid_thw is None
-        assert retrieved.model_specific_data is None
+        assert retrieved.video_grid_thw is None
+        assert retrieved.second_per_grid_ts is None
+        assert retrieved.video_timestamps is None
 
     def test_set_and_get_with_grid(self):
         cache = MultimodalEmbeddingCacheManager(capacity_bytes=1024 * 1024)
@@ -270,26 +272,36 @@ class TestCachedEmbeddingNamedTuple:
 
     def test_fields(self):
         tensor = torch.randn(4, 4)
-        grid = [[1, 2, 3]]
-        metadata = {"image_grid_thw": grid}
-        entry = CachedEmbedding(tensor=tensor, model_specific_data=metadata)
+        video_grid = [[1, 2, 3]]
+        timestamps = [[0.0, 0.5]]
+        entry = CachedEmbedding(
+            tensor=tensor,
+            video_grid_thw=video_grid,
+            second_per_grid_ts=0.5,
+            video_timestamps=timestamps,
+        )
 
         assert torch.equal(entry.tensor, tensor)
         assert entry.image_grid_thw is None
-        assert entry.model_specific_data == metadata
+        assert entry.video_grid_thw == video_grid
+        assert entry.second_per_grid_ts == 0.5
+        assert entry.video_timestamps == timestamps
 
     def test_none_grid(self):
         tensor = torch.randn(4, 4)
         entry = CachedEmbedding(tensor=tensor, image_grid_thw=None)
         assert entry.image_grid_thw is None
-        assert entry.model_specific_data is None
+        assert entry.video_grid_thw is None
+        assert entry.second_per_grid_ts is None
+        assert entry.video_timestamps is None
 
     def test_unpacking(self):
         tensor = torch.randn(4, 4)
         grid = [[1, 2, 3]]
-        metadata = {"image_grid_thw": grid}
-        entry = CachedEmbedding(tensor=tensor, model_specific_data=metadata)
-        t, g, m = entry
+        entry = CachedEmbedding(tensor=tensor, image_grid_thw=grid)
+        t, image_grid, video_grid, second_per_grid_ts, video_timestamps = entry
         assert torch.equal(t, tensor)
-        assert g is None
-        assert m == metadata
+        assert image_grid == grid
+        assert video_grid is None
+        assert second_per_grid_ts is None
+        assert video_timestamps is None

--- a/components/src/dynamo/common/tests/memory/test_multimodal_embedding_cache_manager.py
+++ b/components/src/dynamo/common/tests/memory/test_multimodal_embedding_cache_manager.py
@@ -272,12 +272,10 @@ class TestCachedEmbeddingNamedTuple:
         tensor = torch.randn(4, 4)
         grid = [[1, 2, 3]]
         metadata = {"image_grid_thw": grid}
-        entry = CachedEmbedding(
-            tensor=tensor, image_grid_thw=grid, model_specific_data=metadata
-        )
+        entry = CachedEmbedding(tensor=tensor, model_specific_data=metadata)
 
         assert torch.equal(entry.tensor, tensor)
-        assert entry.image_grid_thw == grid
+        assert entry.image_grid_thw is None
         assert entry.model_specific_data == metadata
 
     def test_none_grid(self):
@@ -290,10 +288,8 @@ class TestCachedEmbeddingNamedTuple:
         tensor = torch.randn(4, 4)
         grid = [[1, 2, 3]]
         metadata = {"image_grid_thw": grid}
-        entry = CachedEmbedding(
-            tensor=tensor, image_grid_thw=grid, model_specific_data=metadata
-        )
+        entry = CachedEmbedding(tensor=tensor, model_specific_data=metadata)
         t, g, m = entry
         assert torch.equal(t, tensor)
-        assert g == grid
+        assert g is None
         assert m == metadata

--- a/components/src/dynamo/sglang/protocol.py
+++ b/components/src/dynamo/sglang/protocol.py
@@ -121,11 +121,11 @@ class MultiModalInput(BaseModel):
 class MultiModalGroup(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     multimodal_input: Optional[MultiModalInput] = Field(default_factory=MultiModalInput)
-    modality: Optional[str] = None
     image_grid_thw: Optional[List[Any]] = None
     video_grid_thw: Optional[List[Any]] = None
+    second_per_grid_ts: Optional[Any] = None
+    video_timestamps: Optional[Any] = None
     num_mm_tokens: Optional[int] = None
-    model_specific_data: dict[str, Any] = Field(default_factory=dict)
 
 
 class SglangMultimodalRequest(BaseModel):

--- a/components/src/dynamo/sglang/protocol.py
+++ b/components/src/dynamo/sglang/protocol.py
@@ -121,9 +121,11 @@ class MultiModalInput(BaseModel):
 class MultiModalGroup(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     multimodal_input: Optional[MultiModalInput] = Field(default_factory=MultiModalInput)
+    modality: Optional[str] = None
     image_grid_thw: Optional[List[Any]] = None
     video_grid_thw: Optional[List[Any]] = None
     num_mm_tokens: Optional[int] = None
+    model_specific_data: dict[str, Any] = Field(default_factory=dict)
 
 
 class SglangMultimodalRequest(BaseModel):

--- a/components/src/dynamo/sglang/protocol.py
+++ b/components/src/dynamo/sglang/protocol.py
@@ -118,13 +118,17 @@ class MultiModalInput(BaseModel):
     video_url: Optional[str] = None
 
 
+# One MultiModalGroup carries timestamps for a single video.
+SingleVideoTimestamps = List[float]
+
+
 class MultiModalGroup(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     multimodal_input: Optional[MultiModalInput] = Field(default_factory=MultiModalInput)
     image_grid_thw: Optional[List[Any]] = None
     video_grid_thw: Optional[List[Any]] = None
     second_per_grid_ts: Optional[float] = None
-    video_timestamps: Optional[List[float]] = None
+    video_timestamps: Optional[SingleVideoTimestamps] = None
     num_mm_tokens: Optional[int] = None
 
 

--- a/components/src/dynamo/sglang/protocol.py
+++ b/components/src/dynamo/sglang/protocol.py
@@ -123,8 +123,8 @@ class MultiModalGroup(BaseModel):
     multimodal_input: Optional[MultiModalInput] = Field(default_factory=MultiModalInput)
     image_grid_thw: Optional[List[Any]] = None
     video_grid_thw: Optional[List[Any]] = None
-    second_per_grid_ts: Optional[Any] = None
-    video_timestamps: Optional[Any] = None
+    second_per_grid_ts: Optional[float] = None
+    video_timestamps: Optional[List[float]] = None
     num_mm_tokens: Optional[int] = None
 
 

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -66,6 +66,8 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
     and forwards to the PD worker.
     """
 
+    _missing_video_cache_key_config_warned = False
+
     def __init__(
         self,
         config: Config,
@@ -177,13 +179,26 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
             return cls._url_hash(url)
 
         video_config = {}
+        missing_config_fields: list[str] = []
         vision_config = getattr(encoder, "vision_config", None)
         if isinstance(vision_config, dict):
             video_config = cls._normalize_cache_key_value(
                 vision_config.get("video", {})
             )
+        else:
+            missing_config_fields.append("vision_config")
 
         video_processor = getattr(encoder, "video_processor", None)
+        if video_processor is None:
+            missing_config_fields.append("video_processor")
+        if missing_config_fields and not cls._missing_video_cache_key_config_warned:
+            logger.warning(
+                "Video embedding cache key could not include encoder %s; "
+                "cache reuse may not reflect all video processor settings.",
+                ", ".join(missing_config_fields),
+            )
+            cls._missing_video_cache_key_config_warned = True
+
         cache_key_payload = {
             "modality": getattr(modality, "name", str(modality)),
             "url": url,
@@ -226,6 +241,20 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
                 return candidate_id
 
         return None
+
+    @staticmethod
+    def _ensure_batched_grid(grid_dim: Any, item_count: int) -> list:
+        grid_list = (
+            grid_dim.tolist() if isinstance(grid_dim, torch.Tensor) else grid_dim
+        )
+        if (
+            item_count == 1
+            and isinstance(grid_list, list)
+            and len(grid_list) == 3
+            and not isinstance(grid_list[0], list)
+        ):
+            return [grid_list]
+        return grid_list
 
     @staticmethod
     def _grid_units(grid_item: Any, modality: str) -> int:
@@ -286,8 +315,15 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
             if value.ndim == 0:
                 return value.item()
             value = value.tolist()
-        if isinstance(value, (list, tuple)) and len(value) == item_count:
-            return cls._jsonable_media_value(value[index])
+        if isinstance(value, (list, tuple)):
+            if len(value) == item_count:
+                return cls._jsonable_media_value(value[index])
+            if item_count == 1:
+                return cls._jsonable_media_value(value)
+            raise ValueError(
+                "Auxiliary media metadata length mismatch: "
+                f"expected {item_count} items, got {len(value)}"
+            )
         return cls._jsonable_media_value(value)
 
     async def _encode_with_cache(
@@ -301,6 +337,7 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
         """
         assert self._embedding_cache is not None
 
+        modality_name = getattr(modality, "name", str(modality))
         cached: dict[int, CachedEmbedding] = {}
         uncached_indices: list[int] = []
         uncached_urls: list[str] = []
@@ -332,23 +369,13 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
                     f"expected CPU. Moving to CPU."
                 )
                 new_embeddings = new_embeddings.to(target_device)
-            grid_list: list = (
-                grid_dim.tolist() if isinstance(grid_dim, torch.Tensor) else grid_dim
-            )
-            if (
-                len(uncached_urls) == 1
-                and isinstance(grid_list, list)
-                and len(grid_list) == 3
-                and not isinstance(grid_list[0], list)
-            ):
-                grid_list = [grid_list]
+            grid_list = self._ensure_batched_grid(grid_dim, len(uncached_urls))
             if not (
                 isinstance(new_embeddings, torch.Tensor) and new_embeddings.ndim == 2
             ):
                 raise ValueError(
                     f"Unsupported embeddings type from encoder: {type(new_embeddings)}"
                 )
-            modality_name = getattr(modality, "name", str(modality))
             token_counts = self._split_token_counts(
                 grid_list, new_embeddings.shape[0], modality_name
             )
@@ -383,7 +410,6 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
                 new_entries[orig_idx] = entry
 
         # Reassemble results in original URL order
-        modality_name = getattr(modality, "name", str(modality))
         all_grid_thw: list = []
         all_entries: list[CachedEmbedding] = []
         embedding_parts: list[torch.Tensor] = []
@@ -563,19 +589,7 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
                             urls, modality_enum
                         )
 
-                grid_list = (
-                    grid_dim.tolist()
-                    if isinstance(grid_dim, torch.Tensor)
-                    else grid_dim
-                )
-                if len(urls) == 1:
-                    if modality_name in ("IMAGE", "VIDEO"):
-                        if (
-                            isinstance(grid_list, list)
-                            and len(grid_list) == 3
-                            and not isinstance(grid_list[0], list)
-                        ):
-                            grid_list = [grid_list]
+                grid_list = self._ensure_batched_grid(grid_dim, len(urls))
 
                 if not isinstance(grid_list, list) or len(grid_list) != len(urls):
                     raise ValueError(

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -274,33 +274,25 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
         return value
 
     @classmethod
-    def _build_group_model_specific_data(
+    def _aux_value_for_item(
         cls,
-        modality: Any,
-        grid_shape: list[Any],
-        aux_data: dict[str, Any] | None,
+        value: Any,
         index: int,
-    ) -> dict[str, Any]:
-        modality_name = getattr(modality, "name", str(modality))
-        model_specific_data: dict[str, Any] = {}
-        if modality_name == "IMAGE":
-            model_specific_data["image_grid_thw"] = grid_shape
-        elif modality_name == "VIDEO":
-            model_specific_data["video_grid_thw"] = grid_shape
-            for key, value in (aux_data or {}).items():
-                if value is None:
-                    continue
-                if isinstance(value, (list, tuple, torch.Tensor)):
-                    model_specific_data[key] = cls._jsonable_media_value(value[index])
-                else:
-                    model_specific_data[key] = cls._jsonable_media_value(value)
-        else:
-            raise ValueError(f"Unsupported multimodal modality: {modality}")
-        return model_specific_data
+        item_count: int,
+    ) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, torch.Tensor):
+            if value.ndim == 0:
+                return value.item()
+            value = value.tolist()
+        if isinstance(value, (list, tuple)) and len(value) == item_count:
+            return cls._jsonable_media_value(value[index])
+        return cls._jsonable_media_value(value)
 
     async def _encode_with_cache(
         self, media_urls: list[str], modality: Any
-    ) -> tuple[Any, torch.Tensor, list[dict[str, Any]]]:
+    ) -> tuple[Any, torch.Tensor, list[CachedEmbedding]]:
         """Cache-aware multimodal encoding.
 
         Checks the CPU LRU cache per media URL. Uncached URLs are batch-encoded,
@@ -343,6 +335,13 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
             grid_list: list = (
                 grid_dim.tolist() if isinstance(grid_dim, torch.Tensor) else grid_dim
             )
+            if (
+                len(uncached_urls) == 1
+                and isinstance(grid_list, list)
+                and len(grid_list) == 3
+                and not isinstance(grid_list[0], list)
+            ):
+                grid_list = [grid_list]
             if not (
                 isinstance(new_embeddings, torch.Tensor) and new_embeddings.ndim == 2
             ):
@@ -354,19 +353,29 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
                 grid_list, new_embeddings.shape[0], modality_name
             )
             split_tensors = torch.split(new_embeddings, token_counts, dim=0)
-            new_group_model_data = [
-                self._build_group_model_specific_data(
-                    modality, grid_shape, aux_data, idx
-                )
-                for idx, grid_shape in enumerate(grid_list)
-            ]
-            for orig_idx, _url, tensor, group_model_data in zip(
-                uncached_indices, uncached_urls, split_tensors, new_group_model_data
+            item_count = len(grid_list)
+            for local_idx, (orig_idx, _url, tensor, grid_thw) in enumerate(
+                zip(uncached_indices, uncached_urls, split_tensors, grid_list)
             ):
-                entry = CachedEmbedding(
-                    tensor=tensor.contiguous(),
-                    model_specific_data=group_model_data,
-                )
+                entry_kwargs: dict[str, Any] = {"tensor": tensor.contiguous()}
+                if modality_name == "IMAGE":
+                    entry_kwargs["image_grid_thw"] = grid_thw
+                elif modality_name == "VIDEO":
+                    entry_kwargs["video_grid_thw"] = grid_thw
+                    if aux_data:
+                        entry_kwargs["second_per_grid_ts"] = self._aux_value_for_item(
+                            aux_data.get("second_per_grid_ts"),
+                            local_idx,
+                            item_count,
+                        )
+                        entry_kwargs["video_timestamps"] = self._aux_value_for_item(
+                            aux_data.get("video_timestamps"),
+                            local_idx,
+                            item_count,
+                        )
+                else:
+                    raise ValueError(f"Unsupported multimodal modality: {modality}")
+                entry = CachedEmbedding(**entry_kwargs)
                 mutation = self._embedding_cache.set_with_delta(
                     cache_keys[orig_idx], entry
                 )
@@ -374,31 +383,27 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
                 new_entries[orig_idx] = entry
 
         # Reassemble results in original URL order
-        grid_key = (
-            "image_grid_thw"
-            if getattr(modality, "name", str(modality)) == "IMAGE"
-            else "video_grid_thw"
-        )
+        modality_name = getattr(modality, "name", str(modality))
         all_grid_thw: list = []
-        all_model_specific_data: list[dict[str, Any]] = []
+        all_entries: list[CachedEmbedding] = []
         embedding_parts: list[torch.Tensor] = []
         for i in range(len(media_urls)):
             entry = cached[i] if i in cached else new_entries[i]
-            group_model_data = dict(entry.model_specific_data or {})
-            if (
-                entry.image_grid_thw is not None
-                and "image_grid_thw" not in group_model_data
-            ):
-                group_model_data["image_grid_thw"] = entry.image_grid_thw
-            grid_thw = group_model_data.get(grid_key)
+            grid_thw = (
+                entry.image_grid_thw
+                if modality_name == "IMAGE"
+                else entry.video_grid_thw
+            )
             if grid_thw is None:
-                raise ValueError(f"{grid_key} is required for cached multimodal item")
+                raise ValueError(
+                    f"{modality_name.lower()}_grid_thw is required for cached item"
+                )
             all_grid_thw.append(grid_thw)
-            all_model_specific_data.append(group_model_data)
+            all_entries.append(entry)
             embedding_parts.append(entry.tensor)
 
         full_embeddings = torch.cat(embedding_parts, dim=0)
-        return torch.tensor(all_grid_thw), full_embeddings, all_model_specific_data
+        return torch.tensor(all_grid_thw), full_embeddings, all_entries
 
     def _extract_media_urls(
         self, request: Dict[str, Any]
@@ -545,13 +550,13 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
                     )
 
                 aux_data: dict[str, Any] | None = None
-                group_model_data_list: list[dict[str, Any]] | None = None
+                cached_entries: list[CachedEmbedding] | None = None
                 with _nvtx.annotate("mm:enc:vision_encode", color="red"):
                     if self._embedding_cache is not None:
                         (
                             grid_dim,
                             embeddings,
-                            group_model_data_list,
+                            cached_entries,
                         ) = await self._encode_with_cache(urls, modality_enum)
                     else:
                         grid_dim, embeddings, aux_data = await self.encoder._encode(
@@ -598,17 +603,27 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
                 for idx, (mm_group, grid_item, token_count) in enumerate(
                     zip(group_slice, grid_list, token_counts)
                 ):
-                    mm_group.modality = modality_name
                     setattr(mm_group, grid_attr, grid_item)
                     mm_group.num_mm_tokens = int(token_count)
-                    if group_model_data_list is not None:
-                        mm_group.model_specific_data = dict(group_model_data_list[idx])
-                    else:
-                        mm_group.model_specific_data = (
-                            self._build_group_model_specific_data(
-                                modality_enum, grid_item, aux_data, idx
+                    if modality_name == "VIDEO":
+                        if cached_entries is not None:
+                            mm_group.second_per_grid_ts = cached_entries[
+                                idx
+                            ].second_per_grid_ts
+                            mm_group.video_timestamps = cached_entries[
+                                idx
+                            ].video_timestamps
+                        elif aux_data:
+                            mm_group.second_per_grid_ts = self._aux_value_for_item(
+                                aux_data.get("second_per_grid_ts"),
+                                idx,
+                                len(urls),
                             )
-                        )
+                            mm_group.video_timestamps = self._aux_value_for_item(
+                                aux_data.get("video_timestamps"),
+                                idx,
+                                len(urls),
+                            )
                     if mm_group.multimodal_input is not None:
                         setattr(mm_group.multimodal_input, url_attr, None)
 

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -66,8 +66,6 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
     and forwards to the PD worker.
     """
 
-    _missing_video_cache_key_config_warned = False
-
     def __init__(
         self,
         config: Config,
@@ -79,6 +77,7 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
         self.pd_worker_client = pd_worker_client
         self._cache_publisher = cache_publisher
         self.model = config.server_args.model_path
+        self._missing_video_cache_key_config_warned = False
 
         if MMEncoder is None:
             raise RuntimeError(
@@ -162,7 +161,7 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
         if isinstance(value, dict):
             return {
                 str(key): cls._normalize_cache_key_value(nested_value)
-                for key, nested_value in sorted(value.items())
+                for key, nested_value in value.items()
             }
         if isinstance(value, (list, tuple)):
             return [cls._normalize_cache_key_value(item) for item in value]
@@ -172,45 +171,36 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
             return value
         return str(value)
 
-    @classmethod
-    def _media_cache_key(cls, url: str, modality: Any, encoder: Any) -> str:
+    def _media_cache_key(self, url: str, modality: Any, encoder: Any) -> str:
         """Build a cache key that is URL-stable for images and config-aware for video."""
         if modality != Modality.VIDEO:
-            return cls._url_hash(url)
+            return self._url_hash(url)
 
         video_config = {}
         missing_config_fields: list[str] = []
         vision_config = getattr(encoder, "vision_config", None)
         if isinstance(vision_config, dict):
-            video_config = cls._normalize_cache_key_value(
+            video_config = self._normalize_cache_key_value(
                 vision_config.get("video", {})
             )
         else:
             missing_config_fields.append("vision_config")
 
-        video_processor = getattr(encoder, "video_processor", None)
-        if video_processor is None:
-            missing_config_fields.append("video_processor")
-        if missing_config_fields and not cls._missing_video_cache_key_config_warned:
+        if missing_config_fields and not getattr(
+            self, "_missing_video_cache_key_config_warned", False
+        ):
             logger.warning(
                 "Video embedding cache key could not include encoder %s; "
                 "cache reuse may not reflect all video processor settings.",
                 ", ".join(missing_config_fields),
             )
-            cls._missing_video_cache_key_config_warned = True
+            self._missing_video_cache_key_config_warned = True
 
         cache_key_payload = {
-            "modality": getattr(modality, "name", str(modality)),
             "url": url,
-            "model_type": cls._normalize_cache_key_value(
-                getattr(encoder, "model_type", None)
-            ),
-            "temporal_patch_size": cls._normalize_cache_key_value(
-                getattr(video_processor, "temporal_patch_size", None)
-            ),
             "video_config": video_config,
         }
-        return cls._url_hash(
+        return self._url_hash(
             json.dumps(cache_key_payload, sort_keys=True, separators=(",", ":"))
         )
 
@@ -253,6 +243,8 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
             and len(grid_list) == 3
             and not isinstance(grid_list[0], list)
         ):
+            # SGLang may squeeze the batch dimension for a single media item.
+            # Normalize that flat THW grid to the batched shape used below.
             return [grid_list]
         return grid_list
 
@@ -349,7 +341,7 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
         for i, (url, cache_key) in enumerate(zip(media_urls, cache_keys)):
             hit = self._embedding_cache.get(cache_key)
             if hit is not None:
-                logger.debug("Embedding cache hit for URL index %d", i)
+                logger.info("Embedding cache hit for %s URL index %d", modality_name, i)
                 cached[i] = hit
             else:
                 uncached_indices.append(i)
@@ -599,8 +591,7 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
 
                 if not isinstance(embeddings, torch.Tensor) or embeddings.ndim != 2:
                     raise ValueError(
-                        "Unsupported embeddings type from encoder: "
-                        f"{type(embeddings)}"
+                        f"Unsupported embeddings type from encoder: {type(embeddings)}"
                     )
 
                 token_counts = self._split_token_counts(

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -299,7 +299,7 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
         return model_specific_data
 
     async def _encode_with_cache(
-        self, media_urls: list[str], modality: Any = Modality.IMAGE
+        self, media_urls: list[str], modality: Any
     ) -> tuple[Any, torch.Tensor, list[dict[str, Any]]]:
         """Cache-aware multimodal encoding.
 

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -151,8 +151,53 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
 
     @staticmethod
     def _url_hash(url: str) -> str:
-        """Stable blake3 hash of an image URL, used as embedding cache key."""
+        """Stable blake3 hash of a media URL, used as embedding cache key."""
         return blake3(url.encode()).hexdigest()
+
+    @classmethod
+    def _normalize_cache_key_value(cls, value: Any) -> Any:
+        """Convert nested config values into a stable JSON-serializable form."""
+        if isinstance(value, dict):
+            return {
+                str(key): cls._normalize_cache_key_value(nested_value)
+                for key, nested_value in sorted(value.items())
+            }
+        if isinstance(value, (list, tuple)):
+            return [cls._normalize_cache_key_value(item) for item in value]
+        if isinstance(value, torch.Tensor):
+            return value.item() if value.ndim == 0 else value.tolist()
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            return value
+        return str(value)
+
+    @classmethod
+    def _media_cache_key(cls, url: str, modality: Any, encoder: Any) -> str:
+        """Build a cache key that is URL-stable for images and config-aware for video."""
+        if modality != Modality.VIDEO:
+            return cls._url_hash(url)
+
+        video_config = {}
+        vision_config = getattr(encoder, "vision_config", None)
+        if isinstance(vision_config, dict):
+            video_config = cls._normalize_cache_key_value(
+                vision_config.get("video", {})
+            )
+
+        video_processor = getattr(encoder, "video_processor", None)
+        cache_key_payload = {
+            "modality": getattr(modality, "name", str(modality)),
+            "url": url,
+            "model_type": cls._normalize_cache_key_value(
+                getattr(encoder, "model_type", None)
+            ),
+            "temporal_patch_size": cls._normalize_cache_key_value(
+                getattr(video_processor, "temporal_patch_size", None)
+            ),
+            "video_config": video_config,
+        }
+        return cls._url_hash(
+            json.dumps(cache_key_payload, sort_keys=True, separators=(",", ":"))
+        )
 
     def _resolve_mm_token_id(
         self, token_str: Optional[str], preferred_token: Optional[str] = None
@@ -222,17 +267,45 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
             )
         return token_counts
 
+    @staticmethod
+    def _jsonable_media_value(value: Any) -> Any:
+        if isinstance(value, torch.Tensor):
+            return value.item() if value.ndim == 0 else value.tolist()
+        return value
+
+    @classmethod
+    def _build_group_model_specific_data(
+        cls,
+        modality: Any,
+        grid_shape: list[Any],
+        aux_data: dict[str, Any] | None,
+        index: int,
+    ) -> dict[str, Any]:
+        modality_name = getattr(modality, "name", str(modality))
+        model_specific_data: dict[str, Any] = {}
+        if modality_name == "IMAGE":
+            model_specific_data["image_grid_thw"] = grid_shape
+        elif modality_name == "VIDEO":
+            model_specific_data["video_grid_thw"] = grid_shape
+            for key, value in (aux_data or {}).items():
+                if value is None:
+                    continue
+                if isinstance(value, (list, tuple, torch.Tensor)):
+                    model_specific_data[key] = cls._jsonable_media_value(value[index])
+                else:
+                    model_specific_data[key] = cls._jsonable_media_value(value)
+        else:
+            raise ValueError(f"Unsupported multimodal modality: {modality}")
+        return model_specific_data
+
     async def _encode_with_cache(
-        self, image_urls: list[str]
-    ) -> tuple[Any, torch.Tensor]:
-        """Cache-aware vision encoding.
+        self, media_urls: list[str], modality: Any = Modality.IMAGE
+    ) -> tuple[Any, torch.Tensor, list[dict[str, Any]]]:
+        """Cache-aware multimodal encoding.
 
-        Checks the CPU LRU cache per URL. Uncached URLs are batch-encoded,
-        split per image, stored in cache, then reassembled with the cached
-        hits in the original URL order.
-
-        Returns the same (image_grid_dim, embeddings) shape as
-        ``self.encoder._encode()``.
+        Checks the CPU LRU cache per media URL. Uncached URLs are batch-encoded,
+        split per item, stored in cache, then reassembled with the cached hits in
+        the original URL order.
         """
         assert self._embedding_cache is not None
 
@@ -240,8 +313,12 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
         uncached_indices: list[int] = []
         uncached_urls: list[str] = []
 
-        for i, url in enumerate(image_urls):
-            hit = self._embedding_cache.get(self._url_hash(url))
+        cache_keys = [
+            self._media_cache_key(url, modality, self.encoder) for url in media_urls
+        ]
+
+        for i, (url, cache_key) in enumerate(zip(media_urls, cache_keys)):
+            hit = self._embedding_cache.get(cache_key)
             if hit is not None:
                 logger.debug("Embedding cache hit for URL index %d", i)
                 cached[i] = hit
@@ -253,8 +330,8 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
         # SGLang's _encode outputs are already on CPU; use CPU as target for consistency
         target_device = torch.device("cpu")
         if uncached_urls:
-            grid_dim, new_embeddings, _aux = await self.encoder._encode(
-                uncached_urls, Modality.IMAGE
+            grid_dim, new_embeddings, aux_data = await self.encoder._encode(
+                uncached_urls, modality
             )
             # Verify SGLang output is on CPU as expected
             if new_embeddings.device != target_device:
@@ -272,33 +349,56 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
                 raise ValueError(
                     f"Unsupported embeddings type from encoder: {type(new_embeddings)}"
                 )
+            modality_name = getattr(modality, "name", str(modality))
             token_counts = self._split_token_counts(
-                grid_list, new_embeddings.shape[0], "IMAGE"
+                grid_list, new_embeddings.shape[0], modality_name
             )
             split_tensors = torch.split(new_embeddings, token_counts, dim=0)
-            for orig_idx, url, tensor, grid_thw in zip(
-                uncached_indices, uncached_urls, split_tensors, grid_list
+            new_group_model_data = [
+                self._build_group_model_specific_data(
+                    modality, grid_shape, aux_data, idx
+                )
+                for idx, grid_shape in enumerate(grid_list)
+            ]
+            for orig_idx, _url, tensor, group_model_data in zip(
+                uncached_indices, uncached_urls, split_tensors, new_group_model_data
             ):
                 entry = CachedEmbedding(
                     tensor=tensor.contiguous(),
-                    image_grid_thw=grid_thw,
+                    model_specific_data=group_model_data,
                 )
                 mutation = self._embedding_cache.set_with_delta(
-                    self._url_hash(url), entry
+                    cache_keys[orig_idx], entry
                 )
                 self._publish_cache_delta(mutation.added_keys, mutation.removed_keys)
                 new_entries[orig_idx] = entry
 
         # Reassemble results in original URL order
+        grid_key = (
+            "image_grid_thw"
+            if getattr(modality, "name", str(modality)) == "IMAGE"
+            else "video_grid_thw"
+        )
         all_grid_thw: list = []
+        all_model_specific_data: list[dict[str, Any]] = []
         embedding_parts: list[torch.Tensor] = []
-        for i in range(len(image_urls)):
+        for i in range(len(media_urls)):
             entry = cached[i] if i in cached else new_entries[i]
-            all_grid_thw.append(entry.image_grid_thw)
+            group_model_data = dict(entry.model_specific_data or {})
+            if (
+                entry.image_grid_thw is not None
+                and "image_grid_thw" not in group_model_data
+            ):
+                group_model_data["image_grid_thw"] = entry.image_grid_thw
+            grid_thw = group_model_data.get(grid_key)
+            if grid_thw is None:
+                raise ValueError(f"{grid_key} is required for cached multimodal item")
+            all_grid_thw.append(grid_thw)
+            all_model_specific_data.append(group_model_data)
             embedding_parts.append(entry.tensor)
 
         full_embeddings = torch.cat(embedding_parts, dim=0)
-        return torch.tensor(all_grid_thw), full_embeddings
+        return torch.tensor(all_grid_thw), full_embeddings, all_model_specific_data
 
     def _extract_media_urls(
         self, request: Dict[str, Any]
@@ -444,11 +544,17 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
                         f"{modality_name.lower()} token is not defined in chat template"
                     )
 
+                aux_data: dict[str, Any] | None = None
+                group_model_data_list: list[dict[str, Any]] | None = None
                 with _nvtx.annotate("mm:enc:vision_encode", color="red"):
-                    if modality_name == "IMAGE" and self._embedding_cache is not None:
-                        grid_dim, embeddings = await self._encode_with_cache(urls)
+                    if self._embedding_cache is not None:
+                        (
+                            grid_dim,
+                            embeddings,
+                            group_model_data_list,
+                        ) = await self._encode_with_cache(urls, modality_enum)
                     else:
-                        grid_dim, embeddings, _aux = await self.encoder._encode(
+                        grid_dim, embeddings, aux_data = await self.encoder._encode(
                             urls, modality_enum
                         )
 
@@ -489,11 +595,20 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
                     )
 
                 group_slice = multimodal_groups[group_offset : group_offset + len(urls)]
-                for mm_group, grid_item, token_count in zip(
-                    group_slice, grid_list, token_counts
+                for idx, (mm_group, grid_item, token_count) in enumerate(
+                    zip(group_slice, grid_list, token_counts)
                 ):
+                    mm_group.modality = modality_name
                     setattr(mm_group, grid_attr, grid_item)
                     mm_group.num_mm_tokens = int(token_count)
+                    if group_model_data_list is not None:
+                        mm_group.model_specific_data = dict(group_model_data_list[idx])
+                    else:
+                        mm_group.model_specific_data = (
+                            self._build_group_model_specific_data(
+                                modality_enum, grid_item, aux_data, idx
+                            )
+                        )
                     if mm_group.multimodal_input is not None:
                         setattr(mm_group.multimodal_input, url_attr, None)
 

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -118,9 +118,10 @@ class EmbeddingsProcessor:
     @staticmethod
     def create_multimodal_item(
         embeddings: torch.Tensor,
-        grid_values=None,
+        grid_values,
         modality: str = "IMAGE",
-        model_specific_data: dict[str, Any] | None = None,
+        second_per_grid_ts: Any | None = None,
+        video_timestamps: Any | None = None,
     ) -> dict:
         """Create processor_output mm_item for SGLang async_generate."""
         precomputed = embeddings.to(MultimodalConfig.EMBEDDINGS_DTYPE)
@@ -131,20 +132,16 @@ class EmbeddingsProcessor:
                 f"Unsupported modality for precomputed mm_item: {modality}"
             )
         grid_key = GRID_KEYS[modality]
-        mm_item: dict[str, Any] = {}
-        model_specific_data = dict(model_specific_data or {})
-        if grid_key not in model_specific_data:
-            if grid_values is None:
-                raise ValueError(f"{grid_key} is required")
-            model_specific_data[grid_key] = grid_values
+        grid_payload = torch.tensor(grid_values)
 
-        for key, value in model_specific_data.items():
-            if key in GRID_KEYS.values():
-                mm_item[key] = torch.tensor(value)
-            elif key == "second_per_grid_ts":
-                mm_item[key] = torch.tensor(value, dtype=torch.float32)
-            else:
-                mm_item[key] = value
+        mm_item: dict[str, Any] = {grid_key: grid_payload}
+        if modality == "VIDEO":
+            if second_per_grid_ts is not None:
+                mm_item["second_per_grid_ts"] = torch.tensor(
+                    second_per_grid_ts, dtype=torch.float32
+                )
+            if video_timestamps is not None:
+                mm_item["video_timestamps"] = video_timestamps
 
         mm_item.update(
             {
@@ -275,45 +272,28 @@ async def _build_mm_items(
     image_mm_items: list[dict] = []
     video_data_items: list[dict] = []
 
-    encoded_groups: list[tuple[str, Any, int, dict[str, Any]]] = []
+    encoded_groups: list[tuple[str, Any, int, Any, Any]] = []
 
     for group in request.multimodal_inputs:
         if group.num_mm_tokens is not None and group.num_mm_tokens > 0:
-            group_model_data = dict(group.model_specific_data)
-            if (
-                group.image_grid_thw is not None
-                and "image_grid_thw" not in group_model_data
-            ):
-                group_model_data["image_grid_thw"] = group.image_grid_thw
-            if (
-                group.video_grid_thw is not None
-                and "video_grid_thw" not in group_model_data
-            ):
-                group_model_data["video_grid_thw"] = group.video_grid_thw
-
-            group_modality = group.modality
-            if group_modality is None:
-                if "image_grid_thw" in group_model_data:
-                    group_modality = "IMAGE"
-                elif "video_grid_thw" in group_model_data:
-                    group_modality = "VIDEO"
-
-            if group_modality == "IMAGE":
+            if group.image_grid_thw is not None:
                 encoded_groups.append(
                     (
                         "IMAGE",
-                        group_model_data["image_grid_thw"],
+                        group.image_grid_thw,
                         group.num_mm_tokens,
-                        group_model_data,
+                        None,
+                        None,
                     )
                 )
-            elif group_modality == "VIDEO":
+            elif group.video_grid_thw is not None:
                 encoded_groups.append(
                     (
                         "VIDEO",
-                        group_model_data["video_grid_thw"],
+                        group.video_grid_thw,
                         group.num_mm_tokens,
-                        group_model_data,
+                        group.second_per_grid_ts,
+                        group.video_timestamps,
                     )
                 )
             else:
@@ -327,17 +307,27 @@ async def _build_mm_items(
 
         grouped_grids: dict[str, list[Any]] = {"IMAGE": [], "VIDEO": []}
         grouped_embeds: dict[str, list[torch.Tensor]] = {"IMAGE": [], "VIDEO": []}
-        grouped_model_data: dict[str, dict[str, list[Any]]] = {"IMAGE": {}, "VIDEO": {}}
+        video_second_per_grid_ts: list[Any] = []
+        video_timestamps: list[Any] = []
 
         offset = 0
-        for modality, grid_item, token_count, group_model_data in encoded_groups:
+        for (
+            modality,
+            grid_item,
+            token_count,
+            second_per_grid_ts,
+            timestamps,
+        ) in encoded_groups:
             next_offset = offset + int(token_count)
             if next_offset > embeddings.shape[0]:
                 raise ValueError("Encoded token counts exceed received embedding rows")
             grouped_grids[modality].append(grid_item)
             grouped_embeds[modality].append(embeddings[offset:next_offset])
-            for key, value in group_model_data.items():
-                grouped_model_data[modality].setdefault(key, []).append(value)
+            if modality == "VIDEO":
+                if second_per_grid_ts is not None:
+                    video_second_per_grid_ts.append(second_per_grid_ts)
+                if timestamps is not None:
+                    video_timestamps.append(timestamps)
             offset = next_offset
 
         if offset != embeddings.shape[0]:
@@ -349,16 +339,28 @@ async def _build_mm_items(
                     torch.cat(grouped_embeds["IMAGE"], dim=0),
                     grouped_grids["IMAGE"],
                     modality="IMAGE",
-                    model_specific_data=grouped_model_data["IMAGE"],
                 )
             )
         if grouped_embeds["VIDEO"]:
+            video_group_count = len(grouped_grids["VIDEO"])
+            if (
+                video_second_per_grid_ts
+                and len(video_second_per_grid_ts) != video_group_count
+            ):
+                raise ValueError(
+                    "second_per_grid_ts must be present for every video group"
+                )
+            if video_timestamps and len(video_timestamps) != video_group_count:
+                raise ValueError(
+                    "video_timestamps must be present for every video group"
+                )
             video_data_items.append(
                 embeddings_processor.create_multimodal_item(
                     torch.cat(grouped_embeds["VIDEO"], dim=0),
                     grouped_grids["VIDEO"],
                     modality="VIDEO",
-                    model_specific_data=grouped_model_data["VIDEO"],
+                    second_per_grid_ts=video_second_per_grid_ts or None,
+                    video_timestamps=video_timestamps or None,
                 )
             )
 

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -117,7 +117,10 @@ class EmbeddingsProcessor:
 
     @staticmethod
     def create_multimodal_item(
-        embeddings: torch.Tensor, grid_values, modality: str = "IMAGE"
+        embeddings: torch.Tensor,
+        grid_values=None,
+        modality: str = "IMAGE",
+        model_specific_data: dict[str, Any] | None = None,
     ) -> dict:
         """Create processor_output mm_item for SGLang async_generate."""
         precomputed = embeddings.to(MultimodalConfig.EMBEDDINGS_DTYPE)
@@ -128,9 +131,21 @@ class EmbeddingsProcessor:
                 f"Unsupported modality for precomputed mm_item: {modality}"
             )
         grid_key = GRID_KEYS[modality]
-        grid_payload = torch.tensor(grid_values)
+        mm_item: dict[str, Any] = {}
+        model_specific_data = dict(model_specific_data or {})
+        if grid_key not in model_specific_data:
+            if grid_values is None:
+                raise ValueError(f"{grid_key} is required")
+            model_specific_data[grid_key] = grid_values
 
-        mm_item: dict[str, Any] = {grid_key: grid_payload}
+        for key, value in model_specific_data.items():
+            if key in GRID_KEYS.values():
+                mm_item[key] = torch.tensor(value)
+            elif key == "second_per_grid_ts":
+                mm_item[key] = torch.tensor(value, dtype=torch.float32)
+            else:
+                mm_item[key] = value
+
         mm_item.update(
             {
                 "format": "processor_output",
@@ -260,17 +275,46 @@ async def _build_mm_items(
     image_mm_items: list[dict] = []
     video_data_items: list[dict] = []
 
-    encoded_groups: list[tuple[str, Any, int]] = []
+    encoded_groups: list[tuple[str, Any, int, dict[str, Any]]] = []
 
     for group in request.multimodal_inputs:
         if group.num_mm_tokens is not None and group.num_mm_tokens > 0:
-            if group.image_grid_thw is not None:
+            group_model_data = dict(group.model_specific_data)
+            if (
+                group.image_grid_thw is not None
+                and "image_grid_thw" not in group_model_data
+            ):
+                group_model_data["image_grid_thw"] = group.image_grid_thw
+            if (
+                group.video_grid_thw is not None
+                and "video_grid_thw" not in group_model_data
+            ):
+                group_model_data["video_grid_thw"] = group.video_grid_thw
+
+            group_modality = group.modality
+            if group_modality is None:
+                if "image_grid_thw" in group_model_data:
+                    group_modality = "IMAGE"
+                elif "video_grid_thw" in group_model_data:
+                    group_modality = "VIDEO"
+
+            if group_modality == "IMAGE":
                 encoded_groups.append(
-                    ("IMAGE", group.image_grid_thw, group.num_mm_tokens)
+                    (
+                        "IMAGE",
+                        group_model_data["image_grid_thw"],
+                        group.num_mm_tokens,
+                        group_model_data,
+                    )
                 )
-            elif group.video_grid_thw is not None:
+            elif group_modality == "VIDEO":
                 encoded_groups.append(
-                    ("VIDEO", group.video_grid_thw, group.num_mm_tokens)
+                    (
+                        "VIDEO",
+                        group_model_data["video_grid_thw"],
+                        group.num_mm_tokens,
+                        group_model_data,
+                    )
                 )
             else:
                 raise ValueError("Encoded multimodal group missing grid metadata")
@@ -283,14 +327,17 @@ async def _build_mm_items(
 
         grouped_grids: dict[str, list[Any]] = {"IMAGE": [], "VIDEO": []}
         grouped_embeds: dict[str, list[torch.Tensor]] = {"IMAGE": [], "VIDEO": []}
+        grouped_model_data: dict[str, dict[str, list[Any]]] = {"IMAGE": {}, "VIDEO": {}}
 
         offset = 0
-        for modality, grid_item, token_count in encoded_groups:
+        for modality, grid_item, token_count, group_model_data in encoded_groups:
             next_offset = offset + int(token_count)
             if next_offset > embeddings.shape[0]:
                 raise ValueError("Encoded token counts exceed received embedding rows")
             grouped_grids[modality].append(grid_item)
             grouped_embeds[modality].append(embeddings[offset:next_offset])
+            for key, value in group_model_data.items():
+                grouped_model_data[modality].setdefault(key, []).append(value)
             offset = next_offset
 
         if offset != embeddings.shape[0]:
@@ -302,6 +349,7 @@ async def _build_mm_items(
                     torch.cat(grouped_embeds["IMAGE"], dim=0),
                     grouped_grids["IMAGE"],
                     modality="IMAGE",
+                    model_specific_data=grouped_model_data["IMAGE"],
                 )
             )
         if grouped_embeds["VIDEO"]:
@@ -310,6 +358,7 @@ async def _build_mm_items(
                     torch.cat(grouped_embeds["VIDEO"], dim=0),
                     grouped_grids["VIDEO"],
                     modality="VIDEO",
+                    model_specific_data=grouped_model_data["VIDEO"],
                 )
             )
 

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -4,7 +4,7 @@
 import asyncio
 import json
 import logging
-from typing import Any, AsyncIterator, Callable, Optional
+from typing import Any, AsyncIterator, Callable, Literal, Optional, Protocol
 
 import sglang as sgl
 import torch
@@ -42,6 +42,29 @@ class MultimodalConfig:
 
     EMBEDDINGS_DTYPE = torch.float16
     EMBEDDINGS_DEVICE = "cpu"
+
+
+class EmbeddingsProcessorLike(Protocol):
+    async def process_embeddings(
+        self, request: SglangMultimodalRequest
+    ) -> tuple[torch.Tensor, int]:
+        ...
+
+    def create_multimodal_image_item(
+        self,
+        embeddings: torch.Tensor,
+        image_grid_thw: list[Any],
+    ) -> dict[str, Any]:
+        ...
+
+    def create_multimodal_video_item(
+        self,
+        embeddings: torch.Tensor,
+        video_grid_thw: list[Any],
+        second_per_grid_ts: list[float] | None = None,
+        video_timestamps: list[list[float]] | None = None,
+    ) -> dict[str, Any]:
+        ...
 
 
 class SglangUtils:
@@ -116,42 +139,59 @@ class EmbeddingsProcessor:
         self.embedding_receiver.release_tensor(tensor_id)
 
     @staticmethod
-    def create_multimodal_item(
+    def _create_processor_output_item(
         embeddings: torch.Tensor,
+        grid_key: Literal["image_grid_thw", "video_grid_thw"],
         grid_values: list[Any],
-        modality: str = "IMAGE",
-        second_per_grid_ts: list[float] | None = None,
-        video_timestamps: list[list[float]] | None = None,
-    ) -> dict:
-        """Create processor_output mm_item for SGLang async_generate."""
+        modality: Literal["IMAGE", "VIDEO"],
+    ) -> dict[str, Any]:
+        """Create shared processor_output fields for SGLang async_generate."""
         precomputed = embeddings.to(MultimodalConfig.EMBEDDINGS_DTYPE)
-
-        GRID_KEYS = {"IMAGE": "image_grid_thw", "VIDEO": "video_grid_thw"}
-        if modality not in GRID_KEYS:
-            raise ValueError(
-                f"Unsupported modality for precomputed mm_item: {modality}"
-            )
-        grid_key = GRID_KEYS[modality]
         grid_payload = torch.tensor(grid_values)
 
-        mm_item: dict[str, Any] = {grid_key: grid_payload}
-        if modality == "VIDEO":
-            if second_per_grid_ts is not None:
-                mm_item["second_per_grid_ts"] = torch.tensor(
-                    second_per_grid_ts, dtype=torch.float32
-                )
-            if video_timestamps is not None:
-                # Keep per-video timestamp lists nested; Qwen VL indexes by video.
-                mm_item["video_timestamps"] = video_timestamps
+        mm_item: dict[str, Any] = {
+            grid_key: grid_payload,
+            "format": "processor_output",
+            "precomputed_embeddings": precomputed,
+            "modality": modality,
+        }
 
-        mm_item.update(
-            {
-                "format": "processor_output",
-                "precomputed_embeddings": precomputed,
-                "modality": modality,
-            }
+        return mm_item
+
+    @staticmethod
+    def create_multimodal_image_item(
+        embeddings: torch.Tensor,
+        image_grid_thw: list[Any],
+    ) -> dict[str, Any]:
+        """Create an image processor_output mm_item for SGLang async_generate."""
+        return EmbeddingsProcessor._create_processor_output_item(
+            embeddings,
+            "image_grid_thw",
+            image_grid_thw,
+            "IMAGE",
         )
 
+    @staticmethod
+    def create_multimodal_video_item(
+        embeddings: torch.Tensor,
+        video_grid_thw: list[Any],
+        second_per_grid_ts: list[float] | None = None,
+        video_timestamps: list[list[float]] | None = None,
+    ) -> dict[str, Any]:
+        """Create a video processor_output mm_item for SGLang async_generate."""
+        mm_item = EmbeddingsProcessor._create_processor_output_item(
+            embeddings,
+            "video_grid_thw",
+            video_grid_thw,
+            "VIDEO",
+        )
+        if second_per_grid_ts is not None:
+            mm_item["second_per_grid_ts"] = torch.tensor(
+                second_per_grid_ts, dtype=torch.float32
+            )
+        if video_timestamps is not None:
+            # Keep per-video timestamp lists nested; Qwen VL indexes by video.
+            mm_item["video_timestamps"] = video_timestamps
         return mm_item
 
 
@@ -263,7 +303,7 @@ class ErrorResponseBuilder:
 
 
 async def _build_mm_items(
-    request: SglangMultimodalRequest, embeddings_processor: EmbeddingsProcessor
+    request: SglangMultimodalRequest, embeddings_processor: EmbeddingsProcessorLike
 ) -> tuple[list[dict], list[dict], Optional[torch.Tensor], Optional[int]]:
     """Process embeddings and build multimodal items for SGLang.
 
@@ -337,10 +377,9 @@ async def _build_mm_items(
 
         if grouped_embeds["IMAGE"]:
             image_mm_items.append(
-                embeddings_processor.create_multimodal_item(
+                embeddings_processor.create_multimodal_image_item(
                     torch.cat(grouped_embeds["IMAGE"], dim=0),
                     grouped_grids["IMAGE"],
-                    modality="IMAGE",
                 )
             )
         if grouped_embeds["VIDEO"]:
@@ -357,10 +396,9 @@ async def _build_mm_items(
                     "video_timestamps must be present for every video group"
                 )
             video_data_items.append(
-                embeddings_processor.create_multimodal_item(
+                embeddings_processor.create_multimodal_video_item(
                     torch.cat(grouped_embeds["VIDEO"], dim=0),
                     grouped_grids["VIDEO"],
-                    modality="VIDEO",
                     second_per_grid_ts=video_second_per_grid_ts or None,
                     video_timestamps=video_timestamps or None,
                 )

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -88,7 +88,7 @@ class EmbeddingsProcessor:
         self, request: SglangMultimodalRequest
     ) -> tuple[torch.Tensor, int]:
         """Process one concatenated embedding tensor from serialized request."""
-        logger.debug("Processing embeddings with shape: " f"{request.embeddings_shape}")
+        logger.debug(f"Processing embeddings with shape: {request.embeddings_shape}")
 
         multimodal_groups = request.multimodal_inputs
         if not multimodal_groups:
@@ -118,10 +118,10 @@ class EmbeddingsProcessor:
     @staticmethod
     def create_multimodal_item(
         embeddings: torch.Tensor,
-        grid_values,
+        grid_values: list[Any],
         modality: str = "IMAGE",
-        second_per_grid_ts: Any | None = None,
-        video_timestamps: Any | None = None,
+        second_per_grid_ts: list[float] | None = None,
+        video_timestamps: list[list[float]] | None = None,
     ) -> dict:
         """Create processor_output mm_item for SGLang async_generate."""
         precomputed = embeddings.to(MultimodalConfig.EMBEDDINGS_DTYPE)
@@ -141,6 +141,7 @@ class EmbeddingsProcessor:
                     second_per_grid_ts, dtype=torch.float32
                 )
             if video_timestamps is not None:
+                # Keep per-video timestamp lists nested; Qwen VL indexes by video.
                 mm_item["video_timestamps"] = video_timestamps
 
         mm_item.update(
@@ -272,7 +273,7 @@ async def _build_mm_items(
     image_mm_items: list[dict] = []
     video_data_items: list[dict] = []
 
-    encoded_groups: list[tuple[str, Any, int, Any, Any]] = []
+    encoded_groups: list[tuple[str, Any, int, float | None, list[float] | None]] = []
 
     for group in request.multimodal_inputs:
         if group.num_mm_tokens is not None and group.num_mm_tokens > 0:
@@ -307,8 +308,9 @@ async def _build_mm_items(
 
         grouped_grids: dict[str, list[Any]] = {"IMAGE": [], "VIDEO": []}
         grouped_embeds: dict[str, list[torch.Tensor]] = {"IMAGE": [], "VIDEO": []}
-        video_second_per_grid_ts: list[Any] = []
-        video_timestamps: list[Any] = []
+        video_second_per_grid_ts: list[float] = []
+        # SGLang expects one timestamp list per video in the grouped item.
+        video_timestamps: list[list[float]] = []
 
         offset = 0
         for (
@@ -580,7 +582,7 @@ class MultimodalWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, str]):
                     "Shape mismatch error - this likely indicates a tokenization/embedding alignment issue"
                 )
                 logger.error(f"Request token IDs length: {len(input_ids)}")
-                logger.error("Embeddings shape: " f"{request.embeddings_shape}")
+                logger.error(f"Embeddings shape: {request.embeddings_shape}")
                 logger.error(f"Token sequence preview: {input_ids[:20]}...")
                 error_msg = (
                     f"Multimodal embedding alignment error: {str(e)}. "

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 import torch
+from sglang.srt.managers.schedule_batch import Modality
 
 import dynamo.sglang.request_handlers.multimodal.encode_worker_handler as encode_worker_module
 from dynamo.common.memory.multimodal_embedding_cache_manager import (

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
@@ -81,7 +81,7 @@ async def test_encode_with_cache_partial_hit_and_reuse(
         None,
     )
 
-    grid, full_embeddings, group_model_data = await cache_handler._encode_with_cache(
+    grid, full_embeddings, entries = await cache_handler._encode_with_cache(
         urls, Modality.IMAGE
     )
 
@@ -90,10 +90,10 @@ async def test_encode_with_cache_partial_hit_and_reuse(
     )
 
     assert grid.tolist() == [[1, 2, 4], [1, 2, 2], [1, 2, 2]]
-    assert group_model_data == [
-        {"image_grid_thw": [1, 2, 4]},
-        {"image_grid_thw": [1, 2, 2]},
-        {"image_grid_thw": [1, 2, 2]},
+    assert [entry.image_grid_thw for entry in entries] == [
+        [1, 2, 4],
+        [1, 2, 2],
+        [1, 2, 2],
     ]
     assert torch.equal(full_embeddings[:8], encoded[:8])
     assert torch.equal(full_embeddings[8:12], cached_tensor)
@@ -102,22 +102,24 @@ async def test_encode_with_cache_partial_hit_and_reuse(
         cache_handler._url_hash(urls[0])
     )
     assert new_cached_entry is not None
-    assert new_cached_entry.image_grid_thw is None
-    assert new_cached_entry.model_specific_data == {"image_grid_thw": [1, 2, 4]}
+    assert new_cached_entry.image_grid_thw == [1, 2, 4]
+    assert new_cached_entry.video_grid_thw is None
 
     new_cached_entry = cache_handler._embedding_cache.get(
         cache_handler._url_hash(urls[0])
     )
     assert new_cached_entry is not None
-    assert new_cached_entry.image_grid_thw is None
-    assert new_cached_entry.model_specific_data == {"image_grid_thw": [1, 2, 4]}
+    assert new_cached_entry.image_grid_thw == [1, 2, 4]
+    assert new_cached_entry.video_grid_thw is None
 
-    grid2, full_embeddings2, group_model_data2 = await cache_handler._encode_with_cache(
+    grid2, full_embeddings2, entries2 = await cache_handler._encode_with_cache(
         urls, Modality.IMAGE
     )
     assert cache_handler.encoder.encode_mock.await_count == 1
     assert grid2.tolist() == grid.tolist()
-    assert group_model_data2 == group_model_data
+    assert [entry.image_grid_thw for entry in entries2] == [
+        entry.image_grid_thw for entry in entries
+    ]
     assert torch.equal(full_embeddings2, full_embeddings)
 
 
@@ -154,14 +156,14 @@ async def test_encode_with_cache_all_hit_no_remote_call(
         CachedEmbedding(tensor=y, image_grid_thw=[1, 1, 1]),
     )
 
-    grid, full_embeddings, group_model_data = await cache_handler._encode_with_cache(
+    grid, full_embeddings, entries = await cache_handler._encode_with_cache(
         urls, Modality.IMAGE
     )
     cache_handler.encoder.encode_mock.assert_not_called()
     assert grid.tolist() == [[1, 1, 2], [1, 1, 1]]
-    assert group_model_data == [
-        {"image_grid_thw": [1, 1, 2]},
-        {"image_grid_thw": [1, 1, 1]},
+    assert [entry.image_grid_thw for entry in entries] == [
+        [1, 1, 2],
+        [1, 1, 1],
     ]
     assert torch.equal(full_embeddings, torch.cat([x, y], dim=0))
 
@@ -178,7 +180,7 @@ async def test_video_requests_reuse_cached_embeddings(
     cache_handler.video_token_id = video_token_id
 
     cache_handler.encoder.encode_mock.return_value = (
-        torch.tensor([[2, 3, 4]]),
+        torch.tensor([2, 3, 4]),
         torch.arange(24, dtype=torch.float32).reshape(6, 4),
         {
             "second_per_grid_ts": [0.5],
@@ -242,11 +244,9 @@ async def test_video_requests_reuse_cached_embeddings(
         cache_handler._media_cache_key(video_url, Modality.VIDEO, cache_handler.encoder)
     )
     assert cached_entry is not None
-    assert cached_entry.model_specific_data == {
-        "video_grid_thw": [2, 3, 4],
-        "second_per_grid_ts": 0.5,
-        "video_timestamps": [0.25, 0.75],
-    }
+    assert cached_entry.video_grid_thw == [2, 3, 4]
+    assert cached_entry.second_per_grid_ts == 0.5
+    assert cached_entry.video_timestamps == [0.25, 0.75]
 
     assert len(cache_handler.pd_worker_client.requests) == 2
     for pd_request, request_context in cache_handler.pd_worker_client.requests:
@@ -255,10 +255,10 @@ async def test_video_requests_reuse_cached_embeddings(
             102
         ]
         group = pd_request["multimodal_inputs"][0]
-        assert group["modality"] == "VIDEO"
         assert group["video_grid_thw"] == [2, 3, 4]
+        assert group["second_per_grid_ts"] == 0.5
+        assert group["video_timestamps"] == [0.25, 0.75]
         assert group["num_mm_tokens"] == 6
-        assert group["model_specific_data"] == cached_entry.model_specific_data
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
@@ -105,13 +105,6 @@ async def test_encode_with_cache_partial_hit_and_reuse(
     assert new_cached_entry.image_grid_thw == [1, 2, 4]
     assert new_cached_entry.video_grid_thw is None
 
-    new_cached_entry = cache_handler._embedding_cache.get(
-        cache_handler._url_hash(urls[0])
-    )
-    assert new_cached_entry is not None
-    assert new_cached_entry.image_grid_thw == [1, 2, 4]
-    assert new_cached_entry.video_grid_thw is None
-
     grid2, full_embeddings2, entries2 = await cache_handler._encode_with_cache(
         urls, Modality.IMAGE
     )
@@ -259,6 +252,21 @@ async def test_video_requests_reuse_cached_embeddings(
         assert group["second_per_grid_ts"] == 0.5
         assert group["video_timestamps"] == [0.25, 0.75]
         assert group["num_mm_tokens"] == 6
+
+
+def test_aux_value_for_item_rejects_mismatched_batched_lists() -> None:
+    with pytest.raises(ValueError, match="Auxiliary media metadata length mismatch"):
+        MultimodalEncodeWorkerHandler._aux_value_for_item([0.5], 0, 2)
+
+    assert MultimodalEncodeWorkerHandler._aux_value_for_item(0.5, 1, 2) == 0.5
+    assert (
+        MultimodalEncodeWorkerHandler._aux_value_for_item(torch.tensor([0.5]), 0, 1)
+        == 0.5
+    )
+    assert MultimodalEncodeWorkerHandler._aux_value_for_item([0.25, 0.75], 0, 1) == [
+        0.25,
+        0.75,
+    ]
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
@@ -48,6 +48,14 @@ def cache_handler() -> MultimodalEncodeWorkerHandler:
             return await self.encode_mock(mm_items, modality)
 
     handler = MultimodalEncodeWorkerHandler.__new__(MultimodalEncodeWorkerHandler)
+
+    def _set_token_ids_for_test(image_token_id: int, video_token_id: int) -> None:
+        handler.image_token_id = image_token_id
+        handler.video_token_id = video_token_id
+
+    handler.set_token_ids_for_test = _set_token_ids_for_test
+    handler.set_token_ids_for_test(151655, 151656)
+    handler._missing_video_cache_key_config_warned = False
     handler._embedding_cache = MultimodalEmbeddingCacheManager(
         capacity_bytes=32 * 1024 * 1024
     )
@@ -168,9 +176,7 @@ async def test_video_requests_reuse_cached_embeddings(
     """Second identical video request should reuse cached embeddings."""
 
     video_url = "https://example.com/clip.mp4"
-    video_token_id = 151656
-    cache_handler.image_token_id = 151655
-    cache_handler.video_token_id = video_token_id
+    video_token_id = cache_handler.video_token_id
 
     cache_handler.encoder.encode_mock.return_value = (
         torch.tensor([2, 3, 4]),

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
@@ -10,9 +10,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 import torch
-from sglang.srt.managers.schedule_batch import Modality
 
-import dynamo.sglang.request_handlers.multimodal.encode_worker_handler as encode_worker_module
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     CachedEmbedding,
     MultimodalEmbeddingCacheManager,
@@ -100,6 +98,12 @@ async def test_encode_with_cache_partial_hit_and_reuse(
     assert torch.equal(full_embeddings[:8], encoded[:8])
     assert torch.equal(full_embeddings[8:12], cached_tensor)
     assert torch.equal(full_embeddings[12:16], encoded[8:12])
+    new_cached_entry = cache_handler._embedding_cache.get(
+        cache_handler._url_hash(urls[0])
+    )
+    assert new_cached_entry is not None
+    assert new_cached_entry.image_grid_thw is None
+    assert new_cached_entry.model_specific_data == {"image_grid_thw": [1, 2, 4]}
 
     new_cached_entry = cache_handler._embedding_cache.get(
         cache_handler._url_hash(urls[0])
@@ -164,7 +168,7 @@ async def test_encode_with_cache_all_hit_no_remote_call(
 
 @pytest.mark.asyncio
 async def test_video_requests_reuse_cached_embeddings(
-    cache_handler: MultimodalEncodeWorkerHandler, monkeypatch: pytest.MonkeyPatch
+    cache_handler: MultimodalEncodeWorkerHandler,
 ) -> None:
     """Second identical video request should reuse cached embeddings."""
 
@@ -173,17 +177,14 @@ async def test_video_requests_reuse_cached_embeddings(
     cache_handler.image_token_id = 151655
     cache_handler.video_token_id = video_token_id
 
-    mm_encode_mock = AsyncMock(
-        return_value=(
-            torch.tensor([[2, 3, 4]]),
-            torch.arange(24, dtype=torch.float32).reshape(6, 4),
-            {
-                "second_per_grid_ts": [0.5],
-                "video_timestamps": [[0.25, 0.75]],
-            },
-        )
+    cache_handler.encoder.encode_mock.return_value = (
+        torch.tensor([[2, 3, 4]]),
+        torch.arange(24, dtype=torch.float32).reshape(6, 4),
+        {
+            "second_per_grid_ts": [0.5],
+            "video_timestamps": [[0.25, 0.75]],
+        },
     )
-    monkeypatch.setattr(encode_worker_module, "mm_encode", mm_encode_mock)
 
     transfer_future = asyncio.get_running_loop().create_future()
     transfer_future.set_result(None)
@@ -230,11 +231,9 @@ async def test_video_requests_reuse_cached_embeddings(
     async for item in cache_handler.generate(raw_request, context=None):
         outputs_second.append(item)
 
-    mm_encode_mock.assert_awaited_once()
-    mm_encode_args = mm_encode_mock.await_args.args
-    assert mm_encode_args[0] is cache_handler.encoder
-    assert mm_encode_args[1] == [video_url]
-    assert mm_encode_args[2] == Modality.VIDEO
+    cache_handler.encoder.encode_mock.assert_awaited_once_with(
+        [video_url], Modality.VIDEO
+    )
 
     assert outputs == [{"token_ids": [7]}]
     assert outputs_second == [{"token_ids": [7]}]
@@ -264,22 +263,19 @@ async def test_video_requests_reuse_cached_embeddings(
 
 @pytest.mark.asyncio
 async def test_video_cache_key_includes_sampling_config(
-    cache_handler: MultimodalEncodeWorkerHandler, monkeypatch: pytest.MonkeyPatch
+    cache_handler: MultimodalEncodeWorkerHandler,
 ) -> None:
     """Changing video sampling config should force a cache miss for the same URL."""
 
     video_url = "https://example.com/clip.mp4"
-    mm_encode_mock = AsyncMock(
-        return_value=(
-            torch.tensor([[2, 3, 4]]),
-            torch.arange(24, dtype=torch.float32).reshape(6, 4),
-            {
-                "second_per_grid_ts": [0.5],
-                "video_timestamps": [[0.25, 0.75]],
-            },
-        )
+    cache_handler.encoder.encode_mock.return_value = (
+        torch.tensor([[2, 3, 4]]),
+        torch.arange(24, dtype=torch.float32).reshape(6, 4),
+        {
+            "second_per_grid_ts": [0.5],
+            "video_timestamps": [[0.25, 0.75]],
+        },
     )
-    monkeypatch.setattr(encode_worker_module, "mm_encode", mm_encode_mock)
 
     first_key = cache_handler._media_cache_key(
         video_url, Modality.VIDEO, cache_handler.encoder
@@ -295,6 +291,6 @@ async def test_video_cache_key_includes_sampling_config(
     await cache_handler._encode_with_cache([video_url], Modality.VIDEO)
 
     assert first_key != second_key
-    assert mm_encode_mock.await_count == 2
+    assert cache_handler.encoder.encode_mock.await_count == 2
     assert cache_handler._embedding_cache.get(first_key) is not None
     assert cache_handler._embedding_cache.get(second_key) is not None

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
@@ -3,17 +3,22 @@
 
 """Unit tests for SGLang multimodal embedding cache behavior."""
 
+import asyncio
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 import torch
 
+import dynamo.sglang.request_handlers.multimodal.encode_worker_handler as encode_worker_module
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     CachedEmbedding,
     MultimodalEmbeddingCacheManager,
 )
+from dynamo.common.multimodal import TransferRequest
 from dynamo.sglang.request_handlers.multimodal.encode_worker_handler import (
+    Modality,
     MultimodalEncodeWorkerHandler,
 )
 
@@ -23,18 +28,32 @@ pytestmark = [
     pytest.mark.gpu_1,  # sglang tests run on GPU-enabled workers
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
+    pytest.mark.skipif(Modality is None, reason="SGLang Modality is required"),
 ]
 
 
 @pytest.fixture
 def cache_handler() -> MultimodalEncodeWorkerHandler:
     """Create a lightweight handler instance for cache-path unit tests."""
+
+    class _DummyEncoder:
+        def __init__(self) -> None:
+            self.encode_mock = AsyncMock()
+            self.model_type = "test_video_model"
+            self.vision_config = {
+                "video": {"fps": 2.0, "max_frames": 768, "min_frames": 4}
+            }
+            self.video_processor = SimpleNamespace(temporal_patch_size=2)
+
+        async def _encode(self, mm_items, modality):
+            return await self.encode_mock(mm_items, modality)
+
     handler = MultimodalEncodeWorkerHandler.__new__(MultimodalEncodeWorkerHandler)
     handler._embedding_cache = MultimodalEmbeddingCacheManager(
         capacity_bytes=32 * 1024 * 1024
     )
     handler._cache_publisher = None
-    handler.encoder = SimpleNamespace(_encode=AsyncMock())
+    handler.encoder = _DummyEncoder()
     return handler
 
 
@@ -43,7 +62,6 @@ async def test_encode_with_cache_partial_hit_and_reuse(
     cache_handler: MultimodalEncodeWorkerHandler,
 ) -> None:
     """Partial-hit should encode only misses and preserve URL order in output."""
-    from sglang.srt.managers.schedule_batch import Modality
 
     urls = [
         "http://example.com/a.jpg",
@@ -51,38 +69,50 @@ async def test_encode_with_cache_partial_hit_and_reuse(
         "http://example.com/c.jpg",
     ]
 
-    # Pre-cache url[1] (4 tokens x 3 hidden)
     cached_tensor = torch.full((4, 3), fill_value=-1.0)
     cache_handler._embedding_cache.set(
         cache_handler._url_hash(urls[1]),
         CachedEmbedding(tensor=cached_tensor, image_grid_thw=[1, 2, 2]),
     )
 
-    # Encode only misses url[0], url[2]: token counts [8, 4]
     encoded = torch.arange(12 * 3, dtype=torch.float32).reshape(12, 3)
-    cache_handler.encoder._encode.return_value = (
+    cache_handler.encoder.encode_mock.return_value = (
         torch.tensor([[1, 2, 4], [1, 2, 2]]),
         encoded,
-        None,  # aux_data (unused by cache path)
+        None,
     )
 
-    grid, full_embeddings = await cache_handler._encode_with_cache(urls)
+    grid, full_embeddings, group_model_data = await cache_handler._encode_with_cache(
+        urls, Modality.IMAGE
+    )
 
-    # Encoder called once for uncached URLs only
-    cache_handler.encoder._encode.assert_awaited_once_with(
+    cache_handler.encoder.encode_mock.assert_awaited_once_with(
         [urls[0], urls[2]], Modality.IMAGE
     )
 
-    # Order should match original URL order: a(8), b(4 cached), c(4)
     assert grid.tolist() == [[1, 2, 4], [1, 2, 2], [1, 2, 2]]
+    assert group_model_data == [
+        {"image_grid_thw": [1, 2, 4]},
+        {"image_grid_thw": [1, 2, 2]},
+        {"image_grid_thw": [1, 2, 2]},
+    ]
     assert torch.equal(full_embeddings[:8], encoded[:8])
     assert torch.equal(full_embeddings[8:12], cached_tensor)
     assert torch.equal(full_embeddings[12:16], encoded[8:12])
 
-    # Second call should be all-cache hit: no additional encoder calls
-    grid2, full_embeddings2 = await cache_handler._encode_with_cache(urls)
-    assert cache_handler.encoder._encode.await_count == 1
+    new_cached_entry = cache_handler._embedding_cache.get(
+        cache_handler._url_hash(urls[0])
+    )
+    assert new_cached_entry is not None
+    assert new_cached_entry.image_grid_thw is None
+    assert new_cached_entry.model_specific_data == {"image_grid_thw": [1, 2, 4]}
+
+    grid2, full_embeddings2, group_model_data2 = await cache_handler._encode_with_cache(
+        urls, Modality.IMAGE
+    )
+    assert cache_handler.encoder.encode_mock.await_count == 1
     assert grid2.tolist() == grid.tolist()
+    assert group_model_data2 == group_model_data
     assert torch.equal(full_embeddings2, full_embeddings)
 
 
@@ -119,7 +149,151 @@ async def test_encode_with_cache_all_hit_no_remote_call(
         CachedEmbedding(tensor=y, image_grid_thw=[1, 1, 1]),
     )
 
-    grid, full_embeddings = await cache_handler._encode_with_cache(urls)
-    cache_handler.encoder._encode.assert_not_called()
+    grid, full_embeddings, group_model_data = await cache_handler._encode_with_cache(
+        urls, Modality.IMAGE
+    )
+    cache_handler.encoder.encode_mock.assert_not_called()
     assert grid.tolist() == [[1, 1, 2], [1, 1, 1]]
+    assert group_model_data == [
+        {"image_grid_thw": [1, 1, 2]},
+        {"image_grid_thw": [1, 1, 1]},
+    ]
     assert torch.equal(full_embeddings, torch.cat([x, y], dim=0))
+
+
+@pytest.mark.asyncio
+async def test_video_requests_reuse_cached_embeddings(
+    cache_handler: MultimodalEncodeWorkerHandler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Second identical video request should reuse cached embeddings."""
+
+    video_url = "https://example.com/clip.mp4"
+    video_token_id = 151656
+    cache_handler.image_token_id = 151655
+    cache_handler.video_token_id = video_token_id
+
+    mm_encode_mock = AsyncMock(
+        return_value=(
+            torch.tensor([[2, 3, 4]]),
+            torch.arange(24, dtype=torch.float32).reshape(6, 4),
+            {
+                "second_per_grid_ts": [0.5],
+                "video_timestamps": [[0.25, 0.75]],
+            },
+        )
+    )
+    monkeypatch.setattr(encode_worker_module, "mm_encode", mm_encode_mock)
+
+    transfer_future = asyncio.get_running_loop().create_future()
+    transfer_future.set_result(None)
+
+    class _DummyEmbeddingSender:
+        async def send_embeddings(self, embeddings):
+            self.embeddings = embeddings
+            return (
+                TransferRequest(
+                    embeddings_shape=list(embeddings.shape),
+                    embedding_dtype_str=str(embeddings.dtype),
+                    serialized_request={"kind": "mock-transfer"},
+                ),
+                transfer_future,
+            )
+
+    class _DummyPdWorkerClient:
+        def __init__(self) -> None:
+            self.requests = []
+
+        async def round_robin(self, request_json, context=None):
+            self.requests.append((json.loads(request_json), context))
+
+            async def _responses():
+                yield json.dumps({"token_ids": [7], "finished": True, "text": ""})
+
+            return _responses()
+
+    cache_handler.embedding_sender = _DummyEmbeddingSender()
+    cache_handler.pd_worker_client = _DummyPdWorkerClient()
+
+    raw_request = {
+        "token_ids": [101, video_token_id, 102],
+        "stop_conditions": {"max_tokens": 8},
+        "sampling_options": {"temperature": 0.0},
+        "multi_modal_data": {"video_url": [{"Url": video_url}]},
+    }
+
+    outputs = []
+    async for item in cache_handler.generate(raw_request, context=None):
+        outputs.append(item)
+
+    outputs_second = []
+    async for item in cache_handler.generate(raw_request, context=None):
+        outputs_second.append(item)
+
+    mm_encode_mock.assert_awaited_once()
+    mm_encode_args = mm_encode_mock.await_args.args
+    assert mm_encode_args[0] is cache_handler.encoder
+    assert mm_encode_args[1] == [video_url]
+    assert mm_encode_args[2] == Modality.VIDEO
+
+    assert outputs == [{"token_ids": [7]}]
+    assert outputs_second == [{"token_ids": [7]}]
+
+    cached_entry = cache_handler._embedding_cache.get(
+        cache_handler._media_cache_key(video_url, Modality.VIDEO, cache_handler.encoder)
+    )
+    assert cached_entry is not None
+    assert cached_entry.model_specific_data == {
+        "video_grid_thw": [2, 3, 4],
+        "second_per_grid_ts": 0.5,
+        "video_timestamps": [0.25, 0.75],
+    }
+
+    assert len(cache_handler.pd_worker_client.requests) == 2
+    for pd_request, request_context in cache_handler.pd_worker_client.requests:
+        assert request_context is None
+        assert pd_request["request"]["token_ids"] == [101] + [video_token_id] * 6 + [
+            102
+        ]
+        group = pd_request["multimodal_inputs"][0]
+        assert group["modality"] == "VIDEO"
+        assert group["video_grid_thw"] == [2, 3, 4]
+        assert group["num_mm_tokens"] == 6
+        assert group["model_specific_data"] == cached_entry.model_specific_data
+
+
+@pytest.mark.asyncio
+async def test_video_cache_key_includes_sampling_config(
+    cache_handler: MultimodalEncodeWorkerHandler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Changing video sampling config should force a cache miss for the same URL."""
+
+    video_url = "https://example.com/clip.mp4"
+    mm_encode_mock = AsyncMock(
+        return_value=(
+            torch.tensor([[2, 3, 4]]),
+            torch.arange(24, dtype=torch.float32).reshape(6, 4),
+            {
+                "second_per_grid_ts": [0.5],
+                "video_timestamps": [[0.25, 0.75]],
+            },
+        )
+    )
+    monkeypatch.setattr(encode_worker_module, "mm_encode", mm_encode_mock)
+
+    first_key = cache_handler._media_cache_key(
+        video_url, Modality.VIDEO, cache_handler.encoder
+    )
+    await cache_handler._encode_with_cache([video_url], Modality.VIDEO)
+
+    cache_handler.encoder.vision_config["video"]["fps"] = 4.0
+
+    second_key = cache_handler._media_cache_key(
+        video_url, Modality.VIDEO, cache_handler.encoder
+    )
+    await cache_handler._encode_with_cache([video_url], Modality.VIDEO)
+    await cache_handler._encode_with_cache([video_url], Modality.VIDEO)
+
+    assert first_key != second_key
+    assert mm_encode_mock.await_count == 2
+    assert cache_handler._embedding_cache.get(first_key) is not None
+    assert cache_handler._embedding_cache.get(second_key) is not None

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py
@@ -75,13 +75,18 @@ async def test_build_mm_items_routes_video_to_video_data():
 
         @staticmethod
         def create_multimodal_item(
-            embeddings, grid_values=None, modality="IMAGE", model_specific_data=None
+            embeddings,
+            grid_values,
+            modality="IMAGE",
+            second_per_grid_ts=None,
+            video_timestamps=None,
         ):
             return EmbeddingsProcessor.create_multimodal_item(
                 embeddings,
                 grid_values,
                 modality=modality,
-                model_specific_data=model_specific_data,
+                second_per_grid_ts=second_per_grid_ts,
+                video_timestamps=video_timestamps,
             )
 
     request = SglangMultimodalRequest(
@@ -93,14 +98,10 @@ async def test_build_mm_items_routes_video_to_video_data():
         multimodal_inputs=[
             MultiModalGroup(
                 multimodal_input=MultiModalInput(),
-                modality="VIDEO",
                 video_grid_thw=[2, 3, 4],
+                second_per_grid_ts=0.5,
+                video_timestamps=[0.25, 0.75],
                 num_mm_tokens=6,
-                model_specific_data={
-                    "video_grid_thw": [2, 3, 4],
-                    "second_per_grid_ts": 0.5,
-                    "video_timestamps": [0.25, 0.75],
-                },
             )
         ],
     )

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from dynamo.sglang.protocol import (
+    MultiModalGroup,
+    MultiModalInput,
+    PreprocessedRequest,
+    SamplingOptions,
+    SglangMultimodalRequest,
+    StopConditions,
+)
+from dynamo.sglang.request_handlers.multimodal.encode_worker_handler import (
+    Modality,
+    MultimodalEncodeWorkerHandler,
+)
+from dynamo.sglang.request_handlers.multimodal.worker_handler import (
+    EmbeddingsProcessor,
+    _build_mm_items,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.profiled_vram_gib(0),
+    pytest.mark.pre_merge,
+    pytest.mark.skipif(Modality is None, reason="SGLang Modality is required"),
+]
+
+
+def test_extract_media_urls_supports_video_urls():
+    handler = MultimodalEncodeWorkerHandler.__new__(MultimodalEncodeWorkerHandler)
+
+    image_urls, video_urls = handler._extract_media_urls(
+        {
+            "multi_modal_data": {
+                "video_url": [
+                    {"Url": "https://example.com/clip.mp4"},
+                    "file:///tmp/local.mp4",
+                ]
+            }
+        }
+    )
+
+    assert image_urls == []
+    assert video_urls == ["https://example.com/clip.mp4", "file:///tmp/local.mp4"]
+
+
+def test_extract_media_urls_supports_mixed_image_and_video():
+    handler = MultimodalEncodeWorkerHandler.__new__(MultimodalEncodeWorkerHandler)
+
+    image_urls, video_urls = handler._extract_media_urls(
+        {
+            "multi_modal_data": {
+                "image_url": [{"Url": "https://example.com/image.png"}],
+                "video_url": [{"Url": "https://example.com/clip.mp4"}],
+            }
+        }
+    )
+
+    assert image_urls == ["https://example.com/image.png"]
+    assert video_urls == ["https://example.com/clip.mp4"]
+
+
+@pytest.mark.asyncio
+async def test_build_mm_items_routes_video_to_video_data():
+    embeddings = torch.arange(24, dtype=torch.float16).reshape(6, 4)
+
+    class _FakeEmbeddingsProcessor:
+        async def process_embeddings(self, request):
+            return embeddings, 17
+
+        @staticmethod
+        def create_multimodal_item(
+            embeddings, grid_values=None, modality="IMAGE", model_specific_data=None
+        ):
+            return EmbeddingsProcessor.create_multimodal_item(
+                embeddings,
+                grid_values,
+                modality=modality,
+                model_specific_data=model_specific_data,
+            )
+
+    request = SglangMultimodalRequest(
+        request=PreprocessedRequest(
+            token_ids=[151652, 151656, 151653],
+            stop_conditions=StopConditions(max_tokens=32),
+            sampling_options=SamplingOptions(temperature=0.0),
+        ),
+        multimodal_inputs=[
+            MultiModalGroup(
+                multimodal_input=MultiModalInput(),
+                modality="VIDEO",
+                video_grid_thw=[2, 3, 4],
+                num_mm_tokens=6,
+                model_specific_data={
+                    "video_grid_thw": [2, 3, 4],
+                    "second_per_grid_ts": 0.5,
+                    "video_timestamps": [0.25, 0.75],
+                },
+            )
+        ],
+    )
+
+    image_items, video_items, combined_embeddings, tensor_id = await _build_mm_items(
+        request, _FakeEmbeddingsProcessor()
+    )
+
+    assert tensor_id == 17
+    assert torch.equal(combined_embeddings, embeddings)
+    assert image_items == []
+    assert len(video_items) == 1
+
+    mm_item = video_items[0]
+    assert mm_item["modality"] == "VIDEO"
+    assert torch.equal(mm_item["video_grid_thw"], torch.tensor([[2, 3, 4]]))
+    assert torch.equal(
+        mm_item["second_per_grid_ts"], torch.tensor([0.5], dtype=torch.float32)
+    )
+    assert mm_item["video_timestamps"] == [[0.25, 0.75]]

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py
@@ -74,17 +74,25 @@ async def test_build_mm_items_routes_video_to_video_data():
             return embeddings, 17
 
         @staticmethod
-        def create_multimodal_item(
+        def create_multimodal_image_item(
             embeddings,
-            grid_values,
-            modality="IMAGE",
+            image_grid_thw,
+        ):
+            return EmbeddingsProcessor.create_multimodal_image_item(
+                embeddings,
+                image_grid_thw,
+            )
+
+        @staticmethod
+        def create_multimodal_video_item(
+            embeddings,
+            video_grid_thw,
             second_per_grid_ts=None,
             video_timestamps=None,
         ):
-            return EmbeddingsProcessor.create_multimodal_item(
+            return EmbeddingsProcessor.create_multimodal_video_item(
                 embeddings,
-                grid_values,
-                modality=modality,
+                video_grid_thw,
                 second_per_grid_ts=second_per_grid_ts,
                 video_timestamps=video_timestamps,
             )

--- a/docs/features/multimodal/embedding-cache.md
+++ b/docs/features/multimodal/embedding-cache.md
@@ -25,7 +25,7 @@ If your workload consists entirely of unique images, the cache provides no benef
 |---------|------------|----------------------|-------|
 | **vLLM** | ✅ | ✅ | Aggregated uses vLLM-native `ec_both`; disaggregated uses Dynamo `EmbeddingCacheManager` |
 | **TRT-LLM** | ❌ | ✅ | Dynamo `MultimodalEmbeddingCacheManager` in PD worker |
-| **SGLang** | ❌ | ❌ | Not supported yet |
+| **SGLang** | ❌ | ✅ | Dynamo `MultimodalEmbeddingCacheManager` in the encode worker |
 
 This support requires vLLM `0.17.0` or newer.
 

--- a/docs/features/multimodal/embedding-cache.md
+++ b/docs/features/multimodal/embedding-cache.md
@@ -2,22 +2,23 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Embedding Cache
-subtitle: Cache vision encoder embeddings to skip re-encoding repeated images
+subtitle: Cache vision encoder embeddings to skip re-encoding repeated multimodal content
 ---
 
 ## Overview
 
-The embedding cache is a CPU-side LRU cache that stores vision encoder outputs. When the same image appears in multiple requests, the cached embedding is reused instead of running the vision encoder again. This reduces GPU load on the encoder and lowers latency for repeated images.
+The embedding cache is a CPU-side LRU cache that stores vision encoder outputs. When the same multimodal content, such as an image or video, appears in multiple requests, the cached embedding is reused instead of running the vision encoder again. This reduces GPU load on the encoder and lowers latency for repeated content.
 > Note: This feature can also be referred to as **encoder cache**. Embedding cache is separate from KV cache, which reuses attention key/value state after prefill to skip prefill and go straight to decode. For KV cache reuse and routing, see [Multimodal KV Routing](multimodal-kv-routing.md).
 ## When to Use
 
-Use the embedding cache when your workload includes repeated images across requests. Common scenarios:
+Use the embedding cache when your workload includes repeated multimodal content across requests. Common scenarios:
 
 - Product catalog queries where users ask about the same product images
 - Document processing pipelines that reference shared diagrams or figures
 - Chat sessions where the same image is discussed across multiple turns, like an architecture diagram in a code-gen use case.
+- Video QA or benchmark workloads that repeatedly reference the same clips
 
-If your workload consists entirely of unique images, the cache provides no benefit.
+If your workload consists entirely of unique multimodal content, the cache provides no benefit.
 
 ## Support Matrix
 
@@ -31,7 +32,9 @@ This support requires vLLM `0.17.0` or newer.
 
 ## How It Works
 
-The prefill worker owns the CPU-side LRU cache. On a hit, the encode worker is skipped entirely. On a miss, the encode worker produces the embedding, transfers it via NIXL, and the prefill worker saves it to the cache.
+In vLLM/TRT-LLM disaggregated flows, the prefill worker owns the CPU-side LRU cache. On a hit, the encode worker is skipped entirely. On a miss, the encode worker produces the embedding, transfers it via NIXL, and the prefill worker saves it to the cache.
+
+In SGLang E/PD, the encode worker owns the cache and skips re-encoding on cache hits before forwarding the cached image or video embeddings downstream.
 
 ```mermaid
 flowchart LR
@@ -63,6 +66,6 @@ cd $DYNAMO_HOME/examples/backends/trtllm
 |-----------|-------------|---------|
 | `--multimodal-embedding-cache-capacity-gb` | CPU-side LRU cache size in GB | 0 (disabled) |
 
-Set the capacity based on your expected working set of unique images. A larger cache holds more embeddings but consumes more host memory.
+Set the capacity based on your expected working set of unique multimodal content. A larger cache holds more embeddings but consumes more host memory.
 
 See the backend-specific documentation ([vLLM](multimodal-vllm.md#embedding-cache), [TRT-LLM](multimodal-trtllm.md#embedding-cache)) for more details.

--- a/examples/backends/sglang/launch/multimodal_epd.sh
+++ b/examples/backends/sglang/launch/multimodal_epd.sh
@@ -16,6 +16,8 @@ source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait
 MODEL_NAME="Qwen/Qwen2.5-VL-7B-Instruct"
 CHAT_TEMPLATE="qwen2-vl"
 PROVIDED_CHAT_TEMPLATE=""
+CACHE_CAPACITY_GB=""
+TRANSFER_BACKEND="${DYN_SGLANG_DISAGGREGATION_TRANSFER_BACKEND:-nixl}"
 
 # --single-gpu: Packs both workers (encode, PD) onto a single GPU.
 # This is intended for functional testing with small models (e.g. 2B) where CI
@@ -41,6 +43,14 @@ while [[ $# -gt 0 ]]; do
             SINGLE_GPU=true
             shift
             ;;
+        --multimodal-embedding-cache-capacity-gb)
+            CACHE_CAPACITY_GB=$2
+            shift 2
+            ;;
+        --disaggregation-transfer-backend)
+            TRANSFER_BACKEND=$2
+            shift 2
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo "Options:"
@@ -48,6 +58,10 @@ while [[ $# -gt 0 ]]; do
             echo "  --served-model-name <served_model_name> Specify the served model name to use (default: empty)"
             echo "  --chat-template <template> Specify the SGLang chat template to use (default: $CHAT_TEMPLATE)"
             echo "  --single-gpu         Pack both workers on 1 GPU (for small models, e.g. 2B)"
+            echo "  --multimodal-embedding-cache-capacity-gb <gb>"
+            echo "                       Enable encode-worker CPU embedding cache with this capacity"
+            echo "  --disaggregation-transfer-backend <backend>"
+            echo "                       SGLang disaggregation transfer backend (default: $TRANSFER_BACKEND)"
             echo "  -h, --help           Show this help message"
             exit 0
             ;;
@@ -96,6 +110,10 @@ GPU_MEM_ARGS=$(build_sglang_gpu_mem_args)
 
 ENCODE_EXTRA_ARGS="$GPU_MEM_ARGS"
 WORKER_EXTRA_ARGS="$GPU_MEM_ARGS"
+
+if [[ -n "$CACHE_CAPACITY_GB" ]]; then
+    ENCODE_EXTRA_ARGS="$ENCODE_EXTRA_ARGS --multimodal-embedding-cache-capacity-gb $CACHE_CAPACITY_GB"
+fi
 
 if [[ "$SINGLE_GPU" == "true" ]]; then
     # Both workers share one GPU; cap activations tightly.
@@ -157,7 +175,7 @@ env ${_WORKER_CUDA_PIN:+"$_WORKER_CUDA_PIN"} python3 -m dynamo.sglang \
   --trust-remote-code \
   --skip-tokenizer-init \
   --disable-radix-cache \
-  --disaggregation-transfer-backend nixl \
+  --disaggregation-transfer-backend "$TRANSFER_BACKEND" \
   $WORKER_EXTRA_ARGS &
 
 # Exit on first worker failure; kill 0 in the EXIT trap tears down the rest

--- a/examples/backends/sglang/launch/multimodal_epd.sh
+++ b/examples/backends/sglang/launch/multimodal_epd.sh
@@ -84,6 +84,12 @@ if [[ -n "$SERVED_MODEL_NAME" ]]; then
     SERVED_MODEL_ARG="--served-model-name $SERVED_MODEL_NAME"
 fi
 
+# TODO: Switch back to nixl-write once Dynamo embedding transfer can share a
+# NIXL/UCX backend with SGLang NIXL KV transfer in the same worker process.
+if [[ "$TRANSFER_BACKEND" == "nixl" && -z "${DYN_SGL_EMBEDDING_TRANSFER_MODE:-}" ]]; then
+    export DYN_SGL_EMBEDDING_TRANSFER_MODE="nixl-read"
+fi
+
 # GPU assignments (override via environment variables)
 if [[ "$SINGLE_GPU" == "true" ]]; then
     DYN_ENCODE_WORKER_GPU=${DYN_ENCODE_WORKER_GPU:-0}

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -565,11 +565,14 @@ sglang_configs = {
             "--chat-template",
             "qwen2-vl",
             "--single-gpu",
+            "--multimodal-embedding-cache-capacity-gb",
+            "0.1",
         ],
         timeout=360,
         env={
             "DYN_ENCODE_GPU_MEM": "0.1",
             "DYN_WORKER_GPU_MEM": "0.4",
+            "DYN_SGL_EMBEDDING_TRANSFER_MODE": "local",
         },
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
@@ -585,7 +588,21 @@ sglang_configs = {
                 expected_response=["guitar", "tablet", "draw"],
                 temperature=0.0,
                 max_tokens=100,
-            )
+            ),
+            chat_payload(
+                [
+                    {"type": "text", "text": "Describe the video in detail"},
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": REMOTE_VIDEO_TEST_URI},
+                    },
+                ],
+                repeat_count=1,
+                expected_response=["guitar", "tablet", "draw"],
+                expected_log=["Embedding cache hit for VIDEO URL index 0"],
+                temperature=0.0,
+                max_tokens=100,
+            ),
         ],
     ),
     "embedding_agg": SGLangConfig(


### PR DESCRIPTION
#### Overview

This PR add video embedding cache support in Dynamo's SGLang multimodal encode worker. It makes cached video embeddings reusable across repeated video requests and preserves the video processor metadata needed for SGLang to consume cached `processor_output` video data correctly.

#### Details

- Extended `CachedEmbedding` to store video-specific metadata:
  - `video_grid_thw`
  - `second_per_grid_ts`
  - `video_timestamps`
- Generalized the encode-worker embedding cache path from image-only to image/video
- Added config-aware video cache keys scoped by URL, modality, model type, and relevant video processor settings
- Kept existing image cache key behavior unchanged
- Preserved video aux metadata through cache hit and cache miss paths
- Forwarded cached video metadata through the SGLang multimodal protocol
- Updated the downstream multimodal worker path so cached video embeddings are reconstructed as `video_data=[{"format":"processor_output", ...}]`
- Added launch-script support for enabling multimodal embedding cache in EPD runs
- Added/updated tests for video cache reuse, video metadata propagation, and mixed image/video request handling


##### Validation

I validated the disagg/EPD video path on the following Qwen-series models:

- `Qwen/Qwen2.5-VL-7B-Instruct`
- `Qwen/Qwen3-VL-8B-Instruct`
- `Qwen/Qwen3.5-4B`

##### Benchmark

Benchmark config/workload generation is split into PR #10000. I ran the SGLang E/PD video embedding-cache sweep using `benchmarks/multimodal/sweep/experiments/embedding_cache/sglang_video_e_pd.yaml`.

Settings:
- Model: `Qwen/Qwen3-VL-2B-Instruct`
- Workflow: `examples/backends/sglang/launch/multimodal_epd.sh`
- Embedding cache switch: `--multimodal-embedding-cache-capacity-gb 0` or `10`
- 100 requests, concurrencies `[1, 2, 4, 8]`, OSL 128, warmup 2
- Local run used Mooncake transfer backend with local embedding transfer mode

Results below are averaged across concurrencies. Throughput / TTFT / avg latency are cache-on values; delta is avg latency change vs cache-off.

| workload | reuse% | throughput | TTFT | avg latency | delta |
|---|---:|---:|---:|---:|---:|
| `100req_1vid_20pool` | 80% | 2.876 req/s | 715.9 ms | 1114.1 ms | -46.2% |
| `100req_1vid_80pool` | 20% | 1.865 req/s | 1330.5 ms | 1760.9 ms | -4.9% |
| `100req_2vid_160pool` | 20% | 1.071 req/s | 2573.6 ms | 3056.4 ms | -4.0% |

#### Testing

- `pytest -q components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py components/src/dynamo/sglang/tests/test_sglang_decode_handler.py`
- `pytest -q components/src/dynamo/common/tests/memory/test_multimodal_embedding_cache_manager.py`

#### Where should the reviewer start?
<table>
  <thead>
    <tr>
      <th>Area</th>
      <th>File</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td rowspan="2">Core video request flow</td>
      <td>
        <code>components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py</code>
        <ul>
          <li><code>video_url</code> extraction</li>
          <li>modality-aware <code>MMEncoder</code> routing</li>
          <li>video placeholder expansion</li>
          <li>video embedding cache keying and hit/miss assembly</li>
        </ul>
      </td>
    </tr>
    <tr>
      <td>
        <code>components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py</code>
        <ul>
          <li>reconstruction of precomputed multimodal embeddings</li>
          <li>forwarding video processor output through <code>video_data</code></li>
        </ul>
      </td>
    </tr>
    <tr>
      <td>Protocol / metadata</td>
      <td>
        <code>components/src/dynamo/sglang/protocol.py</code>
        <ul>
          <li>video metadata passed between encode and worker paths</li>
          <li><code>video_grid_thw</code>, <code>second_per_grid_ts</code>, and <code>video_timestamps</code></li>
        </ul>
      </td>
    </tr>
    <tr>
      <td>Embedding cache</td>
      <td>
        <code>components/src/dynamo/common/memory/multimodal_embedding_cache_manager.py</code>
        <ul>
          <li>cached entry metadata for image/video grids</li>
          <li>video aux metadata stored with cached embeddings</li>
        </ul>
      </td>
    </tr>
    <tr>
      <td>Launch / validation</td>
      <td>
        <code>examples/backends/sglang/launch/multimodal_epd.sh</code>
        <ul>
          <li>multimodal embedding cache launch flag</li>
          <li>temporary <code>nixl-read</code> workaround for SGLang NIXL E/PD</li>
        </ul>
      </td>
    </tr>
    <tr>
      <td rowspan="3">Tests</td>
      <td>
        <code>components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py</code>
        <ul>
          <li>video URL extraction coverage</li>
          <li>video embedding-to-worker reconstruction coverage</li>
        </ul>
      </td>
    </tr>
    <tr>
      <td>
        <code>components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py</code>
        <ul>
          <li>image/video embedding cache behavior</li>
          <li>video metadata cache reuse</li>
        </ul>
      </td>
    </tr>
    <tr>
      <td>
        <code>components/src/dynamo/common/tests/memory/test_multimodal_embedding_cache_manager.py</code>
        <ul>
          <li>shared cache manager behavior</li>
        </ul>
      </td>
    </tr>
  </tbody>
</table>

#### Related Issues

- Relates to PR #10000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added video support to multimodal encoding alongside existing image support
  * Extended multimodal system to track modality information and model-specific metadata for improved flexibility

* **Documentation**
  * Clarified encode worker descriptions in deployment scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->