### PR TITLE
Improve error reporting for worker initialization failures

### DIFF
--- a/lib/kvbm-connector/src/connector/leader/init.rs
+++ b/lib/kvbm-connector/src/connector/leader/init.rs
@@ -291,9 +291,15 @@ impl ConnectorLeader {
 
         for (i, future) in initialize_futures.into_iter().enumerate() {
             tracing::trace!(worker_idx = i, "Awaiting initialization for worker");
-            let worker_layout = future
-                .await
-                .with_context(|| format!("Failed to initialize worker {}", i))?;
+            let worker_layout = future.await.map_err(|e| {
+                tracing::error!(
+                    worker_idx = i,
+                    error = %e,
+                    error_chain = ?e,
+                    "Worker initialization failed"
+                );
+                e
+            }).with_context(|| format!("Failed to initialize worker {}", i))?;
             tracing::trace!(worker_idx = i, "Worker initialization completed");
 
             // Collect metadata for later storage

--- a/lib/kvbm-connector/src/connector/worker/init/pending.rs
+++ b/lib/kvbm-connector/src/connector/worker/init/pending.rs
@@ -232,11 +232,29 @@ impl PendingWorkerState {
 
             let mut host_layout = self.layout_config.clone();
             host_layout.num_blocks = config.host_block_count;
+
+            let total_bytes = host_layout.required_bytes() as u64;
+            tracing::info!(
+                host_block_count = config.host_block_count,
+                bytes_per_block = host_layout.bytes_per_block(),
+                total_gb = total_bytes / (1024 * 1024 * 1024),
+                "Allocating pinned host memory for G2 layout"
+            );
+
             let host_layout = PhysicalLayoutBuilder::new(nixl_agent.clone())
                 .with_config(host_layout)
                 .fully_contiguous()
                 .allocate_pinned(Some(self.cuda_device_id as u32))
-                .build()?;
+                .build()
+                .map_err(|e| {
+                    tracing::error!(
+                        host_block_count = config.host_block_count,
+                        total_gb = total_bytes / (1024 * 1024 * 1024),
+                        error = %e,
+                        "Failed to allocate pinned host memory for G2 layout"
+                    );
+                    e
+                })?;
 
             let g2_handle = transfer_manager.register_layout(host_layout)?;
             created_layouts.push(LogicalLayoutHandle::G2);
@@ -245,6 +263,15 @@ impl PendingWorkerState {
             let g3_handle = if let Some(disk_blocks) = config.disk_block_count {
                 let mut disk_layout = self.layout_config.clone();
                 disk_layout.num_blocks = disk_blocks;
+
+                let disk_total_bytes = disk_layout.required_bytes() as u64;
+                tracing::info!(
+                    disk_block_count = disk_blocks,
+                    bytes_per_block = disk_layout.bytes_per_block(),
+                    total_gb = disk_total_bytes / (1024 * 1024 * 1024),
+                    "Allocating disk-backed memory for G3 layout"
+                );
+
                 let disk_layout = PhysicalLayoutBuilder::new(nixl_agent.clone())
                     .with_config(disk_layout)
                     .fully_contiguous()
@@ -252,7 +279,16 @@ impl PendingWorkerState {
                         "/tmp/kvbm_g3_{}.bin",
                         runtime.messenger().instance_id()
                     ))))
-                    .build()?;
+                    .build()
+                    .map_err(|e| {
+                        tracing::error!(
+                            disk_block_count = disk_blocks,
+                            total_gb = disk_total_bytes / (1024 * 1024 * 1024),
+                            error = %e,
+                            "Failed to allocate disk-backed memory for G3 layout"
+                        );
+                        e
+                    })?;
 
                 let handle = transfer_manager.register_layout(disk_layout)?;
                 created_layouts.push(LogicalLayoutHandle::G3);

--- a/lib/kvbm-connector/src/connector/worker/state.rs
+++ b/lib/kvbm-connector/src/connector/worker/state.rs
@@ -205,7 +205,16 @@ impl WorkerState {
         );
 
         // Complete initialization
-        let (worker, response) = pending.complete_initialization(&self.runtime, config)?;
+        let (worker, response) = pending
+            .complete_initialization(&self.runtime, config)
+            .map_err(|e| {
+                tracing::error!(
+                    error = %e,
+                    error_chain = ?e,
+                    "Worker complete_initialization failed"
+                );
+                e
+            })?;
 
         // Pre-allocate CUDA events for layer-wise operations (onboarding and offloading)
         let num_layers = self


### PR DESCRIPTION
Log the full error chain when complete_initialization fails on the worker side and when the leader receives the failure. Also log the requested G2/G3 allocation size before attempting memory allocation.

Previously, failures during worker init produced only "Failed to initialize worker 0" with no indication of the root cause.

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
