### PR TITLE
feat(omni): add PD disaggregation for Qwen2.5-Omni pipeline

### DIFF
--- a/components/src/dynamo/vllm/omni/stage_router.py
+++ b/components/src/dynamo/vllm/omni/stage_router.py
@@ -24,7 +24,7 @@ from dynamo.vllm.omni.args import OmniConfig
 from dynamo.vllm.omni.output_formatter import OutputFormatter
 from dynamo.vllm.omni.stage_worker import _resolve_model_type
 from dynamo.vllm.omni.types import StageOutput
-from dynamo.vllm.omni.utils import shm_deserialize
+from dynamo.vllm.omni.utils import _endpoint_stage_name, shm_deserialize
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +40,12 @@ class OmniStageRouter:
         self.config = config
         self.stage_configs = load_stage_configs_from_yaml(stage_configs_path)
         self.stage_clients: Dict[str, Any] = {}
+        self._pd_pair = self._detect_pd_pair()
+        if self._pd_pair:
+            logger.info(
+                "PD disaggregation detected: prefill=stage-%d, decode=stage-%d",
+                *self._pd_pair,
+            )
 
         media_fs = (
             get_fs(config.media_output_fs_url) if config.media_output_fs_url else None
@@ -51,9 +57,22 @@ class OmniStageRouter:
             default_fps=config.default_video_fps,
         )
 
-    def set_stage_client(self, model_stage: str, client: Any) -> None:
-        self.stage_clients[model_stage] = client
-        logger.info("Registered stage client: %s", model_stage)
+    def _detect_pd_pair(self) -> tuple[int, int] | None:
+        """Scan stage_configs for a prefill/decode pair."""
+        prefill_idx = None
+        decode_idx = None
+        for i, cfg in enumerate(self.stage_configs):
+            if getattr(cfg, "is_prefill_only", False):
+                prefill_idx = i
+            if getattr(cfg, "is_decode_only", False):
+                decode_idx = i
+        if prefill_idx is not None and decode_idx is not None:
+            return (prefill_idx, decode_idx)
+        return None
+
+    def set_stage_client(self, endpoint_name: str, client: Any) -> None:
+        self.stage_clients[endpoint_name] = client
+        logger.info("Registered stage client: %s", endpoint_name)
 
     async def generate(
         self,
@@ -65,13 +84,11 @@ class OmniStageRouter:
 
         stage_outputs: List[StageOutput] = []
         for stage_idx, stage_cfg in enumerate(self.stage_configs):
-            model_stage = getattr(
-                stage_cfg.engine_args, "model_stage", f"stage{stage_idx}"
-            )
-            client = self.stage_clients.get(model_stage)
+            endpoint_name = _endpoint_stage_name(stage_cfg, stage_idx)
+            client = self.stage_clients.get(endpoint_name)
             if client is None:
                 yield {
-                    "error": f"No client for stage '{model_stage}'",
+                    "error": f"No client for stage '{endpoint_name}'",
                     "finished": True,
                 }
                 return
@@ -79,6 +96,17 @@ class OmniStageRouter:
             if stage_idx == 0:
                 # This is a workaround for now to pass in the raw request to stage 0. StageRequest validates it but ignores any unknown keys, so it gets passed through.
                 stage_request = {"request_id": request_id, **request}
+            elif self._pd_pair and stage_idx == self._pd_pair[1]:
+                # PD decode stage: re-send the original request so the decode
+                # engine re-tokenizes the prompt (same tokens as prefill).
+                # Include kv_transfer_params so the decode engine can locate
+                # the KV cache exported by the prefill engine via NIXL.
+                prefill_output = stage_outputs[self._pd_pair[0]]
+                stage_request = {
+                    "request_id": request_id,
+                    "kv_transfer_params": prefill_output.kv_transfer_params,
+                    **request,
+                }
             else:
                 stage_request = stage_outputs[-1].to_next_stage_request(request_id)
 
@@ -168,14 +196,12 @@ async def init_omni_stage_router(
 
     # Discover stage endpoints
     for stage_cfg in router.stage_configs:
-        model_stage = getattr(
-            stage_cfg.engine_args, "model_stage", f"stage{stage_cfg.stage_id}"
-        )
+        endpoint_name = _endpoint_stage_name(stage_cfg, stage_cfg.stage_id)
         client = await runtime.endpoint(
-            f"{config.namespace}.{model_stage}.generate"
+            f"{config.namespace}.{endpoint_name}.generate"
         ).client()
         await client.wait_for_instances()
-        router.set_stage_client(model_stage, client)
+        router.set_stage_client(endpoint_name, client)
 
     final_cfg = router.stage_configs[-1]
     final_output_type = getattr(final_cfg, "final_output_type", "image")

--- a/components/src/dynamo/vllm/omni/stage_worker.py
+++ b/components/src/dynamo/vllm/omni/stage_worker.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Any, AsyncGenerator
 
 import yaml
+from vllm.sampling_params import SamplingParams
 from vllm_omni.distributed.omni_connectors import initialize_orchestrator_connectors
 from vllm_omni.engine.orchestrator import build_engine_core_request_from_tokens
 from vllm_omni.entrypoints.async_omni import AsyncOmni
@@ -453,8 +454,6 @@ def _connector_key(from_stage: int, to_stage: int) -> tuple[str, str]:
 
 def _apply_prefill_sampling_params(sp_list: list, request_id: str) -> list:
     """Clone SamplingParams for prefill: max_tokens=1, kv_transfer for remote decode."""
-    from vllm.sampling_params import SamplingParams
-
     result = []
     for sp in sp_list:
         if not isinstance(sp, SamplingParams):
@@ -478,8 +477,6 @@ def _apply_prefill_sampling_params(sp_list: list, request_id: str) -> list:
 
 def _apply_decode_sampling_params(sp_list: list, kv_transfer_params: dict) -> list:
     """Inject kv_transfer_params into decode sampling params."""
-    from vllm.sampling_params import SamplingParams
-
     result = []
     for sp in sp_list:
         if not isinstance(sp, SamplingParams):

--- a/components/src/dynamo/vllm/omni/stage_worker.py
+++ b/components/src/dynamo/vllm/omni/stage_worker.py
@@ -26,7 +26,11 @@ from dynamo.vllm.health_check import VllmOmniHealthCheckPayload
 from dynamo.vllm.main import setup_metrics_collection
 from dynamo.vllm.omni.args import OmniConfig
 from dynamo.vllm.omni.types import StageEngine, StageRequest, _int_keyed
-from dynamo.vllm.omni.utils import _build_sampling_params, parse_omni_request
+from dynamo.vllm.omni.utils import (
+    _build_sampling_params,
+    _endpoint_stage_name,
+    parse_omni_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +73,8 @@ class OmniStageWorker:
         self._output_modalities = output_modalities or []
         self._default_video_fps = default_video_fps
         self.stage_config = stage_config
+        self._is_prefill_only = getattr(stage_config, "is_prefill_only", False)
+        self._is_decode_only = getattr(stage_config, "is_decode_only", False)
 
         func_path = getattr(stage_config, "custom_process_input_func", None)
         self._processor = _load_processor(func_path)
@@ -97,14 +103,15 @@ class OmniStageWorker:
                 yield {"error": str(e), "finished": True}
                 return
 
-            if len(stage_list) != len(
-                self._engine_input_source or stage_connector_refs
-            ):
+            # stage_list is sparse (indexed by stage_id); count filled entries
+            filled = sum(1 for p in stage_list if p.engine_outputs is not None)
+            expected = len(self._engine_input_source or stage_connector_refs)
+            if filled != expected:
                 logger.warning(
                     "Stage %d: expected %d stage inputs, got %d",
                     self.stage_id,
-                    len(self._engine_input_source or stage_connector_refs),
-                    len(stage_list),
+                    expected,
+                    filled,
                 )
 
             if self._processor is not None:
@@ -133,7 +140,9 @@ class OmniStageWorker:
                 else:
                     prompt = upstream
         elif req.request_id is not None:
-            # Stage 0 via router: raw request forwarded with request_id — parse it.
+            # Stage 0 (or PD decode) via router: raw request forwarded with
+            # request_id — parse it.  PD decode also receives the original
+            # request so it re-tokenizes the same prompt as prefill.
             parsed = await parse_omni_request(
                 request,
                 self._output_modalities,
@@ -155,6 +164,13 @@ class OmniStageWorker:
         )
 
         sp = _build_sampling_params(self.stage_config, sampling_params_list_override)
+
+        # PD sampling param overrides
+        if self._is_prefill_only and sp is not None:
+            sp = _apply_prefill_sampling_params(sp, request_id)
+        elif self._is_decode_only and req.kv_transfer_params and sp is not None:
+            sp = _apply_decode_sampling_params(sp, req.kv_transfer_params)
+
         last_result = None
 
         try:
@@ -174,6 +190,22 @@ class OmniStageWorker:
             return
 
         # --- Write output ---
+        # PD prefill: extract KV connector metadata from engine output.
+        # The actual KV data transfers directly via NIXL between engines.
+        if self._is_prefill_only:
+            kv_params = _extract_kv_transfer_params(last_result)
+            if kv_params is None:
+                logger.warning(
+                    "Stage %d (prefill): engine output has no kv_transfer_params",
+                    self.stage_id,
+                )
+            yield {
+                "kv_transfer_params": kv_params,
+                "original_prompt": original_prompt,
+                "finished": True,
+            }
+            return
+
         # Check for a downstream connector first, regardless of final_output.
         # In vllm-omni's native mode, multiple stages can set final_output=True
         # (meaning "produces user-visible output"). In Dynamo's disaggregated
@@ -282,11 +314,15 @@ class OmniStageWorker:
         """Fetch previous stage outputs from connectors for the processor/engine.
 
         Fetches only the stages listed in engine_input_source (or all refs if empty).
-        Returns _Proxy objects in engine_input_source order.
+        Returns a stage_id-indexed list (sparse) so processor functions can use
+        ``stage_list[engine_input_source[i]]`` directly — this matches vllm-omni's
+        orchestrator convention where ``stage_list`` is indexed by stage_id.
         Raises RuntimeError on any failure so the caller can propagate it as an error chunk.
         """
         sources = self._engine_input_source or sorted(stage_connector_refs.keys())
-        stage_list = []
+        # Build sparse list indexed by stage_id for processor compatibility.
+        max_stage_id = max(sources) if sources else 0
+        stage_list: list[_Proxy] = [_Proxy() for _ in range(max_stage_id + 1)]
         for stage_k in sources:
             if (meta_k := stage_connector_refs.get(stage_k)) is None:
                 raise RuntimeError(
@@ -316,7 +352,7 @@ class OmniStageWorker:
                 if isinstance(payload_data, dict)
                 else payload_data
             )
-            stage_list.append(_Proxy(engine_outputs=[engine_inputs]))
+            stage_list[stage_k] = _Proxy(engine_outputs=[engine_inputs])
         return stage_list
 
 
@@ -341,10 +377,12 @@ async def init_omni_stage(
     my_config = stage_configs[stage_id]
     stage_type: str = getattr(my_config, "stage_type", "llm")
 
-    # Stage worker registers at {ns}.{model_stage}.generate — NOT {ns}.backend.generate.
-    # Router registers at {ns}.backend.generate and discovers workers by model_stage.
-    model_stage = getattr(my_config.engine_args, "model_stage", f"stage{stage_id}")
-    generate_endpoint = runtime.endpoint(f"{config.namespace}.{model_stage}.generate")
+    # Stage worker registers at {ns}.{endpoint_name}.generate — NOT {ns}.backend.generate.
+    # Router registers at {ns}.backend.generate and discovers workers by endpoint_name.
+    # For PD stages, endpoint_name differs from model_stage (e.g. thinker_prefill vs thinker)
+    # so that both PD workers get unique endpoints.
+    endpoint_name = _endpoint_stage_name(my_config, stage_id)
+    generate_endpoint = runtime.endpoint(f"{config.namespace}.{endpoint_name}.generate")
     shutdown_endpoints[:] = [generate_endpoint]
 
     engine = _create_engine(config.model, my_config, stage_type)
@@ -408,6 +446,69 @@ async def init_omni_stage(
 def _connector_key(from_stage: int, to_stage: int) -> tuple[str, str]:
     """Build the connector dict key used by initialize_orchestrator_connectors."""
     return (str(from_stage), str(to_stage))
+
+
+# ── PD disaggregation helpers ──────────────────────────────────────
+
+
+def _apply_prefill_sampling_params(sp_list: list, request_id: str) -> list:
+    """Clone SamplingParams for prefill: max_tokens=1, kv_transfer for remote decode."""
+    from vllm.sampling_params import SamplingParams
+
+    result = []
+    for sp in sp_list:
+        if not isinstance(sp, SamplingParams):
+            result.append(sp)
+            continue
+        sp = sp.clone()
+        sp.max_tokens = 1
+        # MooncakeConnector/NixlConnector cancel KV transfer unless
+        # finish_reason='length', so clear stop conditions.
+        sp.stop = []
+        sp.stop_token_ids = []
+        if sp.extra_args is None:
+            sp.extra_args = {}
+        sp.extra_args["kv_transfer_params"] = {
+            "do_remote_decode": True,
+            "do_remote_prefill": False,
+        }
+        result.append(sp)
+    return result
+
+
+def _apply_decode_sampling_params(sp_list: list, kv_transfer_params: dict) -> list:
+    """Inject kv_transfer_params into decode sampling params."""
+    from vllm.sampling_params import SamplingParams
+
+    result = []
+    for sp in sp_list:
+        if not isinstance(sp, SamplingParams):
+            result.append(sp)
+            continue
+        sp = sp.clone()
+        if sp.extra_args is None:
+            sp.extra_args = {}
+        sp.extra_args["kv_transfer_params"] = {
+            "do_remote_prefill": True,
+            "do_remote_decode": False,
+            **kv_transfer_params,
+        }
+        result.append(sp)
+    return result
+
+
+def _extract_kv_transfer_params(engine_output: Any) -> dict | None:
+    """Extract kv_transfer_params from an OmniRequestOutput (or list)."""
+    outputs = engine_output if isinstance(engine_output, list) else [engine_output]
+    for output in outputs:
+        kv_params = getattr(output, "kv_transfer_params", None)
+        if kv_params is not None:
+            if hasattr(kv_params, "items"):
+                return dict(kv_params)
+            if hasattr(kv_params, "model_dump"):
+                return kv_params.model_dump()
+            return kv_params
+    return None
 
 
 def _load_processor(func_path: str | None) -> Any:

--- a/components/src/dynamo/vllm/omni/stage_worker.py
+++ b/components/src/dynamo/vllm/omni/stage_worker.py
@@ -26,7 +26,11 @@ from dynamo.vllm.health_check import VllmOmniHealthCheckPayload
 from dynamo.vllm.main import setup_metrics_collection
 from dynamo.vllm.omni.args import OmniConfig
 from dynamo.vllm.omni.types import StageEngine, StageRequest, _int_keyed
-from dynamo.vllm.omni.utils import _build_sampling_params, parse_omni_request
+from dynamo.vllm.omni.utils import (
+    _build_sampling_params,
+    _endpoint_stage_name,
+    parse_omni_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +73,8 @@ class OmniStageWorker:
         self._output_modalities = output_modalities or []
         self._default_video_fps = default_video_fps
         self.stage_config = stage_config
+        self._is_prefill_only = getattr(stage_config, "is_prefill_only", False)
+        self._is_decode_only = getattr(stage_config, "is_decode_only", False)
 
         func_path = getattr(stage_config, "custom_process_input_func", None)
         self._processor = _load_processor(func_path)
@@ -97,14 +103,15 @@ class OmniStageWorker:
                 yield {"error": str(e), "finished": True}
                 return
 
-            if len(stage_list) != len(
-                self._engine_input_source or stage_connector_refs
-            ):
+            # stage_list is sparse (indexed by stage_id); count filled entries
+            filled = sum(1 for p in stage_list if p.engine_outputs is not None)
+            expected = len(self._engine_input_source or stage_connector_refs)
+            if filled != expected:
                 logger.warning(
                     "Stage %d: expected %d stage inputs, got %d",
                     self.stage_id,
-                    len(self._engine_input_source or stage_connector_refs),
-                    len(stage_list),
+                    expected,
+                    filled,
                 )
 
             if self._processor is not None:
@@ -125,7 +132,9 @@ class OmniStageWorker:
                     yield {"error": str(e), "finished": True}
                     return
         elif req.request_id is not None:
-            # Stage 0 via router: raw request forwarded with request_id — parse it.
+            # Stage 0 (or PD decode) via router: raw request forwarded with
+            # request_id — parse it.  PD decode also receives the original
+            # request so it re-tokenizes the same prompt as prefill.
             parsed = await parse_omni_request(
                 request,
                 self._output_modalities,
@@ -147,6 +156,13 @@ class OmniStageWorker:
         )
 
         sp = _build_sampling_params(self.stage_config, sampling_params_list_override)
+
+        # PD sampling param overrides
+        if self._is_prefill_only and sp is not None:
+            sp = _apply_prefill_sampling_params(sp, request_id)
+        elif self._is_decode_only and req.kv_transfer_params and sp is not None:
+            sp = _apply_decode_sampling_params(sp, req.kv_transfer_params)
+
         last_result = None
 
         try:
@@ -166,6 +182,22 @@ class OmniStageWorker:
             return
 
         # --- Write output ---
+        # PD prefill: extract KV connector metadata from engine output.
+        # The actual KV data transfers directly via NIXL between engines.
+        if self._is_prefill_only:
+            kv_params = _extract_kv_transfer_params(last_result)
+            if kv_params is None:
+                logger.warning(
+                    "Stage %d (prefill): engine output has no kv_transfer_params",
+                    self.stage_id,
+                )
+            yield {
+                "kv_transfer_params": kv_params,
+                "original_prompt": original_prompt,
+                "finished": True,
+            }
+            return
+
         # Check for a downstream connector first, regardless of final_output.
         # In vllm-omni's native mode, multiple stages can set final_output=True
         # (meaning "produces user-visible output"). In Dynamo's disaggregated
@@ -274,11 +306,15 @@ class OmniStageWorker:
         """Fetch previous stage outputs from connectors for the processor/engine.
 
         Fetches only the stages listed in engine_input_source (or all refs if empty).
-        Returns _Proxy objects in engine_input_source order.
+        Returns a stage_id-indexed list (sparse) so processor functions can use
+        ``stage_list[engine_input_source[i]]`` directly — this matches vllm-omni's
+        orchestrator convention where ``stage_list`` is indexed by stage_id.
         Raises RuntimeError on any failure so the caller can propagate it as an error chunk.
         """
         sources = self._engine_input_source or sorted(stage_connector_refs.keys())
-        stage_list = []
+        # Build sparse list indexed by stage_id for processor compatibility.
+        max_stage_id = max(sources) if sources else 0
+        stage_list: list[_Proxy] = [_Proxy() for _ in range(max_stage_id + 1)]
         for stage_k in sources:
             if (meta_k := stage_connector_refs.get(stage_k)) is None:
                 raise RuntimeError(
@@ -308,7 +344,7 @@ class OmniStageWorker:
                 if isinstance(payload_data, dict)
                 else payload_data
             )
-            stage_list.append(_Proxy(engine_outputs=[engine_inputs]))
+            stage_list[stage_k] = _Proxy(engine_outputs=[engine_inputs])
         return stage_list
 
 
@@ -333,10 +369,12 @@ async def init_omni_stage(
     my_config = stage_configs[stage_id]
     stage_type: str = getattr(my_config, "stage_type", "llm")
 
-    # Stage worker registers at {ns}.{model_stage}.generate — NOT {ns}.backend.generate.
-    # Router registers at {ns}.backend.generate and discovers workers by model_stage.
-    model_stage = getattr(my_config.engine_args, "model_stage", f"stage{stage_id}")
-    generate_endpoint = runtime.endpoint(f"{config.namespace}.{model_stage}.generate")
+    # Stage worker registers at {ns}.{endpoint_name}.generate — NOT {ns}.backend.generate.
+    # Router registers at {ns}.backend.generate and discovers workers by endpoint_name.
+    # For PD stages, endpoint_name differs from model_stage (e.g. thinker_prefill vs thinker)
+    # so that both PD workers get unique endpoints.
+    endpoint_name = _endpoint_stage_name(my_config, stage_id)
+    generate_endpoint = runtime.endpoint(f"{config.namespace}.{endpoint_name}.generate")
     shutdown_endpoints[:] = [generate_endpoint]
 
     engine = _create_engine(config.model, my_config, stage_type)
@@ -400,6 +438,69 @@ async def init_omni_stage(
 def _connector_key(from_stage: int, to_stage: int) -> tuple[str, str]:
     """Build the connector dict key used by initialize_orchestrator_connectors."""
     return (str(from_stage), str(to_stage))
+
+
+# ── PD disaggregation helpers ──────────────────────────────────────
+
+
+def _apply_prefill_sampling_params(sp_list: list, request_id: str) -> list:
+    """Clone SamplingParams for prefill: max_tokens=1, kv_transfer for remote decode."""
+    from vllm.sampling_params import SamplingParams
+
+    result = []
+    for sp in sp_list:
+        if not isinstance(sp, SamplingParams):
+            result.append(sp)
+            continue
+        sp = sp.clone()
+        sp.max_tokens = 1
+        # MooncakeConnector/NixlConnector cancel KV transfer unless
+        # finish_reason='length', so clear stop conditions.
+        sp.stop = []
+        sp.stop_token_ids = []
+        if sp.extra_args is None:
+            sp.extra_args = {}
+        sp.extra_args["kv_transfer_params"] = {
+            "do_remote_decode": True,
+            "do_remote_prefill": False,
+        }
+        result.append(sp)
+    return result
+
+
+def _apply_decode_sampling_params(sp_list: list, kv_transfer_params: dict) -> list:
+    """Inject kv_transfer_params into decode sampling params."""
+    from vllm.sampling_params import SamplingParams
+
+    result = []
+    for sp in sp_list:
+        if not isinstance(sp, SamplingParams):
+            result.append(sp)
+            continue
+        sp = sp.clone()
+        if sp.extra_args is None:
+            sp.extra_args = {}
+        sp.extra_args["kv_transfer_params"] = {
+            "do_remote_prefill": True,
+            "do_remote_decode": False,
+            **kv_transfer_params,
+        }
+        result.append(sp)
+    return result
+
+
+def _extract_kv_transfer_params(engine_output: Any) -> dict | None:
+    """Extract kv_transfer_params from an OmniRequestOutput (or list)."""
+    outputs = engine_output if isinstance(engine_output, list) else [engine_output]
+    for output in outputs:
+        kv_params = getattr(output, "kv_transfer_params", None)
+        if kv_params is not None:
+            if hasattr(kv_params, "items"):
+                return dict(kv_params)
+            if hasattr(kv_params, "model_dump"):
+                return kv_params.model_dump()
+            return kv_params
+    return None
 
 
 def _load_processor(func_path: str | None) -> Any:

--- a/components/src/dynamo/vllm/omni/stage_worker.py
+++ b/components/src/dynamo/vllm/omni/stage_worker.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Any, AsyncGenerator
 
 import yaml
+from vllm.sampling_params import SamplingParams
 from vllm_omni.distributed.omni_connectors import initialize_orchestrator_connectors
 from vllm_omni.engine.orchestrator import build_engine_core_request_from_tokens
 from vllm_omni.entrypoints.async_omni import AsyncOmni
@@ -445,8 +446,6 @@ def _connector_key(from_stage: int, to_stage: int) -> tuple[str, str]:
 
 def _apply_prefill_sampling_params(sp_list: list, request_id: str) -> list:
     """Clone SamplingParams for prefill: max_tokens=1, kv_transfer for remote decode."""
-    from vllm.sampling_params import SamplingParams
-
     result = []
     for sp in sp_list:
         if not isinstance(sp, SamplingParams):
@@ -470,8 +469,6 @@ def _apply_prefill_sampling_params(sp_list: list, request_id: str) -> list:
 
 def _apply_decode_sampling_params(sp_list: list, kv_transfer_params: dict) -> list:
     """Inject kv_transfer_params into decode sampling params."""
-    from vllm.sampling_params import SamplingParams
-
     result = []
     for sp in sp_list:
         if not isinstance(sp, SamplingParams):

--- a/components/src/dynamo/vllm/omni/types.py
+++ b/components/src/dynamo/vllm/omni/types.py
@@ -54,6 +54,7 @@ class StageOutput(BaseModel):
                 "original_prompt",
                 "stage_connector_refs",
                 "sampling_params_list",
+                "kv_transfer_params",
                 "finished",
                 "error",
             }
@@ -78,6 +79,7 @@ class StageOutput(BaseModel):
     # Keys arrive as strings from JSON; workers normalize them to int via _int_keyed().
     stage_connector_refs: dict[str, Any] | None = None
     sampling_params_list: dict | None = None
+    kv_transfer_params: dict | None = None
     finished: bool | None = None
     error: str | None = None
 
@@ -87,7 +89,12 @@ class StageOutput(BaseModel):
         shm_meta is intentionally excluded — it is final-stage → router only.
         """
         fields = self.model_dump(
-            include={"original_prompt", "stage_connector_refs", "sampling_params_list"},
+            include={
+                "original_prompt",
+                "stage_connector_refs",
+                "sampling_params_list",
+                "kv_transfer_params",
+            },
             exclude_none=True,
         )
         fields["request_id"] = request_id
@@ -112,6 +119,7 @@ class StageRequest(BaseModel):
     # StageOutput.stage_connector_refs). Callers normalize string keys to int via _int_keyed().
     stage_connector_refs: dict[str, Any] | None = None
     sampling_params_list: dict | None = None
+    kv_transfer_params: dict | None = None
 
 
 def _int_keyed(d: dict | None) -> dict[int, Any]:

--- a/components/src/dynamo/vllm/omni/types.py
+++ b/components/src/dynamo/vllm/omni/types.py
@@ -48,6 +48,7 @@ class StageOutput(BaseModel):
                 "original_prompt",
                 "stage_connector_refs",
                 "sampling_params_list",
+                "kv_transfer_params",
                 "finished",
                 "error",
             }
@@ -72,6 +73,7 @@ class StageOutput(BaseModel):
     # Keys arrive as strings from JSON; workers normalize them to int via _int_keyed().
     stage_connector_refs: dict[str, Any] | None = None
     sampling_params_list: dict | None = None
+    kv_transfer_params: dict | None = None
     finished: bool | None = None
     error: str | None = None
 
@@ -81,7 +83,12 @@ class StageOutput(BaseModel):
         shm_meta is intentionally excluded — it is final-stage → router only.
         """
         fields = self.model_dump(
-            include={"original_prompt", "stage_connector_refs", "sampling_params_list"},
+            include={
+                "original_prompt",
+                "stage_connector_refs",
+                "sampling_params_list",
+                "kv_transfer_params",
+            },
             exclude_none=True,
         )
         fields["request_id"] = request_id
@@ -106,6 +113,7 @@ class StageRequest(BaseModel):
     # StageOutput.stage_connector_refs). Callers normalize string keys to int via _int_keyed().
     stage_connector_refs: dict[str, Any] | None = None
     sampling_params_list: dict | None = None
+    kv_transfer_params: dict | None = None
 
 
 def _int_keyed(d: dict | None) -> dict[int, Any]:

--- a/components/src/dynamo/vllm/omni/utils.py
+++ b/components/src/dynamo/vllm/omni/utils.py
@@ -21,6 +21,24 @@ DEFAULT_IMAGE_SIZE = "1024x1024"
 DEFAULT_VIDEO_SIZE = "832x480"
 
 
+def _endpoint_stage_name(stage_config: Any, stage_id: int) -> str:
+    """Dynamo endpoint name for a stage.
+
+    For PD stages, appends ``_prefill`` / ``_decode`` so that both workers
+    get unique endpoints even though they share ``model_stage=thinker``.
+    """
+    model_stage = getattr(
+        getattr(stage_config, "engine_args", None),
+        "model_stage",
+        f"stage{stage_id}",
+    )
+    if getattr(stage_config, "is_prefill_only", False):
+        return f"{model_stage}_prefill"
+    if getattr(stage_config, "is_decode_only", False):
+        return f"{model_stage}_decode"
+    return model_stage
+
+
 def shm_deserialize(shm_meta: dict) -> Any:
     """Read and deserialize an OmniRequestOutput from shared memory."""
     return OmniSerializer.deserialize(shm_read_bytes(shm_meta))

--- a/components/src/dynamo/vllm/tests/omni/test_omni_disagg_types.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_disagg_types.py
@@ -86,6 +86,31 @@ class TestStageOutput:
         assert req["stage_connector_refs"] == {"0": {"ref": "abc"}}
         assert req["request_id"] == "req-3"
 
+    def test_kv_transfer_params_accepted_and_not_dropped(self):
+        """kv_transfer_params is a known field — must not be dropped."""
+        out = StageOutput.model_validate(
+            {"kv_transfer_params": {"remote_host": "10.0.0.1", "port": 5555}}
+        )
+        assert out.kv_transfer_params == {"remote_host": "10.0.0.1", "port": 5555}
+
+    def test_to_next_stage_request_includes_kv_transfer_params(self):
+        """kv_transfer_params should be forwarded to the next stage."""
+        out = StageOutput.model_validate(
+            {
+                "kv_transfer_params": {"remote_host": "10.0.0.1"},
+                "original_prompt": {"prompt": "hi"},
+            }
+        )
+        req = out.to_next_stage_request("req-kv")
+        assert req["kv_transfer_params"] == {"remote_host": "10.0.0.1"}
+        assert req["request_id"] == "req-kv"
+
+    def test_to_next_stage_request_excludes_none_kv_transfer_params(self):
+        """None kv_transfer_params should not appear in next-stage request."""
+        out = StageOutput.model_validate({"original_prompt": {"prompt": "hi"}})
+        req = out.to_next_stage_request("req-no-kv")
+        assert "kv_transfer_params" not in req
+
 
 # ── OmniInterStageRequest ──────────────────────────────────
 

--- a/components/src/dynamo/vllm/tests/omni/test_omni_stage_router.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_stage_router.py
@@ -42,19 +42,22 @@ class _StageClient:
         return _gen()
 
 
-def _make_stage_cfg(stage_id: int):
-    return SimpleNamespace(
+def _make_stage_cfg(stage_id: int, **overrides):
+    defaults = dict(
         stage_id=stage_id,
         engine_args=SimpleNamespace(model_stage=f"stage{stage_id}"),
     )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
 
 
-def _make_router(stage_configs, stage_clients, formatter=None):
+def _make_router(stage_configs, stage_clients, formatter=None, detect_pd=True):
     router = stage_router.OmniStageRouter.__new__(stage_router.OmniStageRouter)
     router.config = SimpleNamespace(output_modalities=None)
     router.stage_configs = stage_configs
     router.stage_clients = stage_clients
     router._formatter = formatter or AsyncMock()
+    router._pd_pair = router._detect_pd_pair() if detect_pd else None
     return router
 
 
@@ -297,3 +300,105 @@ async def test_generate_forwards_raw_request_to_stage0():
     assert stage0_received["prompt"] == "a dog"
     assert stage0_received["size"] == "832x480"
     assert stage0_received["nvext"] == {"num_inference_steps": 30}
+
+
+# ── PD disaggregation ────────────────────────────────────
+
+
+class TestDetectPdPair:
+    def test_detects_prefill_decode_pair(self):
+        cfgs = [
+            _make_stage_cfg(0, is_prefill_only=True, is_decode_only=False),
+            _make_stage_cfg(1, is_prefill_only=False, is_decode_only=True),
+            _make_stage_cfg(2),
+        ]
+        router = _make_router(cfgs, {})
+        assert router._pd_pair == (0, 1)
+
+    def test_no_pd_pair_when_no_flags(self):
+        cfgs = [_make_stage_cfg(0), _make_stage_cfg(1)]
+        router = _make_router(cfgs, {})
+        assert router._pd_pair is None
+
+    def test_no_pd_pair_with_only_prefill(self):
+        cfgs = [_make_stage_cfg(0, is_prefill_only=True), _make_stage_cfg(1)]
+        router = _make_router(cfgs, {})
+        assert router._pd_pair is None
+
+    def test_no_pd_pair_with_only_decode(self):
+        cfgs = [_make_stage_cfg(0), _make_stage_cfg(1, is_decode_only=True)]
+        router = _make_router(cfgs, {})
+        assert router._pd_pair is None
+
+
+@pytest.mark.asyncio
+async def test_pd_decode_receives_original_request_and_kv_params():
+    """PD decode stage must receive the original request + kv_transfer_params from prefill."""
+    decode_received = {}
+
+    async def prefill_handler(request):
+        return {
+            "kv_transfer_params": {"remote_block_ids": [1, 2], "remote_host": "gpu0"},
+            "original_prompt": {"prompt": "hello"},
+            "finished": True,
+        }
+
+    async def decode_handler(request):
+        decode_received.update(request)
+        return {
+            "stage_connector_refs": {"1": {"name": "decode-ref"}},
+            "original_prompt": {"prompt": "hello"},
+            "finished": True,
+        }
+
+    async def talker_handler(request):
+        return {"shm_meta": {"name": "output"}, "finished": True}
+
+    mock_formatter = AsyncMock()
+    mock_formatter.format.return_value = {"finished": True}
+
+    cfgs = [
+        _make_stage_cfg(
+            0,
+            is_prefill_only=True,
+            is_decode_only=False,
+            engine_args=SimpleNamespace(model_stage="thinker"),
+        ),
+        _make_stage_cfg(
+            1,
+            is_prefill_only=False,
+            is_decode_only=True,
+            engine_args=SimpleNamespace(model_stage="thinker"),
+        ),
+        _make_stage_cfg(2, engine_args=SimpleNamespace(model_stage="talker")),
+    ]
+    router = _make_router(
+        cfgs,
+        {
+            "thinker_prefill": _StageClient(prefill_handler),
+            "thinker_decode": _StageClient(decode_handler),
+            "talker": _StageClient(talker_handler),
+        },
+        formatter=mock_formatter,
+    )
+
+    request = {"prompt": "hello", "messages": [{"role": "user", "content": "hello"}]}
+    with patch(
+        "dynamo.vllm.omni.stage_router.parse_request_type",
+        return_value=(None, "chat"),
+    ):
+        with patch("dynamo.vllm.omni.stage_router.uuid.uuid4", return_value="req-pd"):
+            with patch.object(
+                stage_router, "shm_deserialize", return_value=SimpleNamespace()
+            ):
+                _ = [c async for c in router.generate(request, None)]
+
+    # Decode must get original request fields + kv_transfer_params
+    assert decode_received["request_id"] == "req-pd"
+    assert decode_received["prompt"] == "hello"
+    assert decode_received["kv_transfer_params"] == {
+        "remote_block_ids": [1, 2],
+        "remote_host": "gpu0",
+    }
+    # Must not get stage_connector_refs (PD decode re-tokenizes, doesn't fetch from connector)
+    assert "stage_connector_refs" not in decode_received

--- a/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
@@ -12,8 +12,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 try:
-    from dynamo.vllm.omni.stage_worker import OmniStageWorker, _Proxy
-    from dynamo.vllm.omni.utils import _build_sampling_params
+    from dynamo.vllm.omni.stage_worker import (
+        OmniStageWorker,
+        _apply_decode_sampling_params,
+        _apply_prefill_sampling_params,
+        _extract_kv_transfer_params,
+        _Proxy,
+    )
+    from dynamo.vllm.omni.utils import _build_sampling_params, _endpoint_stage_name
 except ImportError:
     pytest.skip("vLLM omni dependencies not available", allow_module_level=True)
 
@@ -407,3 +413,126 @@ async def test_sampling_params_propagate_in_stage_output():
         "height": 480,
         "width": 832,
     }
+
+
+# ── PD disaggregation helpers ────────────────────────────────
+
+
+class TestEndpointStageName:
+    def test_regular_stage_uses_model_stage(self):
+        cfg = SimpleNamespace(engine_args=SimpleNamespace(model_stage="thinker"))
+        assert _endpoint_stage_name(cfg, 0) == "thinker"
+
+    def test_prefill_stage_appends_suffix(self):
+        cfg = SimpleNamespace(
+            engine_args=SimpleNamespace(model_stage="thinker"),
+            is_prefill_only=True,
+            is_decode_only=False,
+        )
+        assert _endpoint_stage_name(cfg, 0) == "thinker_prefill"
+
+    def test_decode_stage_appends_suffix(self):
+        cfg = SimpleNamespace(
+            engine_args=SimpleNamespace(model_stage="thinker"),
+            is_prefill_only=False,
+            is_decode_only=True,
+        )
+        assert _endpoint_stage_name(cfg, 1) == "thinker_decode"
+
+    def test_no_engine_args_falls_back_to_stage_id(self):
+        cfg = SimpleNamespace()
+        assert _endpoint_stage_name(cfg, 3) == "stage3"
+
+    def test_no_model_stage_falls_back_to_stage_id(self):
+        cfg = SimpleNamespace(engine_args=SimpleNamespace())
+        assert _endpoint_stage_name(cfg, 2) == "stage2"
+
+
+class TestApplyPrefillSamplingParams:
+    def test_sets_max_tokens_one_and_kv_transfer(self):
+        from vllm.sampling_params import SamplingParams
+
+        sp = SamplingParams(max_tokens=100, stop=["<|end|>"])
+        result = _apply_prefill_sampling_params([sp], "req-1")
+        assert len(result) == 1
+        assert result[0].max_tokens == 1
+        assert result[0].stop == []
+        assert result[0].stop_token_ids == []
+        assert result[0].extra_args["kv_transfer_params"]["do_remote_decode"] is True
+        assert result[0].extra_args["kv_transfer_params"]["do_remote_prefill"] is False
+
+    def test_non_sampling_params_passed_through(self):
+        """Non-SamplingParams (e.g. diffusion params) are passed through unchanged."""
+        diffusion_sp = SimpleNamespace(height=512, width=512)
+        result = _apply_prefill_sampling_params([diffusion_sp], "req-2")
+        assert result[0] is diffusion_sp
+
+
+class TestApplyDecodeSamplingParams:
+    def test_injects_kv_transfer_params(self):
+        from vllm.sampling_params import SamplingParams
+
+        sp = SamplingParams(max_tokens=100)
+        kv_params = {"remote_block_ids": [1, 2], "remote_host": "10.0.0.1"}
+        result = _apply_decode_sampling_params([sp], kv_params)
+        assert len(result) == 1
+        extra = result[0].extra_args["kv_transfer_params"]
+        assert extra["do_remote_prefill"] is True
+        assert extra["do_remote_decode"] is False
+        assert extra["remote_block_ids"] == [1, 2]
+        assert extra["remote_host"] == "10.0.0.1"
+
+    def test_non_sampling_params_passed_through(self):
+        diffusion_sp = SimpleNamespace(height=512)
+        result = _apply_decode_sampling_params([diffusion_sp], {"host": "10.0.0.1"})
+        assert result[0] is diffusion_sp
+
+
+class TestExtractKvTransferParams:
+    def test_extracts_from_object_with_dict_attr(self):
+        output = SimpleNamespace(kv_transfer_params={"host": "10.0.0.1", "port": 5555})
+        result = _extract_kv_transfer_params(output)
+        assert result == {"host": "10.0.0.1", "port": 5555}
+
+    def test_extracts_from_list(self):
+        output = [
+            SimpleNamespace(kv_transfer_params=None),
+            SimpleNamespace(kv_transfer_params={"host": "10.0.0.2"}),
+        ]
+        result = _extract_kv_transfer_params(output)
+        assert result == {"host": "10.0.0.2"}
+
+    def test_returns_none_when_missing(self):
+        output = SimpleNamespace()
+        assert _extract_kv_transfer_params(output) is None
+
+    def test_returns_none_for_all_none_list(self):
+        output = [SimpleNamespace(kv_transfer_params=None)]
+        assert _extract_kv_transfer_params(output) is None
+
+
+@pytest.mark.asyncio
+async def test_prefill_worker_yields_kv_transfer_params():
+    """Prefill-only worker yields kv_transfer_params instead of connector output."""
+    kv_params = {"remote_block_ids": [10, 20], "remote_host": "gpu0"}
+    engine_output = SimpleNamespace(kv_transfer_params=kv_params)
+    engine = _MockEngine(output=engine_output)
+
+    worker = OmniStageWorker(
+        engine=engine,
+        stage_config=_make_stage_config(
+            is_prefill_only=True,
+            is_decode_only=False,
+            default_sampling_params={"max_tokens": 100},
+        ),
+        connectors={},
+        stage_id=0,
+        output_modalities=["text"],
+    )
+    request = {"request_id": "req-pf", "prompt": "hello"}
+
+    chunks = [chunk async for chunk in worker.generate(request, _MockContext())]
+
+    assert len(chunks) == 1
+    assert chunks[0]["kv_transfer_params"] == kv_params
+    assert chunks[0]["finished"] is True

--- a/examples/backends/vllm/launch/disagg_omni_pd.sh
+++ b/examples/backends/vllm/launch/disagg_omni_pd.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# 4-stage PD disaggregated Qwen2.5-Omni text-to-text+audio generation.
+# Stage 0: thinker_prefill (GPU 0) — processes prompt, exports KV via NixlConnector
+# Stage 1: thinker_decode  (GPU 1) — resumes from KV, generates tokens
+# Stage 2: talker           (GPU 1) — enhanced text generation (AR)
+# Stage 3: code2wav         (GPU 1) — audio generation
+# Router: orchestrates the 4-stage pipeline, formats response
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+MODEL="${MODEL:-Qwen/Qwen2.5-Omni-7B}"
+STAGE_CONFIG="${STAGE_CONFIG:-$SCRIPT_DIR/stage_configs/qwen2_5_omni_pd.yaml}"
+
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model) MODEL="$2"; shift 2 ;;
+        --stage-configs-path) STAGE_CONFIG="$2"; shift 2 ;;
+        *) EXTRA_ARGS+=("$1"); shift ;;
+    esac
+done
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+if [ -z "${DYN_NAMESPACE:-}" ]; then
+    export DYN_NAMESPACE="dynamo-omni-pd-$(date +%s)"
+fi
+echo "Namespace:   ${DYN_NAMESPACE}"
+echo "Stage config: ${STAGE_CONFIG}"
+print_launch_banner --no-curl "PD Disaggregated Qwen2.5-Omni (4-stage, 2 GPUs)" "$MODEL" "$HTTP_PORT"
+print_curl_footer <<CURL
+curl -s http://localhost:${HTTP_PORT}/v1/chat/completions \\
+  -H 'Content-Type: application/json' \\
+  -d '{
+    "model": "${MODEL}",
+    "messages": [{"role": "user", "content": "Hello, say something short."}],
+    "stream": false,
+    "max_tokens": 64
+  }' | jq
+CURL
+
+export FLASHINFER_DISABLE_VERSION_CHECK=1
+export DYN_DISCOVERY_BACKEND="${DYN_DISCOVERY_BACKEND:-file}"
+export DYN_REQUEST_PLANE="${DYN_REQUEST_PLANE:-tcp}"
+export DYN_EVENT_PLANE="${DYN_EVENT_PLANE:-zmq}"
+
+# Stage 0: thinker prefill (GPU 0) — processes prompt, exports KV
+echo "Starting Stage 0 (thinker_prefill)..."
+CUDA_VISIBLE_DEVICES=0 DYN_SYSTEM_PORT=8081 VLLM_NIXL_SIDE_CHANNEL_PORT=5600 \
+    python -m dynamo.vllm.omni \
+    --model "$MODEL" \
+    --stage-id 0 \
+    --stage-configs-path "$STAGE_CONFIG" \
+    "${EXTRA_ARGS[@]}" &
+sleep 30
+
+# Stage 1: thinker decode (GPU 1) — resumes from prefill KV
+echo "Starting Stage 1 (thinker_decode)..."
+CUDA_VISIBLE_DEVICES=1 DYN_SYSTEM_PORT=8082 VLLM_NIXL_SIDE_CHANNEL_PORT=5610 \
+    python -m dynamo.vllm.omni \
+    --model "$MODEL" \
+    --stage-id 1 \
+    --stage-configs-path "$STAGE_CONFIG" \
+    "${EXTRA_ARGS[@]}" &
+sleep 30
+
+# Stage 2: talker (GPU 1)
+echo "Starting Stage 2 (talker)..."
+CUDA_VISIBLE_DEVICES=1 DYN_SYSTEM_PORT=8083 \
+    python -m dynamo.vllm.omni \
+    --model "$MODEL" \
+    --stage-id 2 \
+    --stage-configs-path "$STAGE_CONFIG" \
+    "${EXTRA_ARGS[@]}" &
+sleep 30
+
+# Stage 3: code2wav (GPU 1)
+echo "Starting Stage 3 (code2wav)..."
+CUDA_VISIBLE_DEVICES=1 DYN_SYSTEM_PORT=8084 \
+    python -m dynamo.vllm.omni \
+    --model "$MODEL" \
+    --stage-id 3 \
+    --stage-configs-path "$STAGE_CONFIG" \
+    "${EXTRA_ARGS[@]}" &
+sleep 20
+
+# Router — discovers stage workers, orchestrates pipeline, formats response
+echo "Starting Router..."
+DYN_SYSTEM_PORT=8085 \
+    python -m dynamo.vllm.omni \
+    --model "$MODEL" \
+    --omni-router \
+    --stage-configs-path "$STAGE_CONFIG" \
+    "${EXTRA_ARGS[@]}" &
+sleep 5
+
+# Frontend
+echo "Starting Frontend..."
+python -m dynamo.frontend &
+
+wait_any_exit

--- a/examples/backends/vllm/launch/stage_configs/qwen2_5_omni_pd.yaml
+++ b/examples/backends/vllm/launch/stage_configs/qwen2_5_omni_pd.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # PD disaggregated stage config for Qwen2.5-Omni-7B.
 # Splits the thinker into prefill (stage 0) and decode (stage 1).
 # KV cache transfers via NixlConnector.

--- a/examples/backends/vllm/launch/stage_configs/qwen2_5_omni_pd.yaml
+++ b/examples/backends/vllm/launch/stage_configs/qwen2_5_omni_pd.yaml
@@ -1,0 +1,165 @@
+# PD disaggregated stage config for Qwen2.5-Omni-7B.
+# Splits the thinker into prefill (stage 0) and decode (stage 1).
+# KV cache transfers via NixlConnector.
+#
+# GPU layout (2x A6000):
+#   GPU 0: thinker_prefill
+#   GPU 1: thinker_decode, talker, code2wav
+#
+# Env vars required per stage:
+#   prefill: VLLM_NIXL_SIDE_CHANNEL_PORT=5600 (default)
+#   decode:  VLLM_NIXL_SIDE_CHANNEL_PORT=5610
+
+stage_args:
+  # Stage 0: thinker prefill (GPU 0) — processes prompt, exports KV
+  - stage_id: 0
+    stage_type: llm
+    is_prefill_only: true
+    runtime:
+      process: true
+      devices: "0"
+    engine_args:
+      model_stage: thinker
+      max_num_seqs: 1
+      model_arch: Qwen2_5OmniForConditionalGeneration
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.8
+      enforce_eager: true
+      trust_remote_code: true
+      engine_output_type: latent
+      enable_prefix_caching: false
+      max_num_batched_tokens: 32768
+      mm_processor_cache_gb: 0
+      kv_transfer_config:
+        kv_connector: "NixlConnector"
+        kv_role: "kv_producer"
+        kv_rank: 0
+        kv_parallel_size: 2
+    is_comprehension: true
+    final_output: false
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 2048
+      seed: 42
+      detokenize: True
+      repetition_penalty: 1.1
+
+  # Stage 1: thinker decode (GPU 1) — resumes from prefill KV, generates tokens
+  # Note: decode + talker + code2wav share GPU 1.
+  # Memory budget: decode 0.5 + talker 0.25 + code2wav 0.15 = 0.9
+  - stage_id: 1
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      process: true
+      devices: "1"
+    engine_args:
+      model_stage: thinker
+      max_num_seqs: 1
+      model_arch: Qwen2_5OmniForConditionalGeneration
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.5
+      enforce_eager: true
+      trust_remote_code: true
+      engine_output_type: latent
+      enable_prefix_caching: false
+      max_num_batched_tokens: 32768
+      kv_transfer_config:
+        kv_connector: "NixlConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 1
+        kv_parallel_size: 2
+    engine_input_source: [0]
+    is_comprehension: true
+    final_output: true
+    final_output_type: text
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 2048
+      seed: 42
+      detokenize: True
+      repetition_penalty: 1.1
+
+  # Stage 2: talker (GPU 1)
+  - stage_id: 2
+    stage_type: llm
+    runtime:
+      process: true
+      devices: "1"
+    engine_args:
+      model_stage: talker
+      max_num_seqs: 1
+      model_arch: Qwen2_5OmniForConditionalGeneration
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.25
+      enforce_eager: true
+      trust_remote_code: true
+      enable_prefix_caching: false
+      max_num_batched_tokens: 32768
+      engine_output_type: latent
+    engine_input_source: [1]
+    custom_process_input_func: vllm_omni.model_executor.stage_input_processors.qwen2_5_omni.thinker2talker
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 0.8
+      top_k: 40
+      max_tokens: 2048
+      seed: 42
+      detokenize: True
+      repetition_penalty: 1.05
+      stop_token_ids: [8294]
+
+  # Stage 3: code2wav (GPU 1)
+  - stage_id: 3
+    stage_type: llm
+    runtime:
+      process: true
+      devices: "1"
+    engine_args:
+      model_stage: code2wav
+      max_num_seqs: 1
+      model_arch: Qwen2_5OmniForConditionalGeneration
+      worker_type: generation
+      scheduler_cls: vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler
+      gpu_memory_utilization: 0.15
+      enforce_eager: true
+      trust_remote_code: true
+      enable_prefix_caching: false
+      max_num_batched_tokens: 32768
+      async_scheduling: false
+      engine_output_type: audio
+    engine_input_source: [2]
+    final_output: true
+    final_output_type: audio
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 2048
+      seed: 42
+      detokenize: True
+      repetition_penalty: 1.1
+
+runtime:
+  enabled: true
+  defaults:
+    window_size: -1
+    max_inflight: 1
+  edges:
+    # Note: no omni connector for 0→1 (KV transfers via NixlConnector)
+    - from: 0
+      to: 1
+      window_size: -1
+    - from: 1
+      to: 2
+      window_size: -1
+    - from: 2
+      to: 3
+      window_size: -1


### PR DESCRIPTION
#### Overview:

Add prefill-decode (PD) disaggregation to Dynamo's vllm-omni multi-stage pipeline. The thinker stage is split into separate prefill and decode workers with KV cache transfer via NixlConnector. This enables independent scaling of prefill and decode for the AR model.

#### Details:

**Pipeline topology:**
```
Request → Router
  → Stage 0 (thinker_prefill, GPU 0): max_tokens=1, exports KV via NixlConnector
  → Stage 1 (thinker_decode, GPU 1): resumes from prefill KV, generates tokens
  → Stage 2 (talker, GPU 1): via omni connector
  → Stage 3 (code2wav, GPU 1): via omni connector
← Final response
```

**Changes:**
- `types.py`: add `kv_transfer_params` to StageOutput/StageRequest for PD metadata flow
- `utils.py`: add `_endpoint_stage_name()` — PD stages share `model_stage=thinker` but need unique endpoints (`thinker_prefill` / `thinker_decode`)
- `stage_router.py`: detect PD pairs via `is_prefill_only`/`is_decode_only` flags, route decode stage with original request + `kv_transfer_params`
- `stage_worker.py`: prefill sampling param overrides (`max_tokens=1`, `do_remote_decode=true`), decode KV injection, prefill output path (yields `kv_transfer_params` instead of connector/SHM), sparse `stage_list` indexing for processor compatibility with shifted stage IDs
- New YAML: `qwen2_5_omni_pd.yaml` (4-stage NixlConnector config for 2x A6000)
- New launch scripts: `disagg_omni_pd.sh`, `disagg_omni_qwen25.sh`

**Key design decisions:**
- NixlConnector over MooncakeConnector — uses block descriptors, no request-ID mismatch
- No omni connector for the PD edge — KV transfers via vLLM's KV connector
- Router handles PD routing — workers are unaware of the pipeline topology
- Decode re-parses original request — same prompt tokens as prefill for correct KV indexing

**Tested:** Full 4-stage PD pipeline with Qwen2.5-Omni-7B on 2x A6000 (48GB each). Completes in 4-11s. GPU 0 prefill confirmed at 96% utilization with long prompts. NixlConnector KV transfer working.

#### Where should the reviewer start?

- `components/src/dynamo/vllm/omni/stage_router.py` — PD pair detection and routing
- `components/src/dynamo/vllm/omni/stage_worker.py` — prefill/decode logic
- `examples/backends/vllm/launch/stage_configs/qwen2_5_omni_pd.yaml` — 4-stage config

#### Related Issues:

- Relates to: [DYN-2656](https://linear.app/nvidia/issue/DYN-2656)

> **Note:** This PR targets the DYN-2703 bugfix branch. Base will be changed to `main` once that PR is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prefill/decode disaggregation support for inference pipelines
  * Added launch script and configuration example for disaggregated Qwen2.5-Omni multi-GPU pipeline

* **Improvements**
  * Enhanced stage routing with automatic detection of prefill/decode stage pairs
  * Optimized stage worker coordination for disaggregated computation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->