### PR TITLE
fix(parsers): back-port sglang kimi-k2 tool-call and reasoning detection

### DIFF
--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -63,10 +63,7 @@ pub struct BasicReasoningParser {
     stripped_think_start: bool,
     /// Optional marker that force-exits reasoning mode when encountered inside a
     /// reasoning block (e.g. Kimi-K2/K2.5 models sometimes emit
-    /// `<|tool_calls_section_begin|>` without first closing `</think>`). When set,
-    /// the content before the marker becomes reasoning and the marker plus remainder
-    /// becomes normal text. Ported from sglang `BaseReasoningFormatDetector`
-    /// (PR sgl-project/sglang#19552).
+    /// `<|tool_calls_section_begin|>` without first closing `</think>`).
     tool_start_token: Option<String>,
 }
 
@@ -89,7 +86,7 @@ impl BasicReasoningParser {
     }
 
     /// Enables force-exit from reasoning when `token` appears inside an open reasoning
-    /// block. Used by the Kimi-K2/K2.5 reasoning parser.
+    /// block.
     pub fn with_tool_start_token(mut self, token: impl Into<String>) -> Self {
         self.tool_start_token = Some(token.into());
         self
@@ -146,7 +143,7 @@ impl ReasoningParser for BasicReasoningParser {
                     cursor += self.think_start_token.len();
                 }
                 // Look for the earliest reasoning exit point: either </think> or the
-                // optional tool_start_token (Kimi-K2 force-exit).
+                // optional tool_start_token (force-exit case).
                 let end_offset = text[cursor..].find(&self.think_end_token);
                 let tool_offset = self
                     .tool_start_token
@@ -248,7 +245,6 @@ impl ReasoningParser for BasicReasoningParser {
             }
 
             if self._in_reasoning {
-                // Find the earliest reasoning exit point.
                 let end_idx = current_text.find(self.think_end_token.as_str());
                 let tool_idx = self
                     .tool_start_token
@@ -263,8 +259,6 @@ impl ReasoningParser for BasicReasoningParser {
                 };
 
                 if let Some(tool_at) = force_exit_idx {
-                    // Kimi-K2 force-exit: content before marker is reasoning, marker + rest
-                    // is normal text. Mirrors sglang BaseReasoningFormatDetector behavior.
                     accumulated_reasoning.push_str(&current_text[..tool_at]);
                     accumulated_normal.push_str(&current_text[tool_at..]);
                     self._buffer.clear();
@@ -349,6 +343,7 @@ impl ReasoningParser for BasicReasoningParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn test_detect_and_parse_reasoning_reasoning() {
@@ -1135,31 +1130,33 @@ mod tests {
         assert_eq!(overlap("no match", "◁think▷"), 0);
     }
 
-    // =========================================================================
-    // Kimi-K2 force-exit tests (tool_start_token)
-    //
-    // Models like Kimi-K2.5/K2.6 sometimes emit <|tool_calls_section_begin|>
-    // directly inside a <think> block without closing it first. The parser must
-    // split at the marker: content before → reasoning, marker + rest → normal.
-    // Ported from sglang PR #19552.
-    // =========================================================================
-
     fn kimi_k2_parser() -> BasicReasoningParser {
         // Mirrors the `kimi_k25` registration in reasoning/mod.rs.
         BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true)
             .with_tool_start_token(crate::reasoning::KIMI_K2_TOOL_SECTION_BEGIN)
     }
 
-    #[test]
-    fn test_force_exit_on_tool_section_one_shot() {
+    #[rstest]
+    #[case(
+        "thinking text <|tool_calls_section_begin|><|tool_call_begin|>functions.foo:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>",
+        "thinking text",
+        "<|tool_calls_section_begin|><|tool_call_begin|>functions.foo:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"
+    )]
+    #[case("r</think>a", "r", "a")]
+    #[case(
+        "reasoning</think>answer <|tool_calls_section_begin|>tc",
+        "reasoning",
+        "answer <|tool_calls_section_begin|>tc"
+    )]
+    fn test_kimi_k2_one_shot_split(
+        #[case] input: &str,
+        #[case] expected_reasoning: &str,
+        #[case] expected_normal: &str,
+    ) {
         let mut parser = kimi_k2_parser();
-        let input = "thinking text <|tool_calls_section_begin|><|tool_call_begin|>functions.foo:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>";
         let r = parser.detect_and_parse_reasoning(input, &[]);
-        assert_eq!(r.reasoning_text, "thinking text");
-        assert_eq!(
-            r.normal_text,
-            "<|tool_calls_section_begin|><|tool_call_begin|>functions.foo:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"
-        );
+        assert_eq!(r.reasoning_text, expected_reasoning);
+        assert_eq!(r.normal_text, expected_normal);
     }
 
     #[test]
@@ -1208,29 +1205,6 @@ mod tests {
         let r2 = parser.parse_reasoning_streaming_incremental("xxx", &[]);
         assert_eq!(r2.reasoning_text, "<|tool_caxxx");
         assert_eq!(r2.normal_text, "");
-    }
-
-    #[test]
-    fn test_classic_think_close_not_regressed_with_tool_token_set() {
-        // With tool_start_token set, a normal </think> close must still work.
-        let mut parser = kimi_k2_parser();
-        let r = parser.detect_and_parse_reasoning("r</think>a", &[]);
-        assert_eq!(r.reasoning_text, "r");
-        assert_eq!(r.normal_text, "a");
-    }
-
-    #[test]
-    fn test_think_end_wins_over_later_tool_start() {
-        // When </think> arrives before <|tool_calls_section_begin|>, the classic
-        // close wins and the tool marker becomes part of normal text (where the
-        // downstream tool-call parser will pick it up).
-        let mut parser = kimi_k2_parser();
-        let r = parser.detect_and_parse_reasoning(
-            "reasoning</think>answer <|tool_calls_section_begin|>tc",
-            &[],
-        );
-        assert_eq!(r.reasoning_text, "reasoning");
-        assert_eq!(r.normal_text, "answer <|tool_calls_section_begin|>tc");
     }
 
     #[test]

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -1147,7 +1147,7 @@ mod tests {
     fn kimi_k2_parser() -> BasicReasoningParser {
         // Mirrors the `kimi_k25` registration in reasoning/mod.rs.
         BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true)
-            .with_tool_start_token("<|tool_calls_section_begin|>")
+            .with_tool_start_token(crate::reasoning::KIMI_K2_TOOL_SECTION_BEGIN)
     }
 
     #[test]

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -61,6 +61,13 @@ pub struct BasicReasoningParser {
     stream_reasoning: bool,
     _buffer: String,
     stripped_think_start: bool,
+    /// Optional marker that force-exits reasoning mode when encountered inside a
+    /// reasoning block (e.g. Kimi-K2/K2.5 models sometimes emit
+    /// `<|tool_calls_section_begin|>` without first closing `</think>`). When set,
+    /// the content before the marker becomes reasoning and the marker plus remainder
+    /// becomes normal text. Ported from sglang `BaseReasoningFormatDetector`
+    /// (PR sgl-project/sglang#19552).
+    tool_start_token: Option<String>,
 }
 
 impl BasicReasoningParser {
@@ -77,7 +84,15 @@ impl BasicReasoningParser {
             stream_reasoning,
             _buffer: String::new(),
             stripped_think_start: false,
+            tool_start_token: None,
         }
+    }
+
+    /// Enables force-exit from reasoning when `token` appears inside an open reasoning
+    /// block. Used by the Kimi-K2/K2.5 reasoning parser.
+    pub fn with_tool_start_token(mut self, token: impl Into<String>) -> Self {
+        self.tool_start_token = Some(token.into());
+        self
     }
 }
 
@@ -101,8 +116,17 @@ impl ReasoningParser for BasicReasoningParser {
             };
         }
 
-        // If force_reasoning and no start tag, treat entire text as reasoning
-        if self._in_reasoning && !has_think_tag && !text.contains(&self.think_end_token) {
+        // If force_reasoning and no start tag, no end tag, and no tool-start marker,
+        // treat entire text as reasoning.
+        let has_tool_start = self
+            .tool_start_token
+            .as_deref()
+            .is_some_and(|tok| text.contains(tok));
+        if self._in_reasoning
+            && !has_think_tag
+            && !text.contains(&self.think_end_token)
+            && !has_tool_start
+        {
             return ParserResult {
                 normal_text: String::new(),
                 reasoning_text: text.to_string(),
@@ -121,15 +145,39 @@ impl ReasoningParser for BasicReasoningParser {
                 if text[cursor..].starts_with(&self.think_start_token) {
                     cursor += self.think_start_token.len();
                 }
-                // We're inside a reasoning block — look for end token
-                if let Some(end_offset) = text[cursor..].find(&self.think_end_token) {
-                    reasoning_parts.push(&text[cursor..cursor + end_offset]);
-                    cursor += end_offset + self.think_end_token.len();
-                    currently_reasoning = false;
-                } else {
-                    // No end token — rest is reasoning (truncated)
-                    reasoning_parts.push(&text[cursor..]);
-                    cursor = text.len();
+                // Look for the earliest reasoning exit point: either </think> or the
+                // optional tool_start_token (Kimi-K2 force-exit).
+                let end_offset = text[cursor..].find(&self.think_end_token);
+                let tool_offset = self
+                    .tool_start_token
+                    .as_deref()
+                    .and_then(|tok| text[cursor..].find(tok));
+
+                match (end_offset, tool_offset) {
+                    (Some(e), Some(t)) if t < e => {
+                        // tool_start arrives before </think> — force-exit.
+                        reasoning_parts.push(&text[cursor..cursor + t]);
+                        normal_parts.push(&text[cursor + t..]);
+                        cursor = text.len();
+                        currently_reasoning = false;
+                    }
+                    (Some(e), _) => {
+                        reasoning_parts.push(&text[cursor..cursor + e]);
+                        cursor += e + self.think_end_token.len();
+                        currently_reasoning = false;
+                    }
+                    (None, Some(t)) => {
+                        // No </think> but tool_start is present — force-exit.
+                        reasoning_parts.push(&text[cursor..cursor + t]);
+                        normal_parts.push(&text[cursor + t..]);
+                        cursor = text.len();
+                        currently_reasoning = false;
+                    }
+                    (None, None) => {
+                        // No end token — rest is reasoning (truncated)
+                        reasoning_parts.push(&text[cursor..]);
+                        cursor = text.len();
+                    }
                 }
             } else {
                 // We're in normal text — look for start token
@@ -200,7 +248,32 @@ impl ReasoningParser for BasicReasoningParser {
             }
 
             if self._in_reasoning {
-                if let Some(end_idx) = current_text.find(self.think_end_token.as_str()) {
+                // Find the earliest reasoning exit point.
+                let end_idx = current_text.find(self.think_end_token.as_str());
+                let tool_idx = self
+                    .tool_start_token
+                    .as_deref()
+                    .and_then(|tok| current_text.find(tok));
+
+                // Prefer whichever marker appears first. If only one is present, use it.
+                let force_exit_idx = match (end_idx, tool_idx) {
+                    (Some(e), Some(t)) if t < e => Some(t),
+                    (None, Some(t)) => Some(t),
+                    _ => None,
+                };
+
+                if let Some(tool_at) = force_exit_idx {
+                    // Kimi-K2 force-exit: content before marker is reasoning, marker + rest
+                    // is normal text. Mirrors sglang BaseReasoningFormatDetector behavior.
+                    accumulated_reasoning.push_str(&current_text[..tool_at]);
+                    accumulated_normal.push_str(&current_text[tool_at..]);
+                    self._buffer.clear();
+                    self._in_reasoning = false;
+                    self.stripped_think_start = false;
+                    break;
+                }
+
+                if let Some(end_idx) = end_idx {
                     // End of reasoning block: accumulate content and transition out.
                     accumulated_reasoning.push_str(&current_text[..end_idx]);
                     let after_end = end_idx + self.think_end_token.len();
@@ -211,8 +284,16 @@ impl ReasoningParser for BasicReasoningParser {
                 } else {
                     // No complete end token — check for partial at end of buffer
                     // (e.g., "reasoning content</th" where "</th" is a prefix of "</think>").
+                    // Partial prefixes of tool_start_token must also be buffered so the
+                    // force-exit marker isn't split into reasoning text.
                     if self.stream_reasoning {
-                        let ol = overlap(&current_text, &self.think_end_token);
+                        let ol_end = overlap(&current_text, &self.think_end_token);
+                        let ol_tool = self
+                            .tool_start_token
+                            .as_deref()
+                            .map(|tok| overlap(&current_text, tok))
+                            .unwrap_or(0);
+                        let ol = ol_end.max(ol_tool);
                         if ol >= 2 {
                             let safe_end = current_text.len() - ol;
                             if safe_end > 0 {
@@ -1052,5 +1133,118 @@ mod tests {
         assert_eq!(overlap("text◁th", "◁think▷"), 5);
         assert_eq!(overlap("text◁/thi", "◁/think▷"), 7);
         assert_eq!(overlap("no match", "◁think▷"), 0);
+    }
+
+    // =========================================================================
+    // Kimi-K2 force-exit tests (tool_start_token)
+    //
+    // Models like Kimi-K2.5/K2.6 sometimes emit <|tool_calls_section_begin|>
+    // directly inside a <think> block without closing it first. The parser must
+    // split at the marker: content before → reasoning, marker + rest → normal.
+    // Ported from sglang PR #19552.
+    // =========================================================================
+
+    fn kimi_k2_parser() -> BasicReasoningParser {
+        // Mirrors the `kimi_k25` registration in reasoning/mod.rs.
+        BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true)
+            .with_tool_start_token("<|tool_calls_section_begin|>")
+    }
+
+    #[test]
+    fn test_force_exit_on_tool_section_one_shot() {
+        let mut parser = kimi_k2_parser();
+        let input = "thinking text <|tool_calls_section_begin|><|tool_call_begin|>functions.foo:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>";
+        let r = parser.detect_and_parse_reasoning(input, &[]);
+        assert_eq!(r.reasoning_text, "thinking text");
+        assert_eq!(
+            r.normal_text,
+            "<|tool_calls_section_begin|><|tool_call_begin|>functions.foo:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"
+        );
+    }
+
+    #[test]
+    fn test_force_exit_streaming_single_chunk() {
+        let mut parser = kimi_k2_parser();
+        let r = parser.parse_reasoning_streaming_incremental(
+            "thinking text <|tool_calls_section_begin|><|tool_call_begin|>functions.foo:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>",
+            &[],
+        );
+        assert_eq!(r.reasoning_text, "thinking text ");
+        assert_eq!(
+            r.normal_text,
+            "<|tool_calls_section_begin|><|tool_call_begin|>functions.foo:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"
+        );
+    }
+
+    #[test]
+    fn test_force_exit_streaming_split_across_chunks() {
+        let mut parser = kimi_k2_parser();
+
+        let r1 = parser.parse_reasoning_streaming_incremental("thinking ", &[]);
+        assert_eq!(r1.reasoning_text, "thinking ");
+        assert_eq!(r1.normal_text, "");
+
+        // Second chunk ends with a prefix of the tool marker — the suffix must be buffered.
+        let r2 = parser.parse_reasoning_streaming_incremental("text <|tool_cal", &[]);
+        assert_eq!(r2.reasoning_text, "text ");
+        assert_eq!(r2.normal_text, "");
+
+        let r3 = parser.parse_reasoning_streaming_incremental("ls_section_begin|>rest", &[]);
+        assert_eq!(r3.reasoning_text, "");
+        assert_eq!(r3.normal_text, "<|tool_calls_section_begin|>rest");
+    }
+
+    #[test]
+    fn test_force_exit_partial_marker_resolves_as_non_marker() {
+        // First chunk ends with "<|tool_ca" (prefix of marker) — must be buffered.
+        // Second chunk "xxx" makes the combined "<|tool_caxxx" which is NOT a marker.
+        // With force_reasoning=true, the content then flushes as reasoning.
+        let mut parser = kimi_k2_parser();
+
+        let r1 = parser.parse_reasoning_streaming_incremental("abc <|tool_ca", &[]);
+        assert_eq!(r1.reasoning_text, "abc ");
+        assert_eq!(r1.normal_text, "");
+
+        let r2 = parser.parse_reasoning_streaming_incremental("xxx", &[]);
+        assert_eq!(r2.reasoning_text, "<|tool_caxxx");
+        assert_eq!(r2.normal_text, "");
+    }
+
+    #[test]
+    fn test_classic_think_close_not_regressed_with_tool_token_set() {
+        // With tool_start_token set, a normal </think> close must still work.
+        let mut parser = kimi_k2_parser();
+        let r = parser.detect_and_parse_reasoning("r</think>a", &[]);
+        assert_eq!(r.reasoning_text, "r");
+        assert_eq!(r.normal_text, "a");
+    }
+
+    #[test]
+    fn test_think_end_wins_over_later_tool_start() {
+        // When </think> arrives before <|tool_calls_section_begin|>, the classic
+        // close wins and the tool marker becomes part of normal text (where the
+        // downstream tool-call parser will pick it up).
+        let mut parser = kimi_k2_parser();
+        let r = parser.detect_and_parse_reasoning(
+            "reasoning</think>answer <|tool_calls_section_begin|>tc",
+            &[],
+        );
+        assert_eq!(r.reasoning_text, "reasoning");
+        assert_eq!(r.normal_text, "answer <|tool_calls_section_begin|>tc");
+    }
+
+    #[test]
+    fn test_no_tool_start_token_behaves_as_before() {
+        // Without the tool_start_token setter, BasicReasoningParser is byte-identical
+        // to the pre-patch behavior — the marker is just reasoning content.
+        let mut parser =
+            BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true);
+        let r =
+            parser.detect_and_parse_reasoning("thinking <|tool_calls_section_begin|>stuff", &[]);
+        assert_eq!(
+            r.reasoning_text,
+            "thinking <|tool_calls_section_begin|>stuff"
+        );
+        assert_eq!(r.normal_text, "");
     }
 }

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -168,12 +168,10 @@ impl ReasoningParserType {
                 )),
             },
             ReasoningParserType::KimiK25 => ReasoningParserWrapper {
-                parser: Box::new(BasicReasoningParser::new(
-                    "<think>".into(),
-                    "</think>".into(),
-                    true,
-                    true,
-                )),
+                parser: Box::new(
+                    BasicReasoningParser::new("<think>".into(), "</think>".into(), true, true)
+                        .with_tool_start_token("<|tool_calls_section_begin|>"),
+                ),
             },
             ReasoningParserType::Mistral => ReasoningParserWrapper {
                 parser: Box::new(BasicReasoningParser::new(

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -14,6 +14,11 @@ pub use gpt_oss_parser::GptOssReasoningParser;
 pub use granite_parser::GraniteReasoningParser;
 pub use minimax_append_think_parser::MiniMaxAppendThinkParser;
 
+/// Kimi-K2/K2.5 tool-call section marker. Shared between the `kimi_k25` reasoning-parser
+/// registration and its test fixtures so both stay in sync. Mirrors
+/// `KimiK2ParserConfig::default().section_start` in `crate::tool_calling::config`.
+pub(crate) const KIMI_K2_TOOL_SECTION_BEGIN: &str = "<|tool_calls_section_begin|>";
+
 static REASONING_PARSER_MAP: OnceLock<HashMap<&'static str, ReasoningParserType>> = OnceLock::new();
 
 /// Initialize the global reasoning parser map
@@ -170,7 +175,7 @@ impl ReasoningParserType {
             ReasoningParserType::KimiK25 => ReasoningParserWrapper {
                 parser: Box::new(
                     BasicReasoningParser::new("<think>".into(), "</think>".into(), true, true)
-                        .with_tool_start_token("<|tool_calls_section_begin|>"),
+                        .with_tool_start_token(KIMI_K2_TOOL_SECTION_BEGIN),
                 ),
             },
             ReasoningParserType::Mistral => ReasoningParserWrapper {

--- a/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -21,12 +21,13 @@ static TOOL_CALL_REGEX: OnceLock<Regex> = OnceLock::new();
 /// `arguments` (JSON object) between the configured `call_start`, `argument_begin`, and
 /// `call_end` tokens.
 ///
-/// The `function_id` pattern `[\w.]+:\d+` matches the `functions.name:index` format used by
-/// Kimi K2, consistent with sglang/vllm reference implementations.
+/// The `function_id` pattern `[\w.\-]+:\d+` matches the `functions.name:index` format used by
+/// Kimi K2, consistent with sglang's reference implementation. The hyphen is included to
+/// support function names with dashes (common in MCP tools, e.g. `mcp__portal__search-documents`).
 fn get_tool_call_regex(config: &KimiK2ParserConfig) -> &'static Regex {
     TOOL_CALL_REGEX.get_or_init(|| {
         let pattern = format!(
-            r"(?s){}\s*(?P<function_id>[\w.]+:\d+)\s*{}\s*(?P<arguments>\{{.*?\}})\s*{}",
+            r"(?s){}\s*(?P<function_id>[\w.\-]+:\d+)\s*{}\s*(?P<arguments>\{{.*?\}})\s*{}",
             regex::escape(&config.call_start),
             regex::escape(&config.argument_begin),
             regex::escape(&config.call_end),
@@ -37,7 +38,7 @@ fn get_tool_call_regex(config: &KimiK2ParserConfig) -> &'static Regex {
 
 fn get_id_regex() -> &'static Regex {
     ID_REGEX.get_or_init(|| {
-        Regex::new(r"^(?:functions\.)?(?P<name>[\w\.]+):(?P<index>\d+)$")
+        Regex::new(r"^(?:functions\.)?(?P<name>[\w.\-]+):(?P<index>\d+)$")
             .expect("Failed to compile kimi k2 id regex")
     })
 }
@@ -630,7 +631,7 @@ mod tests {
     fn test_parse_invalid_function_id_rejected_by_regex() {
         // vllm: test_extract_tool_calls_invalid_funcall
         // sglang: test_invalid_tool_call
-        // After C2 fix, function_id regex requires [\w.]+:\d+ — IDs without :digit are rejected
+        // function_id regex requires [\w.\-]+:\d+ — IDs without :digit are rejected
         let config = default_config();
 
         // No colon+digit suffix at all
@@ -733,5 +734,47 @@ mod tests {
             Some("Here is my answer.  And more text.".to_string()),
             "Text around empty section should be preserved"
         );
+    }
+
+    #[test]
+    fn test_parse_hyphenated_function_name() {
+        // sglang PR #19552: function names with a single hyphen (common in MCP tools).
+        let config = default_config();
+        let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.list-tasklists:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"#;
+
+        let (calls, normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "Hyphenated name should parse as a tool call"
+        );
+        assert_eq!(calls[0].function.name, "list-tasklists");
+        assert_eq!(calls[0].function.arguments, "{}");
+        assert_eq!(normal, Some("".to_string()));
+    }
+
+    #[test]
+    fn test_parse_mcp_style_name_with_multiple_separators() {
+        // sglang PR #19552: names mixing underscores and hyphens, non-zero index.
+        let config = default_config();
+        let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.mcp__portal__search-documents:3<|tool_call_argument_begin|>{"q":"roger federer"}<|tool_call_end|><|tool_calls_section_end|>"#;
+
+        let (calls, _normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "mcp__portal__search-documents");
+        assert_eq!(calls[0].id, "functions.mcp__portal__search-documents:3");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["q"], "roger federer");
+    }
+
+    #[test]
+    fn test_parse_real_world_gtasks_name() {
+        // Real production case: Kimi-K2.6 emitting gtasks_list-tasklists via MCP.
+        let config = default_config();
+        let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.gtasks_list-tasklists:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"#;
+
+        let (calls, _normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "gtasks_list-tasklists");
     }
 }

--- a/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -301,6 +301,7 @@ fn parse_section_block(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     fn default_config() -> KimiK2ParserConfig {
         KimiK2ParserConfig::default()
@@ -736,45 +737,27 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_parse_hyphenated_function_name() {
-        // sglang PR #19552: function names with a single hyphen (common in MCP tools).
+    #[rstest]
+    #[case(
+        r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.list-tasklists:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"#,
+        "list-tasklists",
+        "functions.list-tasklists:0"
+    )]
+    #[case(
+        r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.mcp__portal__search-documents:3<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"#,
+        "mcp__portal__search-documents",
+        "functions.mcp__portal__search-documents:3"
+    )]
+    #[case(
+        r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.gtasks_list-tasklists:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"#,
+        "gtasks_list-tasklists",
+        "functions.gtasks_list-tasklists:0"
+    )]
+    fn test_parse_names_with_hyphens(#[case] input: &str, #[case] name: &str, #[case] id: &str) {
         let config = default_config();
-        let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.list-tasklists:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"#;
-
-        let (calls, normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
-        assert_eq!(
-            calls.len(),
-            1,
-            "Hyphenated name should parse as a tool call"
-        );
-        assert_eq!(calls[0].function.name, "list-tasklists");
-        assert_eq!(calls[0].function.arguments, "{}");
-        assert_eq!(normal, Some("".to_string()));
-    }
-
-    #[test]
-    fn test_parse_mcp_style_name_with_multiple_separators() {
-        // sglang PR #19552: names mixing underscores and hyphens, non-zero index.
-        let config = default_config();
-        let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.mcp__portal__search-documents:3<|tool_call_argument_begin|>{"q":"roger federer"}<|tool_call_end|><|tool_calls_section_end|>"#;
-
         let (calls, _normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].function.name, "mcp__portal__search-documents");
-        assert_eq!(calls[0].id, "functions.mcp__portal__search-documents:3");
-        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
-        assert_eq!(args["q"], "roger federer");
-    }
-
-    #[test]
-    fn test_parse_real_world_gtasks_name() {
-        // Real production case: Kimi-K2.6 emitting gtasks_list-tasklists via MCP.
-        let config = default_config();
-        let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.gtasks_list-tasklists:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"#;
-
-        let (calls, _normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].function.name, "gtasks_list-tasklists");
+        assert_eq!(calls[0].function.name, name);
+        assert_eq!(calls[0].id, id);
     }
 }


### PR DESCRIPTION
#### Overview:

Back-port two upstream sglang fixes (PR sgl-project/sglang#19552) into Dynamo's Rust parsers so Kimi-K2.6 tool calling works correctly with hyphenated MCP tool names and stops leaking final answers into reasoning_content.

#### Details:

  Widens the kimi_k2 tool-parser regex from [\w.]+ to [\w.\-]+ so names like gtasks_list-tasklists are captured as structured tool_calls instead of raw text. Adds an optional tool_start_token to BasicReasoningParser that force-exits reasoning when <|tool_calls_section_begin|> appears before </think>, and wires it for the kimi_k25 parser; all other parsers are unaffected (None short-circuits the hot path).

#### Where should the reviewer start?

lib/parsers/src/reasoning/base_parser.rs — the force-exit branches in detect_and_parse_reasoning and parse_reasoning_streaming_incremental, plus the rstest-based tests at the end of the file. lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs is a small regex widening with 3 new table-driven cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced reasoning parsing to handle tool invocation markers during reasoning phase, allowing early termination of reasoning blocks.
  * Extended function identifier patterns to accept hyphens in function names, supporting a broader range of naming conventions.

* **Improvements**
  * Improved parser compatibility with advanced reasoning models through better tool-call handling during reasoning blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->