### PR TITLE
test: add KVBM v2 pre_merge tests

### DIFF
--- a/tests/kvbm_integration/common.py
+++ b/tests/kvbm_integration/common.py
@@ -519,6 +519,9 @@ def llm_server_kvbm(request, runtime_services_dynamic_ports):
             [{"cpu_blocks": 100, "gpu_blocks": 10, "model": "Qwen/Qwen3-0.6B"}], indirect=True)
         def test_example(llm_server_kvbm):
             ...
+
+    Pass ``"v2": True`` in the params to exercise the KVBM v2 connector
+    (``kvbm.v2.vllm.connector``) with the NIXL UCX backend enabled.
     """
     import os
     import time
@@ -533,6 +536,7 @@ def llm_server_kvbm(request, runtime_services_dynamic_ports):
         "model",
         os.environ.get("KVBM_MODEL_ID", "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"),
     )
+    v2 = params.get("v2", False)
 
     # Unpack NATS and etcd processes from runtime_services_dynamic_ports
     nats_process, etcd_process = runtime_services_dynamic_ports
@@ -567,6 +571,11 @@ def llm_server_kvbm(request, runtime_services_dynamic_ports):
     #   3. Add to command: "--gpu-memory-utilization", str(gpu_memory_fraction)
     #   Example: 2 workers → 42.5% each, 3 workers → 28.3% each
     #   Trade-off: Smaller GPU memory per worker = smaller KV cache = more CPU offloads
+    kv_transfer_config = (
+        '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.v2.vllm.connector","kv_role":"kv_both"}'
+        if v2
+        else '{"kv_connector":"DynamoConnector","kv_role":"kv_both", "kv_connector_module_path": "kvbm.vllm_integration.connector"}'
+    )
     command = [
         "vllm",
         "serve",
@@ -575,7 +584,7 @@ def llm_server_kvbm(request, runtime_services_dynamic_ports):
         "--port",
         str(port),
         "--kv-transfer-config",
-        '{"kv_connector":"DynamoConnector","kv_role":"kv_both", "kv_connector_module_path": "kvbm.vllm_integration.connector"}',
+        kv_transfer_config,
         model,
         "--max-model-len",
         "8000",  # Required to fit on L4 GPU with smaller models
@@ -611,6 +620,10 @@ def llm_server_kvbm(request, runtime_services_dynamic_ports):
     # CPU cache blocks override via env
     if cpu_blocks is not None:
         env["DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS"] = str(cpu_blocks)
+
+    # KVBM v2 requires the NIXL UCX backend to be enabled.
+    if v2:
+        env["DYN_KVBM_NIXL_BACKEND_UCX"] = "true"
 
     # Start server with ManagedProcess
     timeout = int(os.environ.get("KVBM_SERVER_START_TIMEOUT", "600"))

--- a/tests/kvbm_integration/test_kvbm.py
+++ b/tests/kvbm_integration/test_kvbm.py
@@ -5,6 +5,11 @@
 """
 KVBM (KV Block Manager) integration tests for vLLM.
 
+Each test runs twice — once for KVBM v1 (``kvbm.vllm_integration.connector``)
+and once for KVBM v2 (``kvbm.v2.vllm.connector`` with the NIXL UCX backend),
+selected via the indirect ``llm_server_kvbm`` fixture parametrize. If v1 and
+v2 diverge in expected behavior, split these back into separate files.
+
 These tests validate core KVBM functionality:
 1. Offload/Onboard: Request offloads to CPU, cache reset, re-request triggers onboarding
 2. Eviction: GPU cache fills, blocks evicted, later retrieved without corruption
@@ -113,7 +118,14 @@ def tester(llm_server_kvbm):  # noqa: F811
 
 
 # Tests
-@pytest.mark.parametrize("llm_server_kvbm", [{"model": KVBM_TEST_MODEL}], indirect=True)
+@pytest.mark.parametrize(
+    "llm_server_kvbm",
+    [
+        pytest.param({"model": KVBM_TEST_MODEL}, id="v1"),
+        pytest.param({"model": KVBM_TEST_MODEL, "v2": True}, id="v2"),
+    ],
+    indirect=True,
+)
 @pytest.mark.timeout(170)  # 4x measured (~41s), rounded up
 def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
     """
@@ -178,7 +190,15 @@ def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
 
 @pytest.mark.parametrize(
     "llm_server_kvbm",
-    [{"cpu_blocks": 200, "gpu_blocks": 20, "model": KVBM_TEST_MODEL}],
+    [
+        pytest.param(
+            {"cpu_blocks": 200, "gpu_blocks": 20, "model": KVBM_TEST_MODEL}, id="v1"
+        ),
+        pytest.param(
+            {"cpu_blocks": 200, "gpu_blocks": 20, "model": KVBM_TEST_MODEL, "v2": True},
+            id="v2",
+        ),
+    ],
     indirect=True,
 )
 @pytest.mark.timeout(170)  # 4x measured (~42s), rounded up
@@ -253,7 +273,15 @@ def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
 
 @pytest.mark.parametrize(
     "llm_server_kvbm",
-    [{"cpu_blocks": 200, "gpu_blocks": 20, "model": KVBM_TEST_MODEL}],
+    [
+        pytest.param(
+            {"cpu_blocks": 200, "gpu_blocks": 20, "model": KVBM_TEST_MODEL}, id="v1"
+        ),
+        pytest.param(
+            {"cpu_blocks": 200, "gpu_blocks": 20, "model": KVBM_TEST_MODEL, "v2": True},
+            id="v2",
+        ),
+    ],
     indirect=True,
 )
 @pytest.mark.timeout(160)  # 4x measured (~39s), rounded up


### PR DESCRIPTION
adding pre_merge KVBM test for v2

it turns out the test needed metrics already work with v2, i.e. `kvbm_offload_blocks_d2h` and `kvbm_onboard_blocks_h2d`, but not everything

as agreed, as P0, we only need KVBM metrics to make CI pass. for the rest KVBM metrics, will be added as separated efforts

grafana dashboards show kvbm_offload_blocks_d2h and kvbm_onboard_blocks_h2d are working e2e with kvbm v2:
<img width="3424" height="1321" alt="Screenshot 2026-04-20 at 5 44 46 PM" src="https://github.com/user-attachments/assets/85b459ee-2b37-40cb-a156-9577a227a82c" />


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
