### PR TITLE
fix(profiler): pass total_gpus to AIC enumerate so candidates respect budget

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@1fe8084c817194827706947cc175107ee9e6ea25",
+    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@b33a136e78f9351a7ad17db1e2a1abd7b295cc6a",
     "aiperf==0.6.0",
     "matplotlib",
     "networkx",

--- a/components/src/dynamo/profiler/thorough.py
+++ b/components/src/dynamo/profiler/thorough.py
@@ -356,6 +356,7 @@ async def run_thorough(
         isl=isl,
         osl=osl,
         num_gpus_per_node=dgdr.hardware.numGpusPerNode,
+        total_gpus=total_gpus,
         k8s_pvc_name=model_cache.pvcName,
         k8s_pvc_mount_path=model_cache.pvcMountPath,
         k8s_model_path_in_pvc=model_cache.pvcModelPath,

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -3,7 +3,7 @@
 
 # Dependencies required by the planner, profiler, and global_planner services.
 
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@1fe8084c817194827706947cc175107ee9e6ea25
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@b33a136e78f9351a7ad17db1e2a1abd7b295cc6a
 aiofiles<=25.1.0
 aiohttp>=3.9.0,<4.0
 filterpy==1.4.5


### PR DESCRIPTION
## Summary

Threads the deployment's total GPU budget from DGDR into AIC's `enumerate_profiling_configs`, and bumps the AIC pin to pick up the upstream change.

Closes the enumeration gap where:
- A 32-GPU cluster could be handed a 64-GPU decode candidate (`decode_max_gpus` was `max(num_gpu_per_worker) = 64` for MoE wide-EP).
- The memory-fit floor was capped at `num_gpus_per_node`, so for DeepSeek R1 FP8 on 32 H100s, 8-GPU wide-EP candidates passed the filter but OOM'd on deploy — the floor should be 16 GPUs to hold FP8 weights.

## Changes

1. **`components/src/dynamo/profiler/thorough.py`** — pass `total_gpus=total_gpus` through to `enumerate_profiling_configs`. One-line threading; the parameter was already in scope.
2. **`container/deps/requirements.planner.txt`** — bump aiconfigurator pin from `1fe8084c` to `b33a136e` (upstream merge of ai-dynamo/aiconfigurator#887).
3. **`benchmarks/pyproject.toml`** — same pin bump.

## Effect for R1 / V3.2-scale MoE on 32 H100s

- 8-GPU wide-EP candidates (which OOM) are pruned — floor becomes 16.
- 64-GPU impossible candidates are dropped — cap becomes 32.
- 16-GPU and 32-GPU candidates are preserved.

## Test plan

- [x] `thorough.py` imports cleanly with rebuilt AIC pin
- [x] Existing `tests/integration/test_profile_sla_dgdr.py::test_empty_candidates_due_to_small_gpu` case (R1 on 1 L40S) expectation unchanged — still returns empty candidate list (floor becomes 1, cap becomes 1, no wide-EP candidates ≥ 4 survive)
- [x] `pre-commit` clean on changed files (code hooks pass)
- [ ] End-to-end: thorough-mode run for DeepSeek R1 on 32 H100, verify candidate list matches expectation

## Related

- Upstream (merged): ai-dynamo/aiconfigurator#887