### PR TITLE
ci(container): wire SBOM + ATTRIBUTIONS generation into runtime images

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -78,6 +78,7 @@ core:
   - 'container/templates/args.Dockerfile'
   - 'container/templates/dynamo_*'
   - 'container/templates/wheel_builder.Dockerfile'
+  - 'container/templates/sbom_inject.Dockerfile'
   - '.dockerignore'
   - 'container/deps/*'
   - 'container/compliance/**'

--- a/container/templates/sbom_inject.Dockerfile
+++ b/container/templates/sbom_inject.Dockerfile
@@ -1,0 +1,57 @@
+{#
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#}
+# === BEGIN templates/sbom_inject.Dockerfile ===
+# Generates the per-runtime CycloneDX 1.6 SBOM and ATTRIBUTIONS-container-*
+# files in-place in the final runtime image, where every framework artifact,
+# Python site-packages tree, and source-compiled binary is already present.
+# Scan targets are discovered dynamically: the script always scans /opt/dynamo
+# and then probes a fixed allowlist of framework install roots and the Python
+# site-/dist-packages directories on the image, adding each that exists. Pass
+# --build-arg SBOM_EXTRA_TARGETS="dir:/foo dir:/bar" to append more targets at
+# docker build time.
+#
+# Outputs:
+#   /opt/dynamo/sbom/dynamo.cdx.json       (+ .sha256 sidecar)
+#   /opt/dynamo/licenses/ATTRIBUTIONS-container-*.{md,csv}
+#   /opt/dynamo/licenses/LICENSE-MANIFEST.csv
+#   /opt/dynamo/licenses/LICENSES/<spdx-id>.txt
+#
+# Include this fragment near the end of a runtime template, after the last
+# wheel_builder COPY block and before the final USER/ENTRYPOINT lines.
+USER root
+
+ARG DYNAMO_COMMIT_SHA
+ARG SBOM_EXTRA_TARGETS=""
+RUN --mount=type=bind,from=anchore/syft:v1.16.0,source=/syft,target=/usr/local/bin/syft \
+    --mount=type=bind,source=./container/compliance,target=/tmp/compliance,ro \
+    set -eux; \
+    mkdir -p /opt/dynamo/sbom /opt/dynamo/licenses; \
+    # Dynamic scan-target discovery. /opt/dynamo is always present; the rest
+    # depend on the framework's install layout, so probe and add what exists.
+    SCAN_TARGETS=("dir:/opt/dynamo"); \
+    for candidate in /opt/vllm /opt/sglang /opt/tensorrt_llm /opt/trtllm /workspace/sglang /workspace/vllm; do \
+        [ -d "$candidate" ] && SCAN_TARGETS+=("dir:$candidate"); \
+    done; \
+    for d in /usr/local/lib/python*/dist-packages /usr/local/lib/python*/site-packages /usr/lib/python*/dist-packages /opt/conda/lib/python*/site-packages; do \
+        [ -d "$d" ] && SCAN_TARGETS+=("dir:$d"); \
+    done; \
+    for t in ${SBOM_EXTRA_TARGETS}; do SCAN_TARGETS+=("$t"); done; \
+    SCAN_ARGS=(); \
+    for t in "${SCAN_TARGETS[@]}"; do SCAN_ARGS+=(--scan-target "$t"); done; \
+    echo ">> SBOM scan targets: ${SCAN_TARGETS[*]}"; \
+    bash /tmp/compliance/sbom/generate_sbom.sh \
+        "${SCAN_ARGS[@]}" \
+        --framework {{ framework }} \
+        --output-dir /opt/dynamo/sbom \
+        --name dynamo; \
+    python3 /tmp/compliance/sbom/render_attributions.py \
+        --bom /opt/dynamo/sbom/dynamo.cdx.json \
+        --release "${DYNAMO_COMMIT_SHA:-HEAD}" \
+        --output-dir /opt/dynamo/licenses; \
+    chmod -R a+rX /opt/dynamo/sbom /opt/dynamo/licenses; \
+    chown -R dynamo:0 /opt/dynamo/sbom /opt/dynamo/licenses
+
+USER dynamo
+# === END templates/sbom_inject.Dockerfile ===

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -87,6 +87,10 @@ RUN chmod 755 /opt/dynamo/.launch_screen && \
     echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc && \
     ln -s /workspace /sgl-workspace/dynamo
 
+{% if target == "runtime" %}
+{% include "templates/sbom_inject.Dockerfile" %}
+{% endif %}
+
 USER dynamo
 ARG DYNAMO_COMMIT_SHA
 ENV DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA}

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -314,6 +314,10 @@ RUN chmod g+w ${VIRTUAL_ENV} /workspace /workspace/* /opt/dynamo /opt/dynamo/* &
     echo 'source /opt/dynamo/venv/bin/activate' >> /etc/bash.bashrc && \
     echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc
 
+{% if target == "runtime" %}
+{% include "templates/sbom_inject.Dockerfile" %}
+{% endif %}
+
 USER dynamo
 ARG DYNAMO_COMMIT_SHA
 ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -409,6 +409,10 @@ RUN cd /usr/local/lib && \
     ldconfig
 {% endif %}
 
+{% if target == "runtime" %}
+{% include "templates/sbom_inject.Dockerfile" %}
+{% endif %}
+
 USER dynamo
 
 ARG DYNAMO_COMMIT_SHA

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -626,3 +626,45 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
 
 # Consolidate all wheels from the runtime wheel builder stage
 COPY --from=runtime_wheel_builder /opt/dynamo/dist/ /opt/dynamo/dist/
+
+##################################
+##### Build-time SBOM Tooling ####
+##################################
+# cargo-auditable is installed during wheel_builder so any Rust crate compiled
+# in this stage embeds a `.dep-v0` section that syft can read later. The actual
+# SBOM scan + attribution rendering happens in the runtime stage (see
+# templates/sbom_inject.Dockerfile) where the framework site-packages and all
+# other runtime artifacts are present and can be discovered dynamically.
+{% if target == "runtime" %}
+
+# Install cargo-auditable from pre-built binary (saves 2-3 min vs cargo install).
+# cargo-auditable embeds dependency-tree metadata into Rust binaries for SBOM tooling.
+# The cargo-wrapper script below ensures maturin invokes cargo-auditable transparently.
+ARG CARGO_AUDITABLE_VERSION=0.6.4
+USER root
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) CARGO_AUD_TRIPLE="x86_64-unknown-linux-gnu" ;; \
+      arm64) CARGO_AUD_TRIPLE="aarch64-unknown-linux-gnu" ;; \
+      *) echo "Unsupported arch: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    CARGO_AUD_URL="https://github.com/rust-secure-code/cargo-auditable/releases/download/v${CARGO_AUDITABLE_VERSION}/cargo-auditable-${CARGO_AUD_TRIPLE}.tar.gz"; \
+    if curl -fsSL --head "$CARGO_AUD_URL" >/dev/null 2>&1; then \
+        curl -fsSL "$CARGO_AUD_URL" | tar -xz -C /usr/local/cargo/bin/ --strip-components=1 "cargo-auditable-${CARGO_AUD_TRIPLE}/cargo-auditable"; \
+    else \
+        echo "Binary not available for ${CARGO_AUD_TRIPLE}, falling back to cargo install"; \
+        /usr/local/cargo/bin/cargo install --locked cargo-auditable@${CARGO_AUDITABLE_VERSION}; \
+    fi; \
+    chmod +x /usr/local/cargo/bin/cargo-auditable
+
+# Create cargo wrapper so maturin uses cargo-auditable transparently.
+# Maturin honors the CARGO environment variable; this wrapper invokes
+# `cargo auditable` which embeds dependency metadata into compiled binaries.
+# TODO(SBOM): Verify maturin + cargo-auditable integration produces valid .dep-v0 sections
+RUN printf '#!/bin/sh\nexec /usr/local/cargo/bin/cargo auditable "$@"\n' > /usr/local/bin/cargo-wrapper && \
+    chmod +x /usr/local/bin/cargo-wrapper
+ENV CARGO=/usr/local/bin/cargo-wrapper
+
+# Drop privileges back to dynamo before any subsequent stage COPYs from this one.
+USER dynamo
+{% endif %}


### PR DESCRIPTION
## Summary

Wires the SBOM toolkit from #8448 into the multi-arch runtime build, so every
published image ships its own CycloneDX BOM and matching
`ATTRIBUTIONS-container-*.{md,csv}` corpus. SBOM generation now runs in the
final runtime stage where every framework artifact is present, with **dynamic
discovery** of scan targets — no per-framework scan lists to maintain.

## Three-PR system

| PR | Scope | Outputs |
|---|---|---|
| **#8448** | Self-contained SBOM rendering toolkit | `container/compliance/sbom/` |
| **this PR** | Wires the toolkit into runtime Dockerfiles | `dynamo.cdx.json`, `ATTRIBUTIONS-container-*.{md,csv}` inside each runtime image |
| **#8519** | Repo-root tool for **direct** deps (supersedes #7402) | `ATTRIBUTIONS-{Rust,Python,Go}.md` at repo root |

## What changed

### `wheel_builder.Dockerfile` — build-time only
- Installs `cargo-auditable` from the upstream pre-built binary so any Rust crate compiled here embeds a `.dep-v0` section that `syft` can read at scan time. Falls back to `cargo install` only when no binary is published for the triple.
- Sets `CARGO=/usr/local/bin/cargo-wrapper` so maturin transparently invokes `cargo auditable` for every wheel build.
- All SBOM rendering work was intentionally **removed** from this stage — the framework `site-packages` and runtime artifacts that nSpect cares about do not exist here yet.

### `sbom_inject.Dockerfile` — runtime stage
- Performs the full `syft` scan + `render_attributions.py` render in the final runtime image.
- **Scan targets discovered dynamically:**
  - `/opt/dynamo` is always scanned
  - Probes a fixed allowlist of framework install roots (`/opt/vllm`, `/opt/sglang`, `/opt/tensorrt_llm`, `/opt/trtllm`, `/workspace/{sglang,vllm}`)
  - Probes Python `{site,dist}-packages` directories
  - Build callers can append more via `--build-arg SBOM_EXTRA_TARGETS="dir:/foo dir:/bar"`
- Outputs at:
  - `/opt/dynamo/sbom/dynamo.cdx.json` (+ `.sha256` sidecar)
  - `/opt/dynamo/licenses/ATTRIBUTIONS-container-*.{md,csv}`
  - `/opt/dynamo/licenses/LICENSE-MANIFEST.csv`
  - `/opt/dynamo/licenses/LICENSES/<spdx-id>.txt`
- Pinned `syft v1.16.0` via bind-mount from `anchore/syft`. Slim image, reproducible toolchain version.
- `USER root` / `USER dynamo` transitions bracketed tightly so subsequent COPY operations see the expected uid.

### Per-framework wiring
`vllm_runtime`, `sglang_runtime`, `trtllm_runtime` include `sbom_inject` just before the final `USER`/`ENTRYPOINT`, so the BOM captures the fully-assembled image.

### CI
`.github/filters.yaml` routes `sbom_inject.Dockerfile` changes through the `core` filter so container-affecting edits trigger the appropriate workflows.

## Cross-PR contract

- Depends on the toolkit added in #8448.
- Produces `ATTRIBUTIONS-container-*.md` (no collision with the repo-root `ATTRIBUTIONS-*.md` from #8519).

## Verification

```bash
# Render each runtime template to confirm sbom_inject is correctly placed
python3 container/render.py --framework vllm --target runtime --cuda-version 12.9 \
    --output /tmp/vllm-runtime.Dockerfile
grep -A2 "sbom_inject" /tmp/vllm-runtime.Dockerfile
```

## Reviewer checklist

- [ ] Confirm `cargo-auditable` is installed only in the runtime build
- [ ] Confirm dynamic discovery in `sbom_inject.Dockerfile` covers your framework's install layout
- [ ] Confirm `USER` transitions don't break downstream COPY operations
- [ ] Confirm CI `core` filter triggers on `sbom_inject.Dockerfile` changes