### PR TITLE
fix(operator): drop Recreate override on restore-target Deployments

### DIFF
--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -43,7 +43,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -975,17 +974,6 @@ func (r *DynamoComponentDeploymentReconciler) generateDeployment(ctx context.Con
 			strategy = appsv1.DeploymentStrategy{
 				Type: appsv1.RecreateDeploymentStrategyType,
 			}
-		}
-	}
-
-	// Checkpoint-restore pods must avoid overlap with prior replicas.
-	// Enforce Recreate whenever the rendered template is a restore target so
-	// the old pod is terminated before the restore placeholder is started.
-	if podTemplateSpec != nil &&
-		podTemplateSpec.Labels != nil &&
-		podTemplateSpec.Labels[snapshotprotocol.RestoreTargetLabel] == commonconsts.KubeLabelValueTrue {
-		strategy = appsv1.DeploymentStrategy{
-			Type: appsv1.RecreateDeploymentStrategyType,
 		}
 	}
 

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1681,7 +1681,11 @@ func TestDynamoComponentDeploymentReconciler_generateDeployment_RestoreStrategy(
 		}
 	}
 
-	t.Run("ready checkpoint forces Recreate strategy", func(t *testing.T) {
+	t.Run("ready checkpoint keeps RollingUpdate strategy", func(t *testing.T) {
+		// Restore-target pods do not need a special Recreate override. The
+		// default RollingUpdate strategy works for failure-replacement and
+		// scale-up; users who specifically want Recreate on tight-GPU nodes
+		// can still opt in via the nvidia.com/deployment-strategy annotation.
 		identity := v1alpha1.DynamoCheckpointIdentity{Model: "test-model", BackendFramework: "vllm"}
 		checkpointName, err := checkpoint.ComputeIdentityHash(identity)
 		if err != nil {
@@ -1709,8 +1713,8 @@ func TestDynamoComponentDeploymentReconciler_generateDeployment_RestoreStrategy(
 		if toDelete {
 			t.Fatalf("expected deployment to be retained")
 		}
-		if deploy.Spec.Strategy.Type != appsv1.RecreateDeploymentStrategyType {
-			t.Fatalf("expected Recreate strategy, got %s", deploy.Spec.Strategy.Type)
+		if deploy.Spec.Strategy.Type != appsv1.RollingUpdateDeploymentStrategyType {
+			t.Fatalf("expected RollingUpdate strategy, got %s", deploy.Spec.Strategy.Type)
 		}
 	})
 


### PR DESCRIPTION
#### Overview:

Restore-target worker Deployments in checkpoint-enabled DGDs were hardcoded to `strategy: Recreate`, which tore down the serving cold-start replica whenever the pod template changed (e.g. scaling `replicas: 1 -> 2` after the `DynamoCheckpoint` became `Ready`). The override had a comment but no concrete mechanism behind it. Drop the override and fall through to the default `RollingUpdate{maxSurge: 25%, maxUnavailable: 25%}`.

Follow-up to #8403.

#### Details:

The bug is an 8-line block in `deploy/operator/internal/controller/dynamocomponentdeployment_controller.go` that forces `Recreate` on any Deployment whose rendered pod template carries `nvidia.com/snapshot-is-restore-target=true`. The comment says "Checkpoint-restore pods must avoid overlap with prior replicas," but an audit of the paths that could plausibly care about two restore-target pods overlapping briefly (CRIU, `cuda-checkpoint`, snapshot-agent per-node serialization, checkpoint PVC access, discovery instance identity, KV event publishing) does not surface any code path that actually breaks:

- The checkpoint PVC is RWX.
- `snapshot-agent` serializes on `(pod, containerID)`, not per node, and runs restores as parallel goroutines.
- `cuda-checkpoint` restores are per-PID-namespace; each pod has its own.
- Discovery instance IDs hash the pod name, so sibling pods always have distinct IDs.
- The Grove rollout path does not have this override and runs fine in production.

Meanwhile the override has a real user-visible cost: scaling a checkpoint-enabled DGD from `replicas: 1 -> 2` after a `DynamoCheckpoint` becomes `Ready` triggers a pod-template change (cold-start template -> restore-target template), and `Recreate` then terminates the original cold-start replica before the new restore-target replicas start serving. The serving worker is evicted for no reason.

After this change, scaling produces a standard rolling update: the cold-start pod keeps serving while the new restore-target replica comes up beside it. The existing opt-in escape hatch via `nvidia.com/deployment-strategy=Recreate` still works for users on tight-GPU nodes who want evict-then-restore; previously the override was silently stomping that annotation.

Failure-replacement behavior is unchanged. If a worker pod dies after `DynamoCheckpoint=Ready`, the ReplicaSet recreates it from the Deployment's current pod template, which the DCD reconciler refreshes on every `Deployment.status` update via `Owns(&Deployment{}, UpdateFunc: true)`; the replacement comes up as a restore target regardless of strategy.

#### Where should the reviewer start?

- `deploy/operator/internal/controller/dynamocomponentdeployment_controller.go` — the 12-line deletion (includes one orphan import). This is the whole behavior change.
- `deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go` — the flipped subtest `ready checkpoint keeps RollingUpdate strategy` (previously asserted `Recreate`).

#### Testing

Validated on the nscale dev cluster with Qwen3-0.6B TP=1 for both vLLM and SGLang backends; all nine scenarios pass:

- Scale `1 -> 2` after `DynamoCheckpoint=Ready`: serving cold-start replica stays up, new restore-target replica comes up beside it, and inference HTTP 200 holds throughout the rollout. Both final replicas report `nvidia.com/snapshot-restore-status=completed` and the snapshot-agent log shows `External restore completed` for each.
- Scale `1 -> 3`: all three replicas come up as restore targets, no pod gets stuck Pending.
- Scale `2 -> 1`: graceful drain, surviving replica keeps serving without interruption.
- `spec.restart.id` bump: worker rolls via RollingUpdate, inference 200 throughout.
- Force-delete a restore-target pod: ReplicaSet creates a replacement that comes up restored, the other replica keeps serving uninterrupted.
- Opt-in annotation `nvidia.com/deployment-strategy=Recreate`: still honored end-to-end.
- Operator upgrade (old Recreate-strategy Deployments on cluster flip to RollingUpdate): strategy updates in place without rolling the existing pods.
- Manual `checkpointRef` DGD scaled `1 -> 2`: cold-start replica UID stable during scale-up, new replica restores.

Unit tests: `make test` (envtest-backed suite in `deploy/operator/internal/controller/...` plus `internal/checkpoint`) all pass. The flipped subtest exercises the new default strategy assertion.

#### Related Issues:

Follow-up to #8403.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deployment strategy for restore-target pods. Deployments now use the default rolling update strategy during restoration. Users can override this via the `nvidia.com/deployment-strategy` annotation if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->