### PR TITLE
fix(planner/tests): scope test_advisory_mode stubs so they don't leak

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -36,7 +36,6 @@ jobs:
       run_cpu_only_tests: true
       cpu_only_test_markers: '(pre_merge or post_merge) and planner and gpu_0'
       cpu_only_test_timeout_minutes: 30
-      cpu_parallel_mode: '0'
       run_single_gpu_tests: false
       run_multi_gpu_tests: false
       copy_to_acr: false

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -36,6 +36,7 @@ jobs:
       run_cpu_only_tests: true
       cpu_only_test_markers: '(pre_merge or post_merge) and planner and gpu_0'
       cpu_only_test_timeout_minutes: 30
+      cpu_parallel_mode: '2'
       run_single_gpu_tests: false
       run_multi_gpu_tests: false
       copy_to_acr: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -367,6 +367,7 @@ jobs:
       run_cpu_only_tests: true
       cpu_only_test_markers: 'pre_merge and planner and gpu_0'
       cpu_only_test_timeout_minutes: 30
+      cpu_parallel_mode: '2'
       run_gpu_tests: false
     secrets: inherit
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -367,7 +367,6 @@ jobs:
       run_cpu_only_tests: true
       cpu_only_test_markers: 'pre_merge and planner and gpu_0'
       cpu_only_test_timeout_minutes: 30
-      cpu_parallel_mode: '0'
       run_gpu_tests: false
     secrets: inherit
 

--- a/components/src/dynamo/planner/tests/unit/test_advisory_mode.py
+++ b/components/src/dynamo/planner/tests/unit/test_advisory_mode.py
@@ -3,51 +3,59 @@
 
 """Unit tests for advisory mode and decision summary logging."""
 
-import sys
-import types
-from unittest.mock import MagicMock
-
 import pytest
 
-# ---------------------------------------------------------------
-# Stub native Rust modules so planner config can be imported
-# without building dynamo._core
-# ---------------------------------------------------------------
-_stubs = {
-    "dynamo._core": {
-        "Client": MagicMock,
-        "DistributedRuntime": MagicMock,
-        "VirtualConnectorCoordinator": MagicMock,
-    },
-    "dynamo.runtime": {
-        "DistributedRuntime": MagicMock,
-        "dynamo_worker": lambda: lambda f: f,
-    },
-    "dynamo.runtime.logging": {
-        "configure_dynamo_logging": lambda: None,
-    },
-    "dynamo.llm": {
-        "FpmEventSubscriber": MagicMock,
-        "FpmEventRelay": MagicMock,
-    },
-    "dynamo.common.forward_pass_metrics": {
-        "ForwardPassMetrics": MagicMock,
-        "ScheduledRequestMetrics": MagicMock,
-    },
-}
-for _mod_name, _attrs in _stubs.items():
-    _m = types.ModuleType(_mod_name)
-    for _k, _v in _attrs.items():
-        setattr(_m, _k, _v)
-    sys.modules.setdefault(_mod_name, _m)
-
-from dynamo.planner.config.defaults import SLAPlannerDefaults  # noqa: E402
+from dynamo.planner.config.defaults import SLAPlannerDefaults
 
 pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
     pytest.mark.unit,
 ]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _stub_heavy_deps():
+    # Stub optional Rust/IO-heavy dynamo modules when absent so planner.config
+    # imports used below can resolve. Scoped to this module and torn down after
+    # so sibling test modules see the real modules (regression: #8244 left
+    # these stubs in sys.modules and caused later tests to skip).
+    import sys
+    import types
+    from unittest.mock import MagicMock
+
+    stubs = {
+        "dynamo._core": {
+            "Client": MagicMock,
+            "DistributedRuntime": MagicMock,
+            "VirtualConnectorCoordinator": MagicMock,
+        },
+        "dynamo.runtime": {
+            "DistributedRuntime": MagicMock,
+            "dynamo_worker": lambda: lambda f: f,
+        },
+        "dynamo.runtime.logging": {
+            "configure_dynamo_logging": lambda: None,
+        },
+        "dynamo.llm": {
+            "FpmEventSubscriber": MagicMock,
+            "FpmEventRelay": MagicMock,
+        },
+        "dynamo.common.forward_pass_metrics": {
+            "ForwardPassMetrics": MagicMock,
+            "ScheduledRequestMetrics": MagicMock,
+        },
+    }
+    mp = pytest.MonkeyPatch()
+    for name, attrs in stubs.items():
+        if name in sys.modules:
+            continue
+        mod = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(mod, k, v)
+        mp.setitem(sys.modules, name, mod)
+    yield
+    mp.undo()
 
 
 class TestAdvisoryDefaults:

--- a/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
@@ -9,6 +9,7 @@ DecodeRegressionModel, AggRegressionModel) without any planner adapter.
 FPM-driven scaling integration tests live in test_state_machine.py.
 """
 
+import os
 from unittest.mock import Mock, patch
 
 import pytest
@@ -671,8 +672,17 @@ class TestRefreshWorkerInfoFromConnector:
 
     def _make_planner(self, require_prefill=False, require_decode=True):
         """Build a minimal NativePlannerBase with no_operation=True."""
-        with patch("dynamo.planner.monitoring.planner_metrics.Gauge") as mock_gauge:
-            mock_gauge.return_value = Mock()
+        # Bypass Prometheus registration (Gauge+Enum double-register across
+        # tests). KubernetesConnector.__init__ loads ~/.kube/config and reads
+        # DYN_PARENT_DGD_K8S_NAME; stub both so this runs in plain pytest envs.
+        with patch(
+            "dynamo.planner.core.base.PlannerPrometheusMetrics"
+        ) as mock_metrics, patch(
+            "dynamo.planner.connectors.kubernetes.KubernetesAPI"
+        ), patch.dict(
+            os.environ, {"DYN_PARENT_DGD_K8S_NAME": "test-graph"}
+        ):
+            mock_metrics.return_value = Mock()
             config = PlannerConfig.model_construct(
                 throughput_adjustment_interval=60,
                 prefill_engine_num_gpu=1,


### PR DESCRIPTION
## Summary
`test_advisory_mode.py` installed stubs for `dynamo._core`, `dynamo.runtime`, `dynamo.llm`, and `dynamo.common.forward_pass_metrics` into `sys.modules` at module-import (pytest collection) time. Because it's collected alphabetically before the other planner/profiler tests, those later modules resolved their imports against the stubs — stubs that don't expose `ModelType`, `QueuedRequestMetrics`, etc. — which tripped the `pytest.skip(...)` guards added in the same PR (#8244).

Net effect on the `dynamo-planner-test-cpu` image with the CI command:
- Before #8244 (commit `71af9675`): **335 passed, 1 skipped**
- After #8244 (current main, e.g. `c388483a`): **153 passed, 13 skipped**

Fix: move the stub injection into a `scope="module", autouse=True` fixture that
- skips any module already imported (don't shadow reals),
- uses `pytest.MonkeyPatch().setitem(sys.modules, ...)`,
- calls `mp.undo()` on teardown so `sys.modules` is clean for sibling test modules.

Unmasking those tests also surfaced two pre-existing issues in `TestRefreshWorkerInfoFromConnector` (added in #8042, never exercised): the test built `NativePlannerBase` with `environment="kubernetes"`, which calls `config.load_kube_config()` and registers Prometheus `Enum` metrics globally. Patched `KubernetesAPI`, `PlannerPrometheusMetrics`, and `DYN_PARENT_DGD_K8S_NAME` inside `_make_planner` to sandbox them.

## pytest parallelism
CI runners expose 8 cores, but `-n auto` is slow because per-worker startup/isolation dominates for a 392-test suite. Measured on this PR's planner-test image (392 passed, 1 skipped on every run):

| workers | AMD64 (CI) | ARM64 (CI) | local (laptop) |
|---|---|---|---|
| `-n 0`        | 163s | 226s | 73s |
| `-n 2`        | **109s** | **157s** | **58s** |
| `-n 4`        | — | — | 62s |
| `-n auto` (8) | 110s | 159s | 61s |

Switched planner's CI override to `cpu_parallel_mode: '2'` for both pre-merge and post-merge. Two workers match `auto` on CI and beat it locally; `-n 0` is ~50% slower.

## Verification
Local run of the exact CI pytest command against the `c388483a` planner-test-cpu image with this fix + the `TestRefreshWorkerInfoFromConnector` mocks:

```
=========== 392 passed, 1 skipped, 74 deselected in 57.89s ===========
```

vs. same image unpatched: `153 passed, 13 skipped, 11 deselected`. The single remaining skip is the legitimate `test_virtual_connector.py:48` guard.

## Test plan
- [x] pre-merge CI: `planner-test` on amd64 and arm64 reports 392 passed / 1 skipped.
- [x] No new skips introduced for `test_advisory_mode.py` or `test_load_based_scaling.py`.
- [x] Planner tests complete well under the 30-minute timeout with `-n 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)