### PR TITLE
test(fault_tolerance): skip flaky sglang migration NATS combo, drop stale graceful_shutdown xfail

### DIFF
--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -46,13 +46,7 @@ pytestmark = [
         "immediate_kill",
         [
             pytest.param(True, id="worker_failure"),
-            pytest.param(
-                False,
-                id="graceful_shutdown",
-                marks=pytest.mark.xfail(
-                    strict=False, reason="SGLang graceful shutdown not yet implemented"
-                ),
-            ),
+            pytest.param(False, id="graceful_shutdown"),
         ],
     ),
     pytest.mark.parametrize(
@@ -240,6 +234,22 @@ def test_request_migration_sglang_aggregated(
         request_api: "chat" for chat completion API, "completion" for completion API
         stream: True for streaming, False for non-streaming
     """
+
+    # TODO(<LINEAR-ID>): Flaky on NATS transport — first-token delay routinely
+    # exceeds the 6s threshold in utils.validate_response. Other parameter
+    # combinations (including the TCP variant) are stable.
+    if (
+        migration_limit == 3
+        and migration_max_seq_len is None
+        and immediate_kill is True
+        and request_api == "chat"
+        and stream is True
+        and request.getfixturevalue("request_plane") == "nats"
+    ):
+        pytest.skip(
+            "Flaky on NATS transport: first-token delay > 6s threshold. "
+            "TODO(<LINEAR-ID>)"
+        )
 
     # Step 1: Start the frontend
     with DynamoFrontendProcess(

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -248,7 +248,7 @@ def test_request_migration_sglang_aggregated(
     ):
         pytest.skip(
             "Flaky on NATS transport: first-token delay > 6s threshold. "
-            "TODO(<LINEAR-ID>)"
+            "OPS-4446"
         )
 
     # Step 1: Start the frontend


### PR DESCRIPTION
## Summary

Two small, related changes to `tests/fault_tolerance/migration/test_sglang.py` to stop the post-merge `sglang / Test cuda* (amd64)` job from failing on main:

- **Skip** the single flaky parameter combination `test_request_migration_sglang_aggregated[migration_enabled-max_seq_len_disabled-worker_failure-chat-stream-nats]`. It has failed on every amd64 post-merge run this cycle — e.g. runs [24685348314](https://github.com/ai-dynamo/dynamo/actions/runs/24685348314), [24683926404](https://github.com/ai-dynamo/dynamo/actions/runs/24683926404), [24683166462](https://github.com/ai-dynamo/dynamo/actions/runs/24683166462), [24680832233](https://github.com/ai-dynamo/dynamo/actions/runs/24680832233), [24680530215](https://github.com/ai-dynamo/dynamo/actions/runs/24680530215). The adjacent TCP variant is stable. Failure signature:
  ```
  AssertionError: Delay before response > 6 secs, got 13.050 secs
  tests/fault_tolerance/migration/utils.py:417 in validate_response
  ```
  Only the NATS transport is affected — first-token delay under migration lands around 13s where the 6s assertion trips.

- **Remove** the `xfail(reason="SGLang graceful shutdown not yet implemented")` mark on the `graceful_shutdown` (`immediate_kill=False`) parameter. Every non-skipped `graceful_shutdown[-chat-stream-*]` combination (both `nats` and `tcp`, across all `migration_limit` × `migration_max_seq_len` values) has been `XPASS` in the same runs above, so the stated reason no longer holds.

The skip references a `TODO(<LINEAR-ID>)` placeholder — please swap in the real Linear ticket ID before merge. Last author on the file / the `delay <= 6.0` assertion in `utils.py:417` is @kthui, who should own the follow-up investigation.

## Test plan
- [ ] Post-merge `sglang / Test cuda12.9 (amd64)` passes with the skip in place
- [ ] The previously-xfailed `graceful_shutdown-chat-stream-{nats,tcp}` combos run as regular passing cases (no XPASS, no XFAIL)
- [ ] Swap `<LINEAR-ID>` placeholder for real Linear ticket ID before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled graceful shutdown test case previously marked as expected to fail.
  * Added conditional skip for specific parameter combinations experiencing timing-related flakiness to improve test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->