### PR TITLE
test(fault_tolerance): replace hand-rolled SSE parser with openai SDK

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,3 +90,4 @@ repos:
         - filelock
         - pyyaml
         - prometheus_client>=0.23.1
+        - openai

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -102,7 +102,10 @@ def start_completion_request(
                     stream=True,
                 ):
                     text = chunk.choices[0].text if chunk.choices else None
-                    if text:
+                    # Match the original hand-rolled parser: keep empty strings,
+                    # drop only None. Empty chunks (e.g. the first stream frame)
+                    # still count as a response arrival for delay measurement.
+                    if text is not None:
                         response_list.append((text, time.time()))
             else:
                 resp = client.completions.create(
@@ -166,7 +169,11 @@ def start_chat_completion_request(
                     stream=True,
                 ):
                     content = chunk.choices[0].delta.content if chunk.choices else None
-                    if content:
+                    # Match the original hand-rolled parser: keep empty strings,
+                    # drop only None. Empty chunks (e.g. the first `role`-only
+                    # stream frame) still count as a response arrival for delay
+                    # measurement.
+                    if content is not None:
                         response_list.append((content, time.time()))
             else:
                 resp = client.chat.completions.create(

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 import logging
 import re
 import threading
@@ -9,6 +8,7 @@ import time
 
 import pytest
 import requests
+from openai import APIError, OpenAI
 
 from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
 from tests.utils.managed_process import (
@@ -46,34 +46,18 @@ class DynamoFrontendProcess(BaseDynamoFrontendProcess):
         )
 
 
-def _parse_completion_sse_content(line: str) -> str | Exception | None:
+def _make_client(frontend_port: int) -> OpenAI:
+    """Build an OpenAI client pointed at the test frontend.
+
+    max_retries=0 so fault-tolerance tests see the first error instead of
+    silent retries; api_key is a placeholder since the frontend doesn't auth.
     """
-    Parse an SSE line from the completions API and extract the text content.
-
-    Args:
-        line: Raw SSE line string
-
-    Returns:
-        str: The text content if found
-        Exception: If error event or parse error
-        None: If no content (e.g., [DONE] or empty)
-    """
-    if line.startswith("event: error"):
-        return Exception(f"SSE error event received: {line}")
-
-    if not line.startswith("data: "):
-        return None  # Skip non-data lines
-
-    data_str = line[6:]  # Remove "data: " prefix
-    if data_str == "[DONE]":
-        return None
-
-    try:
-        chunk = json.loads(data_str)
-        text = chunk["choices"][0].get("text")
-        return text  # May be None if no text content
-    except Exception as e:
-        return Exception(f"Error parsing response chunk: {e}")
+    return OpenAI(
+        base_url=f"http://localhost:{frontend_port}/v1",
+        api_key="not-needed",
+        max_retries=0,
+        timeout=240,
+    )
 
 
 def start_completion_request(
@@ -102,14 +86,6 @@ def start_completion_request(
         prompt = "Tell me a long long long story about yourself?"
         if use_long_prompt:
             prompt += " Make sure it is" + " long" * 8000 + "!"
-        timeout = 240  # Extended timeout for long request
-
-        payload = {
-            "model": FAULT_TOLERANCE_MODEL_NAME,
-            "prompt": prompt,
-            "stream": stream,
-        }
-        headers = {"Content-Type": "application/json"}
 
         logger.info(
             f"Sending completion request (stream={stream}) with prompt: '{prompt[:50]}...'"
@@ -118,45 +94,27 @@ def start_completion_request(
         response_list.append((None, time.time()))  # start timestamp
 
         try:
-            with requests.post(
-                f"http://localhost:{frontend_port}/v1/completions",
-                headers=headers,
-                json=payload,
-                timeout=timeout,
-                stream=stream,
-            ) as response:
-                logger.info(
-                    f"Received response with status code: {response.status_code}"
+            client = _make_client(frontend_port)
+            if stream:
+                for chunk in client.completions.create(
+                    model=FAULT_TOLERANCE_MODEL_NAME,
+                    prompt=prompt,
+                    stream=True,
+                ):
+                    text = chunk.choices[0].text if chunk.choices else None
+                    if text:
+                        response_list.append((text, time.time()))
+            else:
+                resp = client.completions.create(
+                    model=FAULT_TOLERANCE_MODEL_NAME,
+                    prompt=prompt,
+                    stream=False,
                 )
-                if response.status_code != 200:
-                    response_list.append(
-                        (
-                            Exception(
-                                f"Request failed with status {response.status_code}: {response.text}"
-                            ),
-                            time.time(),
-                        )
-                    )
-                    return
-
-                if stream:
-                    for line in response.iter_lines():
-                        if line:
-                            content = _parse_completion_sse_content(
-                                line.decode("utf-8")
-                            )
-                            if content is not None:
-                                response_list.append((content, time.time()))
-                else:
-                    try:
-                        content = response.json()["choices"][0]["text"]
-                        response_list.append((content, time.time()))
-                    except Exception as e:
-                        response_list.append(
-                            (Exception(f"Error parsing response: {e}"), time.time())
-                        )
-
+                response_list.append((resp.choices[0].text, time.time()))
         except Exception as e:
+            # openai.APIError subclasses cover HTTP non-200, mid-stream
+            # structured `data: {"error": {...}}` frames, connection failures,
+            # and timeouts. Non-openai exceptions (network, etc.) also bubble.
             logger.error(f"Request failed with error: {e}")
             response_list.append((e, time.time()))
 
@@ -164,36 +122,6 @@ def start_completion_request(
     request_thread.start()
 
     return request_thread, response_list
-
-
-def _parse_chat_completion_sse_content(line: str) -> str | Exception | None:
-    """
-    Parse an SSE line and extract the content.
-
-    Args:
-        line: Raw SSE line string
-
-    Returns:
-        str: The content delta if found
-        Exception: If error event or parse error
-        None: If no content (e.g., [DONE] or empty delta)
-    """
-    if line.startswith("event: error"):
-        return Exception(f"SSE error event received: {line}")
-
-    if not line.startswith("data: "):
-        return None  # Skip non-data lines
-
-    data_str = line[6:]  # Remove "data: " prefix
-    if data_str == "[DONE]":
-        return None
-
-    try:
-        chunk = json.loads(data_str)
-        content = chunk["choices"][0]["delta"].get("content")
-        return content  # May be None if delta has no content
-    except Exception as e:
-        return Exception(f"Error parsing response chunk: {e}")
 
 
 def start_chat_completion_request(
@@ -222,14 +150,6 @@ def start_chat_completion_request(
         prompt = "Tell me a long long long story about yourself?"
         if use_long_prompt:
             prompt += " Make sure it is" + " long" * 8000 + "!"
-        timeout = 240  # Extended timeout for long request
-
-        payload = {
-            "model": FAULT_TOLERANCE_MODEL_NAME,
-            "messages": [{"role": "user", "content": prompt}],
-            "stream": stream,
-        }
-        headers = {"Content-Type": "application/json"}
 
         logger.info(
             f"Sending chat completion request (stream={stream}) with prompt: '{prompt[:50]}...'"
@@ -238,45 +158,27 @@ def start_chat_completion_request(
         response_list.append((None, time.time()))  # start timestamp
 
         try:
-            with requests.post(
-                f"http://localhost:{frontend_port}/v1/chat/completions",
-                headers=headers,
-                json=payload,
-                timeout=timeout,
-                stream=stream,
-            ) as response:
-                logger.info(
-                    f"Received response with status code: {response.status_code}"
-                )
-                if response.status_code != 200:
-                    response_list.append(
-                        (
-                            Exception(
-                                f"Request failed with status {response.status_code}: {response.text}"
-                            ),
-                            time.time(),
-                        )
-                    )
-                    return
-
-                if stream:
-                    for line in response.iter_lines():
-                        if line:
-                            content = _parse_chat_completion_sse_content(
-                                line.decode("utf-8")
-                            )
-                            if content is not None:
-                                response_list.append((content, time.time()))
-                else:
-                    try:
-                        content = response.json()["choices"][0]["message"]["content"]
+            client = _make_client(frontend_port)
+            if stream:
+                for chunk in client.chat.completions.create(
+                    model=FAULT_TOLERANCE_MODEL_NAME,
+                    messages=[{"role": "user", "content": prompt}],
+                    stream=True,
+                ):
+                    content = chunk.choices[0].delta.content if chunk.choices else None
+                    if content:
                         response_list.append((content, time.time()))
-                    except Exception as e:
-                        response_list.append(
-                            (Exception(f"Error parsing response: {e}"), time.time())
-                        )
-
+            else:
+                resp = client.chat.completions.create(
+                    model=FAULT_TOLERANCE_MODEL_NAME,
+                    messages=[{"role": "user", "content": prompt}],
+                    stream=False,
+                )
+                response_list.append((resp.choices[0].message.content, time.time()))
         except Exception as e:
+            # openai.APIError subclasses cover HTTP non-200, mid-stream
+            # structured `data: {"error": {...}}` frames, connection failures,
+            # and timeouts. Non-openai exceptions also bubble for visibility.
             logger.error(f"Request failed with error: {e}")
             response_list.append((e, time.time()))
 
@@ -634,12 +536,12 @@ def run_migration_test(
             pytest.fail(
                 "Request succeeded unexpectedly when migration should have failed"
             )
-        except Exception as e:
-            error_str = str(e)
-            assert (
-                "SSE error event received:" in error_str
-                or "Request failed with status" in error_str
-            ), f"Unexpected error: {e}"
+        except APIError as e:
+            # Expected: openai.APIError covers mid-stream structured error
+            # frames (DIS-1768 contract) and HTTP non-200 responses. A typed
+            # check is more robust than matching the exception's stringified
+            # message against a specific wire-format prefix.
+            logger.info(f"Got expected APIError: {e}")
 
         try:
             verify_migration_occurred(frontend)


### PR DESCRIPTION
## Summary

Replace the hand-rolled SSE parser in `tests/fault_tolerance/migration/utils.py` with the `openai` Python SDK. Eliminates ~160 lines of custom parsing, unblocks the sglang post-merge amd64 job that broke when #8430 landed earlier today, and makes the test resilient to future frontend SSE wire-format changes.

## What broke

#8430 (DIS-1768, commit `f53fa64c24` by @keivenchang, merged ~3 hr before the regression) changed the frontend's mid-stream fault wire format from

```
event: error
: <error message>
```

to the OpenAI-compliant

```
data: {"error":{"message":..., "type":"internal_server_error", "code":500}}
data: [DONE]
```

The old hand-rolled parsers (`_parse_completion_sse_content`, `_parse_chat_completion_sse_content`) only recognised the old `event: error` trailer. The new frame slipped through to `chunk["choices"][0]["delta"]` → `KeyError('choices')` → 17 parametrizations of `test_request_migration_sglang_aggregated[*-chat-stream-*]` fail with `AssertionError: Unexpected error: Error parsing response chunk: 'choices'` in [job 72561414779](https://github.com/ai-dynamo/dynamo/actions/runs/24794701228/job/72561414779).

## Root cause, not bandaid

The initial version of this PR just taught the parser the new format alongside the old one. That worked, but only patched a symptom — the real weakness is that the test does manual `requests.post(stream=True)` + `iter_lines()` + per-line SSE parsing, so every time the server changes its SSE contract the test breaks again.

The `openai` Python SDK is already at 2.6.1 in `container/deps/requirements.test.txt` and already used in `tests/frontend/test_prompt_embeds.py`. It:

- iterates `ChatCompletionChunk` / `Completion` objects with proper structured types
- raises typed `openai.APIError` subclasses on mid-stream faults, HTTP non-200, connection failure, and timeout — whether the server emits the old `event: error` trailer or the new structured `data: {"error": {...}}` frame
- will absorb any future SSE wire-format tweaks without needing test-side edits

So I swapped it in. No more manual SSE parsing.

## Commits on this PR

1. **`846de8b2e` — `test(fault_tolerance): replace hand-rolled SSE parser with openai SDK`**
   - Deletes `_parse_completion_sse_content` + `_parse_chat_completion_sse_content` entirely.
   - `start_completion_request` / `start_chat_completion_request` now use `client.completions.create(stream=True)` and `client.chat.completions.create(stream=True)` from openai.
   - One new `_make_client(port)` helper: `OpenAI(base_url="http://localhost:{port}/v1", api_key="not-needed", max_retries=0, timeout=240)`. `max_retries=0` so fault-tolerance tests see the first error instead of a retry-masked one.
   - In `run_migration_test`, the assertion that expects a failed request (`migration disabled` or `max_seq_len_exceeded`) is narrowed from a permissive string match (`"SSE error event received:"` or `"Request failed with status"`) to `except APIError`. Typed check > string match.
   - Adds `openai` to the pre-commit `pytest-marker-report` hook's `additional_dependencies` so the hook can statically collect test files that import `openai` at module level (same pattern that `tests/frontend/test_prompt_embeds.py` already depends on).

2. **`5bbb667b2` — `test(fault_tolerance): preserve empty content chunks in openai-SDK flow`**
   - Match the original hand-rolled parser's `if content is not None` semantics so empty-string delta chunks (e.g. the first role-only streaming frame OpenAI emits) still count as a response arrival for `validate_response`'s delay measurement. Caught during PR verification; without this fix, the first-token delay measurement skewed ~10 s upward because the initial empty chunk wasn't accounted for.

Public function signatures and `response_list` tuple shape are unchanged, so `validate_response`, `run_migration_test`, and the test files themselves need no edits beyond the narrowed assertion.

## Diff summary

```
.pre-commit-config.yaml                  |   1 +
tests/fault_tolerance/migration/utils.py | 211 +++++++++----------------------
2 files changed, 60 insertions(+), 152 deletions(-)
```

## Verified

### Local (gpu host, nightly-matching image `sglang-runtime-test-cuda13@69823d72eb`)

| Param | Path | Result |
|---|---|---|
| `migration_enabled-max_seq_len_exceeded-worker_failure-chat-stream-tcp` | error | PASSED |
| `migration_disabled-max_seq_len_disabled-worker_failure-chat-stream-tcp` | error | PASSED |
| `migration_enabled-max_seq_len_not_exceeded-worker_failure-chat-stream-tcp` | success | PASSED |

### PR CI (commit `3207291bd7`, a temporary DEBUG commit that flipped `test_request_migration_sglang_aggregated` to `@pre_merge` and bumped the job timeout to 60 min; DEBUG commit dropped from the final branch before merge)

All ~22 previously-failing `chat-stream-*` parametrizations of `test_request_migration_sglang_aggregated` **PASS** on both cuda12.9 and cuda13.0 amd64.

Two residual failures, both **pre-existing and unrelated to this PR**:

1. `test_request_migration_sglang_aggregated[migration_enabled-max_seq_len_disabled-graceful_shutdown-chat-stream-nats]` — OPS-4446 first-token delay flake. Confirmed pre-existing: same test failed with `Delay before response > 6 secs, got 16.109 secs` in post-merge job [72508610419](https://github.com/ai-dynamo/dynamo/actions/runs/24779871891/job/72508610419), run on head SHA `9bf9709a65` which is **before** the SSE fix `f53fa64c24` and before this PR. Sibling `worker_failure-chat-stream-*` combos are already inline-skipped under OPS-4446; this one isn't. Out of scope here.
2. `tests/frontend/test_tool_calling_sglang.py::TestToolCallingProtocol::test_tool_call_ids_unique_in_single_response` — `unexpected finish_reason='length', allowed=['tool_calls']`. Same small-model + guided-decoding generation-variance class that caused PR #8474 to delete the sibling `test_sql_tool_arguments_schema_valid` the day before this PR. 8/8 recent post-merge runs show this specific test PASSING, so it's a rare hit of a known flake class. My PR doesn't touch tool-calling code. Out of scope here.

## Test plan
- [ ] Post-merge `sglang / Test cuda12.9 (amd64)` and `sglang / Test cuda13.0 (amd64)` pass after merge.
- [ ] vllm/trtllm migration tests (share `utils.py`) pass on their next post-merge run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)