### PR TITLE
fix(planner): normalize model_name case in KubernetesConnector comparisons (cherry-pick of #8384)

### DIFF
--- a/components/src/dynamo/planner/connectors/kubernetes.py
+++ b/components/src/dynamo/planner/connectors/kubernetes.py
@@ -203,7 +203,7 @@ class KubernetesConnector(PlannerConnector):
                 model_name = decode_model_name
             elif decode_model_name is None:
                 model_name = prefill_model_name
-            elif prefill_model_name != decode_model_name:
+            elif prefill_model_name.lower() != decode_model_name.lower():
                 raise DeploymentModelNameMismatchError(
                     prefill_model_name, decode_model_name
                 )
@@ -224,7 +224,7 @@ class KubernetesConnector(PlannerConnector):
 
         # If user provided a model name and it doesn't match the model name from the deployment, raise an error
         if self.user_provided_model_name:
-            if model_name != self.user_provided_model_name:
+            if model_name.lower() != self.user_provided_model_name:
                 raise UserProvidedModelNameMismatchError(
                     model_name, self.user_provided_model_name
                 )


### PR DESCRIPTION
## Summary

Cherry-pick of #8384 to `release/1.1.0`.

Fixes case-sensitivity bugs in `KubernetesConnector.get_model_name()` that caused Planner to enter `CrashLoopBackOff` in active mode when deployment model names retained original casing (e.g. `Qwen/Qwen3-0.6B`).

## Test plan

- [x] Clean cherry-pick (no conflicts)
- [x] Original fix validated end-to-end on single-node K8s cluster in #8384
- [ ] CI passes on release branch

Closes #8359 on release/1.1.0