### PR TITLE
fix: typing.Self ImportError on Python 3.10 (#8322)

### DIFF
--- a/components/src/dynamo/common/configuration/config_base.py
+++ b/components/src/dynamo/common/configuration/config_base.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import argparse
-from typing import Self
+
+try:
+    from typing import Self
+except ImportError:  # Python < 3.11
+    from typing_extensions import Self
 
 
 class ConfigBase:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "msgspec>=0.19.0",
     "pyzmq>=26.0.0",
     "msgpack==1.1.2",
+    "typing_extensions>=4.0; python_version < '3.11'",
 ]
 
 classifiers = [


### PR DESCRIPTION
## Summary
Fix `ImportError` that prevents Dynamo from importing on Python 3.10 by making the `typing.Self` import version-compatible. Falls back to `typing_extensions.Self` on Python < 3.11.

Fixes #8322

## Root Cause
`components/src/dynamo/common/configuration/config_base.py` imports `Self` directly from the stdlib `typing` module. `typing.Self` was introduced in Python 3.11 (PEP 673), so on Python 3.10 the import fails at module load time:

```
ImportError: cannot import name 'Self' from 'typing'
```

Because `config_base.py` is imported transitively during `dynamo.frontend` initialisation, the CLI crashes before argument parsing — even `python -m dynamo.frontend --help` fails. A repo-wide audit (`git grep 'from typing import.*Self'`) confirmed this is the only offending file.

## Solution
Replace the unconditional import with a `try/except ImportError` compatibility pattern, and declare `typing_extensions` as a conditional dependency for Python < 3.11.

```python
try:
    from typing import Self
except ImportError:  # Python < 3.11
    from typing_extensions import Self
```

The `try/except` pattern tests actual symbol availability rather than relying on a `sys.version_info` check, which is the more Pythonic approach and handles edge cases (e.g. backports) correctly.

## Changes
```
components/src/dynamo/common/configuration/config_base.py | 6 +++++-
 pyproject.toml                                            | 1 +
 2 files changed, 6 insertions(+), 1 deletion(-)
```

- `components/src/dynamo/common/configuration/config_base.py` — version-compatible `Self` import via `try/except ImportError` fallback to `typing_extensions`
- `pyproject.toml` — add `typing_extensions>=4.0` as a conditional dependency (`python_version < '3.11'`) so it's only installed where needed

## Testing
Manual reproduction of the original failure path:

```bash
conda create -n dynamo-py310 python=3.10 -y
conda activate dynamo-py310
pip install -e .
python -m dynamo.frontend --help
# Before: ImportError: cannot import name 'Self' from 'typing'
# After:  prints help, exits 0
```

On Python 3.11+ the stdlib `typing.Self` path is taken and behaviour is unchanged. On Python 3.10 `typing_extensions.Self` is used transparently. The full dynamo test suite requires the dynamo dev container and is best validated in CI.

## Risks
- **Low risk.** `typing_extensions` is already a transitive dependency of most modern ML stacks (pydantic, torch, etc.); the `>=4.0` constraint ensures `Self` is available.
- **Fully backwards-compatible.** Python 3.11+ keeps the stdlib path; Python 3.10 gains working imports where it previously crashed.
- **Isolated scope.** Only the single offending file plus a `pyproject.toml` dependency declaration.