### PR TITLE
[DO NOT MERGE] fix(sglang): add enable_trace to diffusion worker ServerArgs stub

### DIFF
--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -360,6 +360,7 @@ async def parse_args(args: list[str]) -> Config:
         server_args.disaggregation_mode = None
         server_args.dllm_algorithm = False
         server_args.load_format = None
+        server_args.enable_trace = getattr(parsed_args, "enable_trace", False)
         logging.info(
             f"Created stub ServerArgs for {worker_type}: model_path={server_args.model_path}"
         )

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -144,7 +144,7 @@ class BaseGenerativeHandler(ABC, Generic[RequestT, ResponseT]):
             publisher: Optional metrics publisher for the worker.
         """
         self.config = config
-        self.enable_trace = config.server_args.enable_trace
+        self.enable_trace = getattr(config.server_args, "enable_trace", False)
 
         # Set up metrics and KV publishers
         self.metrics_publisher: Optional[WorkerMetricsPublisher] = None


### PR DESCRIPTION
## Summary
- Fixes text-to-video and image diffusion worker startup crash (`AttributeError: 'types.SimpleNamespace' object has no attribute 'enable_trace'`)
- Adds `enable_trace` to the `SimpleNamespace` stub in `args.py` that is created for diffusion workers instead of full `ServerArgs`
- Adds defensive `getattr()` fallback in `BaseGenerativeHandler.__init__` to future-proof against similar missing fields

## Root Cause
The `SimpleNamespace` stub for diffusion/video workers (args.py:350-366) was created before `enable_trace` was added to `BaseGenerativeHandler.__init__`. When `VideoGenerationWorkerHandler` calls `super().__init__()`, the base class reads `config.server_args.enable_trace` which doesn't exist on the stub.

## Test plan
- [ ] Launch text-to-video worker with `Wan-AI/Wan2.1-T2V-1.3B-Diffusers` and verify it passes health check
- [ ] Launch image diffusion worker with `black-forest-labs/FLUX.1-dev` and verify startup
- [ ] Verify LLM workers (decode, prefill) are unaffected (they use real `ServerArgs`)

Fixes DYN-2711

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
