### PR TITLE
docs: add --prerelease=allow to sglang install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ Also available: [`tensorrtllm-runtime:1.0.1`](https://docs.nvidia.com/dynamo/res
 Install [uv](https://github.com/astral-sh/uv) (`curl -LsSf https://astral.sh/uv/install.sh | sh`), then:
 
 ```bash
-uv pip install --prerelease=allow "ai-dynamo[sglang]"   # or [vllm] or [trtllm]
+uv pip install --prerelease=allow "ai-dynamo[sglang]"   # or [vllm]
 ```
+
+> **Note:** TensorRT-LLM requires `pip` with `--extra-index-url https://pypi.nvidia.com`. See the [install guide](docs/getting-started/local-installation.md) for TRT-LLM-specific instructions.
 
 Then start the frontend and a worker as shown above. See the [full installation guide](docs/getting-started/local-installation.md) for system dependencies and backend-specific notes.
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,10 @@ Also available: [`tensorrtllm-runtime:1.0.1`](https://docs.nvidia.com/dynamo/res
 
 ### Option B: Install from PyPI
 
+Install [uv](https://github.com/astral-sh/uv) (`curl -LsSf https://astral.sh/uv/install.sh | sh`), then:
+
 ```bash
-pip install "ai-dynamo[sglang]"   # or [vllm] or [trtllm]
+uv pip install --prerelease=allow "ai-dynamo[sglang]"   # or [vllm] or [trtllm]
 ```
 
 Then start the frontend and a worker as shown above. See the [full installation guide](docs/getting-started/local-installation.md) for system dependencies and backend-specific notes.

--- a/docs/backends/sglang/README.md
+++ b/docs/backends/sglang/README.md
@@ -20,7 +20,7 @@ We recommend using [uv](https://github.com/astral-sh/uv) to install:
 
 ```bash
 uv venv --python 3.12 --seed
-uv pip install "ai-dynamo[sglang]"
+uv pip install --prerelease=allow "ai-dynamo[sglang]"
 ```
 
 This installs Dynamo with the compatible SGLang version.

--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -104,7 +104,7 @@ docker pull nvcr.io/nvidia/ai-dynamo/snapshot-agent:1.0.1
 ```bash
 # Install Dynamo with a specific backend (Recommended)
 uv pip install "ai-dynamo[vllm]==1.0.1"
-uv pip install "ai-dynamo[sglang]==1.0.1"
+uv pip install --prerelease=allow "ai-dynamo[sglang]==1.0.1"
 # TensorRT-LLM requires the NVIDIA PyPI index and pip
 pip install --pre --extra-index-url https://pypi.nvidia.com "ai-dynamo[trtllm]==1.0.1"
 


### PR DESCRIPTION
#### Overview:
`sglang 0.5.10.post1` (pinned by ai-dynamo 1.1.0) depends on `flash-attn-4>=4.0.0b4` which has no stable release. `pip/uv` refuse transitive pre-releases by default, so plain `pip install ai-dynamo[sglang]` will fail once 1.1.0 publishes to PyPI.

Add --prerelease=allow (uv) to the three sglang install commands that were missing it. Switch the README from pip to uv to avoid a silent PIP_CONSTRAINT backtrack issue in NGC pytorch containers.

#### Details:
- Add `--prerelease=allow` to 3 sglang pip-install commands missing it (README.md, docs/backends/sglang/README.md, docs/reference/release-artifacts.md)
- Switch README from `pip` to `uv pip install` to match project convention and avoid silent `PIP_CONSTRAINT` backtrack in NGC pytorch containers
- Add inline `uv` install hint to README

Resolves: DYN-2727
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions across multiple sections to enable pre-release package versions
  * Updated package manager guidance to use `uv` for dependency installation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->