### PR TITLE
fix(runtime): TCP request-plane reliability under sustained high concurrency

### DIFF
--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -25,6 +25,9 @@ fn is_migratable(err: &(dyn StdError + 'static)) -> bool {
         ErrorType::CannotConnect,
         ErrorType::Disconnected,
         ErrorType::ConnectionTimeout,
+        // Worker queue was full — the worker explicitly rejected the request.
+        // Retrying on a different worker is the correct response.
+        ErrorType::Overload,
         ErrorType::Backend(BackendError::EngineShutdown),
     ];
     const NON_MIGRATABLE: &[ErrorType] = &[ErrorType::Cancelled, ErrorType::ResourceExhausted];

--- a/lib/runtime/src/error.rs
+++ b/lib/runtime/src/error.rs
@@ -57,6 +57,12 @@ pub enum ErrorType {
     Cancelled,
     /// The system does not have enough resources to handle the request.
     ResourceExhausted,
+    /// The worker's request queue is full and the request was rejected immediately.
+    ///
+    /// This is explicit backpressure: the worker cannot accept more work right now.
+    /// Unlike `ResourceExhausted` (which is permanent), `Overload` is transient —
+    /// retrying on a different worker is the correct response.
+    Overload,
     /// Error originating from a backend engine.
     Backend(BackendError),
 }
@@ -72,6 +78,7 @@ impl fmt::Display for ErrorType {
             ErrorType::ResponseTimeout => write!(f, "ResponseTimeout"),
             ErrorType::Cancelled => write!(f, "Cancelled"),
             ErrorType::ResourceExhausted => write!(f, "ResourceExhausted"),
+            ErrorType::Overload => write!(f, "Overload"),
             ErrorType::Backend(sub) => write!(f, "Backend{sub}"),
         }
     }
@@ -469,6 +476,7 @@ mod tests {
         );
         assert_eq!(ErrorType::ResponseTimeout.to_string(), "ResponseTimeout");
         assert_eq!(ErrorType::Cancelled.to_string(), "Cancelled");
+        assert_eq!(ErrorType::Overload.to_string(), "Overload");
         assert_eq!(
             ErrorType::Backend(BackendError::Unknown).to_string(),
             "BackendUnknown"

--- a/lib/runtime/src/pipeline/network/codec.rs
+++ b/lib/runtime/src/pipeline/network/codec.rs
@@ -20,6 +20,17 @@ pub mod zero_copy_decoder;
 pub use two_part::{TwoPartCodec, TwoPartMessage, TwoPartMessageType};
 pub use zero_copy_decoder::{TcpRequestMessageZeroCopy, ZeroCopyTcpDecoder};
 
+/// Magic sentinel prefix sent in lieu of a normal empty ACK when the worker's
+/// request queue is full.  The client detects this prefix and returns an
+/// `ErrorType::Overload` error immediately rather than waiting for the outer
+/// 5-second ACK timeout.
+///
+/// Chosen constraints:
+/// - First byte `0x7f` (ASCII DEL) is never the first byte of a valid empty ACK
+///   (`\x00\x00\x00\x00` for a zero-length response payload).
+/// - The full string is long enough to be unmistakable and short enough to be cheap.
+pub const OVERLOAD_SENTINEL: &[u8] = b"\x7fDYNAMO-OVERLOAD";
+
 /// TCP request plane protocol message with endpoint routing and trace headers
 ///
 /// Wire format:

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -664,19 +664,41 @@ impl TcpConnection {
             None
         };
 
-        // Bounded admission: block until a slot is free (channel_buffer hard limit).
-        // The permit is held for the duration of this call and released on drop,
-        // whether the caller returns normally, errors out, or the enclosing
-        // tokio::time::timeout drops this future mid-flight.
-        // This prevents unbounded SegQueue growth and heap OOM under overload.
-        // encode() runs AFTER acquire so callers blocked on the semaphore do not
-        // hold a pre-allocated encoded frame, bounding peak memory to
-        // channel_buffer * frame_size per connection.
-        let _permit = self
-            .admission
-            .acquire()
-            .await
-            .map_err(|_| anyhow::anyhow!("Connection closed (admission gate shut)"))?;
+        // Bounded admission (channel_buffer hard limit). Permit is held for the
+        // call and released on drop on every exit path -- Prevents unbounded SegQueue growth.
+        //
+        // Fast path: try_acquire() is a synchronous atomic decrement; the
+        // previous unconditional .acquire().await forced a Tokio scheduler
+        // round-trip even when a permit was free
+        //
+        // Slow path: on NoPermits, fall back to .acquire().await (preserves
+        // OOM bound and back-pressure) and re-check health after parking --
+        // the fast-path permit is granted ns after the pre-check above, so a
+        // second atomic load on that path would be redundant.
+        let _permit = match self.admission.try_acquire() {
+            Ok(p) => p,
+            Err(tokio::sync::TryAcquireError::NoPermits) => {
+                let permit = self
+                    .admission
+                    .acquire()
+                    .await
+                    .map_err(|_| anyhow::anyhow!("Connection closed (admission gate shut)"))?;
+                // Re-check health: the connection may have gone unhealthy while
+                // we were parked on the semaphore. Fail fast so the caller can
+                // retry on a fresh connection rather than pushing to a dead
+                // submit_queue.
+                if !self.healthy.load(Ordering::Relaxed) {
+                    anyhow::bail!("Connection unhealthy (tasks failed)");
+                }
+                if self.closed.load(Ordering::Acquire) {
+                    anyhow::bail!("Connection closed (writer exited)");
+                }
+                permit
+            }
+            Err(tokio::sync::TryAcquireError::Closed) => {
+                anyhow::bail!("Connection closed (admission gate shut)");
+            }
+        };
 
         // encode() called here — after admission is granted — so the frame is
         // only allocated once we have capacity to process it.
@@ -684,16 +706,6 @@ impl TcpConnection {
         let encoded_data = request_msg.encode()?;
 
         let (response_tx, response_rx) = oneshot::channel();
-
-        // Re-check health: the connection may have gone unhealthy while we
-        // were waiting for a permit.  Fail fast so the caller can retry on a
-        // fresh connection rather than pushing to a dead submit_queue.
-        if !self.healthy.load(Ordering::Relaxed) {
-            anyhow::bail!("Connection unhealthy (tasks failed)");
-        }
-        if self.closed.load(Ordering::Acquire) {
-            anyhow::bail!("Connection closed (writer exited)");
-        }
 
         // Increment inflight and attach a RAII guard that decrements it on ALL
         // exit paths: normal return, `?` propagation, tokio::time::timeout

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -665,40 +665,42 @@ impl TcpConnection {
         };
 
         // Bounded admission (channel_buffer hard limit). Permit is held for the
-        // call and released on drop on every exit path -- Prevents unbounded SegQueue growth.
+        // call and released on drop on every exit path -- prevents unbounded
+        // SegQueue growth.
         //
         // Fast path: try_acquire() is a synchronous atomic decrement; the
         // previous unconditional .acquire().await forced a Tokio scheduler
-        // round-trip even when a permit was free
+        // round-trip even when a permit was free.
         //
         // Slow path: on NoPermits, fall back to .acquire().await (preserves
-        // OOM bound and back-pressure) and re-check health after parking --
-        // the fast-path permit is granted ns after the pre-check above, so a
-        // second atomic load on that path would be redundant.
+        // OOM bound and back-pressure).
         let _permit = match self.admission.try_acquire() {
             Ok(p) => p,
-            Err(tokio::sync::TryAcquireError::NoPermits) => {
-                let permit = self
-                    .admission
-                    .acquire()
-                    .await
-                    .map_err(|_| anyhow::anyhow!("Connection closed (admission gate shut)"))?;
-                // Re-check health: the connection may have gone unhealthy while
-                // we were parked on the semaphore. Fail fast so the caller can
-                // retry on a fresh connection rather than pushing to a dead
-                // submit_queue.
-                if !self.healthy.load(Ordering::Relaxed) {
-                    anyhow::bail!("Connection unhealthy (tasks failed)");
-                }
-                if self.closed.load(Ordering::Acquire) {
-                    anyhow::bail!("Connection closed (writer exited)");
-                }
-                permit
-            }
+            Err(tokio::sync::TryAcquireError::NoPermits) => self
+                .admission
+                .acquire()
+                .await
+                .map_err(|_| anyhow::anyhow!("Connection closed (admission gate shut)"))?,
             Err(tokio::sync::TryAcquireError::Closed) => {
                 anyhow::bail!("Connection closed (admission gate shut)");
             }
         };
+
+        // Re-check health AFTER acquiring the permit, on both fast and slow
+        // paths. The upfront check at the top of send_request establishes
+        // `healthy == true && closed == false`, but the writer/reader
+        // shutdown path can land after that check and before `try_acquire()`
+        // observes `admission.close()` (closed teardown is: `healthy.store(false)`
+        // -> `closed.store(true)` -> `admission.close()`). Without this
+        // re-check, a request could acquire a valid permit on a dying
+        // connection, push onto a submit_queue the writer will never drain,
+        // and hang until the outer request timeout.
+        if !self.healthy.load(Ordering::Relaxed) {
+            anyhow::bail!("Connection unhealthy (tasks failed)");
+        }
+        if self.closed.load(Ordering::Acquire) {
+            anyhow::bail!("Connection closed (writer exited)");
+        }
 
         // encode() called here — after admission is granted — so the frame is
         // only allocated once we have capacity to process it.

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -1414,6 +1414,22 @@ impl RequestPlaneClient for TcpRequestClient {
 
         match result {
             Ok(Ok(response)) => {
+                // Detect overload sentinel: the worker queue was full and the
+                // worker sent this magic prefix instead of an empty ACK.
+                // Return ErrorType::Overload so the migration layer can retry
+                // on a different worker immediately, without hitting a timeout.
+                if response.starts_with(crate::pipeline::network::codec::OVERLOAD_SENTINEL) {
+                    self.stats.errors.fetch_add(1, Ordering::Relaxed);
+                    TCP_ERRORS_TOTAL.inc();
+                    tracing::debug!("TCP overload rejection from {}: worker queue full", addr);
+                    return Err(anyhow::anyhow!(
+                        crate::error::DynamoError::builder()
+                            .error_type(crate::error::ErrorType::Overload)
+                            .message(format!("Worker {addr} queue full — request rejected"))
+                            .build()
+                    ));
+                }
+
                 self.stats
                     .responses_received
                     .fetch_add(1, Ordering::Relaxed);

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -232,17 +232,12 @@ struct TcpConnection {
     /// This closes the race where a request can enqueue after the final drain pass
     /// and then wait until the outer request timeout.
     closed: Arc<AtomicBool>,
-    /// Number of in-flight requests (for capacity heuristic)
+    /// In-flight count, advisory only — feeds `available_capacity()` for
+    /// round-robin selection. Backpressure is enforced end-to-end by the
+    /// server-side mpsc queue (`OVERLOAD_SENTINEL` on Full).
     inflight: Arc<AtomicU64>,
-    /// Max inflight for capacity heuristic (matches channel_buffer)
+    /// Advisory cap for `available_capacity()` heuristic.
     channel_buffer: usize,
-    /// Bounded admission semaphore (permits == channel_buffer).
-    /// Callers must acquire a permit before pushing to submit_queue,
-    /// enforcing channel_buffer as a hard limit and preventing unbounded
-    /// SegQueue growth and heap OOM under sustained overload.
-    /// Permit is held for the lifetime of the call and released on drop
-    /// (success, error via `?`, or timeout/cancel future drop).
-    admission: Arc<tokio::sync::Semaphore>,
     #[cfg(test)]
     post_enqueue_barrier: Option<Arc<tokio::sync::Barrier>>,
 }
@@ -265,7 +260,6 @@ impl TcpConnection {
         let healthy = Arc::new(AtomicBool::new(true));
         let closed = Arc::new(AtomicBool::new(false));
         let inflight = Arc::new(AtomicU64::new(0));
-        let admission = Arc::new(tokio::sync::Semaphore::new(channel_buffer));
 
         // Spawn writer task (batches into BytesMut, single write_all per drain)
         let writer_handle = {
@@ -274,7 +268,6 @@ impl TcpConnection {
             let notify = writer_notify.clone();
             let healthy = healthy.clone();
             let closed = closed.clone();
-            let admission = admission.clone();
             tokio::spawn(async move {
                 if let Err(e) = Self::writer_task(
                     write_half,
@@ -291,9 +284,6 @@ impl TcpConnection {
                     // drain_pending; these are idempotent backstops.
                     healthy.store(false, Ordering::Relaxed);
                     closed.store(true, Ordering::Release);
-                    // Unblock any callers currently waiting to acquire a permit
-                    // so they fail fast via the post-acquire health re-check.
-                    admission.close();
                 }
             })
         };
@@ -303,15 +293,12 @@ impl TcpConnection {
             let response_q = response_queue.clone();
             let healthy = healthy.clone();
             let writer_notify = writer_notify.clone();
-            let admission = admission.clone();
             tokio::spawn(async move {
                 if let Err(e) =
                     Self::reader_task(read_half, response_q, healthy.clone(), writer_notify).await
                 {
                     tracing::debug!("Reader task failed for {}: {}", addr, e);
                     healthy.store(false, Ordering::Relaxed);
-                    // Unblock any callers currently waiting to acquire a permit.
-                    admission.close();
                 }
             })
         };
@@ -327,7 +314,6 @@ impl TcpConnection {
             closed,
             inflight,
             channel_buffer,
-            admission,
             #[cfg(test)]
             post_enqueue_barrier: None,
         })
@@ -664,46 +650,8 @@ impl TcpConnection {
             None
         };
 
-        // Bounded admission (channel_buffer hard limit). Permit is held for the
-        // call and released on drop on every exit path -- prevents unbounded
-        // SegQueue growth.
-        //
-        // Fast path: try_acquire() is a synchronous atomic decrement; the
-        // previous unconditional .acquire().await forced a Tokio scheduler
-        // round-trip even when a permit was free.
-        //
-        // Slow path: on NoPermits, fall back to .acquire().await (preserves
-        // OOM bound and back-pressure).
-        let _permit = match self.admission.try_acquire() {
-            Ok(p) => p,
-            Err(tokio::sync::TryAcquireError::NoPermits) => self
-                .admission
-                .acquire()
-                .await
-                .map_err(|_| anyhow::anyhow!("Connection closed (admission gate shut)"))?,
-            Err(tokio::sync::TryAcquireError::Closed) => {
-                anyhow::bail!("Connection closed (admission gate shut)");
-            }
-        };
-
-        // Re-check health AFTER acquiring the permit, on both fast and slow
-        // paths. The upfront check at the top of send_request establishes
-        // `healthy == true && closed == false`, but the writer/reader
-        // shutdown path can land after that check and before `try_acquire()`
-        // observes `admission.close()` (closed teardown is: `healthy.store(false)`
-        // -> `closed.store(true)` -> `admission.close()`). Without this
-        // re-check, a request could acquire a valid permit on a dying
-        // connection, push onto a submit_queue the writer will never drain,
-        // and hang until the outer request timeout.
-        if !self.healthy.load(Ordering::Relaxed) {
-            anyhow::bail!("Connection unhealthy (tasks failed)");
-        }
-        if self.closed.load(Ordering::Acquire) {
-            anyhow::bail!("Connection closed (writer exited)");
-        }
-
-        // encode() called here — after admission is granted — so the frame is
-        // only allocated once we have capacity to process it.
+        // Backpressure is enforced end-to-end by the server mpsc queue
+        // (`OVERLOAD_SENTINEL` on Full). No client-side admission gate.
         let request_msg = TcpRequestMessage::with_headers(endpoint_path, headers.clone(), payload);
         let encoded_data = request_msg.encode()?;
 
@@ -747,7 +695,6 @@ impl TcpConnection {
 
         // Await response. On timeout the enclosing future is dropped here:
         // `_inflight_guard` drops → fetch_sub(Release) runs automatically.
-        // `_permit` drops     → semaphore slot is released automatically.
         let result = response_rx
             .await
             .map_err(|_| anyhow::anyhow!("Reader task closed"))?;
@@ -1237,10 +1184,8 @@ impl TcpConnectionPool {
                 let snap = host.snapshot.load();
                 for conn in snap.iter() {
                     conn.healthy.store(false, Ordering::Relaxed);
-                    // Unblock callers waiting on the admission semaphore so
-                    // they fail fast via the post-acquire health re-check,
-                    // rather than waiting for drain_pending to free permits.
-                    conn.admission.close();
+                    // Wake the writer so it observes `healthy == false` and
+                    // drains pending callers via the terminal path.
                     conn.writer_notify.notify_one();
                     conn.reader_handle.abort();
                 }

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -500,8 +500,11 @@ impl SharedTcpServer {
                 endpoint_name: handler.endpoint_name.clone(),
             };
 
-            // Send to worker pool with backpressure - BEFORE sending ACK
-            match work_tx.send(work_item).await {
+            // Attempt to enqueue work without blocking the TCP read loop.
+            // try_send() is non-blocking: it either succeeds immediately or
+            // returns Full/Closed.  This prevents the read loop from stalling
+            // when the worker pool queue is saturated
+            match work_tx.try_send(work_item) {
                 Ok(_) => {
                     // Send acknowledgment ONLY after successful queuing
                     let ack_response = TcpResponseMessage::empty();
@@ -521,30 +524,40 @@ impl SharedTcpServer {
                         "Request queued and acknowledged"
                     );
                 }
-                Err(e) => {
-                    tracing::warn!(
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                    // Queue is full: send the overload sentinel immediately instead
+                    // of stalling the read loop.  The client detects this sentinel
+                    // and returns ErrorType::Overload so the migration layer can
+                    // retry on a different worker.
+                    tracing::debug!(
                         endpoint = handler.endpoint_name.as_str(),
                         instance_id = handler.instance_id,
-                        error = %e,
-                        "Failed to queue work to worker pool, sending error response"
+                        "Worker queue full — rejecting request immediately (overload)"
                     );
-
-                    // Send error response to client instead of ACK
+                    let overload_response = TcpResponseMessage::new(Bytes::from_static(
+                        crate::pipeline::network::codec::OVERLOAD_SENTINEL,
+                    ));
+                    if let Ok(encoded) = overload_response.encode() {
+                        let _ = response_tx.send(encoded);
+                    }
+                    handler.inflight.fetch_sub(1, Ordering::SeqCst);
+                    handler.notify.notify_one();
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                    tracing::error!(
+                        endpoint = handler.endpoint_name.as_str(),
+                        instance_id = handler.instance_id,
+                        "Worker pool channel closed, shutting down read loop"
+                    );
+                    // Send a generic error to the client
                     let error_response =
-                        TcpResponseMessage::new(Bytes::from(format!("Server overloaded: {}", e)));
+                        TcpResponseMessage::new(Bytes::from_static(b"Worker pool channel closed"));
                     if let Ok(encoded) = error_response.encode() {
                         let _ = response_tx.send(encoded);
                     }
-
-                    // Clean up inflight counter
                     handler.inflight.fetch_sub(1, Ordering::SeqCst);
                     handler.notify.notify_one();
-
-                    // If channel is closed, break the loop
-                    if matches!(e, tokio::sync::mpsc::error::SendError(_)) {
-                        tracing::error!("Worker pool channel closed, shutting down read loop");
-                        break;
-                    }
+                    break;
                 }
             }
         }

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -94,9 +94,22 @@ struct EndpointHandler {
 
 impl SharedTcpServer {
     pub fn new(bind_addr: SocketAddr, cancellation_token: CancellationToken) -> Arc<Self> {
-        let worker_pool_size = get_worker_pool_size();
-        let work_queue_size = get_work_queue_size();
+        Self::new_with_sizes(
+            bind_addr,
+            cancellation_token,
+            get_worker_pool_size(),
+            get_work_queue_size(),
+        )
+    }
 
+    /// Construct a server with explicit worker-pool and work-queue sizes.
+    /// Prefer `new` in production; this bypasses env vars for tests.
+    pub fn new_with_sizes(
+        bind_addr: SocketAddr,
+        cancellation_token: CancellationToken,
+        worker_pool_size: usize,
+        work_queue_size: usize,
+    ) -> Arc<Self> {
         tracing::info!(
             "Initializing TCP server with dispatcher (concurrency={}, queue={})",
             worker_pool_size,
@@ -988,5 +1001,216 @@ mod tests {
 
         // Cleanup
         cancellation_token.cancel();
+    }
+
+    /// Outcome buckets for backpressure repro tests.
+    #[derive(Debug)]
+    #[allow(dead_code)]
+    struct BackpressureOutcome {
+        total: usize,
+        success: usize,
+        overload: usize,
+        cannot_connect: usize,
+        other: usize,
+        elapsed: Duration,
+    }
+
+    /// Stand up a loopback server + client, fire `total_requests`
+    /// concurrently, classify each outcome, return counts.
+    #[allow(clippy::too_many_arguments)]
+    async fn run_backpressure_scenario(
+        scenario: &str,
+        server_pool: usize,
+        server_queue: usize,
+        handler_delay: Duration,
+        client_pool_size: usize,
+        client_channel_buffer: usize,
+        client_request_timeout: Duration,
+        total_requests: usize,
+    ) -> BackpressureOutcome {
+        use crate::pipeline::network::egress::tcp_client::{TcpRequestClient, TcpRequestConfig};
+        use crate::pipeline::network::egress::unified_client::{Headers, RequestPlaneClient};
+        use std::sync::atomic::AtomicUsize;
+
+        crate::logging::init();
+
+        let cancellation_token = CancellationToken::new();
+        let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let server = SharedTcpServer::new_with_sizes(
+            bind_addr,
+            cancellation_token.clone(),
+            server_pool,
+            server_queue,
+        );
+
+        let actual_addr = server
+            .clone()
+            .bind_and_start()
+            .await
+            .expect("server should bind");
+
+        let handler = Arc::new(SlowMockHandler::new(handler_delay));
+        let endpoint_path = format!("test.repro.{scenario}");
+        let system_health = Arc::new(Mutex::new(SystemHealth::new(
+            crate::HealthStatus::Ready,
+            vec![],
+            false,
+            "/health".to_string(),
+            "/live".to_string(),
+        )));
+
+        server
+            .register_endpoint(
+                endpoint_path.clone(),
+                handler.clone() as Arc<dyn PushWorkHandler>,
+                1,
+                "test".to_string(),
+                "repro".to_string(),
+                scenario.to_string(),
+                system_health,
+            )
+            .await
+            .expect("register_endpoint should succeed");
+
+        let client = Arc::new(
+            TcpRequestClient::with_config(TcpRequestConfig {
+                request_timeout: client_request_timeout,
+                connect_timeout: Duration::from_secs(2),
+                pool_size: client_pool_size,
+                channel_buffer: client_channel_buffer,
+            })
+            .expect("client should build"),
+        );
+
+        let address = format!(
+            "tcp://{}:{}/{}",
+            actual_addr.ip(),
+            actual_addr.port(),
+            endpoint_path
+        );
+
+        let succ = Arc::new(AtomicUsize::new(0));
+        let overload = Arc::new(AtomicUsize::new(0));
+        let cannot_connect = Arc::new(AtomicUsize::new(0));
+        let other = Arc::new(AtomicUsize::new(0));
+
+        let start = Instant::now();
+        let mut handles = Vec::with_capacity(total_requests);
+        for i in 0..total_requests {
+            let address = address.clone();
+            let client = client.clone();
+            let succ = succ.clone();
+            let overload = overload.clone();
+            let cannot_connect = cannot_connect.clone();
+            let other = other.clone();
+
+            handles.push(tokio::spawn(async move {
+                let headers = Headers::new();
+                let payload = Bytes::from(format!("req_{i}"));
+                match client.send_request(address, payload, headers).await {
+                    Ok(_) => {
+                        succ.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Err(e) => {
+                        // Walk the error chain to find the DynamoError + ErrorType.
+                        let mut source: Option<&(dyn std::error::Error + 'static)> =
+                            Some(e.as_ref() as &(dyn std::error::Error + 'static));
+                        let mut classified = false;
+                        while let Some(err) = source {
+                            if let Some(dyn_err) = err.downcast_ref::<crate::error::DynamoError>() {
+                                match dyn_err.error_type() {
+                                    crate::error::ErrorType::Overload => {
+                                        overload.fetch_add(1, Ordering::Relaxed);
+                                    }
+                                    crate::error::ErrorType::CannotConnect => {
+                                        cannot_connect.fetch_add(1, Ordering::Relaxed);
+                                    }
+                                    _ => {
+                                        other.fetch_add(1, Ordering::Relaxed);
+                                    }
+                                }
+                                classified = true;
+                                break;
+                            }
+                            source = err.source();
+                        }
+                        if !classified {
+                            other.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                }
+            }));
+        }
+
+        for h in handles {
+            let _ = h.await;
+        }
+        let elapsed = start.elapsed();
+
+        let s = succ.load(Ordering::Relaxed);
+        let o = overload.load(Ordering::Relaxed);
+        let c = cannot_connect.load(Ordering::Relaxed);
+        let x = other.load(Ordering::Relaxed);
+        let total = s + o + c + x;
+
+        println!(
+            "[{scenario}] total={total} success={s} overload={o} \
+             cannot_connect={c} other={x} elapsed={elapsed:?}",
+        );
+
+        cancellation_token.cancel();
+
+        BackpressureOutcome {
+            total,
+            success: s,
+            overload: o,
+            cannot_connect: c,
+            other: x,
+            elapsed,
+        }
+    }
+
+    /// Server-side mpsc queue saturation: tiny queue + slow handler vs 200
+    /// concurrent clients. With `try_send` + `OVERLOAD_SENTINEL` we see clean
+    /// `Overload` rejections; reverting to `.send().await` reproduces the
+    /// production `CannotConnect` ACK-timeout pathology.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_backpressure_server_queue_saturation() {
+        let outcome = run_backpressure_scenario(
+            "server_queue_saturation",
+            /* server_pool            */ 4,
+            /* server_queue           */ 32,
+            /* handler_delay          */ Duration::from_millis(100),
+            /* client_pool_size       */ 8,
+            /* client_channel_buffer  */ 64,
+            /* client_request_timeout */ Duration::from_secs(2),
+            /* total_requests         */ 200,
+        )
+        .await;
+
+        assert_eq!(outcome.total, 200, "every request must be accounted for");
+        assert!(outcome.success > 0, "at least some requests must succeed");
+    }
+
+    /// Client-side admission saturation: ample server, tiny client
+    /// (pool_size=1, channel_buffer=8). Before/after signal for changes to
+    /// the client admission path — removing the gate should drop wall-time
+    /// and keep `cannot_connect` at zero.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_backpressure_client_admission_saturation() {
+        let outcome = run_backpressure_scenario(
+            "client_admission_saturation",
+            /* server_pool            */ 8,
+            /* server_queue           */ 1024,
+            /* handler_delay          */ Duration::from_millis(100),
+            /* client_pool_size       */ 1,
+            /* client_channel_buffer  */ 8,
+            /* client_request_timeout */ Duration::from_secs(3),
+            /* total_requests         */ 200,
+        )
+        .await;
+
+        assert_eq!(outcome.total, 200, "every request must be accounted for");
+        assert!(outcome.success > 0, "at least some requests must succeed");
     }
 }


### PR DESCRIPTION
## Problem

Under sustained high-concurrency load, a significant fraction of TCP requests from frontend to vLLM workers fail with `CannotConnect` errors. Connections are established successfully — requests time out waiting for an ACK from the worker after the configured request-timeout (default 5 s).

### Root cause

The worker's TCP request plane acknowledges a request only after successfully enqueueing it onto an internal bounded work queue, using a blocking send. When the per-worker arrival rate exceeds vLLM's drain rate, the queue fills, the blocking send stalls the worker's TCP read loop, and every in-flight client request on that connection times out.

The frontend's outbound TCP path adds a second layer of admission control on top of the worker queue. Under the same saturation conditions, this gate adds scheduler overhead on every request and amplifies the impact of slow ACKs. An older revision of the code — before this gate was introduced — ran the same workload at a much lower error rate.

Request migration exists on the frontend but is disabled by default, so even when a migratable error surfaces, the router does not retry on another worker.

## What this PR changes

1. **Non-blocking worker-queue backpressure** (`shared_tcp_endpoint.rs`): when the worker's queue is full, reject immediately with a typed `OVERLOAD_SENTINEL` response instead of stalling the TCP read loop. The client maps the sentinel to `ErrorType::Overload`, which is added to the migratable set so the router retries on a different worker.

2. **Remove the frontend-side admission gate** (`tcp_client.rs`): drop the per-connection admission semaphore and its teardown coordination. Backpressure is now enforced end-to-end by the worker's queue + typed overload response — a single source of truth matching the pre-regression architecture, and removing scheduler overhead on the hot path.

3. **Tighten the health-check / admission race**: close the window where a dying connection can accept a request between its upfront health check and the actual send.

4. **Local reproduction harness**: a deterministic loopback tokio test that drives the worker queue to saturation and the frontend's admission path to contention. Reproduces the `CannotConnect` pathology on the pre-fix path and validates the fix in well under a second, without needing a cluster.

## Files changed

| File | Change |
|---|---|
| `lib/runtime/src/pipeline/network/codec.rs` | `OVERLOAD_SENTINEL` constant (shared server/client) |
| `lib/runtime/src/error.rs` | `ErrorType::Overload` variant |
| `lib/llm/src/migration.rs` | `Overload` added to `MIGRATABLE` |
| `lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs` | `try_send` + sentinel dispatch, local repro tests |
| `lib/runtime/src/pipeline/network/egress/tcp_client.rs` | Sentinel detection, admission-gate removal, post-acquire health re-check |
| `docs/proposals/tcp-worker-queue-backpressure.md` | Design proposal |

## Test plan

- [ ] `cargo check -p dynamo-runtime -p dynamo-llm` — clean
- [ ] `cargo test -p dynamo-runtime` — all runtime unit tests pass, including the new backpressure repro tests
- [ ] `cargo test -p dynamo-llm` — migration tests pass
- [ ] End-to-end: run the high-concurrency scale test with request migration enabled (`DYN_MIGRATION_LIMIT >= 1`) and verify that `CannotConnect` errors drop sharply and net-transit latency returns to the pre-regression baseline