### PR TITLE
feat(operator): add SKU-filtered GFD node-label fallback when DCGM discovery fails

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1471,7 +1471,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 		}
 	}
 	if discoveredInfo == nil {
-		discoveredInfo, err = gpu.DiscoverGPUs(ctx, r.APIReader)
+		discoveredInfo, err = gpu.DiscoverGPUsFiltered(ctx, r.APIReader, hw.GPUSKU)
 		if err != nil {
 			logger.Info("Node-label discovery also failed", "error", err.Error())
 			return fmt.Errorf("auto-discovery failed: %w", err)

--- a/deploy/operator/internal/controller/enrich_hardware_test.go
+++ b/deploy/operator/internal/controller/enrich_hardware_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	gpupkg "github.com/ai-dynamo/dynamo/deploy/operator/internal/gpu"
 	"k8s.io/utils/ptr"
 )
@@ -44,6 +45,7 @@ func newFakeReconciler(objs ...client.Object) *DynamoGraphDeploymentRequestRecon
 		Client:    fakeClient,
 		APIReader: fakeClient,
 		Recorder:  &record.FakeRecorder{},
+		Config:    &configv1alpha1.OperatorConfiguration{},
 	}
 }
 

--- a/deploy/operator/internal/gpu/discovery.go
+++ b/deploy/operator/internal/gpu/discovery.go
@@ -715,15 +715,27 @@ func parseMetrics(ctx context.Context, families map[string]*dto.MetricFamily) (*
 }
 
 // DiscoverGPUs queries Kubernetes nodes to determine GPU configuration.
+// It is a convenience wrapper around DiscoverGPUsFiltered with no SKU filter.
+// See DiscoverGPUsFiltered for full documentation.
+func DiscoverGPUs(ctx context.Context, k8sClient client.Reader) (*GPUInfo, error) {
+	return DiscoverGPUsFiltered(ctx, k8sClient, "")
+}
+
+// DiscoverGPUsFiltered queries Kubernetes nodes to determine GPU configuration.
 // It extracts GPU information from NVIDIA GPU Feature Discovery (GFD) labels
 // and returns aggregated GPU info, preferring nodes with higher GPU count,
 // then higher VRAM if counts are equal.
 //
+// When filterSKU is non-empty, only nodes whose inferred SKU matches are
+// considered for selection and counting. When empty, the best node is selected
+// first and then only nodes with the same SKU are counted.
+//
 // This function requires cluster-wide node read permissions and expects nodes
 // to have GFD labels. If no nodes with GPU labels are found, it returns an error.
-func DiscoverGPUs(ctx context.Context, k8sClient client.Reader) (*GPUInfo, error) {
+func DiscoverGPUsFiltered(ctx context.Context, k8sClient client.Reader, filterSKU nvidiacomv1beta1.GPUSKUType) (*GPUInfo, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("Starting GPU discovery from cluster nodes")
+	logger.Info("Starting GPU discovery from cluster nodes", "filterSKU", filterSKU)
+
 	// List all nodes in the cluster
 	nodeList := &corev1.NodeList{}
 	if err := k8sClient.List(ctx, nodeList); err != nil {
@@ -733,48 +745,74 @@ func DiscoverGPUs(ctx context.Context, k8sClient client.Reader) (*GPUInfo, error
 		return nil, fmt.Errorf("no nodes found in cluster")
 	}
 	logger.Info("Found cluster nodes", "count", len(nodeList.Items))
-	// Track the best GPU configuration found
-	var bestGPUInfo *GPUInfo
-	nodesWithGPUs := 0
+
+	// Collect per-node GPU info with inferred SKU.
+	type nodeInfo struct {
+		info *GPUInfo
+		sku  nvidiacomv1beta1.GPUSKUType
+	}
+	allNodes := make([]nodeInfo, 0, len(nodeList.Items))
 	for i := range nodeList.Items {
 		node := &nodeList.Items[i]
 		gpuInfo, err := extractGPUInfoFromNode(node)
 		if err != nil {
-			// Node doesn't have GPU labels or has invalid labels, skip it
 			logger.V(1).Info("Skipping node without valid GPU info",
 				"node", node.Name,
 				"reason", err.Error())
 			continue
 		}
-		nodesWithGPUs++
+		gpuInfo.NodeName = node.Name
+		sku := InferHardwareSystem(gpuInfo.Model)
 		logger.Info("Found GPU node",
 			"node", node.Name,
 			"gpus", gpuInfo.GPUsPerNode,
 			"model", gpuInfo.Model,
-			"vram", gpuInfo.VRAMPerGPU)
-		// Select best configuration: prefer higher GPU count, then higher VRAM
-		if bestGPUInfo == nil ||
-			gpuInfo.GPUsPerNode > bestGPUInfo.GPUsPerNode ||
-			(gpuInfo.GPUsPerNode == bestGPUInfo.GPUsPerNode && gpuInfo.VRAMPerGPU > bestGPUInfo.VRAMPerGPU) {
-			bestGPUInfo = gpuInfo
+			"vram", gpuInfo.VRAMPerGPU,
+			"sku", sku)
+		allNodes = append(allNodes, nodeInfo{info: gpuInfo, sku: sku})
+	}
+
+	// Select best node (only from matching SKU when filtered).
+	var bestNode *GPUInfo
+	var bestSKU nvidiacomv1beta1.GPUSKUType
+	for _, n := range allNodes {
+		if filterSKU != "" && n.sku != filterSKU {
+			continue
+		}
+		if bestNode == nil ||
+			n.info.GPUsPerNode > bestNode.GPUsPerNode ||
+			(n.info.GPUsPerNode == bestNode.GPUsPerNode && n.info.VRAMPerGPU > bestNode.VRAMPerGPU) {
+			bestNode = n.info
+			bestSKU = n.sku
 		}
 	}
-	if bestGPUInfo == nil {
+	if bestNode == nil {
+		if filterSKU != "" {
+			return nil, fmt.Errorf("no nodes with NVIDIA GPU Feature Discovery labels matching SKU %q found (checked %d nodes)",
+				filterSKU, len(nodeList.Items))
+		}
 		return nil, fmt.Errorf("no nodes with NVIDIA GPU Feature Discovery labels found (checked %d nodes). "+
 			"Ensure GPU nodes have labels: %s, %s, %s",
 			len(nodeList.Items), LabelGPUCount, LabelGPUProduct, LabelGPUMemory)
 	}
-	// Infer hardware system from GPU model
-	bestGPUInfo.System = InferHardwareSystem(bestGPUInfo.Model)
-	bestGPUInfo.NodesWithGPUs = nodesWithGPUs
+
+	// Count only nodes with the same SKU as the selected best node.
+	nodesWithGPUs := 0
+	for _, n := range allNodes {
+		if n.sku == bestSKU {
+			nodesWithGPUs++
+		}
+	}
+	bestNode.System = bestSKU
+	bestNode.NodesWithGPUs = nodesWithGPUs
 	logger.Info("GPU discovery completed",
-		"gpusPerNode", bestGPUInfo.GPUsPerNode,
-		"nodesWithGPUs", bestGPUInfo.NodesWithGPUs,
-		"totalGpus", bestGPUInfo.GPUsPerNode*bestGPUInfo.NodesWithGPUs,
-		"model", bestGPUInfo.Model,
-		"vram", bestGPUInfo.VRAMPerGPU,
-		"system", bestGPUInfo.System)
-	return bestGPUInfo, nil
+		"gpusPerNode", bestNode.GPUsPerNode,
+		"nodesWithGPUs", bestNode.NodesWithGPUs,
+		"totalGpus", bestNode.GPUsPerNode*bestNode.NodesWithGPUs,
+		"model", bestNode.Model,
+		"vram", bestNode.VRAMPerGPU,
+		"system", bestNode.System)
+	return bestNode, nil
 }
 
 // extractGPUInfoFromNode extracts GPU information from a single node's labels.

--- a/deploy/operator/internal/gpu/discovery_test.go
+++ b/deploy/operator/internal/gpu/discovery_test.go
@@ -231,6 +231,90 @@ func TestDiscoverGPUs_NoNodes(t *testing.T) {
 	assert.Contains(t, err.Error(), "no nodes found")
 }
 
+func TestDiscoverGPUsFiltered_MixedSKU(t *testing.T) {
+	ctx := context.Background()
+
+	h100Node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "h100-node",
+			Labels: map[string]string{
+				LabelGPUCount:   "8",
+				LabelGPUProduct: "H100-SXM5-80GB",
+				LabelGPUMemory:  "81920",
+			},
+		},
+	}
+	a100Node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "a100-node",
+			Labels: map[string]string{
+				LabelGPUCount:   "4",
+				LabelGPUProduct: "A100-SXM4-40GB",
+				LabelGPUMemory:  "40960",
+			},
+		},
+	}
+	k8sClient := newFakeClient(h100Node, a100Node)
+
+	t.Run("unfiltered selects best and counts only matching SKU", func(t *testing.T) {
+		info, err := DiscoverGPUsFiltered(ctx, k8sClient, "")
+		require.NoError(t, err)
+		// H100 wins (8 GPUs > 4 GPUs)
+		assert.Equal(t, 8, info.GPUsPerNode)
+		assert.Equal(t, "H100-SXM5-80GB", info.Model)
+		assert.Equal(t, nvidiacomv1beta1.GPUSKUType("h100_sxm"), info.System)
+		// Only 1 node with matching H100 SKU
+		assert.Equal(t, 1, info.NodesWithGPUs)
+	})
+
+	t.Run("filter by a100_sxm selects A100 node", func(t *testing.T) {
+		info, err := DiscoverGPUsFiltered(ctx, k8sClient, "a100_sxm")
+		require.NoError(t, err)
+		assert.Equal(t, 4, info.GPUsPerNode)
+		assert.Equal(t, "A100-SXM4-40GB", info.Model)
+		assert.Equal(t, nvidiacomv1beta1.GPUSKUType("a100_sxm"), info.System)
+		assert.Equal(t, 1, info.NodesWithGPUs)
+	})
+
+	t.Run("filter by nonexistent SKU returns error", func(t *testing.T) {
+		_, err := DiscoverGPUsFiltered(ctx, k8sClient, "l40s")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "l40s")
+	})
+}
+
+func TestDiscoverGPUsFiltered_HomogeneousCountsAllNodes(t *testing.T) {
+	ctx := context.Background()
+
+	// Two H100 nodes
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "h100-node-1",
+			Labels: map[string]string{
+				LabelGPUCount:   "8",
+				LabelGPUProduct: "H100-SXM5-80GB",
+				LabelGPUMemory:  "81920",
+			},
+		},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "h100-node-2",
+			Labels: map[string]string{
+				LabelGPUCount:   "8",
+				LabelGPUProduct: "H100-SXM5-80GB",
+				LabelGPUMemory:  "81920",
+			},
+		},
+	}
+	k8sClient := newFakeClient(node1, node2)
+
+	info, err := DiscoverGPUsFiltered(ctx, k8sClient, "")
+	require.NoError(t, err)
+	assert.Equal(t, 8, info.GPUsPerNode)
+	assert.Equal(t, 2, info.NodesWithGPUs)
+}
+
 func TestDiscoverGPUs_NoGPUNodes(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

- Add `DiscoverGPUsFiltered` for GFD (GPU Feature Discovery) node-label based GPU discovery with SKU filtering, mirroring `DiscoverGPUsFromDCGMFiltered` semantics
- Use `DiscoverGPUsFiltered` as fallback in `enrichHardwareFromDiscovery` when DCGM exporter pods are unavailable (e.g. vClusters where GFD labels are synced from the host but DCGM pods don't run)

Addresses item 2 from https://github.com/ai-dynamo/dynamo/pull/8267#issuecomment-4271360510 (NVBug 6088006).

## Test plan

- [x] Existing `TestDiscoverGPUs_*` tests pass (refactored `DiscoverGPUs` delegates to `DiscoverGPUsFiltered`)
- [x] New `TestDiscoverGPUsFiltered_MixedSKU` — verifies SKU-filtered selection and per-SKU node counting
- [x] New `TestDiscoverGPUsFiltered_HomogeneousCountsAllNodes` — verifies all same-SKU nodes are counted
- [x] `TestEnrichHardwareFromDiscovery` passes including error cases (fallback path exercised)
- [ ] Manual test in vCluster environment with GFD labels synced but no DCGM pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)