### PR TITLE
fix(kvbm): Fix consolidator e2e tests

### DIFF
--- a/tests/kvbm_integration/test_consolidator_router_e2e.py
+++ b/tests/kvbm_integration/test_consolidator_router_e2e.py
@@ -387,6 +387,13 @@ def llm_worker(frontend_server, test_directory, runtime_services, engine_type):
             "ETCD_ENDPOINTS": "http://localhost:2379",
             "DYN_KVBM_CPU_CACHE_GB": "5",
             "DYN_KVBM_DISK_CACHE_GB": "5",
+            # Disable O_DIRECT on the KVBM G3 disk cache so the test runs on
+            # hardware / filesystems that don't support `fcntl(F_SETFL, O_DIRECT)`
+            # (e.g. tmpfs on Linux kernels <~6.1, lustre, overlay, NFS). Without
+            # this, trtllm's blocking layout init hangs until the 120s worker
+            # registration timeout. Only affects disk I/O path, not functional
+            # event/dedup coverage this test exercises.
+            "DYN_KVBM_DISK_DISABLE_O_DIRECT": "true",
             "DYN_LOG": "debug",  # Enable debug logs for consolidator visibility
         }
     )
@@ -817,6 +824,12 @@ class TestConsolidatorRouterE2E:
                     "ETCD_ENDPOINTS": "http://localhost:2379",
                     "DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS": str(g2_cpu_blocks),
                     "DYN_KVBM_DISK_CACHE_OVERRIDE_NUM_BLOCKS": str(g3_disk_blocks),
+                    # Disable O_DIRECT on the KVBM G3 disk cache so the test runs
+                    # on hardware / filesystems that don't support
+                    # `fcntl(F_SETFL, O_DIRECT)` (e.g. tmpfs on Linux kernels
+                    # <~6.1, lustre, overlay, NFS). Only affects disk I/O path,
+                    # not the event/dedup behavior under test.
+                    "DYN_KVBM_DISK_DISABLE_O_DIRECT": "true",
                     "DYN_LOG": "debug",
                 }
             )

--- a/tests/kvbm_integration/test_consolidator_router_e2e.py
+++ b/tests/kvbm_integration/test_consolidator_router_e2e.py
@@ -356,6 +356,8 @@ def llm_worker(frontend_server, test_directory, runtime_services, engine_type):
             model_id,
             "--kv-transfer-config",
             '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}',
+            "--kv-events-config",
+            '{"enable_kv_cache_events": true}',
             "--enforce-eager",  # For faster startup in tests
         ]
     else:  # trtllm
@@ -779,6 +781,8 @@ class TestConsolidatorRouterE2E:
                     model_id,
                     "--kv-transfer-config",
                     '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}',
+                    "--kv-events-config",
+                    '{"enable_kv_cache_events": true}',
                     "--enforce-eager",
                     "--enable-prefix-caching",
                     "--num-gpu-blocks-override",


### PR DESCRIPTION
- Add `--kv-events-config '{"enable_kv_cache_events": true}'` to both the `llm_worker` fixture and the inline worker in `test_remove_deduplication_across_sources` so the consolidator wires up correctly. PR #7591 removed the automatic default `KVEventsConfig` on the vllm side; without this flag the consolidator silently fails to attach (AttributeError on `None.endpoint`) and every test asserts `consolidator_started=False`.
- Set `DYN_KVBM_DISK_DISABLE_O_DIRECT=true` in both the `llm_worker` fixture and the inline worker in `test_remove_deduplication_across_sources` so the suite runs on any kernel/filesystem combo. On kernels
  <~6.1 (Ubuntu 22.04 tmpfs, lustre, overlay, NFS), `fcntl(F_SETFL, O_DIRECT)` returns EINVAL; trtllm's blocking layout init then hangs until the 120s worker registration timeout.

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated vLLM integration test configurations to enable KV cache event tracking during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->