### PR TITLE
refactor(build): consolidate sccache AWS credential handling

### DIFF
--- a/.github/actions/docker-remote-build/action.yml
+++ b/.github/actions/docker-remote-build/action.yml
@@ -162,16 +162,28 @@ runs:
           done <<< "$EXTRA_BUILD_ARGS"
         fi
 
-        # Pass AWS credentials as build secrets for sccache S3 access.
-        # Dockerfile steps reference these via --mount=type=secret,id=aws-key-id,env=...
+        # Compose AWS credentials as a single file-backed BuildKit secret so
+        # they are never present in the Dockerfile RUN environment. This
+        # prevents env-dump leaks into build-tool logs (e.g. ffmpeg's
+        # ffbuild/config.log). Dockerfile RUN blocks read the file via the
+        # AWS_SHARED_CREDENTIALS_FILE env set at the wheel_builder stage.
         # Disable tracing to prevent set -x from leaking credentials into logs.
         set +x
         SECRET_ARGS=""
+        AWS_CREDENTIALS_FILE=""
         if [ "${{ inputs.use_sccache }}" == "true" ] && [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
-          SECRET_ARGS+=" --secret id=aws-key-id,env=AWS_ACCESS_KEY_ID"
-          SECRET_ARGS+=" --secret id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY"
+          AWS_CREDENTIALS_FILE="$(mktemp)"
+          chmod 600 "$AWS_CREDENTIALS_FILE"
+          cat > "$AWS_CREDENTIALS_FILE" <<EOF
+        [default]
+        aws_access_key_id=${AWS_ACCESS_KEY_ID}
+        aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+        EOF
+          SECRET_ARGS+=" --secret id=aws-credentials,src=${AWS_CREDENTIALS_FILE}"
         fi
         set -x
+        # Ensure the credentials tempfile is removed even if buildx fails.
+        trap '[ -n "${AWS_CREDENTIALS_FILE:-}" ] && [ -f "${AWS_CREDENTIALS_FILE}" ] && rm -f "${AWS_CREDENTIALS_FILE}"' EXIT
 
         docker buildx build \
           --progress=plain \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -252,17 +252,11 @@ RUN if [ "$USE_SCCACHE" = "true" ]; then \
 ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
     SCCACHE_REGION=${USE_SCCACHE:+${SCCACHE_REGION}}
 
-# Point the AWS SDK credential chain at the BuildKit secret file that each
-# AWS-consuming RUN mounts below. Keeping creds in a file (not env vars)
-# prevents tools like ffmpeg's ./configure from dumping them into build logs
-# (e.g. ffbuild/config.log). Scoped to this stage; not inherited by runtime
-# images (they FROM a different base).
-ENV AWS_SHARED_CREDENTIALS_FILE=/run/secrets/aws-credentials
-
 # Always build FFmpeg so libs are available for Rust checks in CI
 # Do not delete the source tarball for legal reasons
 ARG FFMPEG_VERSION
 RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
+    export AWS_SHARED_CREDENTIALS_FILE=/run/secrets/aws-credentials && \
     export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}} && \
     if [ "$USE_SCCACHE" = "true" ]; then \
         eval $(/tmp/use-sccache.sh setup-env); \
@@ -304,6 +298,7 @@ RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,m
 
 # Build and install UCX
 RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
+    export AWS_SHARED_CREDENTIALS_FILE=/run/secrets/aws-credentials && \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}}" && \
     if [ "$USE_SCCACHE" = "true" ]; then \
         eval $(/tmp/use-sccache.sh setup-env); \
@@ -369,6 +364,7 @@ RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,m
 {% if device == "cuda" %}
 ARG NIXL_LIBFABRIC_REF
 RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
+    export AWS_SHARED_CREDENTIALS_FILE=/run/secrets/aws-credentials && \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}}" && \
     if [ "$USE_SCCACHE" = "true" ]; then \
         eval $(/tmp/use-sccache.sh setup-env); \
@@ -400,6 +396,7 @@ RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,m
 # Build and install AWS SDK C++ (required for NIXL OBJ backend / S3 support)
 ARG AWS_SDK_CPP_VERSION=1.11.760
 RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
+    export AWS_SHARED_CREDENTIALS_FILE=/run/secrets/aws-credentials && \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}}" && \
     if [ "$USE_SCCACHE" = "true" ]; then \
         eval $(/tmp/use-sccache.sh setup-env cmake); \
@@ -444,6 +441,7 @@ RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,m
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/root/.cache/uv \
+    export AWS_SHARED_CREDENTIALS_FILE=/run/secrets/aws-credentials && \
     export UV_CACHE_DIR=/root/.cache/uv && \
     export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}} && \
     if [ "$USE_SCCACHE" = "true" ]; then \
@@ -508,6 +506,7 @@ ARG CUDA_MAJOR
 {% endif %}
 
 RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
+    export AWS_SHARED_CREDENTIALS_FILE=/run/secrets/aws-credentials && \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}}" && \
     if [ "$USE_SCCACHE" = "true" ]; then \
         eval $(/tmp/use-sccache.sh setup-env); \
@@ -566,6 +565,7 @@ RUN echo "$NIXL_LIB_DIR" > /etc/ld.so.conf.d/nixl.conf && \
 ARG PYTHON_VERSION
 RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
     --mount=type=cache,target=/root/.cache/uv \
+    export AWS_SHARED_CREDENTIALS_FILE=/run/secrets/aws-credentials && \
     export UV_CACHE_DIR=/root/.cache/uv && \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}}" && \
     if [ "$USE_SCCACHE" = "true" ]; then \
@@ -587,6 +587,7 @@ RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,m
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/root/.cache/uv \
+    export AWS_SHARED_CREDENTIALS_FILE=/run/secrets/aws-credentials && \
     export UV_CACHE_DIR=/root/.cache/uv && \
     export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}} && \
     ARCH_ALT=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "aarch64") && \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -252,11 +252,17 @@ RUN if [ "$USE_SCCACHE" = "true" ]; then \
 ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
     SCCACHE_REGION=${USE_SCCACHE:+${SCCACHE_REGION}}
 
+# Point the AWS SDK credential chain at the BuildKit secret file that each
+# AWS-consuming RUN mounts below. Keeping creds in a file (not env vars)
+# prevents tools like ffmpeg's ./configure from dumping them into build logs
+# (e.g. ffbuild/config.log). Scoped to this stage; not inherited by runtime
+# images (they FROM a different base).
+ENV AWS_SHARED_CREDENTIALS_FILE=/run/secrets/aws-credentials
+
 # Always build FFmpeg so libs are available for Rust checks in CI
 # Do not delete the source tarball for legal reasons
 ARG FFMPEG_VERSION
-RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
-    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
     export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}} && \
     if [ "$USE_SCCACHE" = "true" ]; then \
         eval $(/tmp/use-sccache.sh setup-env); \
@@ -297,8 +303,7 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     mv /tmp/ffmpeg-${FFMPEG_VERSION}* /usr/local/src/ffmpeg/
 
 # Build and install UCX
-RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
-    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}}" && \
     if [ "$USE_SCCACHE" = "true" ]; then \
         eval $(/tmp/use-sccache.sh setup-env); \
@@ -363,8 +368,7 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
 
 {% if device == "cuda" %}
 ARG NIXL_LIBFABRIC_REF
-RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
-    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}}" && \
     if [ "$USE_SCCACHE" = "true" ]; then \
         eval $(/tmp/use-sccache.sh setup-env); \
@@ -395,8 +399,7 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
 {% if framework == "vllm" and device == "cuda" %}
 # Build and install AWS SDK C++ (required for NIXL OBJ backend / S3 support)
 ARG AWS_SDK_CPP_VERSION=1.11.760
-RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
-    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}}" && \
     if [ "$USE_SCCACHE" = "true" ]; then \
         eval $(/tmp/use-sccache.sh setup-env cmake); \
@@ -437,8 +440,7 @@ COPY components/ /opt/dynamo/components/
 # Build ai-dynamo (pure Python) and ai-dynamo-runtime (maturin) wheels
 ARG USE_SCCACHE
 ARG ENABLE_MEDIA_FFMPEG
-RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
-    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/root/.cache/uv \
@@ -505,8 +507,7 @@ ARG USE_SCCACHE
 ARG CUDA_MAJOR
 {% endif %}
 
-RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
-    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}}" && \
     if [ "$USE_SCCACHE" = "true" ]; then \
         eval $(/tmp/use-sccache.sh setup-env); \
@@ -563,8 +564,7 @@ RUN echo "$NIXL_LIB_DIR" > /etc/ld.so.conf.d/nixl.conf && \
 
 # Build NIXL wheel → /opt/dynamo/dist/nixl/nixl*.whl (C++ transport library, all targets)
 ARG PYTHON_VERSION
-RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
-    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
     --mount=type=cache,target=/root/.cache/uv \
     export UV_CACHE_DIR=/root/.cache/uv && \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}}" && \
@@ -583,8 +583,7 @@ COPY components/ /opt/dynamo/components/
 
 # Build kvbm wheel (with nixl linkage via auditwheel repair)
 ARG ENABLE_KVBM
-RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
-    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+RUN --mount=type=secret,id=aws-credentials,target=/run/secrets/aws-credentials,mode=0400,uid=0,gid=0 \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/root/.cache/uv \


### PR DESCRIPTION
## Summary

- Consolidate the per-variable BuildKit secret mounts in `wheel_builder.Dockerfile` into a single shared-credentials-file mount.
- Point the AWS SDK default provider chain at the mounted file via `AWS_SHARED_CREDENTIALS_FILE` so sccache resolves credentials transparently.
- Compose the credentials file once in the CI composite action and emit a single `--secret id=aws-credentials,src=...` to buildx.

## Test plan

- [ ] CI wheel build completes on amd64/arm64
- [ ] sccache reports cache activity during FFMPEG/UCX/libfabric/NIXL builds
- [ ] Rendered Dockerfile parses for sglang/vllm/trtllm frameworks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container build process security by refactoring credential handling to use a file-based approach instead of environment variables, reducing credential exposure during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->