### PR TITLE
fix: remove the tool calling flaky test as the small model is not stable in generating Json format

### DIFF
--- a/tests/frontend/test_tool_calling_sglang.py
+++ b/tests/frontend/test_tool_calling_sglang.py
@@ -706,40 +706,6 @@ class TestToolCallingProtocol:
         ids = [tc["id"] for tc in result.tool_calls]
         assert len(ids) == len(set(ids)), f"duplicate tool ids: {ids}"
 
-    def test_complex_nested_arguments_schema_valid(self, client: OpenAI, model: str):
-        result = stream_chat(
-            client,
-            model,
-            messages=[
-                {
-                    "role": "user",
-                    "content": (
-                        "Create a weekly team standup meeting titled 'Engineering Standup' "
-                        "from 2025-01-15T09:00:00Z to 2025-01-15T09:30:00Z. "
-                        "Add attendees: Alice (alice@example.com, required) and "
-                        "Bob (bob@example.com, optional). "
-                        "Set recurrence weekly every 1 week for 10 occurrences. "
-                        "Location: Conference Room B. "
-                        "Use the create_event tool."
-                    ),
-                }
-            ],
-            tools=TOOLS_COMPLEX_ARGS,
-        )
-        if result.finish_reason != "tool_calls":
-            pytest.skip(
-                "Model declined to call create_event for complex schema "
-                f"(finish_reason={result.finish_reason!r})"
-            )
-        schema = tool_schema_map(TOOLS_COMPLEX_ARGS)
-        args = parse_and_validate_tool_call(
-            result.tool_calls[0], schema, expected_name="create_event"
-        )
-        assert args["title"]
-        assert args["start_time"]
-        assert args["end_time"]
-        assert isinstance(args.get("attendees", []), list)
-
     def test_array_argument_schema_valid(self, client: OpenAI, model: str):
         tools = [
             {


### PR DESCRIPTION
#### Overview:

remove the tool calling flaky test as the small model is not stable in generating Json format

#### Details:

will move the tests to the nightly pipeline

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed test case for complex nested arguments schema validation in tool calling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->