### PR TITLE
fix(sglang): add enable_trace to diffusion worker ServerArgs stub

### DIFF
--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -360,6 +360,7 @@ async def parse_args(args: list[str]) -> Config:
         server_args.disaggregation_mode = None
         server_args.dllm_algorithm = False
         server_args.load_format = None
+        server_args.enable_trace = getattr(parsed_args, "enable_trace", False)
         logging.info(
             f"Created stub ServerArgs for {worker_type}: model_path={server_args.model_path}"
         )

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -144,7 +144,7 @@ class BaseGenerativeHandler(ABC, Generic[RequestT, ResponseT]):
             publisher: Optional metrics publisher for the worker.
         """
         self.config = config
-        self.enable_trace = config.server_args.enable_trace
+        self.enable_trace = getattr(config.server_args, "enable_trace", False)
 
         # Set up metrics and KV publishers
         self.metrics_publisher: Optional[WorkerMetricsPublisher] = None
@@ -699,7 +699,7 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
             self.kv_publisher = publisher.kv_publisher
         self.serving_mode = config.serving_mode
         self.use_sglang_tokenizer = config.dynamo_args.use_sglang_tokenizer
-        self.enable_trace = config.server_args.enable_trace
+        self.enable_trace = getattr(config.server_args, "enable_trace", False)
 
         if engine is not None:
             self.input_param_manager = InputParamManager(


### PR DESCRIPTION
#### Overview:

The `SimpleNamespace` stub created for image/video diffusion workers omitted `enable_trace`, causing `BaseGenerativeHandler()` to crash with `AttributeError` before health check. Add the field to the stub and use `getattr()` defensively in both `BaseGenerativeHandler` and `BaseWorkerHandler`.

#### Details:
- Fixes text-to-video and image diffusion worker startup crash (AttributeError on enable_trace)
- Adds enable_trace to the SimpleNamespace stub in args.py for diffusion workers
- Uses defensive getattr() in both `BaseGenerativeHandler.__init__` and `BaseWorkerHandler.__init__`

#### Where should the reviewer start?

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

Fixes DYN-2711
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential errors in trace configuration handling to ensure stable operation when trace settings are unavailable.
  * Improved robustness of trace flag initialization during worker startup to prevent missing attribute errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->