### PR TITLE
chore: copy attribution and license into planner image

### DIFF
--- a/container/templates/planner.Dockerfile
+++ b/container/templates/planner.Dockerfile
@@ -70,6 +70,7 @@ COPY --chmod=775 --chown=dynamo:0 components/src/dynamo/profiler /workspace/comp
 COPY --chmod=775 --chown=dynamo:0 components/src/dynamo/global_planner /workspace/components/src/dynamo/global_planner
 COPY --chmod=775 --chown=dynamo:0 deploy /workspace/deploy
 COPY --chmod=775 --chown=dynamo:0 examples /workspace/examples
+COPY --chmod=664 --chown=dynamo:0 ATTRIBUTION* LICENSE /workspace/
 
 FROM ${PLANNER_RUNTIME_IMAGE}:${PLANNER_RUNTIME_IMAGE_TAG} AS planner
 


### PR DESCRIPTION
## Summary
- Adds `COPY --chmod=664 --chown=dynamo:0 ATTRIBUTION* LICENSE /workspace/` to the planner builder stage, matching the existing pattern in `sglang_runtime.Dockerfile`, `vllm_runtime.Dockerfile`, and `trtllm_runtime.Dockerfile`.
- The files propagate into the final `planner` stage via the existing `COPY --from=planner_builder /workspace /workspace`.

## Test plan
- [ ] Build the planner image and confirm `/workspace/LICENSE` and `/workspace/ATTRIBUTIONS*.md` are present with `664` perms and `dynamo:0` ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to include attribution and license files in the workspace directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->