### PR TITLE
feat(trtllm): set highest priority on canary health check request

### DIFF
--- a/components/src/dynamo/trtllm/health_check.py
+++ b/components/src/dynamo/trtllm/health_check.py
@@ -69,6 +69,7 @@ class TrtllmHealthCheckPayload(HealthCheckPayload):
 
         self.default_payload = {
             "token_ids": [bos_token_id],
+            "priority": 1.0,  # Highest TRT-LLM priority — health check must not be starved
             "stop_conditions": {
                 "max_tokens": 1,
                 "stop": None,

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -27,6 +27,7 @@ import torch
 from tensorrt_llm.executor.result import GenerationResult
 from tensorrt_llm.executor.utils import RequestError
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
+from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY
 from tensorrt_llm.llmapi.disagg_utils import get_global_disagg_request_id
 from tensorrt_llm.llmapi.llm import SamplingParams
 from tensorrt_llm.sampling_params import GuidedDecodingParams
@@ -1095,15 +1096,11 @@ class HandlerBase(BaseGenerativeHandler):
             )
 
         # Extract priority if set (e.g., health check sets 1.0 for highest priority).
-        # TRT-LLM accepts priority as a float in [0.0, 1.0], default 0.5.
-        priority = request.get("priority")
+        # TRT-LLM BaseLLM.generate_async() accepts priority as a float in [0.0, 1.0],
+        # defaulting to 0.5.
+        priority = request.get("priority", DEFAULT_REQUEST_PRIORITY)
 
         try:
-            # Build optional kwargs — only pass priority if explicitly set
-            optional_kwargs = {}
-            if priority is not None:
-                optional_kwargs["priority"] = priority
-
             # NEW: Updated engine call to include multimodal data
             generation_result = self.engine.llm.generate_async(
                 inputs=processed_input,  # Use the correctly extracted inputs
@@ -1112,7 +1109,7 @@ class HandlerBase(BaseGenerativeHandler):
                 streaming=streaming,
                 trace_headers=trace_headers,
                 scheduling_params=scheduling_params,
-                **optional_kwargs,
+                priority=priority,
             )
 
             # In disagg decode mode, wrap abort() to defer until first token

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1094,7 +1094,16 @@ class HandlerBase(BaseGenerativeHandler):
                 f"Using dynamo router dp_rank={dp_rank} for TRTLLM attention DP scheduling"
             )
 
+        # Extract priority if set (e.g., health check sets 1.0 for highest priority).
+        # TRT-LLM accepts priority as a float in [0.0, 1.0], default 0.5.
+        priority = request.get("priority")
+
         try:
+            # Build optional kwargs — only pass priority if explicitly set
+            optional_kwargs = {}
+            if priority is not None:
+                optional_kwargs["priority"] = priority
+
             # NEW: Updated engine call to include multimodal data
             generation_result = self.engine.llm.generate_async(
                 inputs=processed_input,  # Use the correctly extracted inputs
@@ -1103,6 +1112,7 @@ class HandlerBase(BaseGenerativeHandler):
                 streaming=streaming,
                 trace_headers=trace_headers,
                 scheduling_params=scheduling_params,
+                **optional_kwargs,
             )
 
             # In disagg decode mode, wrap abort() to defer until first token

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -24,10 +24,10 @@ from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Optional, Protocol, Union
 
 import torch
+from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY
 from tensorrt_llm.executor.result import GenerationResult
 from tensorrt_llm.executor.utils import RequestError
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
-from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY
 from tensorrt_llm.llmapi.disagg_utils import get_global_disagg_request_id
 from tensorrt_llm.llmapi.llm import SamplingParams
 from tensorrt_llm.sampling_params import GuidedDecodingParams
@@ -1095,9 +1095,7 @@ class HandlerBase(BaseGenerativeHandler):
                 f"Using dynamo router dp_rank={dp_rank} for TRTLLM attention DP scheduling"
             )
 
-        # Extract priority if set (e.g., health check sets 1.0 for highest priority).
-        # TRT-LLM BaseLLM.generate_async() accepts priority as a float in [0.0, 1.0],
-        # defaulting to 0.5.
+        # Priority is a float in [0.0, 1.0]; health checks use 1.0. Default is 0.5.
         priority = request.get("priority", DEFAULT_REQUEST_PRIORITY)
 
         try:

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -40,6 +40,8 @@ class MockSamplingParams:
     top_p: float = 1.0
     top_k: int = 50
     repetition_penalty: float = 1.0
+    presence_penalty: float = 0.0
+    frequency_penalty: float = 0.0
     seed: int | None = None
     ignore_eos: bool = False
     guided_decoding: object | None = None

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -17,8 +17,11 @@ if not torch.cuda.is_available():
         "CUDA/GPU not available, but tensorrt_llm import and the test require GPU.",
         allow_module_level=True,
     )
+from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY
+
 from dynamo.llm.exceptions import EngineShutdown
 from dynamo.trtllm.constants import DisaggregationMode
+from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
 from dynamo.trtllm.request_handlers.handler_base import HandlerBase
 
 pytestmark = [
@@ -595,3 +598,95 @@ class TestDisaggRequestId:
             request={}, ep_disaggregated_params=None
         )
         assert params_a.disagg_request_id != params_b.disagg_request_id
+
+
+class TestHealthCheckPriority:
+    """Verify generate_locally forwards the correct priority to generate_async.
+
+    Health check requests (built by TrtllmHealthCheckPayload) must reach
+    the TRT-LLM engine at priority=1.0.  Regular inference requests
+    (built by the Rust frontend as PreprocessedRequest, which has no
+    priority field) must fall back to DEFAULT_REQUEST_PRIORITY (0.5).
+    """
+
+    def _make_handler(self) -> HandlerBase:
+        config = MagicMock()
+        config.shutdown_event = None
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        handler = _ConcreteHandler(config)
+        handler.publisher = None
+        handler.multimodal_processor = None
+        handler.additional_metrics = None
+        handler.max_seq_len = None
+        handler.default_sampling_params = MockSamplingParams()
+        return handler
+
+    def _make_mock_generation_result(self):
+        """Mock GenerationResult that yields a single finished token."""
+        output = MagicMock()
+        output.token_ids = [42]
+        output.finish_reason = "stop"
+        output.stop_reason = None
+        output.request_perf_metrics = None
+
+        res = MagicMock()
+        res.outputs = [output]
+        res.finished = True
+
+        generation_result = MagicMock()
+        generation_result.abort = MagicMock()
+
+        async def mock_aiter(self_mock):
+            yield res
+
+        generation_result.__aiter__ = mock_aiter
+        return generation_result
+
+    def _make_context(self):
+        """Mock Context whose cancellation never fires."""
+        context = MagicMock()
+        never_resolve = asyncio.get_event_loop().create_future()
+        context.async_killed_or_stopped.return_value = never_resolve
+        context.id.return_value = "test-priority"
+        return context
+
+    @pytest.mark.asyncio
+    async def test_health_check_gets_priority_1(self):
+        """TrtllmHealthCheckPayload → generate_locally → generate_async priority=1.0."""
+        handler = self._make_handler()
+        generation_result = self._make_mock_generation_result()
+        handler.engine.llm.generate_async = MagicMock(return_value=generation_result)
+
+        request = TrtllmHealthCheckPayload(
+            disaggregation_mode=DisaggregationMode.AGGREGATED,
+        ).to_dict()
+
+        context = self._make_context()
+        chunks = [c async for c in handler.generate_locally(request, context)]
+        assert len(chunks) > 0
+
+        handler.engine.llm.generate_async.assert_called_once()
+        _, kwargs = handler.engine.llm.generate_async.call_args
+        assert kwargs["priority"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_regular_request_gets_default_priority(self):
+        """Rust PreprocessedRequest shape (no priority key) → default 0.5."""
+        handler = self._make_handler()
+        generation_result = self._make_mock_generation_result()
+        handler.engine.llm.generate_async = MagicMock(return_value=generation_result)
+
+        # Mirrors the Rust PreprocessedRequest struct — no priority field.
+        request = {
+            "token_ids": [1, 2, 3],
+            "stop_conditions": {"max_tokens": 10},
+            "sampling_options": {"temperature": 0.7},
+        }
+
+        context = self._make_context()
+        chunks = [c async for c in handler.generate_locally(request, context)]
+        assert len(chunks) > 0
+
+        handler.engine.llm.generate_async.assert_called_once()
+        _, kwargs = handler.engine.llm.generate_async.call_args
+        assert kwargs["priority"] == DEFAULT_REQUEST_PRIORITY

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -70,6 +70,33 @@ trtllm_configs = {
             metric_payload_default(min_num_requests=6, backend="trtllm"),
         ],
     ),
+    # Aggregated with canary health check enabled.
+    # Validates the health check payload (with priority=1.0) is accepted by
+    # the engine and the /health endpoint reports ready after canary succeeds.
+    "aggregated_health_check": TRTLLMConfig(
+        name="aggregated_health_check",
+        directory=trtllm_dir,
+        script_name="agg.sh",
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.pre_merge,
+            pytest.mark.trtllm,
+            pytest.mark.profiled_vram_gib(3.9),
+            pytest.mark.requested_trtllm_kv_tokens(2592),
+            pytest.mark.timeout(300),
+        ],
+        model="Qwen/Qwen3-0.6B",
+        frontend_port=DefaultPort.FRONTEND.value,
+        delayed_start=5,
+        health_check_workers=True,
+        env={
+            "DYN_HEALTH_CHECK_ENABLED": "true",
+            "DYN_CANARY_WAIT_TIME": "2",
+        },
+        request_payloads=[
+            chat_payload_default(),
+        ],
+    ),
     "aggregated_unified": TRTLLMConfig(
         name="aggregated_unified",
         directory=trtllm_dir,

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -70,34 +70,6 @@ trtllm_configs = {
             metric_payload_default(min_num_requests=6, backend="trtllm"),
         ],
     ),
-    # Aggregated with canary health check enabled.
-    # Validates the health check payload (with priority=1.0) is accepted by
-    # TRT-LLM's generate_async() and the engine serves requests normally.
-    # Note: health_check_workers is not set because agg.sh starts a single
-    # worker but the test harness allocates 2 system ports — only one is bound.
-    "aggregated_health_check": TRTLLMConfig(
-        name="aggregated_health_check",
-        directory=trtllm_dir,
-        script_name="agg.sh",
-        marks=[
-            pytest.mark.gpu_1,
-            pytest.mark.pre_merge,
-            pytest.mark.trtllm,
-            pytest.mark.profiled_vram_gib(3.9),
-            pytest.mark.requested_trtllm_kv_tokens(2592),
-            pytest.mark.timeout(300),
-        ],
-        model="Qwen/Qwen3-0.6B",
-        frontend_port=DefaultPort.FRONTEND.value,
-        delayed_start=5,
-        env={
-            "DYN_HEALTH_CHECK_ENABLED": "true",
-            "DYN_CANARY_WAIT_TIME": "2",
-        },
-        request_payloads=[
-            chat_payload_default(),
-        ],
-    ),
     "aggregated_unified": TRTLLMConfig(
         name="aggregated_unified",
         directory=trtllm_dir,
@@ -637,5 +609,55 @@ def test_chat_only_aggregated_with_test_logits_processor(
             "MODEL_PATH": config.model,
             "SERVED_MODEL_NAME": config.model,
         }
+    )
+    run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
+
+
+@pytest.mark.e2e
+@pytest.mark.gpu_1
+@pytest.mark.trtllm
+@pytest.mark.pre_merge
+@pytest.mark.profiled_vram_gib(3.9)
+@pytest.mark.requested_trtllm_kv_tokens(2592)
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("num_system_ports", [1], indirect=True)
+def test_aggregated_health_check_priority(
+    request,
+    runtime_services_dynamic_ports,
+    dynamo_dynamic_ports,
+    num_system_ports,
+    predownload_models,
+):
+    """
+    Validate the canary health check with priority=1.0 on an aggregated
+    TRT-LLM deployment.
+
+    Starts the engine with DYN_HEALTH_CHECK_ENABLED=true and
+    health_check_workers=True (1 system port). The test passes only if:
+    1. The worker /health endpoint reports ready (canary with priority=1.0
+       was accepted by generate_async and returned a valid response)
+    2. A normal chat request succeeds alongside the canary
+    """
+    base = trtllm_configs["aggregated"]
+    config = TRTLLMConfig(
+        name="aggregated_health_check",
+        directory=base.directory,
+        script_name=base.script_name,
+        marks=[],
+        model="Qwen/Qwen3-0.6B",
+        frontend_port=dynamo_dynamic_ports.frontend_port,
+        delayed_start=base.delayed_start,
+        timeout=base.timeout,
+        health_check_workers=True,
+        env={
+            "DYN_HEALTH_CHECK_ENABLED": "true",
+            "DYN_CANARY_WAIT_TIME": "2",
+            "DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS": '["generate"]',
+            "MODEL_PATH": "Qwen/Qwen3-0.6B",
+            "SERVED_MODEL_NAME": "Qwen/Qwen3-0.6B",
+        },
+        request_payloads=[
+            chat_payload_default(),
+        ],
     )
     run_serve_deployment(config, request, ports=dynamo_dynamic_ports)

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -652,7 +652,6 @@ def test_aggregated_health_check_priority(
         env={
             "DYN_HEALTH_CHECK_ENABLED": "true",
             "DYN_CANARY_WAIT_TIME": "2",
-            "DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS": '["generate"]',
             "MODEL_PATH": "Qwen/Qwen3-0.6B",
             "SERVED_MODEL_NAME": "Qwen/Qwen3-0.6B",
         },

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -72,7 +72,9 @@ trtllm_configs = {
     ),
     # Aggregated with canary health check enabled.
     # Validates the health check payload (with priority=1.0) is accepted by
-    # the engine and the /health endpoint reports ready after canary succeeds.
+    # TRT-LLM's generate_async() and the engine serves requests normally.
+    # Note: health_check_workers is not set because agg.sh starts a single
+    # worker but the test harness allocates 2 system ports — only one is bound.
     "aggregated_health_check": TRTLLMConfig(
         name="aggregated_health_check",
         directory=trtllm_dir,
@@ -88,7 +90,6 @@ trtllm_configs = {
         model="Qwen/Qwen3-0.6B",
         frontend_port=DefaultPort.FRONTEND.value,
         delayed_start=5,
-        health_check_workers=True,
         env={
             "DYN_HEALTH_CHECK_ENABLED": "true",
             "DYN_CANARY_WAIT_TIME": "2",

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -616,7 +616,7 @@ def test_chat_only_aggregated_with_test_logits_processor(
 @pytest.mark.e2e
 @pytest.mark.gpu_1
 @pytest.mark.trtllm
-@pytest.mark.pre_merge
+@pytest.mark.nightly
 @pytest.mark.profiled_vram_gib(3.9)
 @pytest.mark.requested_trtllm_kv_tokens(2592)
 @pytest.mark.timeout(300)


### PR DESCRIPTION
#### Overview:

Set `priority=1.0` (highest) on the TRT-LLM canary health check request so it is scheduled ahead of queued inference requests. Observed in production where workers were experiencing false-negative health check timeouts under load — the 1-token canary request was starved behind long-context requests at default priority (0.5).

#### Details:

- **`components/src/dynamo/trtllm/health_check.py`**: Added `"priority": 1.0` to `TrtllmHealthCheckPayload.default_payload`
- **`components/src/dynamo/trtllm/request_handlers/handler_base.py`**: Extract `priority` from the request dict and forward it to `generate_async()`.

TRT-LLM's `generate_async()` accepts priority as a float in `[0.0, 1.0]` where higher = higher priority. No server-side flag is required — priority scheduling is always active.

#### Where should the reviewer start?

`handler_base.py` (~line 1105).

#### Related Issues:

- Closes DYN-2848
- Relates to DYN-2845

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request priority support. The system now accepts optional priority fields in requests and processes them during execution. Requests without explicit priority default to 1.0, ensuring backward compatibility. Priority parameters are conditionally applied when present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->