### PR TITLE
fix(ci): Cleanup build logs

### DIFF
--- a/.github/actions/docker-remote-build/action.yml
+++ b/.github/actions/docker-remote-build/action.yml
@@ -164,11 +164,14 @@ runs:
 
         # Pass AWS credentials as build secrets for sccache S3 access.
         # Dockerfile steps reference these via --mount=type=secret,id=aws-key-id,env=...
+        # Disable tracing to prevent set -x from leaking credentials into logs.
+        set +x
         SECRET_ARGS=""
         if [ "${{ inputs.use_sccache }}" == "true" ] && [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
           SECRET_ARGS+=" --secret id=aws-key-id,env=AWS_ACCESS_KEY_ID"
           SECRET_ARGS+=" --secret id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY"
         fi
+        set -x
 
         docker buildx build \
           --progress=plain \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -292,6 +292,8 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     /tmp/use-sccache.sh show-stats "FFMPEG" && \
     ldconfig && \
     mkdir -p /usr/local/src/ffmpeg && \
+    # Remove build artifacts (config.log, etc.) before preserving the source.
+    find /tmp/ffmpeg-${FFMPEG_VERSION} -name config.log -delete && \
     mv /tmp/ffmpeg-${FFMPEG_VERSION}* /usr/local/src/ffmpeg/
 
 # Build and install UCX


### PR DESCRIPTION
## Summary
- Disables bash tracing (`set +x`) around the block in `docker-remote-build` that reads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` into BuildKit `--secret` arguments
- Re-enables tracing (`set -x`) immediately after, so the rest of the build log remains verbose
- Prevents credentials from being expanded into build logs captured by `2>&1 | tee`

## Test plan
- [ ] Verify CI build logs no longer contain AWS credential values
- [ ] Verify sccache still works (cache hits in build output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified build pipeline logging behavior to exclude sensitive variable values from trace output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->