### PR TITLE
fix(operator): DYN-2719 always attempt DCGM + node-label GPU discovery for DGDR and prevent nil-panic on partial spec.hardware

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1042,42 +1042,55 @@ func (r *DynamoGraphDeploymentRequestReconciler) validateSpec(ctx context.Contex
 	return errors.Join(errs...)
 }
 
-// validateGPUHardwareInfo ensures GPU hardware information is available when required for profiling
+// validateGPUHardwareInfo ensures GPU hardware information is available when required for profiling.
+//
+// Discovery order when the user did not provide spec.hardware:
+//  1. DCGM exporter scrape (r.GPUDiscovery.DiscoverGPUsFromDCGM). Pods are
+//     reached via their per-pod IP, so this works from any namespace and does
+//     not require cluster-scoped RBAC — it is safe to attempt in both
+//     cluster-wide and namespace-scoped installs.
+//  2. Node-label fallback (gpu.DiscoverGPUs) using NVIDIA GFD labels. This
+//     path requires node read access (the gpu-discovery ClusterRole Helm
+//     provisions when gpuDiscovery.enabled=true) and is useful in
+//     environments where DCGM exporter pods cannot run but GFD labels are
+//     populated (e.g. vCluster syncing labels from the host cluster).
 func (r *DynamoGraphDeploymentRequestReconciler) validateGPUHardwareInfo(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
 	logger := log.FromContext(ctx)
 
-	// Check if user provided hardware info in the typed spec
+	// If the user provided any hardware field, accept it here; missing fields
+	// will be filled in (or the request will be rejected again) by
+	// enrichHardwareFromDiscovery on the profiling path.
 	hasManualConfig := dgdr.Spec.Hardware != nil && (dgdr.Spec.Hardware.GPUSKU != "" ||
 		dgdr.Spec.Hardware.VRAMMB != nil ||
 		dgdr.Spec.Hardware.NumGPUsPerNode != nil)
-
-	// If manual config is provided, validation passes
 	if hasManualConfig {
 		return nil
 	}
 
-	isNamespaceScoped := r.Config.Namespace.Restricted != ""
-	if isNamespaceScoped {
-		return fmt.Errorf(
-			"GPU hardware info required but cannot be auto-discovered." +
-				"\n\nOptions to resolve:" +
-				"\n\n1. Re-enable GPU discovery (if it was disabled during Helm install):" +
-				"\n   helm upgrade ... --set dynamo-operator.gpuDiscovery.enabled=true" +
-				"\n\n2. Add hardware config to spec.hardware:" +
-				"\n   numGpusPerNode: 8" +
-				"\n   gpuSku: \"H100-SXM5-80GB\"" +
-				"\n   vramMb: 81920")
+	if _, err := r.GPUDiscovery.DiscoverGPUsFromDCGM(ctx, r.APIReader, r.GPUDiscoveryCache); err == nil {
+		return nil
+	} else {
+		logger.Info("DCGM GPU discovery unavailable",
+			"reason", GetGPUDiscoveryFailureReason(err), "error", err.Error())
 	}
 
-	_, err := r.GPUDiscovery.DiscoverGPUsFromDCGM(ctx, r.APIReader, r.GPUDiscoveryCache)
-	if err == nil {
-		// GPU discovery is available, validation passes
-		return nil
+	if ptr.Deref(r.Config.GPU.DiscoveryEnabled, true) {
+		if _, err := gpu.DiscoverGPUs(ctx, r.APIReader); err == nil {
+			return nil
+		} else {
+			logger.Info("Node-label GPU discovery unavailable", "error", err.Error())
+		}
 	}
-	// Refine the logger message
-	reason := GetGPUDiscoveryFailureReason(err)
-	logger.Info("GPU discovery not available", "reason", reason, "error", err.Error())
-	return fmt.Errorf("GPU hardware info required but auto-discovery failed. Add spec.hardware.gpuSku, spec.hardware.vramMb, spec.hardware.numGpusPerNode")
+
+	return fmt.Errorf(
+		"GPU hardware info required but auto-discovery failed." +
+			"\n\nOptions to resolve:" +
+			"\n\n1. Verify the DCGM exporter is deployed and reachable from the operator's namespace (typically installed by the NVIDIA GPU Operator in the gpu-operator namespace)." +
+			"\n2. Ensure nodes carry NVIDIA GPU Feature Discovery labels (nvidia.com/gpu.count, nvidia.com/gpu.product, nvidia.com/gpu.memory) and that node read access is enabled via Helm: --set dynamo-operator.gpuDiscovery.enabled=true" +
+			"\n3. Specify hardware explicitly in spec.hardware:" +
+			"\n   numGpusPerNode: 8" +
+			"\n   gpuSku: \"H100-SXM5-80GB\"" +
+			"\n   vramMb: 81920")
 }
 
 // GetGPUDiscoveryFailureReason classifies a GPU discovery error and
@@ -1430,45 +1443,60 @@ func marshalDGDRSpec(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (strin
 
 // enrichHardwareFromDiscovery fills in hardware fields that the user didn't set.
 // Called before marshalDGDRSpec(). Mutates dgdr.Spec.Hardware in-place (memory only, not persisted).
+//
+// Discovery is triggered whenever any required field (GPUSKU, VRAMMB,
+// NumGPUsPerNode) is missing — including partial user configs such as
+// numGpusPerNode without gpuSku/vramMb. Previously, partial configs were
+// treated as "fully specified" and skipped discovery, then dereferenced a nil
+// gpuInfo below.
+//
+// Discovery order:
+//  1. DCGM exporter scrape (r.GPUDiscovery.DiscoverGPUsFromDCGM).
+//  2. Node-label fallback (gpu.DiscoverGPUs) via NVIDIA GFD labels, gated on
+//     r.Config.GPU.DiscoveryEnabled. This handles environments like vCluster
+//     where DCGM exporter pods cannot run but GFD labels are synchronised
+//     from the host cluster.
 func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
 	if dgdr.Spec.Hardware == nil {
 		dgdr.Spec.Hardware = &nvidiacomv1beta1.HardwareSpec{}
 	}
 	hw := dgdr.Spec.Hardware
 
+	// Fast path: every field the profiler consumes is already set. TotalGPUs
+	// is intentionally not required here — it is only auto-filled from
+	// discovery when discovery runs.
 	if hw.GPUSKU != "" && hw.VRAMMB != nil && hw.NumGPUsPerNode != nil {
-		return nil // all fields already set by user; TotalGPUs is filled below when discovery runs
+		return nil
 	}
 
-	var gpuInfo *gpu.GPUInfo
 	logger := log.FromContext(ctx)
-	// Check if user provided hardware info in the typed spec
-	hasManualConfig := dgdr.Spec.Hardware != nil && (dgdr.Spec.Hardware.GPUSKU != "" ||
-		dgdr.Spec.Hardware.VRAMMB != nil ||
-		dgdr.Spec.Hardware.NumGPUsPerNode != nil)
-	if !hasManualConfig {
+	logger.Info("Attempting GPU discovery for profiling job")
 
-		logger.Info("Attempting GPU discovery for profiling job")
-		discoveredInfo, err := r.GPUDiscovery.DiscoverGPUsFromDCGM(ctx, r.APIReader, r.GPUDiscoveryCache)
-		if err != nil {
-			// This path is expected for namespace-restricted operators without node read permissions
-			// Refine the logger message
-			reason := GetGPUDiscoveryFailureReason(err)
-			logger.Info("GPU discovery not available, using manual hardware configuration from profiling config",
-				"reason", reason, "error", err.Error())
+	gpuInfo, err := r.GPUDiscovery.DiscoverGPUsFromDCGM(ctx, r.APIReader, r.GPUDiscoveryCache)
+	if err != nil {
+		logger.Info("DCGM GPU discovery failed, attempting node-label fallback",
+			"reason", GetGPUDiscoveryFailureReason(err), "error", err.Error())
+
+		if !ptr.Deref(r.Config.GPU.DiscoveryEnabled, true) {
 			return err
-		} else {
-			gpuInfo = discoveredInfo
-			logger.Info("GPU discovery completed successfully",
-				"gpusPerNode", gpuInfo.GPUsPerNode,
-				"nodesWithGPUs", gpuInfo.NodesWithGPUs,
-				"totalGpus", gpuInfo.GPUsPerNode*gpuInfo.NodesWithGPUs,
-				"model", gpuInfo.Model,
-				"vramMiB", gpuInfo.VRAMPerGPU,
-				"system", gpuInfo.System,
-				"cloudprovider", gpuInfo.CloudProvider)
+		}
+		gpuInfo, err = gpu.DiscoverGPUs(ctx, r.APIReader)
+		if err != nil {
+			logger.Info("Node-label GPU discovery also failed",
+				"reason", GetGPUDiscoveryFailureReason(err), "error", err.Error())
+			return err
 		}
 	}
+
+	logger.Info("GPU discovery completed successfully",
+		"gpusPerNode", gpuInfo.GPUsPerNode,
+		"nodesWithGPUs", gpuInfo.NodesWithGPUs,
+		"totalGpus", gpuInfo.GPUsPerNode*gpuInfo.NodesWithGPUs,
+		"model", gpuInfo.Model,
+		"vramMiB", gpuInfo.VRAMPerGPU,
+		"system", gpuInfo.System,
+		"cloudprovider", gpuInfo.CloudProvider)
+
 	if hw.GPUSKU == "" {
 		if gpuInfo.System != "" {
 			hw.GPUSKU = gpuInfo.System

--- a/deploy/operator/internal/controller/enrich_hardware_test.go
+++ b/deploy/operator/internal/controller/enrich_hardware_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -48,6 +50,26 @@ func newFakeReconciler(nodes ...*corev1.Node) *DynamoGraphDeploymentRequestRecon
 		APIReader: fakeClient,
 		Recorder:  &record.FakeRecorder{},
 	}
+}
+
+// newFakeReconcilerWithDiscovery returns a reconciler wired up with a non-nil
+// GPUDiscovery (so DiscoverGPUsFromDCGM can run against the fake client) and
+// an OperatorConfiguration with GPU.DiscoveryEnabled=true so the node-label
+// fallback branch is exercised.
+//
+// The embedded scraper is never invoked by these tests because the fake
+// client does not carry DCGM exporter pods — DiscoverGPUsFromDCGM fails early
+// and the reconciler falls back to gpu.DiscoverGPUs.
+func newFakeReconcilerWithDiscovery(nodes ...*corev1.Node) *DynamoGraphDeploymentRequestReconciler {
+	r := newFakeReconciler(nodes...)
+	r.GPUDiscovery = gpupkg.NewGPUDiscovery(gpupkg.ScrapeMetricsEndpoint)
+	r.GPUDiscoveryCache = gpupkg.NewGPUDiscoveryCache()
+	r.Config = &configv1alpha1.OperatorConfiguration{
+		GPU: configv1alpha1.GPUConfiguration{
+			DiscoveryEnabled: ptr.To(true),
+		},
+	}
+	return r
 }
 
 func gpuNode(name, product string, gpuCount int, vramMiB int) *corev1.Node {
@@ -136,4 +158,101 @@ func TestEnrichHardwareFromDiscovery_FallsBackToModelForUnknownGPU(t *testing.T)
 	require.NotNil(t, dgdr.Spec.Hardware)
 	assert.Equal(t, "Tesla-V100-SXM2-16GB", string(dgdr.Spec.Hardware.GPUSKU),
 		"Unknown GPU should fall back to raw model name")
+}
+
+// TestEnrichHardwareFromDiscovery_PartialSpecNoPanic is the regression test for
+// defect 2: a DGDR spec with a partial spec.hardware (for example only
+// numGpusPerNode set) used to be treated as "fully specified", skip discovery,
+// and then dereference a nil gpuInfo in the enrichment block, crashing the
+// reconciler with a nil pointer panic.
+//
+// The fix runs discovery whenever any required field is missing, so partial
+// specs now successfully enrich (via DCGM — or, as in this test, the
+// node-label fallback when DCGM is unreachable).
+func TestEnrichHardwareFromDiscovery_PartialSpecNoPanic(t *testing.T) {
+	r := newFakeReconcilerWithDiscovery(gpuNode("gpu-node-1", "NVIDIA-H200-SXM5-141GB", 8, 143771))
+	gpus := int32(8)
+
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+			Hardware: &nvidiacomv1beta1.HardwareSpec{
+				NumGPUsPerNode: &gpus,
+			},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+		require.NoError(t, err)
+	}, "partial spec.hardware must not trigger a nil pointer dereference")
+
+	require.NotNil(t, dgdr.Spec.Hardware)
+	assert.Equal(t, "h200_sxm", string(dgdr.Spec.Hardware.GPUSKU),
+		"missing GPUSKU should be filled from node-label fallback")
+	require.NotNil(t, dgdr.Spec.Hardware.VRAMMB)
+	assert.InDelta(t, 143771, *dgdr.Spec.Hardware.VRAMMB, 0.001,
+		"missing VRAMMB should be filled from node-label fallback")
+	require.NotNil(t, dgdr.Spec.Hardware.NumGPUsPerNode)
+	assert.Equal(t, int32(8), *dgdr.Spec.Hardware.NumGPUsPerNode,
+		"user-provided NumGPUsPerNode must be preserved")
+}
+
+// TestEnrichHardwareFromDiscovery_NodeLabelFallback is the regression test for
+// defect 2's missing-fallback symptom: in environments where DCGM exporter
+// pods cannot be scraped (e.g. vCluster) but GFD node labels are present, the
+// enrichment path used to return the DCGM failure error without attempting
+// node-label discovery, leaving the DGDR stuck.
+func TestEnrichHardwareFromDiscovery_NodeLabelFallback(t *testing.T) {
+	r := newFakeReconcilerWithDiscovery(gpuNode("gpu-node-1", "NVIDIA-H200-SXM5-141GB", 8, 143771))
+
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{},
+	}
+
+	err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+	require.NoError(t, err, "node-label fallback should succeed when DCGM is unreachable")
+	require.NotNil(t, dgdr.Spec.Hardware)
+	assert.Equal(t, "h200_sxm", string(dgdr.Spec.Hardware.GPUSKU))
+	require.NotNil(t, dgdr.Spec.Hardware.NumGPUsPerNode)
+	assert.Equal(t, int32(8), *dgdr.Spec.Hardware.NumGPUsPerNode)
+	require.NotNil(t, dgdr.Spec.Hardware.VRAMMB)
+	assert.InDelta(t, 143771, *dgdr.Spec.Hardware.VRAMMB, 0.001)
+}
+
+// TestEnrichHardwareFromDiscovery_NodeLabelFallbackDisabled verifies that when
+// node read access is explicitly disabled (helm gpuDiscovery.enabled=false),
+// the fallback branch is skipped and the DCGM error is returned verbatim so
+// the user sees the real failure reason rather than a misleading one.
+func TestEnrichHardwareFromDiscovery_NodeLabelFallbackDisabled(t *testing.T) {
+	r := newFakeReconcilerWithDiscovery(gpuNode("gpu-node-1", "NVIDIA-H200", 8, 143771))
+	r.Config.GPU.DiscoveryEnabled = ptr.To(false)
+
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{},
+	}
+
+	err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+	require.Error(t, err, "with fallback disabled, DCGM failure must surface")
+}
+
+// TestValidateGPUHardwareInfo_NamespaceScopedAttemptsDiscovery is the
+// regression test for defect 1: namespace-scoped installs used to
+// short-circuit with ValidationFailed before attempting any discovery, even
+// when DCGM was reachable and/or GFD labels were populated. The fix drops
+// the namespace-scope short-circuit and runs discovery uniformly.
+func TestValidateGPUHardwareInfo_NamespaceScopedAttemptsDiscovery(t *testing.T) {
+	r := newFakeReconcilerWithDiscovery(gpuNode("gpu-node-1", "NVIDIA-H200", 8, 143771))
+	// Simulate namespace-scoped operator install. The production controller
+	// still reads this deprecated field (dynamographdeploymentrequest_controller.go
+	// and dynamographdeployment_controller.go both gate RBAC setup on it), so the
+	// regression test must exercise it directly.
+	r.Config.Namespace.Restricted = "djangoz" //nolint:staticcheck // SA1019: testing deprecated namespace-restricted mode the controller still supports
+
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{},
+	}
+
+	err := r.validateGPUHardwareInfo(context.Background(), dgdr)
+	assert.NoError(t, err,
+		"namespace-scoped install must not short-circuit discovery when node labels are available")
 }


### PR DESCRIPTION
Closes DYN-2719
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved GPU hardware validation to accept partial configurations that will be enriched during profiling
  * Enhanced GPU auto-discovery with better fallback mechanism when primary discovery is unavailable
  * Adjusted error messaging to clarify GPU discovery resolution options

* **Tests**
  * Added comprehensive test coverage for GPU discovery and validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->