### PR TITLE
fix(gms): follow-up fixes for #8194 CodeRabbit and reviewer comments

### DIFF
--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -236,6 +236,23 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Equal(t, []string{"run"}, podSpec.Containers[1].Args)
 	})
 
+	t.Run("ready checkpoint resolves main even when not at index zero", func(t *testing.T) {
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "istio-proxy", Image: "istio:latest", Command: []string{"istio"}, Args: []string{"run"}},
+				{Name: "main", Image: "main:latest", Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}},
+			},
+		}
+		info := &CheckpointInfo{Enabled: true, Ready: true, Hash: testHash}
+		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
+
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info))
+		assert.Equal(t, []string{"istio"}, podSpec.Containers[0].Command, "sidecar at index 0 must remain untouched")
+		assert.Equal(t, []string{"run"}, podSpec.Containers[0].Args)
+		assert.Equal(t, []string{"sleep", "infinity"}, podSpec.Containers[1].Command, "main at index 1 should receive the restore override")
+		assert.Nil(t, podSpec.Containers[1].Args)
+	})
+
 	t.Run("ready gms checkpoint injects restore sidecars and loader mount", func(t *testing.T) {
 		podSpec := testPodSpec()
 		podSpec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu"}}
@@ -280,7 +297,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 			errMsg  string
 		}{
 			{"hash empty and identity nil", testPodSpec(), &CheckpointInfo{Enabled: true}, fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "identity is nil"},
-			{"no containers", &corev1.PodSpec{}, testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "no container named"},
+			{"no containers", &corev1.PodSpec{}, testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "no containers found"},
 			{"snapshot daemonset missing", testPodSpec(), testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).Build(), "no snapshot-agent daemonset found"},
 		} {
 			t.Run(tc.name, func(t *testing.T) {

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -27,10 +27,20 @@ const (
 	envCheckpointDir = "GMS_CHECKPOINT_DIR"
 )
 
-// EnsureGMSRestoreSidecars adds GMS server + loader containers to the pod spec
-// for a checkpoint restore. The server runs as a regular container (not init)
-// because the CRIU-restored main process already has GPU memory mapped and
-// all containers must start in parallel.
+// EnsureGMSRestoreSidecars adds GMS server + loader containers to the pod
+// spec for a checkpoint restore.
+//
+// Precondition: the upstream DGD path has already run EnsureServerSidecar,
+// which adds the GMS server as a blocking init container (so socket
+// readiness gates the workload). The restore path does not need the
+// server to block startup because the CRIU-restored workload brings its
+// GPU memory back mapped and all init sidecars must start in parallel.
+// This function therefore:
+//
+//  1. Removes the existing init gms-server added by EnsureServerSidecar.
+//  2. Re-adds it as an always-restarting init sidecar together with the
+//     gms-loader, which hydrates the server from the checkpoint artifact
+//     directory on the snapshot PVC.
 func EnsureGMSRestoreSidecars(
 	podSpec *corev1.PodSpec,
 	mainContainer *corev1.Container,

--- a/deploy/operator/internal/checkpoint/podinfo.go
+++ b/deploy/operator/internal/checkpoint/podinfo.go
@@ -8,70 +8,38 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// EnsurePodInfoVolume installs the canonical DownwardAPI volume carrying
+// checkpoint/restore metadata onto podSpec. If a volume with the same name
+// already exists, it is overwritten so that the volume source type and item
+// list always match what the snapshot tooling expects to read at
+// /etc/podinfo/*. The name is a dynamo-internal constant, so replacing any
+// user-supplied entry with the canonical definition is the right default.
 func EnsurePodInfoVolume(podSpec *corev1.PodSpec) {
-	for _, volume := range podSpec.Volumes {
-		if volume.Name == commonconsts.PodInfoVolumeName {
-			return
-		}
-	}
-
-	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+	canonical := corev1.Volume{
 		Name: commonconsts.PodInfoVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			DownwardAPI: &corev1.DownwardAPIVolumeSource{
 				Items: []corev1.DownwardAPIVolumeFile{
-					{
-						Path: "pod_name",
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodName,
-						},
-					},
-					{
-						Path: "pod_uid",
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodUID,
-						},
-					},
-					{
-						Path: "pod_namespace",
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodNamespace,
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynNamespace,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoNamespace + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynNamespaceWorkerSuffix,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoWorkerHash + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynComponent,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoComponentType + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynParentDGDName,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoGraphDeploymentName + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynParentDGDNamespace,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodNamespace,
-						},
-					},
+					{Path: "pod_name", FieldRef: &corev1.ObjectFieldSelector{FieldPath: commonconsts.PodInfoFieldPodName}},
+					{Path: "pod_uid", FieldRef: &corev1.ObjectFieldSelector{FieldPath: commonconsts.PodInfoFieldPodUID}},
+					{Path: "pod_namespace", FieldRef: &corev1.ObjectFieldSelector{FieldPath: commonconsts.PodInfoFieldPodNamespace}},
+					{Path: commonconsts.PodInfoFileDynNamespace, FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoNamespace + "']"}},
+					{Path: commonconsts.PodInfoFileDynNamespaceWorkerSuffix, FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoWorkerHash + "']"}},
+					{Path: commonconsts.PodInfoFileDynComponent, FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoComponentType + "']"}},
+					{Path: commonconsts.PodInfoFileDynParentDGDName, FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoGraphDeploymentName + "']"}},
+					{Path: commonconsts.PodInfoFileDynParentDGDNamespace, FieldRef: &corev1.ObjectFieldSelector{FieldPath: commonconsts.PodInfoFieldPodNamespace}},
 				},
 			},
 		},
-	})
+	}
+
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name == commonconsts.PodInfoVolumeName {
+			podSpec.Volumes[i] = canonical
+			return
+		}
+	}
+	podSpec.Volumes = append(podSpec.Volumes, canonical)
 }
 
 func EnsurePodInfoMount(container *corev1.Container) {

--- a/deploy/operator/internal/checkpoint/podinfo_test.go
+++ b/deploy/operator/internal/checkpoint/podinfo_test.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package checkpoint
+
+import (
+	"testing"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func expectedPodInfoItemPaths() []string {
+	return []string{
+		"pod_name",
+		"pod_uid",
+		"pod_namespace",
+		commonconsts.PodInfoFileDynNamespace,
+		commonconsts.PodInfoFileDynNamespaceWorkerSuffix,
+		commonconsts.PodInfoFileDynComponent,
+		commonconsts.PodInfoFileDynParentDGDName,
+		commonconsts.PodInfoFileDynParentDGDNamespace,
+	}
+}
+
+func assertCanonicalPodInfoVolume(t *testing.T, volume corev1.Volume) {
+	t.Helper()
+	assert.Equal(t, commonconsts.PodInfoVolumeName, volume.Name)
+	if assert.NotNil(t, volume.VolumeSource.DownwardAPI, "expected DownwardAPI source") {
+		paths := make([]string, 0, len(volume.VolumeSource.DownwardAPI.Items))
+		for _, item := range volume.VolumeSource.DownwardAPI.Items {
+			paths = append(paths, item.Path)
+		}
+		assert.ElementsMatch(t, expectedPodInfoItemPaths(), paths)
+	}
+}
+
+func TestEnsurePodInfoVolumeAppendsWhenMissing(t *testing.T) {
+	spec := &corev1.PodSpec{Volumes: []corev1.Volume{{Name: "other"}}}
+
+	EnsurePodInfoVolume(spec)
+
+	if assert.Len(t, spec.Volumes, 2) {
+		assert.Equal(t, "other", spec.Volumes[0].Name)
+		assertCanonicalPodInfoVolume(t, spec.Volumes[1])
+	}
+}
+
+func TestEnsurePodInfoVolumeReplacesWrongSourceType(t *testing.T) {
+	spec := &corev1.PodSpec{Volumes: []corev1.Volume{
+		{Name: commonconsts.PodInfoVolumeName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+	}}
+
+	EnsurePodInfoVolume(spec)
+
+	if assert.Len(t, spec.Volumes, 1) {
+		assertCanonicalPodInfoVolume(t, spec.Volumes[0])
+	}
+}
+
+func TestEnsurePodInfoVolumeRepairsPartialItems(t *testing.T) {
+	spec := &corev1.PodSpec{Volumes: []corev1.Volume{{
+		Name: commonconsts.PodInfoVolumeName,
+		VolumeSource: corev1.VolumeSource{DownwardAPI: &corev1.DownwardAPIVolumeSource{
+			Items: []corev1.DownwardAPIVolumeFile{
+				{Path: "pod_name", FieldRef: &corev1.ObjectFieldSelector{FieldPath: commonconsts.PodInfoFieldPodName}},
+			},
+		}},
+	}}}
+
+	EnsurePodInfoVolume(spec)
+
+	if assert.Len(t, spec.Volumes, 1) {
+		assertCanonicalPodInfoVolume(t, spec.Volumes[0])
+	}
+}
+
+func TestEnsurePodInfoVolumeIsIdempotent(t *testing.T) {
+	spec := &corev1.PodSpec{}
+
+	EnsurePodInfoVolume(spec)
+	EnsurePodInfoVolume(spec)
+
+	if assert.Len(t, spec.Volumes, 1) {
+		assertCanonicalPodInfoVolume(t, spec.Volumes[0])
+	}
+}

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,19 +35,6 @@ func ApplyRestorePodMetadata(labels map[string]string, annotations map[string]st
 		artifactVersion = checkpointInfo.ArtifactVersion
 	}
 	snapshotprotocol.ApplyRestoreTargetMetadata(labels, annotations, enabled, hash, artifactVersion)
-}
-
-// resolveMainContainer finds the container named "main" in the pod spec.
-// ExtraPodSpec.PodSpec.Containers can inject user containers before the main
-// container (mergo merge happens before main is appended), so index 0 is
-// not guaranteed to be the main container here.
-func resolveMainContainer(podSpec *corev1.PodSpec) *corev1.Container {
-	for i := range podSpec.Containers {
-		if podSpec.Containers[i].Name == commonconsts.MainContainerName {
-			return &podSpec.Containers[i]
-		}
-	}
-	return nil
 }
 
 func InjectCheckpointIntoPodSpec(
@@ -75,9 +61,9 @@ func InjectCheckpointIntoPodSpec(
 		info.Hash = hash
 	}
 
-	mainContainer := resolveMainContainer(podSpec)
+	mainContainer := snapshotprotocol.ResolveMainContainer(podSpec)
 	if mainContainer == nil {
-		return fmt.Errorf("no container named %q found in pod spec", commonconsts.MainContainerName)
+		return fmt.Errorf("no containers found in pod spec")
 	}
 	if reader == nil {
 		return fmt.Errorf("checkpoint client is required")
@@ -87,7 +73,6 @@ func InjectCheckpointIntoPodSpec(
 		reader,
 		namespace,
 		podSpec,
-		mainContainer,
 		info.Hash,
 		info.ArtifactVersion,
 		snapshotprotocol.DefaultSeccompLocalhostProfile,

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/common"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,7 +62,7 @@ func InjectCheckpointIntoPodSpec(
 		info.Hash = hash
 	}
 
-	mainContainer := snapshotprotocol.ResolveMainContainer(podSpec)
+	mainContainer := common.ResolveMainContainer(podSpec)
 	if mainContainer == nil {
 		return fmt.Errorf("no containers found in pod spec")
 	}

--- a/deploy/operator/internal/common/maincontainer.go
+++ b/deploy/operator/internal/common/maincontainer.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ResolveMainContainer returns a pointer to the workload container in podSpec.
+// It prefers the container named commonconsts.MainContainerName and falls back
+// to Containers[0] so that pods rendered before the naming convention (or by
+// non-operator tooling in tests) still resolve to a sensible target.
+// Returns nil only when podSpec has no containers.
+//
+// Keep this helper on the operator side. Snapshot tooling has its own copy in
+// snapshotprotocol because deploy/snapshot is a separate Go module and cannot
+// import deploy/operator/internal. The two implementations must match.
+func ResolveMainContainer(podSpec *corev1.PodSpec) *corev1.Container {
+	if podSpec == nil || len(podSpec.Containers) == 0 {
+		return nil
+	}
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == commonconsts.MainContainerName {
+			return &podSpec.Containers[i]
+		}
+	}
+	return &podSpec.Containers[0]
+}

--- a/deploy/operator/internal/common/maincontainer_test.go
+++ b/deploy/operator/internal/common/maincontainer_test.go
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestResolveMainContainer(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		spec     *corev1.PodSpec
+		wantName string
+		wantNil  bool
+	}{
+		{
+			name:    "nil spec",
+			spec:    nil,
+			wantNil: true,
+		},
+		{
+			name:    "no containers",
+			spec:    &corev1.PodSpec{},
+			wantNil: true,
+		},
+		{
+			name: "single container named main",
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{{Name: commonconsts.MainContainerName}},
+			},
+			wantName: commonconsts.MainContainerName,
+		},
+		{
+			name: "picks container named main even when not first",
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "istio-proxy"},
+					{Name: commonconsts.MainContainerName},
+					{Name: "sidecar-frontend"},
+				},
+			},
+			wantName: commonconsts.MainContainerName,
+		},
+		{
+			name: "falls back to first container when none named main",
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "worker"},
+					{Name: "sidecar"},
+				},
+			},
+			wantName: "worker",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveMainContainer(tc.spec)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected container %q, got nil", tc.wantName)
+			}
+			if got.Name != tc.wantName {
+				t.Fatalf("expected container %q, got %q", tc.wantName, got.Name)
+			}
+		})
+	}
+}

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -3,6 +3,7 @@ package consts
 import (
 	"time"
 
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -122,7 +123,10 @@ const (
 	GroveRoleSuffixLeader = "ldr"
 	GroveRoleSuffixWorker = "wkr"
 
-	MainContainerName            = "main"
+	// MainContainerName is the conventional name of the workload container.
+	// Source of truth lives in snapshotprotocol so that both the operator and
+	// the snapshot tooling agree on the contract.
+	MainContainerName            = snapshotprotocol.MainContainerName
 	FrontendSidecarContainerName = "sidecar-frontend"
 
 	RestartAnnotation = "nvidia.com/restartAt"

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -3,7 +3,6 @@ package consts
 import (
 	"time"
 
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -123,10 +122,13 @@ const (
 	GroveRoleSuffixLeader = "ldr"
 	GroveRoleSuffixWorker = "wkr"
 
-	// MainContainerName is the conventional name of the workload container.
-	// Source of truth lives in snapshotprotocol so that both the operator and
-	// the snapshot tooling agree on the contract.
-	MainContainerName            = snapshotprotocol.MainContainerName
+	// MainContainerName is the conventional name of the workload container in
+	// operator-rendered pods. The operator originated this convention (LWS
+	// multinode enforcement); other subsystems (snapshot/protocol) that need
+	// to match on the name keep their own local copy because deploy/snapshot
+	// is a separate Go module and cannot import deploy/operator/internal.
+	// Keep the two copies in sync.
+	MainContainerName            = "main"
 	FrontendSidecarContainerName = "sidecar-frontend"
 
 	RestartAnnotation = "nvidia.com/restartAt"

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -10,6 +10,7 @@ import (
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
@@ -81,7 +82,7 @@ func buildCheckpointJob(
 
 	checkpoint.EnsurePodInfoVolume(&podTemplate.Spec)
 
-	mainContainer := snapshotprotocol.ResolveMainContainer(&podTemplate.Spec)
+	mainContainer := common.ResolveMainContainer(&podTemplate.Spec)
 	if mainContainer == nil {
 		return nil, fmt.Errorf("checkpoint job requires at least one container")
 	}
@@ -129,7 +130,7 @@ func buildCheckpointJob(
 		}
 		// Re-acquire pointer: append in EnsureGMSCheckpointJobSidecars may
 		// have reallocated the Containers slice.
-		mainContainer = snapshotprotocol.ResolveMainContainer(&podTemplate.Spec)
+		mainContainer = common.ResolveMainContainer(&podTemplate.Spec)
 	}
 
 	activeDeadlineSeconds := ckpt.Spec.Job.ActiveDeadlineSeconds

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -82,10 +82,10 @@ func buildCheckpointJob(
 
 	checkpoint.EnsurePodInfoVolume(&podTemplate.Spec)
 
-	if len(podTemplate.Spec.Containers) == 0 {
+	mainContainer := snapshotprotocol.ResolveMainContainer(&podTemplate.Spec)
+	if mainContainer == nil {
 		return nil, fmt.Errorf("checkpoint job requires at least one container")
 	}
-	mainContainer := &podTemplate.Spec.Containers[0]
 	mainContainer.Env = dynamo.MergeEnvs(
 		buildCheckpointWorkerDefaultEnv(ckpt, podTemplate),
 		mainContainer.Env,
@@ -131,7 +131,7 @@ func buildCheckpointJob(
 		}
 		// Re-acquire pointer: append in EnsureGMSCheckpointJobSidecars may
 		// have reallocated the Containers slice.
-		mainContainer = &podTemplate.Spec.Containers[0]
+		mainContainer = snapshotprotocol.ResolveMainContainer(&podTemplate.Spec)
 	}
 
 	activeDeadlineSeconds := ckpt.Spec.Job.ActiveDeadlineSeconds

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -111,7 +111,7 @@ func buildCheckpointJob(
 
 	if ckpt.Spec.GPUMemoryService != nil && ckpt.Spec.GPUMemoryService.Enabled {
 		claimTemplateName := dra.ResourceClaimTemplateName("checkpoint-"+hash, "worker")
-		if err := dra.ApplyClaim(&podTemplate.Spec, claimTemplateName); err != nil {
+		if err := dra.ApplyClaim(&podTemplate.Spec, mainContainer, claimTemplateName); err != nil {
 			return nil, fmt.Errorf("failed to apply DRA claim for GMS checkpoint: %w", err)
 		}
 		storage, err := snapshotprotocol.DiscoverAndResolveStorage(

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -6,7 +6,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -107,7 +106,6 @@ func buildCheckpointJob(
 	mainContainer.LivenessProbe = nil
 	mainContainer.StartupProbe = nil
 
-	// The snapshot agent sends SIGUSR1 to PID 1 of the main container after
 	checkpoint.EnsurePodInfoMount(mainContainer)
 	dynamo.ApplySharedMemoryVolumeAndMount(&podTemplate.Spec, mainContainer, ckpt.Spec.Job.SharedMemory)
 
@@ -152,16 +150,6 @@ func buildCheckpointJob(
 		pp = 1
 	}
 	wrapLaunchJob := tp*pp > 1
-
-	// For single-GPU jobs (no cuda-checkpoint wrapper), unwrap /bin/sh -c so
-	// the actual process is PID 1 and receives SIGUSR1 from the snapshot agent.
-	if !wrapLaunchJob && len(mainContainer.Command) >= 2 &&
-		mainContainer.Command[len(mainContainer.Command)-1] == "-c" &&
-		len(mainContainer.Args) == 1 {
-		parts := strings.Fields(mainContainer.Args[0])
-		mainContainer.Command = parts[:1]
-		mainContainer.Args = parts[1:]
-	}
 
 	ttlSecondsAfterFinish := snapshotprotocol.DefaultCheckpointJobTTLSeconds
 

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -207,10 +207,7 @@ func (r *CheckpointReconciler) handlePending(ctx context.Context, ckpt *nvidiaco
 		}
 		gpuQty := ckpt.Spec.Job.PodTemplateSpec.Spec.Containers[0].Resources.Limits[corev1.ResourceName(consts.KubeResourceGPUNvidia)]
 		gpuCount := int(gpuQty.Value())
-		deviceClassName := ""
-		if ckpt.Spec.GPUMemoryService != nil {
-			deviceClassName = ckpt.Spec.GPUMemoryService.DeviceClassName
-		}
+		deviceClassName := ckpt.Spec.GPUMemoryService.DeviceClassName
 		claimTemplateName := dra.ResourceClaimTemplateName("checkpoint-"+hash, "worker")
 		_, _, err := commonController.SyncResource(ctx, r, ckpt, func(ctx context.Context) (*resourcev1.ResourceClaimTemplate, bool, error) {
 			return dra.GenerateResourceClaimTemplate(ctx, r.Client, claimTemplateName, ckpt.Namespace, gpuCount, deviceClassName)

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1410,12 +1410,15 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
 		}
 
-		find := func(name string) *corev1.Container {
+		findRegular := func(name string) *corev1.Container {
 			for i := range podTemplateSpec.Spec.Containers {
 				if podTemplateSpec.Spec.Containers[i].Name == name {
 					return &podTemplateSpec.Spec.Containers[i]
 				}
 			}
+			return nil
+		}
+		findInit := func(name string) *corev1.Container {
 			for i := range podTemplateSpec.Spec.InitContainers {
 				if podTemplateSpec.Spec.InitContainers[i].Name == name {
 					return &podTemplateSpec.Spec.InitContainers[i]
@@ -1424,10 +1427,15 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			return nil
 		}
 
-		gmsServer := find(gms.ServerContainerName)
-		require.NotNil(t, gmsServer)
-		loader := find(checkpoint.GMSLoaderContainer)
-		require.NotNil(t, loader)
+		// GMS server and loader must be init sidecars so they start before the
+		// workload and are restarted under the pod's init restart policy.
+		require.Nil(t, findRegular(gms.ServerContainerName), "gms-server must not be a regular container")
+		require.Nil(t, findRegular(checkpoint.GMSLoaderContainer), "gms-loader must not be a regular container")
+
+		gmsServer := findInit(gms.ServerContainerName)
+		require.NotNil(t, gmsServer, "gms-server must be an init container")
+		loader := findInit(checkpoint.GMSLoaderContainer)
+		require.NotNil(t, loader, "gms-loader must be an init container")
 
 		mounts := map[string]string{}
 		for _, mount := range loader.VolumeMounts {

--- a/deploy/operator/internal/dra/dra.go
+++ b/deploy/operator/internal/dra/dra.go
@@ -28,13 +28,14 @@ const (
 	defaultDeviceClassName = "gpu.nvidia.com"
 )
 
-// ApplyClaim replaces the first container's nvidia.com/gpu resources with a
+// ApplyClaim replaces the target container's nvidia.com/gpu resources with a
 // shared DRA ResourceClaim. Every container that references this claim name
 // will share the same physical GPUs. The function is idempotent — calling it
-// on a pod that already has the claim is a no-op.
-func ApplyClaim(podSpec *corev1.PodSpec, claimTemplateName string) error {
-	if len(podSpec.Containers) == 0 {
-		return fmt.Errorf("pod spec must have at least one container for DRA claim")
+// on a pod that already has the claim is a no-op. Pass the workload container
+// explicitly; the caller owns main-container resolution.
+func ApplyClaim(podSpec *corev1.PodSpec, target *corev1.Container, claimTemplateName string) error {
+	if target == nil {
+		return fmt.Errorf("DRA claim target container is required")
 	}
 
 	// Skip if the pod-level claim already exists (idempotent).
@@ -46,9 +47,9 @@ func ApplyClaim(podSpec *corev1.PodSpec, claimTemplateName string) error {
 
 	// Replace nvidia.com/gpu with the shared DRA claim.
 	gpuResource := corev1.ResourceName(commonconsts.KubeResourceGPUNvidia)
-	delete(podSpec.Containers[0].Resources.Limits, gpuResource)
-	delete(podSpec.Containers[0].Resources.Requests, gpuResource)
-	podSpec.Containers[0].Resources.Claims = append(podSpec.Containers[0].Resources.Claims, corev1.ResourceClaim{
+	delete(target.Resources.Limits, gpuResource)
+	delete(target.Resources.Requests, gpuResource)
+	target.Resources.Claims = append(target.Resources.Claims, corev1.ResourceClaim{
 		Name: ClaimName,
 	})
 

--- a/deploy/operator/internal/dra/dra_test.go
+++ b/deploy/operator/internal/dra/dra_test.go
@@ -46,16 +46,16 @@ func basePodSpec() corev1.PodSpec {
 	}
 }
 
-func TestApplyClaim_EmptyContainers(t *testing.T) {
+func TestApplyClaim_NilTarget(t *testing.T) {
 	ps := corev1.PodSpec{}
-	err := ApplyClaim(&ps, "myapp-worker-gpu")
+	err := ApplyClaim(&ps, nil, "myapp-worker-gpu")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "at least one container")
+	assert.Contains(t, err.Error(), "target container")
 }
 
 func TestApplyClaim_ReplacesGPUWithDRAClaim(t *testing.T) {
 	ps := basePodSpec()
-	err := ApplyClaim(&ps, "myapp-worker-gpu")
+	err := ApplyClaim(&ps, &ps.Containers[0], "myapp-worker-gpu")
 	require.NoError(t, err)
 
 	main := ps.Containers[0]
@@ -81,16 +81,22 @@ func TestApplyClaim_ReplacesGPUWithDRAClaim(t *testing.T) {
 	assert.Empty(t, ps.InitContainers)
 }
 
-func TestApplyClaim_AlwaysTargetsFirstContainer(t *testing.T) {
-	ps := basePodSpec()
-	ps.Containers = append(ps.Containers, corev1.Container{Name: "sidecar", Image: "sidecar:latest"})
+func TestApplyClaim_TargetsCallerSuppliedContainer(t *testing.T) {
+	ps := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{Name: "istio-proxy", Image: "istio:latest"},
+			{Name: "main", Image: "test-image:latest", Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceName(commonconsts.KubeResourceGPUNvidia): resource.MustParse("2")},
+			}},
+		},
+	}
 
-	err := ApplyClaim(&ps, "myapp-worker-gpu")
+	err := ApplyClaim(&ps, &ps.Containers[1], "myapp-worker-gpu")
 	require.NoError(t, err)
 
-	require.Len(t, ps.Containers[0].Resources.Claims, 1)
-	assert.Equal(t, ClaimName, ps.Containers[0].Resources.Claims[0].Name)
-	assert.Empty(t, ps.Containers[1].Resources.Claims)
+	assert.Empty(t, ps.Containers[0].Resources.Claims, "sidecar at index 0 must not receive the claim")
+	require.Len(t, ps.Containers[1].Resources.Claims, 1)
+	assert.Equal(t, ClaimName, ps.Containers[1].Resources.Claims[0].Name)
 }
 
 func TestGenerateResourceClaimTemplate_Enabled(t *testing.T) {

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -40,7 +40,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/imdario/mergo"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -1164,6 +1163,18 @@ func GenerateBasePodSpec(
 
 	podSpec.Volumes = append(podSpec.Volumes, volumes...)
 	ApplySharedMemoryVolumeAndMount(&podSpec, &container, component.SharedMemory)
+
+	// Wire GMS into the main container while we still hold it locally, before
+	// it lands in podSpec.Containers. This avoids needing to search the slice
+	// for the "main" container after the fact, and keeps graph.go decoupled
+	// from snapshot-protocol naming conventions.
+	if component.GPUMemoryService != nil && component.GPUMemoryService.Enabled {
+		claimTemplateName := dra.ResourceClaimTemplateName(parentGraphDeploymentName, serviceName)
+		if err := dra.ApplyClaim(&podSpec, &container, claimTemplateName); err != nil {
+			return nil, fmt.Errorf("failed to apply DRA claim for GMS: %w", err)
+		}
+		gms.EnsureServerSidecar(&podSpec, &container)
+	}
 	podSpec.Containers = append(podSpec.Containers, container)
 	podSpec.ImagePullSecrets = controller_common.AppendUniqueImagePullSecrets(podSpec.ImagePullSecrets, imagePullSecrets)
 
@@ -1183,19 +1194,6 @@ func GenerateBasePodSpec(
 				resolveImagePullSecrets(secretsRetriever, namespace, component.FrontendSidecar.Image),
 			)
 		}
-	}
-
-	// GMS: replace nvidia.com/gpu with a shared DRA claim and add the server sidecar.
-	if component.GPUMemoryService != nil && component.GPUMemoryService.Enabled {
-		claimTemplateName := dra.ResourceClaimTemplateName(parentGraphDeploymentName, serviceName)
-		if err := dra.ApplyClaim(&podSpec, claimTemplateName); err != nil {
-			return nil, fmt.Errorf("failed to apply DRA claim for GMS: %w", err)
-		}
-		mainContainer := snapshotprotocol.ResolveMainContainer(&podSpec)
-		if mainContainer == nil {
-			return nil, fmt.Errorf("cannot wire GMS: pod spec has no containers")
-		}
-		gms.EnsureServerSidecar(&podSpec, mainContainer)
 	}
 
 	// Clone main container into two engine containers (active + standby) for failover.

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/imdario/mergo"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -1190,7 +1191,11 @@ func GenerateBasePodSpec(
 		if err := dra.ApplyClaim(&podSpec, claimTemplateName); err != nil {
 			return nil, fmt.Errorf("failed to apply DRA claim for GMS: %w", err)
 		}
-		gms.EnsureServerSidecar(&podSpec, &podSpec.Containers[0])
+		mainContainer := snapshotprotocol.ResolveMainContainer(&podSpec)
+		if mainContainer == nil {
+			return nil, fmt.Errorf("cannot wire GMS: pod spec has no containers")
+		}
+		gms.EnsureServerSidecar(&podSpec, mainContainer)
 	}
 
 	// Clone main container into two engine containers (active + standby) for failover.

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/google/go-cmp/cmp"
@@ -5152,6 +5154,107 @@ func TestGenerateBasePodSpec_PlannerServiceAccount(t *testing.T) {
 					podSpec.ServiceAccountName, tt.expectedServiceAcc)
 			}
 		})
+	}
+}
+
+// TestGenerateBasePodSpec_GMSWiredToMainBeforeFailover covers the invariant
+// that failover requires: GMS wiring must land on the main container before
+// buildFailoverPod clones it into engine-0 / engine-1, so both engines
+// inherit the shared socket volume, mount, env, and DRA claim.
+func TestGenerateBasePodSpec_GMSWiredToMainBeforeFailover(t *testing.T) {
+	component := &v1alpha1.DynamoComponentDeploymentSharedSpec{
+		ComponentType: commonconsts.ComponentTypeWorker,
+		ExtraPodSpec: &v1alpha1.ExtraPodSpec{
+			MainContainer: &corev1.Container{
+				Image:   "test-image:latest",
+				Command: []string{"python3", "-m", "dynamo.vllm"},
+				Args:    []string{"--model", "Qwen/Qwen3-0.6B"},
+			},
+		},
+		Resources: &v1alpha1.Resources{
+			Limits: &v1alpha1.ResourceItem{GPU: "1"},
+		},
+		GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{Enabled: true},
+		Failover:         &v1alpha1.FailoverSpec{Enabled: true},
+	}
+	controllerConfig := &configv1alpha1.OperatorConfiguration{}
+
+	podSpec, err := GenerateBasePodSpec(
+		component,
+		BackendFrameworkVLLM,
+		&mockSecretsRetriever{},
+		"test-deployment",
+		"default",
+		RoleMain,
+		1,
+		controllerConfig,
+		commonconsts.MultinodeDeploymentTypeGrove,
+		"test-service",
+		nil,
+	)
+	require.NoError(t, err)
+
+	// After failover transformation the workload lives in engine-0 / engine-1,
+	// not in a single "main" container. The GMS server sidecar remains in
+	// InitContainers and is shared across both engines.
+	var engines []corev1.Container
+	for _, c := range podSpec.Containers {
+		if strings.HasPrefix(c.Name, "engine-") {
+			engines = append(engines, c)
+		}
+	}
+	require.Len(t, engines, 2, "failover should produce engine-0 and engine-1")
+
+	var gmsServer *corev1.Container
+	for i := range podSpec.InitContainers {
+		if podSpec.InitContainers[i].Name == gms.ServerContainerName {
+			gmsServer = &podSpec.InitContainers[i]
+			break
+		}
+	}
+	require.NotNil(t, gmsServer, "gms-server must be registered as an init sidecar")
+
+	// Shared socket volume is a pod-level prerequisite for engine <-> gms-server
+	// communication. It must exist exactly once regardless of engine count.
+	var sharedVolume *corev1.Volume
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name == gms.SharedVolumeName {
+			sharedVolume = &podSpec.Volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, sharedVolume, "gms shared socket volume must be present")
+
+	// Each engine must carry the GMS mount, env, and DRA claim it inherited
+	// from the main container via DeepCopy in buildEngineContainer.
+	for i := range engines {
+		engine := engines[i]
+		name := engine.Name
+
+		var mount *corev1.VolumeMount
+		for j := range engine.VolumeMounts {
+			if engine.VolumeMounts[j].Name == gms.SharedVolumeName {
+				mount = &engine.VolumeMounts[j]
+				break
+			}
+		}
+		require.NotNil(t, mount, "%s must mount the GMS shared volume", name)
+		assert.Equal(t, gms.SharedMountPath, mount.MountPath, "%s GMS mount path", name)
+
+		var socketDirEnv string
+		for _, e := range engine.Env {
+			if e.Name == gms.EnvSocketDir {
+				socketDirEnv = e.Value
+				break
+			}
+		}
+		assert.Equal(t, gms.SharedMountPath, socketDirEnv, "%s %s env", name, gms.EnvSocketDir)
+
+		require.Len(t, engine.Resources.Claims, 1, "%s must inherit the DRA claim", name)
+		assert.Equal(t, dra.ClaimName, engine.Resources.Claims[0].Name, "%s DRA claim", name)
+
+		_, hasLimit := engine.Resources.Limits[corev1.ResourceName(commonconsts.KubeResourceGPUNvidia)]
+		assert.False(t, hasLimit, "%s nvidia.com/gpu limit must be removed in favor of DRA claim", name)
 	}
 }
 

--- a/deploy/snapshot/cmd/snapshotctl/kube.go
+++ b/deploy/snapshot/cmd/snapshotctl/kube.go
@@ -95,28 +95,23 @@ func loadPod(manifestPath string) (*corev1.Pod, error) {
 	if kind := strings.TrimSpace(pod.Kind); kind != "" && kind != "Pod" {
 		return nil, fmt.Errorf("manifest %s is kind %q, expected Pod", manifestPath, kind)
 	}
-	if len(pod.Spec.Containers) == 0 {
+	workerContainer := snapshotprotocol.ResolveMainContainer(&pod.Spec)
+	if workerContainer == nil {
 		return nil, fmt.Errorf(
 			"manifest %s has no worker containers; snapshotctl requires at least one worker container",
 			manifestPath,
 		)
 	}
-	workerContainer := &pod.Spec.Containers[0]
-	if len(pod.Spec.Containers) > 1 {
-		workerContainer = nil
-		for index := range pod.Spec.Containers {
-			if pod.Spec.Containers[index].Name == "main" {
-				workerContainer = &pod.Spec.Containers[index]
-				break
-			}
-		}
-		if workerContainer == nil {
-			return nil, fmt.Errorf(
-				"manifest %s has %d containers; snapshotctl requires a worker container named main",
-				manifestPath,
-				len(pod.Spec.Containers),
-			)
-		}
+	// In multi-container manifests the author must pick the worker explicitly
+	// by naming it "main"; otherwise the ResolveMainContainer fallback would
+	// silently target whichever container happens to be first.
+	if len(pod.Spec.Containers) > 1 && workerContainer.Name != snapshotprotocol.MainContainerName {
+		return nil, fmt.Errorf(
+			"manifest %s has %d containers; snapshotctl requires a worker container named %q",
+			manifestPath,
+			len(pod.Spec.Containers),
+			snapshotprotocol.MainContainerName,
+		)
 	}
 	if strings.TrimSpace(workerContainer.Image) == "" {
 		return nil, fmt.Errorf("manifest %s: worker container image is required", manifestPath)

--- a/deploy/snapshot/internal/controller/util.go
+++ b/deploy/snapshot/internal/controller/util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
@@ -48,13 +49,12 @@ func podFromInformerObj(obj interface{}) (*corev1.Pod, bool) {
 	return pod, ok
 }
 
-// resolveMainContainerName returns the name of the workload container, which
-// is always Containers[0]. GMS sidecars are appended after the workload.
+// resolveMainContainerName returns the name of the workload container by
+// deferring to snapshotprotocol.ResolveMainContainerName. That helper prefers
+// the container named "main" and falls back to Containers[0] so pods produced
+// before the naming convention (or by non-operator tooling) still resolve.
 func resolveMainContainerName(pod *corev1.Pod) string {
-	if len(pod.Spec.Containers) == 0 {
-		return ""
-	}
-	return pod.Spec.Containers[0].Name
+	return snapshotprotocol.ResolveMainContainerName(pod)
 }
 
 func isPodReady(pod *corev1.Pod) bool {

--- a/deploy/snapshot/internal/executor/restore.go
+++ b/deploy/snapshot/internal/executor/restore.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/logging"
 	snapshotruntime "github.com/ai-dynamo/dynamo/deploy/snapshot/internal/runtime"
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 // RestoreRequest holds the parameters for a restore operation.
@@ -122,7 +123,7 @@ func inspectRestore(ctx context.Context, ctrd *containerd.Client, log logr.Logge
 
 	containerName := req.ContainerName
 	if containerName == "" {
-		containerName = "main"
+		containerName = snapshotprotocol.MainContainerName
 	}
 
 	placeholderPID, _, err := snapshotruntime.ResolveContainerByPod(ctx, ctrd, req.PodName, req.PodNamespace, containerName)

--- a/deploy/snapshot/protocol/checkpoint.go
+++ b/deploy/snapshot/protocol/checkpoint.go
@@ -5,7 +5,6 @@ package protocol
 
 import (
 	"fmt"
-	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -56,11 +55,14 @@ func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOpt
 	if opts.SeccompProfile != "" {
 		EnsureLocalhostSeccompProfile(&podTemplate.Spec, opts.SeccompProfile)
 	}
+	container := ResolveMainContainer(&podTemplate.Spec)
+	if container == nil {
+		return nil, fmt.Errorf("checkpoint job requires at least one container")
+	}
+	if err := RequireExecFormCommand(container); err != nil {
+		return nil, err
+	}
 	if opts.WrapLaunchJob {
-		container := ResolveMainContainer(&podTemplate.Spec)
-		if container == nil {
-			return nil, fmt.Errorf("checkpoint job requires at least one container")
-		}
 		if len(container.Command) == 0 {
 			return nil, fmt.Errorf("checkpoint job requires container.command when cuda-checkpoint launch-job wrapping is enabled")
 		}
@@ -157,18 +159,11 @@ func EnsureLocalhostSeccompProfile(podSpec *corev1.PodSpec, profile string) {
 	}
 }
 
+// wrapWithCudaCheckpointLaunchJob prepends cuda-checkpoint --launch-job to
+// the container's exec-form command+args. Callers must validate exec form via
+// RequireExecFormCommand first; a shell-wrapped command here would make
+// cuda-checkpoint launch sh, which swallows SIGUSR1.
 func wrapWithCudaCheckpointLaunchJob(command []string, args []string) ([]string, []string) {
-	// Unwrap "/bin/sh -c <single-string>" so cuda-checkpoint launches the
-	// actual process directly. Otherwise sh sits between cuda-checkpoint and
-	// the real process and swallows SIGUSR1.
-	if len(command) >= 2 && command[len(command)-1] == "-c" && len(args) == 1 {
-		shell := command[:len(command)-1] // e.g. ["/bin/sh"] — discarded
-		_ = shell
-		parts := strings.Fields(args[0])
-		command = parts[:1] // e.g. ["python3"]
-		args = parts[1:]    // e.g. ["-m", "dynamo.vllm", "--model", ...]
-	}
-
 	wrappedArgs := make([]string, 0, len(command)+len(args)+1)
 	wrappedArgs = append(wrappedArgs, "--launch-job")
 	wrappedArgs = append(wrappedArgs, command...)

--- a/deploy/snapshot/protocol/checkpoint.go
+++ b/deploy/snapshot/protocol/checkpoint.go
@@ -57,10 +57,10 @@ func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOpt
 		EnsureLocalhostSeccompProfile(&podTemplate.Spec, opts.SeccompProfile)
 	}
 	if opts.WrapLaunchJob {
-		if len(podTemplate.Spec.Containers) == 0 {
+		container := ResolveMainContainer(&podTemplate.Spec)
+		if container == nil {
 			return nil, fmt.Errorf("checkpoint job requires at least one container")
 		}
-		container := &podTemplate.Spec.Containers[0]
 		if len(container.Command) == 0 {
 			return nil, fmt.Errorf("checkpoint job requires container.command when cuda-checkpoint launch-job wrapping is enabled")
 		}

--- a/deploy/snapshot/protocol/checkpoint_job_test.go
+++ b/deploy/snapshot/protocol/checkpoint_job_test.go
@@ -170,6 +170,39 @@ func TestNewCheckpointJobAllowsSingleNonMainContainer(t *testing.T) {
 
 
 
+func TestNewCheckpointJobRejectsShellWrappedCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		command       []string
+		wrapLaunchJob bool
+	}{
+		{"single GPU sh -c", []string{"/bin/sh", "-c"}, false},
+		{"multi GPU sh -c", []string{"/bin/sh", "-c"}, true},
+		{"single GPU bash -c", []string{"bash", "-c"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:    "main",
+						Image:   "test:latest",
+						Command: tc.command,
+						Args:    []string{"python3 -m dynamo.vllm --model x"},
+					}},
+				},
+			}, CheckpointJobOptions{
+				Namespace:     "test-ns",
+				CheckpointID:  "hash",
+				Name:          "test-job",
+				WrapLaunchJob: tc.wrapLaunchJob,
+			})
+			if err == nil {
+				t.Fatal("expected NewCheckpointJob to reject shell-wrapped command")
+			}
+		})
+	}
+}
+
 func TestGetCheckpointJobName(t *testing.T) {
 	name := GetCheckpointJobName("abc123def4567890", "2")
 	if name != "checkpoint-job-abc123def4567890-2" {

--- a/deploy/snapshot/protocol/maincontainer.go
+++ b/deploy/snapshot/protocol/maincontainer.go
@@ -24,6 +24,11 @@ const MainContainerName = "main"
 // Containers[0] so that pods rendered before the naming convention (or by
 // non-operator tooling in tests) still resolve to a sensible target.
 // Returns nil only when podSpec has no containers.
+//
+// Operator code should use common.ResolveMainContainer in
+// deploy/operator/internal/common instead of importing this function.
+// The duplication exists because deploy/snapshot and deploy/operator are
+// separate Go modules; both implementations must match.
 func ResolveMainContainer(podSpec *corev1.PodSpec) *corev1.Container {
 	if podSpec == nil || len(podSpec.Containers) == 0 {
 		return nil

--- a/deploy/snapshot/protocol/maincontainer.go
+++ b/deploy/snapshot/protocol/maincontainer.go
@@ -3,7 +3,12 @@
 
 package protocol
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"fmt"
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 // MainContainerName is the conventional name of the workload container that
 // checkpoint/restore operates on. The operator always sets this name on the
@@ -39,4 +44,37 @@ func ResolveMainContainerName(pod *corev1.Pod) string {
 		return ""
 	}
 	return container.Name
+}
+
+// RequireExecFormCommand returns an error if container uses a shell-wrapped
+// entrypoint (e.g. /bin/sh -c "python3 ..."). Checkpoint/restore needs the
+// real workload process to be PID 1 inside the container so that SIGUSR1
+// from the snapshot agent (and SIGTERM from cuda-checkpoint --launch-job)
+// reaches it directly; an intermediate shell swallows those signals unless
+// the shell happens to tail-call exec, which only fires for simple payloads.
+// Callers that build checkpoint artifacts should invoke this before emitting
+// a checkpoint Job.
+func RequireExecFormCommand(container *corev1.Container) error {
+	if container == nil || len(container.Command) == 0 {
+		return nil
+	}
+	base := filepath.Base(container.Command[0])
+	switch base {
+	case "sh", "bash", "dash", "zsh", "ash", "busybox":
+	default:
+		return nil
+	}
+	for _, token := range container.Command[1:] {
+		if token == "-c" {
+			return fmt.Errorf(
+				"checkpoint/restore requires exec-form command on container %q; "+
+					"got shell wrapper %v. Set extraPodSpec.mainContainer.command to the "+
+					"actual workload entrypoint (e.g. command: [python3], "+
+					"args: [-m, dynamo.vllm, --model, foo]) so the workload process is "+
+					"PID 1 and receives SIGUSR1 from the snapshot agent directly",
+				container.Name, container.Command,
+			)
+		}
+	}
+	return nil
 }

--- a/deploy/snapshot/protocol/maincontainer.go
+++ b/deploy/snapshot/protocol/maincontainer.go
@@ -11,10 +11,12 @@ import (
 )
 
 // MainContainerName is the conventional name of the workload container that
-// checkpoint/restore operates on. The operator always sets this name on the
-// pods it emits. Keeping the constant in the snapshot protocol package makes
-// it the shared contract between the operator (which builds pods) and the
-// snapshot agent / snapshotctl (which checkpoint them).
+// checkpoint/restore operates on. The operator originated this convention
+// for LWS multinode enforcement and the authoritative copy lives in
+// deploy/operator/internal/consts (commonconsts.MainContainerName). This
+// package keeps a local copy because deploy/snapshot is a separate Go
+// module and cannot import deploy/operator/internal. Keep the two copies
+// in sync.
 const MainContainerName = "main"
 
 // ResolveMainContainer returns a pointer to the workload container in podSpec.

--- a/deploy/snapshot/protocol/maincontainer.go
+++ b/deploy/snapshot/protocol/maincontainer.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package protocol
+
+import corev1 "k8s.io/api/core/v1"
+
+// MainContainerName is the conventional name of the workload container that
+// checkpoint/restore operates on. The operator always sets this name on the
+// pods it emits. Keeping the constant in the snapshot protocol package makes
+// it the shared contract between the operator (which builds pods) and the
+// snapshot agent / snapshotctl (which checkpoint them).
+const MainContainerName = "main"
+
+// ResolveMainContainer returns a pointer to the workload container in podSpec.
+// It prefers the container named MainContainerName and falls back to
+// Containers[0] so that pods rendered before the naming convention (or by
+// non-operator tooling in tests) still resolve to a sensible target.
+// Returns nil only when podSpec has no containers.
+func ResolveMainContainer(podSpec *corev1.PodSpec) *corev1.Container {
+	if podSpec == nil || len(podSpec.Containers) == 0 {
+		return nil
+	}
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == MainContainerName {
+			return &podSpec.Containers[i]
+		}
+	}
+	return &podSpec.Containers[0]
+}
+
+// ResolveMainContainerName returns the name of the workload container in pod.
+// Used by the snapshot agent, which reads pods from an informer cache and
+// needs to send signals to the matching ContainerStatus entry by name.
+// Returns "" only when pod has no containers.
+func ResolveMainContainerName(pod *corev1.Pod) string {
+	container := ResolveMainContainer(&pod.Spec)
+	if container == nil {
+		return ""
+	}
+	return container.Name
+}

--- a/deploy/snapshot/protocol/maincontainer_test.go
+++ b/deploy/snapshot/protocol/maincontainer_test.go
@@ -73,6 +73,41 @@ func TestResolveMainContainer(t *testing.T) {
 	}
 }
 
+func TestRequireExecFormCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cmd     []string
+		wantErr bool
+	}{
+		{"nil command", nil, false},
+		{"empty command", []string{}, false},
+		{"exec form python", []string{"python3", "-m", "dynamo.vllm"}, false},
+		{"exec form /usr/bin/python3", []string{"/usr/bin/python3"}, false},
+		{"shell without -c is fine", []string{"/bin/sh", "my-entrypoint.sh"}, false},
+		{"bash without -c is fine", []string{"bash", "-l"}, false},
+		{"/bin/sh -c rejected", []string{"/bin/sh", "-c"}, true},
+		{"sh -c rejected", []string{"sh", "-c"}, true},
+		{"bash -c rejected", []string{"/bin/bash", "-c"}, true},
+		{"dash -c rejected", []string{"dash", "-c"}, true},
+		{"busybox sh -c rejected", []string{"/bin/busybox", "sh", "-c"}, true},
+		{"custom binary passes", []string{"/opt/my-runner", "-c", "config.yaml"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := RequireExecFormCommand(&corev1.Container{Name: "main", Command: tc.cmd})
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+
+	if err := RequireExecFormCommand(nil); err != nil {
+		t.Fatalf("nil container should return nil error, got %v", err)
+	}
+}
+
 func TestResolveMainContainerName(t *testing.T) {
 	pod := &corev1.Pod{Spec: corev1.PodSpec{
 		Containers: []corev1.Container{

--- a/deploy/snapshot/protocol/maincontainer_test.go
+++ b/deploy/snapshot/protocol/maincontainer_test.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package protocol
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestResolveMainContainer(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		spec     *corev1.PodSpec
+		wantName string
+		wantNil  bool
+	}{
+		{
+			name:    "nil spec",
+			spec:    nil,
+			wantNil: true,
+		},
+		{
+			name:    "no containers",
+			spec:    &corev1.PodSpec{},
+			wantNil: true,
+		},
+		{
+			name: "single container is main by convention",
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "main"}},
+			},
+			wantName: "main",
+		},
+		{
+			name: "picks container named main even when not first",
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "istio-proxy"},
+					{Name: "main"},
+					{Name: "sidecar-frontend"},
+				},
+			},
+			wantName: "main",
+		},
+		{
+			name: "falls back to first container when none named main",
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "worker"},
+					{Name: "sidecar"},
+				},
+			},
+			wantName: "worker",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveMainContainer(tc.spec)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected container %q, got nil", tc.wantName)
+			}
+			if got.Name != tc.wantName {
+				t.Fatalf("expected container %q, got %q", tc.wantName, got.Name)
+			}
+		})
+	}
+}
+
+func TestResolveMainContainerName(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{
+		Containers: []corev1.Container{
+			{Name: "istio-proxy"},
+			{Name: "main"},
+		},
+	}}
+	if got := ResolveMainContainerName(pod); got != "main" {
+		t.Fatalf("expected main, got %q", got)
+	}
+
+	pod = &corev1.Pod{Spec: corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "worker"}},
+	}}
+	if got := ResolveMainContainerName(pod); got != "worker" {
+		t.Fatalf("expected worker (fallback), got %q", got)
+	}
+
+	pod = &corev1.Pod{}
+	if got := ResolveMainContainerName(pod); got != "" {
+		t.Fatalf("expected empty string for container-less pod, got %q", got)
+	}
+}

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -39,7 +39,7 @@ func NewRestorePod(pod *corev1.Pod, opts PodOptions) *corev1.Pod {
 		pod.Annotations = map[string]string{}
 	}
 	ApplyRestoreTargetMetadata(pod.Labels, pod.Annotations, true, opts.CheckpointID, opts.ArtifactVersion)
-	container := resolveWorkerContainer(&pod.Spec)
+	container := ResolveMainContainer(&pod.Spec)
 	if container == nil {
 		return nil
 	}
@@ -47,15 +47,6 @@ func NewRestorePod(pod *corev1.Pod, opts PodOptions) *corev1.Pod {
 	pod.Namespace = opts.Namespace
 	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
 	return pod
-}
-
-// resolveWorkerContainer returns the workload container, which is always
-// Containers[0]. GMS sidecars are appended after the workload.
-func resolveWorkerContainer(podSpec *corev1.PodSpec) *corev1.Container {
-	if podSpec == nil || len(podSpec.Containers) == 0 {
-		return nil
-	}
-	return &podSpec.Containers[0]
 }
 
 func PrepareRestorePodSpec(
@@ -105,7 +96,7 @@ func ValidateRestorePodSpec(
 	if podSpec == nil {
 		return fmt.Errorf("pod spec is nil")
 	}
-	container := resolveWorkerContainer(podSpec)
+	container := ResolveMainContainer(podSpec)
 	if container == nil {
 		return fmt.Errorf("restore target must have at least one container")
 	}
@@ -235,17 +226,25 @@ func DiscoverAndResolveStorage(
 	return ResolveCheckpointStorage(checkpointID, artifactVersion, storage)
 }
 
+// PrepareRestorePodSpecForCheckpoint resolves the workload container via
+// ResolveMainContainer (prefers "main", falls back to Containers[0]) and then
+// wires storage and restore semantics onto it. Callers do not pass the
+// container pointer — the function is the single source of truth for which
+// container carries the restore.
 func PrepareRestorePodSpecForCheckpoint(
 	ctx context.Context,
 	reader ctrlclient.Reader,
 	namespace string,
 	podSpec *corev1.PodSpec,
-	container *corev1.Container,
 	checkpointID string,
 	artifactVersion string,
 	seccompProfile string,
 	isCheckpointReady bool,
 ) error {
+	container := ResolveMainContainer(podSpec)
+	if container == nil {
+		return fmt.Errorf("restore target must have at least one container")
+	}
 	storage, err := DiscoverAndResolveStorage(ctx, reader, namespace, checkpointID, artifactVersion)
 	if err != nil {
 		return err

--- a/docs/kubernetes/snapshot.md
+++ b/docs/kubernetes/snapshot.md
@@ -25,6 +25,39 @@ title: Snapshot
 - NVIDIA driver 580.xx or newer on the target GPU nodes (590.xx or newer if testing multi-GPU snapshots)
 - vLLM or SGLang backend today
 - `ReadWriteMany` storage for cross-node restore
+- Exec-form container entrypoint for any workload that participates in checkpoint/restore (see [Container entrypoint shape](#container-entrypoint-shape))
+
+### Container entrypoint shape
+
+Checkpoint/restore needs the real workload process to be PID 1 inside the
+container so that `SIGUSR1` (from the snapshot agent) and the signals that
+`cuda-checkpoint --launch-job` delivers reach it directly. A shell wrapper
+in between can swallow those signals.
+
+Set `command` and `args` in **exec form** on the main container:
+
+```yaml
+extraPodSpec:
+  mainContainer:
+    command: [python3]
+    args: [-m, dynamo.vllm, --model, Qwen/Qwen3-0.6B]
+```
+
+Do **not** use a shell wrapper like `/bin/sh -c "python3 -m dynamo.vllm ..."`.
+The operator will reject checkpoint Jobs built from a shell-wrapped container
+with a clear error.
+
+If you need env-var expansion in the args, use Kubernetes' `$(VAR)` substitution
+(which the kubelet resolves before `execve`) rather than shell expansion:
+
+```yaml
+mainContainer:
+  env:
+    - name: MODEL_PATH
+      value: Qwen/Qwen3-0.6B
+  command: [python3]
+  args: [-m, dynamo.vllm, --model, $(MODEL_PATH)]
+```
 
 ## Quick Start via `DynamoCheckpoint` CR
 

--- a/examples/backends/vllm/deploy/gaie/agg.yaml
+++ b/examples/backends/vllm/deploy/gaie/agg.yaml
@@ -67,11 +67,24 @@ spec:
               value: "Qwen/Qwen3-0.6B"
             - name: DYN_STORE_KV
               value: "mem"
-          args:
-          - "python3 -m dynamo.vllm --model $MODEL_PATH --served-model-name $SERVED_MODEL_NAME --tensor-parallel-size 1 --data-parallel-size 1 --gpu-memory-utilization 0.90 --no-enable-prefix-caching --block-size 128"
           command:
-          - /bin/sh
-          - -c
+          - python3
+          - -m
+          - dynamo.vllm
+          args:
+          - --model
+          - $(MODEL_PATH)
+          - --served-model-name
+          - $(SERVED_MODEL_NAME)
+          - --tensor-parallel-size
+          - "1"
+          - --data-parallel-size
+          - "1"
+          - --gpu-memory-utilization
+          - "0.90"
+          - --no-enable-prefix-caching
+          - --block-size
+          - "128"
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
       replicas: 1

--- a/examples/backends/vllm/deploy/gaie/disagg.yaml
+++ b/examples/backends/vllm/deploy/gaie/disagg.yaml
@@ -96,11 +96,30 @@ spec:
               value: "Qwen/Qwen3-0.6B"
             - name: MODEL_PATH
               value: "Qwen/Qwen3-0.6B"
-          args:
-          - "python3 -m dynamo.vllm --model $MODEL_PATH --served-model-name $SERVED_MODEL_NAME --tensor-parallel-size 1 --data-parallel-size 1 --disaggregation-mode prefill --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' --gpu-memory-utilization 0.90 --enable-prefix-caching --block-size 16 --kv-events-config '{\"enable_kv_cache_events\":true}'"
           command:
-          - /bin/sh
-          - -c
+          - python3
+          - -m
+          - dynamo.vllm
+          args:
+          - --model
+          - $(MODEL_PATH)
+          - --served-model-name
+          - $(SERVED_MODEL_NAME)
+          - --tensor-parallel-size
+          - "1"
+          - --data-parallel-size
+          - "1"
+          - --disaggregation-mode
+          - prefill
+          - --kv-transfer-config
+          - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+          - --gpu-memory-utilization
+          - "0.90"
+          - --enable-prefix-caching
+          - --block-size
+          - "16"
+          - --kv-events-config
+          - '{"enable_kv_cache_events":true}'
           image: docker.io/lambda108/dynamo:post-rebase
           imagePullPolicy: IfNotPresent
           workingDir: /workspace/examples/backends/vllm
@@ -143,11 +162,27 @@ spec:
               value: "Qwen/Qwen3-0.6B"
             - name: MODEL_PATH
               value: "Qwen/Qwen3-0.6B"
-          args:
-          - "python3 -m dynamo.vllm --model $MODEL_PATH --served-model-name $SERVED_MODEL_NAME --tensor-parallel-size 1 --data-parallel-size 1 --disaggregation-mode decode --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' --gpu-memory-utilization 0.90 --block-size 16"
           command:
-          - /bin/sh
-          - -c
+          - python3
+          - -m
+          - dynamo.vllm
+          args:
+          - --model
+          - $(MODEL_PATH)
+          - --served-model-name
+          - $(SERVED_MODEL_NAME)
+          - --tensor-parallel-size
+          - "1"
+          - --data-parallel-size
+          - "1"
+          - --disaggregation-mode
+          - decode
+          - --kv-transfer-config
+          - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+          - --gpu-memory-utilization
+          - "0.90"
+          - --block-size
+          - "16"
           image: docker.io/lambda108/dynamo:post-rebase
           imagePullPolicy: IfNotPresent
           workingDir: /workspace/examples/backends/vllm


### PR DESCRIPTION
#### Overview:

Follow-up fixes addressing CodeRabbit and reviewer comments on #8194 (merged as `b2f7f22`). The PR rewrote GMS checkpoint/restore operator wiring and went in with resolved review threads; this PR closes the actionable feedback left on those threads.

Size: ~630 net lines across nine commits. The work is a focused follow-up to already-reviewed feedback, not a new contribution — flagging per the contribution guide size guidance, which asks for an issue for changes ≥100 lines. Happy to split the two behavioral commits from the later cleanup/refactor commits into separate PRs if that's easier to land.

#### Architectural decisions

Five decisions worth calling out explicitly because they change contracts that future contributors need to respect.

**1. Main-container resolution: prefer-by-name with Containers[0] fallback.** Five different sites used to hardcode `podSpec.Containers[0]` as "the workload". That assumption breaks whenever `ExtraPodSpec.PodSpec.Containers` or a sidecar (istio-proxy, etc.) lands ahead of the workload in the slice. New contract, encoded in `snapshotprotocol.ResolveMainContainer`:

```
ResolveMainContainer(podSpec):
  1. if no containers -> nil
  2. scan for container named "main" -> return it
  3. fall back to Containers[0]    (preserves pre-convention pods and tests)
```

The fallback is deliberate — dropping it would break any pod rendered before the naming convention or produced by non-operator tooling (`snapshotctl` manifests authored by hand, old fixtures, manual pods). `snapshotctl` tightens the rule further: in multi-container manifests it requires the worker to be explicitly named `main`, because in CLI-authored input the ambiguity is user-visible.

**2. Operator and snapshot each own their own main-container logic.** The `"main"` container name convention predates the snapshot subsystem (LWS multinode enforcement, PR #3390, Oct 2025). Operator code must not import snapshotprotocol helpers that operate on pod-spec shape; the snapshot module is a consumer of the operator's convention, not the owner of the lookup. After this PR:

- `commonconsts.MainContainerName` + `common.ResolveMainContainer` are the authoritative operator-side copies. All operator callers (`graph.go`, `checkpoint_job.go`, `checkpoint/podspec.go`) use these.
- `snapshotprotocol.MainContainerName` + `snapshotprotocol.ResolveMainContainer` / `ResolveMainContainerName` are the snapshot-side copies. Snapshot agent, snapshotctl, and snapshot protocol internals use these.
- Both sides carry cross-reference comments pointing at the other copy, with a "must be kept in sync" note.

This is option (b) in the design tradeoff (duplicate constant + helper, documented on both sides) rather than option (a) (new shared Go module). `deploy/operator` and `deploy/snapshot` are separate `go.mod`s and cannot cross-import `internal/` packages; creating a third module purely for a constant and a five-line function would cost more than the drift risk of duplication.

**3. GMS wires onto the main container *by pointer*, before it lands in the slice.** Instead of searching `podSpec.Containers` for the workload after the fact, `GenerateBasePodSpec` now passes the in-scope local `container` variable directly to `dra.ApplyClaim` and `gms.EnsureServerSidecar`. `dra.ApplyClaim`'s signature changed from `(podSpec, claimName)` to `(podSpec, target *corev1.Container, claimName)` to match `gms.EnsureServerSidecar(podSpec, mainContainer)`. Rationale:

- The main container exists as a local at the GMS wire point; searching the slice is unnecessary work.
- Removes `graph.go`'s import of `snapshotprotocol`. Non-snapshot DGDs (most of them) no longer touch that package.
- Closes a latent bug in `checkpoint_job.go`: commit 1's name-based lookup could place the main container at a non-zero index, but the old `dra.ApplyClaim(podSpec, name)` still stripped `nvidia.com/gpu` from `Containers[0]` — so GMS and the DRA claim could land on different containers.

**4. GMS ↔ failover ordering invariant.** `buildFailoverPod` deletes the single `main` container and replaces it with `engine-0` / `engine-1` (DeepCopy + engine-specific overrides). The flow must be:

```
build local `container` (name="main")
     |
     v
apply GMS wiring (DRA claim + shared volume + env + mount)
     |
     v
podSpec.Containers = append(..., container)
     |
     v
backend.UpdatePodSpec  (multinode init containers, etc.)
     |
     v
append frontend sidecar (if any)
     |
     v
buildFailoverPod: DeepCopy "main" -> engine-0, engine-1
                  engines inherit GMS volume/mount/env/claim transitively
```

Moving GMS wiring later (after failover) would require wiring both engines independently and coordinating the shared volume. Keeping GMS before failover is the simpler invariant: one container gets GMS, failover clones it. Pinned by the new `TestGenerateBasePodSpec_GMSWiredToMainBeforeFailover` integration test.

**5. Checkpoint requires exec-form `command`; no more shell unwrapping.** The previous code tried to turn `[/bin/sh -c, "python3 -m dynamo.vllm ..."]` into `[python3, -m, dynamo.vllm, ...]` at checkpoint Job build time via `strings.Fields(Args[0])`. That silently relied on dash's `execve` tail-call optimization for correctness, panicked on empty args, and dropped shell quoting and compound commands. New contract:

- At `NewCheckpointJob` time, `RequireExecFormCommand` fails the Job with a clear error if the main container's command is a shell wrapper (`sh`/`bash`/`dash`/`zsh`/`ash`/`busybox` + `-c`).
- Users who need env-var substitution use Kubernetes `$(VAR)` syntax (resolved by kubelet pre-`execve`) rather than shell `$VAR`.
- The two in-repo GAIE vLLM examples that used shell form are rewritten to exec form in this PR.
- Documented in `docs/kubernetes/snapshot.md` under a new "Container entrypoint shape" section.

Non-checkpoint DGDs are unaffected — the default `[/bin/sh, -c]` placeholder in `component_common.go` stays where it is for users who only provide `args`.

#### Details:

Eight commits, each addressing a specific piece of feedback. Ordered so the behavioral fixes land first.

| Commit | Addresses | Summary |
|---|---|---|
| `fix(snapshot): resolve main container by name with Containers[0] fallback` | CodeRabbit D, E, I | Introduce `snapshotprotocol.ResolveMainContainer` / `ResolveMainContainerName` — prefer the container named `main`, fall back to `Containers[0]`. Replace five hardcoded index-0 sites in the operator and snapshot agent/snapshotctl (GMS wire, checkpoint job init, checkpoint restore, informer handler, CLI manifest loader). `PrepareRestorePodSpecForCheckpoint` now resolves the worker internally so callers can't accidentally pass a sidecar pointer. (Commit 8 later moves the `MainContainerName` constant back to the operator side where it originated; see below.) |
| `fix(snapshot): require exec-form command for checkpoint containers` | CodeRabbit B, C | **The only real crash bug.** The previous `strings.Fields(Args[0])` / `parts[:1]` unwrap of `/bin/sh -c "..."` panicked on empty args, mangled shell quoting, broke `exec` prefixes, and silently flattened compound commands. Replace it with an up-front validator that rejects shell-wrapped commands with a clear error message, so users see their misconfiguration at reconcile time rather than seeing checkpoints silently never fire. Update the two vLLM GAIE example YAMLs to exec form (using Kubernetes `$(VAR)` substitution in place of shell `$VAR`) and document the requirement in `docs/kubernetes/snapshot.md`. |
| `fix(operator): validate and repair pod-info volume contents` | CodeRabbit A | `EnsurePodInfoVolume` short-circuited on name match alone, so an upstream helper that installed a differently-sourced `podinfo` volume caused the loader to silently see missing `/etc/podinfo/dyn_*` files. Overwrite with the canonical definition when the name matches (the name is a dynamo-internal constant). |
| `chore(operator): drop redundant GMS nil-check, tighten init-container test, document EnsureGMSRestoreSidecars` | CodeRabbit G, H, J | Drop a redundant `ckpt.Spec.GPUMemoryService != nil` inner check. Split the test helper `find()` into `findRegular()` and `findInit()` so a regression that moves `gms-server`/`gms-loader` back to regular containers actually fails. Rewrite a stale `EnsureGMSRestoreSidecars` godoc that claimed the restore server runs as a regular container (it runs as an init sidecar) and spell out the `EnsureServerSidecar` precondition. |
| `fix(gms): align ready-file directory with socket directory fallback` | CodeRabbit F | `cli/server.py` fell back to `/tmp` but `common/utils.get_socket_path` falls back to `tempfile.gettempdir()`. With `TMPDIR` set, sockets and the ready file diverged. Use the same fallback on both sides. Also resolves the ruff S108 warning. |
| `chore(gms): add saver docstring and name the post-save idle constant` | reviewer M, N | Docstring on `_save_device`, rename the magic `3600` to `_POST_SAVE_IDLE_SECONDS`. |
| `refactor(operator): wire GMS onto main container by pointer, not by search` | addresses self-review of commit 1 | In `graph.go` the main container is still in scope as a local variable when GMS wires it, so searching `podSpec.Containers` for a container named `main` was unnecessary and pulled `snapshotprotocol` into a non-snapshot code path (layering violation: most DGDs never checkpoint). Reorder so GMS runs against the local `container` before it is appended to the slice, and change `dra.ApplyClaim`'s signature from `(podSpec, claimName)` to `(podSpec, target *corev1.Container, claimName)` so it mutates a caller-supplied container. The signature change also fixes a latent bug in `checkpoint_job.go`: after commit 1 the main container there is resolved by name (may not be at index 0), but the old `dra.ApplyClaim` kept stripping `nvidia.com/gpu` from `Containers[0]` and writing the claim there — so GMS and the DRA claim could land on different containers. Aligning both on a single caller-supplied pointer closes that. |
| `refactor(operator): keep MainContainerName on operator side; document the duplicate` | corrects provenance of the constant | The `main` container name convention predates the snapshot subsystem (added for LWS multinode enforcement in PR #3390, Oct 2025) and is owned by the operator, not by snapshot-protocol. Commit 1 inverted that by making `commonconsts.MainContainerName` alias `snapshotprotocol.MainContainerName`, which put the producer behind the consumer. Restore the authoritative constant to the operator side and keep a local copy in snapshotprotocol with a cross-reference comment explaining that `deploy/snapshot` is a separate Go module and cannot import `deploy/operator/internal` directly. Also swap a third hardcoded `"main"` in the snapshot executor for the constant. Adds a new integration test `TestGenerateBasePodSpec_GMSWiredToMainBeforeFailover` that exercises GMS + failover end-to-end — verifies that after `buildFailoverPod` replaces the "main" container with `engine-0`/`engine-1`, both engines inherit the GMS shared-socket volume mount, `GMS_SOCKET_DIR` env, and DRA claim (via `DeepCopy` in `buildEngineContainer`), and that the pod-level `gms-server` init sidecar and shared volume land exactly once. This closes the coverage gap around the GMS-wire-then-failover-clone sequencing that commit 7 depends on. |
| `refactor(operator): move main-container resolver to operator common package` | finishes decoupling operator from snapshot helpers | Operator code should not import `snapshotprotocol.ResolveMainContainer` — the snapshot module is a consumer of the operator's main-container convention, not the owner of the lookup logic. Add `common.ResolveMainContainer` in `deploy/operator/internal/common/` with unit tests and convert the two remaining operator call sites (`controller/checkpoint_job.go`, `checkpoint/podspec.go`). Snapshot-side callers (`snapshotctl`, snapshot agent, snapshot protocol internals) keep the `snapshotprotocol` copy; both files gain cross-reference comments pointing at the other copy. |

Ordering of behavioral commits is deliberate — the main-container helper (commit 1) is a dependency of the exec-form validator (commit 2, which also uses `ResolveMainContainer` in `NewCheckpointJob`) and of the GMS refactor (commit 7, which removes the need for it inside graph.go). Commits 8 and 9 are follow-ups that split the helper along module boundaries after review feedback.

#### Where should the reviewer start?

1. **`deploy/snapshot/protocol/maincontainer.go`** — new file, one helper + one validator with full unit-test coverage in `maincontainer_test.go`. Note the cross-reference comment on `MainContainerName` explaining why the constant is duplicated across the operator and snapshot modules.
2. **`deploy/operator/internal/dynamo/graph.go`** GMS block (post-commit 7/8) — the main container is wired by pointer against the in-scope local variable, no `snapshotprotocol` import here. The regression test `TestGenerateBasePodSpec_GMSWiredToMainBeforeFailover` pins the failover interaction.
3. **`deploy/operator/internal/controller/checkpoint_job.go`** — second half of the exec-form fix; verify the unwrap is gone and the validator runs via `NewCheckpointJob`.
4. **`examples/backends/vllm/deploy/gaie/{agg,disagg}.yaml`** — verify the exec-form translation is functionally equivalent to the previous shell-form invocation (env expansion now uses Kubernetes `$(VAR)`, which the kubelet resolves pre-exec, in place of shell `$VAR`).
5. **`docs/kubernetes/snapshot.md`** new "Container entrypoint shape" section — the user-facing contract change.
6. `deploy/operator/internal/checkpoint/podinfo.go` — tiny but behavioral.
7. Skim the nit commits.

#### Tests

- New unit tests:
  - `protocol.ResolveMainContainer` + `ResolveMainContainerName` (snapshot side).
  - `common.ResolveMainContainer` (operator side).
  - `protocol.RequireExecFormCommand` — 12 shell-form / exec-form cases, including `/bin/sh -c`, `bash -c`, `dash -c`, busybox invocation, and false-positive safe cases like plain `bash -l`.
  - `NewCheckpointJob` rejects shell-wrapped commands in both single-GPU and `WrapLaunchJob` paths.
  - `InjectCheckpointIntoPodSpec` — added "resolves main even when not at index zero" case (sidecar at index 0, `main` at index 1) alongside the existing "targets the container named main" case.
  - `EnsurePodInfoVolume` — append / replace-wrong-source / repair-partial-items / idempotent.
  - `TestGenerateBasePodSpec_GMSWiredToMainBeforeFailover` — asserts that GMS shared volume mount, `GMS_SOCKET_DIR` env, and DRA claim survive the `buildFailoverPod` DeepCopy onto `engine-0`/`engine-1`.
- Existing test that asserted `no container named` in an error message updated to match the new resolver's error string.
- All `deploy/operator` unit tests pass (`make envtest` + `go test $(go list ./... | grep -v /e2e | grep -v /test)`).
- All `deploy/snapshot` tests pass (`go test ./...`).
- `go vet ./...` clean in both modules.
- `ruff check lib/gpu_memory_service/` clean.
- `pre-commit run` across the changeset: all 18 hooks pass.

#### Risk notes for deploy-codeowners

- The main-container resolver's `Containers[0]` fallback preserves today's behavior for any pod rendered before the naming convention or produced by non-operator tooling, so this commit is safe to cherry-pick without needing to audit every pod-emitting path.
- The exec-form validator **breaks deployments** that currently use `/bin/sh -c "python ..."` as the main container command on a checkpoint/GMS-enabled worker. The only in-repo YAMLs that matched this pattern are the two GAIE vLLM examples, which are fixed in this PR. External users with shell-wrapped workers on a checkpoint path will see a clean reconcile-time error telling them to switch to exec form. Worth calling out in the release note.
- No Go module or Python dependency changes.
- No API changes. `PrepareRestorePodSpecForCheckpoint` drops the `container` argument, but it has no callers outside this repo (and the one in-repo caller is updated).

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #8194 (addresses resolved CodeRabbit threads and reviewer comments left on the merged PR)
