### PR TITLE
docs(kubernetes/dgdr): publish supported GPU SKU table, fix h100_sxm example, add PCIe profiler callout

### DIFF
--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -119,7 +119,7 @@ For the full spec reference, see the [DGDR API Reference](api-reference.md) and
 >   ...
 >   hardware:
 >     numGpusPerNode: 1
->     gpuSku: "H100-SXM5-80GB"
+>     gpuSku: "h100_sxm"
 >     vramMb: 81920
 > ```
 >

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -349,6 +349,11 @@ kubectl get pods -n ${NAMESPACE} | grep frontend
 kubectl logs <frontend-pod-name> -n ${NAMESPACE}
 ```
 
+## Known issues
+
+- **`pareto_analysis.py` produces NaN for some configurations.** Tracked as an engineering follow-up (VDR §1.3 item 5 — DGDR `pareto_analysis.py` NaN output). Workaround: re-run with a narrower sweep; narrow sweeps bypass the NaN path in practice.
+- **PCIe profiler data not yet available.** See callout above the SKU table.
+
 ## Next Steps
 
 - **Tune for production SLAs**: Add `sla` (TTFT, ITL) and `workload` (ISL, OSL) targets to

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -128,6 +128,30 @@ For the full spec reference, see the [DGDR API Reference](api-reference.md) and
 >
 > **Note:** Namespace-scoped mode is deprecated. Use cluster-wide mode for new deployments.
 
+## Supported GPU SKUs
+
+DGDR's webhook accepts exactly these values in `spec.hardware.gpuSku`. Anything else is rejected at admission. Values are sourced from the CRD enum at [`deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go) lines 183–202.
+
+| Family | CRD value | Form factor | Profiler support |
+|---|---|---|---|
+| GB200 | `gb200_sxm` | SXM | TBD (profiler team) |
+| B200 | `b200_sxm` | SXM | TBD |
+| H200 | `h200_sxm` | SXM | TBD |
+| H100 | `h100_sxm` | SXM | TBD |
+| H100 | `h100_pcie` | PCIe | Not yet supported |
+| A100 | `a100_sxm` | SXM | TBD |
+| A100 | `a100_pcie` | PCIe | Not yet supported |
+| L40S | `l40s` | single | TBD |
+| L40 | `l40` | single | Not yet supported |
+| L4 | `l4` | single | Not yet supported |
+| V100 | `v100_sxm` | SXM | Not yet supported |
+| V100 | `v100_pcie` | PCIe | Not yet supported |
+| T4 | `t4` | single | Not yet supported |
+| AMD MI200 | `mi200` | single | Not yet supported |
+| AMD MI300 | `mi300` | single | Not yet supported |
+
+> **PCIe variants not yet supported by profiler.** DGDR's CRD admits PCIe SKUs (`h100_pcie`, `a100_pcie`, `v100_pcie`) but the profiler does not currently ship training data for them. You can submit a DGDR with a PCIe value; the operator will accept it but profiler-assisted sizing will fall back to defaults. Tracking: VDR §1.3 engineering follow-up for PCIe profiler support.
+
 ## Step 3: Monitor Profiling Progress
 
 Profiling is the automated step where Dynamo sweeps across candidate configurations (parallelism, batching, scheduling strategies) to find the one that best meets your SLA and hardware — so you don't have to tune it manually.

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -115,7 +115,7 @@ For the full spec reference, see the [DGDR API Reference](api-reference.md) and
 >   ...
 >   hardware:
 >     numGpusPerNode: 1
->     gpuSku: "H100-SXM5-80GB"
+>     gpuSku: "h100_sxm"
 >     vramMb: 81920
 > ```
 >

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -345,6 +345,11 @@ kubectl get pods -n ${NAMESPACE} | grep frontend
 kubectl logs <frontend-pod-name> -n ${NAMESPACE}
 ```
 
+## Known issues
+
+- **`pareto_analysis.py` produces NaN for some configurations.** Tracked as an engineering follow-up (VDR §1.3 item 5 — DGDR `pareto_analysis.py` NaN output). Workaround: re-run with a narrower sweep; narrow sweeps bypass the NaN path in practice.
+- **PCIe profiler data not yet available.** See callout above the SKU table.
+
 ## Next Steps
 
 - **Tune for production SLAs**: Add `sla` (TTFT, ITL) and `workload` (ISL, OSL) targets to

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -146,7 +146,7 @@ DGDR's webhook accepts exactly these values in `spec.hardware.gpuSku`. Anything 
 | AMD MI200 | `mi200` | single | Not yet supported |
 | AMD MI300 | `mi300` | single | Not yet supported |
 
-> **PCIe variants not yet supported by profiler.** DGDR's CRD admits PCIe SKUs (`h100_pcie`, `a100_pcie`, `v100_pcie`) but the profiler does not currently ship training data for them. You can submit a DGDR with a PCIe value; the operator will accept it but profiler-assisted sizing will fall back to defaults. Tracking: VDR §1.3 engineering follow-up for PCIe profiler support.
+> **PCIe variants not yet supported by profiler.** DGDR's CRD admits PCIe SKUs (`h100_pcie`, `a100_pcie`, `v100_pcie`) but the profiler does not currently ship training data for them. You can submit a DGDR with a PCIe value; the operator will accept it but profiler-assisted sizing will fall back to defaults. Profiler support for PCIe SKUs is tracked as an engineering follow-up.
 
 ## Step 3: Monitor Profiling Progress
 
@@ -347,7 +347,7 @@ kubectl logs <frontend-pod-name> -n ${NAMESPACE}
 
 ## Known issues
 
-- **`pareto_analysis.py` produces NaN for some configurations.** Tracked as an engineering follow-up (VDR §1.3 item 5 — DGDR `pareto_analysis.py` NaN output). Workaround: re-run with a narrower sweep; narrow sweeps bypass the NaN path in practice.
+- **`pareto_analysis.py` produces NaN for some configurations.** Tracked as an engineering follow-up. Workaround: re-run with a narrower sweep; narrow sweeps bypass the NaN path in practice.
 - **PCIe profiler data not yet available.** See callout above the SKU table.
 
 ## Next Steps

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -124,6 +124,30 @@ For the full spec reference, see the [DGDR API Reference](api-reference.md) and
 >
 > **Note:** Namespace-scoped mode is deprecated. Use cluster-wide mode for new deployments.
 
+## Supported GPU SKUs
+
+DGDR's webhook accepts exactly these values in `spec.hardware.gpuSku`. Anything else is rejected at admission. Values are sourced from the CRD enum at [`deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go) lines 183–202.
+
+| Family | CRD value | Form factor | Profiler support |
+|---|---|---|---|
+| GB200 | `gb200_sxm` | SXM | TBD (profiler team) |
+| B200 | `b200_sxm` | SXM | TBD |
+| H200 | `h200_sxm` | SXM | TBD |
+| H100 | `h100_sxm` | SXM | TBD |
+| H100 | `h100_pcie` | PCIe | Not yet supported |
+| A100 | `a100_sxm` | SXM | TBD |
+| A100 | `a100_pcie` | PCIe | Not yet supported |
+| L40S | `l40s` | single | TBD |
+| L40 | `l40` | single | Not yet supported |
+| L4 | `l4` | single | Not yet supported |
+| V100 | `v100_sxm` | SXM | Not yet supported |
+| V100 | `v100_pcie` | PCIe | Not yet supported |
+| T4 | `t4` | single | Not yet supported |
+| AMD MI200 | `mi200` | single | Not yet supported |
+| AMD MI300 | `mi300` | single | Not yet supported |
+
+> **PCIe variants not yet supported by profiler.** DGDR's CRD admits PCIe SKUs (`h100_pcie`, `a100_pcie`, `v100_pcie`) but the profiler does not currently ship training data for them. You can submit a DGDR with a PCIe value; the operator will accept it but profiler-assisted sizing will fall back to defaults. Tracking: VDR §1.3 engineering follow-up for PCIe profiler support.
+
 ## Step 3: Monitor Profiling Progress
 
 Profiling is the automated step where Dynamo sweeps across candidate configurations (parallelism, batching, scheduling strategies) to find the one that best meets your SLA and hardware — so you don't have to tune it manually.

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -150,7 +150,7 @@ DGDR's webhook accepts exactly these values in `spec.hardware.gpuSku`. Anything 
 | AMD MI200 | `mi200` | single | Not yet supported |
 | AMD MI300 | `mi300` | single | Not yet supported |
 
-> **PCIe variants not yet supported by profiler.** DGDR's CRD admits PCIe SKUs (`h100_pcie`, `a100_pcie`, `v100_pcie`) but the profiler does not currently ship training data for them. You can submit a DGDR with a PCIe value; the operator will accept it but profiler-assisted sizing will fall back to defaults. Tracking: VDR §1.3 engineering follow-up for PCIe profiler support.
+> **PCIe variants not yet supported by profiler.** DGDR's CRD admits PCIe SKUs (`h100_pcie`, `a100_pcie`, `v100_pcie`) but the profiler does not currently ship training data for them. You can submit a DGDR with a PCIe value; the operator will accept it but profiler-assisted sizing will fall back to defaults. Profiler support for PCIe SKUs is tracked as an engineering follow-up.
 
 ## Step 3: Monitor Profiling Progress
 
@@ -351,7 +351,7 @@ kubectl logs <frontend-pod-name> -n ${NAMESPACE}
 
 ## Known issues
 
-- **`pareto_analysis.py` produces NaN for some configurations.** Tracked as an engineering follow-up (VDR §1.3 item 5 — DGDR `pareto_analysis.py` NaN output). Workaround: re-run with a narrower sweep; narrow sweeps bypass the NaN path in practice.
+- **`pareto_analysis.py` produces NaN for some configurations.** Tracked as an engineering follow-up. Workaround: re-run with a narrower sweep; narrow sweeps bypass the NaN path in practice.
 - **PCIe profiler data not yet available.** See callout above the SKU table.
 
 ## Next Steps


### PR DESCRIPTION
#### Overview

Documents the DGDR supported GPU SKUs in user-facing docs and fixes an example YAML that used `gpuSku: "H100-SXM5-80GB"`, which is rejected by the admission webhook. Single-file docs-only change.

#### Details

All changes are in `docs/kubernetes/dgdr.md`:

1. **New "Supported GPU SKUs" section** (placed between Step 2's namespace-scoped `hardware` example and Step 3). Table has one row per CRD enum value, sourced from `deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go` lines 183–202. Columns: Family, CRD value, Form factor, Profiler support. SXM rows are marked `TBD` in the Profiler-support column — the profiler team will fill those in as a post-merge touch.
2. **PCIe callout** under the table: CRD admits `h100_pcie` / `a100_pcie` / `v100_pcie`, but the profiler doesn't ship training data for them yet; the operator accepts the value and profiler-assisted sizing falls back to defaults. Tracked as an engineering follow-up.
3. **Example YAML fix**: `gpuSku: "H100-SXM5-80GB"` → `gpuSku: "h100_sxm"` in the namespace-scoped `hardware` block.
4. **New "Known issues" section** before "Next Steps" — `pareto_analysis.py` NaN with a narrower-sweep workaround, plus a pointer to the PCIe profiler gap.

Delivered as four separate signed-off commits (table, example fix, known issues, and a follow-up commit that scrubbed internal tracker references from the doc).

#### Updates since last revision

- Dropped stale "16-SKU" wording from the title and description; the CRD enum and table both contain **15** values.
- Removed internal "VDR §1.3" references from the PCIe callout and the Known Issues bullets. The follow-ups are now described as generic "engineering follow-up" items.

#### Where should the reviewer start?

- `docs/kubernetes/dgdr.md` — the only file touched. Things to verify:
  - **CRD value list**: the table's 15 CRD values should equal the enum at `deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go` lines 183–202 one-for-one, in order. Double-check none drifted or were misspelled.
  - **Field name**: the original working spec referenced `spec.gpuProductName`, but the actual CRD json tag is `spec.hardware.gpuSku`. The table's intro sentence uses `spec.hardware.gpuSku` to match the code. Please confirm that is the field you want documented.
  - **Profiler-support column**: the "TBD" vs "Not yet supported" split was inherited from the working spec, not independently validated against profiler code. If any SXM row actually has training data today, a follow-up edit will be needed.

#### Out of scope

- Engineering fix for `pareto_analysis.py` NaN.
- Engineering fix for PCIe profiler support.
- Other K8s docs and unified troubleshooting — separate PRs.
- Standalone `dgdr-known-issues.md` file — deferred.

#### Related Issues:

- Relates to: N/A

#### Test plan

- [ ] Docs build passes in CI.
- [ ] Reviewer confirms the 15 table values match the CRD enum at `deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go` lines 183–202.
- [ ] Profiler team fills in the "TBD" Profiler-support cells in a follow-up.

Link to Devin session: https://nvidia.devinenterprise.com/sessions/8cb048d213b84c3398b7a3ef36248ec9
Requested by: @dagil-nvidia

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GPU SKU configuration examples with latest supported values
  * Added reference table of supported GPU families with profiler compatibility details, including PCIe variant status
  * Documented known limitations for profile generation in specific configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->