### PR TITLE
docs(profiler): clarify when planner-profile-data ConfigMap is emitted [DYN-2751]

### DIFF
--- a/components/src/dynamo/profiler/profile_sla.py
+++ b/components/src/dynamo/profiler/profile_sla.py
@@ -402,6 +402,14 @@ async def run_profile(
                 phase=ops.current_phase,
             )
             if not is_disagg_config:
+                # TODO: agg + throughput-scaling has no profiling-data
+                # fallback today. The NPZ sweep (thorough) and the AIC
+                # spec (rapid, see build_aic_interpolation_spec) are both
+                # shaped around prefill + decode picks. For agg picks the
+                # planner currently falls back to DYN_BENCHMARK_MODE at
+                # runtime only. Extend AICInterpolationSpec and
+                # run_interpolation to carry an agg_pick so both paths
+                # work for aggregated deployments too.
                 logger.info(
                     "Picked config is aggregated (chosen_exp=%r) — "
                     "skipping interpolation (requires disaggregated config).",

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -90,7 +90,11 @@ def assemble_final_config(
        planner config so the planner runs AIC interpolation at bootstrap
        if the endpoint is unavailable.
     4. **Profile data** — attach interpolation-data ConfigMap when mocker
-       or planner-thorough is enabled.
+       or planner-thorough is enabled. The ConfigMap is only emitted when
+       the picked config is disaggregated AND the interpolation NPZ files
+       were produced on disk; rapid-mode deployments never emit it (the
+       planner uses AIC in-process or ``get_perf_metrics`` instead), and
+       agg picks skip interpolation entirely.
     """
     if not dgd_config:
         return dgd_config
@@ -519,6 +523,19 @@ def build_aic_interpolation_spec(
     * ``pre_deployment_sweeping_mode`` is not ``Rapid``
     * picks are missing
     * ``resolved_backend`` is not one AIC supports
+
+    .. note::
+        The spec only carries ``prefill_pick`` + ``decode_pick``, so the
+        caller in ``profile_sla.py`` gates this on a disaggregated pick
+        (``is_disagg_config``). When rapid AIC picks an aggregated config
+        and the override to disagg fails, ``aic_spec`` is ``None`` and the
+        planner has no AIC fallback — it relies solely on the
+        ``get_perf_metrics`` endpoint (``DYN_BENCHMARK_MODE``).
+
+        TODO: extend ``AICInterpolationSpec`` with an ``agg_pick`` so
+        throughput-scaling on an aggregated deployment has a matching
+        AIC bootstrap path (planner + mocker + thorough NPZ). Tracking
+        via the wider agg+throughput-scaling rework.
     """
     planner = (
         dgdr.features.planner  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary

Documents the conditions under which `planner-profile-data-XXXX` is emitted, and flags the agg + throughput-scaling gap that showed up in QA ticket [DYN-2751](https://linear.app/nvidia/issue/DYN-2751).

- `assemble_final_config` — profile-data ConfigMap only lands when the picked config is disagg AND NPZ sweep ran (thorough only). Rapid deployments never emit it.
- `build_aic_interpolation_spec` — spec only carries `prefill_pick` + `decode_pick`, so agg picks on rapid have no AIC bootstrap fallback. Planner currently relies solely on `DYN_BENCHMARK_MODE` runtime endpoint.
- `profile_sla.py` — `TODO` at the agg-skip site pointing at the wider fix (extend `AICInterpolationSpec` + `run_interpolation` with an `agg_pick`).

No behavior change — docstrings and `TODO` only. The bigger rework (plumb agg through the profiler + planner AIC handoff + mocker worker flags) is deliberately out of scope for a release QA bug fix.

## Related

- QA ticket: DYN-2751 (release/1.1.0)
- Planned cherry-pick to `release/1.1.0` after this lands.

## Test plan

- [x] `pre-commit run` on the two touched files passes (isort / black / flake8 / ruff / codespell).
- [ ] Lint-only PR — no runtime change, no unit tests added.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified profiler behavior for interpolation handling across different deployment configurations, specifying when interpolation data is generated and the coverage limitations for disaggregated vs. aggregated deployments.

* **Chores**
  * Updated internal profiler documentation with implementation constraints and TODO notes for future enhancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->