### PR TITLE
ci(release): fix planner ECR tag suffix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,9 +259,12 @@ jobs:
           copy_image "${OPERATOR_SOURCE}" "${OPERATOR_TARGET}" "kubernetes-operator:${NGC_VERSION_TAG}"
 
           # ---- Planner image (CPU-only, multi-arch from post-merge planner-pipeline) ----
+          # Post-merge appends "-cpu" to the ECR tag for cpu_only builds (see
+          # shared-build-image.yml IMAGE_TAG_SUFFIX). Match that here or crane
+          # will hit MANIFEST_UNKNOWN. Broke 1.1.0rc0 and rc1 publish.
           echo ""
           echo "=== Planner Image ==="
-          SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${COMMIT_SHA}-dynamo-planner"
+          SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${COMMIT_SHA}-dynamo-planner-cpu"
           TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/dynamo-planner:${NGC_VERSION_TAG}"
           copy_image "${SOURCE}" "${TARGET}" "dynamo-planner:${NGC_VERSION_TAG}"
           # ---- Snapshot image ----


### PR DESCRIPTION
## Summary

The release pipeline's `Copy images to NGC` step has been failing on every release-publish dispatch because the source ECR tag for the planner image doesn't match what post-merge CI actually pushes.

`post-merge-ci.yml` runs the `planner-pipeline` with `cpu_only: true`, which causes `shared-build-image.yml` to append `-cpu` (`IMAGE_TAG_SUFFIX`) to the pushed tag — so the planner manifest in ECR is `<sha>-dynamo-planner-cpu`. The release workflow was looking for the bare `<sha>-dynamo-planner` tag, hit `MANIFEST_UNKNOWN`, and aborted the whole copy script (the `set -euo pipefail` + `copy_image` `return 1` combo exits before snapshot-agent and Helm push run).

This broke both `v1.1.0-rc0` (run [24485011739](https://github.com/ai-dynamo/dynamo/actions/runs/24485011739)) and `v1.1.0-rc1` (run [24639408733](https://github.com/ai-dynamo/dynamo/actions/runs/24639408733)). In both runs the runtime, frontend, and operator images copied successfully — only planner / snapshot / Helm never reached NGC.

One-line fix: source the planner image with the matching `-cpu` suffix. Verified against `04c6efb62c` post-merge logs that the actual ECR tag is `<sha>-dynamo-planner-cpu` (and `compliance-dynamo-planner-cpu-amd64` artifact name, same suffix).

## Test plan

- [ ] Cherry-pick to `release/1.1.0`.
- [ ] Re-dispatch Release Pipeline on `release/1.1.0` with `action=release-publish`, `commit_sha=04c6efb62cfaa52138c6e1a3229dc8bea52c26c8`, `rc_number=2` and confirm `dynamo-planner:1.1.0rc2`, `snapshot-agent:1.1.0rc2`, and the Helm chart all land in NGC.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release workflow to use the correct Docker image configuration, improving release reliability and preventing image selection failures during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->