### PR TITLE
fix(planner): use dynamo-planner image for profiler job and planner pods [DYN-2733][DYN-2746]

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -86,13 +86,6 @@ const (
 	// Sidecar image
 	SidecarImage = "bitnami/kubectl:latest"
 
-	// PlannerImageName is the image-name component of the published planner/profiler
-	// image. The profiler job must run from this image because the backend runtime
-	// images no longer carry planner/profiler Python dependencies (see DYN-2540).
-	// derivePlannerImage swaps spec.image's name component with this value while
-	// preserving the registry and tag.
-	PlannerImageName = "dynamo-planner"
-
 	// Volume names
 	VolumeNameProfilingOutput = "profiling-output"
 	VolumeNameProfilingConfig = "profiling-config"
@@ -1258,17 +1251,20 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 		// --output-dir must match ProfilingOutputPath so the sidecar can find profiler_status.yaml
 		profilerArgs := []string{"--config", specJSON, "--output-dir", ProfilingOutputPath}
 
-		// spec.image identifies the deployment's image family (frontend or backend
-		// runtime); the defaulting webhook fills it in for production builds. The
-		// profiler job itself must run from the planner/profiler image because the
-		// backend runtime images no longer carry planner deps (DYN-2540), so we derive
-		// the planner image from spec.image, preserving the registry and tag.
+		// Use image from spec; the defaulting webhook fills this in for production builds.
 		// Guard against empty image in case the webhook didn't run (e.g. local dev builds).
-		if dgdr.Spec.Image == "" {
+		//
+		// Starting with Dynamo 1.1.0, the profiler's runtime dependencies
+		// (kubernetes_asyncio, pmdarima, prophet, aiconfigurator, ...) live in the
+		// dedicated dynamo-planner image, not in backend runtime or frontend images.
+		// Users on 1.1.0+ must set spec.image to a planner image
+		// (e.g. nvcr.io/nvidia/ai-dynamo/dynamo-planner:<version>); earlier versions
+		// can continue using the frontend/backend image they were using before.
+		imageName := dgdr.Spec.Image
+		if imageName == "" {
 			return nil, false, fmt.Errorf("spec.image is required but not set; ensure the defaulting webhook ran or set spec.image explicitly")
 		}
-		imageName := derivePlannerImage(dgdr.Spec.Image)
-		logger.Info("Using profiler image", "image", imageName, "derivedFrom", dgdr.Spec.Image)
+		logger.Info("Using profiler image", "image", imageName)
 
 		profilerContainer := corev1.Container{
 			Name:         ContainerNameProfiler,
@@ -1509,37 +1505,6 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 		hw.TotalGPUs = &total
 	}
 	return nil
-}
-
-// derivePlannerImage swaps the image-name component of ref for PlannerImageName,
-// preserving the registry path, tag, and digest. Mirrors the Python
-// dynamo.profiler.utils.profile_common.derive_planner_image helper so the profiler
-// job and the Planner service in the generated DGD share the same derivation rule.
-//
-// Examples:
-//
-//	"nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.3"
-//	  → "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.3"
-//	"nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0rc0"
-//	  → "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.0rc0"
-func derivePlannerImage(ref string) string {
-	prefix := ""
-	suffix := ref
-	if i := strings.LastIndex(ref, "/"); i >= 0 {
-		prefix = ref[:i+1]
-		suffix = ref[i+1:]
-	}
-	nameAndTag := suffix
-	digestSuffix := ""
-	if j := strings.Index(suffix, "@"); j >= 0 {
-		nameAndTag = suffix[:j]
-		digestSuffix = suffix[j:]
-	}
-	tag := ""
-	if k := strings.LastIndex(nameAndTag, ":"); k >= 0 {
-		tag = nameAndTag[k:]
-	}
-	return prefix + PlannerImageName + tag + digestSuffix
 }
 
 // extractModelCachePVCConfig reads model cache PVC settings from the typed v1beta1 spec.

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -86,6 +86,13 @@ const (
 	// Sidecar image
 	SidecarImage = "bitnami/kubectl:latest"
 
+	// PlannerImageName is the image-name component of the published planner/profiler
+	// image. The profiler job must run from this image because the backend runtime
+	// images no longer carry planner/profiler Python dependencies (see DYN-2540).
+	// derivePlannerImage swaps spec.image's name component with this value while
+	// preserving the registry and tag.
+	PlannerImageName = "dynamo-planner"
+
 	// Volume names
 	VolumeNameProfilingOutput = "profiling-output"
 	VolumeNameProfilingConfig = "profiling-config"
@@ -1251,13 +1258,17 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 		// --output-dir must match ProfilingOutputPath so the sidecar can find profiler_status.yaml
 		profilerArgs := []string{"--config", specJSON, "--output-dir", ProfilingOutputPath}
 
-		// Use image from spec; the defaulting webhook fills this in for production builds.
+		// spec.image identifies the deployment's image family (frontend or backend
+		// runtime); the defaulting webhook fills it in for production builds. The
+		// profiler job itself must run from the planner/profiler image because the
+		// backend runtime images no longer carry planner deps (DYN-2540), so we derive
+		// the planner image from spec.image, preserving the registry and tag.
 		// Guard against empty image in case the webhook didn't run (e.g. local dev builds).
-		imageName := dgdr.Spec.Image
-		if imageName == "" {
+		if dgdr.Spec.Image == "" {
 			return nil, false, fmt.Errorf("spec.image is required but not set; ensure the defaulting webhook ran or set spec.image explicitly")
 		}
-		logger.Info("Using profiler image", "image", imageName)
+		imageName := derivePlannerImage(dgdr.Spec.Image)
+		logger.Info("Using profiler image", "image", imageName, "derivedFrom", dgdr.Spec.Image)
 
 		profilerContainer := corev1.Container{
 			Name:         ContainerNameProfiler,
@@ -1498,6 +1509,37 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 		hw.TotalGPUs = &total
 	}
 	return nil
+}
+
+// derivePlannerImage swaps the image-name component of ref for PlannerImageName,
+// preserving the registry path, tag, and digest. Mirrors the Python
+// dynamo.profiler.utils.profile_common.derive_planner_image helper so the profiler
+// job and the Planner service in the generated DGD share the same derivation rule.
+//
+// Examples:
+//
+//	"nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.3"
+//	  → "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.3"
+//	"nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0rc0"
+//	  → "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.0rc0"
+func derivePlannerImage(ref string) string {
+	prefix := ""
+	suffix := ref
+	if i := strings.LastIndex(ref, "/"); i >= 0 {
+		prefix = ref[:i+1]
+		suffix = ref[i+1:]
+	}
+	nameAndTag := suffix
+	digestSuffix := ""
+	if j := strings.Index(suffix, "@"); j >= 0 {
+		nameAndTag = suffix[:j]
+		digestSuffix = suffix[j:]
+	}
+	tag := ""
+	if k := strings.LastIndex(nameAndTag, ":"); k >= 0 {
+		tag = nameAndTag[k:]
+	}
+	return prefix + PlannerImageName + tag + digestSuffix
 }
 
 // extractModelCachePVCConfig reads model cache PVC settings from the typed v1beta1 spec.

--- a/deploy/operator/internal/controller/profiling_job_overrides_test.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides_test.go
@@ -81,6 +81,53 @@ func baseJob() *batchv1.Job {
 	}
 }
 
+func TestDerivePlannerImage(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "frontend image with tag",
+			in:   "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.3",
+			want: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.3",
+		},
+		{
+			name: "backend runtime image with tag (DYN-2733/2746 user input)",
+			in:   "nvcr.io/nvstaging/ai-dynamo/vllm-runtime:1.1.0rc0",
+			want: "nvcr.io/nvstaging/ai-dynamo/dynamo-planner:1.1.0rc0",
+		},
+		{
+			name: "image with digest only",
+			in:   "nvcr.io/nvidia/ai-dynamo/dynamo-frontend@sha256:deadbeef",
+			want: "nvcr.io/nvidia/ai-dynamo/dynamo-planner@sha256:deadbeef",
+		},
+		{
+			name: "image with tag and digest",
+			in:   "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.3@sha256:deadbeef",
+			want: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.3@sha256:deadbeef",
+		},
+		{
+			name: "image without registry path",
+			in:   "test-profiler:latest",
+			want: "dynamo-planner:latest",
+		},
+		{
+			name: "image without tag",
+			in:   "nvcr.io/nvidia/ai-dynamo/dynamo-frontend",
+			want: "nvcr.io/nvidia/ai-dynamo/dynamo-planner",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := derivePlannerImage(tc.in); got != tc.want {
+				t.Errorf("derivePlannerImage(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestApplyProfilingJobOverrides_NilOverrides(t *testing.T) {
 	job := baseJob()
 	original := job.Spec.BackoffLimit

--- a/deploy/operator/internal/controller/profiling_job_overrides_test.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides_test.go
@@ -81,53 +81,6 @@ func baseJob() *batchv1.Job {
 	}
 }
 
-func TestDerivePlannerImage(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{
-			name: "frontend image with tag",
-			in:   "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.3",
-			want: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.3",
-		},
-		{
-			name: "backend runtime image with tag (DYN-2733/2746 user input)",
-			in:   "nvcr.io/nvstaging/ai-dynamo/vllm-runtime:1.1.0rc0",
-			want: "nvcr.io/nvstaging/ai-dynamo/dynamo-planner:1.1.0rc0",
-		},
-		{
-			name: "image with digest only",
-			in:   "nvcr.io/nvidia/ai-dynamo/dynamo-frontend@sha256:deadbeef",
-			want: "nvcr.io/nvidia/ai-dynamo/dynamo-planner@sha256:deadbeef",
-		},
-		{
-			name: "image with tag and digest",
-			in:   "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.3@sha256:deadbeef",
-			want: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.3@sha256:deadbeef",
-		},
-		{
-			name: "image without registry path",
-			in:   "test-profiler:latest",
-			want: "dynamo-planner:latest",
-		},
-		{
-			name: "image without tag",
-			in:   "nvcr.io/nvidia/ai-dynamo/dynamo-frontend",
-			want: "nvcr.io/nvidia/ai-dynamo/dynamo-planner",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := derivePlannerImage(tc.in); got != tc.want {
-				t.Errorf("derivePlannerImage(%q) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
-	}
-}
-
 func TestApplyProfilingJobOverrides_NilOverrides(t *testing.T) {
 	job := baseJob()
 	original := job.Spec.BackoffLimit

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler.go
@@ -35,7 +35,13 @@ const (
 
 	// defaultImage is the default profiler image used when spec.image is not set.
 	// Default image derivation is only supported for public release versions (1.0.0+).
-	defaultImage = "nvcr.io/nvidia/ai-dynamo/dynamo-frontend"
+	//
+	// Starting with Dynamo 1.1.0, the profiler's runtime dependencies
+	// (kubernetes_asyncio, pmdarima, prophet, aiconfigurator, ...) ship only in the
+	// dedicated dynamo-planner image, so we default to that image here. Users who
+	// pin an earlier version may continue to override spec.image explicitly with
+	// the frontend image they were using before.
+	defaultImage = "nvcr.io/nvidia/ai-dynamo/dynamo-planner"
 )
 
 // DGDRDefaulter is a mutating webhook handler that fills in default values for
@@ -43,7 +49,7 @@ const (
 //
 // If spec.image is not set, it is derived as:
 //
-//	nvcr.io/nvidia/ai-dynamo/dynamo-frontend:<operatorVersion>
+//	nvcr.io/nvidia/ai-dynamo/dynamo-planner:<operatorVersion>
 //
 // Defaulting requires a known operator version and is only supported for
 // operator versions 1.0.0 and later.

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler_test.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestDGDRDefaulter_defaultImageFor(t *testing.T) {
+	// Note: the default planner image is only published starting from Dynamo 1.1.0,
+	// so these tests use 1.1.0 as the earliest known valid version.
 	tests := []struct {
 		name            string
 		operatorVersion string
@@ -35,13 +37,13 @@ func TestDGDRDefaulter_defaultImageFor(t *testing.T) {
 	}{
 		{
 			name:            "known version produces default image",
-			operatorVersion: "1.0.0",
-			expectedImage:   "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.0.0",
+			operatorVersion: "1.1.0",
+			expectedImage:   "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.0",
 		},
 		{
 			name:            "pre-release version is valid",
-			operatorVersion: "1.0.0-rc1",
-			expectedImage:   "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.0.0-rc1",
+			operatorVersion: "1.1.0-rc1",
+			expectedImage:   "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.0-rc1",
 		},
 		{
 			name:            "unknown operator version cannot be defaulted",
@@ -85,14 +87,14 @@ func TestDGDRDefaulter_Default(t *testing.T) {
 	}{
 		{
 			name:          "CREATE with empty image defaults to operator version",
-			version:       "1.0.0",
+			version:       "1.1.0",
 			operation:     admissionv1.Create,
 			initialImage:  "",
-			expectedImage: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.0.0",
+			expectedImage: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.0",
 		},
 		{
 			name:          "CREATE with preset image is not overwritten",
-			version:       "1.0.0",
+			version:       "1.1.0",
 			operation:     admissionv1.Create,
 			initialImage:  "my-registry/my-image:custom",
 			expectedImage: "my-registry/my-image:custom",
@@ -106,7 +108,7 @@ func TestDGDRDefaulter_Default(t *testing.T) {
 		},
 		{
 			name:          "UPDATE does not default image",
-			version:       "1.0.0",
+			version:       "1.1.0",
 			operation:     admissionv1.Update,
 			initialImage:  "",
 			expectedImage: "",

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler_test.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler_test.go
@@ -36,12 +36,12 @@ func TestDGDRDefaulter_defaultImageFor(t *testing.T) {
 		{
 			name:            "known version produces default image",
 			operatorVersion: "1.0.0",
-			expectedImage:   "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.0.0",
+			expectedImage:   "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.0.0",
 		},
 		{
 			name:            "pre-release version is valid",
 			operatorVersion: "1.0.0-rc1",
-			expectedImage:   "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.0.0-rc1",
+			expectedImage:   "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.0.0-rc1",
 		},
 		{
 			name:            "unknown operator version cannot be defaulted",
@@ -88,7 +88,7 @@ func TestDGDRDefaulter_Default(t *testing.T) {
 			version:       "1.0.0",
 			operation:     admissionv1.Create,
 			initialImage:  "",
-			expectedImage: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.0.0",
+			expectedImage: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.0.0",
 		},
 		{
 			name:          "CREATE with preset image is not overwritten",

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -80,8 +80,12 @@ spec:
   model: Qwen/Qwen3-0.6B
 
   # Container image for the profiling job — must match your installed platform version.
-  # This is the same dynamo-frontend image used by the deployed inference service.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:${RELEASE_VERSION}"
+  #   Dynamo >= 1.1.0: use the dedicated planner/profiler image (dynamo-planner).
+  #     Planner/profiler runtime deps (kubernetes_asyncio, pmdarima, prophet,
+  #     aiconfigurator, ...) ship only in this image; the frontend and backend
+  #     runtime images do not.
+  #   Dynamo <  1.1.0: use the dynamo-frontend image you deploy with.
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:${RELEASE_VERSION}"
 ```
 
 Apply it (uses `envsubst` to substitute the `RELEASE_VERSION` shell variable into the YAML):
@@ -95,7 +99,7 @@ envsubst < qwen3-first-model.yaml | kubectl apply -f - -n ${NAMESPACE}
 | Field | Required | Default | Purpose |
 |---|---|---|---|
 | `model` | Yes | — | HuggingFace model ID (e.g. `Qwen/Qwen3-0.6B`) |
-| `image` | No | — | Container image for the profiling job (`dynamo-frontend`) |
+| `image` | No | — | Container image for the profiling job. For Dynamo ≥ 1.1.0 this must be the `dynamo-planner` image; for earlier versions it is the `dynamo-frontend` image. |
 | `backend` | No | `auto` | Inference engine (`auto`, `vllm`, `sglang`, `trtllm`) |
 | `searchStrategy` | No | `rapid` | Profiling depth — `rapid` (~30s, AIC simulation) or `thorough` (2–4h, real GPUs) |
 | `autoApply` | No | `true` | Automatically create and start the deployment after profiling |

--- a/examples/backends/sglang/deploy/disagg_planner.yaml
+++ b/examples/backends/sglang/deploy/disagg_planner.yaml
@@ -62,8 +62,13 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          # Planner/profiler runtime deps (kubernetes_asyncio, pmdarima, prophet, aiconfigurator, ...)
-          # live in the dynamo-planner image, not the backend runtime image (DYN-2540).
+          # Planner image selection:
+          #   Dynamo >= 1.1.0: use the dedicated planner image
+          #     <registry>/dynamo-planner:<version>
+          #     (backend runtime images no longer ship planner runtime deps
+          #     such as kubernetes_asyncio, pmdarima, prophet, aiconfigurator).
+          #   Dynamo <  1.1.0: use the backend runtime image
+          #     <registry>/sglang-runtime:<version>.
           image: my-registry/dynamo-planner:my-tag
           command:
           - python3

--- a/examples/backends/sglang/deploy/disagg_planner.yaml
+++ b/examples/backends/sglang/deploy/disagg_planner.yaml
@@ -62,7 +62,9 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          # Planner/profiler runtime deps (kubernetes_asyncio, pmdarima, prophet, aiconfigurator, ...)
+          # live in the dynamo-planner image, not the backend runtime image (DYN-2540).
+          image: my-registry/dynamo-planner:my-tag
           command:
           - python3
           - -m

--- a/examples/backends/trtllm/deploy/disagg_planner.yaml
+++ b/examples/backends/trtllm/deploy/disagg_planner.yaml
@@ -79,7 +79,9 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          # Planner/profiler runtime deps (kubernetes_asyncio, pmdarima, prophet, aiconfigurator, ...)
+          # live in the dynamo-planner image, not the backend runtime image (DYN-2540).
+          image: my-registry/dynamo-planner:my-tag
           ports:
             - name: metrics
               containerPort: 9085

--- a/examples/backends/trtllm/deploy/disagg_planner.yaml
+++ b/examples/backends/trtllm/deploy/disagg_planner.yaml
@@ -79,8 +79,13 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          # Planner/profiler runtime deps (kubernetes_asyncio, pmdarima, prophet, aiconfigurator, ...)
-          # live in the dynamo-planner image, not the backend runtime image (DYN-2540).
+          # Planner image selection:
+          #   Dynamo >= 1.1.0: use the dedicated planner image
+          #     <registry>/dynamo-planner:<version>
+          #     (backend runtime images no longer ship planner runtime deps
+          #     such as kubernetes_asyncio, pmdarima, prophet, aiconfigurator).
+          #   Dynamo <  1.1.0: use the backend runtime image
+          #     <registry>/tensorrtllm-runtime:<version>.
           image: my-registry/dynamo-planner:my-tag
           ports:
             - name: metrics

--- a/examples/backends/vllm/deploy/disagg_planner.yaml
+++ b/examples/backends/vllm/deploy/disagg_planner.yaml
@@ -61,8 +61,13 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          # Planner/profiler runtime deps (kubernetes_asyncio, pmdarima, prophet, aiconfigurator, ...)
-          # live in the dynamo-planner image, not the backend runtime image (DYN-2540).
+          # Planner image selection:
+          #   Dynamo >= 1.1.0: use the dedicated planner image
+          #     nvcr.io/nvidia/ai-dynamo/dynamo-planner:<version>
+          #     (backend runtime images no longer ship planner runtime deps
+          #     such as kubernetes_asyncio, pmdarima, prophet, aiconfigurator).
+          #   Dynamo <  1.1.0: use the backend runtime image
+          #     nvcr.io/nvidia/ai-dynamo/vllm-runtime:<version>.
           image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:my-tag
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_planner.yaml
+++ b/examples/backends/vllm/deploy/disagg_planner.yaml
@@ -61,7 +61,9 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          # Planner/profiler runtime deps (kubernetes_asyncio, pmdarima, prophet, aiconfigurator, ...)
+          # live in the dynamo-planner image, not the backend runtime image (DYN-2540).
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:my-tag
           command:
           - python3
           - -m


### PR DESCRIPTION
## Summary

Fixes two QA-release bugs caused by PR #7748 (DYN-2540), which moved planner/profiler runtime dependencies (kubernetes_asyncio, pmdarima, prophet, aiconfigurator, ...) out of backend runtime images into the new standalone `dynamo-planner` image but did not update the consumers:

- **[DYN-2733](https://linear.app/nvidia/issue/DYN-2733)** — DGDR profiler Job fails with `ModuleNotFoundError: No module named 'kubernetes_asyncio'`. The controller ran `python -m dynamo.profiler` against `spec.image` (a backend runtime image), which no longer ships planner deps.
- **[DYN-2746](https://linear.app/nvidia/issue/DYN-2746)** — `disagg_planner.yaml` Planner pod fails with `ModuleNotFoundError: No module named 'pmdarima'`. The example still pinned the Planner service to the backend runtime image.

## Changes

- **Operator controller** (`dynamographdeploymentrequest_controller.go`): introduces `derivePlannerImage(ref)` which swaps the image-name component of `spec.image` for `dynamo-planner`, preserving the registry path, tag, and digest. The profiler Job container now uses this derived image. Mirrors the existing Python helper `dynamo.profiler.utils.profile_common.derive_planner_image`, so the profiler Job and the Planner service the profiler writes into the generated DGD share one derivation rule.
- **Examples** (`examples/backends/{vllm,sglang,trtllm}/deploy/disagg_planner.yaml`): point the `Planner` pod at `<registry>/dynamo-planner:<tag>` and add a short comment explaining why.
- **Tests**: adds `TestDerivePlannerImage` covering frontend/backend-style inputs, tag-only, digest-only, tag+digest, and the registry-less edge case.

## Test plan

- [x] `go build ./...` in `deploy/operator`
- [x] `go test -run 'TestDerivePlannerImage|TestApplyProfilingJobOverrides' ./internal/controller/...` — passes
- [x] `pytest components/src/dynamo/profiler/tests/unit/test_planner_image_selection.py` — 8/8 pass (the existing Python helper this mirrors)
- [ ] DGDR end-to-end on a cluster (requires `nvcr.io/.../dynamo-planner:<tag>` to be present in the target registry — QA should confirm the 1.1.0rc1 publish includes it)
- [ ] `kubectl apply -f examples/backends/vllm/deploy/disagg_planner.yaml` with `my-tag` → a valid planner tag

Note: Ginkgo suite (envtest) wasn't exercised here due to a missing `bin/k8s/1.29.0-linux-amd64/etcd` binary in the local setup; this is a pre-existing infra issue.

## Follow-up

Will cherry-pick to `release/1.1.0` once merged.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Planner component now uses a dedicated `dynamo-planner` container image instead of backend runtime images.
  * Example deployment configurations for sglang, TensorRT-LLM, and vLLM backends updated with new planner image references.
  * Enhanced logic for handling planner container image references during job creation.

* **Tests**
  * Added comprehensive unit tests for planner image reference derivation and transformation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->