### PR TITLE
feat: add DYN_WORKER_DISABLE_GC to disable Python GC on workers

### DIFF
--- a/components/src/dynamo/common/utils/gc_control.py
+++ b/components/src/dynamo/common/utils/gc_control.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Handler-process Python GC tuning controlled by environment variables.
+
+Under high concurrency (thousands of in-flight streaming coroutines),
+GC sweeps can pause the handler process for hundreds of ms to several
+seconds while holding the GIL, which can push the system into a
+lower-throughput equilibrium it cannot recover from during a load burst.
+
+Controlled by env var ``DYN_WORKER_DISABLE_GC``:
+
+- ``0`` (or unset): no change — stock CPython GC behavior.
+- ``1``: ``gc.collect()`` then ``gc.disable()`` at handler startup.
+  Reference counting still frees most objects; reference cycles will
+  leak (fine for a bounded-lifetime process, may accumulate over days
+  in long-running servers).
+"""
+
+import gc
+import logging
+import os
+
+_ENV_VAR = "DYN_WORKER_DISABLE_GC"
+
+def configure_gc(worker_role: str) -> None:
+    """Apply the GC setting selected by ``DYN_WORKER_DISABLE_GC``.
+
+    Call this once at the start of a worker's init function. ``worker_role``
+    (e.g., ``"decode"``, ``"prefill"``, ``"encode"``) is included in the log
+    message for visibility in multi-process deployments.
+    """
+    env_value = os.environ.get(_ENV_VAR, "0").lower().strip()
+    if env_value == "0":
+        return
+    if env_value == "1":
+        gc.collect()
+        gc.disable()
+        logging.info("GC disabled for %s handler (%s=1)", worker_role, _ENV_VAR)
+        return
+    logging.warning(
+        "Unrecognized %s=%r (expected 0 or 1); leaving GC unchanged",
+        _ENV_VAR,
+        env_value,
+    )

--- a/components/src/dynamo/common/utils/gc_control.py
+++ b/components/src/dynamo/common/utils/gc_control.py
@@ -21,7 +21,10 @@ import gc
 import logging
 import os
 
+logger = logging.getLogger(__name__)
+
 _ENV_VAR = "DYN_WORKER_DISABLE_GC"
+
 
 def configure_gc(worker_role: str) -> None:
     """Apply the GC setting selected by ``DYN_WORKER_DISABLE_GC``.
@@ -36,9 +39,9 @@ def configure_gc(worker_role: str) -> None:
     if env_value == "1":
         gc.collect()
         gc.disable()
-        logging.info("GC disabled for %s handler (%s=1)", worker_role, _ENV_VAR)
+        logger.info("GC disabled for %s handler (%s=1)", worker_role, _ENV_VAR)
         return
-    logging.warning(
+    logger.warning(
         "Unrecognized %s=%r (expected 0 or 1); leaving GC unchanged",
         _ENV_VAR,
         env_value,

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -11,6 +11,7 @@ import sglang as sgl
 
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
+from dynamo.common.utils.gc_control import configure_gc
 from dynamo.llm import ModelInput, ModelType
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
@@ -63,6 +64,7 @@ async def init_decode(
     run_deferred_handlers: Callable[[], Awaitable[None]] | None = None,
     snapshot_engine: Optional[sgl.Engine] = None,
 ) -> None:
+    configure_gc("decode")
     server_args, dynamo_args = config.server_args, config.dynamo_args
 
     if server_args.node_rank >= 1:
@@ -191,6 +193,7 @@ async def init_prefill(
     run_deferred_handlers: Callable[[], Awaitable[None]] | None = None,
     snapshot_engine: Optional[sgl.Engine] = None,
 ) -> None:
+    configure_gc("prefill")
     server_args, dynamo_args = config.server_args, config.dynamo_args
 
     if server_args.node_rank >= 1:

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -17,6 +17,7 @@ from vllm.v1.engine.async_llm import AsyncLLM
 
 from dynamo import prometheus_names
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
+from dynamo.common.utils.gc_control import configure_gc
 from dynamo.common.utils.prometheus import (
     LLMBackendMetrics,
     register_embedding_cache_metrics,
@@ -134,10 +135,12 @@ class WorkerFactory:
         # The encode worker path does not wire benchmark waiting or
         # the get_perf_metrics endpoint.
         if config.disaggregation_mode == DisaggregationMode.ENCODE:
+            configure_gc("encode")
             await self._create_multimodal_encode_worker(
                 runtime, config, shutdown_event, shutdown_endpoints
             )
         elif config.disaggregation_mode == DisaggregationMode.PREFILL:
+            configure_gc("prefill")
             await self._create_prefill_worker(
                 runtime,
                 config,
@@ -147,6 +150,7 @@ class WorkerFactory:
             )
         else:
             # AGGREGATED or DECODE
+            configure_gc("decode")
             await self._create_decode_worker(
                 runtime,
                 config,

--- a/docs/backends/sglang/sglang-reference-guide.md
+++ b/docs/backends/sglang/sglang-reference-guide.md
@@ -52,6 +52,35 @@ These arguments are added by Dynamo on top of SGLang's native arguments.
 
 The current supported parser names for both flags are documented in [Tool Calling](../../agents/tool-calling.md#supported-tool-call-parsers) and [Reasoning](../../agents/reasoning.md#supported-reasoning-parsers).
 
+### Runtime Tuning Environment Variables
+
+These environment variables tune handler-process runtime behavior and have no
+command-line equivalent. Applied at the start of `init_decode` / `init_prefill`.
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `DYN_WORKER_DISABLE_GC` | `0` | Disable Python GC on the handler process. See below. |
+
+#### `DYN_WORKER_DISABLE_GC`
+
+Under high concurrency (thousands of in-flight streaming coroutines), Python's
+generational garbage collector can pause the handler for hundreds of ms to
+several seconds while holding the GIL. During such a pause, incoming NATS
+messages are not accepted and outbound SSE chunks are not yielded, which can
+push the system into a lower-throughput equilibrium it cannot recover from
+during a load burst.
+
+| Value | Behavior |
+|-------|----------|
+| `0` (or unset) | No change — stock CPython GC. |
+| `1` | `gc.collect()` then `gc.disable()` at handler startup. Reference counting continues, so most objects are freed promptly. **Cyclic garbage leaks** — fine for bounded-lifetime processes (benchmarks, short-lived jobs); not recommended for always-on servers. |
+
+When disabled, the handler logs at startup:
+
+```
+GC disabled for decode handler (DYN_WORKER_DISABLE_GC=1)
+```
+
 ## Tokenizer Behavior
 
 By default, Dynamo handles tokenization and detokenization through its Rust-based frontend, passing `input_ids` to SGLang. This enables all frontend endpoints (`v1/chat/completions`, `v1/completions`, `v1/embeddings`).

--- a/docs/backends/sglang/sglang-reference-guide.md
+++ b/docs/backends/sglang/sglang-reference-guide.md
@@ -77,7 +77,7 @@ during a load burst.
 
 When disabled, the handler logs at startup:
 
-```
+```text
 GC disabled for decode handler (DYN_WORKER_DISABLE_GC=1)
 ```
 

--- a/docs/backends/vllm/vllm-reference-guide.md
+++ b/docs/backends/vllm/vllm-reference-guide.md
@@ -39,6 +39,36 @@ Dynamo supports [vLLM prompt embeddings](https://docs.vllm.ai/en/stable/features
 - Embeddings are sent as base64-encoded PyTorch tensors via the `prompt_embeds` field in the Completions API
 - NATS must be configured with a 15MB max payload for large embeddings (already set in default deployments)
 
+### Runtime Tuning Environment Variables
+
+These environment variables tune handler-process runtime behavior and have no
+command-line equivalent. Applied at the start of `WorkerFactory.create`
+(covers encode, prefill, and decode paths).
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `DYN_WORKER_DISABLE_GC` | `0` | Disable Python GC on the handler process. See below. |
+
+#### `DYN_WORKER_DISABLE_GC`
+
+Under high concurrency (thousands of in-flight streaming coroutines), Python's
+generational garbage collector can pause the handler for hundreds of ms to
+several seconds while holding the GIL. During such a pause, incoming NATS
+messages are not accepted and outbound SSE chunks are not yielded, which can
+push the system into a lower-throughput equilibrium it cannot recover from
+during a load burst.
+
+| Value | Behavior |
+|-------|----------|
+| `0` (or unset) | No change — stock CPython GC. |
+| `1` | `gc.collect()` then `gc.disable()` at handler startup. Reference counting continues, so most objects are freed promptly. **Cyclic garbage leaks** — fine for bounded-lifetime processes (benchmarks, short-lived jobs); not recommended for always-on servers. |
+
+When disabled, the handler logs at startup:
+
+```
+GC disabled for decode handler (DYN_WORKER_DISABLE_GC=1)
+```
+
 ## Hashing Consistency for KV Events
 
 When using KV-aware routing, ensure deterministic hashing across processes to avoid radix tree mismatches. Choose one of the following:

--- a/docs/backends/vllm/vllm-reference-guide.md
+++ b/docs/backends/vllm/vllm-reference-guide.md
@@ -65,7 +65,7 @@ during a load burst.
 
 When disabled, the handler logs at startup:
 
-```
+```text
 GC disabled for decode handler (DYN_WORKER_DISABLE_GC=1)
 ```
 


### PR DESCRIPTION
## Original Issue

  Benchmark runs on a DeepSeek-R1 PD-disaggregation setup (4 prefill × 4 GPU + 8 decode × 4 GPU = 48 GB300 GPUs, TP=32 DP=32 decode) showed non-deterministic throughput degradation at 8192 concurrency with up to 1.5x output throughput difference. Same config, same benchmark (81920 requests, seed=0, ISL=1024, OSL=1024), different results:

* GOOD run : avg ~200 req/s
* BAD run: avg ~150 req/s with periodic dips to 80-120


## Investigation

  Per-request decode handler timing:

| Metric | Good Run (p50) | Bad Run (p50) | Observation |
| :--- | :--- | :--- | :--- |
| **`first_token_ms`** | 16,453ms | 23,264ms | **+6,811ms** delay before first token |
| **`generation_ms`** | 21,587ms | 20,961ms | Nearly identical |
| **`total_ms`** | 38,134ms | 45,294ms | Total latency driven by initial wait |


  Bad run — dispatch delay (decode_recv - prefill_recv):
    p50 = 1.8ms        ← most requests fine
    p95 = 2278ms       ← 5% are 2+ seconds late
    p99 = 3139ms
    max = 3352ms
    Initial burst: p50 = 2334ms (single handler accepting serially)
    Steady state: p95 oscillating every 20-30s between 3ms and 2500ms

  The cause was Python GC pauses. With ~8000 concurrent coroutines on the handler's event loop, GC sweeps walk millions of objects while holding the GIL. Each collection stalls the process for 100ms–2.5s, during which:
  - No messages accepted
  - No SSE chunks stream back
  - All 8192 concurrent requests pause

With fixed 8192 concurrency, the completion rate drop cascaded into fewer resubmissions → smaller prefill batches (3 vs 18
   seq) → fewer running decode requests (96 vs 139) → lower aggregate throughput. The system settled into a lower-throughput equilibrium it couldn't escape during the benchmark.

## Solution

  Disable Python GC on decode + prefill handler processes.

Add new `DYN_WORKER_DISABLE_GC` env variable to disable Python GC on workers.

##  Verification — Runs with GC disabled

  Throughput is now rock-steady at ~215 req/s (no dips, no oscillation):

```
  [throughput] t=161s  rate=215.0 req/s  inflight=8192
  [throughput] t=192s  rate=233.0 req/s  inflight=8192
  [throughput] t=222s  rate=220.2 req/s  inflight=8192
  [throughput] t=252s  rate=219.1 req/s  inflight=8192
  [throughput] t=282s  rate=210.6 req/s  inflight=8192
  [throughput] t=312s  rate=216.8 req/s  inflight=8192
  [throughput] t=342s  rate=218.0 req/s  inflight=8192
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DYN_WORKER_DISABLE_GC` environment variable to control Python garbage collection behavior in handler processes (sglang and vLLM backends). Default is enabled; set to `1` to disable GC after initial collection.

* **Documentation**
  * Added runtime tuning environment variables section to backend reference guides documenting GC control configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->