### PR TITLE
fix(planner): normalize deployment model_name case before comparing with user-provided name

### DIFF
--- a/components/src/dynamo/planner/connectors/kubernetes.py
+++ b/components/src/dynamo/planner/connectors/kubernetes.py
@@ -224,7 +224,7 @@ class KubernetesConnector(PlannerConnector):
 
         # If user provided a model name and it doesn't match the model name from the deployment, raise an error
         if self.user_provided_model_name:
-            if model_name != self.user_provided_model_name:
+            if model_name.lower() != self.user_provided_model_name:
                 raise UserProvidedModelNameMismatchError(
                     model_name, self.user_provided_model_name
                 )


### PR DESCRIPTION
## Summary

Fixes a case-sensitivity bug in `KubernetesConnector.get_model_name()` that caused Planner to enter `CrashLoopBackOff` in active mode when the deployment model name had different casing than the user-provided config value.

fix [DYN-2747](https://linear.app/nvidia/issue/DYN-2747/dynamorelease110planner-planner-fails-to-read-worker-capabilities-from)

**Root cause**: `self.user_provided_model_name` is normalized to lowercase in `__init__` (line 58, `model_name.lower()`), but `model_name` retrieved from the DGD/deployment at line 227 was compared as-is. When a model like `Qwen/Qwen3-0.6B` is registered with original casing, the comparison `\"Qwen/Qwen3-0.6B\" != \"qwen/qwen3-0.6b\"` spuriously raises `UserProvidedModelNameMismatchError`.

**Fix**: Normalize `model_name` to lowercase before comparison (one-line change).

```diff
- if model_name != self.user_provided_model_name:
+ if model_name.lower() != self.user_provided_model_name:
```

## Test Plan

Validated end-to-end on a single-node Kubernetes cluster (L20 GPU) with a DGD containing:
- `model_name: \"Qwen/Qwen3-0.6B\"` (mixed case)
- `scaling_mode: \"active\"`

Results:
- [x] Planner pod enters `Running` state (no CrashLoopBackOff, no `UserProvidedModelNameMismatchError` in logs)
- [x] Startup log contains `Planner started in ACTIVE mode` (no `[ADVISORY]` markers)
- [x] Under load, Planner invokes `KubernetesAPI._update_dgd_replicas` and scales `VllmDecodeWorker` from 1 -> 2 replicas
- [x] Advisory mode continues to work unchanged

Closes #8359
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model name validation to handle case differences correctly, preventing false mismatch errors when model names differ only in letter casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->