### PR TITLE
fix(container): preserve file permissions in SGLang dev venv setup

### DIFF
--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -299,8 +299,9 @@ COPY --from=wheel_builder --chown=dynamo:0 --chmod=775 /workspace/.venv/bin/matu
 COPY --from=ghcr.io/astral-sh/uv:0.10.7 /uv /tmp/uv-binary
 RUN mkdir -p /opt/dynamo/venv && \
     python3 -m venv --system-site-packages /opt/dynamo/venv && \
-    cp -r --no-preserve=mode /usr/local/lib/python${PYTHON_VERSION}/dist-packages/* \
+    cp -r /usr/local/lib/python${PYTHON_VERSION}/dist-packages/* \
           /opt/dynamo/venv/lib/python${PYTHON_VERSION}/site-packages/ && \
+    chmod -R g+w /opt/dynamo/venv/lib/python${PYTHON_VERSION}/site-packages/ && \
     cp /tmp/uv-binary /opt/dynamo/venv/bin/uv && \
     chmod +x /opt/dynamo/venv/bin/uv && \
     pip install --ignore-installed maturin[patchelf]


### PR DESCRIPTION
#### Overview:
The `cp --no-preserve=mode` flag stripped execute bits from all files when copying system site-packages into the dev venv. This broke `imageio_ffmpeg`'s bundled `ffmpeg` binary (744 → 644), causing video generation to fail with "No ffmpeg exe could be found".

Replace with `cp -r` (preserves source permissions) followed by `chmod -R g+w` (adds group-write for OpenShift compatibility without affecting execute bits). 

#### Details:
- Fixes `ffmpeg` binary losing execute permission in SGLang dev container venv
- Root cause: `cp --no-preserve=mode` strips all permission bits; replaced with `cp -r` + `chmod -R g+w`
- Affects only dev/local-dev targets, not runtime

Failure when running diffusion models in dev container:
```
Traceback (most recent call last):
  File "<string>", line 5, in <module>
  File "imageio_ffmpeg/_utils.py", line 33, in get_ffmpeg_exe
    raise RuntimeError(
RuntimeError: No ffmpeg exe could be found.
  Install ffmpeg on your system, or set the
  IMAGEIO_FFMPEG_EXE environment variable.
```

Note: This issue is not seen in runtime container because the runtime flow involves doing `pip install --break-system-packages ...` with no venv copy step or `--no-preserve=mode` step.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved file permission handling in the development build process for Python package installation to ensure proper group access to the virtual environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->