### PR TITLE
docs(profiler): clarify when planner-profile-data ConfigMap is emitted [DYN-2751] (cherry-pick of #8486)

### DIFF
--- a/components/src/dynamo/profiler/profile_sla.py
+++ b/components/src/dynamo/profiler/profile_sla.py
@@ -385,6 +385,16 @@ async def run_profile(
                 phase=ops.current_phase,
             )
             if not is_disagg_config:
+                # TODO: agg + throughput-scaling / agg + mocker has no
+                # profiling-data fallback today. run_interpolation is
+                # shaped around prefill + decode picks, so for agg picks
+                # the NPZ sweep is skipped entirely and no
+                # planner-profile-data ConfigMap is produced — the
+                # planner and mocker have nothing to consume on
+                # aggregated deployments. Extend run_interpolation (and
+                # the downstream _load_profiling_data / mount logic) to
+                # handle an agg pick so both paths work for aggregated
+                # deployments too.
                 logger.info(
                     "Picked config is aggregated (chosen_exp=%r) — "
                     "skipping interpolation (requires disaggregated config).",

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -70,7 +70,12 @@ def assemble_final_config(
     1. **Mocker** — swap the base to the mocker DGD template if enabled.
     2. **Planner** — inject the Planner service + planner-config ConfigMap.
     3. **Profile data** — attach interpolation-data ConfigMap when mocker
-       or planner-throughput is enabled.
+       or planner-throughput is enabled. The ConfigMap is only emitted
+       when the picked config is disaggregated AND the interpolation NPZ
+       files were produced on disk; agg picks skip interpolation entirely
+       (see the gate in ``profile_sla.py``), so no ConfigMap is attached
+       in that case and the planner / mocker have no profiling-data
+       fallback for aggregated deployments today.
     """
     if not dgd_config:
         return dgd_config


### PR DESCRIPTION
## Summary

Cherry-pick of #8486 to `release/1.1.0`, with the docstring / TODO text **adjusted for the release branch's actual behavior** (rapid mode on release/1.1.0 still writes NPZ to disk — the main branch's AIC-in-planner deferral doesn't exist here yet).

Changes vs. the main PR:
- Dropped the `build_aic_interpolation_spec` function addition entirely — it was introduced on main by #8335 and has no home on release/1.1.0.
- Dropped the "vLLM self-benchmark (`DYN_BENCHMARK_MODE`)" and "rapid mode defers to planner" language from the `assemble_final_config` docstring — neither exists on release/1.1.0.
- Reworded the `profile_sla.py` TODO: on release, the gap is that `run_interpolation` skips agg picks entirely (no NPZ → no `planner-profile-data-XXXX` ConfigMap → planner/mocker have nothing to consume for agg deployments).

Net effect: documents the actual release/1.1.0 behavior observed in [DYN-2751](https://linear.app/nvidia/issue/DYN-2751) and flags the agg + profiling-data gap with a TODO. No behavior change.

## Test plan

- [x] `pre-commit run` on the two touched files passes.
- [ ] Lint-only PR — no runtime change, no tests added.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
