### PR TITLE
fix(runtime): reset canary health check timer on request arrival and per streaming chunk

### DIFF
--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -479,11 +479,12 @@ mod push_handler_notify_tests {
         (server, connection_info)
     }
 
-    /// Registers an endpoint in the DRT: health check target + local engine +
-    /// returns the notifier that the real HealthCheckManager will listen on.
+    /// Registers an endpoint in the DRT with the given engine in local registry.
+    /// Returns the notifier that the real HealthCheckManager will listen on.
     fn register_endpoint(
         drt: &crate::DistributedRuntime,
         endpoint_name: &str,
+        local_engine: LocalAsyncEngine,
     ) -> Arc<tokio::sync::Notify> {
         let payload = serde_json::json!({
             "prompt": "health",
@@ -502,11 +503,8 @@ mod push_handler_notify_tests {
             payload,
         );
 
-        // Register a mock engine in local registry so send_health_check_request
-        // can call engine.generate() when the canary fires.
-        let mock_engine: LocalAsyncEngine = MockStreamingEngine::success(1);
         drt.local_endpoint_registry()
-            .register(endpoint_name.to_string(), mock_engine);
+            .register(endpoint_name.to_string(), local_engine);
 
         drt.system_health()
             .lock()
@@ -514,32 +512,35 @@ mod push_handler_notify_tests {
             .expect("Notifier should exist for registered endpoint")
     }
 
-    /// Tests that when a request flows through push_handler (streaming 5 chunks),
-    /// the real HealthCheckManager's canary timer is reset via notify_one(),
-    /// preventing the canary from firing and keeping the endpoint in its initial
-    /// NotReady state (i.e., send_health_check_request is never called).
+    /// Tests the full notification → timer reset → status Ready path.
+    ///
+    /// The local registry engine returns errors, so if the canary fires,
+    /// send_health_check_request will set NotReady. This proves that a
+    /// Ready status can only come from the notification path.
     #[tokio::test]
     async fn test_notifier_resets_canary_timer() {
         let drt = create_test_drt_async().await;
         let endpoint_name = "test.push_handler.timer_reset";
 
-        let notifier = register_endpoint(&drt, endpoint_name);
+        // Register with an error engine — if the canary fires, status stays NotReady.
+        let notifier = register_endpoint(&drt, endpoint_name, MockStreamingEngine::all_errors(1));
 
-        // Verify initial status is NotReady before any activity
+        // Endpoint starts NotReady
         let status = drt
             .system_health()
             .lock()
             .get_endpoint_health_status(endpoint_name);
         assert_eq!(status, Some(HealthStatus::NotReady));
 
-        let engine: Arc<MockStreamingEngine> = MockStreamingEngine::success(5);
+        // Set up the push_handler pipeline
+        let engine = MockStreamingEngine::success(5);
         let ingress =
             Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();
         ingress
             .set_endpoint_health_check_notifier(notifier.clone())
             .unwrap();
 
-        // Pre-create the TCP receiver and encoded payload
+        // Pre-create request before starting HealthCheckManager
         let request_id = uuid::Uuid::new_v4().to_string();
         let (_server, connection_info) = setup_tcp_receiver(&request_id).await;
         let payload = encode_request(
@@ -548,10 +549,7 @@ mod push_handler_notify_tests {
             &serde_json::json!({"prompt": "test"}),
         );
 
-        // Send the request through push_handler BEFORE starting the
-        // HealthCheckManager. This way we can use a separate Notify for
-        // counting without competing with the manager (notify_one only
-        // wakes one waiter).
+        // Phase 1: count notifications (no HealthCheckManager competing)
         let notify_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let count_clone = notify_count.clone();
         let notifier_for_counter = notifier.clone();
@@ -571,28 +569,16 @@ mod push_handler_notify_tests {
         let result = ingress
             .handle_payload(payload, Some(request_id.clone()))
             .await;
-        assert!(
-            result.is_ok(),
-            "handle_payload should succeed: {:?}",
-            result.err()
-        );
+        assert!(result.is_ok(), "handle_payload should succeed");
 
-        // Wait for the counter task to finish collecting notifications
         counter_task.await.unwrap();
-
-        // Verify notifications were received. Notify coalesces multiple calls
-        // into single wakeups, so the exact count depends on scheduling. With
-        // 5 chunks + 1 stream completion = 6 notify_one() calls, we expect
-        // at least 2 wakeups - one for a streaming chunk, one for stream completion.
         let count = notify_count.load(std::sync::atomic::Ordering::SeqCst);
         assert!(
             count >= 2,
-            "Expected at least 2 notification wakeup from push_handler streaming, got {count}"
+            "Expected at least 2 wakeups (chunks + completion), got {count}"
         );
 
-        // NOW start the HealthCheckManager. It will be the sole consumer of
-        // the notifier going forward. The canary wait is 500ms — we'll send
-        // another request to reset the timer, then verify it didn't fire.
+        // Phase 2: start HealthCheckManager, send another request to reset timer
         let config = HealthCheckConfig {
             canary_wait_time: Duration::from_millis(500),
             request_timeout: Duration::from_secs(1),
@@ -600,7 +586,6 @@ mod push_handler_notify_tests {
         let manager = Arc::new(HealthCheckManager::new(drt.clone(), config));
         manager.clone().start().await.unwrap();
 
-        // Send a second request to reset the canary timer
         let request_id2 = uuid::Uuid::new_v4().to_string();
         let (_server2, connection_info2) = setup_tcp_receiver(&request_id2).await;
         let payload2 = encode_request(
@@ -611,12 +596,10 @@ mod push_handler_notify_tests {
         let result2 = ingress.handle_payload(payload2, Some(request_id2)).await;
         assert!(result2.is_ok(), "second handle_payload should succeed");
 
-        // Wait less than canary_wait_time
         tokio::time::sleep(Duration::from_millis(200)).await;
 
-        // The canary should NOT have fired. The status should be Ready because
-        // the notification from push_handler's successful streaming set it to
-        // Ready (without the canary ever needing to fire).
+        // Ready can only come from the notification path (the canary would set
+        // NotReady because the local registry engine returns errors).
         let status = drt
             .system_health()
             .lock()
@@ -624,8 +607,7 @@ mod push_handler_notify_tests {
         assert_eq!(
             status,
             Some(HealthStatus::Ready),
-            "Status should be Ready — push_handler's successful streaming \
-             should have set it via the notification path"
+            "Status should be Ready from notification path (canary engine returns errors)"
         );
     }
 
@@ -638,7 +620,7 @@ mod push_handler_notify_tests {
         let drt = create_test_drt_async().await;
         let endpoint_name = "test.push_handler.canary_fires";
 
-        let _notifier = register_endpoint(&drt, endpoint_name);
+        let _notifier = register_endpoint(&drt, endpoint_name, MockStreamingEngine::success(1));
 
         // Start the real HealthCheckManager with a very short canary wait
         let config = HealthCheckConfig {

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -625,17 +625,18 @@ mod push_handler_notify_tests {
 
         // Pipeline streams only errors — no notifications sent
         let ingress = create_ingress(MockStreamingEngine::all_errors(3), notifier);
-        start_manager(&drt, 500).await;
+        start_manager(&drt, 50).await;
 
         send_request(&ingress).await;
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Wait for canary to fire (50ms wait + margin)
+        tokio::time::sleep(Duration::from_millis(300)).await;
 
-        // No notification (all errors), canary hasn't fired yet (500ms wait)
+        // Error streaming didn't notify, canary fired but engine also errored
         assert_status(
             &drt,
             endpoint,
             HealthStatus::NotReady,
-            "error streaming should not notify, status stays NotReady",
+            "error streaming should not notify, canary also errors — stays NotReady",
         );
     }
 

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -503,6 +503,26 @@ mod push_handler_notify_tests {
         let manager = Arc::new(HealthCheckManager::new(drt.clone(), config));
         manager.clone().start().await.unwrap();
 
+        // Spawn a counter task that observes notifications on the same notifier.
+        // Since Notify coalesces, we count wakeups (not individual notify_one calls).
+        // push_handler calls notify_one() on each chunk + stream completion,
+        // so we expect at least 1 wakeup.
+        let notify_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let count_clone = notify_count.clone();
+        let notifier_for_counter = notifier.clone();
+        let counter_task = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = notifier_for_counter.notified() => {
+                        count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(500)) => {
+                        break;
+                    }
+                }
+            }
+        });
+
         // Set up the push_handler pipeline with the SAME notifier
         let engine: Arc<MockStreamingEngine> = Arc::new(MockStreamingEngine { num_chunks: 5 });
         let ingress =
@@ -512,7 +532,7 @@ mod push_handler_notify_tests {
             .unwrap();
 
         // Send a request through push_handler — this will call notify_one()
-        // on each of the 5 streaming chunks, resetting the canary timer each time.
+        // on each of the 5 streaming chunks + stream completion.
         let request_id = uuid::Uuid::new_v4().to_string();
         let (_server, connection_info) = setup_tcp_receiver(&request_id).await;
         let payload = encode_request(
@@ -529,8 +549,18 @@ mod push_handler_notify_tests {
             result.err()
         );
 
-        // Wait a bit — but less than the canary wait time
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait for the counter task to finish collecting notifications
+        counter_task.await.unwrap();
+
+        // Verify notifications were received. Notify coalesces multiple calls
+        // into single wakeups, so the exact count depends on scheduling. With
+        // 5 chunks + 1 stream completion = 6 notify_one() calls, we expect
+        // at least 1 wakeup (coalesced) but typically 2-4.
+        let count = notify_count.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            count >= 1,
+            "Expected at least 1 notification wakeup from push_handler streaming, got {count}"
+        );
 
         // The canary should NOT have fired. Since the endpoint starts as NotReady
         // and send_health_check_request (which sets Ready on success) was never

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -586,7 +586,24 @@ mod push_handler_notify_tests {
         let drt = create_test_drt_async().await;
         let endpoint_name = "test.push_handler.canary_fires";
 
-        let _notifier = register_endpoint(&drt, endpoint_name);
+        let notifier = register_endpoint(&drt, endpoint_name);
+
+        // Spawn a counter task to confirm zero notifications arrive
+        let notify_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let count_clone = notify_count.clone();
+        let notifier_for_counter = notifier.clone();
+        let counter_task = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = notifier_for_counter.notified() => {
+                        count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(500)) => {
+                        break;
+                    }
+                }
+            }
+        });
 
         // Start the real HealthCheckManager with a very short canary wait
         let config = HealthCheckConfig {
@@ -607,7 +624,14 @@ mod push_handler_notify_tests {
         // The canary will call send_health_check_request, which finds the mock
         // engine in local_endpoint_registry, calls generate(), gets a successful
         // response, and sets status to Ready.
-        tokio::time::sleep(Duration::from_millis(300)).await;
+        counter_task.await.unwrap();
+
+        // No requests were sent through push_handler, so no notifications
+        let count = notify_count.load(std::sync::atomic::Ordering::SeqCst);
+        assert_eq!(
+            count, 0,
+            "Expected 0 notification wakeups since no requests were processed, got {count}"
+        );
 
         let status = drt
             .system_health()

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -512,177 +512,8 @@ mod push_handler_notify_tests {
             .expect("Notifier should exist for registered endpoint")
     }
 
-    /// Tests the full notification → timer reset → status Ready path.
-    ///
-    /// The local registry engine returns errors, so if the canary fires,
-    /// send_health_check_request will set NotReady. This proves that a
-    /// Ready status can only come from the notification path.
-    #[tokio::test]
-    async fn test_notifier_resets_canary_timer() {
-        let drt = create_test_drt_async().await;
-        let endpoint_name = "test.push_handler.timer_reset";
-
-        // Register with an error engine — if the canary fires, status stays NotReady.
-        let notifier = register_endpoint(&drt, endpoint_name, MockStreamingEngine::all_errors(1));
-
-        // Endpoint starts NotReady
-        let status = drt
-            .system_health()
-            .lock()
-            .get_endpoint_health_status(endpoint_name);
-        assert_eq!(status, Some(HealthStatus::NotReady));
-
-        // Set up the push_handler pipeline
-        let engine = MockStreamingEngine::success(5);
-        let ingress =
-            Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();
-        ingress
-            .set_endpoint_health_check_notifier(notifier.clone())
-            .unwrap();
-
-        // Pre-create request before starting HealthCheckManager
-        let request_id = uuid::Uuid::new_v4().to_string();
-        let (_server, connection_info) = setup_tcp_receiver(&request_id).await;
-        let payload = encode_request(
-            &request_id,
-            connection_info,
-            &serde_json::json!({"prompt": "test"}),
-        );
-
-        // Phase 1: count notifications (no HealthCheckManager competing)
-        let notify_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
-        let count_clone = notify_count.clone();
-        let notifier_for_counter = notifier.clone();
-        let counter_task = tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    _ = notifier_for_counter.notified() => {
-                        count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    }
-                    _ = tokio::time::sleep(Duration::from_millis(500)) => {
-                        break;
-                    }
-                }
-            }
-        });
-
-        let result = ingress
-            .handle_payload(payload, Some(request_id.clone()))
-            .await;
-        assert!(result.is_ok(), "handle_payload should succeed");
-
-        counter_task.await.unwrap();
-        let count = notify_count.load(std::sync::atomic::Ordering::SeqCst);
-        assert!(
-            count >= 2,
-            "Expected at least 2 wakeups (chunks + completion), got {count}"
-        );
-
-        // Phase 2: start HealthCheckManager, send another request to reset timer
-        let config = HealthCheckConfig {
-            canary_wait_time: Duration::from_millis(500),
-            request_timeout: Duration::from_secs(1),
-        };
-        let manager = Arc::new(HealthCheckManager::new(drt.clone(), config));
-        manager.clone().start().await.unwrap();
-
-        let request_id2 = uuid::Uuid::new_v4().to_string();
-        let (_server2, connection_info2) = setup_tcp_receiver(&request_id2).await;
-        let payload2 = encode_request(
-            &request_id2,
-            connection_info2,
-            &serde_json::json!({"prompt": "test2"}),
-        );
-        let result2 = ingress.handle_payload(payload2, Some(request_id2)).await;
-        assert!(result2.is_ok(), "second handle_payload should succeed");
-
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        // Ready can only come from the notification path (the canary would set
-        // NotReady because the local registry engine returns errors).
-        let status = drt
-            .system_health()
-            .lock()
-            .get_endpoint_health_status(endpoint_name);
-        assert_eq!(
-            status,
-            Some(HealthStatus::Ready),
-            "Status should be Ready from notification path (canary engine returns errors)"
-        );
-    }
-
-    /// Tests that without any requests flowing through push_handler, the real
-    /// HealthCheckManager's canary timer expires, fires send_health_check_request,
-    /// and transitions the endpoint status from NotReady to Ready (proving the
-    /// canary executed the full health check path).
-    #[tokio::test]
-    async fn test_canary_fires_without_activity() {
-        let drt = create_test_drt_async().await;
-        let endpoint_name = "test.push_handler.canary_fires";
-
-        let _notifier = register_endpoint(&drt, endpoint_name, MockStreamingEngine::success(1));
-
-        // Start the real HealthCheckManager with a very short canary wait
-        let config = HealthCheckConfig {
-            canary_wait_time: Duration::from_millis(50),
-            request_timeout: Duration::from_secs(1),
-        };
-        let manager = Arc::new(HealthCheckManager::new(drt.clone(), config));
-        manager.clone().start().await.unwrap();
-
-        // Verify initial status is NotReady
-        let status = drt
-            .system_health()
-            .lock()
-            .get_endpoint_health_status(endpoint_name);
-        assert_eq!(status, Some(HealthStatus::NotReady));
-
-        // Don't send any requests — let the canary fire.
-        // The canary will call send_health_check_request, which finds the mock
-        // engine in local_endpoint_registry, calls generate(), gets a successful
-        // response, and sets status to Ready.
-        tokio::time::sleep(Duration::from_millis(300)).await;
-
-        let status = drt
-            .system_health()
-            .lock()
-            .get_endpoint_health_status(endpoint_name);
-        assert_eq!(
-            status,
-            Some(HealthStatus::Ready),
-            "Status should be Ready — the canary should have fired and \
-             send_health_check_request should have succeeded with the mock engine"
-        );
-    }
-
-    // ----------------------------------------------------------------
-    // Push handler notification tests (error-gating behavior)
-    // These test the push_handler directly via handle_payload to verify
-    // that notifications are only sent for non-error response chunks.
-    // ----------------------------------------------------------------
-
-    /// Helper: send a request through the given ingress pipeline and count
-    /// the notifications that arrive on the notifier.
-    async fn send_and_count_notifications(
-        ingress: &Ingress<SingleIn<TestRequest>, ManyOut<TestResponse>>,
-        notifier: &Arc<tokio::sync::Notify>,
-    ) -> u32 {
-        let notify_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
-        let count_clone = notify_count.clone();
-        let notifier_clone = notifier.clone();
-        let counter_task = tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    _ = notifier_clone.notified() => {
-                        count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    }
-                    _ = tokio::time::sleep(Duration::from_millis(500)) => {
-                        break;
-                    }
-                }
-            }
-        });
-
+    /// Helper: send a request through the ingress pipeline.
+    async fn send_request(ingress: &Ingress<SingleIn<TestRequest>, ManyOut<TestResponse>>) {
         let request_id = uuid::Uuid::new_v4().to_string();
         let (_server, connection_info) = setup_tcp_receiver(&request_id).await;
         let payload = encode_request(
@@ -691,80 +522,172 @@ mod push_handler_notify_tests {
             &serde_json::json!({"prompt": "test"}),
         );
         let result = ingress.handle_payload(payload, Some(request_id)).await;
-        assert!(
-            result.is_ok(),
-            "handle_payload should succeed: {:?}",
-            result.err()
-        );
-
-        counter_task.await.unwrap();
-        notify_count.load(std::sync::atomic::Ordering::SeqCst)
+        assert!(result.is_ok(), "handle_payload should succeed");
     }
 
-    /// Successful request: notified on each chunk and on stream completion.
-    #[tokio::test]
-    async fn test_successful_request_notifies_on_chunks_and_completion() {
-        let engine = MockStreamingEngine::success(5);
+    /// Helper: assert endpoint health status.
+    fn assert_status(
+        drt: &crate::DistributedRuntime,
+        endpoint_name: &str,
+        expected: HealthStatus,
+        msg: &str,
+    ) {
+        let status = drt
+            .system_health()
+            .lock()
+            .get_endpoint_health_status(endpoint_name);
+        assert_eq!(status, Some(expected), "{msg}");
+    }
+
+    /// Helper: create ingress pipeline with given engine and notifier.
+    fn create_ingress(
+        engine: Arc<MockStreamingEngine>,
+        notifier: Arc<tokio::sync::Notify>,
+    ) -> Arc<Ingress<SingleIn<TestRequest>, ManyOut<TestResponse>>> {
         let ingress =
             Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();
-
-        let notifier = Arc::new(tokio::sync::Notify::new());
         ingress
-            .set_endpoint_health_check_notifier(notifier.clone())
+            .set_endpoint_health_check_notifier(notifier)
             .unwrap();
+        ingress
+    }
 
-        let count = send_and_count_notifications(&ingress, &notifier).await;
+    /// Helper: start HealthCheckManager with given canary wait.
+    async fn start_manager(drt: &crate::DistributedRuntime, canary_wait_ms: u64) {
+        let config = HealthCheckConfig {
+            canary_wait_time: Duration::from_millis(canary_wait_ms),
+            request_timeout: Duration::from_secs(1),
+        };
+        let manager = Arc::new(HealthCheckManager::new(drt.clone(), config));
+        manager.start().await.unwrap();
+    }
 
-        // 5 chunks + 1 stream completion = 6 notify_one() calls.
-        // Coalescing means we get fewer wakeups, but at least 2.
-        assert!(
-            count >= 2,
-            "Expected at least 2 notification wakeups for 5 successful chunks + completion, got {count}"
+    // =================================================================
+    // Test 1: Successful streaming → notification → Ready
+    // Canary engine returns errors, so Ready can only come from notify.
+    // =================================================================
+    #[tokio::test]
+    async fn test_successful_streaming_sets_ready() {
+        let drt = create_test_drt_async().await;
+        let endpoint = "test.successful_streaming";
+
+        let notifier = register_endpoint(&drt, endpoint, MockStreamingEngine::all_errors(1));
+        assert_status(&drt, endpoint, HealthStatus::NotReady, "initial");
+
+        let ingress = create_ingress(MockStreamingEngine::success(5), notifier);
+        start_manager(&drt, 500).await;
+
+        send_request(&ingress).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Ready can only come from notification (canary engine errors)
+        assert_status(
+            &drt,
+            endpoint,
+            HealthStatus::Ready,
+            "successful streaming should set Ready via notification path",
         );
     }
 
-    /// All-error request: no notifications since every chunk is an error.
+    // =================================================================
+    // Test 2: Idle engine → canary fires → successful health check → Ready
+    // =================================================================
     #[tokio::test]
-    async fn test_error_response_does_not_notify() {
-        let engine = MockStreamingEngine::all_errors(3);
-        let ingress =
-            Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();
+    async fn test_canary_fires_on_idle_engine() {
+        let drt = create_test_drt_async().await;
+        let endpoint = "test.canary_idle";
 
-        let notifier = Arc::new(tokio::sync::Notify::new());
-        ingress
-            .set_endpoint_health_check_notifier(notifier.clone())
-            .unwrap();
+        let _notifier = register_endpoint(&drt, endpoint, MockStreamingEngine::success(1));
+        assert_status(&drt, endpoint, HealthStatus::NotReady, "initial");
 
-        let count = send_and_count_notifications(&ingress, &notifier).await;
+        start_manager(&drt, 50).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
 
-        assert_eq!(
-            count, 0,
-            "Expected 0 notifications for all-error response, got {count}"
+        // No requests sent — canary fired and succeeded
+        assert_status(
+            &drt,
+            endpoint,
+            HealthStatus::Ready,
+            "canary should fire and set Ready on idle engine",
         );
     }
 
-    /// Mixed response: successful chunks followed by an error chunk at the end.
-    /// Only the successful chunks should notify; the error chunk and stream
-    /// completion should not.
+    // =================================================================
+    // Test 3: Error streaming → no notification → canary errors → NotReady
+    // =================================================================
     #[tokio::test]
-    async fn test_mixed_response_only_notifies_on_success_chunks() {
-        // 5 chunks total, last one (index 4) is an error
-        let engine = MockStreamingEngine::with_error_at(5, vec![4]);
-        let ingress =
-            Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();
+    async fn test_error_streaming_stays_not_ready() {
+        let drt = create_test_drt_async().await;
+        let endpoint = "test.error_streaming";
 
-        let notifier = Arc::new(tokio::sync::Notify::new());
-        ingress
-            .set_endpoint_health_check_notifier(notifier.clone())
-            .unwrap();
+        let notifier = register_endpoint(&drt, endpoint, MockStreamingEngine::all_errors(1));
+        assert_status(&drt, endpoint, HealthStatus::NotReady, "initial");
 
-        let count = send_and_count_notifications(&ingress, &notifier).await;
+        // Pipeline streams only errors — no notifications sent
+        let ingress = create_ingress(MockStreamingEngine::all_errors(3), notifier);
+        start_manager(&drt, 500).await;
 
-        // 4 successful chunks should notify, error chunk + completion should not.
-        // Coalescing means fewer wakeups, but at least 1.
-        assert!(
-            count >= 1,
-            "Expected at least 1 notification for 4 successful chunks, got {count}"
+        send_request(&ingress).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // No notification (all errors), canary hasn't fired yet (500ms wait)
+        assert_status(
+            &drt,
+            endpoint,
+            HealthStatus::NotReady,
+            "error streaming should not notify, status stays NotReady",
+        );
+    }
+
+    // =================================================================
+    // Test 4: Idle engine → canary fires → failing health check → NotReady
+    // =================================================================
+    #[tokio::test]
+    async fn test_idle_engine_with_failing_canary() {
+        let drt = create_test_drt_async().await;
+        let endpoint = "test.canary_fails";
+
+        let _notifier = register_endpoint(&drt, endpoint, MockStreamingEngine::all_errors(1));
+        assert_status(&drt, endpoint, HealthStatus::NotReady, "initial");
+
+        start_manager(&drt, 50).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // No requests sent, canary fired but engine returned error
+        assert_status(
+            &drt,
+            endpoint,
+            HealthStatus::NotReady,
+            "canary fired but engine errored, status stays NotReady",
+        );
+    }
+
+    // =================================================================
+    // Test 5: Mixed streaming (success + trailing error) → Ready
+    // Successful chunks notify before the error, so status becomes Ready.
+    // Canary engine errors, proving Ready came from notification path.
+    // =================================================================
+    #[tokio::test]
+    async fn test_mixed_streaming_sets_ready() {
+        let drt = create_test_drt_async().await;
+        let endpoint = "test.mixed_streaming";
+
+        let notifier = register_endpoint(&drt, endpoint, MockStreamingEngine::all_errors(1));
+        assert_status(&drt, endpoint, HealthStatus::NotReady, "initial");
+
+        // 5 chunks: 4 success + error at index 4
+        let ingress = create_ingress(MockStreamingEngine::with_error_at(5, vec![4]), notifier);
+        start_manager(&drt, 500).await;
+
+        send_request(&ingress).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Successful chunks notified before the error chunk
+        assert_status(
+            &drt,
+            endpoint,
+            HealthStatus::Ready,
+            "successful chunks should set Ready despite trailing error",
         );
     }
 }

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -595,24 +595,7 @@ mod push_handler_notify_tests {
         let drt = create_test_drt_async().await;
         let endpoint_name = "test.push_handler.canary_fires";
 
-        let notifier = register_endpoint(&drt, endpoint_name);
-
-        // Spawn a counter task to confirm zero notifications arrive
-        let notify_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
-        let count_clone = notify_count.clone();
-        let notifier_for_counter = notifier.clone();
-        let counter_task = tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    _ = notifier_for_counter.notified() => {
-                        count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    }
-                    _ = tokio::time::sleep(Duration::from_millis(500)) => {
-                        break;
-                    }
-                }
-            }
-        });
+        let _notifier = register_endpoint(&drt, endpoint_name);
 
         // Start the real HealthCheckManager with a very short canary wait
         let config = HealthCheckConfig {
@@ -633,14 +616,7 @@ mod push_handler_notify_tests {
         // The canary will call send_health_check_request, which finds the mock
         // engine in local_endpoint_registry, calls generate(), gets a successful
         // response, and sets status to Ready.
-        counter_task.await.unwrap();
-
-        // No requests were sent through push_handler, so no notifications
-        let count = notify_count.load(std::sync::atomic::Ordering::SeqCst);
-        assert_eq!(
-            count, 0,
-            "Expected 0 notification wakeups since no requests were processed, got {count}"
-        );
+        tokio::time::sleep(Duration::from_millis(300)).await;
 
         let status = drt
             .system_health()

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -461,6 +461,7 @@ mod push_handler_notify_tests {
                 namespace: "test_namespace".to_string(),
                 instance_id: 0,
                 transport: TransportType::Nats(endpoint_name.to_string()),
+                device_type: None,
             },
             payload,
         );
@@ -493,20 +494,32 @@ mod push_handler_notify_tests {
 
         let notifier = register_endpoint(&drt, endpoint_name);
 
-        // Start the real HealthCheckManager with a short canary wait.
-        // If the canary fires, it will call send_health_check_request which
-        // succeeds (mock engine registered) and sets status to Ready.
-        let config = HealthCheckConfig {
-            canary_wait_time: Duration::from_millis(200),
-            request_timeout: Duration::from_secs(1),
-        };
-        let manager = Arc::new(HealthCheckManager::new(drt.clone(), config));
-        manager.clone().start().await.unwrap();
+        // Set up the push_handler pipeline BEFORE starting the HealthCheckManager
+        // so we can send a request immediately and avoid a race where the canary
+        // fires before handle_payload has a chance to notify.
+        let engine: Arc<MockStreamingEngine> = Arc::new(MockStreamingEngine { num_chunks: 5 });
+        let ingress =
+            Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();
+        ingress
+            .set_endpoint_health_check_notifier(notifier.clone())
+            .unwrap();
 
-        // Spawn a counter task that observes notifications on the same notifier.
-        // Since Notify coalesces, we count wakeups (not individual notify_one calls).
-        // push_handler calls notify_one() on each chunk + stream completion,
-        // so we expect at least 1 wakeup.
+        // Pre-create the TCP receiver and encoded payload
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let (_server, connection_info) = setup_tcp_receiver(&request_id).await;
+        let payload = encode_request(
+            &request_id,
+            connection_info,
+            &serde_json::json!({"prompt": "test"}),
+        );
+
+        // Send the request through push_handler BEFORE starting the
+        // HealthCheckManager. This way we can use a separate Notify for
+        // counting without competing with the manager (notify_one only
+        // wakes one waiter).
+        //
+        // push_handler will call notify_one() on each of the 5 chunks
+        // + stream completion. The counter task is the sole consumer.
         let notify_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let count_clone = notify_count.clone();
         let notifier_for_counter = notifier.clone();
@@ -523,23 +536,6 @@ mod push_handler_notify_tests {
             }
         });
 
-        // Set up the push_handler pipeline with the SAME notifier
-        let engine: Arc<MockStreamingEngine> = Arc::new(MockStreamingEngine { num_chunks: 5 });
-        let ingress =
-            Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();
-        ingress
-            .set_endpoint_health_check_notifier(notifier)
-            .unwrap();
-
-        // Send a request through push_handler — this will call notify_one()
-        // on each of the 5 streaming chunks + stream completion.
-        let request_id = uuid::Uuid::new_v4().to_string();
-        let (_server, connection_info) = setup_tcp_receiver(&request_id).await;
-        let payload = encode_request(
-            &request_id,
-            connection_info,
-            &serde_json::json!({"prompt": "test"}),
-        );
         let result = ingress
             .handle_payload(payload, Some(request_id.clone()))
             .await;
@@ -561,6 +557,30 @@ mod push_handler_notify_tests {
             count >= 1,
             "Expected at least 1 notification wakeup from push_handler streaming, got {count}"
         );
+
+        // NOW start the HealthCheckManager. It will be the sole consumer of
+        // the notifier going forward. The canary wait is 500ms — we'll send
+        // another request to reset the timer, then verify it didn't fire.
+        let config = HealthCheckConfig {
+            canary_wait_time: Duration::from_millis(500),
+            request_timeout: Duration::from_secs(1),
+        };
+        let manager = Arc::new(HealthCheckManager::new(drt.clone(), config));
+        manager.clone().start().await.unwrap();
+
+        // Send a second request to reset the canary timer
+        let request_id2 = uuid::Uuid::new_v4().to_string();
+        let (_server2, connection_info2) = setup_tcp_receiver(&request_id2).await;
+        let payload2 = encode_request(
+            &request_id2,
+            connection_info2,
+            &serde_json::json!({"prompt": "test2"}),
+        );
+        let result2 = ingress.handle_payload(payload2, Some(request_id2)).await;
+        assert!(result2.is_ok(), "second handle_payload should succeed");
+
+        // Wait less than canary_wait_time
+        tokio::time::sleep(Duration::from_millis(200)).await;
 
         // The canary should NOT have fired. Since the endpoint starts as NotReady
         // and send_health_check_request (which sets Ready on success) was never
@@ -692,6 +712,7 @@ mod integration_tests {
                 namespace: "test_namespace".to_string(),
                 instance_id: 12345,
                 transport: crate::component::TransportType::Nats(endpoint.to_string()),
+                device_type: None,
             },
             payload.clone(),
         );
@@ -727,6 +748,7 @@ mod integration_tests {
                     namespace: "test_namespace".to_string(),
                     instance_id: i,
                     transport: crate::component::TransportType::Nats(endpoint.clone()),
+                    device_type: None,
                 },
                 payload,
             );
@@ -770,6 +792,7 @@ mod integration_tests {
                 namespace: "test_namespace".to_string(),
                 instance_id: 999,
                 transport: crate::component::TransportType::Nats(endpoint.to_string()),
+                device_type: None,
             },
             payload.clone(),
         );

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -119,9 +119,14 @@ impl HealthCheckManager {
                     }
 
                     _ = notifier.notified() => {
-                        // Activity detected - reset timer for this endpoint only
+                        // Activity detected - reset timer for this endpoint only.
+                        // A notification means push_handler successfully streamed
+                        // a non-error response chunk, proving the engine is healthy.
                         debug!("Activity detected for {}, resetting health check timer", endpoint_subject);
-                        // Loop continues, timer resets
+                        manager.drt.system_health().lock().set_endpoint_health_status(
+                            &endpoint_subject,
+                            crate::config::HealthStatus::Ready,
+                        );
                     }
                 }
             }
@@ -602,18 +607,18 @@ mod push_handler_notify_tests {
         // Wait less than canary_wait_time
         tokio::time::sleep(Duration::from_millis(200)).await;
 
-        // The canary should NOT have fired. Since the endpoint starts as NotReady
-        // and send_health_check_request (which sets Ready on success) was never
-        // called, the status should still be NotReady.
+        // The canary should NOT have fired. The status should be Ready because
+        // the notification from push_handler's successful streaming set it to
+        // Ready (without the canary ever needing to fire).
         let status = drt
             .system_health()
             .lock()
             .get_endpoint_health_status(endpoint_name);
         assert_eq!(
             status,
-            Some(HealthStatus::NotReady),
-            "Status should still be NotReady — the canary should not have fired \
-             because push_handler reset the timer via notify_one()"
+            Some(HealthStatus::Ready),
+            "Status should be Ready — push_handler's successful streaming \
+             should have set it via the notification path"
         );
     }
 

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -345,6 +345,254 @@ pub async fn get_health_check_status(
     }))
 }
 
+// ============================================================
+// Full pipeline tests: push_handler → notify → HealthCheckManager
+// These tests use the real HealthCheckManager (spawn_endpoint_health_check_task)
+// and the real push_handler pipeline (TwoPartCodec + TCP + engine.generate()).
+// ============================================================
+#[cfg(all(test, feature = "integration"))]
+mod push_handler_notify_tests {
+    use super::*;
+    use crate::component::{Instance, TransportType};
+    use crate::config::HealthStatus;
+    use crate::distributed::distributed_test_utils::create_test_drt_async;
+    use crate::engine::{AsyncEngine, AsyncEngineContextProvider};
+    use crate::local_endpoint_registry::LocalAsyncEngine;
+    use crate::pipeline::network::codec::{TwoPartCodec, TwoPartMessage};
+    use crate::pipeline::network::tcp::server::{ServerOptions, TcpStreamServer};
+    use crate::pipeline::network::{
+        ConnectionInfo, Ingress, PushWorkHandler, ResponseService, StreamOptions,
+    };
+    use crate::pipeline::{ManyOut, ResponseStream, SingleIn};
+    use crate::protocols::annotated::Annotated;
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use futures::stream;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    type TestRequest = serde_json::Value;
+    type TestResponse = Annotated<serde_json::Value>;
+
+    /// A mock engine that streams `num_chunks` response chunks.
+    /// Used both as the push_handler pipeline engine and registered in
+    /// the local endpoint registry for health check requests.
+    struct MockStreamingEngine {
+        num_chunks: usize,
+    }
+
+    #[async_trait]
+    impl AsyncEngine<SingleIn<TestRequest>, ManyOut<TestResponse>, anyhow::Error>
+        for MockStreamingEngine
+    {
+        async fn generate(
+            &self,
+            input: SingleIn<TestRequest>,
+        ) -> anyhow::Result<ManyOut<TestResponse>> {
+            let (_data, ctx) = input.into_parts();
+            let chunks: Vec<TestResponse> = (0..self.num_chunks)
+                .map(|i| Annotated::from_data(serde_json::json!({"token": i})))
+                .collect();
+            Ok(ResponseStream::new(
+                Box::pin(stream::iter(chunks)),
+                ctx.context(),
+            ))
+        }
+    }
+
+    /// Encodes a request as a TwoPartCodec payload with the given connection info.
+    fn encode_request(
+        request_id: &str,
+        connection_info: ConnectionInfo,
+        request_body: &serde_json::Value,
+    ) -> Bytes {
+        let control = serde_json::json!({
+            "id": request_id,
+            "request_type": "single_in",
+            "response_type": "many_out",
+            "connection_info": connection_info,
+        });
+        let header = serde_json::to_vec(&control).unwrap();
+        let data = serde_json::to_vec(request_body).unwrap();
+        let msg = TwoPartMessage::new(Bytes::from(header), Bytes::from(data));
+        TwoPartCodec::default().encode_message(msg).unwrap()
+    }
+
+    /// Sets up a TCP server and registers a response stream for push_handler
+    /// to connect back to.
+    async fn setup_tcp_receiver(request_id: &str) -> (Arc<TcpStreamServer>, ConnectionInfo) {
+        let options = ServerOptions::builder().port(0).build().unwrap();
+        let server = TcpStreamServer::new(options).await.unwrap();
+
+        let context = crate::pipeline::Context::with_id((), request_id.to_string());
+        let stream_options = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(false)
+            .enable_response_stream(true)
+            .build()
+            .unwrap();
+
+        let pending = server.register(stream_options).await;
+        let connection_info = pending
+            .recv_stream
+            .as_ref()
+            .unwrap()
+            .connection_info
+            .clone();
+
+        (server, connection_info)
+    }
+
+    /// Registers an endpoint in the DRT: health check target + local engine +
+    /// returns the notifier that the real HealthCheckManager will listen on.
+    fn register_endpoint(
+        drt: &crate::DistributedRuntime,
+        endpoint_name: &str,
+    ) -> Arc<tokio::sync::Notify> {
+        let payload = serde_json::json!({
+            "prompt": "health",
+            "_health_check": true
+        });
+        drt.system_health().lock().register_health_check_target(
+            endpoint_name,
+            Instance {
+                component: "test_component".to_string(),
+                endpoint: endpoint_name.to_string(),
+                namespace: "test_namespace".to_string(),
+                instance_id: 0,
+                transport: TransportType::Nats(endpoint_name.to_string()),
+            },
+            payload,
+        );
+
+        // Register a mock engine in local registry so send_health_check_request
+        // can call engine.generate() when the canary fires.
+        let mock_engine: LocalAsyncEngine = Arc::new(MockStreamingEngine { num_chunks: 1 });
+        drt.local_endpoint_registry()
+            .register(endpoint_name.to_string(), mock_engine);
+
+        drt.system_health()
+            .lock()
+            .get_endpoint_health_check_notifier(endpoint_name)
+            .expect("Notifier should exist for registered endpoint")
+    }
+
+    /// Tests that when a request flows through push_handler (streaming 5 chunks),
+    /// the real HealthCheckManager's canary timer is reset via notify_one(),
+    /// preventing the canary from firing and keeping the endpoint in its initial
+    /// NotReady state (i.e., send_health_check_request is never called).
+    ///
+    /// Full path tested:
+    ///   push_handler.handle_payload() → notify_one() (request arrival + per chunk)
+    ///   → HealthCheckManager.spawn_endpoint_health_check_task select! loop resets
+    ///   → canary never fires → send_health_check_request never called
+    #[tokio::test]
+    async fn test_notifier_resets_canary_timer() {
+        let drt = create_test_drt_async().await;
+        let endpoint_name = "test.push_handler.timer_reset";
+
+        let notifier = register_endpoint(&drt, endpoint_name);
+
+        // Start the real HealthCheckManager with a short canary wait.
+        // If the canary fires, it will call send_health_check_request which
+        // succeeds (mock engine registered) and sets status to Ready.
+        let config = HealthCheckConfig {
+            canary_wait_time: Duration::from_millis(200),
+            request_timeout: Duration::from_secs(1),
+        };
+        let manager = Arc::new(HealthCheckManager::new(drt.clone(), config));
+        manager.clone().start().await.unwrap();
+
+        // Set up the push_handler pipeline with the SAME notifier
+        let engine: Arc<MockStreamingEngine> = Arc::new(MockStreamingEngine { num_chunks: 5 });
+        let ingress =
+            Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();
+        ingress
+            .set_endpoint_health_check_notifier(notifier)
+            .unwrap();
+
+        // Send a request through push_handler — this will call notify_one()
+        // on request arrival and on each of the 5 streaming chunks, resetting
+        // the canary timer each time.
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let (_server, connection_info) = setup_tcp_receiver(&request_id).await;
+        let payload = encode_request(
+            &request_id,
+            connection_info,
+            &serde_json::json!({"prompt": "test"}),
+        );
+        let result = ingress
+            .handle_payload(payload, Some(request_id.clone()))
+            .await;
+        assert!(
+            result.is_ok(),
+            "handle_payload should succeed: {:?}",
+            result.err()
+        );
+
+        // Wait a bit — but less than the canary wait time
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // The canary should NOT have fired. Since the endpoint starts as NotReady
+        // and send_health_check_request (which sets Ready on success) was never
+        // called, the status should still be NotReady.
+        let status = drt
+            .system_health()
+            .lock()
+            .get_endpoint_health_status(endpoint_name);
+        assert_eq!(
+            status,
+            Some(HealthStatus::NotReady),
+            "Status should still be NotReady — the canary should not have fired \
+             because push_handler reset the timer via notify_one()"
+        );
+    }
+
+    /// Tests that without any requests flowing through push_handler, the real
+    /// HealthCheckManager's canary timer expires, fires send_health_check_request,
+    /// and transitions the endpoint status from NotReady to Ready (proving the
+    /// canary executed the full health check path).
+    #[tokio::test]
+    async fn test_canary_fires_without_activity() {
+        let drt = create_test_drt_async().await;
+        let endpoint_name = "test.push_handler.canary_fires";
+
+        let _notifier = register_endpoint(&drt, endpoint_name);
+
+        // Start the real HealthCheckManager with a very short canary wait
+        let config = HealthCheckConfig {
+            canary_wait_time: Duration::from_millis(50),
+            request_timeout: Duration::from_secs(1),
+        };
+        let manager = Arc::new(HealthCheckManager::new(drt.clone(), config));
+        manager.clone().start().await.unwrap();
+
+        // Verify initial status is NotReady
+        let status = drt
+            .system_health()
+            .lock()
+            .get_endpoint_health_status(endpoint_name);
+        assert_eq!(status, Some(HealthStatus::NotReady));
+
+        // Don't send any requests — let the canary fire.
+        // The canary will call send_health_check_request, which finds the mock
+        // engine in local_endpoint_registry, calls generate(), gets a successful
+        // response, and sets status to Ready.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let status = drt
+            .system_health()
+            .lock()
+            .get_endpoint_health_status(endpoint_name);
+        assert_eq!(
+            status,
+            Some(HealthStatus::Ready),
+            "Status should be Ready — the canary should have fired and \
+             send_health_check_request should have succeeded with the mock engine"
+        );
+    }
+}
+
 // ===============================
 // Integration Tests (require DRT)
 // ===============================

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -374,11 +374,36 @@ mod push_handler_notify_tests {
     type TestRequest = serde_json::Value;
     type TestResponse = Annotated<serde_json::Value>;
 
-    /// A mock engine that streams `num_chunks` response chunks.
+    /// A mock engine that streams a configurable sequence of success/error chunks.
     /// Used both as the push_handler pipeline engine and registered in
     /// the local endpoint registry for health check requests.
     struct MockStreamingEngine {
         num_chunks: usize,
+        /// If set, chunks at these indices will be error responses.
+        error_indices: Vec<usize>,
+    }
+
+    impl MockStreamingEngine {
+        fn success(num_chunks: usize) -> Arc<Self> {
+            Arc::new(Self {
+                num_chunks,
+                error_indices: vec![],
+            })
+        }
+
+        fn all_errors(num_chunks: usize) -> Arc<Self> {
+            Arc::new(Self {
+                num_chunks,
+                error_indices: (0..num_chunks).collect(),
+            })
+        }
+
+        fn with_error_at(num_chunks: usize, error_indices: Vec<usize>) -> Arc<Self> {
+            Arc::new(Self {
+                num_chunks,
+                error_indices,
+            })
+        }
     }
 
     #[async_trait]
@@ -391,7 +416,13 @@ mod push_handler_notify_tests {
         ) -> anyhow::Result<ManyOut<TestResponse>> {
             let (_data, ctx) = input.into_parts();
             let chunks: Vec<TestResponse> = (0..self.num_chunks)
-                .map(|i| Annotated::from_data(serde_json::json!({"token": i})))
+                .map(|i| {
+                    if self.error_indices.contains(&i) {
+                        Annotated::from_error(format!("mock error at chunk {i}"))
+                    } else {
+                        Annotated::from_data(serde_json::json!({"token": i}))
+                    }
+                })
                 .collect();
             Ok(ResponseStream::new(
                 Box::pin(stream::iter(chunks)),
@@ -468,7 +499,7 @@ mod push_handler_notify_tests {
 
         // Register a mock engine in local registry so send_health_check_request
         // can call engine.generate() when the canary fires.
-        let mock_engine: LocalAsyncEngine = Arc::new(MockStreamingEngine { num_chunks: 1 });
+        let mock_engine: LocalAsyncEngine = MockStreamingEngine::success(1);
         drt.local_endpoint_registry()
             .register(endpoint_name.to_string(), mock_engine);
 
@@ -489,7 +520,7 @@ mod push_handler_notify_tests {
 
         let notifier = register_endpoint(&drt, endpoint_name);
 
-        let engine: Arc<MockStreamingEngine> = Arc::new(MockStreamingEngine { num_chunks: 5 });
+        let engine: Arc<MockStreamingEngine> = MockStreamingEngine::success(5);
         let ingress =
             Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();
         ingress
@@ -627,6 +658,119 @@ mod push_handler_notify_tests {
             Some(HealthStatus::Ready),
             "Status should be Ready — the canary should have fired and \
              send_health_check_request should have succeeded with the mock engine"
+        );
+    }
+
+    // ----------------------------------------------------------------
+    // Push handler notification tests (error-gating behavior)
+    // These test the push_handler directly via handle_payload to verify
+    // that notifications are only sent for non-error response chunks.
+    // ----------------------------------------------------------------
+
+    /// Helper: send a request through the given ingress pipeline and count
+    /// the notifications that arrive on the notifier.
+    async fn send_and_count_notifications(
+        ingress: &Ingress<SingleIn<TestRequest>, ManyOut<TestResponse>>,
+        notifier: &Arc<tokio::sync::Notify>,
+    ) -> u32 {
+        let notify_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let count_clone = notify_count.clone();
+        let notifier_clone = notifier.clone();
+        let counter_task = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = notifier_clone.notified() => {
+                        count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(500)) => {
+                        break;
+                    }
+                }
+            }
+        });
+
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let (_server, connection_info) = setup_tcp_receiver(&request_id).await;
+        let payload = encode_request(
+            &request_id,
+            connection_info,
+            &serde_json::json!({"prompt": "test"}),
+        );
+        let result = ingress.handle_payload(payload, Some(request_id)).await;
+        assert!(
+            result.is_ok(),
+            "handle_payload should succeed: {:?}",
+            result.err()
+        );
+
+        counter_task.await.unwrap();
+        notify_count.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Successful request: notified on each chunk and on stream completion.
+    #[tokio::test]
+    async fn test_successful_request_notifies_on_chunks_and_completion() {
+        let engine = MockStreamingEngine::success(5);
+        let ingress =
+            Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();
+
+        let notifier = Arc::new(tokio::sync::Notify::new());
+        ingress
+            .set_endpoint_health_check_notifier(notifier.clone())
+            .unwrap();
+
+        let count = send_and_count_notifications(&ingress, &notifier).await;
+
+        // 5 chunks + 1 stream completion = 6 notify_one() calls.
+        // Coalescing means we get fewer wakeups, but at least 2.
+        assert!(
+            count >= 2,
+            "Expected at least 2 notification wakeups for 5 successful chunks + completion, got {count}"
+        );
+    }
+
+    /// All-error request: no notifications since every chunk is an error.
+    #[tokio::test]
+    async fn test_error_response_does_not_notify() {
+        let engine = MockStreamingEngine::all_errors(3);
+        let ingress =
+            Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();
+
+        let notifier = Arc::new(tokio::sync::Notify::new());
+        ingress
+            .set_endpoint_health_check_notifier(notifier.clone())
+            .unwrap();
+
+        let count = send_and_count_notifications(&ingress, &notifier).await;
+
+        assert_eq!(
+            count, 0,
+            "Expected 0 notifications for all-error response, got {count}"
+        );
+    }
+
+    /// Mixed response: successful chunks followed by an error chunk at the end.
+    /// Only the successful chunks should notify; the error chunk and stream
+    /// completion should not.
+    #[tokio::test]
+    async fn test_mixed_response_only_notifies_on_success_chunks() {
+        // 5 chunks total, last one (index 4) is an error
+        let engine = MockStreamingEngine::with_error_at(5, vec![4]);
+        let ingress =
+            Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();
+
+        let notifier = Arc::new(tokio::sync::Notify::new());
+        ingress
+            .set_endpoint_health_check_notifier(notifier.clone())
+            .unwrap();
+
+        let count = send_and_count_notifications(&ingress, &notifier).await;
+
+        // 4 successful chunks should notify, error chunk + completion should not.
+        // Coalescing means fewer wakeups, but at least 1.
+        assert!(
+            count >= 1,
+            "Expected at least 1 notification for 4 successful chunks, got {count}"
         );
     }
 }

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -482,11 +482,6 @@ mod push_handler_notify_tests {
     /// the real HealthCheckManager's canary timer is reset via notify_one(),
     /// preventing the canary from firing and keeping the endpoint in its initial
     /// NotReady state (i.e., send_health_check_request is never called).
-    ///
-    /// Full path tested:
-    ///   push_handler.handle_payload() → notify_one() (request arrival + per chunk)
-    ///   → HealthCheckManager.spawn_endpoint_health_check_task select! loop resets
-    ///   → canary never fires → send_health_check_request never called
     #[tokio::test]
     async fn test_notifier_resets_canary_timer() {
         let drt = create_test_drt_async().await;
@@ -494,9 +489,6 @@ mod push_handler_notify_tests {
 
         let notifier = register_endpoint(&drt, endpoint_name);
 
-        // Set up the push_handler pipeline BEFORE starting the HealthCheckManager
-        // so we can send a request immediately and avoid a race where the canary
-        // fires before handle_payload has a chance to notify.
         let engine: Arc<MockStreamingEngine> = Arc::new(MockStreamingEngine { num_chunks: 5 });
         let ingress =
             Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();
@@ -517,9 +509,6 @@ mod push_handler_notify_tests {
         // HealthCheckManager. This way we can use a separate Notify for
         // counting without competing with the manager (notify_one only
         // wakes one waiter).
-        //
-        // push_handler will call notify_one() on each of the 5 chunks
-        // + stream completion. The counter task is the sole consumer.
         let notify_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let count_clone = notify_count.clone();
         let notifier_for_counter = notifier.clone();
@@ -551,11 +540,11 @@ mod push_handler_notify_tests {
         // Verify notifications were received. Notify coalesces multiple calls
         // into single wakeups, so the exact count depends on scheduling. With
         // 5 chunks + 1 stream completion = 6 notify_one() calls, we expect
-        // at least 1 wakeup (coalesced) but typically 2-4.
+        // at least 2 wakeups - one for a streaming chunk, one for stream completion.
         let count = notify_count.load(std::sync::atomic::Ordering::SeqCst);
         assert!(
-            count >= 1,
-            "Expected at least 1 notification wakeup from push_handler streaming, got {count}"
+            count >= 2,
+            "Expected at least 2 notification wakeup from push_handler streaming, got {count}"
         );
 
         // NOW start the HealthCheckManager. It will be the sole consumer of

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -512,8 +512,7 @@ mod push_handler_notify_tests {
             .unwrap();
 
         // Send a request through push_handler — this will call notify_one()
-        // on request arrival and on each of the 5 streaming chunks, resetting
-        // the canary timer each time.
+        // on each of the 5 streaming chunks, resetting the canary timer each time.
         let request_id = uuid::Uuid::new_v4().to_string();
         let (_server, connection_info) = setup_tcp_receiver(&request_id).await;
         let payload = encode_request(

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -525,6 +525,13 @@ mod push_handler_notify_tests {
 
         let notifier = register_endpoint(&drt, endpoint_name);
 
+        // Verify initial status is NotReady before any activity
+        let status = drt
+            .system_health()
+            .lock()
+            .get_endpoint_health_status(endpoint_name);
+        assert_eq!(status, Some(HealthStatus::NotReady));
+
         let engine: Arc<MockStreamingEngine> = MockStreamingEngine::success(5);
         let ingress =
             Ingress::<SingleIn<TestRequest>, ManyOut<TestResponse>>::for_engine(engine).unwrap();

--- a/lib/runtime/src/pipeline/network/ingress/push_handler.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_handler.rs
@@ -261,6 +261,14 @@ where
             PipelineError::Generic(format!("Failed to create response stream: {:?}", e,))
         })?;
 
+        // Notify the health check manager that a new request has arrived.
+        // This resets the canary timer during the prefill phase, preventing
+        // false health check triggers on long-context requests that may take
+        // tens of seconds before producing the first token.
+        if let Some(notifier) = self.endpoint_health_check_notifier.get() {
+            notifier.notify_one();
+        }
+
         tracing::trace!("calling generate");
         let stream = self
             .segment
@@ -347,6 +355,15 @@ where
                         .inc();
                 }
                 break;
+            } else {
+                // Notify the health check manager on each successfully streamed
+                // chunk. Each chunk proves the engine is alive and producing
+                // output, preventing the canary from firing during long streaming
+                // responses. tokio::sync::Notify coalesces multiple calls into a
+                // single wakeup, so the overhead is one atomic store per chunk.
+                if let Some(notifier) = self.endpoint_health_check_notifier.get() {
+                    notifier.notify_one();
+                }
             }
         }
         if send_complete_final {
@@ -371,7 +388,8 @@ where
                 }
             }
             // Notify the health check manager that the stream has finished.
-            // This resets the timer, delaying the next canary health check.
+            // This complements the per-chunk and request-arrival notifications
+            // above, ensuring the timer is also reset on stream completion.
             if let Some(notifier) = self.endpoint_health_check_notifier.get() {
                 notifier.notify_one();
             }

--- a/lib/runtime/src/pipeline/network/ingress/push_handler.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_handler.rs
@@ -311,8 +311,13 @@ where
 
         // TODO: Detect end-of-stream using Server-Sent Events (SSE)
         let mut send_complete_final = true;
+        let mut saw_error_response = false;
         while let Some(resp) = stream.next().await {
             tracing::trace!("Sending response: {:?}", resp);
+            let is_error = resp.err().is_some();
+            if is_error {
+                saw_error_response = true;
+            }
             let resp_wrapper = NetworkStreamWrapper {
                 data: Some(resp),
                 complete_final: false,
@@ -347,8 +352,9 @@ where
                         .inc();
                 }
                 break;
-            } else {
-                // Notify the health check manager on each successfully streamed chunk
+            } else if !is_error {
+                // Only notify on non-error chunks — error responses don't prove
+                // the engine is healthy and should not reset the canary timer.
                 if let Some(notifier) = self.endpoint_health_check_notifier.get() {
                     notifier.notify_one();
                 }
@@ -375,8 +381,11 @@ where
                         .inc();
                 }
             }
-            // Notify the health check manager that the stream has finished.
-            if let Some(notifier) = self.endpoint_health_check_notifier.get() {
+            // Only notify on stream completion if no error responses were seen
+            if let (false, Some(notifier)) = (
+                saw_error_response,
+                self.endpoint_health_check_notifier.get(),
+            ) {
                 notifier.notify_one();
             }
         }

--- a/lib/runtime/src/pipeline/network/ingress/push_handler.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_handler.rs
@@ -261,14 +261,6 @@ where
             PipelineError::Generic(format!("Failed to create response stream: {:?}", e,))
         })?;
 
-        // Notify the health check manager that a new request has arrived.
-        // This resets the canary timer during the prefill phase, preventing
-        // false health check triggers on long-context requests that may take
-        // tens of seconds before producing the first token.
-        if let Some(notifier) = self.endpoint_health_check_notifier.get() {
-            notifier.notify_one();
-        }
-
         tracing::trace!("calling generate");
         let stream = self
             .segment
@@ -356,11 +348,7 @@ where
                 }
                 break;
             } else {
-                // Notify the health check manager on each successfully streamed
-                // chunk. Each chunk proves the engine is alive and producing
-                // output, preventing the canary from firing during long streaming
-                // responses. tokio::sync::Notify coalesces multiple calls into a
-                // single wakeup, so the overhead is one atomic store per chunk.
+                // Notify the health check manager on each successfully streamed chunk
                 if let Some(notifier) = self.endpoint_health_check_notifier.get() {
                     notifier.notify_one();
                 }
@@ -388,8 +376,6 @@ where
                 }
             }
             // Notify the health check manager that the stream has finished.
-            // This complements the per-chunk and request-arrival notifications
-            // above, ensuring the timer is also reset on stream completion.
             if let Some(notifier) = self.endpoint_health_check_notifier.get() {
                 notifier.notify_one();
             }

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -1147,6 +1147,7 @@ mod integration_tests {
                             namespace: "test_namespace".to_string(),
                             instance_id: 1,
                             transport: crate::component::TransportType::Nats(endpoint.to_string()),
+                            device_type: None,
                         },
                         health_check_payload.clone(),
                     );


### PR DESCRIPTION
#### Overview:

The canary health check timer previously only reset on response stream completion (`send_complete_final`), causing false-negative health check triggers during long-context requests and long streaming responses. This led to unnecessary worker restarts on GLM-4.7 and Qwen Coder deployments.

The root cause is that a single long-context request (e.g., 200K input tokens) can take >10s before producing its first token (prefill), or a streaming response can take 60+ seconds total. Since the canary wait time defaults to 10s and the timer only reset on stream *completion*, the canary would fire mid-stream on a perfectly healthy engine.

#### Details:

- **`lib/runtime/src/pipeline/network/ingress/push_handler.rs`**: Added `notify_one()` calls at one new points:
  1. **On each successfully streamed chunk** (in the `while let Some(resp) = stream.next()` loop) — resets the timer during generation, proving the engine is alive and producing output
  2. **On stream completion** (existing, preserved) — updated comment to clarify it complements the new notifications

`tokio::sync::Notify` coalesces multiple `notify_one()` calls into a single wakeup, so the per-chunk notification adds negligible overhead (~1µs atomic store per chunk, vs 1-50µs for existing serialization work).

Health check requests are unaffected — they bypass `push_handler` entirely, going directly through `health_check.rs` → `engine.generate()`.

#### Where should the reviewer start?

`lib/runtime/src/pipeline/network/ingress/push_handler.rs` — the two `notify_one()` call sites (per-chunk at line 356, stream completion at line 376).

#### Related Issues:

- Closes DYN-2850
- Relates to DYN-2845
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal stream handling and health monitoring mechanisms to enhance overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->