### PR TITLE
fix(planner): match MDC component field against backend default, not DGD key (cherry-pick of #8489)

### DIFF
--- a/components/src/dynamo/planner/connectors/kubernetes.py
+++ b/components/src/dynamo/planner/connectors/kubernetes.py
@@ -505,17 +505,28 @@ class KubernetesConnector(PlannerConnector):
         # Resolve the expected component name so we can scope card selection
         # and avoid picking up LoRA-adapter cards that share the same CR but
         # carry a different component/model identity.
-        expected_component: Optional[str] = None
+        #
+        # The MDC "component" field is written by the Rust runtime from the
+        # registered Endpoint name (e.g. "prefill" / "backend" /
+        # "tensorrt_llm"), NOT from the DGD spec.services dict key (which
+        # is typically PascalCase like "VllmPrefillWorker"). Source of
+        # truth, in priority order:
+        #   1. The user's --endpoint <ns>.<component>.<ep> override in the
+        #      worker's container args (vllm/sglang/trtllm all honor it).
+        #   2. The backend-specific default from
+        #      build_worker_info_from_defaults.
+        defaults = build_worker_info_from_defaults(backend, sub_component_type)
+        expected_component: Optional[str] = defaults.component_name or None
         try:
             deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
             service = get_service_from_sub_component_type_or_name(
                 deployment, sub_component_type
             )
-            expected_component = service.name
+            user_component = service.get_component_name_from_endpoint_arg()
+            if user_component:
+                expected_component = user_component
         except PlannerError:
-            expected_component = build_worker_info_from_defaults(
-                backend, sub_component_type
-            ).component_name
+            pass
 
         for entry in entries:
             is_prefill = self._mdc_entry_is_prefill(entry)

--- a/components/src/dynamo/planner/monitoring/dgd_services.py
+++ b/components/src/dynamo/planner/monitoring/dgd_services.py
@@ -19,6 +19,7 @@ from typing import Optional
 
 from pydantic import BaseModel
 
+from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.planner.config.defaults import SubComponentType
 from dynamo.planner.errors import DuplicateSubComponentError, SubComponentNotFoundError
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -70,6 +71,34 @@ class Service(BaseModel):
             return args[args.index("--model") + 1]
 
         return None
+
+    def get_component_name_from_endpoint_arg(self) -> Optional[str]:
+        """Return the component name from ``--endpoint`` in the container args.
+
+        Worker backends (vLLM, SGLang, TRT-LLM) accept
+        ``--endpoint <namespace>.<component>.<endpoint_name>`` (optionally
+        prefixed with ``dyn://``) which overrides the default component
+        name written to the MDC ``component`` field. When the user sets
+        this, the Planner's MDC filter must match the user's value, not
+        the backend default. Returns ``None`` if ``--endpoint`` is not
+        present or malformed.
+        """
+        args = (
+            self.service.get("extraPodSpec", {})
+            .get("mainContainer", {})
+            .get("args", [])
+        )
+        args = break_arguments(args)
+        if "--endpoint" not in args:
+            return None
+        idx = args.index("--endpoint")
+        if len(args) <= idx + 1:
+            return None
+        try:
+            _, component, _ = parse_endpoint(args[idx + 1])
+            return component
+        except ValueError:
+            return None
 
     def get_gpu_count(self) -> int:
         """Get the GPU count from the service's resource specification.

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -1040,3 +1040,211 @@ def test_get_actual_worker_counts_no_components(kubernetes_connector, mock_kube_
     assert prefill_count == 0
     assert decode_count == 0
     assert is_stable is True
+
+
+# Tests for get_worker_info / Service.get_component_name_from_endpoint_arg.
+#
+# Regression: the filter that compares an MDC entry's ``component`` field
+# against the expected value must use the lowercase backend-default name
+# (what the Rust runtime writes to MDC), NOT the DGD ``spec.services``
+# dict key. The DGD key is typically PascalCase (``VllmPrefillWorker``)
+# while MDC carries the Endpoint name (``prefill`` / ``backend`` /
+# ``tensorrt_llm``); comparing those fields would cause every real-world
+# MDC entry to be skipped, leaving WorkerInfo without ``context_length``
+# and silently breaking easy-mode load scaling.
+
+
+def _make_mdc_cr(
+    cr_name: str, component: str, is_prefill: bool, context_length: int = 40960
+) -> dict:
+    """Build a minimal DynamoWorkerMetadata CR dict with one model_card."""
+    return {
+        "metadata": {"name": cr_name},
+        "spec": {
+            "data": {
+                "model_cards": {
+                    "0": {
+                        "type": "Model",
+                        "component": component,
+                        "endpoint": "generate",
+                        "card_json": {
+                            "display_name": "Qwen/Qwen3-8B",
+                            "context_length": context_length,
+                            "kv_cache_block_size": 16,
+                            "model_type": 0x10 if is_prefill else 0x01,
+                            "runtime_config": {
+                                "total_kv_blocks": 49231,
+                                "max_num_seqs": 256,
+                                "max_num_batched_tokens": 8192,
+                            },
+                        },
+                    }
+                }
+            }
+        },
+    }
+
+
+def test_get_worker_info_prefill_finds_mdc_when_dgd_key_is_pascal_case(
+    kubernetes_connector, mock_kube_api
+):
+    """PascalCase DGD key must not prevent matching MDC entry with component="prefill"."""
+    mock_deployment = {
+        "metadata": {"name": "test-graph"},
+        "spec": {
+            "services": {
+                "VllmPrefillWorker": {
+                    "replicas": 1,
+                    "subComponentType": "prefill",
+                },
+            }
+        },
+    }
+    mock_kube_api.get_graph_deployment.return_value = mock_deployment
+    mock_kube_api.custom_api.list_namespaced_custom_object.return_value = {
+        "items": [_make_mdc_cr("test-graph-0-vllmprefillworker-abc", "prefill", True)]
+    }
+    mock_kube_api.current_namespace = "default"
+
+    info = kubernetes_connector.get_worker_info(
+        SubComponentType.PREFILL, backend="vllm"
+    )
+
+    assert info.context_length == 40960
+    assert info.total_kv_blocks == 49231
+
+
+def test_get_worker_info_decode_matches_backend_component_not_subcomponent_value(
+    kubernetes_connector, mock_kube_api
+):
+    """vLLM decode: MDC carries "backend", NOT "decode". Filter must match "backend"."""
+    mock_deployment = {
+        "metadata": {"name": "test-graph"},
+        "spec": {
+            "services": {
+                "VllmDecodeWorker": {
+                    "replicas": 1,
+                    "subComponentType": "decode",
+                },
+            }
+        },
+    }
+    mock_kube_api.get_graph_deployment.return_value = mock_deployment
+    mock_kube_api.custom_api.list_namespaced_custom_object.return_value = {
+        "items": [_make_mdc_cr("test-graph-0-vllmdecodeworker-xyz", "backend", False)]
+    }
+    mock_kube_api.current_namespace = "default"
+
+    info = kubernetes_connector.get_worker_info(SubComponentType.DECODE, backend="vllm")
+
+    # If the filter used sub_component_type.value ("decode") or service.name
+    # ("VllmDecodeWorker") instead of the backend default ("backend"), this
+    # would fall back to defaults with context_length=None.
+    assert info.context_length == 40960
+
+
+def test_get_worker_info_respects_user_endpoint_override(
+    kubernetes_connector, mock_kube_api
+):
+    """User's --endpoint override makes the worker write a custom component name;
+    the filter must match that same value."""
+    mock_deployment = {
+        "metadata": {"name": "test-graph"},
+        "spec": {
+            "services": {
+                "VllmPrefillWorker": {
+                    "replicas": 1,
+                    "subComponentType": "prefill",
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "args": [
+                                "--endpoint",
+                                "my-ns.my-custom-prefill.generate",
+                            ]
+                        }
+                    },
+                },
+            }
+        },
+    }
+    mock_kube_api.get_graph_deployment.return_value = mock_deployment
+    mock_kube_api.custom_api.list_namespaced_custom_object.return_value = {
+        "items": [
+            _make_mdc_cr(
+                "test-graph-0-vllmprefillworker-abc", "my-custom-prefill", True
+            )
+        ]
+    }
+    mock_kube_api.current_namespace = "default"
+
+    info = kubernetes_connector.get_worker_info(
+        SubComponentType.PREFILL, backend="vllm"
+    )
+
+    assert info.context_length == 40960
+
+
+def test_service_get_component_name_from_endpoint_arg_present():
+    service = Service(
+        name="VllmPrefillWorker",
+        service={
+            "extraPodSpec": {
+                "mainContainer": {
+                    "args": [
+                        "--endpoint",
+                        "ns.custom-comp.generate",
+                        "--other",
+                        "flag",
+                    ]
+                }
+            }
+        },
+    )
+    assert service.get_component_name_from_endpoint_arg() == "custom-comp"
+
+
+def test_service_get_component_name_from_endpoint_arg_with_dyn_prefix():
+    """parse_endpoint accepts 'dyn://' prefix; the extracted component must strip it."""
+    service = Service(
+        name="VllmDecodeWorker",
+        service={
+            "extraPodSpec": {
+                "mainContainer": {
+                    "args": ["--endpoint", "dyn://ns.user-decode.generate"]
+                }
+            }
+        },
+    )
+    assert service.get_component_name_from_endpoint_arg() == "user-decode"
+
+
+def test_service_get_component_name_from_endpoint_arg_absent():
+    service = Service(
+        name="VllmPrefillWorker",
+        service={
+            "extraPodSpec": {
+                "mainContainer": {"args": ["--model", "Qwen/Qwen3-8B"]},
+            }
+        },
+    )
+    assert service.get_component_name_from_endpoint_arg() is None
+
+
+def test_service_get_component_name_from_endpoint_arg_missing_value():
+    """--endpoint with no following arg should return None, not raise IndexError."""
+    service = Service(
+        name="VllmPrefillWorker",
+        service={"extraPodSpec": {"mainContainer": {"args": ["--endpoint"]}}},
+    )
+    assert service.get_component_name_from_endpoint_arg() is None
+
+
+def test_service_get_component_name_from_endpoint_arg_malformed():
+    """Malformed endpoint (wrong number of dots) returns None via ValueError."""
+    service = Service(
+        name="VllmPrefillWorker",
+        service={
+            "extraPodSpec": {"mainContainer": {"args": ["--endpoint", "only.two"]}}
+        },
+    )
+    assert service.get_component_name_from_endpoint_arg() is None


### PR DESCRIPTION
## Summary

Cherry-pick of #8489 to `release/1.1.0`. Fixes silent autoscaling breakage in every 1.1.0 Planner deployment that uses a PascalCase DGD services key (which is all upstream examples).

### Not a clean cherry-pick

`release/1.1.0` still has `get_worker_info()` / `_build_worker_info_from_mdc()` inlined on `KubernetesConnector`; `main` moved that logic into `connectors/mdc.py` (`select_entry` / `worker_info_from_mdc`) and added a `_resolve_dgd_service()` helper. The fix had to be re-applied inline and tests rewritten to exercise `get_worker_info` end-to-end instead of the `_resolve_dgd_service` helper. Functional behavior matches #8489.

## Fix

`get_worker_info()` now computes `expected_component` from what the worker **actually writes to MDC**:

1. The user's `--endpoint <ns>.<component>.<ep>` override in the DGD container args (parsed via the new `Service.get_component_name_from_endpoint_arg()`).
2. The backend-specific default from `build_worker_info_from_defaults()` (`"prefill"` / `"backend"` / `"tensorrt_llm"`).

`service.name` (the PascalCase DGD key) is no longer used as the filter identifier.

## Test Plan

- [x] 8 new tests on the release branch:
  - 3 `get_worker_info` end-to-end tests (prefill with PascalCase DGD key, vLLM decode ``"backend"``, `--endpoint` override)
  - 5 `Service.get_component_name_from_endpoint_arg` unit tests (present / `dyn://` prefix / absent / missing-value / malformed)
- [x] Full `test_kubernetes_connector.py` passes (48/48)
- [x] pre-commit (isort/black/flake8/ruff/codespell) clean
- [ ] E2E validation on K8s with QA's DGD YAML from DYN-2747 (Qwen3-8B disagg, planner active mode) — same validation plan as #8489

## Closes

- DYN-2747 on `release/1.1.0`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
