### PR TITLE
fix(snapshot): require exec-form command for checkpoint containers

### DIFF
--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -6,7 +6,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -107,7 +106,6 @@ func buildCheckpointJob(
 	mainContainer.LivenessProbe = nil
 	mainContainer.StartupProbe = nil
 
-	// The snapshot agent sends SIGUSR1 to PID 1 of the main container after
 	checkpoint.EnsurePodInfoMount(mainContainer)
 	dynamo.ApplySharedMemoryVolumeAndMount(&podTemplate.Spec, mainContainer, ckpt.Spec.Job.SharedMemory)
 
@@ -152,16 +150,6 @@ func buildCheckpointJob(
 		pp = 1
 	}
 	wrapLaunchJob := tp*pp > 1
-
-	// For single-GPU jobs (no cuda-checkpoint wrapper), unwrap /bin/sh -c so
-	// the actual process is PID 1 and receives SIGUSR1 from the snapshot agent.
-	if !wrapLaunchJob && len(mainContainer.Command) >= 2 &&
-		mainContainer.Command[len(mainContainer.Command)-1] == "-c" &&
-		len(mainContainer.Args) == 1 {
-		parts := strings.Fields(mainContainer.Args[0])
-		mainContainer.Command = parts[:1]
-		mainContainer.Args = parts[1:]
-	}
 
 	ttlSecondsAfterFinish := snapshotprotocol.DefaultCheckpointJobTTLSeconds
 

--- a/deploy/snapshot/protocol/checkpoint.go
+++ b/deploy/snapshot/protocol/checkpoint.go
@@ -5,7 +5,6 @@ package protocol
 
 import (
 	"fmt"
-	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -56,11 +55,14 @@ func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOpt
 	if opts.SeccompProfile != "" {
 		EnsureLocalhostSeccompProfile(&podTemplate.Spec, opts.SeccompProfile)
 	}
+	if len(podTemplate.Spec.Containers) == 0 {
+		return nil, fmt.Errorf("checkpoint job requires at least one container")
+	}
+	container := &podTemplate.Spec.Containers[0]
+	if err := RequireExecFormCommand(container); err != nil {
+		return nil, err
+	}
 	if opts.WrapLaunchJob {
-		if len(podTemplate.Spec.Containers) == 0 {
-			return nil, fmt.Errorf("checkpoint job requires at least one container")
-		}
-		container := &podTemplate.Spec.Containers[0]
 		if len(container.Command) == 0 {
 			return nil, fmt.Errorf("checkpoint job requires container.command when cuda-checkpoint launch-job wrapping is enabled")
 		}
@@ -157,18 +159,11 @@ func EnsureLocalhostSeccompProfile(podSpec *corev1.PodSpec, profile string) {
 	}
 }
 
+// wrapWithCudaCheckpointLaunchJob prepends cuda-checkpoint --launch-job to
+// the container's exec-form command+args. Callers must validate exec form via
+// RequireExecFormCommand first; a shell-wrapped command here would make
+// cuda-checkpoint launch sh, which swallows SIGUSR1.
 func wrapWithCudaCheckpointLaunchJob(command []string, args []string) ([]string, []string) {
-	// Unwrap "/bin/sh -c <single-string>" so cuda-checkpoint launches the
-	// actual process directly. Otherwise sh sits between cuda-checkpoint and
-	// the real process and swallows SIGUSR1.
-	if len(command) >= 2 && command[len(command)-1] == "-c" && len(args) == 1 {
-		shell := command[:len(command)-1] // e.g. ["/bin/sh"] — discarded
-		_ = shell
-		parts := strings.Fields(args[0])
-		command = parts[:1] // e.g. ["python3"]
-		args = parts[1:]    // e.g. ["-m", "dynamo.vllm", "--model", ...]
-	}
-
 	wrappedArgs := make([]string, 0, len(command)+len(args)+1)
 	wrappedArgs = append(wrappedArgs, "--launch-job")
 	wrappedArgs = append(wrappedArgs, command...)

--- a/deploy/snapshot/protocol/checkpoint_job_test.go
+++ b/deploy/snapshot/protocol/checkpoint_job_test.go
@@ -170,6 +170,39 @@ func TestNewCheckpointJobAllowsSingleNonMainContainer(t *testing.T) {
 
 
 
+func TestNewCheckpointJobRejectsShellWrappedCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		command       []string
+		wrapLaunchJob bool
+	}{
+		{"single GPU sh -c", []string{"/bin/sh", "-c"}, false},
+		{"multi GPU sh -c", []string{"/bin/sh", "-c"}, true},
+		{"single GPU bash -c", []string{"bash", "-c"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:    "main",
+						Image:   "test:latest",
+						Command: tc.command,
+						Args:    []string{"python3 -m dynamo.vllm --model x"},
+					}},
+				},
+			}, CheckpointJobOptions{
+				Namespace:     "test-ns",
+				CheckpointID:  "hash",
+				Name:          "test-job",
+				WrapLaunchJob: tc.wrapLaunchJob,
+			})
+			if err == nil {
+				t.Fatal("expected NewCheckpointJob to reject shell-wrapped command")
+			}
+		})
+	}
+}
+
 func TestGetCheckpointJobName(t *testing.T) {
 	name := GetCheckpointJobName("abc123def4567890", "2")
 	if name != "checkpoint-job-abc123def4567890-2" {

--- a/deploy/snapshot/protocol/execform.go
+++ b/deploy/snapshot/protocol/execform.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package protocol
+
+import (
+	"fmt"
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// RequireExecFormCommand returns an error if container uses a shell-wrapped
+// entrypoint (e.g. /bin/sh -c "python3 ..."). Checkpoint/restore needs the
+// real workload process to be PID 1 inside the container so that SIGUSR1
+// from the snapshot agent (and SIGTERM from cuda-checkpoint --launch-job)
+// reaches it directly; an intermediate shell swallows those signals unless
+// the shell happens to tail-call exec, which only fires for simple payloads.
+// Callers that build checkpoint artifacts should invoke this before emitting
+// a checkpoint Job.
+func RequireExecFormCommand(container *corev1.Container) error {
+	if container == nil || len(container.Command) == 0 {
+		return nil
+	}
+	base := filepath.Base(container.Command[0])
+	switch base {
+	case "sh", "bash", "dash", "zsh", "ash", "busybox":
+	default:
+		return nil
+	}
+	for _, token := range container.Command[1:] {
+		if token == "-c" {
+			return fmt.Errorf(
+				"checkpoint/restore requires exec-form command on container %q; "+
+					"got shell wrapper %v. Set extraPodSpec.mainContainer.command to the "+
+					"actual workload entrypoint (e.g. command: [python3], "+
+					"args: [-m, dynamo.vllm, --model, foo]) so the workload process is "+
+					"PID 1 and receives SIGUSR1 from the snapshot agent directly",
+				container.Name, container.Command,
+			)
+		}
+	}
+	return nil
+}

--- a/deploy/snapshot/protocol/execform_test.go
+++ b/deploy/snapshot/protocol/execform_test.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package protocol
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestRequireExecFormCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cmd     []string
+		wantErr bool
+	}{
+		{"nil command", nil, false},
+		{"empty command", []string{}, false},
+		{"exec form python", []string{"python3", "-m", "dynamo.vllm"}, false},
+		{"exec form /usr/bin/python3", []string{"/usr/bin/python3"}, false},
+		{"shell without -c is fine", []string{"/bin/sh", "my-entrypoint.sh"}, false},
+		{"bash without -c is fine", []string{"bash", "-l"}, false},
+		{"/bin/sh -c rejected", []string{"/bin/sh", "-c"}, true},
+		{"sh -c rejected", []string{"sh", "-c"}, true},
+		{"bash -c rejected", []string{"/bin/bash", "-c"}, true},
+		{"dash -c rejected", []string{"dash", "-c"}, true},
+		{"busybox sh -c rejected", []string{"/bin/busybox", "sh", "-c"}, true},
+		{"custom binary passes", []string{"/opt/my-runner", "-c", "config.yaml"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := RequireExecFormCommand(&corev1.Container{Name: "main", Command: tc.cmd})
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+
+	if err := RequireExecFormCommand(nil); err != nil {
+		t.Fatalf("nil container should return nil error, got %v", err)
+	}
+}

--- a/docs/kubernetes/snapshot.md
+++ b/docs/kubernetes/snapshot.md
@@ -25,6 +25,39 @@ title: Snapshot
 - NVIDIA driver 580.xx or newer on the target GPU nodes (590.xx or newer if testing multi-GPU snapshots)
 - vLLM or SGLang backend today
 - `ReadWriteMany` storage for cross-node restore
+- Exec-form container entrypoint for any workload that participates in checkpoint/restore (see [Container entrypoint shape](#container-entrypoint-shape))
+
+### Container entrypoint shape
+
+Checkpoint/restore needs the real workload process to be PID 1 inside the
+container so that `SIGUSR1` (from the snapshot agent) and the signals that
+`cuda-checkpoint --launch-job` delivers reach it directly. A shell wrapper
+in between can swallow those signals.
+
+Set `command` and `args` in **exec form** on the main container:
+
+```yaml
+extraPodSpec:
+  mainContainer:
+    command: [python3]
+    args: [-m, dynamo.vllm, --model, Qwen/Qwen3-0.6B]
+```
+
+Do **not** use a shell wrapper like `/bin/sh -c "python3 -m dynamo.vllm ..."`.
+The operator will reject checkpoint Jobs built from a shell-wrapped container
+with a clear error.
+
+If you need env-var expansion in the args, use Kubernetes' `$(VAR)` substitution
+(which the kubelet resolves before `execve`) rather than shell expansion:
+
+```yaml
+mainContainer:
+  env:
+    - name: MODEL_PATH
+      value: Qwen/Qwen3-0.6B
+  command: [python3]
+  args: [-m, dynamo.vllm, --model, $(MODEL_PATH)]
+```
 
 ## Quick Start via `DynamoCheckpoint` CR
 

--- a/examples/backends/vllm/deploy/gaie/agg.yaml
+++ b/examples/backends/vllm/deploy/gaie/agg.yaml
@@ -67,11 +67,24 @@ spec:
               value: "Qwen/Qwen3-0.6B"
             - name: DYN_STORE_KV
               value: "mem"
-          args:
-          - "python3 -m dynamo.vllm --model $MODEL_PATH --served-model-name $SERVED_MODEL_NAME --tensor-parallel-size 1 --data-parallel-size 1 --gpu-memory-utilization 0.90 --no-enable-prefix-caching --block-size 128"
           command:
-          - /bin/sh
-          - -c
+          - python3
+          - -m
+          - dynamo.vllm
+          args:
+          - --model
+          - $(MODEL_PATH)
+          - --served-model-name
+          - $(SERVED_MODEL_NAME)
+          - --tensor-parallel-size
+          - "1"
+          - --data-parallel-size
+          - "1"
+          - --gpu-memory-utilization
+          - "0.90"
+          - --no-enable-prefix-caching
+          - --block-size
+          - "128"
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
       replicas: 1

--- a/examples/backends/vllm/deploy/gaie/disagg.yaml
+++ b/examples/backends/vllm/deploy/gaie/disagg.yaml
@@ -96,11 +96,30 @@ spec:
               value: "Qwen/Qwen3-0.6B"
             - name: MODEL_PATH
               value: "Qwen/Qwen3-0.6B"
-          args:
-          - "python3 -m dynamo.vllm --model $MODEL_PATH --served-model-name $SERVED_MODEL_NAME --tensor-parallel-size 1 --data-parallel-size 1 --disaggregation-mode prefill --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' --gpu-memory-utilization 0.90 --enable-prefix-caching --block-size 16 --kv-events-config '{\"enable_kv_cache_events\":true}'"
           command:
-          - /bin/sh
-          - -c
+          - python3
+          - -m
+          - dynamo.vllm
+          args:
+          - --model
+          - $(MODEL_PATH)
+          - --served-model-name
+          - $(SERVED_MODEL_NAME)
+          - --tensor-parallel-size
+          - "1"
+          - --data-parallel-size
+          - "1"
+          - --disaggregation-mode
+          - prefill
+          - --kv-transfer-config
+          - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+          - --gpu-memory-utilization
+          - "0.90"
+          - --enable-prefix-caching
+          - --block-size
+          - "16"
+          - --kv-events-config
+          - '{"enable_kv_cache_events":true}'
           image: docker.io/lambda108/dynamo:post-rebase
           imagePullPolicy: IfNotPresent
           workingDir: /workspace/examples/backends/vllm
@@ -143,11 +162,27 @@ spec:
               value: "Qwen/Qwen3-0.6B"
             - name: MODEL_PATH
               value: "Qwen/Qwen3-0.6B"
-          args:
-          - "python3 -m dynamo.vllm --model $MODEL_PATH --served-model-name $SERVED_MODEL_NAME --tensor-parallel-size 1 --data-parallel-size 1 --disaggregation-mode decode --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' --gpu-memory-utilization 0.90 --block-size 16"
           command:
-          - /bin/sh
-          - -c
+          - python3
+          - -m
+          - dynamo.vllm
+          args:
+          - --model
+          - $(MODEL_PATH)
+          - --served-model-name
+          - $(SERVED_MODEL_NAME)
+          - --tensor-parallel-size
+          - "1"
+          - --data-parallel-size
+          - "1"
+          - --disaggregation-mode
+          - decode
+          - --kv-transfer-config
+          - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+          - --gpu-memory-utilization
+          - "0.90"
+          - --block-size
+          - "16"
           image: docker.io/lambda108/dynamo:post-rebase
           imagePullPolicy: IfNotPresent
           workingDir: /workspace/examples/backends/vllm


### PR DESCRIPTION
#### Overview:

One of three follow-up PRs closing reviewer feedback from #8194 (merged as `b2f7f22`). Fixes the only real crash bug in the GMS checkpoint/restore rewrite: an unsafe `strings.Fields(Args[0])` unwrap of shell-wrapped entrypoints at checkpoint-Job build time.

Companion PRs (to be opened next):
- `refactor: resolve workload container by name with fallback; wire GMS by pointer` — CodeRabbit D, E, I
- `fix(operator): validate pod-info volume; operator review nits` — CodeRabbit A, G, H, J

GMS Python changes (F, M, N) deferred to a separate GMS Python cleanup PR that is already in flight.

Closed predecessor: #8299.

#### Details:

The previous unwrap path at checkpoint-Job build time tried to turn `Command: ["/bin/sh","-c"], Args: ["python -m dynamo.vllm ..."]` into exec form by splitting on whitespace:

```go
parts := strings.Fields(mainContainer.Args[0])
mainContainer.Command = parts[:1]
mainContainer.Args = parts[1:]
```

Concrete bugs in this:

- `strings.Fields("")` returns an empty slice, then `parts[:1]` panics. `Args = [""]` is a legal PodSpec and nothing upstream rejects it.
- Shell quoting silently dropped: `python -c 'print(1)'` becomes `["python", "-c", "'print(1)'"]`, and Python sees the literal string `'print(1)'` (with quotes) and fails.
- `exec python foo` becomes `execve("exec", ...)` which fails — `exec` is a shell builtin, not a file.
- Compound commands silently flattened: `python foo && echo done` becomes `["python","foo","&&","echo","done"]`, dropping the second command.

More importantly this was a design problem. The checkpoint contract requires the workload process to be PID 1 so SIGUSR1 from the snapshot agent reaches it, but the whitespace-unwrap path only ever produced correct output when the shell happened to tail-call exec into a single simple command. Anything else was quietly broken.

This PR replaces the unwrap with an up-front validator:

- `snapshotprotocol.RequireExecFormCommand(container)` rejects shell wrappers (`sh`, `bash`, `dash`, `ash`, `zsh`, `busybox`) used with `-c`.
- `NewCheckpointJob` calls it before building the Job, so bad inputs fail at reconcile time with a clear error message rather than silently producing a Job whose SIGUSR1 goes nowhere.
- Users who need env-var expansion can use Kubernetes `$(VAR)` syntax (resolved by the kubelet pre-`execve`) instead of shell `$VAR`.

In-repo example YAMLs that previously used shell form are updated:

- `examples/backends/vllm/deploy/gaie/agg.yaml`
- `examples/backends/vllm/deploy/gaie/disagg.yaml`

Both now use `command: [python3, -m, dynamo.vllm]` with Kubernetes `$(VAR)` substitution for `MODEL_PATH` and `SERVED_MODEL_NAME`.

#### Where should the reviewer start?

1. **`deploy/snapshot/protocol/execform.go`** — new file, 12-line validator with 12 test cases in `execform_test.go`.
2. **`deploy/snapshot/protocol/checkpoint.go`** — `NewCheckpointJob` now calls the validator before building the Job; `wrapWithCudaCheckpointLaunchJob` is reduced to its essential task (no more silent unwrap).
3. **`deploy/operator/internal/controller/checkpoint_job.go`** — deleted the matching unwrap for the single-GPU path; also removed a dangling stale comment.
4. **`examples/backends/vllm/deploy/gaie/{agg,disagg}.yaml`** — verify the exec-form translation is functionally equivalent. The `$(VAR)` syntax is what the kubelet substitutes before `execve`, not shell `$VAR`.
5. **`docs/kubernetes/snapshot.md`** new "Container entrypoint shape" section — user-facing contract.

#### Tests

- `RequireExecFormCommand` — 12 shell-form / exec-form cases including `/bin/sh -c`, `bash -c`, `dash -c`, busybox + `sh -c`, plus false-positive safe cases (plain `bash -l`, `sh my-entrypoint.sh`, `/opt/my-runner -c config.yaml`).
- `NewCheckpointJob` rejects shell-wrapped commands in both single-GPU and `WrapLaunchJob` paths.
- All `deploy/operator` unit tests pass (`go test` against envtest assets).
- All `deploy/snapshot` tests pass.
- `go vet ./...` clean in both modules.
- `pre-commit run --from-ref origin/main --to-ref HEAD` passes.

#### Risk notes for deploy-codeowners

This PR **breaks** any deployment whose main container command is a shell wrapper (e.g. `[/bin/sh, -c, "python ..."]`) **on a checkpoint/GMS-enabled worker**. Non-checkpoint DGDs are unaffected.

In-repo effect: the two GAIE vLLM examples are fixed in this PR. External users with shell-wrapped workers on a checkpoint path will now see a reconcile-time error instead of a silently broken checkpoint. The error text tells them exactly how to fix it.

The default `[/bin/sh, -c]` placeholder in `component_common.go` is unchanged — it only matters for users who supply `args` without `command`, and only on checkpoint-enabled workers would they hit the new validator.

No API changes. No dependency changes.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #8194 (addresses resolved CodeRabbit threads B and C)
- Replaces: #8299 (closed; split into three single-concern PRs)
