### PR TITLE
feat: add nixl parameters to backend

### DIFF
--- a/lib/bindings/kvbm/src/v2/runtime.rs
+++ b/lib/bindings/kvbm/src/v2/runtime.rs
@@ -61,15 +61,25 @@ impl PyKvbmRuntime {
             None => KvbmConfig::from_env_for_worker().map_err(to_pyerr)?,
         };
 
-        // Create tokio runtime from config
-        let tokio_rt = config.tokio.build_runtime().map_err(to_pyerr)?;
+        // Create tokio runtime from config.
+        //
+        // IMPORTANT: keep one strong Arc outside the async `block_on` below.
+        // If `build_worker()` returns an error partway through async startup,
+        // the future is unwound inside a Tokio runtime context. Dropping the
+        // *last* Runtime owner there triggers Tokio's
+        // "Cannot drop a runtime in a context where blocking is not allowed"
+        // panic, which masks the real initialization error. By retaining one
+        // owner outside `block_on`, the async future only drops a clone on
+        // error, and the final drop happens safely after `block_on` returns.
+        let tokio_rt = Arc::new(config.tokio.build_runtime().map_err(to_pyerr)?);
         let handle = tokio_rt.handle().clone();
+        let tokio_rt_for_build = tokio_rt.clone();
 
         // Build KvbmRuntime using block_on
         let runtime = handle
-            .block_on(async {
+            .block_on(async move {
                 KvbmRuntimeBuilder::new(config)
-                    .with_runtime(Arc::new(tokio_rt))
+                    .with_runtime(tokio_rt_for_build)
                     .build_worker()
                     .await
             })
@@ -107,15 +117,17 @@ impl PyKvbmRuntime {
             None => KvbmConfig::from_env_for_leader().map_err(to_pyerr)?,
         };
 
-        // Create tokio runtime from config
-        let tokio_rt = config.tokio.build_runtime().map_err(to_pyerr)?;
+        // Mirror the worker-side ownership pattern above so leader init errors
+        // do not drop the final Tokio runtime owner from inside async context.
+        let tokio_rt = Arc::new(config.tokio.build_runtime().map_err(to_pyerr)?);
         let handle = tokio_rt.handle().clone();
+        let tokio_rt_for_build = tokio_rt.clone();
 
         // Build KvbmRuntime using block_on
         let runtime = handle
-            .block_on(async {
+            .block_on(async move {
                 KvbmRuntimeBuilder::new(config)
-                    .with_runtime(Arc::new(tokio_rt))
+                    .with_runtime(tokio_rt_for_build)
                     .build_leader()
                     .await
             })

--- a/lib/kvbm-config/src/onboard.rs
+++ b/lib/kvbm-config/src/onboard.rs
@@ -8,11 +8,15 @@
 
 use serde::{Deserialize, Serialize};
 
+fn default_stage_chunk_size() -> usize {
+    16
+}
+
 /// Configuration for KV cache onboarding strategy.
 ///
 /// Onboarding is the process of loading external KV cache blocks from
 /// G2 (host memory) into G1 (GPU memory) for use during inference.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OnboardConfig {
     /// The onboarding mode to use.
     ///
@@ -20,6 +24,22 @@ pub struct OnboardConfig {
     /// - `intra`: Synchronous layer-wise loading during forward pass
     #[serde(default)]
     pub mode: OnboardMode,
+
+    /// Number of blocks per G3->G2 staging transfer request.
+    ///
+    /// This is a fixed-size chunk used when staging from disk to host to bound
+    /// transfer request size and background notification pressure.
+    #[serde(default = "default_stage_chunk_size")]
+    pub stage_chunk_size: usize,
+}
+
+impl Default for OnboardConfig {
+    fn default() -> Self {
+        Self {
+            mode: OnboardMode::default(),
+            stage_chunk_size: default_stage_chunk_size(),
+        }
+    }
 }
 
 /// Onboarding mode for loading external KV cache blocks.
@@ -58,6 +78,7 @@ mod tests {
     fn test_default_mode_is_inter() {
         let config = OnboardConfig::default();
         assert_eq!(config.mode, OnboardMode::Inter);
+        assert_eq!(config.stage_chunk_size, 16);
     }
 
     #[test]
@@ -66,11 +87,21 @@ mod tests {
         let json = r#"{"mode": "inter"}"#;
         let config: OnboardConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.mode, OnboardMode::Inter);
+        assert_eq!(config.stage_chunk_size, 16);
 
         // Test intra mode
         let json = r#"{"mode": "intra"}"#;
         let config: OnboardConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.mode, OnboardMode::Intra);
+        assert_eq!(config.stage_chunk_size, 16);
+    }
+
+    #[test]
+    fn test_stage_chunk_size_serde_roundtrip() {
+        let json = r#"{"mode": "inter", "stage_chunk_size": 32}"#;
+        let config: OnboardConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.mode, OnboardMode::Inter);
+        assert_eq!(config.stage_chunk_size, 32);
     }
 
     #[test]
@@ -78,5 +109,6 @@ mod tests {
         let json = r#"{}"#;
         let config: OnboardConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.mode, OnboardMode::Inter);
+        assert_eq!(config.stage_chunk_size, 16);
     }
 }

--- a/lib/kvbm-connector/src/connector/leader/finish.rs
+++ b/lib/kvbm-connector/src/connector/leader/finish.rs
@@ -162,11 +162,8 @@ impl ConnectorLeader {
 
         let mut slot = shared_slot.lock();
         let onboarding_state = slot.txn_take_onboarding()?;
-        if let Some(session_id) = onboarding_state.find_session.session_id() {
-            self.instance_leader
-                .get()
-                .unwrap()
-                .release_session(session_id);
+        if let Some(instance_leader) = self.instance_leader.get() {
+            onboarding_state.release_all(instance_leader);
         }
         Ok(())
     }

--- a/lib/kvbm-connector/src/connector/leader/init.rs
+++ b/lib/kvbm-connector/src/connector/leader/init.rs
@@ -268,6 +268,13 @@ impl ConnectorLeader {
                     rank: idx,
                     host_block_count,
                     disk_block_count,
+                    disk_storage_path: self
+                        .runtime
+                        .config()
+                        .cache
+                        .disk
+                        .as_ref()
+                        .and_then(|disk| disk.storage_path.clone()),
                     object: object_config.clone(),
                     parallelism: self.runtime.config().cache.parallelism,
                 };
@@ -408,6 +415,7 @@ impl ConnectorLeader {
             .messenger(self.runtime.messenger().clone())
             .registry(registry)
             .g2_manager(g2_manager)
+            .stage_chunk_size(self.runtime.config().onboard.stage_chunk_size)
             .workers(
                 worker_clients
                     .into_iter()

--- a/lib/kvbm-connector/src/connector/leader/mod.rs
+++ b/lib/kvbm-connector/src/connector/leader/mod.rs
@@ -9,9 +9,7 @@ use super::worker::ConnectorWorkerClient;
 use crate::{BlockId, G2, InstanceId, KvbmRuntime};
 use kvbm_config::OnboardMode;
 use kvbm_engine::leader::InstanceLeader;
-use kvbm_engine::leader::{
-    FindMatchesOptions, FindMatchesResult, Leader, OnboardingStatus, StagingMode,
-};
+use kvbm_engine::leader::{FindMatchesOptions, Leader, StagingMode};
 use kvbm_engine::offload::OffloadEngine;
 use kvbm_engine::worker::SerializedLayout;
 use kvbm_engine::worker::VeloWorkerClient;
@@ -276,9 +274,9 @@ impl ConnectorLeader {
         let outcome = self.process_match(&mut slot, num_computed_tokens);
         let match_breakdown = slot
             .onboarding_state()
-            .map(|state| state.find_session.match_breakdown())
+            .map(|state| state.aggregate_breakdown())
             .unwrap_or_default();
-        let blocks_queried = slot.match_query_blocks();
+        let blocks_queried = slot.total_query_blocks();
 
         // Single point for state transition
         match slot.finalize_match_check(outcome) {

--- a/lib/kvbm-connector/src/connector/leader/onboard.rs
+++ b/lib/kvbm-connector/src/connector/leader/onboard.rs
@@ -9,6 +9,68 @@ use kvbm_physical::TransferOptions;
 
 use super::*;
 
+/// Future type returned by `FindMatchesResult::wait_for_completion()`.
+type StagingCompletion = Either<Ready<Result<()>>, BoxFuture<'static, Result<()>>>;
+
+/// Collect the G2 blocks destined for onboarding from every shard, honoring
+/// the `[effective_start .. final_end)` span (first-hole contiguous match).
+///
+/// This walks shards in order, calling `take_g2_blocks()` on each. It then
+/// drops the leading `effective_start - shards[0].start_block` blocks (the
+/// Case-B mask) from the head and truncates the tail to `final_end -
+/// effective_start` elements. Any excess beyond `final_end` in the hole-shard
+/// (the shard whose match count was < num_queried_blocks) comes pre-filtered
+/// because terminal shards have `matched_count` g2 blocks available.
+fn collect_g2_blocks_from_shards(
+    state: &mut slot::OnboardingState,
+    block_size: usize,
+) -> Result<Vec<ImmutableBlock<G2>>> {
+    debug_assert!(!state.shards.is_empty());
+    debug_assert!(state.all_shards_terminal());
+
+    let (effective_start, final_end) = state.matched_span(block_size);
+    debug_assert!(effective_start <= final_end);
+    let desired_blocks = final_end - effective_start;
+    let leading_skip = effective_start - state.shards[0].start_block;
+
+    let mut collected: Vec<ImmutableBlock<G2>> = Vec::new();
+    for shard in state.shards.iter_mut() {
+        // Stop early once we have enough blocks.
+        if collected.len() >= leading_skip + desired_blocks {
+            break;
+        }
+        let blocks = shard
+            .find_session
+            .take_g2_blocks()
+            .ok_or_else(|| anyhow!("No G2 blocks found for shard at {}", shard.start_block))?;
+        collected.extend(blocks);
+    }
+
+    // Apply head mask.
+    if leading_skip > 0 {
+        if leading_skip > collected.len() {
+            bail!(
+                "effective_start mask ({}) exceeds collected g2 blocks ({})",
+                leading_skip,
+                collected.len()
+            );
+        }
+        collected.drain(..leading_skip);
+    }
+
+    // Truncate the tail to exactly desired_blocks.
+    if collected.len() < desired_blocks {
+        bail!(
+            "collected {} g2 blocks but span requested {}",
+            collected.len(),
+            desired_blocks
+        );
+    }
+    collected.truncate(desired_blocks);
+
+    Ok(collected)
+}
+
 impl ConnectorLeader {
     /// Prepare intra-pass onboarding by storing G2/G1 block pairs.
     ///
@@ -27,26 +89,40 @@ impl ConnectorLeader {
     ) -> Result<()> {
         let shared_slot = self.get_slot(request_id)?;
         let mut slot = shared_slot.lock();
+
+        let block_size = self.block_size();
         let num_computed_tokens = slot
             .onboarding_state()
             .expect("session should exist")
             .num_computed_tokens;
 
-        let num_computed_blocks = num_computed_tokens / self.block_size();
-        let num_external_blocks = num_external_tokens / self.block_size();
+        let num_computed_blocks = num_computed_tokens / block_size;
+        let num_external_blocks = num_external_tokens / block_size;
+
+        // The g1 slice starts at `num_computed_blocks` (i.e. the effective
+        // start used when computing matched_tokens; see `matched_span`) and
+        // spans `num_external_blocks` entries. We take this slice up front so
+        // we can own it without borrowing `block_ids` past `apply_new_blocks`.
         let g1_block_ids =
             block_ids[num_computed_blocks..num_computed_blocks + num_external_blocks].to_vec();
 
         // Record the block_ids - this assigns them to the token_block sequence hashes
         slot.apply_new_blocks(block_ids);
 
-        // Extract G2 blocks from the find session (takes ownership)
-        let g2_blocks = slot
-            .onboarding_state_mut()
-            .ok_or_else(|| anyhow!("Expected active onboarding state for {}", request_id))?
-            .find_session
-            .take_g2_blocks()
-            .ok_or_else(|| anyhow!("No G2 blocks found for intra-pass onboarding"))?;
+        // Extract G2 blocks from every shard (with head mask + tail truncate)
+        // and also capture the session IDs we now need to release.
+        let (g2_blocks, session_ids_to_release) = {
+            let state = slot
+                .onboarding_state_mut()
+                .ok_or_else(|| anyhow!("Expected active onboarding state for {}", request_id))?;
+            let g2_blocks = collect_g2_blocks_from_shards(state, block_size)?;
+            let session_ids: Vec<_> = state
+                .shards
+                .iter()
+                .filter_map(|s| s.find_session.session_id())
+                .collect();
+            (g2_blocks, session_ids)
+        };
 
         let g2_block_ids: Vec<BlockId> = g2_blocks.iter().map(|b| b.block_id()).collect();
 
@@ -76,6 +152,14 @@ impl ConnectorLeader {
         slot.txn_to_error(); // Clear the PreparingToOnboard state
         let _ = slot.txn_take_error(); // Discard and transition to Inactive
 
+        // Release server-side session state for every shard's async session
+        // (Ready variants return None, so they're skipped).
+        if let Some(instance_leader) = self.instance_leader() {
+            for session_id in session_ids_to_release {
+                instance_leader.release_session(session_id);
+            }
+        }
+
         Ok(())
     }
 
@@ -87,8 +171,9 @@ impl ConnectorLeader {
     ) -> Result<()> {
         let shared_slot = self.get_slot(request_id)?;
 
-        // Extract session_id and transition to Onboarding state
-        let (staging_fut, onboard_blocks_ids) = {
+        // Extract a wait_for_completion future for every shard, then transition
+        // to Onboarding.
+        let (staging_futs, onboard_blocks_ids) = {
             let mut slot = shared_slot.lock();
 
             let num_external_blocks = num_external_tokens / self.block_size();
@@ -99,8 +184,12 @@ impl ConnectorLeader {
             // this will assign the block_ids to the token_block sequence hashes
             slot.apply_new_blocks(block_ids);
 
-            let staging_fut = match slot.onboarding_state() {
-                Some(onboarding_state) => onboarding_state.find_session.wait_for_completion(),
+            let staging_futs: Vec<_> = match slot.onboarding_state() {
+                Some(onboarding_state) => onboarding_state
+                    .shards
+                    .iter()
+                    .map(|shard| shard.find_session.wait_for_completion())
+                    .collect(),
                 None => bail!("Expected active onboarding state for {}", request_id),
             };
 
@@ -109,19 +198,21 @@ impl ConnectorLeader {
                 bail!("Failed to start onboarding: {}", e);
             }
 
-            (staging_fut, onboard_blocks_ids)
+            (staging_futs, onboard_blocks_ids)
         };
 
         let leader = self.clone();
         let handle = self.runtime.tokio();
         let request_id = request_id.to_string();
+        let block_size = self.block_size();
 
         handle.spawn(async move {
             match execute_onboarding(
                 leader.clone(),
                 shared_slot.clone(),
                 onboard_blocks_ids.clone(),
-                staging_fut,
+                staging_futs,
+                block_size,
             )
             .await
             {
@@ -143,14 +234,24 @@ impl ConnectorLeader {
                 }
             }
 
-            // This will clean up the find session if it exists, this is necessary to avoid resource leaks.
-            if let Some(session_id) = shared_slot
+            // Release server-side state for every shard's async session (Ready
+            // variants return None).
+            let session_ids: Vec<_> = shared_slot
                 .lock()
                 .onboarding_state()
-                .and_then(|state| state.find_session.session_id())
-            {
+                .map(|state| {
+                    state
+                        .shards
+                        .iter()
+                        .filter_map(|s| s.find_session.session_id())
+                        .collect()
+                })
+                .unwrap_or_default();
+            if !session_ids.is_empty() {
                 let instance_leader = leader.instance_leader().expect("InstanceLeader not set");
-                instance_leader.release_session(session_id);
+                for session_id in session_ids {
+                    instance_leader.release_session(session_id);
+                }
             }
 
             // regardess of error, we mark the onboarding as complete
@@ -174,22 +275,24 @@ async fn execute_onboarding(
     leader: Arc<ConnectorLeader>,
     slot: Arc<Mutex<RequestSlot>>,
     block_ids: Vec<BlockId>,
-    staging_fut: Either<Ready<Result<()>>, BoxFuture<'static, Result<()>>>,
+    staging_futs: Vec<StagingCompletion>,
+    block_size: usize,
 ) -> Result<()> {
     let g1_block_ids = block_ids;
 
-    // Wait for find_session completion by accessing it through the slot
-    staging_fut
-        .await
-        .context("Onboarding find_session operation failed")?;
+    // Wait for every shard's find_session to reach a terminal state.
+    for fut in staging_futs {
+        fut.await
+            .context("Onboarding find_session operation failed")?;
+    }
 
-    let g2_blocks = slot
-        .lock()
-        .onboarding_state_mut()
-        .expect("Onboarding state not found")
-        .find_session
-        .take_g2_blocks()
-        .ok_or_else(|| anyhow::anyhow!("No G2 blocks found"))?;
+    let g2_blocks = {
+        let mut slot = slot.lock();
+        let state = slot
+            .onboarding_state_mut()
+            .expect("Onboarding state not found");
+        collect_g2_blocks_from_shards(state, block_size)?
+    };
 
     let g2_block_ids: Vec<BlockId> = g2_blocks.iter().map(|b| b.block_id()).collect();
 

--- a/lib/kvbm-connector/src/connector/leader/search.rs
+++ b/lib/kvbm-connector/src/connector/leader/search.rs
@@ -1,7 +1,222 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Search reconciliation for `get_num_new_matched_tokens`.
+//!
+//! vLLM may re-poll `get_num_new_matched_tokens` for the same request between
+//! forward passes with a different `num_computed_tokens`. Between polls the
+//! scheduler may:
+//!   * absorb more G1 blocks (`new > old`),
+//!   * evict previously-computed G1 blocks (`new < old`), or
+//!   * restore a prefix from eviction and thereby grow the visible sequence.
+//!
+//! Rather than discarding the saved search on mismatch (the previous behavior,
+//! which panicked in debug and returned `(None, false)` in release per
+//! issue #5285), we reconcile a list of `OnboardingShard`s covering contiguous
+//! block-index ranges of the sequence. Each shard owns its own
+//! `FindMatchesResult`. On a mismatch we:
+//!   * Case B (`new > old`): update `num_computed_tokens`; the completion walk
+//!     masks off the redundant prefix via `effective_start`.
+//!   * Case C (`new < old`): prepend a new shard covering
+//!     `[new/bs .. shards[0].start_block)`.
+//!   * Case D (`total_tokens` grew, indicating eviction restore): append a new
+//!     shard for the new upper range.
+//!
+//! On completion, the outcome is computed by walking shards in order and
+//! short-circuiting at the first hole (first-hole first-match semantics).
+
 use super::*;
+use kvbm_common::SequenceHash;
+use kvbm_engine::leader::Leader;
+use slot::{OnboardingShard, OnboardingState};
+
+/// Compute the exclusive upper-block-index of the search range for a given
+/// `total_tokens`. Matches the invariant the original `process_match` used:
+/// if the token count lands exactly on a block boundary, the last full block
+/// is excluded from the search.
+fn compute_last_block_index(total_tokens: usize, block_size: usize) -> usize {
+    if total_tokens.is_multiple_of(block_size) {
+        (total_tokens / block_size).saturating_sub(1)
+    } else {
+        total_tokens / block_size
+    }
+}
+
+/// Issue a new find_matches for the given block-index range and return a shard.
+///
+/// `sequence_hashes` is the slot's full sequence-hash vector; we slice
+/// `[start_block .. end_block_exclusive)`.
+fn issue_shard(
+    leader: &dyn Leader,
+    sequence_hashes: &[SequenceHash],
+    start_block: usize,
+    end_block_exclusive: usize,
+) -> Result<OnboardingShard> {
+    debug_assert!(start_block < end_block_exclusive);
+    debug_assert!(end_block_exclusive <= sequence_hashes.len());
+
+    let slice = &sequence_hashes[start_block..end_block_exclusive];
+    let options = FindMatchesOptions {
+        search_remote: true,
+        staging_mode: StagingMode::Full,
+    };
+
+    tracing::debug!(
+        start_block,
+        end_block_exclusive,
+        num_hashes = slice.len(),
+        "issuing new shard find_matches_with_options"
+    );
+
+    let find_session = leader
+        .find_matches_with_options(slice, options)
+        .map_err(|e| {
+            tracing::error!("Failed to start find operation: {}", e);
+            anyhow!("Failed to start find operation: {}", e)
+        })?;
+
+    Ok(OnboardingShard {
+        start_block,
+        num_queried_blocks: end_block_exclusive - start_block,
+        find_session,
+    })
+}
+
+/// Reconcile the stored onboarding state against the latest
+/// `num_computed_tokens` and `total_tokens`, issuing new shards as needed,
+/// and return the current match outcome.
+///
+/// Cases (let `old = state.num_computed_tokens`, `new = num_computed_tokens`,
+/// `bs = block_size`):
+///   * **A** — `new == old` and `total_tokens` unchanged: no-op.
+///   * **B** — `new > old`: update `state.num_computed_tokens = new`. Shards
+///     are untouched; the completion walk masks the prefix via `effective_start`.
+///   * **C** — `new < old`: prepend a new shard covering
+///     `[new/bs .. shards[0].start_block)`.
+///   * **D** — `current_last_block_index > shards.last().end_block()`: append
+///     a new shard for `[shards.last().end_block() .. current_last_block_index)`.
+///
+/// B+D and C+D may apply in the same call.
+pub(crate) fn reconcile_state(
+    state: &mut OnboardingState,
+    num_computed_tokens: usize,
+    total_tokens: usize,
+    block_size: usize,
+    sequence_hashes: &[SequenceHash],
+    leader: &dyn Leader,
+) -> Result<()> {
+    debug_assert!(!state.shards.is_empty());
+    state.debug_assert_contiguous();
+
+    let old = state.num_computed_tokens;
+    let new = num_computed_tokens;
+
+    // Contract asserts (unchanged from legacy behavior): vLLM always passes
+    // block-aligned values. A mismatch here is a caller-side contract breach.
+    assert!(
+        new.is_multiple_of(block_size),
+        "num_computed_tokens {} must be a multiple of block_size {}",
+        new,
+        block_size
+    );
+
+    // Case B: new > old ----------------------------------------------------
+    if new > old {
+        let delta = new - old;
+        assert!(
+            delta.is_multiple_of(block_size),
+            "num_computed_tokens delta {} -> {} must be a multiple of block_size {}",
+            old,
+            new,
+            block_size,
+        );
+        tracing::debug!(
+            old,
+            new,
+            "num_computed_tokens increased; masking prefix via effective_start"
+        );
+        state.num_computed_tokens = new;
+    }
+
+    // Case C: new < old ----------------------------------------------------
+    if new < old {
+        let delta = old - new;
+        assert!(
+            delta.is_multiple_of(block_size),
+            "num_computed_tokens delta {} -> {} must be a multiple of block_size {}",
+            old,
+            new,
+            block_size,
+        );
+        let new_start_block = new / block_size;
+        let current_head_start = state.shards[0].start_block;
+        debug_assert!(new_start_block <= current_head_start);
+
+        if new_start_block < current_head_start {
+            tracing::debug!(
+                old,
+                new,
+                new_start_block,
+                current_head_start,
+                "num_computed_tokens decreased; prepending prefix shard"
+            );
+            let new_shard =
+                issue_shard(leader, sequence_hashes, new_start_block, current_head_start)?;
+            state.shards.insert(0, new_shard);
+        }
+        state.num_computed_tokens = new;
+    }
+
+    // Case D: total_tokens grew -------------------------------------------
+    let current_last_block_index = compute_last_block_index(total_tokens, block_size);
+    let existing_end = state.shards.last().unwrap().end_block();
+    if current_last_block_index > existing_end {
+        tracing::debug!(
+            existing_end,
+            current_last_block_index,
+            "total_tokens grew (eviction restore); appending suffix shard"
+        );
+        let new_shard = issue_shard(
+            leader,
+            sequence_hashes,
+            existing_end,
+            current_last_block_index,
+        )?;
+        state.shards.push(new_shard);
+    }
+
+    state.debug_assert_contiguous();
+    Ok(())
+}
+
+/// Compute the outcome from a reconciled onboarding state.
+pub(crate) fn compute_outcome(state: &OnboardingState, block_size: usize) -> MatchCheckOutcome {
+    // Step 1: any shard still working? Return InProgress.
+    if !state.all_shards_terminal() {
+        tracing::trace!("Find operation still in progress (some shards non-terminal)");
+        return MatchCheckOutcome::InProgress;
+    }
+
+    // Step 2: walk contiguously with first-hole short-circuit.
+    let (effective_start, final_end) = state.matched_span(block_size);
+    let matched_tokens = final_end.saturating_sub(effective_start) * block_size;
+
+    tracing::debug!(
+        effective_start,
+        final_end,
+        matched_tokens,
+        num_shards = state.shards.len(),
+        "Find completed (walk)"
+    );
+
+    if matched_tokens == 0 {
+        // No external blocks usable — either the prefix had a hole, or the
+        // `effective_start` ate the whole range. Flow to Inactive via Found{0}.
+        MatchCheckOutcome::Found { matched_tokens: 0 }
+    } else {
+        MatchCheckOutcome::Found { matched_tokens }
+    }
+}
 
 impl ConnectorLeader {
     /// Internal helper to check match status and determine the outcome.
@@ -17,6 +232,8 @@ impl ConnectorLeader {
 
         // Early exit if we cannot match a full block
         if (total_tokens - num_computed_tokens) < block_size {
+            // If a stale onboarding state exists for some reason, drop it via
+            // finalize's txn_to_inactive path by returning NoMatch.
             return Ok(MatchCheckOutcome::NoMatch);
         }
 
@@ -24,50 +241,63 @@ impl ConnectorLeader {
             .instance_leader
             .get()
             .ok_or_else(|| anyhow!("InstanceLeader not set; called before initialized"))?;
+        let leader: &dyn Leader = instance_leader;
 
-        // Check if we have an active find session
+        // Contract: num_computed_tokens must be block-aligned.
+        assert!(
+            num_computed_tokens.is_multiple_of(block_size),
+            "num_computed_tokens {} must be a multiple of block_size {}",
+            num_computed_tokens,
+            block_size,
+        );
+
+        let sequence_hashes = slot.all_sequence_hashes();
+        assert!(!sequence_hashes.is_empty());
+
+        // Initial search path: no active onboarding state -> kick off a fresh
+        // single-shard search.
         if !slot.has_onboarding_state() {
-            // Start a new find operation
-            let sequence_hashes = slot.all_sequence_hashes();
-            assert!(!sequence_hashes.is_empty());
-
-            // Remove the already computed tokens from the search list
-            assert!(num_computed_tokens.is_multiple_of(block_size));
             let num_device_blocks = num_computed_tokens / block_size;
+            let last_block_index = compute_last_block_index(total_tokens, block_size);
 
-            // If the total number of tokens is an even multiple of the block size,
-            // then we do not include the last full block in the search.
-            let last_block_index = if total_tokens.is_multiple_of(block_size) {
-                (total_tokens / block_size) - 1
-            } else {
-                total_tokens / block_size
-            };
-
-            let search_sequence_hashes = &sequence_hashes[num_device_blocks..last_block_index];
-            slot.set_match_query_blocks(search_sequence_hashes.len());
-
-            let options = FindMatchesOptions {
-                search_remote: true,
-                staging_mode: StagingMode::Full,
-            };
-
-            tracing::debug!(
-                num_hashes = sequence_hashes.len(),
-                "Starting find_matches_with_options"
-            );
-
-            match instance_leader.find_matches_with_options(search_sequence_hashes, options) {
-                Ok(result) => {
-                    if let Err(e) = slot.txn_prepare_to_onboard(num_computed_tokens, result) {
-                        tracing::error!("Failed to set find session: {}", e);
-                        bail!("Failed to set find session: {}", e);
-                    }
-                }
-                Err(e) => {
-                    tracing::error!("Failed to start find operation: {}", e);
-                    bail!("Failed to start find operation: {}", e);
-                }
+            // Defensive: if there's nothing left to search, return NoMatch.
+            if num_device_blocks >= last_block_index {
+                return Ok(MatchCheckOutcome::NoMatch);
             }
+
+            let shard = issue_shard(
+                leader,
+                &sequence_hashes,
+                num_device_blocks,
+                last_block_index,
+            )?;
+            let num_queried_blocks = shard.num_queried_blocks;
+
+            if let Err(e) = slot.txn_prepare_to_onboard(
+                num_computed_tokens,
+                total_tokens,
+                num_device_blocks,
+                num_queried_blocks,
+                shard.find_session,
+            ) {
+                tracing::error!("Failed to set find session: {}", e);
+                bail!("Failed to set find session: {}", e);
+            }
+        } else {
+            // Existing onboarding state: reconcile against the new inputs.
+            debug_assert!(matches!(
+                slot.txn_state(),
+                TransactionState::PreparingToOnboard(_)
+            ));
+            let state = slot.onboarding_state_mut().expect("state should exist");
+            reconcile_state(
+                state,
+                num_computed_tokens,
+                total_tokens,
+                block_size,
+                &sequence_hashes,
+                leader,
+            )?;
         }
 
         debug_assert!(matches!(
@@ -75,77 +305,8 @@ impl ConnectorLeader {
             TransactionState::PreparingToOnboard(_)
         ));
 
-        // Check the status of the find session and produce outcome
-        let session = slot.onboarding_state_mut().expect("session should exist");
-
-        // todo: if this changes, then we need to update the state of the find or issue a new search op.
-        if session.num_computed_tokens != num_computed_tokens {
-            // todo: add a known issue to github and remote that issue id if this warning is triggered.
-            tracing::error!(
-                "performance issue detected: num_computed_tokens changed from {} to {}; see https://github.com/ai-dynamo/dynamo/issues/5285",
-                session.num_computed_tokens,
-                num_computed_tokens
-            );
-
-            // todo: abort the search and report no matches found.
-            let session = slot.txn_take_onboarding().expect("session should exist");
-            drop(session);
-
-            // if debuging fail here
-            #[cfg(debug_assertions)]
-            panic!(
-                "performance issue detected: see https://github.com/ai-dynamo/dynamo/issues/5285"
-            );
-            // if release, return no matches found.
-            #[cfg(not(debug_assertions))]
-            return Ok(MatchCheckOutcome::NoMatch);
-        }
-
-        let outcome = match &session.find_session {
-            FindMatchesResult::Ready(ready) => {
-                // Ready result means immediate completion (local only, no async work)
-                let matched_blocks = ready.g2_count();
-                let matched_tokens = matched_blocks * block_size;
-
-                tracing::debug!(
-                    matched_blocks,
-                    matched_tokens,
-                    "Find completed immediately (Ready)"
-                );
-
-                MatchCheckOutcome::Found { matched_tokens }
-            }
-            FindMatchesResult::AsyncSession(async_session) => {
-                // Check if the async session is complete
-                let status = async_session.status();
-
-                match status {
-                    OnboardingStatus::Searching
-                    | OnboardingStatus::Preparing { .. }
-                    | OnboardingStatus::Staging { .. } => {
-                        tracing::trace!(?status, "Find operation still in progress");
-                        MatchCheckOutcome::InProgress
-                    }
-                    OnboardingStatus::Complete { matched_blocks } => {
-                        // Completed - blocks are now in local G2
-                        let matched_tokens = matched_blocks * block_size;
-
-                        tracing::debug!(
-                            matched_blocks,
-                            matched_tokens,
-                            "Find completed (Full mode)"
-                        );
-
-                        MatchCheckOutcome::Found { matched_tokens }
-                    }
-                    OnboardingStatus::Holding { .. } | OnboardingStatus::Prepared { .. } => {
-                        unreachable!("Should not be in a holding or prepared state");
-                    }
-                }
-            }
-        };
-
-        Ok(outcome)
+        let state = slot.onboarding_state().expect("state should exist");
+        Ok(compute_outcome(state, block_size))
     }
 
     /// Recover from a match error by transitioning to error state and extracting state for cleanup.
@@ -157,16 +318,16 @@ impl ConnectorLeader {
         if let Ok(active_data) = slot.txn_take_error() {
             match active_data {
                 slot::ActiveStateData::Onboarding(onboarding_state) => {
-                    match onboarding_state.find_session {
-                        FindMatchesResult::Ready(_) => {
-                            // no-op - Ready sessions have no async cleanup
-                        }
-                        FindMatchesResult::AsyncSession(_async_session) => {
-                            // todo: cancel and clean up the async session
-                            tracing::warn!(
-                                "Async session cleanup not yet implemented - session may leak"
-                            );
-                        }
+                    // Release every shard's session. For Ready variants this
+                    // is a no-op; for AsyncSession variants this returns
+                    // server-side session state to the pool.
+                    if let Some(instance_leader) = self.instance_leader.get() {
+                        onboarding_state.release_all(instance_leader);
+                    } else {
+                        tracing::warn!(
+                            "recover_from_match_error: InstanceLeader not set; cannot release {} shard session(s)",
+                            onboarding_state.shards.len()
+                        );
                     }
                 }
                 slot::ActiveStateData::Offloading(_offloading_state) => {
@@ -177,5 +338,525 @@ impl ConnectorLeader {
             }
         }
         // Slot is now in Inactive state
+    }
+}
+
+// ============================================================================
+// Reconciliation unit tests
+// ============================================================================
+//
+// These tests exercise `reconcile_state` and `compute_outcome` directly via a
+// minimal `TestLeader` stub of the `Leader` trait. They cover Cases A/B/C/D
+// from the design and the multi-shard walk + first-hole semantics. Async
+// shard variants use `AsyncSessionResult::new_complete_for_test` /
+// `new_pending_for_test` to construct terminal/pending states without a
+// real session.
+
+#[cfg(test)]
+mod reconcile_tests {
+    use super::*;
+    use kvbm_engine::leader::{AsyncSessionResult, FindMatchesResult, MatchBreakdown, ReadyResult};
+    use std::sync::Mutex as StdMutex;
+    use tokio::sync::watch;
+
+    const BS: usize = 4;
+
+    /// A stub `Leader` that returns canned `FindMatchesResult`s in queue
+    /// order. Each call consumes the next item from `responses`. If the queue
+    /// is exhausted, the call panics — tests should provide exactly the
+    /// number of canned results they expect.
+    struct TestLeader {
+        responses: StdMutex<Vec<FindMatchesResult>>,
+        calls: StdMutex<Vec<usize>>,
+    }
+
+    impl TestLeader {
+        fn new(responses: Vec<FindMatchesResult>) -> Self {
+            Self {
+                responses: StdMutex::new(responses),
+                calls: StdMutex::new(Vec::new()),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.lock().unwrap().len()
+        }
+    }
+
+    impl Leader for TestLeader {
+        fn find_matches_with_options(
+            &self,
+            sequence_hashes: &[SequenceHash],
+            _options: FindMatchesOptions,
+        ) -> Result<FindMatchesResult> {
+            self.calls.lock().unwrap().push(sequence_hashes.len());
+            let mut q = self.responses.lock().unwrap();
+            assert!(
+                !q.is_empty(),
+                "TestLeader: unexpected find_matches_with_options call ({} hashes)",
+                sequence_hashes.len()
+            );
+            Ok(q.remove(0))
+        }
+    }
+
+    /// Build a vector of dummy `SequenceHash` values. The tests don't depend
+    /// on actual hash content, only on slice indices.
+    fn dummy_hashes(n: usize) -> Vec<SequenceHash> {
+        (0..n as u64)
+            .map(|i| SequenceHash::new(i, None, i))
+            .collect()
+    }
+
+    /// Construct a Ready shard result with `g2_count` empty G2 placeholders.
+    /// Since `ImmutableBlock<G2>` cannot be constructed outside kvbm-logical,
+    /// this only works for `g2_count == 0`. Callers that need a non-zero
+    /// match count should use `complete_async(matched)` instead.
+    fn ready_zero() -> FindMatchesResult {
+        FindMatchesResult::Ready(ReadyResult::new(vec![], MatchBreakdown::default()))
+    }
+
+    /// Construct a terminal AsyncSession with `matched_blocks` reported via
+    /// the watch channel. The blocks vec is empty (only the count matters
+    /// for reconciliation/walk logic).
+    fn complete_async(matched: usize) -> FindMatchesResult {
+        FindMatchesResult::AsyncSession(AsyncSessionResult::new_complete_for_test(
+            matched,
+            vec![],
+            MatchBreakdown::default(),
+        ))
+    }
+
+    /// Construct a pending AsyncSession (status = Searching). Returns the
+    /// session and the watch sender so tests can transition it later.
+    fn pending_async() -> (
+        FindMatchesResult,
+        watch::Sender<kvbm_engine::leader::OnboardingStatus>,
+    ) {
+        let (session, tx) = AsyncSessionResult::new_pending_for_test();
+        (FindMatchesResult::AsyncSession(session), tx)
+    }
+
+    /// Build a fresh `OnboardingState` with a single shard.
+    fn make_state(
+        num_computed_tokens: usize,
+        total_tokens_at_start: usize,
+        start_block: usize,
+        num_queried_blocks: usize,
+        find_session: FindMatchesResult,
+    ) -> slot::OnboardingState {
+        slot::OnboardingState::new(
+            num_computed_tokens,
+            total_tokens_at_start,
+            slot::OnboardingShard {
+                start_block,
+                num_queried_blocks,
+                find_session,
+            },
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Case A — no change
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn case_a_unchanged_in_progress() {
+        // single shard, async pending. Expect InProgress, shards untouched.
+        let (pending, _tx) = pending_async();
+        let mut state = make_state(40, 64, 10, 5, pending);
+        let hashes = dummy_hashes(20);
+        let leader = TestLeader::new(vec![]);
+
+        reconcile_state(&mut state, 40, 64, BS, &hashes, &leader).unwrap();
+        assert_eq!(leader.call_count(), 0);
+        assert_eq!(state.shards.len(), 1);
+        assert!(matches!(
+            compute_outcome(&state, BS),
+            MatchCheckOutcome::InProgress
+        ));
+    }
+
+    #[test]
+    fn case_a_unchanged_terminal_full_match() {
+        // single shard, async complete with all 5 blocks. Expect Found{5*BS}.
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(20);
+        let leader = TestLeader::new(vec![]);
+
+        reconcile_state(&mut state, 40, 64, BS, &hashes, &leader).unwrap();
+        assert_eq!(leader.call_count(), 0);
+        match compute_outcome(&state, BS) {
+            MatchCheckOutcome::Found { matched_tokens } => assert_eq!(matched_tokens, 5 * BS),
+            other => panic!("expected Found, got {:?}", other_repr(&other)),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Case B — new > old (mask via effective_start)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn case_b_mask_partial() {
+        // Shard at start_block=10, num_queried=5, all 5 matched.
+        // num_computed grows from 40 (=10*BS) to 48 (=12*BS): mask 2 blocks.
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(20);
+        let leader = TestLeader::new(vec![]);
+
+        reconcile_state(&mut state, 48, 64, BS, &hashes, &leader).unwrap();
+        assert_eq!(leader.call_count(), 0);
+        assert_eq!(state.num_computed_tokens, 48);
+        assert_eq!(state.shards.len(), 1);
+
+        // effective_start = max(10, 12) = 12; final_end = 15; matched = 3*BS
+        match compute_outcome(&state, BS) {
+            MatchCheckOutcome::Found { matched_tokens } => assert_eq!(matched_tokens, 3 * BS),
+            other => panic!("expected Found, got {:?}", other_repr(&other)),
+        }
+    }
+
+    #[test]
+    fn case_b_mask_consumes_all() {
+        // Mask covers the entire matched range -> 0 effective external tokens.
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(20);
+        let leader = TestLeader::new(vec![]);
+
+        reconcile_state(&mut state, 60, 64, BS, &hashes, &leader).unwrap();
+        // effective_start = 15, final_end = 15 -> 0
+        match compute_outcome(&state, BS) {
+            MatchCheckOutcome::Found { matched_tokens } => assert_eq!(matched_tokens, 0),
+            other => panic!("expected Found{{0}}, got {:?}", other_repr(&other)),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "must be a multiple of block_size")]
+    fn case_b_unaligned_delta_panics() {
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(20);
+        let leader = TestLeader::new(vec![]);
+
+        // 42 is not a multiple of BS=4 -> the top-level alignment assert fires.
+        reconcile_state(&mut state, 42, 64, BS, &hashes, &leader).unwrap();
+    }
+
+    // ------------------------------------------------------------------
+    // Case C — new < old (prepend prefix shard)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn case_c_prepend_full_match() {
+        // shard at start_block=10, num=5, complete with 5 matches.
+        // num_computed drops from 40 to 32 -> prepend shard [8..10) of size 2.
+        // Test leader returns a fully-matched (2/2) async response for the prefix.
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(20);
+        let leader = TestLeader::new(vec![complete_async(2)]);
+
+        reconcile_state(&mut state, 32, 64, BS, &hashes, &leader).unwrap();
+        assert_eq!(leader.call_count(), 1);
+        assert_eq!(state.num_computed_tokens, 32);
+        assert_eq!(state.shards.len(), 2);
+        assert_eq!(state.shards[0].start_block, 8);
+        assert_eq!(state.shards[0].num_queried_blocks, 2);
+        assert_eq!(state.shards[1].start_block, 10);
+
+        // effective_start = max(8, 8) = 8; running_end walks 8 -> 10 -> 15.
+        // matched = (15 - 8)*BS = 28.
+        match compute_outcome(&state, BS) {
+            MatchCheckOutcome::Found { matched_tokens } => assert_eq!(matched_tokens, 7 * BS),
+            other => panic!("expected Found, got {:?}", other_repr(&other)),
+        }
+    }
+
+    #[test]
+    fn case_c_prefix_hole_zero_match() {
+        // Prefix shard returns a hole (1 of 2 matched). Walk short-circuits at
+        // running_end + 1 = 9. effective_start = 8. final_end = 9. matched = 1*BS.
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(20);
+        let leader = TestLeader::new(vec![complete_async(1)]);
+
+        reconcile_state(&mut state, 32, 64, BS, &hashes, &leader).unwrap();
+        match compute_outcome(&state, BS) {
+            MatchCheckOutcome::Found { matched_tokens } => assert_eq!(matched_tokens, BS),
+            other => panic!("expected Found{{BS}}, got {:?}", other_repr(&other)),
+        }
+    }
+
+    #[test]
+    fn case_c_prefix_zero_match() {
+        // Prefix shard returns 0 matches -> full hole at the very start.
+        // running_end starts at 8, matched=0 -> final_end=8. effective_start=8.
+        // matched = 0.
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(20);
+        let leader = TestLeader::new(vec![complete_async(0)]);
+
+        reconcile_state(&mut state, 32, 64, BS, &hashes, &leader).unwrap();
+        match compute_outcome(&state, BS) {
+            MatchCheckOutcome::Found { matched_tokens } => assert_eq!(matched_tokens, 0),
+            other => panic!("expected Found{{0}}, got {:?}", other_repr(&other)),
+        }
+    }
+
+    #[test]
+    fn case_c_prefix_pending_keeps_in_progress() {
+        // Old suffix terminal, new prefix in progress -> InProgress.
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(20);
+        let (pending, _tx) = pending_async();
+        let leader = TestLeader::new(vec![pending]);
+
+        reconcile_state(&mut state, 32, 64, BS, &hashes, &leader).unwrap();
+        assert!(matches!(
+            compute_outcome(&state, BS),
+            MatchCheckOutcome::InProgress
+        ));
+    }
+
+    #[test]
+    fn case_c_full_preemption_no_special_logging() {
+        // num_computed_tokens drops to 0. Should be handled identically to any
+        // other Case C — prepend a shard for the full prefix.
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(20);
+        let leader = TestLeader::new(vec![complete_async(10)]);
+
+        reconcile_state(&mut state, 0, 64, BS, &hashes, &leader).unwrap();
+        assert_eq!(state.num_computed_tokens, 0);
+        assert_eq!(state.shards.len(), 2);
+        assert_eq!(state.shards[0].start_block, 0);
+        assert_eq!(state.shards[0].num_queried_blocks, 10);
+        // effective_start = max(0, 0) = 0; full match across both shards = 15 * BS
+        match compute_outcome(&state, BS) {
+            MatchCheckOutcome::Found { matched_tokens } => assert_eq!(matched_tokens, 15 * BS),
+            other => panic!("expected Found, got {:?}", other_repr(&other)),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "must be a multiple of block_size")]
+    fn case_c_unaligned_delta_panics() {
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(20);
+        let leader = TestLeader::new(vec![]);
+        // 38 is not a multiple of BS=4.
+        reconcile_state(&mut state, 38, 64, BS, &hashes, &leader).unwrap();
+    }
+
+    // ------------------------------------------------------------------
+    // Case D — total_tokens grew (eviction restore)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn case_d_appends_upper_shard() {
+        // Original total_tokens=64 -> last_block_index=15; shard covers [10..15).
+        // total_tokens grows to 96 -> last_block_index=23. Append [15..23).
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(30);
+        let leader = TestLeader::new(vec![complete_async(8)]);
+
+        reconcile_state(&mut state, 40, 96, BS, &hashes, &leader).unwrap();
+        assert_eq!(leader.call_count(), 1);
+        assert_eq!(state.shards.len(), 2);
+        assert_eq!(state.shards[1].start_block, 15);
+        assert_eq!(state.shards[1].num_queried_blocks, 8);
+        // walk: 10 -> 15 (shard0 full) -> 23 (shard1 full). effective_start=10. matched=13*BS.
+        match compute_outcome(&state, BS) {
+            MatchCheckOutcome::Found { matched_tokens } => assert_eq!(matched_tokens, 13 * BS),
+            other => panic!("expected Found, got {:?}", other_repr(&other)),
+        }
+    }
+
+    #[test]
+    fn case_d_pending_upper_shard() {
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(30);
+        let (pending, _tx) = pending_async();
+        let leader = TestLeader::new(vec![pending]);
+
+        reconcile_state(&mut state, 40, 96, BS, &hashes, &leader).unwrap();
+        assert!(matches!(
+            compute_outcome(&state, BS),
+            MatchCheckOutcome::InProgress
+        ));
+    }
+
+    // ------------------------------------------------------------------
+    // Combinations: B+D, C+D
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn case_b_plus_d() {
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(30);
+        let leader = TestLeader::new(vec![complete_async(8)]);
+
+        // num grows by 8 (mask 2), total grows -> append shard [15..23) full
+        reconcile_state(&mut state, 48, 96, BS, &hashes, &leader).unwrap();
+        // effective_start = max(10, 12) = 12; final_end = 23 -> matched = 11*BS
+        match compute_outcome(&state, BS) {
+            MatchCheckOutcome::Found { matched_tokens } => assert_eq!(matched_tokens, 11 * BS),
+            other => panic!("expected Found, got {:?}", other_repr(&other)),
+        }
+    }
+
+    #[test]
+    fn case_c_plus_d() {
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(30);
+        // First call: prefix [8..10) (Case C), then second: upper [15..23) (Case D).
+        let leader = TestLeader::new(vec![complete_async(2), complete_async(8)]);
+
+        reconcile_state(&mut state, 32, 96, BS, &hashes, &leader).unwrap();
+        assert_eq!(leader.call_count(), 2);
+        assert_eq!(state.shards.len(), 3);
+        // walk: 8 -> 10 -> 15 -> 23. effective_start=8. matched = 15*BS.
+        match compute_outcome(&state, BS) {
+            MatchCheckOutcome::Found { matched_tokens } => assert_eq!(matched_tokens, 15 * BS),
+            other => panic!("expected Found, got {:?}", other_repr(&other)),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Walk semantics edge cases
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn walk_short_circuits_on_first_hole() {
+        // Two terminal shards; first has a hole (matched < num_queried).
+        // Second shard's match count is irrelevant past the hole.
+        let mut state = make_state(40, 64, 10, 5, complete_async(3));
+        // Pre-attach a second shard manually for this test.
+        state.shards.push(slot::OnboardingShard {
+            start_block: 15,
+            num_queried_blocks: 3,
+            find_session: complete_async(3),
+        });
+        // walk: 10 -> 13 (hole). effective_start = 10. matched = 3*BS.
+        match compute_outcome(&state, BS) {
+            MatchCheckOutcome::Found { matched_tokens } => assert_eq!(matched_tokens, 3 * BS),
+            other => panic!("expected Found, got {:?}", other_repr(&other)),
+        }
+    }
+
+    #[test]
+    fn walk_one_pending_shard_returns_in_progress() {
+        // Two shards: first terminal (full), second pending. Step-1 returns
+        // InProgress (no partial reporting).
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let (pending, _tx) = pending_async();
+        state.shards.push(slot::OnboardingShard {
+            start_block: 15,
+            num_queried_blocks: 3,
+            find_session: pending,
+        });
+        assert!(matches!(
+            compute_outcome(&state, BS),
+            MatchCheckOutcome::InProgress
+        ));
+    }
+
+    // ------------------------------------------------------------------
+    // Invariants and metric plumbing
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn shard_contiguity_invariant_after_reconcile() {
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(30);
+        let leader = TestLeader::new(vec![complete_async(2), complete_async(8)]);
+
+        reconcile_state(&mut state, 32, 96, BS, &hashes, &leader).unwrap();
+        // debug_assert_contiguous would have panicked if the invariant was
+        // violated; call it explicitly to be sure.
+        state.debug_assert_contiguous();
+        assert_eq!(state.shards[0].end_block(), state.shards[1].start_block);
+        assert_eq!(state.shards[1].end_block(), state.shards[2].start_block);
+    }
+
+    #[test]
+    fn total_query_blocks_sums_across_shards() {
+        let mut state = make_state(40, 64, 10, 5, complete_async(5));
+        let hashes = dummy_hashes(30);
+        let leader = TestLeader::new(vec![complete_async(2), complete_async(8)]);
+
+        reconcile_state(&mut state, 32, 96, BS, &hashes, &leader).unwrap();
+        assert_eq!(state.total_query_blocks(), 2 + 5 + 8);
+    }
+
+    /// Direct repro of the scenario reported in #5285: at bs=16, vLLM polled
+    /// `get_num_new_matched_tokens` first with 21536 and then with 21520 (a
+    /// 16-token == 1-block decrease, i.e. one G1 block was evicted between
+    /// scheduler passes). The legacy code panicked in debug here. With
+    /// reconciliation, we simply prepend a one-block prefix shard and report
+    /// a (potentially) extended match without losing the suffix work.
+    #[test]
+    fn issue_5285_repro_one_block_eviction() {
+        const REAL_BS: usize = 16;
+        // total_tokens beyond the first poll's range; pick something that gives
+        // headroom and a stable last_block_index.
+        let total_tokens = 24_000_usize;
+        let last_block_index = total_tokens / REAL_BS;
+        // First poll: num_computed_tokens=21536 -> shard at 21536/16 = 1346,
+        // covering [1346 .. last_block_index). Suppose all blocks matched.
+        let num_blocks_first = last_block_index - 1346;
+        let mut state = slot::OnboardingState::new(
+            21536,
+            total_tokens,
+            slot::OnboardingShard {
+                start_block: 1346,
+                num_queried_blocks: num_blocks_first,
+                find_session: complete_async(num_blocks_first),
+            },
+        );
+        let hashes = dummy_hashes(last_block_index);
+
+        // Second poll: 21520 = 1345 * 16. We expect a new prefix shard
+        // [1345..1346) of size 1.
+        let leader = TestLeader::new(vec![complete_async(1)]);
+        reconcile_state(&mut state, 21520, total_tokens, REAL_BS, &hashes, &leader).unwrap();
+
+        assert_eq!(leader.call_count(), 1);
+        assert_eq!(state.shards.len(), 2);
+        assert_eq!(state.shards[0].start_block, 1345);
+        assert_eq!(state.shards[0].num_queried_blocks, 1);
+
+        // effective_start = max(1345, 21520/16=1345) = 1345
+        // final_end = last_block_index
+        // matched = (last_block_index - 1345) * 16
+        let expected = (last_block_index - 1345) * REAL_BS;
+        match compute_outcome(&state, REAL_BS) {
+            MatchCheckOutcome::Found { matched_tokens } => {
+                assert_eq!(matched_tokens, expected)
+            }
+            other => panic!("expected Found, got {:?}", other_repr(&other)),
+        }
+    }
+
+    #[test]
+    fn ready_zero_match_returns_found_zero() {
+        // A Ready variant with no matched blocks -> Found{0}. (This is the
+        // legacy single-shard happy path with an empty result.)
+        let mut state = make_state(40, 64, 10, 5, ready_zero());
+        let hashes = dummy_hashes(20);
+        let leader = TestLeader::new(vec![]);
+
+        reconcile_state(&mut state, 40, 64, BS, &hashes, &leader).unwrap();
+        match compute_outcome(&state, BS) {
+            MatchCheckOutcome::Found { matched_tokens } => assert_eq!(matched_tokens, 0),
+            other => panic!("expected Found{{0}}, got {:?}", other_repr(&other)),
+        }
+    }
+
+    fn other_repr(o: &MatchCheckOutcome) -> &'static str {
+        match o {
+            MatchCheckOutcome::InProgress => "InProgress",
+            MatchCheckOutcome::NoMatch => "NoMatch",
+            MatchCheckOutcome::Found { .. } => "Found",
+        }
     }
 }

--- a/lib/kvbm-connector/src/connector/leader/search.rs
+++ b/lib/kvbm-connector/src/connector/leader/search.rs
@@ -348,16 +348,21 @@ impl ConnectorLeader {
 // These tests exercise `reconcile_state` and `compute_outcome` directly via a
 // minimal `TestLeader` stub of the `Leader` trait. They cover Cases A/B/C/D
 // from the design and the multi-shard walk + first-hole semantics. Async
-// shard variants use `AsyncSessionResult::new_complete_for_test` /
-// `new_pending_for_test` to construct terminal/pending states without a
-// real session.
+// shard variants construct `AsyncSessionResult`s directly from the public
+// `::new` constructor with pre-filled status/blocks, so the tests don't
+// require the kvbm-engine `testing` feature.
 
 #[cfg(test)]
 mod reconcile_tests {
     use super::*;
-    use kvbm_engine::leader::{AsyncSessionResult, FindMatchesResult, MatchBreakdown, ReadyResult};
+    use kvbm_engine::leader::{
+        AsyncSessionResult, FindMatchesResult, MatchBreakdown, OnboardingStatus, ReadyResult,
+        SessionId,
+    };
+    use std::sync::Arc;
     use std::sync::Mutex as StdMutex;
-    use tokio::sync::watch;
+    use tokio::sync::{Mutex as TokioMutex, watch};
+    use uuid::Uuid;
 
     const BS: usize = 4;
 
@@ -420,21 +425,32 @@ mod reconcile_tests {
     /// the watch channel. The blocks vec is empty (only the count matters
     /// for reconciliation/walk logic).
     fn complete_async(matched: usize) -> FindMatchesResult {
-        FindMatchesResult::AsyncSession(AsyncSessionResult::new_complete_for_test(
-            matched,
-            vec![],
-            MatchBreakdown::default(),
+        // Drop the sender so the channel stays at its latest value; receivers
+        // will still observe `Complete { matched_blocks: matched }`.
+        let (status_tx, status_rx) =
+            watch::channel(OnboardingStatus::Complete { matched_blocks: matched });
+        drop(status_tx);
+        FindMatchesResult::AsyncSession(AsyncSessionResult::new(
+            SessionId::from(Uuid::nil()),
+            status_rx,
+            Arc::new(TokioMutex::new(Some(Vec::new()))),
+            Arc::new(TokioMutex::new(MatchBreakdown::default())),
+            None,
         ))
     }
 
     /// Construct a pending AsyncSession (status = Searching). Returns the
     /// session and the watch sender so tests can transition it later.
-    fn pending_async() -> (
-        FindMatchesResult,
-        watch::Sender<kvbm_engine::leader::OnboardingStatus>,
-    ) {
-        let (session, tx) = AsyncSessionResult::new_pending_for_test();
-        (FindMatchesResult::AsyncSession(session), tx)
+    fn pending_async() -> (FindMatchesResult, watch::Sender<OnboardingStatus>) {
+        let (status_tx, status_rx) = watch::channel(OnboardingStatus::Searching);
+        let session = AsyncSessionResult::new(
+            SessionId::from(Uuid::nil()),
+            status_rx,
+            Arc::new(TokioMutex::new(None)),
+            Arc::new(TokioMutex::new(MatchBreakdown::default())),
+            None,
+        );
+        (FindMatchesResult::AsyncSession(session), status_tx)
     }
 
     /// Build a fresh `OnboardingState` with a single shard.

--- a/lib/kvbm-connector/src/connector/leader/search.rs
+++ b/lib/kvbm-connector/src/connector/leader/search.rs
@@ -427,8 +427,9 @@ mod reconcile_tests {
     fn complete_async(matched: usize) -> FindMatchesResult {
         // Drop the sender so the channel stays at its latest value; receivers
         // will still observe `Complete { matched_blocks: matched }`.
-        let (status_tx, status_rx) =
-            watch::channel(OnboardingStatus::Complete { matched_blocks: matched });
+        let (status_tx, status_rx) = watch::channel(OnboardingStatus::Complete {
+            matched_blocks: matched,
+        });
         drop(status_tx);
         FindMatchesResult::AsyncSession(AsyncSessionResult::new(
             SessionId::from(Uuid::nil()),

--- a/lib/kvbm-connector/src/connector/leader/slot.rs
+++ b/lib/kvbm-connector/src/connector/leader/slot.rs
@@ -9,7 +9,7 @@ use dynamo_tokens::TokenBlockSequence;
 use super::Request;
 use super::scheduler::CachedRequestData;
 use kvbm_common::{BlockId, SequenceHash};
-use kvbm_engine::leader::FindMatchesResult;
+use kvbm_engine::leader::{FindMatchesResult, InstanceLeader, MatchBreakdown, OnboardingStatus};
 use kvbm_engine::offload::TransferHandle;
 use kvbm_logical::KvbmSequenceHashProvider;
 
@@ -35,18 +35,197 @@ pub enum StateTransitionError {
 // State Data Structs
 // ============================================================================
 
+/// A single contiguous sub-range of the logical sequence being searched.
+///
+/// Multiple shards exist when the search has been reconciled against a changing
+/// `num_computed_tokens` or `total_tokens`: for example, when vLLM evicts G1 blocks
+/// between polls we prepend a new prefix shard, and when tokens are restored from
+/// eviction we append a new upper shard. On completion we walk shards in order
+/// and unify their match counts using first-hole semantics.
+#[derive(Debug)]
+pub struct OnboardingShard {
+    /// Block index in the logical sequence where this shard's search starts (inclusive).
+    pub start_block: usize,
+
+    /// Number of sequence hashes this shard queried. The shard covers block
+    /// indices `[start_block .. start_block + num_queried_blocks)`.
+    pub num_queried_blocks: usize,
+
+    /// The find session that owns the matched blocks via RAII.
+    pub find_session: FindMatchesResult,
+}
+
+impl OnboardingShard {
+    /// Exclusive end block index of this shard.
+    pub fn end_block(&self) -> usize {
+        self.start_block + self.num_queried_blocks
+    }
+
+    /// Best-effort release of the underlying session.
+    ///
+    /// For `Ready` variants this is a no-op (blocks drop via RAII). For
+    /// `AsyncSession` variants this calls `release_session` on the leader so
+    /// that server-side session state is freed.
+    pub fn release(&self, leader: &InstanceLeader) {
+        if let Some(session_id) = self.find_session.session_id() {
+            leader.release_session(session_id);
+        }
+    }
+}
+
 /// Data associated with onboarding operations (both PreparingToOnboard and Onboarding states).
 ///
 /// This struct holds all the state needed for finding and loading external KV cache blocks.
-/// The `session_id` is `None` while preparing (searching/staging) and becomes `Some` when
-/// actively onboarding.
+/// It is a list of contiguous `OnboardingShard`s covering some block-index range of the
+/// logical sequence; shards are reconciled and added when `num_computed_tokens` or
+/// `total_tokens` changes between calls to `get_num_new_matched_tokens` (see
+/// `reconcile_and_process` in `search.rs`).
 #[derive(Debug)]
 pub struct OnboardingState {
-    /// The number of tokens that match tokens already in the G1 storage
+    /// The number of tokens that match tokens already in the G1 storage,
+    /// as last reported by vLLM. May be updated on retries.
     pub num_computed_tokens: usize,
 
-    /// The active find session for discovering external blocks.
-    pub find_session: FindMatchesResult,
+    /// The `total_tokens` captured when the earliest shard was issued. Used
+    /// to detect when the logical sequence has grown (eviction restore).
+    pub total_tokens_at_start: usize,
+
+    /// Shards sorted by `start_block` ascending. Invariant: contiguous and
+    /// non-overlapping, i.e. `shards[i+1].start_block == shards[i].end_block()`.
+    pub shards: Vec<OnboardingShard>,
+}
+
+impl OnboardingState {
+    /// Build a new state from a single initial shard.
+    pub fn new(
+        num_computed_tokens: usize,
+        total_tokens_at_start: usize,
+        initial_shard: OnboardingShard,
+    ) -> Self {
+        let state = Self {
+            num_computed_tokens,
+            total_tokens_at_start,
+            shards: vec![initial_shard],
+        };
+        state.debug_assert_contiguous();
+        state
+    }
+
+    /// Total number of blocks queried across all shards (for metrics).
+    pub fn total_query_blocks(&self) -> usize {
+        self.shards.iter().map(|s| s.num_queried_blocks).sum()
+    }
+
+    /// Sum of match breakdowns across all shards.
+    pub fn aggregate_breakdown(&self) -> MatchBreakdown {
+        self.shards
+            .iter()
+            .map(|s| s.find_session.match_breakdown())
+            .fold(MatchBreakdown::default(), |acc, b| MatchBreakdown {
+                host_blocks: acc.host_blocks + b.host_blocks,
+                disk_blocks: acc.disk_blocks + b.disk_blocks,
+                object_blocks: acc.object_blocks + b.object_blocks,
+            })
+    }
+
+    /// Return `true` iff every shard has reached a terminal state.
+    pub fn all_shards_terminal(&self) -> bool {
+        self.shards.iter().all(shard_is_terminal)
+    }
+
+    /// Compute the `(effective_start, final_end)` block-index span covered by
+    /// the contiguous match so far.
+    ///
+    /// `effective_start` is the greater of the earliest shard's start and the
+    /// current `num_computed_tokens / bs`. `final_end` is the first-hole
+    /// boundary walking contiguously from `shards[0].start_block`.
+    ///
+    /// Precondition: all shards are terminal (`all_shards_terminal()` is true).
+    pub fn matched_span(&self, block_size: usize) -> (usize, usize) {
+        debug_assert!(!self.shards.is_empty());
+        debug_assert!(self.all_shards_terminal());
+
+        let mut running_end = self.shards[0].start_block;
+        let mut final_end = running_end;
+        for shard in &self.shards {
+            debug_assert_eq!(shard.start_block, running_end);
+            let matched = shard_terminal_matched_count(shard);
+            if matched < shard.num_queried_blocks {
+                final_end = running_end + matched;
+                break;
+            }
+            running_end += shard.num_queried_blocks;
+            final_end = running_end;
+        }
+
+        let new_computed_blocks = self.num_computed_tokens / block_size;
+        let effective_start = self.shards[0].start_block.max(new_computed_blocks);
+        (effective_start, final_end)
+    }
+
+    /// Check invariants on shard list (contiguous, non-overlapping, sorted).
+    pub(crate) fn debug_assert_contiguous(&self) {
+        if cfg!(debug_assertions) {
+            for pair in self.shards.windows(2) {
+                debug_assert_eq!(
+                    pair[1].start_block,
+                    pair[0].end_block(),
+                    "OnboardingState shards must be contiguous: {:?}",
+                    self.shards
+                        .iter()
+                        .map(|s| (s.start_block, s.num_queried_blocks))
+                        .collect::<Vec<_>>()
+                );
+            }
+        }
+    }
+
+    /// Release sessions for every shard (best-effort cleanup).
+    pub fn release_all(&self, leader: &InstanceLeader) {
+        for shard in &self.shards {
+            shard.release(leader);
+        }
+    }
+}
+
+/// True if the find session of this shard has reached a terminal state.
+pub fn shard_is_terminal(shard: &OnboardingShard) -> bool {
+    match &shard.find_session {
+        FindMatchesResult::Ready(_) => true,
+        FindMatchesResult::AsyncSession(s) => matches!(
+            s.status(),
+            OnboardingStatus::Complete { .. }
+                | OnboardingStatus::Holding { .. }
+                | OnboardingStatus::Prepared { .. }
+        ),
+    }
+}
+
+/// Return the matched block count for a terminal shard.
+///
+/// Panics if called on a non-terminal shard; callers must gate on
+/// [`OnboardingState::all_shards_terminal`] first.
+pub fn shard_terminal_matched_count(shard: &OnboardingShard) -> usize {
+    match &shard.find_session {
+        FindMatchesResult::Ready(r) => r.g2_count(),
+        FindMatchesResult::AsyncSession(s) => match s.status() {
+            OnboardingStatus::Complete { matched_blocks } => matched_blocks,
+            // Holding / Prepared are not currently produced on this path; treat the
+            // session as if its g2_count() is authoritative.
+            OnboardingStatus::Holding { .. } | OnboardingStatus::Prepared { .. } => {
+                s.get_blocks_count().unwrap_or(0)
+            }
+            OnboardingStatus::Searching
+            | OnboardingStatus::Preparing { .. }
+            | OnboardingStatus::Staging { .. } => {
+                debug_assert!(
+                    false,
+                    "shard_terminal_matched_count called on non-terminal shard"
+                );
+                0
+            }
+        },
+    }
 }
 
 /// Data associated with offloading operations.
@@ -517,9 +696,6 @@ pub struct RequestSlot {
     /// the `KvConnectorMetadata.intra_pass_load` field.
     pending_intra_pass: Option<IntraPassPending>,
 
-    /// Number of cache blocks queried for the active match attempt.
-    match_query_blocks: usize,
-
     /// Prevent duplicate matched-token metric emission during repeated polling.
     matched_tokens_reported: bool,
 }
@@ -660,7 +836,6 @@ impl RequestSlot {
             finished_evaluating: false,
             match_requires_reset: false,
             pending_intra_pass: None,
-            match_query_blocks: 0,
             matched_tokens_reported: false,
         })
     }
@@ -749,13 +924,20 @@ impl RequestSlot {
         self.match_requires_reset = requires_reset;
     }
 
-    pub fn set_match_query_blocks(&mut self, match_query_blocks: usize) {
-        self.match_query_blocks = match_query_blocks;
+    /// Reset the matched-tokens metric reporting flag. Called when a new
+    /// onboarding search is kicked off so that the next match count is
+    /// reported exactly once.
+    pub fn reset_matched_tokens_reported(&mut self) {
         self.matched_tokens_reported = false;
     }
 
-    pub fn match_query_blocks(&self) -> usize {
-        self.match_query_blocks
+    /// Total number of blocks queried across all shards of the active
+    /// onboarding search, or 0 if there is no active onboarding state.
+    pub fn total_query_blocks(&self) -> usize {
+        self.state
+            .onboarding_state()
+            .map(|s| s.total_query_blocks())
+            .unwrap_or(0)
     }
 
     pub fn mark_matched_tokens_reported(&mut self) -> bool {
@@ -816,19 +998,48 @@ impl RequestSlot {
 
     /// Begin preparing to onboard blocks from remote storage.
     ///
-    /// Creates an `OnboardingState` with the given find session and computed tokens count.
-    /// Only valid when in `Inactive` state and slot is not marked for deletion.
+    /// Creates an `OnboardingState` with a single initial shard covering
+    /// `[start_block .. start_block + num_queried_blocks)`. Only valid when
+    /// in `Inactive` state and slot is not marked for deletion.
     pub fn txn_prepare_to_onboard(
+        &mut self,
+        num_computed_tokens: usize,
+        total_tokens_at_start: usize,
+        start_block: usize,
+        num_queried_blocks: usize,
+        find_session: FindMatchesResult,
+    ) -> Result<(), StateTransitionError> {
+        let initial_shard = OnboardingShard {
+            start_block,
+            num_queried_blocks,
+            find_session,
+        };
+        let state = OnboardingState::new(num_computed_tokens, total_tokens_at_start, initial_shard);
+        self.evaluated_tokens = 0;
+        self.matched_tokens_reported = false;
+        self.state.txn_prepare_to_onboard(state)
+    }
+
+    /// Test-only convenience wrapper matching the legacy 2-argument signature
+    /// of `txn_prepare_to_onboard`. Defaults `total_tokens_at_start`, `start_block`,
+    /// and `num_queried_blocks` to values consistent with the existing
+    /// state-machine tests (which don't exercise reconciliation).
+    #[cfg(test)]
+    pub fn txn_prepare_to_onboard_legacy(
         &mut self,
         num_computed_tokens: usize,
         find_session: FindMatchesResult,
     ) -> Result<(), StateTransitionError> {
-        let state = OnboardingState {
+        // Pick plausible-but-arbitrary shard metadata; tests that care about
+        // these values use `txn_prepare_to_onboard` directly.
+        let block_size = self.block_size();
+        self.txn_prepare_to_onboard(
             num_computed_tokens,
+            num_computed_tokens,
+            num_computed_tokens / block_size,
+            1,
             find_session,
-        };
-        self.evaluated_tokens = 0;
-        self.state.txn_prepare_to_onboard(state)
+        )
     }
 
     /// Transition from PreparingToOnboard to Onboarding.
@@ -975,7 +1186,6 @@ impl RequestSlot {
 
         // Clear the reset flag
         self.match_requires_reset = false;
-        self.match_query_blocks = 0;
         self.matched_tokens_reported = false;
 
         // NOTE: Do NOT clear pending_intra_pass here. By the time reset_for_preemption
@@ -2308,10 +2518,12 @@ mod tests {
             RequestSlot::new(request, TEST_BLOCK_SIZE).expect("Failed to create RequestSlot")
         }
 
-        /// Helper to create a mock OnboardingState for testing.
-        /// Returns (num_computed_tokens, FindMatchesResult).
+        /// Helper to create a mock `(num_computed_tokens, FindMatchesResult)`
+        /// pair for state-machine testing. Callers pass the pair to
+        /// [`RequestSlot::txn_prepare_to_onboard_legacy`], which fills in
+        /// shard metadata with test defaults.
         fn create_mock_onboarding_state() -> (usize, FindMatchesResult) {
-            // Create a Ready result with no blocks for testing purposes
+            // Create a Ready result with no blocks for testing purposes.
             let ready_result = ReadyResult::new(vec![], Default::default());
             (100, FindMatchesResult::Ready(ready_result))
         }
@@ -2329,7 +2541,7 @@ mod tests {
             assert!(slot.txn_state().is_inactive());
 
             // Transition to PreparingToOnboard should succeed
-            let result = slot.txn_prepare_to_onboard(num_computed_tokens, find_session);
+            let result = slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session);
             assert!(result.is_ok());
 
             // Verify state changed
@@ -2345,12 +2557,12 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // First transition to PreparingToOnboard
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
 
             // Try to prepare again - should fail
             let (num_computed_tokens2, find_session2) = create_mock_onboarding_state();
-            let result = slot.txn_prepare_to_onboard(num_computed_tokens2, find_session2);
+            let result = slot.txn_prepare_to_onboard_legacy(num_computed_tokens2, find_session2);
 
             assert!(result.is_err());
             assert!(matches!(
@@ -2369,7 +2581,7 @@ mod tests {
 
             // Try to prepare to onboard - should fail
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
-            let result = slot.txn_prepare_to_onboard(num_computed_tokens, find_session);
+            let result = slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session);
 
             assert!(result.is_err());
             assert!(matches!(
@@ -2384,7 +2596,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // First prepare to onboard
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
 
             // Then start onboarding
@@ -2415,7 +2627,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // Prepare to onboard
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
 
             // Mark for deletion
@@ -2437,7 +2649,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // Setup: Inactive -> PreparingToOnboard -> Onboarding
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
             slot.txn_start_onboarding().unwrap();
 
@@ -2472,7 +2684,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // Only prepare, don't start
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
 
             // Try to take onboarding from PreparingToOnboard - should fail
@@ -2581,7 +2793,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // Setup: Inactive -> PreparingToOnboard -> Onboarding
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
             slot.txn_start_onboarding().unwrap();
 
@@ -2623,7 +2835,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // Setup: get to Error state
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
             slot.txn_start_onboarding().unwrap();
             slot.txn_to_error();
@@ -2732,7 +2944,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // Setup onboarding
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
             slot.txn_start_onboarding().unwrap();
 
@@ -2754,7 +2966,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // Setup and transition to error
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
             slot.txn_to_error();
 
@@ -2783,7 +2995,7 @@ mod tests {
             assert!(slot.txn_state().is_inactive());
 
             // 2. Prepare to onboard
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
             assert!(matches!(
                 slot.txn_state(),
@@ -2854,7 +3066,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // 1. Prepare to onboard
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
 
             // 2. Request finished while preparing
@@ -2880,7 +3092,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // 1. Start onboarding
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
             slot.txn_start_onboarding().unwrap();
 
@@ -2911,7 +3123,7 @@ mod tests {
 
             // Setup some state
             slot.apply_new_blocks(vec![100, 200]);
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
             slot.advance_evaluated_tokens(50);
             slot.set_match_requires_reset(true);
@@ -2956,7 +3168,7 @@ mod tests {
             assert!(!slot.has_onboarding_state());
 
             // True when preparing
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
             assert!(slot.has_onboarding_state());
 
@@ -2978,7 +3190,7 @@ mod tests {
             assert!(slot.onboarding_state().is_none());
 
             // Some when preparing
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
             let state = slot.onboarding_state().unwrap();
             assert_eq!(state.num_computed_tokens, 100);
@@ -3026,7 +3238,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // Start onboarding
-            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
                 .unwrap();
 
             // Try to start offloading - should fail
@@ -3043,7 +3255,7 @@ mod tests {
             slot.txn_start_offloading().unwrap();
 
             // Try to prepare onboard - should fail
-            let result = slot.txn_prepare_to_onboard(num_computed_tokens, find_session);
+            let result = slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session);
             assert!(result.is_err());
         }
     }

--- a/lib/kvbm-connector/src/connector/worker/init/pending.rs
+++ b/lib/kvbm-connector/src/connector/worker/init/pending.rs
@@ -34,9 +34,6 @@ use kvbm_common::LogicalLayoutHandle;
 use kvbm_physical::TransferManager;
 use kvbm_physical::layout::{BlockDimension, LayoutConfig, PhysicalLayoutBuilder};
 
-const DISK_CACHE_KEY: &str = "DYN_KVBM_DISK_CACHE_DIR";
-const DEFAULT_DISK_CACHE_DIR: &str = "/tmp";
-
 /// Cached state from `register_kv_caches` for deferred initialization.
 ///
 /// This struct holds all the information needed to complete NIXL registration
@@ -248,9 +245,11 @@ impl PendingWorkerState {
             let g3_handle = if let Some(disk_blocks) = config.disk_block_count {
                 let mut disk_layout = self.layout_config.clone();
                 disk_layout.num_blocks = disk_blocks;
-                let disk_cache_dir = std::env::var(DISK_CACHE_KEY)
-                    .unwrap_or_else(|_| DEFAULT_DISK_CACHE_DIR.to_string());
-                let disk_path = PathBuf::from(disk_cache_dir)
+                let disk_cache_dir = config
+                    .disk_storage_path
+                    .clone()
+                    .unwrap_or_else(|| PathBuf::from("/tmp"));
+                let disk_path = disk_cache_dir
                     .join(format!("kvbm_g3_{}.bin", runtime.messenger().instance_id()));
                 let disk_layout = PhysicalLayoutBuilder::new(nixl_agent.clone())
                     .with_config(disk_layout)

--- a/lib/kvbm-connector/src/connector/worker/init/pending.rs
+++ b/lib/kvbm-connector/src/connector/worker/init/pending.rs
@@ -34,6 +34,9 @@ use kvbm_common::LogicalLayoutHandle;
 use kvbm_physical::TransferManager;
 use kvbm_physical::layout::{BlockDimension, LayoutConfig, PhysicalLayoutBuilder};
 
+const DISK_CACHE_KEY: &str = "DYN_KVBM_DISK_CACHE_DIR";
+const DEFAULT_DISK_CACHE_DIR: &str = "/tmp";
+
 /// Cached state from `register_kv_caches` for deferred initialization.
 ///
 /// This struct holds all the information needed to complete NIXL registration
@@ -245,13 +248,14 @@ impl PendingWorkerState {
             let g3_handle = if let Some(disk_blocks) = config.disk_block_count {
                 let mut disk_layout = self.layout_config.clone();
                 disk_layout.num_blocks = disk_blocks;
+                let disk_cache_dir = std::env::var(DISK_CACHE_KEY)
+                    .unwrap_or_else(|_| DEFAULT_DISK_CACHE_DIR.to_string());
+                let disk_path = PathBuf::from(disk_cache_dir)
+                    .join(format!("kvbm_g3_{}.bin", runtime.messenger().instance_id()));
                 let disk_layout = PhysicalLayoutBuilder::new(nixl_agent.clone())
                     .with_config(disk_layout)
                     .fully_contiguous()
-                    .allocate_disk(Some(PathBuf::from(format!(
-                        "/tmp/kvbm_g3_{}.bin",
-                        runtime.messenger().instance_id()
-                    ))))
+                    .allocate_disk(Some(disk_path))
                     .build()?;
 
                 let handle = transfer_manager.register_layout(disk_layout)?;

--- a/lib/kvbm-engine/src/leader/instance.rs
+++ b/lib/kvbm-engine/src/leader/instance.rs
@@ -114,6 +114,9 @@ pub struct InstanceLeader {
     /// Object storage client for G4 search and load operations.
     /// Leader calls has_blocks on S3 directly, coordinates workers for get_blocks.
     object_client: Option<Arc<dyn ObjectBlockOps>>,
+
+    /// Number of blocks per G3->G2 staging transfer request.
+    stage_chunk_size: usize,
 }
 
 /// Builder for InstanceLeader.
@@ -128,6 +131,7 @@ pub struct InstanceLeaderBuilder {
     remote_leaders: Option<Vec<InstanceId>>,
     cached_worker_metadata: Option<Vec<SerializedLayout>>,
     object_client: Option<Arc<dyn ObjectBlockOps>>,
+    stage_chunk_size: usize,
 }
 
 impl InstanceLeaderBuilder {
@@ -215,6 +219,11 @@ impl InstanceLeaderBuilder {
         self
     }
 
+    pub fn stage_chunk_size(mut self, size: usize) -> Self {
+        self.stage_chunk_size = size.max(1);
+        self
+    }
+
     pub fn build(self) -> Result<InstanceLeader> {
         let messenger = self
             .messenger
@@ -266,6 +275,7 @@ impl InstanceLeaderBuilder {
             transport,
             session_sessions: Arc::new(DashMap::new()),
             object_client: self.object_client,
+            stage_chunk_size: self.stage_chunk_size.max(1),
         })
     }
 }
@@ -516,6 +526,7 @@ impl InstanceLeader {
         let g2_manager = self.g2_manager.clone();
         let g3_manager = self.g3_manager.clone();
         let parallel_worker = self.parallel_worker.clone();
+        let stage_chunk_size = self.stage_chunk_size;
         let transport = self.transport.clone();
         let sessions = self.sessions.clone();
 
@@ -536,6 +547,7 @@ impl InstanceLeader {
                     g2_manager.clone(),
                     g3_manager.clone(),
                     parallel_worker.clone(),
+                    stage_chunk_size,
                     transport.clone(),
                 );
 
@@ -686,6 +698,7 @@ impl InstanceLeader {
             worker_g2_handles,
             self.g2_manager.clone(),
             self.parallel_worker.clone(),
+            self.stage_chunk_size,
             cmd_rx,
             ServerSessionOptions {
                 auto_stage: options.auto_stage,
@@ -1239,6 +1252,7 @@ impl Leader for InstanceLeader {
             self.g3_manager.clone(),
             self.parallel_worker.clone(),
             self.transport.clone(),
+            self.stage_chunk_size,
             status_tx.clone(),
             all_g2_blocks.clone(),
             match_breakdown.clone(),

--- a/lib/kvbm-engine/src/leader/session/initiator.rs
+++ b/lib/kvbm-engine/src/leader/session/initiator.rs
@@ -99,6 +99,7 @@ pub struct InitiatorSession {
     g3_manager: Option<Arc<BlockManager<G3>>>,
     parallel_worker: Option<Arc<dyn ParallelWorkers>>,
     transport: Arc<MessageTransport>,
+    stage_chunk_size: usize,
     status_tx: watch::Sender<OnboardingStatus>,
 
     // Held blocks from local search using BlockHolder for RAII semantics
@@ -140,6 +141,7 @@ impl InitiatorSession {
         g3_manager: Option<Arc<BlockManager<G3>>>,
         parallel_worker: Option<Arc<dyn ParallelWorkers>>,
         transport: Arc<MessageTransport>,
+        stage_chunk_size: usize,
         status_tx: watch::Sender<OnboardingStatus>,
         all_g2_blocks: Arc<Mutex<Option<Vec<ImmutableBlock<G2>>>>>,
         match_breakdown: Arc<Mutex<MatchBreakdown>>,
@@ -154,6 +156,7 @@ impl InitiatorSession {
             g3_manager,
             parallel_worker,
             transport,
+            stage_chunk_size,
             status_tx,
             local_g2_blocks: BlockHolder::empty(),
             local_g3_blocks: BlockHolder::empty(),
@@ -894,9 +897,13 @@ impl InitiatorSession {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("ParallelWorker required for G3→G2 staging"))?;
 
-        let result =
-            staging::stage_g3_to_g2(&self.local_g3_blocks, &self.g2_manager, &**parallel_worker)
-                .await?;
+        let result = staging::stage_g3_to_g2(
+            &self.local_g3_blocks,
+            &self.g2_manager,
+            &**parallel_worker,
+            self.stage_chunk_size,
+        )
+        .await?;
 
         let _ = self.local_g3_blocks.take_all();
         self.local_g2_blocks.extend(result.new_g2_blocks);

--- a/lib/kvbm-engine/src/leader/session/responder.rs
+++ b/lib/kvbm-engine/src/leader/session/responder.rs
@@ -33,6 +33,7 @@ pub struct ResponderSession {
     g2_manager: Arc<BlockManager<G2>>,
     g3_manager: Option<Arc<BlockManager<G3>>>,
     parallel_worker: Option<Arc<dyn ParallelWorkers>>,
+    stage_chunk_size: usize,
     transport: Arc<MessageTransport>,
     // Held blocks using BlockHolder for RAII semantics
     // Blocks are automatically released when the session drops
@@ -49,6 +50,7 @@ impl ResponderSession {
         g2_manager: Arc<BlockManager<G2>>,
         g3_manager: Option<Arc<BlockManager<G3>>>,
         parallel_worker: Option<Arc<dyn ParallelWorkers>>,
+        stage_chunk_size: usize,
         transport: Arc<MessageTransport>,
     ) -> Self {
         Self {
@@ -58,6 +60,7 @@ impl ResponderSession {
             g2_manager,
             g3_manager,
             parallel_worker,
+            stage_chunk_size,
             transport,
             held_g2_blocks: BlockHolder::empty(),
             held_g3_blocks: BlockHolder::empty(),
@@ -252,6 +255,7 @@ impl ResponderSession {
             &self.held_g3_blocks,
             &self.g2_manager,
             &**parallel_worker,
+            self.stage_chunk_size,
         )
         .await?;
 

--- a/lib/kvbm-engine/src/leader/session/server_session.rs
+++ b/lib/kvbm-engine/src/leader/session/server_session.rs
@@ -167,6 +167,9 @@ pub struct ServerSession {
     /// Parallel worker for G3→G2 staging.
     parallel_worker: Option<Arc<dyn ParallelWorkers>>,
 
+    /// Number of blocks per G3->G2 staging transfer request.
+    stage_chunk_size: usize,
+
     /// Channel for receiving local commands.
     cmd_rx: mpsc::Receiver<ServerSessionCommand>,
 
@@ -215,6 +218,7 @@ impl ServerSession {
             g3_blocks: BlockHolder::empty(),
             g2_manager: None,
             parallel_worker: None,
+            stage_chunk_size: 16,
             cmd_rx,
             options: ServerSessionOptions { auto_stage: false },
             staging_started: false,
@@ -231,6 +235,7 @@ impl ServerSession {
         worker_handles: Vec<LayoutHandle>,
         g2_manager: Arc<BlockManager<G2>>,
         parallel_worker: Option<Arc<dyn ParallelWorkers>>,
+        stage_chunk_size: usize,
         cmd_rx: mpsc::Receiver<ServerSessionCommand>,
         options: ServerSessionOptions,
     ) -> Self {
@@ -241,6 +246,7 @@ impl ServerSession {
             g3_blocks,
             g2_manager: Some(g2_manager),
             parallel_worker,
+            stage_chunk_size,
             cmd_rx,
             options,
             staging_started: false,
@@ -520,8 +526,13 @@ impl ServerSession {
             return Ok(Vec::new());
         }
 
-        let result =
-            staging::stage_g3_to_g2(&self.g3_blocks, g2_manager, &**parallel_worker).await?;
+        let result = staging::stage_g3_to_g2(
+            &self.g3_blocks,
+            g2_manager,
+            &**parallel_worker,
+            self.stage_chunk_size,
+        )
+        .await?;
 
         // Build BlockInfo for newly staged blocks
         let starting_index = self.g2_blocks.count();

--- a/lib/kvbm-engine/src/leader/session/staging.rs
+++ b/lib/kvbm-engine/src/leader/session/staging.rs
@@ -18,6 +18,21 @@ use kvbm_physical::transfer::TransferOptions;
 
 use super::blocks::BlockHolder;
 
+/// Default number of blocks per NIXL transfer request for G3→G2 staging.
+///
+/// Bounding request size prevents io_uring SQ ring exhaustion when staging
+/// large sequences. Chunks are processed sequentially to avoid overflowing
+/// the background NIXL notification channel when many sessions run concurrently.
+const DEFAULT_STAGE_CHUNK_SIZE: usize = 16;
+
+fn stage_chunk_size() -> usize {
+    std::env::var("KVBM_STAGE_CHUNK_SIZE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_STAGE_CHUNK_SIZE)
+}
+
 /// Result of staging G3 blocks to G2.
 pub struct StagingResult {
     /// Newly created G2 blocks (registered with the G2 manager).
@@ -26,8 +41,14 @@ pub struct StagingResult {
 
 /// Stage G3 blocks to G2.
 ///
-/// Core staging kernel: allocate G2 destinations → execute local transfer (G3→G2)
-/// → register new G2 blocks with the source sequence hashes → return new blocks.
+/// Core staging kernel: allocate G2 destinations → execute local transfers (G3→G2)
+/// in fixed-size chunks sequentially → register new G2 blocks with the source
+/// sequence hashes → return new blocks.
+///
+/// Chunking bounds the number of io_uring SQ entries per NIXL XferReq, preventing
+/// ring exhaustion on large sequences. Chunks are processed sequentially (one
+/// XferReq at a time) to avoid overflowing the background NIXL notification
+/// channel when many sessions stage concurrently.
 ///
 /// The caller is responsible for:
 /// - Clearing the G3 holder (`take_all()`)
@@ -45,27 +66,32 @@ pub async fn stage_g3_to_g2(
     }
 
     let src_ids: Vec<BlockId> = g3_blocks.blocks().iter().map(|b| b.block_id()).collect();
+    let chunk_size = stage_chunk_size();
 
-    // Allocate destination G2 blocks
+    // Allocate all destination G2 blocks upfront
     let dst_blocks = g2_manager
         .allocate_blocks(src_ids.len())
         .ok_or_else(|| anyhow::anyhow!("Failed to allocate G2 blocks"))?;
 
     let dst_ids: Vec<BlockId> = dst_blocks.iter().map(|b| b.block_id()).collect();
 
-    // Execute transfer
-    let notification = parallel_worker.execute_local_transfer(
-        LogicalLayoutHandle::G3,
-        LogicalLayoutHandle::G2,
-        Arc::from(src_ids),
-        Arc::from(dst_ids),
-        TransferOptions::default(),
-    )?;
+    // Process each chunk sequentially: submit one NIXL XferReq, await completion,
+    // then submit the next. Sequential dispatch keeps at most one notification
+    // in the background polling channel at a time, preventing channel overflow
+    // when many staging sessions run concurrently.
+    for (src_chunk, dst_chunk) in src_ids.chunks(chunk_size).zip(dst_ids.chunks(chunk_size)) {
+        let notification = parallel_worker.execute_local_transfer(
+            LogicalLayoutHandle::G3,
+            LogicalLayoutHandle::G2,
+            Arc::from(src_chunk),
+            Arc::from(dst_chunk),
+            TransferOptions::default(),
+        )?;
+        notification.into_future().await?;
+    }
 
-    // Wait for transfer to complete
-    notification.await?;
-
-    // Register new G2 blocks using the G3 blocks' metadata (sequence hashes)
+    // Register new G2 blocks using the G3 blocks' metadata (sequence hashes).
+    // Chunk boundaries do not affect registration order.
     let new_g2_blocks: Vec<ImmutableBlock<G2>> = dst_blocks
         .into_iter()
         .zip(g3_blocks.blocks().iter())

--- a/lib/kvbm-engine/src/leader/session/staging.rs
+++ b/lib/kvbm-engine/src/leader/session/staging.rs
@@ -18,21 +18,6 @@ use kvbm_physical::transfer::TransferOptions;
 
 use super::blocks::BlockHolder;
 
-/// Default number of blocks per NIXL transfer request for G3→G2 staging.
-///
-/// Bounding request size prevents io_uring SQ ring exhaustion when staging
-/// large sequences. Chunks are processed sequentially to avoid overflowing
-/// the background NIXL notification channel when many sessions run concurrently.
-const DEFAULT_STAGE_CHUNK_SIZE: usize = 16;
-
-fn stage_chunk_size() -> usize {
-    std::env::var("KVBM_STAGE_CHUNK_SIZE")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(DEFAULT_STAGE_CHUNK_SIZE)
-}
-
 /// Result of staging G3 blocks to G2.
 pub struct StagingResult {
     /// Newly created G2 blocks (registered with the G2 manager).
@@ -58,6 +43,7 @@ pub async fn stage_g3_to_g2(
     g3_blocks: &BlockHolder<G3>,
     g2_manager: &BlockManager<G2>,
     parallel_worker: &dyn ParallelWorkers,
+    stage_chunk_size: usize,
 ) -> Result<StagingResult> {
     if g3_blocks.is_empty() {
         return Ok(StagingResult {
@@ -66,7 +52,7 @@ pub async fn stage_g3_to_g2(
     }
 
     let src_ids: Vec<BlockId> = g3_blocks.blocks().iter().map(|b| b.block_id()).collect();
-    let chunk_size = stage_chunk_size();
+    let chunk_size = stage_chunk_size.max(1);
 
     // Allocate all destination G2 blocks upfront
     let dst_blocks = g2_manager

--- a/lib/kvbm-engine/src/leader/types.rs
+++ b/lib/kvbm-engine/src/leader/types.rs
@@ -198,6 +198,49 @@ impl AsyncSessionResult {
             .map(|v| *v)
             .unwrap_or_default()
     }
+
+    /// Test-only constructor for a terminal (Complete) `AsyncSessionResult`.
+    ///
+    /// Creates an `AsyncSessionResult` pre-wired with `OnboardingStatus::Complete`
+    /// and a ready-to-take blocks slot. Use this from unit tests that need an
+    /// AsyncSession variant without spinning up a real session.
+    ///
+    /// `matched_blocks` is the count reported by the status watcher; the
+    /// `blocks` vec is used as-is for RAII purposes (typically empty in tests).
+    #[cfg(any(test, feature = "testing"))]
+    pub fn new_complete_for_test(
+        matched_blocks: usize,
+        blocks: Vec<ImmutableBlock<G2>>,
+        breakdown: MatchBreakdown,
+    ) -> Self {
+        let (status_tx, status_rx) = watch::channel(OnboardingStatus::Complete { matched_blocks });
+        // Drop the sender so the channel stays at its latest value.
+        drop(status_tx);
+        Self {
+            session_id: SessionId::from(uuid::Uuid::nil()),
+            status_rx,
+            blocks: Arc::new(Mutex::new(Some(blocks))),
+            match_breakdown: Arc::new(Mutex::new(breakdown)),
+            session_handle: None,
+        }
+    }
+
+    /// Test-only constructor for an in-progress (`Searching`) `AsyncSessionResult`.
+    ///
+    /// Returns both the session result and the `watch::Sender` so tests can
+    /// transition the status to `Complete` later.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn new_pending_for_test() -> (Self, watch::Sender<OnboardingStatus>) {
+        let (status_tx, status_rx) = watch::channel(OnboardingStatus::Searching);
+        let session = Self {
+            session_id: SessionId::from(uuid::Uuid::nil()),
+            status_rx,
+            blocks: Arc::new(Mutex::new(None)),
+            match_breakdown: Arc::new(Mutex::new(MatchBreakdown::default())),
+            session_handle: None,
+        };
+        (session, status_tx)
+    }
 }
 
 impl FindMatchesResult {

--- a/lib/kvbm-engine/src/leader/types.rs
+++ b/lib/kvbm-engine/src/leader/types.rs
@@ -198,49 +198,6 @@ impl AsyncSessionResult {
             .map(|v| *v)
             .unwrap_or_default()
     }
-
-    /// Test-only constructor for a terminal (Complete) `AsyncSessionResult`.
-    ///
-    /// Creates an `AsyncSessionResult` pre-wired with `OnboardingStatus::Complete`
-    /// and a ready-to-take blocks slot. Use this from unit tests that need an
-    /// AsyncSession variant without spinning up a real session.
-    ///
-    /// `matched_blocks` is the count reported by the status watcher; the
-    /// `blocks` vec is used as-is for RAII purposes (typically empty in tests).
-    #[cfg(any(test, feature = "testing"))]
-    pub fn new_complete_for_test(
-        matched_blocks: usize,
-        blocks: Vec<ImmutableBlock<G2>>,
-        breakdown: MatchBreakdown,
-    ) -> Self {
-        let (status_tx, status_rx) = watch::channel(OnboardingStatus::Complete { matched_blocks });
-        // Drop the sender so the channel stays at its latest value.
-        drop(status_tx);
-        Self {
-            session_id: SessionId::from(uuid::Uuid::nil()),
-            status_rx,
-            blocks: Arc::new(Mutex::new(Some(blocks))),
-            match_breakdown: Arc::new(Mutex::new(breakdown)),
-            session_handle: None,
-        }
-    }
-
-    /// Test-only constructor for an in-progress (`Searching`) `AsyncSessionResult`.
-    ///
-    /// Returns both the session result and the `watch::Sender` so tests can
-    /// transition the status to `Complete` later.
-    #[cfg(any(test, feature = "testing"))]
-    pub fn new_pending_for_test() -> (Self, watch::Sender<OnboardingStatus>) {
-        let (status_tx, status_rx) = watch::channel(OnboardingStatus::Searching);
-        let session = Self {
-            session_id: SessionId::from(uuid::Uuid::nil()),
-            status_rx,
-            blocks: Arc::new(Mutex::new(None)),
-            match_breakdown: Arc::new(Mutex::new(MatchBreakdown::default())),
-            session_handle: None,
-        };
-        (session, status_tx)
-    }
 }
 
 impl FindMatchesResult {

--- a/lib/kvbm-engine/src/worker/protocol.rs
+++ b/lib/kvbm-engine/src/worker/protocol.rs
@@ -4,6 +4,7 @@
 use anyhow::Result;
 use futures::future::{Either, Ready, ready};
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use std::{
     pin::Pin,
     task::{Context, Poll},
@@ -169,6 +170,12 @@ pub struct LeaderLayoutConfig {
 
     /// Number of disk blocks for G3 tier (None = no disk tier).
     pub disk_block_count: Option<usize>,
+
+    /// Base directory for worker-local G3 backing files.
+    ///
+    /// When omitted, workers fall back to `/tmp`.
+    #[serde(default)]
+    pub disk_storage_path: Option<PathBuf>,
 
     /// Object storage configuration for G4 tier (None = no object tier).
     ///

--- a/lib/kvbm-physical/src/manager/mod.rs
+++ b/lib/kvbm-physical/src/manager/mod.rs
@@ -513,7 +513,7 @@ impl TransferManager {
     pub(crate) fn register_cuda_event(
         &self,
         event: cudarc::driver::CudaEvent,
-    ) -> TransferCompleteNotification {
+    ) -> Result<TransferCompleteNotification> {
         self.context.register_cuda_event(event)
     }
 

--- a/lib/kvbm-physical/src/transfer/context.rs
+++ b/lib/kvbm-physical/src/transfer/context.rs
@@ -27,6 +27,17 @@ use notifications::RegisterPollingNotification;
 pub(crate) use super::notifications;
 pub use super::notifications::TransferCompleteNotification;
 
+/// Default capacity for background NIXL/CUDA notification channels.
+const DEFAULT_NOTIFICATION_CHANNEL_CAPACITY: usize = 1024;
+
+fn notification_channel_capacity() -> usize {
+    std::env::var("KVBM_NOTIFICATION_CHANNEL_CAPACITY")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_NOTIFICATION_CHANNEL_CAPACITY)
+}
+
 #[derive(Clone, Builder)]
 #[builder(pattern = "owned", build_fn(private, name = "build_internal"), public)]
 #[allow(dead_code)] // Fields are used in build() but derive macros confuse dead code analysis
@@ -256,10 +267,12 @@ impl TransferContext {
         }
         let cuda_pool = Arc::new(pool_builder.build()?);
 
-        // Create channels for background notification handlers
-        let (tx_nixl_status, rx_nixl_status) = mpsc::channel(64);
-        let (tx_cuda_event, rx_cuda_event) = mpsc::channel(64);
-        let (tx_nixl_events, rx_nixl_events) = mpsc::channel(64);
+        // Create channels for background notification handlers.
+        // Overflow silently drops notifications and can orphan transfer requests.
+        let cap = notification_channel_capacity();
+        let (tx_nixl_status, rx_nixl_status) = mpsc::channel(cap);
+        let (tx_cuda_event, rx_cuda_event) = mpsc::channel(cap);
+        let (tx_nixl_events, rx_nixl_events) = mpsc::channel(cap);
 
         // Spawn background handlers
         let handle = tokio_runtime.handle();

--- a/lib/kvbm-physical/src/transfer/context.rs
+++ b/lib/kvbm-physical/src/transfer/context.rs
@@ -38,6 +38,20 @@ fn notification_channel_capacity() -> usize {
         .unwrap_or(DEFAULT_NOTIFICATION_CHANNEL_CAPACITY)
 }
 
+fn enqueue_notification<T>(
+    tx: &mpsc::Sender<T>,
+    notification: T,
+    channel_name: &'static str,
+) -> Result<()> {
+    tx.try_send(notification).map_err(|err| {
+        anyhow::anyhow!(
+            "failed to enqueue {} notification: channel full or closed: {}",
+            channel_name,
+            err
+        )
+    })
+}
+
 #[derive(Clone, Builder)]
 #[builder(pattern = "owned", build_fn(private, name = "build_internal"), public)]
 #[allow(dead_code)] // Fields are used in build() but derive macros confuse dead code analysis
@@ -419,7 +433,7 @@ impl TransferContext {
     pub(crate) fn register_nixl_status(
         &self,
         xfer_req: XferRequest,
-    ) -> TransferCompleteNotification {
+    ) -> Result<TransferCompleteNotification> {
         let event = self
             .event_system
             .new_event()
@@ -439,22 +453,19 @@ impl TransferContext {
             event_handle: handle,
         };
 
-        // Send to background handler — log error if channel is full or closed
-        if let Err(e) = self.tx_nixl_status.try_send(notification) {
-            tracing::error!(
-                "Failed to enqueue NIXL status notification: channel full or closed: {}",
-                e
-            );
-        }
+        enqueue_notification(&self.tx_nixl_status, notification, "NIXL status")?;
 
-        TransferCompleteNotification::from_awaiter(awaiter)
+        Ok(TransferCompleteNotification::from_awaiter(awaiter))
     }
 
     /// Register a CUDA event for polling completion.
     ///
     /// This method enqueues the CUDA event to be polled for completion.
     /// Returns a notification object that can be awaited for completion.
-    pub(crate) fn register_cuda_event(&self, event: CudaEvent) -> TransferCompleteNotification {
+    pub(crate) fn register_cuda_event(
+        &self,
+        event: CudaEvent,
+    ) -> Result<TransferCompleteNotification> {
         let new_event = self
             .event_system
             .new_event()
@@ -471,15 +482,9 @@ impl TransferContext {
             event_handle: handle,
         };
 
-        // Send to background handler — log error if channel is full or closed
-        if let Err(e) = self.tx_cuda_event.try_send(notification) {
-            tracing::error!(
-                "Failed to enqueue CUDA event notification: channel full or closed: {}",
-                e
-            );
-        }
+        enqueue_notification(&self.tx_cuda_event, notification, "CUDA event")?;
 
-        TransferCompleteNotification::from_awaiter(awaiter)
+        Ok(TransferCompleteNotification::from_awaiter(awaiter))
     }
 
     /// Register a NIXL transfer request for notification-based completion.
@@ -491,7 +496,7 @@ impl TransferContext {
     pub(crate) fn register_nixl_event(
         &self,
         xfer_req: XferRequest,
-    ) -> TransferCompleteNotification {
+    ) -> Result<TransferCompleteNotification> {
         let event = self
             .event_system
             .new_event()
@@ -508,19 +513,41 @@ impl TransferContext {
             event_handle: handle,
         };
 
-        // Send to background handler — log error if channel is full or closed
-        if let Err(e) = self.tx_nixl_events.try_send(notification) {
-            tracing::error!(
-                "Failed to enqueue NIXL event notification: channel full or closed: {}",
-                e
-            );
-        }
+        enqueue_notification(&self.tx_nixl_events, notification, "NIXL event")?;
 
-        TransferCompleteNotification::from_awaiter(awaiter)
+        Ok(TransferCompleteNotification::from_awaiter(awaiter))
     }
 
     /// Get the worker ID for this context.
     pub(crate) fn worker_id(&self) -> u64 {
         self.worker_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+
+    use super::enqueue_notification;
+
+    #[test]
+    fn enqueue_notification_returns_error_when_channel_is_full() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tx.try_send(1usize).unwrap();
+
+        let err = enqueue_notification(&tx, 2usize, "test").unwrap_err();
+
+        assert!(err.to_string().contains("channel full or closed"));
+        assert_eq!(rx.try_recv().unwrap(), 1usize);
+    }
+
+    #[test]
+    fn enqueue_notification_returns_error_when_channel_is_closed() {
+        let (tx, rx) = mpsc::channel::<usize>(1);
+        drop(rx);
+
+        let err = enqueue_notification(&tx, 1usize, "test").unwrap_err();
+
+        assert!(err.to_string().contains("channel full or closed"));
     }
 }

--- a/lib/kvbm-physical/src/transfer/executor/cuda.rs
+++ b/lib/kvbm-physical/src/transfer/executor/cuda.rs
@@ -148,7 +148,7 @@ pub fn execute_cuda_transfer(
             | TransferStrategy::CudaAsyncD2D
     ) {
         let event = stream.record_event(None)?;
-        Ok(ctx.register_cuda_event(event))
+        ctx.register_cuda_event(event)
     } else {
         // Blocking transfers are already synchronized
         Ok(TransferCompleteNotification::completed())

--- a/lib/kvbm-physical/src/transfer/executor/nixl.rs
+++ b/lib/kvbm-physical/src/transfer/executor/nixl.rs
@@ -372,7 +372,7 @@ impl<'a> NixlTransferBuilder<'a, Set, Set, Set, Set, Set> {
 
         if still_pending {
             // Register for async completion via status polling
-            Ok(ctx.register_nixl_status(xfer_req))
+            ctx.register_nixl_status(xfer_req)
         } else {
             // Transfer completed synchronously
             Ok(TransferCompleteNotification::completed())

--- a/lib/memory/Cargo.toml
+++ b/lib/memory/Cargo.toml
@@ -23,6 +23,7 @@ testing-nixl = []
 testing-all = ["testing-cuda", "testing-nixl"]
 
 [dependencies]
+aligned-vec = "0.6.4"
 anyhow = { workspace = true }
 cudarc = { workspace = true }
 nixl-sys = { version = "=0.10.1" }

--- a/lib/memory/src/disk.rs
+++ b/lib/memory/src/disk.rs
@@ -11,8 +11,8 @@ use std::path::{Path, PathBuf};
 use core::ffi::c_char;
 use nix::fcntl::{FallocateFlags, fallocate};
 use nix::unistd::{ftruncate, unlink};
-use std::fs::File;
 use std::ffi::CString;
+use std::fs::File;
 use std::io::Write;
 use std::os::fd::{BorrowedFd, RawFd};
 

--- a/lib/memory/src/disk.rs
+++ b/lib/memory/src/disk.rs
@@ -4,17 +4,95 @@
 //! Disk-backed memory storage using memory-mapped files.
 
 use super::{MemoryDescriptor, Result, StorageError, StorageKind, nixl::NixlDescriptor};
+use aligned_vec::{AVec, ConstAlign};
 use std::any::Any;
 use std::path::{Path, PathBuf};
 
 use core::ffi::c_char;
 use nix::fcntl::{FallocateFlags, fallocate};
-use nix::unistd::unlink;
+use nix::unistd::{ftruncate, unlink};
+use std::fs::File;
 use std::ffi::CString;
-use std::os::fd::BorrowedFd;
+use std::io::Write;
+use std::os::fd::{BorrowedFd, RawFd};
 
 const DISK_CACHE_KEY: &str = "DYN_KVBM_DISK_CACHE_DIR";
 const DEFAULT_DISK_CACHE_DIR: &str = "/tmp/";
+const DISK_ZEROFILL_FALLBACK_KEY: &str = "DYN_KVBM_DISK_ZEROFILL_FALLBACK";
+const ZERO_BUF_SIZE: usize = 16 * 1024 * 1024;
+const PAGE_SIZE: usize = 4096;
+type Align4096 = ConstAlign<4096>;
+
+fn env_truthy(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+fn create_aligned_buffer(size: usize) -> anyhow::Result<AVec<u8, Align4096>> {
+    let aligned_size = size.div_ceil(PAGE_SIZE) * PAGE_SIZE;
+    let mut buf = AVec::<u8, Align4096>::new(PAGE_SIZE);
+    buf.resize(aligned_size, 0u8);
+    Ok(buf)
+}
+
+fn allocate_file(fd: RawFd, size: u64) -> anyhow::Result<()> {
+    let borrowed_fd = unsafe { BorrowedFd::borrow_raw(fd) };
+    match fallocate(borrowed_fd, FallocateFlags::empty(), 0, size as i64) {
+        Ok(_) => Ok(()),
+        Err(err) => match err {
+            nix::errno::Errno::EOPNOTSUPP => {
+                if env_truthy(DISK_ZEROFILL_FALLBACK_KEY) {
+                    tracing::warn!(
+                        "fallocate() not supported; using zero-fill fallback via {}",
+                        DISK_ZEROFILL_FALLBACK_KEY
+                    );
+                    let buf = create_aligned_buffer(ZERO_BUF_SIZE)?;
+                    let dup_fd = nix::unistd::dup(borrowed_fd)?;
+                    let mut file = File::from(dup_fd);
+                    let mut written: u64 = 0;
+                    while written < size {
+                        let remaining = size - written;
+                        let to_write = if remaining >= buf.len() as u64 {
+                            buf.len()
+                        } else {
+                            let aligned = (remaining as usize).div_ceil(PAGE_SIZE) * PAGE_SIZE;
+                            std::cmp::min(aligned, buf.len())
+                        };
+                        match file.write(&buf[..to_write]) {
+                            Ok(n) if n == to_write => written += n as u64,
+                            Ok(n) => anyhow::bail!(
+                                "Partial zero-fill write: expected {} bytes, wrote {}",
+                                to_write,
+                                n
+                            ),
+                            Err(e) if e.raw_os_error() == Some(22) => {
+                                anyhow::bail!(
+                                    "Zero-fill write failed with EINVAL while using O_DIRECT. Original error: {}",
+                                    e
+                                )
+                            }
+                            Err(e) => anyhow::bail!("Zero-fill write failed: {}", e),
+                        }
+                    }
+                    file.flush()?;
+                    if written > size {
+                        ftruncate(borrowed_fd, size as i64)?;
+                    }
+                    Ok(())
+                } else {
+                    tracing::warn!(
+                        "fallocate() not supported; using truncate fallback. Set {}=true for zero-fill fallback.",
+                        DISK_ZEROFILL_FALLBACK_KEY
+                    );
+                    ftruncate(borrowed_fd, size as i64)?;
+                    Ok(())
+                }
+            }
+            _ => Err(err.into()),
+        },
+    }
+}
 
 /// Disk-backed storage using memory-mapped files with O_DIRECT support.
 #[derive(Debug)]
@@ -126,18 +204,9 @@ impl DiskStorage {
             (fd, file_path)
         };
 
-        // We need to use fallocate to actually allocate the storage and create the blocks on disk.
-        unsafe {
-            fallocate(
-                BorrowedFd::borrow_raw(raw_fd),
-                FallocateFlags::empty(),
-                0,
-                len as i64,
-            )
-            .map_err(|e| {
-                StorageError::AllocationFailed(format!("Failed to allocate temp file: {}", e))
-            })?
-        };
+        allocate_file(raw_fd, len as u64).map_err(|e| {
+            StorageError::AllocationFailed(format!("Failed to allocate temp file: {}", e))
+        })?;
 
         Ok(Self {
             fd: raw_fd as u64,

--- a/lib/memory/src/nixl/agent.rs
+++ b/lib/memory/src/nixl/agent.rs
@@ -65,11 +65,11 @@ impl NixlAgent {
 
     /// Add a backend to the agent with optional custom parameters.
     ///
-    /// If `custom_params` is non-empty, those parameters are used instead of
-    /// the plugin defaults. If empty, default parameters from the plugin are used.
-    ///
-    /// # Errors
-    /// Returns an error if custom parameters are provided (not yet supported until nixl_sys 0.9).
+    /// Plugin defaults are fetched from NIXL via `get_plugin_params` and then any
+    /// keys in `custom_params` are overlaid on top via `Params::set`, so callers
+    /// only have to specify the fields they want to change (for example the
+    /// POSIX plugin's `use_uring` / `use_aio` / `use_posix_aio` selector). An
+    /// empty `custom_params` uses plugin defaults as before.
     pub fn add_backend_with_params(
         &mut self,
         backend: &str,
@@ -80,24 +80,34 @@ impl NixlAgent {
             return Ok(());
         }
 
-        // TODO(DIS-1310): Custom params require nixl_sys 0.9+ which adds nixl_capi_params_add
-        if !custom_params.is_empty() {
-            anyhow::bail!(
-                "Custom NIXL backend parameters for {} are not yet supported. \
-                 This feature requires nixl_sys 0.9+. Params provided: {:?}",
-                backend_upper,
-                custom_params.keys().collect::<Vec<_>>()
-            );
-        }
-
-        // Get default params from plugin
-        let (_, params) = match self.agent.get_plugin_params(&backend_upper) {
+        // Get default params from plugin, then overlay any caller-provided
+        // overrides on top.
+        let (_, mut params) = match self.agent.get_plugin_params(&backend_upper) {
             Ok(result) => result,
             Err(_) => anyhow::bail!("No {} plugin found", backend_upper),
         };
 
+        for (key, value) in custom_params {
+            params.set(key.as_str(), value.as_str()).map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to set NIXL {} param {}={}: {}",
+                    backend_upper,
+                    key,
+                    value,
+                    e
+                )
+            })?;
+        }
+
         match self.agent.create_backend(&backend_upper, &params) {
             Ok(_) => {
+                if !custom_params.is_empty() {
+                    tracing::debug!(
+                        backend = %backend_upper,
+                        overrides = ?custom_params.keys().collect::<Vec<_>>(),
+                        "Created NIXL backend with custom params"
+                    );
+                }
                 self.available_backends.insert(backend_upper);
                 Ok(())
             }
@@ -255,36 +265,31 @@ mod tests {
     }
 
     #[test]
-    fn test_add_backend_with_custom_params_fails() {
+    fn test_add_backend_with_custom_params() {
         let mut agent = NixlAgent::new("test_custom_params").expect("Failed to create agent");
 
-        // Custom params should fail until nixl_sys 0.9
+        // Custom params are merged into plugin defaults. Use a benign override
+        // key/value pair so the test exercises the Rust-side params path
+        // without depending on a specific plugin rejecting or requiring it.
         let mut params = HashMap::new();
         params.insert("some_key".to_string(), "some_value".to_string());
 
         let result = agent.add_backend_with_params("UCX", &params);
-        assert!(result.is_err());
-
-        let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("not yet supported"));
-        assert!(err_msg.contains("nixl_sys 0.9"));
-        assert!(err_msg.contains("some_key"));
+        assert!(result.is_ok());
+        assert!(agent.has_backend("UCX"));
     }
 
     #[test]
-    fn test_from_nixl_backend_config_with_custom_params_fails() {
-        // Config with custom params should fail
+    fn test_from_nixl_backend_config_with_custom_params() {
+        // Config with custom params should now succeed.
         let mut params = HashMap::new();
         params.insert("threads".to_string(), "4".to_string());
 
         let config = NixlBackendConfig::default().with_backend_params("UCX", params);
 
         let result = NixlAgent::from_nixl_backend_config("test_config_params", config);
-        assert!(result.is_err());
-
-        let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("not yet supported"));
-        assert!(err_msg.contains("threads"));
+        assert!(result.is_ok());
+        assert!(result.unwrap().has_backend("UCX"));
     }
 
     #[test]


### PR DESCRIPTION
#### Overview:
This PR is the follow-up delta on top of `cheese-head/connector-p0-zerofill`. It reconciles the leader onboarding/search flow with the latest token accounting changes, cleans up the related test path, and adds support for custom NIXL backend parameters.

#### Details:

- Rework the leader onboarding/search path to align with the current `num_computed_tokens` behavior and keep slot/search state consistent during request reconciliation.
- Inline `AsyncSession` test construction and apply follow-up formatting so the updated reconciliation path stays CI-compatible.
- Update `NixlAgent::add_backend_with_params` to start from plugin defaults, overlay caller-provided key/value overrides, and validate that custom backend params now succeed in tests.
- Adjust `KvbmRuntime` worker and leader construction to keep a Tokio runtime owner alive outside `block_on`, preventing init failures from surfacing as a Tokio runtime drop panic.

#### Where should the reviewer start?

- `lib/kvbm-connector/src/connector/leader/search.rs`
- `lib/kvbm-connector/src/connector/leader/onboard.rs`
- `lib/memory/src/nixl/agent.rs`
- `lib/bindings/kvbm/src/v2/runtime.rs`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
