### PR TITLE
refactor: resolve workload container by name with Containers[0] fallback; wire GMS by pointer

### DIFF
--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -236,6 +236,23 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Equal(t, []string{"run"}, podSpec.Containers[1].Args)
 	})
 
+	t.Run("ready checkpoint resolves main even when not at index zero", func(t *testing.T) {
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "istio-proxy", Image: "istio:latest", Command: []string{"istio"}, Args: []string{"run"}},
+				{Name: "main", Image: "main:latest", Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}},
+			},
+		}
+		info := &CheckpointInfo{Enabled: true, Ready: true, Hash: testHash}
+		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
+
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info))
+		assert.Equal(t, []string{"istio"}, podSpec.Containers[0].Command, "sidecar at index 0 must remain untouched")
+		assert.Equal(t, []string{"run"}, podSpec.Containers[0].Args)
+		assert.Equal(t, []string{"sleep", "infinity"}, podSpec.Containers[1].Command, "main at index 1 should receive the restore override")
+		assert.Nil(t, podSpec.Containers[1].Args)
+	})
+
 	t.Run("ready gms checkpoint injects restore sidecars and loader mount", func(t *testing.T) {
 		podSpec := testPodSpec()
 		podSpec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu"}}
@@ -280,7 +297,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 			errMsg  string
 		}{
 			{"hash empty and identity nil", testPodSpec(), &CheckpointInfo{Enabled: true}, fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "identity is nil"},
-			{"no containers", &corev1.PodSpec{}, testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "no container named"},
+			{"no containers", &corev1.PodSpec{}, testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "no containers found"},
 			{"snapshot daemonset missing", testPodSpec(), testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).Build(), "no snapshot-agent daemonset found"},
 		} {
 			t.Run(tc.name, func(t *testing.T) {

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,19 +35,6 @@ func ApplyRestorePodMetadata(labels map[string]string, annotations map[string]st
 		artifactVersion = checkpointInfo.ArtifactVersion
 	}
 	snapshotprotocol.ApplyRestoreTargetMetadata(labels, annotations, enabled, hash, artifactVersion)
-}
-
-// resolveMainContainer finds the container named "main" in the pod spec.
-// ExtraPodSpec.PodSpec.Containers can inject user containers before the main
-// container (mergo merge happens before main is appended), so index 0 is
-// not guaranteed to be the main container here.
-func resolveMainContainer(podSpec *corev1.PodSpec) *corev1.Container {
-	for i := range podSpec.Containers {
-		if podSpec.Containers[i].Name == commonconsts.MainContainerName {
-			return &podSpec.Containers[i]
-		}
-	}
-	return nil
 }
 
 func InjectCheckpointIntoPodSpec(
@@ -75,9 +61,9 @@ func InjectCheckpointIntoPodSpec(
 		info.Hash = hash
 	}
 
-	mainContainer := resolveMainContainer(podSpec)
+	mainContainer := snapshotprotocol.ResolveMainContainer(podSpec)
 	if mainContainer == nil {
-		return fmt.Errorf("no container named %q found in pod spec", commonconsts.MainContainerName)
+		return fmt.Errorf("no containers found in pod spec")
 	}
 	if reader == nil {
 		return fmt.Errorf("checkpoint client is required")
@@ -87,7 +73,6 @@ func InjectCheckpointIntoPodSpec(
 		reader,
 		namespace,
 		podSpec,
-		mainContainer,
 		info.Hash,
 		info.ArtifactVersion,
 		snapshotprotocol.DefaultSeccompLocalhostProfile,

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/common"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,7 +62,7 @@ func InjectCheckpointIntoPodSpec(
 		info.Hash = hash
 	}
 
-	mainContainer := snapshotprotocol.ResolveMainContainer(podSpec)
+	mainContainer := common.ResolveMainContainer(podSpec)
 	if mainContainer == nil {
 		return fmt.Errorf("no containers found in pod spec")
 	}

--- a/deploy/operator/internal/common/maincontainer.go
+++ b/deploy/operator/internal/common/maincontainer.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ResolveMainContainer returns a pointer to the workload container in podSpec.
+// It prefers the container named commonconsts.MainContainerName and falls back
+// to Containers[0] so that pods rendered before the naming convention (or by
+// non-operator tooling in tests) still resolve to a sensible target.
+// Returns nil only when podSpec has no containers.
+//
+// Keep this helper on the operator side. Snapshot tooling has its own copy in
+// snapshotprotocol because deploy/snapshot is a separate Go module and cannot
+// import deploy/operator/internal. The two implementations must match.
+func ResolveMainContainer(podSpec *corev1.PodSpec) *corev1.Container {
+	if podSpec == nil || len(podSpec.Containers) == 0 {
+		return nil
+	}
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == commonconsts.MainContainerName {
+			return &podSpec.Containers[i]
+		}
+	}
+	return &podSpec.Containers[0]
+}

--- a/deploy/operator/internal/common/maincontainer_test.go
+++ b/deploy/operator/internal/common/maincontainer_test.go
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestResolveMainContainer(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		spec     *corev1.PodSpec
+		wantName string
+		wantNil  bool
+	}{
+		{
+			name:    "nil spec",
+			spec:    nil,
+			wantNil: true,
+		},
+		{
+			name:    "no containers",
+			spec:    &corev1.PodSpec{},
+			wantNil: true,
+		},
+		{
+			name: "single container named main",
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{{Name: commonconsts.MainContainerName}},
+			},
+			wantName: commonconsts.MainContainerName,
+		},
+		{
+			name: "picks container named main even when not first",
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "istio-proxy"},
+					{Name: commonconsts.MainContainerName},
+					{Name: "sidecar-frontend"},
+				},
+			},
+			wantName: commonconsts.MainContainerName,
+		},
+		{
+			name: "falls back to first container when none named main",
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "worker"},
+					{Name: "sidecar"},
+				},
+			},
+			wantName: "worker",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveMainContainer(tc.spec)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected container %q, got nil", tc.wantName)
+			}
+			if got.Name != tc.wantName {
+				t.Fatalf("expected container %q, got %q", tc.wantName, got.Name)
+			}
+		})
+	}
+}

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -3,6 +3,7 @@ package consts
 import (
 	"time"
 
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -122,7 +123,10 @@ const (
 	GroveRoleSuffixLeader = "ldr"
 	GroveRoleSuffixWorker = "wkr"
 
-	MainContainerName            = "main"
+	// MainContainerName is the conventional name of the workload container.
+	// Source of truth lives in snapshotprotocol so that both the operator and
+	// the snapshot tooling agree on the contract.
+	MainContainerName            = snapshotprotocol.MainContainerName
 	FrontendSidecarContainerName = "sidecar-frontend"
 
 	RestartAnnotation = "nvidia.com/restartAt"

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -3,7 +3,6 @@ package consts
 import (
 	"time"
 
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -123,10 +122,13 @@ const (
 	GroveRoleSuffixLeader = "ldr"
 	GroveRoleSuffixWorker = "wkr"
 
-	// MainContainerName is the conventional name of the workload container.
-	// Source of truth lives in snapshotprotocol so that both the operator and
-	// the snapshot tooling agree on the contract.
-	MainContainerName            = snapshotprotocol.MainContainerName
+	// MainContainerName is the conventional name of the workload container in
+	// operator-rendered pods. The operator originated this convention (LWS
+	// multinode enforcement); other subsystems (snapshot/protocol) that need
+	// to match on the name keep their own local copy because deploy/snapshot
+	// is a separate Go module and cannot import deploy/operator/internal.
+	// Keep the two copies in sync.
+	MainContainerName            = "main"
 	FrontendSidecarContainerName = "sidecar-frontend"
 
 	RestartAnnotation = "nvidia.com/restartAt"

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -113,7 +113,7 @@ func buildCheckpointJob(
 
 	if ckpt.Spec.GPUMemoryService != nil && ckpt.Spec.GPUMemoryService.Enabled {
 		claimTemplateName := dra.ResourceClaimTemplateName("checkpoint-"+hash, "worker")
-		if err := dra.ApplyClaim(&podTemplate.Spec, claimTemplateName); err != nil {
+		if err := dra.ApplyClaim(&podTemplate.Spec, mainContainer, claimTemplateName); err != nil {
 			return nil, fmt.Errorf("failed to apply DRA claim for GMS checkpoint: %w", err)
 		}
 		storage, err := snapshotprotocol.DiscoverAndResolveStorage(

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -82,10 +82,10 @@ func buildCheckpointJob(
 
 	checkpoint.EnsurePodInfoVolume(&podTemplate.Spec)
 
-	if len(podTemplate.Spec.Containers) == 0 {
+	mainContainer := snapshotprotocol.ResolveMainContainer(&podTemplate.Spec)
+	if mainContainer == nil {
 		return nil, fmt.Errorf("checkpoint job requires at least one container")
 	}
-	mainContainer := &podTemplate.Spec.Containers[0]
 	mainContainer.Env = dynamo.MergeEnvs(
 		buildCheckpointWorkerDefaultEnv(ckpt, podTemplate),
 		mainContainer.Env,
@@ -131,7 +131,7 @@ func buildCheckpointJob(
 		}
 		// Re-acquire pointer: append in EnsureGMSCheckpointJobSidecars may
 		// have reallocated the Containers slice.
-		mainContainer = &podTemplate.Spec.Containers[0]
+		mainContainer = snapshotprotocol.ResolveMainContainer(&podTemplate.Spec)
 	}
 
 	activeDeadlineSeconds := ckpt.Spec.Job.ActiveDeadlineSeconds

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -11,6 +11,7 @@ import (
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
@@ -82,7 +83,7 @@ func buildCheckpointJob(
 
 	checkpoint.EnsurePodInfoVolume(&podTemplate.Spec)
 
-	mainContainer := snapshotprotocol.ResolveMainContainer(&podTemplate.Spec)
+	mainContainer := common.ResolveMainContainer(&podTemplate.Spec)
 	if mainContainer == nil {
 		return nil, fmt.Errorf("checkpoint job requires at least one container")
 	}
@@ -131,7 +132,7 @@ func buildCheckpointJob(
 		}
 		// Re-acquire pointer: append in EnsureGMSCheckpointJobSidecars may
 		// have reallocated the Containers slice.
-		mainContainer = snapshotprotocol.ResolveMainContainer(&podTemplate.Spec)
+		mainContainer = common.ResolveMainContainer(&podTemplate.Spec)
 	}
 
 	activeDeadlineSeconds := ckpt.Spec.Job.ActiveDeadlineSeconds

--- a/deploy/operator/internal/dra/dra.go
+++ b/deploy/operator/internal/dra/dra.go
@@ -28,13 +28,14 @@ const (
 	defaultDeviceClassName = "gpu.nvidia.com"
 )
 
-// ApplyClaim replaces the first container's nvidia.com/gpu resources with a
+// ApplyClaim replaces the target container's nvidia.com/gpu resources with a
 // shared DRA ResourceClaim. Every container that references this claim name
 // will share the same physical GPUs. The function is idempotent — calling it
-// on a pod that already has the claim is a no-op.
-func ApplyClaim(podSpec *corev1.PodSpec, claimTemplateName string) error {
-	if len(podSpec.Containers) == 0 {
-		return fmt.Errorf("pod spec must have at least one container for DRA claim")
+// on a pod that already has the claim is a no-op. Pass the workload container
+// explicitly; the caller owns main-container resolution.
+func ApplyClaim(podSpec *corev1.PodSpec, target *corev1.Container, claimTemplateName string) error {
+	if target == nil {
+		return fmt.Errorf("DRA claim target container is required")
 	}
 
 	// Skip if the pod-level claim already exists (idempotent).
@@ -46,9 +47,9 @@ func ApplyClaim(podSpec *corev1.PodSpec, claimTemplateName string) error {
 
 	// Replace nvidia.com/gpu with the shared DRA claim.
 	gpuResource := corev1.ResourceName(commonconsts.KubeResourceGPUNvidia)
-	delete(podSpec.Containers[0].Resources.Limits, gpuResource)
-	delete(podSpec.Containers[0].Resources.Requests, gpuResource)
-	podSpec.Containers[0].Resources.Claims = append(podSpec.Containers[0].Resources.Claims, corev1.ResourceClaim{
+	delete(target.Resources.Limits, gpuResource)
+	delete(target.Resources.Requests, gpuResource)
+	target.Resources.Claims = append(target.Resources.Claims, corev1.ResourceClaim{
 		Name: ClaimName,
 	})
 

--- a/deploy/operator/internal/dra/dra_test.go
+++ b/deploy/operator/internal/dra/dra_test.go
@@ -46,16 +46,16 @@ func basePodSpec() corev1.PodSpec {
 	}
 }
 
-func TestApplyClaim_EmptyContainers(t *testing.T) {
+func TestApplyClaim_NilTarget(t *testing.T) {
 	ps := corev1.PodSpec{}
-	err := ApplyClaim(&ps, "myapp-worker-gpu")
+	err := ApplyClaim(&ps, nil, "myapp-worker-gpu")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "at least one container")
+	assert.Contains(t, err.Error(), "target container")
 }
 
 func TestApplyClaim_ReplacesGPUWithDRAClaim(t *testing.T) {
 	ps := basePodSpec()
-	err := ApplyClaim(&ps, "myapp-worker-gpu")
+	err := ApplyClaim(&ps, &ps.Containers[0], "myapp-worker-gpu")
 	require.NoError(t, err)
 
 	main := ps.Containers[0]
@@ -81,16 +81,22 @@ func TestApplyClaim_ReplacesGPUWithDRAClaim(t *testing.T) {
 	assert.Empty(t, ps.InitContainers)
 }
 
-func TestApplyClaim_AlwaysTargetsFirstContainer(t *testing.T) {
-	ps := basePodSpec()
-	ps.Containers = append(ps.Containers, corev1.Container{Name: "sidecar", Image: "sidecar:latest"})
+func TestApplyClaim_TargetsCallerSuppliedContainer(t *testing.T) {
+	ps := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{Name: "istio-proxy", Image: "istio:latest"},
+			{Name: "main", Image: "test-image:latest", Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceName(commonconsts.KubeResourceGPUNvidia): resource.MustParse("2")},
+			}},
+		},
+	}
 
-	err := ApplyClaim(&ps, "myapp-worker-gpu")
+	err := ApplyClaim(&ps, &ps.Containers[1], "myapp-worker-gpu")
 	require.NoError(t, err)
 
-	require.Len(t, ps.Containers[0].Resources.Claims, 1)
-	assert.Equal(t, ClaimName, ps.Containers[0].Resources.Claims[0].Name)
-	assert.Empty(t, ps.Containers[1].Resources.Claims)
+	assert.Empty(t, ps.Containers[0].Resources.Claims, "sidecar at index 0 must not receive the claim")
+	require.Len(t, ps.Containers[1].Resources.Claims, 1)
+	assert.Equal(t, ClaimName, ps.Containers[1].Resources.Claims[0].Name)
 }
 
 func TestGenerateResourceClaimTemplate_Enabled(t *testing.T) {

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -40,7 +40,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/imdario/mergo"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -1164,6 +1163,18 @@ func GenerateBasePodSpec(
 
 	podSpec.Volumes = append(podSpec.Volumes, volumes...)
 	ApplySharedMemoryVolumeAndMount(&podSpec, &container, component.SharedMemory)
+
+	// Wire GMS into the main container while we still hold it locally, before
+	// it lands in podSpec.Containers. This avoids needing to search the slice
+	// for the "main" container after the fact, and keeps graph.go decoupled
+	// from snapshot-protocol naming conventions.
+	if component.GPUMemoryService != nil && component.GPUMemoryService.Enabled {
+		claimTemplateName := dra.ResourceClaimTemplateName(parentGraphDeploymentName, serviceName)
+		if err := dra.ApplyClaim(&podSpec, &container, claimTemplateName); err != nil {
+			return nil, fmt.Errorf("failed to apply DRA claim for GMS: %w", err)
+		}
+		gms.EnsureServerSidecar(&podSpec, &container)
+	}
 	podSpec.Containers = append(podSpec.Containers, container)
 	podSpec.ImagePullSecrets = controller_common.AppendUniqueImagePullSecrets(podSpec.ImagePullSecrets, imagePullSecrets)
 
@@ -1183,19 +1194,6 @@ func GenerateBasePodSpec(
 				resolveImagePullSecrets(secretsRetriever, namespace, component.FrontendSidecar.Image),
 			)
 		}
-	}
-
-	// GMS: replace nvidia.com/gpu with a shared DRA claim and add the server sidecar.
-	if component.GPUMemoryService != nil && component.GPUMemoryService.Enabled {
-		claimTemplateName := dra.ResourceClaimTemplateName(parentGraphDeploymentName, serviceName)
-		if err := dra.ApplyClaim(&podSpec, claimTemplateName); err != nil {
-			return nil, fmt.Errorf("failed to apply DRA claim for GMS: %w", err)
-		}
-		mainContainer := snapshotprotocol.ResolveMainContainer(&podSpec)
-		if mainContainer == nil {
-			return nil, fmt.Errorf("cannot wire GMS: pod spec has no containers")
-		}
-		gms.EnsureServerSidecar(&podSpec, mainContainer)
 	}
 
 	// Clone main container into two engine containers (active + standby) for failover.

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/imdario/mergo"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -1190,7 +1191,11 @@ func GenerateBasePodSpec(
 		if err := dra.ApplyClaim(&podSpec, claimTemplateName); err != nil {
 			return nil, fmt.Errorf("failed to apply DRA claim for GMS: %w", err)
 		}
-		gms.EnsureServerSidecar(&podSpec, &podSpec.Containers[0])
+		mainContainer := snapshotprotocol.ResolveMainContainer(&podSpec)
+		if mainContainer == nil {
+			return nil, fmt.Errorf("cannot wire GMS: pod spec has no containers")
+		}
+		gms.EnsureServerSidecar(&podSpec, mainContainer)
 	}
 
 	// Clone main container into two engine containers (active + standby) for failover.

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/google/go-cmp/cmp"
@@ -5152,6 +5154,107 @@ func TestGenerateBasePodSpec_PlannerServiceAccount(t *testing.T) {
 					podSpec.ServiceAccountName, tt.expectedServiceAcc)
 			}
 		})
+	}
+}
+
+// TestGenerateBasePodSpec_GMSWiredToMainBeforeFailover covers the invariant
+// that failover requires: GMS wiring must land on the main container before
+// buildFailoverPod clones it into engine-0 / engine-1, so both engines
+// inherit the shared socket volume, mount, env, and DRA claim.
+func TestGenerateBasePodSpec_GMSWiredToMainBeforeFailover(t *testing.T) {
+	component := &v1alpha1.DynamoComponentDeploymentSharedSpec{
+		ComponentType: commonconsts.ComponentTypeWorker,
+		ExtraPodSpec: &v1alpha1.ExtraPodSpec{
+			MainContainer: &corev1.Container{
+				Image:   "test-image:latest",
+				Command: []string{"python3", "-m", "dynamo.vllm"},
+				Args:    []string{"--model", "Qwen/Qwen3-0.6B"},
+			},
+		},
+		Resources: &v1alpha1.Resources{
+			Limits: &v1alpha1.ResourceItem{GPU: "1"},
+		},
+		GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{Enabled: true},
+		Failover:         &v1alpha1.FailoverSpec{Enabled: true},
+	}
+	controllerConfig := &configv1alpha1.OperatorConfiguration{}
+
+	podSpec, err := GenerateBasePodSpec(
+		component,
+		BackendFrameworkVLLM,
+		&mockSecretsRetriever{},
+		"test-deployment",
+		"default",
+		RoleMain,
+		1,
+		controllerConfig,
+		commonconsts.MultinodeDeploymentTypeGrove,
+		"test-service",
+		nil,
+	)
+	require.NoError(t, err)
+
+	// After failover transformation the workload lives in engine-0 / engine-1,
+	// not in a single "main" container. The GMS server sidecar remains in
+	// InitContainers and is shared across both engines.
+	var engines []corev1.Container
+	for _, c := range podSpec.Containers {
+		if strings.HasPrefix(c.Name, "engine-") {
+			engines = append(engines, c)
+		}
+	}
+	require.Len(t, engines, 2, "failover should produce engine-0 and engine-1")
+
+	var gmsServer *corev1.Container
+	for i := range podSpec.InitContainers {
+		if podSpec.InitContainers[i].Name == gms.ServerContainerName {
+			gmsServer = &podSpec.InitContainers[i]
+			break
+		}
+	}
+	require.NotNil(t, gmsServer, "gms-server must be registered as an init sidecar")
+
+	// Shared socket volume is a pod-level prerequisite for engine <-> gms-server
+	// communication. It must exist exactly once regardless of engine count.
+	var sharedVolume *corev1.Volume
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name == gms.SharedVolumeName {
+			sharedVolume = &podSpec.Volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, sharedVolume, "gms shared socket volume must be present")
+
+	// Each engine must carry the GMS mount, env, and DRA claim it inherited
+	// from the main container via DeepCopy in buildEngineContainer.
+	for i := range engines {
+		engine := engines[i]
+		name := engine.Name
+
+		var mount *corev1.VolumeMount
+		for j := range engine.VolumeMounts {
+			if engine.VolumeMounts[j].Name == gms.SharedVolumeName {
+				mount = &engine.VolumeMounts[j]
+				break
+			}
+		}
+		require.NotNil(t, mount, "%s must mount the GMS shared volume", name)
+		assert.Equal(t, gms.SharedMountPath, mount.MountPath, "%s GMS mount path", name)
+
+		var socketDirEnv string
+		for _, e := range engine.Env {
+			if e.Name == gms.EnvSocketDir {
+				socketDirEnv = e.Value
+				break
+			}
+		}
+		assert.Equal(t, gms.SharedMountPath, socketDirEnv, "%s %s env", name, gms.EnvSocketDir)
+
+		require.Len(t, engine.Resources.Claims, 1, "%s must inherit the DRA claim", name)
+		assert.Equal(t, dra.ClaimName, engine.Resources.Claims[0].Name, "%s DRA claim", name)
+
+		_, hasLimit := engine.Resources.Limits[corev1.ResourceName(commonconsts.KubeResourceGPUNvidia)]
+		assert.False(t, hasLimit, "%s nvidia.com/gpu limit must be removed in favor of DRA claim", name)
 	}
 }
 

--- a/deploy/snapshot/cmd/snapshotctl/kube.go
+++ b/deploy/snapshot/cmd/snapshotctl/kube.go
@@ -95,28 +95,23 @@ func loadPod(manifestPath string) (*corev1.Pod, error) {
 	if kind := strings.TrimSpace(pod.Kind); kind != "" && kind != "Pod" {
 		return nil, fmt.Errorf("manifest %s is kind %q, expected Pod", manifestPath, kind)
 	}
-	if len(pod.Spec.Containers) == 0 {
+	workerContainer := snapshotprotocol.ResolveMainContainer(&pod.Spec)
+	if workerContainer == nil {
 		return nil, fmt.Errorf(
 			"manifest %s has no worker containers; snapshotctl requires at least one worker container",
 			manifestPath,
 		)
 	}
-	workerContainer := &pod.Spec.Containers[0]
-	if len(pod.Spec.Containers) > 1 {
-		workerContainer = nil
-		for index := range pod.Spec.Containers {
-			if pod.Spec.Containers[index].Name == "main" {
-				workerContainer = &pod.Spec.Containers[index]
-				break
-			}
-		}
-		if workerContainer == nil {
-			return nil, fmt.Errorf(
-				"manifest %s has %d containers; snapshotctl requires a worker container named main",
-				manifestPath,
-				len(pod.Spec.Containers),
-			)
-		}
+	// In multi-container manifests the author must pick the worker explicitly
+	// by naming it "main"; otherwise the ResolveMainContainer fallback would
+	// silently target whichever container happens to be first.
+	if len(pod.Spec.Containers) > 1 && workerContainer.Name != snapshotprotocol.MainContainerName {
+		return nil, fmt.Errorf(
+			"manifest %s has %d containers; snapshotctl requires a worker container named %q",
+			manifestPath,
+			len(pod.Spec.Containers),
+			snapshotprotocol.MainContainerName,
+		)
 	}
 	if strings.TrimSpace(workerContainer.Image) == "" {
 		return nil, fmt.Errorf("manifest %s: worker container image is required", manifestPath)

--- a/deploy/snapshot/internal/controller/util.go
+++ b/deploy/snapshot/internal/controller/util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
@@ -48,13 +49,12 @@ func podFromInformerObj(obj interface{}) (*corev1.Pod, bool) {
 	return pod, ok
 }
 
-// resolveMainContainerName returns the name of the workload container, which
-// is always Containers[0]. GMS sidecars are appended after the workload.
+// resolveMainContainerName returns the name of the workload container by
+// deferring to snapshotprotocol.ResolveMainContainerName. That helper prefers
+// the container named "main" and falls back to Containers[0] so pods produced
+// before the naming convention (or by non-operator tooling) still resolve.
 func resolveMainContainerName(pod *corev1.Pod) string {
-	if len(pod.Spec.Containers) == 0 {
-		return ""
-	}
-	return pod.Spec.Containers[0].Name
+	return snapshotprotocol.ResolveMainContainerName(pod)
 }
 
 func isPodReady(pod *corev1.Pod) bool {

--- a/deploy/snapshot/internal/executor/restore.go
+++ b/deploy/snapshot/internal/executor/restore.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/logging"
 	snapshotruntime "github.com/ai-dynamo/dynamo/deploy/snapshot/internal/runtime"
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 // RestoreRequest holds the parameters for a restore operation.
@@ -122,7 +123,7 @@ func inspectRestore(ctx context.Context, ctrd *containerd.Client, log logr.Logge
 
 	containerName := req.ContainerName
 	if containerName == "" {
-		containerName = "main"
+		containerName = snapshotprotocol.MainContainerName
 	}
 
 	placeholderPID, _, err := snapshotruntime.ResolveContainerByPod(ctx, ctrd, req.PodName, req.PodNamespace, containerName)

--- a/deploy/snapshot/protocol/checkpoint.go
+++ b/deploy/snapshot/protocol/checkpoint.go
@@ -57,10 +57,10 @@ func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOpt
 		EnsureLocalhostSeccompProfile(&podTemplate.Spec, opts.SeccompProfile)
 	}
 	if opts.WrapLaunchJob {
-		if len(podTemplate.Spec.Containers) == 0 {
+		container := ResolveMainContainer(&podTemplate.Spec)
+		if container == nil {
 			return nil, fmt.Errorf("checkpoint job requires at least one container")
 		}
-		container := &podTemplate.Spec.Containers[0]
 		if len(container.Command) == 0 {
 			return nil, fmt.Errorf("checkpoint job requires container.command when cuda-checkpoint launch-job wrapping is enabled")
 		}

--- a/deploy/snapshot/protocol/maincontainer.go
+++ b/deploy/snapshot/protocol/maincontainer.go
@@ -6,10 +6,12 @@ package protocol
 import corev1 "k8s.io/api/core/v1"
 
 // MainContainerName is the conventional name of the workload container that
-// checkpoint/restore operates on. The operator always sets this name on the
-// pods it emits. Keeping the constant in the snapshot protocol package makes
-// it the shared contract between the operator (which builds pods) and the
-// snapshot agent / snapshotctl (which checkpoint them).
+// checkpoint/restore operates on. The operator originated this convention
+// for LWS multinode enforcement and the authoritative copy lives in
+// deploy/operator/internal/consts (commonconsts.MainContainerName). This
+// package keeps a local copy because deploy/snapshot is a separate Go
+// module and cannot import deploy/operator/internal. Keep the two copies
+// in sync.
 const MainContainerName = "main"
 
 // ResolveMainContainer returns a pointer to the workload container in podSpec.

--- a/deploy/snapshot/protocol/maincontainer.go
+++ b/deploy/snapshot/protocol/maincontainer.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package protocol
+
+import corev1 "k8s.io/api/core/v1"
+
+// MainContainerName is the conventional name of the workload container that
+// checkpoint/restore operates on. The operator always sets this name on the
+// pods it emits. Keeping the constant in the snapshot protocol package makes
+// it the shared contract between the operator (which builds pods) and the
+// snapshot agent / snapshotctl (which checkpoint them).
+const MainContainerName = "main"
+
+// ResolveMainContainer returns a pointer to the workload container in podSpec.
+// It prefers the container named MainContainerName and falls back to
+// Containers[0] so that pods rendered before the naming convention (or by
+// non-operator tooling in tests) still resolve to a sensible target.
+// Returns nil only when podSpec has no containers.
+func ResolveMainContainer(podSpec *corev1.PodSpec) *corev1.Container {
+	if podSpec == nil || len(podSpec.Containers) == 0 {
+		return nil
+	}
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == MainContainerName {
+			return &podSpec.Containers[i]
+		}
+	}
+	return &podSpec.Containers[0]
+}
+
+// ResolveMainContainerName returns the name of the workload container in pod.
+// Used by the snapshot agent, which reads pods from an informer cache and
+// needs to send signals to the matching ContainerStatus entry by name.
+// Returns "" only when pod has no containers.
+func ResolveMainContainerName(pod *corev1.Pod) string {
+	container := ResolveMainContainer(&pod.Spec)
+	if container == nil {
+		return ""
+	}
+	return container.Name
+}

--- a/deploy/snapshot/protocol/maincontainer.go
+++ b/deploy/snapshot/protocol/maincontainer.go
@@ -19,6 +19,11 @@ const MainContainerName = "main"
 // Containers[0] so that pods rendered before the naming convention (or by
 // non-operator tooling in tests) still resolve to a sensible target.
 // Returns nil only when podSpec has no containers.
+//
+// Operator code should use common.ResolveMainContainer in
+// deploy/operator/internal/common instead of importing this function.
+// The duplication exists because deploy/snapshot and deploy/operator are
+// separate Go modules; both implementations must match.
 func ResolveMainContainer(podSpec *corev1.PodSpec) *corev1.Container {
 	if podSpec == nil || len(podSpec.Containers) == 0 {
 		return nil

--- a/deploy/snapshot/protocol/maincontainer_test.go
+++ b/deploy/snapshot/protocol/maincontainer_test.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package protocol
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestResolveMainContainer(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		spec     *corev1.PodSpec
+		wantName string
+		wantNil  bool
+	}{
+		{
+			name:    "nil spec",
+			spec:    nil,
+			wantNil: true,
+		},
+		{
+			name:    "no containers",
+			spec:    &corev1.PodSpec{},
+			wantNil: true,
+		},
+		{
+			name: "single container is main by convention",
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "main"}},
+			},
+			wantName: "main",
+		},
+		{
+			name: "picks container named main even when not first",
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "istio-proxy"},
+					{Name: "main"},
+					{Name: "sidecar-frontend"},
+				},
+			},
+			wantName: "main",
+		},
+		{
+			name: "falls back to first container when none named main",
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "worker"},
+					{Name: "sidecar"},
+				},
+			},
+			wantName: "worker",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveMainContainer(tc.spec)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected container %q, got nil", tc.wantName)
+			}
+			if got.Name != tc.wantName {
+				t.Fatalf("expected container %q, got %q", tc.wantName, got.Name)
+			}
+		})
+	}
+}
+
+func TestResolveMainContainerName(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{
+		Containers: []corev1.Container{
+			{Name: "istio-proxy"},
+			{Name: "main"},
+		},
+	}}
+	if got := ResolveMainContainerName(pod); got != "main" {
+		t.Fatalf("expected main, got %q", got)
+	}
+
+	pod = &corev1.Pod{Spec: corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "worker"}},
+	}}
+	if got := ResolveMainContainerName(pod); got != "worker" {
+		t.Fatalf("expected worker (fallback), got %q", got)
+	}
+
+	pod = &corev1.Pod{}
+	if got := ResolveMainContainerName(pod); got != "" {
+		t.Fatalf("expected empty string for container-less pod, got %q", got)
+	}
+}

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -39,7 +39,7 @@ func NewRestorePod(pod *corev1.Pod, opts PodOptions) *corev1.Pod {
 		pod.Annotations = map[string]string{}
 	}
 	ApplyRestoreTargetMetadata(pod.Labels, pod.Annotations, true, opts.CheckpointID, opts.ArtifactVersion)
-	container := resolveWorkerContainer(&pod.Spec)
+	container := ResolveMainContainer(&pod.Spec)
 	if container == nil {
 		return nil
 	}
@@ -47,15 +47,6 @@ func NewRestorePod(pod *corev1.Pod, opts PodOptions) *corev1.Pod {
 	pod.Namespace = opts.Namespace
 	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
 	return pod
-}
-
-// resolveWorkerContainer returns the workload container, which is always
-// Containers[0]. GMS sidecars are appended after the workload.
-func resolveWorkerContainer(podSpec *corev1.PodSpec) *corev1.Container {
-	if podSpec == nil || len(podSpec.Containers) == 0 {
-		return nil
-	}
-	return &podSpec.Containers[0]
 }
 
 func PrepareRestorePodSpec(
@@ -105,7 +96,7 @@ func ValidateRestorePodSpec(
 	if podSpec == nil {
 		return fmt.Errorf("pod spec is nil")
 	}
-	container := resolveWorkerContainer(podSpec)
+	container := ResolveMainContainer(podSpec)
 	if container == nil {
 		return fmt.Errorf("restore target must have at least one container")
 	}
@@ -235,17 +226,25 @@ func DiscoverAndResolveStorage(
 	return ResolveCheckpointStorage(checkpointID, artifactVersion, storage)
 }
 
+// PrepareRestorePodSpecForCheckpoint resolves the workload container via
+// ResolveMainContainer (prefers "main", falls back to Containers[0]) and then
+// wires storage and restore semantics onto it. Callers do not pass the
+// container pointer — the function is the single source of truth for which
+// container carries the restore.
 func PrepareRestorePodSpecForCheckpoint(
 	ctx context.Context,
 	reader ctrlclient.Reader,
 	namespace string,
 	podSpec *corev1.PodSpec,
-	container *corev1.Container,
 	checkpointID string,
 	artifactVersion string,
 	seccompProfile string,
 	isCheckpointReady bool,
 ) error {
+	container := ResolveMainContainer(podSpec)
+	if container == nil {
+		return fmt.Errorf("restore target must have at least one container")
+	}
 	storage, err := DiscoverAndResolveStorage(ctx, reader, namespace, checkpointID, artifactVersion)
 	if err != nil {
 		return err


### PR DESCRIPTION
#### Overview:

One of three follow-up PRs closing reviewer feedback from #8194. This is the main-container resolution refactor: every site that hardcoded `podSpec.Containers[0]` as "the workload" is now resolved via a shared helper that prefers-by-name with `Containers[0]` fallback.

Companion PRs:
- **PR 1 — `fix(snapshot): require exec-form command for checkpoint containers`** (#8318, already open) — CodeRabbit B, C
- **PR 3 — `fix(operator): validate pod-info volume; operator review nits`** (next) — CodeRabbit A, G, H, J

GMS Python changes (F, M, N) deferred to a separate GMS Python cleanup PR already in flight.

Closed predecessor: #8299.

#### Architectural decisions

**1. Prefer-by-name with `Containers[0]` fallback.** Seven sites used to hardcode `podSpec.Containers[0]` as "the workload". That assumption breaks whenever `ExtraPodSpec.PodSpec.Containers` or a webhook-injected sidecar (istio-proxy, etc.) lands ahead of the workload in the slice. New contract:

```
ResolveMainContainer(podSpec):
  1. if no containers -> nil
  2. scan for container named "main" -> return it
  3. fall back to Containers[0]    (preserves pre-convention pods and tests)
```

The fallback is deliberate — dropping it would break any pod rendered before the naming convention or produced by non-operator tooling (`snapshotctl` manifests authored by hand, old fixtures, manual pods). `snapshotctl` tightens the rule further: in multi-container manifests it requires the worker to be explicitly named `main`, because in CLI-authored input the ambiguity is user-visible.

**2. Operator and snapshot each own their own copy.** The `"main"` container name convention predates the snapshot subsystem (LWS multinode enforcement, PR #3390, Oct 2025) and is owned by the operator. Operator code must not import `snapshotprotocol` helpers that operate on pod-spec shape. After this PR:

- `commonconsts.MainContainerName` + `common.ResolveMainContainer` are the authoritative operator-side copies. Operator callers (`graph.go`, `checkpoint_job.go`, `checkpoint/podspec.go`) use these.
- `snapshotprotocol.MainContainerName` + `snapshotprotocol.ResolveMainContainer` / `ResolveMainContainerName` are the snapshot-side copies. Snapshot agent, snapshotctl, and snapshot protocol internals use these.
- Both sides carry cross-reference comments pointing at the other copy.

Why duplicate instead of share: `deploy/operator` and `deploy/snapshot` are separate `go.mod`s and cannot cross-import `internal/` packages. Creating a third Go module purely for one constant and one 10-line function would cost more than the drift risk of duplication, especially given the cross-reference comments.

**3. GMS wires onto the main container by pointer, before it lands in the slice.** `GenerateBasePodSpec` now holds the main container as a local variable at the GMS wire point and passes `&container` directly to `dra.ApplyClaim` and `gms.EnsureServerSidecar`. Rationale:

- The main container exists as a local; searching the slice is unnecessary work.
- Removes `graph.go`'s import of `snapshotprotocol`. Non-snapshot DGDs (most of them) no longer touch that package.
- Closes a latent bug: `checkpoint_job.go`'s post-Commit 1 main-container lookup could put the workload at a non-zero index, but the old `dra.ApplyClaim(podSpec, name)` still stripped `nvidia.com/gpu` from `Containers[0]` and wrote the claim there. So GMS and the DRA claim could land on different containers. The new `dra.ApplyClaim(podSpec, target *corev1.Container, name)` signature matches `gms.EnsureServerSidecar(podSpec, mainContainer)`, and both receive the caller-resolved pointer.

**4. GMS ↔ failover ordering invariant.** `buildFailoverPod` deletes the single `main` container and replaces it with `engine-0` / `engine-1` (DeepCopy + engine-specific overrides). Ordering must be:

```
build local `container` (name="main")
     |
     v
apply GMS wiring (DRA claim + shared volume + env + mount)
     |
     v
podSpec.Containers = append(..., container)
     |
     v
backend.UpdatePodSpec  (multinode init containers, etc.)
     |
     v
append frontend sidecar (if any)
     |
     v
buildFailoverPod: DeepCopy "main" -> engine-0, engine-1
                  engines inherit GMS volume/mount/env/claim transitively
```

Pinned by the new `TestGenerateBasePodSpec_GMSWiredToMainBeforeFailover` integration test.

**5. `PrepareRestorePodSpecForCheckpoint` owns worker resolution.** The helper no longer accepts an arbitrary `container *corev1.Container` pointer; it resolves the worker internally via `ResolveMainContainer`. Callers cannot pass a sidecar pointer by mistake. Closes the part of CodeRabbit I that was about API footguns.

#### Details:

| Commit | Summary |
|---|---|
| `fix(snapshot): resolve main container by name with Containers[0] fallback` | Introduce `snapshotprotocol.ResolveMainContainer` / `ResolveMainContainerName`. Replace hardcoded index-0 sites in the operator and snapshot agent/snapshotctl. Make `PrepareRestorePodSpecForCheckpoint` own its own worker resolution. |
| `refactor(operator): wire GMS onto main container by pointer, not by search` | Reorder `graph.go` so GMS runs against the local `container` variable before it is appended to the slice; update `dra.ApplyClaim` signature to take a target container pointer; this closes a latent "GMS and DRA claim land on different containers" bug in `checkpoint_job.go`. |
| `refactor(operator): keep MainContainerName on operator side; document the duplicate` | Correct the provenance of the constant: operator is the owner, snapshot keeps a local copy with cross-reference docs. Also adds the GMS+failover integration test. |
| `refactor(operator): move main-container resolver to operator common package` | Finish decoupling: operator code no longer imports `snapshotprotocol.ResolveMainContainer`. New `common.ResolveMainContainer` lives in `deploy/operator/internal/common/` with its own tests. |

#### Where should the reviewer start?

1. **`deploy/snapshot/protocol/maincontainer.go`** and **`deploy/operator/internal/common/maincontainer.go`** — the two identical resolvers, each with tests. The cross-reference comments on both files spell out the "keep in sync" invariant.
2. **`deploy/operator/internal/dynamo/graph.go`** GMS block — verify the in-scope `container` local is passed directly, no `snapshotprotocol` import. The regression test `TestGenerateBasePodSpec_GMSWiredToMainBeforeFailover` pins the failover interaction.
3. **`deploy/operator/internal/dra/dra.go`** — signature change from `(podSpec, claimName)` to `(podSpec, target *corev1.Container, claimName)`. Both callers updated. Tests updated.
4. **`deploy/snapshot/protocol/restore.go`** `PrepareRestorePodSpecForCheckpoint` — now resolves the worker internally; the sole operator caller in `checkpoint/podspec.go` is updated to not pass the pointer in.
5. **`deploy/snapshot/cmd/snapshotctl/kube.go`** — the tightened multi-container rule (requires explicit `name: main` when the manifest has multiple containers).

#### Tests

- New unit tests:
  - `snapshotprotocol.ResolveMainContainer` + `ResolveMainContainerName` — nil spec, empty containers, single-container-is-main, main-at-non-zero-index, fallback.
  - `common.ResolveMainContainer` — same cases on the operator side.
  - `TestGenerateBasePodSpec_GMSWiredToMainBeforeFailover` — asserts that after `buildFailoverPod` replaces the "main" container with `engine-0`/`engine-1`, both engines inherit the GMS shared-socket volume mount, `GMS_SOCKET_DIR` env, and DRA claim (via `DeepCopy` in `buildEngineContainer`), and that the pod-level `gms-server` init sidecar and shared volume land exactly once.
  - `TestApplyClaim_TargetsCallerSuppliedContainer` (replaces the old `_AlwaysTargetsFirstContainer`) — verifies the sidecar-at-index-0 case.
  - `TestInjectCheckpointIntoPodSpec` — added "resolves main even when not at index zero" case.
- All `deploy/operator` unit tests pass (`go test` against envtest assets).
- All `deploy/snapshot` tests pass.
- `go vet ./...` clean in both modules.
- `pre-commit run --from-ref origin/main --to-ref HEAD` passes.

#### Risk notes for deploy-codeowners

- Behavior preservation via fallback: any pod rendered before the naming convention (or produced by non-operator tooling) still resolves via `Containers[0]`, so this refactor is safe to cherry-pick without auditing every pod-emitting path. The regression surface is "pods that have a sidecar at index 0 *and* a container named `main` at a non-zero index" — the fallback would have been wrong here pre-refactor anyway.
- `dra.ApplyClaim` is an internal-package function (`deploy/operator/internal/dra/`), not part of any published API surface. Signature change has zero external impact.
- `PrepareRestorePodSpecForCheckpoint` is exported from `deploy/snapshot/protocol`, but I am not aware of any out-of-tree callers. Its one in-repo caller (`checkpoint/podspec.go:InjectCheckpointIntoPodSpec`) is updated.
- No API changes to CRDs, no Go module or Python dependency changes.
- This PR is safe to merge before or after PR 1 (#8318). The two are independent — PR 1 keeps `Containers[0]` for its validator, PR 2 replaces it. Whichever lands second picks up the other's work via rebase.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #8194 (addresses resolved CodeRabbit threads D, E, I)
- Replaces: #8299 (closed; split into three single-concern PRs)
