### PR TITLE
fix: Inter-pass onboard writing G2 data to wrong G1 blocks

### DIFF
--- a/lib/kvbm-connector/src/connector/leader/onboard.rs
+++ b/lib/kvbm-connector/src/connector/leader/onboard.rs
@@ -28,9 +28,9 @@ fn select_onboard_block_ids(
     num_external_tokens: usize,
     block_size: usize,
 ) -> Vec<BlockId> {
+    let num_computed_blocks = num_computed_tokens / block_size;
     let num_external_blocks = num_external_tokens / block_size;
-    let onboard_start_block_idx = block_ids.len().saturating_sub(num_external_blocks);
-    block_ids[onboard_start_block_idx..].to_vec()
+    block_ids[num_computed_blocks..num_computed_blocks + num_external_blocks].to_vec()
 }
 
 impl ConnectorLeader {
@@ -56,10 +56,8 @@ impl ConnectorLeader {
             .expect("session should exist")
             .num_computed_tokens;
 
-        let num_computed_blocks = num_computed_tokens / self.block_size();
-        let num_external_blocks = num_external_tokens / self.block_size();
         let g1_block_ids =
-            block_ids[num_computed_blocks..num_computed_blocks + num_external_blocks].to_vec();
+            select_onboard_block_ids(&block_ids, num_computed_tokens, num_external_tokens, self.block_size());
 
         // Record the block_ids - this assigns them to the token_block sequence hashes
         slot.apply_new_blocks(block_ids);
@@ -115,8 +113,12 @@ impl ConnectorLeader {
         let (staging_fut, onboard_blocks_ids) = {
             let mut slot = shared_slot.lock();
 
+            let num_computed_tokens = match slot.onboarding_state() {
+                Some(state) => state.num_computed_tokens,
+                None => 0,
+            };
             let onboard_blocks_ids =
-                select_onboard_block_ids(&block_ids, 0, num_external_tokens, self.block_size());
+                select_onboard_block_ids(&block_ids, num_computed_tokens, num_external_tokens, self.block_size());
 
             // record the block_ids
             // this will assign the block_ids to the token_block sequence hashes

--- a/lib/kvbm-connector/src/connector/leader/onboard.rs
+++ b/lib/kvbm-connector/src/connector/leader/onboard.rs
@@ -9,6 +9,30 @@ use kvbm_physical::TransferOptions;
 
 use super::*;
 
+/// Select the G1 block IDs that correspond to externally-matched (onboard) blocks.
+///
+/// When onboarding, the `block_ids` list contains ALL blocks for the request:
+///   [computed_blocks... | external_blocks... | new_blocks...]
+///
+/// The external (matched) blocks start right after the computed prefix and span
+/// `num_external_tokens / block_size` entries.
+///
+/// # Arguments
+/// * `block_ids` - All block IDs allocated for the request
+/// * `num_computed_tokens` - Tokens already present in G1 (prefix cache hit)
+/// * `num_external_tokens` - Tokens matched externally (to be onboarded)
+/// * `block_size` - Tokens per block
+fn select_onboard_block_ids(
+    block_ids: &[BlockId],
+    num_computed_tokens: usize,
+    num_external_tokens: usize,
+    block_size: usize,
+) -> Vec<BlockId> {
+    let num_external_blocks = num_external_tokens / block_size;
+    let onboard_start_block_idx = block_ids.len().saturating_sub(num_external_blocks);
+    block_ids[onboard_start_block_idx..].to_vec()
+}
+
 impl ConnectorLeader {
     /// Prepare intra-pass onboarding by storing G2/G1 block pairs.
     ///
@@ -91,9 +115,8 @@ impl ConnectorLeader {
         let (staging_fut, onboard_blocks_ids) = {
             let mut slot = shared_slot.lock();
 
-            let num_external_blocks = num_external_tokens / self.block_size();
-            let onboard_start_block_idx = block_ids.len().saturating_sub(num_external_blocks);
-            let onboard_blocks_ids = block_ids[onboard_start_block_idx..].to_vec();
+            let onboard_blocks_ids =
+                select_onboard_block_ids(&block_ids, 0, num_external_tokens, self.block_size());
 
             // record the block_ids
             // this will assign the block_ids to the token_block sequence hashes
@@ -223,4 +246,86 @@ async fn execute_onboarding(
     //     duration,
     // );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BLOCK_SIZE: usize = 16; // tokens per block
+
+    /// Onboard blocks must come from after the computed prefix,
+    /// not from the end of the block list.
+    ///
+    /// Scenario: 10 blocks total, first 2 are computed (already in G1),
+    /// next 3 are external (to be onboarded from G2), remaining 5 are new.
+    ///
+    /// block_ids:  [100, 101, 102, 103, 104, 105, 106, 107, 108, 109]
+    ///              ^^^^^^^^^^^  ^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^
+    ///              computed(2)  external(3)      new(5)
+    #[test]
+    fn test_select_onboard_blocks_after_computed_prefix() {
+        let block_ids: Vec<BlockId> = (100..110).collect(); // 10 blocks
+        let num_computed_tokens = 2 * BLOCK_SIZE; // 2 blocks already computed
+        let num_external_tokens = 3 * BLOCK_SIZE; // 3 blocks to onboard
+
+        let result =
+            select_onboard_block_ids(&block_ids, num_computed_tokens, num_external_tokens, BLOCK_SIZE);
+
+        // Must select blocks [102, 103, 104] — the 3 blocks after the 2 computed ones
+        assert_eq!(result, vec![102, 103, 104]);
+    }
+
+    /// When nothing is computed, external blocks start at the beginning.
+    #[test]
+    fn test_select_onboard_blocks_no_computed_prefix() {
+        let block_ids: Vec<BlockId> = (100..108).collect(); // 8 blocks
+        let num_computed_tokens = 0;
+        let num_external_tokens = 5 * BLOCK_SIZE;
+
+        let result =
+            select_onboard_block_ids(&block_ids, num_computed_tokens, num_external_tokens, BLOCK_SIZE);
+
+        assert_eq!(result, vec![100, 101, 102, 103, 104]);
+    }
+
+    /// When all blocks are external (full cache hit from G2).
+    #[test]
+    fn test_select_onboard_blocks_all_external() {
+        let block_ids: Vec<BlockId> = (100..106).collect(); // 6 blocks
+        let num_computed_tokens = 0;
+        let num_external_tokens = 6 * BLOCK_SIZE;
+
+        let result =
+            select_onboard_block_ids(&block_ids, num_computed_tokens, num_external_tokens, BLOCK_SIZE);
+
+        assert_eq!(result, vec![100, 101, 102, 103, 104, 105]);
+    }
+
+    /// When all blocks are computed (nothing to onboard).
+    #[test]
+    fn test_select_onboard_blocks_nothing_external() {
+        let block_ids: Vec<BlockId> = (100..106).collect();
+        let num_computed_tokens = 6 * BLOCK_SIZE;
+        let num_external_tokens = 0;
+
+        let result =
+            select_onboard_block_ids(&block_ids, num_computed_tokens, num_external_tokens, BLOCK_SIZE);
+
+        assert_eq!(result, Vec::<BlockId>::new());
+    }
+
+    /// Single external block after a large computed prefix.
+    #[test]
+    fn test_select_onboard_blocks_single_external_after_large_prefix() {
+        let block_ids: Vec<BlockId> = (100..120).collect(); // 20 blocks
+        let num_computed_tokens = 15 * BLOCK_SIZE;
+        let num_external_tokens = 1 * BLOCK_SIZE;
+
+        let result =
+            select_onboard_block_ids(&block_ids, num_computed_tokens, num_external_tokens, BLOCK_SIZE);
+
+        // Block at index 15 (after 15 computed blocks)
+        assert_eq!(result, vec![115]);
+    }
 }


### PR DESCRIPTION
Fixes KVBM-397

Symptom
-------

During determinism testing of the KVBM v2 TRT-LLM connector, model outputs
diverged after G2->G1 onboarding. With temperature=0, seed=42, top_k=1:

- O1 (fresh compute): deterministic output
- O2 (G1 prefix cache hit): O1 == O2 -- deterministic
- O3 (after eviction, onboarded from G2): O1 != O3 -- different text, different logprobs

The output wasn't garbage -- it was coherent English -- but the probability
distribution shifted (first token logprob: -1.27 vs -1.14), indicating KV
cache data was being placed in the wrong physical blocks.


Root Cause
----------

In start_onboarding (the inter-pass onboard path), the code selected G1
target block IDs from the END of the block_ids list:

    let onboard_start_block_idx = block_ids.len().saturating_sub(num_external_blocks);
    let onboard_blocks_ids = block_ids[onboard_start_block_idx..].to_vec();

But matched/external blocks are a PREFIX -- they correspond to the first
tokens of the sequence. The block layout is:

    block_ids:  [computed... | external (matched from G2)... | new (recomputed)...]

Concrete example from the failing test:

- 65 tokens, block_size=32 -> 3 blocks [C, D, E]
- 0 computed, 2 external (64 matched tokens), 1 new (1 remaining token)
- Old code: 3 - 2 = 1 -> selects [D, E] (last 2 -- WRONG)
- Correct: 0..2 -> selects [C, D] (first 2 -- the actual external blocks)

G2 prefix data was written to blocks D and E, but the framework expected it
in C and D. The model read stale/zero data from C and D during attention,
producing different outputs.


Why it was hard to find
-----------------------

- The intra-pass path (prepare_intra_pass_onboarding) already had the correct
  logic using num_computed_blocks offset -- only the inter-pass path was wrong.

- When num_computed_blocks == 0 AND all blocks are external (no trailing new
  blocks), the old code accidentally produces the correct result:
  len - external == 0, same as 0..external. The bug only manifests when there
  are new blocks beyond the external blocks (i.e., the prompt has tokens beyond
  the matched prefix).

- The output was coherent (not garbage), so it looked like a subtle numerical
  issue rather than a block mapping bug.

- Initial investigation chased byte offsets, stride issues, and FullyContiguous
  layout problems before block dumps revealed the data was in the wrong physical
  locations.


Debugging that identified it
-----------------------------

Block content dumps (dump_block via get_finished) showed:

- First onboard:           block[0].first4 = [0.233, 0.034, -0.246, 0.135]
- After re-onboard (O3):   block[0].first4 = [-0.006, 0.316, ...]
  This was block 1's data, placed in block 0's slot.

Note: early attempts with torch.cuda.synchronize() in save_kv_layer caused
timeouts. Dumps were moved to get_finished only (after forward pass), using
GPU-only ops to avoid blocking.


Fix
---

Use num_computed_blocks as the offset into block_ids, matching the intra-pass
logic:

    let num_computed_blocks = num_computed_tokens / self.block_size();
    let num_external_blocks = num_external_tokens / self.block_size();
    let onboard_blocks_ids =
        block_ids[num_computed_blocks..num_computed_blocks + num_external_blocks].to_vec();


Verification
------------

After fix: O1 == O2 == O3, logprobs bit-identical at -1.2768203020095825.
