### PR TITLE
feat: Add KV transfer params support to request metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4509,6 +4509,7 @@ dependencies = [
  "kvbm-physical",
  "oneshot",
  "parking_lot",
+ "proptest",
  "rstest 0.23.0",
  "serde",
  "serde_json",

--- a/lib/bindings/kvbm/python/kvbm/v1/vllm_integration/connector/pd_connector.py
+++ b/lib/bindings/kvbm/python/kvbm/v1/vllm_integration/connector/pd_connector.py
@@ -21,14 +21,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
 
 try:
     # vllm >= 0.19.1: nixl_connector module became the `nixl` package
-    from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
-        NixlConnector,
-        NixlHandshakePayload,
-    )
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlConnector
 except ImportError:
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
         NixlConnector,
-        NixlHandshakePayload,
     )
 
 from vllm.v1.core.sched.output import SchedulerOutput

--- a/lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/leader.py
+++ b/lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/leader.py
@@ -21,6 +21,7 @@ Bring-up flow:
 
 from __future__ import annotations
 
+import json
 import os
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -273,6 +274,16 @@ class SchedulerConnectorLeader:
             # Single-sequence case: already flat
             all_token_ids = [int(token) for token in request.all_token_ids]
 
+        # vLLM carries connector-specific transfer params as a
+        # dict[str, Any] | None on the Request. Serialize to JSON here so the
+        # Rust side receives a well-defined payload. json.dumps will raise
+        # TypeError on unserializable values — we deliberately let that
+        # propagate so the misconfiguration is loud.
+        kv_transfer_params = getattr(request, "kv_transfer_params", None)
+        kv_transfer_params_json = (
+            json.dumps(kv_transfer_params) if kv_transfer_params is not None else None
+        )
+
         kv_request = KvbmRequest(
             request_id=request.request_id,
             tokens=all_token_ids,
@@ -283,6 +294,7 @@ class SchedulerConnectorLeader:
             if getattr(request, "cache_salt", None) is not None
             else None,
             max_tokens=request.max_tokens,
+            kv_transfer_params_json=kv_transfer_params_json,
         )
 
         self.leader.create_slot(kv_request)

--- a/lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/leader.py
+++ b/lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/leader.py
@@ -275,13 +275,18 @@ class SchedulerConnectorLeader:
             all_token_ids = [int(token) for token in request.all_token_ids]
 
         # vLLM carries connector-specific transfer params as a
-        # dict[str, Any] | None on the Request. Serialize to JSON here so the
-        # Rust side receives a well-defined payload. json.dumps will raise
-        # TypeError on unserializable values — we deliberately let that
-        # propagate so the misconfiguration is loud.
-        kv_transfer_params = getattr(request, "kv_transfer_params", None)
+        # dict[str, Any] | None on the Request. Access the attribute
+        # directly so a future vLLM rename surfaces as AttributeError
+        # rather than silently masking the regression. Serialize with
+        # allow_nan=False so NaN / Infinity raise ValueError on this
+        # side instead of producing a payload serde_json will reject
+        # with a less informative error; TypeError on unserializable
+        # values likewise propagates unchanged.
+        kv_transfer_params = request.kv_transfer_params
         kv_transfer_params_json = (
-            json.dumps(kv_transfer_params) if kv_transfer_params is not None else None
+            json.dumps(kv_transfer_params, allow_nan=False)
+            if kv_transfer_params is not None
+            else None
         )
 
         kv_request = KvbmRequest(

--- a/lib/bindings/kvbm/src/v2/connector/leader/request.rs
+++ b/lib/bindings/kvbm/src/v2/connector/leader/request.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use kvbm_connector::RequestMetadata;
 
 #[derive(Clone)]
 #[pyclass(name = "KvbmRequest")]
@@ -12,22 +13,45 @@ pub struct PyRequest {
 #[pymethods]
 impl PyRequest {
     #[new]
-    #[pyo3(signature = (request_id, tokens, lora_name=None, salt_hash=None, max_tokens=None))]
+    #[pyo3(signature = (
+        request_id,
+        tokens,
+        lora_name=None,
+        salt_hash=None,
+        max_tokens=None,
+        kv_transfer_params_json=None,
+    ))]
     pub fn new(
         request_id: String,
         tokens: Vec<usize>,
         lora_name: Option<String>,
         salt_hash: Option<String>,
         max_tokens: Option<usize>,
+        kv_transfer_params_json: Option<String>,
     ) -> PyResult<Self> {
         if max_tokens.is_none() {
             return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
                 "max_tokens is required",
             ));
         }
-        Ok(Self {
-            inner: Request::new(request_id, tokens, lora_name, salt_hash, max_tokens),
-        })
+
+        let metadata = match kv_transfer_params_json {
+            Some(s) => {
+                let value: serde_json::Value = serde_json::from_str(&s).map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                        "invalid kv_transfer_params JSON: {e}"
+                    ))
+                })?;
+                Some(RequestMetadata::with_kv_transfer_params(value))
+            }
+            None => None,
+        };
+
+        let inner = Request::with_token_limits(
+            request_id, tokens, lora_name, salt_hash, None, max_tokens, metadata,
+        );
+
+        Ok(Self { inner })
     }
 
     #[getter]

--- a/lib/bindings/kvbm/tests/test_kvbm_request_kv_transfer_params.py
+++ b/lib/bindings/kvbm/tests/test_kvbm_request_kv_transfer_params.py
@@ -127,9 +127,11 @@ class TestAdversarialJson:
 class TestAdversarialPython:
     """
     The Python side of the contract is that callers serialize with
-    ``json.dumps`` before handing the string to the shim. These tests pin
-    that the loud failure mode (TypeError from json.dumps) happens in
-    Python as expected for values that are not JSON-serializable.
+    ``json.dumps(..., allow_nan=False)`` before handing the string to the
+    shim. These tests pin the two loud failure modes: TypeError for
+    values that are not JSON-serializable at all, and ValueError for
+    non-finite floats under strict mode (which serde_json on the Rust
+    side also rejects).
     """
 
     @pytest.mark.parametrize(
@@ -142,7 +144,20 @@ class TestAdversarialPython:
     )
     def test_json_dumps_raises_on_unserializable(self, unserializable):
         with pytest.raises(TypeError):
-            json.dumps(unserializable)
+            json.dumps(unserializable, allow_nan=False)
+
+    @pytest.mark.parametrize(
+        "non_finite",
+        [
+            {"bad": float("nan")},
+            {"bad": float("inf")},
+            {"bad": float("-inf")},
+            {"nested": [1.0, float("nan"), 2.0]},
+        ],
+    )
+    def test_json_dumps_rejects_non_finite_floats_in_strict_mode(self, non_finite):
+        with pytest.raises(ValueError):
+            json.dumps(non_finite, allow_nan=False)
 
 
 # ---------------------------------------------------------------------------

--- a/lib/bindings/kvbm/tests/test_kvbm_request_kv_transfer_params.py
+++ b/lib/bindings/kvbm/tests/test_kvbm_request_kv_transfer_params.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for the `kv_transfer_params_json` FFI hop on `KvbmRequest`.
+
+These tests exercise the pyo3 shim directly — they do not require vLLM.
+They cover both the golden path (well-formed params serialize and reach the
+Rust side without mutation) and adversarial inputs (non-serializable Python
+objects, invalid JSON, empty/None cases, exotic dict shapes).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import kvbm
+
+if not kvbm.v2.is_available():
+    pytest.skip(
+        "kvbm v2 feature not compiled; skipping KvbmRequest tests",
+        allow_module_level=True,
+    )
+
+KvbmRequest = kvbm.v2.KvbmRequest
+
+
+# ---------------------------------------------------------------------------
+# Golden paths
+# ---------------------------------------------------------------------------
+
+
+def _build(kv_transfer_params_json=None, **overrides):
+    """Construct a KvbmRequest with sensible defaults for these tests."""
+    kwargs = {
+        "request_id": "req-test",
+        "tokens": [1, 2, 3, 4],
+        "lora_name": None,
+        "salt_hash": None,
+        "max_tokens": 128,
+        "kv_transfer_params_json": kv_transfer_params_json,
+    }
+    kwargs.update(overrides)
+    return KvbmRequest(**kwargs)
+
+
+class TestGolden:
+    def test_accepts_none(self):
+        """No params supplied is the common case — must not raise."""
+        req = _build(kv_transfer_params_json=None)
+        assert req.request_id == "req-test"
+
+    def test_accepts_empty_object(self):
+        """An empty `{}` is valid JSON and should be accepted."""
+        _build(kv_transfer_params_json=json.dumps({}))
+
+    def test_accepts_typical_mooncake_payload(self):
+        """Real-world vLLM Mooncake-style params must pass through."""
+        payload = {
+            "transfer_id": "abc-123",
+            "remote_engine_id": "engine-7",
+            "remote_host": "10.0.0.1",
+            "remote_port": 9000,
+            "remote_block_ids": [1, 2, 3, 4, 5],
+            "do_remote_prefill": True,
+            "do_remote_decode": False,
+        }
+        _build(kv_transfer_params_json=json.dumps(payload))
+
+    def test_accepts_nested_structures(self):
+        """Arbitrary nesting permitted under `dict[str, Any]`."""
+        payload = {
+            "peers": [
+                {"host": "a", "port": 1},
+                {"host": "b", "port": 2, "opts": {"enabled": True}},
+            ],
+            "counts": {"blocks": 128, "tokens": 4096},
+            "nullable": None,
+        }
+        _build(kv_transfer_params_json=json.dumps(payload))
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            {"flag": True},
+            {"int_val": -42},
+            {"float_val": 3.14},
+            {"str_val": "hello"},
+            {"list_val": [1, 2.0, "three", None, True]},
+            {"unicode": "日本語🚀"},
+        ],
+    )
+    def test_accepts_all_json_primitive_types(self, value):
+        _build(kv_transfer_params_json=json.dumps(value))
+
+
+# ---------------------------------------------------------------------------
+# Adversarial inputs
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialJson:
+    """Strings that parse poorly or not at all must raise on the Rust side."""
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "not json at all",
+            "{unterminated",
+            "{'single': 'quotes'}",  # single quotes are not valid JSON
+            "{trailing: comma,}",
+            "",  # empty string is not valid JSON
+        ],
+    )
+    def test_malformed_json_raises_value_error(self, bad):
+        with pytest.raises(ValueError, match="invalid kv_transfer_params JSON"):
+            _build(kv_transfer_params_json=bad)
+
+
+class TestAdversarialPython:
+    """
+    The Python side of the contract is that callers serialize with
+    ``json.dumps`` before handing the string to the shim. These tests pin
+    that the loud failure mode (TypeError from json.dumps) happens in
+    Python as expected for values that are not JSON-serializable.
+    """
+
+    @pytest.mark.parametrize(
+        "unserializable",
+        [
+            {"blob": b"raw bytes"},
+            {"set": {1, 2, 3}},
+            {"custom": object()},
+        ],
+    )
+    def test_json_dumps_raises_on_unserializable(self, unserializable):
+        with pytest.raises(TypeError):
+            json.dumps(unserializable)
+
+
+# ---------------------------------------------------------------------------
+# Boundary interaction with other KvbmRequest fields
+# ---------------------------------------------------------------------------
+
+
+class TestFieldInteractions:
+    def test_max_tokens_still_required_even_with_params(self):
+        """max_tokens=None must still raise regardless of kv_transfer_params."""
+        with pytest.raises(ValueError, match="max_tokens is required"):
+            KvbmRequest(
+                request_id="req-x",
+                tokens=[1, 2, 3],
+                lora_name=None,
+                salt_hash=None,
+                max_tokens=None,
+                kv_transfer_params_json=json.dumps({"transfer_id": "z"}),
+            )
+
+    def test_params_can_coexist_with_lora_and_salt(self):
+        _build(
+            lora_name="lora-a",
+            salt_hash="salt-42",
+            kv_transfer_params_json=json.dumps({"do_remote_prefill": True}),
+        )

--- a/lib/bindings/kvbm/tests/test_kvbm_request_kv_transfer_params.py
+++ b/lib/bindings/kvbm/tests/test_kvbm_request_kv_transfer_params.py
@@ -14,9 +14,8 @@ from __future__ import annotations
 
 import json
 
-import pytest
-
 import kvbm
+import pytest
 
 if not kvbm.v2.is_available():
     pytest.skip(

--- a/lib/bindings/kvbm/tests/test_kvbm_request_kv_transfer_params.py
+++ b/lib/bindings/kvbm/tests/test_kvbm_request_kv_transfer_params.py
@@ -17,6 +17,12 @@ import json
 import kvbm
 import pytest
 
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.unit,
+]
+
 if not kvbm.v2.is_available():
     pytest.skip(
         "kvbm v2 feature not compiled; skipping KvbmRequest tests",

--- a/lib/kvbm-connector/Cargo.toml
+++ b/lib/kvbm-connector/Cargo.toml
@@ -51,6 +51,7 @@ serde_json     = { workspace = true }
 tracing-subscriber = { workspace = true }
 insta = { version = "1.41", features = ["json", "redactions"] }
 rstest = "0.23"
+proptest = "1.5.0"
 
 [features]
 static-kernels = ["kvbm-physical/static-kernels"]

--- a/lib/kvbm-connector/src/common/request.rs
+++ b/lib/kvbm-connector/src/common/request.rs
@@ -288,6 +288,7 @@ impl Request {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use serde_json::json;
 
     #[test]
@@ -327,5 +328,152 @@ mod tests {
             Some(RequestMetadata::default()),
         );
         assert!(request.kv_transfer_params().is_none());
+    }
+
+    // -------- Property tests for the FFI boundary --------
+    //
+    // The Python side serializes `dict[str, Any]` with `json.dumps`; the
+    // pyo3 shim deserializes with `serde_json::from_str::<serde_json::Value>`
+    // and hands the result to `RequestMetadata::with_kv_transfer_params`.
+    // These tests mirror that path over arbitrary JSON values that Python
+    // could reasonably produce, and assert the value stored on the request
+    // is byte-for-byte the one we put in.
+
+    /// Strategy: arbitrary JSON value up to bounded depth/size. Deliberately
+    /// keeps primitives inside what `json.dumps` on a plain Python dict
+    /// would emit (no NaN/Infinity — `json.dumps` rejects those by default).
+    fn arb_json_value() -> impl Strategy<Value = serde_json::Value> {
+        let leaf = prop_oneof![
+            Just(serde_json::Value::Null),
+            any::<bool>().prop_map(serde_json::Value::Bool),
+            any::<i64>().prop_map(|n| json!(n)),
+            // finite f64s only — json.dumps does not emit NaN/Inf.
+            any::<f64>()
+                .prop_filter("finite", |f| f.is_finite())
+                .prop_map(|f| json!(f)),
+            ".*".prop_map(serde_json::Value::String),
+        ];
+        leaf.prop_recursive(
+            4,  // up to 4 levels of nesting
+            32, // target total node count
+            8,  // max children per collection
+            |inner| {
+                prop_oneof![
+                    prop::collection::vec(inner.clone(), 0..8).prop_map(serde_json::Value::Array),
+                    prop::collection::hash_map(".*", inner, 0..8)
+                        .prop_map(|m| serde_json::Value::Object(m.into_iter().collect())),
+                ]
+            },
+        )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+        /// Any value that Python's `json.dumps` could emit must survive the
+        /// FFI hop: serialize → parse → store on Request → retrieve.
+        #[test]
+        fn ffi_json_string_round_trip(value in arb_json_value()) {
+            // Python side: json.dumps(dict)
+            let wire = serde_json::to_string(&value).expect("serializable");
+            // pyo3 shim side: serde_json::from_str
+            let parsed: serde_json::Value =
+                serde_json::from_str(&wire).expect("valid JSON round-trips");
+            let request = Request::with_token_limits(
+                "req-prop",
+                vec![1_u32, 2, 3],
+                None,
+                None,
+                None,
+                Some(128),
+                Some(RequestMetadata::with_kv_transfer_params(parsed.clone())),
+            );
+            prop_assert_eq!(request.kv_transfer_params(), Some(&parsed));
+            // Transitivity: re-serializing what we stored should equal `wire`'s
+            // canonical form (both sides parsed from the same bytes).
+            prop_assert_eq!(
+                serde_json::to_string(request.kv_transfer_params().unwrap()).unwrap(),
+                serde_json::to_string(&parsed).unwrap()
+            );
+        }
+
+        /// Object-shaped payloads (the common vLLM case: `dict[str, Any]`)
+        /// round-trip and preserve every key. Scoped to top-level objects to
+        /// match the vLLM protocol's shape.
+        #[test]
+        fn top_level_object_preserves_keys(
+            m in prop::collection::hash_map(".{1,16}", arb_json_value(), 0..10)
+        ) {
+            let value = serde_json::Value::Object(m.clone().into_iter().collect());
+            let wire = serde_json::to_string(&value).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(&wire).unwrap();
+
+            let request = Request::with_token_limits(
+                "req-obj",
+                vec![1_u32],
+                None,
+                None,
+                None,
+                Some(1),
+                Some(RequestMetadata::with_kv_transfer_params(parsed)),
+            );
+            let stored = request
+                .kv_transfer_params()
+                .expect("params present")
+                .as_object()
+                .expect("top-level object");
+            for key in m.keys() {
+                prop_assert!(stored.contains_key(key), "lost key: {key}");
+            }
+            prop_assert_eq!(stored.len(), m.len());
+        }
+    }
+
+    // -------- Spot-check adversarial / boundary cases --------
+
+    #[test]
+    fn malformed_json_is_rejected_by_shim_path() {
+        // Mirrors the pyo3 shim's failure branch without reaching into pyo3.
+        for bad in ["not json", "{unterminated", "", "{\"k\": }"] {
+            let err = serde_json::from_str::<serde_json::Value>(bad);
+            assert!(err.is_err(), "expected {bad:?} to fail to parse");
+        }
+    }
+
+    #[test]
+    fn deeply_nested_json_round_trips() {
+        // vLLM connectors occasionally nest config dicts a few layers deep.
+        let value = json!({
+            "a": {"b": {"c": {"d": [1, 2, {"e": "deep"}]}}},
+        });
+        let wire = serde_json::to_string(&value).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        let request = Request::with_token_limits(
+            "req-nested",
+            vec![1_u32],
+            None,
+            None,
+            None,
+            Some(1),
+            Some(RequestMetadata::with_kv_transfer_params(parsed.clone())),
+        );
+        assert_eq!(request.kv_transfer_params(), Some(&parsed));
+    }
+
+    #[test]
+    fn unicode_keys_and_values_round_trip() {
+        let value = json!({"日本語": "🚀", "emoji-key-🔑": [1, 2, 3]});
+        let wire = serde_json::to_string(&value).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        let request = Request::with_token_limits(
+            "req-unicode",
+            vec![1_u32],
+            None,
+            None,
+            None,
+            Some(1),
+            Some(RequestMetadata::with_kv_transfer_params(parsed.clone())),
+        );
+        assert_eq!(request.kv_transfer_params(), Some(&parsed));
     }
 }

--- a/lib/kvbm-connector/src/common/request.rs
+++ b/lib/kvbm-connector/src/common/request.rs
@@ -9,11 +9,26 @@ use serde::Serialize;
 
 /// Metadata for KVBM request integration.
 ///
-/// This struct holds optional metadata that can be passed from the scheduler
-/// to the connector. Fields will be added as needed.
+/// Holds optional data forwarded from the scheduler (e.g. a vLLM
+/// `Request`) into the connector layer. Today this carries the raw
+/// `kv_transfer_params` JSON as an opaque `serde_json::Value`; a
+/// follow-up change will introduce a typed `TransferParams` that
+/// parses this lazily on demand.
 #[derive(Debug, Clone, Default)]
 pub struct RequestMetadata {
-    // Empty for now - will be extended in the future
+    /// Connector-specific KV transfer parameters, as received from the
+    /// scheduler protocol. `None` when the upstream request did not
+    /// supply any (the common case for non-disaggregated requests).
+    pub kv_transfer_params: Option<serde_json::Value>,
+}
+
+impl RequestMetadata {
+    /// Construct metadata carrying only a `kv_transfer_params` JSON payload.
+    pub fn with_kv_transfer_params(value: serde_json::Value) -> Self {
+        Self {
+            kv_transfer_params: Some(value),
+        }
+    }
 }
 
 /// Minimal representation of a scheduler slot request.
@@ -256,5 +271,61 @@ impl Request {
     /// Get the metadata if present.
     pub fn metadata(&self) -> Option<&RequestMetadata> {
         self.metadata.as_ref()
+    }
+
+    /// Borrow the raw KV transfer params JSON, if any.
+    ///
+    /// Returns `None` when the upstream request did not supply
+    /// `kv_transfer_params`. Callers that require the data decide
+    /// locally whether absence is fatal.
+    pub fn kv_transfer_params(&self) -> Option<&serde_json::Value> {
+        self.metadata
+            .as_ref()
+            .and_then(|m| m.kv_transfer_params.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn kv_transfer_params_round_trips() {
+        let params = json!({
+            "transfer_id": "abc-123",
+            "do_remote_prefill": true,
+            "remote_block_ids": [1, 2, 3],
+        });
+        let request = Request::with_token_limits(
+            "req-1",
+            vec![1_u32, 2, 3],
+            None,
+            None,
+            None,
+            Some(128),
+            Some(RequestMetadata::with_kv_transfer_params(params.clone())),
+        );
+        assert_eq!(request.kv_transfer_params(), Some(&params));
+    }
+
+    #[test]
+    fn kv_transfer_params_absent_when_no_metadata() {
+        let request = Request::new("req-2", vec![1_u32, 2, 3], None, None, Some(64));
+        assert!(request.kv_transfer_params().is_none());
+    }
+
+    #[test]
+    fn kv_transfer_params_absent_when_metadata_has_none() {
+        let request = Request::with_token_limits(
+            "req-3",
+            vec![1_u32, 2, 3],
+            None,
+            None,
+            None,
+            Some(64),
+            Some(RequestMetadata::default()),
+        );
+        assert!(request.kv_transfer_params().is_none());
     }
 }

--- a/lib/kvbm-connector/src/connector/leader/slot.rs
+++ b/lib/kvbm-connector/src/connector/leader/slot.rs
@@ -673,6 +673,12 @@ impl RequestSlot {
         &self.request.request_id
     }
 
+    /// Borrow the raw KV transfer params JSON carried on this slot's
+    /// request, if any. Callers decide whether absence is fatal.
+    pub fn kv_transfer_params(&self) -> Option<&serde_json::Value> {
+        self.request.kv_transfer_params()
+    }
+
     /// Get the current transaction state (read-only).
     pub fn txn_state(&self) -> &TransactionState {
         self.state.txn_state()


### PR DESCRIPTION
#### Overview:

This PR adds support for passing connector-specific KV transfer parameters through the request metadata layer, enabling vLLM to communicate disaggregated inference configuration to the KVBM connector.

#### Details:

**Core Changes:**

1. **`RequestMetadata` struct enhancement** (`lib/kvbm-connector/src/common/request.rs`):
   - Added `kv_transfer_params: Option<serde_json::Value>` field to carry raw KV transfer parameters from the scheduler
   - Implemented `with_kv_transfer_params()` constructor for ergonomic metadata creation
   - Added `Request::kv_transfer_params()` accessor method to retrieve the params
   - Added comprehensive unit tests covering round-trip serialization and absence cases

2. **Python bindings update** (`lib/bindings/kvbm/src/v2/connector/leader/request.rs`):
   - Extended `PyRequest::new()` to accept optional `kv_transfer_params_json` parameter
   - Added JSON parsing with proper error handling (invalid JSON raises `PyValueError`)
   - Passes metadata through to the Rust `Request` constructor

3. **vLLM scheduler integration** (`lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/leader.py`):
   - Extracts `kv_transfer_params` attribute from vLLM `Request` objects
   - Serializes to JSON before passing to Rust layer (ensures well-defined payload format)
   - Allows misconfiguration to fail loudly via `TypeError` on unserializable values

4. **Slot accessor** (`lib/kvbm-connector/src/connector/leader/slot.rs`):
   - Added `RequestSlot::kv_transfer_params()` method for convenient access from slot context

#### Where should the reviewer start?

1. `lib/kvbm-connector/src/common/request.rs` — Core metadata structure and tests
2. `lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/leader.py` — Integration point showing how vLLM data flows through
3. `lib/bindings/kvbm/src/v2/connector/leader/request.rs` — Python binding layer

#### Related Issues:

- Relates to disaggregated inference support in KVBM connector

https://claude.ai/code/session_01SeVEqBfhsYxqmPWVLn2LRF
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional KV transfer parameters field to requests with built-in validation for enhanced scheduler control.

* **Tests**
  * Comprehensive test coverage for parameter handling, validation, serialization, and error scenarios.

* **Chores**
  * Updated development testing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->