### PR TITLE
ci: set skopeo runner to be prod-skopeo-v1

### DIFF
--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -424,7 +424,7 @@ jobs:
       needs.build.result == 'success' &&
       (needs.test.result == 'success' || needs.test.result == 'skipped')
     name: copy-to-acr ${{ inputs.cpu_only && 'cpu' || format('cuda{0}', inputs.cuda_version) }}
-    runs-on: prod-default-small-v2
+    runs-on: prod-skopeo-v1
     outputs:
       target_tag_plain: ${{ needs.build.outputs.target_tag_plain }}
     steps:

--- a/.github/workflows/shared-copy.yml
+++ b/.github/workflows/shared-copy.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         cuda_version: ${{ fromJson(inputs.cuda_version) }}
     name: Copy to ACR cuda${{ matrix.cuda_version }}${{ inputs.override_arch != '' && format(', {0}', inputs.override_arch) || '' }}
-    runs-on: prod-default-small-v2
+    runs-on: prod-skopeo-v1
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
#### Overview:

Change Skopeo runner, again :) 

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment infrastructure runner configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->