### PR TITLE
fix: support typing.Self on Python 3.10 via typing_extensions

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -40,6 +40,7 @@ jobs:
             --accept "200..=299, 403, 429"
             --exclude-all-private
             --exclude 0.0.0.0
+            --exclude "https://helm.sh"
             --verbose
             --host-concurrency 10
             --host-request-interval 1s

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -40,7 +40,7 @@ jobs:
             --accept "200..=299, 403, 429"
             --exclude-all-private
             --exclude 0.0.0.0
-            --exclude "https://helm.sh"
+            --exclude "https://helm\.sh(/.*)?$"
             --verbose
             --host-concurrency 10
             --host-request-interval 1s

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -41,6 +41,7 @@ jobs:
             --exclude-all-private
             --exclude 0.0.0.0
             --exclude "https://helm\.sh(/.*)?$"
+            --exclude "https://www\.conventionalcommits\.org(/.*)?$"
             --verbose
             --host-concurrency 10
             --host-request-interval 1s

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -40,8 +40,6 @@ jobs:
             --accept "200..=299, 403, 429"
             --exclude-all-private
             --exclude 0.0.0.0
-            --exclude "https://helm\.sh(/.*)?$"
-            --exclude "https://www\.conventionalcommits\.org(/.*)?$"
             --verbose
             --host-concurrency 10
             --host-request-interval 1s

--- a/components/src/dynamo/common/configuration/config_base.py
+++ b/components/src/dynamo/common/configuration/config_base.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import argparse
-from typing import Self
+import sys
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class ConfigBase:


### PR DESCRIPTION
## Summary

Fixes #8322 — `ImportError` when running `python3 -m dynamo.frontend` on Python 3.10.

- `typing.Self` was introduced in Python 3.11 ([PEP 673](https://peps.python.org/pep-0673/))
- `config_base.py` imported it unconditionally from `typing`, crashing on Python 3.10
- Fix: guard with `sys.version_info >= (3, 11)`, fall back to `typing_extensions.Self` which is already a transitive dependency via `pydantic`

**Change:**
```python
import sys

if sys.version_info >= (3, 11):
    from typing import Self
else:
    from typing_extensions import Self
```

## Test plan

- [ ] `python3.10 -c "from dynamo.common.configuration.config_base import ConfigBase"` — no ImportError
- [ ] `python3.10 -m dynamo.frontend --help` — prints help as expected
- [ ] Existing Python 3.11+ behavior unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Python version compatibility for type handling in internal configuration components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->