### PR TITLE
fix(profiler): prevent model path doubling when modelCache lacks pvcModelPath

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -569,9 +569,9 @@ def test_build_dgd_config_pvc_without_model_path_sets_hf_home() -> None:
         hf_homes = [
             e for e in env_list if isinstance(e, dict) and e.get("name") == "HF_HOME"
         ]
-        assert len(hf_homes) == 1, (
-            f"Expected exactly one HF_HOME env on {svc_name}, got {len(hf_homes)}"
-        )
+        assert (
+            len(hf_homes) == 1
+        ), f"Expected exactly one HF_HOME env on {svc_name}, got {len(hf_homes)}"
         assert hf_homes[0]["value"] == mount, f"HF_HOME on {svc_name} should be {mount}"
 
 
@@ -602,6 +602,6 @@ def test_build_dgd_config_pvc_with_model_path_no_hf_home() -> None:
         hf_homes = [
             e for e in env_list if isinstance(e, dict) and e.get("name") == "HF_HOME"
         ]
-        assert len(hf_homes) == 0, (
-            f"HF_HOME should not be set on {svc_name} when model_path is a PVC subpath"
-        )
+        assert (
+            len(hf_homes) == 0
+        ), f"HF_HOME should not be set on {svc_name} when model_path is a PVC subpath"

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -566,8 +566,12 @@ def test_build_dgd_config_pvc_without_model_path_sets_hf_home() -> None:
         eps = svc.get("extraPodSpec", {})
         mc = eps.get("mainContainer", {})
         env_list = mc.get("env", [])
-        hf_homes = [e for e in env_list if isinstance(e, dict) and e.get("name") == "HF_HOME"]
-        assert len(hf_homes) == 1, f"Expected exactly one HF_HOME env on {svc_name}, got {len(hf_homes)}"
+        hf_homes = [
+            e for e in env_list if isinstance(e, dict) and e.get("name") == "HF_HOME"
+        ]
+        assert len(hf_homes) == 1, (
+            f"Expected exactly one HF_HOME env on {svc_name}, got {len(hf_homes)}"
+        )
         assert hf_homes[0]["value"] == mount, f"HF_HOME on {svc_name} should be {mount}"
 
 
@@ -595,5 +599,9 @@ def test_build_dgd_config_pvc_with_model_path_no_hf_home() -> None:
         eps = svc.get("extraPodSpec", {})
         mc = eps.get("mainContainer", {})
         env_list = mc.get("env", [])
-        hf_homes = [e for e in env_list if isinstance(e, dict) and e.get("name") == "HF_HOME"]
-        assert len(hf_homes) == 0, f"HF_HOME should not be set on {svc_name} when model_path is a PVC subpath"
+        hf_homes = [
+            e for e in env_list if isinstance(e, dict) and e.get("name") == "HF_HOME"
+        ]
+        assert len(hf_homes) == 0, (
+            f"HF_HOME should not be set on {svc_name} when model_path is a PVC subpath"
+        )

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -541,3 +541,59 @@ def test_build_dgd_config_pvc_with_model_path_uses_pvc_path(backend) -> None:
             f"Worker '{svc_name}' should use PVC model path '{model_path}'. "
             f"args={args}"
         )
+
+
+def test_build_dgd_config_pvc_without_model_path_sets_hf_home() -> None:
+    """When pvc_name is set but model_path doesn't point inside the PVC,
+    HF_HOME must be set to pvc_mount_path so HuggingFace finds cached weights."""
+    modifier = CONFIG_MODIFIERS["sglang"]
+    mount = "/opt/model-cache"
+    dgd_config = modifier.build_dgd_config(
+        mode="disagg",
+        model_name="Qwen/Qwen3-32B",
+        image="nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.0",
+        prefill_cli_args=["--max-running-requests", "1"],
+        prefill_replicas=1,
+        prefill_gpus=1,
+        decode_cli_args=["--tp", "4"],
+        decode_replicas=1,
+        decode_gpus=4,
+        pvc_name="model-cache",
+        pvc_mount_path=mount,
+    )
+
+    for svc_name, svc in dgd_config["spec"]["services"].items():
+        eps = svc.get("extraPodSpec", {})
+        mc = eps.get("mainContainer", {})
+        env_list = mc.get("env", [])
+        hf_homes = [e for e in env_list if isinstance(e, dict) and e.get("name") == "HF_HOME"]
+        assert len(hf_homes) == 1, f"Expected exactly one HF_HOME env on {svc_name}, got {len(hf_homes)}"
+        assert hf_homes[0]["value"] == mount, f"HF_HOME on {svc_name} should be {mount}"
+
+
+def test_build_dgd_config_pvc_with_model_path_no_hf_home() -> None:
+    """When pvc_name is set and model_path points inside the PVC,
+    HF_HOME should NOT be injected — model is loaded by explicit path."""
+    modifier = CONFIG_MODIFIERS["sglang"]
+    mount = "/opt/model-cache"
+    dgd_config = modifier.build_dgd_config(
+        mode="disagg",
+        model_name="Qwen/Qwen3-32B",
+        image="nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.0",
+        prefill_cli_args=["--max-running-requests", "1"],
+        prefill_replicas=1,
+        prefill_gpus=1,
+        decode_cli_args=["--tp", "4"],
+        decode_replicas=1,
+        decode_gpus=4,
+        pvc_name="model-cache",
+        pvc_mount_path=mount,
+        model_path=f"{mount}/qwen3-32b",
+    )
+
+    for svc_name, svc in dgd_config["spec"]["services"].items():
+        eps = svc.get("extraPodSpec", {})
+        mc = eps.get("mainContainer", {})
+        env_list = mc.get("env", [])
+        hf_homes = [e for e in env_list if isinstance(e, dict) and e.get("name") == "HF_HOME"]
+        assert len(hf_homes) == 0, f"HF_HOME should not be set on {svc_name} when model_path is a PVC subpath"

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -571,7 +571,10 @@ class BaseConfigModifier:
             # known path inside the PVC.  Let update_model_from_pvc handle
             # volume mount + CLI patching.
             pvc_path = ""
-            if effective_model_path and effective_model_path.startswith(pvc_mount_path):
+            if effective_model_path and (
+                effective_model_path == pvc_mount_path
+                or effective_model_path.startswith(pvc_mount_path + "/")
+            ):
                 pvc_path = effective_model_path[len(pvc_mount_path) :].strip("/")
             if pvc_path:
                 result = cls.update_model_from_pvc(

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -598,6 +598,7 @@ class BaseConfigModifier:
             cls._ensure_spec_pvc(cfg, pvc_name)
             for _svc_name, svc in cfg.spec.services.items():
                 cls._ensure_service_volume_mount(svc, pvc_name, pvc_mount_path)
+                cls._ensure_service_hf_home_env(svc, pvc_mount_path)
             result = cls.update_model(
                 cfg.model_dump(),
                 model_name=model_name,

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -259,6 +259,29 @@ class BaseConfigModifier:
         volume_mounts.append({"name": pvc_name, "mountPoint": mount_path})
         setattr(service, "volumeMounts", volume_mounts)
 
+    @staticmethod
+    def _ensure_service_hf_home_env(service: Any, hf_home: str) -> None:
+        eps = getattr(service, "extraPodSpec", None)
+        if eps is None:
+            return
+        mc = getattr(eps, "mainContainer", None)
+        if mc is None:
+            return
+
+        env_list = getattr(mc, "env", None)
+        if env_list is None:
+            env_list = []
+        if not isinstance(env_list, list):
+            env_list = []
+
+        env_list[:] = [
+            e
+            for e in env_list
+            if not (isinstance(e, dict) and e.get("name") == "HF_HOME")
+        ]
+        env_list.append({"name": "HF_HOME", "value": hf_home})
+        setattr(mc, "env", env_list)
+
     @classmethod
     def _update_container_args_preserving_shell_form(
         cls, container: Container, update_fn
@@ -562,6 +585,7 @@ class BaseConfigModifier:
                 cls._ensure_spec_pvc(cfg, pvc_name)
                 for _svc_name, svc in cfg.spec.services.items():
                     cls._ensure_service_volume_mount(svc, pvc_name, pvc_mount_path)
+                    cls._ensure_service_hf_home_env(svc, pvc_mount_path)
                 result = cls.update_model(
                     cfg.model_dump(),
                     model_name=model_name,

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -44,7 +44,8 @@ class ConfigModifierProtocol(Protocol):
         config: dict,
         target: EngineType,
         is_moe_model: bool = False,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
     def set_config_tp_size(
@@ -52,7 +53,8 @@ class ConfigModifierProtocol(Protocol):
         config: dict,
         tp_size: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
     def set_config_tep_size(
@@ -61,7 +63,8 @@ class ConfigModifierProtocol(Protocol):
         tep_size: int,
         num_gpus_per_node: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
     def set_config_dep_size(
@@ -70,10 +73,12 @@ class ConfigModifierProtocol(Protocol):
         dep_size: int,
         num_gpus_per_node: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
-    def get_model_name(cls, config: dict) -> Tuple[str, str]: ...
+    def get_model_name(cls, config: dict) -> Tuple[str, str]:
+        ...
 
     @classmethod
     def set_prefill_config(
@@ -82,26 +87,32 @@ class ConfigModifierProtocol(Protocol):
         max_batch_size: int,
         max_num_tokens: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
-    def get_port(cls, config: dict) -> int: ...
+    def get_port(cls, config: dict) -> int:
+        ...
 
     @classmethod
     def get_kv_cache_size_from_dynamo_log(
         cls, dynamo_log_fn: str, attention_dp_size: int = 1
-    ) -> int: ...
+    ) -> int:
+        ...
 
     @classmethod
-    def load_default_config(cls, mode: str = "disagg") -> dict: ...
+    def load_default_config(cls, mode: str = "disagg") -> dict:
+        ...
 
     @classmethod
     def update_model(
         cls, config: dict, model_name: str, model_path: str | None = None
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
-    def update_image(cls, config: dict, image: str) -> dict: ...
+    def update_image(cls, config: dict, image: str) -> dict:
+        ...
 
     @classmethod
     def update_model_from_pvc(
@@ -111,7 +122,8 @@ class ConfigModifierProtocol(Protocol):
         pvc_name: str,
         pvc_mount_path: str,
         pvc_path: str,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
     def build_dgd_config(
@@ -133,7 +145,8 @@ class ConfigModifierProtocol(Protocol):
         pvc_name: str | None = None,
         pvc_mount_path: str | None = None,
         num_gpus_per_node: int | None = None,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
 
 class BaseConfigModifier:

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -550,17 +550,24 @@ class BaseConfigModifier:
             pvc_path = ""
             if effective_model_path and effective_model_path.startswith(pvc_mount_path):
                 pvc_path = effective_model_path[len(pvc_mount_path) :].strip("/")
-            result = cls.update_model_from_pvc(
-                cfg.model_dump(),
-                model_name=model_name,
-                pvc_name=pvc_name,
-                pvc_mount_path=pvc_mount_path,
-                pvc_path=pvc_path,
-            )
+            if pvc_path:
+                result = cls.update_model_from_pvc(
+                    cfg.model_dump(),
+                    model_name=model_name,
+                    pvc_name=pvc_name,
+                    pvc_mount_path=pvc_mount_path,
+                    pvc_path=pvc_path,
+                )
+            else:
+                cls._ensure_spec_pvc(cfg, pvc_name)
+                for _svc_name, svc in cfg.spec.services.items():
+                    cls._ensure_service_volume_mount(svc, pvc_name, pvc_mount_path)
+                result = cls.update_model(
+                    cfg.model_dump(),
+                    model_name=model_name,
+                    model_path=effective_model_path,
+                )
         elif pvc_name and pvc_mount_path:
-            # PVC configured as an HF cache directory (no explicit model path
-            # within it).  Mount the PVC so workers can find cached weights,
-            # but keep the HF model ID as the worker model argument.
             cls._ensure_spec_pvc(cfg, pvc_name)
             for _svc_name, svc in cfg.spec.services.items():
                 cls._ensure_service_volume_mount(svc, pvc_name, pvc_mount_path)

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -44,8 +44,7 @@ class ConfigModifierProtocol(Protocol):
         config: dict,
         target: EngineType,
         is_moe_model: bool = False,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
     def set_config_tp_size(
@@ -53,8 +52,7 @@ class ConfigModifierProtocol(Protocol):
         config: dict,
         tp_size: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
     def set_config_tep_size(
@@ -63,8 +61,7 @@ class ConfigModifierProtocol(Protocol):
         tep_size: int,
         num_gpus_per_node: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
     def set_config_dep_size(
@@ -73,12 +70,10 @@ class ConfigModifierProtocol(Protocol):
         dep_size: int,
         num_gpus_per_node: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
-    def get_model_name(cls, config: dict) -> Tuple[str, str]:
-        ...
+    def get_model_name(cls, config: dict) -> Tuple[str, str]: ...
 
     @classmethod
     def set_prefill_config(
@@ -87,32 +82,26 @@ class ConfigModifierProtocol(Protocol):
         max_batch_size: int,
         max_num_tokens: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
-    def get_port(cls, config: dict) -> int:
-        ...
+    def get_port(cls, config: dict) -> int: ...
 
     @classmethod
     def get_kv_cache_size_from_dynamo_log(
         cls, dynamo_log_fn: str, attention_dp_size: int = 1
-    ) -> int:
-        ...
+    ) -> int: ...
 
     @classmethod
-    def load_default_config(cls, mode: str = "disagg") -> dict:
-        ...
+    def load_default_config(cls, mode: str = "disagg") -> dict: ...
 
     @classmethod
     def update_model(
         cls, config: dict, model_name: str, model_path: str | None = None
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
-    def update_image(cls, config: dict, image: str) -> dict:
-        ...
+    def update_image(cls, config: dict, image: str) -> dict: ...
 
     @classmethod
     def update_model_from_pvc(
@@ -122,8 +111,7 @@ class ConfigModifierProtocol(Protocol):
         pvc_name: str,
         pvc_mount_path: str,
         pvc_path: str,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
     def build_dgd_config(
@@ -145,8 +133,7 @@ class ConfigModifierProtocol(Protocol):
         pvc_name: str | None = None,
         pvc_mount_path: str | None = None,
         num_gpus_per_node: int | None = None,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
 
 class BaseConfigModifier:


### PR DESCRIPTION
## Summary
- Fix model path doubling bug (e.g. `/opt/model-cache/opt/model-cache`) when a DGDR specifies `modelCache.pvcName` without `pvcModelPath`
- When the model is an HF ID (not a PVC-local path), mount the PVC for HF cache but keep the HF model name as the model identifier
- Previously, `build_dgd_config()` unconditionally called `update_model_from_pvc()` with an empty `pvc_path`, which caused the mount path to be prepended twice

See `dgdr-model-path-doubling-bug.md` (not committed) for full root cause analysis.

## Workaround (pre-fix)
Set `pvcModelPath` explicitly to the HF cache snapshot path within the PVC:
```yaml
modelCache:
  pvcName: model-cache
  pvcMountPath: /home/dynamo/.cache/huggingface
  pvcModelPath: hub/models--Qwen--Qwen3-32B/snapshots/<sha>
```

## Test plan
- [ ] Deploy a DGDR with `modelCache.pvcName` set but `pvcModelPath` omitted — verify workers receive `--model <HF-ID>` (not a doubled path)
- [ ] Deploy a DGDR with `modelCache.pvcModelPath` set — verify existing behavior (PVC-based path) is unchanged
- [ ] Deploy a DGDR without `modelCache` — verify existing behavior is unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation with earlier error detection to prevent deployment failures
  * Enhanced handling of model storage paths with more robust path resolution capabilities
  * Strengthened setup of deployment storage infrastructure to support more complex scenarios with improved error reporting

* **Refactor**
  * Streamlined internal configuration processing logic for improved reliability and stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->