### PR TITLE
docs(recipes): clarify Qwen3-235B DEEPGEMM requires Blackwell (SM100+)

### DIFF
--- a/recipes/qwen3-235b-a22b-fp8/README.md
+++ b/recipes/qwen3-235b-a22b-fp8/README.md
@@ -12,7 +12,7 @@ Production-ready deployments for **Qwen3-235B-A22B** (MoE model with 22B active 
 ## Prerequisites
 
 1. **Dynamo Platform installed** — See [Kubernetes Deployment Guide](../../docs/kubernetes/README.md)
-2. **GPU cluster** with H100/H200 GPUs (high memory recommended)
+2. **GPU cluster** with Blackwell GPUs (B100/B200; SM100+) — see [Hardware Requirements](#hardware-requirements)
 3. **HuggingFace token** with access to Qwen models
 
 ## Quick Start
@@ -62,12 +62,16 @@ curl http://localhost:8000/v1/chat/completions \
 
 ## Hardware Requirements
 
-This is a large MoE model requiring significant GPU resources:
+This recipe uses `moe_config.backend: DEEPGEMM`, which requires **Blackwell GPUs (SM100+, e.g. B100/B200)**.
+DeepGEMM's FP8 grouped-GEMM kernels are designed for SM100/SM103 only and will crash on Hopper (SM90).
+
+> **Note:** To run on Hopper (H100/H200), remove the `moe_config` block from the ConfigMaps in
+> `deploy.yaml`. This falls back to the default MoE backend at a modest throughput reduction.
 
 | Configuration | GPUs | Min GPU VRAM (Total) |
 |--------------|------|----------------------|
-| Aggregated | 16x H100/H200 | ~1.3TB |
-| Disaggregated | 16x H100/H200 | ~1.3TB |
+| Aggregated | 16x B100/B200 | ~1.3TB |
+| Disaggregated | 16x B100/B200 | ~1.3TB |
 
 ## Notes
 

--- a/recipes/qwen3-235b-a22b-fp8/README.md
+++ b/recipes/qwen3-235b-a22b-fp8/README.md
@@ -65,8 +65,8 @@ curl http://localhost:8000/v1/chat/completions \
 This recipe uses `moe_config.backend: DEEPGEMM`, which requires **Blackwell GPUs (SM100+, e.g. B100/B200)**.
 DeepGEMM's FP8 grouped-GEMM kernels are designed for SM100/SM103 only and will crash on Hopper (SM90).
 
-> **Note:** To run on Hopper (H100/H200), remove the `moe_config` block from the ConfigMaps in
-> `deploy.yaml`. This falls back to the default MoE backend at a modest throughput reduction.
+> **Note:** To run on Hopper (H100/H200, SM90), remove the `moe_config` block from the ConfigMaps in
+> `trtllm/agg/deploy.yaml` and `trtllm/disagg/deploy.yaml`. This falls back to the default MoE backend at a modest throughput reduction.
 
 | Configuration | GPUs | Min GPU VRAM (Total) |
 |--------------|------|----------------------|

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml
@@ -24,7 +24,7 @@ data:
       max_batch_size: 128
     disable_overlap_scheduler: false
     print_iter_log: false
-    # DEEPGEMM requires Blackwell (SM100+). Remove this block to run on Hopper (SM90).
+    # DEEPGEMM requires Blackwell (SM100+). Remove moe_config block to run on Hopper (SM90).
     moe_config:
       backend: DEEPGEMM
       max_num_tokens: 8192

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml
@@ -24,6 +24,7 @@ data:
       max_batch_size: 128
     disable_overlap_scheduler: false
     print_iter_log: false
+    # DEEPGEMM requires Blackwell (SM100+). Remove this block to run on Hopper (SM90).
     moe_config:
       backend: DEEPGEMM
       max_num_tokens: 8192

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/deploy.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/deploy.yaml
@@ -24,7 +24,7 @@ data:
       max_batch_size: 2
     disable_overlap_scheduler: true
     print_iter_log: false
-    # DEEPGEMM requires Blackwell (SM100+). Remove this block to run on Hopper (SM90).
+    # DEEPGEMM requires Blackwell (SM100+). Remove moe_config block to run on Hopper (SM90).
     moe_config:
       backend: DEEPGEMM
       max_num_tokens: 8192
@@ -53,7 +53,7 @@ data:
       max_batch_size: 512
     disable_overlap_scheduler: false
     print_iter_log: false
-    # DEEPGEMM requires Blackwell (SM100+). Remove this block to run on Hopper (SM90).
+    # DEEPGEMM requires Blackwell (SM100+). Remove moe_config block to run on Hopper (SM90).
     moe_config:
       backend: DEEPGEMM
       max_num_tokens: 8192

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/deploy.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/deploy.yaml
@@ -24,6 +24,7 @@ data:
       max_batch_size: 2
     disable_overlap_scheduler: true
     print_iter_log: false
+    # DEEPGEMM requires Blackwell (SM100+). Remove this block to run on Hopper (SM90).
     moe_config:
       backend: DEEPGEMM
       max_num_tokens: 8192
@@ -52,6 +53,7 @@ data:
       max_batch_size: 512
     disable_overlap_scheduler: false
     print_iter_log: false
+    # DEEPGEMM requires Blackwell (SM100+). Remove this block to run on Hopper (SM90).
     moe_config:
       backend: DEEPGEMM
       max_num_tokens: 8192


### PR DESCRIPTION
## Summary

- Update `recipes/qwen3-235b-a22b-fp8/README.md` hardware requirements from H100/H200 to B100/B200, and add a note explaining that `moe_config.backend: DEEPGEMM` requires Blackwell (SM100+)
- Add inline `# DEEPGEMM requires Blackwell (SM100+)` comment to `moe_config` blocks in both `trtllm/agg/deploy.yaml` and `trtllm/disagg/deploy.yaml`
- Include fallback instructions for running on Hopper (remove the `moe_config` block)

## Root cause (DIS-1780 / #8327)

`DeepGemmFusedMoE` in TRT-LLM has been SM100/SM103-only since it was introduced (PR #6486, Aug 2025). Its FP8 scale-factor producers emit `int32` (packed UE8M0) tensors; the SM90 kernel contract at `layout.hpp:49` requires `torch::kFloat`. The backend selector (`create_moe.get_moe_cls`) returns `DeepGemmFusedMoE` unconditionally for explicit `backend: DEEPGEMM` config, bypassing the SM90 guard, so the crash occurs at kernel dispatch rather than at startup.

Verified on 2× GH200 (SM90) with both `tensorrtllm-runtime:1.0.1` (TRT-LLM 1.3.0rc5.post1) and `tensorrtllm-runtime:1.1.0rc1-cuda13` (TRT-LLM 1.3.0rc11):
- `DeepGemmFusedMoE.can_implement(FP8_BLOCK_SCALES)` → `(False, 'requires SM100 or SM103, got SM90')` ✅
- `get_moe_cls('DEEPGEMM')` → `DeepGemmFusedMoE` despite guard (bypass confirmed) ✅
- CUTLASS fallback (moe_config removed) → `can_implement` = `(True, None)` on same SM90 node ✅

Closes #8327

## Test plan

- [ ] Review README hardware table and note are accurate
- [ ] Verify inline comments appear in both `agg/deploy.yaml` and `disagg/deploy.yaml` at the `moe_config` block
- [ ] Confirm recipe deploys correctly on Blackwell (B100/B200) with `moe_config.backend: DEEPGEMM`
- [ ] Confirm recipe deploys on Hopper (H100/H200) after removing the `moe_config` block (per the note)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated recipe documentation to target Blackwell GPUs (B100/B200) with clearer hardware requirements.
  * Added configuration guidance for running on Hopper GPUs, including necessary modifications and expected throughput impacts.
  * Updated GPU sizing recommendations to reflect Blackwell specifications while maintaining the same total VRAM requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->