### PR TITLE
test: stabilize nightly — skip engine-init failures, convert xfails to skips, fix http URL validation regression

### DIFF
--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -40,7 +40,7 @@ pytestmark = [
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
     pytest.mark.nightly,
     pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True),
-    pytest.mark.xfail(reason="Cancellation is temporarily disabled", strict=True),
+    pytest.mark.skip(reason="Cancellation is temporarily disabled"),
 ]
 
 
@@ -473,7 +473,7 @@ def test_request_cancellation_trtllm_prefill_cancel(
                 )
 
 
-@pytest.mark.xfail(reason="Test fails only on CI", strict=False)
+@pytest.mark.skip(reason="Test fails only on CI")
 @pytest.mark.timeout(195)  # 3x average
 def test_request_cancellation_trtllm_kv_transfer_cancel(
     request, runtime_services_dynamic_ports, predownload_models

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -396,6 +396,7 @@ def test_request_cancellation_vllm_decode_cancel(
                 )
 
 
+@pytest.mark.skip(reason="Nightly CI failure: TODO(<LINEAR-ID>)")
 @pytest.mark.timeout(150)  # 3x average
 @pytest.mark.nightly
 @pytest.mark.gpu_2

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -396,7 +396,7 @@ def test_request_cancellation_vllm_decode_cancel(
                 )
 
 
-@pytest.mark.skip(reason="Nightly CI failure: TODO(<LINEAR-ID>)")
+@pytest.mark.skip(reason="Nightly CI failure: OPS-4448")
 @pytest.mark.timeout(150)  # 3x average
 @pytest.mark.nightly
 @pytest.mark.gpu_2

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -235,20 +235,18 @@ def test_request_migration_sglang_aggregated(
         stream: True for streaming, False for non-streaming
     """
 
-    # TODO(<LINEAR-ID>): Flaky on NATS transport — first-token delay routinely
-    # exceeds the 6s threshold in utils.validate_response. Other parameter
-    # combinations (including the TCP variant) are stable.
+    # OPS-4446: first-token delay routinely exceeds the 6s threshold in
+    # utils.validate_response for this parameter combination. Originally only
+    # the NATS variant tripped; once the NATS skip landed, the TCP variant
+    # started failing the same way (now bears the cold-start cost first).
     if (
         migration_limit == 3
         and migration_max_seq_len is None
         and immediate_kill is True
         and request_api == "chat"
         and stream is True
-        and request.getfixturevalue("request_plane") == "nats"
     ):
-        pytest.skip(
-            "Flaky on NATS transport: first-token delay > 6s threshold. OPS-4446"
-        )
+        pytest.skip("Flaky: first-token delay > 6s threshold. OPS-4446")
 
     # Step 1: Start the frontend
     with DynamoFrontendProcess(

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -271,7 +271,7 @@ def test_request_migration_vllm_aggregated(
                 )
 
 
-@pytest.mark.xfail(strict=False, reason="Prefill migration not yet supported")
+@pytest.mark.skip(reason="Prefill migration not yet supported")
 @pytest.mark.timeout(350)  # 3x average
 @pytest.mark.nightly
 def test_request_migration_vllm_prefill(
@@ -346,8 +346,7 @@ def test_request_migration_vllm_prefill(
                     )
 
 
-@pytest.mark.xfail(
-    strict=False,
+@pytest.mark.skip(
     reason=(
         "Migration reuses the same request_id for vLLM, but the prefill worker's "
         "KV cache still holds the request due to delay_free_blocks in disaggregated mode. "
@@ -430,8 +429,7 @@ def test_request_migration_vllm_kv_transfer(
                     )
 
 
-@pytest.mark.xfail(
-    strict=False,
+@pytest.mark.skip(
     reason=(
         "Migration reuses the same request_id for vLLM, but the prefill worker's "
         "KV cache still holds the request due to delay_free_blocks in disaggregated mode. "

--- a/tests/gpu_memory_service/test_quiesce_resume.py
+++ b/tests/gpu_memory_service/test_quiesce_resume.py
@@ -131,6 +131,7 @@ def test_gms_basic_quiesce_resume_sglang(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skip(reason="Nightly CI failure: TODO(<LINEAR-ID>)")
 @pytest.mark.trtllm
 @pytest.mark.e2e
 @pytest.mark.gpu_1
@@ -177,6 +178,7 @@ def test_gms_basic_quiesce_resume_trtllm(
         )
 
 
+@pytest.mark.skip(reason="Nightly CI failure: TODO(<LINEAR-ID>)")
 @pytest.mark.trtllm
 @pytest.mark.e2e
 @pytest.mark.gpu_1

--- a/tests/gpu_memory_service/test_quiesce_resume.py
+++ b/tests/gpu_memory_service/test_quiesce_resume.py
@@ -131,7 +131,7 @@ def test_gms_basic_quiesce_resume_sglang(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skip(reason="Nightly CI failure: TODO(<LINEAR-ID>)")
+@pytest.mark.skip(reason="Nightly CI failure: https://linear.app/nvidia/issue/OPS-4450")
 @pytest.mark.trtllm
 @pytest.mark.e2e
 @pytest.mark.gpu_1
@@ -178,7 +178,7 @@ def test_gms_basic_quiesce_resume_trtllm(
         )
 
 
-@pytest.mark.skip(reason="Nightly CI failure: TODO(<LINEAR-ID>)")
+@pytest.mark.skip(reason="Nightly CI failure: https://linear.app/nvidia/issue/OPS-4450")
 @pytest.mark.trtllm
 @pytest.mark.e2e
 @pytest.mark.gpu_1

--- a/tests/gpu_memory_service/test_shadow_failover.py
+++ b/tests/gpu_memory_service/test_shadow_failover.py
@@ -302,6 +302,7 @@ def _trtllm_quiesce(
     return ws
 
 
+@pytest.mark.skip(reason="Nightly CI failure: TODO(<LINEAR-ID>)")
 @pytest.mark.trtllm
 @pytest.mark.e2e
 @pytest.mark.gpu_1

--- a/tests/gpu_memory_service/test_shadow_failover.py
+++ b/tests/gpu_memory_service/test_shadow_failover.py
@@ -302,7 +302,7 @@ def _trtllm_quiesce(
     return ws
 
 
-@pytest.mark.skip(reason="Nightly CI failure: TODO(<LINEAR-ID>)")
+@pytest.mark.skip(reason="Nightly CI failure: https://linear.app/nvidia/issue/OPS-4450")
 @pytest.mark.trtllm
 @pytest.mark.e2e
 @pytest.mark.gpu_1

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -32,7 +32,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 marks=[
                     pytest.mark.skip(
                         reason="vLLM engine core init fails on disagg e_pd. "
-                        "TODO(<LINEAR-ID>)"
+                        "https://linear.app/nvidia/issue/OPS-4445"
                     ),
                     pytest.mark.pre_merge,
                 ],
@@ -43,7 +43,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 marks=[
                     pytest.mark.skip(
                         reason="vLLM engine core init fails on disagg epd. "
-                        "TODO(<LINEAR-ID>)"
+                        "https://linear.app/nvidia/issue/OPS-4445"
                     ),
                     pytest.mark.pre_merge,
                 ],
@@ -71,7 +71,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 marks=[
                     pytest.mark.skip(
                         reason="vLLM engine core init fails on disagg epd. "
-                        "TODO(<LINEAR-ID>)"
+                        "https://linear.app/nvidia/issue/OPS-4445"
                     ),
                     pytest.mark.pre_merge,
                 ],

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -29,12 +29,24 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 profiled_vram_gib=9.6,
             ),
             "e_pd": TopologyConfig(
-                marks=[pytest.mark.pre_merge],
+                marks=[
+                    pytest.mark.skip(
+                        reason="vLLM engine core init fails on disagg e_pd. "
+                        "TODO(<LINEAR-ID>)"
+                    ),
+                    pytest.mark.pre_merge,
+                ],
                 timeout_s=340,
                 single_gpu=True,
             ),
             "epd": TopologyConfig(
-                marks=[pytest.mark.pre_merge],
+                marks=[
+                    pytest.mark.skip(
+                        reason="vLLM engine core init fails on disagg epd. "
+                        "TODO(<LINEAR-ID>)"
+                    ),
+                    pytest.mark.pre_merge,
+                ],
                 timeout_s=300,
                 single_gpu=True,
             ),
@@ -56,7 +68,13 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 delayed_start=60,
             ),
             "epd": TopologyConfig(
-                marks=[pytest.mark.pre_merge],
+                marks=[
+                    pytest.mark.skip(
+                        reason="vLLM engine core init fails on disagg epd. "
+                        "TODO(<LINEAR-ID>)"
+                    ),
+                    pytest.mark.pre_merge,
+                ],
                 timeout_s=600,
                 delayed_start=60,
                 single_gpu=True,

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -138,6 +138,7 @@ trtllm_configs = {
         directory=trtllm_dir,
         script_name="disagg_same_gpu.sh",
         marks=[
+            pytest.mark.skip(reason="Nightly CI failure: TODO(<LINEAR-ID>)"),
             pytest.mark.gpu_1,  # 1 GPU(s) used, peak 6.6 GiB
             pytest.mark.pre_merge,
             pytest.mark.trtllm,

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -138,7 +138,9 @@ trtllm_configs = {
         directory=trtllm_dir,
         script_name="disagg_same_gpu.sh",
         marks=[
-            pytest.mark.skip(reason="Nightly CI failure: https://linear.app/nvidia/issue/OPS-4450"),
+            pytest.mark.skip(
+                reason="Nightly CI failure: https://linear.app/nvidia/issue/OPS-4450"
+            ),
             pytest.mark.gpu_1,  # 1 GPU(s) used, peak 6.6 GiB
             pytest.mark.pre_merge,
             pytest.mark.trtllm,

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -138,7 +138,7 @@ trtllm_configs = {
         directory=trtllm_dir,
         script_name="disagg_same_gpu.sh",
         marks=[
-            pytest.mark.skip(reason="Nightly CI failure: TODO(<LINEAR-ID>)"),
+            pytest.mark.skip(reason="Nightly CI failure: https://linear.app/nvidia/issue/OPS-4450"),
             pytest.mark.gpu_1,  # 1 GPU(s) used, peak 6.6 GiB
             pytest.mark.pre_merge,
             pytest.mark.trtllm,

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -422,6 +422,7 @@ vllm_configs = {
         ],
         model="llava-hf/llava-1.5-7b-hf",
         script_args=["--model", "llava-hf/llava-1.5-7b-hf"],
+        env={"DYN_MM_ALLOW_INTERNAL": "1"},
         delayed_start=0,
         timeout=360,
         request_payloads=[
@@ -471,6 +472,7 @@ vllm_configs = {
             "--dyn-tool-call-parser",
             "hermes",
         ],
+        env={"DYN_MM_ALLOW_INTERNAL": "1"},
         delayed_start=0,
         timeout=600,
         request_payloads=[


### PR DESCRIPTION
## Summary

A bundle of nightly-stabilisation changes for the vLLM and SGLang pipelines. Five distinct concerns, each commit-scoped; none overlap.

### 1. Skip flaky/broken engine-init and cancellation tests

**`test_request_cancellation_vllm_prefill_cancel`** in `tests/fault_tolerance/cancellation/test_vllm.py` — commit `712761e1f4`

Both `[nats]` and `[tcp]` parametrizations have failed in every nightly `vllm-pipeline / Multi-gpu test cuda12.9` run on main for the last 8 nights (16/16 failures). The vLLM engine dies with `EngineDeadError` when cancelling mid-prefill, so the expected `Aborted Prefill Request ID:` log line is never emitted and the 500 ms poll budget expires. Same class of bug as the twin `test_request_cancellation_vllm_decode_cancel` already skipped under **DYN-2606** in #8006. Tracked under **OPS-4448** (@kthui).

Example failing nightlies: [24713014658](https://github.com/ai-dynamo/dynamo/actions/runs/24713014658/job/72349014641), 24657547996, 24624817902, 24600680008, 24587232619, 24556217800, 24500822470, 24445034832.

**`test_serve_deployment[mm_{e_pd,epd}_qwen3-vl-2b]` + `[mm_epd_qwen3-vl-2b-video]`** in `tests/serve/multimodal_profiles/vllm.py` — commits `32ce9e998e` + `e4e89963ef`

All three have failed in every nightly `vllm-pipeline / Test cuda12.9 (amd64)` run for the last 7+ nights. Error signature: `RuntimeError: Engine core initialization failed` (`vllm/v1/engine/utils.py:1057 wait_for_engine_startup`) — same family as the Qwen2-Audio case skipped in #8411. Only the `e_pd`/`epd` disagg topologies fail; the sibling `agg` and `p_d` topologies pass, so this is specific to `disagg_multimodal_e_pd.sh` / `disagg_multimodal_epd.sh`. Tracked under **OPS-4445**.

Example failing nightlies: [24713014658](https://github.com/ai-dynamo/dynamo/actions/runs/24713014658/job/72349014718), 24657547996, 24624817902, 24600680008, 24587232619, 24556217800, 24500822470, 24445034832.

### 2. Convert vllm migration xfails → skips

In `tests/fault_tolerance/migration/test_vllm.py` — commit `c1cc2fa45d`

Three tests have function-level `@pytest.mark.xfail(strict=False, ...)` for known architectural limitations:
- `test_request_migration_vllm_prefill` — prefill migration unsupported
- `test_request_migration_vllm_kv_transfer` — request_id reuse + delay_free_blocks KV cache issue
- `test_request_migration_vllm_decode` — same request_id / KV cache issue

Last 7 nightly vllm multi-gpu runs: **144 XFAIL, 0 XPASS**, 216 SKIPPED. Every non-skipped parameterisation fails exactly as the xfail reasons predict. Running them anyway still incurs per-param GPU setup cost. Converting to `@pytest.mark.skip` with the same reason strings — no functional change (no XPASS means nothing silently-passing is being masked), just stops wasting GPU time and cleans up the report.

### 3. Fix http:// URL validation regression (NOT a skip — real fix)

In `tests/serve/test_vllm.py` — commit `d634588d6d`

Today's nightly flagged two **new** failures:
- `test_serve_deployment[multimodal_agg_llava]`
- `test_serve_deployment[aggregated_toolcalling]`

Both error with:
```
Exception: Failed to load image from http://...:
  http:// URLs are not allowed; set DYN_MM_ALLOW_INTERNAL=1 to enable
```

The strict URL validator landed in #8282 (2026-04-20) correctly plumbed `DYN_MM_ALLOW_INTERNAL=1` through the factory for `VLLM_MULTIMODAL_PROFILES`-generated configs (`tests/utils/multimodal.py::make_multimodal_configs`), but missed these two hand-authored `VLLMConfig` entries that still use http:// URLs (cocodataset HTTP image for llava, localhost:8806 fixture server for toolcalling). Adds the same env var on both configs.

### 4. Extend sglang migration skip to TCP transport (OPS-4446)

In `tests/fault_tolerance/migration/test_sglang.py` — commit `b3ac5ce25e`

#8404 skipped only the `[nats]` variant of
`test_request_migration_sglang_aggregated[migration_enabled-max_seq_len_disabled-worker_failure-chat-stream-*]`
because the TCP sibling was stable at the time. From the very first post-merge run after #8404 landed, the `[tcp]` variant began failing with the identical symptom (`AssertionError: Delay before response > 6 secs, got ~13 secs` at `utils.py:417`) in every run: 24733651809, 24733908729, 24734216001, 24735128282, and onwards.

Cause is test-ordering: when NATS ran first it warmed the path; with NATS skipped, TCP now pays the cold-start cost itself. Dropping the `request_plane == "nats"` clause so both transports skip under the same OPS-4446 ticket. Also replaces the stale `TODO(<LINEAR-ID>)` comment left over from #8404 with the OPS-4446 reference that the skip reason string already uses.

### 5. Skip persistent TRTLLM nightly failures + convert cancellation xfails to skips

In `tests/fault_tolerance/cancellation/test_trtllm.py`, `tests/gpu_memory_service/test_quiesce_resume.py`, `tests/gpu_memory_service/test_shadow_failover.py`, and `tests/serve/test_trtllm.py` — commits `2dabd67f33` + `8084d1bf70`

**Convert xfails → skips (same pattern as section 2).** Module-level `@pytest.mark.xfail(strict=True, "Cancellation is temporarily disabled")` and function-level `@pytest.mark.xfail(strict=False, "Test fails only on CI")` on `test_request_cancellation_trtllm_kv_transfer_cancel` produced 7/7 XFAIL and 0 XPASS across recent nightlies. Switched to `@pytest.mark.skip` with the same reason text.

**Skip 4 persistent failures.** All four have failed in the last 6+/7 nightly amd64 runs:

- `test_gms_basic_quiesce_resume_trtllm`
- `test_gms_read_only_import_trtllm`
- `test_gms_shadow_engine_failover_trtllm`
- `test_deployment[disaggregated_same_gpu-2]`

GMS tests fail with `AssertionError: assert 'error' == 'ok'` (quiesce/resume/shadow ops returning `'error'`); the disagg_same_gpu serve test fails with `RuntimeError: Main server process exited with code 1 while waiting for health check` and `RuntimeError: Executor worker returned error`. Likely share a common trtllm-executor root cause. Tracked under **OPS-4450**.

## Linear tickets

| Skip | Ticket | Owner |
|---|---|---|
| vllm prefill_cancel | OPS-4448 | @kthui |
| qwen3-vl-2b disagg (e_pd, epd image, epd video) | OPS-4445 | @furionw |
| sglang migration (nats + tcp) | OPS-4446 | — |
| vllm migration xfail→skip | n/a — skips preserve existing architectural-limitation reasons | — |
| TRTLLM nightly (GMS + disagg_same_gpu) | OPS-4450 | — |
| http URL regression | n/a — real fix, not a skip | FYI @zhongdaor-nv (author of #8282) |

## Files

```
tests/fault_tolerance/cancellation/test_trtllm.py |  4 ++--
tests/fault_tolerance/cancellation/test_vllm.py   |  1 +
tests/fault_tolerance/migration/test_sglang.py    | 12 +++++-------
tests/fault_tolerance/migration/test_vllm.py      |  8 +++-----
tests/gpu_memory_service/test_quiesce_resume.py   |  2 ++
tests/gpu_memory_service/test_shadow_failover.py  |  1 +
tests/serve/multimodal_profiles/vllm.py           | 24 +++++++++++++++++++++---
tests/serve/test_trtllm.py                        |  1 +
tests/serve/test_vllm.py                          |  2 ++
```

## Test plan
- [x] All `<LINEAR-ID>` placeholders replaced
- [ ] Next nightly `vllm-pipeline` jobs (Multi-gpu + amd64) pass with the skips and env fixes applied
- [ ] Next post-merge `sglang-amd64` job no longer fails on the tcp variant of the migration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
