### PR TITLE
test(sglang): add hang repro job and diagnostic post-step

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -271,6 +271,65 @@ runs:
         # Always continue to results processing
         exit 0
 
+    - name: Diagnose on hang or cancellation
+      # Fires after every pytest run. If the step was cancelled by a timeout
+      # or pytest left a container/subprocess alive, dump enough state to know
+      # where it got stuck. A healthy run produces essentially no output.
+      if: always()
+      shell: bash
+      env:
+        CONTAINER_ID: test_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}
+      run: |
+        set +e
+        CONTAINER_NAME="${CONTAINER_ID}_pytest"
+
+        # If the pytest container never survived the step (normal happy path)
+        # there is nothing to diagnose.
+        if ! docker ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+          echo "ℹ️  No lingering ${CONTAINER_NAME} container — nothing to diagnose."
+          exit 0
+        fi
+
+        echo "⚠️  Found lingering ${CONTAINER_NAME} — capturing diagnostics."
+
+        echo "=============== host: docker ps ==============="
+        docker ps --no-trunc
+
+        echo "=============== host: nvidia-smi ==============="
+        nvidia-smi || true
+
+        echo "=============== host: ss -tunlp (abbreviated) ==============="
+        (ss -tunlp 2>/dev/null || netstat -tunlp 2>/dev/null) | head -100 || true
+
+        echo "=============== container: process tree ==============="
+        docker exec "${CONTAINER_NAME}" sh -c 'ps auxf 2>/dev/null || ps -ef' || true
+
+        echo "=============== container: pytest/sglang/dynamo pids ==============="
+        PIDS=$(docker exec "${CONTAINER_NAME}" sh -c "pgrep -af 'pytest|sglang|dynamo' 2>/dev/null" || true)
+        echo "${PIDS}"
+
+        echo "=============== container: py-spy dumps ==============="
+        # py-spy may not be installed in every image; install into a venv we can ignore.
+        docker exec "${CONTAINER_NAME}" sh -c '
+          command -v py-spy >/dev/null 2>&1 || pip install --quiet --disable-pip-version-check py-spy 2>/dev/null || true
+          for pid in $(pgrep -f "pytest|python.*dynamo.sglang" 2>/dev/null); do
+            echo "--- py-spy dump --pid $pid ---"
+            py-spy dump --pid "$pid" 2>&1 || true
+          done
+        ' || true
+
+        echo "=============== container: /proc/<pid>/stack (kernel side) ==============="
+        docker exec "${CONTAINER_NAME}" sh -c '
+          for pid in $(pgrep -f "pytest|python.*dynamo.sglang" 2>/dev/null); do
+            echo "--- /proc/$pid/stack ---"
+            cat "/proc/$pid/stack" 2>/dev/null || echo "(kernel stack unavailable)"
+          done
+        ' || true
+
+        # Kill the container so it does not hold the runner for the next step.
+        echo "=============== cleanup: force-removing ${CONTAINER_NAME} ==============="
+        docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+
     - name: Process Test Results
       shell: bash
       run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -404,6 +404,21 @@ jobs:
           docker exec "${CONTAINER_NAME}" sh -c 'ps auxf 2>/dev/null || ps -ef' || true
           echo "=== container: pytest/sglang/dynamo pids ==="
           docker exec "${CONTAINER_NAME}" sh -c "pgrep -af 'pytest|sglang|dynamo' 2>/dev/null" || true
+          echo "=== container: per-worker log tails (DYN-2784) ==="
+          docker exec "${CONTAINER_NAME}" sh -c '
+            set +e
+            found=0
+            for f in /tmp/dynamo_tests/*/worker_*/python3.log.txt \
+                     /tmp/dynamo_tests/*/python3.log.txt; do
+              [ -f "$f" ] || continue
+              found=1
+              echo "--- tail -200 $f ---"
+              tail -200 "$f"
+            done
+            if [ "$found" = "0" ]; then
+              echo "(no worker log files under /tmp/dynamo_tests/)"
+            fi
+          ' || true
           echo "=== container: py-spy dumps ==="
           docker exec "${CONTAINER_NAME}" sh -c '
             command -v py-spy >/dev/null 2>&1 || pip install --quiet --disable-pip-version-check py-spy 2>/dev/null || true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -317,6 +317,111 @@ jobs:
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
+  # ---------------------------------------------------------------------------
+  # TEMPORARY: reproduce the nightly sglang hang in a focused, fast-feedback
+  # job so we can capture diagnostics. The nightly `sglang-pipeline Test (amd64)`
+  # deadlocks after test_sglang_kv_router_basic[tcp] -> the next test
+  # (test_router_decisions_sglang_multiple_workers) never completes. This job
+  # runs only the minimum preceding sequence we suspect of leaving orphan GPU
+  # state, so we get an answer in ~30-45 minutes instead of 3-5 hours.
+  # Delete this job once the hang is understood and fixed.
+  # ---------------------------------------------------------------------------
+  sglang-hang-repro:
+    name: sglang-hang-repro (temp)
+    needs: [changed-files, sglang-build]
+    if: |
+      always() && !cancelled() &&
+      needs.sglang-build.result == 'success' &&
+      (needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true')
+    runs-on: prod-tester-amd-gpu-v1
+    timeout-minutes: 75
+    env:
+      CONTAINER_NAME: hang-repro-${{ github.run_id }}-${{ github.run_attempt }}-pytest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Calculate test image tag
+        id: tag
+        shell: bash
+        env:
+          ECR_REPOSITORY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo
+        run: |
+          set -euo pipefail
+          IMAGE_TAG="${{ github.sha }}-${{ needs.sglang-build.outputs.target_tag_plain }}-cuda12"
+          TEST_IMAGE="${ECR_REPOSITORY}:${IMAGE_TAG}-test"
+          echo "test_image=${TEST_IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "Using test image: ${TEST_IMAGE}"
+      - name: Docker login
+        uses: ./.github/actions/docker-login
+        with:
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+      - name: Pull test image
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker pull "${{ steps.tag.outputs.test_image }}"
+      - name: Run 4-test poisoning sequence
+        id: repro
+        timeout-minutes: 45
+        shell: bash
+        run: |
+          set -o pipefail
+          # Run ONLY the sequence we suspect of triggering the nightly hang.
+          # --timeout=300 (pytest-timeout, thread method) kills any single test
+          # that exceeds 5 min -- much faster than the 5h nightly timeout.
+          docker run --gpus all --network host --rm \
+            --name "${CONTAINER_NAME}" \
+            -w /workspace \
+            -e DYNAMO_TEST_FRAMEWORK=sglang \
+            -e DYNAMO_TEST_PLATFORM=amd64 \
+            -e DYNAMO_TEST_TYPE=pre_merge_gpu \
+            "${{ steps.tag.outputs.test_image }}" \
+            sh -c 'umask 0022 && pytest -v --tb=short --timeout=300 --timeout-method=thread \
+              -o cache_dir=/tmp/.pytest_cache --basetemp=/tmp/pytest_temp \
+              tests/gpu_memory_service/test_quiesce_resume.py::test_gms_basic_quiesce_resume_sglang \
+              tests/gpu_memory_service/test_shadow_failover.py::test_gms_shadow_engine_failover_sglang \
+              "tests/router/test_router_e2e_with_sglang.py::test_sglang_kv_router_basic[tcp]" \
+              "tests/router/test_router_e2e_with_sglang.py::test_router_decisions_sglang_multiple_workers[tcp]"'
+      - name: Diagnose on hang or failure
+        # Mirrors the diagnostic step in .github/actions/pytest/action.yml but
+        # scoped to this job's container. Fires even if the pytest step was
+        # cancelled by timeout-minutes.
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          if ! docker ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+            echo "ℹ️  No lingering ${CONTAINER_NAME} — nothing to diagnose."
+            exit 0
+          fi
+          echo "⚠️  Container ${CONTAINER_NAME} survived the step — gathering diagnostics."
+          echo "=== host: docker ps ===";            docker ps --no-trunc
+          echo "=== host: nvidia-smi ===";           nvidia-smi || true
+          echo "=== host: listening sockets (top 80) ==="
+          (ss -tunlp 2>/dev/null || netstat -tunlp 2>/dev/null) | head -80 || true
+          echo "=== container: process tree ==="
+          docker exec "${CONTAINER_NAME}" sh -c 'ps auxf 2>/dev/null || ps -ef' || true
+          echo "=== container: pytest/sglang/dynamo pids ==="
+          docker exec "${CONTAINER_NAME}" sh -c "pgrep -af 'pytest|sglang|dynamo' 2>/dev/null" || true
+          echo "=== container: py-spy dumps ==="
+          docker exec "${CONTAINER_NAME}" sh -c '
+            command -v py-spy >/dev/null 2>&1 || pip install --quiet --disable-pip-version-check py-spy 2>/dev/null || true
+            for pid in $(pgrep -f "pytest|python.*dynamo.sglang" 2>/dev/null); do
+              echo "--- py-spy dump --pid $pid ---"
+              py-spy dump --pid "$pid" 2>&1 || true
+            done
+          ' || true
+          echo "=== container: /proc/<pid>/stack ==="
+          docker exec "${CONTAINER_NAME}" sh -c '
+            for pid in $(pgrep -f "pytest|python.*dynamo.sglang" 2>/dev/null); do
+              echo "--- /proc/$pid/stack ---"
+              cat "/proc/$pid/stack" 2>/dev/null || echo "(kernel stack unavailable)"
+            done
+          ' || true
+          echo "=== cleanup: force-removing ${CONTAINER_NAME} ==="
+          docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+
   trtllm-test:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [changed-files, trtllm-build]

--- a/tests/router/e2e_harness.py
+++ b/tests/router/e2e_harness.py
@@ -53,6 +53,27 @@ class ManagedEngineProcessMixin:
     init_delay_reason = "initialize before starting next worker"
     cleanup_delay_seconds = 2
 
+    def _assert_workers_alive(self, launched_count: int) -> None:
+        """Verify every worker launched so far is still running.
+
+        Sequential worker startup had no death detection: if worker N died
+        during init, we would still launch worker N+1 and later block forever
+        in KvRouter construction waiting for instances that never register.
+        See DYN-2784. Raise as soon as we see a dead subprocess so the test
+        fails with a useful message instead of hanging the whole job.
+        """
+        for j in range(launched_count):
+            proc = self.worker_processes[j].proc
+            if proc is None:
+                continue
+            rc = proc.poll()
+            if rc is not None:
+                log_path = getattr(self.worker_processes[j], "_log_path", "?")
+                raise RuntimeError(
+                    f"{self.process_name} {j} exited during startup with code {rc}. "
+                    f"See log: {log_path}"
+                )
+
     def __enter__(self):
         logger.info(
             "[%s] Starting %d worker processes sequentially...",
@@ -89,6 +110,7 @@ class ManagedEngineProcessMixin:
                     process.proc.pid if process.proc else "unknown",
                 )
                 time.sleep(process.delayed_start)
+                self._assert_workers_alive(i + 1)
 
                 if i < len(self.worker_processes) - 1:
                     logger.info(
@@ -99,6 +121,7 @@ class ManagedEngineProcessMixin:
                         self.init_delay_reason,
                     )
                     time.sleep(self.init_delay_seconds)
+                    self._assert_workers_alive(i + 1)
 
             except Exception:
                 logger.exception(

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -35,13 +35,20 @@ pytestmark = [
 ]
 PAGE_SIZE = 16  # SGLang uses "page_size" instead of "block_size"
 
-# Shared SGLang configuration for all tests
-# mem_fraction_static limits actual VRAM allocation (required for multi-worker on same GPU)
+# Shared SGLang configuration for all tests.
+#
+# mem_fraction_static limits the KV-cache portion of VRAM, but sglang's actual
+# per-worker footprint also includes CUDA context, library init, PyTorch
+# caching allocator overhead, and model weights. On sglang 0.5.10 two workers
+# on a single GPU at mem_fraction_static=0.4 were OOMing worker #2 with
+# "RuntimeError: Not enough memory. Please try to increase --mem-fraction-static."
+# (DYN-2784). 0.3 leaves enough headroom: 2 * 0.3 = 0.6 for KV cache, and the
+# remaining 0.4 absorbs per-process overhead.
 SGLANG_ARGS: Dict[str, Any] = {
     "page_size": PAGE_SIZE,
     "model": MODEL_NAME,
-    "mem_fraction_static": 0.4,  # Limit VRAM allocation per worker (equivalent to vLLM's gpu_memory_utilization)
-    "context_length": 1024,  # Limit context length to reduce KV cache size (equivalent to vLLM's max_model_len)
+    "mem_fraction_static": 0.3,  # Limit VRAM per worker (equivalent to vLLM's gpu_memory_utilization)
+    "context_length": 512,  # Smaller KV cache per request to further reduce footprint for 2-worker same-GPU
     "disable_cuda_graph": True,  # Disable CUDA graphs for faster startup & lower memory (equivalent to vLLM's enforce_eager)
 }
 

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -207,7 +207,10 @@ class SGLangProcess(ManagedEngineProcessMixin):
 
             env.update(env_vars)
 
-            # Create managed process for the worker
+            # Create managed process for the worker. Each worker gets its own
+            # log subdir so stdout/stderr don't race into a shared file -- when
+            # a worker dies during startup (e.g. DYN-2784) we need to preserve
+            # its final output to understand why.
             process = ManagedProcess(
                 command=command,
                 env=env,
@@ -215,7 +218,7 @@ class SGLangProcess(ManagedEngineProcessMixin):
                 display_output=True,
                 health_check_ports=[],
                 health_check_urls=[],
-                log_dir=request.node.name,
+                log_dir=os.path.join(request.node.name, f"worker_{worker_idx}"),
                 terminate_all_matching_process_names=False,
             )
             self.worker_processes.append(process)

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -263,6 +263,7 @@ def test_sglang_kv_router_basic(
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+@pytest.mark.timeout(300)  # fail fast instead of hanging the whole job if worker startup deadlocks
 def test_router_decisions_sglang_multiple_workers(
     request,
     runtime_services_dynamic_ports,


### PR DESCRIPTION
## Summary
- Adds `pytest.mark.timeout(300)` to `test_router_decisions_sglang_multiple_workers` so future hangs fail in 5 minutes instead of 5 hours.
- Adds an `if: always()` diagnostic post-step to `.github/actions/pytest/action.yml` that dumps process tree, `py-spy` stacks, `nvidia-smi`, and `/proc/<pid>/stack` from inside the pytest container whenever it survives the step (cancellation, timeout, abnormal exit), then force-removes the container.
- Adds a temporary `sglang-hang-repro` job to `.github/workflows/pr.yaml` that runs only the suspected 4-test poisoning sequence against the just-built sglang-runtime-test image. Gives a 30-45 min signal on whether the minimal sequence reproduces the nightly hang, vs. the 5h nightly pipeline.

## Motivation
Nightly `sglang-pipeline / Test (amd64)` has timed out at 5h every night since 2026-04-15 (see run https://github.com/ai-dynamo/dynamo/actions/runs/24657547996). The deadlock happens right after `test_sglang_kv_router_basic[tcp] PASSED [96%]` when pytest moves on to `test_router_decisions_sglang_multiple_workers`, which brings up two sglang workers on a single GPU. That test has no per-test timeout, and the same test passes on PR pipelines (~17 min), so the asymmetry points at earlier GMS / fault-tolerance tests leaving the GPU poisoned.

## Test plan
- [ ] PR CI kicks off `sglang-hang-repro` on this branch and either:
  - passes (minimum sequence does not reproduce; widen the set and retry), or
  - hits the 45-min step timeout and the diagnostic step prints `py-spy dump` + `/proc/<pid>/stack` showing where pytest is stuck.
- [ ] `sglang-test` (normal sglang pre-merge GPU) still passes, confirming the diagnostic post-step is a no-op on healthy runs.
- [ ] Once diagnosed: revert the `sglang-hang-repro` job; keep the `pytest.mark.timeout(300)` safety net and the action's diagnostic post-step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)