### PR TITLE
fix(benchmarks): use --conversation-num for grouped single_turn sweeps (DIS-1807)

### DIFF
--- a/benchmarks/multimodal/sweep/README.md
+++ b/benchmarks/multimodal/sweep/README.md
@@ -29,7 +29,10 @@ python -m benchmarks.multimodal.sweep \
 model: Qwen/Qwen3-VL-30B-A3B-Instruct-FP8
 concurrencies: [16, 32, 64, 128, 256]
 osl: 150                    # output sequence length
-request_count: 1000         # requests per concurrency level
+conversation_num: 10        # sessions per sweep value (optional; derived from
+                            # input JSONL's unique session_id count if unset)
+request_count: 200          # OPTIONAL hard cap on total credits; rejected if
+                            # set alone without conversation_num
 warmup_count: 5
 port: 8000
 timeout: 900                # seconds to wait for server readiness
@@ -64,9 +67,49 @@ python -m benchmarks.multimodal.sweep \
   --config experiments/embedding_cache/vllm_serve.yaml \
   --concurrencies 1,2,4 \
   --osl 200 \
-  --request-count 50 \
+  --conversation-num 10 \
   --skip-plots
 ```
+
+## Grouped Single-Turn Semantics (aiperf 0.7.0+)
+
+`aiperf==0.7.0` (via [PR 824](https://github.com/ai-dynamo/aiperf/pull/824))
+groups single_turn rows by JSONL `session_id`. A JSONL with 10 users × 10 turns
+each dispatches 10 causal-ordered chains (turn-(k+1) for user A only after
+turn-k for user A returns).
+
+Control the session count via `conversation_num`. **`request_count` alone is
+rejected at config-load** because it triggers SequentialSampler wrap (extra
+turn-0 sessions, incomplete chains) — the exact DIS-1807 bug. Use
+`conversation_num` as the primary control; add `request_count` only as a safety
+cap when you need one.
+
+### Upgrading aiperf in an existing container
+
+The benchmark image currently pins `aiperf==0.6.0`. Until the pin is bumped
+(tracked separately), any new cloud-session container starts pre-824 and
+must be upgraded before running the sweep. Install aiperf 0.7.0 from the
+pre-staged wheel:
+
+```bash
+pip install --no-deps --force-reinstall \
+  /home/scratch.qiwa_ent/workspace/aiperf-wheels/aiperf-0.7.0-py3-none-any.whl
+```
+
+Works on air-gapped nodes (scratch NFS is visible inside the Pyxis overlay).
+Sentinel that PR 824 is active:
+
+```bash
+python -c "from aiperf.dataset.loader.single_turn import SingleTurnDatasetLoader; import inspect; assert 'single_turn_data.session_id or' in inspect.getsource(SingleTurnDatasetLoader.load_dataset)"
+```
+
+### Warmup semantics
+
+`warmup_count: N` is a credit budget, NOT a session budget. aiperf's
+continuation-turn priority means the first `N` warmup credits feed `user_0`
+turns `0..N-1` (then sampler advances). Profiling then starts at `user_1` and
+wraps to a fresh `user_0` instance after `user_9`. `warmup_count > turns per
+session` consumes multiple sessions — keep it small.
 
 ## Output Directory Structure
 

--- a/benchmarks/multimodal/sweep/README.md
+++ b/benchmarks/multimodal/sweep/README.md
@@ -30,9 +30,8 @@ model: Qwen/Qwen3-VL-30B-A3B-Instruct-FP8
 concurrencies: [16, 32, 64, 128, 256]
 osl: 150                    # output sequence length
 conversation_num: 10        # sessions per sweep value (optional; derived from
-                            # input JSONL's unique session_id count if unset)
-request_count: 200          # OPTIONAL hard cap on total credits; rejected if
-                            # set alone without conversation_num
+                            # input JSONL's unique session_id count if unset;
+                            # flat JSONLs count each row as a 1-turn conversation)
 warmup_count: 5
 port: 8000
 timeout: 900                # seconds to wait for server readiness
@@ -78,11 +77,11 @@ groups single_turn rows by JSONL `session_id`. A JSONL with 10 users × 10 turns
 each dispatches 10 causal-ordered chains (turn-(k+1) for user A only after
 turn-k for user A returns).
 
-Control the session count via `conversation_num`. **`request_count` alone is
-rejected at config-load** because it triggers SequentialSampler wrap (extra
-turn-0 sessions, incomplete chains) — the exact DIS-1807 bug. Use
-`conversation_num` as the primary control; add `request_count` only as a safety
-cap when you need one.
+Control the session count via `conversation_num`. For flat JSONLs (random
+requests, single_turn without shared `session_id`), `conversation_num` still
+works — each row is treated as a 1-turn conversation, so total requests =
+`conversation_num × 1 = conversation_num`. If unset, it defaults to the
+detected unique session_id count (or row count for flat JSONLs).
 
 ### Upgrading aiperf in an existing container
 

--- a/benchmarks/multimodal/sweep/README.md
+++ b/benchmarks/multimodal/sweep/README.md
@@ -70,45 +70,16 @@ python -m benchmarks.multimodal.sweep \
   --skip-plots
 ```
 
-## Grouped Single-Turn Semantics (aiperf 0.7.0+)
+## Warmup semantics
 
-`aiperf==0.7.0` (via [PR 824](https://github.com/ai-dynamo/aiperf/pull/824))
-groups single_turn rows by JSONL `session_id`. A JSONL with 10 users × 10 turns
-each dispatches 10 causal-ordered chains (turn-(k+1) for user A only after
-turn-k for user A returns).
-
-Control the session count via `conversation_num`. For flat JSONLs (random
-requests, single_turn without shared `session_id`), `conversation_num` still
-works — each row is treated as a 1-turn conversation, so total requests =
-`conversation_num × 1 = conversation_num`. If unset, it defaults to the
-detected unique session_id count (or row count for flat JSONLs).
-
-### Upgrading aiperf in an existing container
-
-The benchmark image currently pins `aiperf==0.6.0`. Until the pin is bumped
-(tracked separately), any new cloud-session container starts pre-824 and
-must be upgraded before running the sweep. Install aiperf 0.7.0 from the
-pre-staged wheel:
-
-```bash
-pip install --no-deps --force-reinstall \
-  /home/scratch.qiwa_ent/workspace/aiperf-wheels/aiperf-0.7.0-py3-none-any.whl
-```
-
-Works on air-gapped nodes (scratch NFS is visible inside the Pyxis overlay).
-Sentinel that PR 824 is active:
-
-```bash
-python -c "from aiperf.dataset.loader.single_turn import SingleTurnDatasetLoader; import inspect; assert 'single_turn_data.session_id or' in inspect.getsource(SingleTurnDatasetLoader.load_dataset)"
-```
-
-### Warmup semantics
-
-`warmup_count: N` is a credit budget, NOT a session budget. aiperf's
-continuation-turn priority means the first `N` warmup credits feed `user_0`
-turns `0..N-1` (then sampler advances). Profiling then starts at `user_1` and
-wraps to a fresh `user_0` instance after `user_9`. `warmup_count > turns per
-session` consumes multiple sessions — keep it small.
+`warmup_count: N` is a **request (turn) budget**, not a session budget. For a
+10×10 JSONL with `warmup_count: 2`, warmup issues 2 total requests — both go
+to `user_0` (turns 0 and 1) because aiperf's continuation-turn priority keeps
+feeding the in-flight session until its budget runs out. Warmup does NOT
+consume 2 full sessions (20 requests). Profiling then starts at `user_1`,
+runs `user_1..user_9` to completion, and wraps to a fresh `user_0` instance
+for the 10th session. Keep `warmup_count` small (≤ turns-per-session) so
+warmup stays within a single session's prefix.
 
 ## Output Directory Structure
 

--- a/benchmarks/multimodal/sweep/args.py
+++ b/benchmarks/multimodal/sweep/args.py
@@ -59,10 +59,23 @@ def parse_args(argv=None) -> argparse.Namespace:
         help="Override output sequence length.",
     )
     parser.add_argument(
+        "--conversation-num",
+        type=int,
+        default=None,
+        help=(
+            "Override number of grouped conversations (sessions) per sweep value. "
+            "Primary control for grouped single_turn dispatch. If unset, derived "
+            "from the input JSONL's unique session_id count."
+        ),
+    )
+    parser.add_argument(
         "--request-count",
         type=int,
         default=None,
-        help="Override request count per sweep value.",
+        help=(
+            "Optional hard cap on total credits per sweep value. Must be set "
+            "alongside --conversation-num; a cap alone is rejected at config-load."
+        ),
     )
     parser.add_argument(
         "--skip-plots",

--- a/benchmarks/multimodal/sweep/args.py
+++ b/benchmarks/multimodal/sweep/args.py
@@ -63,18 +63,9 @@ def parse_args(argv=None) -> argparse.Namespace:
         type=int,
         default=None,
         help=(
-            "Override number of grouped conversations (sessions) per sweep value. "
-            "Primary control for grouped single_turn dispatch. If unset, derived "
-            "from the input JSONL's unique session_id count."
-        ),
-    )
-    parser.add_argument(
-        "--request-count",
-        type=int,
-        default=None,
-        help=(
-            "Optional hard cap on total credits per sweep value. Must be set "
-            "alongside --conversation-num; a cap alone is rejected at config-load."
+            "Override number of conversations (sessions) per sweep value. "
+            "If unset, derived from the input JSONL's unique session_id count "
+            "(flat JSONLs count each row as a 1-turn conversation)."
         ),
     )
     parser.add_argument(

--- a/benchmarks/multimodal/sweep/config.py
+++ b/benchmarks/multimodal/sweep/config.py
@@ -33,7 +33,6 @@ class SweepConfig:
     concurrencies: Optional[List[int]] = None
     osl: int = 150
     conversation_num: Optional[int] = None
-    request_count: Optional[int] = None
     warmup_count: int = 5
     port: int = 8000
     timeout: int = 600
@@ -87,15 +86,6 @@ class SweepConfig:
                 "At least one of request_rates or concurrencies is required."
             )
 
-        if self.request_count is not None and self.conversation_num is None:
-            raise ValueError(
-                "'request_count' alone is no longer supported. Set "
-                "'conversation_num: N' (derived from your JSONL's unique "
-                "session_id count, typically N users). 'request_count' is "
-                "accepted only as an optional hard-cap alongside "
-                "'conversation_num'."
-            )
-
 
 _DEFAULT_REQUEST_RATES: List[int] = [4, 8, 16, 32, 64]
 
@@ -138,7 +128,6 @@ def load_config(
         concurrencies=yaml_concurrencies,
         osl=raw.get("osl", 150),
         conversation_num=raw.get("conversation_num"),
-        request_count=raw.get("request_count"),
         warmup_count=raw.get("warmup_count", 5),
         port=raw.get("port", 8000),
         timeout=raw.get("timeout", 600),

--- a/benchmarks/multimodal/sweep/config.py
+++ b/benchmarks/multimodal/sweep/config.py
@@ -32,7 +32,8 @@ class SweepConfig:
     request_rates: Optional[List[int]] = None
     concurrencies: Optional[List[int]] = None
     osl: int = 150
-    request_count: int = 1000
+    conversation_num: Optional[int] = None
+    request_count: Optional[int] = None
     warmup_count: int = 5
     port: int = 8000
     timeout: int = 600
@@ -86,6 +87,15 @@ class SweepConfig:
                 "At least one of request_rates or concurrencies is required."
             )
 
+        if self.request_count is not None and self.conversation_num is None:
+            raise ValueError(
+                "'request_count' alone is no longer supported. Set "
+                "'conversation_num: N' (derived from your JSONL's unique "
+                "session_id count, typically N users). 'request_count' is "
+                "accepted only as an optional hard-cap alongside "
+                "'conversation_num'."
+            )
+
 
 _DEFAULT_REQUEST_RATES: List[int] = [4, 8, 16, 32, 64]
 
@@ -127,7 +137,8 @@ def load_config(
         request_rates=yaml_request_rates,
         concurrencies=yaml_concurrencies,
         osl=raw.get("osl", 150),
-        request_count=raw.get("request_count", 1000),
+        conversation_num=raw.get("conversation_num"),
+        request_count=raw.get("request_count"),
         warmup_count=raw.get("warmup_count", 5),
         port=raw.get("port", 8000),
         timeout=raw.get("timeout", 600),

--- a/benchmarks/multimodal/sweep/dataset_shape.py
+++ b/benchmarks/multimodal/sweep/dataset_shape.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def count_session_ids(jsonl_path: str | Path) -> int:
+    """Count unique ``session_id`` values in a JSONL dataset.
+
+    Used to derive ``conversation_num`` for the sweep when the user hasn't set
+    it explicitly. Rows without ``session_id`` count as distinct sessions
+    (matches aiperf's per-row UUID fallback in ``SingleTurnDatasetLoader``).
+
+    For multi_turn rows (``{"type": "multi_turn", "session_id": ..., "turns": [...]}``),
+    the top-level ``session_id`` is what counts.
+    """
+    sessions: set[str] = set()
+    anon_count = 0
+    with open(jsonl_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            sid = row.get("session_id")
+            if sid is None:
+                anon_count += 1
+            else:
+                sessions.add(str(sid))
+    return len(sessions) + anon_count

--- a/benchmarks/multimodal/sweep/orchestrator.py
+++ b/benchmarks/multimodal/sweep/orchestrator.py
@@ -69,8 +69,6 @@ def run_sweep(
     print(f"  OSL:           {config.osl}")
     if config.conversation_num is not None:
         print(f"  Conversations: {config.conversation_num} per {sweep_mode}")
-    if config.request_count is not None:
-        print(f"  Request cap:   {config.request_count} per {sweep_mode}")
     print(
         f"  Restart:       {'every run' if config.restart_server_every_benchmark else 'per config'}"
     )
@@ -177,7 +175,6 @@ def _run_config(
                     sweep_mode=sweep_mode,
                     sweep_value=value,
                     conversation_num=conversation_num,
-                    request_count=config.request_count,
                     warmup_count=config.warmup_count,
                     input_file=input_file,
                     osl=config.osl,

--- a/benchmarks/multimodal/sweep/orchestrator.py
+++ b/benchmarks/multimodal/sweep/orchestrator.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from .config import BenchmarkConfig, SweepConfig, input_file_tag, resolve_repo_root
+from .dataset_shape import count_session_ids
 from .runner import run_aiperf_single
 from .server import ServerManager
 
@@ -16,6 +17,26 @@ def _resolve_workflow(workflow: str, repo_root: Path) -> str:
     if p.is_absolute():
         return str(p)
     return str(repo_root / p)
+
+
+def _resolve_conversation_num(config: SweepConfig, input_file: str) -> int:
+    """Pick conversation_num for this input file: explicit value from config wins,
+    otherwise derive from the JSONL's unique session_id count. Error if an
+    explicit value exceeds the JSONL's capacity (sampler would wrap)."""
+    detected = count_session_ids(input_file)
+    if config.conversation_num is None:
+        print(
+            f"  conversation_num derived from {input_file}: {detected}",
+            flush=True,
+        )
+        return detected
+    if config.conversation_num > detected:
+        raise ValueError(
+            f"conversation_num={config.conversation_num} exceeds unique "
+            f"session_id count ({detected}) in {input_file}. SequentialSampler "
+            f"would wrap. Set conversation_num <= {detected} or reshape the JSONL."
+        )
+    return config.conversation_num
 
 
 def _print_banner(title: str, char: str = "=", width: int = 70) -> None:
@@ -46,7 +67,10 @@ def run_sweep(
     print(f"  Sweep mode:    {sweep_mode}")
     print(f"  Sweep values:  {sweep_values}")
     print(f"  OSL:           {config.osl}")
-    print(f"  Requests:      {config.request_count} per {sweep_mode}")
+    if config.conversation_num is not None:
+        print(f"  Conversations: {config.conversation_num} per {sweep_mode}")
+    if config.request_count is not None:
+        print(f"  Request cap:   {config.request_count} per {sweep_mode}")
     print(
         f"  Restart:       {'every run' if config.restart_server_every_benchmark else 'per config'}"
     )
@@ -98,10 +122,12 @@ def _run_config(
     _print_banner(f"Config: {bench_cfg.label}", char="#")
 
     # Collect pending runs, skipping those with existing results.
-    pending_runs: List[tuple[str, str, int, Path]] = []
+    pending_runs: List[tuple[str, str, int, Path, int]] = []
     for input_file in config.input_files:
         file_tag = input_file_tag(input_file)
         sweep_dir = output_base / file_tag / bench_cfg.label
+
+        conversation_num = _resolve_conversation_num(config, input_file)
 
         for value in sorted(sweep_values):
             artifact_dir = sweep_dir / f"{sweep_mode}{value}"
@@ -113,7 +139,9 @@ def _run_config(
                     flush=True,
                 )
             else:
-                pending_runs.append((input_file, file_tag, value, artifact_dir))
+                pending_runs.append(
+                    (input_file, file_tag, value, artifact_dir, conversation_num)
+                )
 
     if not pending_runs:
         print(f"  All runs skipped for {bench_cfg.label}", flush=True)
@@ -128,7 +156,7 @@ def _run_config(
         )
 
     try:
-        for input_file, file_tag, value, artifact_dir in pending_runs:
+        for input_file, file_tag, value, artifact_dir, conversation_num in pending_runs:
             _print_banner(
                 f"[{file_tag}] Config: {bench_cfg.label}  " f"{sweep_mode}={value}",
                 char="-",
@@ -148,6 +176,7 @@ def _run_config(
                     port=config.port,
                     sweep_mode=sweep_mode,
                     sweep_value=value,
+                    conversation_num=conversation_num,
                     request_count=config.request_count,
                     warmup_count=config.warmup_count,
                     input_file=input_file,

--- a/benchmarks/multimodal/sweep/runner.py
+++ b/benchmarks/multimodal/sweep/runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 
 def _build_aiperf_cmd(
@@ -14,7 +14,6 @@ def _build_aiperf_cmd(
     sweep_mode: str,
     sweep_value: int,
     conversation_num: int,
-    request_count: Optional[int],
     warmup_count: int,
     input_file: str,
     osl: int,
@@ -25,7 +24,7 @@ def _build_aiperf_cmd(
     else:
         sweep_flag = "--request-rate"
 
-    cmd = [
+    return [
         "aiperf",
         "profile",
         "-m",
@@ -57,9 +56,6 @@ def _build_aiperf_cmd(
         "none",
         "--no-server-metrics",
     ]
-    if request_count is not None:
-        cmd += ["--request-count", str(request_count)]
-    return cmd
 
 
 def run_aiperf_single(
@@ -68,7 +64,6 @@ def run_aiperf_single(
     sweep_mode: str,
     sweep_value: int,
     conversation_num: int,
-    request_count: Optional[int],
     warmup_count: int,
     input_file: str,
     osl: int,
@@ -82,7 +77,6 @@ def run_aiperf_single(
         sweep_mode=sweep_mode,
         sweep_value=sweep_value,
         conversation_num=conversation_num,
-        request_count=request_count,
         warmup_count=warmup_count,
         input_file=input_file,
         osl=osl,
@@ -111,7 +105,6 @@ def run_sweep(
     sweep_mode: str,
     sweep_values: List[int],
     conversation_num: int,
-    request_count: Optional[int],
     warmup_count: int,
     input_file: str,
     osl: int,
@@ -127,7 +120,6 @@ def run_sweep(
             sweep_mode=sweep_mode,
             sweep_value=value,
             conversation_num=conversation_num,
-            request_count=request_count,
             warmup_count=warmup_count,
             input_file=input_file,
             osl=osl,

--- a/benchmarks/multimodal/sweep/runner.py
+++ b/benchmarks/multimodal/sweep/runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 
 def _build_aiperf_cmd(
@@ -13,7 +13,8 @@ def _build_aiperf_cmd(
     port: int,
     sweep_mode: str,
     sweep_value: int,
-    request_count: int,
+    conversation_num: int,
+    request_count: Optional[int],
     warmup_count: int,
     input_file: str,
     osl: int,
@@ -24,7 +25,7 @@ def _build_aiperf_cmd(
     else:
         sweep_flag = "--request-rate"
 
-    return [
+    cmd = [
         "aiperf",
         "profile",
         "-m",
@@ -33,8 +34,8 @@ def _build_aiperf_cmd(
         f"http://localhost:{port}",
         sweep_flag,
         str(sweep_value),
-        "--request-count",
-        str(request_count),
+        "--conversation-num",
+        str(conversation_num),
         "--warmup-request-count",
         str(warmup_count),
         "--input-file",
@@ -56,6 +57,9 @@ def _build_aiperf_cmd(
         "none",
         "--no-server-metrics",
     ]
+    if request_count is not None:
+        cmd += ["--request-count", str(request_count)]
+    return cmd
 
 
 def run_aiperf_single(
@@ -63,7 +67,8 @@ def run_aiperf_single(
     port: int,
     sweep_mode: str,
     sweep_value: int,
-    request_count: int,
+    conversation_num: int,
+    request_count: Optional[int],
     warmup_count: int,
     input_file: str,
     osl: int,
@@ -76,6 +81,7 @@ def run_aiperf_single(
         port=port,
         sweep_mode=sweep_mode,
         sweep_value=sweep_value,
+        conversation_num=conversation_num,
         request_count=request_count,
         warmup_count=warmup_count,
         input_file=input_file,
@@ -104,7 +110,8 @@ def run_sweep(
     port: int,
     sweep_mode: str,
     sweep_values: List[int],
-    request_count: int,
+    conversation_num: int,
+    request_count: Optional[int],
     warmup_count: int,
     input_file: str,
     osl: int,
@@ -119,6 +126,7 @@ def run_sweep(
             port=port,
             sweep_mode=sweep_mode,
             sweep_value=value,
+            conversation_num=conversation_num,
             request_count=request_count,
             warmup_count=warmup_count,
             input_file=input_file,


### PR DESCRIPTION
## Why

Our sweep feeds aiperf a JSONL with 10 users × 10 turns each, intending to benchmark 10 conversations where each user goes through all 10 of their turns in order. With `--request-count 100`, aiperf has no notion of "a conversation is complete" — it just issues 100 credits. It runs through the 10 users once, then re-dispatches some of them as brand-new sessions to spend the remaining credits, and cuts off mid-conversation when the 100 limit is reached. We end up with 20 session instances maxing out at 5 turns deep, not the 10 × 10 we wanted. That distorts KV-cache hit rates (re-dispatched users warm-hit their own prefix) and skews every per-request latency.

Fix: use `--conversation-num 10`, which tells aiperf "run 10 full sessions." Produces the clean 10 × 10 shape.

Related Linear: DIS-1807.

## What Change

- Runner now emits `--conversation-num` as the primary control for grouped single_turn dispatch; `--request-count` retained only as optional hard cap.
- `SweepConfig` validator rejects `request_count` set alone at load time so legacy YAMLs fail loudly rather than silently regress; `conversation_num` is derived from the JSONL's unique `session_id` count when unset, and an explicit value exceeding capacity errors (would wrap).
- Does NOT bump the `aiperf==0.6.0` pin — see README for the active-container upgrade procedure using the pre-staged 0.7.0 wheel.

## Test plan

- Reran the local verification harness against aiperf-mock-server on the new flag set. Probe output: `sessions 10×10`, `conversation_ids 10`, `x_correlation_ids 10`, `turn_index {0:10, 1:10, ..., 9:10}`, `0 causality violations`.
- Unit-level: exercised `_build_aiperf_cmd`, `SweepConfig.validate`, and `_resolve_conversation_num` across the four migration cases (neither / only `conversation_num` / only `request_count` → rejected / both) and the over-limit guard.
- Full-dataset remote sweep rerun is a follow-up task once the production container is upgraded to aiperf 0.7.0 (out of scope here).

## Sample and command

jsonl example

```
{"session_id":"user_0","text":"Describe the scene in the first image.","images":["http://images.cocodataset.org/test2017/000000000001.jpg","http://images.cocodataset.org/test2017/000000000002.jpg","http://images.cocodataset.org/test2017/000000000003.jpg","http://images.cocodataset.org/test2017/000000000004.jpg","http://images.cocodataset.org/test2017/000000000005.jpg"]}
{"session_id":"user_1","text":"Describe the scene in the first image.","images":["http://images.cocodataset.org/test2017/000000000011.jpg","http://images.cocodataset.org/test2017/000000000012.jpg","http://images.cocodataset.org/test2017/000000000013.jpg","http://images.cocodataset.org/test2017/000000000014.jpg","http://images.cocodataset.org/test2017/000000000015.jpg"]}
{"session_id":"user_2","text":"Describe the scene in the first image.","images":["http://images.cocodataset.org/test2017/000000000021.jpg","http://images.cocodataset.org/test2017/000000000022.jpg","http://images.cocodataset.org/test2017/000000000023.jpg","http://images.cocodataset.org/test2017/000000000024.jpg","http://images.cocodataset.org/test2017/000000000025.jpg"]}
{"session_id":"user_0","text":"Now tell me what changed in this next image.","images":["http://images.cocodataset.org/test2017/000000000002.jpg","http://images.cocodataset.org/test2017/000000000003.jpg","http://images.cocodataset.org/test2017/000000000004.jpg","http://images.cocodataset.org/test2017/000000000005.jpg","http://images.cocodataset.org/test2017/000000000006.jpg"]}
{"session_id":"user_1","text":"Now tell me what changed in this next image.","images":["http://images.cocodataset.org/test2017/000000000012.jpg","http://images.cocodataset.org/test2017/000000000013.jpg","http://images.cocodataset.org/test2017/000000000014.jpg","http://images.cocodataset.org/test2017/000000000015.jpg","http://images.cocodataset.org/test2017/000000000016.jpg"]}
{"session_id":"user_2","text":"Now tell me what changed in this next image.","images":["http://images.cocodataset.org/test2017/000000000022.jpg","http://images.cocodataset.org/test2017/000000000023.jpg","http://images.cocodataset.org/test2017/000000000024.jpg","http://images.cocodataset.org/test2017/000000000025.jpg","http://images.cocodataset.org/test2017/000000000026.jpg"]}
{"session_id":"user_0","text":"Summarize everything you have seen so far.","images":["http://images.cocodataset.org/test2017/000000000003.jpg","http://images.cocodataset.org/test2017/000000000004.jpg","http://images.cocodataset.org/test2017/000000000005.jpg","http://images.cocodataset.org/test2017/000000000006.jpg","http://images.cocodataset.org/test2017/000000000007.jpg"]}
{"session_id":"user_1","text":"Summarize everything you have seen so far.","images":["http://images.cocodataset.org/test2017/000000000013.jpg","http://images.cocodataset.org/test2017/000000000014.jpg","http://images.cocodataset.org/test2017/000000000015.jpg","http://images.cocodataset.org/test2017/000000000016.jpg","http://images.cocodataset.org/test2017/000000000017.jpg"]}
{"session_id":"user_2","text":"Summarize everything you have seen so far.","images":["http://images.cocodataset.org/test2017/000000000023.jpg","http://images.cocodataset.org/test2017/000000000024.jpg","http://images.cocodataset.org/test2017/000000000025.jpg","http://images.cocodataset.org/test2017/000000000026.jpg","http://images.cocodataset.org/test2017/000000000027.jpg"]}
```

command

```
python benchmarks/multimodal/jsonl/main.py sliding-window \
    --num-users 10 \
    --turns-per-user 10 \
    --window-size 5 \
    --user-text-tokens 300 \
    --image-mode http \
    --seed 42
```