### PR TITLE
docs(vllm-omni): note ARM64 not supported; flag GLM-Image as experimental

### DIFF
--- a/docs/backends/vllm/vllm-omni.md
+++ b/docs/backends/vllm/vllm-omni.md
@@ -12,11 +12,13 @@ This guide assumes familiarity with deploying Dynamo with vLLM as described in t
 
 ### Installation
 
-Dynamo container images include vLLM-Omni pre-installed. If you are using `pip install ai-dynamo[vllm]`, vLLM-Omni is **not** included automatically because the matching release is not yet available on PyPI. Install it separately from source:
+Dynamo container images include vLLM-Omni pre-installed. If you are using `pip install ai-dynamo[vllm]`, vLLM-Omni is **not** included automatically because the matching release is not yet available on PyPI. Install it separately from source, pinning the vLLM-Omni release that matches your installed vLLM version (see the [vLLM-Omni releases](https://github.com/vllm-project/vllm-omni/releases) page):
 
 ```bash
-pip install git+https://github.com/vllm-project/vllm-omni.git@v0.16.0rc1
+pip install git+https://github.com/vllm-project/vllm-omni.git@<version>
 ```
+
+> **ARM64 not supported:** vLLM-Omni is currently only installed on `amd64` builds. On `arm64`, the container build skips the install and vLLM-Omni features are unavailable.
 
 ## Supported Modalities
 
@@ -372,6 +374,8 @@ sequenceDiagram
 
 GLM-Image is a 2-stage text-to-image model with an AR stage (generates prior token IDs) and a DiT stage (diffusion denoising + VAE decode). The built-in vLLM-Omni stage config already assigns each stage to a separate GPU.
 
+> **Experimental:** GLM-Image support is experimental; generation may fail or produce incorrect/garbled outputs for some prompts and sizes.
+>
 > **Known issue:** GLM-Image requires `transformers>=5.0` to recognize the `glm_image` architecture. Older versions fail at model config creation with `The checkpoint you are trying to load has model type 'glm_image' but Transformers does not recognize this architecture`.
 
 ```bash


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Doc-only update to `docs/backends/vllm/vllm-omni.md`:
- Note that vLLM-Omni is not currently installed on `arm64` builds.
- Flag `zai-org/GLM-Image` as experimental — generation may fail or produce incorrect outputs for some prompts/sizes.

No code changes.

#### Details:

<!-- Describe the changes made in this PR. -->

- Under `## Prerequisites → ### Installation`, add an "ARM64 not supported" callout: the container build skips the vLLM-Omni install on `arm64`, so vLLM-Omni features are unavailable on that arch today.
- Under `### Quick Start: GLM-Image (2-Stage, 2 GPUs)`, add an "Experimental" callout above the existing `transformers>=5.0` known-issue note, warning that generation may fail or produce incorrect/garbled outputs for some prompts and sizes.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

- `docs/backends/vllm/vllm-omni.md` — the only file changed. +4 lines.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to [DYN-2741: dynamo/release-1.1.0/vllm-runtime/arm64 — vllm-omni module missing from arm64](https://linear.app/nvidia/issue/DYN-2741/dynamorelease110vllm-runtimearm64-vllm-omni-module-missing-from-arm64)
