### PR TITLE
fix: DIS-1768 emit structured SSE error + [DONE] on mid-stream fault

### DIFF
--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -221,7 +221,24 @@ pub fn monitor_for_disconnects(
                         Some(Err(err)) => {
                             // Mark error as internal since it's a streaming error
                             inflight_guard.mark_error(ErrorType::Internal);
-                            yield Event::default().event("error").comment(err.to_string());
+                            // DIS-1768: this is needed because bare SSE was emitting
+                            // `event: error\n: <comment>\n\n` with no `data: [DONE]`,
+                            // which violates the OpenAI SSE contract — naive
+                            // `data:`-line parsers silently skip the frame and
+                            // never see a stream terminator, so clients get
+                            // no actionable detail and no clean end-of-stream.
+                            // The fix is to emit a structured OpenAI-style
+                            // `data: {"error":{...}}` frame followed by
+                            // `data: [DONE]`, and it is here:
+                            let err_json = serde_json::json!({
+                                "error": {
+                                    "message": err.to_string(),
+                                    "type": "internal_server_error",
+                                    "code": 500,
+                                }
+                            });
+                            yield Event::default().data(err_json.to_string());
+                            yield Event::default().data("[DONE]");
                             // Break to prevent any subsequent mark_ok() from overwriting the error
                             break;
                         }
@@ -490,5 +507,97 @@ mod tests {
             0,
             "inflight gauge leaked in phase 2"
         );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // DIS-1768: mid-stream fault SSE contract
+    //
+    // When the upstream stream yields `Err(_)` mid-stream — e.g. an upstream
+    // worker dies and the mpsc channel reports
+    // `Disconnected: Stream ended before generation completed`, or the Python
+    // chat-processor raises and the Rust→Python `tx.send()` fails with
+    // `Failed to send response: SendError { .. }` — the client MUST receive:
+    //   1. a structured `data: {"error":{"message":..., "type":... or "code":...}}` frame, then
+    //   2. a `data: [DONE]` terminator.
+    // Before the fix, the code emitted the bare SSE trailer
+    // `event: error\n: <comment>\n\n` with no `[DONE]`, which violates the
+    // OpenAI SSE contract and is silently skipped by naive `data:`-line parsers.
+    // The two tests below pin the post-fix contract.
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    /// Builds a stream that yields `data_chunks` successful events, then yields an
+    /// `Err` carrying `err_msg`, simulating a mid-stream upstream fault.
+    fn simulate_mid_stream_error(
+        data_chunks: usize,
+        err_msg: &'static str,
+    ) -> impl futures::Stream<Item = Result<axum::response::sse::Event, axum::Error>> {
+        async_stream::try_stream! {
+            for i in 0..data_chunks {
+                yield axum::response::sse::Event::default().data(format!("chunk-{i}"));
+            }
+            Err(axum::Error::new(err_msg))?;
+        }
+    }
+
+    /// Collect the wire-format SSE body from a monitored stream.
+    async fn collect_sse_body(
+        stream: impl Stream<Item = Result<Event, axum::Error>> + Send + 'static,
+    ) -> String {
+        use axum::body::to_bytes;
+        use axum::response::{IntoResponse, Sse};
+        let response = Sse::new(stream).into_response();
+        let body = to_bytes(response.into_body(), 1 << 20)
+            .await
+            .expect("body bytes");
+        String::from_utf8(body.to_vec()).expect("utf8 body")
+    }
+
+    /// Assert the post-fix SSE fault contract: structured error frame + `[DONE]` + no bare trailer.
+    fn assert_fault_contract(case: &str, text: &str) {
+        assert!(
+            text.contains("data: [DONE]"),
+            "[{case}] body does not terminate with `data: [DONE]`. Body:\n{text}"
+        );
+        let has_structured_error = text.lines().any(|line| {
+            line.starts_with("data: ")
+                && line.contains("\"error\"")
+                && line.contains("\"message\"")
+                && (line.contains("\"type\"") || line.contains("\"code\""))
+        });
+        assert!(
+            has_structured_error,
+            "[{case}] body missing structured `data: {{\"error\":{{...}}}}` frame with message and type/code. Body:\n{text}"
+        );
+        assert!(
+            !text.contains("event: error\n: "),
+            "[{case}] body contains bare `event: error\\n: <comment>` trailer (no actionable detail — the pre-fix bug). Body:\n{text}"
+        );
+    }
+
+    /// Upstream worker killed mid-stream → mpsc channel reports `Disconnected` to the
+    /// HTTP layer. Client MUST receive structured error + `[DONE]`.
+    #[tokio::test]
+    #[serial]
+    async fn test_simulate_worker_kill_emits_structured_error_and_done() {
+        let (_metrics, guard, ctx, handle) = setup_test("worker-kill-model", "req-wk", "0");
+        let stream =
+            simulate_mid_stream_error(3, "Disconnected: Stream ended before generation completed");
+        let monitored = monitor_for_disconnects(stream, ctx, guard, handle);
+        let body = collect_sse_body(monitored).await;
+        cleanup_env();
+        assert_fault_contract("worker_kill", &body);
+    }
+
+    /// Python chat-processor raises mid-stream → Rust→Python `tx.send()` fails with
+    /// `SendError`. Client MUST receive structured error + `[DONE]`.
+    #[tokio::test]
+    #[serial]
+    async fn test_simulate_python_consumer_drop_emits_structured_error_and_done() {
+        let (_metrics, guard, ctx, handle) = setup_test("py-drop-model", "req-py", "0");
+        let stream = simulate_mid_stream_error(3, "Failed to send response: SendError { .. }");
+        let monitored = monitor_for_disconnects(stream, ctx, guard, handle);
+        let body = collect_sse_body(monitored).await;
+        cleanup_env();
+        assert_fault_contract("python_consumer_drop", &body);
     }
 }

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -221,15 +221,13 @@ pub fn monitor_for_disconnects(
                         Some(Err(err)) => {
                             // Mark error as internal since it's a streaming error
                             inflight_guard.mark_error(ErrorType::Internal);
-                            // DIS-1768: this is needed because bare SSE was emitting
-                            // `event: error\n: <comment>\n\n` with no `data: [DONE]`,
-                            // which violates the OpenAI SSE contract — naive
-                            // `data:`-line parsers silently skip the frame and
-                            // never see a stream terminator, so clients get
-                            // no actionable detail and no clean end-of-stream.
-                            // The fix is to emit a structured OpenAI-style
-                            // `data: {"error":{...}}` frame followed by
-                            // `data: [DONE]`, and it is here:
+                            // We're terminating the stream intentionally here with a
+                            // structured error + [DONE]; disarm so the stream handle
+                            // doesn't later record this as ClosedUnexpectedly (which
+                            // would mis-attribute the fault as a client disconnect).
+                            stream_handle.disarm();
+                            // DIS-1768: emit structured OpenAI-style error frame + `data: [DONE]`
+                            // so naive `data:`-line parsers see both the error and a stream terminator.
                             let err_json = serde_json::json!({
                                 "error": {
                                     "message": err.to_string(),
@@ -552,25 +550,56 @@ mod tests {
         String::from_utf8(body.to_vec()).expect("utf8 body")
     }
 
-    /// Assert the post-fix SSE fault contract: structured error frame + `[DONE]` + no bare trailer.
-    fn assert_fault_contract(case: &str, text: &str) {
-        assert!(
-            text.contains("data: [DONE]"),
-            "[{case}] body does not terminate with `data: [DONE]`. Body:\n{text}"
-        );
-        let has_structured_error = text.lines().any(|line| {
-            line.starts_with("data: ")
-                && line.contains("\"error\"")
-                && line.contains("\"message\"")
-                && (line.contains("\"type\"") || line.contains("\"code\""))
+    /// Assert the post-fix SSE fault contract: parsed structured error frame with exact
+    /// message/type/code, positioned before `[DONE]`, and no bare `event: error` trailer.
+    fn assert_fault_contract(case: &str, text: &str, expected_message: &str) {
+        let done_pos = text.find("data: [DONE]").unwrap_or_else(|| {
+            panic!("[{case}] body does not terminate with `data: [DONE]`. Body:\n{text}")
         });
+
+        let (error_line, error_frame) = text
+            .lines()
+            .find_map(|line| {
+                let payload = line.strip_prefix("data: ")?;
+                serde_json::from_str::<serde_json::Value>(payload)
+                    .ok()
+                    .filter(|v| v.get("error").is_some())
+                    .map(|v| (line, v))
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "[{case}] body missing structured JSON `data: {{\"error\":{{...}}}}` frame. Body:\n{text}"
+                )
+            });
+
+        let error_pos = text.find(error_line).unwrap_or_default();
         assert!(
-            has_structured_error,
-            "[{case}] body missing structured `data: {{\"error\":{{...}}}}` frame with message and type/code. Body:\n{text}"
+            error_pos < done_pos,
+            "[{case}] structured error frame must precede `data: [DONE]`. Body:\n{text}"
+        );
+
+        let error = error_frame
+            .get("error")
+            .and_then(|v| v.as_object())
+            .unwrap_or_else(|| panic!("[{case}] `error` field is not an object. Body:\n{text}"));
+        assert_eq!(
+            error.get("message").and_then(|v| v.as_str()),
+            Some(expected_message),
+            "[{case}] structured error `message` mismatch. Body:\n{text}"
+        );
+        assert_eq!(
+            error.get("type").and_then(|v| v.as_str()),
+            Some("internal_server_error"),
+            "[{case}] structured error `type` mismatch. Body:\n{text}"
+        );
+        assert_eq!(
+            error.get("code").and_then(|v| v.as_i64()),
+            Some(500),
+            "[{case}] structured error `code` mismatch. Body:\n{text}"
         );
         assert!(
             !text.contains("event: error\n: "),
-            "[{case}] body contains bare `event: error\\n: <comment>` trailer (no actionable detail — the pre-fix bug). Body:\n{text}"
+            "[{case}] body contains bare `event: error\\n: <comment>` trailer (pre-fix bug). Body:\n{text}"
         );
     }
 
@@ -580,12 +609,12 @@ mod tests {
     #[serial]
     async fn test_simulate_worker_kill_emits_structured_error_and_done() {
         let (_metrics, guard, ctx, handle) = setup_test("worker-kill-model", "req-wk", "0");
-        let stream =
-            simulate_mid_stream_error(3, "Disconnected: Stream ended before generation completed");
+        let expected_message = "Disconnected: Stream ended before generation completed";
+        let stream = simulate_mid_stream_error(3, expected_message);
         let monitored = monitor_for_disconnects(stream, ctx, guard, handle);
         let body = collect_sse_body(monitored).await;
         cleanup_env();
-        assert_fault_contract("worker_kill", &body);
+        assert_fault_contract("worker_kill", &body, expected_message);
     }
 
     /// Python chat-processor raises mid-stream → Rust→Python `tx.send()` fails with
@@ -594,10 +623,11 @@ mod tests {
     #[serial]
     async fn test_simulate_python_consumer_drop_emits_structured_error_and_done() {
         let (_metrics, guard, ctx, handle) = setup_test("py-drop-model", "req-py", "0");
-        let stream = simulate_mid_stream_error(3, "Failed to send response: SendError { .. }");
+        let expected_message = "Failed to send response: SendError { .. }";
+        let stream = simulate_mid_stream_error(3, expected_message);
         let monitored = monitor_for_disconnects(stream, ctx, guard, handle);
         let body = collect_sse_body(monitored).await;
         cleanup_env();
-        assert_fault_contract("python_consumer_drop", &body);
+        assert_fault_contract("python_consumer_drop", &body, expected_message);
     }
 }


### PR DESCRIPTION
#### Overview:

On any mid-stream fault the Rust FE was emitting a bare `event: error\n: <comment>\n\n` with no `data: [DONE]`, which most OpenAI-style clients silently skip — so the request looks like "HTTP 200, a few chunks, then nothing." This swaps that out for a proper `data: {"error":{...}}` + `data: [DONE]`, which is what upstream vLLM already does.

#### Details:

- In the `Some(Err(err))` arm of `monitor_for_disconnects`, yield a structured `data: {"error":{"message":..,"type":"internal_server_error","code":500}}` frame followed by `data: [DONE]`
- `break` right after, otherwise the trailing `mark_ok()` clobbers the error state on the way out (and the inflight-guard metric records success when it shouldn't)
- Added `test_simulate_worker_kill_emits_structured_error_and_done` — uses the literal mpsc channel error string that shows up when the worker dies mid-stream
- Added `test_simulate_python_consumer_drop_emits_structured_error_and_done` — uses the literal error string the Rust→Python bridge produces when the Python chat processor raises
- Both tests check for `data: {"error":{...}}` with `message`/`type`/`code`, `data: [DONE]`, and NO bare `event: error\n: ` trailer. Fail on pre-fix, pass on post-fix.
- Sanity-checked against upstream vLLM 0.19.0 standalone (probe script + wire capture in the DIS-1768 activity log) — this lands us on the exact same wire shape they already emit, so nothing new to invent.

#### Where should the reviewer start?

`lib/llm/src/http/service/disconnect.rs`

#### Related Issues:

- Relates to DIS-1768 (will close after David confirms)

/coderabbit profile chill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mid-stream error handling for HTTP streaming responses: now returns structured JSON error payloads with error details followed by a completion signal, replacing previous bare error frames.

* **Tests**
  * Added comprehensive test coverage for mid-stream error scenarios in streaming responses to validate the new error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->