### PR TITLE
chore(deps): bump vLLM to 0.19.1

### DIFF
--- a/components/src/dynamo/vllm/multimodal_utils/models/qwen.py
+++ b/components/src/dynamo/vllm/multimodal_utils/models/qwen.py
@@ -45,16 +45,19 @@ def load_qwen_grid_params(model_name: str) -> QwenGridParams | None:
         merge_size: int = processor.merge_size
         factor = patch_size * merge_size
 
-        # Qwen2/2.5-VL use min_pixels/max_pixels directly.
-        # Qwen3-VL sets them to None and uses size.shortest_edge/longest_edge.
+        # Qwen2/2.5-VL expose min_pixels/max_pixels attributes (transformers v4);
+        # transformers v5 and Qwen3-VL drop those attributes and rely on
+        # size.shortest_edge / size.longest_edge instead.
+        proc_min_pixels = getattr(processor, "min_pixels", None)
+        proc_max_pixels = getattr(processor, "max_pixels", None)
         min_pixels: int = (
-            processor.min_pixels
-            if processor.min_pixels is not None
+            proc_min_pixels
+            if proc_min_pixels is not None
             else processor.size.get("shortest_edge", factor)
         )
         max_pixels: int = (
-            processor.max_pixels
-            if processor.max_pixels is not None
+            proc_max_pixels
+            if proc_max_pixels is not None
             else processor.size.get("longest_edge", factor * factor * 1280)
         )
         vision_hidden_dim: int = getattr(

--- a/components/src/dynamo/vllm/omni/args.py
+++ b/components/src/dynamo/vllm/omni/args.py
@@ -6,8 +6,11 @@
 import argparse
 import dataclasses
 import logging
+import os
 from typing import Optional
 
+import huggingface_hub
+from vllm.transformers_utils.repo_utils import get_model_path
 from vllm_omni.engine.arg_utils import OmniEngineArgs
 
 try:
@@ -422,6 +425,31 @@ def parse_omni_args() -> OmniConfig:
 
     vllm_args = vllm_parser.parse_args(unknown)
     config.model = vllm_args.model
+
+    # Resolve repo id to local snapshot path under HF_HUB_OFFLINE so
+    # vllm-omni diffusion workers don't hit transformers v5's offline
+    # LocalEntryNotFoundError (vLLM's EngineArgs does the same rewrite).
+    if (
+        huggingface_hub.constants.HF_HUB_OFFLINE
+        and config.model
+        and not os.path.exists(config.model)
+    ):
+        model_id = config.model
+        config.model = get_model_path(
+            config.model, getattr(vllm_args, "revision", None)
+        )
+        if model_id != config.model:
+            # Preserve the original repo id as the user-facing model name
+            # so /v1/models still advertises "Wan-AI/..." not the snapshot path.
+            if getattr(config, "served_model_name", None) is None:
+                config.served_model_name = model_id
+            logger.info(
+                "HF_HUB_OFFLINE is True; replaced omni model_id [%s] "
+                "with model_path [%s] so vllm-omni diffusion workers "
+                "see a local snapshot.",
+                model_id,
+                config.model,
+            )
 
     engine_args = OmniEngineArgs.from_cli_args(vllm_args)
 

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -44,13 +44,13 @@ vllm:
     runtime_image: nvcr.io/nvidia/cuda
     base_image_tag: 25.06-cuda12.9-devel-ubuntu24.04
     runtime_image_tag: 12.9.1-runtime-ubuntu24.04
-    vllm_ref: v0.19.0
+    vllm_ref: v0.19.1
   cuda13.0:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: nvcr.io/nvidia/cuda
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
     runtime_image_tag: 13.0.2-runtime-ubuntu24.04
-    vllm_ref: v0.19.0
+    vllm_ref: v0.19.1
   xpu:
     base_image: intel/deep-learning-essentials
     runtime_image: intel/deep-learning-essentials

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-VLLM_VER="0.19.0"
+VLLM_VER="0.19.1"
 VLLM_REF="v${VLLM_VER}"
 DEVICE="cuda"
 

--- a/docs/backends/vllm/vllm-omni.md
+++ b/docs/backends/vllm/vllm-omni.md
@@ -375,8 +375,6 @@ sequenceDiagram
 GLM-Image is a 2-stage text-to-image model with an AR stage (generates prior token IDs) and a DiT stage (diffusion denoising + VAE decode). The built-in vLLM-Omni stage config already assigns each stage to a separate GPU.
 
 > **Experimental:** GLM-Image support is experimental; generation may fail or produce incorrect/garbled outputs for some prompts and sizes.
->
-> **Known issue:** GLM-Image requires `transformers>=5.0` to recognize the `glm_image` architecture. Older versions fail at model config creation with `The checkpoint you are trying to load has model type 'glm_image' but Transformers does not recognize this architecture`.
 
 ```bash
 bash examples/backends/vllm/launch/disagg_omni_glm_image.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ trtllm =[
 vllm = [
     "uvloop",
     "nixl[cu12]<=0.10.1",
-    "vllm[flashinfer,runai,otel]==0.19.0",
+    "vllm[flashinfer,runai,otel]==0.19.1",
     # vllm-omni is installed separately in container builds (see
     # container/deps/vllm/install_vllm.sh). Do not add it to ai-dynamo[vllm]:
     # pip/uv dependency resolution for omni can override the vLLM torch stack.


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Bumps vLLM from 0.19.0 → 0.19.1 (patch release: Transformers v5.5.4 upgrade + Gemma4 bugfixes). `vllm-omni` is intentionally unchanged.

Follow-up commits on this branch also fix a Dynamo-side regression exposed by the transformers v5 upgrade, and clean up a now-obsolete doc note.

#### Details:

<!-- Describe the changes made in this PR. -->

**1. Pin bumps**
- `pyproject.toml`: `vllm[flashinfer,runai,otel]==0.19.0` → `0.19.1`
- `container/context.yaml`: `vllm_ref: v0.19.1` for `cuda12.9` and `cuda13.0` (xpu/cpu/omni pins unchanged)
- `container/deps/vllm/install_vllm.sh`: default `VLLM_VER="0.19.1"`

**2. Compatibility fix — `components/src/dynamo/vllm/multimodal_utils/models/qwen.py`**

transformers v5 dropped `Qwen2VLImageProcessor.min_pixels` / `max_pixels` as attributes — switched to `getattr(..., None)` so the loader works on both transformers v4 (Qwen2/2.5-VL) and v5 (Qwen3-VL), falling through to `processor.size["shortest_edge"/"longest_edge"]` when the attributes are absent.

**3. Fix for vllm-omni diffusion workers under `HF_HUB_OFFLINE=1` — `components/src/dynamo/vllm/omni/args.py`**

CI sets `HF_HUB_OFFLINE=1` to keep runs hermetic. Under transformers v5, `AutoTokenizer.from_pretrained(<repo-id>, local_files_only=True)` no longer walks the local HF cache by repo id — it routes through `hf_hub_download` and raises `LocalEntryNotFoundError` even when the snapshot is on disk. vLLM's own `EngineArgs.__post_init__` sidesteps this by rewriting `model` → snapshot path up front, but `OmniConfig` bypasses `EngineArgs`, so the raw repo id leaked into vllm-omni's multiproc diffusion worker subprocess (`pipeline_wan*.py`) and crashed the `StageDiffusionProc` handshake. This manifested as `omni_t2v` / `omni_i2v` CI failures.

The fix mirrors vLLM's own rewrite inside `parse_omni_args` right after `config.model` is populated:

- Under `HF_HUB_OFFLINE=1`, resolve the repo id to the local snapshot path via `vllm.transformers_utils.repo_utils.get_model_path` (same helper vLLM uses).
- Preserve the original repo id in `config.served_model_name` so `/v1/models` still advertises `"Wan-AI/..."` rather than the snapshot path.
- No-op when offline mode is off.

**4. Doc cleanup — `docs/backends/vllm/vllm-omni.md`**

Dropped the GLM-Image "requires `transformers>=5.0`" known-issue note — the vLLM 0.19.1 bump pulls in transformers 5.5.4, so the constraint is now always satisfied.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

- `components/src/dynamo/vllm/omni/args.py` — the `HF_HUB_OFFLINE` rewrite block added in `parse_omni_args`.
- `components/src/dynamo/vllm/multimodal_utils/models/qwen.py` — transformers v5 compatibility for Qwen VL processors.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes [DYN-2757: vllm upgrade 0.19.1](https://linear.app/nvidia/issue/DYN-2757/vllm-upgrade-0191)

---

#### Test Plan

Local validation environment: Python 3.12 venv with `vllm==0.19.1`, `lmcache==0.4.2`, `flashinfer==0.6.6`, `transformers==5.5.4`, `vllm-omni==0.19.0rc1` (built from `release/v0.19.0rc1` per `context.yaml`).

**Unit test ladder**

Phase 1 — vLLM component single-file unit tests:
- [x] `components/src/dynamo/vllm/tests/test_vllm_chat_message_utils.py` — 8 passed
- [x] `components/src/dynamo/vllm/tests/test_vllm_renderer_api.py` — 16 passed
- [x] `components/src/dynamo/vllm/tests/test_vllm_kv_events_api.py` — 7 passed
- [x] `components/src/dynamo/vllm/tests/test_vllm_logging.py` — 6 passed
- [x] `components/src/dynamo/vllm/tests/test_vllm_worker_factory.py` — 9 passed
- [x] `components/src/dynamo/vllm/tests/test_vllm_engine_monitor_stats.py` — 9 passed
- [x] `components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py` — 25 passed
- [x] `components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py` — 6 passed
- [x] `components/src/dynamo/vllm/tests/test_vllm_unit.py` — 58 passed

Phase 2 — Full vLLM component test directory (omni handler excluded):
- [x] `components/src/dynamo/vllm/tests --ignore=.../omni/test_omni_handler.py` — 194 passed / 16 skipped (the 5 `TestBuildEmbeddingParams` failures seen before the qwen.py fix are resolved)

Phase 3 — Frontend tests:
- [x] `tests/frontend/test_prepost.py` — 5 passed
- [x] `tests/frontend/test_prepost_mistral.py` — 2 passed
- [ ] `tests/frontend/test_vllm.py` — `e2e+gpu_1`, requires `etcd` and GPT-OSS; deferred to CI

Phase 5 — Scoped vLLM unit sweep:
- [x] `components/src/dynamo/vllm/tests -m "vllm and unit"` (omni handler excluded) — 179 passed

**vLLM-Omni unit tests** (`vllm-omni==0.19.0rc1` from source):
- [x] `test_omni_args.py` — 25 passed
- [x] `test_output_formatter.py` — 34 passed
- [x] `test_audio_handler.py` — 18 passed
- [x] `test_omni_handler.py` — 19 passed
- [x] `test_omni_base_handler.py` — 2 passed
- [x] `test_omni_disagg_types.py` — 9 passed
- [x] `test_omni_stage_router.py` — 6 passed
- [x] `test_omni_stage_worker.py` — 12 passed

**Aggregated launch scripts (upstream-tracked) — end-to-end generation validated**
- [x] `examples/backends/vllm/launch/agg_omni_image.sh` — `Qwen/Qwen-Image`: `POST /v1/images/generations` ("A red apple on a white table", 512×512, 20 steps) → HTTP 200, valid 249 KB PNG (b64 decoded, magic bytes verified), gen 4s after boot
- [x] `examples/backends/vllm/launch/agg_omni_audio.sh` — `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice`: `POST /v1/audio/speech` (voice=vivian, English) → HTTP 200, valid 7.7 KB WAV (RIFF / PCM 16-bit mono 24 kHz), gen 28s after boot
- [x] `examples/backends/vllm/launch/agg_omni_video.sh` — `Wan-AI/Wan2.1-T2V-1.3B-Diffusers`: `POST /v1/videos` ("Dog running on a beach", 832×480, 20 steps, 30 frames) → HTTP 200, valid 89 KB MP4 (ISO 14496-12) at `file:///tmp/dynamo_media/videos/...mp4`, gen 8s after boot
- [x] `examples/backends/vllm/launch/agg_omni_i2v.sh` — `Wan-AI/Wan2.2-TI2V-5B-Diffusers`: boot-only validation (end-to-end generation requires an input reference image; boot 311s, 26 GB on GPU, `/v1/models` served the repo id)

**Disaggregated launch script — end-to-end generation**
- [x] `examples/backends/vllm/launch/disagg_omni_glm_image.sh` — `zai-org/GLM-Image` (AR → DiT, 2 GPUs). `POST /v1/images/generations` with `"size": "1024x1024"` returned HTTP 200 in ~63s with a valid 1024×1024 PNG (decoded, verified magic bytes + IHDR dimensions).

**HF_HUB_OFFLINE=1 fix verification** (mirrors the CI failure mode)
- [x] Before fix: `HF_HUB_OFFLINE=1 agg_omni_video.sh` → FAIL-BOOT at `pipeline_wan2_2.py:270 AutoTokenizer.from_pretrained → LocalEntryNotFoundError → OSError → StageDiffusionProc died (exit code 1)` — identical signature to CI `omni_t2v` / `omni_i2v` failures.
- [x] After fix: `HF_HUB_OFFLINE=1 agg_omni_video.sh` → PASS-BOOT. Rewrite log line: `HF_HUB_OFFLINE is True; replaced omni model_id [Wan-AI/Wan2.1-T2V-1.3B-Diffusers] with model_path [/home/.../snapshots/0fad780a.../]`. `/v1/models` advertises the repo id `Wan-AI/Wan2.1-T2V-1.3B-Diffusers`, not the snapshot path.

**Deferred to CI (not run locally)**
- [ ] Phase 4 — `tests/kvbm_integration/test_kvbm_vllm_integration.py` (needs kvbm wheel + etcd)
- [ ] Phase 6 — `tests/serve/test_vllm.py -m "vllm and gpu_1 and pre_merge"`
- [ ] Phase 7 — `tests/router/test_router_e2e_with_vllm.py`, `tests/kvbm_integration/test_kvbm.py`, `tests/kvbm_integration/test_consolidator_router_e2e.py`
- [ ] Phase 8 — Broader `vllm and e2e and gpu_1` suite
- [ ] Phase 9 — Omni serve path: `tests/serve/test_vllm_omni.py -m "gpu_1"` (primary target for the `HF_HUB_OFFLINE` fix)
