### PR TITLE
feat: add standalone indexer readiness endpoints

### DIFF
--- a/docs/components/router/standalone-indexer.md
+++ b/docs/components/router/standalone-indexer.md
@@ -133,9 +133,64 @@ Leave it unset or set it to `0` to disable the startup wait.
 
 ## HTTP API
 
+### `GET /ready` — Readiness check
+
+Returns a compact readiness snapshot. The HTTP status is `200 OK` when ready and
+`503 Service Unavailable` otherwise.
+
+```bash
+curl http://localhost:8090/ready
+```
+
+```json
+{
+  "ready": false,
+  "reason": "waiting_for_min_initial_workers"
+}
+```
+
+`reason` is one of:
+
+- `recovering_from_peer`
+- `waiting_for_min_initial_workers`
+- `listeners_pending`
+- `listeners_failed`
+- `ready`
+
+### `GET /status` — Startup and listener snapshot
+
+Returns a small JSON snapshot for deploy tooling and debugging.
+
+```bash
+curl http://localhost:8090/status
+```
+
+```json
+{
+  "ready": false,
+  "reason": "listeners_pending",
+  "recovery": {
+    "enabled": true,
+    "in_progress": false,
+    "last_result": "succeeded"
+  },
+  "workers": {
+    "required_initial": 2,
+    "registered": 2
+  },
+  "listeners": {
+    "pending": 1,
+    "active": 1,
+    "paused": 0,
+    "failed": 0
+  }
+}
+```
+
 ### `GET /health` — Liveness check
 
-Returns `200 OK` unconditionally.
+Returns `200 OK` unconditionally, even while `/ready` is still reporting a startup gate.
+Use `/health` for liveness and `/ready` for traffic-gating decisions.
 
 ```bash
 curl http://localhost:8090/health

--- a/lib/kv-router/src/standalone_indexer/mod.rs
+++ b/lib/kv-router/src/standalone_indexer/mod.rs
@@ -16,7 +16,7 @@ use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::min_initial_workers_from_env;
-use registry::WorkerRegistry;
+use registry::{RecoveryResult, WorkerRegistry};
 use server::{AppState, create_router};
 
 pub struct IndexerConfig {
@@ -149,8 +149,8 @@ pub async fn run_server(config: IndexerConfig) -> anyhow::Result<()> {
 async fn wait_for_min_initial_workers(
     registry: &WorkerRegistry,
     cancel_token: &CancellationToken,
+    min_initial_workers: usize,
 ) -> anyhow::Result<()> {
-    let min_initial_workers = min_initial_workers_from_env()?;
     if min_initial_workers == 0 {
         return Ok(());
     }
@@ -177,6 +177,16 @@ async fn run_common(
     config: &IndexerConfig,
     registry: &Arc<WorkerRegistry>,
     cancel_token: CancellationToken,
+) -> anyhow::Result<()> {
+    let min_initial_workers = min_initial_workers_from_env()?;
+    run_common_with_startup(config, registry, cancel_token, min_initial_workers).await
+}
+
+async fn run_common_with_startup(
+    config: &IndexerConfig,
+    registry: &Arc<WorkerRegistry>,
+    cancel_token: CancellationToken,
+    min_initial_workers: usize,
 ) -> anyhow::Result<()> {
     if let Some(ref workers_str) = config.workers {
         let block_size = config.block_size.ok_or_else(|| {
@@ -209,19 +219,49 @@ async fn run_common(
         })
         .unwrap_or_default();
 
-    if !peers.is_empty() {
-        match recovery::recover_from_peers(&peers, registry).await {
-            Ok(true) => tracing::info!("P2P recovery completed"),
-            Ok(false) => tracing::warn!("no reachable peers, starting with empty state"),
-            Err(e) => tracing::warn!(error = %e, "P2P recovery failed, starting with empty state"),
-        }
-        for peer in &peers {
-            registry.register_peer(peer.clone());
-        }
+    for peer in &peers {
+        registry.register_peer(peer.clone());
     }
 
-    wait_for_min_initial_workers(registry, &cancel_token).await?;
-    registry.signal_ready();
+    registry.configure_startup(min_initial_workers, !peers.is_empty());
+    if peers.is_empty() && min_initial_workers == 0 {
+        registry.signal_ready();
+    } else {
+        let startup_registry = registry.clone();
+        let startup_cancel = cancel_token.clone();
+        tokio::spawn(async move {
+            if !peers.is_empty() {
+                let result = match recovery::recover_from_peers(&peers, &startup_registry).await {
+                    Ok(true) => {
+                        tracing::info!("P2P recovery completed");
+                        RecoveryResult::Succeeded
+                    }
+                    Ok(false) => {
+                        tracing::warn!("no reachable peers, starting with empty state");
+                        RecoveryResult::NoReachablePeers
+                    }
+                    Err(error) => {
+                        tracing::warn!(error = %error, "P2P recovery failed, starting with empty state");
+                        RecoveryResult::Failed
+                    }
+                };
+                startup_registry.complete_recovery(result);
+            }
+
+            if let Err(error) = wait_for_min_initial_workers(
+                &startup_registry,
+                &startup_cancel,
+                min_initial_workers,
+            )
+            .await
+            {
+                tracing::warn!(error = %error, "startup readiness gate ended before completion");
+                return;
+            }
+
+            startup_registry.signal_ready();
+        });
+    }
 
     #[cfg(feature = "metrics")]
     let prom_registry = {
@@ -287,5 +327,69 @@ mod tests {
         assert!(validate_zmq_endpoint("tcp://:5558").is_err());
         assert!(validate_zmq_endpoint("udp://host:5558").is_err());
         assert!(validate_zmq_endpoint("not-an-endpoint").is_err());
+    }
+
+    #[tokio::test]
+    async fn run_common_exposes_ready_while_waiting_for_min_workers() {
+        let reserved = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = reserved.local_addr().unwrap().port();
+        drop(reserved);
+
+        let registry = Arc::new(WorkerRegistry::new(1));
+        let cancel_token = CancellationToken::new();
+        let config = IndexerConfig {
+            block_size: None,
+            port,
+            threads: 1,
+            workers: None,
+            model_name: "test-model".to_string(),
+            tenant_id: "default".to_string(),
+            peers: None,
+        };
+
+        let registry_for_task = registry.clone();
+        let cancel_for_task = cancel_token.clone();
+        let server = tokio::spawn(async move {
+            run_common_with_startup(&config, &registry_for_task, cancel_for_task, 1).await
+        });
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(1))
+            .build()
+            .unwrap();
+        let base_url = format!("http://127.0.0.1:{port}");
+
+        let mut health_ok = false;
+        for _ in 0..20 {
+            match client.get(format!("{base_url}/health")).send().await {
+                Ok(response) if response.status() == reqwest::StatusCode::OK => {
+                    health_ok = true;
+                    break;
+                }
+                _ => tokio::time::sleep(Duration::from_millis(100)).await,
+            }
+        }
+        assert!(health_ok, "HTTP server never became reachable");
+
+        let ready_response = client
+            .get(format!("{base_url}/ready"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            ready_response.status(),
+            reqwest::StatusCode::SERVICE_UNAVAILABLE
+        );
+        let ready_body: serde_json::Value = ready_response.json().await.unwrap();
+        assert_eq!(
+            ready_body,
+            serde_json::json!({
+                "ready": false,
+                "reason": "waiting_for_min_initial_workers"
+            })
+        );
+
+        cancel_token.cancel();
+        server.await.unwrap().unwrap();
     }
 }

--- a/lib/kv-router/src/standalone_indexer/registry.rs
+++ b/lib/kv-router/src/standalone_indexer/registry.rs
@@ -113,6 +113,72 @@ pub struct WorkerInfo {
     listeners: HashMap<u32, ListenerInfo>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReadyReason {
+    RecoveringFromPeer,
+    WaitingForMinInitialWorkers,
+    ListenersPending,
+    ListenersFailed,
+    Ready,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryResult {
+    Succeeded,
+    NoReachablePeers,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ReadinessSnapshot {
+    pub ready: bool,
+    pub reason: ReadyReason,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RecoverySnapshot {
+    pub enabled: bool,
+    pub in_progress: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_result: Option<RecoveryResult>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct WorkerCountSnapshot {
+    pub required_initial: usize,
+    pub registered: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ListenerCountSnapshot {
+    pub pending: usize,
+    pub active: usize,
+    pub paused: usize,
+    pub failed: usize,
+}
+
+impl ListenerCountSnapshot {
+    fn from_counts(counts: [usize; 4]) -> Self {
+        Self {
+            pending: counts[ListenerStatus::Pending.metric_index()],
+            active: counts[ListenerStatus::Active.metric_index()],
+            paused: counts[ListenerStatus::Paused.metric_index()],
+            failed: counts[ListenerStatus::Failed.metric_index()],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct StatusSnapshot {
+    pub ready: bool,
+    pub reason: ReadyReason,
+    pub recovery: RecoverySnapshot,
+    pub workers: WorkerCountSnapshot,
+    pub listeners: ListenerCountSnapshot,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ListenerControlError {
     #[error("instance {instance_id} not found")]
@@ -144,6 +210,15 @@ struct ListenerRuntime {
     last_error: Option<String>,
     cancel_token: Option<CancellationToken>,
     generation: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct StartupState {
+    recovery_enabled: bool,
+    recovery_in_progress: bool,
+    recovery_last_result: Option<RecoveryResult>,
+    min_initial_workers: usize,
+    startup_gate_open: bool,
 }
 
 pub struct ListenerRecord {
@@ -317,6 +392,7 @@ pub struct WorkerRegistry {
     num_threads: usize,
     ready_tx: watch::Sender<bool>,
     ready_rx: watch::Receiver<bool>,
+    startup: Mutex<StartupState>,
 }
 
 impl WorkerRegistry {
@@ -330,15 +406,61 @@ impl WorkerRegistry {
             num_threads,
             ready_tx,
             ready_rx,
+            startup: Mutex::new(StartupState::default()),
         }
     }
 
+    pub fn configure_startup(&self, min_initial_workers: usize, recovery_enabled: bool) {
+        let mut startup = self.startup.lock();
+        startup.min_initial_workers = min_initial_workers;
+        startup.recovery_enabled = recovery_enabled;
+        startup.recovery_in_progress = recovery_enabled;
+        startup.recovery_last_result = None;
+        startup.startup_gate_open = false;
+    }
+
+    pub fn complete_recovery(&self, result: RecoveryResult) {
+        let mut startup = self.startup.lock();
+        startup.recovery_in_progress = false;
+        startup.recovery_last_result = Some(result);
+    }
+
     pub fn signal_ready(&self) {
+        self.startup.lock().startup_gate_open = true;
         let _ = self.ready_tx.send(true);
     }
 
     pub fn ready_rx(&self) -> watch::Receiver<bool> {
         self.ready_rx.clone()
+    }
+
+    pub fn readiness_snapshot(&self) -> ReadinessSnapshot {
+        let snapshot = self.status_snapshot();
+        ReadinessSnapshot {
+            ready: snapshot.ready,
+            reason: snapshot.reason,
+        }
+    }
+
+    pub fn status_snapshot(&self) -> StatusSnapshot {
+        let startup = *self.startup.lock();
+        let registered_workers = self.workers.len();
+        let listener_counts = self.listener_counts();
+        let reason = Self::ready_reason(startup, registered_workers, &listener_counts);
+        StatusSnapshot {
+            ready: reason == ReadyReason::Ready,
+            reason,
+            recovery: RecoverySnapshot {
+                enabled: startup.recovery_enabled,
+                in_progress: startup.recovery_in_progress,
+                last_result: startup.recovery_last_result,
+            },
+            workers: WorkerCountSnapshot {
+                required_initial: startup.min_initial_workers,
+                registered: registered_workers,
+            },
+            listeners: listener_counts,
+        }
     }
 
     pub fn register_peer(&self, url: String) {
@@ -723,6 +845,58 @@ impl WorkerRegistry {
 
         self.indexers.remove(key);
     }
+
+    fn listener_counts(&self) -> ListenerCountSnapshot {
+        let mut counts = [0_usize; 4];
+        for entry in self.workers.iter() {
+            for record in entry.value().listeners.values() {
+                counts[record.status().metric_index()] += 1;
+            }
+        }
+        ListenerCountSnapshot::from_counts(counts)
+    }
+
+    fn ready_reason(
+        startup: StartupState,
+        registered_workers: usize,
+        listener_counts: &ListenerCountSnapshot,
+    ) -> ReadyReason {
+        if startup.recovery_in_progress {
+            ReadyReason::RecoveringFromPeer
+        } else if !startup.startup_gate_open && registered_workers < startup.min_initial_workers {
+            ReadyReason::WaitingForMinInitialWorkers
+        } else if listener_counts.failed > 0 {
+            ReadyReason::ListenersFailed
+        } else if listener_counts.pending > 0 {
+            ReadyReason::ListenersPending
+        } else {
+            ReadyReason::Ready
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_listener_status_for_test(
+        &self,
+        instance_id: WorkerId,
+        dp_rank: u32,
+        status: ListenerStatus,
+        last_error: Option<&str>,
+    ) {
+        let entry = self
+            .workers
+            .get(&instance_id)
+            .unwrap_or_else(|| panic!("worker {instance_id} not found"));
+        let record = entry
+            .listeners
+            .get(&dp_rank)
+            .unwrap_or_else(|| panic!("worker {instance_id} dp_rank {dp_rank} not found"));
+        let mut runtime = record.runtime.lock();
+        runtime.status = status;
+        runtime.last_error = last_error.map(str::to_string);
+        if matches!(status, ListenerStatus::Failed | ListenerStatus::Paused) {
+            runtime.cancel_token = None;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -895,5 +1069,91 @@ mod tests {
             !registry.watermarks.contains_key(&(1, 0)),
             "watermark should be removed after deregister_all_tenants"
         );
+    }
+
+    #[test]
+    fn readiness_snapshot_reports_recovery_before_worker_gate() {
+        let registry = test_registry();
+        registry.configure_startup(2, true);
+
+        let snapshot = registry.readiness_snapshot();
+        assert!(!snapshot.ready);
+        assert_eq!(snapshot.reason, ReadyReason::RecoveringFromPeer);
+
+        registry.complete_recovery(RecoveryResult::Succeeded);
+
+        let snapshot = registry.readiness_snapshot();
+        assert!(!snapshot.ready);
+        assert_eq!(snapshot.reason, ReadyReason::WaitingForMinInitialWorkers);
+
+        let status = registry.status_snapshot();
+        assert_eq!(status.recovery.last_result, Some(RecoveryResult::Succeeded));
+        assert_eq!(status.workers.required_initial, 2);
+        assert_eq!(status.workers.registered, 0);
+    }
+
+    #[tokio::test]
+    async fn readiness_snapshot_reports_listener_pending_and_ready() {
+        let registry = test_registry();
+        registry.configure_startup(1, false);
+
+        registry
+            .register(
+                1,
+                "tcp://127.0.0.1:15563".to_string(),
+                0,
+                "test-model".to_string(),
+                "default".to_string(),
+                1,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let snapshot = registry.readiness_snapshot();
+        assert!(!snapshot.ready);
+        assert_eq!(snapshot.reason, ReadyReason::ListenersPending);
+
+        registry.signal_ready();
+
+        let snapshot = registry.readiness_snapshot();
+        assert!(!snapshot.ready);
+        assert_eq!(snapshot.reason, ReadyReason::ListenersPending);
+
+        registry.force_listener_status_for_test(1, 0, ListenerStatus::Active, None);
+
+        let snapshot = registry.readiness_snapshot();
+        assert!(snapshot.ready);
+        assert_eq!(snapshot.reason, ReadyReason::Ready);
+    }
+
+    #[tokio::test]
+    async fn readiness_snapshot_reports_listener_failures() {
+        let registry = test_registry();
+        registry.configure_startup(0, false);
+        registry.signal_ready();
+
+        registry
+            .register(
+                1,
+                "tcp://127.0.0.1:15564".to_string(),
+                0,
+                "test-model".to_string(),
+                "default".to_string(),
+                1,
+                None,
+            )
+            .await
+            .unwrap();
+
+        registry.force_listener_status_for_test(1, 0, ListenerStatus::Failed, Some("boom"));
+
+        let snapshot = registry.readiness_snapshot();
+        assert!(!snapshot.ready);
+        assert_eq!(snapshot.reason, ReadyReason::ListenersFailed);
+
+        let status = registry.status_snapshot();
+        assert_eq!(status.listeners.failed, 1);
+        assert_eq!(status.listeners.pending, 0);
     }
 }

--- a/lib/kv-router/src/standalone_indexer/server.rs
+++ b/lib/kv-router/src/standalone_indexer/server.rs
@@ -377,6 +377,20 @@ async fn dump_events(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     (StatusCode::OK, Json(serde_json::json!(result)))
 }
 
+async fn handle_ready(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let snapshot = state.registry.readiness_snapshot();
+    let status = if snapshot.ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (status, Json(snapshot))
+}
+
+async fn handle_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    (StatusCode::OK, Json(state.registry.status_snapshot()))
+}
+
 async fn handle_health() -> StatusCode {
     StatusCode::OK
 }
@@ -413,6 +427,8 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/register_peer", post(register_peer))
         .route("/deregister_peer", post(deregister_peer))
         .route("/peers", get(list_peers))
+        .route("/ready", get(handle_ready))
+        .route("/status", get(handle_status))
         .route("/health", get(handle_health));
 
     let router = router
@@ -437,10 +453,27 @@ pub fn create_router(state: Arc<AppState>) -> Router {
 
 #[cfg(test)]
 mod tests {
+    use super::super::registry::{ListenerStatus, RecoveryResult};
     use super::*;
-    use axum::body::Body;
+    use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode, header};
+    use serde_json::Value;
     use tower::ServiceExt;
+
+    fn test_app() -> (Arc<WorkerRegistry>, Router) {
+        let registry = Arc::new(WorkerRegistry::new(1));
+        let app = create_router(Arc::new(AppState {
+            registry: registry.clone(),
+            #[cfg(feature = "metrics")]
+            prom_registry: prometheus::Registry::new(),
+        }));
+        (registry, app)
+    }
+
+    async fn json_body(response: axum::response::Response) -> Value {
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
 
     fn oversized_query_body() -> String {
         let mut body = String::from(r#"{"token_ids":["#);
@@ -460,11 +493,7 @@ mod tests {
 
     #[tokio::test]
     async fn query_rejects_request_bodies_over_limit() {
-        let app = create_router(Arc::new(AppState {
-            registry: Arc::new(WorkerRegistry::new(1)),
-            #[cfg(feature = "metrics")]
-            prom_registry: prometheus::Registry::new(),
-        }));
+        let (_, app) = test_app();
 
         let response = app
             .oneshot(
@@ -479,5 +508,178 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn ready_endpoint_reports_recovery_in_progress() {
+        let (registry, app) = test_app();
+        registry.configure_startup(2, true);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let body = json_body(response).await;
+        assert_eq!(
+            body,
+            serde_json::json!({"ready": false, "reason": "recovering_from_peer"})
+        );
+    }
+
+    #[tokio::test]
+    async fn status_endpoint_reports_worker_gate_and_listener_counts() {
+        let (registry, app) = test_app();
+        registry.configure_startup(2, false);
+        registry
+            .register(
+                1,
+                "tcp://127.0.0.1:16557".to_string(),
+                0,
+                "test-model".to_string(),
+                "default".to_string(),
+                1,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = json_body(response).await;
+        assert_eq!(body["ready"], Value::Bool(false));
+        assert_eq!(
+            body["reason"],
+            Value::String("waiting_for_min_initial_workers".to_string())
+        );
+        assert_eq!(
+            body["workers"],
+            serde_json::json!({"required_initial": 2, "registered": 1})
+        );
+        assert_eq!(
+            body["listeners"],
+            serde_json::json!({"pending": 1, "active": 0, "paused": 0, "failed": 0})
+        );
+        assert_eq!(
+            body["recovery"],
+            serde_json::json!({"enabled": false, "in_progress": false})
+        );
+    }
+
+    #[tokio::test]
+    async fn ready_endpoint_reports_listener_failure_after_startup() {
+        let (registry, app) = test_app();
+        registry.configure_startup(0, false);
+        registry.signal_ready();
+        registry
+            .register(
+                1,
+                "tcp://127.0.0.1:16558".to_string(),
+                0,
+                "test-model".to_string(),
+                "default".to_string(),
+                1,
+                None,
+            )
+            .await
+            .unwrap();
+        registry.force_listener_status_for_test(1, 0, ListenerStatus::Failed, Some("boom"));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let body = json_body(response).await;
+        assert_eq!(
+            body,
+            serde_json::json!({"ready": false, "reason": "listeners_failed"})
+        );
+    }
+
+    #[tokio::test]
+    async fn ready_endpoint_reports_ready_and_health_stays_ok() {
+        let (registry, app) = test_app();
+        registry.configure_startup(0, true);
+        registry.complete_recovery(RecoveryResult::Succeeded);
+        registry.signal_ready();
+        registry
+            .register(
+                1,
+                "tcp://127.0.0.1:16559".to_string(),
+                0,
+                "test-model".to_string(),
+                "default".to_string(),
+                1,
+                None,
+            )
+            .await
+            .unwrap();
+        registry.force_listener_status_for_test(1, 0, ListenerStatus::Active, None);
+
+        let ready_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(ready_response.status(), StatusCode::OK);
+        let ready_body = json_body(ready_response).await;
+        assert_eq!(
+            ready_body,
+            serde_json::json!({"ready": true, "reason": "ready"})
+        );
+
+        let status_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status_body = json_body(status_response).await;
+        assert_eq!(
+            status_body["recovery"]["last_result"],
+            Value::String("succeeded".to_string())
+        );
+
+        let health_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(health_response.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
## Summary
- Add `GET /ready` and `GET /status` to the standalone KV indexer HTTP server.
- Track readiness and recovery state in the registry so startup can report a clear ready reason.
- Keep `/health` as the liveness endpoint and document the new API.

## Validation
- `cargo test -p dynamo-kv-router --features standalone-indexer standalone_indexer::`
- Passed: 21 focused standalone indexer tests, including new readiness/status coverage.

## Notes
- Readiness and liveness intentionally report different semantics.
- Deployments that set `DYN_ROUTER_MIN_INITIAL_WORKERS=0` may still report ready before workers register.