### PR TITLE
test(serve): skip mm_agg_qwen2-audio-7b vLLM deployment on post-merge

### DIFF
--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -87,7 +87,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 marks=[
                     pytest.mark.skip(
                         reason="vLLM engine core init fails on amd64 post-merge. "
-                        "TODO(<LINEAR-ID>)"
+                        "OPS-4445"
                     ),
                     pytest.mark.post_merge,
                 ],

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -85,6 +85,10 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         topologies={
             "agg": TopologyConfig(
                 marks=[
+                    pytest.mark.skip(
+                        reason="vLLM engine core init fails on amd64 post-merge. "
+                        "TODO(<LINEAR-ID>)"
+                    ),
                     pytest.mark.post_merge,
                 ],
                 timeout_s=600,


### PR DESCRIPTION
## Summary

`test_serve_deployment[mm_agg_qwen2-audio-7b]` has failed on every `vllm / Test cuda12.9 (amd64)` and `vllm / Test cuda13.0 (amd64)` post-merge run this cycle. Re-adds a `pytest.mark.skip` on the `TopologyConfig` for the Qwen2-Audio-7B agg profile in `tests/serve/multimodal_profiles/vllm.py`.

Example failing runs (all amd64 jobs in the same GitHub Actions run on main):
- [24685348314](https://github.com/ai-dynamo/dynamo/actions/runs/24685348314/job/72193276317) — cuda13.0
- [24683926404](https://github.com/ai-dynamo/dynamo/actions/runs/24683926404) — cuda12.9 + cuda13.0
- [24683166462](https://github.com/ai-dynamo/dynamo/actions/runs/24683166462) — both
- [24682173455](https://github.com/ai-dynamo/dynamo/actions/runs/24682173455) — both
- [24680832233](https://github.com/ai-dynamo/dynamo/actions/runs/24680832233) — both
- [24680530215](https://github.com/ai-dynamo/dynamo/actions/runs/24680530215) — both

Failure signature: the vLLM worker never becomes healthy on `http://localhost:8093/v1/models`; after ~100s of retries the main server dies with exit code -15 and the `bash.log` tail shows:
```
RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
  at vllm/v1/engine/utils.py:1057 wait_for_engine_startup
  at vllm/v1/engine/utils.py:998 launch_core_engines
  at vllm/v1/engine/core_client.py:535 __init__
```

So this is **not** a flaky/timing issue — it's a deterministic vLLM engine startup failure specifically for `Qwen/Qwen2-Audio-7B-Instruct` on amd64. Only this parameter combination fails; `qwen3-vl-2b`, `qwen3-vl-2b-video`, and `qwen2.5-vl-7b` all pass in the same job.

## Prior history

- #8006 previously skipped this exact parameter under Linear **DYN-2604** ("persistent nightly CI failures").
- #7964 ("fix(ci): multimodal vLLM nightly — predownload, audio KV, 7B toolcalling", DYN-2569) removed the skip and added `extra_vllm_args=["--max-model-len", "7232"]` as part of the fix. Since then, the test has been consistently failing again on amd64 post-merge.

So this may be a regression of DYN-2604 or a new symptom — please confirm when filing the ticket and reference the appropriate one. **@knarangN (Kavita Narang)** is the last author on the Qwen2-Audio block and owned the re-enable in #7964 — suggested owner for the follow-up investigation.

## Test plan
- [ ] Post-merge `vllm / Test cuda12.9 (amd64)` and `vllm / Test cuda13.0 (amd64)` pass with the skip in place
- [ ] Swap `<LINEAR-ID>` placeholder (in `tests/serve/multimodal_profiles/vllm.py`) for the real Linear ticket ID before merge
- [ ] Assign @knarangN to the Linear ticket to root-cause the engine core init failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added skip marker for Qwen2-Audio-7B-Instruct model's distributed topology test due to vLLM engine initialization issues on AMD64 architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->