### PR TITLE
feat(sglang): Enable SGLang for Dynamo Planner

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_sglang_xpu.py
+++ b/components/src/dynamo/profiler/tests/unit/test_sglang_xpu.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for SGLang XPU / set_device_type paths."""
+
+import copy
+
+import pytest
+
+from dynamo.profiler.utils.config_modifiers import CONFIG_MODIFIERS
+from dynamo.profiler.utils.dgdr_v1beta1_types import DeviceType
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.planner,
+    pytest.mark.parallel,
+]
+
+
+def _make_agg_config(
+    *, gpu_count: str = "2", metadata_name: str = "sglang-agg"
+) -> dict:
+    """Return a minimal SGLang aggregated DGD config dict."""
+    return {
+        "apiVersion": "nvidia.com/v1alpha1",
+        "kind": "DynamoGraphDeployment",
+        "metadata": {"name": metadata_name},
+        "spec": {
+            "services": {
+                "Frontend": {
+                    "componentType": "frontend",
+                    "replicas": 1,
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "image": "my-registry/sglang-runtime:my-tag",
+                        }
+                    },
+                },
+                "decode": {
+                    "componentType": "worker",
+                    "replicas": 1,
+                    "resources": {
+                        "limits": {"gpu": gpu_count},
+                        "requests": {"gpu": gpu_count},
+                    },
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "image": "my-registry/sglang-runtime:my-tag",
+                            "args": [
+                                "--model-path",
+                                "Qwen/Qwen3-0.6B",
+                                "--tp",
+                                "1",
+                            ],
+                        }
+                    },
+                },
+            }
+        },
+    }
+
+
+def _make_disagg_config(*, gpu_count: str = "1") -> dict:
+    """Return a minimal SGLang disaggregated DGD config dict with prefill + decode workers."""
+    return {
+        "apiVersion": "nvidia.com/v1alpha1",
+        "kind": "DynamoGraphDeployment",
+        "metadata": {"name": "sglang-disagg"},
+        "spec": {
+            "services": {
+                "Frontend": {
+                    "componentType": "frontend",
+                    "replicas": 1,
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "image": "my-registry/sglang-runtime:my-tag",
+                        }
+                    },
+                },
+                "prefill": {
+                    "componentType": "worker",
+                    "subComponentType": "prefill",
+                    "replicas": 1,
+                    "resources": {
+                        "limits": {"gpu": gpu_count},
+                        "requests": {"gpu": gpu_count},
+                    },
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "image": "my-registry/sglang-runtime:my-tag",
+                            "args": [
+                                "--model-path",
+                                "Qwen/Qwen3-0.6B",
+                                "--tp",
+                                "1",
+                                "--disaggregation-mode",
+                                "prefill",
+                            ],
+                        }
+                    },
+                },
+                "decode": {
+                    "componentType": "worker",
+                    "subComponentType": "decode",
+                    "replicas": 1,
+                    "resources": {
+                        "limits": {"gpu": gpu_count},
+                        "requests": {"gpu": gpu_count},
+                    },
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "image": "my-registry/sglang-runtime:my-tag",
+                            "args": [
+                                "--model-path",
+                                "Qwen/Qwen3-0.6B",
+                                "--tp",
+                                "1",
+                                "--disaggregation-mode",
+                                "decode",
+                            ],
+                        }
+                    },
+                },
+            }
+        },
+    }
+
+
+class TestSetDeviceTypeCudaNoop:
+    """set_device_type is a no-op for CUDA (default) device type."""
+
+    def test_cuda_string_returns_unchanged(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config()
+        original = copy.deepcopy(config)
+        result = modifier.set_device_type(config, "cuda")
+        assert result == original
+
+    def test_cuda_enum_returns_unchanged(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config()
+        original = copy.deepcopy(config)
+        result = modifier.set_device_type(config, DeviceType.Cuda)
+        assert result == original
+
+
+class TestSetDeviceTypeXpu:
+    """set_device_type injects XPU-specific config when device_type is 'xpu'."""
+
+    def test_removes_gpu_resource_limits_and_requests(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config(gpu_count="4")
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        worker = result["spec"]["services"]["decode"]
+        resources = worker.get("resources") or {}
+        limits = resources.get("limits") or {}
+        requests = resources.get("requests") or {}
+        assert "gpu" not in limits
+        assert "gpu" not in requests
+
+    def test_creates_resource_claim_template(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config()
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        rct = result.get("_xpu_resource_claim_template")
+        assert rct is not None
+        assert rct["kind"] == "ResourceClaimTemplate"
+        assert rct["apiVersion"] == "resource.k8s.io/v1"
+
+    def test_template_name_derived_from_metadata(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config(metadata_name="my-sglang-deployment")
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        rct = result["_xpu_resource_claim_template"]
+        assert rct["metadata"]["name"] == "my-sglang-deployment-gpu-template"
+
+        worker = result["spec"]["services"]["decode"]
+        pod_claims = worker["extraPodSpec"]["resourceClaims"]
+        assert any(
+            rc.get("resourceClaimTemplateName") == "my-sglang-deployment-gpu-template"
+            for rc in pod_claims
+        )
+
+    def test_template_name_fallback_without_metadata_name(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config(metadata_name="")
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+        rct = result["_xpu_resource_claim_template"]
+        assert rct["metadata"]["name"] == "gpu-template"
+
+    def test_gpu_count_from_resources(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config(gpu_count="4")
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        rct = result["_xpu_resource_claim_template"]
+        devices = rct["spec"]["spec"]["devices"]["requests"][0]
+        assert devices["exactly"]["count"] == 4
+        assert devices["exactly"]["deviceClassName"] == "gpu.intel.com"
+
+    def test_gpu_count_fallback_when_no_resources(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config()
+        del config["spec"]["services"]["decode"]["resources"]
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        rct = result["_xpu_resource_claim_template"]
+        devices = rct["spec"]["spec"]["devices"]["requests"][0]
+        assert devices["exactly"]["count"] == 1
+
+    def test_gpu_count_inferred_from_tp_arg(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config()
+        del config["spec"]["services"]["decode"]["resources"]
+        config["spec"]["services"]["decode"]["extraPodSpec"]["mainContainer"][
+            "args"
+        ] = [
+            "--model-path",
+            "Qwen/Qwen3-0.6B",
+            "--tp",
+            "8",
+        ]
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        rct = result["_xpu_resource_claim_template"]
+        devices = rct["spec"]["spec"]["devices"]["requests"][0]
+        assert devices["exactly"]["count"] == 8
+
+    def test_gpu_count_inferred_from_tensor_parallel_size(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config()
+        del config["spec"]["services"]["decode"]["resources"]
+        config["spec"]["services"]["decode"]["extraPodSpec"]["mainContainer"][
+            "args"
+        ] = [
+            "--model-path",
+            "Qwen/Qwen3-0.6B",
+            "--tensor-parallel-size",
+            "4",
+        ]
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        rct = result["_xpu_resource_claim_template"]
+        devices = rct["spec"]["spec"]["devices"]["requests"][0]
+        assert devices["exactly"]["count"] == 4
+
+    def test_worker_pod_has_resource_claims(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config()
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        worker = result["spec"]["services"]["decode"]
+        pod_claims = worker["extraPodSpec"]["resourceClaims"]
+        assert any(rc.get("name") == "gpu" for rc in pod_claims)
+        container_resources = worker["extraPodSpec"]["mainContainer"]["resources"]
+        assert any(c.get("name") == "gpu" for c in container_resources["claims"])
+
+    def test_frontend_not_modified(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config()
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        result_frontend = result["spec"]["services"]["Frontend"]
+        fe_container = result_frontend.get("extraPodSpec", {}).get("mainContainer", {})
+        assert "env" not in fe_container or fe_container["env"] is None
+        assert "resourceClaims" not in result_frontend.get("extraPodSpec", {})
+
+    def test_xpu_string_accepted(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config()
+        result = modifier.set_device_type(config, "xpu")
+        assert "_xpu_resource_claim_template" in result
+
+    def test_disagg_both_workers_get_xpu_config(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_disagg_config()
+        result = modifier.set_device_type(config, DeviceType.Xpu)
+
+        for worker_name in ("prefill", "decode"):
+            worker = result["spec"]["services"][worker_name]
+            pod_claims = worker["extraPodSpec"]["resourceClaims"]
+            assert any(
+                rc.get("name") == "gpu" for rc in pod_claims
+            ), f"{worker_name} missing resourceClaim"
+            container_resources = worker["extraPodSpec"]["mainContainer"]["resources"]
+            assert any(
+                c.get("name") == "gpu" for c in container_resources["claims"]
+            ), f"{worker_name} missing container claim"
+
+    def test_idempotent_double_call(self) -> None:
+        modifier = CONFIG_MODIFIERS["sglang"]
+        config = _make_agg_config()
+        result1 = modifier.set_device_type(config, DeviceType.Xpu)
+        result2 = modifier.set_device_type(result1, DeviceType.Xpu)
+
+        worker = result2["spec"]["services"]["decode"]
+        pod_claims = worker["extraPodSpec"]["resourceClaims"]
+        gpu_claims = [rc for rc in pod_claims if rc.get("name") == "gpu"]
+        assert len(gpu_claims) == 1, "GPU resource claim should not be duplicated"

--- a/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
@@ -26,6 +26,7 @@ from dynamo.profiler.utils.defaults import (
     EngineType,
     resolve_deploy_path,
 )
+from dynamo.profiler.utils.dgdr_v1beta1_types import DeviceType
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -62,6 +63,130 @@ class SGLangConfigModifier(BaseConfigModifier):
     def update_image(cls, config, image: str) -> dict:
         """Update container image for all DGD services (frontend, planner, workers)."""
         return update_image(config, image)
+
+    @classmethod
+    def set_device_type(cls, config: dict, device_type: str) -> dict:
+        """Inject XPU-specific configuration when device_type is 'xpu'.
+
+        For NVIDIA CUDA (default), this method is a no-op.
+        For Intel XPU:
+        - Removes generic ``gpu`` resource limits/requests (not used by Intel DRA).
+        - Adds a ``ResourceClaimTemplate`` for Intel DRA (``gpu.intel.com``) and
+          the matching ``resourceClaims`` + ``claims`` references to each worker
+          pod spec.
+        """
+        device_str = (
+            device_type.value
+            if isinstance(device_type, DeviceType)
+            else str(device_type).lower()
+        )
+        if device_str != DeviceType.Xpu.value:
+            return config
+
+        cfg = Config.model_validate(config)
+        worker_names: list[str] = []
+        gpu_count_per_worker = 1  # fallback
+        gpu_count_parsed = False
+        for name, service in cfg.spec.services.items():
+            if name in cls._NON_WORKER_SERVICES:
+                continue
+            if not service.extraPodSpec or not service.extraPodSpec.mainContainer:
+                continue
+
+            container = service.extraPodSpec.mainContainer
+
+            # 1. Remove NVIDIA-style gpu resource requests/limits (incompatible
+            #    with DRA).  Capture the GPU count first so we can use it in the
+            #    ResourceClaimTemplate.
+            if service.resources:
+                for bucket in ("requests", "limits"):
+                    res_dict = getattr(service.resources, bucket, None) or {}
+                    if isinstance(res_dict, dict):
+                        gpu_val = res_dict.pop("gpu", None)
+                        if gpu_val is not None:
+                            try:
+                                gpu_count_per_worker = int(gpu_val)
+                                gpu_count_parsed = True
+                            except (ValueError, TypeError):
+                                pass
+                        setattr(service.resources, bucket, res_dict or None)
+
+            # If gpu count was not in resources, infer from --tensor-parallel-size
+            if not gpu_count_parsed and container.args:
+                args = list(container.args)
+                for i, arg in enumerate(args):
+                    if arg in ("--tensor-parallel-size", "--tp") and i + 1 < len(args):
+                        try:
+                            gpu_count_per_worker = int(args[i + 1])
+                            gpu_count_parsed = True
+                        except (ValueError, TypeError):
+                            pass
+                        break
+
+            worker_names.append(name)
+
+        if not gpu_count_parsed and worker_names:
+            logger.warning(
+                "No gpu resource count found in worker config (resources or "
+                "--tensor-parallel-size); defaulting to %d GPU(s) per worker "
+                "for ResourceClaimTemplate.",
+                gpu_count_per_worker,
+            )
+
+        # 2. Add a single shared ResourceClaimTemplate for Intel DRA and wire
+        #    each worker pod to use it.
+        template_name = (
+            f"{cfg.metadata.name}-gpu-template" if cfg.metadata.name else "gpu-template"
+        )
+        if worker_names:
+            for name in worker_names:
+                service = cfg.spec.services[name]
+                pod_extra = service.extraPodSpec.model_extra
+                pod_extra.setdefault("resourceClaims", [])
+                existing_claim_names = [
+                    rc.get("name")
+                    for rc in pod_extra["resourceClaims"]
+                    if isinstance(rc, dict)
+                ]
+                if "gpu" not in existing_claim_names:
+                    pod_extra["resourceClaims"].append(
+                        {"name": "gpu", "resourceClaimTemplateName": template_name}
+                    )
+                container = service.extraPodSpec.mainContainer
+                container_resources = container.model_extra.get("resources") or {}
+                claims: list = container_resources.get("claims") or []
+                if not any(
+                    isinstance(c, dict) and c.get("name") == "gpu" for c in claims
+                ):
+                    claims.append({"name": "gpu"})
+                container_resources["claims"] = claims
+                container.model_extra["resources"] = container_resources
+
+        dumped = cfg.model_dump()
+
+        # 3. Prepend the ResourceClaimTemplate as a separate K8s document.
+        resource_claim_template = {
+            "apiVersion": "resource.k8s.io/v1",
+            "kind": "ResourceClaimTemplate",
+            "metadata": {"name": template_name},
+            "spec": {
+                "spec": {
+                    "devices": {
+                        "requests": [
+                            {
+                                "name": "gpu",
+                                "exactly": {
+                                    "deviceClassName": "gpu.intel.com",
+                                    "count": gpu_count_per_worker,
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+        }
+        dumped["_xpu_resource_claim_template"] = resource_claim_template
+        return dumped
 
     @classmethod
     def convert_config(


### PR DESCRIPTION
Enable SGLang workers to run a startup self-benchmark so the Dynamo Planner can obtain pre-deployment ForwardPassMetrics (FPM) data via the priority-1 `get_perf_metrics` endpoint, analogous to the existing vLLM DYN_BENCHMARK_MODE support.

Changes:
- backend_args.py: add --benchmark-mode / --benchmark-output-path / --benchmark-timeout args (env DYN_BENCHMARK_MODE etc.) to DynamoSGLangArgGroup and DynamoSGLangConfig
- benchmark.py (new): async run_sglang_benchmark() that sweeps prefill ISLs and/or decode context lengths, writes results JSON in the FPM format expected by perf_metrics.py
- request_handlers/handler_base.py: add _benchmark_results class var and get_perf_metrics() async generator to BaseWorkerHandler
- init_llm.py: run self-benchmark after engine start when benchmark_mode is set; expose get_perf_metrics endpoint in both init_decode() and init_prefill()
- profiler/utils/dgd_generation.py: add _sglang_worker_roles(), enable_sglang_benchmark_mode(), and call it in assemble_final_config when resolved_backend == 'sglang'