### PR TITLE
fix(protocols): always serialize chat message content (null when absent)

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -342,11 +342,6 @@ impl From<DeltaChoice> for dynamo_protocols::types::ChatChoice {
         } else if !delta.text.is_empty() {
             // Text-only response (backward compatible)
             Some(ChatCompletionMessageContent::Text(delta.text))
-        } else if delta.reasoning_content.is_some() {
-            // Reasoning-only response: keep `content` as an empty string so
-            // `skip_serializing_if` doesn't drop the key alongside
-            // `reasoning_content` (DGH-651).
-            Some(ChatCompletionMessageContent::Text(String::new()))
         } else {
             None
         };
@@ -1192,11 +1187,12 @@ mod tests {
     }
 
     #[test]
-    fn test_reasoning_only_delta_serializes_content_key() {
-        // DGH-651: when a DeltaChoice has reasoning_content but no text or
-        // content parts, the converted ChatChoice must still carry a
-        // non-None `content` field so serde doesn't drop the key via
-        // skip_serializing_if.
+    fn test_reasoning_only_response_serializes_content_key_as_null() {
+        // DGH-651: when a response carries reasoning_content but no text or
+        // content parts, the `content` key must still be present in the
+        // serialized JSON (as `null`) so clients can rely on it alongside
+        // `reasoning_content`. Fixed by removing skip_serializing_if from
+        // ChatCompletionResponseMessage.content.
         let delta = DeltaChoice {
             index: 0,
             text: String::new(),
@@ -1211,17 +1207,18 @@ mod tests {
 
         let choice: dynamo_protocols::types::ChatChoice = delta.into();
 
-        assert_eq!(
-            choice.message.content,
-            Some(ChatCompletionMessageContent::Text(String::new()))
-        );
+        assert!(choice.message.content.is_none());
         assert_eq!(
             choice.message.reasoning_content.as_deref(),
             Some("Analyzing the question.")
         );
 
         let json = serde_json::to_value(&choice.message).unwrap();
-        assert!(json.get("content").is_some(), "content key must be serialized");
+        assert_eq!(
+            json.get("content"),
+            Some(&serde_json::Value::Null),
+            "content key must be serialized as null when absent"
+        );
         assert!(json.get("reasoning_content").is_some());
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -342,6 +342,11 @@ impl From<DeltaChoice> for dynamo_protocols::types::ChatChoice {
         } else if !delta.text.is_empty() {
             // Text-only response (backward compatible)
             Some(ChatCompletionMessageContent::Text(delta.text))
+        } else if delta.reasoning_content.is_some() {
+            // Reasoning-only response: keep `content` as an empty string so
+            // `skip_serializing_if` doesn't drop the key alongside
+            // `reasoning_content` (DGH-651).
+            Some(ChatCompletionMessageContent::Text(String::new()))
         } else {
             None
         };
@@ -1184,5 +1189,39 @@ mod tests {
             choice.message.tool_calls.as_ref().unwrap()[0].r#type,
             dynamo_protocols::types::FunctionType::Function
         );
+    }
+
+    #[test]
+    fn test_reasoning_only_delta_serializes_content_key() {
+        // DGH-651: when a DeltaChoice has reasoning_content but no text or
+        // content parts, the converted ChatChoice must still carry a
+        // non-None `content` field so serde doesn't drop the key via
+        // skip_serializing_if.
+        let delta = DeltaChoice {
+            index: 0,
+            text: String::new(),
+            role: Some(dynamo_protocols::types::Role::Assistant),
+            finish_reason: Some(dynamo_protocols::types::FinishReason::Stop),
+            stop_reason: None,
+            logprobs: None,
+            tool_calls: None,
+            reasoning_content: Some("Analyzing the question.".to_string()),
+            content_parts: vec![],
+        };
+
+        let choice: dynamo_protocols::types::ChatChoice = delta.into();
+
+        assert_eq!(
+            choice.message.content,
+            Some(ChatCompletionMessageContent::Text(String::new()))
+        );
+        assert_eq!(
+            choice.message.reasoning_content.as_deref(),
+            Some("Analyzing the question.")
+        );
+
+        let json = serde_json::to_value(&choice.message).unwrap();
+        assert!(json.get("content").is_some(), "content key must be serialized");
+        assert!(json.get("reasoning_content").is_some());
     }
 }

--- a/lib/protocols/src/types/chat.rs
+++ b/lib/protocols/src/types/chat.rs
@@ -574,7 +574,9 @@ pub enum ServiceTierResponse {
 /// - `reasoning_content`: model reasoning output (DeepSeek-R1, QwQ)
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct ChatCompletionResponseMessage {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Always serialized (as `null` when None) so clients can rely on the
+    /// `content` key being present alongside `reasoning_content` or
+    /// `tool_calls`. Matches the upstream OpenAI API shape (DGH-651).
     pub content: Option<ChatCompletionMessageContent>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refusal: Option<String>,


### PR DESCRIPTION
## Summary

Non-streaming `/v1/chat/completions` responses were dropping the `content` key entirely from the JSON `message` any time `content` was `None` (reasoning-only responses, tool-call-only responses). This broke clients like the one in DGH-651 that read `response.json()['choices'][0]['message']['content']`.

Root cause: `ChatCompletionResponseMessage.content` carried `#[serde(skip_serializing_if = "Option::is_none")]`, so `None` was omitted instead of serialized as `null`. Upstream OpenAI's API always emits the `content` key (as `null` when there is no content) alongside `reasoning_content` or `tool_calls`.

Fix: remove `skip_serializing_if` from that one field. Now `content: null` is always emitted when there's no text/content-parts, matching OpenAI's wire format.

Approach history:
- First commit attempted a narrower workaround in the aggregator (set `content` to `Some(Text(""))` when `reasoning_content` was present). That was a semantic muddle ("no content" vs "empty content") and only fixed the reasoning case, not the tool-call-only case.
- Second commit replaces it with the serialization-level fix, which is simpler (1 attribute removed) and covers both shapes.

Fixes: DGH-651
Closes #7154

## Test plan

- [x] New unit test `test_reasoning_only_response_serializes_content_key_as_null` asserts `content` serializes as `serde_json::Value::Null` when reasoning-only.
- [x] Empirically verified the test fails on `main` without the fix, passes with it.
- [x] Full workspace test suite: **2000+ tests, 0 failures**.

\`\`\`
cargo test --workspace --lib
# all passing
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)