### PR TITLE
feat(trtllm): EAGLE3 shadow-engine failover (8B validated; Kimi shadow co-location blocked)

### DIFF
--- a/components/src/dynamo/trtllm/args.py
+++ b/components/src/dynamo/trtllm/args.py
@@ -39,6 +39,12 @@ class Config(DynamoRuntimeConfig, DynamoTrtllmConfig):
         # Derive use_kv_events from publish_events_and_metrics
         self.use_kv_events = self.publish_events_and_metrics
 
+        if self.gms_shadow_mode and self.load_format != "gms":
+            raise ValueError(
+                "--gms-shadow-mode requires --load-format gms. "
+                "Shadow mode depends on GMS for VA-stable weight sharing."
+            )
+
         # fix the connector as trtllm accepts only one connector and it should be in VALID_TRTLLM_CONNECTORS
         # while the runtime args accepts a list of connectors
         if self.connector:

--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -177,6 +177,19 @@ class DynamoTrtllmArgGroup(ArgGroup):
                 "(e.g. '{\"gms_read_only\": true}')."
             ),
         )
+        add_negatable_bool_argument(
+            g,
+            flag_name="--gms-shadow-mode",
+            env_var="DYN_TRTLLM_GMS_SHADOW_MODE",
+            default=False,
+            help=(
+                "Enable GMS shadow/standby mode. When set, the engine's "
+                "gms_read_only flag is derived from ENGINE_ID (0 → writer, "
+                "others → read-only importers), unlocking shadow-engine "
+                "failover across co-located engines on one GPU. "
+                "Requires --load-format=gms."
+            ),
+        )
         add_argument(
             g,
             flag_name="--disaggregation-mode",
@@ -472,6 +485,7 @@ class DynamoTrtllmConfig(ConfigBase):
     disable_request_abort: bool
     load_format: str
     model_loader_extra_config: str
+    gms_shadow_mode: bool = False
     guided_decoding_backend: Optional[str] = None
 
     disaggregation_mode: DisaggregationMode

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -100,20 +100,34 @@ class TRTLLMEngineQuiesceController:
         self._is_quiesced = False
 
     def _collective_rpc(self, method: str, rpc_tags: list[str]) -> None:
-        """Call TRT-LLM collective_rpc for KV cache sleep/wake."""
+        """Call TRT-LLM collective_rpc for KV cache sleep/wake.
+
+        Non-Ray executors (single-process ``GenerationExecutorWorker``) have
+        no collective RPC; fall back to the local virtual-memory tag API.
+        """
         rpc = getattr(self._engine.llm, "_collective_rpc", None)
-        if rpc is None:
-            logger.warning(
-                "TRT-LLM does not expose _collective_rpc; skipping %s", method
-            )
-            return
-        try:
-            rpc(method, args=(rpc_tags,), kwargs={}, non_block=False)
-        except Exception:
-            if method != "wakeup":
-                raise
-            # Some TRT-LLM versions use "wake_up" instead of "wakeup"
-            rpc("wake_up", args=(rpc_tags,), kwargs={}, non_block=False)
+        if rpc is not None:
+            try:
+                rpc(method, args=(rpc_tags,), kwargs={}, non_block=False)
+                return
+            except Exception as exc:
+                if "does not support collective RPC" not in str(exc):
+                    if method != "wakeup":
+                        raise
+                    rpc("wake_up", args=(rpc_tags,), kwargs={}, non_block=False)
+                    return
+                logger.info(
+                    "TRT-LLM executor lacks collective RPC; using local tag API for %s",
+                    method,
+                )
+        from tensorrt_llm._torch.virtual_memory import (
+            materialize_with_tag,
+            release_with_tag,
+        )
+
+        action = release_with_tag if method == "sleep" else materialize_with_tag
+        for tag in rpc_tags:
+            action(tag)
 
     @staticmethod
     def _release_gms_weights() -> None:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -94,6 +94,12 @@ class TRTLLMEngineQuiesceController:
             self._restore_gms_weights()
         if "kv_cache" in tags:
             self._collective_rpc("wakeup", ["kv_cache"])
+            # release_with_tag("kv_cache") zeroes the physical KV pages but leaves
+            # TRT-LLM's block-reuse hash table pointing at them. Post-wake requests
+            # would hit those stale hashes (cached_tokens>0) and read garbage KV —
+            # coherent-looking text but wrong. Drop the reuse state here so the
+            # first post-wake prefill recomputes from scratch.
+            self._reset_prefix_cache()
         return True
 
     def mark_resumed(self) -> None:
@@ -128,6 +134,20 @@ class TRTLLMEngineQuiesceController:
         action = release_with_tag if method == "sleep" else materialize_with_tag
         for tag in rpc_tags:
             action(tag)
+
+    def _reset_prefix_cache(self) -> None:
+        """Invalidate TRT-LLM's KV block-reuse state after a wake."""
+        llm = getattr(self._engine, "llm", None)
+        executor = getattr(llm, "_executor", None) if llm is not None else None
+        py_executor = getattr(executor, "engine", None) if executor is not None else None
+        reset = getattr(py_executor, "reset_prefix_cache", None)
+        if reset is None:
+            logger.debug("TRT-LLM executor has no reset_prefix_cache; skipping")
+            return
+        try:
+            reset()
+        except Exception as exc:  # noqa: BLE001 — best-effort post-wake hygiene
+            logger.warning("reset_prefix_cache failed: %s", exc)
 
     @staticmethod
     def _release_gms_weights() -> None:

--- a/components/src/dynamo/trtllm/tests/test_trtllm_shadow_mode.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_shadow_mode.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for TRT-LLM GMS shadow mode configuration.
+
+These tests only exercise pure-Python logic in
+gpu_memory_service/integrations/trtllm/utils.py — no CUDA, no tensorrt_llm,
+so they run anywhere.
+"""
+
+import pytest
+from gpu_memory_service.integrations.trtllm.utils import (
+    configure_gms_lock_mode,
+    is_shadow_mode,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge]
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    monkeypatch.delenv("DYN_GMS_SHADOW_MODE", raising=False)
+    monkeypatch.delenv("ENGINE_ID", raising=False)
+
+
+def test_is_shadow_mode_default(clean_env):
+    assert is_shadow_mode() is False
+
+
+def test_is_shadow_mode_enabled(monkeypatch, clean_env):
+    monkeypatch.setenv("DYN_GMS_SHADOW_MODE", "1")
+    assert is_shadow_mode() is True
+
+
+def test_engine_id_0_leaves_lock_mode_unset(monkeypatch, clean_env):
+    monkeypatch.setenv("ENGINE_ID", "0")
+    extra = {}
+    configure_gms_lock_mode(extra)
+    assert "gms_read_only" not in extra
+
+
+def test_engine_id_1_forces_read_only(monkeypatch, clean_env):
+    monkeypatch.setenv("ENGINE_ID", "1")
+    extra = {}
+    configure_gms_lock_mode(extra)
+    assert extra["gms_read_only"] is True
+
+
+def test_engine_id_missing_defaults_to_writer(clean_env):
+    extra = {}
+    configure_gms_lock_mode(extra)
+    assert "gms_read_only" not in extra
+
+
+def test_engine_id_0_with_explicit_read_only_raises(monkeypatch, clean_env):
+    monkeypatch.setenv("ENGINE_ID", "0")
+    with pytest.raises(ValueError, match="primary writer"):
+        configure_gms_lock_mode({"gms_read_only": True})
+
+
+def test_engine_id_1_with_explicit_writer_raises(monkeypatch, clean_env):
+    monkeypatch.setenv("ENGINE_ID", "1")
+    with pytest.raises(ValueError, match="requires gms_read_only=True"):
+        configure_gms_lock_mode({"gms_read_only": False})
+
+
+def test_engine_id_1_with_explicit_read_only_is_ok(monkeypatch, clean_env):
+    monkeypatch.setenv("ENGINE_ID", "1")
+    extra = {"gms_read_only": True}
+    configure_gms_lock_mode(extra)
+    assert extra["gms_read_only"] is True
+
+
+def test_configure_returns_same_dict(monkeypatch, clean_env):
+    monkeypatch.setenv("ENGINE_ID", "2")
+    extra = {}
+    returned = configure_gms_lock_mode(extra)
+    assert returned is extra

--- a/components/src/dynamo/trtllm/tests/test_trtllm_shadow_mode.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_shadow_mode.py
@@ -10,8 +10,12 @@ so they run anywhere.
 
 import pytest
 from gpu_memory_service.integrations.trtllm.utils import (
+    SHADOW_KV_CACHE_FRACTION,
+    SHADOW_KV_CACHE_MAX_BYTES,
     configure_gms_lock_mode,
     is_shadow_mode,
+    is_shadow_standby,
+    shrink_kv_cache_for_shadow,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.pre_merge]
@@ -76,3 +80,32 @@ def test_configure_returns_same_dict(monkeypatch, clean_env):
     extra = {}
     returned = configure_gms_lock_mode(extra)
     assert returned is extra
+
+
+def test_is_shadow_standby_only_for_nonzero_shadow(monkeypatch, clean_env):
+    # Shadow mode off: standby is always False
+    monkeypatch.setenv("ENGINE_ID", "1")
+    assert is_shadow_standby() is False
+
+    monkeypatch.setenv("DYN_GMS_SHADOW_MODE", "1")
+    # Engine 0 is the primary, not a standby
+    monkeypatch.setenv("ENGINE_ID", "0")
+    assert is_shadow_standby() is False
+
+    # Engine 1+ in shadow mode is a standby
+    monkeypatch.setenv("ENGINE_ID", "1")
+    assert is_shadow_standby() is True
+
+    monkeypatch.setenv("ENGINE_ID", "3")
+    assert is_shadow_standby() is True
+
+
+def test_shrink_kv_cache_clamps_fraction_and_bytes():
+    class FakeCfg:
+        free_gpu_memory_fraction = 0.9
+        max_gpu_total_bytes = 0
+
+    cfg = FakeCfg()
+    shrink_kv_cache_for_shadow(cfg)
+    assert cfg.free_gpu_memory_fraction == SHADOW_KV_CACHE_FRACTION
+    assert cfg.max_gpu_total_bytes == SHADOW_KV_CACHE_MAX_BYTES

--- a/components/src/dynamo/trtllm/tests/test_trtllm_shadow_mode.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_shadow_mode.py
@@ -10,9 +10,11 @@ so they run anywhere.
 
 import pytest
 from gpu_memory_service.integrations.trtllm.utils import (
+    SHADOW_ALLREDUCE_STRATEGY,
     SHADOW_KV_CACHE_FRACTION,
     SHADOW_KV_CACHE_MAX_BYTES,
     configure_gms_lock_mode,
+    force_nccl_allreduce_for_shadow,
     is_shadow_mode,
     is_shadow_standby,
     shrink_kv_cache_for_shadow,
@@ -109,3 +111,21 @@ def test_shrink_kv_cache_clamps_fraction_and_bytes():
     shrink_kv_cache_for_shadow(cfg)
     assert cfg.free_gpu_memory_fraction == SHADOW_KV_CACHE_FRACTION
     assert cfg.max_gpu_total_bytes == SHADOW_KV_CACHE_MAX_BYTES
+
+
+def test_force_nccl_allreduce_overrides_mnnvl():
+    arg_map = {"allreduce_strategy": "MNNVL"}
+    force_nccl_allreduce_for_shadow(arg_map)
+    assert arg_map["allreduce_strategy"] == SHADOW_ALLREDUCE_STRATEGY
+
+
+def test_force_nccl_allreduce_sets_when_unset():
+    arg_map = {}
+    force_nccl_allreduce_for_shadow(arg_map)
+    assert arg_map["allreduce_strategy"] == SHADOW_ALLREDUCE_STRATEGY
+
+
+def test_force_nccl_allreduce_is_idempotent():
+    arg_map = {"allreduce_strategy": SHADOW_ALLREDUCE_STRATEGY}
+    force_nccl_allreduce_for_shadow(arg_map)
+    assert arg_map["allreduce_strategy"] == SHADOW_ALLREDUCE_STRATEGY

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -207,11 +207,19 @@ async def init_llm_worker(
     if config.load_format == "gms":
         try:
             from gpu_memory_service.integrations.trtllm import setup_gms
+            from gpu_memory_service.integrations.trtllm.utils import (
+                configure_gms_lock_mode,
+            )
         except ImportError as exc:
             raise RuntimeError(
                 "gpu-memory-service is required for --load-format gms. "
                 "Install or update the package."
             ) from exc
+        if config.gms_shadow_mode:
+            # Shared flag read by both vLLM and TRT-LLM GMS integrations; set
+            # early so downstream code sees shadow mode before engine init.
+            os.environ["DYN_GMS_SHADOW_MODE"] = "1"
+            configure_gms_lock_mode(model_loader_extra_config)
         setup_gms(model_loader_extra_config)
         logging.info(
             "TRT-LLM GMS integration enabled (extra=%s)", model_loader_extra_config

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -321,16 +321,22 @@ async def init_llm_worker(
             logging.error(f"Failed to parse override_engine_args as JSON: {e}")
             sys.exit(1)
 
-    # Shadow-standby engines (ENGINE_ID != 0 under gms_shadow_mode) must
-    # downsize the KV cache so their init fits alongside engine-0's active
-    # KV pool. Applied last so it is not overwritten by --extra-engine-args
-    # or --override-engine-args. Operates on both KvCacheConfig and dict
-    # shapes because publish-events path may have flattened it above.
+    # Shadow-mode init overrides, applied last so they are not overwritten
+    # by --extra-engine-args or --override-engine-args:
+    #   1. Force allreduce_strategy=NCCL on BOTH engines. MNNVL's 180 GiB
+    #      symmetric VA window cannot coexist with a second co-located
+    #      engine on the same GPU set.
+    #   2. Shrink KV cache on standby (ENGINE_ID != 0) to fit alongside
+    #      engine-0's active KV pool.
+    # Operates on both KvCacheConfig and dict shapes because the
+    # publish-events path may have flattened kv_cache_config above.
     if config.load_format == "gms" and config.gms_shadow_mode:
         from gpu_memory_service.integrations.trtllm.utils import (
+            force_nccl_allreduce_for_shadow,
             is_shadow_standby,
             shrink_kv_cache_for_shadow,
         )
+        force_nccl_allreduce_for_shadow(arg_map)
         if is_shadow_standby():
             current_kv = arg_map["kv_cache_config"]
             if isinstance(current_kv, dict):

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -209,6 +209,7 @@ async def init_llm_worker(
             from gpu_memory_service.integrations.trtllm import setup_gms
             from gpu_memory_service.integrations.trtllm.utils import (
                 configure_gms_lock_mode,
+                is_shadow_standby,
             )
         except ImportError as exc:
             raise RuntimeError(
@@ -220,6 +221,15 @@ async def init_llm_worker(
             # early so downstream code sees shadow mode before engine init.
             os.environ["DYN_GMS_SHADOW_MODE"] = "1"
             configure_gms_lock_mode(model_loader_extra_config)
+            if is_shadow_standby():
+                # Shadow standby engines cannot share active engine's KV
+                # budget at init. Skip TRT-LLM's estimation run so it never
+                # tries to probe headroom by allocating a large INIT_KV_CACHE.
+                os.environ["TRTLLM_SKIP_KV_CACHE_ESTIMATION"] = "1"
+                logging.info(
+                    "[Shadow] ENGINE_ID=%s set TRTLLM_SKIP_KV_CACHE_ESTIMATION=1",
+                    os.environ.get("ENGINE_ID", "?"),
+                )
         setup_gms(model_loader_extra_config)
         logging.info(
             "TRT-LLM GMS integration enabled (extra=%s)", model_loader_extra_config
@@ -310,6 +320,25 @@ async def init_llm_worker(
         except json.JSONDecodeError as e:
             logging.error(f"Failed to parse override_engine_args as JSON: {e}")
             sys.exit(1)
+
+    # Shadow-standby engines (ENGINE_ID != 0 under gms_shadow_mode) must
+    # downsize the KV cache so their init fits alongside engine-0's active
+    # KV pool. Applied last so it is not overwritten by --extra-engine-args
+    # or --override-engine-args. Operates on both KvCacheConfig and dict
+    # shapes because publish-events path may have flattened it above.
+    if config.load_format == "gms" and config.gms_shadow_mode:
+        from gpu_memory_service.integrations.trtllm.utils import (
+            is_shadow_standby,
+            shrink_kv_cache_for_shadow,
+        )
+        if is_shadow_standby():
+            current_kv = arg_map["kv_cache_config"]
+            if isinstance(current_kv, dict):
+                shim = KvCacheConfig(**current_kv)
+                shrink_kv_cache_for_shadow(shim)
+                arg_map["kv_cache_config"] = shim.model_dump(exclude_none=True)
+            else:
+                shrink_kv_cache_for_shadow(current_kv)
 
     if config.publish_events_and_metrics:
         # 'event_buffer_max_size' is required to enable TRTLLM to publish kv cache events.

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -263,12 +263,29 @@ async def init_llm_worker(
     arg_map["load_format"] = engine_load_format
 
     # Enable sleep_config when GMS manages weights — required for GMS
-    # unmap/remap. Conditional because SleepConfig contains unpicklable
-    # lambdas that break MPI-based multi-rank distribution.
+    # unmap/remap. SleepConfig's default restore_modes is a defaultdict whose
+    # default_factory is a lambda defined inside
+    # SleepConfig._make_defaulted_restore_modes; mpi4py cannot pickle local
+    # lambdas, which breaks the TP>1 MPI worker bootstrap. py_executor_creator
+    # later indexes `sleep_config.restore_modes[MODEL_ENGINE_MAIN]` so a plain
+    # dict is not enough — we must keep the defaultdict behaviour but swap the
+    # lambda for a picklable `functools.partial` callable.
     if config.load_format == "gms":
-        from tensorrt_llm.llmapi.llm_args import SleepConfig
+        from collections import defaultdict
+        from functools import partial
 
-        arg_map["sleep_config"] = SleepConfig()
+        from tensorrt_llm._torch.virtual_memory import RestoreMode
+        from tensorrt_llm.llmapi.llm_args import SleepConfig, prefer_pinned
+
+        sleep_config = SleepConfig()
+        default_mode = (
+            RestoreMode.PINNED if prefer_pinned() else RestoreMode.CPU
+        )
+        sleep_config.restore_modes = defaultdict(
+            partial(RestoreMode, default_mode.value),
+            dict(sleep_config.restore_modes),
+        )
+        arg_map["sleep_config"] = sleep_config
 
     # Add guided decoding backend if specified
     if config.guided_decoding_backend is not None:

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -56,8 +56,10 @@ func buildFailoverPod(
 	switch backendFramework {
 	case BackendFrameworkVLLM:
 		applyVLLMOverrides(podSpec, numberOfNodes)
+	case BackendFrameworkTRTLLM:
+		applyTRTLLMOverrides(podSpec, numberOfNodes)
 	default:
-		return fmt.Errorf("failover is currently supported only for vLLM (detected: %s)", backendFramework)
+		return fmt.Errorf("failover is not supported for backend %q (only vllm and trtllm)", backendFramework)
 	}
 
 	return nil

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -93,11 +93,11 @@ func TestBuildFailoverPod_EmptyContainers(t *testing.T) {
 	assert.Contains(t, err.Error(), "at least one container")
 }
 
-func TestBuildFailoverPod_RejectsNonVLLM(t *testing.T) {
+func TestBuildFailoverPod_RejectsSGLang(t *testing.T) {
 	ps := failoverPodSpec()
 	err := buildFailoverPod(&ps, 1, BackendFrameworkSGLang)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "currently supported only for vLLM")
+	assert.Contains(t, err.Error(), "sglang")
 }
 
 func TestBuildFailoverPod_EngineEnvVars(t *testing.T) {
@@ -195,6 +195,98 @@ func TestBuildFailoverPod_MultinodeNNODES(t *testing.T) {
 func TestBuildFailoverPod_SingleNodeNoNNODES(t *testing.T) {
 	ps := failoverPodSpec()
 	err := buildFailoverPod(&ps, 1, BackendFrameworkVLLM)
+	require.NoError(t, err)
+
+	for i := range 2 {
+		env := envToMap(ps.Containers[i].Env)
+		_, has := env["NNODES"]
+		assert.False(t, has, "engine-%d should not have NNODES for single-node", i)
+	}
+}
+
+// --- TRT-LLM failover ---
+
+func trtllmFailoverPodSpec() corev1.PodSpec {
+	ps := failoverPodSpec()
+	// Swap the entrypoint so the main container looks like a TRT-LLM worker.
+	ps.Containers[0].Command = []string{"python3", "-m", "dynamo.trtllm"}
+	return ps
+}
+
+func TestBuildFailoverPod_TRTLLM_TwoEnginesPlusSidecar(t *testing.T) {
+	ps := trtllmFailoverPodSpec()
+	err := buildFailoverPod(&ps, 1, BackendFrameworkTRTLLM)
+	require.NoError(t, err)
+
+	assert.Len(t, ps.Containers, 3)
+	assert.Equal(t, "engine-0", ps.Containers[0].Name)
+	assert.Equal(t, "engine-1", ps.Containers[1].Name)
+	assert.Equal(t, "frontend-sidecar", ps.Containers[2].Name)
+}
+
+func TestBuildFailoverPod_TRTLLM_EngineEnvVars(t *testing.T) {
+	ps := trtllmFailoverPodSpec()
+	err := buildFailoverPod(&ps, 1, BackendFrameworkTRTLLM)
+	require.NoError(t, err)
+
+	for i := range 2 {
+		engine := ps.Containers[i]
+		env := envToMap(engine.Env)
+		assert.Equal(t, strconv.Itoa(i), env["ENGINE_ID"], "engine-%d ENGINE_ID", i)
+		assert.Equal(t, fmt.Sprintf("engine-%d", i), env["CONTAINER_NAME"], "engine-%d CONTAINER_NAME", i)
+		assert.Equal(t, failoverLockFile, env["FAILOVER_LOCK_PATH"], "engine-%d FAILOVER_LOCK_PATH", i)
+		assert.Equal(t, "true", env["DYN_TRTLLM_GMS_SHADOW_MODE"], "engine-%d shadow mode", i)
+		assert.Equal(t, "notready", env["DYN_SYSTEM_STARTING_HEALTH_STATUS"], "engine-%d starting health", i)
+		assert.Equal(t, "true", env["DYN_SYSTEM_ENABLED"], "engine-%d system enabled", i)
+
+		// vLLM-specific env vars must not leak into TRT-LLM engines.
+		_, hasVLLMShadow := env["DYN_VLLM_GMS_SHADOW_MODE"]
+		assert.False(t, hasVLLMShadow, "engine-%d should not have DYN_VLLM_GMS_SHADOW_MODE", i)
+		_, hasNixl := env["VLLM_NIXL_SIDE_CHANNEL_PORT"]
+		assert.False(t, hasNixl, "engine-%d should not have VLLM_NIXL_SIDE_CHANNEL_PORT", i)
+	}
+}
+
+func TestBuildFailoverPod_TRTLLM_StaggeredMasterPort(t *testing.T) {
+	ps := trtllmFailoverPodSpec()
+	err := buildFailoverPod(&ps, 1, BackendFrameworkTRTLLM)
+	require.NoError(t, err)
+
+	engine0Env := envToMap(ps.Containers[0].Env)
+	engine1Env := envToMap(ps.Containers[1].Env)
+	assert.Equal(t, "29500", engine0Env["MASTER_PORT"], "engine-0 MASTER_PORT")
+	assert.Equal(t, "29600", engine1Env["MASTER_PORT"], "engine-1 MASTER_PORT")
+}
+
+func TestBuildFailoverPod_TRTLLM_StaggeredSystemPorts(t *testing.T) {
+	ps := trtllmFailoverPodSpec()
+	err := buildFailoverPod(&ps, 1, BackendFrameworkTRTLLM)
+	require.NoError(t, err)
+
+	for i := range 2 {
+		engine := ps.Containers[i]
+		env := envToMap(engine.Env)
+		assert.Equal(t, strconv.Itoa(commonconsts.DynamoSystemPort+i), env["DYN_SYSTEM_PORT"])
+		require.Len(t, engine.Ports, 1)
+		assert.Equal(t, int32(commonconsts.DynamoSystemPort+i), engine.Ports[0].ContainerPort)
+		assert.Equal(t, fmt.Sprintf("system-%d", i), engine.Ports[0].Name)
+	}
+}
+
+func TestBuildFailoverPod_TRTLLM_MultinodeNNODES(t *testing.T) {
+	ps := trtllmFailoverPodSpec()
+	err := buildFailoverPod(&ps, 4, BackendFrameworkTRTLLM)
+	require.NoError(t, err)
+
+	for i := range 2 {
+		env := envToMap(ps.Containers[i].Env)
+		assert.Equal(t, "4", env["NNODES"], "engine-%d should have NNODES=4", i)
+	}
+}
+
+func TestBuildFailoverPod_TRTLLM_SingleNodeNoNNODES(t *testing.T) {
+	ps := trtllmFailoverPodSpec()
+	err := buildFailoverPod(&ps, 1, BackendFrameworkTRTLLM)
 	require.NoError(t, err)
 
 	for i := range 2 {

--- a/deploy/operator/internal/dynamo/failover_trtllm.go
+++ b/deploy/operator/internal/dynamo/failover_trtllm.go
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// applyTRTLLMOverrides — TRT-LLM failover env injection and port staggering.
+//
+// TRT-LLM does not expose a --master-port CLI flag; torch.distributed picks
+// up MASTER_PORT from the environment. When two engine containers share a
+// pod network namespace and use TP>1, both torch.distributed groups would
+// otherwise collide on the default 29500 TCP store.
+//
+// Env injected per engine:
+//
+//	DYN_TRTLLM_GMS_SHADOW_MODE=true       (contract for TRT-LLM shadow mode;
+//	                                       not yet consumed by
+//	                                       components/src/dynamo/trtllm or
+//	                                       lib/gpu_memory_service/integrations/trtllm.
+//	                                       Mirrors DYN_VLLM_GMS_SHADOW_MODE.)
+//	MASTER_PORT=<base + engineID*stride>  (torch.distributed TCP store)
+//	NNODES=<numberOfNodes>                (multinode only)
+//
+// TODOs (not blocking this change):
+//   - DYN_KVBM_LEADER_ZMQ_PUB_PORT (default 56001) collides when KVBM
+//     connector is enabled for both engines — stagger when that path ships
+//     under failover.
+//   - NIXL side-channel port for TRT-LLM cross-engine transfers is not yet
+//     exposed via a knob; revisit if we run disagg/multi-engine NIXL under
+//     failover.
+
+package dynamo
+
+import (
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	trtllmMasterPortBase   = 29500
+	trtllmMasterPortStride = 100
+)
+
+func applyTRTLLMOverrides(podSpec *corev1.PodSpec, numberOfNodes int32) {
+	for i := range podSpec.Containers {
+		c := &podSpec.Containers[i]
+		if !strings.HasPrefix(c.Name, "engine-") {
+			continue
+		}
+
+		engineID, _ := strconv.Atoi(strings.TrimPrefix(c.Name, "engine-"))
+
+		c.Env = append(c.Env,
+			corev1.EnvVar{Name: "DYN_TRTLLM_GMS_SHADOW_MODE", Value: "true"},
+			corev1.EnvVar{
+				Name:  "MASTER_PORT",
+				Value: strconv.Itoa(trtllmMasterPortBase + engineID*trtllmMasterPortStride),
+			},
+		)
+
+		if numberOfNodes > 1 {
+			c.Env = append(c.Env,
+				corev1.EnvVar{Name: "NNODES", Value: strconv.Itoa(int(numberOfNodes))},
+			)
+		}
+	}
+}

--- a/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
+++ b/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# TRT-LLM EAGLE3 shadow-failover sample DGD (nscale).
+#
+# Image: REPLACE_WITH_TRTLLM_RUNTIME_TAG — substitute with the tag
+# produced by the eagle3-local-impl docker build once it completes.
+#
+# Failover behavior:
+#   - Operator clones the worker into engine-0 (active) + engine-1 (standby)
+#     sharing 1 GPU via DRA.
+#   - DYN_TRTLLM_GMS_SHADOW_MODE=true is injected by the operator.
+#   - Each engine reads ENGINE_ID and sets gms_lock_mode accordingly
+#     (engine-0: rw_or_ro, engine-1: ro).
+#   - When engine-0 dies, engine-1 acquires the failover flock and resumes.
+#
+# Deploy: `kubectl apply -n schwinns -f examples/backends/trtllm/deploy/agg_failover_eagle.yaml`
+#
+# Decoding config shape verified against TensorRT-LLM HEAD 497b07d6c:
+#   - tensorrt_llm/llmapi/llm_args.py:1025-1026   -> decoding_type: "Eagle3"
+#   - tensorrt_llm/llmapi/llm_args.py:649-653     -> speculative_model (AliasChoices
+#                                                   also accepts speculative_model_dir)
+#   - tensorrt_llm/llmapi/llm_args.py:885-891     -> eagle3_one_model default=True
+#   - tests/unittest/_torch/speculative/test_eagle3.py:201-209 (reference usage)
+#
+# Attention backend: TRT-LLM _torch default is "TRTLLM" (tensorrt_llm/_torch/
+# model_config.py:98), NOT FlashInfer, so the B200 FlashInfer + shadow-init
+# crash we hit on vLLM does not apply here. No attn_backend override needed.
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: trtllm-agg-failover-eagle
+  annotations:
+    nvidia.com/dynamo-kube-discovery-mode: container
+spec:
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        imagePullSecrets:
+          - name: ngc-secret
+        mainContainer:
+          image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
+    TrtllmWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      gpuMemoryService:
+        enabled: true
+      failover:
+        enabled: true
+      extraPodSpec:
+        imagePullSecrets:
+          - name: ngc-secret
+        mainContainer:
+          image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
+          workingDir: /workspace/examples/backends/trtllm
+          command:
+            - python3
+            - -m
+            - dynamo.trtllm
+          args:
+            - --model
+            - meta-llama/Llama-3.1-8B-Instruct
+            - --gpus-per-node
+            - "1"
+            - --load-format
+            - gms
+            # Enables ENGINE_ID -> gms_lock_mode plumbing for shadow failover.
+            - --gms-shadow-mode
+            # Leave headroom for cuda-graph capture on top of weights + KV.
+            - --free-gpu-memory-fraction
+            - "0.75"
+            - --max-seq-len
+            - "256"
+            - --max-num-tokens
+            - "256"
+            # EAGLE3 one-engine: target + draft live under a single nn.Module,
+            # so a single ModelLoader.load call covers both models and the
+            # existing GMS one-engine patch handles it without change.
+            - --override-engine-args
+            - '{"speculative_config":{"decoding_type":"Eagle3","speculative_model":"yuhuili/EAGLE3-LLaMA3.1-Instruct-8B","max_draft_len":3,"eagle3_one_model":true}}'
+          env:
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /home/dynamo/.cache/huggingface
+        volumes:
+          - name: hf-cache
+            persistentVolumeClaim:
+              claimName: shared-model-cache
+        nodeSelector:
+          gds-test: "true"
+          nvidia.com/gpu.present: "true"
+        tolerations:
+          - effect: NoSchedule
+            key: nvidia.com/gpu
+            operator: Exists
+          - effect: NoSchedule
+            key: dra
+            operator: Exists

--- a/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
+++ b/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
@@ -92,6 +92,24 @@ spec:
           env:
             - name: HF_HOME
               value: /home/dynamo/.cache/huggingface
+            # TRT-LLM's MPI-based executor spawns worker ranks via fork/spawn and
+            # pickles the LLM kwargs into them. With --load-format gms, Dynamo
+            # attaches a SleepConfig that contains unpicklable `lambda` defaults
+            # (SleepConfig._make_defaulted_restore_modes). Force the single-process
+            # executor to keep everything in one interpreter and skip the pickle.
+            - name: TLLM_WORKER_USE_SINGLE_PROCESS
+              value: "1"
+            # OpenMPI transport safety: single-container run, no RDMA.
+            - name: MPI4PY_MPIABI
+              value: openmpi
+            - name: OMPI_MCA_coll_ucc_enable
+              value: "0"
+            - name: OMPI_MCA_coll_hcoll_enable
+              value: "0"
+            - name: OMPI_MCA_pml
+              value: ob1
+            - name: OMPI_MCA_btl
+              value: "self,vader,tcp"
           volumeMounts:
             - name: hf-cache
               mountPath: /home/dynamo/.cache/huggingface

--- a/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
+++ b/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
@@ -44,7 +44,7 @@ spec:
           - name: ngc-secret
         mainContainer:
           image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
-    TrtllmWorker:
+    TRTLLMWorker:
       envFromSecret: hf-token-secret
       componentType: worker
       replicas: 1

--- a/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
+++ b/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
@@ -108,8 +108,12 @@ spec:
               value: "0"
             - name: OMPI_MCA_pml
               value: ob1
+            # vader (shared-memory BTL) segfaults in
+            # ompi_dpm_connect_accept -> mca_btl_vader_poll_handle_frag on
+            # co-located engines. Drop it; self+tcp is enough for the MPI
+            # connect/accept handshake between the two engine containers.
             - name: OMPI_MCA_btl
-              value: "self,vader,tcp"
+              value: "self,tcp"
           volumeMounts:
             - name: hf-cache
               mountPath: /home/dynamo/.cache/huggingface

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -203,6 +203,15 @@ def _load_ro(self, checkpoint_dir, checkpoint_loader, gms_client, device_index):
         if hasattr(model, "post_load_weights"):
             model.post_load_weights()
 
+        # Pre-bind shared submodules for speculative one-engine draft models.
+        # EAGLE3 / MTP / draft_target_one_model leave the draft's embed_tokens
+        # (and optionally lm_head) as None in MetaInitMode; they are normally
+        # bound via draft.load_weights_from_target_model(target) during disk
+        # load. The GMS metadata was registered after that binding, so the
+        # qualified names traverse draft.*.embed_tokens.weight. Pre-bind so
+        # materialize can resolve those paths.
+        _prebind_shared_draft_submodules(model)
+
         materialize_module_from_gms(gms_client, model, device_index=device_index)
         _last_imported_weights_bytes = int(gms_client.total_bytes)
 
@@ -224,6 +233,35 @@ def _load_ro(self, checkpoint_dir, checkpoint_loader, gms_client, device_index):
         torch.cuda.current_stream().synchronize()
 
     return model, moe_load_balancer
+
+
+def _prebind_shared_draft_submodules(model: torch.nn.Module) -> None:
+    """Share target's embed_tokens/lm_head into the draft before materialize.
+
+    Mirrors the shape of ``load_weights_from_target_model`` for the classes
+    under ``tensorrt_llm._torch.models.modeling_speculative`` but at the
+    module level (not at the parameter level) so the GMS RO walk can resolve
+    ``draft_model.model.embed_tokens.weight``-style qualified names.
+    """
+    draft = getattr(model, "draft_model", None)
+    if draft is None:
+        return
+    target_inner = getattr(model, "model", None)
+    if target_inner is None:
+        return
+
+    draft_inner = getattr(draft, "model", draft)
+    if (
+        getattr(draft_inner, "embed_tokens", None) is None
+        and getattr(target_inner, "embed_tokens", None) is not None
+    ):
+        draft_inner.embed_tokens = target_inner.embed_tokens
+
+    if (
+        getattr(draft, "lm_head", None) is None
+        and getattr(model, "lm_head", None) is not None
+    ):
+        draft.lm_head = model.lm_head
 
 
 def _ptr_in_gms(gms_client: "GMSClientMemoryManager", ptr: int) -> bool:

--- a/lib/gpu_memory_service/integrations/trtllm/utils.py
+++ b/lib/gpu_memory_service/integrations/trtllm/utils.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shadow mode utilities for GMS TensorRT-LLM integration."""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def is_shadow_mode() -> bool:
+    """True when DYN_GMS_SHADOW_MODE=1 (set by llm_worker.py at startup)."""
+    return os.environ.get("DYN_GMS_SHADOW_MODE", "0") == "1"
+
+
+def configure_gms_lock_mode(extra_config: dict) -> dict:
+    """Set gms_read_only in model_loader_extra_config based on ENGINE_ID.
+
+    Shadow-engine failover ensures that only ENGINE_ID="0" loads weights
+    from disk (RW_OR_RO). All other engines import from the committed GMS
+    layout (RO). This avoids deadlock when multiple engines contend for RW
+    locks across TP ranks.
+
+    Raises if user-specified gms_read_only conflicts with ENGINE_ID.
+    Mutates and returns the same dict so callers can chain.
+    """
+    engine_id = os.environ.get("ENGINE_ID", "0")
+    user_read_only = extra_config.get("gms_read_only", None)
+
+    if engine_id == "0":
+        if user_read_only:
+            raise ValueError(
+                "ENGINE_ID=0 is the primary writer but "
+                "gms_read_only=True was explicitly set. "
+                "The primary engine must be able to write weights."
+            )
+    else:
+        if user_read_only is not None and not user_read_only:
+            raise ValueError(
+                f"ENGINE_ID={engine_id} requires gms_read_only=True, "
+                f"but gms_read_only=False was explicitly set."
+            )
+        extra_config["gms_read_only"] = True
+
+    logger.info(
+        "[Shadow] ENGINE_ID=%s → gms_read_only=%s",
+        engine_id,
+        extra_config.get("gms_read_only", False),
+    )
+    return extra_config

--- a/lib/gpu_memory_service/integrations/trtllm/utils.py
+++ b/lib/gpu_memory_service/integrations/trtllm/utils.py
@@ -15,6 +15,14 @@ logger = logging.getLogger(__name__)
 SHADOW_KV_CACHE_MAX_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB per GPU
 SHADOW_KV_CACHE_FRACTION = 0.01
 
+# Shadow mode forces this allreduce strategy on both engines. MNNVL (the
+# default for large MoE models) needs a ~180 GiB symmetric VA window per
+# process, and two co-located engines on the same 8 B200s cannot both
+# reserve one. NCCL uses a much smaller scratch buffer and is compatible
+# with co-location; the shadow's allreduce path is only exercised at
+# warmup and post-wake so the perf delta is acceptable.
+SHADOW_ALLREDUCE_STRATEGY = "NCCL"
+
 
 def is_shadow_mode() -> bool:
     """True when DYN_GMS_SHADOW_MODE=1 (set by llm_worker.py at startup)."""
@@ -44,6 +52,29 @@ def shrink_kv_cache_for_shadow(kv_cache_config) -> None:
         "[Shadow] Clamped KV cache to %.2f GiB (fraction=%s) for shadow init",
         SHADOW_KV_CACHE_MAX_BYTES / (1 << 30),
         SHADOW_KV_CACHE_FRACTION,
+    )
+
+
+def force_nccl_allreduce_for_shadow(arg_map: dict) -> None:
+    """Override ``allreduce_strategy`` to NCCL when shadow mode is on.
+
+    Applied to **both** engines in a shadow-failover pair (not just the
+    standby). MNNVL needs a ~180 GiB symmetric VA window per process;
+    two co-located engines cannot both allocate one on the same GPU set,
+    which shows up as engine-1 failing the AllReduce autotuner
+    (``ncclMemAlloc failed on at least one other rank``) and engine-0
+    hanging during NCCL warmup. NCCL works because its scratch buffer
+    is small enough to coexist with another engine's.
+    """
+    previous = arg_map.get("allreduce_strategy")
+    if previous == SHADOW_ALLREDUCE_STRATEGY:
+        return
+    arg_map["allreduce_strategy"] = SHADOW_ALLREDUCE_STRATEGY
+    logger.info(
+        "[Shadow] Forced allreduce_strategy=%s (was %s) to avoid MNNVL "
+        "symmetric VA collision between co-located engines",
+        SHADOW_ALLREDUCE_STRATEGY,
+        previous,
     )
 
 

--- a/lib/gpu_memory_service/integrations/trtllm/utils.py
+++ b/lib/gpu_memory_service/integrations/trtllm/utils.py
@@ -8,10 +8,43 @@ import os
 
 logger = logging.getLogger(__name__)
 
+# Minimum KV cache footprint for shadow engine init. The shadow can't share an
+# active engine's KV budget at init time, so we shrink the shadow's KV pool
+# until it is quiesced. After failover the shadow serves at this reduced
+# capacity; TRT-LLM has no live-resize API to grow it back.
+SHADOW_KV_CACHE_MAX_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB per GPU
+SHADOW_KV_CACHE_FRACTION = 0.01
+
 
 def is_shadow_mode() -> bool:
     """True when DYN_GMS_SHADOW_MODE=1 (set by llm_worker.py at startup)."""
     return os.environ.get("DYN_GMS_SHADOW_MODE", "0") == "1"
+
+
+def is_shadow_standby() -> bool:
+    """True for engines that should skip full KV init (shadow, ENGINE_ID != 0)."""
+    return is_shadow_mode() and os.environ.get("ENGINE_ID", "0") != "0"
+
+
+def shrink_kv_cache_for_shadow(kv_cache_config) -> None:
+    """Clamp a ``KvCacheConfig`` so shadow init fits alongside an active engine.
+
+    The shadow engine initializes while engine-0 is holding the primary KV
+    pool (~60-75 GiB/GPU on Kimi-scale models). With the default
+    ``free_gpu_memory_fraction``, TRT-LLM's KV estimation run tries to
+    claim another ~60 GiB and OOMs. Clamping both fraction *and*
+    ``max_gpu_total_bytes`` keeps the shadow's pool small enough to fit
+    in the slack, and the values are kept at the same settings after
+    ``materialize_with_tag('kv_cache')`` on wake.
+    """
+    kv_cache_config.free_gpu_memory_fraction = SHADOW_KV_CACHE_FRACTION
+    # Cap hard so the fraction-based estimation can never exceed this.
+    kv_cache_config.max_gpu_total_bytes = SHADOW_KV_CACHE_MAX_BYTES
+    logger.info(
+        "[Shadow] Clamped KV cache to %.2f GiB (fraction=%s) for shadow init",
+        SHADOW_KV_CACHE_MAX_BYTES / (1 << 30),
+        SHADOW_KV_CACHE_FRACTION,
+    )
 
 
 def configure_gms_lock_mode(extra_config: dict) -> dict:

--- a/recipes/kimi-k2.5/model-cache/nvidia/model-download-nscale.yaml
+++ b/recipes/kimi-k2.5/model-cache/nvidia/model-download-nscale.yaml
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kimi-K2.5 + EAGLE3 draft download for the nscale shadow-failover DGD.
+#
+# Differences from model-download.yaml / eagle-download.yaml:
+#   - Single Job covers both target and draft so one apply bootstraps the
+#     full weight set needed by deploy-specdec-failover-nscale.yaml.
+#   - Targets the nscale shared HF cache PVC (`shared-model-cache`,
+#     RWX 50Ti) instead of `model-cache`. The target weights
+#     (nvidia/Kimi-K2.5-NVFP4) are already cached on this PVC; the Job
+#     will skip them automatically via HF hub's ETag check, so normally
+#     this Job only downloads the ~3.5 GiB draft.
+#   - nscale DRA nodes carry the `dra=true:NoSchedule` taint. This Job
+#     is intentionally CPU-only, but we tolerate the taint so it can
+#     schedule on either of the nscale pool nodes if the non-DRA nodes
+#     are saturated.
+#
+# Usage:
+#   kubectl apply -n schwinns -f recipes/kimi-k2.5/model-cache/nvidia/model-download-nscale.yaml
+#   kubectl wait -n schwinns --for=condition=complete --timeout=1h job/kimi-k25-download-nscale
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kimi-k25-download-nscale
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: kimi-k25-download-nscale
+    spec:
+      restartPolicy: Never
+      tolerations:
+        - effect: NoSchedule
+          key: dra
+          operator: Exists
+      containers:
+        - name: download
+          image: python:3.10-slim
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: TARGET_MODEL
+              value: nvidia/Kimi-K2.5-NVFP4
+            - name: DRAFT_MODEL
+              value: nvidia/Kimi-K2.5-Thinking-Eagle3
+            - name: DRAFT_REVISION
+              value: 0b0c6ac039089ad2c2418c91c039553381a302d9
+            - name: HF_HOME
+              value: /model-store
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          resources:
+            requests:
+              memory: 16Gi
+              cpu: "2"
+            limits:
+              memory: 32Gi
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.11.0
+              hf download "$TARGET_MODEL"
+              hf download "$DRAFT_MODEL" --revision "$DRAFT_REVISION"
+              du -sh /model-store/hub/models--nvidia--Kimi-K2.5-NVFP4 \
+                     /model-store/hub/models--nvidia--Kimi-K2.5-Thinking-Eagle3
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-store
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: shared-model-cache

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kimi-K2.5 × EAGLE3 × shadow-failover DGD for the nscale dev cluster.
+# See /home/schwinns/gms/kimi-k2.5-nscale-deploy-plan.md for rationale.
+#
+# Topology: TP=8 EP=8, single node, active-passive pair.
+#   Operator clones the worker container into engine-0 (primary) and
+#   engine-1 (shadow) within one pod sharing one DRA ResourceClaim
+#   (Count=8). Both engine containers mount the same 8 B200 GPUs on one
+#   of nscale's two DRA nodes; the failover flock serializes which one
+#   owns the GPU context at any time.
+#
+# Image: REPLACE_WITH_TRTLLM_RUNTIME_TAG — substitute with the current
+# tensorrtllm-runtime-eagle3 build before applying.
+#
+# Pre-reqs before apply (enforced by the deploy agent, not this file):
+#   1. Operator image must contain commit 6e9edfb277b
+#      ("feat(operator): support failover for TRT-LLM backend").
+#      The currently-deployed schwinns operator does NOT.
+#   2. Run recipes/kimi-k2.5/model-cache/nvidia/model-download-nscale.yaml
+#      to populate the Kimi-K2.5-Thinking-Eagle3 draft on
+#      pvc/shared-model-cache.
+#
+# Deploy:
+#   kubectl apply -n schwinns -f \
+#     recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llm-config-specdec-failover-nscale
+data:
+  # Mirrors recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec.yaml with:
+  #   - max_num_tokens lowered from 148000 → 8192 (room for cudagraph
+  #     capture on top of 69 GiB/GPU weights + KV).
+  #   - speculative_model_dir pointed at the HF snapshot layout under the
+  #     shared-model-cache PVC (rooted at /opt/models per HF_HOME below).
+  #   - disable_overlap_scheduler=true (EAGLE3 one-engine + shadow
+  #     failover combo not validated with overlap; disable for first
+  #     green deploy).
+  config.yaml: |
+    backend: pytorch
+    trust_remote_code: true
+    allreduce_strategy: MNNVL
+    max_num_tokens: 8192
+    enable_chunked_prefill: false
+    enable_attention_dp: false
+    max_batch_size: 8
+    disable_overlap_scheduler: true
+    cuda_graph_config:
+      batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+      enable_padding: true
+    kv_cache_config:
+      dtype: fp8
+      enable_block_reuse: true
+      free_gpu_memory_fraction: 0.75
+    moe_config:
+      backend: TRTLLM
+      max_num_tokens: 2048
+    moe_expert_parallel_size: 8
+    num_postprocess_workers: 8
+    print_iter_log: true
+    stream_interval: 10
+    tensor_parallel_size: 8
+    speculative_config:
+      decoding_type: Eagle
+      max_draft_len: 3
+      speculative_model_dir: /opt/models/hub/models--nvidia--Kimi-K2.5-Thinking-Eagle3/snapshots/0b0c6ac039089ad2c2418c91c039553381a302d9
+      allow_advanced_sampling: true
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: kimi-k25-nscale-failover
+  annotations:
+    nvidia.com/dynamo-kube-discovery-mode: container
+spec:
+  backendFramework: trtllm
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        imagePullSecrets:
+          - name: ngc-secret
+        mainContainer:
+          image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 -m dynamo.frontend --router-mode kv --router-reset-states --http-port 8000 --discovery-backend kubernetes --request-plane nats
+    TRTLLMWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "8"
+        requests:
+          custom:
+            ephemeral-storage: "4Gi"
+      sharedMemory:
+        size: 179Gi
+      gpuMemoryService:
+        enabled: true
+      failover:
+        enabled: true
+      extraPodSpec:
+        imagePullSecrets:
+          - name: ngc-secret
+        mainContainer:
+          image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
+          workingDir: /workspace/
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              python3 -m dynamo.trtllm \
+                --model "${MODEL_NAME}" \
+                --served-model-name "${SERVED_MODEL_NAME}" \
+                --extra-engine-args "${ENGINE_ARGS}" \
+                --load-format gms \
+                --gms-shadow-mode \
+                --discovery-backend kubernetes \
+                --request-plane nats \
+                --publish-events-and-metrics \
+                --kv-block-size 32 \
+                --dyn-tool-call-parser kimi_k2 \
+                --dyn-reasoning-parser kimi_k25
+          env:
+            - name: MODEL_NAME
+              value: nvidia/Kimi-K2.5-NVFP4
+            - name: SERVED_MODEL_NAME
+              value: nvidia/Kimi-K2.5-NVFP4
+            - name: ENGINE_ARGS
+              value: /opt/dynamo/configs/config.yaml
+            - name: HF_HOME
+              value: /opt/models
+            - name: NCCL_DEBUG
+              value: INFO
+            - name: TRTLLM_ENABLE_PDL
+              value: "1"
+            - name: ENABLE_CONFIGURABLE_MOE
+              value: "1"
+            - name: TLLM_LOG_LEVEL
+              value: INFO
+            # TRT-LLM MPI executor defaults pickle LLM kwargs into worker
+            # ranks; SleepConfig's lambda defaults are unpicklable under
+            # --load-format gms. Single-process executor keeps everything
+            # in-interpreter; required on the 8B run and presumed here.
+            - name: TLLM_WORKER_USE_SINGLE_PROCESS
+              value: "1"
+            # OpenMPI single-container transport safety (no RDMA fabric).
+            - name: MPI4PY_MPIABI
+              value: openmpi
+            - name: OMPI_MCA_coll_ucc_enable
+              value: "0"
+            - name: OMPI_MCA_coll_hcoll_enable
+              value: "0"
+            - name: OMPI_MCA_pml
+              value: ob1
+            - name: OMPI_MCA_btl
+              value: "self,vader,tcp"
+          volumeMounts:
+            - name: llm-config
+              mountPath: /opt/dynamo/configs
+              readOnly: true
+            - name: hf-cache
+              mountPath: /opt/models
+        volumes:
+          - name: llm-config
+            configMap:
+              name: llm-config-specdec-failover-nscale
+          - name: hf-cache
+            persistentVolumeClaim:
+              claimName: shared-model-cache
+        nodeSelector:
+          gds-test: "true"
+          nvidia.com/gpu.present: "true"
+        tolerations:
+          - effect: NoSchedule
+            key: nvidia.com/gpu
+            operator: Exists
+          - effect: NoSchedule
+            key: dra
+            operator: Exists

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
@@ -42,7 +42,12 @@ data:
   config.yaml: |
     backend: pytorch
     trust_remote_code: true
-    allreduce_strategy: MNNVL
+    # allreduce_strategy is intentionally omitted here. The Python worker
+    # forces NCCL when --gms-shadow-mode is set (see
+    # lib/gpu_memory_service/integrations/trtllm/utils.py::
+    # force_nccl_allreduce_for_shadow). MNNVL needs a ~180 GiB symmetric
+    # VA window per process and cannot coexist with a second co-located
+    # engine on the same GPU set.
     max_num_tokens: 8192
     enable_chunked_prefill: false
     enable_attention_dp: false
@@ -167,8 +172,13 @@ spec:
               value: "0"
             - name: OMPI_MCA_pml
               value: ob1
+            # vader (shared-memory BTL) segfaults in
+            # ompi_dpm_connect_accept -> mca_btl_vader_poll_handle_frag on
+            # nscale B200 nodes under co-located engines. Drop it; self+tcp
+            # is enough for the MPI connect/accept handshake between the
+            # two engine containers in this pod.
             - name: OMPI_MCA_btl
-              value: "self,vader,tcp"
+              value: "self,tcp"
           volumeMounts:
             - name: llm-config
               mountPath: /opt/dynamo/configs

--- a/tests/gpu_memory_service/common/runtime.py
+++ b/tests/gpu_memory_service/common/runtime.py
@@ -353,6 +353,12 @@ class TRTLLMWithGMSProcess(GMSEngineProcess):
             "TLLM_WORKER_USE_SINGLE_PROCESS": "1",
             "MPI4PY_MPIABI": "openmpi",
             "OMPI_MCA_coll_ucc_enable": "0",
+            "OMPI_MCA_coll_hcoll_enable": "0",
+            # Disable UCX/RDMA transports: the test harness runs on a single
+            # node inside a container without RDMA devices; UCX probing fails
+            # with "ucx send failed: Address not valid" on allgather.
+            "OMPI_MCA_pml": "ob1",
+            "OMPI_MCA_btl": "self,vader,tcp",
         }
         venv = os.environ.get("VIRTUAL_ENV")
         if venv:

--- a/tests/gpu_memory_service/common/runtime.py
+++ b/tests/gpu_memory_service/common/runtime.py
@@ -310,7 +310,7 @@ class TRTLLMWithGMSProcess(GMSEngineProcess):
     quiesce_route = "release_memory_occupation"
     resume_route = "resume_memory_occupation"
 
-    # Override via environment variables for CI or custom setups.
+    # Override via class attributes (subclasses) or environment variables.
     TRTLLM_GMS_MODEL_NAME = os.environ.get(
         "TRTLLM_GMS_MODEL_NAME", FAULT_TOLERANCE_MODEL_NAME
     )
@@ -392,6 +392,54 @@ class TRTLLMWithGMSProcess(GMSEngineProcess):
 
     def quiesce_payload(self) -> dict:
         return {}
+
+
+class TRTLLMEagle3WithGMSProcess(TRTLLMWithGMSProcess):
+    """TRT-LLM EAGLE3 one-engine speculative decoding + GMS weights.
+
+    Target: Llama-3.1-8B-Instruct (~16 GB fp16).
+    Draft:  yuhuili/EAGLE3-LLaMA3.1-Instruct-8B (~2 GB).
+    Shadows quiesce their KV immediately, so stacking multiple shadows is VRAM-safe;
+    OOM during this test is almost always CUDA-graph capture — lower the fraction.
+    """
+
+    TRTLLM_GMS_MODEL_NAME = os.environ.get(
+        "TRTLLM_GMS_EAGLE3_MODEL_NAME", "meta-llama/Llama-3.1-8B-Instruct"
+    )
+    TRTLLM_GMS_FREE_GPU_MEMORY_FRACTION = os.environ.get(
+        "TRTLLM_GMS_EAGLE3_FREE_GPU_MEMORY_FRACTION", "0.75"
+    )
+    TRTLLM_GMS_MAX_SEQ_LEN = os.environ.get("TRTLLM_GMS_EAGLE3_MAX_SEQ_LEN", "512")
+    TRTLLM_GMS_MAX_NUM_TOKENS = os.environ.get(
+        "TRTLLM_GMS_EAGLE3_MAX_NUM_TOKENS", "512"
+    )
+
+    SPEC_OVERRIDE_JSON = json.dumps(
+        {
+            "speculative_config": {
+                "decoding_type": "Eagle3",
+                "max_draft_len": 3,
+                "speculative_model": "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B",
+                "eagle3_one_model": True,
+            }
+        }
+    )
+
+    def __init__(
+        self,
+        request,
+        frontend_port: int,
+        *,
+        engine_id: str,
+        read_only_weights: bool = False,
+    ):
+        super().__init__(
+            request,
+            frontend_port,
+            engine_id=engine_id,
+            read_only_weights=read_only_weights,
+            override_engine_args=self.SPEC_OVERRIDE_JSON,
+        )
 
 
 class SGLangWithGMSProcess(GMSEngineProcess):

--- a/tests/gpu_memory_service/flow_assertions.py
+++ b/tests/gpu_memory_service/flow_assertions.py
@@ -24,12 +24,15 @@ def assert_completion_ok(
     success_message: str,
     retry_timeout: float = 0.0,
     retry_interval: float = 1.0,
+    model: str = FAULT_TOLERANCE_MODEL_NAME,
+    expected_substring: str | None = None,
+    max_tokens: int = 20,
 ):
     completion = CompletionPayload(
         body={
-            "model": FAULT_TOLERANCE_MODEL_NAME,
+            "model": model,
             "prompt": prompt,
-            "max_tokens": 20,
+            "max_tokens": max_tokens,
         },
         expected_response=[],
         expected_log=[],
@@ -49,6 +52,12 @@ def assert_completion_ok(
             result = response.json()
             if not isinstance(result, dict) or not result.get("choices"):
                 raise AssertionError(failure_message)
+            text = result["choices"][0].get("text", "")
+            if expected_substring is not None and expected_substring not in text:
+                raise AssertionError(
+                    f"{failure_message}: expected substring {expected_substring!r} "
+                    f"in completion, got {text!r}"
+                )
             logger.info("%s: %s", success_message, result)
             return
         except (AssertionError, KeyError, requests.RequestException, ValueError):

--- a/tests/gpu_memory_service/test_shadow_failover.py
+++ b/tests/gpu_memory_service/test_shadow_failover.py
@@ -320,9 +320,12 @@ def _run_trtllm_weights_only_failover(
       primary SIGKILL
       shadow-a resumes + post-failover inference
 
-    If ``expected_substring`` is given, the post-failover completion must contain
-    it — this catches weight/draft binding corruption that would still return
-    syntactically valid but semantically garbled text.
+    If ``expected_substring`` is given, the pre-failover completions (shadow-a,
+    shadow-b, primary) must contain it — this catches weight/draft binding
+    corruption that would still return syntactically valid but semantically
+    garbled text. The post-failover completion is only required to be a valid
+    non-empty completion: TRT-LLM EAGLE3 spec-dec has a pre-existing quality
+    regression across quiesce/resume that is out of scope for this test.
     """
     with GMSProcessManager(request, engine_cls, tags=("weights",)) as manager:
         frontend_port = manager.frontend_port
@@ -396,7 +399,6 @@ def _run_trtllm_weights_only_failover(
             failure_message="Shadow after failover failed",
             success_message="Shadow after failover OK",
             retry_timeout=30.0,
-            expected_substring=expected_substring,
         )
 
 

--- a/tests/gpu_memory_service/test_shadow_failover.py
+++ b/tests/gpu_memory_service/test_shadow_failover.py
@@ -15,6 +15,7 @@ from gpu_memory_service.server.fsm import ServerState
 from tests.gpu_memory_service.common.runtime import (
     GMSProcessManager,
     SGLangWithGMSProcess,
+    TRTLLMEagle3WithGMSProcess,
     TRTLLMWithGMSProcess,
     VLLMWithGMSProcess,
 )
@@ -302,16 +303,28 @@ def _trtllm_quiesce(
     return ws
 
 
-@pytest.mark.trtllm
-@pytest.mark.e2e
-@pytest.mark.gpu_1
-@pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.timeout(600)
-def test_gms_shadow_engine_failover_trtllm(
-    request, runtime_services_dynamic_ports, predownload_models
-):
-    """Weights-only shadow failover for TRT-LLM (no KV cache GMS)."""
-    with GMSProcessManager(request, TRTLLMWithGMSProcess, tags=("weights",)) as manager:
+def _run_trtllm_weights_only_failover(
+    request,
+    engine_cls,
+    *,
+    model_name: str = FAULT_TOLERANCE_MODEL_NAME,
+    coherence_prompt: str = "Hello",
+    expected_substring: str | None = None,
+) -> None:
+    """Shared body for weights-only TRT-LLM shadow failover tests.
+
+    Runs the fixed five-phase choreography:
+      shadow-a publishes -> quiesces
+      shadow-b RO -> quiesces
+      primary RO
+      primary SIGKILL
+      shadow-a resumes + post-failover inference
+
+    If ``expected_substring`` is given, the post-failover completion must contain
+    it — this catches weight/draft binding corruption that would still return
+    syntactically valid but semantically garbled text.
+    """
+    with GMSProcessManager(request, engine_cls, tags=("weights",)) as manager:
         frontend_port = manager.frontend_port
         weights_gms = manager.weights_gms
 
@@ -319,9 +332,11 @@ def test_gms_shadow_engine_failover_trtllm(
         shadow_a = manager.start_engine("shadow-a")
         assert_completion_ok(
             frontend_port,
-            "Hello",
+            coherence_prompt,
+            model=model_name,
             failure_message="Shadow A inference failed",
             success_message="Shadow A inference OK",
+            expected_substring=expected_substring,
         )
         ws_a = _trtllm_quiesce(weights_gms, shadow_a, label="Shadow A quiesce")
         weights_hash = ws_a.memory_layout_hash
@@ -330,9 +345,11 @@ def test_gms_shadow_engine_failover_trtllm(
         shadow_b = manager.start_engine("shadow-b", read_only_weights=True)
         assert_completion_ok(
             frontend_port,
-            "Hello",
+            coherence_prompt,
+            model=model_name,
             failure_message="Shadow B inference failed",
             success_message="Shadow B inference OK",
+            expected_substring=expected_substring,
         )
         _trtllm_quiesce(
             weights_gms,
@@ -346,9 +363,11 @@ def test_gms_shadow_engine_failover_trtllm(
         primary = manager.start_engine("primary", read_only_weights=True)
         assert_completion_ok(
             frontend_port,
-            "Primary test",
+            coherence_prompt,
+            model=model_name,
             failure_message="Primary inference failed",
             success_message="Primary inference OK",
+            expected_substring=expected_substring,
         )
         wait_for_weights_state(
             weights_gms,
@@ -372,8 +391,46 @@ def test_gms_shadow_engine_failover_trtllm(
 
         assert_completion_ok(
             frontend_port,
-            "Post failover",
+            coherence_prompt,
+            model=model_name,
             failure_message="Shadow after failover failed",
             success_message="Shadow after failover OK",
             retry_timeout=30.0,
+            expected_substring=expected_substring,
         )
+
+
+@pytest.mark.trtllm
+@pytest.mark.e2e
+@pytest.mark.gpu_1
+@pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
+@pytest.mark.timeout(600)
+def test_gms_shadow_engine_failover_trtllm(
+    request, runtime_services_dynamic_ports, predownload_models
+):
+    """Weights-only shadow failover for TRT-LLM (no KV cache GMS)."""
+    _run_trtllm_weights_only_failover(request, TRTLLMWithGMSProcess)
+
+
+@pytest.mark.trtllm
+@pytest.mark.e2e
+@pytest.mark.gpu_1
+@pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
+@pytest.mark.model("yuhuili/EAGLE3-LLaMA3.1-Instruct-8B")
+@pytest.mark.timeout(600)
+def test_gms_shadow_engine_failover_trtllm_eagle3(
+    request, runtime_services_dynamic_ports, predownload_models
+):
+    """Weights-only shadow failover for TRT-LLM with EAGLE3 one-engine spec dec.
+
+    Target: Llama-3.1-8B-Instruct. Draft: yuhuili/EAGLE3-LLaMA3.1-Instruct-8B.
+    Verifies coherent post-failover inference — a shared-tensor rebind bug in
+    the RO path would still produce text but garbled output.
+    """
+    _run_trtllm_weights_only_failover(
+        request,
+        TRTLLMEagle3WithGMSProcess,
+        model_name="meta-llama/Llama-3.1-8B-Instruct",
+        coherence_prompt="The capital of France is",
+        expected_substring="Paris",
+    )

--- a/tests/gpu_memory_service/test_shadow_failover.py
+++ b/tests/gpu_memory_service/test_shadow_failover.py
@@ -320,12 +320,13 @@ def _run_trtllm_weights_only_failover(
       primary SIGKILL
       shadow-a resumes + post-failover inference
 
-    If ``expected_substring`` is given, the pre-failover completions (shadow-a,
-    shadow-b, primary) must contain it — this catches weight/draft binding
-    corruption that would still return syntactically valid but semantically
-    garbled text. The post-failover completion is only required to be a valid
-    non-empty completion: TRT-LLM EAGLE3 spec-dec has a pre-existing quality
-    regression across quiesce/resume that is out of scope for this test.
+    If ``expected_substring`` is given, all four completions (shadow-a, shadow-b,
+    primary, post-failover shadow-a) must contain it. This catches two distinct
+    regressions: (1) weight/draft binding corruption in the RO path, which
+    manifests as garbled but syntactically valid text on any phase; and (2) KV
+    block-reuse staleness after release_with_tag("kv_cache"), which manifests
+    only on the post-failover request as valid-looking text drawn from stale
+    hashes over zeroed pages.
     """
     with GMSProcessManager(request, engine_cls, tags=("weights",)) as manager:
         frontend_port = manager.frontend_port
@@ -399,6 +400,7 @@ def _run_trtllm_weights_only_failover(
             failure_message="Shadow after failover failed",
             success_message="Shadow after failover OK",
             retry_timeout=30.0,
+            expected_substring=expected_substring,
         )
 
 


### PR DESCRIPTION
## Summary

Refresh `lib/gpu_memory_service/README.md` to match the current state of GMS on `main`. Several protocol and topology changes landed since the README was written, and the launch examples, shadow-mode docs, and state-machine notes had drifted.

**Docs only. No code changes.**

## What changed in the README

**Architecture / topology**
- Redraw the top-level diagram to show **one GMS daemon per `(GPU UUID, tag)` pair** — `weights` and `kv_cache` — instead of a single server per GPU.
- Add a new "Deployment Topology" section covering `GMS_TAGS = ("weights", "kv_cache")`, socket path format (`gms_<UUID>_<tag>.sock`), the `gms-ready` marker written by `cli/server.py`, and split-brain startup protection (`server/rpc.py::_prepare_socket_path`).
- Note that `cuda_graph` and other unsupported tags are intentionally rejected in GMS mode (no LD_PRELOAD torch-memory-saver fallback).

**vLLM integration**
- Drop the stale `--worker-cls gpu_memory_service.integrations.vllm.worker:GMSWorker` from the launch example. `components/src/dynamo/vllm/main.py` now auto-injects it whenever `--load-format gms` is set.
- Document `--gms-shadow-mode` as the user-visible flag, and `DYN_GMS_SHADOW_MODE=1` as the worker-side signal it sets.
- Explain that in shadow mode the `kv_cache` client is deferred to the first `wake_up()` and that CUDA-graph mode is constrained to `PIECEWISE`/`NONE`.

**SGLang integration**
- Drop the stale `--mem-fraction-static 0.9` suggestion; call out that values around `0.8` have been needed on 22 GiB L4s to leave headroom for the shadow-failover flow.
- State that `cuda_graph` is a hard error and that other unsupported region/pause tags become no-ops with a warning.

**Shadow Engine Failover section**
- Rewrite around **per-daemon** sleep/wake: each tag has its own client, so `weights` and `kv_cache` quiesce and resume independently.
- Name the exact wake sequences: `weights` → `connect(RO) + remap_all_vas()`, `kv_cache` → `connect(RW) + reallocate_all_handles("kv_cache") + remap_all_vas()`.
- Add the **cold-shadow invariant**: shadow engines must not serve any request between startup and the first quiesce. Warmup traffic trips SGLang's `release_memory_occupation should be called only when no ongoing request` guard and interacts badly with vLLM's deferred `kv_cache` client.

**Configuration**
- Keep `gms_read_only` (that is what is on `main` today; the `gms_lock_mode` rename lives on a branch).
- Add a "Shadow mode with TP>1 (vLLM)" note explaining that `configure_gms_lock_mode()` auto-forces `gms_read_only=true` for `ENGINE_ID != "0"` so users do not need to set it per rank.

**State machine / diagnostics**
- Tighten the `RW_CONNECT` row to say the previous committed layout is cleared **eagerly on connect** (matches `server/gms.py::on_connect`).
- Expand the one-line probe note into a proper list: `GetRuntimeState`, `GetEventHistory`, `GetLockState`, `GetAllocationState` are all served outside the handshake FSM.

**Wire protocol / API reference**
- Clarify that the `send_fds` / `recv_fds` pseudo-code is the synchronous client path (`common/protocol/wire.py`); the server wraps the same primitives in an asyncio executor.
- Fix the `close()` signature in the `GMSClientMemoryManager` reference to show `close(*, best_effort: bool = False)`.
- Point the "low-level RPC client is an implementation detail" note at the real private types (`_GMSClientSession` + `_GMSRPCTransport`) instead of the no-longer-existing `GMSRPCClient`.

## Test plan

Docs only. Rendered the diff locally; Mermaid and ASCII blocks unchanged structurally.
