### PR TITLE
refactor(multimodal): split httpx timeout exception

### DIFF
--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -105,6 +105,30 @@ class ImageLoader:
         except httpx.HTTPStatusError as e:
             logger.error(f"HTTP {e.response.status_code} loading image: '{image_url}'")
             raise
+        except httpx.PoolTimeout as e:
+            logger.error(
+                f"PoolTimeout loading image: '{image_url}' "
+                f"(timeout={self._http_timeout}s)"
+            )
+            raise ValueError(f"PoolTimeout loading image: '{image_url}'") from e
+        except httpx.ConnectTimeout as e:
+            logger.error(
+                f"ConnectTimeout loading image: '{image_url}' "
+                f"(timeout={self._http_timeout}s)"
+            )
+            raise ValueError(f"ConnectTimeout loading image: '{image_url}'") from e
+        except httpx.ReadTimeout as e:
+            logger.error(
+                f"ReadTimeout loading image: '{image_url}' "
+                f"(timeout={self._http_timeout}s)"
+            )
+            raise ValueError(f"ReadTimeout loading image: '{image_url}'") from e
+        except httpx.WriteTimeout as e:
+            logger.error(
+                f"WriteTimeout loading image: '{image_url}' "
+                f"(timeout={self._http_timeout}s)"
+            )
+            raise ValueError(f"WriteTimeout loading image: '{image_url}'") from e
         except httpx.TimeoutException as e:
             logger.error(
                 f"{type(e).__name__} loading image: '{image_url}' "


### PR DESCRIPTION
#### Overview:

Image loader script uses TimeoutException base class for catching timeout errors, but httpx offers more granular exceptions that would help end users debug image loading issues.

#### Details:

Added subclasses of TimeoutException to make exception handling more granular (based on httpx [docs](https://www.python-httpx.org/exceptions/))

#### Where should the reviewer start?

components/src/dynamo/common/multimodal/image_loader.py 

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced timeout error handling and logging. The system now provides more specific error messages for various timeout scenarios with configured timeout details, improving diagnostics for network connectivity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->