### PR TITLE
feat: add worker-pool saturation metrics

### DIFF
--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -423,12 +423,14 @@ class work_handler:
     NETWORK_TRANSIT_SECONDS = "network_transit_seconds"
     # Backend processing: handle_payload entry to first response sent
     TIME_TO_FIRST_RESPONSE_SECONDS = "time_to_first_response_seconds"
-    # Current items in the bounded work queue awaiting a worker (gauge)
+    # Current items in the bounded work queue awaiting dispatcher pickup (gauge)
     QUEUE_DEPTH = "queue_depth"
     # Configured capacity of the bounded work queue (gauge, static)
     QUEUE_CAPACITY = "queue_capacity"
-    # Total times queueing failed because the work queue was full or closed
-    QUEUE_FULL_TOTAL = "queue_full_total"
+    # Total times enqueuing work failed because the dispatcher channel was closed.
+    # tokio bounded mpsc applies backpressure on full — saturation shows up as
+    # rising QUEUE_DEPTH toward QUEUE_CAPACITY.
+    ENQUEUE_REJECTED_TOTAL = "enqueue_rejected_total"
     # Time spent waiting to acquire a worker-pool permit (histogram)
     PERMIT_WAIT_SECONDS = "permit_wait_seconds"
     # Current number of active worker-pool tasks holding a permit (gauge)

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -423,5 +423,17 @@ class work_handler:
     NETWORK_TRANSIT_SECONDS = "network_transit_seconds"
     # Backend processing: handle_payload entry to first response sent
     TIME_TO_FIRST_RESPONSE_SECONDS = "time_to_first_response_seconds"
+    # Current items in the bounded work queue awaiting a worker (gauge)
+    QUEUE_DEPTH = "queue_depth"
+    # Configured capacity of the bounded work queue (gauge, static)
+    QUEUE_CAPACITY = "queue_capacity"
+    # Total times queueing failed because the work queue was full or closed
+    QUEUE_FULL_TOTAL = "queue_full_total"
+    # Time spent waiting to acquire a worker-pool permit (histogram)
+    PERMIT_WAIT_SECONDS = "permit_wait_seconds"
+    # Current number of active worker-pool tasks holding a permit (gauge)
+    POOL_ACTIVE_TASKS = "pool_active_tasks"
+    # Configured worker-pool size / total permits (gauge, static)
+    POOL_CAPACITY = "pool_capacity"
     # Label name for error type classification
     ERROR_TYPE_LABEL = "error_type"

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -12,6 +12,7 @@ pub mod request_plane;
 pub mod tokio_perf;
 pub mod transport_metrics;
 pub mod work_handler_perf;
+pub mod work_handler_pool;
 
 use parking_lot::Mutex;
 use std::collections::HashSet;

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -376,6 +376,24 @@ pub mod work_handler {
     /// Backend processing: handle_payload entry to first response sent
     pub const TIME_TO_FIRST_RESPONSE_SECONDS: &str = "time_to_first_response_seconds";
 
+    /// Current items in the bounded work queue awaiting a worker (gauge)
+    pub const QUEUE_DEPTH: &str = "queue_depth";
+
+    /// Configured capacity of the bounded work queue (gauge, static)
+    pub const QUEUE_CAPACITY: &str = "queue_capacity";
+
+    /// Total times queueing failed because the work queue was full or closed
+    pub const QUEUE_FULL_TOTAL: &str = "queue_full_total";
+
+    /// Time spent waiting to acquire a worker-pool permit (histogram)
+    pub const PERMIT_WAIT_SECONDS: &str = "permit_wait_seconds";
+
+    /// Current number of active worker-pool tasks holding a permit (gauge)
+    pub const POOL_ACTIVE_TASKS: &str = "pool_active_tasks";
+
+    /// Configured worker-pool size / total permits (gauge, static)
+    pub const POOL_CAPACITY: &str = "pool_capacity";
+
     /// Label name for error type classification
     pub const ERROR_TYPE_LABEL: &str = "error_type";
 

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -376,14 +376,16 @@ pub mod work_handler {
     /// Backend processing: handle_payload entry to first response sent
     pub const TIME_TO_FIRST_RESPONSE_SECONDS: &str = "time_to_first_response_seconds";
 
-    /// Current items in the bounded work queue awaiting a worker (gauge)
+    /// Current items in the bounded work queue awaiting dispatcher pickup (gauge)
     pub const QUEUE_DEPTH: &str = "queue_depth";
 
     /// Configured capacity of the bounded work queue (gauge, static)
     pub const QUEUE_CAPACITY: &str = "queue_capacity";
 
-    /// Total times queueing failed because the work queue was full or closed
-    pub const QUEUE_FULL_TOTAL: &str = "queue_full_total";
+    /// Total times enqueuing work failed because the dispatcher channel was closed.
+    /// Note: tokio bounded mpsc applies backpressure on full — it does NOT increment
+    /// this counter. Saturation shows up as rising `QUEUE_DEPTH` toward `QUEUE_CAPACITY`.
+    pub const ENQUEUE_REJECTED_TOTAL: &str = "enqueue_rejected_total";
 
     /// Time spent waiting to acquire a worker-pool permit (histogram)
     pub const PERMIT_WAIT_SECONDS: &str = "permit_wait_seconds";

--- a/lib/runtime/src/metrics/work_handler_pool.rs
+++ b/lib/runtime/src/metrics/work_handler_pool.rs
@@ -18,13 +18,14 @@ fn work_handler_metric_name(suffix: &str) -> String {
     format!("{}_{}", name_prefix::WORK_HANDLER, suffix)
 }
 
-/// Current items sitting in the bounded work queue awaiting a worker. Incremented
-/// on successful `work_tx.send()` and decremented when the dispatcher hands the
-/// item to `handle_work_item`. Combines channel queueing and permit-acquire wait.
+/// Current items sitting in the bounded mpsc work queue awaiting dispatcher
+/// pickup. Incremented on successful `work_tx.send()` and decremented immediately
+/// after `work_rx.recv()`. Permit-acquire wait is NOT counted here — see
+/// `WORK_HANDLER_PERMIT_WAIT_SECONDS`.
 pub static WORK_HANDLER_QUEUE_DEPTH: Lazy<IntGauge> = Lazy::new(|| {
     IntGauge::new(
         work_handler_metric_name(work_handler::QUEUE_DEPTH),
-        "Current items in the bounded work queue awaiting a worker",
+        "Current items in the bounded work queue awaiting dispatcher pickup",
     )
     .expect("work_handler_queue_depth gauge")
 });
@@ -38,14 +39,15 @@ pub static WORK_HANDLER_QUEUE_CAPACITY: Lazy<IntGauge> = Lazy::new(|| {
     .expect("work_handler_queue_capacity gauge")
 });
 
-/// Total times `work_tx.send()` failed because the queue was full or the
-/// dispatcher channel was closed.
-pub static WORK_HANDLER_QUEUE_FULL_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+/// Total times `work_tx.send().await` returned an error, which for tokio's
+/// bounded mpsc only happens when the receiver (dispatcher task) is gone — the
+/// channel applies backpressure on "full" rather than returning an error.
+pub static WORK_HANDLER_ENQUEUE_REJECTED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
     IntCounter::new(
-        work_handler_metric_name(work_handler::QUEUE_FULL_TOTAL),
-        "Times a request was rejected because the work queue was saturated or closed",
+        work_handler_metric_name(work_handler::ENQUEUE_REJECTED_TOTAL),
+        "Times enqueuing work failed because the dispatcher channel was closed",
     )
-    .expect("work_handler_queue_full_total counter")
+    .expect("work_handler_enqueue_rejected_total counter")
 });
 
 /// Time spent waiting to acquire a worker-pool permit. Normal operation is
@@ -99,8 +101,8 @@ pub fn ensure_work_handler_pool_metrics_registered(registry: &MetricsRegistry) {
             "work_handler_queue_capacity",
         );
         registry.add_metric_or_warn(
-            Box::new(WORK_HANDLER_QUEUE_FULL_TOTAL.clone()),
-            "work_handler_queue_full_total",
+            Box::new(WORK_HANDLER_ENQUEUE_REJECTED_TOTAL.clone()),
+            "work_handler_enqueue_rejected_total",
         );
         registry.add_metric_or_warn(
             Box::new(WORK_HANDLER_PERMIT_WAIT_SECONDS.clone()),
@@ -126,7 +128,7 @@ pub fn ensure_work_handler_pool_metrics_registered_prometheus(
             (|| -> Result<(), prometheus::Error> {
                 registry.register(Box::new(WORK_HANDLER_QUEUE_DEPTH.clone()))?;
                 registry.register(Box::new(WORK_HANDLER_QUEUE_CAPACITY.clone()))?;
-                registry.register(Box::new(WORK_HANDLER_QUEUE_FULL_TOTAL.clone()))?;
+                registry.register(Box::new(WORK_HANDLER_ENQUEUE_REJECTED_TOTAL.clone()))?;
                 registry.register(Box::new(WORK_HANDLER_PERMIT_WAIT_SECONDS.clone()))?;
                 registry.register(Box::new(WORK_HANDLER_POOL_ACTIVE_TASKS.clone()))?;
                 registry.register(Box::new(WORK_HANDLER_POOL_CAPACITY.clone()))?;

--- a/lib/runtime/src/metrics/work_handler_pool.rs
+++ b/lib/runtime/src/metrics/work_handler_pool.rs
@@ -84,9 +84,6 @@ pub static WORK_HANDLER_POOL_CAPACITY: Lazy<IntGauge> = Lazy::new(|| {
 /// Guards idempotency for the `MetricsRegistry` registration path.
 static METRICS_REGISTERED: OnceCell<()> = OnceCell::new();
 
-/// Guards idempotency for the raw `prometheus::Registry` registration path.
-static PROMETHEUS_REGISTERED: OnceCell<Result<(), String>> = OnceCell::new();
-
 /// Register worker-pool saturation metrics with the given registry. Idempotent.
 pub fn ensure_work_handler_pool_metrics_registered(registry: &MetricsRegistry) {
     let _ = METRICS_REGISTERED.get_or_init(|| {
@@ -115,26 +112,4 @@ pub fn ensure_work_handler_pool_metrics_registered(registry: &MetricsRegistry) {
             "work_handler_pool_capacity",
         );
     });
-}
-
-/// Register worker-pool saturation metrics with a raw Prometheus registry. Idempotent.
-pub fn ensure_work_handler_pool_metrics_registered_prometheus(
-    registry: &prometheus::Registry,
-) -> Result<(), prometheus::Error> {
-    PROMETHEUS_REGISTERED
-        .get_or_init(|| {
-            (|| -> Result<(), prometheus::Error> {
-                registry.register(Box::new(WORK_HANDLER_QUEUE_DEPTH.clone()))?;
-                registry.register(Box::new(WORK_HANDLER_QUEUE_CAPACITY.clone()))?;
-                registry.register(Box::new(WORK_HANDLER_ENQUEUE_REJECTED_TOTAL.clone()))?;
-                registry.register(Box::new(WORK_HANDLER_PERMIT_WAIT_SECONDS.clone()))?;
-                registry.register(Box::new(WORK_HANDLER_POOL_ACTIVE_TASKS.clone()))?;
-                registry.register(Box::new(WORK_HANDLER_POOL_CAPACITY.clone()))?;
-                Ok(())
-            })()
-            .map_err(|e| e.to_string())
-        })
-        .as_ref()
-        .map(|_| ())
-        .map_err(|e| prometheus::Error::Msg(e.clone()))
 }

--- a/lib/runtime/src/metrics/work_handler_pool.rs
+++ b/lib/runtime/src/metrics/work_handler_pool.rs
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Worker-pool saturation metrics for the shared TCP server (backend side).
+//!
+//! These metrics make the 250K-concurrency failure mode visible: queue buildup
+//! between `work_tx.send()` and dispatcher pickup, and permit starvation in the
+//! bounded worker pool. See `docs/proposals/observability-gaps-250k-postmortem.md`
+//! (Gaps 1 and 3) for the incident context.
+
+use once_cell::sync::{Lazy, OnceCell};
+use prometheus::{Histogram, HistogramOpts, IntCounter, IntGauge};
+
+use super::prometheus_names::{name_prefix, work_handler};
+use crate::MetricsRegistry;
+
+fn work_handler_metric_name(suffix: &str) -> String {
+    format!("{}_{}", name_prefix::WORK_HANDLER, suffix)
+}
+
+/// Current items sitting in the bounded work queue awaiting a worker. Incremented
+/// on successful `work_tx.send()` and decremented when the dispatcher hands the
+/// item to `handle_work_item`. Combines channel queueing and permit-acquire wait.
+pub static WORK_HANDLER_QUEUE_DEPTH: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::new(
+        work_handler_metric_name(work_handler::QUEUE_DEPTH),
+        "Current items in the bounded work queue awaiting a worker",
+    )
+    .expect("work_handler_queue_depth gauge")
+});
+
+/// Configured capacity of the bounded work queue. Static; set once at server init.
+pub static WORK_HANDLER_QUEUE_CAPACITY: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::new(
+        work_handler_metric_name(work_handler::QUEUE_CAPACITY),
+        "Configured capacity of the bounded work queue",
+    )
+    .expect("work_handler_queue_capacity gauge")
+});
+
+/// Total times `work_tx.send()` failed because the queue was full or the
+/// dispatcher channel was closed.
+pub static WORK_HANDLER_QUEUE_FULL_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    IntCounter::new(
+        work_handler_metric_name(work_handler::QUEUE_FULL_TOTAL),
+        "Times a request was rejected because the work queue was saturated or closed",
+    )
+    .expect("work_handler_queue_full_total counter")
+});
+
+/// Time spent waiting to acquire a worker-pool permit. Normal operation is
+/// sub-millisecond; saturation pushes p99 into seconds.
+pub static WORK_HANDLER_PERMIT_WAIT_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            work_handler_metric_name(work_handler::PERMIT_WAIT_SECONDS),
+            "Time spent waiting for a worker-pool permit (seconds)",
+        )
+        .buckets(vec![
+            0.0001, 0.001, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0,
+        ]),
+    )
+    .expect("work_handler_permit_wait_seconds histogram")
+});
+
+/// Current number of active worker-pool tasks (permits in use).
+pub static WORK_HANDLER_POOL_ACTIVE_TASKS: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::new(
+        work_handler_metric_name(work_handler::POOL_ACTIVE_TASKS),
+        "Current number of active worker-pool tasks (permits in use)",
+    )
+    .expect("work_handler_pool_active_tasks gauge")
+});
+
+/// Configured worker-pool capacity (total permits). Static; set once at server init.
+pub static WORK_HANDLER_POOL_CAPACITY: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::new(
+        work_handler_metric_name(work_handler::POOL_CAPACITY),
+        "Configured worker-pool capacity (total permits)",
+    )
+    .expect("work_handler_pool_capacity gauge")
+});
+
+/// Guards idempotency for the `MetricsRegistry` registration path.
+static METRICS_REGISTERED: OnceCell<()> = OnceCell::new();
+
+/// Guards idempotency for the raw `prometheus::Registry` registration path.
+static PROMETHEUS_REGISTERED: OnceCell<Result<(), String>> = OnceCell::new();
+
+/// Register worker-pool saturation metrics with the given registry. Idempotent.
+pub fn ensure_work_handler_pool_metrics_registered(registry: &MetricsRegistry) {
+    let _ = METRICS_REGISTERED.get_or_init(|| {
+        registry.add_metric_or_warn(
+            Box::new(WORK_HANDLER_QUEUE_DEPTH.clone()),
+            "work_handler_queue_depth",
+        );
+        registry.add_metric_or_warn(
+            Box::new(WORK_HANDLER_QUEUE_CAPACITY.clone()),
+            "work_handler_queue_capacity",
+        );
+        registry.add_metric_or_warn(
+            Box::new(WORK_HANDLER_QUEUE_FULL_TOTAL.clone()),
+            "work_handler_queue_full_total",
+        );
+        registry.add_metric_or_warn(
+            Box::new(WORK_HANDLER_PERMIT_WAIT_SECONDS.clone()),
+            "work_handler_permit_wait_seconds",
+        );
+        registry.add_metric_or_warn(
+            Box::new(WORK_HANDLER_POOL_ACTIVE_TASKS.clone()),
+            "work_handler_pool_active_tasks",
+        );
+        registry.add_metric_or_warn(
+            Box::new(WORK_HANDLER_POOL_CAPACITY.clone()),
+            "work_handler_pool_capacity",
+        );
+    });
+}
+
+/// Register worker-pool saturation metrics with a raw Prometheus registry. Idempotent.
+pub fn ensure_work_handler_pool_metrics_registered_prometheus(
+    registry: &prometheus::Registry,
+) -> Result<(), prometheus::Error> {
+    PROMETHEUS_REGISTERED
+        .get_or_init(|| {
+            (|| -> Result<(), prometheus::Error> {
+                registry.register(Box::new(WORK_HANDLER_QUEUE_DEPTH.clone()))?;
+                registry.register(Box::new(WORK_HANDLER_QUEUE_CAPACITY.clone()))?;
+                registry.register(Box::new(WORK_HANDLER_QUEUE_FULL_TOTAL.clone()))?;
+                registry.register(Box::new(WORK_HANDLER_PERMIT_WAIT_SECONDS.clone()))?;
+                registry.register(Box::new(WORK_HANDLER_POOL_ACTIVE_TASKS.clone()))?;
+                registry.register(Box::new(WORK_HANDLER_POOL_CAPACITY.clone()))?;
+                Ok(())
+            })()
+            .map_err(|e| e.to_string())
+        })
+        .as_ref()
+        .map(|_| ())
+        .map_err(|e| prometheus::Error::Msg(e.clone()))
+}

--- a/lib/runtime/src/metrics/work_handler_pool.rs
+++ b/lib/runtime/src/metrics/work_handler_pool.rs
@@ -3,10 +3,8 @@
 
 //! Worker-pool saturation metrics for the shared TCP server (backend side).
 //!
-//! These metrics make the 250K-concurrency failure mode visible: queue buildup
-//! between `work_tx.send()` and dispatcher pickup, and permit starvation in the
-//! bounded worker pool. See `docs/proposals/observability-gaps-250k-postmortem.md`
-//! (Gaps 1 and 3) for the incident context.
+//! These metrics expose queue buildup between `work_tx.send()` and dispatcher
+//! pickup, and permit starvation in the bounded worker pool.
 
 use once_cell::sync::{Lazy, OnceCell};
 use prometheus::{Histogram, HistogramOpts, IntCounter, IntGauge};

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -320,6 +320,13 @@ impl<Req: PipelineIO + Sync, Resp: PipelineIO> Ingress<Req, Resp> {
             endpoint.get_metrics_registry(),
         );
 
+        // Register worker-pool saturation metrics (idempotent). These are
+        // process-global and shared across all endpoints attached to the
+        // same shared TCP server.
+        crate::metrics::work_handler_pool::ensure_work_handler_pool_metrics_registered(
+            endpoint.get_metrics_registry(),
+        );
+
         self.metrics
             .set(Arc::new(metrics))
             .map_err(|_| anyhow::anyhow!("Metrics already set"))

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -186,13 +186,14 @@ impl SharedTcpServer {
                         WORK_HANDLER_PERMIT_WAIT_SECONDS
                             .observe(permit_wait_start.elapsed().as_secs_f64());
 
-                        // Spawn task with owned permit (dropped when task completes)
+                        // Increment before spawn so the gauge is never observed negative
+                        // if the spawned task completes on another worker before we return.
+                        WORK_HANDLER_POOL_ACTIVE_TASKS.inc();
                         tokio::spawn(async move {
                             Self::handle_work_item(work_item).await;
                             drop(permit);
                             WORK_HANDLER_POOL_ACTIVE_TASKS.dec();
                         });
-                        WORK_HANDLER_POOL_ACTIVE_TASKS.inc();
                     }
                 }
             }

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -8,8 +8,9 @@
 
 use crate::SystemHealth;
 use crate::metrics::work_handler_pool::{
-    WORK_HANDLER_PERMIT_WAIT_SECONDS, WORK_HANDLER_POOL_ACTIVE_TASKS, WORK_HANDLER_POOL_CAPACITY,
-    WORK_HANDLER_QUEUE_CAPACITY, WORK_HANDLER_QUEUE_DEPTH, WORK_HANDLER_QUEUE_FULL_TOTAL,
+    WORK_HANDLER_ENQUEUE_REJECTED_TOTAL, WORK_HANDLER_PERMIT_WAIT_SECONDS,
+    WORK_HANDLER_POOL_ACTIVE_TASKS, WORK_HANDLER_POOL_CAPACITY, WORK_HANDLER_QUEUE_CAPACITY,
+    WORK_HANDLER_QUEUE_DEPTH,
 };
 use crate::pipeline::network::PushWorkHandler;
 use anyhow::Result;
@@ -166,6 +167,10 @@ impl SharedTcpServer {
                             tracing::trace!("TCP worker dispatcher shutting down: channel closed");
                             break;
                         };
+                        // Item is out of the mpsc channel — drop queue_depth now so the
+                        // gauge strictly reflects channel occupancy. Permit-acquire wait is
+                        // tracked separately by WORK_HANDLER_PERMIT_WAIT_SECONDS.
+                        WORK_HANDLER_QUEUE_DEPTH.dec();
 
                         // Acquire permit before spawning (bounds concurrency). Time the wait so
                         // pool starvation (permit exhaustion) shows up as rising p99 in
@@ -175,9 +180,6 @@ impl SharedTcpServer {
                             Ok(p) => p,
                             Err(_) => {
                                 tracing::trace!("TCP worker dispatcher: semaphore closed");
-                                // Drain queue-depth accounting for the item we just popped but
-                                // won't process.
-                                WORK_HANDLER_QUEUE_DEPTH.dec();
                                 break;
                             }
                         };
@@ -206,11 +208,6 @@ impl SharedTcpServer {
 
     /// Handle a single work item
     async fn handle_work_item(work_item: WorkItem) {
-        // The item is now leaving the "waiting" state (channel queue + permit acquire)
-        // and entering the "running" state (pool_active_tasks was incremented by the
-        // dispatcher before spawning).
-        WORK_HANDLER_QUEUE_DEPTH.dec();
-
         tracing::trace!(
             instance_id = work_item.instance_id,
             "TCP worker processing request"
@@ -557,7 +554,7 @@ impl SharedTcpServer {
                 }
                 Err(e) => {
                     WORK_HANDLER_QUEUE_DEPTH.dec();
-                    WORK_HANDLER_QUEUE_FULL_TOTAL.inc();
+                    WORK_HANDLER_ENQUEUE_REJECTED_TOTAL.inc();
                     tracing::warn!(
                         endpoint = handler.endpoint_name.as_str(),
                         instance_id = handler.instance_id,

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -62,6 +62,27 @@ fn get_work_queue_size() -> usize {
         .unwrap_or(DEFAULT_WORK_QUEUE_SIZE)
 }
 
+/// RAII guard for `WORK_HANDLER_POOL_ACTIVE_TASKS`. `new()` increments and
+/// `Drop` decrements, so a single owner expresses the "task is active" interval.
+/// Constructed in the dispatcher *before* `tokio::spawn` and moved into the
+/// future, the gauge is incremented before any worker thread can poll the task,
+/// and the decrement runs on every exit path — normal return, panic, or
+/// cancellation.
+struct ActiveTaskGuard;
+
+impl ActiveTaskGuard {
+    fn new() -> Self {
+        WORK_HANDLER_POOL_ACTIVE_TASKS.inc();
+        Self
+    }
+}
+
+impl Drop for ActiveTaskGuard {
+    fn drop(&mut self) {
+        WORK_HANDLER_POOL_ACTIVE_TASKS.dec();
+    }
+}
+
 /// Work item for the worker pool
 struct WorkItem {
     service_handler: Arc<dyn PushWorkHandler>,
@@ -186,13 +207,16 @@ impl SharedTcpServer {
                         WORK_HANDLER_PERMIT_WAIT_SECONDS
                             .observe(permit_wait_start.elapsed().as_secs_f64());
 
-                        // Increment before spawn so the gauge is never observed negative
-                        // if the spawned task completes on another worker before we return.
-                        WORK_HANDLER_POOL_ACTIVE_TASKS.inc();
+                        // Construct the guard before spawn (inc runs synchronously
+                        // here, so the gauge is never observed negative even if
+                        // the future completes on another worker first), then
+                        // move ownership into the future — Drop handles dec on
+                        // every exit path.
+                        let active_guard = ActiveTaskGuard::new();
                         tokio::spawn(async move {
+                            let _active_guard = active_guard;
                             Self::handle_work_item(work_item).await;
                             drop(permit);
-                            WORK_HANDLER_POOL_ACTIVE_TASKS.dec();
                         });
                     }
                 }
@@ -528,13 +552,19 @@ impl SharedTcpServer {
                 endpoint_name: handler.endpoint_name.clone(),
             };
 
-            // Send to worker pool with backpressure - BEFORE sending ACK.
-            // Increment the queue-depth gauge BEFORE send so a concurrent dispatcher
-            // pickup on another thread cannot observe depth < 0. On send failure we
-            // decrement below.
-            WORK_HANDLER_QUEUE_DEPTH.inc();
-            match work_tx.send(work_item).await {
-                Ok(_) => {
+            // Reserve a slot in the bounded channel BEFORE incrementing the
+            // queue-depth gauge. Senders parked in `send().await` waiting for
+            // capacity would otherwise count as queue occupancy, letting the
+            // gauge exceed `queue_capacity` under saturation — exactly the
+            // regime this metric exists to surface. `reserve()` waits for
+            // capacity, then `Permit::send` is non-blocking and infallible,
+            // providing the same happens-before edge to the dispatcher's
+            // `recv()` as `send().await` did.
+            match work_tx.reserve().await {
+                Ok(permit) => {
+                    WORK_HANDLER_QUEUE_DEPTH.inc();
+                    permit.send(work_item);
+
                     // Send acknowledgment ONLY after successful queuing
                     let ack_response = TcpResponseMessage::empty();
                     if let Ok(encoded_ack) = ack_response.encode()
@@ -554,13 +584,15 @@ impl SharedTcpServer {
                     );
                 }
                 Err(e) => {
-                    WORK_HANDLER_QUEUE_DEPTH.dec();
+                    // `reserve()` only errors when the receiver has been
+                    // dropped (channel closed) — the dispatcher is gone, so
+                    // the read loop must terminate.
                     WORK_HANDLER_ENQUEUE_REJECTED_TOTAL.inc();
                     tracing::warn!(
                         endpoint = handler.endpoint_name.as_str(),
                         instance_id = handler.instance_id,
                         error = %e,
-                        "Failed to queue work to worker pool, sending error response"
+                        "Failed to reserve worker pool slot, sending error response"
                     );
 
                     // Send error response to client instead of ACK
@@ -574,11 +606,8 @@ impl SharedTcpServer {
                     handler.inflight.fetch_sub(1, Ordering::SeqCst);
                     handler.notify.notify_one();
 
-                    // If channel is closed, break the loop
-                    if matches!(e, tokio::sync::mpsc::error::SendError(_)) {
-                        tracing::error!("Worker pool channel closed, shutting down read loop");
-                        break;
-                    }
+                    tracing::error!("Worker pool channel closed, shutting down read loop");
+                    break;
                 }
             }
         }

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -7,6 +7,10 @@
 //! by adding endpoint routing to the TCP wire protocol.
 
 use crate::SystemHealth;
+use crate::metrics::work_handler_pool::{
+    WORK_HANDLER_PERMIT_WAIT_SECONDS, WORK_HANDLER_POOL_ACTIVE_TASKS, WORK_HANDLER_POOL_CAPACITY,
+    WORK_HANDLER_QUEUE_CAPACITY, WORK_HANDLER_QUEUE_DEPTH, WORK_HANDLER_QUEUE_FULL_TOTAL,
+};
 use crate::pipeline::network::PushWorkHandler;
 use anyhow::Result;
 use bytes::Bytes;
@@ -15,6 +19,7 @@ use parking_lot::{Mutex, RwLock};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Notify;
@@ -103,6 +108,16 @@ impl SharedTcpServer {
             work_queue_size
         );
 
+        // Publish static capacities so dashboards can compute saturation ratios.
+        // These gauges are process-global and harmless to re-set if multiple TCP
+        // servers are spun up in the same process (tests).
+        WORK_HANDLER_POOL_CAPACITY.set(crate::metrics::prometheus_names::clamp_u64_to_i64(
+            worker_pool_size as u64,
+        ));
+        WORK_HANDLER_QUEUE_CAPACITY.set(crate::metrics::prometheus_names::clamp_u64_to_i64(
+            work_queue_size as u64,
+        ));
+
         // Create bounded channel for work items
         let (work_tx, work_rx) = tokio::sync::mpsc::channel(work_queue_size);
 
@@ -152,20 +167,30 @@ impl SharedTcpServer {
                             break;
                         };
 
-                        // Acquire permit before spawning (bounds concurrency)
+                        // Acquire permit before spawning (bounds concurrency). Time the wait so
+                        // pool starvation (permit exhaustion) shows up as rising p99 in
+                        // `dynamo_work_handler_permit_wait_seconds`.
+                        let permit_wait_start = Instant::now();
                         let permit = match semaphore.clone().acquire_owned().await {
                             Ok(p) => p,
                             Err(_) => {
                                 tracing::trace!("TCP worker dispatcher: semaphore closed");
+                                // Drain queue-depth accounting for the item we just popped but
+                                // won't process.
+                                WORK_HANDLER_QUEUE_DEPTH.dec();
                                 break;
                             }
                         };
+                        WORK_HANDLER_PERMIT_WAIT_SECONDS
+                            .observe(permit_wait_start.elapsed().as_secs_f64());
 
                         // Spawn task with owned permit (dropped when task completes)
                         tokio::spawn(async move {
                             Self::handle_work_item(work_item).await;
                             drop(permit);
+                            WORK_HANDLER_POOL_ACTIVE_TASKS.dec();
                         });
+                        WORK_HANDLER_POOL_ACTIVE_TASKS.inc();
                     }
                 }
             }
@@ -181,6 +206,11 @@ impl SharedTcpServer {
 
     /// Handle a single work item
     async fn handle_work_item(work_item: WorkItem) {
+        // The item is now leaving the "waiting" state (channel queue + permit acquire)
+        // and entering the "running" state (pool_active_tasks was incremented by the
+        // dispatcher before spawning).
+        WORK_HANDLER_QUEUE_DEPTH.dec();
+
         tracing::trace!(
             instance_id = work_item.instance_id,
             "TCP worker processing request"
@@ -500,7 +530,11 @@ impl SharedTcpServer {
                 endpoint_name: handler.endpoint_name.clone(),
             };
 
-            // Send to worker pool with backpressure - BEFORE sending ACK
+            // Send to worker pool with backpressure - BEFORE sending ACK.
+            // Increment the queue-depth gauge BEFORE send so a concurrent dispatcher
+            // pickup on another thread cannot observe depth < 0. On send failure we
+            // decrement below.
+            WORK_HANDLER_QUEUE_DEPTH.inc();
             match work_tx.send(work_item).await {
                 Ok(_) => {
                     // Send acknowledgment ONLY after successful queuing
@@ -522,6 +556,8 @@ impl SharedTcpServer {
                     );
                 }
                 Err(e) => {
+                    WORK_HANDLER_QUEUE_DEPTH.dec();
+                    WORK_HANDLER_QUEUE_FULL_TOTAL.inc();
                     tracing::warn!(
                         endpoint = handler.endpoint_name.as_str(),
                         instance_id = handler.instance_id,
@@ -921,9 +957,12 @@ mod tests {
         let inflight = Arc::new(AtomicU64::new(0));
         let notify = Arc::new(Notify::new());
 
-        // Send more work items than pool size
+        // Send more work items than pool size. Mirror the production read_loop's
+        // queue-depth accounting so `handle_work_item`'s decrement has a matching
+        // increment and the global gauge stays consistent for other tests.
         for i in 0..total_requests {
             inflight.fetch_add(1, Ordering::SeqCst);
+            WORK_HANDLER_QUEUE_DEPTH.inc();
             let work_item = WorkItem {
                 service_handler: handler.clone() as Arc<dyn PushWorkHandler>,
                 payload: Bytes::from(format!("request {}", i)),
@@ -974,6 +1013,83 @@ mod tests {
         );
 
         // Cleanup
+        cancellation_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn test_worker_pool_metrics_are_observed() {
+        crate::logging::init();
+
+        // Monotonic histogram counters: safe to assert even with parallel tests
+        // moving the gauges.
+        let permit_observations_before = WORK_HANDLER_PERMIT_WAIT_SECONDS.get_sample_count();
+
+        let pool_size = 2;
+        let total_requests = 4;
+        let (work_tx, work_rx) = tokio::sync::mpsc::channel::<WorkItem>(total_requests);
+        let cancellation_token = CancellationToken::new();
+        SharedTcpServer::start_worker_pool(pool_size, work_rx, cancellation_token.clone());
+
+        let handler = Arc::new(ConcurrencyTrackingHandler::new(Duration::from_millis(25)));
+        let inflight = Arc::new(AtomicU64::new(0));
+        let notify = Arc::new(Notify::new());
+
+        for i in 0..total_requests {
+            inflight.fetch_add(1, Ordering::SeqCst);
+            // Mirror the production read_loop's inc so handle_work_item's dec has a pair.
+            WORK_HANDLER_QUEUE_DEPTH.inc();
+            let work_item = WorkItem {
+                service_handler: handler.clone() as Arc<dyn PushWorkHandler>,
+                payload: Bytes::from(format!("request {}", i)),
+                headers: std::collections::HashMap::new(),
+                inflight: inflight.clone(),
+                notify: notify.clone(),
+                instance_id: 1,
+                namespace: "test".to_string(),
+                component_name: "test".to_string(),
+                endpoint_name: "test".to_string(),
+            };
+            work_tx.send(work_item).await.expect("send should succeed");
+        }
+
+        // Wait for all work to drain
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while inflight.load(Ordering::SeqCst) > 0 {
+                notify.notified().await;
+            }
+        })
+        .await
+        .expect("all requests should complete");
+
+        // permit_wait histogram is monotonic and records one sample per dispatched
+        // work item — reliable across parallel test threads.
+        assert!(
+            WORK_HANDLER_PERMIT_WAIT_SECONDS.get_sample_count()
+                >= permit_observations_before + total_requests as u64,
+            "permit_wait histogram should record at least one sample per dispatched work item"
+        );
+
+        cancellation_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn test_capacities_published_on_server_init() {
+        crate::logging::init();
+
+        // SharedTcpServer::new publishes static capacities. Any test that instantiates
+        // a SharedTcpServer will have populated the gauges; we just assert they're > 0.
+        let cancellation_token = CancellationToken::new();
+        let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let _server = SharedTcpServer::new(bind_addr, cancellation_token.clone());
+
+        assert!(
+            WORK_HANDLER_POOL_CAPACITY.get() > 0,
+            "pool_capacity should be set to DEFAULT_WORKER_POOL_SIZE"
+        );
+        assert!(
+            WORK_HANDLER_QUEUE_CAPACITY.get() > 0,
+            "queue_capacity should be set to DEFAULT_WORK_QUEUE_SIZE"
+        );
         cancellation_token.cancel();
     }
 }


### PR DESCRIPTION
#### Overview:

Adds six Prometheus metrics to the shared TCP server so operators can see queue buildup and permit starvation before workers get OOM-killed.

#### Details:
Six new metrics on the backend side, all prefixed `dynamo_work_handler_`:

  | Metric | Type | Meaning |
  |---|---|---|
  | `queue_depth` | gauge | items in the bounded mpsc channel awaiting dispatcher pickup |
  | `queue_capacity` | gauge | `DYN_TCP_WORK_QUEUE_SIZE` (static, default 6000) |
  | `enqueue_rejected_total` | counter | `work_tx.send()` errors — fires when the dispatcher channel is closed (not on "full"; tokio bounded mpsc applies backpressure instead) |
  | `permit_wait_seconds` | histogram | time spent in `semaphore.acquire_owned().await` |
  | `pool_active_tasks` | gauge | permits currently held by running `handle_work_item` tasks |
  | `pool_capacity` | gauge | `DYN_TCP_WORKER_POOL_SIZE` (static, default 1500) |

 - New module `lib/runtime/src/metrics/work_handler_pool.rs` follows the existing `work_handler_perf` pattern: Lazy statics + idempotent `ensure_*_registered`.
  - Registration wired through `Ingress::add_metrics` — first endpoint registration kicks it off.
  - `queue_depth` is incremented **before** `work_tx.send()` to avoid a race where the dispatcher could observe a negative gauge; the send-error arm decrements and increments `enqueue_rejected_total`.
  - Python constants in `prometheus_names.py` are edited manually to preserve existing nested classes (the codegen overwrites them).

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- relates to: DIS-1674 (see for details)
- closes GitHub issue:  DIS-1787

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive worker pool and work queue monitoring metrics for improved operational visibility into system saturation and resource utilization.
  * New metrics track queue depth, capacity, fullness events, permit wait times, and active task counts for better observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->