### PR TITLE
feat(kvbm-hub): scaffold kvbm-hub crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4557,6 +4557,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "kvbm-hub"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum 0.8.4",
+ "bytes",
+ "dashmap",
+ "futures",
+ "parking_lot",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+ "velo",
+ "velo-common",
+]
+
+[[package]]
 name = "kvbm-kernels"
 version = "1.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "lib/kvbm-config",
     "lib/kvbm-connector",
     "lib/kvbm-engine",
+    "lib/kvbm-hub",
     "lib/kvbm-kernels",
     "lib/kvbm-logical",
     "lib/kvbm-observability",
@@ -59,6 +60,7 @@ kvbm-logical = { path = "lib/kvbm-logical", version = "1.1.0" }
 kvbm-observability = { path = "lib/kvbm-observability", version = "1.0.0" }
 kvbm-physical = { path = "lib/kvbm-physical", version = "1.1.0" }
 kvbm-connector = { path = "lib/kvbm-connector", version = "0.1.0" }
+kvbm-hub = { path = "lib/kvbm-hub", version = "0.1.0" }
 
 # velo
 velo        = { version = "0.1.0" }

--- a/lib/kvbm-hub/Cargo.toml
+++ b/lib/kvbm-hub/Cargo.toml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "kvbm-hub"
+version = "0.1.0"
+edition.workspace = true
+description = "Central coordination hub for KVBM velo clients (connector/engine) — HTTP PeerDiscovery + control plane"
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+
+[dependencies]
+# Velo (discovery trait, Velo facade, handlers)
+velo        = { workspace = true }
+velo-common = { workspace = true }
+
+# Async / core
+anyhow       = { workspace = true }
+async-trait  = { workspace = true }
+bytes        = { workspace = true }
+dashmap      = { workspace = true }
+futures      = { workspace = true }
+parking_lot  = { workspace = true }
+serde        = { workspace = true }
+serde_json   = { workspace = true }
+thiserror    = { workspace = true }
+tokio        = { workspace = true }
+tokio-util   = { workspace = true }
+tracing      = { workspace = true }
+url          = { workspace = true }
+uuid         = { workspace = true }
+
+# HTTP server
+axum       = { workspace = true }
+tower-http = { workspace = true }
+
+# HTTP client
+reqwest = { workspace = true }
+
+[dev-dependencies]
+tokio              = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
+tracing-subscriber = { workspace = true }

--- a/lib/kvbm-hub/src/client.rs
+++ b/lib/kvbm-hub/src/client.rs
@@ -1,0 +1,386 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP client for the KVBM hub.
+//!
+//! [`HubClient`] is both a `velo::discovery::PeerDiscovery` backend and the
+//! registration handle for a local velo instance. It talks HTTP to a
+//! [`HubServer`](crate::HubServer) on two ports:
+//!
+//! - **Discovery port** (default `1337`) — peer lookups.
+//! - **Control port** (default `8337`) — registration, heartbeat.
+
+use std::sync::{Arc, OnceLock};
+
+use anyhow::{Context, Result, anyhow};
+use futures::future::BoxFuture;
+use reqwest::StatusCode;
+use url::Url;
+use velo::discovery::{PeerDiscovery, PeerRegistrationGuard};
+use velo_common::{InstanceId, PeerInfo, WorkerId};
+
+use crate::handlers;
+use crate::protocol::{
+    self, DEFAULT_CONTROL_PORT, DEFAULT_DISCOVERY_PORT, ErrorBody, PeerLookupResponse,
+    RegisterRequest, RegisterResponse,
+};
+
+/// HTTP client for a [`HubServer`](crate::HubServer).
+///
+/// Construct via [`HubClientBuilder`] / [`crate::create_client_builder`].
+///
+/// The same `Arc<HubClient>` serves three roles:
+/// 1. `Arc<dyn velo::discovery::PeerDiscovery>` — pass to `VeloBuilder::discovery`.
+/// 2. Registration — [`register_instance`](Self::register_instance) stores a
+///    guard in an inner `OnceLock`; dropping the client (or calling
+///    [`unregister`](Self::unregister)) issues an HTTP `DELETE`.
+/// 3. Control plane — [`register_handlers`](Self::register_handlers) installs
+///    velo handlers (heartbeat, ...) on the caller's [`velo::Velo`] instance.
+pub struct HubClient {
+    config: HubClientConfig,
+    http: reqwest::Client,
+    guard: OnceLock<HubRegistrationGuard>,
+}
+
+impl std::fmt::Debug for HubClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HubClient")
+            .field("config", &self.config)
+            .field("registered", &self.guard.get().is_some())
+            .finish()
+    }
+}
+
+/// Resolved connection info for a [`HubClient`].
+#[derive(Debug, Clone)]
+pub struct HubClientConfig {
+    /// Base URL of the peer-discovery HTTP endpoint (port 1337 by default).
+    pub discovery_url: Url,
+    /// Base URL of the control-plane HTTP endpoint (port 8337 by default).
+    pub control_url: Url,
+}
+
+/// Builder for [`HubClient`].
+///
+/// Set `host` and (optionally) the discovery/control ports. `build()` returns
+/// an `Arc<HubClient>` that is not yet registered — call
+/// [`HubClient::register_instance`] after constructing `Velo`.
+#[derive(Debug, Clone)]
+pub struct HubClientBuilder {
+    host: Option<String>,
+    scheme: String,
+    discovery_port: u16,
+    control_port: u16,
+    http_client: Option<reqwest::Client>,
+}
+
+impl Default for HubClientBuilder {
+    fn default() -> Self {
+        Self {
+            host: None,
+            scheme: "http".to_string(),
+            discovery_port: DEFAULT_DISCOVERY_PORT,
+            control_port: DEFAULT_CONTROL_PORT,
+            http_client: None,
+        }
+    }
+}
+
+impl HubClientBuilder {
+    /// Create a new builder with default ports (`1337` discovery, `8337` control).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the hub host (name or IP). Required.
+    pub fn host(mut self, host: impl Into<String>) -> Self {
+        self.host = Some(host.into());
+        self
+    }
+
+    /// Override the URL scheme (defaults to `http`).
+    pub fn scheme(mut self, scheme: impl Into<String>) -> Self {
+        self.scheme = scheme.into();
+        self
+    }
+
+    /// Set the peer-discovery port (default `1337`).
+    pub fn port(mut self, port: u16) -> Self {
+        self.discovery_port = port;
+        self
+    }
+
+    /// Explicitly set the discovery port. Equivalent to [`port`](Self::port).
+    pub fn discovery_port(mut self, port: u16) -> Self {
+        self.discovery_port = port;
+        self
+    }
+
+    /// Set the control-plane port (default `8337`).
+    pub fn control_port(mut self, port: u16) -> Self {
+        self.control_port = port;
+        self
+    }
+
+    /// Provide a pre-configured `reqwest::Client` (e.g. with custom timeouts
+    /// or TLS config). Optional — a default client is built otherwise.
+    pub fn http_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = Some(client);
+        self
+    }
+
+    /// Build the `Arc<HubClient>`.
+    pub fn build(self) -> Result<Arc<HubClient>> {
+        let host = self
+            .host
+            .ok_or_else(|| anyhow!("HubClientBuilder: host is required"))?;
+        let discovery_url = Url::parse(&format!(
+            "{}://{}:{}",
+            self.scheme, host, self.discovery_port
+        ))
+        .context("building discovery URL")?;
+        let control_url = Url::parse(&format!("{}://{}:{}", self.scheme, host, self.control_port))
+            .context("building control URL")?;
+
+        let http = match self.http_client {
+            Some(c) => c,
+            None => reqwest::Client::builder()
+                .build()
+                .context("building default reqwest client")?,
+        };
+
+        Ok(Arc::new(HubClient {
+            config: HubClientConfig {
+                discovery_url,
+                control_url,
+            },
+            http,
+            guard: OnceLock::new(),
+        }))
+    }
+}
+
+impl HubClient {
+    /// Connection info.
+    pub fn config(&self) -> &HubClientConfig {
+        &self.config
+    }
+
+    /// Register the velo control-plane handlers supplied by the hub client on
+    /// the given `Velo` instance. Must be called **before**
+    /// [`register_instance`](Self::register_instance) so the hub can reach the
+    /// instance via velo active messaging immediately after registration.
+    ///
+    /// Currently registers:
+    /// - [`handlers::HEARTBEAT_HANDLER`] — velo-level liveness probe.
+    pub fn register_handlers(self: &Arc<Self>, velo: &velo::Velo) -> Result<()> {
+        velo.register_handler(handlers::create_heartbeat_handler(Arc::clone(self)))?;
+        Ok(())
+    }
+
+    /// Register an instance with the hub.
+    ///
+    /// Stores the returned RAII guard in an inner `OnceLock`. Subsequent calls
+    /// return an error. Dropping the `HubClient` issues an HTTP `DELETE`
+    /// against the control-plane port.
+    pub async fn register_instance(&self, peer_info: PeerInfo) -> Result<()> {
+        if self.guard.get().is_some() {
+            anyhow::bail!("HubClient: instance already registered");
+        }
+        let instance_id = peer_info.instance_id();
+        let url = self.control_url(protocol::paths::INSTANCES)?;
+        let body = RegisterRequest { peer_info };
+        let resp = self
+            .http
+            .post(url)
+            .json(&body)
+            .send()
+            .await
+            .context("POST /v1/instances")?;
+        let _: RegisterResponse = parse_json(resp).await?;
+
+        let guard = HubRegistrationGuard::new(
+            self.http.clone(),
+            self.config.control_url.clone(),
+            instance_id,
+        );
+        self.guard
+            .set(guard)
+            .map_err(|_| anyhow!("HubClient: instance already registered (race)"))?;
+        Ok(())
+    }
+
+    /// Explicitly unregister the current instance (if any).
+    ///
+    /// Prefer this over relying on `Drop` when you can await — `Drop` only
+    /// fires `DELETE` best-effort from the current tokio runtime.
+    pub async fn unregister(&self) -> Result<()> {
+        let Some(guard) = self.guard.get() else {
+            return Ok(());
+        };
+        guard.unregister_http().await
+    }
+
+    /// Return `true` if an instance is currently registered.
+    pub fn is_registered(&self) -> bool {
+        self.guard.get().is_some()
+    }
+
+    /// Send a control-plane heartbeat for the registered instance over HTTP.
+    ///
+    /// Returns an error if no instance has been registered on this client.
+    pub async fn send_heartbeat(&self) -> Result<()> {
+        let instance_id = self
+            .guard
+            .get()
+            .map(|g| g.instance_id)
+            .ok_or_else(|| anyhow!("HubClient: no registered instance to heartbeat"))?;
+        let url = self.control_url(&protocol::instance_heartbeat(instance_id))?;
+        let resp = self
+            .http
+            .post(url)
+            .send()
+            .await
+            .context("POST /v1/instances/{id}/heartbeat")?;
+        let _: protocol::HeartbeatResponse = parse_json(resp).await?;
+        Ok(())
+    }
+
+    fn discovery_url(&self, path: &str) -> Result<Url> {
+        self.config
+            .discovery_url
+            .join(path)
+            .with_context(|| format!("joining discovery path {path}"))
+    }
+
+    fn control_url(&self, path: &str) -> Result<Url> {
+        self.config
+            .control_url
+            .join(path)
+            .with_context(|| format!("joining control path {path}"))
+    }
+
+    async fn lookup(&self, path: String) -> Result<PeerInfo> {
+        let url = self.discovery_url(&path)?;
+        let resp = self
+            .http
+            .get(url)
+            .send()
+            .await
+            .with_context(|| format!("GET {path}"))?;
+        let body: PeerLookupResponse = parse_json(resp).await?;
+        Ok(body.peer_info)
+    }
+}
+
+impl PeerDiscovery for HubClient {
+    fn discover_by_worker_id(&self, worker_id: WorkerId) -> BoxFuture<'_, Result<PeerInfo>> {
+        Box::pin(self.lookup(protocol::peers_by_worker(worker_id)))
+    }
+
+    fn discover_by_instance_id(&self, instance_id: InstanceId) -> BoxFuture<'_, Result<PeerInfo>> {
+        Box::pin(self.lookup(protocol::peers_by_instance(instance_id)))
+    }
+}
+
+/// RAII guard for a single registered instance.
+///
+/// Issues an HTTP `DELETE` on drop (best-effort, from whatever tokio runtime
+/// is available) or via [`PeerRegistrationGuard::unregister`].
+pub struct HubRegistrationGuard {
+    http: reqwest::Client,
+    control_url: Url,
+    instance_id: InstanceId,
+    unregistered: std::sync::atomic::AtomicBool,
+}
+
+impl std::fmt::Debug for HubRegistrationGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HubRegistrationGuard")
+            .field("control_url", &self.control_url.as_str())
+            .field("instance_id", &self.instance_id)
+            .finish()
+    }
+}
+
+impl HubRegistrationGuard {
+    fn new(http: reqwest::Client, control_url: Url, instance_id: InstanceId) -> Self {
+        Self {
+            http,
+            control_url,
+            instance_id,
+            unregistered: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    async fn unregister_http(&self) -> Result<()> {
+        if self
+            .unregistered
+            .swap(true, std::sync::atomic::Ordering::AcqRel)
+        {
+            return Ok(());
+        }
+        let url = self
+            .control_url
+            .join(&protocol::instance_by_id(self.instance_id))
+            .context("joining instance delete path")?;
+        let resp = self
+            .http
+            .delete(url)
+            .send()
+            .await
+            .context("DELETE /v1/instances/{id}")?;
+        if !resp.status().is_success() && resp.status() != StatusCode::NOT_FOUND {
+            let body: ErrorBody = parse_json(resp).await?;
+            return Err(anyhow!("hub returned error: {body}"));
+        }
+        Ok(())
+    }
+}
+
+impl PeerRegistrationGuard for HubRegistrationGuard {
+    fn unregister(&mut self) -> BoxFuture<'_, Result<()>> {
+        Box::pin(self.unregister_http())
+    }
+}
+
+impl Drop for HubRegistrationGuard {
+    fn drop(&mut self) {
+        if self.unregistered.load(std::sync::atomic::Ordering::Acquire) {
+            return;
+        }
+        let http = self.http.clone();
+        let url = match self
+            .control_url
+            .join(&protocol::instance_by_id(self.instance_id))
+        {
+            Ok(u) => u,
+            Err(_) => return,
+        };
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let _ = http.delete(url).send().await;
+            });
+        }
+    }
+}
+
+async fn parse_json<T: serde::de::DeserializeOwned>(resp: reqwest::Response) -> Result<T> {
+    let status = resp.status();
+    if status.is_success() {
+        return resp
+            .json::<T>()
+            .await
+            .context("decoding hub success response");
+    }
+    let url = resp.url().clone();
+    let body_bytes = resp.bytes().await.context("reading hub error body")?;
+    if let Ok(err) = serde_json::from_slice::<ErrorBody>(&body_bytes) {
+        return Err(anyhow!("hub {url} returned {status}: {err}"));
+    }
+    let snippet = String::from_utf8_lossy(&body_bytes);
+    Err(anyhow!(
+        "hub {url} returned {status}: {} bytes of body: {snippet}",
+        body_bytes.len()
+    ))
+}

--- a/lib/kvbm-hub/src/handlers.rs
+++ b/lib/kvbm-hub/src/handlers.rs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Velo active-message handlers installed on a client by
+//! [`HubClient::register_handlers`](crate::HubClient::register_handlers).
+//!
+//! These are the control-plane messages the hub sends to its clients over
+//! velo (not HTTP). HTTP is reserved for discovery + bootstrap registration;
+//! velo is used once both sides know about each other.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use velo::Handler;
+
+use crate::client::HubClient;
+
+/// Velo handler name for the hub → client heartbeat probe.
+pub const HEARTBEAT_HANDLER: &str = "_kvbm_hub_heartbeat";
+
+/// Payload sent by the hub on each heartbeat.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HeartbeatRequest {
+    /// Monotonic sequence from the hub — echoed back for jitter tracking.
+    pub seq: u64,
+}
+
+/// Response returned by the client to acknowledge a heartbeat.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HeartbeatAck {
+    /// Echoed `seq` from the request.
+    pub seq: u64,
+    /// Always `true` for now — reserved for future status flags.
+    pub ok: bool,
+}
+
+/// Build the heartbeat velo handler for this client.
+///
+/// Installed by [`HubClient::register_handlers`](crate::HubClient::register_handlers).
+/// Stub: always acks. Real implementations will consult local state
+/// (connector health, engine readiness, ...) via the captured [`HubClient`].
+pub fn create_heartbeat_handler(_client: Arc<HubClient>) -> Handler {
+    Handler::typed_unary_async::<HeartbeatRequest, HeartbeatAck, _, _>(
+        HEARTBEAT_HANDLER,
+        |ctx| async move {
+            Ok(HeartbeatAck {
+                seq: ctx.input.seq,
+                ok: true,
+            })
+        },
+    )
+    .build()
+}

--- a/lib/kvbm-hub/src/lib.rs
+++ b/lib/kvbm-hub/src/lib.rs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! # KVBM Hub
+//!
+//! Central coordination service for KVBM velo clients (connector / engine).
+//! The hub is a single HTTP service that velo clients use as a shared source
+//! of truth for peer discovery and registration, plus a velo participant
+//! itself for control-plane messaging (heartbeat and, in the future,
+//! scheduling / shard placement / etc).
+//!
+//! # Topology
+//!
+//! A hub server binds two axum listeners:
+//!
+//! - **Discovery port** (`1337` default) — HTTP implementation of the
+//!   `velo::discovery::PeerDiscovery` protocol.
+//! - **Control port** (`8337` default) — registration, heartbeat, health.
+//!
+//! The server is also a velo node: it exposes velo handlers (bidirectional
+//! messaging with clients) in addition to the HTTP surface.
+//!
+//! # Client usage
+//!
+//! ```no_run
+//! # async fn demo() -> anyhow::Result<()> {
+//! use std::sync::Arc;
+//! use kvbm_hub::HubClient;
+//!
+//! let hub: Arc<HubClient> = kvbm_hub::create_client_builder()
+//!     .host("name-or-ip")
+//!     .port(1337)
+//!     .build()?;
+//!
+//! let velo = velo::Velo::builder()
+//!     .discovery(hub.clone())
+//!     .build()
+//!     .await?;
+//!
+//! hub.register_handlers(&velo)?;
+//! hub.register_instance(velo.peer_info()).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! When the last `Arc<HubClient>` is dropped, the held registration guard
+//! issues an HTTP `DELETE` against the hub so the instance is promptly
+//! removed from discovery.
+
+pub mod client;
+pub mod handlers;
+pub mod protocol;
+pub mod server;
+
+pub use client::{HubClient, HubClientBuilder, HubClientConfig, HubRegistrationGuard};
+pub use handlers::{HEARTBEAT_HANDLER, HeartbeatAck, HeartbeatRequest};
+pub use protocol::{DEFAULT_CONTROL_PORT, DEFAULT_DISCOVERY_PORT};
+pub use server::{HubServer, HubServerBuilder, HubServerState};
+
+/// Shorthand for [`HubClientBuilder::new`].
+pub fn create_client_builder() -> HubClientBuilder {
+    HubClientBuilder::new()
+}
+
+/// Shorthand for [`HubServerBuilder::new`].
+pub fn create_server_builder() -> HubServerBuilder {
+    HubServerBuilder::new()
+}

--- a/lib/kvbm-hub/src/protocol.rs
+++ b/lib/kvbm-hub/src/protocol.rs
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP wire protocol shared between [`HubClient`](crate::HubClient) and
+//! [`HubServer`](crate::HubServer).
+//!
+//! The hub exposes two axum listeners:
+//! - **Port 1337** — peer discovery HTTP endpoints (see [`paths`]).
+//! - **Port 8337** — control-plane endpoints (registration, heartbeat, health).
+//!
+//! All request/response bodies are JSON.
+
+use serde::{Deserialize, Serialize};
+use velo_common::{InstanceId, PeerInfo, WorkerId};
+
+/// Default HTTP port for peer-discovery lookups (the `PeerDiscovery` surface).
+pub const DEFAULT_DISCOVERY_PORT: u16 = 1337;
+
+/// Default HTTP port for the control plane (registration, heartbeat).
+pub const DEFAULT_CONTROL_PORT: u16 = 8337;
+
+/// URL path fragments for the HTTP API.
+pub mod paths {
+    /// Peer-discovery lookup by `InstanceId`.
+    ///
+    /// `GET /v1/peers/instance/{instance_id}` → [`super::PeerLookupResponse`]
+    pub const PEERS_BY_INSTANCE: &str = "/v1/peers/instance/{instance_id}";
+
+    /// Peer-discovery lookup by `WorkerId`.
+    ///
+    /// `GET /v1/peers/worker/{worker_id}` → [`super::PeerLookupResponse`]
+    pub const PEERS_BY_WORKER: &str = "/v1/peers/worker/{worker_id}";
+
+    /// Register an instance.
+    ///
+    /// `POST /v1/instances` with body [`super::RegisterRequest`]
+    /// → [`super::RegisterResponse`]
+    pub const INSTANCES: &str = "/v1/instances";
+
+    /// Unregister an instance.
+    ///
+    /// `DELETE /v1/instances/{instance_id}`
+    pub const INSTANCE_BY_ID: &str = "/v1/instances/{instance_id}";
+
+    /// Liveness heartbeat.
+    ///
+    /// `POST /v1/instances/{instance_id}/heartbeat` → [`super::HeartbeatResponse`]
+    pub const INSTANCE_HEARTBEAT: &str = "/v1/instances/{instance_id}/heartbeat";
+
+    /// Hub health probe.
+    ///
+    /// `GET /health` → `200 OK`
+    pub const HEALTH: &str = "/health";
+}
+
+/// Request body for `POST /v1/instances`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterRequest {
+    /// Full peer information (instance id + opaque worker address).
+    pub peer_info: PeerInfo,
+}
+
+/// Response body for `POST /v1/instances`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterResponse {
+    /// The registered instance id, echoed back.
+    pub instance_id: InstanceId,
+}
+
+/// Response body for peer-discovery lookups.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerLookupResponse {
+    /// Full peer information for the requested id.
+    pub peer_info: PeerInfo,
+}
+
+/// Response body for `POST /v1/instances/{instance_id}/heartbeat`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HeartbeatResponse {
+    /// Whether the hub considers this instance registered.
+    pub acknowledged: bool,
+}
+
+/// Typed error body returned by the hub on non-2xx responses.
+#[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error)]
+#[error("{message}")]
+pub struct ErrorBody {
+    /// Stable machine-readable error code.
+    pub code: ErrorCode,
+    /// Human-readable description.
+    pub message: String,
+}
+
+/// Stable error codes returned by the hub API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    /// Requested instance or worker id is not registered.
+    NotFound,
+    /// Registration conflicts with an existing registration.
+    Conflict,
+    /// Request payload was malformed.
+    BadRequest,
+    /// Unexpected server-side failure.
+    Internal,
+}
+
+/// Path helper: format [`paths::PEERS_BY_INSTANCE`] with a concrete id.
+pub fn peers_by_instance(id: InstanceId) -> String {
+    format!("/v1/peers/instance/{id}")
+}
+
+/// Path helper: format [`paths::PEERS_BY_WORKER`] with a concrete id.
+pub fn peers_by_worker(id: WorkerId) -> String {
+    format!("/v1/peers/worker/{}", id.as_u64())
+}
+
+/// Path helper: format [`paths::INSTANCE_BY_ID`] with a concrete id.
+pub fn instance_by_id(id: InstanceId) -> String {
+    format!("/v1/instances/{id}")
+}
+
+/// Path helper: format [`paths::INSTANCE_HEARTBEAT`] with a concrete id.
+pub fn instance_heartbeat(id: InstanceId) -> String {
+    format!("/v1/instances/{id}/heartbeat")
+}

--- a/lib/kvbm-hub/src/server.rs
+++ b/lib/kvbm-hub/src/server.rs
@@ -1,0 +1,401 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Axum-based HTTP server for the KVBM hub.
+//!
+//! Runs two listeners:
+//!
+//! - **Discovery port** (`1337` default) — serves only the PeerDiscovery
+//!   HTTP surface. This is the port a velo client's [`HubClient`](crate::HubClient)
+//!   hits for peer lookups.
+//! - **Control port** (`8337` default) — serves the full control plane
+//!   (registration, heartbeat, health, + discovery for convenience).
+//!
+//! The server is also intended to be a `velo::Velo` participant — register
+//! hub-side handlers on it (future work) so it can push messages (e.g.
+//! heartbeats) to connected clients via velo active messaging.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{delete, get, post},
+};
+use parking_lot::RwLock;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use velo_common::{InstanceId, PeerInfo, WorkerId};
+
+use crate::protocol::{
+    self, ErrorBody, ErrorCode, HeartbeatResponse, PeerLookupResponse, RegisterRequest,
+    RegisterResponse,
+};
+
+/// Server-side in-memory peer registry.
+#[derive(Debug, Default)]
+struct Registry {
+    by_instance: HashMap<InstanceId, PeerInfo>,
+    by_worker: HashMap<WorkerId, InstanceId>,
+}
+
+/// Shared hub server state (cheap to clone, all state is inside `Arc`s).
+#[derive(Clone, Debug)]
+pub struct HubServerState {
+    registry: Arc<RwLock<Registry>>,
+}
+
+impl Default for HubServerState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HubServerState {
+    /// Create fresh, empty hub state.
+    pub fn new() -> Self {
+        Self {
+            registry: Arc::new(RwLock::new(Registry::default())),
+        }
+    }
+
+    /// Snapshot the currently registered peers.
+    pub fn peers(&self) -> Vec<PeerInfo> {
+        self.registry.read().by_instance.values().cloned().collect()
+    }
+}
+
+/// Builder for [`HubServer`].
+#[derive(Debug, Clone)]
+pub struct HubServerBuilder {
+    bind_addr: IpAddr,
+    discovery_port: u16,
+    control_port: u16,
+    state: Option<HubServerState>,
+}
+
+impl Default for HubServerBuilder {
+    fn default() -> Self {
+        Self {
+            bind_addr: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            discovery_port: protocol::DEFAULT_DISCOVERY_PORT,
+            control_port: protocol::DEFAULT_CONTROL_PORT,
+            state: None,
+        }
+    }
+}
+
+impl HubServerBuilder {
+    /// New builder with default bind `0.0.0.0` and default ports.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Bind address (default `0.0.0.0`).
+    pub fn bind_addr(mut self, addr: IpAddr) -> Self {
+        self.bind_addr = addr;
+        self
+    }
+
+    /// Discovery HTTP port (default `1337`).
+    pub fn discovery_port(mut self, port: u16) -> Self {
+        self.discovery_port = port;
+        self
+    }
+
+    /// Control-plane HTTP port (default `8337`).
+    pub fn control_port(mut self, port: u16) -> Self {
+        self.control_port = port;
+        self
+    }
+
+    /// Provide a pre-constructed shared state. Optional.
+    pub fn state(mut self, state: HubServerState) -> Self {
+        self.state = Some(state);
+        self
+    }
+
+    /// Bind both listeners and spawn them. Returns a running [`HubServer`].
+    pub async fn serve(self) -> Result<HubServer> {
+        let state = self.state.unwrap_or_default();
+
+        let discovery_addr = SocketAddr::new(self.bind_addr, self.discovery_port);
+        let control_addr = SocketAddr::new(self.bind_addr, self.control_port);
+
+        let discovery_listener = TcpListener::bind(discovery_addr)
+            .await
+            .with_context(|| format!("binding discovery port {discovery_addr}"))?;
+        let control_listener = TcpListener::bind(control_addr)
+            .await
+            .with_context(|| format!("binding control port {control_addr}"))?;
+
+        let discovery_local = discovery_listener
+            .local_addr()
+            .context("discovery local_addr")?;
+        let control_local = control_listener
+            .local_addr()
+            .context("control local_addr")?;
+
+        let cancel = CancellationToken::new();
+
+        let discovery_router = discovery_router(state.clone());
+        let control_router = control_router(state.clone());
+
+        let discovery_task = spawn_server(discovery_listener, discovery_router, cancel.clone());
+        let control_task = spawn_server(control_listener, control_router, cancel.clone());
+
+        Ok(HubServer {
+            state,
+            discovery_addr: discovery_local,
+            control_addr: control_local,
+            cancel,
+            discovery_task: Some(discovery_task),
+            control_task: Some(control_task),
+        })
+    }
+}
+
+/// A running hub server.
+///
+/// Drop or call [`shutdown`](Self::shutdown) to cancel both listeners and
+/// wait for them to terminate.
+pub struct HubServer {
+    state: HubServerState,
+    discovery_addr: SocketAddr,
+    control_addr: SocketAddr,
+    cancel: CancellationToken,
+    discovery_task: Option<JoinHandle<()>>,
+    control_task: Option<JoinHandle<()>>,
+}
+
+impl std::fmt::Debug for HubServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HubServer")
+            .field("discovery_addr", &self.discovery_addr)
+            .field("control_addr", &self.control_addr)
+            .finish()
+    }
+}
+
+impl HubServer {
+    /// Builder entry point.
+    pub fn builder() -> HubServerBuilder {
+        HubServerBuilder::new()
+    }
+
+    /// Resolved discovery socket address (useful when binding port `0`).
+    pub fn discovery_addr(&self) -> SocketAddr {
+        self.discovery_addr
+    }
+
+    /// Resolved control socket address.
+    pub fn control_addr(&self) -> SocketAddr {
+        self.control_addr
+    }
+
+    /// Shared state handle (for attaching velo hub-side handlers, etc.).
+    pub fn state(&self) -> &HubServerState {
+        &self.state
+    }
+
+    /// Trigger shutdown and await both listeners.
+    pub async fn shutdown(mut self) -> Result<()> {
+        self.cancel.cancel();
+        if let Some(t) = self.discovery_task.take() {
+            let _ = t.await;
+        }
+        if let Some(t) = self.control_task.take() {
+            let _ = t.await;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for HubServer {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+fn spawn_server(
+    listener: TcpListener,
+    router: Router,
+    cancel: CancellationToken,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let serve = axum::serve(listener, router).with_graceful_shutdown(async move {
+            cancel.cancelled().await;
+        });
+        if let Err(e) = serve.await {
+            tracing::error!(error = %e, "kvbm-hub listener exited with error");
+        }
+    })
+}
+
+fn discovery_router(state: HubServerState) -> Router {
+    Router::new()
+        .route(
+            protocol::paths::PEERS_BY_INSTANCE,
+            get(get_peer_by_instance),
+        )
+        .route(protocol::paths::PEERS_BY_WORKER, get(get_peer_by_worker))
+        .route(protocol::paths::HEALTH, get(health))
+        .with_state(state)
+}
+
+fn control_router(state: HubServerState) -> Router {
+    Router::new()
+        .route(protocol::paths::INSTANCES, post(register_instance))
+        .route(protocol::paths::INSTANCE_BY_ID, delete(unregister_instance))
+        .route(protocol::paths::INSTANCE_HEARTBEAT, post(heartbeat))
+        // Discovery endpoints are mirrored here for convenience.
+        .route(
+            protocol::paths::PEERS_BY_INSTANCE,
+            get(get_peer_by_instance),
+        )
+        .route(protocol::paths::PEERS_BY_WORKER, get(get_peer_by_worker))
+        .route(protocol::paths::HEALTH, get(health))
+        .with_state(state)
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn health() -> &'static str {
+    "ok"
+}
+
+async fn register_instance(
+    State(state): State<HubServerState>,
+    Json(req): Json<RegisterRequest>,
+) -> Result<Json<RegisterResponse>, HubError> {
+    let peer = req.peer_info;
+    let instance_id = peer.instance_id();
+    let worker_id = peer.worker_id();
+
+    let mut reg = state.registry.write();
+    if let Some(existing) = reg.by_worker.get(&worker_id)
+        && *existing != instance_id
+    {
+        return Err(HubError::conflict(format!(
+            "worker_id {worker_id} already held by instance {existing}"
+        )));
+    }
+    reg.by_worker.insert(worker_id, instance_id);
+    reg.by_instance.insert(instance_id, peer);
+    Ok(Json(RegisterResponse { instance_id }))
+}
+
+async fn unregister_instance(
+    State(state): State<HubServerState>,
+    Path(instance_id): Path<InstanceId>,
+) -> Result<StatusCode, HubError> {
+    let mut reg = state.registry.write();
+    let removed = reg.by_instance.remove(&instance_id);
+    if let Some(p) = &removed {
+        reg.by_worker.remove(&p.worker_id());
+    }
+    if removed.is_some() {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(HubError::not_found(format!(
+            "instance {instance_id} not registered"
+        )))
+    }
+}
+
+async fn heartbeat(
+    State(state): State<HubServerState>,
+    Path(instance_id): Path<InstanceId>,
+) -> Result<Json<HeartbeatResponse>, HubError> {
+    let registered = state.registry.read().by_instance.contains_key(&instance_id);
+    Ok(Json(HeartbeatResponse {
+        acknowledged: registered,
+    }))
+}
+
+async fn get_peer_by_instance(
+    State(state): State<HubServerState>,
+    Path(instance_id): Path<InstanceId>,
+) -> Result<Json<PeerLookupResponse>, HubError> {
+    let reg = state.registry.read();
+    reg.by_instance
+        .get(&instance_id)
+        .cloned()
+        .map(|peer_info| Json(PeerLookupResponse { peer_info }))
+        .ok_or_else(|| HubError::not_found(format!("instance {instance_id} not found")))
+}
+
+async fn get_peer_by_worker(
+    State(state): State<HubServerState>,
+    Path(worker_id): Path<u64>,
+) -> Result<Json<PeerLookupResponse>, HubError> {
+    let wid = WorkerId::from_u64(worker_id);
+    let reg = state.registry.read();
+    let instance_id = reg
+        .by_worker
+        .get(&wid)
+        .copied()
+        .ok_or_else(|| HubError::not_found(format!("worker {worker_id} not found")))?;
+    let peer_info = reg
+        .by_instance
+        .get(&instance_id)
+        .cloned()
+        .ok_or_else(|| HubError::internal("registry inconsistency".to_string()))?;
+    Ok(Json(PeerLookupResponse { peer_info }))
+}
+
+// ---------------------------------------------------------------------------
+// Error plumbing
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct HubError {
+    status: StatusCode,
+    body: ErrorBody,
+}
+
+impl HubError {
+    fn not_found(message: String) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            body: ErrorBody {
+                code: ErrorCode::NotFound,
+                message,
+            },
+        }
+    }
+
+    fn conflict(message: String) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            body: ErrorBody {
+                code: ErrorCode::Conflict,
+                message,
+            },
+        }
+    }
+
+    fn internal(message: String) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            body: ErrorBody {
+                code: ErrorCode::Internal,
+                message,
+            },
+        }
+    }
+}
+
+impl IntoResponse for HubError {
+    fn into_response(self) -> Response {
+        (self.status, Json(self.body)).into_response()
+    }
+}


### PR DESCRIPTION
HTTP PeerDiscovery + control plane

Introduces `lib/kvbm-hub`, a client/server pair that acts as the central coordination point for kvbm velo participants (connector and engine). The server exposes two axum listeners:

- Discovery port (1337): HTTP implementation of the `velo::discovery::PeerDiscovery` protocol (peer lookups).
- Control port (8337): registration, heartbeat, health.

The client is an `Arc<HubClient>` that:

- Implements `velo::discovery::PeerDiscovery` via HTTP against port 1337.
- Offers `register_instance(peer_info)` that POSTs to the hub and stores a `HubRegistrationGuard` in an inner `OnceLock`; the guard issues an HTTP DELETE on drop / explicit `unregister()`.
- Offers `register_handlers(&velo)` which installs the hub's velo control-plane handlers on the caller's `Velo` instance. The initial handler is `_kvbm_hub_heartbeat` (stubbed to ack) — this is the primary control handler the hub will drive over velo active messaging once clients are registered.
