### PR TITLE
fix: support typing.Required on Python 3.10 via typing_extensions

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -40,6 +40,7 @@ jobs:
             --accept "200..=299, 403, 429"
             --exclude-all-private
             --exclude 0.0.0.0
+            --exclude "https://helm.sh"
             --verbose
             --host-concurrency 10
             --host-request-interval 1s

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -40,7 +40,7 @@ jobs:
             --accept "200..=299, 403, 429"
             --exclude-all-private
             --exclude 0.0.0.0
-            --exclude "https://helm.sh"
+            --exclude "https://helm\.sh(/.*)?$"
             --verbose
             --host-concurrency 10
             --host-request-interval 1s

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -41,6 +41,7 @@ jobs:
             --exclude-all-private
             --exclude 0.0.0.0
             --exclude "https://helm\.sh(/.*)?$"
+            --exclude "https://www\.conventionalcommits\.org(/.*)?$"
             --verbose
             --host-concurrency 10
             --host-request-interval 1s

--- a/components/src/dynamo/common/backend/engine.py
+++ b/components/src/dynamo/common/backend/engine.py
@@ -3,10 +3,10 @@
 
 from __future__ import annotations
 
+import sys
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-import sys
 from typing import TYPE_CHECKING, Any, Optional, TypedDict
 
 if sys.version_info >= (3, 11):

--- a/components/src/dynamo/common/backend/engine.py
+++ b/components/src/dynamo/common/backend/engine.py
@@ -6,7 +6,13 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional, Required, TypedDict
+import sys
+from typing import TYPE_CHECKING, Any, Optional, TypedDict
+
+if sys.version_info >= (3, 11):
+    from typing import Required
+else:
+    from typing_extensions import Required
 
 from dynamo._core import Context
 


### PR DESCRIPTION
## Overview

Followup to #8351 — same class of Python 3.10 compatibility issue in a different file.

## Summary

- `typing.Required` was introduced in Python 3.11 ([PEP 655](https://peps.python.org/pep-0655/))
- `engine.py` imported it unconditionally from `typing`, causing `ImportError` on Python 3.10
- Fix: `sys.version_info >= (3, 11)` guard falling back to `typing_extensions.Required`, which is already a transitive dependency via `pydantic`

## Details

**Change in `components/src/dynamo/common/backend/engine.py`:**
```python
import sys
from typing import TYPE_CHECKING, Any, Optional, TypedDict

if sys.version_info >= (3, 11):
    from typing import Required
else:
    from typing_extensions import Required
```

**Test plan:**
- [ ] `python3.10 -c "from dynamo.common.backend.engine import LLMEngine"` — no ImportError
- [ ] Python 3.11+ behavior unchanged

Related to #8322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced support for Python 3.11+ environments by utilizing standard library typing features.
  * Updated documentation validation configuration to exclude Helm-related resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->