### PR TITLE
feat: add zerofill support

### DIFF
--- a/lib/kvbm-config/src/onboard.rs
+++ b/lib/kvbm-config/src/onboard.rs
@@ -8,11 +8,15 @@
 
 use serde::{Deserialize, Serialize};
 
+fn default_stage_chunk_size() -> usize {
+    16
+}
+
 /// Configuration for KV cache onboarding strategy.
 ///
 /// Onboarding is the process of loading external KV cache blocks from
 /// G2 (host memory) into G1 (GPU memory) for use during inference.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OnboardConfig {
     /// The onboarding mode to use.
     ///
@@ -20,6 +24,22 @@ pub struct OnboardConfig {
     /// - `intra`: Synchronous layer-wise loading during forward pass
     #[serde(default)]
     pub mode: OnboardMode,
+
+    /// Number of blocks per G3->G2 staging transfer request.
+    ///
+    /// This is a fixed-size chunk used when staging from disk to host to bound
+    /// transfer request size and background notification pressure.
+    #[serde(default = "default_stage_chunk_size")]
+    pub stage_chunk_size: usize,
+}
+
+impl Default for OnboardConfig {
+    fn default() -> Self {
+        Self {
+            mode: OnboardMode::default(),
+            stage_chunk_size: default_stage_chunk_size(),
+        }
+    }
 }
 
 /// Onboarding mode for loading external KV cache blocks.
@@ -58,6 +78,7 @@ mod tests {
     fn test_default_mode_is_inter() {
         let config = OnboardConfig::default();
         assert_eq!(config.mode, OnboardMode::Inter);
+        assert_eq!(config.stage_chunk_size, 16);
     }
 
     #[test]
@@ -66,11 +87,21 @@ mod tests {
         let json = r#"{"mode": "inter"}"#;
         let config: OnboardConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.mode, OnboardMode::Inter);
+        assert_eq!(config.stage_chunk_size, 16);
 
         // Test intra mode
         let json = r#"{"mode": "intra"}"#;
         let config: OnboardConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.mode, OnboardMode::Intra);
+        assert_eq!(config.stage_chunk_size, 16);
+    }
+
+    #[test]
+    fn test_stage_chunk_size_serde_roundtrip() {
+        let json = r#"{"mode": "inter", "stage_chunk_size": 32}"#;
+        let config: OnboardConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.mode, OnboardMode::Inter);
+        assert_eq!(config.stage_chunk_size, 32);
     }
 
     #[test]
@@ -78,5 +109,6 @@ mod tests {
         let json = r#"{}"#;
         let config: OnboardConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.mode, OnboardMode::Inter);
+        assert_eq!(config.stage_chunk_size, 16);
     }
 }

--- a/lib/kvbm-connector/src/connector/leader/init.rs
+++ b/lib/kvbm-connector/src/connector/leader/init.rs
@@ -268,6 +268,13 @@ impl ConnectorLeader {
                     rank: idx,
                     host_block_count,
                     disk_block_count,
+                    disk_storage_path: self
+                        .runtime
+                        .config()
+                        .cache
+                        .disk
+                        .as_ref()
+                        .and_then(|disk| disk.storage_path.clone()),
                     object: object_config.clone(),
                     parallelism: self.runtime.config().cache.parallelism,
                 };
@@ -408,6 +415,7 @@ impl ConnectorLeader {
             .messenger(self.runtime.messenger().clone())
             .registry(registry)
             .g2_manager(g2_manager)
+            .stage_chunk_size(self.runtime.config().onboard.stage_chunk_size)
             .workers(
                 worker_clients
                     .into_iter()

--- a/lib/kvbm-connector/src/connector/worker/init/pending.rs
+++ b/lib/kvbm-connector/src/connector/worker/init/pending.rs
@@ -34,9 +34,6 @@ use kvbm_common::LogicalLayoutHandle;
 use kvbm_physical::TransferManager;
 use kvbm_physical::layout::{BlockDimension, LayoutConfig, PhysicalLayoutBuilder};
 
-const DISK_CACHE_KEY: &str = "DYN_KVBM_DISK_CACHE_DIR";
-const DEFAULT_DISK_CACHE_DIR: &str = "/tmp";
-
 /// Cached state from `register_kv_caches` for deferred initialization.
 ///
 /// This struct holds all the information needed to complete NIXL registration
@@ -248,9 +245,11 @@ impl PendingWorkerState {
             let g3_handle = if let Some(disk_blocks) = config.disk_block_count {
                 let mut disk_layout = self.layout_config.clone();
                 disk_layout.num_blocks = disk_blocks;
-                let disk_cache_dir = std::env::var(DISK_CACHE_KEY)
-                    .unwrap_or_else(|_| DEFAULT_DISK_CACHE_DIR.to_string());
-                let disk_path = PathBuf::from(disk_cache_dir)
+                let disk_cache_dir = config
+                    .disk_storage_path
+                    .clone()
+                    .unwrap_or_else(|| PathBuf::from("/tmp"));
+                let disk_path = disk_cache_dir
                     .join(format!("kvbm_g3_{}.bin", runtime.messenger().instance_id()));
                 let disk_layout = PhysicalLayoutBuilder::new(nixl_agent.clone())
                     .with_config(disk_layout)

--- a/lib/kvbm-connector/src/connector/worker/init/pending.rs
+++ b/lib/kvbm-connector/src/connector/worker/init/pending.rs
@@ -34,6 +34,9 @@ use kvbm_common::LogicalLayoutHandle;
 use kvbm_physical::TransferManager;
 use kvbm_physical::layout::{BlockDimension, LayoutConfig, PhysicalLayoutBuilder};
 
+const DISK_CACHE_KEY: &str = "DYN_KVBM_DISK_CACHE_DIR";
+const DEFAULT_DISK_CACHE_DIR: &str = "/tmp";
+
 /// Cached state from `register_kv_caches` for deferred initialization.
 ///
 /// This struct holds all the information needed to complete NIXL registration
@@ -245,13 +248,14 @@ impl PendingWorkerState {
             let g3_handle = if let Some(disk_blocks) = config.disk_block_count {
                 let mut disk_layout = self.layout_config.clone();
                 disk_layout.num_blocks = disk_blocks;
+                let disk_cache_dir = std::env::var(DISK_CACHE_KEY)
+                    .unwrap_or_else(|_| DEFAULT_DISK_CACHE_DIR.to_string());
+                let disk_path = PathBuf::from(disk_cache_dir)
+                    .join(format!("kvbm_g3_{}.bin", runtime.messenger().instance_id()));
                 let disk_layout = PhysicalLayoutBuilder::new(nixl_agent.clone())
                     .with_config(disk_layout)
                     .fully_contiguous()
-                    .allocate_disk(Some(PathBuf::from(format!(
-                        "/tmp/kvbm_g3_{}.bin",
-                        runtime.messenger().instance_id()
-                    ))))
+                    .allocate_disk(Some(disk_path))
                     .build()?;
 
                 let handle = transfer_manager.register_layout(disk_layout)?;

--- a/lib/kvbm-engine/src/leader/instance.rs
+++ b/lib/kvbm-engine/src/leader/instance.rs
@@ -114,6 +114,9 @@ pub struct InstanceLeader {
     /// Object storage client for G4 search and load operations.
     /// Leader calls has_blocks on S3 directly, coordinates workers for get_blocks.
     object_client: Option<Arc<dyn ObjectBlockOps>>,
+
+    /// Number of blocks per G3->G2 staging transfer request.
+    stage_chunk_size: usize,
 }
 
 /// Builder for InstanceLeader.
@@ -128,6 +131,7 @@ pub struct InstanceLeaderBuilder {
     remote_leaders: Option<Vec<InstanceId>>,
     cached_worker_metadata: Option<Vec<SerializedLayout>>,
     object_client: Option<Arc<dyn ObjectBlockOps>>,
+    stage_chunk_size: usize,
 }
 
 impl InstanceLeaderBuilder {
@@ -215,6 +219,11 @@ impl InstanceLeaderBuilder {
         self
     }
 
+    pub fn stage_chunk_size(mut self, size: usize) -> Self {
+        self.stage_chunk_size = size.max(1);
+        self
+    }
+
     pub fn build(self) -> Result<InstanceLeader> {
         let messenger = self
             .messenger
@@ -266,6 +275,7 @@ impl InstanceLeaderBuilder {
             transport,
             session_sessions: Arc::new(DashMap::new()),
             object_client: self.object_client,
+            stage_chunk_size: self.stage_chunk_size.max(1),
         })
     }
 }
@@ -516,6 +526,7 @@ impl InstanceLeader {
         let g2_manager = self.g2_manager.clone();
         let g3_manager = self.g3_manager.clone();
         let parallel_worker = self.parallel_worker.clone();
+        let stage_chunk_size = self.stage_chunk_size;
         let transport = self.transport.clone();
         let sessions = self.sessions.clone();
 
@@ -536,6 +547,7 @@ impl InstanceLeader {
                     g2_manager.clone(),
                     g3_manager.clone(),
                     parallel_worker.clone(),
+                    stage_chunk_size,
                     transport.clone(),
                 );
 
@@ -686,6 +698,7 @@ impl InstanceLeader {
             worker_g2_handles,
             self.g2_manager.clone(),
             self.parallel_worker.clone(),
+            self.stage_chunk_size,
             cmd_rx,
             ServerSessionOptions {
                 auto_stage: options.auto_stage,
@@ -1239,6 +1252,7 @@ impl Leader for InstanceLeader {
             self.g3_manager.clone(),
             self.parallel_worker.clone(),
             self.transport.clone(),
+            self.stage_chunk_size,
             status_tx.clone(),
             all_g2_blocks.clone(),
             match_breakdown.clone(),

--- a/lib/kvbm-engine/src/leader/session/initiator.rs
+++ b/lib/kvbm-engine/src/leader/session/initiator.rs
@@ -99,6 +99,7 @@ pub struct InitiatorSession {
     g3_manager: Option<Arc<BlockManager<G3>>>,
     parallel_worker: Option<Arc<dyn ParallelWorkers>>,
     transport: Arc<MessageTransport>,
+    stage_chunk_size: usize,
     status_tx: watch::Sender<OnboardingStatus>,
 
     // Held blocks from local search using BlockHolder for RAII semantics
@@ -140,6 +141,7 @@ impl InitiatorSession {
         g3_manager: Option<Arc<BlockManager<G3>>>,
         parallel_worker: Option<Arc<dyn ParallelWorkers>>,
         transport: Arc<MessageTransport>,
+        stage_chunk_size: usize,
         status_tx: watch::Sender<OnboardingStatus>,
         all_g2_blocks: Arc<Mutex<Option<Vec<ImmutableBlock<G2>>>>>,
         match_breakdown: Arc<Mutex<MatchBreakdown>>,
@@ -154,6 +156,7 @@ impl InitiatorSession {
             g3_manager,
             parallel_worker,
             transport,
+            stage_chunk_size,
             status_tx,
             local_g2_blocks: BlockHolder::empty(),
             local_g3_blocks: BlockHolder::empty(),
@@ -894,9 +897,13 @@ impl InitiatorSession {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("ParallelWorker required for G3→G2 staging"))?;
 
-        let result =
-            staging::stage_g3_to_g2(&self.local_g3_blocks, &self.g2_manager, &**parallel_worker)
-                .await?;
+        let result = staging::stage_g3_to_g2(
+            &self.local_g3_blocks,
+            &self.g2_manager,
+            &**parallel_worker,
+            self.stage_chunk_size,
+        )
+        .await?;
 
         let _ = self.local_g3_blocks.take_all();
         self.local_g2_blocks.extend(result.new_g2_blocks);

--- a/lib/kvbm-engine/src/leader/session/responder.rs
+++ b/lib/kvbm-engine/src/leader/session/responder.rs
@@ -33,6 +33,7 @@ pub struct ResponderSession {
     g2_manager: Arc<BlockManager<G2>>,
     g3_manager: Option<Arc<BlockManager<G3>>>,
     parallel_worker: Option<Arc<dyn ParallelWorkers>>,
+    stage_chunk_size: usize,
     transport: Arc<MessageTransport>,
     // Held blocks using BlockHolder for RAII semantics
     // Blocks are automatically released when the session drops
@@ -49,6 +50,7 @@ impl ResponderSession {
         g2_manager: Arc<BlockManager<G2>>,
         g3_manager: Option<Arc<BlockManager<G3>>>,
         parallel_worker: Option<Arc<dyn ParallelWorkers>>,
+        stage_chunk_size: usize,
         transport: Arc<MessageTransport>,
     ) -> Self {
         Self {
@@ -58,6 +60,7 @@ impl ResponderSession {
             g2_manager,
             g3_manager,
             parallel_worker,
+            stage_chunk_size,
             transport,
             held_g2_blocks: BlockHolder::empty(),
             held_g3_blocks: BlockHolder::empty(),
@@ -252,6 +255,7 @@ impl ResponderSession {
             &self.held_g3_blocks,
             &self.g2_manager,
             &**parallel_worker,
+            self.stage_chunk_size,
         )
         .await?;
 

--- a/lib/kvbm-engine/src/leader/session/server_session.rs
+++ b/lib/kvbm-engine/src/leader/session/server_session.rs
@@ -167,6 +167,9 @@ pub struct ServerSession {
     /// Parallel worker for G3→G2 staging.
     parallel_worker: Option<Arc<dyn ParallelWorkers>>,
 
+    /// Number of blocks per G3->G2 staging transfer request.
+    stage_chunk_size: usize,
+
     /// Channel for receiving local commands.
     cmd_rx: mpsc::Receiver<ServerSessionCommand>,
 
@@ -215,6 +218,7 @@ impl ServerSession {
             g3_blocks: BlockHolder::empty(),
             g2_manager: None,
             parallel_worker: None,
+            stage_chunk_size: 16,
             cmd_rx,
             options: ServerSessionOptions { auto_stage: false },
             staging_started: false,
@@ -231,6 +235,7 @@ impl ServerSession {
         worker_handles: Vec<LayoutHandle>,
         g2_manager: Arc<BlockManager<G2>>,
         parallel_worker: Option<Arc<dyn ParallelWorkers>>,
+        stage_chunk_size: usize,
         cmd_rx: mpsc::Receiver<ServerSessionCommand>,
         options: ServerSessionOptions,
     ) -> Self {
@@ -241,6 +246,7 @@ impl ServerSession {
             g3_blocks,
             g2_manager: Some(g2_manager),
             parallel_worker,
+            stage_chunk_size,
             cmd_rx,
             options,
             staging_started: false,
@@ -520,8 +526,13 @@ impl ServerSession {
             return Ok(Vec::new());
         }
 
-        let result =
-            staging::stage_g3_to_g2(&self.g3_blocks, g2_manager, &**parallel_worker).await?;
+        let result = staging::stage_g3_to_g2(
+            &self.g3_blocks,
+            g2_manager,
+            &**parallel_worker,
+            self.stage_chunk_size,
+        )
+        .await?;
 
         // Build BlockInfo for newly staged blocks
         let starting_index = self.g2_blocks.count();

--- a/lib/kvbm-engine/src/leader/session/staging.rs
+++ b/lib/kvbm-engine/src/leader/session/staging.rs
@@ -18,6 +18,21 @@ use kvbm_physical::transfer::TransferOptions;
 
 use super::blocks::BlockHolder;
 
+/// Default number of blocks per NIXL transfer request for G3→G2 staging.
+///
+/// Bounding request size prevents io_uring SQ ring exhaustion when staging
+/// large sequences. Chunks are processed sequentially to avoid overflowing
+/// the background NIXL notification channel when many sessions run concurrently.
+const DEFAULT_STAGE_CHUNK_SIZE: usize = 16;
+
+fn stage_chunk_size() -> usize {
+    std::env::var("KVBM_STAGE_CHUNK_SIZE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_STAGE_CHUNK_SIZE)
+}
+
 /// Result of staging G3 blocks to G2.
 pub struct StagingResult {
     /// Newly created G2 blocks (registered with the G2 manager).
@@ -26,8 +41,14 @@ pub struct StagingResult {
 
 /// Stage G3 blocks to G2.
 ///
-/// Core staging kernel: allocate G2 destinations → execute local transfer (G3→G2)
-/// → register new G2 blocks with the source sequence hashes → return new blocks.
+/// Core staging kernel: allocate G2 destinations → execute local transfers (G3→G2)
+/// in fixed-size chunks sequentially → register new G2 blocks with the source
+/// sequence hashes → return new blocks.
+///
+/// Chunking bounds the number of io_uring SQ entries per NIXL XferReq, preventing
+/// ring exhaustion on large sequences. Chunks are processed sequentially (one
+/// XferReq at a time) to avoid overflowing the background NIXL notification
+/// channel when many sessions stage concurrently.
 ///
 /// The caller is responsible for:
 /// - Clearing the G3 holder (`take_all()`)
@@ -45,27 +66,32 @@ pub async fn stage_g3_to_g2(
     }
 
     let src_ids: Vec<BlockId> = g3_blocks.blocks().iter().map(|b| b.block_id()).collect();
+    let chunk_size = stage_chunk_size();
 
-    // Allocate destination G2 blocks
+    // Allocate all destination G2 blocks upfront
     let dst_blocks = g2_manager
         .allocate_blocks(src_ids.len())
         .ok_or_else(|| anyhow::anyhow!("Failed to allocate G2 blocks"))?;
 
     let dst_ids: Vec<BlockId> = dst_blocks.iter().map(|b| b.block_id()).collect();
 
-    // Execute transfer
-    let notification = parallel_worker.execute_local_transfer(
-        LogicalLayoutHandle::G3,
-        LogicalLayoutHandle::G2,
-        Arc::from(src_ids),
-        Arc::from(dst_ids),
-        TransferOptions::default(),
-    )?;
+    // Process each chunk sequentially: submit one NIXL XferReq, await completion,
+    // then submit the next. Sequential dispatch keeps at most one notification
+    // in the background polling channel at a time, preventing channel overflow
+    // when many staging sessions run concurrently.
+    for (src_chunk, dst_chunk) in src_ids.chunks(chunk_size).zip(dst_ids.chunks(chunk_size)) {
+        let notification = parallel_worker.execute_local_transfer(
+            LogicalLayoutHandle::G3,
+            LogicalLayoutHandle::G2,
+            Arc::from(src_chunk),
+            Arc::from(dst_chunk),
+            TransferOptions::default(),
+        )?;
+        notification.into_future().await?;
+    }
 
-    // Wait for transfer to complete
-    notification.await?;
-
-    // Register new G2 blocks using the G3 blocks' metadata (sequence hashes)
+    // Register new G2 blocks using the G3 blocks' metadata (sequence hashes).
+    // Chunk boundaries do not affect registration order.
     let new_g2_blocks: Vec<ImmutableBlock<G2>> = dst_blocks
         .into_iter()
         .zip(g3_blocks.blocks().iter())

--- a/lib/kvbm-engine/src/leader/session/staging.rs
+++ b/lib/kvbm-engine/src/leader/session/staging.rs
@@ -18,21 +18,6 @@ use kvbm_physical::transfer::TransferOptions;
 
 use super::blocks::BlockHolder;
 
-/// Default number of blocks per NIXL transfer request for G3→G2 staging.
-///
-/// Bounding request size prevents io_uring SQ ring exhaustion when staging
-/// large sequences. Chunks are processed sequentially to avoid overflowing
-/// the background NIXL notification channel when many sessions run concurrently.
-const DEFAULT_STAGE_CHUNK_SIZE: usize = 16;
-
-fn stage_chunk_size() -> usize {
-    std::env::var("KVBM_STAGE_CHUNK_SIZE")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(DEFAULT_STAGE_CHUNK_SIZE)
-}
-
 /// Result of staging G3 blocks to G2.
 pub struct StagingResult {
     /// Newly created G2 blocks (registered with the G2 manager).
@@ -58,6 +43,7 @@ pub async fn stage_g3_to_g2(
     g3_blocks: &BlockHolder<G3>,
     g2_manager: &BlockManager<G2>,
     parallel_worker: &dyn ParallelWorkers,
+    stage_chunk_size: usize,
 ) -> Result<StagingResult> {
     if g3_blocks.is_empty() {
         return Ok(StagingResult {
@@ -66,7 +52,7 @@ pub async fn stage_g3_to_g2(
     }
 
     let src_ids: Vec<BlockId> = g3_blocks.blocks().iter().map(|b| b.block_id()).collect();
-    let chunk_size = stage_chunk_size();
+    let chunk_size = stage_chunk_size.max(1);
 
     // Allocate all destination G2 blocks upfront
     let dst_blocks = g2_manager

--- a/lib/kvbm-engine/src/worker/protocol.rs
+++ b/lib/kvbm-engine/src/worker/protocol.rs
@@ -4,6 +4,7 @@
 use anyhow::Result;
 use futures::future::{Either, Ready, ready};
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use std::{
     pin::Pin,
     task::{Context, Poll},
@@ -169,6 +170,12 @@ pub struct LeaderLayoutConfig {
 
     /// Number of disk blocks for G3 tier (None = no disk tier).
     pub disk_block_count: Option<usize>,
+
+    /// Base directory for worker-local G3 backing files.
+    ///
+    /// When omitted, workers fall back to `/tmp`.
+    #[serde(default)]
+    pub disk_storage_path: Option<PathBuf>,
 
     /// Object storage configuration for G4 tier (None = no object tier).
     ///

--- a/lib/kvbm-physical/src/manager/mod.rs
+++ b/lib/kvbm-physical/src/manager/mod.rs
@@ -513,7 +513,7 @@ impl TransferManager {
     pub(crate) fn register_cuda_event(
         &self,
         event: cudarc::driver::CudaEvent,
-    ) -> TransferCompleteNotification {
+    ) -> Result<TransferCompleteNotification> {
         self.context.register_cuda_event(event)
     }
 

--- a/lib/kvbm-physical/src/transfer/context.rs
+++ b/lib/kvbm-physical/src/transfer/context.rs
@@ -27,6 +27,17 @@ use notifications::RegisterPollingNotification;
 pub(crate) use super::notifications;
 pub use super::notifications::TransferCompleteNotification;
 
+/// Default capacity for background NIXL/CUDA notification channels.
+const DEFAULT_NOTIFICATION_CHANNEL_CAPACITY: usize = 1024;
+
+fn notification_channel_capacity() -> usize {
+    std::env::var("KVBM_NOTIFICATION_CHANNEL_CAPACITY")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_NOTIFICATION_CHANNEL_CAPACITY)
+}
+
 #[derive(Clone, Builder)]
 #[builder(pattern = "owned", build_fn(private, name = "build_internal"), public)]
 #[allow(dead_code)] // Fields are used in build() but derive macros confuse dead code analysis
@@ -256,10 +267,12 @@ impl TransferContext {
         }
         let cuda_pool = Arc::new(pool_builder.build()?);
 
-        // Create channels for background notification handlers
-        let (tx_nixl_status, rx_nixl_status) = mpsc::channel(64);
-        let (tx_cuda_event, rx_cuda_event) = mpsc::channel(64);
-        let (tx_nixl_events, rx_nixl_events) = mpsc::channel(64);
+        // Create channels for background notification handlers.
+        // Overflow silently drops notifications and can orphan transfer requests.
+        let cap = notification_channel_capacity();
+        let (tx_nixl_status, rx_nixl_status) = mpsc::channel(cap);
+        let (tx_cuda_event, rx_cuda_event) = mpsc::channel(cap);
+        let (tx_nixl_events, rx_nixl_events) = mpsc::channel(cap);
 
         // Spawn background handlers
         let handle = tokio_runtime.handle();

--- a/lib/kvbm-physical/src/transfer/context.rs
+++ b/lib/kvbm-physical/src/transfer/context.rs
@@ -38,6 +38,20 @@ fn notification_channel_capacity() -> usize {
         .unwrap_or(DEFAULT_NOTIFICATION_CHANNEL_CAPACITY)
 }
 
+fn enqueue_notification<T>(
+    tx: &mpsc::Sender<T>,
+    notification: T,
+    channel_name: &'static str,
+) -> Result<()> {
+    tx.try_send(notification).map_err(|err| {
+        anyhow::anyhow!(
+            "failed to enqueue {} notification: channel full or closed: {}",
+            channel_name,
+            err
+        )
+    })
+}
+
 #[derive(Clone, Builder)]
 #[builder(pattern = "owned", build_fn(private, name = "build_internal"), public)]
 #[allow(dead_code)] // Fields are used in build() but derive macros confuse dead code analysis
@@ -419,7 +433,7 @@ impl TransferContext {
     pub(crate) fn register_nixl_status(
         &self,
         xfer_req: XferRequest,
-    ) -> TransferCompleteNotification {
+    ) -> Result<TransferCompleteNotification> {
         let event = self
             .event_system
             .new_event()
@@ -439,22 +453,19 @@ impl TransferContext {
             event_handle: handle,
         };
 
-        // Send to background handler — log error if channel is full or closed
-        if let Err(e) = self.tx_nixl_status.try_send(notification) {
-            tracing::error!(
-                "Failed to enqueue NIXL status notification: channel full or closed: {}",
-                e
-            );
-        }
+        enqueue_notification(&self.tx_nixl_status, notification, "NIXL status")?;
 
-        TransferCompleteNotification::from_awaiter(awaiter)
+        Ok(TransferCompleteNotification::from_awaiter(awaiter))
     }
 
     /// Register a CUDA event for polling completion.
     ///
     /// This method enqueues the CUDA event to be polled for completion.
     /// Returns a notification object that can be awaited for completion.
-    pub(crate) fn register_cuda_event(&self, event: CudaEvent) -> TransferCompleteNotification {
+    pub(crate) fn register_cuda_event(
+        &self,
+        event: CudaEvent,
+    ) -> Result<TransferCompleteNotification> {
         let new_event = self
             .event_system
             .new_event()
@@ -471,15 +482,9 @@ impl TransferContext {
             event_handle: handle,
         };
 
-        // Send to background handler — log error if channel is full or closed
-        if let Err(e) = self.tx_cuda_event.try_send(notification) {
-            tracing::error!(
-                "Failed to enqueue CUDA event notification: channel full or closed: {}",
-                e
-            );
-        }
+        enqueue_notification(&self.tx_cuda_event, notification, "CUDA event")?;
 
-        TransferCompleteNotification::from_awaiter(awaiter)
+        Ok(TransferCompleteNotification::from_awaiter(awaiter))
     }
 
     /// Register a NIXL transfer request for notification-based completion.
@@ -491,7 +496,7 @@ impl TransferContext {
     pub(crate) fn register_nixl_event(
         &self,
         xfer_req: XferRequest,
-    ) -> TransferCompleteNotification {
+    ) -> Result<TransferCompleteNotification> {
         let event = self
             .event_system
             .new_event()
@@ -508,19 +513,41 @@ impl TransferContext {
             event_handle: handle,
         };
 
-        // Send to background handler — log error if channel is full or closed
-        if let Err(e) = self.tx_nixl_events.try_send(notification) {
-            tracing::error!(
-                "Failed to enqueue NIXL event notification: channel full or closed: {}",
-                e
-            );
-        }
+        enqueue_notification(&self.tx_nixl_events, notification, "NIXL event")?;
 
-        TransferCompleteNotification::from_awaiter(awaiter)
+        Ok(TransferCompleteNotification::from_awaiter(awaiter))
     }
 
     /// Get the worker ID for this context.
     pub(crate) fn worker_id(&self) -> u64 {
         self.worker_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+
+    use super::enqueue_notification;
+
+    #[test]
+    fn enqueue_notification_returns_error_when_channel_is_full() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tx.try_send(1usize).unwrap();
+
+        let err = enqueue_notification(&tx, 2usize, "test").unwrap_err();
+
+        assert!(err.to_string().contains("channel full or closed"));
+        assert_eq!(rx.try_recv().unwrap(), 1usize);
+    }
+
+    #[test]
+    fn enqueue_notification_returns_error_when_channel_is_closed() {
+        let (tx, rx) = mpsc::channel::<usize>(1);
+        drop(rx);
+
+        let err = enqueue_notification(&tx, 1usize, "test").unwrap_err();
+
+        assert!(err.to_string().contains("channel full or closed"));
     }
 }

--- a/lib/kvbm-physical/src/transfer/executor/cuda.rs
+++ b/lib/kvbm-physical/src/transfer/executor/cuda.rs
@@ -148,7 +148,7 @@ pub fn execute_cuda_transfer(
             | TransferStrategy::CudaAsyncD2D
     ) {
         let event = stream.record_event(None)?;
-        Ok(ctx.register_cuda_event(event))
+        ctx.register_cuda_event(event)
     } else {
         // Blocking transfers are already synchronized
         Ok(TransferCompleteNotification::completed())

--- a/lib/kvbm-physical/src/transfer/executor/nixl.rs
+++ b/lib/kvbm-physical/src/transfer/executor/nixl.rs
@@ -372,7 +372,7 @@ impl<'a> NixlTransferBuilder<'a, Set, Set, Set, Set, Set> {
 
         if still_pending {
             // Register for async completion via status polling
-            Ok(ctx.register_nixl_status(xfer_req))
+            ctx.register_nixl_status(xfer_req)
         } else {
             // Transfer completed synchronously
             Ok(TransferCompleteNotification::completed())

--- a/lib/memory/Cargo.toml
+++ b/lib/memory/Cargo.toml
@@ -23,6 +23,7 @@ testing-nixl = []
 testing-all = ["testing-cuda", "testing-nixl"]
 
 [dependencies]
+aligned-vec = "0.6.4"
 anyhow = { workspace = true }
 cudarc = { workspace = true }
 nixl-sys = { version = "=0.10.1" }

--- a/lib/memory/src/disk.rs
+++ b/lib/memory/src/disk.rs
@@ -11,8 +11,8 @@ use std::path::{Path, PathBuf};
 use core::ffi::c_char;
 use nix::fcntl::{FallocateFlags, fallocate};
 use nix::unistd::{ftruncate, unlink};
-use std::fs::File;
 use std::ffi::CString;
+use std::fs::File;
 use std::io::Write;
 use std::os::fd::{BorrowedFd, RawFd};
 

--- a/lib/memory/src/disk.rs
+++ b/lib/memory/src/disk.rs
@@ -4,17 +4,95 @@
 //! Disk-backed memory storage using memory-mapped files.
 
 use super::{MemoryDescriptor, Result, StorageError, StorageKind, nixl::NixlDescriptor};
+use aligned_vec::{AVec, ConstAlign};
 use std::any::Any;
 use std::path::{Path, PathBuf};
 
 use core::ffi::c_char;
 use nix::fcntl::{FallocateFlags, fallocate};
-use nix::unistd::unlink;
+use nix::unistd::{ftruncate, unlink};
+use std::fs::File;
 use std::ffi::CString;
-use std::os::fd::BorrowedFd;
+use std::io::Write;
+use std::os::fd::{BorrowedFd, RawFd};
 
 const DISK_CACHE_KEY: &str = "DYN_KVBM_DISK_CACHE_DIR";
 const DEFAULT_DISK_CACHE_DIR: &str = "/tmp/";
+const DISK_ZEROFILL_FALLBACK_KEY: &str = "DYN_KVBM_DISK_ZEROFILL_FALLBACK";
+const ZERO_BUF_SIZE: usize = 16 * 1024 * 1024;
+const PAGE_SIZE: usize = 4096;
+type Align4096 = ConstAlign<4096>;
+
+fn env_truthy(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+fn create_aligned_buffer(size: usize) -> anyhow::Result<AVec<u8, Align4096>> {
+    let aligned_size = size.div_ceil(PAGE_SIZE) * PAGE_SIZE;
+    let mut buf = AVec::<u8, Align4096>::new(PAGE_SIZE);
+    buf.resize(aligned_size, 0u8);
+    Ok(buf)
+}
+
+fn allocate_file(fd: RawFd, size: u64) -> anyhow::Result<()> {
+    let borrowed_fd = unsafe { BorrowedFd::borrow_raw(fd) };
+    match fallocate(borrowed_fd, FallocateFlags::empty(), 0, size as i64) {
+        Ok(_) => Ok(()),
+        Err(err) => match err {
+            nix::errno::Errno::EOPNOTSUPP => {
+                if env_truthy(DISK_ZEROFILL_FALLBACK_KEY) {
+                    tracing::warn!(
+                        "fallocate() not supported; using zero-fill fallback via {}",
+                        DISK_ZEROFILL_FALLBACK_KEY
+                    );
+                    let buf = create_aligned_buffer(ZERO_BUF_SIZE)?;
+                    let dup_fd = nix::unistd::dup(borrowed_fd)?;
+                    let mut file = File::from(dup_fd);
+                    let mut written: u64 = 0;
+                    while written < size {
+                        let remaining = size - written;
+                        let to_write = if remaining >= buf.len() as u64 {
+                            buf.len()
+                        } else {
+                            let aligned = (remaining as usize).div_ceil(PAGE_SIZE) * PAGE_SIZE;
+                            std::cmp::min(aligned, buf.len())
+                        };
+                        match file.write(&buf[..to_write]) {
+                            Ok(n) if n == to_write => written += n as u64,
+                            Ok(n) => anyhow::bail!(
+                                "Partial zero-fill write: expected {} bytes, wrote {}",
+                                to_write,
+                                n
+                            ),
+                            Err(e) if e.raw_os_error() == Some(22) => {
+                                anyhow::bail!(
+                                    "Zero-fill write failed with EINVAL while using O_DIRECT. Original error: {}",
+                                    e
+                                )
+                            }
+                            Err(e) => anyhow::bail!("Zero-fill write failed: {}", e),
+                        }
+                    }
+                    file.flush()?;
+                    if written > size {
+                        ftruncate(borrowed_fd, size as i64)?;
+                    }
+                    Ok(())
+                } else {
+                    tracing::warn!(
+                        "fallocate() not supported; using truncate fallback. Set {}=true for zero-fill fallback.",
+                        DISK_ZEROFILL_FALLBACK_KEY
+                    );
+                    ftruncate(borrowed_fd, size as i64)?;
+                    Ok(())
+                }
+            }
+            _ => Err(err.into()),
+        },
+    }
+}
 
 /// Disk-backed storage using memory-mapped files with O_DIRECT support.
 #[derive(Debug)]
@@ -126,18 +204,9 @@ impl DiskStorage {
             (fd, file_path)
         };
 
-        // We need to use fallocate to actually allocate the storage and create the blocks on disk.
-        unsafe {
-            fallocate(
-                BorrowedFd::borrow_raw(raw_fd),
-                FallocateFlags::empty(),
-                0,
-                len as i64,
-            )
-            .map_err(|e| {
-                StorageError::AllocationFailed(format!("Failed to allocate temp file: {}", e))
-            })?
-        };
+        allocate_file(raw_fd, len as u64).map_err(|e| {
+            StorageError::AllocationFailed(format!("Failed to allocate temp file: {}", e))
+        })?;
 
         Ok(Self {
             fd: raw_fd as u64,


### PR DESCRIPTION
#### Overview:

  Ports the two P0 KVBM follow-up fixes on top of PR #8014: one for G3->G2 staging stability under concurrency, and one for disk-backed KVBM initialization on filesystems where
  fallocate() is unsupported.

  #### Details:

  - Chunk G3->G2 staging transfers into fixed-size requests and process them sequentially to avoid overflowing background NIXL/CUDA notification channels under concurrent staging.
  - Increase background notification channel capacity from a hardcoded 64 to a tunable value via KVBM_NOTIFICATION_CHANNEL_CAPACITY with a safer default of 1024.
  - Add a disk allocation fallback path for filesystems that return EOPNOTSUPP for fallocate().
  - Keep O_DIRECT enforced, but allow an optional zero-fill fallback via DYN_KVBM_DISK_ZEROFILL_FALLBACK.
  - Fix the FD handling in the zero-fill path by borrowing the original FD and writing through a duplicated handle.
  - Honor DYN_KVBM_DISK_CACHE_DIR when creating G3 backing files instead of hardcoding /tmp.

  #### Where should the reviewer start?

  - lib/kvbm-engine/src/leader/session/staging.rs
  - lib/kvbm-physical/src/transfer/context.rs
  - lib/memory/src/disk.rs
  - lib/kvbm-connector/src/connector/worker/init/pending.rs


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
