### PR TITLE
feat(snapshot): support multi-container snapshot per pod (PR 1/2)

### DIFF
--- a/components/src/dynamo/common/utils/snapshot.py
+++ b/components/src/dynamo/common/utils/snapshot.py
@@ -6,8 +6,8 @@
 import asyncio
 import logging
 import os
-import signal
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Generic, TypeVar
 
 from dynamo.common.utils.namespace import get_worker_namespace
@@ -25,23 +25,31 @@ KUBERNETES_OPTIONAL_PODINFO_FILES = {
 }
 EngineT = TypeVar("EngineT")
 
+# Must match snapshotprotocol.{SnapshotCompleteFile,RestoreCompleteFile,ReadyForCheckpointFile}.
+SNAPSHOT_COMPLETE_FILE = "snapshot-complete"
+RESTORE_COMPLETE_FILE = "restore-complete"
+READY_FOR_CHECKPOINT_FILE = "ready-for-checkpoint"
+
+# Poll interval for the snapshot-control directory. Checkpoint and restore
+# latencies are seconds, so 100ms is negligible overhead.
+_SENTINEL_POLL_INTERVAL_SEC = 0.1
+
 
 class CheckpointConfig:
-    """Parsed checkpoint configuration plus the watcher-driven lifecycle."""
+    """Parsed checkpoint configuration plus the sentinel-driven lifecycle."""
 
-    def __init__(self, ready_file: str):
-        self.ready_file = ready_file
-        self._checkpoint_done = asyncio.Event()
-        self._restore_done = asyncio.Event()
+    def __init__(self, control_dir: str):
+        self.control_dir = control_dir
+        self.ready_file = os.path.join(control_dir, READY_FOR_CHECKPOINT_FILE)
 
     @classmethod
     def from_env(cls) -> "CheckpointConfig | None":
-        ready_file = os.environ.get("DYN_READY_FOR_CHECKPOINT_FILE")
-        if not ready_file:
+        control_dir = os.environ.get("DYN_SNAPSHOT_CONTROL_DIR")
+        if not control_dir:
             return None
 
         configure_checkpoint_transport_env()
-        return cls(ready_file=ready_file)
+        return cls(control_dir=control_dir)
 
     async def run_lifecycle(
         self,
@@ -51,65 +59,53 @@ class CheckpointConfig:
         logger.info("Quiescing model")
         await quiesce_controller.quiesce(*quiesce_args)
 
-        self._install_signal_handlers()
         try:
             with open(self.ready_file, "w", encoding="utf-8") as ready_file:
                 ready_file.write("ready")
-        except Exception:
-            self._remove_signal_handlers()
-            raise
 
-        logger.info(
-            "Ready for checkpoint. Waiting for watcher signal "
-            "(SIGUSR1=checkpoint complete, SIGCONT=restore complete)"
-        )
-
-        try:
-            event = await self._wait_for_watcher_signal()
-            if event == "restore":
-                logger.info("Restore signal detected (SIGCONT)")
-                logger.info("Resuming model after restore")
-                await quiesce_controller.resume()
-                quiesce_controller.mark_resumed()
-                return True
-
-            logger.info("Checkpoint completion signal detected (SIGUSR1)")
-            return False
-        finally:
-            self._remove_signal_handlers()
-            try:
-                os.unlink(self.ready_file)
-            except OSError:
-                pass
-
-    def _install_signal_handlers(self) -> None:
-        loop = asyncio.get_running_loop()
-        loop.add_signal_handler(signal.SIGUSR1, self._checkpoint_done.set)
-        loop.add_signal_handler(signal.SIGCONT, self._restore_done.set)
-
-    def _remove_signal_handlers(self) -> None:
-        loop = asyncio.get_running_loop()
-        loop.remove_signal_handler(signal.SIGUSR1)
-        loop.remove_signal_handler(signal.SIGCONT)
-
-    async def _wait_for_watcher_signal(self) -> str:
-        waiters = {
-            asyncio.create_task(self._checkpoint_done.wait()): "checkpoint",
-            asyncio.create_task(self._restore_done.wait()): "restore",
-        }
-        try:
-            done, pending = await asyncio.wait(
-                waiters.keys(), return_when=asyncio.FIRST_COMPLETED
+            logger.info(
+                "Ready for checkpoint. Polling for sentinel in %s "
+                "(snapshot-complete or restore-complete)",
+                self.control_dir,
             )
-            for task in pending:
-                task.cancel()
-            winner = done.pop()
-            await winner
-            return waiters[winner]
+
+            event = await self._wait_for_sentinel()
         finally:
-            for task in waiters:
-                if not task.done():
-                    task.cancel()
+            self._cleanup_ready_and_sentinels()
+
+        if event == "restore":
+            logger.info("Restore sentinel detected")
+            logger.info("Resuming model after restore")
+            await quiesce_controller.resume()
+            quiesce_controller.mark_resumed()
+            return True
+
+        logger.info("Snapshot completion sentinel detected")
+        return False
+
+    async def _wait_for_sentinel(self) -> str:
+        snapshot_path = Path(self.control_dir) / SNAPSHOT_COMPLETE_FILE
+        restore_path = Path(self.control_dir) / RESTORE_COMPLETE_FILE
+        while True:
+            if snapshot_path.exists():
+                return "checkpoint"
+            if restore_path.exists():
+                return "restore"
+            await asyncio.sleep(_SENTINEL_POLL_INTERVAL_SEC)
+
+    def _cleanup_ready_and_sentinels(self) -> None:
+        for name in (
+            READY_FOR_CHECKPOINT_FILE,
+            SNAPSHOT_COMPLETE_FILE,
+            RESTORE_COMPLETE_FILE,
+        ):
+            path = os.path.join(self.control_dir, name)
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                logger.exception("Failed to clean up %s at %s", name, path)
 
 
 def configure_checkpoint_transport_env() -> None:

--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -164,7 +164,6 @@ The chart includes built-in validation to prevent all operator conflicts:
 | dynamo-operator.webhook.certManager.certificate.rootCA.duration | string | `"87600h"` | Duration for the root CA certificate (e.g., "87600h" for 10 years). The root CA typically has a much longer lifetime than the leaf certificates it signs. |
 | dynamo-operator.webhook.certManager.certificate.rootCA.renewBefore | string | `"720h"` | Time before root CA expiration to trigger renewal (e.g., "720h" for 30 days). Renewing a CA can be disruptive as all signed certificates must be reissued. |
 | dynamo-operator.checkpoint.enabled | bool | `false` | Whether to enable checkpoint/restore functionality |
-| dynamo-operator.checkpoint.readyForCheckpointFilePath | string | `"/tmp/ready-for-checkpoint"` | Path written by worker when model is loaded and ready for checkpointing |
 | grove.tolerations | list | `[]` | Node tolerations for Grove pods |
 | grove.affinity | object | `{}` | Affinity for Grove pods |
 | kai-scheduler.global.tolerations | list | `[]` | Node tolerations for kai-scheduler pods |

--- a/deploy/helm/charts/platform/components/operator/templates/operator-config.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/operator-config.yaml
@@ -132,9 +132,6 @@ data:
     {{- if .Values.checkpoint.enabled }}
     checkpoint:
       enabled: true
-      {{- if ne (.Values.checkpoint.readyForCheckpointFilePath | toString) "/tmp/ready-for-checkpoint" }}
-      readyForCheckpointFilePath: {{ .Values.checkpoint.readyForCheckpointFilePath | quote }}
-      {{- end }}
     {{- end }}
     {{- if and .Values.discoveryBackend (ne (.Values.discoveryBackend | toString) "kubernetes") }}
     discovery:

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -139,10 +139,6 @@ checkpoint:
   # Enable checkpoint/restore functionality
   enabled: false
 
-  # Path written by worker when model is loaded and ready for checkpointing
-  # Must match the path expected by checkpoint-enabled runtime images
-  readyForCheckpointFilePath: "/tmp/ready-for-checkpoint"
-
 # Webhook configuration
 webhook:
   # Certificate configuration

--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -228,9 +228,6 @@ dynamo-operator:
     # -- Whether to enable checkpoint/restore functionality
     enabled: false
 
-    # -- Path written by worker when model is loaded and ready for checkpointing
-    readyForCheckpointFilePath: "/tmp/ready-for-checkpoint"
-
 # Grove component - distributed inference orchestration
 # Installation is controlled by global.grove.install above.
 grove:

--- a/deploy/operator/api/config/v1alpha1/defaults.go
+++ b/deploy/operator/api/config/v1alpha1/defaults.go
@@ -85,11 +85,6 @@ func SetDefaultsOperatorConfiguration(obj *OperatorConfiguration) {
 		obj.GPU.DiscoveryEnabled = ptr.To(true)
 	}
 
-	// Checkpoint defaults
-	if obj.Checkpoint.ReadyForCheckpointFilePath == "" {
-		obj.Checkpoint.ReadyForCheckpointFilePath = "/tmp/ready-for-checkpoint"
-	}
-
 	// Logging defaults
 	if obj.Logging.Level == "" {
 		obj.Logging.Level = "info"

--- a/deploy/operator/api/config/v1alpha1/types.go
+++ b/deploy/operator/api/config/v1alpha1/types.go
@@ -245,9 +245,6 @@ type MPIConfiguration struct {
 type CheckpointConfiguration struct {
 	// Enabled indicates if checkpoint functionality is enabled
 	Enabled bool `json:"enabled"`
-	// ReadyForCheckpointFilePath signals model readiness for checkpoint jobs
-	// +kubebuilder:default="/tmp/ready-for-checkpoint"
-	ReadyForCheckpointFilePath string `json:"readyForCheckpointFilePath"`
 	// Deprecated: Storage is retained for compatibility and ignored by the
 	// current snapshot flow. Snapshot storage is discovered from the
 	// snapshot-agent DaemonSet instead.

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -188,7 +188,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		podSpec := testPodSpec()
 		info := &CheckpointInfo{Enabled: true, Ready: true, Identity: ptr.To(testIdentity())}
 		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
-		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info))
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, []string{consts.MainContainerName}))
 		assert.Equal(t, []string{"sleep", "infinity"}, podSpec.Containers[0].Command)
 		assert.Nil(t, podSpec.Containers[0].Args)
 		assert.Len(t, info.Hash, 16)
@@ -229,7 +229,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		info := &CheckpointInfo{Enabled: true, Ready: true, Hash: testHash}
 		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
 
-		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info))
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, []string{consts.MainContainerName}))
 		assert.Equal(t, []string{"sleep", "infinity"}, podSpec.Containers[0].Command)
 		assert.Nil(t, podSpec.Containers[0].Args)
 		assert.Equal(t, []string{"sidecar"}, podSpec.Containers[1].Command)
@@ -242,10 +242,10 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		info := &CheckpointInfo{Enabled: true, Ready: true, Hash: testHash, GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true}}
 		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
 
-		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info))
-		gmsServer := findContainer(podSpec, gms.ServerContainerName)
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, []string{consts.MainContainerName}))
+		gmsServer := findContainerAcrossInits(podSpec, gms.ServerContainerName)
 		require.NotNil(t, gmsServer)
-		loader := findContainer(podSpec, GMSLoaderContainer)
+		loader := findContainerAcrossInits(podSpec, GMSLoaderContainer)
 		require.NotNil(t, loader)
 
 		// Restore: server and loader are init sidecars (restartPolicy=Always)
@@ -284,7 +284,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 			{"snapshot daemonset missing", testPodSpec(), testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).Build(), "no snapshot-agent daemonset found"},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
-				err := InjectCheckpointIntoPodSpec(context.Background(), tc.reader, testNamespace, tc.podSpec, tc.info)
+				err := InjectCheckpointIntoPodSpec(context.Background(), tc.reader, testNamespace, tc.podSpec, tc.info, []string{consts.MainContainerName})
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.errMsg)
 			})
@@ -453,9 +453,9 @@ func TestResolveCheckpointForService(t *testing.T) {
 	})
 }
 
-// findContainer is a test helper that locates a container by name across both
-// regular containers and init containers.
-func findContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {
+// findContainerAcrossInits is a test helper that locates a container by name
+// across both regular containers and init containers.
+func findContainerAcrossInits(podSpec *corev1.PodSpec, name string) *corev1.Container {
 	for i := range podSpec.Containers {
 		if podSpec.Containers[i].Name == name {
 			return &podSpec.Containers[i]

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -21,13 +21,16 @@ import (
 	"context"
 	"fmt"
 
-	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ApplyRestorePodMetadata(labels map[string]string, annotations map[string]string, checkpointInfo *CheckpointInfo) {
+// ApplyRestorePodMetadata writes restore-target labels and annotations for a
+// restore pod, including the container-name list the snapshot agent must act
+// on. When checkpoint is disabled or not yet ready, per-container status
+// annotations and the container list are cleared.
+func ApplyRestorePodMetadata(labels map[string]string, annotations map[string]string, checkpointInfo *CheckpointInfo, containerNames []string) {
 	enabled := checkpointInfo != nil && checkpointInfo.Enabled && checkpointInfo.Ready
 	hash := ""
 	artifactVersion := ""
@@ -36,30 +39,29 @@ func ApplyRestorePodMetadata(labels map[string]string, annotations map[string]st
 		artifactVersion = checkpointInfo.ArtifactVersion
 	}
 	snapshotprotocol.ApplyRestoreTargetMetadata(labels, annotations, enabled, hash, artifactVersion)
-}
-
-// resolveMainContainer finds the container named "main" in the pod spec.
-// ExtraPodSpec.PodSpec.Containers can inject user containers before the main
-// container (mergo merge happens before main is appended), so index 0 is
-// not guaranteed to be the main container here.
-func resolveMainContainer(podSpec *corev1.PodSpec) *corev1.Container {
-	for i := range podSpec.Containers {
-		if podSpec.Containers[i].Name == commonconsts.MainContainerName {
-			return &podSpec.Containers[i]
-		}
+	if enabled {
+		annotations[snapshotprotocol.CheckpointContainersAnnotation] = snapshotprotocol.FormatCheckpointContainers(containerNames)
+	} else {
+		delete(annotations, snapshotprotocol.CheckpointContainersAnnotation)
 	}
-	return nil
 }
 
+// InjectCheckpointIntoPodSpec shapes podSpec for the listed workload
+// containers as a restore target when checkpoint is enabled. In PR 1 callers
+// always pass []string{"main"}; PR 2 will vary this for failover pods.
 func InjectCheckpointIntoPodSpec(
 	ctx context.Context,
 	reader ctrlclient.Reader,
 	namespace string,
 	podSpec *corev1.PodSpec,
 	checkpointInfo *CheckpointInfo,
+	containerNames []string,
 ) error {
 	if checkpointInfo == nil || !checkpointInfo.Enabled {
 		return nil
+	}
+	if len(containerNames) == 0 {
+		return fmt.Errorf("checkpoint inject requires at least one container name")
 	}
 
 	info := checkpointInfo
@@ -75,10 +77,6 @@ func InjectCheckpointIntoPodSpec(
 		info.Hash = hash
 	}
 
-	mainContainer := resolveMainContainer(podSpec)
-	if mainContainer == nil {
-		return fmt.Errorf("no container named %q found in pod spec", commonconsts.MainContainerName)
-	}
 	if reader == nil {
 		return fmt.Errorf("checkpoint client is required")
 	}
@@ -87,7 +85,7 @@ func InjectCheckpointIntoPodSpec(
 		reader,
 		namespace,
 		podSpec,
-		mainContainer,
+		containerNames,
 		info.Hash,
 		info.ArtifactVersion,
 		snapshotprotocol.DefaultSeccompLocalhostProfile,
@@ -97,20 +95,35 @@ func InjectCheckpointIntoPodSpec(
 	}
 
 	EnsurePodInfoVolume(podSpec)
-	EnsurePodInfoMount(mainContainer)
-	if info.Ready && info.GPUMemoryService != nil && info.GPUMemoryService.Enabled {
-		storage, err := snapshotprotocol.DiscoverAndResolveStorage(
-			ctx,
-			reader,
-			namespace,
-			info.Hash,
-			info.ArtifactVersion,
-		)
-		if err != nil {
-			return err
+	for _, name := range containerNames {
+		container := findContainer(podSpec.Containers, name)
+		if container == nil {
+			return fmt.Errorf("no container named %q found in pod spec", name)
 		}
-		EnsureGMSRestoreSidecars(podSpec, mainContainer, storage)
+		EnsurePodInfoMount(container)
+		if info.Ready && info.GPUMemoryService != nil && info.GPUMemoryService.Enabled {
+			storage, err := snapshotprotocol.DiscoverAndResolveStorage(
+				ctx,
+				reader,
+				namespace,
+				info.Hash,
+				info.ArtifactVersion,
+			)
+			if err != nil {
+				return err
+			}
+			EnsureGMSRestoreSidecars(podSpec, container, storage)
+		}
 	}
 
+	return nil
+}
+
+func findContainer(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
 	return nil
 }

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -140,9 +140,6 @@ const (
 	ResourceStateNotReady = "not_ready"
 	ResourceStateUnknown  = "unknown"
 
-	// Environment variables injected into pods
-	EnvReadyForCheckpointFile = "DYN_READY_FOR_CHECKPOINT_FILE" // Ready-for-checkpoint file path — checkpoint job pods
-
 	// Pod identity (Downward API) ---
 	// After CRIU restore, env vars contain stale values from the checkpoint pod.
 	// The Downward API files at /etc/podinfo always reflect the current pod.

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -75,6 +75,7 @@ func buildCheckpointJob(
 	if podTemplate.Annotations == nil {
 		podTemplate.Annotations = make(map[string]string)
 	}
+	podTemplate.Annotations[snapshotprotocol.CheckpointContainersAnnotation] = consts.MainContainerName
 	if podTemplate.Spec.ServiceAccountName == "" {
 		podTemplate.Spec.ServiceAccountName = discovery.GetK8sDiscoveryServiceAccountName(ckpt.Name)
 	}

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -90,25 +90,11 @@ func buildCheckpointJob(
 		mainContainer.Env,
 	)
 	dynamo.AddStandardEnvVars(mainContainer, config)
-	mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{
-		Name:  consts.EnvReadyForCheckpointFile,
-		Value: config.Checkpoint.ReadyForCheckpointFilePath,
-	})
-	mainContainer.ReadinessProbe = &corev1.Probe{
-		ProbeHandler: corev1.ProbeHandler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"cat", config.Checkpoint.ReadyForCheckpointFilePath},
-			},
-		},
-		InitialDelaySeconds: 15,
-		PeriodSeconds:       2,
-	}
-	mainContainer.LivenessProbe = nil
-	mainContainer.StartupProbe = nil
 
 	checkpoint.EnsurePodInfoMount(mainContainer)
 	dynamo.ApplySharedMemoryVolumeAndMount(&podTemplate.Spec, mainContainer, ckpt.Spec.Job.SharedMemory)
-	snapshotprotocol.EnsureControlVolume(&podTemplate.Spec, mainContainer)
+	// NewCheckpointJob handles control volume + readiness probe from the
+	// snapshot contract.
 
 	if ckpt.Spec.GPUMemoryService != nil && ckpt.Spec.GPUMemoryService.Enabled {
 		claimTemplateName := dra.ResourceClaimTemplateName("checkpoint-"+hash, "worker")

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -6,7 +6,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -107,9 +106,9 @@ func buildCheckpointJob(
 	mainContainer.LivenessProbe = nil
 	mainContainer.StartupProbe = nil
 
-	// The snapshot agent sends SIGUSR1 to PID 1 of the main container after
 	checkpoint.EnsurePodInfoMount(mainContainer)
 	dynamo.ApplySharedMemoryVolumeAndMount(&podTemplate.Spec, mainContainer, ckpt.Spec.Job.SharedMemory)
+	snapshotprotocol.EnsureControlVolume(&podTemplate.Spec, mainContainer)
 
 	if ckpt.Spec.GPUMemoryService != nil && ckpt.Spec.GPUMemoryService.Enabled {
 		claimTemplateName := dra.ResourceClaimTemplateName("checkpoint-"+hash, "worker")
@@ -129,9 +128,6 @@ func buildCheckpointJob(
 		if err := checkpoint.EnsureGMSCheckpointJobSidecars(&podTemplate.Spec, mainContainer, storage); err != nil {
 			return nil, err
 		}
-		// Re-acquire pointer: append in EnsureGMSCheckpointJobSidecars may
-		// have reallocated the Containers slice.
-		mainContainer = &podTemplate.Spec.Containers[0]
 	}
 
 	activeDeadlineSeconds := ckpt.Spec.Job.ActiveDeadlineSeconds
@@ -152,16 +148,6 @@ func buildCheckpointJob(
 		pp = 1
 	}
 	wrapLaunchJob := tp*pp > 1
-
-	// For single-GPU jobs (no cuda-checkpoint wrapper), unwrap /bin/sh -c so
-	// the actual process is PID 1 and receives SIGUSR1 from the snapshot agent.
-	if !wrapLaunchJob && len(mainContainer.Command) >= 2 &&
-		mainContainer.Command[len(mainContainer.Command)-1] == "-c" &&
-		len(mainContainer.Args) == 1 {
-		parts := strings.Fields(mainContainer.Args[0])
-		mainContainer.Command = parts[:1]
-		mainContainer.Args = parts[1:]
-	}
 
 	ttlSecondsAfterFinish := snapshotprotocol.DefaultCheckpointJobTTLSeconds
 

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -580,7 +580,7 @@ func TestCheckpointReconciler_HandleCreating(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        defaultCheckpointJobName,
 				Namespace:   testNamespace,
-				Annotations: map[string]string{snapshotprotocol.CheckpointStatusAnnotation: snapshotprotocol.CheckpointStatusCompleted},
+				Annotations: map[string]string{snapshotprotocol.CheckpointJobStatusAnnotation: snapshotprotocol.CheckpointStatusCompleted},
 			},
 			Status: batchv1.JobStatus{
 				Succeeded: 1,
@@ -672,7 +672,7 @@ func TestCheckpointReconciler_HandleCreating(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "job-agent-failed",
 				Namespace:   testNamespace,
-				Annotations: map[string]string{snapshotprotocol.CheckpointStatusAnnotation: snapshotprotocol.CheckpointStatusFailed},
+				Annotations: map[string]string{snapshotprotocol.CheckpointJobStatusAnnotation: snapshotprotocol.CheckpointStatusFailed},
 			},
 			Status: batchv1.JobStatus{
 				Succeeded: 1,
@@ -698,7 +698,7 @@ func TestCheckpointReconciler_HandleCreating(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "job-running-agent-failed",
 				Namespace:   testNamespace,
-				Annotations: map[string]string{snapshotprotocol.CheckpointStatusAnnotation: snapshotprotocol.CheckpointStatusFailed},
+				Annotations: map[string]string{snapshotprotocol.CheckpointJobStatusAnnotation: snapshotprotocol.CheckpointStatusFailed},
 			},
 			Status: batchv1.JobStatus{Active: 1},
 		}
@@ -736,7 +736,7 @@ func TestCheckpointReconciler_HandleCreating(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        defaultCheckpointJobName,
 				Namespace:   testNamespace,
-				Annotations: map[string]string{snapshotprotocol.CheckpointStatusAnnotation: snapshotprotocol.CheckpointStatusCompleted},
+				Annotations: map[string]string{snapshotprotocol.CheckpointJobStatusAnnotation: snapshotprotocol.CheckpointStatusCompleted},
 			},
 			Status: batchv1.JobStatus{
 				Succeeded: 1,

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -169,6 +169,7 @@ func TestBuildCheckpointJob(t *testing.T) {
 		envMap[e.Name] = e.Value
 	}
 	assert.Equal(t, "/tmp/ready-for-checkpoint", envMap[consts.EnvReadyForCheckpointFile])
+	assert.Equal(t, snapshotprotocol.SnapshotControlMountPath, envMap[snapshotprotocol.SnapshotControlDirEnv])
 	assert.Equal(t, "manual-checkpoint", envMap[consts.DynamoNamespaceEnvVar])
 	assert.Equal(t, consts.ComponentTypeWorker, envMap[consts.DynamoComponentEnvVar])
 	assert.Equal(t, "worker-1234", envMap[consts.DynamoNamespaceWorkerSuffixEnvVar])
@@ -212,6 +213,7 @@ func TestBuildCheckpointJob(t *testing.T) {
 	}
 	assert.False(t, volNames[snapshotprotocol.CheckpointVolumeName])
 	assert.True(t, volNames[consts.PodInfoVolumeName])
+	assert.True(t, volNames[snapshotprotocol.SnapshotControlVolumeName])
 
 	mountPaths := make(map[string]string)
 	for _, m := range main.VolumeMounts {
@@ -221,6 +223,7 @@ func TestBuildCheckpointJob(t *testing.T) {
 	assert.False(t, hasCheckpointMount)
 	assert.Equal(t, consts.PodInfoMountPath, mountPaths[consts.PodInfoVolumeName])
 	assert.Equal(t, consts.DefaultSharedMemoryMountPath, mountPaths[consts.KubeValueNameSharedMemory])
+	assert.Equal(t, snapshotprotocol.SnapshotControlMountPath, mountPaths[snapshotprotocol.SnapshotControlVolumeName])
 
 	foundSharedMemoryVolume := false
 	for _, v := range podSpec.Volumes {
@@ -374,7 +377,7 @@ func TestBuildCheckpointJobAddsGMSSidecars(t *testing.T) {
 	}
 	assert.True(t, volNames[gms.SharedVolumeName])
 	assert.True(t, volNames[snapshotprotocol.CheckpointVolumeName])
-	assert.True(t, volNames[snapshotprotocol.CheckpointVolumeName])
+	assert.True(t, volNames[snapshotprotocol.SnapshotControlVolumeName])
 
 	mainMounts := map[string]string{}
 	for _, m := range main.VolumeMounts {

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -78,8 +78,7 @@ func checkpointTestScheme() *runtime.Scheme {
 func checkpointTestConfig() *configv1alpha1.OperatorConfiguration {
 	return &configv1alpha1.OperatorConfiguration{
 		Checkpoint: configv1alpha1.CheckpointConfiguration{
-			Enabled:                    true,
-			ReadyForCheckpointFilePath: "/tmp/ready-for-checkpoint",
+			Enabled: true,
 		},
 	}
 }
@@ -168,7 +167,6 @@ func TestBuildCheckpointJob(t *testing.T) {
 	for _, e := range main.Env {
 		envMap[e.Name] = e.Value
 	}
-	assert.Equal(t, "/tmp/ready-for-checkpoint", envMap[consts.EnvReadyForCheckpointFile])
 	assert.Equal(t, snapshotprotocol.SnapshotControlMountPath, envMap[snapshotprotocol.SnapshotControlDirEnv])
 	assert.Equal(t, "manual-checkpoint", envMap[consts.DynamoNamespaceEnvVar])
 	assert.Equal(t, consts.ComponentTypeWorker, envMap[consts.DynamoComponentEnvVar])
@@ -202,7 +200,7 @@ func TestBuildCheckpointJob(t *testing.T) {
 
 	// Probes: readiness set, liveness/startup cleared
 	require.NotNil(t, main.ReadinessProbe)
-	assert.Equal(t, []string{"cat", "/tmp/ready-for-checkpoint"}, main.ReadinessProbe.Exec.Command)
+	assert.Equal(t, []string{"cat", "/snapshot-control/ready-for-checkpoint"}, main.ReadinessProbe.Exec.Command)
 	assert.Nil(t, main.LivenessProbe)
 	assert.Nil(t, main.StartupProbe)
 
@@ -304,7 +302,7 @@ func TestBuildCheckpointJobWrapsWithCudaCheckpointForMultiGPU(t *testing.T) {
 	assert.Equal(t, []string{"cuda-checkpoint"}, main.Command)
 	assert.Equal(t, []string{"--launch-job", "python3", "-m", "dynamo.vllm"}, main.Args)
 	require.NotNil(t, main.ReadinessProbe)
-	assert.Equal(t, []string{"cat", "/tmp/ready-for-checkpoint"}, main.ReadinessProbe.Exec.Command)
+	assert.Equal(t, []string{"cat", "/snapshot-control/ready-for-checkpoint"}, main.ReadinessProbe.Exec.Command)
 	assert.Nil(t, main.LivenessProbe)
 	assert.Nil(t, main.StartupProbe)
 
@@ -312,7 +310,7 @@ func TestBuildCheckpointJobWrapsWithCudaCheckpointForMultiGPU(t *testing.T) {
 	for _, env := range main.Env {
 		mainEnv[env.Name] = env.Value
 	}
-	assert.Equal(t, "/tmp/ready-for-checkpoint", mainEnv[consts.EnvReadyForCheckpointFile])
+	assert.Equal(t, snapshotprotocol.SnapshotControlMountPath, mainEnv[snapshotprotocol.SnapshotControlDirEnv])
 	assert.Equal(t, "secret", mainEnv["HF_TOKEN"])
 
 	sidecar := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, "sidecar")
@@ -322,7 +320,7 @@ func TestBuildCheckpointJobWrapsWithCudaCheckpointForMultiGPU(t *testing.T) {
 	assert.Nil(t, sidecar.LivenessProbe)
 	assert.Nil(t, sidecar.StartupProbe)
 	for _, env := range sidecar.Env {
-		assert.NotEqual(t, consts.EnvReadyForCheckpointFile, env.Name)
+		assert.NotEqual(t, snapshotprotocol.SnapshotControlDirEnv, env.Name)
 	}
 }
 

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -1086,6 +1086,7 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 			opt.dynamoComponentDeployment.Namespace,
 			podSpec,
 			checkpointInfo,
+			[]string{commonconsts.MainContainerName},
 		); err != nil {
 			return nil, errors.Wrap(err, "failed to inject checkpoint config")
 		}
@@ -1122,7 +1123,7 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 	}
 	// Restore labels are operator-controlled state. Clear stale values after
 	// metadata merge and only reapply them when checkpoint material is ready.
-	checkpoint.ApplyRestorePodMetadata(podLabels, podAnnotations, checkpointInfo)
+	checkpoint.ApplyRestorePodMetadata(podLabels, podAnnotations, checkpointInfo, []string{commonconsts.MainContainerName})
 
 	// Propagate restart annotation to pod template to trigger rolling restart
 	// This is the same mechanism used by kubectl rollout restart

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1376,6 +1376,9 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		if got := podTemplateSpec.Labels[snapshotprotocol.CheckpointIDLabel]; got != checkpointName {
 			t.Fatalf("expected %s to be checkpoint id, got %q", snapshotprotocol.CheckpointIDLabel, got)
 		}
+		if got := podTemplateSpec.Annotations[snapshotprotocol.CheckpointContainersAnnotation]; got != commonconsts.MainContainerName {
+			t.Fatalf("expected %s annotation to be %q, got %q", snapshotprotocol.CheckpointContainersAnnotation, commonconsts.MainContainerName, got)
+		}
 	})
 
 	t.Run("ready gms checkpoint injects gms restore sidecars", func(t *testing.T) {

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1453,6 +1453,7 @@ func GenerateGrovePodCliqueSet(
 					dynamoDeployment.Namespace,
 					podSpec,
 					checkpointInfo,
+					[]string{commonconsts.MainContainerName},
 				); err != nil {
 					return nil, fmt.Errorf("failed to inject checkpoint config for role %s: %w", r.Name, err)
 				}
@@ -1488,7 +1489,10 @@ func GenerateGrovePodCliqueSet(
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate annotations: %w", err)
 			}
-			checkpoint.ApplyRestorePodMetadata(labels, annotations, checkpointInfo)
+			if annotations == nil {
+				annotations = map[string]string{}
+			}
+			checkpoint.ApplyRestorePodMetadata(labels, annotations, checkpointInfo, []string{commonconsts.MainContainerName})
 
 			// Apply restart annotation if this service should be restarted.
 			// For services not in the current restart order, preserve their existing annotation

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -6881,7 +6881,7 @@ func TestGenerateLabels_RemovesStaleRestoreLabelsWhenCheckpointNotReady(t *testi
 		Enabled: true,
 		Ready:   false,
 		Hash:    "resolved-hash",
-	})
+	}, []string{commonconsts.MainContainerName})
 	assert.Equal(t, "keep", labels["user-label"])
 	assert.Equal(t, "keep-too", labels["extra-label"])
 	_, hasRestoreTarget := labels[snapshotprotocol.RestoreTargetLabel]
@@ -6916,9 +6916,10 @@ func TestGenerateLabels_OverwritesStaleRestoreLabelsWhenCheckpointReady(t *testi
 		Enabled: true,
 		Ready:   true,
 		Hash:    "resolved-hash",
-	})
+	}, []string{commonconsts.MainContainerName})
 	assert.Equal(t, commonconsts.KubeLabelValueTrue, labels[snapshotprotocol.RestoreTargetLabel])
 	assert.Equal(t, "resolved-hash", labels[snapshotprotocol.CheckpointIDLabel])
+	assert.Equal(t, commonconsts.MainContainerName, annotations[snapshotprotocol.CheckpointContainersAnnotation])
 }
 
 func TestGenerateLabels_ReassertsRestoreIdentityLabelsAfterMetadataMerge(t *testing.T) {

--- a/deploy/operator/internal/gms/gms.go
+++ b/deploy/operator/internal/gms/gms.go
@@ -20,11 +20,13 @@ const (
 	ServerContainerName = "gms-server"
 
 	// SharedVolumeName is the emptyDir volume shared between the GMS server
-	// sidecar and the main workload container for UDS sockets.
-	SharedVolumeName = "gms-shared"
+	// sidecar and the main workload container for UDS sockets. The name
+	// disambiguates it from the snapshot-control volume, which carries
+	// checkpoint/restore lifecycle sentinels written by the snapshot agent.
+	SharedVolumeName = "gms-intrapod-control"
 
-	// SharedMountPath is the mount path for the shared GMS socket directory.
-	SharedMountPath = "/shared"
+	// SharedMountPath is the mount path for the GMS intra-pod IPC directory.
+	SharedMountPath = "/gms-intrapod-control"
 
 	// EnvSocketDir is the environment variable name for the GMS UDS socket directory.
 	EnvSocketDir = "GMS_SOCKET_DIR"

--- a/deploy/snapshot/cmd/snapshotctl/checkpoint.go
+++ b/deploy/snapshot/cmd/snapshotctl/checkpoint.go
@@ -25,6 +25,7 @@ type checkpointOptions struct {
 	Namespace                    string
 	KubeContext                  string
 	CheckpointID                 string
+	ContainersFlag               string
 	DisableCudaCheckpointJobFile bool
 	Timeout                      time.Duration
 }
@@ -50,6 +51,9 @@ func runCheckpointFlow(ctx context.Context, opts checkpointOptions) (*result, er
 	pod, clientset, namespace, storage, err := loadRunContext(ctx, opts.ManifestPath, opts.Namespace, opts.KubeContext)
 	if err != nil {
 		return nil, err
+	}
+	if _, err := resolveContainerNames(pod, opts.ContainersFlag); err != nil {
+		return nil, fmt.Errorf("resolve checkpoint containers: %w", err)
 	}
 
 	checkpointID := strings.TrimSpace(opts.CheckpointID)
@@ -130,7 +134,7 @@ func waitForCheckpoint(ctx context.Context, clientset kubernetes.Interface, name
 				return false, fmt.Errorf("unexpected checkpoint watch object %T", event.Object)
 			}
 
-			status = strings.TrimSpace(job.Annotations[snapshotprotocol.CheckpointStatusAnnotation])
+			status = strings.TrimSpace(job.Annotations[snapshotprotocol.CheckpointJobStatusAnnotation])
 			if status == snapshotprotocol.CheckpointStatusCompleted {
 				return true, nil
 			}

--- a/deploy/snapshot/cmd/snapshotctl/kube.go
+++ b/deploy/snapshot/cmd/snapshotctl/kube.go
@@ -82,6 +82,9 @@ func discoverSnapshotStorage(ctx context.Context, clientset kubernetes.Interface
 	return snapshotprotocol.DiscoverStorageFromDaemonSets(namespace, daemonSets.Items)
 }
 
+// loadPod parses a worker Pod manifest. It does not interpret the container
+// list — the set of containers to snapshot or restore comes from the
+// nvidia.com/snapshot-containers annotation (or --containers on the CLI).
 func loadPod(manifestPath string) (*corev1.Pod, error) {
 	content, err := os.ReadFile(manifestPath)
 	if err != nil {
@@ -96,35 +99,29 @@ func loadPod(manifestPath string) (*corev1.Pod, error) {
 		return nil, fmt.Errorf("manifest %s is kind %q, expected Pod", manifestPath, kind)
 	}
 	if len(pod.Spec.Containers) == 0 {
-		return nil, fmt.Errorf(
-			"manifest %s has no worker containers; snapshotctl requires at least one worker container",
-			manifestPath,
-		)
-	}
-	workerContainer := &pod.Spec.Containers[0]
-	if len(pod.Spec.Containers) > 1 {
-		workerContainer = nil
-		for index := range pod.Spec.Containers {
-			if pod.Spec.Containers[index].Name == "main" {
-				workerContainer = &pod.Spec.Containers[index]
-				break
-			}
-		}
-		if workerContainer == nil {
-			return nil, fmt.Errorf(
-				"manifest %s has %d containers; snapshotctl requires a worker container named main",
-				manifestPath,
-				len(pod.Spec.Containers),
-			)
-		}
-	}
-	if strings.TrimSpace(workerContainer.Image) == "" {
-		return nil, fmt.Errorf("manifest %s: worker container image is required", manifestPath)
+		return nil, fmt.Errorf("manifest %s has no containers", manifestPath)
 	}
 	if strings.TrimSpace(pod.Name) == "" {
 		return nil, fmt.Errorf("manifest %s: metadata.name is required", manifestPath)
 	}
+	for i := range pod.Spec.Containers {
+		if strings.TrimSpace(pod.Spec.Containers[i].Image) == "" {
+			return nil, fmt.Errorf("manifest %s: container %q image is required", manifestPath, pod.Spec.Containers[i].Name)
+		}
+	}
 
 	pod.Namespace = strings.TrimSpace(pod.Namespace)
 	return &pod, nil
+}
+
+// resolveContainerNames picks the container list: the CLI flag wins, else the
+// manifest's nvidia.com/snapshot-containers annotation is parsed, else error.
+func resolveContainerNames(pod *corev1.Pod, containersFlag string) ([]string, error) {
+	if strings.TrimSpace(containersFlag) != "" {
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
+		}
+		pod.Annotations[snapshotprotocol.CheckpointContainersAnnotation] = strings.TrimSpace(containersFlag)
+	}
+	return snapshotprotocol.ParseCheckpointContainers(pod.Annotations)
 }

--- a/deploy/snapshot/cmd/snapshotctl/main.go
+++ b/deploy/snapshot/cmd/snapshotctl/main.go
@@ -46,6 +46,7 @@ func runCheckpoint(args []string) error {
 	namespace := flags.String("namespace", "", "Namespace override; defaults to the manifest namespace or current kube context namespace")
 	kubeContext := flags.String("kube-context", "", "Kubernetes context override")
 	checkpointID := flags.String("checkpoint-id", "", "Explicit checkpoint ID; defaults to a generated value")
+	containers := flags.String("containers", "", "Comma-separated, ordered list of workload container names to snapshot. Overrides the manifest's nvidia.com/snapshot-containers annotation.")
 	disableCudaCheckpointJobFile := flags.Bool("disable-cuda-checkpoint-job-file", false, "Preserve the manifest command instead of wrapping it with cuda-checkpoint --launch-job")
 	timeout := flags.Duration("timeout", 45*time.Minute, "Maximum time to wait for checkpoint completion")
 
@@ -65,6 +66,7 @@ func runCheckpoint(args []string) error {
 		Namespace:                    *namespace,
 		KubeContext:                  *kubeContext,
 		CheckpointID:                 *checkpointID,
+		ContainersFlag:               *containers,
 		DisableCudaCheckpointJobFile: *disableCudaCheckpointJobFile,
 		Timeout:                      *timeout,
 	})
@@ -91,6 +93,7 @@ func runRestore(args []string) error {
 	namespace := flags.String("namespace", "", "Namespace override; defaults to the manifest namespace or current kube context namespace")
 	kubeContext := flags.String("kube-context", "", "Kubernetes context override")
 	checkpointID := flags.String("checkpoint-id", "", "Checkpoint ID to restore")
+	containers := flags.String("containers", "", "Comma-separated, ordered list of workload container names to restore. Overrides the manifest's nvidia.com/snapshot-containers annotation.")
 	timeout := flags.Duration("timeout", 45*time.Minute, "Maximum time to wait for restore completion")
 
 	if err := flags.Parse(args); err != nil {
@@ -105,12 +108,13 @@ func runRestore(args []string) error {
 
 	snapshotctlLog.Info("Running restore", "manifest", *manifest, "pod", *podName, "namespace", *namespace, "checkpoint_id", *checkpointID)
 	result, err := runRestoreFlow(context.Background(), restoreOptions{
-		ManifestPath: *manifest,
-		PodName:      *podName,
-		Namespace:    *namespace,
-		KubeContext:  *kubeContext,
-		CheckpointID: *checkpointID,
-		Timeout:      *timeout,
+		ManifestPath:   *manifest,
+		PodName:        *podName,
+		Namespace:      *namespace,
+		KubeContext:    *kubeContext,
+		CheckpointID:   *checkpointID,
+		ContainersFlag: *containers,
+		Timeout:        *timeout,
 	})
 	if err != nil {
 		return err

--- a/deploy/snapshot/cmd/snapshotctl/restore.go
+++ b/deploy/snapshot/cmd/snapshotctl/restore.go
@@ -20,12 +20,13 @@ import (
 )
 
 type restoreOptions struct {
-	ManifestPath string
-	PodName      string
-	Namespace    string
-	KubeContext  string
-	CheckpointID string
-	Timeout      time.Duration
+	ManifestPath   string
+	PodName        string
+	Namespace      string
+	KubeContext    string
+	CheckpointID   string
+	ContainersFlag string
+	Timeout        time.Duration
 }
 
 func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
@@ -56,6 +57,7 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 
 	podName := strings.TrimSpace(opts.PodName)
 	pod := &corev1.Pod{}
+	var containerNames []string
 	if createPodFromManifest {
 		pod, err = loadPod(opts.ManifestPath)
 		if err != nil {
@@ -65,6 +67,10 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 			namespace = strings.TrimSpace(pod.Namespace)
 		}
 		podName = pod.Name
+		containerNames, err = resolveContainerNames(pod, opts.ContainersFlag)
+		if err != nil {
+			return nil, fmt.Errorf("resolve restore containers from manifest: %w", err)
+		}
 	}
 
 	storage, err := discoverSnapshotStorage(ctx, clientset, namespace)
@@ -81,7 +87,7 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 	}
 
 	if createPodFromManifest {
-		restorePod := snapshotprotocol.NewRestorePod(&corev1.Pod{
+		restorePod, err := snapshotprotocol.NewRestorePod(&corev1.Pod{
 			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        pod.Name,
@@ -96,6 +102,9 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 			Storage:         resolvedStorage,
 			SeccompProfile:  snapshotprotocol.DefaultSeccompLocalhostProfile,
 		})
+		if err != nil {
+			return nil, fmt.Errorf("shape restore pod: %w", err)
+		}
 		_, err = clientset.CoreV1().Pods(namespace).Create(ctx, restorePod, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
 			return nil, fmt.Errorf("restore pod %s/%s already exists", namespace, pod.Name)
@@ -111,7 +120,11 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 		if len(pod.Spec.Containers) == 0 {
 			return nil, fmt.Errorf("restore target pod %s/%s has no containers", namespace, podName)
 		}
-		if err := snapshotprotocol.ValidateRestorePodSpec(&pod.Spec, resolvedStorage, snapshotprotocol.DefaultSeccompLocalhostProfile); err != nil {
+		containerNames, err = resolveContainerNames(pod, opts.ContainersFlag)
+		if err != nil {
+			return nil, fmt.Errorf("resolve restore containers on pod %s/%s: %w", namespace, podName, err)
+		}
+		if err := snapshotprotocol.ValidateRestorePodSpec(&pod.Spec, containerNames, resolvedStorage, snapshotprotocol.DefaultSeccompLocalhostProfile); err != nil {
 			return nil, fmt.Errorf("restore target pod %s/%s is not snapshot-compatible: %w", namespace, podName, err)
 		}
 
@@ -124,6 +137,7 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 			annotations[key] = value
 		}
 		snapshotprotocol.ApplyRestoreTargetMetadata(labels, annotations, true, checkpointID, snapshotprotocol.DefaultCheckpointArtifactVersion)
+		annotations[snapshotprotocol.CheckpointContainersAnnotation] = snapshotprotocol.FormatCheckpointContainers(containerNames)
 		patch, err := json.Marshal(map[string]any{
 			"metadata": map[string]any{
 				"labels":      labels,
@@ -140,7 +154,7 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, opts.Timeout)
 	defer cancel()
-	status, err := waitForRestore(waitCtx, clientset, namespace, podName)
+	status, err := waitForRestore(waitCtx, clientset, namespace, podName, containerNames)
 	if err != nil {
 		return nil, err
 	}
@@ -155,8 +169,11 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 	}, nil
 }
 
-func waitForRestore(ctx context.Context, clientset kubernetes.Interface, namespace string, podName string) (string, error) {
-	var status string
+// waitForRestore succeeds when every listed container's per-container restore
+// status reads completed, fails if any of them reads failed, and returns an
+// aggregate status (completed / failed) to the caller.
+func waitForRestore(ctx context.Context, clientset kubernetes.Interface, namespace string, podName string, containerNames []string) (string, error) {
+	var aggregateStatus string
 	err := watchNamedObject(
 		ctx,
 		podName,
@@ -177,15 +194,24 @@ func waitForRestore(ctx context.Context, clientset kubernetes.Interface, namespa
 				return false, fmt.Errorf("unexpected restore watch object %T", event.Object)
 			}
 
-			status = strings.TrimSpace(pod.Annotations[snapshotprotocol.RestoreStatusAnnotation])
-			if status == snapshotprotocol.RestoreStatusCompleted {
-				return true, nil
-			}
-			if status == snapshotprotocol.RestoreStatusFailed {
-				return false, fmt.Errorf("restore pod %s/%s failed", namespace, podName)
+			completed := 0
+			for _, name := range containerNames {
+				key := snapshotprotocol.RestoreStatusAnnotationPrefix + name
+				status := strings.TrimSpace(pod.Annotations[key])
+				if status == snapshotprotocol.RestoreStatusFailed {
+					aggregateStatus = snapshotprotocol.RestoreStatusFailed
+					return false, fmt.Errorf("restore pod %s/%s container %q failed", namespace, podName, name)
+				}
+				if status == snapshotprotocol.RestoreStatusCompleted {
+					completed++
+				}
 			}
 			if pod.Status.Phase == corev1.PodFailed {
 				return false, fmt.Errorf("restore pod %s/%s entered phase Failed (%s)", namespace, podName, pod.Status.Reason)
+			}
+			if completed == len(containerNames) {
+				aggregateStatus = snapshotprotocol.RestoreStatusCompleted
+				return true, nil
 			}
 			return false, nil
 		},
@@ -194,26 +220,32 @@ func waitForRestore(ctx context.Context, clientset kubernetes.Interface, namespa
 		if !errors.Is(err, context.DeadlineExceeded) {
 			return "", err
 		}
-		return "", fmt.Errorf("restore pod %s/%s timed out: %s", namespace, podName, restoreTimeoutSummary(clientset, namespace, podName, status))
+		return "", fmt.Errorf("restore pod %s/%s timed out: %s", namespace, podName, restoreTimeoutSummary(clientset, namespace, podName, aggregateStatus, containerNames))
 	}
-	return status, nil
+	return aggregateStatus, nil
 }
 
-func restoreTimeoutSummary(clientset kubernetes.Interface, namespace string, podName string, status string) string {
+func restoreTimeoutSummary(clientset kubernetes.Interface, namespace string, podName string, aggregateStatus string, containerNames []string) string {
 	summaryCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	pod, err := clientset.CoreV1().Pods(namespace).Get(summaryCtx, podName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return fmt.Sprintf("restore_status=%q pod not found", status)
+			return fmt.Sprintf("restore_status=%q pod not found", aggregateStatus)
 		}
 		return "unable to get restore pod: " + err.Error()
 	}
 
 	parts := []string{
-		fmt.Sprintf("restore_status=%q", status),
+		fmt.Sprintf("restore_status=%q", aggregateStatus),
 		fmt.Sprintf("pod=%s phase=%s", pod.Name, pod.Status.Phase),
+	}
+	for _, name := range containerNames {
+		key := snapshotprotocol.RestoreStatusAnnotationPrefix + name
+		if status := strings.TrimSpace(pod.Annotations[key]); status != "" {
+			parts = append(parts, fmt.Sprintf("%s=%s", name, status))
+		}
 	}
 	if reason := strings.TrimSpace(pod.Status.Reason); reason != "" {
 		parts = append(parts, fmt.Sprintf("reason=%s", reason))

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -317,7 +317,9 @@ func (w *NodeController) reconcileRestorePod(ctx context.Context, pod *corev1.Po
 //  1. Hold and renew the checkpoint lease
 //  2. Resolve the container ID and host PID
 //  3. Call executor.Checkpoint (inspect → configure → CUDA lock/checkpoint → CRIU dump → rootfs diff)
-//  4. SIGUSR1 the process on success (notify workload), SIGKILL on failure (terminate immediately)
+//  4. Write a snapshot-complete sentinel into the pod's snapshot-control
+//     volume on success (observed by the workload via inotify), or SIGKILL
+//     on failure (unrecoverable CUDA-locked process)
 //  5. Mark job as completed or failed
 func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job *batchv1.Job, checkpointID, checkpointLocation, podKey string, startedAt time.Time) error {
 	releasePodOnExit := true
@@ -438,16 +440,21 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 		return nil
 	}
 
-	// Step 2: SIGUSR1 on success: notify the workload that checkpoint completed
-	emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeNormal, "CheckpointSucceeded", fmt.Sprintf("Checkpoint completed: %s", checkpointID))
-	if err := snapshotruntime.SendSignalToPID(log, containerPID, syscall.SIGUSR1, "checkpoint complete"); err != nil {
-		log.Error(err, "Failed to signal checkpoint completion to runtime process")
+	// Step 2: Sentinel on success. Workload observes via polling on the
+	// snapshot-control volume; containerPID is a PID inside the container's
+	// mount namespace, which is all the /host/proc/<pid>/root write path
+	// requires. The Succeeded event is emitted only after the sentinel has
+	// been written so a sentinel-write failure doesn't produce conflicting
+	// Succeeded+Failed events for the same operation.
+	if err := snapshotruntime.WriteControlSentinel(containerPID, snapshotprotocol.SnapshotCompleteFile); err != nil {
+		log.Error(err, "Failed to write snapshot-complete sentinel")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", err.Error())
 		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
 			return statusErr
 		}
 		return nil
 	}
+	emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeNormal, "CheckpointSucceeded", fmt.Sprintf("Checkpoint completed: %s", checkpointID))
 
 	if err := setCheckpointStatus(snapshotprotocol.CheckpointStatusCompleted); err != nil {
 		return err
@@ -458,7 +465,8 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 // runRestore runs the full restore workflow for a pod:
 //  1. Mark the current container instance as in_progress
 //  2. Call executor.Restore (inspect placeholder → nsrestore inside namespace)
-//  3. SIGCONT the restored process to wake it up
+//  3. Write a restore-complete sentinel into the pod's snapshot-control
+//     volume to wake the workload (observed via inotify)
 //  4. Wait for the pod to become Ready
 //  5. Mark the container instance as completed
 func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, containerName, containerID, checkpointID, checkpointLocation, restoreAttemptKey string, startedAt time.Time) error {
@@ -506,13 +514,14 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		ContainerName:      containerName,
 		Clientset:          w.clientset,
 	}
-	restoredPID, err := executor.Restore(restoreCtx, w.containerd, log, req)
+	placeholderHostPID, err := executor.Restore(restoreCtx, w.containerd, log, req)
 	if err != nil {
 		log.Error(err, "External restore failed")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())
 		if statusErr := setRestoreStatus(snapshotprotocol.RestoreStatusFailed); statusErr != nil {
 			return statusErr
 		}
+		// Re-resolve: executor.Restore may have failed before resolving the placeholder.
 		placeholderHostPID, _, pidErr := snapshotruntime.ResolveContainerByPod(ctx, w.containerd, pod.Name, pod.Namespace, containerName)
 		if pidErr != nil {
 			return fmt.Errorf("restore failed and placeholder PID could not be resolved: %w", pidErr)
@@ -523,31 +532,24 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return nil
 	}
 
-	// Step 2: SIGCONT the restored process via PID namespace
-	placeholderHostPID, _, err := snapshotruntime.ResolveContainerByPod(ctx, w.containerd, pod.Name, pod.Namespace, containerName)
-	if err != nil {
-		log.Error(err, "Failed to resolve placeholder host PID for signaling")
+	// Step 2: Write restore-complete sentinel. placeholderHostPID came back
+	// from executor.Restore — any PID inside the container's mount namespace
+	// reaches /snapshot-control via /host/proc/<pid>/root.
+	if err := snapshotruntime.WriteControlSentinel(placeholderHostPID, snapshotprotocol.RestoreCompleteFile); err != nil {
+		log.Error(err, "Failed to write restore-complete sentinel")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())
 		if statusErr := setRestoreStatus(snapshotprotocol.RestoreStatusFailed); statusErr != nil {
 			return statusErr
 		}
-		return fmt.Errorf("failed to resolve placeholder host PID for signaling: %w", err)
-	}
-	if err := snapshotruntime.SendSignalViaPIDNamespace(restoreCtx, log, placeholderHostPID, restoredPID, syscall.SIGCONT, "restore complete"); err != nil {
-		log.Error(err, "Failed to signal restored runtime process")
-		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())
-		if statusErr := setRestoreStatus(snapshotprotocol.RestoreStatusFailed); statusErr != nil {
-			return statusErr
+		if killErr := snapshotruntime.SendSignalToPID(log, placeholderHostPID, syscall.SIGKILL, "restore sentinel failed"); killErr != nil {
+			log.Error(killErr, "Failed to kill placeholder after restore sentinel failure")
 		}
-		if killErr := snapshotruntime.SendSignalToPID(log, placeholderHostPID, syscall.SIGKILL, "restore signaling failed"); killErr != nil {
-			log.Error(killErr, "Failed to kill placeholder after restore signaling failure")
-		}
-		return fmt.Errorf("failed to signal restored runtime process: %w", err)
+		return fmt.Errorf("failed to write restore-complete sentinel: %w", err)
 	}
 
 	// Step 3: Wait for the pod to become Ready
 	if err := waitForPodReady(restoreCtx, w.clientset, pod.Namespace, pod.Name, containerName); err != nil {
-		log.Error(err, "Restore post-signal readiness check failed")
+		log.Error(err, "Restore post-sentinel readiness check failed")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())
 		if statusErr := setRestoreStatus(snapshotprotocol.RestoreStatusFailed); statusErr != nil {
 			return statusErr
@@ -555,7 +557,7 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		if killErr := snapshotruntime.SendSignalToPID(log, placeholderHostPID, syscall.SIGKILL, "restore readiness failed"); killErr != nil {
 			log.Error(killErr, "Failed to kill placeholder after restore readiness failure")
 		}
-		return fmt.Errorf("restore post-signal readiness check failed: %w", err)
+		return fmt.Errorf("restore post-sentinel readiness check failed: %w", err)
 	}
 
 	emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeNormal, "RestoreSucceeded", fmt.Sprintf("Restore completed from checkpoint %s", checkpointID))

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -192,13 +192,19 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 		return
 	}
 
+	containerNames, err := snapshotprotocol.ParseCheckpointContainers(pod.Annotations)
+	if err != nil {
+		w.log.Error(err, "Checkpoint pod has invalid container list annotation", "pod", podKey)
+		return
+	}
+
 	job, err := getCheckpointJob(ctx, w.clientset, pod)
 	if err != nil {
 		w.log.Error(err, "Failed to resolve checkpoint job", "pod", podKey)
 		return
 	}
 
-	jobStatus := job.Annotations[snapshotprotocol.CheckpointStatusAnnotation]
+	jobStatus := job.Annotations[snapshotprotocol.CheckpointJobStatusAnnotation]
 	if jobStatus == snapshotprotocol.CheckpointStatusCompleted || jobStatus == snapshotprotocol.CheckpointStatusFailed {
 		return
 	}
@@ -207,7 +213,7 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 		return
 	}
 
-	checkpointLocation, err := w.checkpointLocationFromPod(pod, checkpointID)
+	podCheckpointRoot, err := w.checkpointLocationFromPod(pod, checkpointID)
 	if err != nil {
 		w.release(podKey)
 		w.log.Error(err, "Checkpoint pod is missing storage metadata", "pod", podKey, "checkpoint_id", checkpointID)
@@ -226,11 +232,12 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 	}
 
 	startedAt := time.Now()
-	w.log.Info("Checkpoint target detected, triggering checkpoint", "pod", podKey, "checkpoint_id", checkpointID)
+	w.log.Info("Checkpoint target detected, triggering checkpoint",
+		"pod", podKey, "checkpoint_id", checkpointID, "containers", containerNames)
 	emitPodEvent(ctx, w.clientset, w.log, pod, "snapshot", corev1.EventTypeNormal, "CheckpointRequested", fmt.Sprintf("Checkpoint requested: %s", checkpointID))
 
 	go func() {
-		if err := w.runCheckpoint(ctx, pod, job, checkpointID, checkpointLocation, podKey, startedAt); err != nil {
+		if err := w.runCheckpoint(ctx, pod, job, checkpointID, podCheckpointRoot, containerNames, podKey, startedAt); err != nil {
 			opLog := w.log.WithValues("pod", podKey, "checkpoint_id", checkpointID)
 			opLog.Error(err, "Checkpoint controller worker failed")
 			emitPodEvent(ctx, w.clientset, opLog, pod, "snapshot", corev1.EventTypeWarning, "CheckpointWorkerFailed", err.Error())
@@ -242,86 +249,109 @@ func (w *NodeController) reconcileRestorePod(ctx context.Context, pod *corev1.Po
 	if pod.Spec.NodeName != w.config.NodeName {
 		return
 	}
-
-	podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-
 	if pod.Status.Phase != corev1.PodRunning {
 		return
 	}
+
+	podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 
 	checkpointID, ok := pod.Labels[snapshotprotocol.CheckpointIDLabel]
 	if !ok || checkpointID == "" {
 		w.log.Info("Restore pod has no checkpoint-id label", "pod", podKey)
 		return
 	}
-
 	if strings.ContainsAny(checkpointID, "/\\") || strings.Contains(checkpointID, "..") || filepath.Clean(checkpointID) != checkpointID {
 		w.log.Error(fmt.Errorf("invalid checkpoint id %q", checkpointID), "Invalid checkpoint id on restore pod", "pod", podKey)
 		return
 	}
 
-	checkpointLocation, err := w.checkpointLocationFromPod(pod, checkpointID)
+	containerNames, err := snapshotprotocol.ParseCheckpointContainers(pod.Annotations)
+	if err != nil {
+		w.log.Error(err, "Restore pod has invalid container list annotation", "pod", podKey)
+		return
+	}
+
+	podCheckpointRoot, err := w.checkpointLocationFromPod(pod, checkpointID)
 	if err != nil {
 		w.log.Error(err, "Restore pod is missing storage metadata", "pod", podKey, "checkpoint_id", checkpointID)
 		return
 	}
-	if _, err := os.Stat(checkpointLocation); os.IsNotExist(err) {
-		w.log.V(1).Info("Checkpoint not ready on disk, skipping restore", "pod", podKey, "checkpoint_id", checkpointID, "checkpoint_location", checkpointLocation)
+	if _, err := os.Stat(podCheckpointRoot); os.IsNotExist(err) {
+		w.log.V(1).Info("Checkpoint not ready on disk, skipping restore",
+			"pod", podKey, "checkpoint_id", checkpointID, "pod_checkpoint_root", podCheckpointRoot)
 		return
 	}
 
-	containerName := resolveMainContainerName(pod)
-	if containerName == "" {
-		w.log.Info("Restore pod has no containers", "pod", podKey)
-		return
-	}
-
-	containerID := ""
+	containerIDByName := make(map[string]string, len(pod.Status.ContainerStatuses))
 	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Name != containerName || cs.ContainerID == "" {
+		if cs.ContainerID == "" {
 			continue
 		}
-		containerID = strings.TrimPrefix(cs.ContainerID, "containerd://")
-		break
-	}
-	if containerID == "" {
-		w.log.V(1).Info("Restore pod has no running main container yet", "pod", podKey, "container", containerName)
-		return
+		containerIDByName[cs.Name] = strings.TrimPrefix(cs.ContainerID, "containerd://")
 	}
 
-	annotationStatus := pod.Annotations[snapshotprotocol.RestoreStatusAnnotation]
-	annotationContainerID := pod.Annotations[snapshotprotocol.RestoreContainerIDAnnotation]
-	if annotationContainerID == containerID && (annotationStatus == snapshotprotocol.RestoreStatusCompleted || annotationStatus == snapshotprotocol.RestoreStatusFailed) {
-		return
-	}
-
-	restoreAttemptKey := fmt.Sprintf("%s/%s", podKey, containerID)
-	if !w.tryAcquire(restoreAttemptKey) {
-		return
-	}
-
-	startedAt := time.Now()
-	w.log.Info("Restore target detected, triggering external restore", "pod", podKey, "checkpoint_id", checkpointID)
-	emitPodEvent(ctx, w.clientset, w.log, pod, "snapshot", corev1.EventTypeNormal, "RestoreRequested", fmt.Sprintf("Restore requested from checkpoint %s", checkpointID))
-
-	go func() {
-		if err := w.runRestore(ctx, pod, containerName, containerID, checkpointID, checkpointLocation, restoreAttemptKey, startedAt); err != nil {
-			opLog := w.log.WithValues("pod", podKey, "checkpoint_id", checkpointID)
-			opLog.Error(err, "Restore controller worker failed")
-			emitPodEvent(ctx, w.clientset, opLog, pod, "snapshot", corev1.EventTypeWarning, "RestoreWorkerFailed", err.Error())
+	for _, containerName := range containerNames {
+		containerID := containerIDByName[containerName]
+		if containerID == "" {
+			w.log.V(1).Info("Restore pod container not running yet", "pod", podKey, "container", containerName)
+			continue
 		}
-	}()
+
+		statusKey := snapshotprotocol.RestoreStatusAnnotationPrefix + containerName
+		idKey := snapshotprotocol.RestoreContainerIDAnnotationPrefix + containerName
+		annotationStatus := pod.Annotations[statusKey]
+		annotationContainerID := pod.Annotations[idKey]
+		if annotationContainerID == containerID &&
+			(annotationStatus == snapshotprotocol.RestoreStatusCompleted || annotationStatus == snapshotprotocol.RestoreStatusFailed) {
+			continue
+		}
+
+		restoreAttemptKey := fmt.Sprintf("%s/%s", podKey, containerID)
+		if !w.tryAcquire(restoreAttemptKey) {
+			continue
+		}
+
+		containerCheckpointPath := snapshotprotocol.ContainerCheckpointPath(podCheckpointRoot, containerName)
+		if _, err := os.Stat(containerCheckpointPath); os.IsNotExist(err) {
+			w.release(restoreAttemptKey)
+			w.log.V(1).Info("Container checkpoint not ready on disk",
+				"pod", podKey, "container", containerName, "path", containerCheckpointPath)
+			continue
+		}
+
+		startedAt := time.Now()
+		w.log.Info("Restore target detected, triggering external restore",
+			"pod", podKey, "container", containerName, "checkpoint_id", checkpointID)
+		emitPodEvent(ctx, w.clientset, w.log, pod, "snapshot", corev1.EventTypeNormal, "RestoreRequested",
+			fmt.Sprintf("Restore requested for container %s from checkpoint %s", containerName, checkpointID))
+
+		go func(name, id, path string, startedAt time.Time) {
+			if err := w.runRestore(ctx, pod, name, id, checkpointID, path, restoreAttemptKey, startedAt); err != nil {
+				opLog := w.log.WithValues("pod", podKey, "container", name, "checkpoint_id", checkpointID)
+				opLog.Error(err, "Restore controller worker failed")
+				emitPodEvent(ctx, w.clientset, opLog, pod, "snapshot", corev1.EventTypeWarning, "RestoreWorkerFailed", err.Error())
+			}
+		}(containerName, containerID, containerCheckpointPath, startedAt)
+	}
 }
 
-// runCheckpoint runs the full checkpoint workflow for a pod:
-//  1. Hold and renew the checkpoint lease
-//  2. Resolve the container ID and host PID
-//  3. Call executor.Checkpoint (inspect → configure → CUDA lock/checkpoint → CRIU dump → rootfs diff)
-//  4. Write a snapshot-complete sentinel into the pod's snapshot-control
-//     volume on success (observed by the workload via inotify), or SIGKILL
-//     on failure (unrecoverable CUDA-locked process)
-//  5. Mark job as completed or failed
-func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job *batchv1.Job, checkpointID, checkpointLocation, podKey string, startedAt time.Time) error {
+// runCheckpoint drives the full checkpoint workflow for a pod:
+//  1. Hold and renew the pod-scoped checkpoint lease
+//  2. For each listed workload container (sequentially, to avoid CRIU/CUDA
+//     contention): resolve containerID + PID, call executor.Checkpoint,
+//     write the per-container snapshot-complete sentinel or SIGKILL on
+//     failure, annotate the pod with per-container status.
+//  3. Write the aggregate job-level status annotation on the batch/v1 Job.
+func (w *NodeController) runCheckpoint(
+	ctx context.Context,
+	pod *corev1.Pod,
+	job *batchv1.Job,
+	checkpointID string,
+	podCheckpointRoot string,
+	containerNames []string,
+	podKey string,
+	startedAt time.Time,
+) error {
 	releasePodOnExit := true
 	defer func() {
 		if releasePodOnExit {
@@ -346,60 +376,95 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 
 	go w.renewCheckpointLease(leaseCtx, log, job, stopLease)
 
-	setCheckpointStatus := func(value string) error {
-		if err := annotateJob(ctx, w.clientset, log, job, map[string]string{
-			snapshotprotocol.CheckpointStatusAnnotation: value,
-		}); err != nil {
+	containerIDByName := make(map[string]string, len(pod.Status.ContainerStatuses))
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.ContainerID == "" {
+			continue
+		}
+		containerIDByName[cs.Name] = strings.TrimPrefix(cs.ContainerID, "containerd://")
+	}
+
+	allCompleted := true
+	for _, containerName := range containerNames {
+		containerLog := log.WithValues("container", containerName)
+		ok, err := w.runContainerCheckpoint(
+			leaseCtx, ctx, pod, checkpointID, podCheckpointRoot,
+			containerName, containerIDByName[containerName], startedAt, containerLog,
+		)
+		if err != nil {
 			releasePodOnExit = false
 			releaseLeaseOnExit = false
-			return fmt.Errorf("failed to persist terminal checkpoint status %q: %w", value, err)
+			return err
+		}
+		if !ok {
+			allCompleted = false
+		}
+	}
+
+	jobStatus := snapshotprotocol.CheckpointStatusCompleted
+	if !allCompleted {
+		jobStatus = snapshotprotocol.CheckpointStatusFailed
+	}
+	if err := annotateJob(ctx, w.clientset, log, job, map[string]string{
+		snapshotprotocol.CheckpointJobStatusAnnotation: jobStatus,
+	}); err != nil {
+		releasePodOnExit = false
+		releaseLeaseOnExit = false
+		return fmt.Errorf("failed to persist terminal job checkpoint status %q: %w", jobStatus, err)
+	}
+	return nil
+}
+
+// runContainerCheckpoint runs the executor for a single workload container.
+// Returns (true, nil) on success, (false, nil) on a per-container failure
+// that has already been recorded on the pod, or (false, err) if the pod
+// annotation itself could not be persisted (caller must keep the lease held
+// so the state can converge on retry).
+func (w *NodeController) runContainerCheckpoint(
+	leaseCtx context.Context,
+	ctx context.Context,
+	pod *corev1.Pod,
+	checkpointID string,
+	podCheckpointRoot string,
+	containerName string,
+	containerID string,
+	startedAt time.Time,
+	log logr.Logger,
+) (bool, error) {
+	statusKey := snapshotprotocol.CheckpointStatusAnnotationPrefix + containerName
+	setContainerStatus := func(value string) error {
+		if err := annotatePod(ctx, w.clientset, log, pod, map[string]string{statusKey: value}); err != nil {
+			return fmt.Errorf("failed to persist per-container checkpoint status %q: %w", value, err)
 		}
 		return nil
 	}
-
-	// Resolve the target container
-	containerName := resolveMainContainerName(pod)
-	if containerName == "" {
-		err := fmt.Errorf("no containers found in pod spec")
-		log.Error(err, "Checkpoint failed")
+	recordFailure := func(reason string, err error) (bool, error) {
+		log.Error(err, reason)
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", err.Error())
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
-			return statusErr
+		if statusErr := setContainerStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
+			return false, statusErr
 		}
-		return nil
-	}
-	var containerID string
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Name == containerName {
-			containerID = strings.TrimPrefix(cs.ContainerID, "containerd://")
-			break
-		}
-	}
-	if containerID == "" {
-		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", "Could not resolve target container ID")
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
-			return statusErr
-		}
-		return nil
+		return false, nil
 	}
 
-	// Resolve the container's host PID (needed for signaling after checkpoint)
+	if containerID == "" {
+		return recordFailure("Checkpoint failed: could not resolve container ID",
+			fmt.Errorf("container %q has no running containerID on pod", containerName))
+	}
+
 	containerPID, _, err := snapshotruntime.ResolveContainer(ctx, w.containerd, containerID)
 	if err != nil {
-		log.Error(err, "Failed to resolve container")
-		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", fmt.Sprintf("Container resolve failed: %v", err))
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
-			return statusErr
-		}
-		return nil
+		return recordFailure("Failed to resolve container",
+			fmt.Errorf("container resolve failed: %w", err))
 	}
 
-	// Step 1: Run the checkpoint orchestrator
+	containerCheckpointPath := snapshotprotocol.ContainerCheckpointPath(podCheckpointRoot, containerName)
 	req := executor.CheckpointRequest{
 		ContainerID:        containerID,
 		ContainerName:      containerName,
 		CheckpointID:       checkpointID,
-		CheckpointLocation: checkpointLocation,
+		CheckpointLocation: containerCheckpointPath,
+		PodCheckpointRoot:  podCheckpointRoot,
 		StartedAt:          startedAt,
 		NodeName:           w.config.NodeName,
 		PodName:            pod.Name,
@@ -410,66 +475,60 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 		if cause := context.Cause(leaseCtx); cause != nil && cause != context.Canceled {
 			err = fmt.Errorf("checkpoint lease lost: %w", cause)
 		}
-		log.Error(err, "Checkpoint failed")
-		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", err.Error())
-		// SIGKILL on failure: process is unrecoverable (CUDA locked), terminate immediately
+		// SIGKILL on failure: process is unrecoverable (CUDA locked), terminate immediately.
 		if signalErr := snapshotruntime.SendSignalToPID(log, containerPID, syscall.SIGKILL, "checkpoint failed"); signalErr != nil {
 			log.Error(signalErr, "Failed to signal checkpoint failure to runtime process")
 		}
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
-			return statusErr
-		}
-		return nil
+		return recordFailure("Checkpoint failed", err)
 	}
 
-	info, err := os.Stat(checkpointLocation)
+	info, err := os.Stat(containerCheckpointPath)
 	if err != nil || !info.IsDir() {
 		if err == nil {
-			err = fmt.Errorf("published checkpoint path %s is not a directory", checkpointLocation)
+			err = fmt.Errorf("published checkpoint path %s is not a directory", containerCheckpointPath)
 		} else {
-			err = fmt.Errorf("published checkpoint path %s is missing: %w", checkpointLocation, err)
+			err = fmt.Errorf("published checkpoint path %s is missing: %w", containerCheckpointPath, err)
 		}
-		log.Error(err, "Checkpoint failed verification")
-		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", err.Error())
 		if signalErr := snapshotruntime.SendSignalToPID(log, containerPID, syscall.SIGKILL, "checkpoint verification failed"); signalErr != nil {
 			log.Error(signalErr, "Failed to signal checkpoint verification failure to runtime process")
 		}
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
-			return statusErr
-		}
-		return nil
+		return recordFailure("Checkpoint failed verification", err)
 	}
 
-	// Step 2: Sentinel on success. Workload observes via polling on the
+	// Sentinel on success. Workload observes via polling on the
 	// snapshot-control volume; containerPID is a PID inside the container's
 	// mount namespace, which is all the /host/proc/<pid>/root write path
 	// requires. The Succeeded event is emitted only after the sentinel has
 	// been written so a sentinel-write failure doesn't produce conflicting
 	// Succeeded+Failed events for the same operation.
 	if err := snapshotruntime.WriteControlSentinel(containerPID, snapshotprotocol.SnapshotCompleteFile); err != nil {
-		log.Error(err, "Failed to write snapshot-complete sentinel")
-		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", err.Error())
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
-			return statusErr
-		}
-		return nil
+		return recordFailure("Failed to write snapshot-complete sentinel", err)
 	}
-	emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeNormal, "CheckpointSucceeded", fmt.Sprintf("Checkpoint completed: %s", checkpointID))
+	emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeNormal, "CheckpointSucceeded",
+		fmt.Sprintf("Checkpoint completed for container %s: %s", containerName, checkpointID))
 
-	if err := setCheckpointStatus(snapshotprotocol.CheckpointStatusCompleted); err != nil {
-		return err
+	if err := setContainerStatus(snapshotprotocol.CheckpointStatusCompleted); err != nil {
+		return false, err
 	}
-	return nil
+	return true, nil
 }
 
-// runRestore runs the full restore workflow for a pod:
-//  1. Mark the current container instance as in_progress
-//  2. Call executor.Restore (inspect placeholder → nsrestore inside namespace)
-//  3. Write a restore-complete sentinel into the pod's snapshot-control
-//     volume to wake the workload (observed via inotify)
-//  4. Wait for the pod to become Ready
-//  5. Mark the container instance as completed
-func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, containerName, containerID, checkpointID, checkpointLocation, restoreAttemptKey string, startedAt time.Time) error {
+// runRestore drives the full restore workflow for a single container:
+//  1. Annotate per-container in_progress on the pod
+//  2. Call executor.Restore for the container's own checkpoint dir
+//  3. Write restore-complete sentinel into the container's snapshot-control subPath
+//  4. Wait for the container to become Ready within the pod
+//  5. Annotate per-container completed / failed
+func (w *NodeController) runRestore(
+	ctx context.Context,
+	pod *corev1.Pod,
+	containerName string,
+	containerID string,
+	checkpointID string,
+	containerCheckpointPath string,
+	restoreAttemptKey string,
+	startedAt time.Time,
+) error {
 	releaseOnExit := true
 	defer func() {
 		if releaseOnExit {
@@ -483,11 +542,13 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		defer cancel()
 	}
 	podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-	log := w.log.WithValues("pod", podKey, "checkpoint_id", checkpointID, "container_id", containerID)
+	log := w.log.WithValues("pod", podKey, "container", containerName, "checkpoint_id", checkpointID, "container_id", containerID)
+	statusKey := snapshotprotocol.RestoreStatusAnnotationPrefix + containerName
+	idKey := snapshotprotocol.RestoreContainerIDAnnotationPrefix + containerName
 	setRestoreStatus := func(value string) error {
 		annotations := map[string]string{
-			snapshotprotocol.RestoreStatusAnnotation:      value,
-			snapshotprotocol.RestoreContainerIDAnnotation: containerID,
+			statusKey: value,
+			idKey:     containerID,
 		}
 		if err := annotatePod(ctx, w.clientset, log, pod, annotations); err != nil {
 			if value == snapshotprotocol.RestoreStatusCompleted || value == snapshotprotocol.RestoreStatusFailed {
@@ -503,10 +564,9 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return fmt.Errorf("failed to annotate pod with restore in_progress: %w", err)
 	}
 
-	// Step 1: Run the restore orchestrator (inspect + nsrestore)
 	req := executor.RestoreRequest{
 		CheckpointID:       checkpointID,
-		CheckpointLocation: checkpointLocation,
+		CheckpointLocation: containerCheckpointPath,
 		StartedAt:          startedAt,
 		NSRestorePath:      w.config.Restore.NSRestorePath,
 		PodName:            pod.Name,
@@ -521,7 +581,7 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		if statusErr := setRestoreStatus(snapshotprotocol.RestoreStatusFailed); statusErr != nil {
 			return statusErr
 		}
-		// Re-resolve: executor.Restore may have failed before resolving the placeholder.
+		// executor.Restore may have failed before resolving the placeholder; re-resolve.
 		placeholderHostPID, _, pidErr := snapshotruntime.ResolveContainerByPod(ctx, w.containerd, pod.Name, pod.Namespace, containerName)
 		if pidErr != nil {
 			return fmt.Errorf("restore failed and placeholder PID could not be resolved: %w", pidErr)
@@ -532,9 +592,6 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return nil
 	}
 
-	// Step 2: Write restore-complete sentinel. placeholderHostPID came back
-	// from executor.Restore — any PID inside the container's mount namespace
-	// reaches /snapshot-control via /host/proc/<pid>/root.
 	if err := snapshotruntime.WriteControlSentinel(placeholderHostPID, snapshotprotocol.RestoreCompleteFile); err != nil {
 		log.Error(err, "Failed to write restore-complete sentinel")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())
@@ -547,7 +604,6 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return fmt.Errorf("failed to write restore-complete sentinel: %w", err)
 	}
 
-	// Step 3: Wait for the pod to become Ready
 	if err := waitForPodReady(restoreCtx, w.clientset, pod.Namespace, pod.Name, containerName); err != nil {
 		log.Error(err, "Restore post-sentinel readiness check failed")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())
@@ -560,29 +616,32 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return fmt.Errorf("restore post-sentinel readiness check failed: %w", err)
 	}
 
-	emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeNormal, "RestoreSucceeded", fmt.Sprintf("Restore completed from checkpoint %s", checkpointID))
+	emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeNormal, "RestoreSucceeded",
+		fmt.Sprintf("Restore completed for container %s from checkpoint %s", containerName, checkpointID))
 	if err := setRestoreStatus(snapshotprotocol.RestoreStatusCompleted); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (w *NodeController) tryAcquire(podKey string) bool {
+func (w *NodeController) tryAcquire(key string) bool {
 	w.inFlightMu.Lock()
 	defer w.inFlightMu.Unlock()
-	if _, held := w.inFlight[podKey]; held {
+	if _, held := w.inFlight[key]; held {
 		return false
 	}
-	w.inFlight[podKey] = struct{}{}
+	w.inFlight[key] = struct{}{}
 	return true
 }
 
-func (w *NodeController) release(podKey string) {
+func (w *NodeController) release(key string) {
 	w.inFlightMu.Lock()
 	defer w.inFlightMu.Unlock()
-	delete(w.inFlight, podKey)
+	delete(w.inFlight, key)
 }
 
+// checkpointLocationFromPod returns the pod-scoped checkpoint root on shared
+// storage. Per-container artifacts live at ContainerCheckpointPath(root, name).
 func (w *NodeController) checkpointLocationFromPod(pod *corev1.Pod, checkpointID string) (string, error) {
 	resolvedStorage, err := snapshotprotocol.ResolveCheckpointStorage(
 		checkpointID,

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -70,6 +70,12 @@ func makePod(name, namespace, nodeName string, phase corev1.PodPhase, ready bool
 			Status: corev1.ConditionTrue,
 		})
 	}
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	if _, has := annotations[snapshotprotocol.CheckpointContainersAnnotation]; !has {
+		annotations[snapshotprotocol.CheckpointContainersAnnotation] = "main"
+	}
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -207,7 +213,7 @@ func TestReconcileCheckpointPod(t *testing.T) {
 			}
 			if tc.annotation != "" {
 				job.Annotations = map[string]string{
-					snapshotprotocol.CheckpointStatusAnnotation: tc.annotation,
+					snapshotprotocol.CheckpointJobStatusAnnotation: tc.annotation,
 				}
 			}
 
@@ -412,8 +418,8 @@ func TestReconcileRestorePod(t *testing.T) {
 			var annotations map[string]string
 			if tc.annotationStatus != "" {
 				annotations = map[string]string{
-					snapshotprotocol.RestoreStatusAnnotation:      tc.annotationStatus,
-					snapshotprotocol.RestoreContainerIDAnnotation: tc.annotationContainerID,
+					snapshotprotocol.RestoreStatusAnnotationPrefix + "main":      tc.annotationStatus,
+					snapshotprotocol.RestoreContainerIDAnnotationPrefix + "main": tc.annotationContainerID,
 				}
 			}
 
@@ -425,7 +431,7 @@ func TestReconcileRestorePod(t *testing.T) {
 			}}
 
 			if tc.createDir && tc.hash != "" {
-				dir := filepath.Join(w.config.Storage.BasePath, tc.hash, "versions", snapshotprotocol.DefaultCheckpointArtifactVersion)
+				dir := filepath.Join(w.config.Storage.BasePath, tc.hash, "versions", snapshotprotocol.DefaultCheckpointArtifactVersion, "containers", "main")
 				if err := os.MkdirAll(dir, 0o755); err != nil {
 					t.Fatalf("failed to create checkpoint dir: %v", err)
 				}
@@ -498,7 +504,7 @@ func TestRunCheckpointKeepsLeaseAndInFlightOnTerminalStatusPatchFailure(t *testi
 		stopCh: make(chan struct{}),
 	}
 
-	err := w.runCheckpoint(context.Background(), pod, job, "abc123", filepath.Join(t.TempDir(), "abc123"), "default/test-pod", time.Now())
+	err := w.runCheckpoint(context.Background(), pod, job, "abc123", filepath.Join(t.TempDir(), "abc123"), []string{"main"}, "default/test-pod", time.Now())
 	if err == nil {
 		t.Fatal("expected terminal checkpoint status update to fail")
 	}

--- a/deploy/snapshot/internal/controller/util.go
+++ b/deploy/snapshot/internal/controller/util.go
@@ -48,15 +48,6 @@ func podFromInformerObj(obj interface{}) (*corev1.Pod, bool) {
 	return pod, ok
 }
 
-// resolveMainContainerName returns the name of the workload container, which
-// is always Containers[0]. GMS sidecars are appended after the workload.
-func resolveMainContainerName(pod *corev1.Pod) string {
-	if len(pod.Spec.Containers) == 0 {
-		return ""
-	}
-	return pod.Spec.Containers[0].Name
-}
-
 func isPodReady(pod *corev1.Pod) bool {
 	if pod.Status.Phase != corev1.PodRunning {
 		return false

--- a/deploy/snapshot/internal/executor/checkpoint.go
+++ b/deploy/snapshot/internal/executor/checkpoint.go
@@ -23,11 +23,15 @@ import (
 )
 
 // CheckpointRequest holds per-checkpoint identifiers for a checkpoint operation.
+// CheckpointLocation is the per-container target directory; PodCheckpointRoot
+// is the pod-scoped root (<base>/<id>/versions/<v>/) under which staging
+// (tmp/<uuid>/) is created so multiple containers share one staging root.
 type CheckpointRequest struct {
 	ContainerID        string
 	ContainerName      string
 	CheckpointID       string
 	CheckpointLocation string
+	PodCheckpointRoot  string
 	StartedAt          time.Time
 	NodeName           string
 	PodName            string
@@ -62,8 +66,12 @@ func Checkpoint(ctx context.Context, ctrd *containerd.Client, log logr.Logger, r
 		return fmt.Errorf("checkpoint location is required")
 	}
 
+	if strings.TrimSpace(req.PodCheckpointRoot) == "" {
+		return fmt.Errorf("pod checkpoint root is required")
+	}
+
 	finalDir := req.CheckpointLocation
-	tmpRoot := filepath.Join(filepath.Dir(finalDir), "tmp")
+	tmpRoot := filepath.Join(req.PodCheckpointRoot, "tmp")
 	if err := os.MkdirAll(tmpRoot, 0700); err != nil {
 		return fmt.Errorf("failed to create checkpoint staging root: %w", err)
 	}
@@ -72,6 +80,10 @@ func Checkpoint(ctx context.Context, ctrd *containerd.Client, log logr.Logger, r
 		return fmt.Errorf("failed to create checkpoint staging directory: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
+
+	if err := os.MkdirAll(filepath.Dir(finalDir), 0700); err != nil {
+		return fmt.Errorf("failed to create container checkpoint parent directory: %w", err)
+	}
 
 	// Phase 1: Inspect container state
 	state, err := inspectContainer(ctx, ctrd, log, req)

--- a/deploy/snapshot/internal/executor/restore.go
+++ b/deploy/snapshot/internal/executor/restore.go
@@ -39,6 +39,10 @@ type RestoreRequest struct {
 // Returns the namespace-relative PID of the restored process.
 // The DaemonSet side inspects the placeholder and launches nsrestore,
 // which handles rootfs application, CRIU restore, and CUDA restore inside the namespace.
+//
+// Returns the placeholder container's host PID so callers can reach into the
+// container's mount namespace (e.g. to write sentinels under /snapshot-control)
+// without re-resolving via containerd.
 func Restore(ctx context.Context, ctrd *containerd.Client, log logr.Logger, req RestoreRequest) (int, error) {
 	restoreStart := time.Now()
 	log.Info("=== Starting external restore ===",
@@ -90,11 +94,12 @@ func Restore(ctx context.Context, ctrd *containerd.Client, log logr.Logger, req 
 
 	log.Info("=== External restore completed ===",
 		"restored_pid", result.RestoredPID,
+		"placeholder_host_pid", snap.PlaceholderPID,
 		"validation_duration", time.Since(validationStart),
 		"total_duration", time.Since(restoreStart),
 	)
 
-	return result.RestoredPID, nil
+	return snap.PlaceholderPID, nil
 }
 
 func inspectRestore(ctx context.Context, ctrd *containerd.Client, log logr.Logger, req RestoreRequest) (*types.RestoreContainerSnapshot, error) {

--- a/deploy/snapshot/internal/executor/restore.go
+++ b/deploy/snapshot/internal/executor/restore.go
@@ -125,9 +125,9 @@ func inspectRestore(ctx context.Context, ctrd *containerd.Client, log logr.Logge
 		return nil, fmt.Errorf("failed to read checkpoint manifest: %w", err)
 	}
 
-	containerName := req.ContainerName
+	containerName := strings.TrimSpace(req.ContainerName)
 	if containerName == "" {
-		containerName = "main"
+		return nil, fmt.Errorf("restore: container name is required")
 	}
 
 	placeholderPID, _, err := snapshotruntime.ResolveContainerByPod(ctx, ctrd, req.PodName, req.PodNamespace, containerName)

--- a/deploy/snapshot/internal/runtime/control.go
+++ b/deploy/snapshot/internal/runtime/control.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
+)
+
+// WriteControlSentinel writes a sentinel file into the workload container's
+// snapshot-control volume at SnapshotControlMountPath/<name>, accessed through
+// the agent's /host/proc/<pid>/root view of the container's mount namespace.
+//
+// hostPID must be a PID inside the container's mount namespace (the container
+// task PID is the canonical choice). The sentinel is observed by the workload
+// via inotify on the control directory; it replaces the SIGUSR1/SIGCONT
+// agent-to-workload signals that previously required the workload to run as
+// PID 1.
+//
+// The write uses create-then-rename so the workload never observes a partial
+// file.
+func WriteControlSentinel(hostPID int, name string) error {
+	if hostPID <= 0 {
+		return fmt.Errorf("invalid host PID %d for control sentinel %q", hostPID, name)
+	}
+	dir := filepath.Join(HostProcPath, strconv.Itoa(hostPID), "root", snapshotprotocol.SnapshotControlMountPath)
+	return writeSentinelInDir(dir, name)
+}
+
+func writeSentinelInDir(dir, name string) error {
+	tmpPath := filepath.Join(dir, "."+name+".tmp")
+	finalPath := filepath.Join(dir, name)
+	if err := os.WriteFile(tmpPath, []byte("done\n"), 0o644); err != nil {
+		return fmt.Errorf("write temp sentinel %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename sentinel %s -> %s: %w", tmpPath, finalPath, err)
+	}
+	return nil
+}

--- a/deploy/snapshot/internal/runtime/control_test.go
+++ b/deploy/snapshot/internal/runtime/control_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteSentinelInDir_CreatesFileAtomically(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := writeSentinelInDir(dir, "snapshot-complete"); err != nil {
+		t.Fatalf("writeSentinelInDir failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "snapshot-complete"))
+	if err != nil {
+		t.Fatalf("sentinel not found: %v", err)
+	}
+	if string(data) != "done\n" {
+		t.Errorf("unexpected sentinel contents: %q", data)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read dir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "snapshot-complete" {
+			t.Errorf("unexpected leftover file %q in control dir", e.Name())
+		}
+	}
+}
+
+func TestWriteSentinelInDir_Overwrites(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeSentinelInDir(dir, "restore-complete"); err != nil {
+		t.Fatalf("first write failed: %v", err)
+	}
+	if err := writeSentinelInDir(dir, "restore-complete"); err != nil {
+		t.Fatalf("second write failed: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "restore-complete"))
+	if err != nil {
+		t.Fatalf("sentinel not found: %v", err)
+	}
+	if string(data) != "done\n" {
+		t.Errorf("unexpected sentinel contents: %q", data)
+	}
+}
+
+func TestWriteSentinelInDir_DirMissing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if err := writeSentinelInDir(missing, "snapshot-complete"); err == nil {
+		t.Fatal("expected error writing into missing directory")
+	}
+}
+
+func TestWriteControlSentinel_RejectsInvalidPID(t *testing.T) {
+	if err := WriteControlSentinel(0, "snapshot-complete"); err == nil {
+		t.Fatal("expected error for PID 0")
+	}
+	if err := WriteControlSentinel(-1, "snapshot-complete"); err == nil {
+		t.Fatal("expected error for negative PID")
+	}
+}

--- a/deploy/snapshot/internal/runtime/namespaces.go
+++ b/deploy/snapshot/internal/runtime/namespaces.go
@@ -1,14 +1,8 @@
 package runtime
 
 import (
-	"context"
 	"fmt"
-	"os/exec"
-	"strconv"
-	"strings"
-	"syscall"
 
-	"github.com/go-logr/logr"
 	"golang.org/x/sys/unix"
 )
 
@@ -20,41 +14,4 @@ func GetNetNSInode(pid int) (uint64, error) {
 		return 0, fmt.Errorf("failed to stat %s: %w", nsPath, err)
 	}
 	return stat.Ino, nil
-}
-
-// SendSignalViaPIDNamespace sends a signal to a namespace-relative PID by entering the
-// PID namespace of referenceHostPID via nsenter.
-func SendSignalViaPIDNamespace(ctx context.Context, log logr.Logger, referenceHostPID, targetNamespacePID int, sig syscall.Signal, reason string) error {
-	if referenceHostPID <= 0 {
-		return fmt.Errorf("invalid reference host PID %d for signal %d", referenceHostPID, int(sig))
-	}
-	if targetNamespacePID <= 0 {
-		return fmt.Errorf("invalid namespace PID %d for signal %d", targetNamespacePID, int(sig))
-	}
-
-	cmd := exec.CommandContext(
-		ctx,
-		"nsenter",
-		"-t", strconv.Itoa(referenceHostPID),
-		"-p",
-		"--",
-		"kill",
-		fmt.Sprintf("-%d", int(sig)),
-		strconv.Itoa(targetNamespacePID),
-	)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf(
-			"failed to signal namespace PID %d via reference host PID %d with signal %d (%s): %w (output: %s)",
-			targetNamespacePID, referenceHostPID, int(sig), reason, err, strings.TrimSpace(string(output)),
-		)
-	}
-
-	log.Info("Signaled runtime process in PID namespace",
-		"reference_host_pid", referenceHostPID,
-		"namespace_pid", targetNamespacePID,
-		"signal", int(sig),
-		"reason", reason,
-	)
-	return nil
 }

--- a/deploy/snapshot/protocol/checkpoint.go
+++ b/deploy/snapshot/protocol/checkpoint.go
@@ -5,7 +5,7 @@ package protocol
 
 import (
 	"fmt"
-	"strings"
+	"path/filepath"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -56,17 +56,36 @@ func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOpt
 	if opts.SeccompProfile != "" {
 		EnsureLocalhostSeccompProfile(&podTemplate.Spec, opts.SeccompProfile)
 	}
+	if len(podTemplate.Spec.Containers) == 0 {
+		return nil, fmt.Errorf("checkpoint job requires at least one container")
+	}
+	mainContainer := &podTemplate.Spec.Containers[0]
+
+	// Snapshot contract: control volume + ready-file readiness probe. The
+	// agent reads the pod's Ready condition before starting CRIU dump, so
+	// the workload signals "model loaded, safe to checkpoint" by writing
+	// $DYN_SNAPSHOT_CONTROL_DIR/ready-for-checkpoint. Any per-container
+	// liveness/startup probes are cleared — a checkpoint job runs to a
+	// quiesce-and-sit state, not a long-lived serving state.
+	EnsureControlVolume(&podTemplate.Spec, mainContainer)
+	mainContainer.ReadinessProbe = &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"cat", filepath.Join(SnapshotControlMountPath, ReadyForCheckpointFile)},
+			},
+		},
+		PeriodSeconds: 1,
+	}
+	mainContainer.LivenessProbe = nil
+	mainContainer.StartupProbe = nil
+
 	if opts.WrapLaunchJob {
-		if len(podTemplate.Spec.Containers) == 0 {
-			return nil, fmt.Errorf("checkpoint job requires at least one container")
-		}
-		container := &podTemplate.Spec.Containers[0]
-		if len(container.Command) == 0 {
+		if len(mainContainer.Command) == 0 {
 			return nil, fmt.Errorf("checkpoint job requires container.command when cuda-checkpoint launch-job wrapping is enabled")
 		}
-		container.Command, container.Args = wrapWithCudaCheckpointLaunchJob(
-			container.Command,
-			container.Args,
+		mainContainer.Command, mainContainer.Args = wrapWithCudaCheckpointLaunchJob(
+			mainContainer.Command,
+			mainContainer.Args,
 		)
 	}
 
@@ -157,18 +176,13 @@ func EnsureLocalhostSeccompProfile(podSpec *corev1.PodSpec, profile string) {
 	}
 }
 
+// wrapWithCudaCheckpointLaunchJob rewrites the container's entrypoint so the
+// workload is launched under `cuda-checkpoint --launch-job`, required for
+// multi-GPU checkpoints. The original command and args are preserved as-is
+// (including shell-form entrypoints): workload-to-agent signaling now uses
+// file sentinels in the snapshot-control volume, so an intervening shell at
+// PID 1 is no longer an issue.
 func wrapWithCudaCheckpointLaunchJob(command []string, args []string) ([]string, []string) {
-	// Unwrap "/bin/sh -c <single-string>" so cuda-checkpoint launches the
-	// actual process directly. Otherwise sh sits between cuda-checkpoint and
-	// the real process and swallows SIGUSR1.
-	if len(command) >= 2 && command[len(command)-1] == "-c" && len(args) == 1 {
-		shell := command[:len(command)-1] // e.g. ["/bin/sh"] — discarded
-		_ = shell
-		parts := strings.Fields(args[0])
-		command = parts[:1] // e.g. ["python3"]
-		args = parts[1:]    // e.g. ["-m", "dynamo.vllm", "--model", ...]
-	}
-
 	wrappedArgs := make([]string, 0, len(command)+len(args)+1)
 	wrappedArgs = append(wrappedArgs, "--launch-job")
 	wrappedArgs = append(wrappedArgs, command...)

--- a/deploy/snapshot/protocol/checkpoint.go
+++ b/deploy/snapshot/protocol/checkpoint.go
@@ -43,6 +43,11 @@ func GetCheckpointJobName(checkpointID string, artifactVersion string) string {
 	return "checkpoint-job-" + checkpointID + "-" + ArtifactVersion(artifactVersion)
 }
 
+// NewCheckpointJob shapes the pod template into a batch/v1 Job that runs the
+// workload containers under cuda-checkpoint launch-job (optionally) and waits
+// on a ready-for-checkpoint readiness probe. The set of workload containers
+// comes from CheckpointContainersAnnotation on the input pod template; every
+// name must resolve to a container in the spec.
 func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOptions) (*batchv1.Job, error) {
 	podTemplate = podTemplate.DeepCopy()
 	if podTemplate.Labels == nil {
@@ -56,37 +61,39 @@ func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOpt
 	if opts.SeccompProfile != "" {
 		EnsureLocalhostSeccompProfile(&podTemplate.Spec, opts.SeccompProfile)
 	}
-	if len(podTemplate.Spec.Containers) == 0 {
-		return nil, fmt.Errorf("checkpoint job requires at least one container")
-	}
-	mainContainer := &podTemplate.Spec.Containers[0]
 
-	// Snapshot contract: control volume + ready-file readiness probe. The
-	// agent reads the pod's Ready condition before starting CRIU dump, so
-	// the workload signals "model loaded, safe to checkpoint" by writing
-	// $DYN_SNAPSHOT_CONTROL_DIR/ready-for-checkpoint. Any per-container
-	// liveness/startup probes are cleared — a checkpoint job runs to a
-	// quiesce-and-sit state, not a long-lived serving state.
-	EnsureControlVolume(&podTemplate.Spec, mainContainer)
-	mainContainer.ReadinessProbe = &corev1.Probe{
-		ProbeHandler: corev1.ProbeHandler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"cat", filepath.Join(SnapshotControlMountPath, ReadyForCheckpointFile)},
-			},
-		},
-		PeriodSeconds: 1,
+	containerNames, err := ParseCheckpointContainers(podTemplate.Annotations)
+	if err != nil {
+		return nil, fmt.Errorf("checkpoint job: %w", err)
 	}
-	mainContainer.LivenessProbe = nil
-	mainContainer.StartupProbe = nil
 
-	if opts.WrapLaunchJob {
-		if len(mainContainer.Command) == 0 {
-			return nil, fmt.Errorf("checkpoint job requires container.command when cuda-checkpoint launch-job wrapping is enabled")
+	for _, name := range containerNames {
+		container := findContainer(podTemplate.Spec.Containers, name)
+		if container == nil {
+			return nil, fmt.Errorf("checkpoint job references unknown container %q in %s", name, CheckpointContainersAnnotation)
 		}
-		mainContainer.Command, mainContainer.Args = wrapWithCudaCheckpointLaunchJob(
-			mainContainer.Command,
-			mainContainer.Args,
-		)
+
+		// Snapshot contract per container: control-volume subPath mount,
+		// ready-file readiness probe, cleared liveness/startup probes so
+		// the checkpoint job runs to a quiesce-and-sit state.
+		EnsureControlVolume(&podTemplate.Spec, container, name)
+		container.ReadinessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"cat", filepath.Join(SnapshotControlMountPath, ReadyForCheckpointFile)},
+				},
+			},
+			PeriodSeconds: 1,
+		}
+		container.LivenessProbe = nil
+		container.StartupProbe = nil
+
+		if opts.WrapLaunchJob {
+			if len(container.Command) == 0 {
+				return nil, fmt.Errorf("checkpoint job requires container.command on %q when cuda-checkpoint launch-job wrapping is enabled", name)
+			}
+			container.Command, container.Args = wrapWithCudaCheckpointLaunchJob(container.Command, container.Args)
+		}
 	}
 
 	return &batchv1.Job{
@@ -123,7 +130,7 @@ func ObserveCheckpointJob(job *batchv1.Job, checkpointWorkerActive bool) Checkpo
 		}
 	}
 
-	status := job.Annotations[CheckpointStatusAnnotation]
+	status := job.Annotations[CheckpointJobStatusAnnotation]
 	if status == CheckpointStatusFailed {
 		observation := CheckpointObservation{
 			Phase:   CheckpointObservationPhaseFailed,
@@ -174,6 +181,15 @@ func EnsureLocalhostSeccompProfile(podSpec *corev1.PodSpec, profile string) {
 		Type:             corev1.SeccompProfileTypeLocalhost,
 		LocalhostProfile: &profile,
 	}
+}
+
+func findContainer(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
 }
 
 // wrapWithCudaCheckpointLaunchJob rewrites the container's entrypoint so the

--- a/deploy/snapshot/protocol/checkpoint_job_test.go
+++ b/deploy/snapshot/protocol/checkpoint_job_test.go
@@ -63,11 +63,27 @@ func TestNewCheckpointJob(t *testing.T) {
 	if job.Spec.Template.Annotations[CheckpointArtifactVersionAnnotation] != "2" {
 		t.Fatalf("expected checkpoint artifact version annotation on template: %#v", job.Spec.Template.Annotations)
 	}
-	if len(job.Spec.Template.Spec.Volumes) != 0 {
-		t.Fatalf("expected no checkpoint volume, got %#v", job.Spec.Template.Spec.Volumes)
+	if len(job.Spec.Template.Spec.Volumes) != 1 || job.Spec.Template.Spec.Volumes[0].Name != SnapshotControlVolumeName {
+		t.Fatalf("expected only %s volume, got %#v", SnapshotControlVolumeName, job.Spec.Template.Spec.Volumes)
 	}
-	if len(job.Spec.Template.Spec.Containers[0].VolumeMounts) != 0 {
-		t.Fatalf("expected no checkpoint volume mount, got %#v", job.Spec.Template.Spec.Containers[0].VolumeMounts)
+	main := &job.Spec.Template.Spec.Containers[0]
+	if len(main.VolumeMounts) != 1 || main.VolumeMounts[0].MountPath != SnapshotControlMountPath {
+		t.Fatalf("expected only %s mount at %s, got %#v", SnapshotControlVolumeName, SnapshotControlMountPath, main.VolumeMounts)
+	}
+	if main.ReadinessProbe == nil || main.ReadinessProbe.Exec == nil {
+		t.Fatalf("expected ready-file readiness probe, got %#v", main.ReadinessProbe)
+	}
+	expectedProbe := []string{"cat", SnapshotControlMountPath + "/" + ReadyForCheckpointFile}
+	if len(main.ReadinessProbe.Exec.Command) != len(expectedProbe) {
+		t.Fatalf("expected readiness probe %#v, got %#v", expectedProbe, main.ReadinessProbe.Exec.Command)
+	}
+	for i := range expectedProbe {
+		if main.ReadinessProbe.Exec.Command[i] != expectedProbe[i] {
+			t.Fatalf("expected readiness probe %#v, got %#v", expectedProbe, main.ReadinessProbe.Exec.Command)
+		}
+	}
+	if main.LivenessProbe != nil || main.StartupProbe != nil {
+		t.Fatalf("expected liveness and startup probes cleared, got liveness=%#v startup=%#v", main.LivenessProbe, main.StartupProbe)
 	}
 	if job.Spec.Template.Spec.RestartPolicy != corev1.RestartPolicyNever {
 		t.Fatalf("expected restartPolicy Never, got %#v", job.Spec.Template.Spec.RestartPolicy)

--- a/deploy/snapshot/protocol/checkpoint_job_test.go
+++ b/deploy/snapshot/protocol/checkpoint_job_test.go
@@ -25,8 +25,11 @@ func requireCheckpointContainer(t *testing.T, containers []corev1.Container, nam
 func TestNewCheckpointJob(t *testing.T) {
 	job, err := NewCheckpointJob(&corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      map[string]string{"existing": "label"},
-			Annotations: map[string]string{"existing": "annotation"},
+			Labels: map[string]string{"existing": "label"},
+			Annotations: map[string]string{
+				"existing":                     "annotation",
+				CheckpointContainersAnnotation: "main",
+			},
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyAlways,
@@ -63,12 +66,15 @@ func TestNewCheckpointJob(t *testing.T) {
 	if job.Spec.Template.Annotations[CheckpointArtifactVersionAnnotation] != "2" {
 		t.Fatalf("expected checkpoint artifact version annotation on template: %#v", job.Spec.Template.Annotations)
 	}
+	if got := job.Spec.Template.Annotations[CheckpointContainersAnnotation]; got != "main" {
+		t.Fatalf("expected containers annotation preserved, got %q", got)
+	}
 	if len(job.Spec.Template.Spec.Volumes) != 1 || job.Spec.Template.Spec.Volumes[0].Name != SnapshotControlVolumeName {
 		t.Fatalf("expected only %s volume, got %#v", SnapshotControlVolumeName, job.Spec.Template.Spec.Volumes)
 	}
 	main := &job.Spec.Template.Spec.Containers[0]
-	if len(main.VolumeMounts) != 1 || main.VolumeMounts[0].MountPath != SnapshotControlMountPath {
-		t.Fatalf("expected only %s mount at %s, got %#v", SnapshotControlVolumeName, SnapshotControlMountPath, main.VolumeMounts)
+	if len(main.VolumeMounts) != 1 || main.VolumeMounts[0].MountPath != SnapshotControlMountPath || main.VolumeMounts[0].SubPath != "main" {
+		t.Fatalf("expected %s mount at %s subPath=main, got %#v", SnapshotControlVolumeName, SnapshotControlMountPath, main.VolumeMounts)
 	}
 	if main.ReadinessProbe == nil || main.ReadinessProbe.Exec == nil {
 		t.Fatalf("expected ready-file readiness probe, got %#v", main.ReadinessProbe)
@@ -114,8 +120,11 @@ func TestNewCheckpointJob(t *testing.T) {
 	}
 }
 
-func TestNewCheckpointJobWrapsFirstContainer(t *testing.T) {
+func TestNewCheckpointJobWrapsOnlyListedContainers(t *testing.T) {
 	job, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{CheckpointContainersAnnotation: "worker"},
+		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{Name: "worker", Command: []string{"python3", "-m", "dynamo.vllm"}, Args: []string{"--model", "Qwen"}},
@@ -136,7 +145,7 @@ func TestNewCheckpointJobWrapsFirstContainer(t *testing.T) {
 
 	worker := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, "worker")
 	if len(worker.Command) != 1 || worker.Command[0] != "cuda-checkpoint" {
-		t.Fatalf("expected first container to be wrapped, got %#v", worker.Command)
+		t.Fatalf("expected listed container to be wrapped, got %#v", worker.Command)
 	}
 	expectedArgs := []string{"--launch-job", "python3", "-m", "dynamo.vllm", "--model", "Qwen"}
 	if len(worker.Args) != len(expectedArgs) {
@@ -155,36 +164,80 @@ func TestNewCheckpointJobWrapsFirstContainer(t *testing.T) {
 	if len(sidecar.Args) != 1 || sidecar.Args[0] != "infinity" {
 		t.Fatalf("expected sidecar args to remain unchanged, got %#v", sidecar.Args)
 	}
+	if len(sidecar.VolumeMounts) != 0 {
+		t.Fatalf("expected sidecar to have no snapshot-control mount, got %#v", sidecar.VolumeMounts)
+	}
 }
 
-func TestNewCheckpointJobAllowsSingleNonMainContainer(t *testing.T) {
-	job, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+func TestNewCheckpointJobRejectsMissingAnnotation(t *testing.T) {
+	_, err := NewCheckpointJob(&corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:    "worker",
-				Command: []string{"python3", "-m", "dynamo.vllm"},
-				Args:    []string{"--model", "Qwen"},
-			}},
+			Containers: []corev1.Container{{Name: "main", Command: []string{"python3"}}},
 		},
 	}, CheckpointJobOptions{
-		Namespace:             "test-ns",
-		CheckpointID:          "hash",
-		ArtifactVersion:       "2",
-		Name:                  "test-job",
+		Namespace: "test-ns", CheckpointID: "hash", Name: "test-job",
+	})
+	if err == nil {
+		t.Fatalf("expected error on missing %s annotation", CheckpointContainersAnnotation)
+	}
+}
+
+func TestNewCheckpointJobRejectsUnknownContainer(t *testing.T) {
+	_, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{CheckpointContainersAnnotation: "not-in-spec"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main", Command: []string{"python3"}}},
+		},
+	}, CheckpointJobOptions{
+		Namespace: "test-ns", CheckpointID: "hash", Name: "test-job",
+	})
+	if err == nil {
+		t.Fatalf("expected error for unknown container")
+	}
+}
+
+func TestNewCheckpointJobWrapsMultipleContainers(t *testing.T) {
+	job, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{CheckpointContainersAnnotation: "engine-0,engine-1"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "engine-0", Command: []string{"python3"}, Args: []string{"--rank=0"}},
+				{Name: "engine-1", Command: []string{"python3"}, Args: []string{"--rank=1"}},
+				{Name: "sidecar-frontend", Command: []string{"frontend"}},
+			},
+		},
+	}, CheckpointJobOptions{
+		Namespace: "test-ns", CheckpointID: "hash", Name: "test-job",
 		TTLSecondsAfterFinish: ptr.To(int32(300)),
 		WrapLaunchJob:         true,
 	})
 	if err != nil {
-		t.Fatalf("expected checkpoint job, got error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-
-	container := &job.Spec.Template.Spec.Containers[0]
-	if len(container.Command) != 1 || container.Command[0] != "cuda-checkpoint" {
-		t.Fatalf("expected single container to be wrapped, got %#v", container.Command)
+	for _, name := range []string{"engine-0", "engine-1"} {
+		c := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, name)
+		if len(c.VolumeMounts) != 1 || c.VolumeMounts[0].SubPath != name {
+			t.Fatalf("expected %s subPath mount, got %#v", name, c.VolumeMounts)
+		}
+		if c.ReadinessProbe == nil || c.ReadinessProbe.Exec == nil {
+			t.Fatalf("expected readiness probe on %s", name)
+		}
+		if len(c.Command) != 1 || c.Command[0] != "cuda-checkpoint" {
+			t.Fatalf("expected %s wrapped, got %#v", name, c.Command)
+		}
+	}
+	sidecar := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, "sidecar-frontend")
+	if len(sidecar.VolumeMounts) != 0 || sidecar.ReadinessProbe != nil {
+		t.Fatalf("expected sidecar-frontend untouched, got mounts=%#v probe=%#v", sidecar.VolumeMounts, sidecar.ReadinessProbe)
+	}
+	if len(job.Spec.Template.Spec.Volumes) != 1 {
+		t.Fatalf("expected single shared snapshot-control volume, got %#v", job.Spec.Template.Spec.Volumes)
 	}
 }
-
-
 
 func TestGetCheckpointJobName(t *testing.T) {
 	name := GetCheckpointJobName("abc123def4567890", "2")

--- a/deploy/snapshot/protocol/checkpoint_observation_test.go
+++ b/deploy/snapshot/protocol/checkpoint_observation_test.go
@@ -22,7 +22,7 @@ func TestObserveCheckpointJob(t *testing.T) {
 			},
 		}
 		if annotation != "" {
-			job.Annotations[CheckpointStatusAnnotation] = annotation
+			job.Annotations[CheckpointJobStatusAnnotation] = annotation
 		}
 		return job
 	}

--- a/deploy/snapshot/protocol/common.go
+++ b/deploy/snapshot/protocol/common.go
@@ -13,14 +13,30 @@ const (
 	CheckpointIDLabel                   = "nvidia.com/snapshot-checkpoint-id"
 	RestoreTargetLabel                  = "nvidia.com/snapshot-is-restore-target"
 	CheckpointArtifactVersionAnnotation = "nvidia.com/snapshot-artifact-version"
-	CheckpointStatusAnnotation          = "nvidia.com/snapshot-checkpoint-status"
-	RestoreStatusAnnotation             = "nvidia.com/snapshot-restore-status"
-	RestoreContainerIDAnnotation        = "nvidia.com/snapshot-restore-container-id"
-	CheckpointVolumeName                = "checkpoint-storage"
-	DefaultCheckpointArtifactVersion    = "1"
-	DefaultCheckpointJobTTLSeconds      = int32(300)
-	DefaultSeccompLocalhostProfile      = "profiles/block-iouring.json"
-	StorageTypePVC                      = "pvc"
+
+	// CheckpointContainersAnnotation names the ordered, comma-separated
+	// list of workload container names to snapshot and restore for this
+	// pod. The operator stamps it at pod-build time; the snapshot agent
+	// reads it on both the checkpoint job's pod template and the restore
+	// pod. Containers not in this list are left untouched.
+	CheckpointContainersAnnotation = "nvidia.com/snapshot-containers"
+
+	// CheckpointJobStatusAnnotation is set on the checkpoint Job (not the
+	// pod) once all container checkpoints have reached a terminal state.
+	CheckpointJobStatusAnnotation = "nvidia.com/snapshot-checkpoint-job-status"
+
+	// Per-container status annotation prefixes. The snapshot agent appends
+	// the container name to these keys so multiple containers can record
+	// independent state on the same pod without clobbering each other.
+	CheckpointStatusAnnotationPrefix   = "nvidia.com/snapshot-checkpoint-status."
+	RestoreStatusAnnotationPrefix      = "nvidia.com/snapshot-restore-status."
+	RestoreContainerIDAnnotationPrefix = "nvidia.com/snapshot-restore-container-id."
+
+	CheckpointVolumeName             = "checkpoint-storage"
+	DefaultCheckpointArtifactVersion = "1"
+	DefaultCheckpointJobTTLSeconds   = int32(300)
+	DefaultSeccompLocalhostProfile   = "profiles/block-iouring.json"
+	StorageTypePVC                   = "pvc"
 
 	CheckpointStatusCompleted = "completed"
 	CheckpointStatusFailed    = "failed"
@@ -44,6 +60,10 @@ func ArtifactVersion(version string) string {
 	return version
 }
 
+// ResolveCheckpointStorage resolves the pod-scoped checkpoint root on
+// shared storage: <basePath>/<checkpointID>/versions/<version>. Per-container
+// artifacts live under <podRoot>/containers/<containerName>/; callers derive
+// those with ContainerCheckpointPath.
 func ResolveCheckpointStorage(checkpointID string, version string, storage Storage) (Storage, error) {
 	resolved, err := resolveStorageConfig(storage)
 	if err != nil {
@@ -66,14 +86,55 @@ func ResolveRestoreStorage(checkpointID string, version string, location string,
 	return resolved, nil
 }
 
+// ContainerCheckpointPath returns the per-container checkpoint directory
+// under the pod's checkpoint root: <podRoot>/containers/<name>.
+func ContainerCheckpointPath(podRoot string, containerName string) string {
+	return strings.TrimRight(podRoot, "/") + "/containers/" + containerName
+}
+
+// ParseCheckpointContainers parses the CheckpointContainersAnnotation into
+// an ordered list of container names. Duplicates and empty entries are
+// rejected; an empty/missing annotation is an error.
+func ParseCheckpointContainers(annotations map[string]string) ([]string, error) {
+	raw := strings.TrimSpace(annotations[CheckpointContainersAnnotation])
+	if raw == "" {
+		return nil, fmt.Errorf("missing %s annotation", CheckpointContainersAnnotation)
+	}
+	parts := strings.Split(raw, ",")
+	names := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			return nil, fmt.Errorf("%s has empty entry: %q", CheckpointContainersAnnotation, raw)
+		}
+		if _, dup := seen[name]; dup {
+			return nil, fmt.Errorf("%s has duplicate entry %q", CheckpointContainersAnnotation, name)
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+// FormatCheckpointContainers renders the CheckpointContainersAnnotation value
+// for a list of container names.
+func FormatCheckpointContainers(names []string) string {
+	return strings.Join(names, ",")
+}
+
 func ApplyRestoreTargetMetadata(labels map[string]string, annotations map[string]string, enabled bool, checkpointID string, artifactVersion string) {
 	delete(labels, CheckpointSourceLabel)
 	delete(labels, RestoreTargetLabel)
 	delete(labels, CheckpointIDLabel)
 	delete(annotations, CheckpointArtifactVersionAnnotation)
-	delete(annotations, CheckpointStatusAnnotation)
-	delete(annotations, RestoreStatusAnnotation)
-	delete(annotations, RestoreContainerIDAnnotation)
+	for key := range annotations {
+		if strings.HasPrefix(key, CheckpointStatusAnnotationPrefix) ||
+			strings.HasPrefix(key, RestoreStatusAnnotationPrefix) ||
+			strings.HasPrefix(key, RestoreContainerIDAnnotationPrefix) {
+			delete(annotations, key)
+		}
+	}
 
 	if !enabled {
 		return

--- a/deploy/snapshot/protocol/constants_test.go
+++ b/deploy/snapshot/protocol/constants_test.go
@@ -5,16 +5,20 @@ package protocol
 
 import "testing"
 
-func TestApplyRestoreTargetMetadata(t *testing.T) {
+func TestApplyRestoreTargetMetadataClearsPerContainerState(t *testing.T) {
 	labels := map[string]string{
 		CheckpointSourceLabel: "true",
 		CheckpointIDLabel:     "old",
 	}
 	annotations := map[string]string{
-		CheckpointArtifactVersionAnnotation: "old",
-		CheckpointStatusAnnotation:          "completed",
-		RestoreStatusAnnotation:             "failed",
-		RestoreContainerIDAnnotation:        "dead-container",
+		CheckpointArtifactVersionAnnotation:                  "old",
+		CheckpointStatusAnnotationPrefix + "main":            "completed",
+		CheckpointStatusAnnotationPrefix + "engine-0":        "failed",
+		RestoreStatusAnnotationPrefix + "main":               "failed",
+		RestoreStatusAnnotationPrefix + "engine-1":           "in_progress",
+		RestoreContainerIDAnnotationPrefix + "main":          "dead-container",
+		RestoreContainerIDAnnotationPrefix + "engine-0":      "older-container",
+		"unrelated/annotation":                               "keep-me",
 	}
 
 	ApplyRestoreTargetMetadata(labels, annotations, true, "hash", "2")
@@ -31,14 +35,15 @@ func TestApplyRestoreTargetMetadata(t *testing.T) {
 	if annotations[CheckpointArtifactVersionAnnotation] != "2" {
 		t.Fatalf("expected checkpoint artifact version annotation, got %#v", annotations)
 	}
-	if _, ok := annotations[CheckpointStatusAnnotation]; ok {
-		t.Fatalf("checkpoint status annotation was not cleared: %#v", annotations)
+	for key := range annotations {
+		switch key {
+		case CheckpointArtifactVersionAnnotation, "unrelated/annotation":
+			continue
+		}
+		t.Fatalf("expected per-container annotation %q to be cleared: %#v", key, annotations)
 	}
-	if _, ok := annotations[RestoreStatusAnnotation]; ok {
-		t.Fatalf("restore status annotation was not cleared: %#v", annotations)
-	}
-	if _, ok := annotations[RestoreContainerIDAnnotation]; ok {
-		t.Fatalf("restore container id annotation was not cleared: %#v", annotations)
+	if annotations["unrelated/annotation"] != "keep-me" {
+		t.Fatalf("expected unrelated annotation to be preserved: %#v", annotations)
 	}
 }
 
@@ -48,10 +53,10 @@ func TestApplyRestoreTargetMetadataDisabledClearsState(t *testing.T) {
 		CheckpointIDLabel:  "hash",
 	}
 	annotations := map[string]string{
-		CheckpointArtifactVersionAnnotation: "2",
-		CheckpointStatusAnnotation:          "completed",
-		RestoreStatusAnnotation:             "failed",
-		RestoreContainerIDAnnotation:        "dead-container",
+		CheckpointArtifactVersionAnnotation:             "2",
+		CheckpointStatusAnnotationPrefix + "main":       "completed",
+		RestoreStatusAnnotationPrefix + "main":          "failed",
+		RestoreContainerIDAnnotationPrefix + "main":     "dead-container",
 	}
 
 	ApplyRestoreTargetMetadata(labels, annotations, false, "", "")
@@ -65,13 +70,52 @@ func TestApplyRestoreTargetMetadataDisabledClearsState(t *testing.T) {
 	if _, ok := annotations[CheckpointArtifactVersionAnnotation]; ok {
 		t.Fatalf("checkpoint artifact version annotation was not cleared: %#v", annotations)
 	}
-	if _, ok := annotations[CheckpointStatusAnnotation]; ok {
-		t.Fatalf("checkpoint status annotation was not cleared: %#v", annotations)
+	for key := range annotations {
+		t.Fatalf("expected all per-container annotations cleared, still has %q: %#v", key, annotations)
 	}
-	if _, ok := annotations[RestoreStatusAnnotation]; ok {
-		t.Fatalf("restore status annotation was not cleared: %#v", annotations)
+}
+
+func TestParseCheckpointContainers(t *testing.T) {
+	t.Run("ordered list", func(t *testing.T) {
+		names, err := ParseCheckpointContainers(map[string]string{
+			CheckpointContainersAnnotation: "engine-0, engine-1 ,main",
+		})
+		if err != nil {
+			t.Fatalf("expected parse ok, got %v", err)
+		}
+		if len(names) != 3 || names[0] != "engine-0" || names[1] != "engine-1" || names[2] != "main" {
+			t.Fatalf("unexpected names: %#v", names)
+		}
+	})
+
+	t.Run("rejects missing", func(t *testing.T) {
+		if _, err := ParseCheckpointContainers(nil); err == nil {
+			t.Fatalf("expected error on missing annotation")
+		}
+	})
+
+	t.Run("rejects empty entry", func(t *testing.T) {
+		if _, err := ParseCheckpointContainers(map[string]string{
+			CheckpointContainersAnnotation: "main,,engine",
+		}); err == nil {
+			t.Fatalf("expected error on empty entry")
+		}
+	})
+
+	t.Run("rejects duplicate", func(t *testing.T) {
+		if _, err := ParseCheckpointContainers(map[string]string{
+			CheckpointContainersAnnotation: "main,main",
+		}); err == nil {
+			t.Fatalf("expected error on duplicate entry")
+		}
+	})
+}
+
+func TestContainerCheckpointPath(t *testing.T) {
+	if got := ContainerCheckpointPath("/checkpoints/abc/versions/2", "engine-0"); got != "/checkpoints/abc/versions/2/containers/engine-0" {
+		t.Fatalf("unexpected container path: %s", got)
 	}
-	if _, ok := annotations[RestoreContainerIDAnnotation]; ok {
-		t.Fatalf("restore container id annotation was not cleared: %#v", annotations)
+	if got := ContainerCheckpointPath("/checkpoints/abc/versions/2/", "main"); got != "/checkpoints/abc/versions/2/containers/main" {
+		t.Fatalf("unexpected container path with trailing slash: %s", got)
 	}
 }

--- a/deploy/snapshot/protocol/control_volume.go
+++ b/deploy/snapshot/protocol/control_volume.go
@@ -38,12 +38,15 @@ const (
 	ReadyForCheckpointFile = "ready-for-checkpoint"
 )
 
-// EnsureControlVolume adds the snapshot-control emptyDir to the pod spec,
-// mounts it on the given container at SnapshotControlMountPath, and sets
-// DYN_SNAPSHOT_CONTROL_DIR on the container's env. Idempotent — safe to call
-// from multiple code paths (operator checkpoint job, restore pod shaping, etc.).
-func EnsureControlVolume(podSpec *corev1.PodSpec, container *corev1.Container) {
-	if podSpec == nil || container == nil {
+// EnsureControlVolume adds the snapshot-control emptyDir to the pod spec and
+// mounts it on the given container at SnapshotControlMountPath with
+// subPath=containerName, plus DYN_SNAPSHOT_CONTROL_DIR on the container env.
+// Multiple containers share the emptyDir but each sees its own directory
+// (the agent writes sentinels into per-subPath files via /host/proc/<pid>/root,
+// and the kubelet hides other subPaths from the container).
+// Idempotent — safe to call from multiple code paths.
+func EnsureControlVolume(podSpec *corev1.PodSpec, container *corev1.Container, containerName string) {
+	if podSpec == nil || container == nil || containerName == "" {
 		return
 	}
 
@@ -63,7 +66,7 @@ func EnsureControlVolume(podSpec *corev1.PodSpec, container *corev1.Container) {
 
 	hasMount := false
 	for _, m := range container.VolumeMounts {
-		if m.Name == SnapshotControlVolumeName {
+		if m.Name == SnapshotControlVolumeName && m.SubPath == containerName {
 			hasMount = true
 			break
 		}
@@ -72,6 +75,7 @@ func EnsureControlVolume(podSpec *corev1.PodSpec, container *corev1.Container) {
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 			Name:      SnapshotControlVolumeName,
 			MountPath: SnapshotControlMountPath,
+			SubPath:   containerName,
 		})
 	}
 

--- a/deploy/snapshot/protocol/control_volume.go
+++ b/deploy/snapshot/protocol/control_volume.go
@@ -30,6 +30,12 @@ const (
 	// control volume when a restore has completed and the workload may
 	// resume.
 	RestoreCompleteFile = "restore-complete"
+
+	// ReadyForCheckpointFile is written by the workload inside the control
+	// volume when the model is loaded and the workload is ready for a
+	// checkpoint. Observed by the checkpoint job's kubelet readiness probe
+	// on the worker container.
+	ReadyForCheckpointFile = "ready-for-checkpoint"
 )
 
 // EnsureControlVolume adds the snapshot-control emptyDir to the pod spec,

--- a/deploy/snapshot/protocol/control_volume.go
+++ b/deploy/snapshot/protocol/control_volume.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package protocol
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// SnapshotControlVolumeName is the per-pod emptyDir used to carry
+	// checkpoint/restore lifecycle sentinels written by the snapshot agent
+	// and observed by the workload. It replaces the SIGUSR1/SIGCONT signals
+	// that previously required the workload to run as PID 1.
+	SnapshotControlVolumeName = "snapshot-control"
+
+	// SnapshotControlMountPath is where the control volume is mounted inside
+	// the workload container.
+	SnapshotControlMountPath = "/snapshot-control"
+
+	// SnapshotControlDirEnv is the environment variable exposing the control
+	// mount path to the workload.
+	SnapshotControlDirEnv = "DYN_SNAPSHOT_CONTROL_DIR"
+
+	// SnapshotCompleteFile is written by the snapshot agent inside the
+	// control volume when a checkpoint has completed successfully.
+	SnapshotCompleteFile = "snapshot-complete"
+
+	// RestoreCompleteFile is written by the snapshot agent inside the
+	// control volume when a restore has completed and the workload may
+	// resume.
+	RestoreCompleteFile = "restore-complete"
+)
+
+// EnsureControlVolume adds the snapshot-control emptyDir to the pod spec,
+// mounts it on the given container at SnapshotControlMountPath, and sets
+// DYN_SNAPSHOT_CONTROL_DIR on the container's env. Idempotent — safe to call
+// from multiple code paths (operator checkpoint job, restore pod shaping, etc.).
+func EnsureControlVolume(podSpec *corev1.PodSpec, container *corev1.Container) {
+	if podSpec == nil || container == nil {
+		return
+	}
+
+	hasVolume := false
+	for _, v := range podSpec.Volumes {
+		if v.Name == SnapshotControlVolumeName {
+			hasVolume = true
+			break
+		}
+	}
+	if !hasVolume {
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+			Name:         SnapshotControlVolumeName,
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		})
+	}
+
+	hasMount := false
+	for _, m := range container.VolumeMounts {
+		if m.Name == SnapshotControlVolumeName {
+			hasMount = true
+			break
+		}
+	}
+	if !hasMount {
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      SnapshotControlVolumeName,
+			MountPath: SnapshotControlMountPath,
+		})
+	}
+
+	hasEnv := false
+	for _, e := range container.Env {
+		if e.Name == SnapshotControlDirEnv {
+			hasEnv = true
+			break
+		}
+	}
+	if !hasEnv {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  SnapshotControlDirEnv,
+			Value: SnapshotControlMountPath,
+		})
+	}
+}

--- a/deploy/snapshot/protocol/control_volume_test.go
+++ b/deploy/snapshot/protocol/control_volume_test.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package protocol
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestEnsureControlVolume(t *testing.T) {
+	t.Run("adds volume mount and env from empty", func(t *testing.T) {
+		ps := &corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}}
+		EnsureControlVolume(ps, &ps.Containers[0])
+
+		if len(ps.Volumes) != 1 || ps.Volumes[0].Name != SnapshotControlVolumeName || ps.Volumes[0].EmptyDir == nil {
+			t.Fatalf("expected one %s emptyDir volume, got %#v", SnapshotControlVolumeName, ps.Volumes)
+		}
+		c := ps.Containers[0]
+		if len(c.VolumeMounts) != 1 || c.VolumeMounts[0].Name != SnapshotControlVolumeName || c.VolumeMounts[0].MountPath != SnapshotControlMountPath {
+			t.Fatalf("expected one %s mount at %s, got %#v", SnapshotControlVolumeName, SnapshotControlMountPath, c.VolumeMounts)
+		}
+		if len(c.Env) != 1 || c.Env[0].Name != SnapshotControlDirEnv || c.Env[0].Value != SnapshotControlMountPath {
+			t.Fatalf("expected env %s=%s, got %#v", SnapshotControlDirEnv, SnapshotControlMountPath, c.Env)
+		}
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		ps := &corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}}
+		EnsureControlVolume(ps, &ps.Containers[0])
+		EnsureControlVolume(ps, &ps.Containers[0])
+		c := ps.Containers[0]
+		if len(ps.Volumes) != 1 || len(c.VolumeMounts) != 1 || len(c.Env) != 1 {
+			t.Fatalf("expected single volume/mount/env after two calls, got volumes=%d mounts=%d env=%d", len(ps.Volumes), len(c.VolumeMounts), len(c.Env))
+		}
+	})
+
+	t.Run("nil pod spec no-op", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("expected no panic, got %v", r)
+			}
+		}()
+		EnsureControlVolume(nil, &corev1.Container{})
+	})
+
+	t.Run("nil container no-op", func(t *testing.T) {
+		ps := &corev1.PodSpec{}
+		EnsureControlVolume(ps, nil)
+		if len(ps.Volumes) != 0 {
+			t.Fatalf("expected no volumes when container is nil, got %#v", ps.Volumes)
+		}
+	})
+
+	t.Run("preserves existing entries", func(t *testing.T) {
+		ps := &corev1.PodSpec{
+			Volumes: []corev1.Volume{{
+				Name:         "other",
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			}},
+			Containers: []corev1.Container{{
+				Name:         "main",
+				VolumeMounts: []corev1.VolumeMount{{Name: "other", MountPath: "/other"}},
+				Env:          []corev1.EnvVar{{Name: "OTHER", Value: "x"}},
+			}},
+		}
+		EnsureControlVolume(ps, &ps.Containers[0])
+		c := ps.Containers[0]
+		if len(ps.Volumes) != 2 || len(c.VolumeMounts) != 2 || len(c.Env) != 2 {
+			t.Fatalf("expected existing + control entries, got volumes=%#v mounts=%#v env=%#v", ps.Volumes, c.VolumeMounts, c.Env)
+		}
+	})
+}

--- a/deploy/snapshot/protocol/control_volume_test.go
+++ b/deploy/snapshot/protocol/control_volume_test.go
@@ -12,7 +12,7 @@ import (
 func TestEnsureControlVolume(t *testing.T) {
 	t.Run("adds volume mount and env from empty", func(t *testing.T) {
 		ps := &corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}}
-		EnsureControlVolume(ps, &ps.Containers[0])
+		EnsureControlVolume(ps, &ps.Containers[0], "main")
 
 		if len(ps.Volumes) != 1 || ps.Volumes[0].Name != SnapshotControlVolumeName || ps.Volumes[0].EmptyDir == nil {
 			t.Fatalf("expected one %s emptyDir volume, got %#v", SnapshotControlVolumeName, ps.Volumes)
@@ -21,6 +21,9 @@ func TestEnsureControlVolume(t *testing.T) {
 		if len(c.VolumeMounts) != 1 || c.VolumeMounts[0].Name != SnapshotControlVolumeName || c.VolumeMounts[0].MountPath != SnapshotControlMountPath {
 			t.Fatalf("expected one %s mount at %s, got %#v", SnapshotControlVolumeName, SnapshotControlMountPath, c.VolumeMounts)
 		}
+		if c.VolumeMounts[0].SubPath != "main" {
+			t.Fatalf("expected subPath=main, got %#v", c.VolumeMounts[0])
+		}
 		if len(c.Env) != 1 || c.Env[0].Name != SnapshotControlDirEnv || c.Env[0].Value != SnapshotControlMountPath {
 			t.Fatalf("expected env %s=%s, got %#v", SnapshotControlDirEnv, SnapshotControlMountPath, c.Env)
 		}
@@ -28,11 +31,30 @@ func TestEnsureControlVolume(t *testing.T) {
 
 	t.Run("idempotent", func(t *testing.T) {
 		ps := &corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}}
-		EnsureControlVolume(ps, &ps.Containers[0])
-		EnsureControlVolume(ps, &ps.Containers[0])
+		EnsureControlVolume(ps, &ps.Containers[0], "main")
+		EnsureControlVolume(ps, &ps.Containers[0], "main")
 		c := ps.Containers[0]
 		if len(ps.Volumes) != 1 || len(c.VolumeMounts) != 1 || len(c.Env) != 1 {
 			t.Fatalf("expected single volume/mount/env after two calls, got volumes=%d mounts=%d env=%d", len(ps.Volumes), len(c.VolumeMounts), len(c.Env))
+		}
+	})
+
+	t.Run("per-container subPath shares volume", func(t *testing.T) {
+		ps := &corev1.PodSpec{Containers: []corev1.Container{
+			{Name: "engine-0"},
+			{Name: "engine-1"},
+		}}
+		EnsureControlVolume(ps, &ps.Containers[0], "engine-0")
+		EnsureControlVolume(ps, &ps.Containers[1], "engine-1")
+
+		if len(ps.Volumes) != 1 {
+			t.Fatalf("expected single shared emptyDir volume, got %#v", ps.Volumes)
+		}
+		if sub := ps.Containers[0].VolumeMounts[0].SubPath; sub != "engine-0" {
+			t.Fatalf("engine-0 subPath = %q, want engine-0", sub)
+		}
+		if sub := ps.Containers[1].VolumeMounts[0].SubPath; sub != "engine-1" {
+			t.Fatalf("engine-1 subPath = %q, want engine-1", sub)
 		}
 	})
 
@@ -42,12 +64,12 @@ func TestEnsureControlVolume(t *testing.T) {
 				t.Fatalf("expected no panic, got %v", r)
 			}
 		}()
-		EnsureControlVolume(nil, &corev1.Container{})
+		EnsureControlVolume(nil, &corev1.Container{}, "main")
 	})
 
 	t.Run("nil container no-op", func(t *testing.T) {
 		ps := &corev1.PodSpec{}
-		EnsureControlVolume(ps, nil)
+		EnsureControlVolume(ps, nil, "main")
 		if len(ps.Volumes) != 0 {
 			t.Fatalf("expected no volumes when container is nil, got %#v", ps.Volumes)
 		}
@@ -65,7 +87,7 @@ func TestEnsureControlVolume(t *testing.T) {
 				Env:          []corev1.EnvVar{{Name: "OTHER", Value: "x"}},
 			}},
 		}
-		EnsureControlVolume(ps, &ps.Containers[0])
+		EnsureControlVolume(ps, &ps.Containers[0], "main")
 		c := ps.Containers[0]
 		if len(ps.Volumes) != 2 || len(c.VolumeMounts) != 2 || len(c.Env) != 2 {
 			t.Fatalf("expected existing + control entries, got volumes=%#v mounts=%#v env=%#v", ps.Volumes, c.VolumeMounts, c.Env)

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -72,6 +72,7 @@ func PrepareRestorePodSpec(
 	if storage.BasePath != "" {
 		injectCheckpointVolumeMount(container, storage.BasePath)
 	}
+	EnsureControlVolume(podSpec, container)
 	if isCheckpointReady {
 		container.Command = []string{"sleep", "infinity"}
 		container.Args = nil
@@ -134,6 +135,36 @@ func ValidateRestorePodSpec(
 		if !hasMount {
 			return fmt.Errorf("missing %s mount at %s", CheckpointVolumeName, storage.BasePath)
 		}
+	}
+	hasControlVolume := false
+	for _, volume := range podSpec.Volumes {
+		if volume.Name == SnapshotControlVolumeName && volume.EmptyDir != nil {
+			hasControlVolume = true
+			break
+		}
+	}
+	if !hasControlVolume {
+		return fmt.Errorf("missing %s emptyDir volume; add it via snapshotprotocol.EnsureControlVolume", SnapshotControlVolumeName)
+	}
+	hasControlMount := false
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == SnapshotControlVolumeName && mount.MountPath == SnapshotControlMountPath {
+			hasControlMount = true
+			break
+		}
+	}
+	if !hasControlMount {
+		return fmt.Errorf("missing %s mount at %s", SnapshotControlVolumeName, SnapshotControlMountPath)
+	}
+	hasControlEnv := false
+	for _, env := range container.Env {
+		if env.Name == SnapshotControlDirEnv {
+			hasControlEnv = true
+			break
+		}
+	}
+	if !hasControlEnv {
+		return fmt.Errorf("missing %s env var on worker container", SnapshotControlDirEnv)
 	}
 	if seccompProfile == "" {
 		return nil

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -30,7 +30,13 @@ type PodOptions struct {
 	SeccompProfile  string
 }
 
-func NewRestorePod(pod *corev1.Pod, opts PodOptions) *corev1.Pod {
+// NewRestorePod shapes the input pod into a restore target: writes the
+// restore-target labels/annotations, turns every container listed in
+// CheckpointContainersAnnotation into a "sleep infinity" placeholder with
+// the snapshot-control + checkpoint-storage mounts, and forces
+// RestartPolicyNever. Returns nil if the annotation is missing, empty, or
+// names a container that isn't in the spec.
+func NewRestorePod(pod *corev1.Pod, opts PodOptions) (*corev1.Pod, error) {
 	pod = pod.DeepCopy()
 	if pod.Labels == nil {
 		pod.Labels = map[string]string{}
@@ -39,45 +45,54 @@ func NewRestorePod(pod *corev1.Pod, opts PodOptions) *corev1.Pod {
 		pod.Annotations = map[string]string{}
 	}
 	ApplyRestoreTargetMetadata(pod.Labels, pod.Annotations, true, opts.CheckpointID, opts.ArtifactVersion)
-	container := resolveWorkerContainer(&pod.Spec)
-	if container == nil {
-		return nil
+
+	names, err := ParseCheckpointContainers(pod.Annotations)
+	if err != nil {
+		return nil, fmt.Errorf("restore pod: %w", err)
 	}
-	PrepareRestorePodSpec(&pod.Spec, container, opts.Storage, opts.SeccompProfile, true)
+	if err := PrepareRestorePodSpec(&pod.Spec, names, opts.Storage, opts.SeccompProfile, true); err != nil {
+		return nil, err
+	}
 	pod.Namespace = opts.Namespace
 	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
-	return pod
+	return pod, nil
 }
 
-// resolveWorkerContainer returns the workload container, which is always
-// Containers[0]. GMS sidecars are appended after the workload.
-func resolveWorkerContainer(podSpec *corev1.PodSpec) *corev1.Container {
-	if podSpec == nil || len(podSpec.Containers) == 0 {
-		return nil
-	}
-	return &podSpec.Containers[0]
-}
-
+// PrepareRestorePodSpec shapes each listed container into a restore
+// placeholder: adds the checkpoint-storage volume once to the pod and,
+// per container, the snapshot-control subPath mount, the control-dir env,
+// and (when isCheckpointReady) a "sleep infinity" command plus a
+// long-tail startup probe.
 func PrepareRestorePodSpec(
 	podSpec *corev1.PodSpec,
-	container *corev1.Container,
+	containerNames []string,
 	storage Storage,
 	seccompProfile string,
 	isCheckpointReady bool,
-) {
+) error {
+	if len(containerNames) == 0 {
+		return fmt.Errorf("restore requires at least one container name")
+	}
 	EnsureLocalhostSeccompProfile(podSpec, seccompProfile)
 	if storage.PVCName != "" {
 		InjectCheckpointVolume(podSpec, storage.PVCName)
 	}
-	if storage.BasePath != "" {
-		injectCheckpointVolumeMount(container, storage.BasePath)
+	for _, name := range containerNames {
+		container := findContainer(podSpec.Containers, name)
+		if container == nil {
+			return fmt.Errorf("restore pod spec has no container named %q", name)
+		}
+		if storage.BasePath != "" {
+			injectCheckpointVolumeMount(container, storage.BasePath)
+		}
+		EnsureControlVolume(podSpec, container, name)
+		if isCheckpointReady {
+			container.Command = []string{"sleep", "infinity"}
+			container.Args = nil
+			ensureRestoreStartupProbe(container)
+		}
 	}
-	EnsureControlVolume(podSpec, container)
-	if isCheckpointReady {
-		container.Command = []string{"sleep", "infinity"}
-		container.Args = nil
-		ensureRestoreStartupProbe(container)
-	}
+	return nil
 }
 
 func ensureRestoreStartupProbe(container *corev1.Container) {
@@ -98,17 +113,21 @@ func ensureRestoreStartupProbe(container *corev1.Container) {
 	container.StartupProbe = startup
 }
 
+// ValidateRestorePodSpec ensures the pod spec carries the checkpoint-storage
+// volume, the snapshot-control emptyDir, and that every listed container has
+// the per-container subPath mount, the checkpoint-storage mount, and the
+// DYN_SNAPSHOT_CONTROL_DIR env var.
 func ValidateRestorePodSpec(
 	podSpec *corev1.PodSpec,
+	containerNames []string,
 	storage Storage,
 	seccompProfile string,
 ) error {
 	if podSpec == nil {
 		return fmt.Errorf("pod spec is nil")
 	}
-	container := resolveWorkerContainer(podSpec)
-	if container == nil {
-		return fmt.Errorf("restore target must have at least one container")
+	if len(containerNames) == 0 {
+		return fmt.Errorf("restore validation requires at least one container name")
 	}
 	if storage.PVCName != "" {
 		hasVolume := false
@@ -124,18 +143,6 @@ func ValidateRestorePodSpec(
 			return fmt.Errorf("missing %s volume for PVC %s", CheckpointVolumeName, storage.PVCName)
 		}
 	}
-	if storage.BasePath != "" {
-		hasMount := false
-		for _, mount := range container.VolumeMounts {
-			if mount.Name == CheckpointVolumeName && mount.MountPath == storage.BasePath {
-				hasMount = true
-				break
-			}
-		}
-		if !hasMount {
-			return fmt.Errorf("missing %s mount at %s", CheckpointVolumeName, storage.BasePath)
-		}
-	}
 	hasControlVolume := false
 	for _, volume := range podSpec.Volumes {
 		if volume.Name == SnapshotControlVolumeName && volume.EmptyDir != nil {
@@ -146,25 +153,43 @@ func ValidateRestorePodSpec(
 	if !hasControlVolume {
 		return fmt.Errorf("missing %s emptyDir volume; add it via snapshotprotocol.EnsureControlVolume", SnapshotControlVolumeName)
 	}
-	hasControlMount := false
-	for _, mount := range container.VolumeMounts {
-		if mount.Name == SnapshotControlVolumeName && mount.MountPath == SnapshotControlMountPath {
-			hasControlMount = true
-			break
+	for _, name := range containerNames {
+		container := findContainer(podSpec.Containers, name)
+		if container == nil {
+			return fmt.Errorf("restore target pod spec has no container named %q", name)
 		}
-	}
-	if !hasControlMount {
-		return fmt.Errorf("missing %s mount at %s", SnapshotControlVolumeName, SnapshotControlMountPath)
-	}
-	hasControlEnv := false
-	for _, env := range container.Env {
-		if env.Name == SnapshotControlDirEnv {
-			hasControlEnv = true
-			break
+		if storage.BasePath != "" {
+			hasMount := false
+			for _, mount := range container.VolumeMounts {
+				if mount.Name == CheckpointVolumeName && mount.MountPath == storage.BasePath {
+					hasMount = true
+					break
+				}
+			}
+			if !hasMount {
+				return fmt.Errorf("container %q missing %s mount at %s", name, CheckpointVolumeName, storage.BasePath)
+			}
 		}
-	}
-	if !hasControlEnv {
-		return fmt.Errorf("missing %s env var on worker container", SnapshotControlDirEnv)
+		hasControlMount := false
+		for _, mount := range container.VolumeMounts {
+			if mount.Name == SnapshotControlVolumeName && mount.MountPath == SnapshotControlMountPath && mount.SubPath == name {
+				hasControlMount = true
+				break
+			}
+		}
+		if !hasControlMount {
+			return fmt.Errorf("container %q missing %s subPath=%s mount at %s", name, SnapshotControlVolumeName, name, SnapshotControlMountPath)
+		}
+		hasControlEnv := false
+		for _, env := range container.Env {
+			if env.Name == SnapshotControlDirEnv {
+				hasControlEnv = true
+				break
+			}
+		}
+		if !hasControlEnv {
+			return fmt.Errorf("container %q missing %s env var", name, SnapshotControlDirEnv)
+		}
 	}
 	if seccompProfile == "" {
 		return nil
@@ -266,12 +291,14 @@ func DiscoverAndResolveStorage(
 	return ResolveCheckpointStorage(checkpointID, artifactVersion, storage)
 }
 
+// PrepareRestorePodSpecForCheckpoint combines storage discovery with
+// PrepareRestorePodSpec for the given container names.
 func PrepareRestorePodSpecForCheckpoint(
 	ctx context.Context,
 	reader ctrlclient.Reader,
 	namespace string,
 	podSpec *corev1.PodSpec,
-	container *corev1.Container,
+	containerNames []string,
 	checkpointID string,
 	artifactVersion string,
 	seccompProfile string,
@@ -282,8 +309,7 @@ func PrepareRestorePodSpecForCheckpoint(
 		return err
 	}
 
-	PrepareRestorePodSpec(podSpec, container, storage, seccompProfile, isCheckpointReady)
-	return nil
+	return PrepareRestorePodSpec(podSpec, containerNames, storage, seccompProfile, isCheckpointReady)
 }
 
 // InjectCheckpointVolume adds the checkpoint PVC volume to the pod spec if

--- a/deploy/snapshot/protocol/restore_test.go
+++ b/deploy/snapshot/protocol/restore_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -85,11 +86,31 @@ func TestNewRestorePod(t *testing.T) {
 	if restorePod.Spec.SecurityContext == nil || restorePod.Spec.SecurityContext.SeccompProfile == nil {
 		t.Fatalf("expected seccomp profile to be injected: %#v", restorePod.Spec.SecurityContext)
 	}
-	if len(restorePod.Spec.Volumes) != 1 {
-		t.Fatalf("expected checkpoint volume, got %#v", restorePod.Spec.Volumes)
+	if len(restorePod.Spec.Volumes) != 2 {
+		t.Fatalf("expected checkpoint and snapshot-control volumes, got %#v", restorePod.Spec.Volumes)
 	}
-	if len(restorePod.Spec.Containers[0].VolumeMounts) != 1 {
-		t.Fatalf("expected checkpoint mount, got %#v", restorePod.Spec.Containers[0].VolumeMounts)
+	if len(restorePod.Spec.Containers[0].VolumeMounts) != 2 {
+		t.Fatalf("expected checkpoint and snapshot-control mounts, got %#v", restorePod.Spec.Containers[0].VolumeMounts)
+	}
+	foundMount := false
+	for _, m := range restorePod.Spec.Containers[0].VolumeMounts {
+		if m.Name == SnapshotControlVolumeName {
+			foundMount = true
+			break
+		}
+	}
+	if !foundMount {
+		t.Fatalf("expected %s mount, got %#v", SnapshotControlVolumeName, restorePod.Spec.Containers[0].VolumeMounts)
+	}
+	foundEnv := false
+	for _, e := range restorePod.Spec.Containers[0].Env {
+		if e.Name == SnapshotControlDirEnv {
+			foundEnv = true
+			break
+		}
+	}
+	if !foundEnv {
+		t.Fatalf("expected %s env, got %#v", SnapshotControlDirEnv, restorePod.Spec.Containers[0].Env)
 	}
 }
 
@@ -117,11 +138,38 @@ func TestPrepareRestorePodSpec(t *testing.T) {
 	if podSpec.SecurityContext == nil || podSpec.SecurityContext.SeccompProfile == nil {
 		t.Fatalf("expected seccomp profile to be injected: %#v", podSpec.SecurityContext)
 	}
-	if len(podSpec.Volumes) != 1 {
-		t.Fatalf("expected checkpoint volume, got %#v", podSpec.Volumes)
+	if len(podSpec.Volumes) != 2 {
+		t.Fatalf("expected checkpoint and snapshot-control volumes, got %#v", podSpec.Volumes)
 	}
-	if len(container.VolumeMounts) != 1 {
-		t.Fatalf("expected checkpoint mount, got %#v", container.VolumeMounts)
+	if len(container.VolumeMounts) != 2 {
+		t.Fatalf("expected checkpoint and snapshot-control mounts, got %#v", container.VolumeMounts)
+	}
+	volCount := 0
+	for _, v := range podSpec.Volumes {
+		if v.Name == SnapshotControlVolumeName {
+			volCount++
+		}
+	}
+	if volCount != 1 {
+		t.Fatalf("expected single %s volume after repeated calls, got %#v", SnapshotControlVolumeName, podSpec.Volumes)
+	}
+	mountCount := 0
+	for _, m := range container.VolumeMounts {
+		if m.Name == SnapshotControlVolumeName {
+			mountCount++
+		}
+	}
+	if mountCount != 1 {
+		t.Fatalf("expected single %s mount after repeated calls, got %#v", SnapshotControlVolumeName, container.VolumeMounts)
+	}
+	envCount := 0
+	for _, e := range container.Env {
+		if e.Name == SnapshotControlDirEnv {
+			envCount++
+		}
+	}
+	if envCount != 1 {
+		t.Fatalf("expected single %s env after repeated calls, got %#v", SnapshotControlDirEnv, container.Env)
 	}
 	if len(container.Command) != 2 || container.Command[0] != "sleep" || container.Command[1] != "infinity" {
 		t.Fatalf("expected placeholder command, got %#v", container.Command)
@@ -257,31 +305,42 @@ func TestPrepareRestorePodSpecSynthesizesStartupProbeFromReadiness(t *testing.T)
 	}
 }
 
-func TestValidateRestorePodSpec(t *testing.T) {
-	profile := DefaultSeccompLocalhostProfile
-	podSpec := &corev1.PodSpec{
+func validRestoreSpecFixture(profile string) *corev1.PodSpec {
+	return &corev1.PodSpec{
 		SecurityContext: &corev1.PodSecurityContext{
 			SeccompProfile: &corev1.SeccompProfile{
 				Type:             corev1.SeccompProfileTypeLocalhost,
 				LocalhostProfile: &profile,
 			},
 		},
-		Volumes: []corev1.Volume{{
-			Name: CheckpointVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: "snapshot-pvc",
+		Volumes: []corev1.Volume{
+			{
+				Name: CheckpointVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "snapshot-pvc",
+					},
 				},
 			},
-		}},
+			{
+				Name:         SnapshotControlVolumeName,
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			},
+		},
 		Containers: []corev1.Container{{
 			Name: "main",
-			VolumeMounts: []corev1.VolumeMount{{
-				Name:      CheckpointVolumeName,
-				MountPath: "/checkpoints",
-			}},
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: CheckpointVolumeName, MountPath: "/checkpoints"},
+				{Name: SnapshotControlVolumeName, MountPath: SnapshotControlMountPath},
+			},
+			Env: []corev1.EnvVar{{Name: SnapshotControlDirEnv, Value: SnapshotControlMountPath}},
 		}},
 	}
+}
+
+func TestValidateRestorePodSpec(t *testing.T) {
+	profile := DefaultSeccompLocalhostProfile
+	podSpec := validRestoreSpecFixture(profile)
 	storage := Storage{
 		Type:     StorageTypePVC,
 		PVCName:  "snapshot-pvc",
@@ -293,15 +352,33 @@ func TestValidateRestorePodSpec(t *testing.T) {
 	}
 
 	badSpec := podSpec.DeepCopy()
-	badSpec.Volumes = nil
+	badSpec.Volumes = []corev1.Volume{badSpec.Volumes[1]}
 	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing checkpoint-storage volume for PVC snapshot-pvc" {
 		t.Fatalf("expected missing volume error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()
-	badSpec.Containers[0].VolumeMounts = nil
+	badSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{badSpec.Containers[0].VolumeMounts[1]}
 	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing checkpoint-storage mount at /checkpoints" {
 		t.Fatalf("expected missing mount error, got %v", err)
+	}
+
+	badSpec = podSpec.DeepCopy()
+	badSpec.Volumes = []corev1.Volume{badSpec.Volumes[0]}
+	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != fmt.Sprintf("missing %s emptyDir volume; add it via snapshotprotocol.EnsureControlVolume", SnapshotControlVolumeName) {
+		t.Fatalf("expected missing control volume error, got %v", err)
+	}
+
+	badSpec = podSpec.DeepCopy()
+	badSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{badSpec.Containers[0].VolumeMounts[0]}
+	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != fmt.Sprintf("missing %s mount at %s", SnapshotControlVolumeName, SnapshotControlMountPath) {
+		t.Fatalf("expected missing control mount error, got %v", err)
+	}
+
+	badSpec = podSpec.DeepCopy()
+	badSpec.Containers[0].Env = nil
+	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != fmt.Sprintf("missing %s env var on worker container", SnapshotControlDirEnv) {
+		t.Fatalf("expected missing control env error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()
@@ -312,33 +389,9 @@ func TestValidateRestorePodSpec(t *testing.T) {
 }
 
 func TestValidateRestorePodSpecAcceptsFirstContainerAsWorker(t *testing.T) {
-	profile := DefaultSeccompLocalhostProfile
-	podSpec := &corev1.PodSpec{
-		SecurityContext: &corev1.PodSecurityContext{
-			SeccompProfile: &corev1.SeccompProfile{
-				Type:             corev1.SeccompProfileTypeLocalhost,
-				LocalhostProfile: &profile,
-			},
-		},
-		Volumes: []corev1.Volume{{
-			Name: CheckpointVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: "snapshot-pvc",
-				},
-			},
-		}},
-		Containers: []corev1.Container{
-			{
-				Name: "worker",
-				VolumeMounts: []corev1.VolumeMount{{
-					Name:      CheckpointVolumeName,
-					MountPath: "/checkpoints",
-				}},
-			},
-			{Name: "sidecar"},
-		},
-	}
+	podSpec := validRestoreSpecFixture(DefaultSeccompLocalhostProfile)
+	podSpec.Containers[0].Name = "worker"
+	podSpec.Containers = append(podSpec.Containers, corev1.Container{Name: "sidecar"})
 
 	storage := Storage{
 		Type:     StorageTypePVC,
@@ -353,33 +406,9 @@ func TestValidateRestorePodSpecAcceptsFirstContainerAsWorker(t *testing.T) {
 }
 
 func TestValidateRestorePodSpecAllowsWorkerWithSidecars(t *testing.T) {
-	profile := DefaultSeccompLocalhostProfile
-	podSpec := &corev1.PodSpec{
-		SecurityContext: &corev1.PodSecurityContext{
-			SeccompProfile: &corev1.SeccompProfile{
-				Type:             corev1.SeccompProfileTypeLocalhost,
-				LocalhostProfile: &profile,
-			},
-		},
-		Volumes: []corev1.Volume{{
-			Name: CheckpointVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: "snapshot-pvc",
-				},
-			},
-		}},
-		Containers: []corev1.Container{
-			{
-				Name: "worker",
-				VolumeMounts: []corev1.VolumeMount{{
-					Name:      CheckpointVolumeName,
-					MountPath: "/checkpoints",
-				}},
-			},
-			{Name: "sidecar"},
-		},
-	}
+	podSpec := validRestoreSpecFixture(DefaultSeccompLocalhostProfile)
+	podSpec.Containers[0].Name = "worker"
+	podSpec.Containers = append(podSpec.Containers, corev1.Container{Name: "sidecar"})
 
 	storage := Storage{
 		Type:     StorageTypePVC,

--- a/deploy/snapshot/protocol/restore_test.go
+++ b/deploy/snapshot/protocol/restore_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package protocol
 
 import (
@@ -14,11 +17,14 @@ func TestNewRestorePod(t *testing.T) {
 	readinessProbe := &corev1.Probe{PeriodSeconds: 7, TimeoutSeconds: 3}
 	livenessProbe := &corev1.Probe{InitialDelaySeconds: 11}
 	startupProbe := &corev1.Probe{FailureThreshold: 120}
-	restorePod := NewRestorePod(&corev1.Pod{
+	restorePod, err := NewRestorePod(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "worker",
-			Labels:      map[string]string{"existing": "label"},
-			Annotations: map[string]string{"existing": "annotation"},
+			Name:   "worker",
+			Labels: map[string]string{"existing": "label"},
+			Annotations: map[string]string{
+				"existing":                     "annotation",
+				CheckpointContainersAnnotation: "main",
+			},
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyAlways,
@@ -43,6 +49,9 @@ func TestNewRestorePod(t *testing.T) {
 		},
 		SeccompProfile: DefaultSeccompLocalhostProfile,
 	})
+	if err != nil {
+		t.Fatalf("NewRestorePod: %v", err)
+	}
 
 	if restorePod.Name != "worker" || restorePod.Namespace != "test-ns" {
 		t.Fatalf("unexpected restore pod identity: %#v", restorePod.ObjectMeta)
@@ -55,6 +64,9 @@ func TestNewRestorePod(t *testing.T) {
 	}
 	if restorePod.Annotations[CheckpointArtifactVersionAnnotation] != "2" {
 		t.Fatalf("expected checkpoint artifact version annotation: %#v", restorePod.Annotations)
+	}
+	if got := restorePod.Annotations[CheckpointContainersAnnotation]; got != "main" {
+		t.Fatalf("expected containers annotation preserved, got %q", got)
 	}
 	if restorePod.Spec.RestartPolicy != corev1.RestartPolicyNever {
 		t.Fatalf("expected restartPolicy Never, got %#v", restorePod.Spec.RestartPolicy)
@@ -96,6 +108,9 @@ func TestNewRestorePod(t *testing.T) {
 	for _, m := range restorePod.Spec.Containers[0].VolumeMounts {
 		if m.Name == SnapshotControlVolumeName {
 			foundMount = true
+			if m.SubPath != "main" {
+				t.Fatalf("expected control subPath=main, got %#v", m)
+			}
 			break
 		}
 	}
@@ -115,16 +130,18 @@ func TestNewRestorePod(t *testing.T) {
 }
 
 func TestPrepareRestorePodSpec(t *testing.T) {
-	podSpec := corev1.PodSpec{}
 	readinessProbe := &corev1.Probe{PeriodSeconds: 13, SuccessThreshold: 1}
 	livenessProbe := &corev1.Probe{TimeoutSeconds: 5}
 	startupProbe := &corev1.Probe{FailureThreshold: 60}
-	container := corev1.Container{
-		Command:        []string{"python3", "-m", "dynamo.vllm"},
-		Args:           []string{"--model", "Qwen"},
-		ReadinessProbe: readinessProbe.DeepCopy(),
-		LivenessProbe:  livenessProbe.DeepCopy(),
-		StartupProbe:   startupProbe.DeepCopy(),
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:           "main",
+			Command:        []string{"python3", "-m", "dynamo.vllm"},
+			Args:           []string{"--model", "Qwen"},
+			ReadinessProbe: readinessProbe.DeepCopy(),
+			LivenessProbe:  livenessProbe.DeepCopy(),
+			StartupProbe:   startupProbe.DeepCopy(),
+		}},
 	}
 
 	storage := Storage{
@@ -132,8 +149,12 @@ func TestPrepareRestorePodSpec(t *testing.T) {
 		PVCName:  "snapshot-pvc",
 		BasePath: "/checkpoints",
 	}
-	PrepareRestorePodSpec(&podSpec, &container, storage, DefaultSeccompLocalhostProfile, true)
-	PrepareRestorePodSpec(&podSpec, &container, storage, DefaultSeccompLocalhostProfile, true)
+	if err := PrepareRestorePodSpec(&podSpec, []string{"main"}, storage, DefaultSeccompLocalhostProfile, true); err != nil {
+		t.Fatalf("PrepareRestorePodSpec: %v", err)
+	}
+	if err := PrepareRestorePodSpec(&podSpec, []string{"main"}, storage, DefaultSeccompLocalhostProfile, true); err != nil {
+		t.Fatalf("PrepareRestorePodSpec repeat: %v", err)
+	}
 
 	if podSpec.SecurityContext == nil || podSpec.SecurityContext.SeccompProfile == nil {
 		t.Fatalf("expected seccomp profile to be injected: %#v", podSpec.SecurityContext)
@@ -141,6 +162,7 @@ func TestPrepareRestorePodSpec(t *testing.T) {
 	if len(podSpec.Volumes) != 2 {
 		t.Fatalf("expected checkpoint and snapshot-control volumes, got %#v", podSpec.Volumes)
 	}
+	container := podSpec.Containers[0]
 	if len(container.VolumeMounts) != 2 {
 		t.Fatalf("expected checkpoint and snapshot-control mounts, got %#v", container.VolumeMounts)
 	}
@@ -201,7 +223,6 @@ func TestPrepareRestorePodSpec(t *testing.T) {
 }
 
 func TestPrepareRestorePodSpecSynthesizesStartupProbeFromLiveness(t *testing.T) {
-	podSpec := corev1.PodSpec{}
 	livenessProbe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{Path: "/livez"},
@@ -210,14 +231,18 @@ func TestPrepareRestorePodSpecSynthesizesStartupProbeFromLiveness(t *testing.T) 
 		TimeoutSeconds:   4,
 		FailureThreshold: 2,
 	}
-	container := corev1.Container{
+	podSpec := corev1.PodSpec{Containers: []corev1.Container{{
+		Name:          "main",
 		Command:       []string{"python3", "-m", "dynamo.vllm"},
 		Args:          []string{"--model", "Qwen"},
 		LivenessProbe: livenessProbe.DeepCopy(),
+	}}}
+
+	if err := PrepareRestorePodSpec(&podSpec, []string{"main"}, Storage{}, "", true); err != nil {
+		t.Fatalf("PrepareRestorePodSpec: %v", err)
 	}
 
-	PrepareRestorePodSpec(&podSpec, &container, Storage{}, "", true)
-
+	container := podSpec.Containers[0]
 	if container.LivenessProbe == nil {
 		t.Fatalf("expected liveness probe to be preserved")
 	}
@@ -235,9 +260,14 @@ func TestPrepareRestorePodSpecSynthesizesStartupProbeFromLiveness(t *testing.T) 
 	}
 }
 
-func TestNewRestorePodTargetsFirstContainerWhenSidecarsPresent(t *testing.T) {
-	restorePod := NewRestorePod(&corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+func TestNewRestorePodOnlyTouchesListedContainers(t *testing.T) {
+	restorePod, err := NewRestorePod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "worker",
+			Annotations: map[string]string{
+				CheckpointContainersAnnotation: "worker",
+			},
+		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{Name: "worker", Image: "test:latest", Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}},
@@ -255,20 +285,24 @@ func TestNewRestorePodTargetsFirstContainerWhenSidecarsPresent(t *testing.T) {
 		},
 		SeccompProfile: DefaultSeccompLocalhostProfile,
 	})
+	if err != nil {
+		t.Fatalf("NewRestorePod: %v", err)
+	}
 
-	if got := restorePod.Spec.Containers[0].Command; len(got) != 2 || got[0] != "sleep" || got[1] != "infinity" {
-		t.Fatalf("expected first container placeholder command, got %#v", got)
+	worker := requireCheckpointContainer(t, restorePod.Spec.Containers, "worker")
+	if got := worker.Command; len(got) != 2 || got[0] != "sleep" || got[1] != "infinity" {
+		t.Fatalf("expected worker placeholder command, got %#v", got)
 	}
-	if restorePod.Spec.Containers[0].Args != nil {
-		t.Fatalf("expected first container args to be cleared: %#v", restorePod.Spec.Containers[0].Args)
-	}
-	if got := restorePod.Spec.Containers[1].Command; len(got) != 1 || got[0] != "sidecar" {
+	sidecar := requireCheckpointContainer(t, restorePod.Spec.Containers, "sidecar")
+	if got := sidecar.Command; len(got) != 1 || got[0] != "sidecar" {
 		t.Fatalf("expected sidecar command to remain unchanged, got %#v", got)
+	}
+	if len(sidecar.VolumeMounts) != 0 {
+		t.Fatalf("expected sidecar mounts untouched, got %#v", sidecar.VolumeMounts)
 	}
 }
 
 func TestPrepareRestorePodSpecSynthesizesStartupProbeFromReadiness(t *testing.T) {
-	podSpec := corev1.PodSpec{}
 	readinessProbe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{Command: []string{"cat", "/tmp/ready"}},
@@ -277,14 +311,18 @@ func TestPrepareRestorePodSpecSynthesizesStartupProbeFromReadiness(t *testing.T)
 		SuccessThreshold: 3,
 		FailureThreshold: 4,
 	}
-	container := corev1.Container{
+	podSpec := corev1.PodSpec{Containers: []corev1.Container{{
+		Name:           "main",
 		Command:        []string{"python3", "-m", "dynamo.vllm"},
 		Args:           []string{"--model", "Qwen"},
 		ReadinessProbe: readinessProbe.DeepCopy(),
+	}}}
+
+	if err := PrepareRestorePodSpec(&podSpec, []string{"main"}, Storage{}, "", true); err != nil {
+		t.Fatalf("PrepareRestorePodSpec: %v", err)
 	}
 
-	PrepareRestorePodSpec(&podSpec, &container, Storage{}, "", true)
-
+	container := podSpec.Containers[0]
 	if container.ReadinessProbe == nil {
 		t.Fatalf("expected readiness probe to be preserved")
 	}
@@ -331,7 +369,7 @@ func validRestoreSpecFixture(profile string) *corev1.PodSpec {
 			Name: "main",
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: CheckpointVolumeName, MountPath: "/checkpoints"},
-				{Name: SnapshotControlVolumeName, MountPath: SnapshotControlMountPath},
+				{Name: SnapshotControlVolumeName, MountPath: SnapshotControlMountPath, SubPath: "main"},
 			},
 			Env: []corev1.EnvVar{{Name: SnapshotControlDirEnv, Value: SnapshotControlMountPath}},
 		}},
@@ -347,67 +385,54 @@ func TestValidateRestorePodSpec(t *testing.T) {
 		BasePath: "/checkpoints",
 	}
 
-	if err := ValidateRestorePodSpec(podSpec, storage, DefaultSeccompLocalhostProfile); err != nil {
+	if err := ValidateRestorePodSpec(podSpec, []string{"main"}, storage, DefaultSeccompLocalhostProfile); err != nil {
 		t.Fatalf("expected restore pod spec to be valid, got %v", err)
 	}
 
 	badSpec := podSpec.DeepCopy()
 	badSpec.Volumes = []corev1.Volume{badSpec.Volumes[1]}
-	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing checkpoint-storage volume for PVC snapshot-pvc" {
+	if err := ValidateRestorePodSpec(badSpec, []string{"main"}, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing checkpoint-storage volume for PVC snapshot-pvc" {
 		t.Fatalf("expected missing volume error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()
 	badSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{badSpec.Containers[0].VolumeMounts[1]}
-	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing checkpoint-storage mount at /checkpoints" {
+	expected := `container "main" missing checkpoint-storage mount at /checkpoints`
+	if err := ValidateRestorePodSpec(badSpec, []string{"main"}, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != expected {
 		t.Fatalf("expected missing mount error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()
 	badSpec.Volumes = []corev1.Volume{badSpec.Volumes[0]}
-	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != fmt.Sprintf("missing %s emptyDir volume; add it via snapshotprotocol.EnsureControlVolume", SnapshotControlVolumeName) {
+	if err := ValidateRestorePodSpec(badSpec, []string{"main"}, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != fmt.Sprintf("missing %s emptyDir volume; add it via snapshotprotocol.EnsureControlVolume", SnapshotControlVolumeName) {
 		t.Fatalf("expected missing control volume error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()
 	badSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{badSpec.Containers[0].VolumeMounts[0]}
-	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != fmt.Sprintf("missing %s mount at %s", SnapshotControlVolumeName, SnapshotControlMountPath) {
+	expected = fmt.Sprintf("container %q missing %s subPath=%s mount at %s", "main", SnapshotControlVolumeName, "main", SnapshotControlMountPath)
+	if err := ValidateRestorePodSpec(badSpec, []string{"main"}, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != expected {
 		t.Fatalf("expected missing control mount error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()
 	badSpec.Containers[0].Env = nil
-	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != fmt.Sprintf("missing %s env var on worker container", SnapshotControlDirEnv) {
+	expected = fmt.Sprintf("container %q missing %s env var", "main", SnapshotControlDirEnv)
+	if err := ValidateRestorePodSpec(badSpec, []string{"main"}, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != expected {
 		t.Fatalf("expected missing control env error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()
 	badSpec.SecurityContext = nil
-	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing localhost seccomp profile" {
+	if err := ValidateRestorePodSpec(badSpec, []string{"main"}, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing localhost seccomp profile" {
 		t.Fatalf("expected missing seccomp error, got %v", err)
-	}
-}
-
-func TestValidateRestorePodSpecAcceptsFirstContainerAsWorker(t *testing.T) {
-	podSpec := validRestoreSpecFixture(DefaultSeccompLocalhostProfile)
-	podSpec.Containers[0].Name = "worker"
-	podSpec.Containers = append(podSpec.Containers, corev1.Container{Name: "sidecar"})
-
-	storage := Storage{
-		Type:     StorageTypePVC,
-		PVCName:  "snapshot-pvc",
-		BasePath: "/checkpoints",
-	}
-
-	// Containers[0] is always the worker, regardless of name
-	if err := ValidateRestorePodSpec(podSpec, storage, DefaultSeccompLocalhostProfile); err != nil {
-		t.Fatalf("expected validation to pass for first container as worker, got %v", err)
 	}
 }
 
 func TestValidateRestorePodSpecAllowsWorkerWithSidecars(t *testing.T) {
 	podSpec := validRestoreSpecFixture(DefaultSeccompLocalhostProfile)
 	podSpec.Containers[0].Name = "worker"
+	podSpec.Containers[0].VolumeMounts[1].SubPath = "worker"
 	podSpec.Containers = append(podSpec.Containers, corev1.Container{Name: "sidecar"})
 
 	storage := Storage{
@@ -416,8 +441,22 @@ func TestValidateRestorePodSpecAllowsWorkerWithSidecars(t *testing.T) {
 		BasePath: "/checkpoints",
 	}
 
-	if err := ValidateRestorePodSpec(podSpec, storage, DefaultSeccompLocalhostProfile); err != nil {
+	if err := ValidateRestorePodSpec(podSpec, []string{"worker"}, storage, DefaultSeccompLocalhostProfile); err != nil {
 		t.Fatalf("expected worker with sidecars to validate, got %v", err)
+	}
+}
+
+func TestValidateRestorePodSpecRejectsMissingListedContainer(t *testing.T) {
+	podSpec := validRestoreSpecFixture(DefaultSeccompLocalhostProfile)
+	storage := Storage{
+		Type:     StorageTypePVC,
+		PVCName:  "snapshot-pvc",
+		BasePath: "/checkpoints",
+	}
+
+	expected := `restore target pod spec has no container named "missing"`
+	if err := ValidateRestorePodSpec(podSpec, []string{"missing"}, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != expected {
+		t.Fatalf("expected missing container error, got %v", err)
 	}
 }
 

--- a/docs/kubernetes/api-reference.md
+++ b/docs/kubernetes/api-reference.md
@@ -1795,7 +1795,6 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Enabled indicates if checkpoint functionality is enabled |  |  |
-| `readyForCheckpointFilePath` _string_ | ReadyForCheckpointFilePath signals model readiness for checkpoint jobs | /tmp/ready-for-checkpoint |  |
 | `storage` _[CheckpointStorageConfiguration](#checkpointstorageconfiguration)_ | Deprecated: Storage is retained for compatibility and ignored by the<br />current snapshot flow. Snapshot storage is discovered from the<br />snapshot-agent DaemonSet instead. |  |  |
 
 


### PR DESCRIPTION
## Problem

A pod with `deploy/snapshot` integration contains two classes of containers:

1. Workload containers — `main` today, but in a failover setup (see #8319) they
   become `engine-0`, `engine-1`, ... and the set can change between pod
   replacements.
2. GMS sidecars — not checkpoint/restore material.

The current code threads a single container through every layer: `Containers[0]`
in protocol helpers, `resolveMainContainerName` in the controller, hardcoded
`main` fallbacks in the executor, pod-scoped singleton status annotations
(`nvidia.com/snapshot-checkpoint-status`, `nvidia.com/snapshot-restore-status`,
`nvidia.com/snapshot-restore-container-id`). Any future multi-container story —
failover especially — cannot safely slot into that shape.

#8319 worked around this for the immediate failover case; this PR supersedes
that approach with end-to-end plumbing of a container-name list. It is PR 1/2.

## Design summary

See `tmp/snapshot-multicontainer-proposal.md` in the branch (and the companion
`tmp/snapshot-multicontainer-qa1.md`) for the full design, including rejected
alternatives (exclusion list, naming convention, per-container labels, CRD
field).

Core shape:

```
                  pod annotation: nvidia.com/snapshot-containers = "c1,c2,..."
                            │
          ┌─────────────────┼─────────────────┐
          ▼                 ▼                 ▼
     protocol           controller          snapshotctl
  NewCheckpointJob   reconcileCheckpoint   --containers
  NewRestorePod      reconcileRestore
  Prepare/Validate
          │                 │
          ▼                 ▼
   storage layout:     status annotations (per-container-keyed):
   <podRoot>/          nvidia.com/snapshot-checkpoint-status.<c>
     containers/<c>/   nvidia.com/snapshot-restore-status.<c>
                       nvidia.com/snapshot-restore-container-id.<c>
                       nvidia.com/snapshot-checkpoint-job-status  (aggregate, on the Job)
```

Volume mount: one shared `snapshot-control` emptyDir; each container mounts
with `subPath: <containerName>`, so concurrent workload containers write their
sentinels to isolated per-container dirs without the workload being aware.

Per-container restore guard stays keyed by containerd container ID (existing
kubelet-restart behavior in `controller.go:281-296` is preserved, just sharded).

## In scope (this PR)

- Protocol: `CheckpointContainersAnnotation`, `ParseCheckpointContainers`,
  `FormatCheckpointContainers`, `ContainerCheckpointPath`. Prefixed
  annotations: `CheckpointStatusAnnotationPrefix`,
  `RestoreStatusAnnotationPrefix`, `RestoreContainerIDAnnotationPrefix`. Plus
  the aggregate job-level `CheckpointJobStatusAnnotation`.
- `NewCheckpointJob`, `NewRestorePod`, `PrepareRestorePodSpec`,
  `ValidateRestorePodSpec`, `PrepareRestorePodSpecForCheckpoint` all take
  `[]string` container lists and error on missing/unknown names.
- `EnsureControlVolume` takes `containerName` and mounts with `subPath=<name>`.
- Controller: sequential per-container checkpoint loop under one pod-scoped
  lease; aggregate job status on completion. Concurrent per-container restore
  with `(pod, containerd-ID)` dedup keys.
- Executor: `CheckpointRequest.PodCheckpointRoot` threaded through so staging
  `tmp/<uuid>` sits at the pod root while `CheckpointLocation` is per-container.
- `snapshotctl` gains `--containers` on both subcommands; `waitForRestore`
  aggregates per-container status.
- Operator (`checkpoint.InjectCheckpointIntoPodSpec`,
  `checkpoint.ApplyRestorePodMetadata`, `buildCheckpointJob`) takes
  `containerNames []string` and always passes `[]string{MainContainerName}`
  today, stamping `nvidia.com/snapshot-containers="main"` on checkpoint jobs
  and restore pods.

## Breaking changes

- Annotations renamed/split. Old singletons (`snapshot-checkpoint-status`,
  `snapshot-restore-status`, `snapshot-restore-container-id`) deleted. No
  backcompat shim — in-flight checkpoints from the old version would not
  observe terminal state and should be drained before rollout.
- Go API: all the functions listed above changed signature. External callers
  would need to adapt.
- On-disk layout: per-container artifacts live under `containers/<name>/`.
  Existing single-container checkpoints taken with the old code are not
  readable by this PR and must be re-taken.
- `snapshotctl` `loadPod` no longer magically picks `Containers[0]` or a
  container named `main`; callers must stamp the annotation (or pass
  `--containers`).

## Deferred to PR 2

- Stamping `["engine-0", "engine-1"]` from the operator for failover pods.
- CRD field on `DynamoComponentDeploymentSpec` (or similar) for explicit
  container lists.
- Validating `cuda-checkpoint --launch-job` scoping per-container on multi-GPU
  pods — gate for PR 2.
- Fix for the pre-existing `inFlight` map leak at `controller.go:492-498` when
  `annotatePod` fails writing terminal status (pod is stuck silently skipped
  until controller restart; multi-container amplifies blast radius, but the
  fix is orthogonal and belongs in its own PR).

## Asymmetric failover (seam, not built)

In failover, checkpoint captures one source container (e.g. `engine-0`) and
restore replays its state to N target containers (e.g. both `engine-0` and
`engine-1`). PR 1 does not exercise this — both lists are always `["main"]`
— but the design does not preclude it:

- `nvidia.com/snapshot-containers` is a property of the pod being shaped, not
  of the checkpoint. The checkpoint job's pod template and the restore pod
  can legitimately carry different values for the same checkpoint ID.
- The on-disk `containers/<name>/` uses the source name; PR 2 will add a
  source-mapping mechanism (likely a manifest field) so restore targets can
  point at the right source dir.
- No protocol, storage, or status code asserts
  `len(restoreTargets) == len(checkpointSources)`.

Constant naming is deliberately single: one `CheckpointContainersAnnotation`
with dual-role semantics documented in the godoc. Splitting into
`CheckpointSource` / `RestoreTarget` is a rename the day PR 2 needs it.

## Validation

- `deploy/snapshot`: `go build ./... && go vet ./... && go test ./...` — all
  green.
- `deploy/operator`: all unit tests green. `TestControllers` (ginkgo envtest
  suite) fails only because the `etcd` kubebuilder binary is not available
  in this environment; unrelated to the change and fails identically on the
  base branch.

## References

- Supersedes #8319 (the failover stopgap that sidesteps this plumbing).
  References, does not close; the operator-side failover wiring that #8319
  proposes is PR 2 of this pair.
