### PR TITLE
docs(observability): fix DYN_SYSTEM_PORT default in health-checks table

### DIFF
--- a/docs/observability/health-checks.md
+++ b/docs/observability/health-checks.md
@@ -14,7 +14,7 @@ orchestration frameworks such as Kubernetes.
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `DYN_SYSTEM_PORT` | System status server port | `8081` | `9090` |
+| `DYN_SYSTEM_PORT` | System status server port | `-1` (disabled) | `8081` |
 | `DYN_SYSTEM_STARTING_HEALTH_STATUS` | Initial health status | `notready` | `ready`, `notready` |
 | `DYN_SYSTEM_HEALTH_PATH` | Custom health endpoint path | `/health` | `/custom/health` |
 | `DYN_SYSTEM_LIVE_PATH` | Custom liveness endpoint path | `/live` | `/custom/live` |


### PR DESCRIPTION
#### Overview:

fix DYN_SYSTEM_PORT default in health-checks table

#### Details:

https://linear.app/nvidia/issue/DYN-2817 Default value should be -1

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: DYN-2817

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system port configuration documentation to clarify that the port is disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->