### PR TITLE
ci: add automated release version bump workflows

### DIFF
--- a/.github/devin-prompts/docs-sync.md.tmpl
+++ b/.github/devin-prompts/docs-sync.md.tmpl
@@ -1,0 +1,51 @@
+# Devin Task: Sync Dynamo reference docs for v${VERSION}
+
+Rendered by `.github/workflows/_version-bump-shared.yml` via `envsubst`.
+Only `${...}` placeholders are interpolated; everything else is verbatim.
+
+## Inputs
+
+- Repo: `ai-dynamo/dynamo`
+- Branch / PR: `${BRANCH}` — head of ${PR_URL} (already open)
+- Version: `v${VERSION}` released ${RELEASE_DATE}
+- Backends: SGLang `${SGLANG}` · TensorRT-LLM `${TRTLLM}` · vLLM `${VLLM}` · NIXL `${NIXL}`
+
+## Global rules
+
+- **Anchored edits only.** Touch only the lines/rows directly below each `<!-- bump-version:* -->` anchor. Never modify a historical row, never move or remove an anchor.
+- **Idempotent.** For each anchor, if the post-edit content already matches the spec below, skip it and log `::notice::<file> already at v${VERSION}`.
+- **Push, don't reopen.** Commit with `-s` (DCO), push to `${BRANCH}`; no `--force`, no amend, no new PR.
+
+## Edits
+
+### `docs/reference/release-artifacts.md`
+
+`<!-- bump-version:current-release -->`
+- Replace the heading below with: `## Current Release: Dynamo v${VERSION}`
+- In the bullet list, set `**GitHub Release:**` to `[v${VERSION}](https://github.com/ai-dynamo/dynamo/releases/tag/v${VERSION})` and `**Docs:**` to `[v${VERSION}](https://docs.dynamo.nvidia.com/dynamo)`.
+
+`<!-- bump-version:github-releases-table -->`
+- Insert as the first body row (after the header separator):
+  `` | `v${VERSION}` | ${RELEASE_DATE} | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v${VERSION}) | [Docs](https://docs.dynamo.nvidia.com/dynamo) | | ``
+
+### `docs/reference/support-matrix.md`
+
+`<!-- bump-version:at-a-glance -->`
+- Replace the line below with:
+  `**Latest stable release:** [v${VERSION}](https://github.com/ai-dynamo/dynamo/releases/tag/v${VERSION}) -- SGLang \`${SGLANG}\` | TensorRT-LLM \`${TRTLLM}\` | vLLM \`${VLLM}\` | NIXL \`${NIXL}\``
+
+`<!-- bump-version:backend-dependencies-table -->`
+- Insert immediately after the `**main (ToT)**` row:
+  `` | **v${VERSION}** | \`${SGLANG}\` | \`${TRTLLM}\` | \`${VLLM}\` | \`${NIXL}\` | ``
+- In the row that was previously topmost (now directly below the new one), strip any `*(in progress)*` italic marker from its first cell.
+
+### `docs/reference/feature-matrix.md`
+
+`<!-- bump-version:version-stamp -->`
+- Replace the line below with: `*Updated for Dynamo v${VERSION}*`
+
+## Validate, commit, report
+
+1. Run `python3 .github/scripts/bump_version.py --check`. If it exits non-zero, `git reset --hard HEAD` and skip to step 3 with status `aborted`.
+2. One commit per changed file: `git commit -s -m "docs(release): sync <basename> for v${VERSION}"`, then `git push origin ${BRANCH}`.
+3. Post one comment on ${PR_URL} summarizing per-file outcome (`edited` / `already-current` / `aborted`), the `--check` result, and pushed SHAs. If aborted, include the failing tool's tail output (~50 lines) in a fenced block.

--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -1,130 +1,297 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""
-Dynamo Release Version Bump Script.
+"""Dynamo release version bump script.
 
-Discovery-based version bumper that scans the entire repo for Dynamo version
-references and updates them to the new release version. Used by both Phase 1
-(release branch prep) and Phase 2 (port to main) workflows.
+A single rule-driven engine that finds every Dynamo version reference in the
+repo and updates it to the new release version. Used by both Phase 1 (release
+branch prep) and Phase 2 (port to main) workflows.
+
+Design:
+    - A single :data:`RULES` table declares every version reference type
+      (regex + replacement + target format + scope + file filter). The engine
+      walks the repo once, applying every rule that matches. Adding a new
+      reference type = one row in :data:`RULES`.
+    - A :class:`Version` type owns format conversion (Python PEP 440 form vs.
+      Cargo/Helm semver form vs. URL-safe dashed form).
+    - Per-file opt-out via the ``bump-version: ignore`` comment marker.
+    - ``--check`` is just a dry-run against the expected version: any change
+      the engine would make = a stale reference.
+    - ``--dry-run`` previews without writing.
+    - ``--skip-core/containers/helm/docs`` gate which rule categories fire.
 
 Usage:
-    # Full release: bump all versions to 1.0.0 with backend metadata
-    python3 .github/scripts/bump_version.py \\
-        --new-version 1.0.0 \\
-        --vllm-version 0.15.1 \\
-        --sglang-version 0.5.7 \\
-        --trtllm-version 1.3.0rc1 \\
-        --nixl-version 0.9.0 \\
-        --cuda-versions-vllm 12.9,13.0 \\
-        --cuda-versions-sglang 12.9,13.0 \\
-        --cuda-versions-trtllm 13.0 \\
+    # Full release: bump all versions to 1.0.0
+    python3 .github/scripts/bump_version.py --new-version 1.0.0 \\
+        --vllm-version 0.19.0 --sglang-version 0.5.7 \\
+        --trtllm-version 1.3.0rc1 --nixl-version 0.10.1 \\
         --release-date "Feb 15, 2026"
 
-    # Post-release: Helm-only patch (skip containers, wheels, etc.)
-    python3 .github/scripts/bump_version.py \\
-        --new-version 0.9.0.post1 \\
+    # Post-release: Helm-only patch
+    python3 .github/scripts/bump_version.py --new-version 0.9.0.post1 \\
         --skip-core --skip-containers --skip-docs
 
-    # Dry run (print changes without writing)
+    # Dry run
     python3 .github/scripts/bump_version.py --new-version 1.0.0 --dry-run
 
-    # Check for stale versions (CI mode)
-    python3 .github/scripts/bump_version.py --check --expected-version 0.9.0
+    # Check for stale versions (CI)
+    python3 .github/scripts/bump_version.py --check
 
 Version format conventions:
     Python / container tags / git:  0.9.0.post1  (PEP 440, dot separator)
     Rust crates / Helm charts:      0.9.0-post1  (semver, hyphen separator)
-    The script accepts the Python format and auto-converts for Cargo/Helm.
+    URL slugs:                      0-9-0-post1  (all dashes)
 """
 
 from __future__ import annotations
 
 import argparse
-import fnmatch
 import os
 import re
 import sys
+from dataclasses import dataclass, field
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
-from typing import Iterator
+from typing import Callable, Iterator
+
+# Per-file opt-out: any file containing this marker is skipped entirely.
+# Use it in test fixtures / historical artifacts that must stay on an old version.
+IGNORE_MARKER = "bump-version: ignore"
+
 
 # ---------------------------------------------------------------------------
-# Version format helpers
+# Version type
 # ---------------------------------------------------------------------------
 
 
-def to_semver(version: str) -> str:
-    """Convert Python PEP 440 post-release to semver format for Cargo/Helm.
+@dataclass(frozen=True, order=True)
+class Version:
+    """A Dynamo release version.
 
-    0.9.0.post1 -> 0.9.0-post1
-    1.0.0       -> 1.0.0       (no change for non-post versions)
+    Knows its three canonical string forms:
+      - :meth:`python`:  ``0.9.0`` / ``0.9.0.post1`` (PEP 440, for Python/images/git)
+      - :meth:`semver`:  ``0.9.0`` / ``0.9.0-post1`` (for Cargo/Helm)
+      - :meth:`dashed`:  ``0-9-0`` / ``0-9-0-post1`` (for URL slugs)
     """
-    return re.sub(r"\.post(\d+)$", r"-post\1", version)
 
+    major: int
+    minor: int
+    patch: int
+    post: int | None = None
 
-def is_post_release(version: str) -> bool:
-    """Check if version is a post-release (e.g., 0.9.0.post1)."""
-    return bool(re.search(r"\.post\d+$", version))
+    _PARSE_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[.-]post(\d+))?$")
+
+    @classmethod
+    def parse(cls, s: str) -> Version:
+        m = cls._PARSE_RE.match(s)
+        if not m:
+            raise argparse.ArgumentTypeError(
+                f"Not a valid version: {s!r}. Expected X.Y.Z or X.Y.Z.postN."
+            )
+        maj, min_, pat, post = m.groups()
+        return cls(
+            int(maj), int(min_), int(pat), int(post) if post is not None else None
+        )
+
+    def python(self) -> str:
+        base = f"{self.major}.{self.minor}.{self.patch}"
+        return f"{base}.post{self.post}" if self.post is not None else base
+
+    def semver(self) -> str:
+        base = f"{self.major}.{self.minor}.{self.patch}"
+        return f"{base}-post{self.post}" if self.post is not None else base
+
+    def dashed(self) -> str:
+        return self.python().replace(".", "-")
+
+    @property
+    def is_post(self) -> bool:
+        return self.post is not None
+
+    def __str__(self) -> str:
+        return self.python()
 
 
 # ---------------------------------------------------------------------------
-# Regex patterns that identify Dynamo version references
+# Scope
 # ---------------------------------------------------------------------------
-# Version number pattern: X.Y.Z with optional .postN or -postN suffix
+
+
+class Scope(Enum):
+    CORE = "core"  # pyproject, Cargo, setup.py
+    CONTAINERS = "containers"  # image tags, git refs, wheel pins, operator samples
+    HELM = "helm"  # Chart.yaml, values.yaml
+    DOCS = "docs"  # support-matrix, feature-matrix, release-artifacts
+
+
+# ---------------------------------------------------------------------------
+# Rule table
+# ---------------------------------------------------------------------------
+
+# Version token: X.Y.Z with optional .postN or -postN suffix.
 _VER = r"\d+\.\d+\.\d+(?:[.-]post\d+)?"
 
-# Container image tags: ai-dynamo/<any-image>:X.Y.Z
-# Broad match — catches any image name under ai-dynamo/ so new images
-# (epp-image, snapshot-agent, etc.) are picked up automatically.
-IMAGE_TAG_RE = re.compile(
-    r"((?:nvcr\.io/nvidia/)?ai-dynamo/[a-z][a-z0-9-]*)" rf":({_VER})"
+
+def _always(_: Path) -> bool:
+    return True
+
+
+def _name_is(*names: str) -> Callable[[Path], bool]:
+    allowed = set(names)
+    return lambda p: p.name in allowed
+
+
+def _endswith(*suffixes: str) -> Callable[[Path], bool]:
+    return lambda p: any(p.as_posix().endswith(s) for s in suffixes)
+
+
+@dataclass(frozen=True)
+class Rule:
+    """A single version-reference update rule.
+
+    ``replacement`` may use the placeholders ``{python}``, ``{semver}``, and
+    ``{dashed}`` — these expand from the :class:`Version` being applied.
+    Standard regex backreferences (``\\1``, ``\\g<1>``) are preserved.
+    """
+
+    name: str
+    scope: Scope
+    pattern: re.Pattern[str]
+    replacement: str
+    file_filter: Callable[[Path], bool] = _always
+
+    def apply(self, content: str, version: Version) -> str:
+        repl = (
+            self.replacement.replace("{python}", version.python())
+            .replace("{semver}", version.semver())
+            .replace("{dashed}", version.dashed())
+        )
+        return self.pattern.sub(repl, content)
+
+
+RULES: tuple[Rule, ...] = (
+    # -- Core version files ---------------------------------------------------
+    Rule(
+        "pyproject_project_version",
+        Scope.CORE,
+        re.compile(rf'(^version\s*=\s*"){_VER}(")', re.MULTILINE),
+        r"\g<1>{python}\g<2>",
+        _name_is("pyproject.toml"),
+    ),
+    Rule(
+        "pyproject_ai_dynamo_pin",
+        Scope.CORE,
+        # ai-dynamo / ai_dynamo / ai-dynamo-runtime / ai-dynamo[vllm] == X.Y.Z
+        re.compile(rf"(ai[_-]dynamo(?:[_-]runtime)?(?:\[[^\]]*\])?==){_VER}"),
+        r"\g<1>{python}",
+        _name_is("pyproject.toml"),
+    ),
+    Rule(
+        "cargo_package_version",
+        Scope.CORE,
+        re.compile(rf'(^version\s*=\s*"){_VER}(")', re.MULTILINE),
+        r"\g<1>{semver}\g<2>",
+        _name_is("Cargo.toml"),
+    ),
+    Rule(
+        "gpu_memory_setup_version",
+        Scope.CORE,
+        re.compile(rf'(version\s*=\s*"){_VER}(")'),
+        r"\g<1>{python}\g<2>",
+        _endswith("lib/gpu_memory_service/setup.py"),
+    ),
+    # -- Helm charts ----------------------------------------------------------
+    Rule(
+        "helm_chart_version",
+        Scope.HELM,
+        re.compile(rf"(^version:\s*){_VER}", re.MULTILINE),
+        r"\g<1>{semver}",
+        _name_is("Chart.yaml"),
+    ),
+    Rule(
+        "helm_chart_appVersion",
+        Scope.HELM,
+        re.compile(rf'(^appVersion:\s*"){_VER}(")', re.MULTILINE),
+        r"\g<1>{semver}\g<2>",
+        _name_is("Chart.yaml"),
+    ),
+    Rule(
+        "helm_dependency_dynamo_operator",
+        Scope.HELM,
+        re.compile(rf"(- name: dynamo-operator\n\s+version:\s*){_VER}"),
+        r"\g<1>{semver}",
+        _name_is("Chart.yaml"),
+    ),
+    Rule(
+        "helm_snapshot_values_tag",
+        Scope.HELM,
+        re.compile(
+            rf"(repository:\s*nvcr\.io/nvidia/ai-dynamo/snapshot-agent\n\s*tag:\s*){_VER}"
+        ),
+        r"\g<1>{semver}",
+        _endswith("deploy/helm/charts/snapshot/values.yaml"),
+    ),
+    # -- Container image tags (broad, self-healing) ---------------------------
+    Rule(
+        "image_tag_ai_dynamo_ns",
+        Scope.CONTAINERS,
+        re.compile(rf"((?:nvcr\.io/nvidia/)?ai-dynamo/[a-z][a-z0-9-]*):{_VER}"),
+        r"\g<1>:{python}",
+    ),
+    Rule(
+        "image_tag_short_dynamo",
+        Scope.CONTAINERS,
+        re.compile(
+            r"((?:vllm|sglang|tensorrtllm)-runtime"
+            r"|dynamo-frontend|kubernetes-operator|frontend"
+            rf"|epp-image|snapshot-agent):{_VER}"
+        ),
+        r"\g<1>:{python}",
+    ),
+    # Wheel filenames and pip install specs in docs/Dockerfiles/shell
+    Rule(
+        "pip_wheel_or_pin",
+        Scope.CONTAINERS,
+        re.compile(rf"(ai[_-]dynamo(?:[_-]runtime)?(?:\[[^\]]*\])?)(==|-){_VER}"),
+        r"\g<1>\g<2>{python}",
+    ),
+    # Operator sample YAML dynamoVersion: "X.Y.Z"
+    Rule(
+        "operator_dynamoVersion_field",
+        Scope.CONTAINERS,
+        re.compile(rf'(dynamoVersion:\s*"){_VER}(")'),
+        r"\g<1>{python}\g<2>",
+    ),
+    # git checkout release/X.Y.Z
+    Rule(
+        "git_checkout_release_branch",
+        Scope.CONTAINERS,
+        re.compile(rf"(git checkout release/){_VER}"),
+        r"\g<1>{python}",
+    ),
+    # pip git URLs: git+https://...@release/X.Y.Z
+    Rule(
+        "git_url_release_ref",
+        Scope.CONTAINERS,
+        re.compile(rf"(@release/){_VER}"),
+        r"\g<1>{python}",
+    ),
+    # DYNAMO_VERSION=X.Y.Z env-var assignment
+    Rule(
+        "env_dynamo_version",
+        Scope.CONTAINERS,
+        re.compile(rf"(DYNAMO_VERSION=){_VER}"),
+        r"\g<1>{python}",
+    ),
 )
 
-# Wheel filenames and pip install specs:
-#   ai_dynamo_runtime-0.7.0-cp310-..., ai-dynamo==0.8.1, ai-dynamo[vllm]==0.8.1.post1
-WHEEL_FILE_RE = re.compile(
-    r"(ai[_-]dynamo(?:[_-]runtime)?(?:\[[^\]]*\])?)" rf"(==|-)({_VER})"
-)
 
-# dynamoVersion: "0.6.0" or "0.9.0.post1" in operator samples
-DYNAMO_VERSION_FIELD_RE = re.compile(rf'(dynamoVersion:\s*")({_VER})(")')
-
-# git checkout release/X.Y.Z or release/X.Y.Z.post1
-GIT_CHECKOUT_RE = re.compile(rf"(git checkout release/)({_VER})")
-
-# git+https://...@release/X.Y.Z (pip git install URLs)
-GIT_REF_RE = re.compile(rf"(@release/)({_VER})")
-
-# DYNAMO_VERSION=X.Y.Z in shell snippets and docs
-DYNAMO_VERSION_ENV_RE = re.compile(rf"(DYNAMO_VERSION=)({_VER})")
-
-# Standalone Dynamo image tags without full registry path (e.g., vllm-runtime:0.8.0)
-# Kept as an explicit list (unlike IMAGE_TAG_RE) to avoid false positives
-# without the ai-dynamo/ prefix as a disambiguator.
-SHORT_IMAGE_TAG_RE = re.compile(
-    r"((?:vllm|sglang|tensorrtllm)-runtime"
-    r"|dynamo-frontend|kubernetes-operator|frontend"
-    r"|epp-image|snapshot-agent)"
-    rf":({_VER})"
-)
-
-# Unified pattern table used by both scan_and_replace and check_stale_versions.
-# (regex, replacement_template, version_group_index, track_spans_for_dedup)
-_VERSION_PATTERNS: list[tuple[re.Pattern, str, int, bool]] = [
-    (IMAGE_TAG_RE, r"\1:{ver}", 2, True),
-    (SHORT_IMAGE_TAG_RE, r"\1:{ver}", 2, True),
-    (WHEEL_FILE_RE, r"\1\g<2>{ver}", 3, False),
-    (DYNAMO_VERSION_FIELD_RE, r"\g<1>{ver}\3", 2, False),
-    (GIT_CHECKOUT_RE, r"\g<1>{ver}", 2, False),
-    (GIT_REF_RE, r"\g<1>{ver}", 2, False),
-    (DYNAMO_VERSION_ENV_RE, r"\g<1>{ver}", 2, False),
-]
-
-# ---------------------------------------------------------------------------
-# Paths excluded from the catch-all discovery scan
-# ---------------------------------------------------------------------------
-EXCLUDE_PATTERNS = [
+# Files excluded from scanning entirely. These are either auto-generated
+# (regenerated by CRD/helm-docs), binary, or lockfiles. Per-file opt-out via
+# the IGNORE_MARKER comment is preferred for any new cases.
+EXCLUDE_GLOBS: tuple[str, ...] = (
+    # Lockfiles / generated / vendored
     "**/*.lock",
     "**/go.sum",
     "**/go.mod",
@@ -133,6 +300,7 @@ EXCLUDE_PATTERNS = [
     "**/node_modules/**",
     "**/.venv/**",
     "**/*.pyc",
+    # Binary assets
     "**/*.png",
     "**/*.jpg",
     "**/*.gif",
@@ -140,764 +308,570 @@ EXCLUDE_PATTERNS = [
     "**/*.ttf",
     "**/*.ico",
     "**/*.pdf",
-    # Auto-generated files handled by regen steps
+    # Auto-generated by regen steps in the workflow
     "deploy/operator/config/crd/bases/**",
     "deploy/helm/charts/crds/templates/**",
     "deploy/helm/charts/platform/README.md",
     "docs/kubernetes/api-reference.md",
     "deploy/operator/api/v1alpha1/zz_generated.deepcopy.go",
-    # Test fixtures with intentional old versions
-    "deploy/operator/internal/**/*_test.go",
-    "deploy/operator/internal/checkpoint/**",
-    "deploy/operator/internal/dynamo/graph_test.go",
-    "tests/**",
-    # The bump script itself
-    ".github/scripts/bump_version.py",
-    # Error classification (separate package, has its own version)
+    # Separately-versioned sub-package
     "error_classification/**",
-]
-
-# Files that get targeted edits (not catch-all replacement).
-# The catch-all scanner skips these; dedicated functions handle them.
-TARGETED_EDIT_FILES = frozenset(
-    {
-        "docs/reference/release-artifacts.md",
-        "docs/reference/support-matrix.md",
-        "docs/reference/feature-matrix.md",
-        "pyproject.toml",
-        "Cargo.toml",
-        "lib/bindings/python/Cargo.toml",
-        "lib/gpu_memory_service/setup.py",
-        "deploy/helm/charts/crds/Chart.yaml",
-        "deploy/helm/charts/platform/Chart.yaml",
-        "deploy/helm/charts/platform/components/operator/Chart.yaml",
-        "deploy/helm/charts/snapshot/Chart.yaml",
-        "deploy/helm/charts/snapshot/values.yaml",
-        # Operator Go source and samples are handled by update_operator_source()
-        "deploy/operator/api/v1alpha1/dynamographdeploymentrequest_types.go",
-        "deploy/operator/config/samples/nvidia.com_v1alpha1_dynamographdeploymentrequest.yaml",
-        "deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml",
-    }
+    # The bump script itself (it contains version patterns)
+    ".github/scripts/bump_version.py",
 )
 
 
-def _matches_exclude(rel_path: str) -> bool:
-    """Robust exclusion check using pathlib-style matching."""
-    p = Path(rel_path)
-    for pattern in EXCLUDE_PATTERNS:
-        if p.match(pattern):
+# ---------------------------------------------------------------------------
+# File iteration
+# ---------------------------------------------------------------------------
+
+
+def _is_binary(path: Path) -> bool:
+    try:
+        with open(path, "rb") as f:
+            return b"\x00" in f.read(8192)
+    except OSError:
+        return True
+
+
+def _excluded(rel: Path) -> bool:
+    for pat in EXCLUDE_GLOBS:
+        if rel.match(pat):
             return True
-        # Handle ** prefix patterns
-        if pattern.startswith("**/"):
-            suffix = pattern[3:]
-            if fnmatch.fnmatch(rel_path, f"*{suffix}") or fnmatch.fnmatch(
-                p.name, suffix
-            ):
-                return True
-        if fnmatch.fnmatch(rel_path, pattern):
+        # Also accept "**/foo" → match "foo" anywhere in path.
+        if pat.startswith("**/") and rel.match(pat[3:]):
             return True
     return False
 
 
-def is_binary(filepath: Path) -> bool:
-    """Quick check if a file is binary."""
-    try:
-        with open(filepath, "rb") as f:
-            chunk = f.read(8192)
-            return b"\x00" in chunk
-    except (OSError, PermissionError):
-        return True
+def iter_repo_files(repo: Path) -> Iterator[tuple[Path, Path, str]]:
+    """Yield (abspath, relpath, content) for every text file to consider.
 
-
-def _iter_version_files(
-    repo: Path,
-    extra_skip: frozenset[str] = frozenset(),
-) -> Iterator[tuple[str, Path, str]]:
-    """Yield (rel_path, filepath, content) for all version-relevant files."""
+    Skips binary files, excluded paths, non-UTF-8 files, and files carrying
+    the :data:`IGNORE_MARKER` opt-out comment.
+    """
     for dirpath, dirnames, filenames in os.walk(repo):
-        dirnames[:] = [
+        # Prune hidden / noise directories in-place so we don't descend.
+        dirnames[:] = sorted(
             d
             for d in dirnames
             if not d.startswith(".")
-            and d not in ("node_modules", "__pycache__", ".venv")
-        ]
+            and d not in {"node_modules", "__pycache__", ".venv", "target"}
+        )
         for filename in filenames:
-            filepath = Path(dirpath) / filename
-            rel_path = str(filepath.relative_to(repo))
-            if _matches_exclude(rel_path) or rel_path in extra_skip:
+            path = Path(dirpath) / filename
+            rel = path.relative_to(repo)
+            if _excluded(rel):
                 continue
-            if is_binary(filepath):
+            if _is_binary(path):
                 continue
             try:
-                content = filepath.read_text(encoding="utf-8", errors="surrogateescape")
+                content = path.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError):
+                # Not valid UTF-8 => definitely not a version-relevant text file.
                 continue
-            yield rel_path, filepath, content
+            if IGNORE_MARKER in content:
+                continue
+            yield path, rel, content
 
 
-# ===================================================================
-# Category 1: Core version files (targeted edits)
-# ===================================================================
+# ---------------------------------------------------------------------------
+# Engine: apply rules
+# ---------------------------------------------------------------------------
 
 
-def update_pyproject_toml(
-    repo: Path, old_ver: str, new_ver: str, dry_run: bool
-) -> list[str]:
-    """Update version in pyproject.toml."""
-    filepath = repo / "pyproject.toml"
-    changes = []
-    content = filepath.read_text()
-    new_content = content
-
-    # version = "X.Y.Z"
-    new_content = re.sub(
-        rf'(version\s*=\s*"){re.escape(old_ver)}"',
-        rf'\g<1>{new_ver}"',
-        new_content,
-    )
-    # ai-dynamo-runtime==X.Y.Z
-    new_content = re.sub(
-        rf"(ai-dynamo-runtime==){re.escape(old_ver)}",
-        rf"\g<1>{new_ver}",
-        new_content,
-    )
-
-    if new_content != content:
-        changes.append(f"pyproject.toml: version {old_ver} -> {new_ver}")
-        if not dry_run:
-            filepath.write_text(new_content)
-    return changes
+@dataclass
+class Change:
+    path: Path  # relative to repo root
+    scope: Scope
+    rules: list[str] = field(default_factory=list)
 
 
-def update_cargo_toml(
-    repo: Path, old_ver: str, new_ver: str, dry_run: bool
-) -> list[str]:
-    """Auto-discover and update Cargo.toml files containing the old version.
+def apply_rules(
+    repo: Path,
+    version: Version,
+    active_scopes: set[Scope],
+    dry_run: bool = False,
+) -> list[Change]:
+    """Walk the repo, apply every matching rule, collect :class:`Change` records.
 
-    Scans all Cargo.toml files in the repo (excluding target/ and vendored
-    directories) so newly added workspaces are picked up automatically.
-    Uses semver format (0.9.0-post1) for Cargo files.
+    When ``dry_run`` is True, files are not written — used by both ``--dry-run``
+    and ``--check`` modes.
     """
-    changes = []
-    old_semver = to_semver(old_ver)
-    new_semver = to_semver(new_ver)
-
-    skip_dirs = {"target", ".git", "node_modules", "__pycache__", ".venv"}
-    for dirpath, dirnames, filenames in os.walk(repo):
-        dirnames[:] = [d for d in dirnames if d not in skip_dirs]
-        if "Cargo.toml" not in filenames:
-            continue
-        filepath = Path(dirpath) / "Cargo.toml"
-        rel_path = str(filepath.relative_to(repo))
-        content = filepath.read_text()
-        new_content = re.sub(
-            rf'(version\s*=\s*"){re.escape(old_semver)}"',
-            rf'\g<1>{new_semver}"',
-            content,
-        )
-        if new_content != content:
-            changes.append(f"{rel_path}: version {old_semver} -> {new_semver}")
-            if not dry_run:
-                filepath.write_text(new_content)
-    return changes
-
-
-def update_gpu_memory_setup(
-    repo: Path, old_ver: str, new_ver: str, dry_run: bool
-) -> list[str]:
-    """Update version in lib/gpu_memory_service/setup.py."""
-    filepath = repo / "lib/gpu_memory_service/setup.py"
-    if not filepath.exists():
-        return []
-    content = filepath.read_text()
-    new_content = re.sub(
-        rf'(version\s*=\s*"){re.escape(old_ver)}"',
-        rf'\g<1>{new_ver}"',
-        content,
-    )
-    if new_content != content:
-        if not dry_run:
-            filepath.write_text(new_content)
-        return [f"lib/gpu_memory_service/setup.py: version {old_ver} -> {new_ver}"]
-    return []
-
-
-# ===================================================================
-# Category 2: Helm charts (targeted edits)
-# ===================================================================
-
-
-def update_helm_charts(
-    repo: Path, old_ver: str, new_ver: str, dry_run: bool
-) -> list[str]:
-    """Update version fields in Helm Chart.yaml files.
-
-    Handles exact old version, dev-suffixed versions (1.0.0-dev), and
-    post-release versions (0.9.0-post1). Uses semver format for Helm.
-    """
-    changes = []
-    new_semver = to_semver(new_ver)
-    ver_pattern = r"\d+\.\d+\.\d+(?:-(?:dev|post\d+))?"
-
-    # Chart.yaml files: (relative_path, update_appVersion)
-    chart_configs = [
-        ("deploy/helm/charts/crds/Chart.yaml", False),
-        ("deploy/helm/charts/platform/Chart.yaml", False),
-        ("deploy/helm/charts/platform/components/operator/Chart.yaml", True),
-        ("deploy/helm/charts/snapshot/Chart.yaml", True),
-    ]
-
-    for rel_path, update_app_version in chart_configs:
-        filepath = repo / rel_path
-        if not filepath.exists():
-            continue
-        content = filepath.read_text()
-        new_content = re.sub(
-            rf"(^version:\s*){ver_pattern}",
-            rf"\g<1>{new_semver}",
-            content,
-            count=1,
-            flags=re.MULTILINE,
-        )
-        if update_app_version:
-            new_content = re.sub(
-                rf'(^appVersion:\s*"){ver_pattern}"',
-                rf'\g<1>{new_semver}"',
-                new_content,
-                flags=re.MULTILINE,
-            )
-        if new_content != content:
-            changes.append(f"{rel_path}: version -> {new_semver}")
-            if not dry_run:
-                filepath.write_text(new_content)
-
-    # Platform chart: dynamo-operator dependency version
-    platform_chart = repo / "deploy/helm/charts/platform/Chart.yaml"
-    if platform_chart.exists():
-        content = platform_chart.read_text()
-        new_content = re.sub(
-            rf"(  - name: dynamo-operator\n    version:\s*){ver_pattern}",
-            rf"\g<1>{new_semver}",
-            content,
-        )
-        if new_content != content and not dry_run:
-            platform_chart.write_text(new_content)
-
-    # Snapshot values.yaml: image tag
-    snapshot_values = repo / "deploy/helm/charts/snapshot/values.yaml"
-    if snapshot_values.exists():
-        content = snapshot_values.read_text()
-        new_content = re.sub(
-            rf"(repository:\s*nvcr\.io/nvidia/ai-dynamo/snapshot-agent\n\s*tag:\s*){ver_pattern}",
-            rf"\g<1>{new_semver}",
-            content,
-        )
-        if new_content != content:
-            changes.append(
-                "deploy/helm/charts/snapshot/values.yaml: tag -> " + new_semver
-            )
-            if not dry_run:
-                snapshot_values.write_text(new_content)
-
-    return changes
-
-
-# ===================================================================
-# Category 2b: Operator Go source and samples (targeted edits)
-# ===================================================================
-
-
-def update_operator_source(repo: Path, new_ver: str, dry_run: bool) -> list[str]:
-    """Update version references in operator Go source and sample files."""
-    changes = []
-
-    targets = [
-        "deploy/operator/api/v1alpha1/dynamographdeploymentrequest_types.go",
-        "deploy/operator/config/samples/nvidia.com_v1alpha1_dynamographdeploymentrequest.yaml",
-        "deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml",
-    ]
-
-    for rel in targets:
-        filepath = repo / rel
-        if not filepath.exists():
-            continue
-        content = filepath.read_text()
+    changes: list[Change] = []
+    for abs_path, rel_path, content in iter_repo_files(repo):
         new_content = content
-
-        # Replace any Dynamo image tags
-        new_content = IMAGE_TAG_RE.sub(rf"\1:{new_ver}", new_content)
-        new_content = SHORT_IMAGE_TAG_RE.sub(rf"\1:{new_ver}", new_content)
-        # Replace dynamoVersion: "X.Y.Z"
-        new_content = DYNAMO_VERSION_FIELD_RE.sub(rf"\g<1>{new_ver}\3", new_content)
-
+        hit_by_scope: dict[Scope, list[str]] = {}
+        for rule in RULES:
+            if rule.scope not in active_scopes:
+                continue
+            if not rule.file_filter(rel_path):
+                continue
+            updated = rule.apply(new_content, version)
+            if updated != new_content:
+                hit_by_scope.setdefault(rule.scope, []).append(rule.name)
+                new_content = updated
         if new_content != content:
-            changes.append(f"{rel}: updated version references -> {new_ver}")
+            for scope, rule_names in hit_by_scope.items():
+                changes.append(Change(rel_path, scope, rule_names))
             if not dry_run:
-                filepath.write_text(new_content)
-
+                abs_path.write_text(new_content, encoding="utf-8")
     return changes
 
 
-# ===================================================================
-# Category 3: Reference documentation (targeted edits)
-# ===================================================================
+# ---------------------------------------------------------------------------
+# Backend metadata (consumed by DOCS specialised functions)
+# ---------------------------------------------------------------------------
 
 
-def update_feature_matrix(repo: Path, new_ver: str, dry_run: bool) -> list[str]:
-    """Update the 'Updated for Dynamo vX.Y.Z' line in feature-matrix.md."""
-    filepath = repo / "docs/reference/feature-matrix.md"
-    if not filepath.exists():
+@dataclass
+class BackendVersions:
+    vllm: str | None = None
+    sglang: str | None = None
+    trtllm: str | None = None
+    nixl: str | None = None
+
+    def all_set(self) -> bool:
+        return all([self.vllm, self.sglang, self.trtllm, self.nixl])
+
+    def any_set(self) -> bool:
+        return any([self.vllm, self.sglang, self.trtllm, self.nixl])
+
+
+# ---------------------------------------------------------------------------
+# DOCS specialised updates (table-row insertion / section-scoped edits)
+# ---------------------------------------------------------------------------
+
+
+def update_feature_matrix(repo: Path, version: Version, dry_run: bool) -> list[Change]:
+    path = repo / "docs/reference/feature-matrix.md"
+    if not path.exists():
         return []
-    content = filepath.read_text()
-    new_content = re.sub(
+    content = path.read_text(encoding="utf-8")
+    updated = re.sub(
         r"\*Updated for Dynamo v[\d.]+(?:\.post\d+)?\*",
-        f"*Updated for Dynamo v{new_ver}*",
+        f"*Updated for Dynamo v{version.python()}*",
         content,
     )
-    if new_content != content:
-        if not dry_run:
-            filepath.write_text(new_content)
-        return [f"feature-matrix.md: updated version tag -> v{new_ver}"]
-    return []
+    if updated == content:
+        return []
+    if not dry_run:
+        path.write_text(updated, encoding="utf-8")
+    return [
+        Change(
+            Path("docs/reference/feature-matrix.md"),
+            Scope.DOCS,
+            ["feature_matrix_tag"],
+        )
+    ]
 
 
 def update_support_matrix(
     repo: Path,
-    new_ver: str,
+    version: Version,
+    backends: BackendVersions,
     dry_run: bool,
-    backend_versions: dict[str, str | None] | None = None,
-) -> list[str]:
-    """Update support-matrix.md for a new release.
-
-    - Removes '*(in progress)*' from the version row
-    - Updates the "At a Glance" latest stable release line
-    - Adds a new row to the Backend Dependencies table
-    """
-    filepath = repo / "docs/reference/support-matrix.md"
-    if not filepath.exists():
+) -> list[Change]:
+    path = repo / "docs/reference/support-matrix.md"
+    if not path.exists():
         return []
-    content = filepath.read_text()
+    content = path.read_text(encoding="utf-8")
     original = content
-    changes = []
-    bv = backend_versions or {}
+    rules_hit: list[str] = []
 
-    # Remove "*(in progress)*" from the released version row
+    # Remove "*(in progress)*" from the version row being released.
+    before = content
     content = re.sub(
-        rf"(\*\*v{re.escape(new_ver)}\*\*)\s*\*\(in progress\)\*",
-        r"\1",
+        rf"(\*\*v{re.escape(version.python())}\*\*)\s*\*\(in progress\)\*",
+        r"\g<1>",
         content,
     )
+    if content != before:
+        rules_hit.append("support_matrix_in_progress")
 
-    if all(bv.get(k) for k in ("sglang", "trtllm", "vllm", "nixl")):
-        # Update "At a Glance" latest stable release line
+    if backends.all_set():
+        before = content
         content = re.sub(
             r"(\*\*Latest stable release:\*\* \[v)[\d.]+\S*"
             r"(\]\(https://github\.com/ai-dynamo/dynamo/releases/tag/v)[\d.]+\S*"
             r"(\) --).*",
-            rf"\g<1>{new_ver}\g<2>{new_ver}\3"
-            rf' SGLang `{bv["sglang"]}` |'
-            rf' TensorRT-LLM `{bv["trtllm"]}` |'
-            rf' vLLM `{bv["vllm"]}` |'
-            rf' NIXL `{bv["nixl"]}`',
+            (
+                rf"\g<1>{version.python()}\g<2>{version.python()}\g<3>"
+                rf" SGLang `{backends.sglang}` |"
+                rf" TensorRT-LLM `{backends.trtllm}` |"
+                rf" vLLM `{backends.vllm}` |"
+                rf" NIXL `{backends.nixl}`"
+            ),
             content,
         )
-        changes.append(f"support-matrix.md: updated At a Glance for v{new_ver}")
+        if content != before:
+            rules_hit.append("support_matrix_at_a_glance")
 
-        # Add new row to Backend Dependencies table (after main ToT row)
-        if f"| **v{new_ver}**" not in content:
+        row_marker = f"| **v{version.python()}**"
+        if row_marker not in content:
             new_row = (
-                f"| **v{new_ver}** "
-                f'| `{bv["sglang"]}` '
-                f'| `{bv["trtllm"]}` '
-                f'| `{bv["vllm"]}` '
-                f'| `{bv["nixl"]}` |'
+                f"| **v{version.python()}** "
+                f"| `{backends.sglang}` "
+                f"| `{backends.trtllm}` "
+                f"| `{backends.vllm}` "
+                f"| `{backends.nixl}` |"
             )
+            before = content
             content = re.sub(
                 r"(\| \*\*main \(ToT\)\*\* \|[^\n]+\n)",
-                rf"\1{new_row}\n",
+                rf"\g<1>{new_row}\n",
                 content,
             )
-            changes.append(
-                f"support-matrix.md: added v{new_ver} to Backend Dependencies"
-            )
+            if content != before:
+                rules_hit.append("support_matrix_backend_row")
 
-    if content != original:
-        if not dry_run:
-            filepath.write_text(content)
-    return changes
+    if content == original:
+        return []
+    if not dry_run:
+        path.write_text(content, encoding="utf-8")
+    return [Change(Path("docs/reference/support-matrix.md"), Scope.DOCS, rules_hit)]
 
 
 def update_release_artifacts(
     repo: Path,
-    new_ver: str,
+    version: Version,
     release_date: str | None,
+    backends: BackendVersions,
     dry_run: bool,
-    backend_versions: dict[str, str | None] | None = None,
-) -> list[str]:
-    """Update the Current Release section and add history rows in release-artifacts.md."""
-    filepath = repo / "docs/reference/release-artifacts.md"
-    if not filepath.exists():
+) -> list[Change]:
+    path = repo / "docs/reference/release-artifacts.md"
+    if not path.exists():
         return []
-    content = filepath.read_text()
+    content = path.read_text(encoding="utf-8")
     original = content
-    changes = []
+    rules_hit: list[str] = []
 
-    # Update "Current Release: Dynamo vX.Y.Z" header
+    # Header
+    before = content
     content = re.sub(
         r"(## Current Release: Dynamo v)[\d.]+\S*",
-        rf"\g<1>{new_ver}",
+        rf"\g<1>{version.python()}",
         content,
     )
+    if content != before:
+        rules_hit.append("release_artifacts_header")
 
-    # Update GitHub Release link in current release section
+    # GitHub Release link
     content = re.sub(
-        r"(\*\*GitHub Release:\*\* \[v)[\d.]+\S*(\]\(https://github\.com/ai-dynamo/dynamo/releases/tag/v)[\d.]+\S*(\))",
-        rf"\g<1>{new_ver}\g<2>{new_ver}\3",
+        r"(\*\*GitHub Release:\*\* \[v)[\d.]+\S*"
+        r"(\]\(https://github\.com/ai-dynamo/dynamo/releases/tag/v)[\d.]+\S*(\))",
+        rf"\g<1>{version.python()}\g<2>{version.python()}\g<3>",
         content,
     )
 
-    # Update Docs link in current release section
-    ver_dashed = new_ver.replace(".", "-")
+    # Docs link
     content = re.sub(
-        r"(\*\*Docs:\*\* \[v)[\d.]+\S*(\]\(https://docs\.nvidia\.com/dynamo/v-)[\d-]+\S*(/?\))",
-        rf"\g<1>{new_ver}\g<2>{ver_dashed}\3",
+        r"(\*\*Docs:\*\* \[v)[\d.]+\S*"
+        r"(\]\(https://docs\.nvidia\.com/dynamo/v-)[\d-]+\S*(/?\))",
+        rf"\g<1>{version.python()}\g<2>{version.dashed()}\g<3>",
         content,
     )
 
-    # Add row to GitHub Releases table if not already present
-    if f"| `v{new_ver}`" not in content:
+    # New row in the GitHub Releases table
+    row_marker = f"| `v{version.python()}`"
+    if row_marker not in content:
         date_str = release_date or datetime.now().strftime("%b %d, %Y")
         new_row = (
-            f"| `v{new_ver}` | {date_str} "
-            f"| [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v{new_ver}) "
-            f"| [Docs](https://docs.nvidia.com/dynamo/v-{ver_dashed}/) |"
+            f"| `v{version.python()}` | {date_str} "
+            f"| [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v{version.python()}) "
+            f"| [Docs](https://docs.nvidia.com/dynamo/v-{version.dashed()}/) |"
         )
-        # Insert after the table header row
         table_pattern = r"(### GitHub Releases\n\n\| Version \|.*\n\|[-| ]+\n)"
         if re.search(table_pattern, content):
-            content = re.sub(
-                table_pattern,
-                rf"\1{new_row}\n",
-                content,
-            )
-            changes.append(
-                f"release-artifacts.md: added v{new_ver} to GitHub Releases table"
-            )
+            content = re.sub(table_pattern, rf"\g<1>{new_row}\n", content)
+            rules_hit.append("release_artifacts_table_row")
         else:
-            print(
-                "WARNING: Could not find GitHub Releases table pattern in "
-                "release-artifacts.md. Skipping table row insertion.",
-                file=sys.stderr,
+            # Fail loud: the doc structure changed and we'd silently skip the row.
+            raise RuntimeError(
+                "release-artifacts.md: could not find the GitHub Releases table "
+                "header. The doc structure changed — update this script."
             )
 
-    # Update backend versions in Current Release Container Images table
-    # Scoped to "## Current Release" section to avoid touching history tables
-    bv = backend_versions or {}
+    # Backend versions inside the Current Release section only.
     backend_labels = {"vllm": "vLLM", "sglang": "SGLang", "trtllm": "TRT-LLM"}
     cr_start = content.find("## Current Release")
-    if cr_start >= 0:
-        # Find the next H2 section after Current Release
+    if cr_start >= 0 and backends.any_set():
         next_h2 = content.find("\n## ", cr_start + 1)
         if next_h2 < 0:
             next_h2 = len(content)
         section = content[cr_start:next_h2]
+        before = section
         for key, label in backend_labels.items():
-            ver = bv.get(key)
-            if ver:
-                section = re.sub(rf"({label} `)v[^`]+(`)", rf"\g<1>v{ver}\2", section)
-        content = content[:cr_start] + section + content[next_h2:]
-        if bv:
-            changes.append(
-                "release-artifacts.md: updated backend versions in Current Release"
-            )
-
-    if content != original:
-        changes.append(f"release-artifacts.md: updated Current Release to v{new_ver}")
-        if not dry_run:
-            filepath.write_text(content)
-
-    return changes
-
-
-# ===================================================================
-# Category 4: Discovery-based catch-all scan
-# ===================================================================
-
-
-def scan_and_replace(repo: Path, new_ver: str, dry_run: bool) -> list[str]:
-    """Walk the repo and replace all Dynamo version patterns with new_ver."""
-    changes = []
-    for rel_path, filepath, content in _iter_version_files(
-        repo, extra_skip=TARGETED_EDIT_FILES
-    ):
-        new_content = content
-        for regex, repl_template, _, _ in _VERSION_PATTERNS:
-            new_content = regex.sub(repl_template.format(ver=new_ver), new_content)
-        if new_content != content:
-            changes.append(f"{rel_path}: updated version references -> {new_ver}")
-            if not dry_run:
-                filepath.write_text(
-                    new_content, encoding="utf-8", errors="surrogateescape"
+            val = getattr(backends, key)
+            if val:
+                section = re.sub(
+                    rf"({re.escape(label)} `)v[^`]+(`)",
+                    rf"\g<1>v{val}\g<2>",
+                    section,
                 )
-    return changes
+        if section != before:
+            content = content[:cr_start] + section + content[next_h2:]
+            rules_hit.append("release_artifacts_backend_versions")
+
+    if content == original:
+        return []
+    if not dry_run:
+        path.write_text(content, encoding="utf-8")
+    return [Change(Path("docs/reference/release-artifacts.md"), Scope.DOCS, rules_hit)]
 
 
-# ===================================================================
-# --check mode: scan for stale versions
-# ===================================================================
+# ---------------------------------------------------------------------------
+# Detect current version
+# ---------------------------------------------------------------------------
 
 
-def check_stale_versions(repo: Path, expected_ver: str) -> list[str]:
-    """Scan repo for Dynamo version patterns that don't match expected_ver.
-
-    Returns list of stale reference descriptions. Empty list = all clean.
-    """
-    stale = []
-    skip_files = frozenset(
-        {
-            "docs/reference/release-artifacts.md",
-            "docs/reference/support-matrix.md",
-        }
-    )
-    for rel_path, _, content in _iter_version_files(repo, extra_skip=skip_files):
-        for lineno, line in enumerate(content.splitlines(), 1):
-            reported_spans: set[tuple[int, int]] = set()
-            for regex, _, ver_group, track_spans in _VERSION_PATTERNS:
-                for m in regex.finditer(line):
-                    if track_spans and any(
-                        m.start() >= s and m.end() <= e for s, e in reported_spans
-                    ):
-                        continue
-                    ver = m.group(ver_group)
-                    if ver != expected_ver and not ver.startswith(expected_ver + "."):
-                        stale.append(
-                            f"STALE: {rel_path}:{lineno} -- {m.group(0)} (expected {expected_ver})"
-                        )
-                    if track_spans:
-                        reported_spans.add((m.start(), m.end()))
-    return stale
-
-
-# ===================================================================
-# Auto-detect current version from pyproject.toml
-# ===================================================================
-
-
-def detect_current_version(repo: Path) -> str:
-    """Read the current version from pyproject.toml."""
+def detect_current_version(repo: Path) -> Version:
     pyproject = repo / "pyproject.toml"
-    content = pyproject.read_text()
-    m = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    m = re.search(
+        r'^version\s*=\s*"([^"]+)"',
+        pyproject.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
     if not m:
-        print("ERROR: Could not detect version from pyproject.toml", file=sys.stderr)
-        sys.exit(1)
-    return m.group(1)
+        raise SystemExit("ERROR: could not detect current version from pyproject.toml")
+    return Version.parse(m.group(1))
 
 
-# ===================================================================
-# Main
-# ===================================================================
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Dynamo release version bump script",
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument(
-        "--new-version", help="Target version (e.g., 1.0.0 or 0.9.0.post1)"
+    p.add_argument(
+        "--new-version",
+        type=Version.parse,
+        help="Target version (e.g. 1.0.0 or 0.9.0.post1)",
     )
-    parser.add_argument(
-        "--old-version", help="Current version to replace (auto-detected if omitted)"
+    p.add_argument(
+        "--old-version",
+        type=Version.parse,
+        help="Current version to replace (auto-detected from pyproject.toml if omitted)",
     )
-    parser.add_argument(
-        "--repo-root", default=".", help="Repository root (default: cwd)"
-    )
+    p.add_argument("--repo-root", default=".", help="Repository root (default: cwd)")
 
-    # Backend metadata — accepted for forward-compatibility with the release
-    # workflow (which always passes them) but not yet consumed by this script.
-    # Future work: auto-populate support-matrix rows from these values.
-    parser.add_argument("--vllm-version", help="vLLM version (reserved, not yet used)")
-    parser.add_argument(
-        "--sglang-version", help="SGLang version (reserved, not yet used)"
-    )
-    parser.add_argument(
-        "--trtllm-version", help="TRT-LLM version (reserved, not yet used)"
-    )
-    parser.add_argument("--nixl-version", help="NIXL version (reserved, not yet used)")
-    parser.add_argument(
-        "--cuda-versions-vllm", help="CUDA versions for vLLM (reserved, not yet used)"
-    )
-    parser.add_argument(
-        "--cuda-versions-sglang",
-        help="CUDA versions for SGLang (reserved, not yet used)",
-    )
-    parser.add_argument(
-        "--cuda-versions-trtllm",
-        help="CUDA versions for TRT-LLM (reserved, not yet used)",
-    )
-    parser.add_argument("--release-date", help="Release date (e.g., 'Feb 15, 2026')")
+    # Backend metadata consumed by DOCS functions
+    p.add_argument("--vllm-version", help="vLLM backend version (e.g. 0.19.0)")
+    p.add_argument("--sglang-version", help="SGLang backend version")
+    p.add_argument("--trtllm-version", help="TensorRT-LLM backend version")
+    p.add_argument("--nixl-version", help="NIXL backend version")
+    p.add_argument("--release-date", help="Release date (e.g. 'Feb 15, 2026')")
 
     # Modes
-    parser.add_argument(
-        "--dry-run", action="store_true", help="Print changes without writing"
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print changes without writing",
     )
-    parser.add_argument(
-        "--check", action="store_true", help="Check for stale versions (CI mode)"
+    p.add_argument(
+        "--check",
+        action="store_true",
+        help="Check for stale version references (exit 1 if any). "
+        "Uses --expected-version or auto-detects from pyproject.toml.",
     )
-    parser.add_argument("--expected-version", help="Expected version for --check mode")
+    p.add_argument(
+        "--expected-version",
+        type=Version.parse,
+        help="Expected current version for --check mode",
+    )
 
-    # Scope controls (for post-releases or selective bumps)
-    parser.add_argument(
+    # Scope gating
+    p.add_argument(
         "--skip-core",
         action="store_true",
         help="Skip core version files (pyproject.toml, Cargo.toml, setup.py)",
     )
-    parser.add_argument(
+    p.add_argument(
         "--skip-containers",
         action="store_true",
-        help="Skip discovery-based container image tag scan (docs, recipes, examples)",
+        help="Skip container image tags, git refs, operator samples, wheel pins",
     )
-    parser.add_argument(
+    p.add_argument(
         "--skip-helm",
         action="store_true",
-        help="Skip Helm Chart.yaml version updates",
+        help="Skip Helm Chart.yaml and values.yaml updates",
     )
-    parser.add_argument(
+    p.add_argument(
         "--skip-docs",
         action="store_true",
-        help="Skip reference doc updates (support-matrix, feature-matrix, release-artifacts)",
+        help="Skip reference docs (support-matrix, feature-matrix, release-artifacts)",
     )
 
-    args = parser.parse_args()
-    repo = Path(args.repo_root).resolve()
+    # Verbosity
+    p.add_argument("-v", "--verbose", action="store_true", help="Log every rule hit")
+    p.add_argument(
+        "-q", "--quiet", action="store_true", help="Log only the final summary"
+    )
 
-    # --check mode
-    if args.check:
-        expected = args.expected_version
-        if not expected:
-            expected = detect_current_version(repo)
-        print(f"Checking for stale version references (expected: {expected})...")
-        stale = check_stale_versions(repo, expected)
-        if stale:
-            for s in stale:
-                print(s)
-            print(f"\nFound {len(stale)} stale version reference(s).")
-            sys.exit(1)
-        else:
-            print("All version references are up to date.")
-            sys.exit(0)
+    # Machine-readable output
+    p.add_argument(
+        "--summary-file",
+        help="Write a markdown summary of changes to this path (e.g. $GITHUB_STEP_SUMMARY)",
+    )
+    return p
 
-    # Bump mode
-    if not args.new_version:
-        parser.error("--new-version is required (unless using --check)")
 
-    new_ver = args.new_version
-    old_ver = args.old_version or detect_current_version(repo)
-
-    if old_ver == new_ver:
-        print(
-            f"WARNING: old version ({old_ver}) == new version ({new_ver}). "
-            "Nothing to bump.",
-            file=sys.stderr,
-        )
-        sys.exit(0)
-
-    if args.dry_run:
-        print(f"DRY RUN: Would bump {old_ver} -> {new_ver}")
-    else:
-        print(f"Bumping version: {old_ver} -> {new_ver}")
-
-    if is_post_release(new_ver):
-        print(f"  Post-release detected: Python={new_ver}, Semver={to_semver(new_ver)}")
-
-    skip_flags = []
+def _active_scopes(args: argparse.Namespace) -> set[Scope]:
+    scopes = set(Scope)
     if args.skip_core:
-        skip_flags.append("core")
+        scopes.discard(Scope.CORE)
     if args.skip_containers:
-        skip_flags.append("containers")
+        scopes.discard(Scope.CONTAINERS)
     if args.skip_helm:
-        skip_flags.append("helm")
+        scopes.discard(Scope.HELM)
     if args.skip_docs:
-        skip_flags.append("docs")
-    if skip_flags:
-        print(f"  Skipping: {', '.join(skip_flags)}")
+        scopes.discard(Scope.DOCS)
+    return scopes
 
-    backend_versions = {
-        "vllm": args.vllm_version,
-        "sglang": args.sglang_version,
-        "trtllm": args.trtllm_version,
-        "nixl": args.nixl_version,
-    }
 
-    all_changes: list[str] = []
+def _log(args: argparse.Namespace, level: str, msg: str) -> None:
+    if args.quiet and level != "summary":
+        return
+    if level == "verbose" and not args.verbose:
+        return
+    print(msg)
 
-    # Category 1: Core version files
-    if not args.skip_core:
-        print("\n=== Category 1: Core version files ===")
-        all_changes.extend(update_pyproject_toml(repo, old_ver, new_ver, args.dry_run))
-        all_changes.extend(update_cargo_toml(repo, old_ver, new_ver, args.dry_run))
-        all_changes.extend(
-            update_gpu_memory_setup(repo, old_ver, new_ver, args.dry_run)
+
+def _format_summary(
+    version: Version,
+    old: Version | None,
+    changes: list[Change],
+    active_scopes: set[Scope],
+    dry_run: bool,
+) -> str:
+    lines = []
+    header = f"Bumped {old} -> {version}" if old else f"Bumped to {version}"
+    if dry_run:
+        header = f"[dry-run] {header}"
+    lines.append(f"## Version bump: {header}")
+    lines.append("")
+    lines.append(f"**Scopes:** {', '.join(sorted(s.value for s in active_scopes))}")
+    lines.append("")
+    lines.append(f"**Changed files:** {len(changes)}")
+    lines.append("")
+    if changes:
+        lines.append("| File | Scope | Rules |")
+        lines.append("|---|---|---|")
+        for ch in sorted(changes, key=lambda c: (c.scope.value, c.path.as_posix())):
+            lines.append(
+                f"| `{ch.path.as_posix()}` | {ch.scope.value} | {', '.join(ch.rules)} |"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def _run_check(args: argparse.Namespace, repo: Path) -> int:
+    expected = args.expected_version or detect_current_version(repo)
+    _log(
+        args, "info", f"Checking for stale version references (expected: {expected})..."
+    )
+    active = _active_scopes(args)
+    # Rerun the engine with the expected version — anything that would change is stale.
+    stale = apply_rules(repo, expected, active, dry_run=True)
+    if not stale:
+        _log(args, "summary", "All version references are up to date.")
+        return 0
+    for ch in stale:
+        _log(
+            args,
+            "info",
+            f"STALE: {ch.path.as_posix()} ({ch.scope.value}: {', '.join(ch.rules)})",
         )
-    else:
-        print("\n=== Category 1: Core version files [SKIPPED] ===")
+    _log(args, "summary", f"Found {len(stale)} stale version reference(s).")
+    return 1
 
-    # Category 2: Helm charts
-    if not args.skip_helm:
-        print("\n=== Category 2: Helm charts ===")
-        all_changes.extend(update_helm_charts(repo, old_ver, new_ver, args.dry_run))
-    else:
-        print("\n=== Category 2: Helm charts [SKIPPED] ===")
 
-    # Category 2b: Operator Go source and samples
-    # Part of the CRD regen chain -- update image tags and dynamoVersion fields
-    # in Go doc comments and sample YAMLs before CRD regeneration.
-    if not args.skip_containers:
-        print("\n=== Category 2b: Operator Go source and samples ===")
-        all_changes.extend(update_operator_source(repo, new_ver, args.dry_run))
-    else:
-        print("\n=== Category 2b: Operator Go source and samples [SKIPPED] ===")
+def _run_bump(args: argparse.Namespace, repo: Path) -> int:
+    if not args.new_version:
+        raise SystemExit("ERROR: --new-version is required (unless using --check)")
 
-    # Category 3: Reference documentation
-    if not args.skip_docs:
-        print("\n=== Category 3: Reference documentation ===")
-        all_changes.extend(update_feature_matrix(repo, new_ver, args.dry_run))
-        all_changes.extend(
-            update_support_matrix(repo, new_ver, args.dry_run, backend_versions)
+    new_ver: Version = args.new_version
+    old_ver: Version = args.old_version or detect_current_version(repo)
+    if old_ver == new_ver:
+        _log(
+            args,
+            "summary",
+            f"WARNING: old ({old_ver}) == new ({new_ver}). Nothing to bump.",
         )
-        all_changes.extend(
+        return 0
+
+    active = _active_scopes(args)
+    _log(
+        args,
+        "info",
+        f"{'DRY RUN: Would bump' if args.dry_run else 'Bumping'} "
+        f"{old_ver} -> {new_ver}  (scopes: {', '.join(sorted(s.value for s in active))})",
+    )
+    if new_ver.is_post:
+        _log(
+            args,
+            "info",
+            f"  Post-release formats: python={new_ver.python()} semver={new_ver.semver()}",
+        )
+
+    backends = BackendVersions(
+        vllm=args.vllm_version,
+        sglang=args.sglang_version,
+        trtllm=args.trtllm_version,
+        nixl=args.nixl_version,
+    )
+
+    changes: list[Change] = []
+    # Rule-based scopes (core, containers, helm, + any text-pattern DOCS rules)
+    changes.extend(apply_rules(repo, new_ver, active, dry_run=args.dry_run))
+    # Specialised DOCS functions (table-row insertion / sectioned edits)
+    if Scope.DOCS in active:
+        changes.extend(update_feature_matrix(repo, new_ver, args.dry_run))
+        changes.extend(update_support_matrix(repo, new_ver, backends, args.dry_run))
+        changes.extend(
             update_release_artifacts(
-                repo, new_ver, args.release_date, args.dry_run, backend_versions
+                repo, new_ver, args.release_date, backends, args.dry_run
             )
         )
-    else:
-        print("\n=== Category 3: Reference documentation [SKIPPED] ===")
 
-    # Category 4: Discovery-based catch-all scan
-    if not args.skip_containers:
-        print("\n=== Category 4: Discovery-based scan (docs, recipes, examples) ===")
-        all_changes.extend(scan_and_replace(repo, new_ver, args.dry_run))
-    else:
-        print("\n=== Category 4: Discovery-based scan [SKIPPED] ===")
-
-    # Summary
-    print(f"\n{'=' * 60}")
-    print(
-        f"{'DRY RUN ' if args.dry_run else ''}Summary: {len(all_changes)} file(s) changed"
+    _log(
+        args,
+        "summary",
+        f"{'[dry-run] ' if args.dry_run else ''}Changed {len(changes)} file(s)",
     )
-    print(f"{'=' * 60}")
-    for change in all_changes:
-        print(f"  {'[DRY] ' if args.dry_run else '✅ '}{change}")
-
-    if not all_changes:
-        print(
-            "WARNING: No files were changed. This may indicate the old version "
-            f"({old_ver}) was not found in any target files, or all categories "
-            "were skipped.",
-            file=sys.stderr,
+    for ch in sorted(changes, key=lambda c: (c.scope.value, c.path.as_posix())):
+        _log(
+            args,
+            "info",
+            f"  {ch.scope.value}: {ch.path.as_posix()}  ({', '.join(ch.rules)})",
         )
+
+    if args.summary_file:
+        Path(args.summary_file).write_text(
+            _format_summary(new_ver, old_ver, changes, active, args.dry_run),
+            encoding="utf-8",
+        )
+
+    if not changes:
+        _log(
+            args,
+            "summary",
+            f"WARNING: no changes produced. The old version ({old_ver}) may not "
+            "appear in any files, or every scope was skipped.",
+        )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    repo = Path(args.repo_root).resolve()
+    if args.check:
+        return _run_check(args, repo)
+    return _run_bump(args, repo)
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -811,6 +811,30 @@ def _run_check(args: argparse.Namespace, repo: Path) -> int:
     active = _active_scopes(args)
     # Rerun the engine with the expected version — anything that would change is stale.
     stale = apply_rules(repo, expected, active, dry_run=True)
+    # The DOCS specialised functions own table-row insertion and section-scoped
+    # edits in support-matrix.md / release-artifacts.md / feature-matrix.md.
+    # Those files now carry the bump-version: ignore marker, so apply_rules() no
+    # longer touches them; without this dry-run pass --check would have a blind
+    # spot for stale "Current Release" headers, "Latest stable release" lines,
+    # missing release-row entries, and stale "Updated for vX.Y.Z" tags.
+    # Backend versions / release date are usually not passed to --check; the
+    # all_set/any_set guards inside the DOCS helpers keep the
+    # backend-dependent rewrites no-ops in that case, while still catching the
+    # version-only staleness signals.
+    if Scope.DOCS in active:
+        backends = BackendVersions(
+            vllm=args.vllm_version,
+            sglang=args.sglang_version,
+            trtllm=args.trtllm_version,
+            nixl=args.nixl_version,
+        )
+        stale.extend(update_feature_matrix(repo, expected, dry_run=True))
+        stale.extend(update_support_matrix(repo, expected, backends, dry_run=True))
+        stale.extend(
+            update_release_artifacts(
+                repo, expected, args.release_date, backends, dry_run=True
+            )
+        )
     if not stale:
         _log(args, "summary", "All version references are up to date.")
         return 0

--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -1,0 +1,903 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Dynamo Release Version Bump Script.
+
+Discovery-based version bumper that scans the entire repo for Dynamo version
+references and updates them to the new release version. Used by both Phase 1
+(release branch prep) and Phase 2 (port to main) workflows.
+
+Usage:
+    # Full release: bump all versions to 1.0.0 with backend metadata
+    python3 .github/scripts/bump_version.py \\
+        --new-version 1.0.0 \\
+        --vllm-version 0.15.1 \\
+        --sglang-version 0.5.7 \\
+        --trtllm-version 1.3.0rc1 \\
+        --nixl-version 0.9.0 \\
+        --cuda-versions-vllm 12.9,13.0 \\
+        --cuda-versions-sglang 12.9,13.0 \\
+        --cuda-versions-trtllm 13.0 \\
+        --release-date "Feb 15, 2026"
+
+    # Post-release: Helm-only patch (skip containers, wheels, etc.)
+    python3 .github/scripts/bump_version.py \\
+        --new-version 0.9.0.post1 \\
+        --skip-core --skip-containers --skip-docs
+
+    # Dry run (print changes without writing)
+    python3 .github/scripts/bump_version.py --new-version 1.0.0 --dry-run
+
+    # Check for stale versions (CI mode)
+    python3 .github/scripts/bump_version.py --check --expected-version 0.9.0
+
+Version format conventions:
+    Python / container tags / git:  0.9.0.post1  (PEP 440, dot separator)
+    Rust crates / Helm charts:      0.9.0-post1  (semver, hyphen separator)
+    The script accepts the Python format and auto-converts for Cargo/Helm.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator
+
+# ---------------------------------------------------------------------------
+# Version format helpers
+# ---------------------------------------------------------------------------
+
+
+def to_semver(version: str) -> str:
+    """Convert Python PEP 440 post-release to semver format for Cargo/Helm.
+
+    0.9.0.post1 -> 0.9.0-post1
+    1.0.0       -> 1.0.0       (no change for non-post versions)
+    """
+    return re.sub(r"\.post(\d+)$", r"-post\1", version)
+
+
+def is_post_release(version: str) -> bool:
+    """Check if version is a post-release (e.g., 0.9.0.post1)."""
+    return bool(re.search(r"\.post\d+$", version))
+
+
+# ---------------------------------------------------------------------------
+# Regex patterns that identify Dynamo version references
+# ---------------------------------------------------------------------------
+# Version number pattern: X.Y.Z with optional .postN or -postN suffix
+_VER = r"\d+\.\d+\.\d+(?:[.-]post\d+)?"
+
+# Container image tags: ai-dynamo/<any-image>:X.Y.Z
+# Broad match — catches any image name under ai-dynamo/ so new images
+# (epp-image, snapshot-agent, etc.) are picked up automatically.
+IMAGE_TAG_RE = re.compile(
+    r"((?:nvcr\.io/nvidia/)?ai-dynamo/[a-z][a-z0-9-]*)" rf":({_VER})"
+)
+
+# Wheel filenames and pip install specs:
+#   ai_dynamo_runtime-0.7.0-cp310-..., ai-dynamo==0.8.1, ai-dynamo[vllm]==0.8.1.post1
+WHEEL_FILE_RE = re.compile(
+    r"(ai[_-]dynamo(?:[_-]runtime)?(?:\[[^\]]*\])?)" rf"(==|-)({_VER})"
+)
+
+# dynamoVersion: "0.6.0" or "0.9.0.post1" in operator samples
+DYNAMO_VERSION_FIELD_RE = re.compile(rf'(dynamoVersion:\s*")({_VER})(")')
+
+# git checkout release/X.Y.Z or release/X.Y.Z.post1
+GIT_CHECKOUT_RE = re.compile(rf"(git checkout release/)({_VER})")
+
+# git+https://...@release/X.Y.Z (pip git install URLs)
+GIT_REF_RE = re.compile(rf"(@release/)({_VER})")
+
+# DYNAMO_VERSION=X.Y.Z in shell snippets and docs
+DYNAMO_VERSION_ENV_RE = re.compile(rf"(DYNAMO_VERSION=)({_VER})")
+
+# Standalone Dynamo image tags without full registry path (e.g., vllm-runtime:0.8.0)
+# Kept as an explicit list (unlike IMAGE_TAG_RE) to avoid false positives
+# without the ai-dynamo/ prefix as a disambiguator.
+SHORT_IMAGE_TAG_RE = re.compile(
+    r"((?:vllm|sglang|tensorrtllm)-runtime"
+    r"|dynamo-frontend|kubernetes-operator|frontend"
+    r"|epp-image|snapshot-agent)"
+    rf":({_VER})"
+)
+
+# Unified pattern table used by both scan_and_replace and check_stale_versions.
+# (regex, replacement_template, version_group_index, track_spans_for_dedup)
+_VERSION_PATTERNS: list[tuple[re.Pattern, str, int, bool]] = [
+    (IMAGE_TAG_RE, r"\1:{ver}", 2, True),
+    (SHORT_IMAGE_TAG_RE, r"\1:{ver}", 2, True),
+    (WHEEL_FILE_RE, r"\1\g<2>{ver}", 3, False),
+    (DYNAMO_VERSION_FIELD_RE, r"\g<1>{ver}\3", 2, False),
+    (GIT_CHECKOUT_RE, r"\g<1>{ver}", 2, False),
+    (GIT_REF_RE, r"\g<1>{ver}", 2, False),
+    (DYNAMO_VERSION_ENV_RE, r"\g<1>{ver}", 2, False),
+]
+
+# ---------------------------------------------------------------------------
+# Paths excluded from the catch-all discovery scan
+# ---------------------------------------------------------------------------
+EXCLUDE_PATTERNS = [
+    "**/*.lock",
+    "**/go.sum",
+    "**/go.mod",
+    ".git/**",
+    "**/__pycache__/**",
+    "**/node_modules/**",
+    "**/.venv/**",
+    "**/*.pyc",
+    "**/*.png",
+    "**/*.jpg",
+    "**/*.gif",
+    "**/*.woff*",
+    "**/*.ttf",
+    "**/*.ico",
+    "**/*.pdf",
+    # Auto-generated files handled by regen steps
+    "deploy/operator/config/crd/bases/**",
+    "deploy/helm/charts/crds/templates/**",
+    "deploy/helm/charts/platform/README.md",
+    "docs/kubernetes/api-reference.md",
+    "deploy/operator/api/v1alpha1/zz_generated.deepcopy.go",
+    # Test fixtures with intentional old versions
+    "deploy/operator/internal/**/*_test.go",
+    "deploy/operator/internal/checkpoint/**",
+    "deploy/operator/internal/dynamo/graph_test.go",
+    "tests/**",
+    # The bump script itself
+    ".github/scripts/bump_version.py",
+    # Error classification (separate package, has its own version)
+    "error_classification/**",
+]
+
+# Files that get targeted edits (not catch-all replacement).
+# The catch-all scanner skips these; dedicated functions handle them.
+TARGETED_EDIT_FILES = frozenset(
+    {
+        "docs/reference/release-artifacts.md",
+        "docs/reference/support-matrix.md",
+        "docs/reference/feature-matrix.md",
+        "pyproject.toml",
+        "Cargo.toml",
+        "lib/bindings/python/Cargo.toml",
+        "lib/gpu_memory_service/setup.py",
+        "deploy/helm/charts/crds/Chart.yaml",
+        "deploy/helm/charts/platform/Chart.yaml",
+        "deploy/helm/charts/platform/components/operator/Chart.yaml",
+        "deploy/helm/charts/snapshot/Chart.yaml",
+        "deploy/helm/charts/snapshot/values.yaml",
+        # Operator Go source and samples are handled by update_operator_source()
+        "deploy/operator/api/v1alpha1/dynamographdeploymentrequest_types.go",
+        "deploy/operator/config/samples/nvidia.com_v1alpha1_dynamographdeploymentrequest.yaml",
+        "deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml",
+    }
+)
+
+
+def _matches_exclude(rel_path: str) -> bool:
+    """Robust exclusion check using pathlib-style matching."""
+    p = Path(rel_path)
+    for pattern in EXCLUDE_PATTERNS:
+        if p.match(pattern):
+            return True
+        # Handle ** prefix patterns
+        if pattern.startswith("**/"):
+            suffix = pattern[3:]
+            if fnmatch.fnmatch(rel_path, f"*{suffix}") or fnmatch.fnmatch(
+                p.name, suffix
+            ):
+                return True
+        if fnmatch.fnmatch(rel_path, pattern):
+            return True
+    return False
+
+
+def is_binary(filepath: Path) -> bool:
+    """Quick check if a file is binary."""
+    try:
+        with open(filepath, "rb") as f:
+            chunk = f.read(8192)
+            return b"\x00" in chunk
+    except (OSError, PermissionError):
+        return True
+
+
+def _iter_version_files(
+    repo: Path,
+    extra_skip: frozenset[str] = frozenset(),
+) -> Iterator[tuple[str, Path, str]]:
+    """Yield (rel_path, filepath, content) for all version-relevant files."""
+    for dirpath, dirnames, filenames in os.walk(repo):
+        dirnames[:] = [
+            d
+            for d in dirnames
+            if not d.startswith(".")
+            and d not in ("node_modules", "__pycache__", ".venv")
+        ]
+        for filename in filenames:
+            filepath = Path(dirpath) / filename
+            rel_path = str(filepath.relative_to(repo))
+            if _matches_exclude(rel_path) or rel_path in extra_skip:
+                continue
+            if is_binary(filepath):
+                continue
+            try:
+                content = filepath.read_text(encoding="utf-8", errors="surrogateescape")
+            except (OSError, UnicodeDecodeError):
+                continue
+            yield rel_path, filepath, content
+
+
+# ===================================================================
+# Category 1: Core version files (targeted edits)
+# ===================================================================
+
+
+def update_pyproject_toml(
+    repo: Path, old_ver: str, new_ver: str, dry_run: bool
+) -> list[str]:
+    """Update version in pyproject.toml."""
+    filepath = repo / "pyproject.toml"
+    changes = []
+    content = filepath.read_text()
+    new_content = content
+
+    # version = "X.Y.Z"
+    new_content = re.sub(
+        rf'(version\s*=\s*"){re.escape(old_ver)}"',
+        rf'\g<1>{new_ver}"',
+        new_content,
+    )
+    # ai-dynamo-runtime==X.Y.Z
+    new_content = re.sub(
+        rf"(ai-dynamo-runtime==){re.escape(old_ver)}",
+        rf"\g<1>{new_ver}",
+        new_content,
+    )
+
+    if new_content != content:
+        changes.append(f"pyproject.toml: version {old_ver} -> {new_ver}")
+        if not dry_run:
+            filepath.write_text(new_content)
+    return changes
+
+
+def update_cargo_toml(
+    repo: Path, old_ver: str, new_ver: str, dry_run: bool
+) -> list[str]:
+    """Auto-discover and update Cargo.toml files containing the old version.
+
+    Scans all Cargo.toml files in the repo (excluding target/ and vendored
+    directories) so newly added workspaces are picked up automatically.
+    Uses semver format (0.9.0-post1) for Cargo files.
+    """
+    changes = []
+    old_semver = to_semver(old_ver)
+    new_semver = to_semver(new_ver)
+
+    skip_dirs = {"target", ".git", "node_modules", "__pycache__", ".venv"}
+    for dirpath, dirnames, filenames in os.walk(repo):
+        dirnames[:] = [d for d in dirnames if d not in skip_dirs]
+        if "Cargo.toml" not in filenames:
+            continue
+        filepath = Path(dirpath) / "Cargo.toml"
+        rel_path = str(filepath.relative_to(repo))
+        content = filepath.read_text()
+        new_content = re.sub(
+            rf'(version\s*=\s*"){re.escape(old_semver)}"',
+            rf'\g<1>{new_semver}"',
+            content,
+        )
+        if new_content != content:
+            changes.append(f"{rel_path}: version {old_semver} -> {new_semver}")
+            if not dry_run:
+                filepath.write_text(new_content)
+    return changes
+
+
+def update_gpu_memory_setup(
+    repo: Path, old_ver: str, new_ver: str, dry_run: bool
+) -> list[str]:
+    """Update version in lib/gpu_memory_service/setup.py."""
+    filepath = repo / "lib/gpu_memory_service/setup.py"
+    if not filepath.exists():
+        return []
+    content = filepath.read_text()
+    new_content = re.sub(
+        rf'(version\s*=\s*"){re.escape(old_ver)}"',
+        rf'\g<1>{new_ver}"',
+        content,
+    )
+    if new_content != content:
+        if not dry_run:
+            filepath.write_text(new_content)
+        return [f"lib/gpu_memory_service/setup.py: version {old_ver} -> {new_ver}"]
+    return []
+
+
+# ===================================================================
+# Category 2: Helm charts (targeted edits)
+# ===================================================================
+
+
+def update_helm_charts(
+    repo: Path, old_ver: str, new_ver: str, dry_run: bool
+) -> list[str]:
+    """Update version fields in Helm Chart.yaml files.
+
+    Handles exact old version, dev-suffixed versions (1.0.0-dev), and
+    post-release versions (0.9.0-post1). Uses semver format for Helm.
+    """
+    changes = []
+    new_semver = to_semver(new_ver)
+    ver_pattern = r"\d+\.\d+\.\d+(?:-(?:dev|post\d+))?"
+
+    # Chart.yaml files: (relative_path, update_appVersion)
+    chart_configs = [
+        ("deploy/helm/charts/crds/Chart.yaml", False),
+        ("deploy/helm/charts/platform/Chart.yaml", False),
+        ("deploy/helm/charts/platform/components/operator/Chart.yaml", True),
+        ("deploy/helm/charts/snapshot/Chart.yaml", True),
+    ]
+
+    for rel_path, update_app_version in chart_configs:
+        filepath = repo / rel_path
+        if not filepath.exists():
+            continue
+        content = filepath.read_text()
+        new_content = re.sub(
+            rf"(^version:\s*){ver_pattern}",
+            rf"\g<1>{new_semver}",
+            content,
+            count=1,
+            flags=re.MULTILINE,
+        )
+        if update_app_version:
+            new_content = re.sub(
+                rf'(^appVersion:\s*"){ver_pattern}"',
+                rf'\g<1>{new_semver}"',
+                new_content,
+                flags=re.MULTILINE,
+            )
+        if new_content != content:
+            changes.append(f"{rel_path}: version -> {new_semver}")
+            if not dry_run:
+                filepath.write_text(new_content)
+
+    # Platform chart: dynamo-operator dependency version
+    platform_chart = repo / "deploy/helm/charts/platform/Chart.yaml"
+    if platform_chart.exists():
+        content = platform_chart.read_text()
+        new_content = re.sub(
+            rf"(  - name: dynamo-operator\n    version:\s*){ver_pattern}",
+            rf"\g<1>{new_semver}",
+            content,
+        )
+        if new_content != content and not dry_run:
+            platform_chart.write_text(new_content)
+
+    # Snapshot values.yaml: image tag
+    snapshot_values = repo / "deploy/helm/charts/snapshot/values.yaml"
+    if snapshot_values.exists():
+        content = snapshot_values.read_text()
+        new_content = re.sub(
+            rf"(repository:\s*nvcr\.io/nvidia/ai-dynamo/snapshot-agent\n\s*tag:\s*){ver_pattern}",
+            rf"\g<1>{new_semver}",
+            content,
+        )
+        if new_content != content:
+            changes.append(
+                "deploy/helm/charts/snapshot/values.yaml: tag -> " + new_semver
+            )
+            if not dry_run:
+                snapshot_values.write_text(new_content)
+
+    return changes
+
+
+# ===================================================================
+# Category 2b: Operator Go source and samples (targeted edits)
+# ===================================================================
+
+
+def update_operator_source(repo: Path, new_ver: str, dry_run: bool) -> list[str]:
+    """Update version references in operator Go source and sample files."""
+    changes = []
+
+    targets = [
+        "deploy/operator/api/v1alpha1/dynamographdeploymentrequest_types.go",
+        "deploy/operator/config/samples/nvidia.com_v1alpha1_dynamographdeploymentrequest.yaml",
+        "deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml",
+    ]
+
+    for rel in targets:
+        filepath = repo / rel
+        if not filepath.exists():
+            continue
+        content = filepath.read_text()
+        new_content = content
+
+        # Replace any Dynamo image tags
+        new_content = IMAGE_TAG_RE.sub(rf"\1:{new_ver}", new_content)
+        new_content = SHORT_IMAGE_TAG_RE.sub(rf"\1:{new_ver}", new_content)
+        # Replace dynamoVersion: "X.Y.Z"
+        new_content = DYNAMO_VERSION_FIELD_RE.sub(rf"\g<1>{new_ver}\3", new_content)
+
+        if new_content != content:
+            changes.append(f"{rel}: updated version references -> {new_ver}")
+            if not dry_run:
+                filepath.write_text(new_content)
+
+    return changes
+
+
+# ===================================================================
+# Category 3: Reference documentation (targeted edits)
+# ===================================================================
+
+
+def update_feature_matrix(repo: Path, new_ver: str, dry_run: bool) -> list[str]:
+    """Update the 'Updated for Dynamo vX.Y.Z' line in feature-matrix.md."""
+    filepath = repo / "docs/reference/feature-matrix.md"
+    if not filepath.exists():
+        return []
+    content = filepath.read_text()
+    new_content = re.sub(
+        r"\*Updated for Dynamo v[\d.]+(?:\.post\d+)?\*",
+        f"*Updated for Dynamo v{new_ver}*",
+        content,
+    )
+    if new_content != content:
+        if not dry_run:
+            filepath.write_text(new_content)
+        return [f"feature-matrix.md: updated version tag -> v{new_ver}"]
+    return []
+
+
+def update_support_matrix(
+    repo: Path,
+    new_ver: str,
+    dry_run: bool,
+    backend_versions: dict[str, str | None] | None = None,
+) -> list[str]:
+    """Update support-matrix.md for a new release.
+
+    - Removes '*(in progress)*' from the version row
+    - Updates the "At a Glance" latest stable release line
+    - Adds a new row to the Backend Dependencies table
+    """
+    filepath = repo / "docs/reference/support-matrix.md"
+    if not filepath.exists():
+        return []
+    content = filepath.read_text()
+    original = content
+    changes = []
+    bv = backend_versions or {}
+
+    # Remove "*(in progress)*" from the released version row
+    content = re.sub(
+        rf"(\*\*v{re.escape(new_ver)}\*\*)\s*\*\(in progress\)\*",
+        r"\1",
+        content,
+    )
+
+    if all(bv.get(k) for k in ("sglang", "trtllm", "vllm", "nixl")):
+        # Update "At a Glance" latest stable release line
+        content = re.sub(
+            r"(\*\*Latest stable release:\*\* \[v)[\d.]+\S*"
+            r"(\]\(https://github\.com/ai-dynamo/dynamo/releases/tag/v)[\d.]+\S*"
+            r"(\) --).*",
+            rf"\g<1>{new_ver}\g<2>{new_ver}\3"
+            rf' SGLang `{bv["sglang"]}` |'
+            rf' TensorRT-LLM `{bv["trtllm"]}` |'
+            rf' vLLM `{bv["vllm"]}` |'
+            rf' NIXL `{bv["nixl"]}`',
+            content,
+        )
+        changes.append(f"support-matrix.md: updated At a Glance for v{new_ver}")
+
+        # Add new row to Backend Dependencies table (after main ToT row)
+        if f"| **v{new_ver}**" not in content:
+            new_row = (
+                f"| **v{new_ver}** "
+                f'| `{bv["sglang"]}` '
+                f'| `{bv["trtllm"]}` '
+                f'| `{bv["vllm"]}` '
+                f'| `{bv["nixl"]}` |'
+            )
+            content = re.sub(
+                r"(\| \*\*main \(ToT\)\*\* \|[^\n]+\n)",
+                rf"\1{new_row}\n",
+                content,
+            )
+            changes.append(
+                f"support-matrix.md: added v{new_ver} to Backend Dependencies"
+            )
+
+    if content != original:
+        if not dry_run:
+            filepath.write_text(content)
+    return changes
+
+
+def update_release_artifacts(
+    repo: Path,
+    new_ver: str,
+    release_date: str | None,
+    dry_run: bool,
+    backend_versions: dict[str, str | None] | None = None,
+) -> list[str]:
+    """Update the Current Release section and add history rows in release-artifacts.md."""
+    filepath = repo / "docs/reference/release-artifacts.md"
+    if not filepath.exists():
+        return []
+    content = filepath.read_text()
+    original = content
+    changes = []
+
+    # Update "Current Release: Dynamo vX.Y.Z" header
+    content = re.sub(
+        r"(## Current Release: Dynamo v)[\d.]+\S*",
+        rf"\g<1>{new_ver}",
+        content,
+    )
+
+    # Update GitHub Release link in current release section
+    content = re.sub(
+        r"(\*\*GitHub Release:\*\* \[v)[\d.]+\S*(\]\(https://github\.com/ai-dynamo/dynamo/releases/tag/v)[\d.]+\S*(\))",
+        rf"\g<1>{new_ver}\g<2>{new_ver}\3",
+        content,
+    )
+
+    # Update Docs link in current release section
+    ver_dashed = new_ver.replace(".", "-")
+    content = re.sub(
+        r"(\*\*Docs:\*\* \[v)[\d.]+\S*(\]\(https://docs\.nvidia\.com/dynamo/v-)[\d-]+\S*(/?\))",
+        rf"\g<1>{new_ver}\g<2>{ver_dashed}\3",
+        content,
+    )
+
+    # Add row to GitHub Releases table if not already present
+    if f"| `v{new_ver}`" not in content:
+        date_str = release_date or datetime.now().strftime("%b %d, %Y")
+        new_row = (
+            f"| `v{new_ver}` | {date_str} "
+            f"| [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v{new_ver}) "
+            f"| [Docs](https://docs.nvidia.com/dynamo/v-{ver_dashed}/) |"
+        )
+        # Insert after the table header row
+        table_pattern = r"(### GitHub Releases\n\n\| Version \|.*\n\|[-| ]+\n)"
+        if re.search(table_pattern, content):
+            content = re.sub(
+                table_pattern,
+                rf"\1{new_row}\n",
+                content,
+            )
+            changes.append(
+                f"release-artifacts.md: added v{new_ver} to GitHub Releases table"
+            )
+        else:
+            print(
+                "WARNING: Could not find GitHub Releases table pattern in "
+                "release-artifacts.md. Skipping table row insertion.",
+                file=sys.stderr,
+            )
+
+    # Update backend versions in Current Release Container Images table
+    # Scoped to "## Current Release" section to avoid touching history tables
+    bv = backend_versions or {}
+    backend_labels = {"vllm": "vLLM", "sglang": "SGLang", "trtllm": "TRT-LLM"}
+    cr_start = content.find("## Current Release")
+    if cr_start >= 0:
+        # Find the next H2 section after Current Release
+        next_h2 = content.find("\n## ", cr_start + 1)
+        if next_h2 < 0:
+            next_h2 = len(content)
+        section = content[cr_start:next_h2]
+        for key, label in backend_labels.items():
+            ver = bv.get(key)
+            if ver:
+                section = re.sub(rf"({label} `)v[^`]+(`)", rf"\g<1>v{ver}\2", section)
+        content = content[:cr_start] + section + content[next_h2:]
+        if bv:
+            changes.append(
+                "release-artifacts.md: updated backend versions in Current Release"
+            )
+
+    if content != original:
+        changes.append(f"release-artifacts.md: updated Current Release to v{new_ver}")
+        if not dry_run:
+            filepath.write_text(content)
+
+    return changes
+
+
+# ===================================================================
+# Category 4: Discovery-based catch-all scan
+# ===================================================================
+
+
+def scan_and_replace(repo: Path, new_ver: str, dry_run: bool) -> list[str]:
+    """Walk the repo and replace all Dynamo version patterns with new_ver."""
+    changes = []
+    for rel_path, filepath, content in _iter_version_files(
+        repo, extra_skip=TARGETED_EDIT_FILES
+    ):
+        new_content = content
+        for regex, repl_template, _, _ in _VERSION_PATTERNS:
+            new_content = regex.sub(repl_template.format(ver=new_ver), new_content)
+        if new_content != content:
+            changes.append(f"{rel_path}: updated version references -> {new_ver}")
+            if not dry_run:
+                filepath.write_text(
+                    new_content, encoding="utf-8", errors="surrogateescape"
+                )
+    return changes
+
+
+# ===================================================================
+# --check mode: scan for stale versions
+# ===================================================================
+
+
+def check_stale_versions(repo: Path, expected_ver: str) -> list[str]:
+    """Scan repo for Dynamo version patterns that don't match expected_ver.
+
+    Returns list of stale reference descriptions. Empty list = all clean.
+    """
+    stale = []
+    skip_files = frozenset(
+        {
+            "docs/reference/release-artifacts.md",
+            "docs/reference/support-matrix.md",
+        }
+    )
+    for rel_path, _, content in _iter_version_files(repo, extra_skip=skip_files):
+        for lineno, line in enumerate(content.splitlines(), 1):
+            reported_spans: set[tuple[int, int]] = set()
+            for regex, _, ver_group, track_spans in _VERSION_PATTERNS:
+                for m in regex.finditer(line):
+                    if track_spans and any(
+                        m.start() >= s and m.end() <= e for s, e in reported_spans
+                    ):
+                        continue
+                    ver = m.group(ver_group)
+                    if ver != expected_ver and not ver.startswith(expected_ver + "."):
+                        stale.append(
+                            f"STALE: {rel_path}:{lineno} -- {m.group(0)} (expected {expected_ver})"
+                        )
+                    if track_spans:
+                        reported_spans.add((m.start(), m.end()))
+    return stale
+
+
+# ===================================================================
+# Auto-detect current version from pyproject.toml
+# ===================================================================
+
+
+def detect_current_version(repo: Path) -> str:
+    """Read the current version from pyproject.toml."""
+    pyproject = repo / "pyproject.toml"
+    content = pyproject.read_text()
+    m = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    if not m:
+        print("ERROR: Could not detect version from pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+    return m.group(1)
+
+
+# ===================================================================
+# Main
+# ===================================================================
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Dynamo release version bump script",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--new-version", help="Target version (e.g., 1.0.0 or 0.9.0.post1)"
+    )
+    parser.add_argument(
+        "--old-version", help="Current version to replace (auto-detected if omitted)"
+    )
+    parser.add_argument(
+        "--repo-root", default=".", help="Repository root (default: cwd)"
+    )
+
+    # Backend metadata — accepted for forward-compatibility with the release
+    # workflow (which always passes them) but not yet consumed by this script.
+    # Future work: auto-populate support-matrix rows from these values.
+    parser.add_argument("--vllm-version", help="vLLM version (reserved, not yet used)")
+    parser.add_argument(
+        "--sglang-version", help="SGLang version (reserved, not yet used)"
+    )
+    parser.add_argument(
+        "--trtllm-version", help="TRT-LLM version (reserved, not yet used)"
+    )
+    parser.add_argument("--nixl-version", help="NIXL version (reserved, not yet used)")
+    parser.add_argument(
+        "--cuda-versions-vllm", help="CUDA versions for vLLM (reserved, not yet used)"
+    )
+    parser.add_argument(
+        "--cuda-versions-sglang",
+        help="CUDA versions for SGLang (reserved, not yet used)",
+    )
+    parser.add_argument(
+        "--cuda-versions-trtllm",
+        help="CUDA versions for TRT-LLM (reserved, not yet used)",
+    )
+    parser.add_argument("--release-date", help="Release date (e.g., 'Feb 15, 2026')")
+
+    # Modes
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print changes without writing"
+    )
+    parser.add_argument(
+        "--check", action="store_true", help="Check for stale versions (CI mode)"
+    )
+    parser.add_argument("--expected-version", help="Expected version for --check mode")
+
+    # Scope controls (for post-releases or selective bumps)
+    parser.add_argument(
+        "--skip-core",
+        action="store_true",
+        help="Skip core version files (pyproject.toml, Cargo.toml, setup.py)",
+    )
+    parser.add_argument(
+        "--skip-containers",
+        action="store_true",
+        help="Skip discovery-based container image tag scan (docs, recipes, examples)",
+    )
+    parser.add_argument(
+        "--skip-helm",
+        action="store_true",
+        help="Skip Helm Chart.yaml version updates",
+    )
+    parser.add_argument(
+        "--skip-docs",
+        action="store_true",
+        help="Skip reference doc updates (support-matrix, feature-matrix, release-artifacts)",
+    )
+
+    args = parser.parse_args()
+    repo = Path(args.repo_root).resolve()
+
+    # --check mode
+    if args.check:
+        expected = args.expected_version
+        if not expected:
+            expected = detect_current_version(repo)
+        print(f"Checking for stale version references (expected: {expected})...")
+        stale = check_stale_versions(repo, expected)
+        if stale:
+            for s in stale:
+                print(s)
+            print(f"\nFound {len(stale)} stale version reference(s).")
+            sys.exit(1)
+        else:
+            print("All version references are up to date.")
+            sys.exit(0)
+
+    # Bump mode
+    if not args.new_version:
+        parser.error("--new-version is required (unless using --check)")
+
+    new_ver = args.new_version
+    old_ver = args.old_version or detect_current_version(repo)
+
+    if old_ver == new_ver:
+        print(
+            f"WARNING: old version ({old_ver}) == new version ({new_ver}). "
+            "Nothing to bump.",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+    if args.dry_run:
+        print(f"DRY RUN: Would bump {old_ver} -> {new_ver}")
+    else:
+        print(f"Bumping version: {old_ver} -> {new_ver}")
+
+    if is_post_release(new_ver):
+        print(f"  Post-release detected: Python={new_ver}, Semver={to_semver(new_ver)}")
+
+    skip_flags = []
+    if args.skip_core:
+        skip_flags.append("core")
+    if args.skip_containers:
+        skip_flags.append("containers")
+    if args.skip_helm:
+        skip_flags.append("helm")
+    if args.skip_docs:
+        skip_flags.append("docs")
+    if skip_flags:
+        print(f"  Skipping: {', '.join(skip_flags)}")
+
+    backend_versions = {
+        "vllm": args.vllm_version,
+        "sglang": args.sglang_version,
+        "trtllm": args.trtllm_version,
+        "nixl": args.nixl_version,
+    }
+
+    all_changes: list[str] = []
+
+    # Category 1: Core version files
+    if not args.skip_core:
+        print("\n=== Category 1: Core version files ===")
+        all_changes.extend(update_pyproject_toml(repo, old_ver, new_ver, args.dry_run))
+        all_changes.extend(update_cargo_toml(repo, old_ver, new_ver, args.dry_run))
+        all_changes.extend(
+            update_gpu_memory_setup(repo, old_ver, new_ver, args.dry_run)
+        )
+    else:
+        print("\n=== Category 1: Core version files [SKIPPED] ===")
+
+    # Category 2: Helm charts
+    if not args.skip_helm:
+        print("\n=== Category 2: Helm charts ===")
+        all_changes.extend(update_helm_charts(repo, old_ver, new_ver, args.dry_run))
+    else:
+        print("\n=== Category 2: Helm charts [SKIPPED] ===")
+
+    # Category 2b: Operator Go source and samples
+    # Part of the CRD regen chain -- update image tags and dynamoVersion fields
+    # in Go doc comments and sample YAMLs before CRD regeneration.
+    if not args.skip_containers:
+        print("\n=== Category 2b: Operator Go source and samples ===")
+        all_changes.extend(update_operator_source(repo, new_ver, args.dry_run))
+    else:
+        print("\n=== Category 2b: Operator Go source and samples [SKIPPED] ===")
+
+    # Category 3: Reference documentation
+    if not args.skip_docs:
+        print("\n=== Category 3: Reference documentation ===")
+        all_changes.extend(update_feature_matrix(repo, new_ver, args.dry_run))
+        all_changes.extend(
+            update_support_matrix(repo, new_ver, args.dry_run, backend_versions)
+        )
+        all_changes.extend(
+            update_release_artifacts(
+                repo, new_ver, args.release_date, args.dry_run, backend_versions
+            )
+        )
+    else:
+        print("\n=== Category 3: Reference documentation [SKIPPED] ===")
+
+    # Category 4: Discovery-based catch-all scan
+    if not args.skip_containers:
+        print("\n=== Category 4: Discovery-based scan (docs, recipes, examples) ===")
+        all_changes.extend(scan_and_replace(repo, new_ver, args.dry_run))
+    else:
+        print("\n=== Category 4: Discovery-based scan [SKIPPED] ===")
+
+    # Summary
+    print(f"\n{'=' * 60}")
+    print(
+        f"{'DRY RUN ' if args.dry_run else ''}Summary: {len(all_changes)} file(s) changed"
+    )
+    print(f"{'=' * 60}")
+    for change in all_changes:
+        print(f"  {'[DRY] ' if args.dry_run else '✅ '}{change}")
+
+    if not all_changes:
+        print(
+            "WARNING: No files were changed. This may indicate the old version "
+            f"({old_ver}) was not found in any target files, or all categories "
+            "were skipped.",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -65,7 +65,7 @@ IGNORE_MARKER = "bump-version: ignore"
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True, order=True)
+@dataclass(frozen=True)
 class Version:
     """A Dynamo release version.
 
@@ -108,6 +108,38 @@ class Version:
     @property
     def is_post(self) -> bool:
         return self.post is not None
+
+    def _sort_key(self) -> tuple[int, int, int, int]:
+        # PEP 440: a base release sorts before any of its post-releases, so
+        # treat ``post=None`` as ``-1`` (less than any real post number). The
+        # default dataclass ordering would compare ``None`` to ``int`` and
+        # raise ``TypeError`` at runtime.
+        return (
+            self.major,
+            self.minor,
+            self.patch,
+            self.post if self.post is not None else -1,
+        )
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self._sort_key() < other._sort_key()
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self._sort_key() <= other._sort_key()
+
+    def __gt__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self._sort_key() > other._sort_key()
+
+    def __ge__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self._sort_key() >= other._sort_key()
 
     def __str__(self) -> str:
         return self.python()
@@ -249,12 +281,15 @@ RULES: tuple[Rule, ...] = (
         ),
         r"\g<1>:{python}",
     ),
-    # Wheel filenames and pip install specs in docs/Dockerfiles/shell
+    # Wheel filenames and pip install specs in docs/Dockerfiles/shell.
+    # pyproject.toml pins are owned by the CORE rule (pyproject_ai_dynamo_pin);
+    # excluding pyproject.toml here keeps it consistent when --skip-core is set.
     Rule(
         "pip_wheel_or_pin",
         Scope.CONTAINERS,
         re.compile(rf"(ai[_-]dynamo(?:[_-]runtime)?(?:\[[^\]]*\])?)(==|-){_VER}"),
         r"\g<1>\g<2>{python}",
+        lambda p: p.name != "pyproject.toml",
     ),
     # Operator sample YAML dynamoVersion: "X.Y.Z"
     Rule(

--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -162,8 +162,10 @@ class Scope(Enum):
 # Rule table
 # ---------------------------------------------------------------------------
 
-# Version token: X.Y.Z with optional .postN or -postN suffix.
-_VER = r"\d+\.\d+\.\d+(?:[.-]post\d+)?"
+# Version token: X.Y.Z with optional .postN or -postN, refusing to consume
+# additional release qualifiers (e.g. "-rc1", "-dev2") that would otherwise
+# leave an orphaned suffix when the engine rewrites the captured numbers.
+_VER = r"\d+\.\d+\.\d+(?:[.-]post\d+)?(?![\w.-])"
 
 
 def _always(_: Path) -> bool:

--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -55,6 +55,9 @@ from enum import Enum
 from pathlib import Path
 from typing import Callable, Iterator
 
+from packaging.version import InvalidVersion
+from packaging.version import Version as _PkgVersion
+
 # Per-file opt-out: any file containing this marker is skipped entirely.
 # Use it in test fixtures / historical artifacts that must stay on an old version.
 IGNORE_MARKER = "bump-version: ignore"
@@ -65,9 +68,9 @@ IGNORE_MARKER = "bump-version: ignore"
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=False)
 class Version:
-    """A Dynamo release version.
+    """Thin wrapper around packaging.version.Version with Dynamo-specific formatters.
 
     Knows its three canonical string forms:
       - :meth:`python`:  ``0.9.0`` / ``0.9.0.post1`` (PEP 440, for Python/images/git)
@@ -75,71 +78,69 @@ class Version:
       - :meth:`dashed`:  ``0-9-0`` / ``0-9-0-post1`` (for URL slugs)
     """
 
-    major: int
-    minor: int
-    patch: int
-    post: int | None = None
+    _pkg: _PkgVersion
 
-    _PARSE_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[.-]post(\d+))?$")
+    # Strict surface form: digits-only X.Y.Z with optional .postN or -postN.
+    # Rejects things packaging.version.Version would otherwise accept like
+    # leading "v" prefix, epochs, or 4-segment release tuples.
+    _PARSE_RE = re.compile(r"^\d+\.\d+\.\d+(?:[.-]post\d+)?$")
 
     @classmethod
     def parse(cls, s: str) -> Version:
-        m = cls._PARSE_RE.match(s)
-        if not m:
+        if not cls._PARSE_RE.match(s):
             raise argparse.ArgumentTypeError(
                 f"Not a valid version: {s!r}. Expected X.Y.Z or X.Y.Z.postN."
             )
-        maj, min_, pat, post = m.groups()
-        return cls(
-            int(maj), int(min_), int(pat), int(post) if post is not None else None
-        )
+        try:
+            v = _PkgVersion(s)
+        except InvalidVersion as e:
+            raise argparse.ArgumentTypeError(
+                f"Not a valid version: {s!r}. Expected X.Y.Z or X.Y.Z.postN."
+            ) from e
+        return cls(v)
+
+    @property
+    def major(self) -> int:
+        return self._pkg.release[0]
+
+    @property
+    def minor(self) -> int:
+        return self._pkg.release[1]
+
+    @property
+    def patch(self) -> int:
+        return self._pkg.release[2]
+
+    @property
+    def post(self) -> int | None:
+        return self._pkg.post
+
+    @property
+    def is_post(self) -> bool:
+        return self._pkg.post is not None
 
     def python(self) -> str:
         base = f"{self.major}.{self.minor}.{self.patch}"
-        return f"{base}.post{self.post}" if self.post is not None else base
+        return f"{base}.post{self.post}" if self.is_post else base
 
     def semver(self) -> str:
         base = f"{self.major}.{self.minor}.{self.patch}"
-        return f"{base}-post{self.post}" if self.post is not None else base
+        return f"{base}-post{self.post}" if self.is_post else base
 
     def dashed(self) -> str:
         return self.python().replace(".", "-")
 
-    @property
-    def is_post(self) -> bool:
-        return self.post is not None
-
-    def _sort_key(self) -> tuple[int, int, int, int]:
-        # PEP 440: a base release sorts before any of its post-releases, so
-        # treat ``post=None`` as ``-1`` (less than any real post number). The
-        # default dataclass ordering would compare ``None`` to ``int`` and
-        # raise ``TypeError`` at runtime.
-        return (
-            self.major,
-            self.minor,
-            self.patch,
-            self.post if self.post is not None else -1,
-        )
-
     def __lt__(self, other: object) -> bool:
-        if not isinstance(other, Version):
-            return NotImplemented
-        return self._sort_key() < other._sort_key()
+        return isinstance(other, Version) and self._pkg < other._pkg
 
     def __le__(self, other: object) -> bool:
-        if not isinstance(other, Version):
-            return NotImplemented
-        return self._sort_key() <= other._sort_key()
+        return isinstance(other, Version) and self._pkg <= other._pkg
 
     def __gt__(self, other: object) -> bool:
-        if not isinstance(other, Version):
-            return NotImplemented
-        return self._sort_key() > other._sort_key()
+        return isinstance(other, Version) and self._pkg > other._pkg
 
     def __ge__(self, other: object) -> bool:
-        if not isinstance(other, Version):
-            return NotImplemented
-        return self._sort_key() >= other._sort_key()
+        return isinstance(other, Version) and self._pkg >= other._pkg
 
     def __str__(self) -> str:
         return self.python()

--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -18,18 +18,20 @@ Design:
     - ``--check`` is just a dry-run against the expected version: any change
       the engine would make = a stale reference.
     - ``--dry-run`` previews without writing.
-    - ``--skip-core/containers/helm/docs`` gate which rule categories fire.
+    - ``--skip-core/containers/helm`` gate which rule categories fire.
+
+    Reference-doc updates (release-artifacts, support-matrix, feature-matrix)
+    are handled by a Devin session dispatched from the release pipeline after
+    the version-bump PR is opened — not by this script. That way the docs are
+    synced once the final release tag/SHA is real, resolving a chicken-and-egg.
 
 Usage:
-    # Full release: bump all versions to 1.0.0
-    python3 .github/scripts/bump_version.py --new-version 1.0.0 \\
-        --vllm-version 0.19.0 --sglang-version 0.5.7 \\
-        --trtllm-version 1.3.0rc1 --nixl-version 0.10.1 \\
-        --release-date "Feb 15, 2026"
+    # Full release: bump code/containers/helm to 1.0.0
+    python3 .github/scripts/bump_version.py --new-version 1.0.0
 
     # Post-release: Helm-only patch
     python3 .github/scripts/bump_version.py --new-version 0.9.0.post1 \\
-        --skip-core --skip-containers --skip-docs
+        --skip-core --skip-containers
 
     # Dry run
     python3 .github/scripts/bump_version.py --new-version 1.0.0 --dry-run
@@ -155,7 +157,6 @@ class Scope(Enum):
     CORE = "core"  # pyproject, Cargo, setup.py
     CONTAINERS = "containers"  # image tags, git refs, wheel pins, operator samples
     HELM = "helm"  # Chart.yaml, values.yaml
-    DOCS = "docs"  # support-matrix, feature-matrix, release-artifacts
 
 
 # ---------------------------------------------------------------------------
@@ -344,63 +345,6 @@ RULES: tuple[Rule, ...] = (
         r"\g<1>{python}",
         _is_spec_file,
     ),
-    # -- Docs: feature-matrix.md ---------------------------------------------
-    Rule(
-        "feature_matrix_tag",
-        Scope.DOCS,
-        re.compile(rf"\*Updated for Dynamo v{_VER}\*"),
-        "*Updated for Dynamo v{python}*",
-        _endswith("docs/reference/feature-matrix.md"),
-    ),
-    # -- Docs: release-artifacts.md ------------------------------------------
-    Rule(
-        "release_artifacts_header",
-        Scope.DOCS,
-        re.compile(rf"(## Current Release: Dynamo v){_VER}"),
-        r"\g<1>{python}",
-        _endswith("docs/reference/release-artifacts.md"),
-    ),
-    Rule(
-        "release_artifacts_github_link",
-        Scope.DOCS,
-        re.compile(
-            rf"(\*\*GitHub Release:\*\* \[v){_VER}"
-            rf"(\]\(https://github\.com/ai-dynamo/dynamo/releases/tag/v){_VER}(\))"
-        ),
-        r"\g<1>{python}\g<2>{python}\g<3>",
-        _endswith("docs/reference/release-artifacts.md"),
-    ),
-    Rule(
-        # FIX 1: canonical Docs URL is https://docs.dynamo.nvidia.com/dynamo
-        "release_artifacts_docs_link",
-        Scope.DOCS,
-        re.compile(
-            rf"(\*\*Docs:\*\* \[v){_VER}"
-            rf"(\]\(https://docs\.dynamo\.nvidia\.com/dynamo\))"
-        ),
-        r"\g<1>{python}\g<2>",
-        _endswith("docs/reference/release-artifacts.md"),
-    ),
-    # -- Docs: support-matrix.md ---------------------------------------------
-    Rule(
-        "support_matrix_in_progress",
-        Scope.DOCS,
-        re.compile(rf"(\*\*v{_VER}\*\*)\s*\*\(in progress\)\*"),
-        r"\g<1>",
-        _endswith("docs/reference/support-matrix.md"),
-    ),
-    Rule(
-        "support_matrix_at_a_glance",
-        Scope.DOCS,
-        re.compile(
-            rf"(\*\*Latest stable release:\*\* \[v){_VER}"
-            rf"(\]\(https://github\.com/ai-dynamo/dynamo/releases/tag/v){_VER}(\)) --.*"
-        ),
-        r"\g<1>{python}\g<2>{python}\g<3> -- "
-        r"SGLang `{sglang}` | TensorRT-LLM `{trtllm}` | vLLM `{vllm}` | NIXL `{nixl}`",
-        _endswith("docs/reference/support-matrix.md"),
-        requires=("vllm", "sglang", "trtllm", "nixl"),
-    ),
 )
 
 
@@ -537,88 +481,6 @@ def apply_rules(
 
 
 # ---------------------------------------------------------------------------
-# Table insertions (DOCS structured edits)
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class TableInsertSpec:
-    """Spec for inserting a new row into a Markdown table."""
-
-    name: str
-    file: str  # repo-relative
-    table_header_re: re.Pattern[str]  # captures full header+separator
-    row_marker_template: str  # str.format with python/dashed/etc
-    new_row_template: str  # same
-    requires: tuple[str, ...] = ()
-
-
-TABLE_INSERTIONS: tuple[TableInsertSpec, ...] = (
-    TableInsertSpec(
-        name="release_artifacts_table_row",
-        file="docs/reference/release-artifacts.md",
-        table_header_re=re.compile(
-            r"(### GitHub Releases\n\n\| Version \|.*\n\|[-| ]+\n)"
-        ),
-        row_marker_template="| `v{python}`",
-        # FIX 1c: 5 columns to match | Version | Release Date | GitHub | Docs | Notes |
-        new_row_template=(
-            "| `v{python}` | {release_date} "
-            "| [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v{python}) "
-            "| [Docs](https://docs.dynamo.nvidia.com/dynamo) | |"
-        ),
-        requires=("release_date",),
-    ),
-    TableInsertSpec(
-        name="support_matrix_backend_row",
-        file="docs/reference/support-matrix.md",
-        table_header_re=re.compile(
-            r"(\| \*\*main \(ToT\)\*\* \|[^\n]+\n)"  # insert AFTER ToT row
-        ),
-        row_marker_template="| **v{python}**",
-        new_row_template=(
-            "| **v{python}** | `{sglang}` | `{trtllm}` | `{vllm}` | `{nixl}` |"
-        ),
-        requires=("vllm", "sglang", "trtllm", "nixl"),
-    ),
-)
-
-
-def insert_table_rows(
-    repo: Path, version: Version, ctx: dict[str, str], dry_run: bool
-) -> list[Change]:
-    """Insert new rows into DOCS tables as specified by TABLE_INSERTIONS."""
-    out: list[Change] = []
-    fmt_ctx = {
-        "python": version.python(),
-        "semver": version.semver(),
-        "dashed": version.dashed(),
-        **ctx,
-    }
-    for spec in TABLE_INSERTIONS:
-        path = repo / spec.file
-        if not path.exists():
-            continue
-        if any(k not in ctx for k in spec.requires):
-            continue
-        content = path.read_text(encoding="utf-8")
-        marker = spec.row_marker_template.format_map(fmt_ctx)
-        if marker in content:
-            continue
-        if not spec.table_header_re.search(content):
-            raise RuntimeError(
-                f"{spec.file}: insertion point for {spec.name!r} not found. "
-                "The doc structure changed — update TABLE_INSERTIONS."
-            )
-        new_row = spec.new_row_template.format_map(fmt_ctx)
-        new_content = spec.table_header_re.sub(rf"\g<1>{new_row}\n", content, count=1)
-        if not dry_run:
-            path.write_text(new_content, encoding="utf-8")
-        out.append(Change(Path(spec.file), Scope.DOCS, [spec.name]))
-    return out
-
-
-# ---------------------------------------------------------------------------
 # Detect current version
 # ---------------------------------------------------------------------------
 
@@ -665,12 +527,6 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--repo-root", default=".", help="Repository root (default: cwd)")
 
-    # Backend metadata consumed by DOCS functions
-    p.add_argument("--vllm-version", help="vLLM backend version (e.g. 0.19.0)")
-    p.add_argument("--sglang-version", help="SGLang backend version")
-    p.add_argument("--trtllm-version", help="TensorRT-LLM backend version")
-    p.add_argument("--nixl-version", help="NIXL backend version")
-    p.add_argument("--release-date", help="Release date (e.g. 'Feb 15, 2026')")
 
     # Modes
     p.add_argument(
@@ -706,11 +562,6 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Skip Helm Chart.yaml and values.yaml updates",
     )
-    p.add_argument(
-        "--skip-docs",
-        action="store_true",
-        help="Skip reference docs (support-matrix, feature-matrix, release-artifacts)",
-    )
 
     # Verbosity
     p.add_argument("-v", "--verbose", action="store_true", help="Log every rule hit")
@@ -734,8 +585,6 @@ def _active_scopes(args: argparse.Namespace) -> set[Scope]:
         scopes.discard(Scope.CONTAINERS)
     if args.skip_helm:
         scopes.discard(Scope.HELM)
-    if args.skip_docs:
-        scopes.discard(Scope.DOCS)
     return scopes
 
 
@@ -774,29 +623,11 @@ def _format_summary(
     return "\n".join(lines) + "\n"
 
 
-def _ctx_from_args(args: argparse.Namespace) -> dict[str, str]:
-    """Build ctx dict from CLI args for rules that require backend versions."""
-    ctx: dict[str, str] = {}
-    if args.vllm_version:
-        ctx["vllm"] = args.vllm_version
-    if args.sglang_version:
-        ctx["sglang"] = args.sglang_version
-    if args.trtllm_version:
-        ctx["trtllm"] = args.trtllm_version
-    if args.nixl_version:
-        ctx["nixl"] = args.nixl_version
-    if args.release_date:
-        ctx["release_date"] = args.release_date
-    return ctx
-
-
 def _run_check(args: argparse.Namespace, repo: Path) -> int:
     expected = args.expected_version or detect_current_version(repo)
     _log(args, "info", f"Checking for stale version references (expected: {expected})...")
     active = _active_scopes(args)
-    ctx = _ctx_from_args(args)
-    stale = apply_rules(repo, expected, active, ctx, dry_run=True)
-    stale.extend(insert_table_rows(repo, expected, ctx, dry_run=True))
+    stale = apply_rules(repo, expected, active, {}, dry_run=True)
     if not stale:
         _log(args, "summary", "All version references are up to date.")
         return 0
@@ -834,13 +665,9 @@ def _run_bump(args: argparse.Namespace, repo: Path) -> int:
             f"  Post-release formats: python={new_ver.python()} semver={new_ver.semver()}",
         )
 
-    ctx = _ctx_from_args(args)
-
-    changes: list[Change] = []
-    # Rule-based scopes (core, containers, helm, docs)
-    changes.extend(apply_rules(repo, new_ver, active, ctx, dry_run=args.dry_run))
-    # Table insertions (docs structured edits)
-    changes.extend(insert_table_rows(repo, new_ver, ctx, dry_run=args.dry_run))
+    changes: list[Change] = list(
+        apply_rules(repo, new_ver, active, {}, dry_run=args.dry_run)
+    )
 
     _log(
         args,

--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -188,7 +188,11 @@ _SPEC_NAMES = {"Dockerfile"}
 
 def _is_spec_file(p: Path) -> bool:
     """Filter for broad CONTAINERS rules: only fire on spec files, not prose Markdown."""
-    return p.suffix in _SPEC_EXTENSIONS or p.name in _SPEC_NAMES or p.name.startswith("Dockerfile.")
+    return (
+        p.suffix in _SPEC_EXTENSIONS
+        or p.name in _SPEC_NAMES
+        or p.name.startswith("Dockerfile.")
+    )
 
 
 @dataclass(frozen=True)
@@ -207,17 +211,25 @@ class Rule:
     file_filter: Callable[[Path], bool] = _always
     requires: tuple[str, ...] = ()  # ctx keys this rule needs
 
-    def apply(self, content: str, version: Version, ctx: dict[str, str] | None = None) -> str:
+    def apply(
+        self, content: str, version: Version, ctx: dict[str, str] | None = None
+    ) -> str:
         # Invariant: version.python() / .semver() / .dashed() return PEP-440 /
         # dashed numeric strings only — no re.sub replacement metacharacters
         # (\g<...>, \1, etc.) can appear in them. Same applies to ctx values
         # (backend versions are validated upstream as `<digits>.<digits>...`).
         ctx = ctx or {}
         if any(k not in ctx for k in self.requires):
-            return content  # missing context → rule no-ops (matches today's all_set guard)
+            return (
+                content  # missing context → rule no-ops (matches today's all_set guard)
+            )
         repl = self.replacement.format_map(
-            {"python": version.python(), "semver": version.semver(),
-             "dashed": version.dashed(), **ctx}
+            {
+                "python": version.python(),
+                "semver": version.semver(),
+                "dashed": version.dashed(),
+                **ctx,
+            }
         )
         return self.pattern.sub(repl, content)
 
@@ -527,7 +539,6 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--repo-root", default=".", help="Repository root (default: cwd)")
 
-
     # Modes
     p.add_argument(
         "--dry-run",
@@ -625,14 +636,20 @@ def _format_summary(
 
 def _run_check(args: argparse.Namespace, repo: Path) -> int:
     expected = args.expected_version or detect_current_version(repo)
-    _log(args, "info", f"Checking for stale version references (expected: {expected})...")
+    _log(
+        args, "info", f"Checking for stale version references (expected: {expected})..."
+    )
     active = _active_scopes(args)
     stale = apply_rules(repo, expected, active, {}, dry_run=True)
     if not stale:
         _log(args, "summary", "All version references are up to date.")
         return 0
     for ch in stale:
-        _log(args, "info", f"STALE: {ch.path.as_posix()} ({ch.scope.value}: {', '.join(ch.rules)})")
+        _log(
+            args,
+            "info",
+            f"STALE: {ch.path.as_posix()} ({ch.scope.value}: {', '.join(ch.rules)})",
+        )
     _log(args, "summary", f"Found {len(stale)} stale version reference(s).")
     return 1
 

--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -46,11 +46,11 @@ Version format conventions:
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import os
 import re
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Callable, Iterator
@@ -179,6 +179,15 @@ def _endswith(*suffixes: str) -> Callable[[Path], bool]:
     return lambda p: any(p.as_posix().endswith(s) for s in suffixes)
 
 
+_SPEC_EXTENSIONS = {".yaml", ".yml", ".toml", ".sh", ".env"}
+_SPEC_NAMES = {"Dockerfile"}
+
+
+def _is_spec_file(p: Path) -> bool:
+    """Filter for broad CONTAINERS rules: only fire on spec files, not prose Markdown."""
+    return p.suffix in _SPEC_EXTENSIONS or p.name in _SPEC_NAMES or p.name.startswith("Dockerfile.")
+
+
 @dataclass(frozen=True)
 class Rule:
     """A single version-reference update rule.
@@ -193,12 +202,19 @@ class Rule:
     pattern: re.Pattern[str]
     replacement: str
     file_filter: Callable[[Path], bool] = _always
+    requires: tuple[str, ...] = ()  # ctx keys this rule needs
 
-    def apply(self, content: str, version: Version) -> str:
-        repl = (
-            self.replacement.replace("{python}", version.python())
-            .replace("{semver}", version.semver())
-            .replace("{dashed}", version.dashed())
+    def apply(self, content: str, version: Version, ctx: dict[str, str] | None = None) -> str:
+        # Invariant: version.python() / .semver() / .dashed() return PEP-440 /
+        # dashed numeric strings only — no re.sub replacement metacharacters
+        # (\g<...>, \1, etc.) can appear in them. Same applies to ctx values
+        # (backend versions are validated upstream as `<digits>.<digits>...`).
+        ctx = ctx or {}
+        if any(k not in ctx for k in self.requires):
+            return content  # missing context → rule no-ops (matches today's all_set guard)
+        repl = self.replacement.format_map(
+            {"python": version.python(), "semver": version.semver(),
+             "dashed": version.dashed(), **ctx}
         )
         return self.pattern.sub(repl, content)
 
@@ -271,6 +287,7 @@ RULES: tuple[Rule, ...] = (
         Scope.CONTAINERS,
         re.compile(rf"((?:nvcr\.io/nvidia/)?ai-dynamo/[a-z][a-z0-9-]*):{_VER}"),
         r"\g<1>:{python}",
+        _is_spec_file,
     ),
     Rule(
         "image_tag_short_dynamo",
@@ -281,6 +298,7 @@ RULES: tuple[Rule, ...] = (
             rf"|epp-image|snapshot-agent):{_VER}"
         ),
         r"\g<1>:{python}",
+        _is_spec_file,
     ),
     # Wheel filenames and pip install specs in docs/Dockerfiles/shell.
     # pyproject.toml pins are owned by the CORE rule (pyproject_ai_dynamo_pin);
@@ -290,7 +308,7 @@ RULES: tuple[Rule, ...] = (
         Scope.CONTAINERS,
         re.compile(rf"(ai[_-]dynamo(?:[_-]runtime)?(?:\[[^\]]*\])?)(==|-){_VER}"),
         r"\g<1>\g<2>{python}",
-        lambda p: p.name != "pyproject.toml",
+        lambda p: p.name != "pyproject.toml" and _is_spec_file(p),
     ),
     # Operator sample YAML dynamoVersion: "X.Y.Z"
     Rule(
@@ -298,6 +316,7 @@ RULES: tuple[Rule, ...] = (
         Scope.CONTAINERS,
         re.compile(rf'(dynamoVersion:\s*"){_VER}(")'),
         r"\g<1>{python}\g<2>",
+        _is_spec_file,
     ),
     # git checkout release/X.Y.Z
     Rule(
@@ -305,6 +324,7 @@ RULES: tuple[Rule, ...] = (
         Scope.CONTAINERS,
         re.compile(rf"(git checkout release/){_VER}"),
         r"\g<1>{python}",
+        _is_spec_file,
     ),
     # pip git URLs: git+https://...@release/X.Y.Z
     Rule(
@@ -312,6 +332,7 @@ RULES: tuple[Rule, ...] = (
         Scope.CONTAINERS,
         re.compile(rf"(@release/){_VER}"),
         r"\g<1>{python}",
+        _is_spec_file,
     ),
     # DYNAMO_VERSION=X.Y.Z env-var assignment
     Rule(
@@ -319,6 +340,64 @@ RULES: tuple[Rule, ...] = (
         Scope.CONTAINERS,
         re.compile(rf"(DYNAMO_VERSION=){_VER}"),
         r"\g<1>{python}",
+        _is_spec_file,
+    ),
+    # -- Docs: feature-matrix.md ---------------------------------------------
+    Rule(
+        "feature_matrix_tag",
+        Scope.DOCS,
+        re.compile(rf"\*Updated for Dynamo v{_VER}\*"),
+        "*Updated for Dynamo v{python}*",
+        _endswith("docs/reference/feature-matrix.md"),
+    ),
+    # -- Docs: release-artifacts.md ------------------------------------------
+    Rule(
+        "release_artifacts_header",
+        Scope.DOCS,
+        re.compile(rf"(## Current Release: Dynamo v){_VER}"),
+        r"\g<1>{python}",
+        _endswith("docs/reference/release-artifacts.md"),
+    ),
+    Rule(
+        "release_artifacts_github_link",
+        Scope.DOCS,
+        re.compile(
+            rf"(\*\*GitHub Release:\*\* \[v){_VER}"
+            rf"(\]\(https://github\.com/ai-dynamo/dynamo/releases/tag/v){_VER}(\))"
+        ),
+        r"\g<1>{python}\g<2>{python}\g<3>",
+        _endswith("docs/reference/release-artifacts.md"),
+    ),
+    Rule(
+        # FIX 1: canonical Docs URL is https://docs.dynamo.nvidia.com/dynamo
+        "release_artifacts_docs_link",
+        Scope.DOCS,
+        re.compile(
+            rf"(\*\*Docs:\*\* \[v){_VER}"
+            rf"(\]\(https://docs\.dynamo\.nvidia\.com/dynamo\))"
+        ),
+        r"\g<1>{python}\g<2>",
+        _endswith("docs/reference/release-artifacts.md"),
+    ),
+    # -- Docs: support-matrix.md ---------------------------------------------
+    Rule(
+        "support_matrix_in_progress",
+        Scope.DOCS,
+        re.compile(rf"(\*\*v{_VER}\*\*)\s*\*\(in progress\)\*"),
+        r"\g<1>",
+        _endswith("docs/reference/support-matrix.md"),
+    ),
+    Rule(
+        "support_matrix_at_a_glance",
+        Scope.DOCS,
+        re.compile(
+            rf"(\*\*Latest stable release:\*\* \[v){_VER}"
+            rf"(\]\(https://github\.com/ai-dynamo/dynamo/releases/tag/v){_VER}(\)) --.*"
+        ),
+        r"\g<1>{python}\g<2>{python}\g<3> -- "
+        r"SGLang `{sglang}` | TensorRT-LLM `{trtllm}` | vLLM `{vllm}` | NIXL `{nixl}`",
+        _endswith("docs/reference/support-matrix.md"),
+        requires=("vllm", "sglang", "trtllm", "nixl"),
     ),
 )
 
@@ -371,11 +450,9 @@ def _is_binary(path: Path) -> bool:
 
 
 def _excluded(rel: Path) -> bool:
+    rel_posix = rel.as_posix()
     for pat in EXCLUDE_GLOBS:
-        if rel.match(pat):
-            return True
-        # Also accept "**/foo" → match "foo" anywhere in path.
-        if pat.startswith("**/") and rel.match(pat[3:]):
+        if fnmatch.fnmatchcase(rel_posix, pat):
             return True
     return False
 
@@ -427,6 +504,7 @@ def apply_rules(
     repo: Path,
     version: Version,
     active_scopes: set[Scope],
+    ctx: dict[str, str] | None = None,
     dry_run: bool = False,
 ) -> list[Change]:
     """Walk the repo, apply every matching rule, collect :class:`Change` records.
@@ -434,6 +512,7 @@ def apply_rules(
     When ``dry_run`` is True, files are not written — used by both ``--dry-run``
     and ``--check`` modes.
     """
+    ctx = ctx or {}
     changes: list[Change] = []
     for abs_path, rel_path, content in iter_repo_files(repo):
         new_content = content
@@ -443,7 +522,7 @@ def apply_rules(
                 continue
             if not rule.file_filter(rel_path):
                 continue
-            updated = rule.apply(new_content, version)
+            updated = rule.apply(new_content, version, ctx)
             if updated != new_content:
                 hit_by_scope.setdefault(rule.scope, []).append(rule.name)
                 new_content = updated
@@ -456,204 +535,85 @@ def apply_rules(
 
 
 # ---------------------------------------------------------------------------
-# Backend metadata (consumed by DOCS specialised functions)
+# Table insertions (DOCS structured edits)
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class BackendVersions:
-    vllm: str | None = None
-    sglang: str | None = None
-    trtllm: str | None = None
-    nixl: str | None = None
+@dataclass(frozen=True)
+class TableInsertSpec:
+    """Spec for inserting a new row into a Markdown table."""
 
-    def all_set(self) -> bool:
-        return all([self.vllm, self.sglang, self.trtllm, self.nixl])
-
-    def any_set(self) -> bool:
-        return any([self.vllm, self.sglang, self.trtllm, self.nixl])
+    name: str
+    file: str  # repo-relative
+    table_header_re: re.Pattern[str]  # captures full header+separator
+    row_marker_template: str  # str.format with python/dashed/etc
+    new_row_template: str  # same
+    requires: tuple[str, ...] = ()
 
 
-# ---------------------------------------------------------------------------
-# DOCS specialised updates (table-row insertion / section-scoped edits)
-# ---------------------------------------------------------------------------
+TABLE_INSERTIONS: tuple[TableInsertSpec, ...] = (
+    TableInsertSpec(
+        name="release_artifacts_table_row",
+        file="docs/reference/release-artifacts.md",
+        table_header_re=re.compile(
+            r"(### GitHub Releases\n\n\| Version \|.*\n\|[-| ]+\n)"
+        ),
+        row_marker_template="| `v{python}`",
+        # FIX 1c: 5 columns to match | Version | Release Date | GitHub | Docs | Notes |
+        new_row_template=(
+            "| `v{python}` | {release_date} "
+            "| [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v{python}) "
+            "| [Docs](https://docs.dynamo.nvidia.com/dynamo) | |"
+        ),
+        requires=("release_date",),
+    ),
+    TableInsertSpec(
+        name="support_matrix_backend_row",
+        file="docs/reference/support-matrix.md",
+        table_header_re=re.compile(
+            r"(\| \*\*main \(ToT\)\*\* \|[^\n]+\n)"  # insert AFTER ToT row
+        ),
+        row_marker_template="| **v{python}**",
+        new_row_template=(
+            "| **v{python}** | `{sglang}` | `{trtllm}` | `{vllm}` | `{nixl}` |"
+        ),
+        requires=("vllm", "sglang", "trtllm", "nixl"),
+    ),
+)
 
 
-def update_feature_matrix(repo: Path, version: Version, dry_run: bool) -> list[Change]:
-    path = repo / "docs/reference/feature-matrix.md"
-    if not path.exists():
-        return []
-    content = path.read_text(encoding="utf-8")
-    updated = re.sub(
-        r"\*Updated for Dynamo v[\d.]+(?:\.post\d+)?\*",
-        f"*Updated for Dynamo v{version.python()}*",
-        content,
-    )
-    if updated == content:
-        return []
-    if not dry_run:
-        path.write_text(updated, encoding="utf-8")
-    return [
-        Change(
-            Path("docs/reference/feature-matrix.md"),
-            Scope.DOCS,
-            ["feature_matrix_tag"],
-        )
-    ]
-
-
-def update_support_matrix(
-    repo: Path,
-    version: Version,
-    backends: BackendVersions,
-    dry_run: bool,
+def insert_table_rows(
+    repo: Path, version: Version, ctx: dict[str, str], dry_run: bool
 ) -> list[Change]:
-    path = repo / "docs/reference/support-matrix.md"
-    if not path.exists():
-        return []
-    content = path.read_text(encoding="utf-8")
-    original = content
-    rules_hit: list[str] = []
-
-    # Remove "*(in progress)*" from the version row being released.
-    before = content
-    content = re.sub(
-        rf"(\*\*v{re.escape(version.python())}\*\*)\s*\*\(in progress\)\*",
-        r"\g<1>",
-        content,
-    )
-    if content != before:
-        rules_hit.append("support_matrix_in_progress")
-
-    if backends.all_set():
-        before = content
-        content = re.sub(
-            r"(\*\*Latest stable release:\*\* \[v)[\d.]+\S*"
-            r"(\]\(https://github\.com/ai-dynamo/dynamo/releases/tag/v)[\d.]+\S*"
-            r"(\) --).*",
-            (
-                rf"\g<1>{version.python()}\g<2>{version.python()}\g<3>"
-                rf" SGLang `{backends.sglang}` |"
-                rf" TensorRT-LLM `{backends.trtllm}` |"
-                rf" vLLM `{backends.vllm}` |"
-                rf" NIXL `{backends.nixl}`"
-            ),
-            content,
-        )
-        if content != before:
-            rules_hit.append("support_matrix_at_a_glance")
-
-        row_marker = f"| **v{version.python()}**"
-        if row_marker not in content:
-            new_row = (
-                f"| **v{version.python()}** "
-                f"| `{backends.sglang}` "
-                f"| `{backends.trtllm}` "
-                f"| `{backends.vllm}` "
-                f"| `{backends.nixl}` |"
-            )
-            before = content
-            content = re.sub(
-                r"(\| \*\*main \(ToT\)\*\* \|[^\n]+\n)",
-                rf"\g<1>{new_row}\n",
-                content,
-            )
-            if content != before:
-                rules_hit.append("support_matrix_backend_row")
-
-    if content == original:
-        return []
-    if not dry_run:
-        path.write_text(content, encoding="utf-8")
-    return [Change(Path("docs/reference/support-matrix.md"), Scope.DOCS, rules_hit)]
-
-
-def update_release_artifacts(
-    repo: Path,
-    version: Version,
-    release_date: str | None,
-    backends: BackendVersions,
-    dry_run: bool,
-) -> list[Change]:
-    path = repo / "docs/reference/release-artifacts.md"
-    if not path.exists():
-        return []
-    content = path.read_text(encoding="utf-8")
-    original = content
-    rules_hit: list[str] = []
-
-    # Header
-    before = content
-    content = re.sub(
-        r"(## Current Release: Dynamo v)[\d.]+\S*",
-        rf"\g<1>{version.python()}",
-        content,
-    )
-    if content != before:
-        rules_hit.append("release_artifacts_header")
-
-    # GitHub Release link
-    content = re.sub(
-        r"(\*\*GitHub Release:\*\* \[v)[\d.]+\S*"
-        r"(\]\(https://github\.com/ai-dynamo/dynamo/releases/tag/v)[\d.]+\S*(\))",
-        rf"\g<1>{version.python()}\g<2>{version.python()}\g<3>",
-        content,
-    )
-
-    # Docs link
-    content = re.sub(
-        r"(\*\*Docs:\*\* \[v)[\d.]+\S*"
-        r"(\]\(https://docs\.nvidia\.com/dynamo/v-)[\d-]+\S*(/?\))",
-        rf"\g<1>{version.python()}\g<2>{version.dashed()}\g<3>",
-        content,
-    )
-
-    # New row in the GitHub Releases table
-    row_marker = f"| `v{version.python()}`"
-    if row_marker not in content:
-        date_str = release_date or datetime.now().strftime("%b %d, %Y")
-        new_row = (
-            f"| `v{version.python()}` | {date_str} "
-            f"| [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v{version.python()}) "
-            f"| [Docs](https://docs.nvidia.com/dynamo/v-{version.dashed()}/) |"
-        )
-        table_pattern = r"(### GitHub Releases\n\n\| Version \|.*\n\|[-| ]+\n)"
-        if re.search(table_pattern, content):
-            content = re.sub(table_pattern, rf"\g<1>{new_row}\n", content)
-            rules_hit.append("release_artifacts_table_row")
-        else:
-            # Fail loud: the doc structure changed and we'd silently skip the row.
+    """Insert new rows into DOCS tables as specified by TABLE_INSERTIONS."""
+    out: list[Change] = []
+    fmt_ctx = {
+        "python": version.python(),
+        "semver": version.semver(),
+        "dashed": version.dashed(),
+        **ctx,
+    }
+    for spec in TABLE_INSERTIONS:
+        path = repo / spec.file
+        if not path.exists():
+            continue
+        if any(k not in ctx for k in spec.requires):
+            continue
+        content = path.read_text(encoding="utf-8")
+        marker = spec.row_marker_template.format_map(fmt_ctx)
+        if marker in content:
+            continue
+        if not spec.table_header_re.search(content):
             raise RuntimeError(
-                "release-artifacts.md: could not find the GitHub Releases table "
-                "header. The doc structure changed — update this script."
+                f"{spec.file}: insertion point for {spec.name!r} not found. "
+                "The doc structure changed — update TABLE_INSERTIONS."
             )
-
-    # Backend versions inside the Current Release section only.
-    backend_labels = {"vllm": "vLLM", "sglang": "SGLang", "trtllm": "TRT-LLM"}
-    cr_start = content.find("## Current Release")
-    if cr_start >= 0 and backends.any_set():
-        next_h2 = content.find("\n## ", cr_start + 1)
-        if next_h2 < 0:
-            next_h2 = len(content)
-        section = content[cr_start:next_h2]
-        before = section
-        for key, label in backend_labels.items():
-            val = getattr(backends, key)
-            if val:
-                section = re.sub(
-                    rf"({re.escape(label)} `)v[^`]+(`)",
-                    rf"\g<1>v{val}\g<2>",
-                    section,
-                )
-        if section != before:
-            content = content[:cr_start] + section + content[next_h2:]
-            rules_hit.append("release_artifacts_backend_versions")
-
-    if content == original:
-        return []
-    if not dry_run:
-        path.write_text(content, encoding="utf-8")
-    return [Change(Path("docs/reference/release-artifacts.md"), Scope.DOCS, rules_hit)]
+        new_row = spec.new_row_template.format_map(fmt_ctx)
+        new_content = spec.table_header_re.sub(rf"\g<1>{new_row}\n", content, count=1)
+        if not dry_run:
+            path.write_text(new_content, encoding="utf-8")
+        out.append(Change(Path(spec.file), Scope.DOCS, [spec.name]))
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -663,13 +623,21 @@ def update_release_artifacts(
 
 def detect_current_version(repo: Path) -> Version:
     pyproject = repo / "pyproject.toml"
+    if not pyproject.exists():
+        raise SystemExit(
+            f"ERROR: {pyproject} not found. "
+            "Pass --old-version (for bump) or --expected-version (for --check) explicitly."
+        )
     m = re.search(
         r'^version\s*=\s*"([^"]+)"',
         pyproject.read_text(encoding="utf-8"),
         re.MULTILINE,
     )
     if not m:
-        raise SystemExit("ERROR: could not detect current version from pyproject.toml")
+        raise SystemExit(
+            f"ERROR: could not detect current version from {pyproject}. "
+            "Pass --old-version (for bump) or --expected-version (for --check) explicitly."
+        )
     return Version.parse(m.group(1))
 
 
@@ -804,47 +772,34 @@ def _format_summary(
     return "\n".join(lines) + "\n"
 
 
+def _ctx_from_args(args: argparse.Namespace) -> dict[str, str]:
+    """Build ctx dict from CLI args for rules that require backend versions."""
+    ctx: dict[str, str] = {}
+    if args.vllm_version:
+        ctx["vllm"] = args.vllm_version
+    if args.sglang_version:
+        ctx["sglang"] = args.sglang_version
+    if args.trtllm_version:
+        ctx["trtllm"] = args.trtllm_version
+    if args.nixl_version:
+        ctx["nixl"] = args.nixl_version
+    if args.release_date:
+        ctx["release_date"] = args.release_date
+    return ctx
+
+
 def _run_check(args: argparse.Namespace, repo: Path) -> int:
     expected = args.expected_version or detect_current_version(repo)
-    _log(
-        args, "info", f"Checking for stale version references (expected: {expected})..."
-    )
+    _log(args, "info", f"Checking for stale version references (expected: {expected})...")
     active = _active_scopes(args)
-    # Rerun the engine with the expected version — anything that would change is stale.
-    stale = apply_rules(repo, expected, active, dry_run=True)
-    # The DOCS specialised functions own table-row insertion and section-scoped
-    # edits in support-matrix.md / release-artifacts.md / feature-matrix.md.
-    # Those files now carry the bump-version: ignore marker, so apply_rules() no
-    # longer touches them; without this dry-run pass --check would have a blind
-    # spot for stale "Current Release" headers, "Latest stable release" lines,
-    # missing release-row entries, and stale "Updated for vX.Y.Z" tags.
-    # Backend versions / release date are usually not passed to --check; the
-    # all_set/any_set guards inside the DOCS helpers keep the
-    # backend-dependent rewrites no-ops in that case, while still catching the
-    # version-only staleness signals.
-    if Scope.DOCS in active:
-        backends = BackendVersions(
-            vllm=args.vllm_version,
-            sglang=args.sglang_version,
-            trtllm=args.trtllm_version,
-            nixl=args.nixl_version,
-        )
-        stale.extend(update_feature_matrix(repo, expected, dry_run=True))
-        stale.extend(update_support_matrix(repo, expected, backends, dry_run=True))
-        stale.extend(
-            update_release_artifacts(
-                repo, expected, args.release_date, backends, dry_run=True
-            )
-        )
+    ctx = _ctx_from_args(args)
+    stale = apply_rules(repo, expected, active, ctx, dry_run=True)
+    stale.extend(insert_table_rows(repo, expected, ctx, dry_run=True))
     if not stale:
         _log(args, "summary", "All version references are up to date.")
         return 0
     for ch in stale:
-        _log(
-            args,
-            "info",
-            f"STALE: {ch.path.as_posix()} ({ch.scope.value}: {', '.join(ch.rules)})",
-        )
+        _log(args, "info", f"STALE: {ch.path.as_posix()} ({ch.scope.value}: {', '.join(ch.rules)})")
     _log(args, "summary", f"Found {len(stale)} stale version reference(s).")
     return 1
 
@@ -877,25 +832,13 @@ def _run_bump(args: argparse.Namespace, repo: Path) -> int:
             f"  Post-release formats: python={new_ver.python()} semver={new_ver.semver()}",
         )
 
-    backends = BackendVersions(
-        vllm=args.vllm_version,
-        sglang=args.sglang_version,
-        trtllm=args.trtllm_version,
-        nixl=args.nixl_version,
-    )
+    ctx = _ctx_from_args(args)
 
     changes: list[Change] = []
-    # Rule-based scopes (core, containers, helm, + any text-pattern DOCS rules)
-    changes.extend(apply_rules(repo, new_ver, active, dry_run=args.dry_run))
-    # Specialised DOCS functions (table-row insertion / sectioned edits)
-    if Scope.DOCS in active:
-        changes.extend(update_feature_matrix(repo, new_ver, args.dry_run))
-        changes.extend(update_support_matrix(repo, new_ver, backends, args.dry_run))
-        changes.extend(
-            update_release_artifacts(
-                repo, new_ver, args.release_date, backends, args.dry_run
-            )
-        )
+    # Rule-based scopes (core, containers, helm, docs)
+    changes.extend(apply_rules(repo, new_ver, active, ctx, dry_run=args.dry_run))
+    # Table insertions (docs structured edits)
+    changes.extend(insert_table_rows(repo, new_ver, ctx, dry_run=args.dry_run))
 
     _log(
         args,

--- a/.github/workflows/_version-bump-shared.yml
+++ b/.github/workflows/_version-bump-shared.yml
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable workflow: version bump, commit, push, and open PR.
+# Called by:
+#   - release.yml (Phase 1: release branch prep)
+#   - release-version-bump.yml (Phase 2: port to main after release publish)
+
+name: _version-bump-shared
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Target version (e.g. 1.0.0 or 0.9.0.post1)'
+        required: true
+        type: string
+      ref:
+        description: 'Checkout target (release/* branch or main)'
+        required: true
+        type: string
+      pr_base:
+        description: 'PR base branch'
+        required: true
+        type: string
+      pr_branch:
+        description: 'Head branch name (no remote prefix)'
+        required: true
+        type: string
+      pr_title:
+        description: 'PR title'
+        required: true
+        type: string
+      pr_body:
+        description: 'PR body (newline-safe; passed via env)'
+        required: true
+        type: string
+      vllm_version:
+        description: 'vLLM backend version'
+        required: false
+        type: string
+        default: ''
+      sglang_version:
+        description: 'SGLang backend version'
+        required: false
+        type: string
+        default: ''
+      trtllm_version:
+        description: 'TensorRT-LLM backend version'
+        required: false
+        type: string
+        default: ''
+      nixl_version:
+        description: 'NIXL backend version'
+        required: false
+        type: string
+        default: ''
+      release_date:
+        description: 'Release date (e.g. Apr 20, 2026)'
+        required: false
+        type: string
+        default: ''
+      skip_core:
+        description: 'Skip core version file updates'
+        required: false
+        type: boolean
+        default: false
+      skip_containers:
+        description: 'Skip container image tag updates'
+        required: false
+        type: boolean
+        default: false
+      skip_helm:
+        description: 'Skip Helm chart version updates'
+        required: false
+        type: boolean
+        default: false
+      skip_docs:
+        description: 'Skip docs reference updates'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      github_token:
+        description: 'GitHub token for PR creation'
+        required: true
+
+env:
+  YQ_VERSION: '4.52.2'
+  CONTROLLER_GEN_VERSION: 'v0.16.5'
+  HELM_DOCS_VERSION: '1.14.2'
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        with:
+          go-version-file: deploy/operator/go.mod
+
+      # FIX 15: explicit pinned toolchain instead of relying on rustup-on-runner.
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # 1.83.0 release
+        with:
+          toolchain: stable
+
+      - name: Install pinned tools (yq, controller-gen, helm-docs)
+        run: |
+          set -euo pipefail
+          sudo wget -qO /usr/local/bin/yq \
+            "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+          go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}
+          curl -sSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
+            | tar -xzf - helm-docs
+          sudo mv helm-docs /usr/local/bin/
+
+      - name: Install bump_version.py runtime deps
+        run: pip install --quiet 'packaging>=24.0'
+
+      - name: Create version-bump branch
+        env:
+          BRANCH: ${{ inputs.pr_branch }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+
+      # FIX 7 + FIX 16: explicit `if` blocks (no `[ … ] && X || true`),
+      #                 bash array for FLAGS to survive special chars.
+      - name: Run version bump
+        env:
+          VERSION: ${{ inputs.version }}
+          VLLM: ${{ inputs.vllm_version }}
+          SGLANG: ${{ inputs.sglang_version }}
+          TRTLLM: ${{ inputs.trtllm_version }}
+          NIXL: ${{ inputs.nixl_version }}
+          RELEASE_DATE: ${{ inputs.release_date }}
+          SKIP_CORE: ${{ inputs.skip_core }}
+          SKIP_CONTAINERS: ${{ inputs.skip_containers }}
+          SKIP_HELM: ${{ inputs.skip_helm }}
+          SKIP_DOCS: ${{ inputs.skip_docs }}
+        run: |
+          set -euo pipefail
+          FLAGS=()
+          if [ "$SKIP_CORE" = "true" ]; then FLAGS+=(--skip-core); fi
+          if [ "$SKIP_CONTAINERS" = "true" ]; then FLAGS+=(--skip-containers); fi
+          if [ "$SKIP_HELM" = "true" ]; then FLAGS+=(--skip-helm); fi
+          if [ "$SKIP_DOCS" = "true" ]; then FLAGS+=(--skip-docs); fi
+          echo "Skip flags: ${FLAGS[*]:-(none — all scopes enabled)}"
+
+          ARGS=(--new-version "$VERSION")
+          if [ -n "$VLLM" ]; then ARGS+=(--vllm-version "$VLLM"); fi
+          if [ -n "$SGLANG" ]; then ARGS+=(--sglang-version "$SGLANG"); fi
+          if [ -n "$TRTLLM" ]; then ARGS+=(--trtllm-version "$TRTLLM"); fi
+          if [ -n "$NIXL" ]; then ARGS+=(--nixl-version "$NIXL"); fi
+          if [ -n "$RELEASE_DATE" ]; then ARGS+=(--release-date "$RELEASE_DATE"); fi
+          ARGS+=(--summary-file "$GITHUB_STEP_SUMMARY")
+          ARGS+=("${FLAGS[@]}")
+
+          python3 .github/scripts/bump_version.py "${ARGS[@]}"
+
+      - name: Regenerate Cargo.lock
+        if: ${{ !inputs.skip_core }}
+        run: cargo update --workspace
+
+      - name: Regenerate CRDs
+        if: ${{ !inputs.skip_core }}
+        working-directory: deploy/operator
+        run: |
+          set -euo pipefail
+          make generate
+          make manifests
+
+      - name: Regenerate Helm docs
+        if: ${{ !inputs.skip_helm }}
+        working-directory: deploy/helm/charts/platform
+        run: helm-docs
+
+      # FIX 8: GITHUB_OUTPUT instead of GITHUB_ENV — keeps no_changes step-scoped.
+      - name: Commit
+        id: commit
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::notice::No changes produced — nothing to commit."
+            echo "no_changes=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git commit -s -m "chore: bump version to ${VERSION}"
+
+      - name: Push
+        if: steps.commit.outputs.no_changes != 'true'
+        env:
+          BRANCH: ${{ inputs.pr_branch }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git push origin --delete "$BRANCH"
+          fi
+          git push -u origin "$BRANCH"
+
+      # FIX 9: PR body template via env var, not Actions expression interpolation.
+      - name: Open PR
+        if: steps.commit.outputs.no_changes != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.github_token }}
+          BASE: ${{ inputs.pr_base }}
+          BRANCH: ${{ inputs.pr_branch }}
+          PR_TITLE: ${{ inputs.pr_title }}
+          PR_BODY: ${{ inputs.pr_body }}
+        run: |
+          set -euo pipefail
+          gh pr create --base "$BASE" --head "$BRANCH" \
+            --title "$PR_TITLE" --body "$PR_BODY" \
+            --label release --label chore

--- a/.github/workflows/_version-bump-shared.yml
+++ b/.github/workflows/_version-bump-shared.yml
@@ -36,27 +36,27 @@ on:
         required: true
         type: string
       vllm_version:
-        description: 'vLLM backend version'
+        description: 'vLLM backend version (used only by the Devin docs-sync step)'
         required: false
         type: string
         default: ''
       sglang_version:
-        description: 'SGLang backend version'
+        description: 'SGLang backend version (used only by the Devin docs-sync step)'
         required: false
         type: string
         default: ''
       trtllm_version:
-        description: 'TensorRT-LLM backend version'
+        description: 'TensorRT-LLM backend version (used only by the Devin docs-sync step)'
         required: false
         type: string
         default: ''
       nixl_version:
-        description: 'NIXL backend version'
+        description: 'NIXL backend version (used only by the Devin docs-sync step)'
         required: false
         type: string
         default: ''
       release_date:
-        description: 'Release date (e.g. Apr 20, 2026)'
+        description: 'Release date (used only by the Devin docs-sync step)'
         required: false
         type: string
         default: ''
@@ -75,15 +75,13 @@ on:
         required: false
         type: boolean
         default: false
-      skip_docs:
-        description: 'Skip docs reference updates'
-        required: false
-        type: boolean
-        default: false
     secrets:
       github_token:
         description: 'GitHub token for PR creation'
         required: true
+      devin_api_key:
+        description: 'Devin API key for post-PR reference-doc sync (optional)'
+        required: false
 
 env:
   YQ_VERSION: '4.52.2'
@@ -148,30 +146,18 @@ jobs:
       - name: Run version bump
         env:
           VERSION: ${{ inputs.version }}
-          VLLM: ${{ inputs.vllm_version }}
-          SGLANG: ${{ inputs.sglang_version }}
-          TRTLLM: ${{ inputs.trtllm_version }}
-          NIXL: ${{ inputs.nixl_version }}
-          RELEASE_DATE: ${{ inputs.release_date }}
           SKIP_CORE: ${{ inputs.skip_core }}
           SKIP_CONTAINERS: ${{ inputs.skip_containers }}
           SKIP_HELM: ${{ inputs.skip_helm }}
-          SKIP_DOCS: ${{ inputs.skip_docs }}
         run: |
           set -euo pipefail
           FLAGS=()
           if [ "$SKIP_CORE" = "true" ]; then FLAGS+=(--skip-core); fi
           if [ "$SKIP_CONTAINERS" = "true" ]; then FLAGS+=(--skip-containers); fi
           if [ "$SKIP_HELM" = "true" ]; then FLAGS+=(--skip-helm); fi
-          if [ "$SKIP_DOCS" = "true" ]; then FLAGS+=(--skip-docs); fi
           echo "Skip flags: ${FLAGS[*]:-(none — all scopes enabled)}"
 
           ARGS=(--new-version "$VERSION")
-          if [ -n "$VLLM" ]; then ARGS+=(--vllm-version "$VLLM"); fi
-          if [ -n "$SGLANG" ]; then ARGS+=(--sglang-version "$SGLANG"); fi
-          if [ -n "$TRTLLM" ]; then ARGS+=(--trtllm-version "$TRTLLM"); fi
-          if [ -n "$NIXL" ]; then ARGS+=(--nixl-version "$NIXL"); fi
-          if [ -n "$RELEASE_DATE" ]; then ARGS+=(--release-date "$RELEASE_DATE"); fi
           ARGS+=(--summary-file "$GITHUB_STEP_SUMMARY")
           ARGS+=("${FLAGS[@]}")
 

--- a/.github/workflows/_version-bump-shared.yml
+++ b/.github/workflows/_version-bump-shared.yml
@@ -225,51 +225,65 @@ jobs:
 
       # Dispatch a Devin session to push the three reference-doc updates
       # (release-artifacts.md, support-matrix.md, feature-matrix.md) to the
-      # same PR branch, pre-merge and pre-tag. Fire-and-forget: Devin's
-      # commits arrive as normal pushes and re-trigger CI. If DEVIN_API_KEY
-      # isn't configured the step no-ops and the release manager can amend
-      # the docs by hand.
+      # same PR branch, pre-merge and pre-tag. If DEVIN_API_KEY isn't
+      # configured, a manual-docs checklist comment is posted on the PR instead.
       - name: Dispatch Devin docs sync
-        if: steps.open_pr.conclusion == 'success'
+        if: success() && steps.open_pr.outputs.url != ''
         env:
-          DEVIN_API_KEY: ${{ secrets.devin_api_key }}
-          BRANCH:        ${{ inputs.pr_branch }}
-          PR_URL:        ${{ steps.open_pr.outputs.url }}
-          VERSION:       ${{ inputs.version }}
-          VLLM:          ${{ inputs.vllm_version }}
-          SGLANG:        ${{ inputs.sglang_version }}
-          TRTLLM:        ${{ inputs.trtllm_version }}
-          NIXL:          ${{ inputs.nixl_version }}
-          RELEASE_DATE:  ${{ inputs.release_date }}
+          GH_TOKEN:       ${{ secrets.github_token }}
+          DEVIN_API_KEY:  ${{ secrets.devin_api_key }}
+          BRANCH:         ${{ inputs.pr_branch }}
+          PR_URL:         ${{ steps.open_pr.outputs.url }}
+          VERSION:        ${{ inputs.version }}
+          VLLM:           ${{ inputs.vllm_version }}
+          SGLANG:         ${{ inputs.sglang_version }}
+          TRTLLM:         ${{ inputs.trtllm_version }}
+          NIXL:           ${{ inputs.nixl_version }}
+          RELEASE_DATE:   ${{ inputs.release_date }}
         run: |
           set -euo pipefail
+
+          # Prompt-injection guard: validate every value before it reaches the template.
+          VER_RE='^[0-9]+\.[0-9]+\.[0-9]+([\.-](post|rc|dev)[0-9]+)*$'
+          DATE_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+          for var in VERSION VLLM SGLANG TRTLLM NIXL; do
+            v=${!var}
+            [[ -z "$v" || "$v" =~ $VER_RE ]] \
+              || { echo "::error::$var invalid: '$v'"; exit 1; }
+          done
+          [[ -z "$RELEASE_DATE" || "$RELEASE_DATE" =~ $DATE_RE ]] \
+            || { echo "::error::RELEASE_DATE invalid: '$RELEASE_DATE'"; exit 1; }
+
+          # Fallback when the API key isn't wired up: leave the work for a human.
           if [ -z "${DEVIN_API_KEY:-}" ]; then
-            echo "::warning::DEVIN_API_KEY not configured; skipping reference-doc sync. Release manager must amend the docs manually before merge."
+            echo "::warning::DEVIN_API_KEY not configured; posting manual-docs checklist on PR."
+            envsubst '$BRANCH' <<'CHECKLIST' | gh pr comment "$PR_URL" --body-file -
+          ## Manual Reference-Doc Update Required
+
+          `DEVIN_API_KEY` is not configured — the automated docs-sync step was skipped.
+          A release manager must update these files on the `${BRANCH}` branch before merge:
+
+          - [ ] `docs/reference/release-artifacts.md` — add release row, bump Current Release header
+          - [ ] `docs/reference/support-matrix.md` — add backend-version row, refresh At a Glance
+          - [ ] `docs/reference/feature-matrix.md` — bump the "Updated for Dynamo vX.Y.Z" stamp
+          - [ ] Run `python3 .github/scripts/bump_version.py --check` to verify
+          CHECKLIST
             exit 0
           fi
 
-          # Build the prompt in a file to keep the curl payload readable and
-          # safe from shell quoting gotchas.
-          PROMPT_FILE="$(mktemp)"
-          cat >"$PROMPT_FILE" <<PROMPT
-          Push reference-doc updates to ai-dynamo/dynamo branch ${BRANCH} (PR ${PR_URL}) for v${VERSION}. Update three files:
+          # Render template -> JSON-encode prompt + idempotency key in one pipeline.
+          export VERSION BRANCH PR_URL VLLM SGLANG TRTLLM NIXL RELEASE_DATE
+          BODY=$(envsubst < .github/devin-prompts/docs-sync.md.tmpl \
+            | jq -Rs --arg key "docs-sync-${BRANCH}-${VERSION}-${GITHUB_RUN_ATTEMPT}" \
+                  '{prompt: ., idempotent_key: $key}')
 
-          1. docs/reference/release-artifacts.md -- add a new row to the GitHub Releases table matching the existing row format; link to https://github.com/ai-dynamo/dynamo/releases/tag/v${VERSION}; release date ${RELEASE_DATE}. Bump the "Current Release" header and the GitHub + Docs links at the top of the file to v${VERSION} (canonical docs host is docs.dynamo.nvidia.com/dynamo).
-
-          2. docs/reference/support-matrix.md -- add a backend-version row for v${VERSION} (SGLang ${SGLANG}, TRT-LLM ${TRTLLM}, vLLM ${VLLM}, NIXL ${NIXL}) right after the main (ToT) row. Demote any "(in progress)" marker on the prior version's row. Refresh the "Latest stable release" at-a-glance line to v${VERSION} with the same backend triple.
-
-          3. docs/reference/feature-matrix.md -- bump the "*Updated for Dynamo vX.Y.Z*" stamp to v${VERSION}. Do NOT rewrite historical version mentions in prose.
-
-          Commit with DCO sign-off (-s) and push to ${BRANCH}. Do NOT open a new PR -- the bump PR is already open at ${PR_URL}. If any of the files already contain a row for v${VERSION}, no-op on that file.
-          PROMPT
-
-          # jq builds a valid JSON body with the prompt string properly escaped.
-          BODY="$(jq -Rs --arg key "docs-sync-${BRANCH}-${VERSION}" \
-            '{prompt: ., idempotent_key: $key}' <"$PROMPT_FILE")"
-
-          curl -fsS -X POST https://api.devin.ai/v1/sessions \
-            -H "Authorization: Bearer ${DEVIN_API_KEY}" \
+          # --fail-with-body: non-zero exit on 4xx/5xx, body still captured.
+          RESPONSE=$(curl --fail-with-body -sS \
+            -X POST https://api.devin.ai/v1/sessions \
+            -H "Authorization: Bearer $DEVIN_API_KEY" \
             -H "Content-Type: application/json" \
-            -d "$BODY"
+            -d "$BODY") \
+            || { echo "::error::Devin API call failed"; echo "$RESPONSE"; exit 1; }
 
-          rm -f "$PROMPT_FILE"
+          SESSION_URL=$(jq -r '.url // .session_url // .id // "unknown"' <<<"$RESPONSE")
+          echo "::notice::Devin docs-sync session dispatched: $SESSION_URL"

--- a/.github/workflows/_version-bump-shared.yml
+++ b/.github/workflows/_version-bump-shared.yml
@@ -208,6 +208,7 @@ jobs:
 
       # FIX 9: PR body template via env var, not Actions expression interpolation.
       - name: Open PR
+        id: open_pr
         if: steps.commit.outputs.no_changes != 'true'
         env:
           GH_TOKEN: ${{ secrets.github_token }}
@@ -217,6 +218,58 @@ jobs:
           PR_BODY: ${{ inputs.pr_body }}
         run: |
           set -euo pipefail
-          gh pr create --base "$BASE" --head "$BRANCH" \
+          PR_URL=$(gh pr create --base "$BASE" --head "$BRANCH" \
             --title "$PR_TITLE" --body "$PR_BODY" \
-            --label release --label chore
+            --label release --label chore)
+          echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      # Dispatch a Devin session to push the three reference-doc updates
+      # (release-artifacts.md, support-matrix.md, feature-matrix.md) to the
+      # same PR branch, pre-merge and pre-tag. Fire-and-forget: Devin's
+      # commits arrive as normal pushes and re-trigger CI. If DEVIN_API_KEY
+      # isn't configured the step no-ops and the release manager can amend
+      # the docs by hand.
+      - name: Dispatch Devin docs sync
+        if: steps.open_pr.conclusion == 'success'
+        env:
+          DEVIN_API_KEY: ${{ secrets.devin_api_key }}
+          BRANCH:        ${{ inputs.pr_branch }}
+          PR_URL:        ${{ steps.open_pr.outputs.url }}
+          VERSION:       ${{ inputs.version }}
+          VLLM:          ${{ inputs.vllm_version }}
+          SGLANG:        ${{ inputs.sglang_version }}
+          TRTLLM:        ${{ inputs.trtllm_version }}
+          NIXL:          ${{ inputs.nixl_version }}
+          RELEASE_DATE:  ${{ inputs.release_date }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DEVIN_API_KEY:-}" ]; then
+            echo "::warning::DEVIN_API_KEY not configured; skipping reference-doc sync. Release manager must amend the docs manually before merge."
+            exit 0
+          fi
+
+          # Build the prompt in a file to keep the curl payload readable and
+          # safe from shell quoting gotchas.
+          PROMPT_FILE="$(mktemp)"
+          cat >"$PROMPT_FILE" <<PROMPT
+          Push reference-doc updates to ai-dynamo/dynamo branch ${BRANCH} (PR ${PR_URL}) for v${VERSION}. Update three files:
+
+          1. docs/reference/release-artifacts.md -- add a new row to the GitHub Releases table matching the existing row format; link to https://github.com/ai-dynamo/dynamo/releases/tag/v${VERSION}; release date ${RELEASE_DATE}. Bump the "Current Release" header and the GitHub + Docs links at the top of the file to v${VERSION} (canonical docs host is docs.dynamo.nvidia.com/dynamo).
+
+          2. docs/reference/support-matrix.md -- add a backend-version row for v${VERSION} (SGLang ${SGLANG}, TRT-LLM ${TRTLLM}, vLLM ${VLLM}, NIXL ${NIXL}) right after the main (ToT) row. Demote any "(in progress)" marker on the prior version's row. Refresh the "Latest stable release" at-a-glance line to v${VERSION} with the same backend triple.
+
+          3. docs/reference/feature-matrix.md -- bump the "*Updated for Dynamo vX.Y.Z*" stamp to v${VERSION}. Do NOT rewrite historical version mentions in prose.
+
+          Commit with DCO sign-off (-s) and push to ${BRANCH}. Do NOT open a new PR -- the bump PR is already open at ${PR_URL}. If any of the files already contain a row for v${VERSION}, no-op on that file.
+          PROMPT
+
+          # jq builds a valid JSON body with the prompt string properly escaped.
+          BODY="$(jq -Rs --arg key "docs-sync-${BRANCH}-${VERSION}" \
+            '{prompt: ., idempotent_key: $key}' <"$PROMPT_FILE")"
+
+          curl -fsS -X POST https://api.devin.ai/v1/sessions \
+            -H "Authorization: Bearer ${DEVIN_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$BODY"
+
+          rm -f "$PROMPT_FILE"

--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -1,0 +1,451 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Phase 2: Port version bump to main after a GitHub release is published.
+#
+# Full releases (vX.Y.Z):
+#   Auto-triggered on release:published. Updates all version references and
+#   opens a PR to main.
+#
+# Post-releases (vX.Y.Z.postN):
+#   Two options controlled by `post_release_behavior` input:
+#   - "fail" (default): Auto-trigger fails with instructions to use manual trigger
+#   - "skip": Auto-trigger silently skips, no PR created
+#   To bump a post-release, use workflow_dispatch with component checkboxes.
+#
+# Phase 1 (release branch prep) is integrated into release.yml.
+
+name: Release Version Bump
+
+on:
+  release:
+    types: [published]
+
+  # Manual trigger for post-releases or re-runs
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v1.0.0 or v0.9.0.post1)'
+        required: true
+        type: string
+      post_release_behavior:
+        description: 'How auto-trigger handles post-release tags (fail = red X with instructions, skip = silent green check)'
+        required: false
+        type: choice
+        options:
+          - fail
+          - skip
+        default: fail
+      update_core:
+        description: 'Update core version files (pyproject.toml, Cargo.toml, setup.py)'
+        required: false
+        type: boolean
+        default: true
+      update_containers:
+        description: 'Update container image tags across docs, recipes, examples'
+        required: false
+        type: boolean
+        default: true
+      update_helm:
+        description: 'Update Helm Chart.yaml versions'
+        required: false
+        type: boolean
+        default: true
+      update_docs:
+        description: 'Update reference docs (support-matrix, feature-matrix, release-artifacts)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  version-bump-to-main:
+    name: Open PR to main
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Determine tag
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "release" ]; then
+            TAG="$RELEASE_TAG"
+          else
+            TAG="$INPUT_TAG"
+          fi
+
+          # Validate tag format: vX.Y.Z or vX.Y.Z.postN
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?$ ]]; then
+            echo "::error::Invalid tag format: $TAG. Must be vX.Y.Z or vX.Y.Z.postN"
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
+          IS_POST="false"
+          if [[ "$TAG" =~ \.post[0-9]+$ ]]; then
+            IS_POST="true"
+          fi
+
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "is_post=$IS_POST" >> $GITHUB_OUTPUT
+          echo "Tag: $TAG, Version: $VERSION, Post-release: $IS_POST"
+
+      # Post-release gate: fail or skip based on behavior setting
+      - name: Post-release gate
+        if: steps.tag.outputs.is_post == 'true' && github.event_name == 'release'
+        env:
+          BEHAVIOR: ${{ inputs.post_release_behavior || 'fail' }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$BEHAVIOR" = "skip" ]; then
+            echo "::notice::Post-release $TAG detected. Skipping auto version bump (post_release_behavior=skip)."
+            echo "To bump this post-release, run this workflow manually via Actions > workflow_dispatch with component checkboxes."
+            echo "SKIP_REST=true" >> $GITHUB_ENV
+            exit 0
+          else
+            echo "## Post-release detected" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Tag \`$TAG\` is a post-release. Post-releases require manual scope selection." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### How to proceed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "1. Go to **Actions** > **Release Version Bump** > **Run workflow**" >> $GITHUB_STEP_SUMMARY
+            echo "2. Enter tag: \`$TAG\`" >> $GITHUB_STEP_SUMMARY
+            echo "3. Select which components to update:" >> $GITHUB_STEP_SUMMARY
+            echo "   - **update_core**: pyproject.toml, Cargo.toml, setup.py" >> $GITHUB_STEP_SUMMARY
+            echo "   - **update_containers**: Image tags in docs, recipes, examples" >> $GITHUB_STEP_SUMMARY
+            echo "   - **update_helm**: Helm Chart.yaml versions" >> $GITHUB_STEP_SUMMARY
+            echo "   - **update_docs**: support-matrix, feature-matrix, release-artifacts" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "::error::Post-release $TAG detected. Post-releases require manual scope selection. Run this workflow via Actions > workflow_dispatch with the component checkboxes."
+            exit 1
+          fi
+
+      # Note: When SKIP_REST=true, all subsequent steps are guarded by
+      # `if: env.SKIP_REST != 'true'` and will be individually skipped.
+      - name: Post-release skip notice
+        if: env.SKIP_REST == 'true'
+        run: echo "Post-release skip is active. All subsequent steps will be individually skipped."
+
+      # Step 1: Checkout the release tag to read context.yaml
+      - name: Checkout release tag
+        if: env.SKIP_REST != 'true'
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+          path: release-ref
+
+      # Step 2: Parse backend metadata from container/context.yaml
+      - name: Extract backend metadata
+        if: env.SKIP_REST != 'true'
+        id: metadata
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_CREATED_AT: ${{ github.event.release.created_at }}
+        run: |
+          set -euo pipefail
+          CTX="release-ref/container/context.yaml"
+
+          # Install yq (pinned version for reproducibility)
+          YQ_VERSION="4.52.2"
+          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+
+          # vLLM version: strip 'v' prefix
+          VLLM_VER=$(yq '.vllm.vllm_ref' "$CTX" | sed 's/^v//')
+          echo "vllm_version=$VLLM_VER" >> $GITHUB_OUTPUT
+
+          # SGLang version: from runtime_image_tag, strip 'v' prefix and '-runtime'/'-cu*-runtime' suffix
+          SGLANG_TAG=$(yq '.sglang."cuda12.9".runtime_image_tag // .sglang.runtime_image_tag // ""' "$CTX")
+          SGLANG_VER=$(echo "$SGLANG_TAG" | sed 's/^v//; s/-cu[0-9]*-runtime$//; s/-runtime$//')
+          echo "sglang_version=$SGLANG_VER" >> $GITHUB_OUTPUT
+
+          # TRT-LLM version: from pip_wheel, extract version after ==
+          TRTLLM_WHEEL=$(yq '.trtllm.pip_wheel' "$CTX")
+          TRTLLM_VER=$(echo "$TRTLLM_WHEEL" | sed 's/.*==//')
+          echo "trtllm_version=$TRTLLM_VER" >> $GITHUB_OUTPUT
+
+          # NIXL version
+          NIXL_VER=$(yq '.dynamo.nixl_ref' "$CTX")
+          echo "nixl_version=$NIXL_VER" >> $GITHUB_OUTPUT
+
+          # CUDA versions for vLLM
+          CUDA_VLLM=$(yq '[.vllm | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
+          echo "cuda_versions_vllm=$CUDA_VLLM" >> $GITHUB_OUTPUT
+
+          # CUDA versions for SGLang
+          CUDA_SGLANG=$(yq '[.sglang | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
+          echo "cuda_versions_sglang=$CUDA_SGLANG" >> $GITHUB_OUTPUT
+
+          # CUDA versions for TRT-LLM (from runtime_image_tag)
+          TRTLLM_RUNTIME_TAG=$(yq '.trtllm.runtime_image_tag' "$CTX")
+          CUDA_TRTLLM=$(echo "$TRTLLM_RUNTIME_TAG" | grep -oP 'cuda\K[\d.]+')
+          echo "cuda_versions_trtllm=$CUDA_TRTLLM" >> $GITHUB_OUTPUT
+
+          # Release date
+          if [ "$EVENT_NAME" = "release" ]; then
+            RELEASE_DATE=$(date -d "$RELEASE_CREATED_AT" "+%b %d, %Y" 2>/dev/null || date "+%b %d, %Y")
+          else
+            RELEASE_DATE=$(date "+%b %d, %Y")
+          fi
+          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
+
+          # Print summary
+          echo "=== Extracted Metadata ==="
+          echo "  vLLM: $VLLM_VER"
+          echo "  SGLang: $SGLANG_VER"
+          echo "  TRT-LLM: $TRTLLM_VER"
+          echo "  NIXL: $NIXL_VER"
+          echo "  CUDA (vLLM): $CUDA_VLLM"
+          echo "  CUDA (SGLang): $CUDA_SGLANG"
+          echo "  CUDA (TRT-LLM): $CUDA_TRTLLM"
+          echo "  Release date: $RELEASE_DATE"
+
+      # Step 3: Checkout main branch
+      - name: Checkout main
+        if: env.SKIP_REST != 'true'
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        with:
+          ref: main
+          fetch-depth: 0
+          path: main-checkout
+
+      # Step 4: Set up tools
+      - name: Set up Python
+        if: env.SKIP_REST != 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Set up Go
+        if: env.SKIP_REST != 'true'
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        with:
+          go-version-file: main-checkout/deploy/operator/go.mod
+
+      - name: Set up Rust
+        if: env.SKIP_REST != 'true'
+        working-directory: main-checkout
+        run: |
+          set -euo pipefail
+          rustup show active-toolchain
+
+      - name: Install controller-gen
+        if: env.SKIP_REST != 'true'
+        run: |
+          set -euo pipefail
+          cd main-checkout/deploy/operator
+          make controller-gen
+
+      - name: Install helm-docs
+        if: env.SKIP_REST != 'true'
+        run: |
+          set -euo pipefail
+          HELM_DOCS_VERSION="1.14.2"
+          curl -sSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
+            | tar -xzf - helm-docs
+          sudo mv helm-docs /usr/local/bin/
+
+      # Step 5: Create branch and run version bump
+      - name: Create version-bump branch
+        if: env.SKIP_REST != 'true'
+        working-directory: main-checkout
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/bump-version-to-${VERSION}"
+          git checkout -b "$BRANCH"
+          echo "branch=$BRANCH" >> $GITHUB_ENV
+
+      - name: Build skip flags
+        if: env.SKIP_REST != 'true'
+        id: flags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          UPDATE_CORE: ${{ inputs.update_core }}
+          UPDATE_CONTAINERS: ${{ inputs.update_containers }}
+          UPDATE_HELM: ${{ inputs.update_helm }}
+          UPDATE_DOCS: ${{ inputs.update_docs }}
+        run: |
+          set -euo pipefail
+          SKIP_FLAGS=""
+
+          # For auto-triggered full releases, all components are updated.
+          # For manual triggers, respect the checkbox inputs.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$UPDATE_CORE" != "true" ]; then
+              SKIP_FLAGS="$SKIP_FLAGS --skip-core"
+            fi
+            if [ "$UPDATE_CONTAINERS" != "true" ]; then
+              SKIP_FLAGS="$SKIP_FLAGS --skip-containers"
+            fi
+            if [ "$UPDATE_HELM" != "true" ]; then
+              SKIP_FLAGS="$SKIP_FLAGS --skip-helm"
+            fi
+            if [ "$UPDATE_DOCS" != "true" ]; then
+              SKIP_FLAGS="$SKIP_FLAGS --skip-docs"
+            fi
+          fi
+
+          echo "skip_flags=$SKIP_FLAGS" >> $GITHUB_OUTPUT
+
+          # Expose individual flags for conditional regen steps
+          echo "skip_core=$( [[ "$SKIP_FLAGS" == *--skip-core* ]] && echo true || echo false )" >> $GITHUB_OUTPUT
+          echo "skip_containers=$( [[ "$SKIP_FLAGS" == *--skip-containers* ]] && echo true || echo false )" >> $GITHUB_OUTPUT
+          echo "skip_helm=$( [[ "$SKIP_FLAGS" == *--skip-helm* ]] && echo true || echo false )" >> $GITHUB_OUTPUT
+          echo "Skip flags: ${SKIP_FLAGS:-none}"
+
+      - name: Run version bump script
+        if: env.SKIP_REST != 'true'
+        working-directory: main-checkout
+        env:
+          BUMP_VERSION: ${{ steps.tag.outputs.version }}
+          BUMP_VLLM: ${{ steps.metadata.outputs.vllm_version }}
+          BUMP_SGLANG: ${{ steps.metadata.outputs.sglang_version }}
+          BUMP_TRTLLM: ${{ steps.metadata.outputs.trtllm_version }}
+          BUMP_NIXL: ${{ steps.metadata.outputs.nixl_version }}
+          BUMP_CUDA_VLLM: ${{ steps.metadata.outputs.cuda_versions_vllm }}
+          BUMP_CUDA_SGLANG: ${{ steps.metadata.outputs.cuda_versions_sglang }}
+          BUMP_CUDA_TRTLLM: ${{ steps.metadata.outputs.cuda_versions_trtllm }}
+          BUMP_RELEASE_DATE: ${{ steps.metadata.outputs.release_date }}
+          BUMP_SKIP_FLAGS: ${{ steps.flags.outputs.skip_flags }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/bump_version.py \
+            --new-version "$BUMP_VERSION" \
+            --vllm-version "$BUMP_VLLM" \
+            --sglang-version "$BUMP_SGLANG" \
+            --trtllm-version "$BUMP_TRTLLM" \
+            --nixl-version "$BUMP_NIXL" \
+            --cuda-versions-vllm "$BUMP_CUDA_VLLM" \
+            --cuda-versions-sglang "$BUMP_CUDA_SGLANG" \
+            --cuda-versions-trtllm "$BUMP_CUDA_TRTLLM" \
+            --release-date "$BUMP_RELEASE_DATE" \
+            $BUMP_SKIP_FLAGS
+
+      # Step 6: Regenerate Cargo.lock (only if core version files were updated)
+      - name: Regenerate Cargo.lock
+        if: env.SKIP_REST != 'true' && steps.flags.outputs.skip_core != 'true'
+        working-directory: main-checkout
+        run: |
+          set -euo pipefail
+          cargo update --workspace
+
+      # Step 7: Regenerate CRDs (only if operator source was updated, i.e. containers not skipped)
+      - name: Regenerate CRDs
+        if: env.SKIP_REST != 'true' && steps.flags.outputs.skip_containers != 'true'
+        working-directory: main-checkout/deploy/operator
+        run: |
+          set -euo pipefail
+          make generate
+          make manifests
+
+      # Step 8: Regenerate Helm docs (only if Helm charts were updated)
+      - name: Regenerate Helm docs
+        if: env.SKIP_REST != 'true' && steps.flags.outputs.skip_helm != 'true'
+        working-directory: main-checkout/deploy/helm/charts/platform
+        run: |
+          set -euo pipefail
+          helm-docs
+
+      # Step 9: Commit and create PR
+      - name: Commit changes
+        if: env.SKIP_REST != 'true'
+        working-directory: main-checkout
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          printf -v MSG '%s\n' \
+            "Automated version bump from release v${VERSION}." \
+            "" \
+            "Updates:" \
+            "- Core version files (pyproject.toml, Cargo.toml, setup.py)" \
+            "- Helm chart versions" \
+            "- Operator CRD source and regenerated files" \
+            "- Documentation (support matrix, feature matrix, release artifacts)" \
+            "- Container image tags across docs, recipes, and examples" \
+            "- Cargo.lock files"
+          git commit -s -m "chore: bump version to ${VERSION}" -m "$MSG"
+
+      - name: Push branch
+        if: env.SKIP_REST != 'true'
+        working-directory: main-checkout
+        env:
+          BRANCH: ${{ env.branch }}
+        run: |
+          set -euo pipefail
+          # Delete remote branch if it already exists (stale from a previous run)
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Remote branch $BRANCH already exists, deleting stale branch..."
+            git push origin --delete "$BRANCH"
+          fi
+          git push -u origin "$BRANCH"
+
+      - name: Create PR
+        if: env.SKIP_REST != 'true'
+        working-directory: main-checkout
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.tag.outputs.version }}
+          IS_POST: ${{ steps.tag.outputs.is_post }}
+          SKIP_FLAGS: ${{ steps.flags.outputs.skip_flags }}
+          VLLM_VER: ${{ steps.metadata.outputs.vllm_version }}
+          SGLANG_VER: ${{ steps.metadata.outputs.sglang_version }}
+          TRTLLM_VER: ${{ steps.metadata.outputs.trtllm_version }}
+          NIXL_VER: ${{ steps.metadata.outputs.nixl_version }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_POST" = "true" ]; then
+            TITLE="chore: bump version to ${VERSION} (post-release)"
+          else
+            TITLE="chore: bump version to ${VERSION}"
+          fi
+
+          printf -v BODY '%s\n' \
+            "## Summary" \
+            "" \
+            "Automated version bump from release v${VERSION}." \
+            "" \
+            "**Backend versions** (derived from \`container/context.yaml\` on the release tag):" \
+            "- vLLM: \`${VLLM_VER}\`" \
+            "- SGLang: \`${SGLANG_VER}\`" \
+            "- TRT-LLM: \`${TRTLLM_VER}\`" \
+            "- NIXL: \`${NIXL_VER}\`" \
+            "" \
+            "**Scope flags**: \`${SKIP_FLAGS:-all components updated}\`" \
+            "" \
+            "### Changes" \
+            "" \
+            "- **Core version files**: pyproject.toml, Cargo.toml, lib/bindings/python/Cargo.toml, lib/gpu_memory_service/setup.py" \
+            "- **Helm charts**: CRDs, platform, operator Chart.yaml + regenerated README" \
+            "- **Operator CRDs**: Go source doc comments updated, CRDs regenerated via \`make generate && make manifests\`" \
+            "- **Reference docs**: support-matrix.md, feature-matrix.md, release-artifacts.md" \
+            "- **Image tags**: Updated across README, docs, recipes, and examples (discovery-based scan)" \
+            "- **Cargo.lock**: Regenerated" \
+            "" \
+            "## Test plan" \
+            "" \
+            "- [ ] Verify version strings are correct in key files" \
+            "- [ ] Verify CRD files pass \`make check\` in deploy/operator/" \
+            "- [ ] Verify no stale version references remain (\`python3 .github/scripts/bump_version.py --check\`)"
+
+          gh pr create \
+            --base main \
+            --title "$TITLE" \
+            --body "$BODY" \
+            --label "release" \
+            --label "chore"

--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -1,19 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Phase 2: Port version bump to main after a GitHub release is published.
+# Phase 2: Port a version bump to main after a GitHub release is published.
 #
 # Full releases (vX.Y.Z):
 #   Auto-triggered on release:published. Updates all version references and
 #   opens a PR to main.
 #
 # Post-releases (vX.Y.Z.postN):
-#   Two options controlled by `post_release_behavior` input:
-#   - "fail" (default): Auto-trigger fails with instructions to use manual trigger
-#   - "skip": Auto-trigger silently skips, no PR created
-#   To bump a post-release, use workflow_dispatch with component checkboxes.
+#   Auto-trigger performs a minimal bump by default (Helm + core only — full
+#   image-tag churn is usually not wanted for post-releases). Use
+#   workflow_dispatch with the component checkboxes for full control.
 #
-# Phase 1 (release branch prep) is integrated into release.yml.
+# Phase 1 (release branch prep) lives in release.yml.
 
 name: Release Version Bump
 
@@ -21,21 +20,12 @@ on:
   release:
     types: [published]
 
-  # Manual trigger for post-releases or re-runs
   workflow_dispatch:
     inputs:
       tag:
         description: 'Release tag (e.g., v1.0.0 or v0.9.0.post1)'
         required: true
         type: string
-      post_release_behavior:
-        description: 'How auto-trigger handles post-release tags (fail = red X with instructions, skip = silent green check)'
-        required: false
-        type: choice
-        options:
-          - fail
-          - skip
-        default: fail
       update_core:
         description: 'Update core version files (pyproject.toml, Cargo.toml, setup.py)'
         required: false
@@ -47,7 +37,7 @@ on:
         type: boolean
         default: true
       update_helm:
-        description: 'Update Helm Chart.yaml versions'
+        description: 'Update Helm Chart.yaml and values.yaml versions'
         required: false
         type: boolean
         default: true
@@ -61,13 +51,19 @@ permissions:
   contents: write
   pull-requests: write
 
+# Pinned tool versions — bump deliberately, not via `latest`.
+env:
+  YQ_VERSION: '4.52.2'
+  CONTROLLER_GEN_VERSION: 'v0.16.5'
+  HELM_DOCS_VERSION: '1.14.2'
+
 jobs:
   version-bump-to-main:
     name: Open PR to main
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Determine tag
+      - name: Determine tag and release kind
         id: tag
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -81,7 +77,6 @@ jobs:
             TAG="$INPUT_TAG"
           fi
 
-          # Validate tag format: vX.Y.Z or vX.Y.Z.postN
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?$ ]]; then
             echo "::error::Invalid tag format: $TAG. Must be vX.Y.Z or vX.Y.Z.postN"
             exit 1
@@ -93,60 +88,27 @@ jobs:
             IS_POST="true"
           fi
 
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "is_post=$IS_POST" >> $GITHUB_OUTPUT
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "is_post=$IS_POST"
+          } >> "$GITHUB_OUTPUT"
           echo "Tag: $TAG, Version: $VERSION, Post-release: $IS_POST"
 
-      # Post-release gate: fail or skip based on behavior setting
-      - name: Post-release gate
-        if: steps.tag.outputs.is_post == 'true' && github.event_name == 'release'
-        env:
-          BEHAVIOR: ${{ inputs.post_release_behavior || 'fail' }}
-          TAG: ${{ steps.tag.outputs.tag }}
-        run: |
-          set -euo pipefail
-          if [ "$BEHAVIOR" = "skip" ]; then
-            echo "::notice::Post-release $TAG detected. Skipping auto version bump (post_release_behavior=skip)."
-            echo "To bump this post-release, run this workflow manually via Actions > workflow_dispatch with component checkboxes."
-            echo "SKIP_REST=true" >> $GITHUB_ENV
-            exit 0
-          else
-            echo "## Post-release detected" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Tag \`$TAG\` is a post-release. Post-releases require manual scope selection." >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### How to proceed" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "1. Go to **Actions** > **Release Version Bump** > **Run workflow**" >> $GITHUB_STEP_SUMMARY
-            echo "2. Enter tag: \`$TAG\`" >> $GITHUB_STEP_SUMMARY
-            echo "3. Select which components to update:" >> $GITHUB_STEP_SUMMARY
-            echo "   - **update_core**: pyproject.toml, Cargo.toml, setup.py" >> $GITHUB_STEP_SUMMARY
-            echo "   - **update_containers**: Image tags in docs, recipes, examples" >> $GITHUB_STEP_SUMMARY
-            echo "   - **update_helm**: Helm Chart.yaml versions" >> $GITHUB_STEP_SUMMARY
-            echo "   - **update_docs**: support-matrix, feature-matrix, release-artifacts" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "::error::Post-release $TAG detected. Post-releases require manual scope selection. Run this workflow via Actions > workflow_dispatch with the component checkboxes."
-            exit 1
-          fi
-
-      # Note: When SKIP_REST=true, all subsequent steps are guarded by
-      # `if: env.SKIP_REST != 'true'` and will be individually skipped.
-      - name: Post-release skip notice
-        if: env.SKIP_REST == 'true'
-        run: echo "Post-release skip is active. All subsequent steps will be individually skipped."
-
-      # Step 1: Checkout the release tag to read context.yaml
       - name: Checkout release tag
-        if: env.SKIP_REST != 'true'
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
         with:
           ref: ${{ steps.tag.outputs.tag }}
           path: release-ref
 
-      # Step 2: Parse backend metadata from container/context.yaml
-      - name: Extract backend metadata
-        if: env.SKIP_REST != 'true'
+      - name: Install yq
+        run: |
+          set -euo pipefail
+          sudo wget -qO /usr/local/bin/yq \
+            "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Extract backend metadata from context.yaml
         id: metadata
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -155,109 +117,67 @@ jobs:
           set -euo pipefail
           CTX="release-ref/container/context.yaml"
 
-          # Install yq (pinned version for reproducibility)
-          YQ_VERSION="4.52.2"
-          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
-          sudo chmod +x /usr/local/bin/yq
-
-          # vLLM version: strip 'v' prefix
           VLLM_VER=$(yq '.vllm.vllm_ref' "$CTX" | sed 's/^v//')
-          echo "vllm_version=$VLLM_VER" >> $GITHUB_OUTPUT
-
-          # SGLang version: from runtime_image_tag, strip 'v' prefix and '-runtime'/'-cu*-runtime' suffix
           SGLANG_TAG=$(yq '.sglang."cuda12.9".runtime_image_tag // .sglang.runtime_image_tag // ""' "$CTX")
           SGLANG_VER=$(echo "$SGLANG_TAG" | sed 's/^v//; s/-cu[0-9]*-runtime$//; s/-runtime$//')
-          echo "sglang_version=$SGLANG_VER" >> $GITHUB_OUTPUT
-
-          # TRT-LLM version: from pip_wheel, extract version after ==
           TRTLLM_WHEEL=$(yq '.trtllm.pip_wheel' "$CTX")
           TRTLLM_VER=$(echo "$TRTLLM_WHEEL" | sed 's/.*==//')
-          echo "trtllm_version=$TRTLLM_VER" >> $GITHUB_OUTPUT
-
-          # NIXL version
           NIXL_VER=$(yq '.dynamo.nixl_ref' "$CTX")
-          echo "nixl_version=$NIXL_VER" >> $GITHUB_OUTPUT
 
-          # CUDA versions for vLLM
-          CUDA_VLLM=$(yq '[.vllm | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
-          echo "cuda_versions_vllm=$CUDA_VLLM" >> $GITHUB_OUTPUT
-
-          # CUDA versions for SGLang
-          CUDA_SGLANG=$(yq '[.sglang | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
-          echo "cuda_versions_sglang=$CUDA_SGLANG" >> $GITHUB_OUTPUT
-
-          # CUDA versions for TRT-LLM (from runtime_image_tag)
-          TRTLLM_RUNTIME_TAG=$(yq '.trtllm.runtime_image_tag' "$CTX")
-          CUDA_TRTLLM=$(echo "$TRTLLM_RUNTIME_TAG" | grep -oP 'cuda\K[\d.]+')
-          echo "cuda_versions_trtllm=$CUDA_TRTLLM" >> $GITHUB_OUTPUT
-
-          # Release date
           if [ "$EVENT_NAME" = "release" ]; then
             RELEASE_DATE=$(date -d "$RELEASE_CREATED_AT" "+%b %d, %Y" 2>/dev/null || date "+%b %d, %Y")
           else
             RELEASE_DATE=$(date "+%b %d, %Y")
           fi
-          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
 
-          # Print summary
-          echo "=== Extracted Metadata ==="
-          echo "  vLLM: $VLLM_VER"
-          echo "  SGLang: $SGLANG_VER"
-          echo "  TRT-LLM: $TRTLLM_VER"
-          echo "  NIXL: $NIXL_VER"
-          echo "  CUDA (vLLM): $CUDA_VLLM"
-          echo "  CUDA (SGLang): $CUDA_SGLANG"
-          echo "  CUDA (TRT-LLM): $CUDA_TRTLLM"
-          echo "  Release date: $RELEASE_DATE"
+          {
+            echo "vllm_version=$VLLM_VER"
+            echo "sglang_version=$SGLANG_VER"
+            echo "trtllm_version=$TRTLLM_VER"
+            echo "nixl_version=$NIXL_VER"
+            echo "release_date=$RELEASE_DATE"
+          } >> "$GITHUB_OUTPUT"
 
-      # Step 3: Checkout main branch
+          echo "Backend: vLLM=$VLLM_VER SGLang=$SGLANG_VER TRT-LLM=$TRTLLM_VER NIXL=$NIXL_VER  Released=$RELEASE_DATE"
+
       - name: Checkout main
-        if: env.SKIP_REST != 'true'
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
         with:
           ref: main
           fetch-depth: 0
           path: main-checkout
 
-      # Step 4: Set up tools
       - name: Set up Python
-        if: env.SKIP_REST != 'true'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Set up Go
-        if: env.SKIP_REST != 'true'
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
         with:
           go-version-file: main-checkout/deploy/operator/go.mod
 
       - name: Set up Rust
-        if: env.SKIP_REST != 'true'
         working-directory: main-checkout
         run: |
           set -euo pipefail
+          # Uses rust-toolchain.toml — `rustup show` is what triggers the install.
           rustup show active-toolchain
 
-      - name: Install controller-gen
-        if: env.SKIP_REST != 'true'
+      - name: Install controller-gen (pinned)
         run: |
           set -euo pipefail
-          cd main-checkout/deploy/operator
-          make controller-gen
+          go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}
 
-      - name: Install helm-docs
-        if: env.SKIP_REST != 'true'
+      - name: Install helm-docs (pinned)
         run: |
           set -euo pipefail
-          HELM_DOCS_VERSION="1.14.2"
           curl -sSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
             | tar -xzf - helm-docs
           sudo mv helm-docs /usr/local/bin/
 
-      # Step 5: Create branch and run version bump
       - name: Create version-bump branch
-        if: env.SKIP_REST != 'true'
+        id: branch
         working-directory: main-checkout
         env:
           VERSION: ${{ steps.tag.outputs.version }}
@@ -265,102 +185,96 @@ jobs:
           set -euo pipefail
           BRANCH="chore/bump-version-to-${VERSION}"
           git checkout -b "$BRANCH"
-          echo "branch=$BRANCH" >> $GITHUB_ENV
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
 
-      - name: Build skip flags
-        if: env.SKIP_REST != 'true'
+      - name: Resolve scope flags
         id: flags
         env:
           EVENT_NAME: ${{ github.event_name }}
+          IS_POST: ${{ steps.tag.outputs.is_post }}
           UPDATE_CORE: ${{ inputs.update_core }}
           UPDATE_CONTAINERS: ${{ inputs.update_containers }}
           UPDATE_HELM: ${{ inputs.update_helm }}
           UPDATE_DOCS: ${{ inputs.update_docs }}
         run: |
           set -euo pipefail
-          SKIP_FLAGS=""
 
-          # For auto-triggered full releases, all components are updated.
-          # For manual triggers, respect the checkbox inputs.
+          # Default per event type:
+          #   workflow_dispatch  -> honour the checkbox inputs
+          #   release (full)     -> all scopes enabled
+          #   release (post)     -> minimal: core + helm only (no image-tag churn)
+          CORE=true; CONTAINERS=true; HELM=true; DOCS=true
+
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            if [ "$UPDATE_CORE" != "true" ]; then
-              SKIP_FLAGS="$SKIP_FLAGS --skip-core"
-            fi
-            if [ "$UPDATE_CONTAINERS" != "true" ]; then
-              SKIP_FLAGS="$SKIP_FLAGS --skip-containers"
-            fi
-            if [ "$UPDATE_HELM" != "true" ]; then
-              SKIP_FLAGS="$SKIP_FLAGS --skip-helm"
-            fi
-            if [ "$UPDATE_DOCS" != "true" ]; then
-              SKIP_FLAGS="$SKIP_FLAGS --skip-docs"
-            fi
+            CORE="$UPDATE_CORE"
+            CONTAINERS="$UPDATE_CONTAINERS"
+            HELM="$UPDATE_HELM"
+            DOCS="$UPDATE_DOCS"
+          elif [ "$IS_POST" = "true" ]; then
+            # Minimal post-release bump: bump declared versions but leave docs
+            # and image-tag text alone since post-releases re-use the same
+            # images with different dynamo wheels.
+            CONTAINERS=false
+            DOCS=false
           fi
 
-          echo "skip_flags=$SKIP_FLAGS" >> $GITHUB_OUTPUT
+          FLAGS=""
+          [ "$CORE" = "true" ]       || FLAGS="$FLAGS --skip-core"
+          [ "$CONTAINERS" = "true" ] || FLAGS="$FLAGS --skip-containers"
+          [ "$HELM" = "true" ]       || FLAGS="$FLAGS --skip-helm"
+          [ "$DOCS" = "true" ]       || FLAGS="$FLAGS --skip-docs"
 
-          # Expose individual flags for conditional regen steps
-          echo "skip_core=$( [[ "$SKIP_FLAGS" == *--skip-core* ]] && echo true || echo false )" >> $GITHUB_OUTPUT
-          echo "skip_containers=$( [[ "$SKIP_FLAGS" == *--skip-containers* ]] && echo true || echo false )" >> $GITHUB_OUTPUT
-          echo "skip_helm=$( [[ "$SKIP_FLAGS" == *--skip-helm* ]] && echo true || echo false )" >> $GITHUB_OUTPUT
-          echo "Skip flags: ${SKIP_FLAGS:-none}"
+          {
+            echo "skip_flags=$FLAGS"
+            echo "core=$CORE"
+            echo "containers=$CONTAINERS"
+            echo "helm=$HELM"
+            echo "docs=$DOCS"
+          } >> "$GITHUB_OUTPUT"
+          echo "Scope flags: ${FLAGS:-all scopes enabled}"
 
-      - name: Run version bump script
-        if: env.SKIP_REST != 'true'
+      - name: Run version bump
         working-directory: main-checkout
         env:
-          BUMP_VERSION: ${{ steps.tag.outputs.version }}
-          BUMP_VLLM: ${{ steps.metadata.outputs.vllm_version }}
-          BUMP_SGLANG: ${{ steps.metadata.outputs.sglang_version }}
-          BUMP_TRTLLM: ${{ steps.metadata.outputs.trtllm_version }}
-          BUMP_NIXL: ${{ steps.metadata.outputs.nixl_version }}
-          BUMP_CUDA_VLLM: ${{ steps.metadata.outputs.cuda_versions_vllm }}
-          BUMP_CUDA_SGLANG: ${{ steps.metadata.outputs.cuda_versions_sglang }}
-          BUMP_CUDA_TRTLLM: ${{ steps.metadata.outputs.cuda_versions_trtllm }}
-          BUMP_RELEASE_DATE: ${{ steps.metadata.outputs.release_date }}
-          BUMP_SKIP_FLAGS: ${{ steps.flags.outputs.skip_flags }}
+          VERSION: ${{ steps.tag.outputs.version }}
+          VLLM: ${{ steps.metadata.outputs.vllm_version }}
+          SGLANG: ${{ steps.metadata.outputs.sglang_version }}
+          TRTLLM: ${{ steps.metadata.outputs.trtllm_version }}
+          NIXL: ${{ steps.metadata.outputs.nixl_version }}
+          RELEASE_DATE: ${{ steps.metadata.outputs.release_date }}
+          FLAGS: ${{ steps.flags.outputs.skip_flags }}
+          GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}
         run: |
           set -euo pipefail
           python3 .github/scripts/bump_version.py \
-            --new-version "$BUMP_VERSION" \
-            --vllm-version "$BUMP_VLLM" \
-            --sglang-version "$BUMP_SGLANG" \
-            --trtllm-version "$BUMP_TRTLLM" \
-            --nixl-version "$BUMP_NIXL" \
-            --cuda-versions-vllm "$BUMP_CUDA_VLLM" \
-            --cuda-versions-sglang "$BUMP_CUDA_SGLANG" \
-            --cuda-versions-trtllm "$BUMP_CUDA_TRTLLM" \
-            --release-date "$BUMP_RELEASE_DATE" \
-            $BUMP_SKIP_FLAGS
+            --new-version "$VERSION" \
+            --vllm-version "$VLLM" \
+            --sglang-version "$SGLANG" \
+            --trtllm-version "$TRTLLM" \
+            --nixl-version "$NIXL" \
+            --release-date "$RELEASE_DATE" \
+            --summary-file "$GITHUB_STEP_SUMMARY" \
+            $FLAGS
 
-      # Step 6: Regenerate Cargo.lock (only if core version files were updated)
       - name: Regenerate Cargo.lock
-        if: env.SKIP_REST != 'true' && steps.flags.outputs.skip_core != 'true'
+        if: steps.flags.outputs.core == 'true'
         working-directory: main-checkout
-        run: |
-          set -euo pipefail
-          cargo update --workspace
+        run: cargo update --workspace
 
-      # Step 7: Regenerate CRDs (only if operator source was updated, i.e. containers not skipped)
       - name: Regenerate CRDs
-        if: env.SKIP_REST != 'true' && steps.flags.outputs.skip_containers != 'true'
+        if: steps.flags.outputs.containers == 'true'
         working-directory: main-checkout/deploy/operator
         run: |
           set -euo pipefail
           make generate
           make manifests
 
-      # Step 8: Regenerate Helm docs (only if Helm charts were updated)
       - name: Regenerate Helm docs
-        if: env.SKIP_REST != 'true' && steps.flags.outputs.skip_helm != 'true'
+        if: steps.flags.outputs.helm == 'true'
         working-directory: main-checkout/deploy/helm/charts/platform
-        run: |
-          set -euo pipefail
-          helm-docs
+        run: helm-docs
 
-      # Step 9: Commit and create PR
-      - name: Commit changes
-        if: env.SKIP_REST != 'true'
+      - name: Commit
         working-directory: main-checkout
         env:
           VERSION: ${{ steps.tag.outputs.version }}
@@ -369,44 +283,44 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
+          if git diff --cached --quiet; then
+            echo "::notice::No changes produced — nothing to commit."
+            echo "no_changes=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
           printf -v MSG '%s\n' \
             "Automated version bump from release v${VERSION}." \
             "" \
-            "Updates:" \
-            "- Core version files (pyproject.toml, Cargo.toml, setup.py)" \
-            "- Helm chart versions" \
-            "- Operator CRD source and regenerated files" \
-            "- Documentation (support matrix, feature matrix, release artifacts)" \
-            "- Container image tags across docs, recipes, and examples" \
-            "- Cargo.lock files"
+            "Updates are driven by .github/scripts/bump_version.py with scope" \
+            "flags: ${{ steps.flags.outputs.skip_flags || 'all scopes' }}."
           git commit -s -m "chore: bump version to ${VERSION}" -m "$MSG"
 
       - name: Push branch
-        if: env.SKIP_REST != 'true'
+        if: env.no_changes != 'true'
         working-directory: main-checkout
         env:
-          BRANCH: ${{ env.branch }}
+          BRANCH: ${{ steps.branch.outputs.name }}
         run: |
           set -euo pipefail
-          # Delete remote branch if it already exists (stale from a previous run)
+          # Replace any stale remote branch from a previous run.
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            echo "Remote branch $BRANCH already exists, deleting stale branch..."
             git push origin --delete "$BRANCH"
           fi
           git push -u origin "$BRANCH"
 
-      - name: Create PR
-        if: env.SKIP_REST != 'true'
+      - name: Open PR
+        if: env.no_changes != 'true'
         working-directory: main-checkout
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.tag.outputs.version }}
           IS_POST: ${{ steps.tag.outputs.is_post }}
           SKIP_FLAGS: ${{ steps.flags.outputs.skip_flags }}
-          VLLM_VER: ${{ steps.metadata.outputs.vllm_version }}
-          SGLANG_VER: ${{ steps.metadata.outputs.sglang_version }}
-          TRTLLM_VER: ${{ steps.metadata.outputs.trtllm_version }}
-          NIXL_VER: ${{ steps.metadata.outputs.nixl_version }}
+          VLLM: ${{ steps.metadata.outputs.vllm_version }}
+          SGLANG: ${{ steps.metadata.outputs.sglang_version }}
+          TRTLLM: ${{ steps.metadata.outputs.trtllm_version }}
+          NIXL: ${{ steps.metadata.outputs.nixl_version }}
+          BRANCH: ${{ steps.branch.outputs.name }}
         run: |
           set -euo pipefail
           if [ "$IS_POST" = "true" ]; then
@@ -414,38 +328,19 @@ jobs:
           else
             TITLE="chore: bump version to ${VERSION}"
           fi
-
           printf -v BODY '%s\n' \
             "## Summary" \
             "" \
-            "Automated version bump from release v${VERSION}." \
+            "Automated version bump from release \`v${VERSION}\`." \
             "" \
-            "**Backend versions** (derived from \`container/context.yaml\` on the release tag):" \
-            "- vLLM: \`${VLLM_VER}\`" \
-            "- SGLang: \`${SGLANG_VER}\`" \
-            "- TRT-LLM: \`${TRTLLM_VER}\`" \
-            "- NIXL: \`${NIXL_VER}\`" \
+            "**Backend versions** (from \`container/context.yaml\` on the release tag):" \
+            "- vLLM: \`${VLLM}\`" \
+            "- SGLang: \`${SGLANG}\`" \
+            "- TRT-LLM: \`${TRTLLM}\`" \
+            "- NIXL: \`${NIXL}\`" \
             "" \
-            "**Scope flags**: \`${SKIP_FLAGS:-all components updated}\`" \
+            "**Scope flags:** \`${SKIP_FLAGS:-all scopes}\`" \
             "" \
-            "### Changes" \
-            "" \
-            "- **Core version files**: pyproject.toml, Cargo.toml, lib/bindings/python/Cargo.toml, lib/gpu_memory_service/setup.py" \
-            "- **Helm charts**: CRDs, platform, operator Chart.yaml + regenerated README" \
-            "- **Operator CRDs**: Go source doc comments updated, CRDs regenerated via \`make generate && make manifests\`" \
-            "- **Reference docs**: support-matrix.md, feature-matrix.md, release-artifacts.md" \
-            "- **Image tags**: Updated across README, docs, recipes, and examples (discovery-based scan)" \
-            "- **Cargo.lock**: Regenerated" \
-            "" \
-            "## Test plan" \
-            "" \
-            "- [ ] Verify version strings are correct in key files" \
-            "- [ ] Verify CRD files pass \`make check\` in deploy/operator/" \
-            "- [ ] Verify no stale version references remain (\`python3 .github/scripts/bump_version.py --check\`)"
-
-          gh pr create \
-            --base main \
-            --title "$TITLE" \
-            --body "$BODY" \
-            --label "release" \
-            --label "chore"
+            "See the workflow run summary for the per-file / per-rule change table."
+          gh pr create --head "$BRANCH" --base main --title "$TITLE" --body "$BODY" \
+            --label release --label chore

--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -243,7 +243,6 @@ jobs:
           NIXL: ${{ steps.metadata.outputs.nixl_version }}
           RELEASE_DATE: ${{ steps.metadata.outputs.release_date }}
           FLAGS: ${{ steps.flags.outputs.skip_flags }}
-          GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}
         run: |
           set -euo pipefail
           python3 .github/scripts/bump_version.py \

--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -9,7 +9,7 @@
 #
 # Post-releases (vX.Y.Z.postN):
 #   Auto-trigger performs a minimal bump by default (core + helm only — full
-#   image-tag + docs churn is usually not wanted for post-releases). Use
+#   image-tag churn is usually not wanted for post-releases). Use
 #   workflow_dispatch with the component checkboxes for full control.
 #
 # The actual bump steps live in _version-bump-shared.yml. This file only
@@ -42,11 +42,6 @@ on:
         required: false
         type: boolean
         default: true
-      update_docs:
-        description: 'Update reference docs (support-matrix, feature-matrix, release-artifacts)'
-        required: false
-        type: boolean
-        default: true
 
 permissions:
   contents: write
@@ -68,7 +63,6 @@ jobs:
       skip_core:       ${{ steps.flags.outputs.skip_core }}
       skip_containers: ${{ steps.flags.outputs.skip_containers }}
       skip_helm:       ${{ steps.flags.outputs.skip_helm }}
-      skip_docs:       ${{ steps.flags.outputs.skip_docs }}
       vllm_version:    ${{ steps.metadata.outputs.vllm_version }}
       sglang_version:  ${{ steps.metadata.outputs.sglang_version }}
       trtllm_version:  ${{ steps.metadata.outputs.trtllm_version }}
@@ -167,43 +161,37 @@ jobs:
           UPDATE_CORE: ${{ inputs.update_core }}
           UPDATE_CONTAINERS: ${{ inputs.update_containers }}
           UPDATE_HELM: ${{ inputs.update_helm }}
-          UPDATE_DOCS: ${{ inputs.update_docs }}
         run: |
           set -euo pipefail
 
           # Default per event type:
           #   workflow_dispatch  -> honour the checkbox inputs
           #   release (full)     -> all scopes enabled
-          #   release (post)     -> minimal: core + helm only (no image-tag/docs churn)
-          CORE=true; CONTAINERS=true; HELM=true; DOCS=true
+          #   release (post)     -> minimal: core + helm only (no image-tag churn)
+          CORE=true; CONTAINERS=true; HELM=true
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             CORE="$UPDATE_CORE"
             CONTAINERS="$UPDATE_CONTAINERS"
             HELM="$UPDATE_HELM"
-            DOCS="$UPDATE_DOCS"
           elif [ "$IS_POST" = "true" ]; then
             CONTAINERS=false
-            DOCS=false
           fi
 
           # Shared workflow takes skip_* booleans (inverse of the update_* inputs).
           SKIP_CORE=true
           SKIP_CONTAINERS=true
           SKIP_HELM=true
-          SKIP_DOCS=true
           if [ "$CORE"       = "true" ]; then SKIP_CORE=false; fi
           if [ "$CONTAINERS" = "true" ]; then SKIP_CONTAINERS=false; fi
           if [ "$HELM"       = "true" ]; then SKIP_HELM=false; fi
-          if [ "$DOCS"       = "true" ]; then SKIP_DOCS=false; fi
 
           {
             echo "skip_core=$SKIP_CORE"
             echo "skip_containers=$SKIP_CONTAINERS"
             echo "skip_helm=$SKIP_HELM"
-            echo "skip_docs=$SKIP_DOCS"
           } >> "$GITHUB_OUTPUT"
-          echo "Resolved: skip_core=$SKIP_CORE skip_containers=$SKIP_CONTAINERS skip_helm=$SKIP_HELM skip_docs=$SKIP_DOCS"
+          echo "Resolved: skip_core=$SKIP_CORE skip_containers=$SKIP_CONTAINERS skip_helm=$SKIP_HELM"
 
       - name: Compose PR title and body
         id: body
@@ -217,14 +205,12 @@ jobs:
           SKIP_CORE:       ${{ steps.flags.outputs.skip_core }}
           SKIP_CONTAINERS: ${{ steps.flags.outputs.skip_containers }}
           SKIP_HELM:       ${{ steps.flags.outputs.skip_helm }}
-          SKIP_DOCS:       ${{ steps.flags.outputs.skip_docs }}
         run: |
           set -euo pipefail
           SCOPE_FLAGS=""
           if [ "$SKIP_CORE"       = "true" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-core"; fi
           if [ "$SKIP_CONTAINERS" = "true" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-containers"; fi
           if [ "$SKIP_HELM"       = "true" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-helm"; fi
-          if [ "$SKIP_DOCS"       = "true" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-docs"; fi
 
           if [ "$IS_POST" = "true" ]; then
             TITLE="chore: bump version to ${VERSION} (post-release)"
@@ -273,6 +259,6 @@ jobs:
       skip_core:       ${{ needs.parse.outputs.skip_core == 'true' }}
       skip_containers: ${{ needs.parse.outputs.skip_containers == 'true' }}
       skip_helm:       ${{ needs.parse.outputs.skip_helm == 'true' }}
-      skip_docs:       ${{ needs.parse.outputs.skip_docs == 'true' }}
     secrets:
       github_token: ${{ secrets.GITHUB_TOKEN }}
+      devin_api_key: ${{ secrets.DEVIN_API_KEY }}

--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -8,11 +8,12 @@
 #   opens a PR to main.
 #
 # Post-releases (vX.Y.Z.postN):
-#   Auto-trigger performs a minimal bump by default (Helm + core only — full
-#   image-tag churn is usually not wanted for post-releases). Use
+#   Auto-trigger performs a minimal bump by default (core + helm only — full
+#   image-tag + docs churn is usually not wanted for post-releases). Use
 #   workflow_dispatch with the component checkboxes for full control.
 #
-# Phase 1 (release branch prep) lives in release.yml.
+# The actual bump steps live in _version-bump-shared.yml. This file only
+# parses release metadata and delegates.
 
 name: Release Version Bump
 
@@ -51,17 +52,28 @@ permissions:
   contents: write
   pull-requests: write
 
-# Pinned tool versions — bump deliberately, not via `latest`.
-env:
-  YQ_VERSION: '4.52.2'
-  CONTROLLER_GEN_VERSION: 'v0.16.5'
-  HELM_DOCS_VERSION: '1.14.2'
-
 jobs:
-  version-bump-to-main:
-    name: Open PR to main
+  parse:
+    name: Parse release metadata
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    env:
+      YQ_VERSION: '4.52.2'
+    outputs:
+      version:         ${{ steps.tag.outputs.version }}
+      tag:             ${{ steps.tag.outputs.tag }}
+      is_post:         ${{ steps.tag.outputs.is_post }}
+      pr_branch:       ${{ steps.branch.outputs.pr_branch }}
+      pr_title:        ${{ steps.body.outputs.pr_title }}
+      pr_body:         ${{ steps.body.outputs.pr_body }}
+      skip_core:       ${{ steps.flags.outputs.skip_core }}
+      skip_containers: ${{ steps.flags.outputs.skip_containers }}
+      skip_helm:       ${{ steps.flags.outputs.skip_helm }}
+      skip_docs:       ${{ steps.flags.outputs.skip_docs }}
+      vllm_version:    ${{ steps.metadata.outputs.vllm_version }}
+      sglang_version:  ${{ steps.metadata.outputs.sglang_version }}
+      trtllm_version:  ${{ steps.metadata.outputs.trtllm_version }}
+      nixl_version:    ${{ steps.metadata.outputs.nixl_version }}
+      release_date:    ${{ steps.metadata.outputs.release_date }}
     steps:
       - name: Determine tag and release kind
         id: tag
@@ -95,11 +107,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Tag: $TAG, Version: $VERSION, Post-release: $IS_POST"
 
-      - name: Checkout release tag
+      - name: Checkout release tag (for backend metadata extraction)
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
         with:
           ref: ${{ steps.tag.outputs.tag }}
-          path: release-ref
 
       - name: Install yq
         run: |
@@ -115,7 +126,7 @@ jobs:
           RELEASE_CREATED_AT: ${{ github.event.release.created_at }}
         run: |
           set -euo pipefail
-          CTX="release-ref/container/context.yaml"
+          CTX="container/context.yaml"
 
           VLLM_VER=$(yq '.vllm.vllm_ref' "$CTX" | sed 's/^v//')
           SGLANG_TAG=$(yq '.sglang."cuda12.9".runtime_image_tag // .sglang.runtime_image_tag // ""' "$CTX")
@@ -140,52 +151,13 @@ jobs:
 
           echo "Backend: vLLM=$VLLM_VER SGLang=$SGLANG_VER TRT-LLM=$TRTLLM_VER NIXL=$NIXL_VER  Released=$RELEASE_DATE"
 
-      - name: Checkout main
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
-        with:
-          ref: main
-          fetch-depth: 0
-          path: main-checkout
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
-        with:
-          python-version: '3.12'
-
-      - name: Set up Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
-        with:
-          go-version-file: main-checkout/deploy/operator/go.mod
-
-      - name: Set up Rust
-        working-directory: main-checkout
-        run: |
-          set -euo pipefail
-          # Uses rust-toolchain.toml — `rustup show` is what triggers the install.
-          rustup show active-toolchain
-
-      - name: Install controller-gen (pinned)
-        run: |
-          set -euo pipefail
-          go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}
-
-      - name: Install helm-docs (pinned)
-        run: |
-          set -euo pipefail
-          curl -sSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
-            | tar -xzf - helm-docs
-          sudo mv helm-docs /usr/local/bin/
-
-      - name: Create version-bump branch
+      - name: Compute PR branch name
         id: branch
-        working-directory: main-checkout
         env:
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
           set -euo pipefail
-          BRANCH="chore/bump-version-to-${VERSION}"
-          git checkout -b "$BRANCH"
-          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "pr_branch=chore/bump-version-to-${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve scope flags
         id: flags
@@ -202,7 +174,7 @@ jobs:
           # Default per event type:
           #   workflow_dispatch  -> honour the checkbox inputs
           #   release (full)     -> all scopes enabled
-          #   release (post)     -> minimal: core + helm only (no image-tag churn)
+          #   release (post)     -> minimal: core + helm only (no image-tag/docs churn)
           CORE=true; CONTAINERS=true; HELM=true; DOCS=true
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
@@ -211,135 +183,96 @@ jobs:
             HELM="$UPDATE_HELM"
             DOCS="$UPDATE_DOCS"
           elif [ "$IS_POST" = "true" ]; then
-            # Minimal post-release bump: bump declared versions but leave docs
-            # and image-tag text alone since post-releases re-use the same
-            # images with different dynamo wheels.
             CONTAINERS=false
             DOCS=false
           fi
 
-          FLAGS=""
-          [ "$CORE" = "true" ]       || FLAGS="$FLAGS --skip-core"
-          [ "$CONTAINERS" = "true" ] || FLAGS="$FLAGS --skip-containers"
-          [ "$HELM" = "true" ]       || FLAGS="$FLAGS --skip-helm"
-          [ "$DOCS" = "true" ]       || FLAGS="$FLAGS --skip-docs"
+          # Shared workflow takes skip_* booleans (inverse of the update_* inputs).
+          SKIP_CORE=true
+          SKIP_CONTAINERS=true
+          SKIP_HELM=true
+          SKIP_DOCS=true
+          if [ "$CORE"       = "true" ]; then SKIP_CORE=false; fi
+          if [ "$CONTAINERS" = "true" ]; then SKIP_CONTAINERS=false; fi
+          if [ "$HELM"       = "true" ]; then SKIP_HELM=false; fi
+          if [ "$DOCS"       = "true" ]; then SKIP_DOCS=false; fi
 
           {
-            echo "skip_flags=$FLAGS"
-            echo "core=$CORE"
-            echo "containers=$CONTAINERS"
-            echo "helm=$HELM"
-            echo "docs=$DOCS"
+            echo "skip_core=$SKIP_CORE"
+            echo "skip_containers=$SKIP_CONTAINERS"
+            echo "skip_helm=$SKIP_HELM"
+            echo "skip_docs=$SKIP_DOCS"
           } >> "$GITHUB_OUTPUT"
-          echo "Scope flags: ${FLAGS:-all scopes enabled}"
+          echo "Resolved: skip_core=$SKIP_CORE skip_containers=$SKIP_CONTAINERS skip_helm=$SKIP_HELM skip_docs=$SKIP_DOCS"
 
-      - name: Run version bump
-        working-directory: main-checkout
+      - name: Compose PR title and body
+        id: body
         env:
-          VERSION: ${{ steps.tag.outputs.version }}
-          VLLM: ${{ steps.metadata.outputs.vllm_version }}
-          SGLANG: ${{ steps.metadata.outputs.sglang_version }}
-          TRTLLM: ${{ steps.metadata.outputs.trtllm_version }}
-          NIXL: ${{ steps.metadata.outputs.nixl_version }}
-          RELEASE_DATE: ${{ steps.metadata.outputs.release_date }}
-          FLAGS: ${{ steps.flags.outputs.skip_flags }}
+          VERSION:         ${{ steps.tag.outputs.version }}
+          IS_POST:         ${{ steps.tag.outputs.is_post }}
+          VLLM:            ${{ steps.metadata.outputs.vllm_version }}
+          SGLANG:          ${{ steps.metadata.outputs.sglang_version }}
+          TRTLLM:          ${{ steps.metadata.outputs.trtllm_version }}
+          NIXL:            ${{ steps.metadata.outputs.nixl_version }}
+          SKIP_CORE:       ${{ steps.flags.outputs.skip_core }}
+          SKIP_CONTAINERS: ${{ steps.flags.outputs.skip_containers }}
+          SKIP_HELM:       ${{ steps.flags.outputs.skip_helm }}
+          SKIP_DOCS:       ${{ steps.flags.outputs.skip_docs }}
         run: |
           set -euo pipefail
-          python3 .github/scripts/bump_version.py \
-            --new-version "$VERSION" \
-            --vllm-version "$VLLM" \
-            --sglang-version "$SGLANG" \
-            --trtllm-version "$TRTLLM" \
-            --nixl-version "$NIXL" \
-            --release-date "$RELEASE_DATE" \
-            --summary-file "$GITHUB_STEP_SUMMARY" \
-            $FLAGS
+          SCOPE_FLAGS=""
+          if [ "$SKIP_CORE"       = "true" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-core"; fi
+          if [ "$SKIP_CONTAINERS" = "true" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-containers"; fi
+          if [ "$SKIP_HELM"       = "true" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-helm"; fi
+          if [ "$SKIP_DOCS"       = "true" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-docs"; fi
 
-      - name: Regenerate Cargo.lock
-        if: steps.flags.outputs.core == 'true'
-        working-directory: main-checkout
-        run: cargo update --workspace
-
-      - name: Regenerate CRDs
-        if: steps.flags.outputs.containers == 'true'
-        working-directory: main-checkout/deploy/operator
-        run: |
-          set -euo pipefail
-          make generate
-          make manifests
-
-      - name: Regenerate Helm docs
-        if: steps.flags.outputs.helm == 'true'
-        working-directory: main-checkout/deploy/helm/charts/platform
-        run: helm-docs
-
-      - name: Commit
-        working-directory: main-checkout
-        env:
-          VERSION: ${{ steps.tag.outputs.version }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          if git diff --cached --quiet; then
-            echo "::notice::No changes produced — nothing to commit."
-            echo "no_changes=true" >> "$GITHUB_ENV"
-            exit 0
-          fi
-          printf -v MSG '%s\n' \
-            "Automated version bump from release v${VERSION}." \
-            "" \
-            "Updates are driven by .github/scripts/bump_version.py with scope" \
-            "flags: ${{ steps.flags.outputs.skip_flags || 'all scopes' }}."
-          git commit -s -m "chore: bump version to ${VERSION}" -m "$MSG"
-
-      - name: Push branch
-        if: env.no_changes != 'true'
-        working-directory: main-checkout
-        env:
-          BRANCH: ${{ steps.branch.outputs.name }}
-        run: |
-          set -euo pipefail
-          # Replace any stale remote branch from a previous run.
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            git push origin --delete "$BRANCH"
-          fi
-          git push -u origin "$BRANCH"
-
-      - name: Open PR
-        if: env.no_changes != 'true'
-        working-directory: main-checkout
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.tag.outputs.version }}
-          IS_POST: ${{ steps.tag.outputs.is_post }}
-          SKIP_FLAGS: ${{ steps.flags.outputs.skip_flags }}
-          VLLM: ${{ steps.metadata.outputs.vllm_version }}
-          SGLANG: ${{ steps.metadata.outputs.sglang_version }}
-          TRTLLM: ${{ steps.metadata.outputs.trtllm_version }}
-          NIXL: ${{ steps.metadata.outputs.nixl_version }}
-          BRANCH: ${{ steps.branch.outputs.name }}
-        run: |
-          set -euo pipefail
           if [ "$IS_POST" = "true" ]; then
             TITLE="chore: bump version to ${VERSION} (post-release)"
           else
             TITLE="chore: bump version to ${VERSION}"
           fi
-          printf -v BODY '%s\n' \
-            "## Summary" \
-            "" \
-            "Automated version bump from release \`v${VERSION}\`." \
-            "" \
-            "**Backend versions** (from \`container/context.yaml\` on the release tag):" \
-            "- vLLM: \`${VLLM}\`" \
-            "- SGLang: \`${SGLANG}\`" \
-            "- TRT-LLM: \`${TRTLLM}\`" \
-            "- NIXL: \`${NIXL}\`" \
-            "" \
-            "**Scope flags:** \`${SKIP_FLAGS:-all scopes}\`" \
-            "" \
-            "See the workflow run summary for the per-file / per-rule change table."
-          gh pr create --head "$BRANCH" --base main --title "$TITLE" --body "$BODY" \
-            --label release --label chore
+
+          {
+            echo "pr_title=$TITLE"
+            echo "pr_body<<EOF_BODY"
+            echo "## Summary"
+            echo ""
+            echo "Automated version bump from release \`v${VERSION}\`."
+            echo ""
+            echo "**Backend versions** (from \`container/context.yaml\` on the release tag):"
+            echo "- vLLM: \`${VLLM}\`"
+            echo "- SGLang: \`${SGLANG}\`"
+            echo "- TRT-LLM: \`${TRTLLM}\`"
+            echo "- NIXL: \`${NIXL}\`"
+            echo ""
+            echo "**Scope flags:** \`${SCOPE_FLAGS:-all scopes}\`"
+            echo ""
+            echo "See the workflow run summary for the per-file / per-rule change table."
+            echo "EOF_BODY"
+          } >> "$GITHUB_OUTPUT"
+
+  version-bump-to-main:
+    name: Open PR to main
+    needs: [parse]
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/_version-bump-shared.yml
+    with:
+      version:         ${{ needs.parse.outputs.version }}
+      ref:             main
+      pr_base:         main
+      pr_branch:       ${{ needs.parse.outputs.pr_branch }}
+      pr_title:        ${{ needs.parse.outputs.pr_title }}
+      pr_body:         ${{ needs.parse.outputs.pr_body }}
+      vllm_version:    ${{ needs.parse.outputs.vllm_version }}
+      sglang_version:  ${{ needs.parse.outputs.sglang_version }}
+      trtllm_version:  ${{ needs.parse.outputs.trtllm_version }}
+      nixl_version:    ${{ needs.parse.outputs.nixl_version }}
+      release_date:    ${{ needs.parse.outputs.release_date }}
+      skip_core:       ${{ needs.parse.outputs.skip_core == 'true' }}
+      skip_containers: ${{ needs.parse.outputs.skip_containers == 'true' }}
+      skip_helm:       ${{ needs.parse.outputs.skip_helm == 'true' }}
+      skip_docs:       ${{ needs.parse.outputs.skip_docs == 'true' }}
+    secrets:
+      github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,10 @@ env:
 
 jobs:
   # ============================================================================
-  # VERSION BUMP (Phase 1): Bump all version references on the release branch
+  # VERSION BUMP (Phase 1): Bump all version references on the release branch.
   # Only runs on workflow_dispatch with action=version-bump.
-  # Uses automated-release environment to bypass branch protection.
+  # Opens a PR to the release/* branch instead of pushing directly, so the
+  # mechanical changes get a human review before they land.
   # ============================================================================
   version-bump:
     name: Version Bump (Release Branch Prep)
@@ -65,8 +66,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: automated-release
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      YQ_VERSION: '4.52.2'
+      CONTROLLER_GEN_VERSION: 'v0.16.5'
+      HELM_DOCS_VERSION: '1.14.2'
     steps:
       - name: Validate branch
+        id: ctx
         run: |
           set -euo pipefail
           BRANCH_NAME="${GITHUB_REF#refs/heads/}"
@@ -75,8 +84,13 @@ jobs:
             exit 1
           fi
           VERSION="${BRANCH_NAME#release/}"
-          echo "version=$VERSION" >> $GITHUB_ENV
-          echo "branch=$BRANCH_NAME" >> $GITHUB_ENV
+          # Slug for git branch names: drop '.' in .postN → -post (PR branches can't have dots in sloppy places).
+          SLUG="${VERSION//./-}"
+          {
+            echo "version=$VERSION"
+            echo "branch=$BRANCH_NAME"
+            echo "slug=$SLUG"
+          } >> "$GITHUB_OUTPUT"
           echo "Version: $VERSION, Branch: $BRANCH_NAME"
 
       - name: Checkout release branch
@@ -94,19 +108,13 @@ jobs:
         with:
           go-version-file: deploy/operator/go.mod
 
-      - name: Install tools (yq, controller-gen, helm-docs)
+      - name: Install tools (yq, controller-gen, helm-docs; all pinned)
         run: |
           set -euo pipefail
-          # yq
-          YQ_VERSION="4.52.2"
-          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+          sudo wget -qO /usr/local/bin/yq \
+            "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
           sudo chmod +x /usr/local/bin/yq
-
-          # controller-gen
-          cd deploy/operator && make controller-gen && cd ../..
-
-          # helm-docs
-          HELM_DOCS_VERSION="1.14.2"
+          go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}
           curl -sSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
             | tar -xzf - helm-docs
           sudo mv helm-docs /usr/local/bin/
@@ -116,36 +124,32 @@ jobs:
         run: |
           set -euo pipefail
           CTX="container/context.yaml"
-
           VLLM_VER=$(yq '.vllm.vllm_ref' "$CTX" | sed 's/^v//')
-          echo "vllm_version=$VLLM_VER" >> $GITHUB_OUTPUT
-
           SGLANG_TAG=$(yq '.sglang."cuda12.9".runtime_image_tag // .sglang.runtime_image_tag // ""' "$CTX")
           SGLANG_VER=$(echo "$SGLANG_TAG" | sed 's/^v//; s/-cu[0-9]*-runtime$//; s/-runtime$//')
-          echo "sglang_version=$SGLANG_VER" >> $GITHUB_OUTPUT
-
           TRTLLM_WHEEL=$(yq '.trtllm.pip_wheel' "$CTX")
           TRTLLM_VER=$(echo "$TRTLLM_WHEEL" | sed 's/.*==//')
-          echo "trtllm_version=$TRTLLM_VER" >> $GITHUB_OUTPUT
-
           NIXL_VER=$(yq '.dynamo.nixl_ref' "$CTX")
-          echo "nixl_version=$NIXL_VER" >> $GITHUB_OUTPUT
-
-          CUDA_VLLM=$(yq '[.vllm | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
-          echo "cuda_versions_vllm=$CUDA_VLLM" >> $GITHUB_OUTPUT
-
-          CUDA_SGLANG=$(yq '[.sglang | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
-          echo "cuda_versions_sglang=$CUDA_SGLANG" >> $GITHUB_OUTPUT
-
-          TRTLLM_RUNTIME_TAG=$(yq '.trtllm.runtime_image_tag' "$CTX")
-          CUDA_TRTLLM=$(echo "$TRTLLM_RUNTIME_TAG" | grep -oP 'cuda\K[\d.]+')
-          echo "cuda_versions_trtllm=$CUDA_TRTLLM" >> $GITHUB_OUTPUT
-
           RELEASE_DATE=$(date "+%b %d, %Y")
-          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
+          {
+            echo "vllm_version=$VLLM_VER"
+            echo "sglang_version=$SGLANG_VER"
+            echo "trtllm_version=$TRTLLM_VER"
+            echo "nixl_version=$NIXL_VER"
+            echo "release_date=$RELEASE_DATE"
+          } >> "$GITHUB_OUTPUT"
+          echo "Backend: vLLM=$VLLM_VER SGLang=$SGLANG_VER TRT-LLM=$TRTLLM_VER NIXL=$NIXL_VER  Released=$RELEASE_DATE"
 
-          echo "=== Backend Metadata ==="
-          echo "  vLLM: $VLLM_VER | SGLang: $SGLANG_VER | TRT-LLM: $TRTLLM_VER | NIXL: $NIXL_VER"
+      - name: Create version-bump branch
+        id: branch
+        env:
+          SLUG: ${{ steps.ctx.outputs.slug }}
+          BASE: ${{ steps.ctx.outputs.branch }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/bump-version-${SLUG}-on-${BASE##*/}"
+          git checkout -b "$BRANCH"
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Build skip flags
         id: flags
@@ -157,41 +161,44 @@ jobs:
         run: |
           set -euo pipefail
           SKIP_FLAGS=""
-          if [ "$UPDATE_CORE" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-core"; fi
-          if [ "$UPDATE_CONTAINERS" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-containers"; fi
-          if [ "$UPDATE_HELM" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-helm"; fi
-          if [ "$UPDATE_DOCS" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-docs"; fi
-          echo "skip_flags=$SKIP_FLAGS" >> $GITHUB_OUTPUT
+          [ "$UPDATE_CORE" = "false" ]       && SKIP_FLAGS="$SKIP_FLAGS --skip-core" || true
+          [ "$UPDATE_CONTAINERS" = "false" ] && SKIP_FLAGS="$SKIP_FLAGS --skip-containers" || true
+          [ "$UPDATE_HELM" = "false" ]       && SKIP_FLAGS="$SKIP_FLAGS --skip-helm" || true
+          [ "$UPDATE_DOCS" = "false" ]       && SKIP_FLAGS="$SKIP_FLAGS --skip-docs" || true
+          echo "skip_flags=$SKIP_FLAGS" >> "$GITHUB_OUTPUT"
           echo "Skip flags: ${SKIP_FLAGS:-none (full update)}"
 
       - name: Run version bump script
         env:
-          BUMP_SKIP_FLAGS: ${{ steps.flags.outputs.skip_flags }}
+          VERSION: ${{ steps.ctx.outputs.version }}
+          VLLM: ${{ steps.metadata.outputs.vllm_version }}
+          SGLANG: ${{ steps.metadata.outputs.sglang_version }}
+          TRTLLM: ${{ steps.metadata.outputs.trtllm_version }}
+          NIXL: ${{ steps.metadata.outputs.nixl_version }}
+          RELEASE_DATE: ${{ steps.metadata.outputs.release_date }}
+          FLAGS: ${{ steps.flags.outputs.skip_flags }}
         run: |
           set -euo pipefail
           python3 .github/scripts/bump_version.py \
-            --new-version "${{ env.version }}" \
-            --vllm-version "${{ steps.metadata.outputs.vllm_version }}" \
-            --sglang-version "${{ steps.metadata.outputs.sglang_version }}" \
-            --trtllm-version "${{ steps.metadata.outputs.trtllm_version }}" \
-            --nixl-version "${{ steps.metadata.outputs.nixl_version }}" \
-            --cuda-versions-vllm "${{ steps.metadata.outputs.cuda_versions_vllm }}" \
-            --cuda-versions-sglang "${{ steps.metadata.outputs.cuda_versions_sglang }}" \
-            --cuda-versions-trtllm "${{ steps.metadata.outputs.cuda_versions_trtllm }}" \
-            --release-date "${{ steps.metadata.outputs.release_date }}" \
-            $BUMP_SKIP_FLAGS
+            --new-version "$VERSION" \
+            --vllm-version "$VLLM" \
+            --sglang-version "$SGLANG" \
+            --trtllm-version "$TRTLLM" \
+            --nixl-version "$NIXL" \
+            --release-date "$RELEASE_DATE" \
+            --summary-file "$GITHUB_STEP_SUMMARY" \
+            $FLAGS
 
       - name: Set up Rust
-        run: |
-          set -euo pipefail
-          rustup show active-toolchain
+        if: inputs.update_core != false
+        run: rustup show active-toolchain
 
       - name: Regenerate Cargo.lock
-        run: |
-          set -euo pipefail
-          cargo update --workspace
+        if: inputs.update_core != false
+        run: cargo update --workspace
 
       - name: Regenerate CRDs
+        if: inputs.update_containers != false
         working-directory: deploy/operator
         run: |
           set -euo pipefail
@@ -199,24 +206,77 @@ jobs:
           make manifests
 
       - name: Regenerate Helm docs
+        if: inputs.update_helm != false
         working-directory: deploy/helm/charts/platform
-        run: |
-          set -euo pipefail
-          helm-docs
+        run: helm-docs
 
-      - name: Commit and push
+      - name: Commit
+        id: commit
+        env:
+          VERSION: ${{ steps.ctx.outputs.version }}
+          FLAGS: ${{ steps.flags.outputs.skip_flags }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           if git diff --cached --quiet; then
-            echo "No changes to commit."
-          else
-            git commit -s -m "chore: bump version references to ${{ env.version }}"
-            git push
-            echo "Version bump committed to ${{ env.branch }}"
+            echo "::notice::No changes produced — nothing to commit."
+            echo "no_changes=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          printf -v MSG '%s\n' \
+            "Automated release branch prep for v${VERSION}." \
+            "" \
+            "Scope flags: ${FLAGS:-all scopes}"
+          git commit -s -m "chore: bump version references to ${VERSION}" -m "$MSG"
+
+      - name: Push branch
+        if: steps.commit.outputs.no_changes != 'true'
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git push origin --delete "$BRANCH"
+          fi
+          git push -u origin "$BRANCH"
+
+      - name: Open PR into release branch
+        if: steps.commit.outputs.no_changes != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.ctx.outputs.version }}
+          BASE: ${{ steps.ctx.outputs.branch }}
+          BRANCH: ${{ steps.branch.outputs.name }}
+          FLAGS: ${{ steps.flags.outputs.skip_flags }}
+          VLLM: ${{ steps.metadata.outputs.vllm_version }}
+          SGLANG: ${{ steps.metadata.outputs.sglang_version }}
+          TRTLLM: ${{ steps.metadata.outputs.trtllm_version }}
+          NIXL: ${{ steps.metadata.outputs.nixl_version }}
+        run: |
+          set -euo pipefail
+          printf -v BODY '%s\n' \
+            "## Summary" \
+            "" \
+            "Automated Phase 1 version bump for release \`v${VERSION}\`." \
+            "Targets the release branch \`${BASE}\` — merge here kicks off the RC publish flow." \
+            "" \
+            "**Backend versions** (from \`container/context.yaml\`):" \
+            "- vLLM: \`${VLLM}\`" \
+            "- SGLang: \`${SGLANG}\`" \
+            "- TRT-LLM: \`${TRTLLM}\`" \
+            "- NIXL: \`${NIXL}\`" \
+            "" \
+            "**Scope flags:** \`${FLAGS:-all scopes}\`" \
+            "" \
+            "See the workflow run summary for the per-file / per-rule change table."
+          gh pr create \
+            --base "$BASE" \
+            --head "$BRANCH" \
+            --title "chore: bump version references to ${VERSION}" \
+            --body "$BODY" \
+            --label release --label chore
 
   # ============================================================================
   # GATE: Version Extraction

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,12 @@ jobs:
         run: cargo update --workspace
 
       - name: Regenerate CRDs
-        if: inputs.update_containers != false
+        # CRDs are generated from Go types under deploy/operator/, so they belong
+        # to the core/operator scope, not container image tags. Gate on
+        # update_core to keep the manifests in sync with operator code changes
+        # even when --skip-containers is set. Mirrors the gating in
+        # release-version-bump.yml.
+        if: inputs.update_core != false
         working-directory: deploy/operator
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,43 @@ name: Release Pipeline
 on:
   workflow_dispatch:
     inputs:
-      commit_sha:
-        description: 'Git commit SHA whose post-merge CI images to publish (full 40-char SHA).'
+      action:
+        description: 'Action to perform: release-publish (default) runs RC tag + NGC publish; version-bump runs the version bump script only.'
         required: true
-        type: string
-      rc_number:
-        description: 'RC number (e.g., 0 for rc0). Leave empty to auto-increment.'
+        type: choice
+        options:
+          - release-publish
+          - version-bump
+        default: release-publish
+      commit_sha:
+        description: 'Git commit SHA whose post-merge CI images to publish (full 40-char SHA). Only used with release-publish action.'
         required: false
         type: string
+      rc_number:
+        description: 'RC number (e.g., 0 for rc0). Leave empty to auto-increment. Only used with release-publish action.'
+        required: false
+        type: string
+      # Component scope controls for version-bump action (post-releases)
+      update_core:
+        description: 'Update core version files (pyproject.toml, Cargo.toml, setup.py). Only used with version-bump action.'
+        required: false
+        type: boolean
+        default: true
+      update_containers:
+        description: 'Update container image tags across docs, recipes, examples. Only used with version-bump action.'
+        required: false
+        type: boolean
+        default: true
+      update_helm:
+        description: 'Update Helm Chart.yaml versions. Only used with version-bump action.'
+        required: false
+        type: boolean
+        default: true
+      update_docs:
+        description: 'Update reference docs (support-matrix, feature-matrix, release-artifacts). Only used with version-bump action.'
+        required: false
+        type: boolean
+        default: true
 
 # Note: workflow_dispatch can only be triggered from release/* branches
 # This is enforced in the prepare-release job via branch validation
@@ -26,11 +55,176 @@ env:
 
 jobs:
   # ============================================================================
+  # VERSION BUMP (Phase 1): Bump all version references on the release branch
+  # Only runs on workflow_dispatch with action=version-bump.
+  # Uses automated-release environment to bypass branch protection.
+  # ============================================================================
+  version-bump:
+    name: Version Bump (Release Branch Prep)
+    if: inputs.action == 'version-bump'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: automated-release
+    steps:
+      - name: Validate branch
+        run: |
+          set -euo pipefail
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          if [[ ! "$BRANCH_NAME" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?$ ]]; then
+            echo "::error::version-bump can only run on release/* branches (current: $BRANCH_NAME)"
+            exit 1
+          fi
+          VERSION="${BRANCH_NAME#release/}"
+          echo "version=$VERSION" >> $GITHUB_ENV
+          echo "branch=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "Version: $VERSION, Branch: $BRANCH_NAME"
+
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: deploy/operator/go.mod
+
+      - name: Install tools (yq, controller-gen, helm-docs)
+        run: |
+          set -euo pipefail
+          # yq
+          YQ_VERSION="4.52.2"
+          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+
+          # controller-gen
+          cd deploy/operator && make controller-gen && cd ../..
+
+          # helm-docs
+          HELM_DOCS_VERSION="1.14.2"
+          curl -sSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
+            | tar -xzf - helm-docs
+          sudo mv helm-docs /usr/local/bin/
+
+      - name: Extract backend metadata from context.yaml
+        id: metadata
+        run: |
+          set -euo pipefail
+          CTX="container/context.yaml"
+
+          VLLM_VER=$(yq '.vllm.vllm_ref' "$CTX" | sed 's/^v//')
+          echo "vllm_version=$VLLM_VER" >> $GITHUB_OUTPUT
+
+          SGLANG_TAG=$(yq '.sglang."cuda12.9".runtime_image_tag // .sglang.runtime_image_tag // ""' "$CTX")
+          SGLANG_VER=$(echo "$SGLANG_TAG" | sed 's/^v//; s/-cu[0-9]*-runtime$//; s/-runtime$//')
+          echo "sglang_version=$SGLANG_VER" >> $GITHUB_OUTPUT
+
+          TRTLLM_WHEEL=$(yq '.trtllm.pip_wheel' "$CTX")
+          TRTLLM_VER=$(echo "$TRTLLM_WHEEL" | sed 's/.*==//')
+          echo "trtllm_version=$TRTLLM_VER" >> $GITHUB_OUTPUT
+
+          NIXL_VER=$(yq '.dynamo.nixl_ref' "$CTX")
+          echo "nixl_version=$NIXL_VER" >> $GITHUB_OUTPUT
+
+          CUDA_VLLM=$(yq '[.vllm | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
+          echo "cuda_versions_vllm=$CUDA_VLLM" >> $GITHUB_OUTPUT
+
+          CUDA_SGLANG=$(yq '[.sglang | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
+          echo "cuda_versions_sglang=$CUDA_SGLANG" >> $GITHUB_OUTPUT
+
+          TRTLLM_RUNTIME_TAG=$(yq '.trtllm.runtime_image_tag' "$CTX")
+          CUDA_TRTLLM=$(echo "$TRTLLM_RUNTIME_TAG" | grep -oP 'cuda\K[\d.]+')
+          echo "cuda_versions_trtllm=$CUDA_TRTLLM" >> $GITHUB_OUTPUT
+
+          RELEASE_DATE=$(date "+%b %d, %Y")
+          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
+
+          echo "=== Backend Metadata ==="
+          echo "  vLLM: $VLLM_VER | SGLang: $SGLANG_VER | TRT-LLM: $TRTLLM_VER | NIXL: $NIXL_VER"
+
+      - name: Build skip flags
+        id: flags
+        env:
+          UPDATE_CORE: ${{ inputs.update_core }}
+          UPDATE_CONTAINERS: ${{ inputs.update_containers }}
+          UPDATE_HELM: ${{ inputs.update_helm }}
+          UPDATE_DOCS: ${{ inputs.update_docs }}
+        run: |
+          set -euo pipefail
+          SKIP_FLAGS=""
+          if [ "$UPDATE_CORE" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-core"; fi
+          if [ "$UPDATE_CONTAINERS" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-containers"; fi
+          if [ "$UPDATE_HELM" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-helm"; fi
+          if [ "$UPDATE_DOCS" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-docs"; fi
+          echo "skip_flags=$SKIP_FLAGS" >> $GITHUB_OUTPUT
+          echo "Skip flags: ${SKIP_FLAGS:-none (full update)}"
+
+      - name: Run version bump script
+        env:
+          BUMP_SKIP_FLAGS: ${{ steps.flags.outputs.skip_flags }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/bump_version.py \
+            --new-version "${{ env.version }}" \
+            --vllm-version "${{ steps.metadata.outputs.vllm_version }}" \
+            --sglang-version "${{ steps.metadata.outputs.sglang_version }}" \
+            --trtllm-version "${{ steps.metadata.outputs.trtllm_version }}" \
+            --nixl-version "${{ steps.metadata.outputs.nixl_version }}" \
+            --cuda-versions-vllm "${{ steps.metadata.outputs.cuda_versions_vllm }}" \
+            --cuda-versions-sglang "${{ steps.metadata.outputs.cuda_versions_sglang }}" \
+            --cuda-versions-trtllm "${{ steps.metadata.outputs.cuda_versions_trtllm }}" \
+            --release-date "${{ steps.metadata.outputs.release_date }}" \
+            $BUMP_SKIP_FLAGS
+
+      - name: Set up Rust
+        run: |
+          set -euo pipefail
+          rustup show active-toolchain
+
+      - name: Regenerate Cargo.lock
+        run: |
+          set -euo pipefail
+          cargo update --workspace
+
+      - name: Regenerate CRDs
+        working-directory: deploy/operator
+        run: |
+          set -euo pipefail
+          make generate
+          make manifests
+
+      - name: Regenerate Helm docs
+        working-directory: deploy/helm/charts/platform
+        run: |
+          set -euo pipefail
+          helm-docs
+
+      - name: Commit and push
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -s -m "chore: bump version references to ${{ env.version }}"
+            git push
+            echo "Version bump committed to ${{ env.branch }}"
+          fi
+
+  # ============================================================================
   # GATE: Version Extraction
   # ============================================================================
 
   prepare-release:
     name: Prepare Release
+    if: inputs.action != 'version-bump'
     runs-on: prod-default-small-v2
     outputs:
       version: ${{ steps.extract.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,17 +94,17 @@ jobs:
           echo "Version: $VERSION, Branch: $BRANCH_NAME"
 
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
         with:
           go-version-file: deploy/operator/go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ on:
         default: true
 
 # Note: workflow_dispatch can only be triggered from release/* branches (or main when nightly=true)
-# This is enforced in the prepare-release job via branch validation
+# This is enforced in the prepare-release / parse-release-bump jobs via branch validation
 
 permissions:
   contents: write
@@ -61,25 +61,27 @@ env:
 jobs:
   # ============================================================================
   # VERSION BUMP (Phase 1): Bump all version references on the release branch.
-  # Only runs on workflow_dispatch with action=version-bump.
-  # Opens a PR to the release/* branch instead of pushing directly, so the
-  # mechanical changes get a human review before they land.
+  # Delegates to _version-bump-shared.yml. A tiny parse job extracts the
+  # release branch's version + backend metadata and composes the PR body.
   # ============================================================================
-  version-bump:
-    name: Version Bump (Release Branch Prep)
+  parse-release-bump:
+    name: Parse release-branch metadata
     if: inputs.action == 'version-bump'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    environment: automated-release
-    permissions:
-      contents: write
-      pull-requests: write
     env:
       YQ_VERSION: '4.52.2'
-      CONTROLLER_GEN_VERSION: 'v0.16.5'
-      HELM_DOCS_VERSION: '1.14.2'
+    outputs:
+      version:        ${{ steps.ctx.outputs.version }}
+      pr_branch:      ${{ steps.ctx.outputs.pr_branch }}
+      pr_title:       ${{ steps.body.outputs.pr_title }}
+      pr_body:        ${{ steps.body.outputs.pr_body }}
+      vllm_version:   ${{ steps.metadata.outputs.vllm_version }}
+      sglang_version: ${{ steps.metadata.outputs.sglang_version }}
+      trtllm_version: ${{ steps.metadata.outputs.trtllm_version }}
+      nixl_version:   ${{ steps.metadata.outputs.nixl_version }}
+      release_date:   ${{ steps.metadata.outputs.release_date }}
     steps:
-      - name: Validate branch
+      - name: Validate branch and derive version
         id: ctx
         run: |
           set -euo pipefail
@@ -89,40 +91,23 @@ jobs:
             exit 1
           fi
           VERSION="${BRANCH_NAME#release/}"
-          # Slug for git branch names: drop '.' in .postN → -post (PR branches can't have dots in sloppy places).
           SLUG="${VERSION//./-}"
+          PR_BRANCH="chore/bump-version-${SLUG}-on-${BRANCH_NAME##*/}"
           {
             echo "version=$VERSION"
-            echo "branch=$BRANCH_NAME"
-            echo "slug=$SLUG"
+            echo "pr_branch=$PR_BRANCH"
           } >> "$GITHUB_OUTPUT"
-          echo "Version: $VERSION, Branch: $BRANCH_NAME"
+          echo "Version: $VERSION, PR branch: $PR_BRANCH"
 
       - name: Checkout release branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
-        with:
-          fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
-        with:
-          python-version: '3.12'
-
-      - name: Set up Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
-        with:
-          go-version-file: deploy/operator/go.mod
-
-      - name: Install tools (yq, controller-gen, helm-docs; all pinned)
+      - name: Install yq
         run: |
           set -euo pipefail
           sudo wget -qO /usr/local/bin/yq \
             "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
           sudo chmod +x /usr/local/bin/yq
-          go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}
-          curl -sSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
-            | tar -xzf - helm-docs
-          sudo mv helm-docs /usr/local/bin/
 
       - name: Extract backend metadata from context.yaml
         id: metadata
@@ -145,148 +130,72 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Backend: vLLM=$VLLM_VER SGLang=$SGLANG_VER TRT-LLM=$TRTLLM_VER NIXL=$NIXL_VER  Released=$RELEASE_DATE"
 
-      - name: Create version-bump branch
-        id: branch
+      - name: Compose PR title and body
+        id: body
         env:
-          SLUG: ${{ steps.ctx.outputs.slug }}
-          BASE: ${{ steps.ctx.outputs.branch }}
-        run: |
-          set -euo pipefail
-          BRANCH="chore/bump-version-${SLUG}-on-${BASE##*/}"
-          git checkout -b "$BRANCH"
-          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
-
-      - name: Build skip flags
-        id: flags
-        env:
-          UPDATE_CORE: ${{ inputs.update_core }}
+          VERSION:           ${{ steps.ctx.outputs.version }}
+          BASE:              ${{ github.ref_name }}
+          VLLM:              ${{ steps.metadata.outputs.vllm_version }}
+          SGLANG:            ${{ steps.metadata.outputs.sglang_version }}
+          TRTLLM:            ${{ steps.metadata.outputs.trtllm_version }}
+          NIXL:              ${{ steps.metadata.outputs.nixl_version }}
+          UPDATE_CORE:       ${{ inputs.update_core }}
           UPDATE_CONTAINERS: ${{ inputs.update_containers }}
-          UPDATE_HELM: ${{ inputs.update_helm }}
-          UPDATE_DOCS: ${{ inputs.update_docs }}
+          UPDATE_HELM:       ${{ inputs.update_helm }}
+          UPDATE_DOCS:       ${{ inputs.update_docs }}
         run: |
           set -euo pipefail
-          SKIP_FLAGS=""
-          [ "$UPDATE_CORE" = "false" ]       && SKIP_FLAGS="$SKIP_FLAGS --skip-core" || true
-          [ "$UPDATE_CONTAINERS" = "false" ] && SKIP_FLAGS="$SKIP_FLAGS --skip-containers" || true
-          [ "$UPDATE_HELM" = "false" ]       && SKIP_FLAGS="$SKIP_FLAGS --skip-helm" || true
-          [ "$UPDATE_DOCS" = "false" ]       && SKIP_FLAGS="$SKIP_FLAGS --skip-docs" || true
-          echo "skip_flags=$SKIP_FLAGS" >> "$GITHUB_OUTPUT"
-          echo "Skip flags: ${SKIP_FLAGS:-none (full update)}"
+          SCOPE_FLAGS=""
+          if [ "$UPDATE_CORE"       = "false" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-core"; fi
+          if [ "$UPDATE_CONTAINERS" = "false" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-containers"; fi
+          if [ "$UPDATE_HELM"       = "false" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-helm"; fi
+          if [ "$UPDATE_DOCS"       = "false" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-docs"; fi
+          {
+            echo "pr_title=chore: bump version references to ${VERSION}"
+            echo "pr_body<<EOF_BODY"
+            echo "## Summary"
+            echo ""
+            echo "Automated Phase 1 version bump for release \`v${VERSION}\`."
+            echo "Targets the release branch \`${BASE}\` -- merge here kicks off the RC publish flow."
+            echo ""
+            echo "**Backend versions** (from \`container/context.yaml\`):"
+            echo "- vLLM: \`${VLLM}\`"
+            echo "- SGLang: \`${SGLANG}\`"
+            echo "- TRT-LLM: \`${TRTLLM}\`"
+            echo "- NIXL: \`${NIXL}\`"
+            echo ""
+            echo "**Scope flags:** \`${SCOPE_FLAGS:-all scopes}\`"
+            echo ""
+            echo "See the workflow run summary for the per-file / per-rule change table."
+            echo "EOF_BODY"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Run version bump script
-        env:
-          VERSION: ${{ steps.ctx.outputs.version }}
-          VLLM: ${{ steps.metadata.outputs.vllm_version }}
-          SGLANG: ${{ steps.metadata.outputs.sglang_version }}
-          TRTLLM: ${{ steps.metadata.outputs.trtllm_version }}
-          NIXL: ${{ steps.metadata.outputs.nixl_version }}
-          RELEASE_DATE: ${{ steps.metadata.outputs.release_date }}
-          FLAGS: ${{ steps.flags.outputs.skip_flags }}
-        run: |
-          set -euo pipefail
-          python3 .github/scripts/bump_version.py \
-            --new-version "$VERSION" \
-            --vllm-version "$VLLM" \
-            --sglang-version "$SGLANG" \
-            --trtllm-version "$TRTLLM" \
-            --nixl-version "$NIXL" \
-            --release-date "$RELEASE_DATE" \
-            --summary-file "$GITHUB_STEP_SUMMARY" \
-            $FLAGS
-
-      - name: Set up Rust
-        if: inputs.update_core != false
-        run: rustup show active-toolchain
-
-      - name: Regenerate Cargo.lock
-        if: inputs.update_core != false
-        run: cargo update --workspace
-
-      - name: Regenerate CRDs
-        # CRDs are generated from Go types under deploy/operator/, so they belong
-        # to the core/operator scope, not container image tags. Gate on
-        # update_core to keep the manifests in sync with operator code changes
-        # even when --skip-containers is set. Mirrors the gating in
-        # release-version-bump.yml.
-        if: inputs.update_core != false
-        working-directory: deploy/operator
-        run: |
-          set -euo pipefail
-          make generate
-          make manifests
-
-      - name: Regenerate Helm docs
-        if: inputs.update_helm != false
-        working-directory: deploy/helm/charts/platform
-        run: helm-docs
-
-      - name: Commit
-        id: commit
-        env:
-          VERSION: ${{ steps.ctx.outputs.version }}
-          FLAGS: ${{ steps.flags.outputs.skip_flags }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          if git diff --cached --quiet; then
-            echo "::notice::No changes produced — nothing to commit."
-            echo "no_changes=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          printf -v MSG '%s\n' \
-            "Automated release branch prep for v${VERSION}." \
-            "" \
-            "Scope flags: ${FLAGS:-all scopes}"
-          git commit -s -m "chore: bump version references to ${VERSION}" -m "$MSG"
-
-      - name: Push branch
-        if: steps.commit.outputs.no_changes != 'true'
-        env:
-          BRANCH: ${{ steps.branch.outputs.name }}
-        run: |
-          set -euo pipefail
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            git push origin --delete "$BRANCH"
-          fi
-          git push -u origin "$BRANCH"
-
-      - name: Open PR into release branch
-        if: steps.commit.outputs.no_changes != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.ctx.outputs.version }}
-          BASE: ${{ steps.ctx.outputs.branch }}
-          BRANCH: ${{ steps.branch.outputs.name }}
-          FLAGS: ${{ steps.flags.outputs.skip_flags }}
-          VLLM: ${{ steps.metadata.outputs.vllm_version }}
-          SGLANG: ${{ steps.metadata.outputs.sglang_version }}
-          TRTLLM: ${{ steps.metadata.outputs.trtllm_version }}
-          NIXL: ${{ steps.metadata.outputs.nixl_version }}
-        run: |
-          set -euo pipefail
-          printf -v BODY '%s\n' \
-            "## Summary" \
-            "" \
-            "Automated Phase 1 version bump for release \`v${VERSION}\`." \
-            "Targets the release branch \`${BASE}\` — merge here kicks off the RC publish flow." \
-            "" \
-            "**Backend versions** (from \`container/context.yaml\`):" \
-            "- vLLM: \`${VLLM}\`" \
-            "- SGLang: \`${SGLANG}\`" \
-            "- TRT-LLM: \`${TRTLLM}\`" \
-            "- NIXL: \`${NIXL}\`" \
-            "" \
-            "**Scope flags:** \`${FLAGS:-all scopes}\`" \
-            "" \
-            "See the workflow run summary for the per-file / per-rule change table."
-          gh pr create \
-            --base "$BASE" \
-            --head "$BRANCH" \
-            --title "chore: bump version references to ${VERSION}" \
-            --body "$BODY" \
-            --label release --label chore
+  version-bump:
+    name: Version Bump (Release Branch Prep)
+    if: inputs.action == 'version-bump'
+    needs: [parse-release-bump]
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/_version-bump-shared.yml
+    with:
+      version:         ${{ needs.parse-release-bump.outputs.version }}
+      ref:             ${{ github.ref }}
+      pr_base:         ${{ github.ref_name }}
+      pr_branch:       ${{ needs.parse-release-bump.outputs.pr_branch }}
+      pr_title:        ${{ needs.parse-release-bump.outputs.pr_title }}
+      pr_body:         ${{ needs.parse-release-bump.outputs.pr_body }}
+      vllm_version:    ${{ needs.parse-release-bump.outputs.vllm_version }}
+      sglang_version:  ${{ needs.parse-release-bump.outputs.sglang_version }}
+      trtllm_version:  ${{ needs.parse-release-bump.outputs.trtllm_version }}
+      nixl_version:    ${{ needs.parse-release-bump.outputs.nixl_version }}
+      release_date:    ${{ needs.parse-release-bump.outputs.release_date }}
+      skip_core:       ${{ !inputs.update_core }}
+      skip_containers: ${{ !inputs.update_containers }}
+      skip_helm:       ${{ !inputs.update_helm }}
+      skip_docs:       ${{ !inputs.update_docs }}
+    secrets:
+      github_token: ${{ secrets.GITHUB_TOKEN }}
 
   # ============================================================================
   # GATE: Version Extraction
@@ -307,12 +216,20 @@ jobs:
           COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
           BRANCH_NAME: ${{ github.ref_name }}
           NIGHTLY: ${{ github.event.inputs.nightly }}
+          ACTION: ${{ inputs.action }}
         run: |
           set -euo pipefail
 
-          if ! [[ "${COMMIT_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Error: commit_sha must be a full 40-character hex SHA (got: '${COMMIT_SHA}')"
-            exit 1
+          # FIX 10: commit_sha is only required for release-publish. When the
+          # workflow is dispatched with action=version-bump the parse-release-bump
+          # job handles validation; this gate should not reject an empty SHA.
+          if [ "$ACTION" = "release-publish" ]; then
+            if ! [[ "${COMMIT_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Error: commit_sha must be a full 40-character hex SHA for action=release-publish (got: '${COMMIT_SHA}')"
+              exit 1
+            fi
+          else
+            echo "Skipping commit_sha validation (action=${ACTION})."
           fi
 
           if [[ "${NIGHTLY}" == "true" ]]; then
@@ -680,4 +597,3 @@ jobs:
             echo "Helm chart:" >> $GITHUB_STEP_SUMMARY
             echo "- \`dynamo-platform:${HELM_CHART_VERSION}\` (pushed to NGC Helm registry)" >> $GITHUB_STEP_SUMMARY
           fi
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,16 @@ name: Release Pipeline
 on:
   workflow_dispatch:
     inputs:
-      commit_sha:
-        description: 'Git commit SHA whose post-merge CI images to publish (full 40-char SHA).'
+      action:
+        description: 'Action to perform: release-publish (default) runs RC tag + NGC publish; version-bump runs the version bump script only.'
         required: true
-        type: string
-      rc_number:
-        description: 'RC number (e.g., 0 for rc0). Leave empty to auto-increment.'
+        type: choice
+        options:
+          - release-publish
+          - version-bump
+        default: release-publish
+      commit_sha:
+        description: 'Git commit SHA whose post-merge CI images to publish (full 40-char SHA). Only used with release-publish action.'
         required: false
         type: string
       nightly:
@@ -19,6 +23,31 @@ on:
         required: false
         type: boolean
         default: false
+      rc_number:
+        description: 'RC number (e.g., 0 for rc0). Leave empty to auto-increment. Only used with release-publish action.'
+        required: false
+        type: string
+      # Component scope controls for version-bump action (post-releases)
+      update_core:
+        description: 'Update core version files (pyproject.toml, Cargo.toml, setup.py). Only used with version-bump action.'
+        required: false
+        type: boolean
+        default: true
+      update_containers:
+        description: 'Update container image tags across docs, recipes, examples. Only used with version-bump action.'
+        required: false
+        type: boolean
+        default: true
+      update_helm:
+        description: 'Update Helm Chart.yaml versions. Only used with version-bump action.'
+        required: false
+        type: boolean
+        default: true
+      update_docs:
+        description: 'Update reference docs (support-matrix, feature-matrix, release-artifacts). Only used with version-bump action.'
+        required: false
+        type: boolean
+        default: true
 
 # Note: workflow_dispatch can only be triggered from release/* branches (or main when nightly=true)
 # This is enforced in the prepare-release job via branch validation
@@ -31,11 +60,176 @@ env:
 
 jobs:
   # ============================================================================
+  # VERSION BUMP (Phase 1): Bump all version references on the release branch
+  # Only runs on workflow_dispatch with action=version-bump.
+  # Uses automated-release environment to bypass branch protection.
+  # ============================================================================
+  version-bump:
+    name: Version Bump (Release Branch Prep)
+    if: inputs.action == 'version-bump'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: automated-release
+    steps:
+      - name: Validate branch
+        run: |
+          set -euo pipefail
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          if [[ ! "$BRANCH_NAME" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?$ ]]; then
+            echo "::error::version-bump can only run on release/* branches (current: $BRANCH_NAME)"
+            exit 1
+          fi
+          VERSION="${BRANCH_NAME#release/}"
+          echo "version=$VERSION" >> $GITHUB_ENV
+          echo "branch=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "Version: $VERSION, Branch: $BRANCH_NAME"
+
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: deploy/operator/go.mod
+
+      - name: Install tools (yq, controller-gen, helm-docs)
+        run: |
+          set -euo pipefail
+          # yq
+          YQ_VERSION="4.52.2"
+          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+
+          # controller-gen
+          cd deploy/operator && make controller-gen && cd ../..
+
+          # helm-docs
+          HELM_DOCS_VERSION="1.14.2"
+          curl -sSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
+            | tar -xzf - helm-docs
+          sudo mv helm-docs /usr/local/bin/
+
+      - name: Extract backend metadata from context.yaml
+        id: metadata
+        run: |
+          set -euo pipefail
+          CTX="container/context.yaml"
+
+          VLLM_VER=$(yq '.vllm.vllm_ref' "$CTX" | sed 's/^v//')
+          echo "vllm_version=$VLLM_VER" >> $GITHUB_OUTPUT
+
+          SGLANG_TAG=$(yq '.sglang."cuda12.9".runtime_image_tag // .sglang.runtime_image_tag // ""' "$CTX")
+          SGLANG_VER=$(echo "$SGLANG_TAG" | sed 's/^v//; s/-cu[0-9]*-runtime$//; s/-runtime$//')
+          echo "sglang_version=$SGLANG_VER" >> $GITHUB_OUTPUT
+
+          TRTLLM_WHEEL=$(yq '.trtllm.pip_wheel' "$CTX")
+          TRTLLM_VER=$(echo "$TRTLLM_WHEEL" | sed 's/.*==//')
+          echo "trtllm_version=$TRTLLM_VER" >> $GITHUB_OUTPUT
+
+          NIXL_VER=$(yq '.dynamo.nixl_ref' "$CTX")
+          echo "nixl_version=$NIXL_VER" >> $GITHUB_OUTPUT
+
+          CUDA_VLLM=$(yq '[.vllm | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
+          echo "cuda_versions_vllm=$CUDA_VLLM" >> $GITHUB_OUTPUT
+
+          CUDA_SGLANG=$(yq '[.sglang | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
+          echo "cuda_versions_sglang=$CUDA_SGLANG" >> $GITHUB_OUTPUT
+
+          TRTLLM_RUNTIME_TAG=$(yq '.trtllm.runtime_image_tag' "$CTX")
+          CUDA_TRTLLM=$(echo "$TRTLLM_RUNTIME_TAG" | grep -oP 'cuda\K[\d.]+')
+          echo "cuda_versions_trtllm=$CUDA_TRTLLM" >> $GITHUB_OUTPUT
+
+          RELEASE_DATE=$(date "+%b %d, %Y")
+          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
+
+          echo "=== Backend Metadata ==="
+          echo "  vLLM: $VLLM_VER | SGLang: $SGLANG_VER | TRT-LLM: $TRTLLM_VER | NIXL: $NIXL_VER"
+
+      - name: Build skip flags
+        id: flags
+        env:
+          UPDATE_CORE: ${{ inputs.update_core }}
+          UPDATE_CONTAINERS: ${{ inputs.update_containers }}
+          UPDATE_HELM: ${{ inputs.update_helm }}
+          UPDATE_DOCS: ${{ inputs.update_docs }}
+        run: |
+          set -euo pipefail
+          SKIP_FLAGS=""
+          if [ "$UPDATE_CORE" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-core"; fi
+          if [ "$UPDATE_CONTAINERS" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-containers"; fi
+          if [ "$UPDATE_HELM" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-helm"; fi
+          if [ "$UPDATE_DOCS" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-docs"; fi
+          echo "skip_flags=$SKIP_FLAGS" >> $GITHUB_OUTPUT
+          echo "Skip flags: ${SKIP_FLAGS:-none (full update)}"
+
+      - name: Run version bump script
+        env:
+          BUMP_SKIP_FLAGS: ${{ steps.flags.outputs.skip_flags }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/bump_version.py \
+            --new-version "${{ env.version }}" \
+            --vllm-version "${{ steps.metadata.outputs.vllm_version }}" \
+            --sglang-version "${{ steps.metadata.outputs.sglang_version }}" \
+            --trtllm-version "${{ steps.metadata.outputs.trtllm_version }}" \
+            --nixl-version "${{ steps.metadata.outputs.nixl_version }}" \
+            --cuda-versions-vllm "${{ steps.metadata.outputs.cuda_versions_vllm }}" \
+            --cuda-versions-sglang "${{ steps.metadata.outputs.cuda_versions_sglang }}" \
+            --cuda-versions-trtllm "${{ steps.metadata.outputs.cuda_versions_trtllm }}" \
+            --release-date "${{ steps.metadata.outputs.release_date }}" \
+            $BUMP_SKIP_FLAGS
+
+      - name: Set up Rust
+        run: |
+          set -euo pipefail
+          rustup show active-toolchain
+
+      - name: Regenerate Cargo.lock
+        run: |
+          set -euo pipefail
+          cargo update --workspace
+
+      - name: Regenerate CRDs
+        working-directory: deploy/operator
+        run: |
+          set -euo pipefail
+          make generate
+          make manifests
+
+      - name: Regenerate Helm docs
+        working-directory: deploy/helm/charts/platform
+        run: |
+          set -euo pipefail
+          helm-docs
+
+      - name: Commit and push
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -s -m "chore: bump version references to ${{ env.version }}"
+            git push
+            echo "Version bump committed to ${{ env.branch }}"
+          fi
+
+  # ============================================================================
   # GATE: Version Extraction
   # ============================================================================
 
   prepare-release:
     name: Prepare Release
+    if: inputs.action != 'version-bump'
     runs-on: prod-default-small-v2
     outputs:
       version: ${{ steps.extract.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,6 @@ on:
         required: false
         type: boolean
         default: true
-      update_docs:
-        description: 'Update reference docs (support-matrix, feature-matrix, release-artifacts). Only used with version-bump action.'
-        required: false
-        type: boolean
-        default: true
 
 # Note: workflow_dispatch can only be triggered from release/* branches (or main when nightly=true)
 # This is enforced in the prepare-release / parse-release-bump jobs via branch validation
@@ -142,14 +137,12 @@ jobs:
           UPDATE_CORE:       ${{ inputs.update_core }}
           UPDATE_CONTAINERS: ${{ inputs.update_containers }}
           UPDATE_HELM:       ${{ inputs.update_helm }}
-          UPDATE_DOCS:       ${{ inputs.update_docs }}
         run: |
           set -euo pipefail
           SCOPE_FLAGS=""
           if [ "$UPDATE_CORE"       = "false" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-core"; fi
           if [ "$UPDATE_CONTAINERS" = "false" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-containers"; fi
           if [ "$UPDATE_HELM"       = "false" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-helm"; fi
-          if [ "$UPDATE_DOCS"       = "false" ]; then SCOPE_FLAGS="$SCOPE_FLAGS --skip-docs"; fi
           {
             echo "pr_title=chore: bump version references to ${VERSION}"
             echo "pr_body<<EOF_BODY"
@@ -193,9 +186,9 @@ jobs:
       skip_core:       ${{ !inputs.update_core }}
       skip_containers: ${{ !inputs.update_containers }}
       skip_helm:       ${{ !inputs.update_helm }}
-      skip_docs:       ${{ !inputs.update_docs }}
     secrets:
       github_token: ${{ secrets.GITHUB_TOKEN }}
+      devin_api_key: ${{ secrets.DEVIN_API_KEY }}
 
   # ============================================================================
   # GATE: Version Extraction

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,12 @@ jobs:
         run: cargo update --workspace
 
       - name: Regenerate CRDs
-        if: inputs.update_containers != false
+        # CRDs are generated from Go types under deploy/operator/, so they belong
+        # to the core/operator scope, not container image tags. Gate on
+        # update_core to keep the manifests in sync with operator code changes
+        # even when --skip-containers is set. Mirrors the gating in
+        # release-version-bump.yml.
+        if: inputs.update_core != false
         working-directory: deploy/operator
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,17 +99,17 @@ jobs:
           echo "Version: $VERSION, Branch: $BRANCH_NAME"
 
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
         with:
           go-version-file: deploy/operator/go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,10 @@ env:
 
 jobs:
   # ============================================================================
-  # VERSION BUMP (Phase 1): Bump all version references on the release branch
+  # VERSION BUMP (Phase 1): Bump all version references on the release branch.
   # Only runs on workflow_dispatch with action=version-bump.
-  # Uses automated-release environment to bypass branch protection.
+  # Opens a PR to the release/* branch instead of pushing directly, so the
+  # mechanical changes get a human review before they land.
   # ============================================================================
   version-bump:
     name: Version Bump (Release Branch Prep)
@@ -70,8 +71,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: automated-release
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      YQ_VERSION: '4.52.2'
+      CONTROLLER_GEN_VERSION: 'v0.16.5'
+      HELM_DOCS_VERSION: '1.14.2'
     steps:
       - name: Validate branch
+        id: ctx
         run: |
           set -euo pipefail
           BRANCH_NAME="${GITHUB_REF#refs/heads/}"
@@ -80,8 +89,13 @@ jobs:
             exit 1
           fi
           VERSION="${BRANCH_NAME#release/}"
-          echo "version=$VERSION" >> $GITHUB_ENV
-          echo "branch=$BRANCH_NAME" >> $GITHUB_ENV
+          # Slug for git branch names: drop '.' in .postN → -post (PR branches can't have dots in sloppy places).
+          SLUG="${VERSION//./-}"
+          {
+            echo "version=$VERSION"
+            echo "branch=$BRANCH_NAME"
+            echo "slug=$SLUG"
+          } >> "$GITHUB_OUTPUT"
           echo "Version: $VERSION, Branch: $BRANCH_NAME"
 
       - name: Checkout release branch
@@ -99,19 +113,13 @@ jobs:
         with:
           go-version-file: deploy/operator/go.mod
 
-      - name: Install tools (yq, controller-gen, helm-docs)
+      - name: Install tools (yq, controller-gen, helm-docs; all pinned)
         run: |
           set -euo pipefail
-          # yq
-          YQ_VERSION="4.52.2"
-          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+          sudo wget -qO /usr/local/bin/yq \
+            "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
           sudo chmod +x /usr/local/bin/yq
-
-          # controller-gen
-          cd deploy/operator && make controller-gen && cd ../..
-
-          # helm-docs
-          HELM_DOCS_VERSION="1.14.2"
+          go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}
           curl -sSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
             | tar -xzf - helm-docs
           sudo mv helm-docs /usr/local/bin/
@@ -121,36 +129,32 @@ jobs:
         run: |
           set -euo pipefail
           CTX="container/context.yaml"
-
           VLLM_VER=$(yq '.vllm.vllm_ref' "$CTX" | sed 's/^v//')
-          echo "vllm_version=$VLLM_VER" >> $GITHUB_OUTPUT
-
           SGLANG_TAG=$(yq '.sglang."cuda12.9".runtime_image_tag // .sglang.runtime_image_tag // ""' "$CTX")
           SGLANG_VER=$(echo "$SGLANG_TAG" | sed 's/^v//; s/-cu[0-9]*-runtime$//; s/-runtime$//')
-          echo "sglang_version=$SGLANG_VER" >> $GITHUB_OUTPUT
-
           TRTLLM_WHEEL=$(yq '.trtllm.pip_wheel' "$CTX")
           TRTLLM_VER=$(echo "$TRTLLM_WHEEL" | sed 's/.*==//')
-          echo "trtllm_version=$TRTLLM_VER" >> $GITHUB_OUTPUT
-
           NIXL_VER=$(yq '.dynamo.nixl_ref' "$CTX")
-          echo "nixl_version=$NIXL_VER" >> $GITHUB_OUTPUT
-
-          CUDA_VLLM=$(yq '[.vllm | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
-          echo "cuda_versions_vllm=$CUDA_VLLM" >> $GITHUB_OUTPUT
-
-          CUDA_SGLANG=$(yq '[.sglang | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
-          echo "cuda_versions_sglang=$CUDA_SGLANG" >> $GITHUB_OUTPUT
-
-          TRTLLM_RUNTIME_TAG=$(yq '.trtllm.runtime_image_tag' "$CTX")
-          CUDA_TRTLLM=$(echo "$TRTLLM_RUNTIME_TAG" | grep -oP 'cuda\K[\d.]+')
-          echo "cuda_versions_trtllm=$CUDA_TRTLLM" >> $GITHUB_OUTPUT
-
           RELEASE_DATE=$(date "+%b %d, %Y")
-          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
+          {
+            echo "vllm_version=$VLLM_VER"
+            echo "sglang_version=$SGLANG_VER"
+            echo "trtllm_version=$TRTLLM_VER"
+            echo "nixl_version=$NIXL_VER"
+            echo "release_date=$RELEASE_DATE"
+          } >> "$GITHUB_OUTPUT"
+          echo "Backend: vLLM=$VLLM_VER SGLang=$SGLANG_VER TRT-LLM=$TRTLLM_VER NIXL=$NIXL_VER  Released=$RELEASE_DATE"
 
-          echo "=== Backend Metadata ==="
-          echo "  vLLM: $VLLM_VER | SGLang: $SGLANG_VER | TRT-LLM: $TRTLLM_VER | NIXL: $NIXL_VER"
+      - name: Create version-bump branch
+        id: branch
+        env:
+          SLUG: ${{ steps.ctx.outputs.slug }}
+          BASE: ${{ steps.ctx.outputs.branch }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/bump-version-${SLUG}-on-${BASE##*/}"
+          git checkout -b "$BRANCH"
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Build skip flags
         id: flags
@@ -162,41 +166,44 @@ jobs:
         run: |
           set -euo pipefail
           SKIP_FLAGS=""
-          if [ "$UPDATE_CORE" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-core"; fi
-          if [ "$UPDATE_CONTAINERS" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-containers"; fi
-          if [ "$UPDATE_HELM" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-helm"; fi
-          if [ "$UPDATE_DOCS" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-docs"; fi
-          echo "skip_flags=$SKIP_FLAGS" >> $GITHUB_OUTPUT
+          [ "$UPDATE_CORE" = "false" ]       && SKIP_FLAGS="$SKIP_FLAGS --skip-core" || true
+          [ "$UPDATE_CONTAINERS" = "false" ] && SKIP_FLAGS="$SKIP_FLAGS --skip-containers" || true
+          [ "$UPDATE_HELM" = "false" ]       && SKIP_FLAGS="$SKIP_FLAGS --skip-helm" || true
+          [ "$UPDATE_DOCS" = "false" ]       && SKIP_FLAGS="$SKIP_FLAGS --skip-docs" || true
+          echo "skip_flags=$SKIP_FLAGS" >> "$GITHUB_OUTPUT"
           echo "Skip flags: ${SKIP_FLAGS:-none (full update)}"
 
       - name: Run version bump script
         env:
-          BUMP_SKIP_FLAGS: ${{ steps.flags.outputs.skip_flags }}
+          VERSION: ${{ steps.ctx.outputs.version }}
+          VLLM: ${{ steps.metadata.outputs.vllm_version }}
+          SGLANG: ${{ steps.metadata.outputs.sglang_version }}
+          TRTLLM: ${{ steps.metadata.outputs.trtllm_version }}
+          NIXL: ${{ steps.metadata.outputs.nixl_version }}
+          RELEASE_DATE: ${{ steps.metadata.outputs.release_date }}
+          FLAGS: ${{ steps.flags.outputs.skip_flags }}
         run: |
           set -euo pipefail
           python3 .github/scripts/bump_version.py \
-            --new-version "${{ env.version }}" \
-            --vllm-version "${{ steps.metadata.outputs.vllm_version }}" \
-            --sglang-version "${{ steps.metadata.outputs.sglang_version }}" \
-            --trtllm-version "${{ steps.metadata.outputs.trtllm_version }}" \
-            --nixl-version "${{ steps.metadata.outputs.nixl_version }}" \
-            --cuda-versions-vllm "${{ steps.metadata.outputs.cuda_versions_vllm }}" \
-            --cuda-versions-sglang "${{ steps.metadata.outputs.cuda_versions_sglang }}" \
-            --cuda-versions-trtllm "${{ steps.metadata.outputs.cuda_versions_trtllm }}" \
-            --release-date "${{ steps.metadata.outputs.release_date }}" \
-            $BUMP_SKIP_FLAGS
+            --new-version "$VERSION" \
+            --vllm-version "$VLLM" \
+            --sglang-version "$SGLANG" \
+            --trtllm-version "$TRTLLM" \
+            --nixl-version "$NIXL" \
+            --release-date "$RELEASE_DATE" \
+            --summary-file "$GITHUB_STEP_SUMMARY" \
+            $FLAGS
 
       - name: Set up Rust
-        run: |
-          set -euo pipefail
-          rustup show active-toolchain
+        if: inputs.update_core != false
+        run: rustup show active-toolchain
 
       - name: Regenerate Cargo.lock
-        run: |
-          set -euo pipefail
-          cargo update --workspace
+        if: inputs.update_core != false
+        run: cargo update --workspace
 
       - name: Regenerate CRDs
+        if: inputs.update_containers != false
         working-directory: deploy/operator
         run: |
           set -euo pipefail
@@ -204,24 +211,77 @@ jobs:
           make manifests
 
       - name: Regenerate Helm docs
+        if: inputs.update_helm != false
         working-directory: deploy/helm/charts/platform
-        run: |
-          set -euo pipefail
-          helm-docs
+        run: helm-docs
 
-      - name: Commit and push
+      - name: Commit
+        id: commit
+        env:
+          VERSION: ${{ steps.ctx.outputs.version }}
+          FLAGS: ${{ steps.flags.outputs.skip_flags }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           if git diff --cached --quiet; then
-            echo "No changes to commit."
-          else
-            git commit -s -m "chore: bump version references to ${{ env.version }}"
-            git push
-            echo "Version bump committed to ${{ env.branch }}"
+            echo "::notice::No changes produced — nothing to commit."
+            echo "no_changes=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          printf -v MSG '%s\n' \
+            "Automated release branch prep for v${VERSION}." \
+            "" \
+            "Scope flags: ${FLAGS:-all scopes}"
+          git commit -s -m "chore: bump version references to ${VERSION}" -m "$MSG"
+
+      - name: Push branch
+        if: steps.commit.outputs.no_changes != 'true'
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git push origin --delete "$BRANCH"
+          fi
+          git push -u origin "$BRANCH"
+
+      - name: Open PR into release branch
+        if: steps.commit.outputs.no_changes != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.ctx.outputs.version }}
+          BASE: ${{ steps.ctx.outputs.branch }}
+          BRANCH: ${{ steps.branch.outputs.name }}
+          FLAGS: ${{ steps.flags.outputs.skip_flags }}
+          VLLM: ${{ steps.metadata.outputs.vllm_version }}
+          SGLANG: ${{ steps.metadata.outputs.sglang_version }}
+          TRTLLM: ${{ steps.metadata.outputs.trtllm_version }}
+          NIXL: ${{ steps.metadata.outputs.nixl_version }}
+        run: |
+          set -euo pipefail
+          printf -v BODY '%s\n' \
+            "## Summary" \
+            "" \
+            "Automated Phase 1 version bump for release \`v${VERSION}\`." \
+            "Targets the release branch \`${BASE}\` — merge here kicks off the RC publish flow." \
+            "" \
+            "**Backend versions** (from \`container/context.yaml\`):" \
+            "- vLLM: \`${VLLM}\`" \
+            "- SGLang: \`${SGLANG}\`" \
+            "- TRT-LLM: \`${TRTLLM}\`" \
+            "- NIXL: \`${NIXL}\`" \
+            "" \
+            "**Scope flags:** \`${FLAGS:-all scopes}\`" \
+            "" \
+            "See the workflow run summary for the per-file / per-rule change table."
+          gh pr create \
+            --base "$BASE" \
+            --head "$BRANCH" \
+            --title "chore: bump version references to ${VERSION}" \
+            --body "$BODY" \
+            --label release --label chore
 
   # ============================================================================
   # GATE: Version Extraction

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -22,6 +22,8 @@ mypy==1.18.2
 # For NATS object store verification in router tests
 nats-py==2.12.0
 openai==2.32.0  # for Fault Tolerance migration tests
+# Required by .github/scripts/bump_version.py for PEP 440 version parsing
+packaging>=24.0
 psutil<=7.0.0  # System package, may vary by platform (was >=5.0.0)
 # Required by pyproject.toml warning filters (pydantic.warnings.PydanticDeprecatedSince20)
 pydantic>=2.11.4,<2.13

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -6,6 +6,7 @@ title: Feature Matrix
 
 This document provides a comprehensive compatibility matrix for key Dynamo features across the supported backends.
 
+<!-- bump-version:version-stamp -->
 *Updated for Dynamo v1.0.1*
 
 **Legend:**

--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -4,6 +4,17 @@
 title: Release Artifacts
 ---
 
+<!--
+  bump-version: ignore
+  This file contains historical release rows whose versions must NOT be
+  rewritten by the broad container-image / pip-pin rules in
+  .github/scripts/bump_version.py. The bump script's specialised
+  update_release_artifacts() function reads this file directly (bypassing
+  iter_repo_files), so the marker only suppresses the broad rule sweep
+  while still allowing targeted edits to the "Current Release" section
+  and the new GitHub Releases table row.
+-->
+
 This document provides a comprehensive inventory of all Dynamo release artifacts including container images, Python wheels, Helm charts, and Rust crates.
 
 > **See also:** [Support Matrix](support-matrix.md) for hardware and platform compatibility | [Feature Matrix](feature-matrix.md) for backend feature support

--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -4,17 +4,6 @@
 title: Release Artifacts
 ---
 
-<!--
-  bump-version: ignore
-  This file contains historical release rows whose versions must NOT be
-  rewritten by the broad container-image / pip-pin rules in
-  .github/scripts/bump_version.py. The bump script's specialised
-  update_release_artifacts() function reads this file directly (bypassing
-  iter_repo_files), so the marker only suppresses the broad rule sweep
-  while still allowing targeted edits to the "Current Release" section
-  and the new GitHub Releases table row.
--->
-
 This document provides a comprehensive inventory of all Dynamo release artifacts including container images, Python wheels, Helm charts, and Rust crates.
 
 > **See also:** [Support Matrix](support-matrix.md) for hardware and platform compatibility | [Feature Matrix](feature-matrix.md) for backend feature support

--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -10,6 +10,7 @@ This document provides a comprehensive inventory of all Dynamo release artifacts
 
 Release history in this document begins at v0.6.0.
 
+<!-- bump-version:current-release -->
 ## Current Release: Dynamo v1.0.1
 
 - **GitHub Release:** [v1.0.1](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.1)
@@ -181,6 +182,7 @@ For a complete list of known issues, refer to the release notes for each version
 
 ### GitHub Releases
 
+<!-- bump-version:github-releases-table -->
 | Version | Release Date | GitHub | Docs | Notes |
 |---------|--------------|--------|------|-------|
 | `v1.1.0-dev.3` | Apr 18, 2026 | [Tag](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.0-dev.3) | — | Experimental (partial: trtllm container + ai-dynamo wheels only) |

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -5,6 +5,17 @@ title: Support Matrix
 subtitle: Hardware, software, and build compatibility for Dynamo
 ---
 
+<!--
+  bump-version: ignore
+  This file contains historical version rows whose backend pins must NOT be
+  rewritten by the broad container-image / pip-pin rules in
+  .github/scripts/bump_version.py. The bump script's specialised
+  update_support_matrix() function reads this file directly (bypassing
+  iter_repo_files), so the marker only suppresses the broad rule sweep
+  while still allowing targeted edits to the "At a Glance" line and the
+  new backend table row.
+-->
+
 **See also:** [Release Artifacts](release-artifacts.md) for container images, wheels, Helm charts, and crates | [Feature Matrix](feature-matrix.md) for backend feature support
 
 ## At a Glance

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -5,17 +5,6 @@ title: Support Matrix
 subtitle: Hardware, software, and build compatibility for Dynamo
 ---
 
-<!--
-  bump-version: ignore
-  This file contains historical version rows whose backend pins must NOT be
-  rewritten by the broad container-image / pip-pin rules in
-  .github/scripts/bump_version.py. The bump script's specialised
-  update_support_matrix() function reads this file directly (bypassing
-  iter_repo_files), so the marker only suppresses the broad rule sweep
-  while still allowing targeted edits to the "At a Glance" line and the
-  new backend table row.
--->
-
 **See also:** [Release Artifacts](release-artifacts.md) for container images, wheels, Helm charts, and crates | [Feature Matrix](feature-matrix.md) for backend feature support
 
 ## At a Glance

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -9,6 +9,7 @@ subtitle: Hardware, software, and build compatibility for Dynamo
 
 ## At a Glance
 
+<!-- bump-version:at-a-glance -->
 **Latest stable release:** [v1.0.1](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.1) -- SGLang `0.5.9` | TensorRT-LLM `1.3.0rc5.post1` | vLLM `0.16.0` | NIXL `0.10.1`
 
 **Experimental releases:**
@@ -30,6 +31,7 @@ subtitle: Hardware, software, and build compatibility for Dynamo
 
 The following table shows the backend framework versions included with each Dynamo release:
 
+<!-- bump-version:backend-dependencies-table -->
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
 | **main (ToT)** | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` |

--- a/tests/scripts/__init__.py
+++ b/tests/scripts/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/scripts/test_bump_version.py
+++ b/tests/scripts/test_bump_version.py
@@ -1,0 +1,522 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for .github/scripts/bump_version.py.
+
+Covers the engine (Version type, rule table, apply_rules) and the CLI
+entry points (--check, --dry-run, full bump, post-release minimal bump).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "bump_version.py"
+
+# Pure unit tests: no GPU, no services, run on every PR.
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+]
+
+
+@pytest.fixture(scope="module")
+def bv():
+    """Load bump_version.py as a module (it lives outside the python package tree).
+
+    Must register the module in sys.modules *before* exec so that the
+    dataclass decorator can resolve forward-referenced annotations like
+    ``int | None`` that the runtime looks up via ``sys.modules[cls.__module__]``.
+    """
+    spec = importlib.util.spec_from_file_location("bump_version", SCRIPT_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["bump_version"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        sys.modules.pop("bump_version", None)
+        raise
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Version type
+# ---------------------------------------------------------------------------
+
+
+class TestVersion:
+    def test_parse_plain(self, bv):
+        v = bv.Version.parse("1.2.3")
+        assert (v.major, v.minor, v.patch, v.post) == (1, 2, 3, None)
+        assert v.python() == "1.2.3"
+        assert v.semver() == "1.2.3"
+        assert v.dashed() == "1-2-3"
+        assert not v.is_post
+
+    def test_parse_post_dot(self, bv):
+        v = bv.Version.parse("0.9.0.post2")
+        assert v.post == 2
+        assert v.python() == "0.9.0.post2"
+        assert v.semver() == "0.9.0-post2"
+        assert v.dashed() == "0-9-0-post2"
+        assert v.is_post
+
+    def test_parse_post_dash(self, bv):
+        v = bv.Version.parse("0.9.0-post2")
+        assert v == bv.Version.parse("0.9.0.post2")
+
+    @pytest.mark.parametrize("bad", ["1.2", "1.2.3.4", "v1.2.3", "1.2.3-rc1", "abc"])
+    def test_parse_rejects_invalid(self, bv, bad):
+        with pytest.raises(Exception):
+            bv.Version.parse(bad)
+
+    def test_ordering(self, bv):
+        assert bv.Version.parse("1.0.0") < bv.Version.parse("1.0.1")
+        # post-releases sort after their base because None < int is False in tuple cmp;
+        # the @dataclass(order=True) comparison puts None before ints, which is the
+        # PEP 440 semantic inverse — assert only the stable cases we rely on.
+        assert bv.Version.parse("0.9.0") < bv.Version.parse("0.10.0")
+
+
+# ---------------------------------------------------------------------------
+# Individual rules
+# ---------------------------------------------------------------------------
+
+
+class TestRules:
+    def _rule(self, bv, name):
+        for r in bv.RULES:
+            if r.name == name:
+                return r
+        raise AssertionError(f"rule {name!r} not found")
+
+    def test_pyproject_project_version(self, bv, tmp_path):
+        path = tmp_path / "pyproject.toml"
+        path.write_text(
+            '[project]\nname = "ai-dynamo"\nversion = "0.9.0"\n',
+            encoding="utf-8",
+        )
+        rule = self._rule(bv, "pyproject_project_version")
+        out = rule.apply(path.read_text(encoding="utf-8"), bv.Version.parse("1.0.0"))
+        assert 'version = "1.0.0"' in out
+        assert "0.9.0" not in out
+
+    def test_pyproject_ai_dynamo_pin_all_extras(self, bv):
+        rule = self._rule(bv, "pyproject_ai_dynamo_pin")
+        txt = (
+            '"ai-dynamo-runtime==0.9.0",\n'
+            '"ai_dynamo_runtime==0.9.0",\n'
+            '"ai-dynamo[vllm]==0.9.0",\n'
+            '"ai-dynamo[sglang,trtllm]==0.9.0",\n'
+        )
+        out = rule.apply(txt, bv.Version.parse("1.0.0"))
+        assert "0.9.0" not in out
+        assert out.count("1.0.0") == 4
+
+    def test_cargo_uses_semver(self, bv):
+        rule = self._rule(bv, "cargo_package_version")
+        out = rule.apply(
+            '[package]\nname = "x"\nversion = "0.9.0"\n',
+            bv.Version.parse("0.9.0.post1"),
+        )
+        assert '"0.9.0-post1"' in out
+        assert "0.9.0.post1" not in out
+
+    def test_helm_chart_version(self, bv):
+        rule = self._rule(bv, "helm_chart_version")
+        out = rule.apply("apiVersion: v2\nversion: 0.9.0\n", bv.Version.parse("1.0.0"))
+        assert "version: 1.0.0" in out
+
+    def test_image_tag_ai_dynamo_ns_broad(self, bv):
+        rule = self._rule(bv, "image_tag_ai_dynamo_ns")
+        src = (
+            "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0\n"
+            "ai-dynamo/dynamo-frontend:0.9.0\n"
+            "ai-dynamo/kubernetes-operator:0.9.0.post1\n"
+        )
+        out = rule.apply(src, bv.Version.parse("1.0.0"))
+        assert out.count("1.0.0") == 3
+        assert "0.9.0" not in out
+
+    def test_image_tag_short_allowlist(self, bv):
+        rule = self._rule(bv, "image_tag_short_dynamo")
+        src = "image: vllm-runtime:0.9.0\nimage: dynamo-frontend:0.9.0\n"
+        out = rule.apply(src, bv.Version.parse("1.0.0"))
+        assert "vllm-runtime:1.0.0" in out
+        assert "dynamo-frontend:1.0.0" in out
+
+    def test_short_tag_does_not_rewrite_unrelated(self, bv):
+        rule = self._rule(bv, "image_tag_short_dynamo")
+        # "postgres:0.9.0" must NOT be rewritten
+        out = rule.apply("postgres:0.9.0\n", bv.Version.parse("1.0.0"))
+        assert "postgres:0.9.0" in out
+
+    def test_operator_dynamo_version_field(self, bv):
+        rule = self._rule(bv, "operator_dynamoVersion_field")
+        out = rule.apply('dynamoVersion: "0.9.0"\n', bv.Version.parse("1.0.0"))
+        assert 'dynamoVersion: "1.0.0"' in out
+
+    def test_git_refs(self, bv):
+        co = self._rule(bv, "git_checkout_release_branch")
+        url = self._rule(bv, "git_url_release_ref")
+        out = co.apply("git checkout release/0.9.0\n", bv.Version.parse("1.0.0"))
+        assert "release/1.0.0" in out
+        out2 = url.apply(
+            "pip install git+https://x@release/0.9.0\n", bv.Version.parse("1.0.0")
+        )
+        assert "release/1.0.0" in out2
+
+    def test_env_dynamo_version(self, bv):
+        rule = self._rule(bv, "env_dynamo_version")
+        out = rule.apply("DYNAMO_VERSION=0.9.0\n", bv.Version.parse("1.0.0"))
+        assert "DYNAMO_VERSION=1.0.0" in out
+
+
+# ---------------------------------------------------------------------------
+# File iteration: exclusions + opt-out marker
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestIteration:
+    def test_ignore_marker_skips_file(self, bv, tmp_path):
+        _write(
+            tmp_path / "keep_old.py",
+            '# bump-version: ignore\nVERSION = "nvcr.io/nvidia/ai-dynamo/foo:0.9.0"\n',
+        )
+        # Only the DOCS table-row rules touch this file; no ai-dynamo image rule should fire.
+        changes = bv.apply_rules(
+            tmp_path,
+            bv.Version.parse("1.0.0"),
+            active_scopes={
+                bv.Scope.CORE,
+                bv.Scope.CONTAINERS,
+                bv.Scope.HELM,
+                bv.Scope.DOCS,
+            },
+            dry_run=True,
+        )
+        assert changes == []
+        # And the file was not rewritten.
+        assert "0.9.0" in (tmp_path / "keep_old.py").read_text(encoding="utf-8")
+
+    def test_excluded_globs(self, bv, tmp_path):
+        _write(tmp_path / "foo.lock", 'tag = "nvcr.io/nvidia/ai-dynamo/x:0.9.0"\n')
+        changes = bv.apply_rules(
+            tmp_path,
+            bv.Version.parse("1.0.0"),
+            active_scopes={bv.Scope.CONTAINERS},
+            dry_run=True,
+        )
+        assert changes == []
+
+    def test_binary_files_skipped(self, bv, tmp_path):
+        (tmp_path / "blob.bin").write_bytes(
+            b"\x00\x01\x02nvcr.io/nvidia/ai-dynamo/x:0.9.0"
+        )
+        changes = bv.apply_rules(
+            tmp_path,
+            bv.Version.parse("1.0.0"),
+            active_scopes={bv.Scope.CONTAINERS},
+            dry_run=True,
+        )
+        assert changes == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end CLI scenarios
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_repo(root: Path, version: str) -> None:
+    """Seed a miniature repo with every scope represented."""
+    _write(
+        root / "pyproject.toml",
+        f'[project]\nname = "ai-dynamo"\nversion = "{version}"\n'
+        f'dependencies = ["ai-dynamo-runtime=={version}", "ai-dynamo[vllm]=={version}"]\n',
+    )
+    _write(
+        root / "lib" / "runtime" / "Cargo.toml",
+        f'[package]\nname = "dynamo-runtime"\nversion = "{version}"\n',
+    )
+    _write(
+        root / "deploy" / "helm" / "charts" / "platform" / "Chart.yaml",
+        f"apiVersion: v2\nname: dynamo-platform\nversion: {version}\n"
+        f'appVersion: "{version}"\n'
+        f"dependencies:\n- name: dynamo-operator\n  version: {version}\n",
+    )
+    _write(
+        root / "deploy" / "helm" / "charts" / "snapshot" / "values.yaml",
+        "image:\n"
+        "  repository: nvcr.io/nvidia/ai-dynamo/snapshot-agent\n"
+        f"  tag: {version}\n",
+    )
+    _write(
+        root / "docs" / "example.md",
+        f"Pull `nvcr.io/nvidia/ai-dynamo/vllm-runtime:{version}` to get started.\n"
+        f"Or: `git checkout release/{version}` then `pip install ai-dynamo=={version}`.\n",
+    )
+    _write(
+        root / "deploy" / "operator" / "samples" / "dgd.yaml",
+        f"apiVersion: nvidia.com/v1alpha1\nkind: DynamoGraphDeployment\nspec:\n"
+        f'  dynamoVersion: "{version}"\n',
+    )
+
+
+def test_dry_run_does_not_write(bv, tmp_path):
+    _make_fake_repo(tmp_path, "0.9.0")
+    rc = bv.main(
+        [
+            "--new-version",
+            "1.0.0",
+            "--repo-root",
+            str(tmp_path),
+            "--dry-run",
+            "--skip-docs",
+        ]
+    )
+    assert rc == 0
+    # pyproject still says 0.9.0 because dry_run=True.
+    assert '"0.9.0"' in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+
+
+def test_full_bump_writes_every_scope(bv, tmp_path):
+    _make_fake_repo(tmp_path, "0.9.0")
+    rc = bv.main(
+        ["--new-version", "1.0.0", "--repo-root", str(tmp_path), "--skip-docs"]
+    )
+    assert rc == 0
+    assert 'version = "1.0.0"' in (tmp_path / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+    # Cargo uses semver form; 1.0.0 has no post so it's the same.
+    assert 'version = "1.0.0"' in (tmp_path / "lib/runtime/Cargo.toml").read_text(
+        encoding="utf-8"
+    )
+    chart = (tmp_path / "deploy/helm/charts/platform/Chart.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "version: 1.0.0" in chart
+    assert 'appVersion: "1.0.0"' in chart
+    snap = (tmp_path / "deploy/helm/charts/snapshot/values.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "tag: 1.0.0" in snap
+    md = (tmp_path / "docs/example.md").read_text(encoding="utf-8")
+    assert "vllm-runtime:1.0.0" in md
+    assert "release/1.0.0" in md
+    assert "ai-dynamo==1.0.0" in md
+    dgd = (tmp_path / "deploy/operator/samples/dgd.yaml").read_text(encoding="utf-8")
+    assert 'dynamoVersion: "1.0.0"' in dgd
+    assert "0.9.0" not in (chart + snap + md + dgd)
+
+
+def test_post_release_uses_semver_in_helm_python_elsewhere(bv, tmp_path):
+    _make_fake_repo(tmp_path, "0.9.0")
+    rc = bv.main(
+        ["--new-version", "0.9.0.post1", "--repo-root", str(tmp_path), "--skip-docs"]
+    )
+    assert rc == 0
+    # Python scope: dotted post
+    assert '"0.9.0.post1"' in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    # Cargo: dashed post (semver)
+    assert '"0.9.0-post1"' in (tmp_path / "lib/runtime/Cargo.toml").read_text(
+        encoding="utf-8"
+    )
+    # Helm Chart.yaml: dashed post
+    chart = (tmp_path / "deploy/helm/charts/platform/Chart.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "version: 0.9.0-post1" in chart
+    assert 'appVersion: "0.9.0-post1"' in chart
+    # Image tag: dotted post
+    md = (tmp_path / "docs/example.md").read_text(encoding="utf-8")
+    assert "vllm-runtime:0.9.0.post1" in md
+
+
+def test_skip_flags_combine(bv, tmp_path):
+    _make_fake_repo(tmp_path, "0.9.0")
+    rc = bv.main(
+        [
+            "--new-version",
+            "1.0.0",
+            "--repo-root",
+            str(tmp_path),
+            "--skip-core",
+            "--skip-helm",
+            "--skip-docs",
+        ]
+    )
+    assert rc == 0
+    # core untouched
+    assert '"0.9.0"' in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    # helm untouched
+    assert "version: 0.9.0" in (
+        tmp_path / "deploy/helm/charts/platform/Chart.yaml"
+    ).read_text(encoding="utf-8")
+    # containers were bumped
+    assert "vllm-runtime:1.0.0" in (tmp_path / "docs/example.md").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_check_mode_stale_exits_nonzero(bv, tmp_path):
+    # repo is on 0.9.0 but we "expect" it to be on 1.0.0 already => everything is stale
+    _make_fake_repo(tmp_path, "0.9.0")
+    rc = bv.main(
+        [
+            "--check",
+            "--expected-version",
+            "1.0.0",
+            "--repo-root",
+            str(tmp_path),
+            "--skip-docs",
+        ]
+    )
+    assert rc == 1
+
+
+def test_check_mode_fresh_exits_zero(bv, tmp_path):
+    # A repo already on 1.0.0 with expected-version 1.0.0 has nothing stale.
+    _make_fake_repo(tmp_path, "1.0.0")
+    rc = bv.main(
+        [
+            "--check",
+            "--expected-version",
+            "1.0.0",
+            "--repo-root",
+            str(tmp_path),
+            "--skip-docs",
+        ]
+    )
+    assert rc == 0
+
+
+def test_check_autodetects_from_pyproject(bv, tmp_path):
+    _make_fake_repo(tmp_path, "0.9.0")
+    rc = bv.main(["--check", "--repo-root", str(tmp_path), "--skip-docs"])
+    assert rc == 0  # everything IS at 0.9.0 (the detected current version)
+
+
+def test_summary_file_is_written(bv, tmp_path):
+    _make_fake_repo(tmp_path, "0.9.0")
+    summary = tmp_path / "summary.md"
+    rc = bv.main(
+        [
+            "--new-version",
+            "1.0.0",
+            "--repo-root",
+            str(tmp_path),
+            "--dry-run",
+            "--skip-docs",
+            "--summary-file",
+            str(summary),
+        ]
+    )
+    assert rc == 0
+    body = summary.read_text(encoding="utf-8")
+    assert "Version bump" in body
+    assert "1.0.0" in body
+
+
+def test_no_change_when_old_equals_new(bv, tmp_path):
+    _make_fake_repo(tmp_path, "1.0.0")
+    rc = bv.main(
+        [
+            "--new-version",
+            "1.0.0",
+            "--repo-root",
+            str(tmp_path),
+            "--old-version",
+            "1.0.0",
+            "--skip-docs",
+        ]
+    )
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# DOCS specialised updates
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseArtifacts:
+    """The GitHub-Releases table insertion must fail loud if the doc structure changes."""
+
+    def test_unknown_table_raises(self, bv, tmp_path):
+        # docs/reference/release-artifacts.md without the expected header
+        p = tmp_path / "docs" / "reference" / "release-artifacts.md"
+        _write(p, "## Current Release: Dynamo v0.9.0\n\nNo table here.\n")
+        with pytest.raises(RuntimeError, match="GitHub Releases table"):
+            bv.update_release_artifacts(
+                tmp_path,
+                bv.Version.parse("1.0.0"),
+                "Feb 15, 2026",
+                bv.BackendVersions(),
+                dry_run=False,
+            )
+
+    def test_table_row_inserted(self, bv, tmp_path):
+        doc = (
+            "## Current Release: Dynamo v0.9.0\n\n"
+            "**GitHub Release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0)\n\n"
+            "### GitHub Releases\n\n"
+            "| Version | Date | Release | Docs |\n"
+            "|---------|------|---------|------|\n"
+            "| `v0.9.0` | Dec 01, 2025 | [Release](x) | [Docs](y) |\n"
+        )
+        p = tmp_path / "docs" / "reference" / "release-artifacts.md"
+        _write(p, doc)
+        bv.update_release_artifacts(
+            tmp_path,
+            bv.Version.parse("1.0.0"),
+            "Feb 15, 2026",
+            bv.BackendVersions(),
+            dry_run=False,
+        )
+        out = p.read_text(encoding="utf-8")
+        assert "| `v1.0.0` | Feb 15, 2026 " in out
+        assert "## Current Release: Dynamo v1.0.0" in out
+
+
+class TestSupportMatrix:
+    def test_at_a_glance_and_row(self, bv, tmp_path):
+        doc = (
+            "**Latest stable release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0) -- "
+            "SGLang `v0.5.0` | TensorRT-LLM `v1.0.0` | vLLM `v0.18.0` | NIXL `v0.10.0`\n\n"
+            "| Version | SGLang | TRT-LLM | vLLM | NIXL |\n"
+            "|---------|--------|---------|------|------|\n"
+            "| **main (ToT)** | `latest` | `latest` | `latest` | `latest` |\n"
+        )
+        p = tmp_path / "docs" / "reference" / "support-matrix.md"
+        _write(p, doc)
+        bv.update_support_matrix(
+            tmp_path,
+            bv.Version.parse("1.0.0"),
+            bv.BackendVersions(
+                vllm="0.19.0", sglang="0.5.7", trtllm="1.3.0", nixl="0.10.1"
+            ),
+            dry_run=False,
+        )
+        out = p.read_text(encoding="utf-8")
+        assert "[v1.0.0]" in out
+        assert "SGLang `0.5.7`" in out
+        assert "| **v1.0.0** | `0.5.7` | `1.3.0` | `0.19.0` | `0.10.1` |" in out
+
+
+class TestFeatureMatrix:
+    def test_updated_for_tag(self, bv, tmp_path):
+        p = tmp_path / "docs" / "reference" / "feature-matrix.md"
+        _write(p, "*Updated for Dynamo v0.9.0*\n\nsome content\n")
+        bv.update_feature_matrix(tmp_path, bv.Version.parse("1.0.0"), dry_run=False)
+        assert "*Updated for Dynamo v1.0.0*" in p.read_text(encoding="utf-8")

--- a/tests/scripts/test_bump_version.py
+++ b/tests/scripts/test_bump_version.py
@@ -8,6 +8,7 @@ entry points (--check, --dry-run, full bump, post-release minimal bump).
 
 from __future__ import annotations
 
+import argparse
 import importlib.util
 import sys
 from pathlib import Path
@@ -73,15 +74,27 @@ class TestVersion:
 
     @pytest.mark.parametrize("bad", ["1.2", "1.2.3.4", "v1.2.3", "1.2.3-rc1", "abc"])
     def test_parse_rejects_invalid(self, bv, bad):
-        with pytest.raises(Exception):
+        with pytest.raises(argparse.ArgumentTypeError):
             bv.Version.parse(bad)
 
     def test_ordering(self, bv):
+        # PEP 440 ordering: base < post-release; minor bumps order numerically.
         assert bv.Version.parse("1.0.0") < bv.Version.parse("1.0.1")
-        # post-releases sort after their base because None < int is False in tuple cmp;
-        # the @dataclass(order=True) comparison puts None before ints, which is the
-        # PEP 440 semantic inverse — assert only the stable cases we rely on.
         assert bv.Version.parse("0.9.0") < bv.Version.parse("0.10.0")
+        assert bv.Version.parse("0.9.0") < bv.Version.parse("0.9.0.post1")
+        assert bv.Version.parse("0.9.0.post1") < bv.Version.parse("0.9.0.post2")
+        assert bv.Version.parse("0.9.0.post2") > bv.Version.parse("0.9.0")
+        # Sorting a mixed list must not raise (regression guard for order=True bug).
+        versions = [
+            bv.Version.parse("0.9.0.post1"),
+            bv.Version.parse("0.9.0"),
+            bv.Version.parse("1.0.0"),
+        ]
+        assert sorted(versions) == [
+            bv.Version.parse("0.9.0"),
+            bv.Version.parse("0.9.0.post1"),
+            bv.Version.parse("1.0.0"),
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -358,13 +371,19 @@ def test_skip_flags_combine(bv, tmp_path):
         ]
     )
     assert rc == 0
-    # core untouched
-    assert '"0.9.0"' in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    # core untouched: both the [project].version line AND the ai-dynamo self-pin
+    # must remain on the old version. Asserting only the version-line would miss
+    # a regression where the broad CONTAINERS pip pin rule rewrites the pin.
+    py = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'version = "0.9.0"' in py
+    assert "ai-dynamo-runtime==0.9.0" in py
+    assert "ai-dynamo[vllm]==0.9.0" in py
+    assert "1.0.0" not in py
     # helm untouched
     assert "version: 0.9.0" in (
         tmp_path / "deploy/helm/charts/platform/Chart.yaml"
     ).read_text(encoding="utf-8")
-    # containers were bumped
+    # containers (outside pyproject.toml) were bumped
     assert "vllm-runtime:1.0.0" in (tmp_path / "docs/example.md").read_text(
         encoding="utf-8"
     )

--- a/tests/scripts/test_bump_version.py
+++ b/tests/scripts/test_bump_version.py
@@ -427,6 +427,54 @@ def test_check_autodetects_from_pyproject(bv, tmp_path):
     assert rc == 0  # everything IS at 0.9.0 (the detected current version)
 
 
+def test_check_mode_detects_stale_docs(bv, tmp_path):
+    """--check must catch staleness in the DOCS specialised functions too.
+
+    The support-matrix / release-artifacts / feature-matrix files carry the
+    bump-version: ignore marker, so apply_rules() skips them entirely. Without
+    a separate dry-run pass through the DOCS helpers, --check would miss a
+    stale "Updated for Dynamo vX.Y.Z" tag (and the support-matrix /
+    release-artifacts equivalents) — regression guard for that blind spot.
+    """
+    _make_fake_repo(tmp_path, "1.0.0")
+    # Plant a stale DOCS-only reference: feature-matrix tag still on the old
+    # version. apply_rules() can't see it (the file is ignore-marked), but the
+    # update_feature_matrix() helper can.
+    fm = tmp_path / "docs" / "reference" / "feature-matrix.md"
+    fm.parent.mkdir(parents=True, exist_ok=True)
+    fm.write_text(
+        "<!-- bump-version: ignore -->\n*Updated for Dynamo v0.9.0*\n",
+        encoding="utf-8",
+    )
+    # Sanity check: with --skip-docs the stale tag is invisible to --check.
+    assert (
+        bv.main(
+            [
+                "--check",
+                "--expected-version",
+                "1.0.0",
+                "--repo-root",
+                str(tmp_path),
+                "--skip-docs",
+            ]
+        )
+        == 0
+    )
+    # Now without --skip-docs it must be flagged.
+    assert (
+        bv.main(
+            [
+                "--check",
+                "--expected-version",
+                "1.0.0",
+                "--repo-root",
+                str(tmp_path),
+            ]
+        )
+        == 1
+    )
+
+
 def test_summary_file_is_written(bv, tmp_path):
     _make_fake_repo(tmp_path, "0.9.0")
     summary = tmp_path / "summary.md"

--- a/tests/scripts/test_bump_version.py
+++ b/tests/scripts/test_bump_version.py
@@ -38,11 +38,13 @@ def bv():
     assert spec and spec.loader
     mod = importlib.util.module_from_spec(spec)
     sys.modules["bump_version"] = mod
+    loaded = False
     try:
         spec.loader.exec_module(mod)
-    except Exception:
-        sys.modules.pop("bump_version", None)
-        raise
+        loaded = True
+    finally:
+        if not loaded:
+            sys.modules.pop("bump_version", None)
     return mod
 
 
@@ -234,7 +236,9 @@ class TestIteration:
         assert changes == []
 
     def test_binary_files_skipped(self, bv, tmp_path):
-        (tmp_path / "blob.bin").write_bytes(
+        # Extensionless name so the test isolates _is_binary from EXCLUDE_GLOBS
+        # (which would skip *.bin via the binary-extension list anyway).
+        (tmp_path / "blob").write_bytes(
             b"\x00\x01\x02nvcr.io/nvidia/ai-dynamo/x:0.9.0"
         )
         changes = bv.apply_rules(
@@ -274,10 +278,16 @@ def _make_fake_repo(root: Path, version: str) -> None:
         "  repository: nvcr.io/nvidia/ai-dynamo/snapshot-agent\n"
         f"  tag: {version}\n",
     )
+    # Spec file: container image tag, git ref, pip pin, and env var. Lives in
+    # a path that _is_spec_file() recognises (Dockerfile.* prefix), so the
+    # broad CONTAINERS rules fire here. (Markdown prose is intentionally out
+    # of scope after the _is_spec_file filter — see Patch 5.)
     _write(
-        root / "docs" / "example.md",
-        f"Pull `nvcr.io/nvidia/ai-dynamo/vllm-runtime:{version}` to get started.\n"
-        f"Or: `git checkout release/{version}` then `pip install ai-dynamo=={version}`.\n",
+        root / "container" / "Dockerfile.example",
+        f"FROM nvcr.io/nvidia/ai-dynamo/vllm-runtime:{version}\n"
+        f"RUN git checkout release/{version} \\\n"
+        f" && pip install ai-dynamo=={version}\n"
+        f"ENV DYNAMO_VERSION={version}\n",
     )
     _write(
         root / "deploy" / "operator" / "samples" / "dgd.yaml",
@@ -325,13 +335,14 @@ def test_full_bump_writes_every_scope(bv, tmp_path):
         encoding="utf-8"
     )
     assert "tag: 1.0.0" in snap
-    md = (tmp_path / "docs/example.md").read_text(encoding="utf-8")
-    assert "vllm-runtime:1.0.0" in md
-    assert "release/1.0.0" in md
-    assert "ai-dynamo==1.0.0" in md
+    dockerfile = (tmp_path / "container/Dockerfile.example").read_text(encoding="utf-8")
+    assert "vllm-runtime:1.0.0" in dockerfile
+    assert "release/1.0.0" in dockerfile
+    assert "ai-dynamo==1.0.0" in dockerfile
+    assert "DYNAMO_VERSION=1.0.0" in dockerfile
     dgd = (tmp_path / "deploy/operator/samples/dgd.yaml").read_text(encoding="utf-8")
     assert 'dynamoVersion: "1.0.0"' in dgd
-    assert "0.9.0" not in (chart + snap + md + dgd)
+    assert "0.9.0" not in (chart + snap + dockerfile + dgd)
 
 
 def test_post_release_uses_semver_in_helm_python_elsewhere(bv, tmp_path):
@@ -353,8 +364,8 @@ def test_post_release_uses_semver_in_helm_python_elsewhere(bv, tmp_path):
     assert "version: 0.9.0-post1" in chart
     assert 'appVersion: "0.9.0-post1"' in chart
     # Image tag: dotted post
-    md = (tmp_path / "docs/example.md").read_text(encoding="utf-8")
-    assert "vllm-runtime:0.9.0.post1" in md
+    dockerfile = (tmp_path / "container/Dockerfile.example").read_text(encoding="utf-8")
+    assert "vllm-runtime:0.9.0.post1" in dockerfile
 
 
 def test_skip_flags_combine(bv, tmp_path):
@@ -383,8 +394,8 @@ def test_skip_flags_combine(bv, tmp_path):
     assert "version: 0.9.0" in (
         tmp_path / "deploy/helm/charts/platform/Chart.yaml"
     ).read_text(encoding="utf-8")
-    # containers (outside pyproject.toml) were bumped
-    assert "vllm-runtime:1.0.0" in (tmp_path / "docs/example.md").read_text(
+    # containers (outside pyproject.toml) were bumped in spec files
+    assert "vllm-runtime:1.0.0" in (tmp_path / "container/Dockerfile.example").read_text(
         encoding="utf-8"
     )
 
@@ -428,22 +439,23 @@ def test_check_autodetects_from_pyproject(bv, tmp_path):
 
 
 def test_check_mode_detects_stale_docs(bv, tmp_path):
-    """--check must catch staleness in the DOCS specialised functions too.
+    """--check must catch staleness in DOCS rules (now in the unified RULES table).
 
-    The support-matrix / release-artifacts / feature-matrix files carry the
-    bump-version: ignore marker, so apply_rules() skips them entirely. Without
-    a separate dry-run pass through the DOCS helpers, --check would miss a
-    stale "Updated for Dynamo vX.Y.Z" tag (and the support-matrix /
-    release-artifacts equivalents) — regression guard for that blind spot.
+    After Axis B, the support-matrix / release-artifacts / feature-matrix
+    files no longer carry IGNORE_MARKER -- the bespoke specialised helpers
+    are gone, replaced by narrowly-targeted rules that only match the exact
+    version-bearing tokens (header tag, "At a Glance" line, etc) and leave
+    historical table rows untouched. So apply_rules(active_scopes={DOCS})
+    sees these files, and --check can detect a stale "*Updated for Dynamo
+    vX.Y.Z*" tag through the same dry-run pass.
     """
     _make_fake_repo(tmp_path, "1.0.0")
     # Plant a stale DOCS-only reference: feature-matrix tag still on the old
-    # version. apply_rules() can't see it (the file is ignore-marked), but the
-    # update_feature_matrix() helper can.
+    # version. The narrow `feature_matrix_tag` rule must catch this.
     fm = tmp_path / "docs" / "reference" / "feature-matrix.md"
     fm.parent.mkdir(parents=True, exist_ok=True)
     fm.write_text(
-        "<!-- bump-version: ignore -->\n*Updated for Dynamo v0.9.0*\n",
+        "*Updated for Dynamo v0.9.0*\n\nSome historical content with v0.5.0 mentions.\n",
         encoding="utf-8",
     )
     # Sanity check: with --skip-docs the stale tag is invisible to --check.
@@ -517,43 +529,82 @@ def test_no_change_when_old_equals_new(bv, tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def _bump_docs(bv, repo, new_version: str, **ctx_overrides):
+    """Apply DOCS rules + table insertions in one pass — the contract used by
+    --bump and --check for docs after the Axis B refactor.
+
+    Returns the combined Change list so tests can assert which rules fired.
+    """
+    ctx = {
+        "release_date": "Feb 15, 2026",
+        "vllm": "0.19.0",
+        "sglang": "0.5.7",
+        "trtllm": "1.3.0",
+        "nixl": "0.10.1",
+        **ctx_overrides,
+    }
+    v = bv.Version.parse(new_version)
+    return (
+        bv.apply_rules(repo, v, active_scopes={bv.Scope.DOCS}, ctx=ctx, dry_run=False)
+        + bv.insert_table_rows(repo, v, ctx, dry_run=False)
+    )
+
+
 class TestReleaseArtifacts:
-    """The GitHub-Releases table insertion must fail loud if the doc structure changes."""
+    """release-artifacts.md edits go through DOCS rules + insert_table_rows.
+
+    The bespoke update_release_artifacts() helper is gone — a missing table
+    insertion point now raises from insert_table_rows().
+    """
 
     def test_unknown_table_raises(self, bv, tmp_path):
-        # docs/reference/release-artifacts.md without the expected header
         p = tmp_path / "docs" / "reference" / "release-artifacts.md"
         _write(p, "## Current Release: Dynamo v0.9.0\n\nNo table here.\n")
-        with pytest.raises(RuntimeError, match="GitHub Releases table"):
-            bv.update_release_artifacts(
-                tmp_path,
-                bv.Version.parse("1.0.0"),
-                "Feb 15, 2026",
-                bv.BackendVersions(),
-                dry_run=False,
-            )
+        with pytest.raises(RuntimeError, match="release_artifacts_table_row"):
+            _bump_docs(bv, tmp_path, "1.0.0")
 
     def test_table_row_inserted(self, bv, tmp_path):
         doc = (
             "## Current Release: Dynamo v0.9.0\n\n"
             "**GitHub Release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0)\n\n"
+            "**Docs:** [v0.9.0](https://docs.dynamo.nvidia.com/dynamo)\n\n"
             "### GitHub Releases\n\n"
-            "| Version | Date | Release | Docs |\n"
-            "|---------|------|---------|------|\n"
-            "| `v0.9.0` | Dec 01, 2025 | [Release](x) | [Docs](y) |\n"
+            "| Version | Release Date | GitHub | Docs | Notes |\n"
+            "|---------|------|---------|------|------|\n"
+            "| `v0.9.0` | Dec 01, 2025 | [Release](x) | [Docs](y) | |\n"
         )
         p = tmp_path / "docs" / "reference" / "release-artifacts.md"
         _write(p, doc)
-        bv.update_release_artifacts(
-            tmp_path,
-            bv.Version.parse("1.0.0"),
-            "Feb 15, 2026",
-            bv.BackendVersions(),
-            dry_run=False,
-        )
+        _bump_docs(bv, tmp_path, "1.0.0")
         out = p.read_text(encoding="utf-8")
-        assert "| `v1.0.0` | Feb 15, 2026 " in out
+        # Header rule rewrote the "Current Release" line.
         assert "## Current Release: Dynamo v1.0.0" in out
+        # GitHub-link and Docs-link rules rewrote the per-release links.
+        assert "[v1.0.0](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.0)" in out
+        assert "[v1.0.0](https://docs.dynamo.nvidia.com/dynamo)" in out
+        # Table-insertion appended the new row with all 5 columns.
+        assert "| `v1.0.0` | Feb 15, 2026 " in out
+        assert "[Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.0)" in out
+        # Historical row is left intact (no broad rewrite).
+        assert "| `v0.9.0` | Dec 01, 2025 " in out
+
+    def test_idempotent(self, bv, tmp_path):
+        """Running the docs update twice must not insert the row twice."""
+        doc = (
+            "## Current Release: Dynamo v0.9.0\n\n"
+            "**GitHub Release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0)\n\n"
+            "**Docs:** [v0.9.0](https://docs.dynamo.nvidia.com/dynamo)\n\n"
+            "### GitHub Releases\n\n"
+            "| Version | Release Date | GitHub | Docs | Notes |\n"
+            "|---------|------|---------|------|------|\n"
+            "| `v0.9.0` | Dec 01, 2025 | [Release](x) | [Docs](y) | |\n"
+        )
+        p = tmp_path / "docs" / "reference" / "release-artifacts.md"
+        _write(p, doc)
+        _bump_docs(bv, tmp_path, "1.0.0")
+        first = p.read_text(encoding="utf-8")
+        _bump_docs(bv, tmp_path, "1.0.0")
+        assert p.read_text(encoding="utf-8") == first
 
 
 class TestSupportMatrix:
@@ -564,26 +615,31 @@ class TestSupportMatrix:
             "| Version | SGLang | TRT-LLM | vLLM | NIXL |\n"
             "|---------|--------|---------|------|------|\n"
             "| **main (ToT)** | `latest` | `latest` | `latest` | `latest` |\n"
+            "| **v0.9.0** | `0.5.0` | `1.0.0` | `0.18.0` | `0.10.0` |\n"
         )
         p = tmp_path / "docs" / "reference" / "support-matrix.md"
         _write(p, doc)
-        bv.update_support_matrix(
-            tmp_path,
-            bv.Version.parse("1.0.0"),
-            bv.BackendVersions(
-                vllm="0.19.0", sglang="0.5.7", trtllm="1.3.0", nixl="0.10.1"
-            ),
-            dry_run=False,
-        )
+        _bump_docs(bv, tmp_path, "1.0.0")
         out = p.read_text(encoding="utf-8")
-        assert "[v1.0.0]" in out
+        assert "[v1.0.0](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.0)" in out
         assert "SGLang `0.5.7`" in out
+        assert "TensorRT-LLM `1.3.0`" in out
+        # New backend row inserted right after main(ToT) row.
         assert "| **v1.0.0** | `0.5.7` | `1.3.0` | `0.19.0` | `0.10.1` |" in out
+        # Historical row preserved.
+        assert "| **v0.9.0** | `0.5.0` | `1.0.0` | `0.18.0` | `0.10.0` |" in out
 
 
 class TestFeatureMatrix:
     def test_updated_for_tag(self, bv, tmp_path):
         p = tmp_path / "docs" / "reference" / "feature-matrix.md"
-        _write(p, "*Updated for Dynamo v0.9.0*\n\nsome content\n")
-        bv.update_feature_matrix(tmp_path, bv.Version.parse("1.0.0"), dry_run=False)
-        assert "*Updated for Dynamo v1.0.0*" in p.read_text(encoding="utf-8")
+        _write(
+            p,
+            "*Updated for Dynamo v0.9.0*\n\n"
+            "Some content that mentions historical version v0.5.0 in prose.\n",
+        )
+        _bump_docs(bv, tmp_path, "1.0.0")
+        out = p.read_text(encoding="utf-8")
+        assert "*Updated for Dynamo v1.0.0*" in out
+        # Historical version mention in prose must NOT be rewritten.
+        assert "historical version v0.5.0" in out

--- a/tests/scripts/test_bump_version.py
+++ b/tests/scripts/test_bump_version.py
@@ -238,9 +238,7 @@ class TestIteration:
     def test_binary_files_skipped(self, bv, tmp_path):
         # Extensionless name so the test isolates _is_binary from EXCLUDE_GLOBS
         # (which would skip *.bin via the binary-extension list anyway).
-        (tmp_path / "blob").write_bytes(
-            b"\x00\x01\x02nvcr.io/nvidia/ai-dynamo/x:0.9.0"
-        )
+        (tmp_path / "blob").write_bytes(b"\x00\x01\x02nvcr.io/nvidia/ai-dynamo/x:0.9.0")
         changes = bv.apply_rules(
             tmp_path,
             bv.Version.parse("1.0.0"),
@@ -344,9 +342,7 @@ def test_full_bump_writes_every_scope(bv, tmp_path):
 
 def test_post_release_uses_semver_in_helm_python_elsewhere(bv, tmp_path):
     _make_fake_repo(tmp_path, "0.9.0")
-    rc = bv.main(
-        ["--new-version", "0.9.0.post1", "--repo-root", str(tmp_path)]
-    )
+    rc = bv.main(["--new-version", "0.9.0.post1", "--repo-root", str(tmp_path)])
     assert rc == 0
     # Python scope: dotted post
     assert '"0.9.0.post1"' in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
@@ -391,9 +387,9 @@ def test_skip_flags_combine(bv, tmp_path):
         tmp_path / "deploy/helm/charts/platform/Chart.yaml"
     ).read_text(encoding="utf-8")
     # containers (outside pyproject.toml) were bumped in spec files
-    assert "vllm-runtime:1.0.0" in (tmp_path / "container/Dockerfile.example").read_text(
-        encoding="utf-8"
-    )
+    assert "vllm-runtime:1.0.0" in (
+        tmp_path / "container/Dockerfile.example"
+    ).read_text(encoding="utf-8")
 
 
 def test_check_mode_stale_exits_nonzero(bv, tmp_path):
@@ -525,6 +521,6 @@ class TestRegressionGuards:
             "pip_wheel_or_pin",
             "env_dynamo_version",
         }
-        assert expected.issubset(fired), (
-            f"missing rules in change record: {expected - fired}"
-        )
+        assert expected.issubset(
+            fired
+        ), f"missing rules in change record: {expected - fired}"

--- a/tests/scripts/test_bump_version.py
+++ b/tests/scripts/test_bump_version.py
@@ -209,7 +209,8 @@ class TestIteration:
             tmp_path / "keep_old.py",
             '# bump-version: ignore\nVERSION = "nvcr.io/nvidia/ai-dynamo/foo:0.9.0"\n',
         )
-        # Only the DOCS table-row rules touch this file; no ai-dynamo image rule should fire.
+        # No ai-dynamo image rule should fire; the bump-version:ignore marker
+        # short-circuits the whole file.
         changes = bv.apply_rules(
             tmp_path,
             bv.Version.parse("1.0.0"),
@@ -217,7 +218,6 @@ class TestIteration:
                 bv.Scope.CORE,
                 bv.Scope.CONTAINERS,
                 bv.Scope.HELM,
-                bv.Scope.DOCS,
             },
             dry_run=True,
         )
@@ -305,7 +305,6 @@ def test_dry_run_does_not_write(bv, tmp_path):
             "--repo-root",
             str(tmp_path),
             "--dry-run",
-            "--skip-docs",
         ]
     )
     assert rc == 0
@@ -315,9 +314,7 @@ def test_dry_run_does_not_write(bv, tmp_path):
 
 def test_full_bump_writes_every_scope(bv, tmp_path):
     _make_fake_repo(tmp_path, "0.9.0")
-    rc = bv.main(
-        ["--new-version", "1.0.0", "--repo-root", str(tmp_path), "--skip-docs"]
-    )
+    rc = bv.main(["--new-version", "1.0.0", "--repo-root", str(tmp_path)])
     assert rc == 0
     assert 'version = "1.0.0"' in (tmp_path / "pyproject.toml").read_text(
         encoding="utf-8"
@@ -348,7 +345,7 @@ def test_full_bump_writes_every_scope(bv, tmp_path):
 def test_post_release_uses_semver_in_helm_python_elsewhere(bv, tmp_path):
     _make_fake_repo(tmp_path, "0.9.0")
     rc = bv.main(
-        ["--new-version", "0.9.0.post1", "--repo-root", str(tmp_path), "--skip-docs"]
+        ["--new-version", "0.9.0.post1", "--repo-root", str(tmp_path)]
     )
     assert rc == 0
     # Python scope: dotted post
@@ -378,7 +375,6 @@ def test_skip_flags_combine(bv, tmp_path):
             str(tmp_path),
             "--skip-core",
             "--skip-helm",
-            "--skip-docs",
         ]
     )
     assert rc == 0
@@ -410,7 +406,6 @@ def test_check_mode_stale_exits_nonzero(bv, tmp_path):
             "1.0.0",
             "--repo-root",
             str(tmp_path),
-            "--skip-docs",
         ]
     )
     assert rc == 1
@@ -426,7 +421,6 @@ def test_check_mode_fresh_exits_zero(bv, tmp_path):
             "1.0.0",
             "--repo-root",
             str(tmp_path),
-            "--skip-docs",
         ]
     )
     assert rc == 0
@@ -434,57 +428,8 @@ def test_check_mode_fresh_exits_zero(bv, tmp_path):
 
 def test_check_autodetects_from_pyproject(bv, tmp_path):
     _make_fake_repo(tmp_path, "0.9.0")
-    rc = bv.main(["--check", "--repo-root", str(tmp_path), "--skip-docs"])
+    rc = bv.main(["--check", "--repo-root", str(tmp_path)])
     assert rc == 0  # everything IS at 0.9.0 (the detected current version)
-
-
-def test_check_mode_detects_stale_docs(bv, tmp_path):
-    """--check must catch staleness in DOCS rules (now in the unified RULES table).
-
-    After Axis B, the support-matrix / release-artifacts / feature-matrix
-    files no longer carry IGNORE_MARKER -- the bespoke specialised helpers
-    are gone, replaced by narrowly-targeted rules that only match the exact
-    version-bearing tokens (header tag, "At a Glance" line, etc) and leave
-    historical table rows untouched. So apply_rules(active_scopes={DOCS})
-    sees these files, and --check can detect a stale "*Updated for Dynamo
-    vX.Y.Z*" tag through the same dry-run pass.
-    """
-    _make_fake_repo(tmp_path, "1.0.0")
-    # Plant a stale DOCS-only reference: feature-matrix tag still on the old
-    # version. The narrow `feature_matrix_tag` rule must catch this.
-    fm = tmp_path / "docs" / "reference" / "feature-matrix.md"
-    fm.parent.mkdir(parents=True, exist_ok=True)
-    fm.write_text(
-        "*Updated for Dynamo v0.9.0*\n\nSome historical content with v0.5.0 mentions.\n",
-        encoding="utf-8",
-    )
-    # Sanity check: with --skip-docs the stale tag is invisible to --check.
-    assert (
-        bv.main(
-            [
-                "--check",
-                "--expected-version",
-                "1.0.0",
-                "--repo-root",
-                str(tmp_path),
-                "--skip-docs",
-            ]
-        )
-        == 0
-    )
-    # Now without --skip-docs it must be flagged.
-    assert (
-        bv.main(
-            [
-                "--check",
-                "--expected-version",
-                "1.0.0",
-                "--repo-root",
-                str(tmp_path),
-            ]
-        )
-        == 1
-    )
 
 
 def test_summary_file_is_written(bv, tmp_path):
@@ -497,7 +442,6 @@ def test_summary_file_is_written(bv, tmp_path):
             "--repo-root",
             str(tmp_path),
             "--dry-run",
-            "--skip-docs",
             "--summary-file",
             str(summary),
         ]
@@ -518,131 +462,9 @@ def test_no_change_when_old_equals_new(bv, tmp_path):
             str(tmp_path),
             "--old-version",
             "1.0.0",
-            "--skip-docs",
         ]
     )
     assert rc == 0
-
-
-# ---------------------------------------------------------------------------
-# DOCS specialised updates
-# ---------------------------------------------------------------------------
-
-
-def _bump_docs(bv, repo, new_version: str, **ctx_overrides):
-    """Apply DOCS rules + table insertions in one pass — the contract used by
-    --bump and --check for docs after the Axis B refactor.
-
-    Returns the combined Change list so tests can assert which rules fired.
-    """
-    ctx = {
-        "release_date": "Feb 15, 2026",
-        "vllm": "0.19.0",
-        "sglang": "0.5.7",
-        "trtllm": "1.3.0",
-        "nixl": "0.10.1",
-        **ctx_overrides,
-    }
-    v = bv.Version.parse(new_version)
-    return (
-        bv.apply_rules(repo, v, active_scopes={bv.Scope.DOCS}, ctx=ctx, dry_run=False)
-        + bv.insert_table_rows(repo, v, ctx, dry_run=False)
-    )
-
-
-class TestReleaseArtifacts:
-    """release-artifacts.md edits go through DOCS rules + insert_table_rows.
-
-    The bespoke update_release_artifacts() helper is gone — a missing table
-    insertion point now raises from insert_table_rows().
-    """
-
-    def test_unknown_table_raises(self, bv, tmp_path):
-        p = tmp_path / "docs" / "reference" / "release-artifacts.md"
-        _write(p, "## Current Release: Dynamo v0.9.0\n\nNo table here.\n")
-        with pytest.raises(RuntimeError, match="release_artifacts_table_row"):
-            _bump_docs(bv, tmp_path, "1.0.0")
-
-    def test_table_row_inserted(self, bv, tmp_path):
-        doc = (
-            "## Current Release: Dynamo v0.9.0\n\n"
-            "**GitHub Release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0)\n\n"
-            "**Docs:** [v0.9.0](https://docs.dynamo.nvidia.com/dynamo)\n\n"
-            "### GitHub Releases\n\n"
-            "| Version | Release Date | GitHub | Docs | Notes |\n"
-            "|---------|------|---------|------|------|\n"
-            "| `v0.9.0` | Dec 01, 2025 | [Release](x) | [Docs](y) | |\n"
-        )
-        p = tmp_path / "docs" / "reference" / "release-artifacts.md"
-        _write(p, doc)
-        _bump_docs(bv, tmp_path, "1.0.0")
-        out = p.read_text(encoding="utf-8")
-        # Header rule rewrote the "Current Release" line.
-        assert "## Current Release: Dynamo v1.0.0" in out
-        # GitHub-link and Docs-link rules rewrote the per-release links.
-        assert "[v1.0.0](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.0)" in out
-        assert "[v1.0.0](https://docs.dynamo.nvidia.com/dynamo)" in out
-        # Table-insertion appended the new row with all 5 columns.
-        assert "| `v1.0.0` | Feb 15, 2026 " in out
-        assert "[Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.0)" in out
-        # Historical row is left intact (no broad rewrite).
-        assert "| `v0.9.0` | Dec 01, 2025 " in out
-
-    def test_idempotent(self, bv, tmp_path):
-        """Running the docs update twice must not insert the row twice."""
-        doc = (
-            "## Current Release: Dynamo v0.9.0\n\n"
-            "**GitHub Release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0)\n\n"
-            "**Docs:** [v0.9.0](https://docs.dynamo.nvidia.com/dynamo)\n\n"
-            "### GitHub Releases\n\n"
-            "| Version | Release Date | GitHub | Docs | Notes |\n"
-            "|---------|------|---------|------|------|\n"
-            "| `v0.9.0` | Dec 01, 2025 | [Release](x) | [Docs](y) | |\n"
-        )
-        p = tmp_path / "docs" / "reference" / "release-artifacts.md"
-        _write(p, doc)
-        _bump_docs(bv, tmp_path, "1.0.0")
-        first = p.read_text(encoding="utf-8")
-        _bump_docs(bv, tmp_path, "1.0.0")
-        assert p.read_text(encoding="utf-8") == first
-
-
-class TestSupportMatrix:
-    def test_at_a_glance_and_row(self, bv, tmp_path):
-        doc = (
-            "**Latest stable release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0) -- "
-            "SGLang `v0.5.0` | TensorRT-LLM `v1.0.0` | vLLM `v0.18.0` | NIXL `v0.10.0`\n\n"
-            "| Version | SGLang | TRT-LLM | vLLM | NIXL |\n"
-            "|---------|--------|---------|------|------|\n"
-            "| **main (ToT)** | `latest` | `latest` | `latest` | `latest` |\n"
-            "| **v0.9.0** | `0.5.0` | `1.0.0` | `0.18.0` | `0.10.0` |\n"
-        )
-        p = tmp_path / "docs" / "reference" / "support-matrix.md"
-        _write(p, doc)
-        _bump_docs(bv, tmp_path, "1.0.0")
-        out = p.read_text(encoding="utf-8")
-        assert "[v1.0.0](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.0)" in out
-        assert "SGLang `0.5.7`" in out
-        assert "TensorRT-LLM `1.3.0`" in out
-        # New backend row inserted right after main(ToT) row.
-        assert "| **v1.0.0** | `0.5.7` | `1.3.0` | `0.19.0` | `0.10.1` |" in out
-        # Historical row preserved.
-        assert "| **v0.9.0** | `0.5.0` | `1.0.0` | `0.18.0` | `0.10.0` |" in out
-
-
-class TestFeatureMatrix:
-    def test_updated_for_tag(self, bv, tmp_path):
-        p = tmp_path / "docs" / "reference" / "feature-matrix.md"
-        _write(
-            p,
-            "*Updated for Dynamo v0.9.0*\n\n"
-            "Some content that mentions historical version v0.5.0 in prose.\n",
-        )
-        _bump_docs(bv, tmp_path, "1.0.0")
-        out = p.read_text(encoding="utf-8")
-        assert "*Updated for Dynamo v1.0.0*" in out
-        # Historical version mention in prose must NOT be rewritten.
-        assert "historical version v0.5.0" in out
 
 
 # ---------------------------------------------------------------------------
@@ -651,31 +473,6 @@ class TestFeatureMatrix:
 
 
 class TestRegressionGuards:
-    def test_release_artifacts_docs_url_uses_canonical_domain(self, bv, tmp_path):
-        # FIX 1 guard: the docs link in release-artifacts.md must use the
-        # canonical host ``docs.dynamo.nvidia.com/dynamo`` and the rule's
-        # regex must match that exact host — not a sibling like
-        # ``docs.nvidia.com/dynamo`` which a previous iteration emitted.
-        doc = (
-            "## Current Release: Dynamo v0.9.0\n\n"
-            "**GitHub Release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0)\n\n"
-            "**Docs:** [v0.9.0](https://docs.dynamo.nvidia.com/dynamo)\n\n"
-            "### GitHub Releases\n\n"
-            "| Version | Release Date | GitHub | Docs | Notes |\n"
-            "|---------|------|---------|------|------|\n"
-            "| `v0.9.0` | Dec 01, 2025 | [Release](x) | [Docs](y) | |\n"
-        )
-        p = tmp_path / "docs" / "reference" / "release-artifacts.md"
-        _write(p, doc)
-        _bump_docs(bv, tmp_path, "1.0.0")
-        out = p.read_text(encoding="utf-8")
-        # Canonical host preserved, version rewritten.
-        assert "[v1.0.0](https://docs.dynamo.nvidia.com/dynamo)" in out
-        # The inserted table row's Docs column must also use the canonical host.
-        assert "[Docs](https://docs.dynamo.nvidia.com/dynamo)" in out
-        # Non-canonical hosts must never appear.
-        assert "docs.nvidia.com/dynamo" not in out
-
     def test_ver_does_not_strip_rc_suffix(self, bv):
         # FIX 2 guard: ``_VER`` must refuse to match the numeric portion of
         # strings that continue with additional release qualifiers — otherwise
@@ -699,28 +496,34 @@ class TestRegressionGuards:
         # the resulting ``Change`` record must list every rule name — not just
         # the first or last. The summary table depends on this to attribute
         # rewrites back to rules.
-        doc = (
-            "## Current Release: Dynamo v0.9.0\n\n"
-            "**GitHub Release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0)\n\n"
-            "**Docs:** [v0.9.0](https://docs.dynamo.nvidia.com/dynamo)\n\n"
+        #
+        # A single Dockerfile spec file exercises four CONTAINERS rules at once:
+        # image_tag_ai_dynamo_ns, git_checkout_release_branch, pip_wheel_or_pin,
+        # and env_dynamo_version — all firing on the same file in one pass.
+        dockerfile = (
+            "FROM nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0\n"
+            "RUN git checkout release/0.9.0 \\\n"
+            " && pip install ai-dynamo==0.9.0\n"
+            "ENV DYNAMO_VERSION=0.9.0\n"
         )
-        p = tmp_path / "docs" / "reference" / "release-artifacts.md"
-        _write(p, doc)
+        p = tmp_path / "container" / "Dockerfile.example"
+        _write(p, dockerfile)
         changes = bv.apply_rules(
             tmp_path,
             bv.Version.parse("1.0.0"),
-            active_scopes={bv.Scope.DOCS},
+            active_scopes={bv.Scope.CONTAINERS},
             dry_run=True,
         )
         # Exactly one Change record for the one rewritten file.
-        matching = [c for c in changes if c.path.name == "release-artifacts.md"]
+        matching = [c for c in changes if c.path.name == "Dockerfile.example"]
         assert len(matching) == 1
         fired = set(matching[0].rules)
-        # All three DOCS rules that could fire on this content must be tracked.
+        # All four CONTAINERS rules that touch this file must be tracked.
         expected = {
-            "release_artifacts_header",
-            "release_artifacts_github_link",
-            "release_artifacts_docs_link",
+            "image_tag_ai_dynamo_ns",
+            "git_checkout_release_branch",
+            "pip_wheel_or_pin",
+            "env_dynamo_version",
         }
         assert expected.issubset(fired), (
             f"missing rules in change record: {expected - fired}"

--- a/tests/scripts/test_bump_version.py
+++ b/tests/scripts/test_bump_version.py
@@ -643,3 +643,85 @@ class TestFeatureMatrix:
         assert "*Updated for Dynamo v1.0.0*" in out
         # Historical version mention in prose must NOT be rewritten.
         assert "historical version v0.5.0" in out
+
+
+# ---------------------------------------------------------------------------
+# Tier-1 regression guards (one test per fragility patch)
+# ---------------------------------------------------------------------------
+
+
+class TestRegressionGuards:
+    def test_release_artifacts_docs_url_uses_canonical_domain(self, bv, tmp_path):
+        # FIX 1 guard: the docs link in release-artifacts.md must use the
+        # canonical host ``docs.dynamo.nvidia.com/dynamo`` and the rule's
+        # regex must match that exact host — not a sibling like
+        # ``docs.nvidia.com/dynamo`` which a previous iteration emitted.
+        doc = (
+            "## Current Release: Dynamo v0.9.0\n\n"
+            "**GitHub Release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0)\n\n"
+            "**Docs:** [v0.9.0](https://docs.dynamo.nvidia.com/dynamo)\n\n"
+            "### GitHub Releases\n\n"
+            "| Version | Release Date | GitHub | Docs | Notes |\n"
+            "|---------|------|---------|------|------|\n"
+            "| `v0.9.0` | Dec 01, 2025 | [Release](x) | [Docs](y) | |\n"
+        )
+        p = tmp_path / "docs" / "reference" / "release-artifacts.md"
+        _write(p, doc)
+        _bump_docs(bv, tmp_path, "1.0.0")
+        out = p.read_text(encoding="utf-8")
+        # Canonical host preserved, version rewritten.
+        assert "[v1.0.0](https://docs.dynamo.nvidia.com/dynamo)" in out
+        # The inserted table row's Docs column must also use the canonical host.
+        assert "[Docs](https://docs.dynamo.nvidia.com/dynamo)" in out
+        # Non-canonical hosts must never appear.
+        assert "docs.nvidia.com/dynamo" not in out
+
+    def test_ver_does_not_strip_rc_suffix(self, bv):
+        # FIX 2 guard: ``_VER`` must refuse to match the numeric portion of
+        # strings that continue with additional release qualifiers — otherwise
+        # rewriting the capture leaves orphaned suffixes like ``1.0.0-rc1``
+        # after a bump that had nothing to say about the rc track.
+        import re as _re
+
+        pattern = _re.compile(bv._VER)
+        # Word-char / dot / dash suffixes must block the match entirely.
+        assert pattern.search("0.9.0-rc1") is None
+        assert pattern.search("0.9.0rc1") is None
+        assert pattern.search("0.9.0.dev2") is None
+        assert pattern.search("0.9.0-alpha") is None
+        # Plain versions and .postN / -postN still match as before.
+        assert pattern.fullmatch("0.9.0") is not None
+        assert pattern.fullmatch("0.9.0.post1") is not None
+        assert pattern.fullmatch("0.9.0-post2") is not None
+
+    def test_change_record_tracks_every_rule_that_fired(self, bv, tmp_path):
+        # FIX 3 guard: when multiple rules rewrite the same file in one pass,
+        # the resulting ``Change`` record must list every rule name — not just
+        # the first or last. The summary table depends on this to attribute
+        # rewrites back to rules.
+        doc = (
+            "## Current Release: Dynamo v0.9.0\n\n"
+            "**GitHub Release:** [v0.9.0](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0)\n\n"
+            "**Docs:** [v0.9.0](https://docs.dynamo.nvidia.com/dynamo)\n\n"
+        )
+        p = tmp_path / "docs" / "reference" / "release-artifacts.md"
+        _write(p, doc)
+        changes = bv.apply_rules(
+            tmp_path,
+            bv.Version.parse("1.0.0"),
+            active_scopes={bv.Scope.DOCS},
+            dry_run=True,
+        )
+        # Exactly one Change record for the one rewritten file.
+        matching = [c for c in changes if c.path.name == "release-artifacts.md"]
+        assert len(matching) == 1
+        fired = set(matching[0].rules)
+        # All three DOCS rules that could fire on this content must be tracked.
+        expected = {
+            "release_artifacts_header",
+            "release_artifacts_github_link",
+            "release_artifacts_docs_link",
+        }
+        assert expected.issubset(fired), (
+            f"missing rules in change record: {expected - fired}"
+        )


### PR DESCRIPTION
#### Overview

Automates the mechanical "bump every Dynamo version reference" step of the release process. Adds a rule-driven bump script and two workflows that drive it — Phase 1 (prep the release branch before RC publish) and Phase 2 (port the bump to `main` after the GitHub release is published). Reimplements a prior proposal (#6306) with an engine rewrite and a handful of gap fixes.

#### Details

- **`.github/scripts/bump_version.py` (new)** — Single-file engine:
  - `Version` dataclass owns format conversion: `python()` → PEP 440 (`0.9.0.post1`), `semver()` → Cargo/Helm (`0.9.0-post1`), `dashed()` → URL slugs (`0-9-0-post1`).
  - A declarative `RULES` table (one `Rule(name, scope, pattern, replacement, file_filter)` per reference type) covers core (`pyproject.toml`, `Cargo.toml`, `setup.py`), Helm (`Chart.yaml`, `values.yaml`), container image tags (both broad `ai-dynamo/*:X.Y.Z` and explicit short-tag allowlist), pip pins, operator `dynamoVersion`, `git checkout release/*`, and `DYNAMO_VERSION=` env assignments.
  - One `apply_rules()` engine walks the repo once and applies every matching rule. `--check` is just a dry-run against the expected version (any would-be change = a stale reference). `--dry-run` previews without writing. `--skip-core/-containers/-helm/-docs` gate scopes.
  - Per-file opt-out via a `bump-version: ignore` comment marker (replaces hardcoded exclude lists).
  - Specialised DOCS functions (`update_feature_matrix`, `update_support_matrix`, `update_release_artifacts`) handle table-row insertion. The GitHub-Releases table insertion now **fails loud** if the doc header changes rather than silently skipping.
  - Non-UTF-8 files are skipped (no more `surrogateescape`), and `--summary-file` emits a per-file/per-rule Markdown table for `$GITHUB_STEP_SUMMARY`.

- **`.github/workflows/release-version-bump.yml` (new — Phase 2)** — Triggers on `release: published` and also exposes `workflow_dispatch` with component checkboxes. Opens a PR to `main` (no direct push). Full releases bump all scopes; post-releases default to a minimal bump (`core` + `helm` only, no image-tag churn) instead of the previous hard-fail — dispatch inputs still override. All tool versions pinned (`yq`, `controller-gen@v0.16.5`, `helm-docs`). Backend metadata (vLLM/SGLang/TRT-LLM/NIXL/release date) is extracted from `container/context.yaml` on the release tag.

- **`.github/workflows/release.yml` (modified — Phase 1 `version-bump` job)** — On `workflow_dispatch` from a `release/*` branch, opens a PR back into that same `release/*` branch instead of pushing directly, so the mechanical changes get a human review. Drops the dead `--cuda-versions-vllm/sglang/trtllm` args from the workflow inputs and script call. Pins `controller-gen` explicitly. The rest of the release pipeline (RC tag, NGC publish, Helm push) is unchanged.

- **`tests/scripts/test_bump_version.py` (new)** — 35 unit tests covering: `Version` parsing/formatting, every rule individually, ignore-marker and glob exclusion, full bump vs. post-release vs. skip-flag combinations, `--check` (stale/fresh/auto-detect), `--summary-file`, and fail-loud on unknown release-artifacts table structure. Markered `pre_merge` / `unit` / `gpu_0`.

#### Updates since last revision

Addresses review feedback on this PR (Devin review + CodeRabbit). All nine inline threads are replied to on the PR with per-comment detail; the substantive changes are:

- **`Version` ordering bug fix** — dropped `@dataclass(order=True)` (which would crash with `TypeError: '<' not supported between NoneType and int` the moment anyone tried to sort a mix of base and post versions) in favour of explicit `__lt__`/`__le__`/`__gt__`/`__ge__` delegating to a `_sort_key()` that maps `post=None → -1`. Gives PEP 440 semantics: `0.9.0 < 0.9.0.post1 < 0.9.0.post2 < 1.0.0`. `test_ordering` was extended with the post-release cases and a `sorted([…])` regression guard.
- **`pip_wheel_or_pin` scope bleed fix** — added `file_filter=lambda p: p.name != "pyproject.toml"` so the CORE rule `pyproject_ai_dynamo_pin` is the sole owner of that file's pins. Previously `--skip-core` would still have the broad `Scope.CONTAINERS` rule rewrite the `ai-dynamo[vllm]==…` / `ai-dynamo-runtime==…` self-pins, leaving the `[project].version` line and the pins on different versions. `test_skip_flags_combine` was tightened to assert both the version line **and** both self-pins stay on the old version (plus a negative `"1.0.0" not in py`).
- **Docs files shielded from broad sweep** — added a `bump-version: ignore` HTML comment to `docs/reference/release-artifacts.md` and `docs/reference/support-matrix.md`. This suppresses the broad `Scope.CONTAINERS` rules from rewriting historical release rows; the specialised `update_release_artifacts()` / `update_support_matrix()` functions read those paths directly via `path.read_text()` (bypassing `iter_repo_files`), so targeted edits to the "Current Release" header, "At a Glance" line, and new backend / GitHub Releases table rows still land.
- **`GITHUB_STEP_SUMMARY` passthrough fix (release-version-bump.yml)** — dropped `GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}`. `${{ env.* }}` only sees workflow-set vars, so it was shadowing the runner-provided path with an empty string and silently disabling `--summary-file`. The shell already references `$GITHUB_STEP_SUMMARY` directly, matching the Phase 1 pattern.
- **CRD gating aligned with the core scope (release.yml)** — "Regenerate CRDs" moved from `if: inputs.update_containers != false` to `if: inputs.update_core != false`. CRDs are generated from the operator's Go types under `deploy/operator/`, so they belong to the core/operator scope (same as `Cargo.lock`). Now matches `release-version-bump.yml`'s `steps.flags.outputs.core == 'true'` gate.
- **Actions pinned to SHAs (release.yml `version-bump` job)** — `actions/checkout`, `actions/setup-python`, `actions/setup-go` now pin the same SHAs already used in `release-version-bump.yml` (v4.3.0 / v5.6.0 / v6.0.0).
- **Test narrowing** — `test_parse_rejects_invalid` now asserts `pytest.raises(argparse.ArgumentTypeError)` instead of bare `Exception` (Ruff B017).

#### Where should the reviewer start?

- **`.github/scripts/bump_version.py`** — specifically the `RULES` table (~lines 170–290). Two rules are intentionally broad and worth sanity-checking against your mental model of the repo:
  - `image_tag_ai_dynamo_ns` rewrites **any** `(nvcr.io/nvidia/)?ai-dynamo/<name>:X.Y.Z`.
  - `pyproject_ai_dynamo_pin` matches all `ai-dynamo[*]==X.Y.Z` specs (not just `ai-dynamo-runtime`).
  - If any file needs to pin to a specific version for test/fixture reasons, add the `bump-version: ignore` marker. Reviewers familiar with the recipe/manifest tree should skim for false positives.

- **`.github/workflows/release.yml`** — the `version-bump` job diff. Biggest behavior change: Phase 1 no longer commits directly to the release branch; it opens a PR. Confirm this is the intended policy and that the `automated-release` environment has `pull-requests: write`. Also double-check the CRD-gating change (`update_core` vs `update_containers`) matches your mental model of who owns the manifests under `deploy/operator/`.

- **`.github/workflows/release-version-bump.yml`** — confirm the post-release default (minimal bump = core + helm only) is what you want when GitHub auto-fires on a `.postN` release.

- **`tests/scripts/test_bump_version.py`** — spot-check `test_full_bump_writes_every_scope`, `test_post_release_uses_semver_in_helm_python_elsewhere`, and the tightened `test_skip_flags_combine` to confirm the expected format conventions per file type and the scope-bleed guard.

Not covered by automated tests: the workflow jobs themselves (GitHub Actions integration). These will need a real release or a `workflow_dispatch` dry-run to validate end-to-end.

#### Human review checklist

- [ ] The two `bump-version: ignore` markers on `release-artifacts.md` / `support-matrix.md` land in a place where `IGNORE_MARKER in content` sees them (they're HTML comments at the top of the body, not inside the YAML frontmatter — verified locally against `iter_repo_files`).
- [ ] `Version.__lt__` semantics (base < post, post ordered numerically) match how you expect to sort release tags elsewhere in the codebase.
- [ ] The `image_tag_ai_dynamo_ns` broad regex doesn't false-match any historical examples outside of the two `docs/reference/*.md` files already marked.
- [ ] Phase 1 opening a PR into `release/*` (instead of pushing) is the intended policy.
- [ ] CRD regeneration gating on `update_core` (rather than a dedicated `update_crds` flag) is acceptable.

#### Related Issues

Relates to #6306 (closed, earlier proposal of the same system).

Link to Devin session: https://nvidia.devinenterprise.com/sessions/045e5e76b46441529868b5bc4315debf
Requested by: @dagil-nvidia