### PR TITLE
Fix LayoutConfig validation to allow FP8 KV cache (dtype_width_bytes=1)

### DIFF
--- a/lib/kvbm-physical/src/layout/config.rs
+++ b/lib/kvbm-physical/src/layout/config.rs
@@ -171,9 +171,9 @@ pub fn validate_power_of_2(alignment: usize) -> Result<(), ValidationError> {
 }
 
 pub fn validate_dtype_width_bytes(dtype_width_bytes: usize) -> Result<(), ValidationError> {
-    if !dtype_width_bytes.is_power_of_two() || !(2..=8).contains(&dtype_width_bytes) {
+    if !dtype_width_bytes.is_power_of_two() || !(1..=8).contains(&dtype_width_bytes) {
         return Err(validator::ValidationError::new(
-            "dtype_width_bytes_must_be_power_of_two_and_less_than_8_bytes",
+            "dtype_width_bytes_must_be_power_of_two_and_at_most_8_bytes",
         ));
     }
     Ok(())


### PR DESCRIPTION
The dtype_width_bytes validator rejected 1-byte dtypes (FP8) because the range check required >= 2. FP8 KV cache (--kv-cache-dtype fp8) is a valid configuration that passes dtype_width_bytes=1. Widen the accepted range from 2..=8 to 1..=8.

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
