### PR TITLE
feat(benchmarks): nsys capture-range triggered by vllm cudaProfilerApi

### DIFF
--- a/benchmarks/multimodal/sweep/README.md
+++ b/benchmarks/multimodal/sweep/README.md
@@ -29,7 +29,10 @@ python -m benchmarks.multimodal.sweep \
 model: Qwen/Qwen3-VL-30B-A3B-Instruct-FP8
 concurrencies: [16, 32, 64, 128, 256]
 osl: 150                    # output sequence length
-request_count: 1000         # requests per concurrency level
+conversation_num: 10        # sessions per sweep value (optional; derived from
+                            # input JSONL's unique session_id count if unset)
+request_count: 200          # OPTIONAL hard cap on total credits; rejected if
+                            # set alone without conversation_num
 warmup_count: 5
 port: 8000
 timeout: 900                # seconds to wait for server readiness
@@ -64,9 +67,49 @@ python -m benchmarks.multimodal.sweep \
   --config experiments/embedding_cache/vllm_serve.yaml \
   --concurrencies 1,2,4 \
   --osl 200 \
-  --request-count 50 \
+  --conversation-num 10 \
   --skip-plots
 ```
+
+## Grouped Single-Turn Semantics (aiperf 0.7.0+)
+
+`aiperf==0.7.0` (via [PR 824](https://github.com/ai-dynamo/aiperf/pull/824))
+groups single_turn rows by JSONL `session_id`. A JSONL with 10 users × 10 turns
+each dispatches 10 causal-ordered chains (turn-(k+1) for user A only after
+turn-k for user A returns).
+
+Control the session count via `conversation_num`. **`request_count` alone is
+rejected at config-load** because it triggers SequentialSampler wrap (extra
+turn-0 sessions, incomplete chains) — the exact DIS-1807 bug. Use
+`conversation_num` as the primary control; add `request_count` only as a safety
+cap when you need one.
+
+### Upgrading aiperf in an existing container
+
+The benchmark image currently pins `aiperf==0.6.0`. Until the pin is bumped
+(tracked separately), any new cloud-session container starts pre-824 and
+must be upgraded before running the sweep. Install aiperf 0.7.0 from the
+pre-staged wheel:
+
+```bash
+pip install --no-deps --force-reinstall \
+  /home/scratch.qiwa_ent/workspace/aiperf-wheels/aiperf-0.7.0-py3-none-any.whl
+```
+
+Works on air-gapped nodes (scratch NFS is visible inside the Pyxis overlay).
+Sentinel that PR 824 is active:
+
+```bash
+python -c "from aiperf.dataset.loader.single_turn import SingleTurnDatasetLoader; import inspect; assert 'single_turn_data.session_id or' in inspect.getsource(SingleTurnDatasetLoader.load_dataset)"
+```
+
+### Warmup semantics
+
+`warmup_count: N` is a credit budget, NOT a session budget. aiperf's
+continuation-turn priority means the first `N` warmup credits feed `user_0`
+turns `0..N-1` (then sampler advances). Profiling then starts at `user_1` and
+wraps to a fresh `user_0` instance after `user_9`. `warmup_count > turns per
+session` consumes multiple sessions — keep it small.
 
 ## Output Directory Structure
 

--- a/benchmarks/multimodal/sweep/README.md
+++ b/benchmarks/multimodal/sweep/README.md
@@ -30,9 +30,8 @@ model: Qwen/Qwen3-VL-30B-A3B-Instruct-FP8
 concurrencies: [16, 32, 64, 128, 256]
 osl: 150                    # output sequence length
 conversation_num: 10        # sessions per sweep value (optional; derived from
-                            # input JSONL's unique session_id count if unset)
-request_count: 200          # OPTIONAL hard cap on total credits; rejected if
-                            # set alone without conversation_num
+                            # input JSONL's unique session_id count if unset;
+                            # flat JSONLs count each row as a 1-turn conversation)
 warmup_count: 5
 port: 8000
 timeout: 900                # seconds to wait for server readiness
@@ -78,11 +77,11 @@ groups single_turn rows by JSONL `session_id`. A JSONL with 10 users × 10 turns
 each dispatches 10 causal-ordered chains (turn-(k+1) for user A only after
 turn-k for user A returns).
 
-Control the session count via `conversation_num`. **`request_count` alone is
-rejected at config-load** because it triggers SequentialSampler wrap (extra
-turn-0 sessions, incomplete chains) — the exact DIS-1807 bug. Use
-`conversation_num` as the primary control; add `request_count` only as a safety
-cap when you need one.
+Control the session count via `conversation_num`. For flat JSONLs (random
+requests, single_turn without shared `session_id`), `conversation_num` still
+works — each row is treated as a 1-turn conversation, so total requests =
+`conversation_num × 1 = conversation_num`. If unset, it defaults to the
+detected unique session_id count (or row count for flat JSONLs).
 
 ### Upgrading aiperf in an existing container
 

--- a/benchmarks/multimodal/sweep/README.md
+++ b/benchmarks/multimodal/sweep/README.md
@@ -70,45 +70,16 @@ python -m benchmarks.multimodal.sweep \
   --skip-plots
 ```
 
-## Grouped Single-Turn Semantics (aiperf 0.7.0+)
+## Warmup semantics
 
-`aiperf==0.7.0` (via [PR 824](https://github.com/ai-dynamo/aiperf/pull/824))
-groups single_turn rows by JSONL `session_id`. A JSONL with 10 users × 10 turns
-each dispatches 10 causal-ordered chains (turn-(k+1) for user A only after
-turn-k for user A returns).
-
-Control the session count via `conversation_num`. For flat JSONLs (random
-requests, single_turn without shared `session_id`), `conversation_num` still
-works — each row is treated as a 1-turn conversation, so total requests =
-`conversation_num × 1 = conversation_num`. If unset, it defaults to the
-detected unique session_id count (or row count for flat JSONLs).
-
-### Upgrading aiperf in an existing container
-
-The benchmark image currently pins `aiperf==0.6.0`. Until the pin is bumped
-(tracked separately), any new cloud-session container starts pre-824 and
-must be upgraded before running the sweep. Install aiperf 0.7.0 from the
-pre-staged wheel:
-
-```bash
-pip install --no-deps --force-reinstall \
-  /home/scratch.qiwa_ent/workspace/aiperf-wheels/aiperf-0.7.0-py3-none-any.whl
-```
-
-Works on air-gapped nodes (scratch NFS is visible inside the Pyxis overlay).
-Sentinel that PR 824 is active:
-
-```bash
-python -c "from aiperf.dataset.loader.single_turn import SingleTurnDatasetLoader; import inspect; assert 'single_turn_data.session_id or' in inspect.getsource(SingleTurnDatasetLoader.load_dataset)"
-```
-
-### Warmup semantics
-
-`warmup_count: N` is a credit budget, NOT a session budget. aiperf's
-continuation-turn priority means the first `N` warmup credits feed `user_0`
-turns `0..N-1` (then sampler advances). Profiling then starts at `user_1` and
-wraps to a fresh `user_0` instance after `user_9`. `warmup_count > turns per
-session` consumes multiple sessions — keep it small.
+`warmup_count: N` is a **request (turn) budget**, not a session budget. For a
+10×10 JSONL with `warmup_count: 2`, warmup issues 2 total requests — both go
+to `user_0` (turns 0 and 1) because aiperf's continuation-turn priority keeps
+feeding the in-flight session until its budget runs out. Warmup does NOT
+consume 2 full sessions (20 requests). Profiling then starts at `user_1`,
+runs `user_1..user_9` to completion, and wraps to a fresh `user_0` instance
+for the 10th session. Keep `warmup_count` small (≤ turns-per-session) so
+warmup stays within a single session's prefix.
 
 ## Output Directory Structure
 

--- a/benchmarks/multimodal/sweep/args.py
+++ b/benchmarks/multimodal/sweep/args.py
@@ -59,10 +59,23 @@ def parse_args(argv=None) -> argparse.Namespace:
         help="Override output sequence length.",
     )
     parser.add_argument(
+        "--conversation-num",
+        type=int,
+        default=None,
+        help=(
+            "Override number of grouped conversations (sessions) per sweep value. "
+            "Primary control for grouped single_turn dispatch. If unset, derived "
+            "from the input JSONL's unique session_id count."
+        ),
+    )
+    parser.add_argument(
         "--request-count",
         type=int,
         default=None,
-        help="Override request count per sweep value.",
+        help=(
+            "Optional hard cap on total credits per sweep value. Must be set "
+            "alongside --conversation-num; a cap alone is rejected at config-load."
+        ),
     )
     parser.add_argument(
         "--skip-plots",

--- a/benchmarks/multimodal/sweep/args.py
+++ b/benchmarks/multimodal/sweep/args.py
@@ -63,18 +63,9 @@ def parse_args(argv=None) -> argparse.Namespace:
         type=int,
         default=None,
         help=(
-            "Override number of grouped conversations (sessions) per sweep value. "
-            "Primary control for grouped single_turn dispatch. If unset, derived "
-            "from the input JSONL's unique session_id count."
-        ),
-    )
-    parser.add_argument(
-        "--request-count",
-        type=int,
-        default=None,
-        help=(
-            "Optional hard cap on total credits per sweep value. Must be set "
-            "alongside --conversation-num; a cap alone is rejected at config-load."
+            "Override number of conversations (sessions) per sweep value. "
+            "If unset, derived from the input JSONL's unique session_id count "
+            "(flat JSONLs count each row as a 1-turn conversation)."
         ),
     )
     parser.add_argument(

--- a/benchmarks/multimodal/sweep/config.py
+++ b/benchmarks/multimodal/sweep/config.py
@@ -42,6 +42,8 @@ class SweepConfig:
     skip_plots: bool = False
     restart_server_every_benchmark: bool = True
     env: Dict[str, str] = field(default_factory=dict)
+    nsys_capture: Optional[str] = None  # "cudaProfilerApi" | None
+    nsys_out: Optional[str] = None
 
     @property
     def sweep_mode(self) -> str:
@@ -84,6 +86,21 @@ class SweepConfig:
         if not self.request_rates and not self.concurrencies:
             raise ValueError(
                 "At least one of request_rates or concurrencies is required."
+            )
+
+        _SUPPORTED_NSYS_CAPTURE = {"cudaProfilerApi"}
+        if self.nsys_capture is not None:
+            if self.nsys_capture not in _SUPPORTED_NSYS_CAPTURE:
+                raise ValueError(
+                    f"nsys_capture={self.nsys_capture!r} is not supported. "
+                    f"Allowed: {sorted(_SUPPORTED_NSYS_CAPTURE)}."
+                )
+            if not self.nsys_out:
+                raise ValueError("nsys_out is required when nsys_capture is set.")
+        elif self.nsys_out is not None:
+            raise ValueError(
+                "nsys_out is set but nsys_capture is not. Set nsys_capture "
+                "or remove nsys_out."
             )
 
 
@@ -137,6 +154,8 @@ def load_config(
         skip_plots=raw.get("skip_plots", False),
         restart_server_every_benchmark=raw.get("restart_server_every_benchmark", True),
         env=raw.get("env", {}),
+        nsys_capture=raw.get("nsys_capture"),
+        nsys_out=raw.get("nsys_out"),
     )
 
     if cli_overrides:

--- a/benchmarks/multimodal/sweep/config.py
+++ b/benchmarks/multimodal/sweep/config.py
@@ -33,7 +33,6 @@ class SweepConfig:
     concurrencies: Optional[List[int]] = None
     osl: int = 150
     conversation_num: Optional[int] = None
-    request_count: Optional[int] = None
     warmup_count: int = 5
     port: int = 8000
     timeout: int = 600
@@ -87,15 +86,6 @@ class SweepConfig:
                 "At least one of request_rates or concurrencies is required."
             )
 
-        if self.request_count is not None and self.conversation_num is None:
-            raise ValueError(
-                "'request_count' alone is no longer supported. Set "
-                "'conversation_num: N' (derived from your JSONL's unique "
-                "session_id count, typically N users). 'request_count' is "
-                "accepted only as an optional hard-cap alongside "
-                "'conversation_num'."
-            )
-
 
 _DEFAULT_REQUEST_RATES: List[int] = [4, 8, 16, 32, 64]
 
@@ -138,7 +128,6 @@ def load_config(
         concurrencies=yaml_concurrencies,
         osl=raw.get("osl", 150),
         conversation_num=raw.get("conversation_num"),
-        request_count=raw.get("request_count"),
         warmup_count=raw.get("warmup_count", 5),
         port=raw.get("port", 8000),
         timeout=raw.get("timeout", 600),

--- a/benchmarks/multimodal/sweep/config.py
+++ b/benchmarks/multimodal/sweep/config.py
@@ -32,7 +32,8 @@ class SweepConfig:
     request_rates: Optional[List[int]] = None
     concurrencies: Optional[List[int]] = None
     osl: int = 150
-    request_count: int = 1000
+    conversation_num: Optional[int] = None
+    request_count: Optional[int] = None
     warmup_count: int = 5
     port: int = 8000
     timeout: int = 600
@@ -86,6 +87,15 @@ class SweepConfig:
                 "At least one of request_rates or concurrencies is required."
             )
 
+        if self.request_count is not None and self.conversation_num is None:
+            raise ValueError(
+                "'request_count' alone is no longer supported. Set "
+                "'conversation_num: N' (derived from your JSONL's unique "
+                "session_id count, typically N users). 'request_count' is "
+                "accepted only as an optional hard-cap alongside "
+                "'conversation_num'."
+            )
+
 
 _DEFAULT_REQUEST_RATES: List[int] = [4, 8, 16, 32, 64]
 
@@ -127,7 +137,8 @@ def load_config(
         request_rates=yaml_request_rates,
         concurrencies=yaml_concurrencies,
         osl=raw.get("osl", 150),
-        request_count=raw.get("request_count", 1000),
+        conversation_num=raw.get("conversation_num"),
+        request_count=raw.get("request_count"),
         warmup_count=raw.get("warmup_count", 5),
         port=raw.get("port", 8000),
         timeout=raw.get("timeout", 600),

--- a/benchmarks/multimodal/sweep/dataset_shape.py
+++ b/benchmarks/multimodal/sweep/dataset_shape.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def count_session_ids(jsonl_path: str | Path) -> int:
+    """Count unique ``session_id`` values in a JSONL dataset.
+
+    Used to derive ``conversation_num`` for the sweep when the user hasn't set
+    it explicitly. Rows without ``session_id`` count as distinct sessions
+    (matches aiperf's per-row UUID fallback in ``SingleTurnDatasetLoader``).
+
+    For multi_turn rows (``{"type": "multi_turn", "session_id": ..., "turns": [...]}``),
+    the top-level ``session_id`` is what counts.
+    """
+    sessions: set[str] = set()
+    anon_count = 0
+    with open(jsonl_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            sid = row.get("session_id")
+            if sid is None:
+                anon_count += 1
+            else:
+                sessions.add(str(sid))
+    return len(sessions) + anon_count

--- a/benchmarks/multimodal/sweep/orchestrator.py
+++ b/benchmarks/multimodal/sweep/orchestrator.py
@@ -69,8 +69,6 @@ def run_sweep(
     print(f"  OSL:           {config.osl}")
     if config.conversation_num is not None:
         print(f"  Conversations: {config.conversation_num} per {sweep_mode}")
-    if config.request_count is not None:
-        print(f"  Request cap:   {config.request_count} per {sweep_mode}")
     print(
         f"  Restart:       {'every run' if config.restart_server_every_benchmark else 'per config'}"
     )
@@ -177,7 +175,6 @@ def _run_config(
                     sweep_mode=sweep_mode,
                     sweep_value=value,
                     conversation_num=conversation_num,
-                    request_count=config.request_count,
                     warmup_count=config.warmup_count,
                     input_file=input_file,
                     osl=config.osl,

--- a/benchmarks/multimodal/sweep/orchestrator.py
+++ b/benchmarks/multimodal/sweep/orchestrator.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from .config import BenchmarkConfig, SweepConfig, input_file_tag, resolve_repo_root
+from .dataset_shape import count_session_ids
 from .runner import run_aiperf_single
 from .server import ServerManager
 
@@ -16,6 +17,26 @@ def _resolve_workflow(workflow: str, repo_root: Path) -> str:
     if p.is_absolute():
         return str(p)
     return str(repo_root / p)
+
+
+def _resolve_conversation_num(config: SweepConfig, input_file: str) -> int:
+    """Pick conversation_num for this input file: explicit value from config wins,
+    otherwise derive from the JSONL's unique session_id count. Error if an
+    explicit value exceeds the JSONL's capacity (sampler would wrap)."""
+    detected = count_session_ids(input_file)
+    if config.conversation_num is None:
+        print(
+            f"  conversation_num derived from {input_file}: {detected}",
+            flush=True,
+        )
+        return detected
+    if config.conversation_num > detected:
+        raise ValueError(
+            f"conversation_num={config.conversation_num} exceeds unique "
+            f"session_id count ({detected}) in {input_file}. SequentialSampler "
+            f"would wrap. Set conversation_num <= {detected} or reshape the JSONL."
+        )
+    return config.conversation_num
 
 
 def _print_banner(title: str, char: str = "=", width: int = 70) -> None:
@@ -46,7 +67,10 @@ def run_sweep(
     print(f"  Sweep mode:    {sweep_mode}")
     print(f"  Sweep values:  {sweep_values}")
     print(f"  OSL:           {config.osl}")
-    print(f"  Requests:      {config.request_count} per {sweep_mode}")
+    if config.conversation_num is not None:
+        print(f"  Conversations: {config.conversation_num} per {sweep_mode}")
+    if config.request_count is not None:
+        print(f"  Request cap:   {config.request_count} per {sweep_mode}")
     print(
         f"  Restart:       {'every run' if config.restart_server_every_benchmark else 'per config'}"
     )
@@ -98,10 +122,12 @@ def _run_config(
     _print_banner(f"Config: {bench_cfg.label}", char="#")
 
     # Collect pending runs, skipping those with existing results.
-    pending_runs: List[tuple[str, str, int, Path]] = []
+    pending_runs: List[tuple[str, str, int, Path, int]] = []
     for input_file in config.input_files:
         file_tag = input_file_tag(input_file)
         sweep_dir = output_base / file_tag / bench_cfg.label
+
+        conversation_num = _resolve_conversation_num(config, input_file)
 
         for value in sorted(sweep_values):
             artifact_dir = sweep_dir / f"{sweep_mode}{value}"
@@ -113,7 +139,9 @@ def _run_config(
                     flush=True,
                 )
             else:
-                pending_runs.append((input_file, file_tag, value, artifact_dir))
+                pending_runs.append(
+                    (input_file, file_tag, value, artifact_dir, conversation_num)
+                )
 
     if not pending_runs:
         print(f"  All runs skipped for {bench_cfg.label}", flush=True)
@@ -128,7 +156,7 @@ def _run_config(
         )
 
     try:
-        for input_file, file_tag, value, artifact_dir in pending_runs:
+        for input_file, file_tag, value, artifact_dir, conversation_num in pending_runs:
             _print_banner(
                 f"[{file_tag}] Config: {bench_cfg.label}  " f"{sweep_mode}={value}",
                 char="-",
@@ -148,6 +176,7 @@ def _run_config(
                     port=config.port,
                     sweep_mode=sweep_mode,
                     sweep_value=value,
+                    conversation_num=conversation_num,
                     request_count=config.request_count,
                     warmup_count=config.warmup_count,
                     input_file=input_file,

--- a/benchmarks/multimodal/sweep/orchestrator.py
+++ b/benchmarks/multimodal/sweep/orchestrator.py
@@ -77,6 +77,10 @@ def run_sweep(
 
     server = ServerManager(port=config.port, timeout=config.timeout)
     env_overrides = dict(config.env) if config.env else {}
+    if config.nsys_capture is not None:
+        env_overrides["DYN_NSYS_CAPTURE"] = config.nsys_capture
+        env_overrides["DYN_NSYS_OUT"] = config.nsys_out  # validated non-None
+        print(f"  nsys capture:  {config.nsys_capture} -> {config.nsys_out}")
 
     try:
         for bench_cfg in config.configs:
@@ -169,6 +173,12 @@ def _run_config(
                 )
 
             try:
+                start_url = stop_url = None
+                if config.nsys_capture == "cudaProfilerApi":
+                    base = f"http://localhost:{config.port}"
+                    start_url = f"{base}/start_profile"
+                    stop_url = f"{base}/stop_profile"
+
                 run_aiperf_single(
                     model=config.model,
                     port=config.port,
@@ -179,6 +189,8 @@ def _run_config(
                     input_file=input_file,
                     osl=config.osl,
                     artifact_dir=artifact_dir,
+                    start_profile_url=start_url,
+                    stop_profile_url=stop_url,
                 )
             finally:
                 if config.restart_server_every_benchmark:

--- a/benchmarks/multimodal/sweep/runner.py
+++ b/benchmarks/multimodal/sweep/runner.py
@@ -4,8 +4,29 @@
 from __future__ import annotations
 
 import subprocess
+import urllib.error
+import urllib.request
 from pathlib import Path
-from typing import List
+from typing import List, Optional
+
+
+def _post_profile(url: str, label: str, *, required: bool) -> None:
+    """POST to vllm's /start_profile or /stop_profile.
+
+    When required=True, any failure raises RuntimeError so the sweep fails
+    fast instead of producing a misleading empty trace. When required=False,
+    failures log a warning and continue (used for stop in a finally block).
+    """
+    req = urllib.request.Request(url, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"{label} returned HTTP {resp.status}")
+    except (urllib.error.URLError, TimeoutError, OSError, RuntimeError) as e:
+        msg = f"{label} at {url} failed: {e!r}"
+        if required:
+            raise RuntimeError(msg) from e
+        print(f"WARNING: {msg}", flush=True)
 
 
 def _build_aiperf_cmd(
@@ -68,8 +89,17 @@ def run_aiperf_single(
     input_file: str,
     osl: int,
     artifact_dir: Path,
+    start_profile_url: Optional[str] = None,
+    stop_profile_url: Optional[str] = None,
 ) -> None:
-    """Run a single aiperf profile invocation."""
+    """Run a single aiperf profile invocation.
+
+    When ``start_profile_url`` / ``stop_profile_url`` are supplied (typically
+    ``http://localhost:{port}/start_profile``), the runner arms / disarms
+    vllm's cudaProfilerApi trigger around the aiperf subprocess. Start is
+    required-success (fail fast); stop is best-effort in a finally block so
+    an aiperf crash can't leave nsys hanging on an un-finalized capture.
+    """
     artifact_dir.mkdir(parents=True, exist_ok=True)
     cmd = _build_aiperf_cmd(
         model=model,
@@ -83,20 +113,30 @@ def run_aiperf_single(
         artifact_dir=artifact_dir,
     )
 
+    if start_profile_url:
+        _post_profile(start_profile_url, "start_profile", required=True)
+
     print(f"  aiperf {sweep_mode}={sweep_value} -> {artifact_dir}", flush=True)
-    proc = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True)
 
-    if proc.returncode != 0:
-        print(f"  aiperf FAILED (exit {proc.returncode})", flush=True)
-        for stream_name, stream in [("stderr", proc.stderr), ("stdout", proc.stdout)]:
-            if stream:
-                for line in stream.strip().splitlines()[-15:]:
-                    print(f"    [{stream_name}] {line}", flush=True)
-        raise subprocess.CalledProcessError(
-            proc.returncode, cmd, output=proc.stdout, stderr=proc.stderr
-        )
+        if proc.returncode != 0:
+            print(f"  aiperf FAILED (exit {proc.returncode})", flush=True)
+            for stream_name, stream in [
+                ("stderr", proc.stderr),
+                ("stdout", proc.stdout),
+            ]:
+                if stream:
+                    for line in stream.strip().splitlines()[-15:]:
+                        print(f"    [{stream_name}] {line}", flush=True)
+            raise subprocess.CalledProcessError(
+                proc.returncode, cmd, output=proc.stdout, stderr=proc.stderr
+            )
 
-    print(f"  aiperf {sweep_mode}={sweep_value} done.", flush=True)
+        print(f"  aiperf {sweep_mode}={sweep_value} done.", flush=True)
+    finally:
+        if stop_profile_url:
+            _post_profile(stop_profile_url, "stop_profile", required=False)
 
 
 def run_sweep(

--- a/benchmarks/multimodal/sweep/runner.py
+++ b/benchmarks/multimodal/sweep/runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 
 def _build_aiperf_cmd(
@@ -14,7 +14,6 @@ def _build_aiperf_cmd(
     sweep_mode: str,
     sweep_value: int,
     conversation_num: int,
-    request_count: Optional[int],
     warmup_count: int,
     input_file: str,
     osl: int,
@@ -25,7 +24,7 @@ def _build_aiperf_cmd(
     else:
         sweep_flag = "--request-rate"
 
-    cmd = [
+    return [
         "aiperf",
         "profile",
         "-m",
@@ -57,9 +56,6 @@ def _build_aiperf_cmd(
         "none",
         "--no-server-metrics",
     ]
-    if request_count is not None:
-        cmd += ["--request-count", str(request_count)]
-    return cmd
 
 
 def run_aiperf_single(
@@ -68,7 +64,6 @@ def run_aiperf_single(
     sweep_mode: str,
     sweep_value: int,
     conversation_num: int,
-    request_count: Optional[int],
     warmup_count: int,
     input_file: str,
     osl: int,
@@ -82,7 +77,6 @@ def run_aiperf_single(
         sweep_mode=sweep_mode,
         sweep_value=sweep_value,
         conversation_num=conversation_num,
-        request_count=request_count,
         warmup_count=warmup_count,
         input_file=input_file,
         osl=osl,
@@ -111,7 +105,6 @@ def run_sweep(
     sweep_mode: str,
     sweep_values: List[int],
     conversation_num: int,
-    request_count: Optional[int],
     warmup_count: int,
     input_file: str,
     osl: int,
@@ -127,7 +120,6 @@ def run_sweep(
             sweep_mode=sweep_mode,
             sweep_value=value,
             conversation_num=conversation_num,
-            request_count=request_count,
             warmup_count=warmup_count,
             input_file=input_file,
             osl=osl,

--- a/benchmarks/multimodal/sweep/runner.py
+++ b/benchmarks/multimodal/sweep/runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 
 def _build_aiperf_cmd(
@@ -13,7 +13,8 @@ def _build_aiperf_cmd(
     port: int,
     sweep_mode: str,
     sweep_value: int,
-    request_count: int,
+    conversation_num: int,
+    request_count: Optional[int],
     warmup_count: int,
     input_file: str,
     osl: int,
@@ -24,7 +25,7 @@ def _build_aiperf_cmd(
     else:
         sweep_flag = "--request-rate"
 
-    return [
+    cmd = [
         "aiperf",
         "profile",
         "-m",
@@ -33,8 +34,8 @@ def _build_aiperf_cmd(
         f"http://localhost:{port}",
         sweep_flag,
         str(sweep_value),
-        "--request-count",
-        str(request_count),
+        "--conversation-num",
+        str(conversation_num),
         "--warmup-request-count",
         str(warmup_count),
         "--input-file",
@@ -56,6 +57,9 @@ def _build_aiperf_cmd(
         "none",
         "--no-server-metrics",
     ]
+    if request_count is not None:
+        cmd += ["--request-count", str(request_count)]
+    return cmd
 
 
 def run_aiperf_single(
@@ -63,7 +67,8 @@ def run_aiperf_single(
     port: int,
     sweep_mode: str,
     sweep_value: int,
-    request_count: int,
+    conversation_num: int,
+    request_count: Optional[int],
     warmup_count: int,
     input_file: str,
     osl: int,
@@ -76,6 +81,7 @@ def run_aiperf_single(
         port=port,
         sweep_mode=sweep_mode,
         sweep_value=sweep_value,
+        conversation_num=conversation_num,
         request_count=request_count,
         warmup_count=warmup_count,
         input_file=input_file,
@@ -104,7 +110,8 @@ def run_sweep(
     port: int,
     sweep_mode: str,
     sweep_values: List[int],
-    request_count: int,
+    conversation_num: int,
+    request_count: Optional[int],
     warmup_count: int,
     input_file: str,
     osl: int,
@@ -119,6 +126,7 @@ def run_sweep(
             port=port,
             sweep_mode=sweep_mode,
             sweep_value=value,
+            conversation_num=conversation_num,
             request_count=request_count,
             warmup_count=warmup_count,
             input_file=input_file,

--- a/benchmarks/multimodal/sweep/workflows/vllm_serve.sh
+++ b/benchmarks/multimodal/sweep/workflows/vllm_serve.sh
@@ -4,6 +4,13 @@
 #
 # Minimal vllm serve wrapper for benchmark sweeps.
 # Launched by the sweep orchestrator via: bash vllm_serve.sh --model <model> [extra_args...]
+#
+# When $DYN_NSYS_CAPTURE=cudaProfilerApi is set, the wrapper prefixes nsys
+# around `vllm serve` and passes `--profiler-config.profiler cuda` so the
+# orchestrator's /start_profile + /stop_profile HTTP triggers drive the
+# capture window. See plans/2026-04-21/nsys-sweep-capture-range/plan.md.
+
+set -e
 
 MODEL=""
 CAPACITY_GB=0
@@ -43,9 +50,59 @@ else
     GPU_MEM_ARGS="--gpu-memory-utilization $GPU_MEM_UTIL"
 fi
 
-vllm serve "$MODEL" \
+NSYS_PREFIX=()
+VLLM_PROFILER_ARGS=()
+if [[ "${DYN_NSYS_CAPTURE:-}" == "cudaProfilerApi" ]]; then
+    : "${DYN_NSYS_OUT:?DYN_NSYS_OUT is required when DYN_NSYS_CAPTURE=cudaProfilerApi}"
+    NSYS_BIN="${DYN_NSYS_BIN:-$(command -v nsys)}"
+    if [[ -z "$NSYS_BIN" ]] || [[ ! -x "$NSYS_BIN" ]]; then
+        echo "FATAL: nsys not found on PATH (set DYN_NSYS_BIN to override)." >&2
+        exit 1
+    fi
+
+    # Preflight: assert this nsys build supports the shutdown model the
+    # orchestrator-triggered capture depends on. Cheap (~1s, /bin/true target).
+    PREFLIGHT_OUT="$(mktemp -u /tmp/nsys_preflight_XXXXXX.nsys-rep)"
+    if ! "$NSYS_BIN" profile \
+        --capture-range=cudaProfilerApi \
+        --capture-range-end=stop-shutdown \
+        --kill=sigterm \
+        -o "$PREFLIGHT_OUT" \
+        --force-overwrite=true \
+        /bin/true >/dev/null 2>&1; then
+        echo "FATAL: $NSYS_BIN lacks --capture-range-end=stop-shutdown + --kill=sigterm support." >&2
+        echo "       Upgrade nsys or drop nsys_capture from the sweep config." >&2
+        rm -f "$PREFLIGHT_OUT"* 2>/dev/null
+        exit 1
+    fi
+    rm -f "$PREFLIGHT_OUT"* 2>/dev/null
+
+    mkdir -p "$(dirname "$DYN_NSYS_OUT")"
+    # Note: `--process-scope=process-tree` exists on newer nsys builds and
+    # would bound the trace to the target's descendants. It's not accepted by
+    # nsys 2025.5.2, so we rely on `--sample=none --cpuctxsw=none` alone to
+    # keep host-thread noise down. Upgrade once available.
+    NSYS_PREFIX=(
+        "$NSYS_BIN" profile
+        --trace=nvtx,cuda
+        --sample=none
+        --cpuctxsw=none
+        --capture-range=cudaProfilerApi
+        --capture-range-end=stop-shutdown
+        --kill=sigterm
+        -o "$DYN_NSYS_OUT"
+        --force-overwrite=true
+    )
+    VLLM_PROFILER_ARGS=(--profiler-config.profiler cuda)
+    echo "[vllm_serve.sh] nsys capture armed: $DYN_NSYS_OUT" >&2
+fi
+
+# exec so nsys becomes the tracked process directly (no lingering bash);
+# ServerManager._process then tracks nsys's PID with clean pgroup semantics.
+exec "${NSYS_PREFIX[@]}" vllm serve "$MODEL" \
     --enable-log-requests \
     --max-model-len 16384 \
     $GPU_MEM_ARGS \
     "${EC_ARGS[@]}" \
+    "${VLLM_PROFILER_ARGS[@]}" \
     "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
## Why

Benchmark sweeps need nsys traces that cover the aiperf request-generation phase, not the vllm boot phase. The prior approach was a hand-tuned `nsys profile --delay=N --duration=M`: if `N/M` didn't match the actual timing on the box, the capture window missed aiperf entirely (we saw this — empty NVTX even though the server ran fine). Same problem for the reverse: making the window large enough "for safety" buys a multi-GB trace dominated by boot noise.

vllm already exposes `POST /start_profile` + `POST /stop_profile`. When `ProfilerConfig.profiler=cuda`, those call `torch.cuda.profiler.start/stop()` → `cudaProfilerStart/Stop`. nsys's `--capture-range=cudaProfilerApi` listens for exactly those events. Pair the sweep orchestrator with nsys and you get a capture bounded to the aiperf subprocess lifecycle with zero wall-clock guessing.

Stacked on #8458 (parent branch `qiwa/dis-1807-aiperf-conversation-num`).

## What Change

- `SweepConfig` gains two typed fields: `nsys_capture: "cudaProfilerApi" | None` and `nsys_out: <path>`. Validator rejects one-without-the-other and unknown capture modes.
- Orchestrator derives `DYN_NSYS_CAPTURE` / `DYN_NSYS_OUT` env + `http://localhost:{port}/start_profile` URLs when `nsys_capture` is set, passes to the runner.
- Runner gets optional `start_profile_url` (required-success — fail fast if arming fails) and `stop_profile_url` (best-effort, inside a `finally` block so aiperf crashes can't leave nsys hanging).
- `workflows/vllm_serve.sh` branches on `$DYN_NSYS_CAPTURE`: stock flow when unset, `nsys profile --capture-range=cudaProfilerApi --capture-range-end=stop-shutdown --kill=sigterm` + `--profiler-config.profiler cuda` when set. `exec` replaces bash so nsys becomes `ServerManager._process` directly — clean pgroup, no finalize-vs-SIGKILL race. Preflight probe asserts the nsys build supports the required flags and fails fast if not.

## Test plan

- Smoke run on Qwen3-VL-2B @ rate 10, local Blackwell: 12.9 MB `.nsys-rep` produced, 5100 `mm:*` NVTX events across 10 named ranges, NVTX wall time 12.7 s (bounded to aiperf phase). aiperf probe clean 10 × 10 (`turn_index` hist `{0:10, ..., 9:10}`, 0 causality violations).
- Verified the preflight rejects the config if nsys lacks `--capture-range-end=stop-shutdown` (forced-fail test).
- Verified `stop_profile` timeout warning is benign: cudaProfilerStop fires before the HTTP response completes; `Profiler stopped successfully.` log confirms. `.nsys-rep` is valid regardless.
- Host-thread noise audit still shows `containerd`/`dockerd` leaking into the Threads panel on this nsys 2025.5.2 build. Known-unknown; `--process-scope=process-tree` would help but isn't accepted by 2025.5.2. Non-fatal; follow-up when the box has newer nsys.

## Scope and follow-ups

- Scoped to stock `vllm serve` only. dynamo frontend + dynamo.vllm full-stack instrumentation is a separate plan (no cudaProfilerApi hooks in Rust; dynamo.vllm embeds vllm's APIServer and can likely reuse this design with a small adapter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
