### PR TITLE
fix(operator): validate and repair pod-info volume; operator review nits

### DIFF
--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -27,10 +27,20 @@ const (
 	envCheckpointDir = "GMS_CHECKPOINT_DIR"
 )
 
-// EnsureGMSRestoreSidecars adds GMS server + loader containers to the pod spec
-// for a checkpoint restore. The server runs as a regular container (not init)
-// because the CRIU-restored main process already has GPU memory mapped and
-// all containers must start in parallel.
+// EnsureGMSRestoreSidecars adds GMS server + loader containers to the pod
+// spec for a checkpoint restore.
+//
+// Precondition: the upstream DGD path has already run EnsureServerSidecar,
+// which adds the GMS server as a blocking init container (so socket
+// readiness gates the workload). The restore path does not need the
+// server to block startup because the CRIU-restored workload brings its
+// GPU memory back mapped and all init sidecars must start in parallel.
+// This function therefore:
+//
+//  1. Removes the existing init gms-server added by EnsureServerSidecar.
+//  2. Re-adds it as an always-restarting init sidecar together with the
+//     gms-loader, which hydrates the server from the checkpoint artifact
+//     directory on the snapshot PVC.
 func EnsureGMSRestoreSidecars(
 	podSpec *corev1.PodSpec,
 	mainContainer *corev1.Container,

--- a/deploy/operator/internal/checkpoint/podinfo.go
+++ b/deploy/operator/internal/checkpoint/podinfo.go
@@ -8,70 +8,38 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// EnsurePodInfoVolume installs the canonical DownwardAPI volume carrying
+// checkpoint/restore metadata onto podSpec. If a volume with the same name
+// already exists, it is overwritten so that the volume source type and item
+// list always match what the snapshot tooling expects to read at
+// /etc/podinfo/*. The name is a dynamo-internal constant, so replacing any
+// user-supplied entry with the canonical definition is the right default.
 func EnsurePodInfoVolume(podSpec *corev1.PodSpec) {
-	for _, volume := range podSpec.Volumes {
-		if volume.Name == commonconsts.PodInfoVolumeName {
-			return
-		}
-	}
-
-	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+	canonical := corev1.Volume{
 		Name: commonconsts.PodInfoVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			DownwardAPI: &corev1.DownwardAPIVolumeSource{
 				Items: []corev1.DownwardAPIVolumeFile{
-					{
-						Path: "pod_name",
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodName,
-						},
-					},
-					{
-						Path: "pod_uid",
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodUID,
-						},
-					},
-					{
-						Path: "pod_namespace",
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodNamespace,
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynNamespace,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoNamespace + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynNamespaceWorkerSuffix,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoWorkerHash + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynComponent,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoComponentType + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynParentDGDName,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoGraphDeploymentName + "']",
-						},
-					},
-					{
-						Path: commonconsts.PodInfoFileDynParentDGDNamespace,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: commonconsts.PodInfoFieldPodNamespace,
-						},
-					},
+					{Path: "pod_name", FieldRef: &corev1.ObjectFieldSelector{FieldPath: commonconsts.PodInfoFieldPodName}},
+					{Path: "pod_uid", FieldRef: &corev1.ObjectFieldSelector{FieldPath: commonconsts.PodInfoFieldPodUID}},
+					{Path: "pod_namespace", FieldRef: &corev1.ObjectFieldSelector{FieldPath: commonconsts.PodInfoFieldPodNamespace}},
+					{Path: commonconsts.PodInfoFileDynNamespace, FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoNamespace + "']"}},
+					{Path: commonconsts.PodInfoFileDynNamespaceWorkerSuffix, FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoWorkerHash + "']"}},
+					{Path: commonconsts.PodInfoFileDynComponent, FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoComponentType + "']"}},
+					{Path: commonconsts.PodInfoFileDynParentDGDName, FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels['" + commonconsts.KubeLabelDynamoGraphDeploymentName + "']"}},
+					{Path: commonconsts.PodInfoFileDynParentDGDNamespace, FieldRef: &corev1.ObjectFieldSelector{FieldPath: commonconsts.PodInfoFieldPodNamespace}},
 				},
 			},
 		},
-	})
+	}
+
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name == commonconsts.PodInfoVolumeName {
+			podSpec.Volumes[i] = canonical
+			return
+		}
+	}
+	podSpec.Volumes = append(podSpec.Volumes, canonical)
 }
 
 func EnsurePodInfoMount(container *corev1.Container) {

--- a/deploy/operator/internal/checkpoint/podinfo_test.go
+++ b/deploy/operator/internal/checkpoint/podinfo_test.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package checkpoint
+
+import (
+	"testing"
+
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func expectedPodInfoItemPaths() []string {
+	return []string{
+		"pod_name",
+		"pod_uid",
+		"pod_namespace",
+		commonconsts.PodInfoFileDynNamespace,
+		commonconsts.PodInfoFileDynNamespaceWorkerSuffix,
+		commonconsts.PodInfoFileDynComponent,
+		commonconsts.PodInfoFileDynParentDGDName,
+		commonconsts.PodInfoFileDynParentDGDNamespace,
+	}
+}
+
+func assertCanonicalPodInfoVolume(t *testing.T, volume corev1.Volume) {
+	t.Helper()
+	assert.Equal(t, commonconsts.PodInfoVolumeName, volume.Name)
+	if assert.NotNil(t, volume.VolumeSource.DownwardAPI, "expected DownwardAPI source") {
+		paths := make([]string, 0, len(volume.VolumeSource.DownwardAPI.Items))
+		for _, item := range volume.VolumeSource.DownwardAPI.Items {
+			paths = append(paths, item.Path)
+		}
+		assert.ElementsMatch(t, expectedPodInfoItemPaths(), paths)
+	}
+}
+
+func TestEnsurePodInfoVolumeAppendsWhenMissing(t *testing.T) {
+	spec := &corev1.PodSpec{Volumes: []corev1.Volume{{Name: "other"}}}
+
+	EnsurePodInfoVolume(spec)
+
+	if assert.Len(t, spec.Volumes, 2) {
+		assert.Equal(t, "other", spec.Volumes[0].Name)
+		assertCanonicalPodInfoVolume(t, spec.Volumes[1])
+	}
+}
+
+func TestEnsurePodInfoVolumeReplacesWrongSourceType(t *testing.T) {
+	spec := &corev1.PodSpec{Volumes: []corev1.Volume{
+		{Name: commonconsts.PodInfoVolumeName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+	}}
+
+	EnsurePodInfoVolume(spec)
+
+	if assert.Len(t, spec.Volumes, 1) {
+		assertCanonicalPodInfoVolume(t, spec.Volumes[0])
+	}
+}
+
+func TestEnsurePodInfoVolumeRepairsPartialItems(t *testing.T) {
+	spec := &corev1.PodSpec{Volumes: []corev1.Volume{{
+		Name: commonconsts.PodInfoVolumeName,
+		VolumeSource: corev1.VolumeSource{DownwardAPI: &corev1.DownwardAPIVolumeSource{
+			Items: []corev1.DownwardAPIVolumeFile{
+				{Path: "pod_name", FieldRef: &corev1.ObjectFieldSelector{FieldPath: commonconsts.PodInfoFieldPodName}},
+			},
+		}},
+	}}}
+
+	EnsurePodInfoVolume(spec)
+
+	if assert.Len(t, spec.Volumes, 1) {
+		assertCanonicalPodInfoVolume(t, spec.Volumes[0])
+	}
+}
+
+func TestEnsurePodInfoVolumeIsIdempotent(t *testing.T) {
+	spec := &corev1.PodSpec{}
+
+	EnsurePodInfoVolume(spec)
+	EnsurePodInfoVolume(spec)
+
+	if assert.Len(t, spec.Volumes, 1) {
+		assertCanonicalPodInfoVolume(t, spec.Volumes[0])
+	}
+}

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -207,10 +207,7 @@ func (r *CheckpointReconciler) handlePending(ctx context.Context, ckpt *nvidiaco
 		}
 		gpuQty := ckpt.Spec.Job.PodTemplateSpec.Spec.Containers[0].Resources.Limits[corev1.ResourceName(consts.KubeResourceGPUNvidia)]
 		gpuCount := int(gpuQty.Value())
-		deviceClassName := ""
-		if ckpt.Spec.GPUMemoryService != nil {
-			deviceClassName = ckpt.Spec.GPUMemoryService.DeviceClassName
-		}
+		deviceClassName := ckpt.Spec.GPUMemoryService.DeviceClassName
 		claimTemplateName := dra.ResourceClaimTemplateName("checkpoint-"+hash, "worker")
 		_, _, err := commonController.SyncResource(ctx, r, ckpt, func(ctx context.Context) (*resourcev1.ResourceClaimTemplate, bool, error) {
 			return dra.GenerateResourceClaimTemplate(ctx, r.Client, claimTemplateName, ckpt.Namespace, gpuCount, deviceClassName)

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1410,12 +1410,15 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
 		}
 
-		find := func(name string) *corev1.Container {
+		findRegular := func(name string) *corev1.Container {
 			for i := range podTemplateSpec.Spec.Containers {
 				if podTemplateSpec.Spec.Containers[i].Name == name {
 					return &podTemplateSpec.Spec.Containers[i]
 				}
 			}
+			return nil
+		}
+		findInit := func(name string) *corev1.Container {
 			for i := range podTemplateSpec.Spec.InitContainers {
 				if podTemplateSpec.Spec.InitContainers[i].Name == name {
 					return &podTemplateSpec.Spec.InitContainers[i]
@@ -1424,10 +1427,15 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			return nil
 		}
 
-		gmsServer := find(gms.ServerContainerName)
-		require.NotNil(t, gmsServer)
-		loader := find(checkpoint.GMSLoaderContainer)
-		require.NotNil(t, loader)
+		// GMS server and loader must be init sidecars so they start before the
+		// workload and are restarted under the pod's init restart policy.
+		require.Nil(t, findRegular(gms.ServerContainerName), "gms-server must not be a regular container")
+		require.Nil(t, findRegular(checkpoint.GMSLoaderContainer), "gms-loader must not be a regular container")
+
+		gmsServer := findInit(gms.ServerContainerName)
+		require.NotNil(t, gmsServer, "gms-server must be an init container")
+		loader := findInit(checkpoint.GMSLoaderContainer)
+		require.NotNil(t, loader, "gms-loader must be an init container")
 
 		mounts := map[string]string{}
 		for _, mount := range loader.VolumeMounts {


### PR DESCRIPTION
#### Overview:

One of three follow-up PRs closing reviewer feedback from #8194. Two small, unrelated operator-side fixes grouped together because each is too small for its own PR:

- **Pod-info volume repair** (CodeRabbit A) — defensive fix for the Downward API volume shape
- **Three review nits** (CodeRabbit G, H, J) — redundant nil-check, test helper tightening, stale godoc

Companion PRs:
- **PR 1 — `fix(snapshot): require exec-form command for checkpoint containers`** (#8318) — CodeRabbit B, C
- **PR 2 — `refactor: resolve workload container by name; wire GMS by pointer`** (#8319) — CodeRabbit D, E, I

GMS Python changes (F, M, N) deferred to a separate GMS Python cleanup PR already in flight.

Closed predecessor: #8299.

#### Details:

**Commit 1 — `fix(operator): validate and repair pod-info volume contents`**

`EnsurePodInfoVolume` short-circuited on name match alone:

```go
for _, volume := range podSpec.Volumes {
    if volume.Name == commonconsts.PodInfoVolumeName {
        return  // <-- bails purely on name match
    }
}
```

If another helper or a user's `ExtraPodSpec` installed a volume with the canonical name `podinfo` but a different `VolumeSource` type (EmptyDir, ConfigMap, etc.) or a partial `DownwardAPI.Items` list, the downstream snapshot loader silently saw missing `/etc/podinfo/dyn_*` files. Now the function overwrites any existing volume with that name using the canonical DownwardAPI definition:

```go
for i := range podSpec.Volumes {
    if podSpec.Volumes[i].Name == commonconsts.PodInfoVolumeName {
        podSpec.Volumes[i] = canonical
        return
    }
}
podSpec.Volumes = append(podSpec.Volumes, canonical)
```

The name is a dynamo-internal constant, so overwriting is the right default — the alternative is silently emitting a pod that can't restore.

New tests cover: append-when-missing, replace-wrong-source-type (EmptyDir), repair-partial-items, and idempotency.

**Commit 2 — `chore(operator): drop redundant GMS nil-check, tighten init-container test, document EnsureGMSRestoreSidecars`**

Three small fixes bundled:

- **G.** `dynamocheckpoint_controller.go` inner `if ckpt.Spec.GPUMemoryService != nil` is redundant because the enclosing block already checked both non-nil and `Enabled`. Drop it and inline the `DeviceClassName` read.
- **H.** `dynamocomponentdeployment_controller_test.go` had a `find()` helper that spanned both `Spec.Containers` and `Spec.InitContainers`. A regression that moved `gms-server`/`gms-loader` back to regular containers would have passed silently. Split into `findRegular()` and `findInit()`, and add `require.Nil(findRegular(...))` assertions for both containers to pin the init-container placement.
- **J.** `EnsureGMSRestoreSidecars` godoc claimed the restore server runs as a regular container. It actually runs as an init sidecar with `restartPolicy=Always`. Fix the doc and spell out the `EnsureServerSidecar` precondition: the upstream DGD path wires a blocking init-server first; this function swaps it out for an always-restarting pair (server + loader).

#### Where should the reviewer start?

1. **`deploy/operator/internal/checkpoint/podinfo.go`** — the behavioral fix (commit 1). 7 lines changed, overwrite-on-name-match.
2. **`deploy/operator/internal/checkpoint/podinfo_test.go`** — new test file covering the four cases.
3. **`deploy/operator/internal/checkpoint/gms.go`** — the godoc rewrite. Longer comment block now, but it accurately describes the two-step wire/swap pattern.
4. **`deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go`** — the tightened test helper.
5. **`deploy/operator/internal/controller/dynamocheckpoint_controller.go`** — one-line cleanup.

#### Tests

- `EnsurePodInfoVolume`:
  - `TestEnsurePodInfoVolumeAppendsWhenMissing` — happy path with a different pre-existing volume.
  - `TestEnsurePodInfoVolumeReplacesWrongSourceType` — existing `podinfo` volume has an `EmptyDir` source, should be overwritten with the canonical DownwardAPI spec.
  - `TestEnsurePodInfoVolumeRepairsPartialItems` — existing `podinfo` DownwardAPI volume with only `pod_name`, should be rehydrated with all 8 canonical items.
  - `TestEnsurePodInfoVolumeIsIdempotent` — calling twice produces exactly one canonical volume.
- All existing `deploy/operator` tests still pass (`go test` against envtest assets).
- `go vet ./...` clean.
- `pre-commit run --from-ref origin/main --to-ref HEAD` passes.

#### Risk notes for deploy-codeowners

- Pod-info volume overwrite is the only behavioral change. If anyone was deliberately installing a differently-shaped `podinfo` volume upstream of `EnsurePodInfoVolume`, their data source is now replaced with the canonical one. In practice nobody should be doing this — the name is a dynamo-internal constant used only for checkpoint/restore identity — but calling it out for completeness.
- The other three are pure cleanup / test coverage, no runtime behavior change.
- No API, CRD, or dependency changes.
- Safe to merge in any order relative to PRs #8318 and #8319.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #8194 (addresses resolved CodeRabbit threads A, G, H, J)
- Replaces: #8299 (closed; split into three single-concern PRs)
