### PR TITLE
fix(operator): reconcile DGD on PodClique readiness-field status changes

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -1731,15 +1731,21 @@ func (r *DynamoGraphDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) err
 					CreateFunc: func(ce event.CreateEvent) bool { return false },
 					DeleteFunc: func(de event.DeleteEvent) bool { return false },
 					UpdateFunc: func(ue event.UpdateEvent) bool {
-						// Only trigger on status changes (readyReplicas or replicas)
 						oldPC, okOld := ue.ObjectOld.(*grovev1alpha1.PodClique)
 						newPC, okNew := ue.ObjectNew.(*grovev1alpha1.PodClique)
 						if !okOld || !okNew {
 							return false
 						}
-						// Trigger if readyReplicas or replicas changed
+						// Mirrors the readiness gates in CheckPodCliqueReady
+						// (dynamo/grove.go): ObservedGeneration, Status.Replicas,
+						// UpdatedReplicas, and ReadyReplicas. Without the
+						// non-ReadyReplicas signals, the DGD can stay stale at the
+						// tail of a rolling update when ReadyReplicas is flat.
 						return oldPC.Status.ReadyReplicas != newPC.Status.ReadyReplicas ||
-							oldPC.Spec.Replicas != newPC.Spec.Replicas
+							oldPC.Status.UpdatedReplicas != newPC.Status.UpdatedReplicas ||
+							oldPC.Status.Replicas != newPC.Status.Replicas ||
+							oldPC.Spec.Replicas != newPC.Spec.Replicas ||
+							!ptrInt64Equal(oldPC.Status.ObservedGeneration, newPC.Status.ObservedGeneration)
 					},
 					GenericFunc: func(ge event.GenericEvent) bool { return false },
 				}),

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -1675,15 +1675,21 @@ func (r *DynamoGraphDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) err
 					CreateFunc: func(ce event.CreateEvent) bool { return false },
 					DeleteFunc: func(de event.DeleteEvent) bool { return false },
 					UpdateFunc: func(ue event.UpdateEvent) bool {
-						// Only trigger on status changes (readyReplicas or replicas)
 						oldPC, okOld := ue.ObjectOld.(*grovev1alpha1.PodClique)
 						newPC, okNew := ue.ObjectNew.(*grovev1alpha1.PodClique)
 						if !okOld || !okNew {
 							return false
 						}
-						// Trigger if readyReplicas or replicas changed
+						// Mirrors the readiness gates in CheckPodCliqueReady
+						// (dynamo/grove.go): ObservedGeneration, Status.Replicas,
+						// UpdatedReplicas, and ReadyReplicas. Without the
+						// non-ReadyReplicas signals, the DGD can stay stale at the
+						// tail of a rolling update when ReadyReplicas is flat.
 						return oldPC.Status.ReadyReplicas != newPC.Status.ReadyReplicas ||
-							oldPC.Spec.Replicas != newPC.Spec.Replicas
+							oldPC.Status.UpdatedReplicas != newPC.Status.UpdatedReplicas ||
+							oldPC.Status.Replicas != newPC.Status.Replicas ||
+							oldPC.Spec.Replicas != newPC.Spec.Replicas ||
+							!ptrInt64Equal(oldPC.Status.ObservedGeneration, newPC.Status.ObservedGeneration)
 					},
 					GenericFunc: func(ge event.GenericEvent) bool { return false },
 				}),


### PR DESCRIPTION
## Summary

Companion to #8328 for the **single-node PodClique** branch of the readiness check at `dynamographdeployment_controller.go:419-423`. #8328 fixed the multi-node path (`CheckPCSGReady`) by adding a PCSG watch; this PR closes the analogous gap on the PodClique path (`CheckPodCliqueReady`).

### Root cause

The existing PodClique watch predicate only triggered on `Status.ReadyReplicas` or `Spec.Replicas` diffs, but `CheckPodCliqueReady` (in `deploy/operator/internal/dynamo/grove.go`) gates readiness on more than that:

| Gate | Field |
| --- | --- |
| `observedGeneration == nil` → not ready | `Status.ObservedGeneration` |
| `observedGeneration < generation` → not ready | `Status.ObservedGeneration` |
| `desiredReplicas != readyReplicas` → not ready | `Status.ReadyReplicas` ✅ already watched |
| `desiredReplicas != updatedReplicas` → not ready | `Status.UpdatedReplicas` |
| `replicas != desiredReplicas` → "performing rolling update" | `Status.Replicas` |

At the tail of a rolling update, `UpdatedReplicas` / `Status.Replicas` / `ObservedGeneration` can transition without `ReadyReplicas` moving. No PodClique event fires that the predicate accepts, so the DGD keeps its stale aggregate until something else triggers a reconcile.

## Changes

* Expand the `UpdateFunc` predicate on the `&grovev1alpha1.PodClique{}` watch to also fire on `Status.UpdatedReplicas`, `Status.Replicas`, and `Status.ObservedGeneration` transitions.
* Reuse the `ptrInt64Equal` helper introduced in #8328 for the optional `ObservedGeneration` (`*int64`) comparison, matching the pattern already used for the sibling PCSG predicate.
* No RBAC changes needed — `grove.io/podcliques` `get;list;watch` is already declared (added in #8328).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced controller event handling to trigger reconciliation on additional status change events, improving system responsiveness and ensuring more reliable state synchronization during deployment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->