### PR TITLE
feat(trtllm): plumb GMS patch into MPI worker processes

### DIFF
--- a/components/src/dynamo/trtllm/tests/test_trtllm_autotuner_gate.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_autotuner_gate.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the GMS+TP>1 autotuner-disable gate in llm_worker.
+
+The gate must read effective TP from the merged ``arg_map`` (post
+extra_engine_args / override_engine_args merge), not from the CLI default,
+because production DGDs commonly set TP only via the JSON/YAML surfaces.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# Import the pure helper directly. It has no tensorrt_llm side effects of its
+# own, but llm_worker.py imports tensorrt_llm at module scope, so skip cleanly
+# if the stack is absent.
+tensorrt_llm = pytest.importorskip("tensorrt_llm")
+
+from dynamo.trtllm.workers.llm_worker import _apply_autotuner_gate  # noqa: E402
+
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.pre_merge,
+]
+
+
+def test_gate_fires_when_tp_set_via_extra_engine_args():
+    """DGD pattern: CLI TP=1, extra_engine_args overrides to TP=8."""
+    arg_map = {"tensor_parallel_size": 8}
+
+    _apply_autotuner_gate(arg_map, load_format="gms")
+
+    assert arg_map["enable_autotuner"] is False
+
+
+def test_gate_fires_at_tp2():
+    arg_map = {"tensor_parallel_size": 2}
+
+    _apply_autotuner_gate(arg_map, load_format="gms")
+
+    assert arg_map["enable_autotuner"] is False
+
+
+def test_gate_does_not_fire_at_tp1():
+    arg_map = {"tensor_parallel_size": 1}
+
+    _apply_autotuner_gate(arg_map, load_format="gms")
+
+    assert "enable_autotuner" not in arg_map
+
+
+def test_gate_does_not_fire_without_gms():
+    arg_map = {"tensor_parallel_size": 8}
+
+    _apply_autotuner_gate(arg_map, load_format="auto")
+
+    assert "enable_autotuner" not in arg_map
+
+
+def test_gate_preserves_user_enable_autotuner_when_not_firing():
+    arg_map = {"tensor_parallel_size": 1, "enable_autotuner": True}
+
+    _apply_autotuner_gate(arg_map, load_format="gms")
+
+    assert arg_map["enable_autotuner"] is True
+
+
+def test_gate_defaults_to_tp1_when_missing():
+    """tensor_parallel_size may be absent if neither CLI nor overrides set it."""
+    arg_map: dict = {}
+
+    _apply_autotuner_gate(arg_map, load_format="gms")
+
+    assert "enable_autotuner" not in arg_map

--- a/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the GMS MPI-worker bootstrap patch.
+
+Exercises the Dynamo-side monkey-patch that propagates setup_gms() into
+TensorRT-LLM's mpi4py.futures.MPIPoolExecutor child processes. Uses sys.modules
+stubs so the test runs without tensorrt_llm, mpi4py, or CUDA.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.pre_merge,
+]
+
+
+@pytest.fixture
+def stubbed_env(monkeypatch):
+    """Stub tensorrt_llm.llmapi.mpi_session and mpi4py.futures before importing bootstrap."""
+    captured_kwargs: dict = {}
+
+    class FakeMPIPoolExecutor:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    class FakeMpiPoolSession:
+        def __init__(self, n_workers: int):
+            self.n_workers = n_workers
+            self.mpi_pool = None
+
+    mpi4py_module = types.ModuleType("mpi4py")
+    mpi4py_futures_module = types.ModuleType("mpi4py.futures")
+    mpi4py_futures_module.MPIPoolExecutor = FakeMPIPoolExecutor
+    mpi4py_module.futures = mpi4py_futures_module
+
+    trtllm_module = types.ModuleType("tensorrt_llm")
+    trtllm_llmapi_module = types.ModuleType("tensorrt_llm.llmapi")
+    trtllm_mpi_session_module = types.ModuleType("tensorrt_llm.llmapi.mpi_session")
+    trtllm_mpi_session_module.MpiPoolSession = FakeMpiPoolSession
+    trtllm_module.llmapi = trtllm_llmapi_module
+    trtllm_llmapi_module.mpi_session = trtllm_mpi_session_module
+
+    monkeypatch.setitem(sys.modules, "mpi4py", mpi4py_module)
+    monkeypatch.setitem(sys.modules, "mpi4py.futures", mpi4py_futures_module)
+    monkeypatch.setitem(sys.modules, "tensorrt_llm", trtllm_module)
+    monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", trtllm_llmapi_module)
+    monkeypatch.setitem(
+        sys.modules, "tensorrt_llm.llmapi.mpi_session", trtllm_mpi_session_module
+    )
+
+    # Force re-import so install_mpi_worker_bootstrap rebinds the stub's class.
+    sys.modules.pop("gpu_memory_service.integrations.trtllm.mpi_bootstrap", None)
+    bootstrap = importlib.import_module(
+        "gpu_memory_service.integrations.trtllm.mpi_bootstrap"
+    )
+    bootstrap._bootstrap_installed = False
+    bootstrap._extra_config_json = None
+
+    yield {
+        "bootstrap": bootstrap,
+        "FakeMpiPoolSession": FakeMpiPoolSession,
+        "captured_kwargs": captured_kwargs,
+    }
+
+
+def test_install_patches_mpi_pool_session_start_method(stubbed_env):
+    bootstrap = stubbed_env["bootstrap"]
+    FakeMpiPoolSession = stubbed_env["FakeMpiPoolSession"]
+    original = FakeMpiPoolSession._start_mpi_pool if hasattr(
+        FakeMpiPoolSession, "_start_mpi_pool"
+    ) else None
+
+    bootstrap.install_mpi_worker_bootstrap()
+
+    patched = FakeMpiPoolSession._start_mpi_pool
+    assert patched is not original
+    assert callable(patched)
+
+
+def test_install_is_idempotent(stubbed_env):
+    bootstrap = stubbed_env["bootstrap"]
+    FakeMpiPoolSession = stubbed_env["FakeMpiPoolSession"]
+
+    bootstrap.install_mpi_worker_bootstrap()
+    first = FakeMpiPoolSession._start_mpi_pool
+
+    bootstrap.install_mpi_worker_bootstrap()
+    assert FakeMpiPoolSession._start_mpi_pool is first
+
+
+def test_start_mpi_pool_injects_initializer_and_extra_config(
+    stubbed_env, monkeypatch
+):
+    bootstrap = stubbed_env["bootstrap"]
+    FakeMpiPoolSession = stubbed_env["FakeMpiPoolSession"]
+    captured_kwargs = stubbed_env["captured_kwargs"]
+
+    monkeypatch.setenv("DYN_GMS_TRTLLM_ENABLED", "1")
+    monkeypatch.setenv("DYN_GMS_SHADOW_MODE", "1")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("TRTLLM_FOO", "bar")
+    monkeypatch.setenv("TLLM_BAZ", "qux")
+
+    bootstrap.set_extra_config({"gms_read_only": True})
+    bootstrap.install_mpi_worker_bootstrap()
+
+    session = FakeMpiPoolSession(n_workers=4)
+    session._start_mpi_pool()
+
+    assert captured_kwargs["max_workers"] == 4
+    assert captured_kwargs["initializer"] is bootstrap.worker_init_hook
+    env_snapshot, extra_config_json = captured_kwargs["initargs"]
+    assert env_snapshot == {
+        "DYN_GMS_TRTLLM_ENABLED": "1",
+        "DYN_GMS_SHADOW_MODE": "1",
+        "ENGINE_ID": "1",
+    }
+    assert extra_config_json == '{"gms_read_only": true}'
+    # TRTLLM_* / TLLM_* vars plus propagated env must flow through executor env=.
+    assert captured_kwargs["env"]["TRTLLM_FOO"] == "bar"
+    assert captured_kwargs["env"]["TLLM_BAZ"] == "qux"
+    assert captured_kwargs["env"]["DYN_GMS_TRTLLM_ENABLED"] == "1"
+
+
+def test_worker_init_hook_restores_env_and_calls_setup_gms(
+    stubbed_env, monkeypatch
+):
+    bootstrap = stubbed_env["bootstrap"]
+
+    # Child environment starts without the propagated vars — simulates fresh interpreter.
+    for key in (
+        "DYN_GMS_TRTLLM_ENABLED",
+        "DYN_GMS_SHADOW_MODE",
+        "ENGINE_ID",
+        "GMS_SOCKET_DIR",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    fake_setup_gms = MagicMock()
+    fake_trtllm_pkg = types.ModuleType("gpu_memory_service.integrations.trtllm")
+    fake_trtllm_pkg.setup_gms = fake_setup_gms
+    monkeypatch.setitem(
+        sys.modules, "gpu_memory_service.integrations.trtllm", fake_trtllm_pkg
+    )
+
+    env_snapshot = {
+        "DYN_GMS_TRTLLM_ENABLED": "1",
+        "DYN_GMS_SHADOW_MODE": "1",
+        "ENGINE_ID": "3",
+    }
+    bootstrap.worker_init_hook(env_snapshot, '{"gms_read_only": true}')
+
+    import os
+
+    assert os.environ["ENGINE_ID"] == "3"
+    assert os.environ["DYN_GMS_SHADOW_MODE"] == "1"
+    fake_setup_gms.assert_called_once_with({"gms_read_only": True})
+
+
+def test_worker_init_hook_no_op_when_gms_disabled(stubbed_env, monkeypatch):
+    bootstrap = stubbed_env["bootstrap"]
+
+    monkeypatch.delenv("DYN_GMS_TRTLLM_ENABLED", raising=False)
+    fake_setup_gms = MagicMock()
+    fake_trtllm_pkg = types.ModuleType("gpu_memory_service.integrations.trtllm")
+    fake_trtllm_pkg.setup_gms = fake_setup_gms
+    monkeypatch.setitem(
+        sys.modules, "gpu_memory_service.integrations.trtllm", fake_trtllm_pkg
+    )
+
+    bootstrap.worker_init_hook({"ENGINE_ID": "1"}, None)
+
+    fake_setup_gms.assert_not_called()
+
+
+def test_worker_init_hook_is_picklable():
+    """mpi4py.futures requires the initializer to be picklable-by-reference."""
+    import pickle
+
+    from gpu_memory_service.integrations.trtllm.mpi_bootstrap import (
+        worker_init_hook,
+    )
+
+    # Function imported by module path; pickle roundtrip resolves back to the same object.
+    assert pickle.loads(pickle.dumps(worker_init_hook)) is worker_init_hook

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -100,6 +100,32 @@ def _warn_override_collisions(target: dict, source: dict, path: str = "") -> Non
                 )
 
 
+def _apply_autotuner_gate(arg_map: dict, load_format: str) -> None:
+    """Disable TRT-LLM autotuner when GMS is active at TP>1.
+
+    At TP>1, TRT-LLM's autotuner warmup routes torch allocations through the
+    virtual_memory pluggable allocator while GMS's pluggable allocator also
+    owns the weights pool. The two collide during tunable_allreduce /
+    flashinfer_rmsnorm, producing an illegal-memory-access (tail lands in
+    KVCacheTransferManager dtor). See trtllm-tp2-kvtransfer-crash.md.
+
+    Reads effective TP from ``arg_map`` (post-merge of extra/override
+    engine args) because production DGDs commonly set TP only via those
+    JSON/YAML surfaces and leave the CLI default at 1.
+    """
+    if load_format != "gms":
+        return
+    effective_tp = arg_map.get("tensor_parallel_size", 1)
+    if effective_tp <= 1:
+        return
+    logging.warning(
+        "[GMS] Disabling autotuner for TP=%d GMS run — dual-pluggable-allocator "
+        "crash workaround (see trtllm-tp2-kvtransfer-crash.md).",
+        effective_tp,
+    )
+    arg_map["enable_autotuner"] = False
+
+
 def _parse_model_loader_extra_config(raw: object) -> dict[str, object]:
     """Parse --model-loader-extra-config into a dict. Accepts a dict or a JSON string."""
     if raw is None or raw == "":
@@ -262,18 +288,6 @@ async def init_llm_worker(
 
         arg_map["sleep_config"] = SleepConfig()
 
-        # At TP>1, TRT-LLM's autotuner warmup runs inside an allocation_scope
-        # that routes torch allocations through the virtual_memory pluggable
-        # allocator. The same process also hosts the GMS pluggable allocator
-        # for weights. The two allocators collide during the first autotuned
-        # allreduce (tunable_allreduce + flashinfer_rmsnorm), producing an
-        # illegal-memory-access whose tail is a KVCacheTransferManager dtor
-        # crash. Disabling the autotuner skips that warmup forward pass; the
-        # fallback allreduce path is correct. Verified on Qwen3-0.6B TP=2
-        # with GMS RW on branch schwinns/trtllm-gms-mpi-workers (B200).
-        if config.tensor_parallel_size > 1:
-            arg_map["enable_autotuner"] = False
-
     # Add guided decoding backend if specified
     if config.guided_decoding_backend is not None:
         arg_map["guided_decoding_backend"] = config.guided_decoding_backend
@@ -297,6 +311,8 @@ async def init_llm_worker(
         except json.JSONDecodeError as e:
             logging.error(f"Failed to parse override_engine_args as JSON: {e}")
             sys.exit(1)
+
+    _apply_autotuner_gate(arg_map, config.load_format)
 
     if config.publish_events_and_metrics:
         # 'event_buffer_max_size' is required to enable TRTLLM to publish kv cache events.

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -262,6 +262,18 @@ async def init_llm_worker(
 
         arg_map["sleep_config"] = SleepConfig()
 
+        # At TP>1, TRT-LLM's autotuner warmup runs inside an allocation_scope
+        # that routes torch allocations through the virtual_memory pluggable
+        # allocator. The same process also hosts the GMS pluggable allocator
+        # for weights. The two allocators collide during the first autotuned
+        # allreduce (tunable_allreduce + flashinfer_rmsnorm), producing an
+        # illegal-memory-access whose tail is a KVCacheTransferManager dtor
+        # crash. Disabling the autotuner skips that warmup forward pass; the
+        # fallback allreduce path is correct. Verified on Qwen3-0.6B TP=2
+        # with GMS RW on branch schwinns/trtllm-gms-mpi-workers (B200).
+        if config.tensor_parallel_size > 1:
+            arg_map["enable_autotuner"] = False
+
     # Add guided decoding backend if specified
     if config.guided_decoding_backend is not None:
         arg_map["guided_decoding_backend"] = config.guided_decoding_backend

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -281,12 +281,29 @@ async def init_llm_worker(
     arg_map["load_format"] = engine_load_format
 
     # Enable sleep_config when GMS manages weights — required for GMS
-    # unmap/remap. Conditional because SleepConfig contains unpicklable
-    # lambdas that break MPI-based multi-rank distribution.
+    # unmap/remap. SleepConfig's default restore_modes is a defaultdict whose
+    # default_factory is a lambda defined inside
+    # SleepConfig._make_defaulted_restore_modes; mpi4py cannot pickle local
+    # lambdas, which breaks the TP>1 MPI worker bootstrap. py_executor_creator
+    # later indexes `sleep_config.restore_modes[MODEL_ENGINE_MAIN]` so a plain
+    # dict is not enough — we must keep the defaultdict behaviour but swap the
+    # lambda for a picklable `functools.partial` callable.
     if config.load_format == "gms":
-        from tensorrt_llm.llmapi.llm_args import SleepConfig
+        from collections import defaultdict
+        from functools import partial
 
-        arg_map["sleep_config"] = SleepConfig()
+        from tensorrt_llm._torch.virtual_memory import RestoreMode
+        from tensorrt_llm.llmapi.llm_args import SleepConfig, prefer_pinned
+
+        sleep_config = SleepConfig()
+        default_mode = (
+            RestoreMode.PINNED if prefer_pinned() else RestoreMode.CPU
+        )
+        sleep_config.restore_modes = defaultdict(
+            partial(RestoreMode, default_mode.value),
+            dict(sleep_config.restore_modes),
+        )
+        arg_map["sleep_config"] = sleep_config
 
     # Add guided decoding backend if specified
     if config.guided_decoding_backend is not None:

--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -58,14 +58,21 @@ def _iter_module_tensors(
             qualified = f"{prefix}{name}" if prefix else name
             yield (qualified, buf, "buffer")
 
-    # Other tensor attributes (not params/buffers/submodules)
+    # Other tensor attributes (not params/buffers/submodules).
+    # Skip @property descriptors: their backing storage is already surfaced
+    # elsewhere (e.g. DeepSeekV3MoeRoutingMethod.e_score_correction_bias is a
+    # read-only property wrapping a tensor owned by another module), and
+    # materialize_module_from_gms would fail on setattr() for read-only ones.
     skip = (
         set(module._parameters.keys())
         | set(module._buffers.keys())
         | set(module._modules.keys())
     )
+    module_cls = type(module)
     for attr_name in dir(module):
         if attr_name in skip or attr_name.startswith("__"):
+            continue
+        if isinstance(getattr(module_cls, attr_name, None), property):
             continue
         try:
             attr_val = getattr(module, attr_name, None)

--- a/lib/gpu_memory_service/integrations/trtllm/__init__.py
+++ b/lib/gpu_memory_service/integrations/trtllm/__init__.py
@@ -16,6 +16,7 @@ Usage:
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 from gpu_memory_service.integrations.common import patch_empty_cache
@@ -27,6 +28,10 @@ from gpu_memory_service.integrations.trtllm.model_loader import (
     patch_model_loader,
     set_gms_enabled,
     set_gms_lock_mode,
+)
+from gpu_memory_service.integrations.trtllm.mpi_bootstrap import (
+    install_mpi_worker_bootstrap,
+    set_extra_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -44,5 +49,12 @@ def setup_gms(model_loader_extra_config: dict[str, Any] | None = None) -> None:
 
     patch_empty_cache()
     patch_model_loader()
+
+    # Mark GMS enabled in env so MPI worker children can detect it, and stash the
+    # extra config so they get the same lock mode. Both must happen before the
+    # MPI session bootstrap is installed — the child hook reads them back.
+    os.environ["DYN_GMS_TRTLLM_ENABLED"] = "1"
+    set_extra_config(extra)
+    install_mpi_worker_bootstrap()
 
     logger.info("[GMS] TensorRT-LLM integration enabled (mode=%s)", lock_mode)

--- a/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
+++ b/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Propagate the GMS TensorRT-LLM integration into MPI worker child processes.
+
+At TP>1, TRT-LLM spawns fresh Python interpreters via mpi4py.futures.MPIPoolExecutor
+(see tensorrt_llm/llmapi/mpi_session.py::MpiPoolSession._start_mpi_pool). Those
+children import tensorrt_llm directly and never import the Dynamo worker module,
+so setup_gms() — which monkey-patches ModelLoader.load — only runs in the parent.
+Every child rank then hits the unpatched load path and allocates its own full
+weight shard, duplicating weights between active and shadow engines.
+
+This module fixes that by monkey-patching MpiPoolSession._start_mpi_pool so the
+MPIPoolExecutor is constructed with an ``initializer=worker_init_hook`` that runs
+first in every child. The hook restores the GMS-relevant env vars from the
+parent's snapshot and calls setup_gms() so that the child's own ModelLoader.load
+is patched before TRT-LLM invokes it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_ENABLED_ENV = "DYN_GMS_TRTLLM_ENABLED"
+# Env vars the children must inherit for the child-side setup_gms to behave
+# identically to the parent. Upstream MpiPoolSession only forwards TRTLLM_*/TLLM_*.
+_PROPAGATED_ENV_VARS: tuple[str, ...] = (
+    _ENABLED_ENV,
+    "DYN_GMS_SHADOW_MODE",
+    "ENGINE_ID",
+    "GMS_SOCKET_DIR",
+)
+
+_extra_config_json: Optional[str] = None
+_bootstrap_installed = False
+
+
+def set_extra_config(extra: "dict[str, Any] | None") -> None:
+    """Stash the model_loader_extra_config so MPI children see the same lock mode."""
+    global _extra_config_json
+    _extra_config_json = json.dumps(extra) if extra else None
+
+
+def worker_init_hook(env_snapshot: dict, extra_config_json: Optional[str]) -> None:
+    """Run once per MPI worker child process before any task executes.
+
+    Must be picklable by reference (module-level function).
+    """
+    # Best-effort: try to identify the rank for logging. MPI_COMM_WORLD may not
+    # be initialised yet in some mpi4py builds; swallow the error if so.
+    try:
+        from mpi4py import MPI  # type: ignore[import-not-found]
+
+        rank = MPI.COMM_WORLD.Get_rank()
+    except Exception:
+        rank = -1
+
+    for key, value in env_snapshot.items():
+        os.environ[key] = value
+
+    if os.environ.get(_ENABLED_ENV) != "1":
+        return
+
+    from gpu_memory_service.integrations.trtllm import setup_gms
+
+    extra = json.loads(extra_config_json) if extra_config_json else None
+    setup_gms(extra)
+    logger.info(
+        "[GMS] MPI worker init hook applied (pid=%d rank=%d)", os.getpid(), rank
+    )
+
+
+def install_mpi_worker_bootstrap() -> None:
+    """Monkey-patch MpiPoolSession to run worker_init_hook in every child. Idempotent."""
+    global _bootstrap_installed
+    if _bootstrap_installed:
+        return
+
+    try:
+        import tensorrt_llm.llmapi.mpi_session as _mpi_session
+    except ImportError as exc:
+        raise RuntimeError(
+            "GMS MPI worker bootstrap requires tensorrt_llm to be importable"
+        ) from exc
+
+    MpiPoolSession = _mpi_session.MpiPoolSession
+
+    def _patched_start_mpi_pool(self) -> None:
+        assert not self.mpi_pool, "MPI session already started"
+        from mpi4py.futures import MPIPoolExecutor  # type: ignore[import-not-found]
+
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key.startswith(("TRTLLM", "TLLM"))
+        }
+        env_snapshot = {
+            key: os.environ[key]
+            for key in _PROPAGATED_ENV_VARS
+            if key in os.environ
+        }
+        # Forward propagated vars through MPI's env= too so they're set before
+        # Python starts (some libs cache at import time).
+        env.update(env_snapshot)
+
+        self.mpi_pool = MPIPoolExecutor(
+            max_workers=self.n_workers,
+            path=sys.path,
+            env=env,
+            initializer=worker_init_hook,
+            initargs=(env_snapshot, _extra_config_json),
+        )
+
+    MpiPoolSession._start_mpi_pool = _patched_start_mpi_pool
+    _bootstrap_installed = True
+    logger.info(
+        "[GMS] Patched TensorRT-LLM MpiPoolSession._start_mpi_pool to bootstrap GMS in MPI workers"
+    )

--- a/lib/gpu_memory_service/tests/test_module_property_skip.py
+++ b/lib/gpu_memory_service/tests/test_module_property_skip.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only coverage for `_iter_module_tensors` property-descriptor handling.
+
+MoE routing classes like TRT-LLM's DeepSeekV3MoeRoutingMethod expose a
+read-only `@property` (e.g. `e_score_correction_bias`) that returns a tensor
+fetched from another module. Iterating these via `getattr` surfaces a tensor
+that cannot be `setattr`-assigned later during materialize, crashing the
+shadow-engine RO path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch", reason="torch is required")
+
+from gpu_memory_service.client.torch.module import _iter_module_tensors
+
+
+class _PropertyOnlyModule(torch.nn.Module):
+    """Module whose tensor attribute is a read-only @property."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._backing = torch.arange(4, dtype=torch.float32)
+
+    @property
+    def routing_bias(self) -> torch.Tensor:
+        return self._backing
+
+
+def test_iter_skips_property_descriptor_even_when_raises():
+    class _Raises(torch.nn.Module):
+        @property
+        def boom(self) -> torch.Tensor:
+            raise AttributeError("cannot materialize outside runtime")
+
+    # Must not raise; the property is skipped before getattr runs.
+    assert list(_iter_module_tensors(_Raises())) == []
+
+
+def test_iter_skips_property_returning_cpu_tensor():
+    # CPU tensors are already filtered by is_cuda, but we must not yield
+    # a (name, tensor, "tensor_attr") entry for the property regardless.
+    names = [name for name, _, _ in _iter_module_tensors(_PropertyOnlyModule())]
+    assert "routing_bias" not in names
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_iter_yields_cuda_params_but_not_cuda_property_tensor():
+    class _Mixed(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(4, 2, bias=False, device="cuda")
+            self._backing = torch.ones(2, device="cuda", dtype=torch.float32)
+
+        @property
+        def computed_bias(self) -> torch.Tensor:
+            return self._backing
+
+    names = [name for name, _, _ in _iter_module_tensors(_Mixed())]
+    # Real CUDA parameter under a submodule is still discovered via recursion.
+    assert "linear.weight" in names
+    # The @property is skipped even though it resolves to a CUDA tensor.
+    assert "computed_bias" not in names


### PR DESCRIPTION
# feat(trtllm): plumb GMS patch into MPI worker processes

**Status: draft.** Fix the foundational gap that made TRT-LLM GMS weight sharing a no-op at TP>1, plus the related TP>1 unblockers that surfaced during validation.

## Problem

At TP>1, TRT-LLM spawns fresh Python interpreters via `mpi4py.futures.MPIPoolExecutor` from `MpiPoolSession._start_mpi_pool`. These child processes never import Dynamo, so the Dynamo `ModelLoader.load` monkey-patch — which turns shadow weight loads into VMM handle imports — only ever ran in the parent. Every MPI child rank on a shadow engine allocated its own full weight shard.

On Kimi K2.5 NVFP4 @ TP=8, that meant **73 GiB/GPU of duplicate weights on the shadow engine**, causing it to OOM at `MODEL_ENGINE_MAIN` during startup. Shadow failover at any real scale was blocked on this.

The invariant the shadow design relies on — "GMS serializes weight allocation between active and shadow" — was not being enforced at TP>1.

`TLLM_WORKER_USE_SINGLE_PROCESS=1` only works at TP==1 and so masked the bug on our 8B test path.

## Fix

Monkey-patch `tensorrt_llm.llmapi.mpi_session.MpiPoolSession._start_mpi_pool` in `setup_gms()`. The patched version constructs `MPIPoolExecutor` with `initializer=worker_init_hook, initargs=(env_snapshot, extra_config_json)`. The module-level `worker_init_hook`:

1. Restores the propagated env (`DYN_GMS_TRTLLM_ENABLED`, `DYN_GMS_SHADOW_MODE`, `ENGINE_ID`, GMS socket overrides).
2. Calls `setup_gms()` so every child has its `ModelLoader.load` and `get_rank_model_storage` patched before TRT-LLM ever invokes them.

`worker_init_hook` is module-level and so picklable for `MPIPoolExecutor`.

## Stacked commits

Five commits on this branch, landed in dependency order:

| SHA | Summary |
|---|---|
| `d2748fdf23b` | **feat(trtllm): plumb GMS patch into MPI worker processes** — the core fix described above. |
| `6bfbbbc714a` | **fix(trtllm): disable autotuner on GMS+TP>1 to avoid dual-pluggable-allocator crash** — TP>1 exposes a second failure: TRT-LLM's autotuner installs its own `CUDAPluggableAllocator` (backing `CudaVirtualMemoryAllocator`) while GMS also has a `CUDAPluggableAllocator` live for the `weights` pool. A kernel launched in one allocator's scope reading tensors from the other hits `cudaErrorIllegalAddress` during warmup (loudest offender: `tunable_allreduce` at TP>1). Band-aid is to disable the autotuner whenever `load_format=gms && TP>1`. |
| `6aca4753b10` | **fix(gms): skip property descriptors when iterating module tensors** — `_iter_module_tensors` trips on class-level `@property` descriptors on MoE routing modules (concrete offender: `DeepSeekV3MoeRoutingMethod.e_score_correction_bias`). Surfaces on shadow materialize, not on normal load. |
| `14133db078a` | **fix(trtllm): read TP from merged arg_map before disabling autotuner** — initial autotune gate read `config.tensor_parallel_size` (Dynamo CLI field), which stays at 1 when TP is set via `extra_engine_args` / backend YAML (the production path). The gate now reads `arg_map.get("tensor_parallel_size", ...)` after `update_llm_args_with_extra_options` has merged the override, so it actually fires for Kimi / DeepSeek-V3 / any DGD specifying TP via engine args. |
| `405b56b2592` | **fix(trtllm): make SleepConfig picklable for TP>1 MPI dispatch** — `SleepConfig()`'s default `restore_modes` is a `defaultdict` whose `default_factory` is a lambda defined inside `SleepConfig._make_defaulted_restore_modes`; `mpi4py` cannot pickle local lambdas, so without this fix the MPI executor init at TP>1 fails with `Can't pickle local object 'SleepConfig._make_defaulted_restore_modes.<locals>.<lambda>'`. A downstream `py_executor_creator::allocation_scope` indexes `sleep_config.restore_modes[MODEL_ENGINE_MAIN]` and relies on the default-factory on miss, so replacing the `defaultdict` with a plain `dict` would break it with `KeyError`. Fix preserves the `defaultdict` behaviour but swaps the lambda for a picklable `functools.partial(RestoreMode, default_mode.value)`. Without this commit the TP=1 path only works if `TLLM_WORKER_USE_SINGLE_PROCESS=1` is set manually, and TP>1 crashes outright; the fork-validator found this during TP=2 bring-up. |

## Validation on nscale B200

TP=2 Qwen3-0.6B, `--load-format gms`, no failover:

```
parent: [GMS] Patched TensorRT-LLM MpiPoolSession._start_mpi_pool
children (x2): [GMS] MPI worker init hook applied (pid=..., rank=0/1)
children (x2): [GMS] Patched TensorRT-LLM ModelLoader.load
children (x2): [GMS] TRT-LLM RW: published 0.60 GiB
0 occurrences of "Use X.XX GB for model weights"   ← upstream unpatched path never fires
```

~41s from `kubectl apply` to both children published.

## Autotuner-disable perf cost

Measured on Qwen3-8B bs=16: **22.2% throughput regression** with `enable_autotuner=False`. Extrapolated estimate for Kimi K2.5 TP=8 / `max_num_tokens=148000`: 25–35% (more kernels, larger shapes). Details in `gms/trtllm-autotune-off-perf.md`.

This is a band-aid, not the fix. The proper fix is to make TRT-LLM's `CudaVirtualMemoryAllocator` pluggable per-tag so GMS registers as the backend for the `weights` tag and there is only ever one pluggable allocator live. Design at `gms/trtllm-vmm-plugin-rfc.md`; the architectural work is being done on a Dynamo-owned fork of TRT-LLM (see `gms/trtllm-fork-infrastructure-plan.md`) so the autotune-disable gate on this PR can be retired in a follow-up stacked PR.

## Files

- `lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py` — new. Worker init hook + `MpiPoolSession._start_mpi_pool` monkey-patch.
- `lib/gpu_memory_service/integrations/trtllm/__init__.py` — `setup_gms()` now also installs the MPI bootstrap.
- `lib/gpu_memory_service/client/torch/module.py` — `_iter_module_tensors` skips property descriptors.
- `components/src/dynamo/trtllm/workers/llm_worker.py` — autotuner gate reading from merged `arg_map`.
- Unit tests for all four commits. Tests pass without CUDA or mpi4py (stubbed via `sys.modules`).

## Scope

- Standalone fix, opened off fresh `main`. No dependency on the EAGLE3 branch.
- The prior EAGLE3 PR (#8436) has been closed; its work was rebased onto this branch as `schwinns/trtllm-specdec-eagle-rebased-on-mpi`. The shrink-KV band-aid was deliberately dropped during the rebase — with the MPI-worker fix in place the shadow no longer duplicates weights.

## Known unrelated issue surfaced by validation

TP=2 + GMS crashes at KV warmup ~2s after the GMS RW publishes complete: `CUDA error: an illegal memory access was encountered` in `KVCacheTransferManager` destructor during autotuner. With the autotuner disable gate (`6bfbbbc714a`) this is papered over, but the underlying crash is tracked separately at `gms/trtllm-tp2-kvtransfer-crash.md` and will be fixed by the VMM-plugin architectural work.

## Follow-ups (separate PRs)

1. **VMM-plugin API on the Dynamo TRT-LLM fork** — retires the `enable_autotuner=False` gate, reclaims 22–35%, closes the dual-allocator class of bugs for good (`gms/trtllm-vmm-plugin-rfc.md`).
2. **Upstream TRT-LLM**: add a first-class worker-init hook (replacing the monkey-patch).
3. **Extend GMS to own TRT-LLM's `kv_cache` VMM tag** so KV is also serialized across engines (per `gms-upstreaming-trtllm.md §3.1`). Needed for honest Kimi-scale shadow co-location.
4. **Stack the EAGLE3 / operator / Kimi DGD work** (`schwinns/trtllm-specdec-eagle-rebased-on-mpi`) once this merges and Kimi TP=8 re-validation completes on nscale.

