### PR TITLE
chore: Pin YAML pip installs to reduce supply chain risk

### DIFF
--- a/examples/backends/vllm/deploy/lora/multimodal/sync-lora-job.yaml
+++ b/examples/backends/vllm/deploy/lora/multimodal/sync-lora-job.yaml
@@ -15,7 +15,7 @@ spec:
         - -c
         - |
           set -eux
-          pip install --no-cache-dir huggingface-hub awscli
+          pip install --no-cache-dir huggingface-hub==1.11.0 awscli==1.44.80
           hf download  $MODEL_NAME --local-dir /tmp/lora
           rm -rf /tmp/lora/.cache
           aws --endpoint-url=http://minio:9000 s3 mb s3://$LORA_ROOT_PATH || true

--- a/examples/backends/vllm/deploy/lora/sync-lora-job.yaml
+++ b/examples/backends/vllm/deploy/lora/sync-lora-job.yaml
@@ -15,7 +15,7 @@ spec:
         - -c
         - |
           set -eux
-          pip install --no-cache-dir huggingface-hub awscli
+          pip install --no-cache-dir huggingface-hub==1.11.0 awscli==1.44.80
           hf download  $MODEL_NAME --local-dir /tmp/lora
           rm -rf /tmp/lora/.cache
           aws --endpoint-url=http://minio:9000 s3 mb s3://$LORA_ROOT_PATH || true

--- a/recipes/deepseek-r1/model-cache/model-download-sglang.yaml
+++ b/recipes/deepseek-r1/model-cache/model-download-sglang.yaml
@@ -27,7 +27,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download deepseek-ai/DeepSeek-R1
           volumeMounts:
             - name: model-cache

--- a/recipes/deepseek-r1/model-cache/model-download-sglang.yaml
+++ b/recipes/deepseek-r1/model-cache/model-download-sglang.yaml
@@ -20,14 +20,14 @@ spec:
           image: python:3.10-slim
           command: ["sh", "-c"]
           env:
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
             - name: HF_HOME
               value: /opt/model-cache
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download deepseek-ai/DeepSeek-R1
           volumeMounts:
             - name: model-cache

--- a/recipes/deepseek-r1/model-cache/model-download.yaml
+++ b/recipes/deepseek-r1/model-cache/model-download.yaml
@@ -32,7 +32,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download nvidia/DeepSeek-R1-FP4 --local-dir /model-cache/deepseek-r1-fp4
               hf download deepseek-ai/DeepSeek-R1 --local-dir /model-cache/deepseek-r1
           volumeMounts:

--- a/recipes/deepseek-r1/model-cache/model-download.yaml
+++ b/recipes/deepseek-r1/model-cache/model-download.yaml
@@ -20,7 +20,7 @@ spec:
           image: python:3.10-slim
           command: ["sh", "-c"]
           env:
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
             # Optional: create with: kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<token> -n <namespace>
             - name: HF_TOKEN
@@ -32,7 +32,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download nvidia/DeepSeek-R1-FP4 --local-dir /model-cache/deepseek-r1-fp4
               hf download deepseek-ai/DeepSeek-R1 --local-dir /model-cache/deepseek-r1
           volumeMounts:

--- a/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/perf.yaml
+++ b/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/perf.yaml
@@ -30,7 +30,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git && apt-get clean
-          pip install aiperf;
+          pip install aiperf==0.6.0;
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range
@@ -152,4 +152,3 @@ spec:
       - name: model-cache
         persistentVolumeClaim:
           claimName: model-cache
-

--- a/recipes/deepseek-v32-fp4/model-cache/model-download.yaml
+++ b/recipes/deepseek-v32-fp4/model-cache/model-download.yaml
@@ -37,7 +37,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download $MODEL_NAME
           volumeMounts:
             - name: model-cache

--- a/recipes/deepseek-v32-fp4/model-cache/model-download.yaml
+++ b/recipes/deepseek-v32-fp4/model-cache/model-download.yaml
@@ -32,12 +32,12 @@ spec:
               value: nvidia/DeepSeek-V3.2-NVFP4
             - name: HF_HOME
               value: /model-store
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download $MODEL_NAME
           volumeMounts:
             - name: model-cache

--- a/recipes/glm-5-nvfp4/model-cache/model-download.yaml
+++ b/recipes/glm-5-nvfp4/model-cache/model-download.yaml
@@ -31,12 +31,12 @@ spec:
               value: nvidia/GLM-5-NVFP4
             - name: HF_HOME
               value: /model-store
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download $MODEL_NAME
           volumeMounts:
             - name: model-cache

--- a/recipes/glm-5-nvfp4/model-cache/model-download.yaml
+++ b/recipes/glm-5-nvfp4/model-cache/model-download.yaml
@@ -36,7 +36,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download $MODEL_NAME
           volumeMounts:
             - name: model-cache

--- a/recipes/glm-5-nvfp4/sglang/disagg/perf.yaml
+++ b/recipes/glm-5-nvfp4/sglang/disagg/perf.yaml
@@ -53,7 +53,7 @@ spec:
         - |
           set -eu
           apt-get update -qq && apt-get install -y -qq curl jq && apt-get clean
-          pip install -q aiperf transformers tokenizers
+          pip install -q aiperf==0.6.0 transformers==4.57.3 tokenizers==0.22.2
 
           echo "Waiting for model at http://$ENDPOINT/v1/models..."
           while ! curl -sf "http://$ENDPOINT/v1/models" | jq -e --arg m "$TARGET_MODEL" '.data[]? | select(.id == $m)' >/dev/null 2>&1; do

--- a/recipes/gpt-oss-120b/model-cache/model-download.yaml
+++ b/recipes/gpt-oss-120b/model-cache/model-download.yaml
@@ -33,7 +33,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download $MODEL_NAME --revision $MODEL_REVISION --exclude "original/*" --exclude "metal/*"
           volumeMounts:
             - name: model-cache

--- a/recipes/gpt-oss-120b/model-cache/model-download.yaml
+++ b/recipes/gpt-oss-120b/model-cache/model-download.yaml
@@ -26,14 +26,14 @@ spec:
               value: openai/gpt-oss-120b
             - name: HF_HOME
               value: /model-store
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
             - name: MODEL_REVISION
               value: b5c939de8f754692c1647ca79fbf85e8c1e70f8a
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download $MODEL_NAME --revision $MODEL_REVISION --exclude "original/*" --exclude "metal/*"
           volumeMounts:
             - name: model-cache

--- a/recipes/kimi-k2.5/model-cache/baseten/model-download.yaml
+++ b/recipes/kimi-k2.5/model-cache/baseten/model-download.yaml
@@ -31,7 +31,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download $MODEL_NAME
           volumeMounts:
             - name: model-cache

--- a/recipes/kimi-k2.5/model-cache/baseten/model-download.yaml
+++ b/recipes/kimi-k2.5/model-cache/baseten/model-download.yaml
@@ -26,12 +26,12 @@ spec:
               value: baseten-admin/Kimi-2.5-text-nvfp4-v3
             - name: HF_HOME
               value: /model-store
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download $MODEL_NAME
           volumeMounts:
             - name: model-cache

--- a/recipes/kimi-k2.5/model-cache/nvidia/eagle-download.yaml
+++ b/recipes/kimi-k2.5/model-cache/nvidia/eagle-download.yaml
@@ -28,12 +28,12 @@ spec:
               value: 0b0c6ac039089ad2c2418c91c039553381a302d9
             - name: HF_HOME
               value: /model-store
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download "$MODEL_NAME" --revision "$MODEL_REVISION"
           volumeMounts:
             - name: model-cache

--- a/recipes/kimi-k2.5/model-cache/nvidia/eagle-download.yaml
+++ b/recipes/kimi-k2.5/model-cache/nvidia/eagle-download.yaml
@@ -33,7 +33,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download "$MODEL_NAME" --revision "$MODEL_REVISION"
           volumeMounts:
             - name: model-cache

--- a/recipes/kimi-k2.5/model-cache/nvidia/model-download.yaml
+++ b/recipes/kimi-k2.5/model-cache/nvidia/model-download.yaml
@@ -31,7 +31,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download $MODEL_NAME
           volumeMounts:
             - name: model-cache

--- a/recipes/kimi-k2.5/model-cache/nvidia/model-download.yaml
+++ b/recipes/kimi-k2.5/model-cache/nvidia/model-download.yaml
@@ -26,12 +26,12 @@ spec:
               value: nvidia/Kimi-K2.5-NVFP4
             - name: HF_HOME
               value: /model-store
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download $MODEL_NAME
           volumeMounts:
             - name: model-cache

--- a/recipes/llama-3-70b/model-cache/model-download.yaml
+++ b/recipes/llama-3-70b/model-cache/model-download.yaml
@@ -26,14 +26,14 @@ spec:
               value: "RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic"
             - name: HF_HOME
               value: /model-store
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
             - name: MODEL_REVISION
               value: ddb4128556dfcff99e0c41aee159ea6c3e655dcd
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download $MODEL_NAME --revision $MODEL_REVISION
           volumeMounts:
             - name: model-cache

--- a/recipes/llama-3-70b/model-cache/model-download.yaml
+++ b/recipes/llama-3-70b/model-cache/model-download.yaml
@@ -33,7 +33,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download $MODEL_NAME --revision $MODEL_REVISION
           volumeMounts:
             - name: model-cache

--- a/recipes/nemotron-3-super-fp8/model-cache/model-download.yaml
+++ b/recipes/nemotron-3-super-fp8/model-cache/model-download.yaml
@@ -31,7 +31,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download $MODEL_NAME
           volumeMounts:
             - name: model-cache

--- a/recipes/nemotron-3-super-fp8/model-cache/model-download.yaml
+++ b/recipes/nemotron-3-super-fp8/model-cache/model-download.yaml
@@ -26,12 +26,12 @@ spec:
               value: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
             - name: HF_HOME
               value: /model-store
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download $MODEL_NAME
           volumeMounts:
             - name: model-cache

--- a/recipes/qwen3-235b-a22b-fp8/model-cache/model-download.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/model-cache/model-download.yaml
@@ -26,14 +26,14 @@ spec:
               value: Qwen/Qwen3-235B-A22B-FP8
             - name: HF_HOME
               value: /model-store
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
             - name: MODEL_REVISION
               value: 39eb2b067ea6b8e3e1dd97d3cd0c7ffeaf3e1a35
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download $MODEL_NAME --revision $MODEL_REVISION
           volumeMounts:
             - name: model-cache

--- a/recipes/qwen3-235b-a22b-fp8/model-cache/model-download.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/model-cache/model-download.yaml
@@ -33,7 +33,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download $MODEL_NAME --revision $MODEL_REVISION
           volumeMounts:
             - name: model-cache

--- a/recipes/qwen3-32b-fp8/model-cache/model-download.yaml
+++ b/recipes/qwen3-32b-fp8/model-cache/model-download.yaml
@@ -26,14 +26,14 @@ spec:
               value: Qwen/Qwen3-32B-FP8
             - name: HF_HOME
               value: /model-store
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
             - name: MODEL_REVISION
               value: aa55da1ecc13d006e8b8e4f54579b1ea8c3db2df
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download $MODEL_NAME --revision $MODEL_REVISION
           volumeMounts:
             - name: model-cache

--- a/recipes/qwen3-32b-fp8/model-cache/model-download.yaml
+++ b/recipes/qwen3-32b-fp8/model-cache/model-download.yaml
@@ -33,7 +33,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download $MODEL_NAME --revision $MODEL_REVISION
           volumeMounts:
             - name: model-cache

--- a/recipes/qwen3-32b/model-cache/model-download.yaml
+++ b/recipes/qwen3-32b/model-cache/model-download.yaml
@@ -33,7 +33,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download $MODEL_NAME --revision $MODEL_REVISION
           volumeMounts:
             - name: model-cache

--- a/recipes/qwen3-32b/model-cache/model-download.yaml
+++ b/recipes/qwen3-32b/model-cache/model-download.yaml
@@ -26,14 +26,14 @@ spec:
               value: "Qwen/Qwen3-32B"
             - name: HF_HOME
               value: /home/dynamo/.cache/huggingface
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
             - name: MODEL_REVISION
               value: 9216db5781bf21249d130ec9da846c4624c16137
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download $MODEL_NAME --revision $MODEL_REVISION
           volumeMounts:
             - name: model-cache

--- a/recipes/qwen3-32b/vllm/agg-round-robin/perf.yaml
+++ b/recipes/qwen3-32b/vllm/agg-round-robin/perf.yaml
@@ -20,7 +20,7 @@ spec:
         apt update && apt install tmux wget curl jq -y
 
         # Install benchmarking tool
-        pip install aiperf
+        pip install aiperf==0.6.0
 
         # Wait for model to be ready
         echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models..."

--- a/recipes/qwen3-32b/vllm/disagg-kv-router/perf.yaml
+++ b/recipes/qwen3-32b/vllm/disagg-kv-router/perf.yaml
@@ -20,7 +20,7 @@ spec:
         apt update && apt install tmux wget curl jq -y
 
         # Install benchmarking tool
-        pip install aiperf
+        pip install aiperf==0.6.0
 
         # Wait for model to be ready
         echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models..."

--- a/recipes/qwen3-vl-30b/model-cache/model-download.yaml
+++ b/recipes/qwen3-vl-30b/model-cache/model-download.yaml
@@ -33,7 +33,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub hf_transfer
+              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
               hf download "$MODEL_NAME" --revision "$MODEL_REVISION"
           volumeMounts:
             - name: model-cache

--- a/recipes/qwen3-vl-30b/model-cache/model-download.yaml
+++ b/recipes/qwen3-vl-30b/model-cache/model-download.yaml
@@ -26,14 +26,14 @@ spec:
               value: "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8"  # Remove FP8 for BF16 variant
             - name: HF_HOME
               value: /home/dynamo/.cache/huggingface
-            - name: HF_HUB_ENABLE_HF_TRANSFER
+            - name: HF_XET_HIGH_PERFORMANCE
               value: "1"
             - name: MODEL_REVISION
               value: "main"
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0 hf_transfer==0.1.9
+              pip install --no-cache-dir huggingface_hub==1.11.0
               hf download "$MODEL_NAME" --revision "$MODEL_REVISION"
           volumeMounts:
             - name: model-cache

--- a/recipes/qwen3-vl-30b/vllm/agg-embedding-cache/perf.yaml
+++ b/recipes/qwen3-vl-30b/vllm/agg-embedding-cache/perf.yaml
@@ -19,7 +19,7 @@ spec:
           ulimit -u 65536
 
           apt update && apt install -y tmux curl jq
-          pip install aiperf
+          pip install aiperf==0.6.0
 
           echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models..."
           until curl -s "http://${FRONTEND}:8000/v1/models" | jq -e --arg model "${MODEL_NAME}" '.data[]? | select(.id == $model)' >/dev/null 2>&1; do


### PR DESCRIPTION
Unpinned `pip install` commands in `recipes/` and `examples/` allow those jobs to resolve whatever package version happens to be current at execution time. That creates avoidable supply chain exposure: a compromised upstream release, malicious dependency swap, or unexpected breaking update can change runtime behavior without any repo change.

This change pins the previously floating package installs in YAML jobs so the resolved artifacts are stable and reviewable.

Version selection:
- `huggingface_hub==1.11.0`, `huggingface-hub==1.11.0`, `hf_transfer==0.1.9`, and `tokenizers==0.22.2` were pinned to the latest versions available on PyPI at the time of this change.
- `aiperf==0.6.0` was pinned to the repo’s existing benchmark baseline already used in `container/deps/requirements.benchmark.txt` and `benchmarks/pyproject.toml`.
- `transformers==4.57.3` was pinned in the SGLang perf job to match the repo’s documented compatibility guidance for that stack.
- `awscli==1.44.80` was pinned to the current PyPI release used by the example sync jobs.
- Existing `git+...@<commit>` installs were left unchanged because they are already pinned to immutable commits.

This makes the YAML-based install surface deterministic and reduces the chance of silently pulling unreviewed upstream changes at deploy or benchmark time.

Assisted-By: Codex:gpt-5.4

---

Also fixes a performance regression by replacing old go-faster env var `HF_HUB_ENABLE_HF_TRANSFER` with the new one for the new backend: `HF_XET_HIGH_PERFORMANCE`.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned runtime Python packages for repeatable deployments (huggingface-hub==1.11.0, aiperf==0.6.0).
  * Removed legacy hf_transfer installs where applicable.
  * Switched transfer-related environment setting to a new runtime variable for transfer behavior.
  * Fixed YAML formatting issues (trailing newlines) across deployment manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->