### PR TITLE
fix(operator): add default preStop hook to frontend container

### DIFF
--- a/deploy/operator/internal/dynamo/component_frontend.go
+++ b/deploy/operator/internal/dynamo/component_frontend.go
@@ -39,6 +39,21 @@ func (f *FrontendDefaults) GetBaseContainer(context ComponentContext) (corev1.Co
 		},
 	}
 
+	// Add a default preStop hook to allow time for endpoint propagation during
+	// rolling updates. Without this, the frontend process begins shutdown on SIGTERM
+	// while proxies (e.g., Kong, NGINX) still route traffic to the terminating pod,
+	// causing 502 errors on non-streaming requests and mid-stream truncations on
+	// streaming ones. The 10-second sleep gives kube-proxy / endpoint controllers
+	// enough time to remove the pod from service endpoints before shutdown begins.
+	// Users can override this via extraPodSpec.mainContainer.lifecycle.
+	container.Lifecycle = &corev1.Lifecycle{
+		PreStop: &corev1.LifecycleHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"sh", "-c", "sleep 10"},
+			},
+		},
+	}
+
 	// Add frontend-specific defaults
 	container.LivenessProbe = &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{

--- a/deploy/operator/internal/dynamo/component_frontend.go
+++ b/deploy/operator/internal/dynamo/component_frontend.go
@@ -39,21 +39,6 @@ func (f *FrontendDefaults) GetBaseContainer(context ComponentContext) (corev1.Co
 		},
 	}
 
-	// Add a default preStop hook to allow time for endpoint propagation during
-	// rolling updates. Without this, the frontend process begins shutdown on SIGTERM
-	// while proxies (e.g., Kong, NGINX) still route traffic to the terminating pod,
-	// causing 502 errors on non-streaming requests and mid-stream truncations on
-	// streaming ones. The 10-second sleep gives kube-proxy / endpoint controllers
-	// enough time to remove the pod from service endpoints before shutdown begins.
-	// Users can override this via extraPodSpec.mainContainer.lifecycle.
-	container.Lifecycle = &corev1.Lifecycle{
-		PreStop: &corev1.LifecycleHandler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"sh", "-c", "sleep 10"},
-			},
-		},
-	}
-
 	// Add frontend-specific defaults
 	container.LivenessProbe = &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
@@ -98,4 +83,18 @@ func (f *FrontendDefaults) GetBaseContainer(context ComponentContext) (corev1.Co
 	}...)
 
 	return container, nil
+}
+
+// maxPreStopSeconds is the upper bound for the frontend preStop sleep duration.
+const maxPreStopSeconds = int64(10)
+
+// ComputeFrontendPreStopSeconds returns the preStop sleep duration for frontend
+// containers based on the pod's TerminationGracePeriodSeconds.
+//
+// The formula min(10, gracePeriod/2) ensures that:
+//   - At least half the grace budget remains for actual graceful shutdown
+//   - The sleep never exceeds 10 seconds (sufficient for endpoint propagation)
+//   - A zero or negative grace period produces 0 (no preStop hook)
+func ComputeFrontendPreStopSeconds(gracePeriodSeconds int64) int64 {
+	return max(0, min(maxPreStopSeconds, gracePeriodSeconds/2))
 }

--- a/deploy/operator/internal/dynamo/component_frontend_test.go
+++ b/deploy/operator/internal/dynamo/component_frontend_test.go
@@ -1,0 +1,136 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dynamo
+
+import (
+	"fmt"
+	"testing"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestFrontendDefaults_GetBaseContainer(t *testing.T) {
+	type fields struct {
+		BaseComponentDefaults *BaseComponentDefaults
+	}
+	tests := []struct {
+		name             string
+		fields           fields
+		componentContext ComponentContext
+		want             corev1.Container
+		wantErr          bool
+	}{
+		{
+			name: "default frontend container includes preStop hook",
+			fields: fields{
+				BaseComponentDefaults: &BaseComponentDefaults{},
+			},
+			componentContext: ComponentContext{
+				numberOfNodes:                  1,
+				ParentGraphDeploymentName:      "name",
+				ParentGraphDeploymentNamespace: "namespace",
+				DynamoNamespace:                "dynamo-namespace",
+				ComponentType:                  commonconsts.ComponentTypeFrontend,
+			},
+			want: corev1.Container{
+				Name:    commonconsts.MainContainerName,
+				Command: []string{"python3"},
+				Args:    []string{"-m", "dynamo.frontend"},
+				Ports: []corev1.ContainerPort{
+					{
+						Protocol:      corev1.ProtocolTCP,
+						Name:          commonconsts.DynamoContainerPortName,
+						ContainerPort: int32(commonconsts.DynamoServicePort),
+					},
+				},
+				Lifecycle: &corev1.Lifecycle{
+					PreStop: &corev1.LifecycleHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"sh", "-c", "sleep 10"},
+						},
+					},
+				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/live",
+							Port: intstr.FromString(commonconsts.DynamoContainerPortName),
+						},
+					},
+					InitialDelaySeconds: 15,
+					PeriodSeconds:       10,
+					TimeoutSeconds:      1,
+					FailureThreshold:    3,
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/health",
+							Port: intstr.FromString(commonconsts.DynamoContainerPortName),
+						},
+					},
+					InitialDelaySeconds: 10,
+					PeriodSeconds:       10,
+					TimeoutSeconds:      3,
+					FailureThreshold:    3,
+				},
+				Env: []corev1.EnvVar{
+					{Name: commonconsts.DynamoNamespaceEnvVar, Value: "dynamo-namespace"},
+					{Name: commonconsts.DynamoComponentEnvVar, Value: commonconsts.ComponentTypeFrontend},
+					{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "name"},
+					{Name: "DYN_PARENT_DGD_K8S_NAMESPACE", Value: "namespace"},
+					{
+						Name: "POD_NAME",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.name",
+							},
+						},
+					},
+					{
+						Name: "POD_NAMESPACE",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.namespace",
+							},
+						},
+					},
+					{
+						Name: "POD_UID",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.uid",
+							},
+						},
+					},
+					{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: "kubernetes"},
+					{Name: commonconsts.EnvDynamoServicePort, Value: fmt.Sprintf("%d", commonconsts.DynamoServicePort)},
+					{Name: "DYN_HTTP_PORT", Value: fmt.Sprintf("%d", commonconsts.DynamoServicePort)},
+					{Name: commonconsts.DynamoNamespacePrefixEnvVar, Value: "dynamo-namespace"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &FrontendDefaults{
+				BaseComponentDefaults: tt.fields.BaseComponentDefaults,
+			}
+			got, err := f.GetBaseContainer(tt.componentContext)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FrontendDefaults.GetBaseContainer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			diff := cmp.Diff(got, tt.want)
+			if diff != "" {
+				t.Errorf("FrontendDefaults.GetBaseContainer() mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/deploy/operator/internal/dynamo/component_frontend_test.go
+++ b/deploy/operator/internal/dynamo/component_frontend_test.go
@@ -15,6 +15,63 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+func TestComputeFrontendPreStopSeconds(t *testing.T) {
+	tests := []struct {
+		name               string
+		gracePeriodSeconds int64
+		wantSleep          int64
+	}{
+		{
+			name:               "default grace period (60s) caps at 10s",
+			gracePeriodSeconds: 60,
+			wantSleep:          10,
+		},
+		{
+			name:               "high grace period still caps at 10s",
+			gracePeriodSeconds: 120,
+			wantSleep:          10,
+		},
+		{
+			name:               "grace period 20s gives exactly 10s",
+			gracePeriodSeconds: 20,
+			wantSleep:          10,
+		},
+		{
+			name:               "grace period 10s gives 5s (half budget)",
+			gracePeriodSeconds: 10,
+			wantSleep:          5,
+		},
+		{
+			name:               "grace period 6s gives 3s",
+			gracePeriodSeconds: 6,
+			wantSleep:          3,
+		},
+		{
+			name:               "grace period 2s gives 1s",
+			gracePeriodSeconds: 2,
+			wantSleep:          1,
+		},
+		{
+			name:               "grace period 1s gives 0 (integer division)",
+			gracePeriodSeconds: 1,
+			wantSleep:          0,
+		},
+		{
+			name:               "zero grace period gives 0",
+			gracePeriodSeconds: 0,
+			wantSleep:          0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComputeFrontendPreStopSeconds(tt.gracePeriodSeconds)
+			if got != tt.wantSleep {
+				t.Errorf("ComputeFrontendPreStopSeconds(%d) = %d, want %d", tt.gracePeriodSeconds, got, tt.wantSleep)
+			}
+		})
+	}
+}
+
 func TestFrontendDefaults_GetBaseContainer(t *testing.T) {
 	type fields struct {
 		BaseComponentDefaults *BaseComponentDefaults
@@ -27,7 +84,7 @@ func TestFrontendDefaults_GetBaseContainer(t *testing.T) {
 		wantErr          bool
 	}{
 		{
-			name: "default frontend container includes preStop hook",
+			name: "default frontend container",
 			fields: fields{
 				BaseComponentDefaults: &BaseComponentDefaults{},
 			},
@@ -47,13 +104,6 @@ func TestFrontendDefaults_GetBaseContainer(t *testing.T) {
 						Protocol:      corev1.ProtocolTCP,
 						Name:          commonconsts.DynamoContainerPortName,
 						ContainerPort: int32(commonconsts.DynamoServicePort),
-					},
-				},
-				Lifecycle: &corev1.Lifecycle{
-					PreStop: &corev1.LifecycleHandler{
-						Exec: &corev1.ExecAction{
-							Command: []string{"sh", "-c", "sleep 10"},
-						},
 					},
 				},
 				LivenessProbe: &corev1.Probe{

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1168,18 +1168,22 @@ func GenerateBasePodSpec(
 	// The sleep duration is min(10, gracePeriod/2) to ensure at least half the grace
 	// budget remains for actual graceful shutdown.
 	// Applied here (after all merges) so we use the final TerminationGracePeriodSeconds.
-	// Users can override via extraPodSpec.mainContainer.lifecycle.
-	if component.ComponentType == commonconsts.ComponentTypeFrontend && container.Lifecycle == nil {
+	// Users can override via extraPodSpec.mainContainer.lifecycle.preStop.
+	// We check PreStop specifically (not just Lifecycle) so that a user-provided
+	// PostStart handler doesn't silently suppress the default PreStop protection.
+	if component.ComponentType == commonconsts.ComponentTypeFrontend &&
+		(container.Lifecycle == nil || container.Lifecycle.PreStop == nil) {
 		gracePeriod := int64(60)
 		if podSpec.TerminationGracePeriodSeconds != nil {
 			gracePeriod = *podSpec.TerminationGracePeriodSeconds
 		}
 		if sleepSeconds := ComputeFrontendPreStopSeconds(gracePeriod); sleepSeconds > 0 {
-			container.Lifecycle = &corev1.Lifecycle{
-				PreStop: &corev1.LifecycleHandler{
-					Exec: &corev1.ExecAction{
-						Command: []string{"sh", "-c", fmt.Sprintf("sleep %d", sleepSeconds)},
-					},
+			if container.Lifecycle == nil {
+				container.Lifecycle = &corev1.Lifecycle{}
+			}
+			container.Lifecycle.PreStop = &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"sh", "-c", fmt.Sprintf("sleep %d", sleepSeconds)},
 				},
 			}
 		}

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1161,6 +1161,30 @@ func GenerateBasePodSpec(
 		}
 	}
 
+	// Apply a default preStop hook for frontend components to allow time for endpoint
+	// propagation during rolling updates. Without this, the frontend process begins
+	// shutdown on SIGTERM while proxies (e.g., Kong, NGINX) still route traffic to
+	// the terminating pod, causing 502 errors and mid-stream truncations.
+	// The sleep duration is min(10, gracePeriod/2) to ensure at least half the grace
+	// budget remains for actual graceful shutdown.
+	// Applied here (after all merges) so we use the final TerminationGracePeriodSeconds.
+	// Users can override via extraPodSpec.mainContainer.lifecycle.
+	if component.ComponentType == commonconsts.ComponentTypeFrontend && container.Lifecycle == nil {
+		gracePeriod := int64(60)
+		if podSpec.TerminationGracePeriodSeconds != nil {
+			gracePeriod = *podSpec.TerminationGracePeriodSeconds
+		}
+		if sleepSeconds := ComputeFrontendPreStopSeconds(gracePeriod); sleepSeconds > 0 {
+			container.Lifecycle = &corev1.Lifecycle{
+				PreStop: &corev1.LifecycleHandler{
+					Exec: &corev1.ExecAction{
+						Command: []string{"sh", "-c", fmt.Sprintf("sleep %d", sleepSeconds)},
+					},
+				},
+			}
+		}
+	}
+
 	podSpec.Volumes = append(podSpec.Volumes, volumes...)
 	ApplySharedMemoryVolumeAndMount(&podSpec, &container, component.SharedMemory)
 	podSpec.Containers = append(podSpec.Containers, container)

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -1490,6 +1490,13 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														},
 													},
 												},
+												Lifecycle: &corev1.Lifecycle{
+													PreStop: &corev1.LifecycleHandler{
+														Exec: &corev1.ExecAction{
+															Command: []string{"sh", "-c", "sleep 10"},
+														},
+													},
+												},
 												Env: []corev1.EnvVar{
 													{
 														Name:  "DYN_HTTP_PORT",
@@ -2488,6 +2495,13 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														},
 													},
 												},
+												Lifecycle: &corev1.Lifecycle{
+													PreStop: &corev1.LifecycleHandler{
+														Exec: &corev1.ExecAction{
+															Command: []string{"sh", "-c", "sleep 10"},
+														},
+													},
+												},
 												Env: []corev1.EnvVar{
 													{
 														Name:  "DYN_HTTP_PORT",
@@ -3483,6 +3497,13 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														HTTPGet: &corev1.HTTPGetAction{
 															Path: "/ready",
 															Port: intstr.FromInt(8080),
+														},
+													},
+												},
+												Lifecycle: &corev1.Lifecycle{
+													PreStop: &corev1.LifecycleHandler{
+														Exec: &corev1.ExecAction{
+															Command: []string{"sh", "-c", "sleep 10"},
 														},
 													},
 												},

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -1493,7 +1493,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 												Lifecycle: &corev1.Lifecycle{
 													PreStop: &corev1.LifecycleHandler{
 														Exec: &corev1.ExecAction{
-															Command: []string{"sh", "-c", "sleep 10"},
+															Command: []string{"sh", "-c", "sleep 5"},
 														},
 													},
 												},
@@ -2498,7 +2498,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 												Lifecycle: &corev1.Lifecycle{
 													PreStop: &corev1.LifecycleHandler{
 														Exec: &corev1.ExecAction{
-															Command: []string{"sh", "-c", "sleep 10"},
+															Command: []string{"sh", "-c", "sleep 5"},
 														},
 													},
 												},
@@ -3503,7 +3503,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 												Lifecycle: &corev1.Lifecycle{
 													PreStop: &corev1.LifecycleHandler{
 														Exec: &corev1.ExecAction{
-															Command: []string{"sh", "-c", "sleep 10"},
+															Command: []string{"sh", "-c", "sleep 5"},
 														},
 													},
 												},


### PR DESCRIPTION
#### Overview:

Adds a default `preStop: sleep 10` lifecycle hook to the Frontend container to prevent 502 errors and mid-stream truncations during rolling updates when the frontend sits behind a proxy (Kong, NGINX, etc.). Without this, the frontend process begins shutdown on SIGTERM while proxies still route traffic to the terminating pod due to the race between endpoint removal and pod termination.

Context on the Pod Termination endpoint removal race here: https://freecontent.manning.com/handling-client-requests-properly-with-kubernetes/

#### Details:

- `deploy/operator/internal/dynamo/component_frontend.go` — Added default `preStop` lifecycle hook (`sh -c sleep 10`) in `FrontendDefaults.GetBaseContainer()`. Users can override via `extraPodSpec.mainContainer.lifecycle`.
- `deploy/operator/internal/dynamo/component_frontend_test.go` — New unit test validating the full frontend container spec including the preStop hook.
- `deploy/operator/internal/dynamo/graph_test.go` — Updated 3 grove pod clique set test expectations to include the new `Lifecycle` field on frontend containers.

#### Alternatives considered:

Adding the sleep/delay to the Dynamo frontend runtime itself (e.g., trapping SIGTERM and delaying shutdown). We opted for the `preStop` hook in the operator instead because:

1. **Kubernetes-specific concern** — This race between endpoint removal and pod termination is specific to Kubernetes environments. Adding a shutdown delay to the runtime would penalize local development and non-Kubernetes deployments for no benefit.
2. **Backwards compatibility** — Operators that pick up this change will immediately get the fix without requiring users to update their runtime images. The preStop hook works with any existing `runtime` image.

#### Where should the reviewer start?

`deploy/operator/internal/dynamo/component_frontend.go` — the core change is ~15 lines adding the lifecycle hook.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
