### PR TITLE
fix: clean up onboarding sessions when cancelled before committed

### DIFF
--- a/lib/kvbm-connector/src/connector/leader/finish.rs
+++ b/lib/kvbm-connector/src/connector/leader/finish.rs
@@ -4,15 +4,27 @@
 use kvbm_engine::offload::{TransferHandle, TransferStatus};
 
 use super::*;
+use slot::OnboardingState;
 
 impl ConnectorLeader {
     /// Mark a request as finished, returning the status.
     ///
-    /// This method:
-    /// 1. Marks the slot for deletion
-    /// 2. If there's an OffloadingState, takes it and checks all transfer handles
-    /// 3. If all handles are complete, returns Finished immediately
-    /// 4. If any handles are incomplete, spawns a cleanup task and returns Pending
+    /// Dispatches on the slot's current `TransactionState`:
+    /// - `Inactive`: the request has no outstanding work; the slot is removed
+    ///   synchronously and `Finished` is returned.
+    /// - `PreparingToOnboard`: the request was cancelled mid-search, before
+    ///   onboarding was committed to the scheduler or the workers. The
+    ///   `OnboardingState` is extracted, the slot is removed synchronously,
+    ///   and a fire-and-forget task drains every shard's find session and
+    ///   releases it. No worker callbacks are emitted because no worker ever
+    ///   learned about this request. Returns `Finished`.
+    /// - `Offloading`: outstanding offload handles must complete before
+    ///   workers can be signalled. If all handles are already complete the
+    ///   slot is removed and `Finished` is returned; otherwise a cleanup
+    ///   task is spawned, `mark_offloading_complete` will be issued on
+    ///   completion, and `Pending` is returned.
+    /// - `Onboarding` / `Error`: not handled in this path yet; the caller
+    ///   sees the pre-existing log-only behaviour.
     #[tracing::instrument(level = "debug", skip(self), fields(?request_id), ret)]
     pub fn request_finished(&self, request_id: &str) -> FinishedStatus {
         tracing::debug!("evaluating finished status");
@@ -22,6 +34,31 @@ impl ConnectorLeader {
         };
 
         let mut slot = shared_slot.lock();
+
+        // Cancel path: request is finished while still in PreparingToOnboard.
+        // No worker callback will ever arrive (scheduler never committed), so we
+        // own the whole cleanup here — remove the slot synchronously and hand
+        // the OnboardingState to a background task for session release.
+        if matches!(slot.txn_state(), TransactionState::PreparingToOnboard(_)) {
+            match slot.txn_take_preparing_to_onboard() {
+                Ok(onboarding_state) => {
+                    drop(slot);
+                    self.remove_slot(request_id);
+                    self.spawn_preparing_to_onboard_cleanup(request_id, onboarding_state);
+                    return FinishedStatus::Finished;
+                }
+                Err(e) => {
+                    // txn_state() said PreparingToOnboard, so this branch should
+                    // be unreachable. Fall through to the legacy path (which
+                    // will log and return Pending) rather than panicking.
+                    tracing::error!(
+                        "Failed to take PreparingToOnboard state for request ID {}: {}",
+                        request_id,
+                        e
+                    );
+                }
+            }
+        }
 
         // Mark the slot for deletion
         let initial_status = slot.slot_mark_finished();
@@ -141,6 +178,37 @@ impl ConnectorLeader {
         }
 
         Ok(())
+    }
+
+    /// Spawn a fire-and-forget task that drains the find sessions of a
+    /// cancelled-in-`PreparingToOnboard` request and releases each one.
+    ///
+    /// The caller must have already removed the slot from the map and taken
+    /// ownership of the `OnboardingState`; this function only touches the
+    /// extracted state and the `InstanceLeader`.
+    fn spawn_preparing_to_onboard_cleanup(
+        &self,
+        request_id: &str,
+        onboarding_state: OnboardingState,
+    ) {
+        let Some(instance_leader) = self.instance_leader.get().cloned() else {
+            // InstanceLeader is set during worker initialization, well before
+            // any request reaches PreparingToOnboard. If it is missing we have
+            // a serious lifecycle bug — log and drop the state (RAII releases
+            // Ready shards; AsyncSession server-side state will be cleaned up
+            // when the leader shuts down).
+            tracing::error!(
+                "InstanceLeader not available; dropping OnboardingState without releasing sessions for request_id: {}",
+                request_id
+            );
+            return;
+        };
+
+        let request_id_owned = request_id.to_string();
+        self.runtime.tokio().spawn(async move {
+            cleanup_preparing_to_onboard(onboarding_state, instance_leader, request_id_owned)
+                .await;
+        });
     }
 
     fn remove_slot(&self, request_id: &str) {
@@ -290,5 +358,73 @@ async fn cleanup_offloading_handles(mut handles: Vec<TransferHandle>, request_id
         "cleanup complete for {} transfer handles for request_id: {}",
         handles.len(),
         request_id
+    );
+}
+
+/// Async cleanup task for a request cancelled while in `PreparingToOnboard`.
+///
+/// Each shard's find session is driven to a terminal state before its
+/// server-side state is released. `FindMatchesResult::Ready` variants resolve
+/// immediately (blocks are held via RAII and will be dropped when the state
+/// falls out of scope at the end of this task); `AsyncSession` variants await
+/// `wait_for_completion` — already-terminal sessions complete on first poll,
+/// and in-flight sessions drain naturally. A session-drain error is logged
+/// but the task still attempts to release the session, because leaving the
+/// leader-side session state mapped would be worse than a failed RPC.
+///
+/// Shards are drained concurrently via `join_all` so that ready / already-
+/// terminal shards free their resources immediately without waiting on the
+/// slowest in-flight shard.
+///
+/// No worker callback (`mark_onboarding_complete` / `mark_failed_onboarding` /
+/// `mark_offloading_complete`) is emitted — the scheduler never committed
+/// this request, so no worker ever learned about it.
+async fn cleanup_preparing_to_onboard(
+    onboarding_state: OnboardingState,
+    instance_leader: InstanceLeader,
+    request_id: String,
+) {
+    let shard_count = onboarding_state.shards.len();
+    tracing::debug!(
+        "starting PreparingToOnboard cleanup of {} shard(s) for request_id: {}",
+        shard_count,
+        request_id
+    );
+
+    let drain_futures = onboarding_state
+        .shards
+        .iter()
+        .map(|shard| {
+            let wait = shard.find_session.wait_for_completion();
+            let session_id = shard.find_session.session_id();
+            let instance_leader = instance_leader.clone();
+            let request_id = request_id.clone();
+            async move {
+                if let Err(e) = wait.await {
+                    tracing::warn!(
+                        "find_session drain failed for request_id {} (session {:?}): {}; \
+                         releasing session anyway",
+                        request_id,
+                        session_id,
+                        e
+                    );
+                }
+                if let Some(session_id) = session_id {
+                    instance_leader.release_session(session_id);
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    futures::future::join_all(drain_futures).await;
+
+    // Dropping `onboarding_state` here releases any `Ready`-variant blocks
+    // held by RAII.
+    drop(onboarding_state);
+
+    tracing::debug!(
+        "PreparingToOnboard cleanup complete for request_id: {} ({} shard(s))",
+        request_id,
+        shard_count
     );
 }

--- a/lib/kvbm-connector/src/connector/leader/finish.rs
+++ b/lib/kvbm-connector/src/connector/leader/finish.rs
@@ -206,8 +206,7 @@ impl ConnectorLeader {
 
         let request_id_owned = request_id.to_string();
         self.runtime.tokio().spawn(async move {
-            cleanup_preparing_to_onboard(onboarding_state, instance_leader, request_id_owned)
-                .await;
+            cleanup_preparing_to_onboard(onboarding_state, instance_leader, request_id_owned).await;
         });
     }
 
@@ -363,18 +362,13 @@ async fn cleanup_offloading_handles(mut handles: Vec<TransferHandle>, request_id
 
 /// Async cleanup task for a request cancelled while in `PreparingToOnboard`.
 ///
-/// Each shard's find session is driven to a terminal state before its
-/// server-side state is released. `FindMatchesResult::Ready` variants resolve
-/// immediately (blocks are held via RAII and will be dropped when the state
-/// falls out of scope at the end of this task); `AsyncSession` variants await
-/// `wait_for_completion` — already-terminal sessions complete on first poll,
-/// and in-flight sessions drain naturally. A session-drain error is logged
-/// but the task still attempts to release the session, because leaving the
-/// leader-side session state mapped would be worse than a failed RPC.
-///
-/// Shards are drained concurrently via `join_all` so that ready / already-
-/// terminal shards free their resources immediately without waiting on the
-/// slowest in-flight shard.
+/// The find session is driven to a terminal state before its server-side
+/// state is released. `FindMatchesResult::Ready` resolves immediately (blocks
+/// are held via RAII and drop when `onboarding_state` falls out of scope);
+/// `AsyncSession` awaits `wait_for_completion` — already-terminal sessions
+/// complete on first poll and in-flight sessions drain naturally. A drain
+/// error is logged but the task still attempts `release_session`, because
+/// leaving the leader-side session state mapped is worse than a failed RPC.
 ///
 /// No worker callback (`mark_onboarding_complete` / `mark_failed_onboarding` /
 /// `mark_offloading_complete`) is emitted — the scheduler never committed
@@ -384,48 +378,35 @@ async fn cleanup_preparing_to_onboard(
     instance_leader: InstanceLeader,
     request_id: String,
 ) {
-    let shard_count = onboarding_state.shards.len();
+    let session_id = onboarding_state.find_session.session_id();
+    let wait = onboarding_state.find_session.wait_for_completion();
+
     tracing::debug!(
-        "starting PreparingToOnboard cleanup of {} shard(s) for request_id: {}",
-        shard_count,
-        request_id
+        "starting PreparingToOnboard cleanup for request_id: {} (session: {:?})",
+        request_id,
+        session_id
     );
 
-    let drain_futures = onboarding_state
-        .shards
-        .iter()
-        .map(|shard| {
-            let wait = shard.find_session.wait_for_completion();
-            let session_id = shard.find_session.session_id();
-            let instance_leader = instance_leader.clone();
-            let request_id = request_id.clone();
-            async move {
-                if let Err(e) = wait.await {
-                    tracing::warn!(
-                        "find_session drain failed for request_id {} (session {:?}): {}; \
-                         releasing session anyway",
-                        request_id,
-                        session_id,
-                        e
-                    );
-                }
-                if let Some(session_id) = session_id {
-                    instance_leader.release_session(session_id);
-                }
-            }
-        })
-        .collect::<Vec<_>>();
-
-    futures::future::join_all(drain_futures).await;
+    if let Err(e) = wait.await {
+        tracing::warn!(
+            "find_session drain failed for request_id {} (session {:?}): {}; \
+             releasing session anyway",
+            request_id,
+            session_id,
+            e
+        );
+    }
+    if let Some(session_id) = session_id {
+        instance_leader.release_session(session_id);
+    }
 
     // Dropping `onboarding_state` here releases any `Ready`-variant blocks
     // held by RAII.
     drop(onboarding_state);
 
     tracing::debug!(
-        "PreparingToOnboard cleanup complete for request_id: {} ({} shard(s))",
-        request_id,
-        shard_count
+        "PreparingToOnboard cleanup complete for request_id: {}",
+        request_id
     );
 }
 
@@ -433,26 +414,22 @@ async fn cleanup_preparing_to_onboard(
 mod cleanup_tests {
     //! Unit tests for `cleanup_preparing_to_onboard`.
     //!
-    //! These cover the observable contract of the cancel-path cleanup task:
-    //! - every `AsyncSession` shard has its session released via
-    //!   `InstanceLeader::release_session`,
-    //! - `Ready` shards are dropped via RAII (no extra release call),
-    //! - non-terminal `AsyncSession` shards block release until they become
-    //!   terminal,
-    //! - shards drain concurrently via `join_all`,
+    //! Covered:
+    //! - `AsyncSession` find session → `InstanceLeader::release_session`,
+    //! - `Ready` find session → no `release_session` call (RAII only),
+    //! - non-terminal `AsyncSession` blocks release until terminal,
     //! - sessions unrelated to the state are left alone.
     //!
-    //! Observability is via the `#[cfg(any(test, feature = "testing"))]`
-    //! `has_session` accessor on `InstanceLeader` — `release_session` removes
-    //! from all three internal session maps; `has_session` returns `true` if
-    //! any of them still sees the id.
+    //! Observability: `release_session` removes from all three internal
+    //! session maps; the `#[cfg(any(test, feature = "testing"))]` `has_session`
+    //! accessor on `InstanceLeader` returns `true` if any still sees the id.
     use super::*;
     use kvbm_engine::leader::{
         AsyncSessionResult, FindMatchesResult, MatchBreakdown, OnboardingStatus, ReadyResult,
         SessionId,
     };
     use kvbm_engine::testing::{managers, messenger};
-    use slot::{OnboardingShard, OnboardingState};
+    use slot::OnboardingState;
     use std::time::Duration;
     use tokio::sync::{Mutex as TokioMutex, watch};
     use uuid::Uuid;
@@ -462,8 +439,6 @@ mod cleanup_tests {
     const TEST_BLOCK_COUNT: usize = 8;
     const TEST_BLOCK_SIZE: usize = 4;
 
-    /// Build a minimal `InstanceLeader` backed by a local TCP messenger. No
-    /// handlers are registered — the tests only touch the session maps.
     async fn build_leader() -> InstanceLeader {
         let m = messenger::create_messenger_tcp()
             .await
@@ -485,7 +460,6 @@ mod cleanup_tests {
             .expect("instance leader")
     }
 
-    /// A terminal `AsyncSession` (status = Complete) with a known session_id.
     fn complete_async(session_id: SessionId) -> FindMatchesResult {
         let (status_tx, status_rx) =
             watch::channel(OnboardingStatus::Complete { matched_blocks: 0 });
@@ -499,8 +473,6 @@ mod cleanup_tests {
         ))
     }
 
-    /// A pending `AsyncSession` (status = Searching) with a known session_id.
-    /// Returns the shard and the watch sender so the test can drive it terminal.
     fn pending_async(
         session_id: SessionId,
     ) -> (FindMatchesResult, watch::Sender<OnboardingStatus>) {
@@ -515,42 +487,22 @@ mod cleanup_tests {
         (FindMatchesResult::AsyncSession(session), status_tx)
     }
 
-    /// A `Ready` shard with no blocks — no session_id, RAII-only release.
     fn ready_empty() -> FindMatchesResult {
         FindMatchesResult::Ready(ReadyResult::new(vec![], MatchBreakdown::default()))
     }
 
-    /// Build an `OnboardingState` from a list of shards, numbering them
-    /// contiguously starting at block 0 with `num_queried_blocks = 1` each.
-    fn state_from(shards: Vec<FindMatchesResult>) -> OnboardingState {
-        assert!(!shards.is_empty());
-        let mut it = shards.into_iter().enumerate();
-        let (i0, first) = it.next().unwrap();
-        let mut state = OnboardingState::new(
-            0,
-            0,
-            OnboardingShard {
-                start_block: i0,
-                num_queried_blocks: 1,
-                find_session: first,
-            },
-        );
-        for (i, find_session) in it {
-            state.shards.push(OnboardingShard {
-                start_block: i,
-                num_queried_blocks: 1,
-                find_session,
-            });
+    fn state_with(find_session: FindMatchesResult) -> OnboardingState {
+        OnboardingState {
+            num_computed_tokens: 0,
+            find_session,
         }
-        state
     }
 
     fn fresh_id() -> SessionId {
         Uuid::new_v4()
     }
 
-    /// Test 1 — a single terminal `AsyncSession` shard: cleanup must release
-    /// the session.
+    /// Terminal `AsyncSession`: cleanup must call `release_session`.
     #[tokio::test]
     async fn cleanup_releases_async_session() {
         let leader = build_leader().await;
@@ -558,37 +510,34 @@ mod cleanup_tests {
         leader.insert_test_session_marker(sid);
         assert!(leader.has_session(sid));
 
-        let state = state_from(vec![complete_async(sid)]);
+        let state = state_with(complete_async(sid));
         cleanup_preparing_to_onboard(state, leader.clone(), "r1".into()).await;
 
         assert!(
             !leader.has_session(sid),
-            "cleanup must release AsyncSession shards"
+            "cleanup must release the AsyncSession's server-side state"
         );
     }
 
-    /// Test 2 — mixed shards: `Ready` shard needs no session call; the
-    /// `AsyncSession` shard is released; an unrelated session is untouched.
+    /// `Ready` find session: no session_id, so no `release_session` call; an
+    /// unrelated registered session must remain.
     #[tokio::test]
-    async fn cleanup_skips_ready_shards_and_scoped_to_state() {
+    async fn cleanup_ready_session_is_noop_and_scoped() {
         let leader = build_leader().await;
-        let sid = fresh_id();
         let unrelated = fresh_id();
-        leader.insert_test_session_marker(sid);
         leader.insert_test_session_marker(unrelated);
 
-        let state = state_from(vec![ready_empty(), complete_async(sid)]);
+        let state = state_with(ready_empty());
         cleanup_preparing_to_onboard(state, leader.clone(), "r2".into()).await;
 
-        assert!(!leader.has_session(sid), "AsyncSession shard must release");
         assert!(
             leader.has_session(unrelated),
             "cleanup must not touch sessions outside the OnboardingState"
         );
     }
 
-    /// Test 3 — a non-terminal `AsyncSession` shard blocks cleanup until the
-    /// status transitions to a terminal state, then releases.
+    /// Non-terminal `AsyncSession` blocks `release_session` until the status
+    /// reaches a terminal state.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cleanup_drains_pending_async_before_release() {
         let leader = build_leader().await;
@@ -596,22 +545,23 @@ mod cleanup_tests {
         leader.insert_test_session_marker(sid);
 
         let (find, status_tx) = pending_async(sid);
-        let state = state_from(vec![find]);
+        let state = state_with(find);
 
         let leader_for_task = leader.clone();
-        let task =
-            tokio::spawn(cleanup_preparing_to_onboard(state, leader_for_task, "r3".into()));
+        let task = tokio::spawn(cleanup_preparing_to_onboard(
+            state,
+            leader_for_task,
+            "r3".into(),
+        ));
 
         // With status still Searching, cleanup is blocked on wait_for_completion.
-        // Give it a tick to ensure it has polled.
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert!(
             leader.has_session(sid),
-            "cleanup must wait for AsyncSession to reach terminal status before releasing"
+            "cleanup must wait for terminal status before releasing"
         );
         assert!(!task.is_finished(), "cleanup task should still be pending");
 
-        // Transition the session to terminal; cleanup should complete and release.
         status_tx
             .send(OnboardingStatus::Complete { matched_blocks: 0 })
             .expect("send terminal status");
@@ -619,48 +569,7 @@ mod cleanup_tests {
 
         assert!(
             !leader.has_session(sid),
-            "cleanup must release after status reaches terminal"
+            "cleanup must release once the status reaches terminal"
         );
-    }
-
-    /// Test 4 — `join_all` drains shards concurrently: a terminal shard does
-    /// not wait for a pending sibling.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn cleanup_drains_concurrently() {
-        let leader = build_leader().await;
-        let terminal_id = fresh_id();
-        let pending_id = fresh_id();
-        leader.insert_test_session_marker(terminal_id);
-        leader.insert_test_session_marker(pending_id);
-
-        let (pending_find, status_tx) = pending_async(pending_id);
-        let state = state_from(vec![complete_async(terminal_id), pending_find]);
-
-        let leader_for_task = leader.clone();
-        let task = tokio::spawn(cleanup_preparing_to_onboard(
-            state,
-            leader_for_task,
-            "r4".into(),
-        ));
-
-        // Drive the test runtime so the terminal shard's release_session can
-        // land even though the pending shard is still blocked.
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        assert!(
-            !leader.has_session(terminal_id),
-            "terminal shard must be released before the pending shard transitions"
-        );
-        assert!(
-            leader.has_session(pending_id),
-            "pending shard must still be registered while its find session is non-terminal"
-        );
-        assert!(!task.is_finished());
-
-        status_tx
-            .send(OnboardingStatus::Complete { matched_blocks: 0 })
-            .expect("send terminal status");
-        task.await.expect("cleanup task");
-
-        assert!(!leader.has_session(pending_id));
     }
 }

--- a/lib/kvbm-connector/src/connector/leader/finish.rs
+++ b/lib/kvbm-connector/src/connector/leader/finish.rs
@@ -42,6 +42,12 @@ impl ConnectorLeader {
         if matches!(slot.txn_state(), TransactionState::PreparingToOnboard(_)) {
             match slot.txn_take_preparing_to_onboard() {
                 Ok(onboarding_state) => {
+                    // Stamp MarkedForDeletion into the shared RequestSlot before
+                    // releasing the lock. Any Arc holder that locks this slot
+                    // afterwards will see the guard and reject new transactions
+                    // (all txn_start_* methods check is_marked_for_deletion()).
+                    // Matches the Offloading branch pattern below.
+                    let _ = slot.slot_mark_finished();
                     drop(slot);
                     self.remove_slot(request_id);
                     self.spawn_preparing_to_onboard_cleanup(request_id, onboarding_state);

--- a/lib/kvbm-connector/src/connector/leader/finish.rs
+++ b/lib/kvbm-connector/src/connector/leader/finish.rs
@@ -428,3 +428,239 @@ async fn cleanup_preparing_to_onboard(
         shard_count
     );
 }
+
+#[cfg(all(test, feature = "testing"))]
+mod cleanup_tests {
+    //! Unit tests for `cleanup_preparing_to_onboard`.
+    //!
+    //! These cover the observable contract of the cancel-path cleanup task:
+    //! - every `AsyncSession` shard has its session released via
+    //!   `InstanceLeader::release_session`,
+    //! - `Ready` shards are dropped via RAII (no extra release call),
+    //! - non-terminal `AsyncSession` shards block release until they become
+    //!   terminal,
+    //! - shards drain concurrently via `join_all`,
+    //! - sessions unrelated to the state are left alone.
+    //!
+    //! Observability is via the `#[cfg(any(test, feature = "testing"))]`
+    //! `has_session` accessor on `InstanceLeader` — `release_session` removes
+    //! from all three internal session maps; `has_session` returns `true` if
+    //! any of them still sees the id.
+    use super::*;
+    use kvbm_engine::leader::{
+        AsyncSessionResult, FindMatchesResult, MatchBreakdown, OnboardingStatus, ReadyResult,
+        SessionId,
+    };
+    use kvbm_engine::testing::{managers, messenger};
+    use slot::{OnboardingShard, OnboardingState};
+    use std::time::Duration;
+    use tokio::sync::{Mutex as TokioMutex, watch};
+    use uuid::Uuid;
+
+    use crate::G2;
+
+    const TEST_BLOCK_COUNT: usize = 8;
+    const TEST_BLOCK_SIZE: usize = 4;
+
+    /// Build a minimal `InstanceLeader` backed by a local TCP messenger. No
+    /// handlers are registered — the tests only touch the session maps.
+    async fn build_leader() -> InstanceLeader {
+        let m = messenger::create_messenger_tcp()
+            .await
+            .expect("tcp messenger");
+        let registry = managers::TestRegistryBuilder::new().build();
+        let g2 = Arc::new(
+            managers::TestManagerBuilder::<G2>::new()
+                .block_count(TEST_BLOCK_COUNT)
+                .block_size(TEST_BLOCK_SIZE)
+                .registry(registry.clone())
+                .build(),
+        );
+        InstanceLeader::builder()
+            .messenger(m)
+            .registry(registry)
+            .g2_manager(g2)
+            .workers(vec![])
+            .build()
+            .expect("instance leader")
+    }
+
+    /// A terminal `AsyncSession` (status = Complete) with a known session_id.
+    fn complete_async(session_id: SessionId) -> FindMatchesResult {
+        let (status_tx, status_rx) =
+            watch::channel(OnboardingStatus::Complete { matched_blocks: 0 });
+        drop(status_tx);
+        FindMatchesResult::AsyncSession(AsyncSessionResult::new(
+            session_id,
+            status_rx,
+            Arc::new(TokioMutex::new(Some(Vec::new()))),
+            Arc::new(TokioMutex::new(MatchBreakdown::default())),
+            None,
+        ))
+    }
+
+    /// A pending `AsyncSession` (status = Searching) with a known session_id.
+    /// Returns the shard and the watch sender so the test can drive it terminal.
+    fn pending_async(
+        session_id: SessionId,
+    ) -> (FindMatchesResult, watch::Sender<OnboardingStatus>) {
+        let (status_tx, status_rx) = watch::channel(OnboardingStatus::Searching);
+        let session = AsyncSessionResult::new(
+            session_id,
+            status_rx,
+            Arc::new(TokioMutex::new(None)),
+            Arc::new(TokioMutex::new(MatchBreakdown::default())),
+            None,
+        );
+        (FindMatchesResult::AsyncSession(session), status_tx)
+    }
+
+    /// A `Ready` shard with no blocks — no session_id, RAII-only release.
+    fn ready_empty() -> FindMatchesResult {
+        FindMatchesResult::Ready(ReadyResult::new(vec![], MatchBreakdown::default()))
+    }
+
+    /// Build an `OnboardingState` from a list of shards, numbering them
+    /// contiguously starting at block 0 with `num_queried_blocks = 1` each.
+    fn state_from(shards: Vec<FindMatchesResult>) -> OnboardingState {
+        assert!(!shards.is_empty());
+        let mut it = shards.into_iter().enumerate();
+        let (i0, first) = it.next().unwrap();
+        let mut state = OnboardingState::new(
+            0,
+            0,
+            OnboardingShard {
+                start_block: i0,
+                num_queried_blocks: 1,
+                find_session: first,
+            },
+        );
+        for (i, find_session) in it {
+            state.shards.push(OnboardingShard {
+                start_block: i,
+                num_queried_blocks: 1,
+                find_session,
+            });
+        }
+        state
+    }
+
+    fn fresh_id() -> SessionId {
+        Uuid::new_v4()
+    }
+
+    /// Test 1 — a single terminal `AsyncSession` shard: cleanup must release
+    /// the session.
+    #[tokio::test]
+    async fn cleanup_releases_async_session() {
+        let leader = build_leader().await;
+        let sid = fresh_id();
+        leader.insert_test_session_marker(sid);
+        assert!(leader.has_session(sid));
+
+        let state = state_from(vec![complete_async(sid)]);
+        cleanup_preparing_to_onboard(state, leader.clone(), "r1".into()).await;
+
+        assert!(
+            !leader.has_session(sid),
+            "cleanup must release AsyncSession shards"
+        );
+    }
+
+    /// Test 2 — mixed shards: `Ready` shard needs no session call; the
+    /// `AsyncSession` shard is released; an unrelated session is untouched.
+    #[tokio::test]
+    async fn cleanup_skips_ready_shards_and_scoped_to_state() {
+        let leader = build_leader().await;
+        let sid = fresh_id();
+        let unrelated = fresh_id();
+        leader.insert_test_session_marker(sid);
+        leader.insert_test_session_marker(unrelated);
+
+        let state = state_from(vec![ready_empty(), complete_async(sid)]);
+        cleanup_preparing_to_onboard(state, leader.clone(), "r2".into()).await;
+
+        assert!(!leader.has_session(sid), "AsyncSession shard must release");
+        assert!(
+            leader.has_session(unrelated),
+            "cleanup must not touch sessions outside the OnboardingState"
+        );
+    }
+
+    /// Test 3 — a non-terminal `AsyncSession` shard blocks cleanup until the
+    /// status transitions to a terminal state, then releases.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cleanup_drains_pending_async_before_release() {
+        let leader = build_leader().await;
+        let sid = fresh_id();
+        leader.insert_test_session_marker(sid);
+
+        let (find, status_tx) = pending_async(sid);
+        let state = state_from(vec![find]);
+
+        let leader_for_task = leader.clone();
+        let task =
+            tokio::spawn(cleanup_preparing_to_onboard(state, leader_for_task, "r3".into()));
+
+        // With status still Searching, cleanup is blocked on wait_for_completion.
+        // Give it a tick to ensure it has polled.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            leader.has_session(sid),
+            "cleanup must wait for AsyncSession to reach terminal status before releasing"
+        );
+        assert!(!task.is_finished(), "cleanup task should still be pending");
+
+        // Transition the session to terminal; cleanup should complete and release.
+        status_tx
+            .send(OnboardingStatus::Complete { matched_blocks: 0 })
+            .expect("send terminal status");
+        task.await.expect("cleanup task");
+
+        assert!(
+            !leader.has_session(sid),
+            "cleanup must release after status reaches terminal"
+        );
+    }
+
+    /// Test 4 — `join_all` drains shards concurrently: a terminal shard does
+    /// not wait for a pending sibling.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cleanup_drains_concurrently() {
+        let leader = build_leader().await;
+        let terminal_id = fresh_id();
+        let pending_id = fresh_id();
+        leader.insert_test_session_marker(terminal_id);
+        leader.insert_test_session_marker(pending_id);
+
+        let (pending_find, status_tx) = pending_async(pending_id);
+        let state = state_from(vec![complete_async(terminal_id), pending_find]);
+
+        let leader_for_task = leader.clone();
+        let task = tokio::spawn(cleanup_preparing_to_onboard(
+            state,
+            leader_for_task,
+            "r4".into(),
+        ));
+
+        // Drive the test runtime so the terminal shard's release_session can
+        // land even though the pending shard is still blocked.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !leader.has_session(terminal_id),
+            "terminal shard must be released before the pending shard transitions"
+        );
+        assert!(
+            leader.has_session(pending_id),
+            "pending shard must still be registered while its find session is non-terminal"
+        );
+        assert!(!task.is_finished());
+
+        status_tx
+            .send(OnboardingStatus::Complete { matched_blocks: 0 })
+            .expect("send terminal status");
+        task.await.expect("cleanup task");
+
+        assert!(!leader.has_session(pending_id));
+    }
+}

--- a/lib/kvbm-connector/src/connector/leader/slot.rs
+++ b/lib/kvbm-connector/src/connector/leader/slot.rs
@@ -285,6 +285,33 @@ impl SlotStateMachine {
         }
     }
 
+    /// Take the onboarding state out of `PreparingToOnboard`, transitioning to Inactive.
+    ///
+    /// Used by the cancel path: a request may be finished while we are still
+    /// searching/staging, before `txn_start_onboarding` has run. In that case
+    /// we need to extract the `OnboardingState` so the caller can drain the
+    /// find sessions and release them — no worker callback will arrive,
+    /// because the scheduler never committed the request.
+    fn txn_take_preparing_to_onboard(
+        &mut self,
+    ) -> Result<OnboardingState, StateTransitionError> {
+        let current = std::mem::replace(&mut self.txn_state, TransactionState::Inactive);
+
+        match current {
+            TransactionState::PreparingToOnboard(state) => {
+                self.txn_to_inactive();
+                Ok(state)
+            }
+            other => {
+                self.txn_state = other;
+                Err(StateTransitionError::InvalidTransition {
+                    from: self.txn_state.name(),
+                    to: "Inactive (via take_preparing_to_onboard)",
+                })
+            }
+        }
+    }
+
     /// Begin offloading blocks to remote storage.
     ///
     /// Only valid from `Inactive` state. Takes ownership of the offloading state.
@@ -844,6 +871,16 @@ impl RequestSlot {
     /// Returns the `OnboardingState` containing the session ID and find session.
     pub fn txn_take_onboarding(&mut self) -> Result<OnboardingState, StateTransitionError> {
         self.state.txn_take_onboarding()
+    }
+
+    /// Take the onboarding state out of `PreparingToOnboard`, transitioning to Inactive.
+    ///
+    /// Used by the cancel path in `request_finished` when a request is
+    /// finished before `txn_start_onboarding` has run.
+    pub fn txn_take_preparing_to_onboard(
+        &mut self,
+    ) -> Result<OnboardingState, StateTransitionError> {
+        self.state.txn_take_preparing_to_onboard()
     }
 
     /// Begin offloading blocks to remote storage.
@@ -2483,6 +2520,95 @@ mod tests {
                 result.unwrap_err(),
                 StateTransitionError::InvalidTransition { .. }
             ));
+        }
+
+        // =========================================================================
+        // Transaction State Transition Tests - PreparingToOnboard Cancel Path
+        // =========================================================================
+
+        #[test]
+        fn test_txn_take_preparing_to_onboard_from_preparing_succeeds() {
+            let mut slot = create_test_slot();
+            let (num_computed_tokens, find_session) = create_mock_onboarding_state();
+
+            // Setup: Inactive -> PreparingToOnboard
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
+                .unwrap();
+            assert!(matches!(
+                slot.txn_state(),
+                TransactionState::PreparingToOnboard(_)
+            ));
+
+            // Take the PreparingToOnboard state
+            let result = slot.txn_take_preparing_to_onboard();
+            assert!(result.is_ok());
+
+            let state = result.unwrap();
+            assert_eq!(state.num_computed_tokens, 100);
+
+            // Verify we're back to Inactive
+            assert!(slot.txn_state().is_inactive());
+        }
+
+        #[test]
+        fn test_txn_take_preparing_to_onboard_from_inactive_fails() {
+            let mut slot = create_test_slot();
+
+            // Try from Inactive - should fail
+            let result = slot.txn_take_preparing_to_onboard();
+
+            assert!(result.is_err());
+            assert!(matches!(
+                result.unwrap_err(),
+                StateTransitionError::InvalidTransition { .. }
+            ));
+        }
+
+        #[test]
+        fn test_txn_take_preparing_to_onboard_from_onboarding_fails() {
+            let mut slot = create_test_slot();
+            let (num_computed_tokens, find_session) = create_mock_onboarding_state();
+
+            // Setup: Inactive -> PreparingToOnboard -> Onboarding
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
+                .unwrap();
+            slot.txn_start_onboarding().unwrap();
+
+            // Try from Onboarding - should fail; Onboarding must go through
+            // txn_take_onboarding, not txn_take_preparing_to_onboard.
+            let result = slot.txn_take_preparing_to_onboard();
+
+            assert!(result.is_err());
+            assert!(matches!(
+                result.unwrap_err(),
+                StateTransitionError::InvalidTransition { .. }
+            ));
+
+            // State is preserved on failed transition
+            assert!(matches!(slot.txn_state(), TransactionState::Onboarding(_)));
+        }
+
+        #[test]
+        fn test_txn_take_preparing_to_onboard_side_effect_when_marked() {
+            let mut slot = create_test_slot();
+            let (num_computed_tokens, find_session) = create_mock_onboarding_state();
+
+            // Setup: Inactive -> PreparingToOnboard
+            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
+                .unwrap();
+
+            // Mark for deletion — this is the cancel path in request_finished.
+            let status = slot.slot_mark_finished();
+            assert_eq!(status, FinishedStatus::Pending);
+
+            // Take the state
+            let _ = slot.txn_take_preparing_to_onboard().unwrap();
+
+            // Slot stays marked for deletion; txn_to_inactive advanced the
+            // slot_state to NotifyWorkersToFinish (same side effect as the
+            // other take_* methods).
+            assert!(slot.is_marked_for_deletion());
+            assert!(slot.txn_state().is_inactive());
         }
 
         // =========================================================================

--- a/lib/kvbm-connector/src/connector/leader/slot.rs
+++ b/lib/kvbm-connector/src/connector/leader/slot.rs
@@ -292,9 +292,7 @@ impl SlotStateMachine {
     /// we need to extract the `OnboardingState` so the caller can drain the
     /// find sessions and release them — no worker callback will arrive,
     /// because the scheduler never committed the request.
-    fn txn_take_preparing_to_onboard(
-        &mut self,
-    ) -> Result<OnboardingState, StateTransitionError> {
+    fn txn_take_preparing_to_onboard(&mut self) -> Result<OnboardingState, StateTransitionError> {
         let current = std::mem::replace(&mut self.txn_state, TransactionState::Inactive);
 
         match current {
@@ -2532,7 +2530,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // Setup: Inactive -> PreparingToOnboard
-            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
                 .unwrap();
             assert!(matches!(
                 slot.txn_state(),
@@ -2570,7 +2568,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // Setup: Inactive -> PreparingToOnboard -> Onboarding
-            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
                 .unwrap();
             slot.txn_start_onboarding().unwrap();
 
@@ -2594,7 +2592,7 @@ mod tests {
             let (num_computed_tokens, find_session) = create_mock_onboarding_state();
 
             // Setup: Inactive -> PreparingToOnboard
-            slot.txn_prepare_to_onboard_legacy(num_computed_tokens, find_session)
+            slot.txn_prepare_to_onboard(num_computed_tokens, find_session)
                 .unwrap();
 
             // Mark for deletion — this is the cancel path in request_finished.

--- a/lib/kvbm-engine/src/leader/instance.rs
+++ b/lib/kvbm-engine/src/leader/instance.rs
@@ -607,6 +607,24 @@ impl InstanceLeader {
         self.session_sessions.remove(&session_id);
     }
 
+    /// Test-only: is `session_id` registered in any of the three session maps?
+    #[cfg(any(test, feature = "testing"))]
+    pub fn has_session(&self, session_id: SessionId) -> bool {
+        self.sessions.contains_key(&session_id)
+            || self.session_states.contains_key(&session_id)
+            || self.session_sessions.contains_key(&session_id)
+    }
+
+    /// Test-only: insert a sentinel entry into `sessions` so a test can verify
+    /// that `release_session` removes it. The channel has capacity 1 and its
+    /// receiver is dropped immediately; the map entry alone is what the test
+    /// observes.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn insert_test_session_marker(&self, session_id: SessionId) {
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        self.sessions.insert(session_id, tx);
+    }
+
     // ========================================================================
     // Inverted Control Pattern (Prefill-Decode) Methods
     // ========================================================================


### PR DESCRIPTION
Closes KVBM-395, KVBM-405

Root cause (one bug): ConnectorLeader::request_finished() in the deployed image (ryan-connector/dynamo @ cheese-head/connector-p0-zerofill, commit f7bb13add2, file lib/kvbm-connector/src/connector/leader/finish.rs) does not handle the case where vLLM terminates a request that is still in PreparingToOnboard / Onboarding. It calls txn_take_offloading() unconditionally, gets StateTransitionError::InvalidTransition, logs an ERROR, and returns Pending — without cancelling the onboarding session or releasing its session_id. The slot, the engine‑side find session, and every G2/G3 block that session had pinned all leak permanently.

Trigger: bench config [2/3] (c=10 n=100) built up a backlog of 10 waiting requests around 15:07:50. The bench client's per‑request 60 s timeout fired at 15:08:46 on 8 of them; vLLM issued request_finished on each → 8 leaked slots with ~2000 pinned blocks.

Why that killed the job:

/reset/g2 does reset_pool.len() == total_blocks; with ~2000 blocks stuck it returned Reset pool count mismatch: expected 203450, got ~202000 on every retry.

The client's clear(…): loop failed for 60 s → FAILED after 1 attempts / 60.1s wall.

SLURM cancelled STEP 644.0 at 2026-04-21T15:09:52.

Meanwhile the server happily spun the scheduler at ~1 kHz (49,714 get_num_new_matched_tokens calls on a single leaked request in ~60 s) — that's why the stderr is 710 MB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for session cleanup and state transition handling.

* **Chores**
  * Enhanced transaction state management with improved cleanup procedures for shard sessions and resource release.
  * Added internal utilities for session tracking and validation during system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->