### PR TITLE
fix(operator): enable DCGM discovery in namespace-scoped mode

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/gpu-discovery-rbac.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/gpu-discovery-rbac.yaml
@@ -27,6 +27,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1052,26 +1052,14 @@ func (r *DynamoGraphDeploymentRequestReconciler) validateGPUHardwareInfo(ctx con
 		return nil
 	}
 
-	isNamespaceScoped := r.Config.Namespace.Restricted != ""
-	if isNamespaceScoped {
-		return fmt.Errorf(
-			"GPU hardware info required but cannot be auto-discovered." +
-				"\n\nOptions to resolve:" +
-				"\n\n1. Re-enable GPU discovery (if it was disabled during Helm install):" +
-				"\n   helm upgrade ... --set dynamo-operator.gpuDiscovery.enabled=true" +
-				"\n\n2. Add hardware config to spec.hardware:" +
-				"\n   gpuSku: \"h100_sxm\"" +
-				"\n   vramMb: 81920" +
-				"\n   numGpusPerNode: 8" +
-				"\n   totalGpus: 8")
-	}
-
+	// Try DCGM discovery. In namespace-scoped mode this requires a ClusterRole
+	// granting pod list/get (provisioned by the Helm chart when
+	// gpuDiscovery.enabled=true).
 	_, err := r.GPUDiscovery.DiscoverGPUsFromDCGM(ctx, r.APIReader, r.GPUDiscoveryCache)
 	if err == nil {
-		// GPU discovery is available, validation passes
 		return nil
 	}
-	// Refine the logger message
+
 	reason := GetGPUDiscoveryFailureReason(err)
 	logger.Info("GPU discovery not available", "reason", reason, "error", err.Error())
 	return fmt.Errorf("GPU hardware info required but auto-discovery failed. Add spec.hardware.gpuSku, spec.hardware.vramMb, spec.hardware.numGpusPerNode, spec.hardware.totalGpus")


### PR DESCRIPTION
Depends on #8267.

## Summary

Namespace-scoped operators previously hard-blocked GPU discovery with
a static error, even though DCGM scraping only needs cluster-wide pod
list access to find exporter pods.

- Remove the namespace-scoped short-circuit in `validateGPUHardwareInfo`
  and let DCGM discovery try regardless of operator scope
- Add pod `get`/`list` to the existing gpu-discovery **ClusterRole**
  (provisioned by Helm when `namespaceRestriction.enabled` and
  `gpuDiscovery.enabled` are both true), giving the operator cluster-wide
  pod read access for DCGM exporter discovery
- Keep `listDCGMExporterPods` listing cluster-wide (DCGM pods may not
  always live in the `gpu-operator` namespace)

Addresses part of [NVBug 6088006](https://nvbugspro.nvidia.com/bug/6088006)
as flagged by @julienmancuso in #8267.

## Test plan
- [x] All unit tests pass (controller + gpu discovery)
- [ ] Test namespace-scoped install with DCGM exporter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GPU discovery to operate reliably in restricted deployment environments with expanded system permissions.
  * Improved error messaging when automatic GPU hardware detection is unavailable, providing users with clearer guidance on manually configuring hardware specifications instead of generic troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->