### PR TITLE
fix(operator): drop Recreate override on restore-target Deployments (cherry-pick of #8434)

### DIFF
--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -43,7 +43,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
-	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -975,17 +974,6 @@ func (r *DynamoComponentDeploymentReconciler) generateDeployment(ctx context.Con
 			strategy = appsv1.DeploymentStrategy{
 				Type: appsv1.RecreateDeploymentStrategyType,
 			}
-		}
-	}
-
-	// Checkpoint-restore pods must avoid overlap with prior replicas.
-	// Enforce Recreate whenever the rendered template is a restore target so
-	// the old pod is terminated before the restore placeholder is started.
-	if podTemplateSpec != nil &&
-		podTemplateSpec.Labels != nil &&
-		podTemplateSpec.Labels[snapshotprotocol.RestoreTargetLabel] == commonconsts.KubeLabelValueTrue {
-		strategy = appsv1.DeploymentStrategy{
-			Type: appsv1.RecreateDeploymentStrategyType,
 		}
 	}
 

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1681,7 +1681,11 @@ func TestDynamoComponentDeploymentReconciler_generateDeployment_RestoreStrategy(
 		}
 	}
 
-	t.Run("ready checkpoint forces Recreate strategy", func(t *testing.T) {
+	t.Run("ready checkpoint keeps RollingUpdate strategy", func(t *testing.T) {
+		// Restore-target pods do not need a special Recreate override. The
+		// default RollingUpdate strategy works for failure-replacement and
+		// scale-up; users who specifically want Recreate on tight-GPU nodes
+		// can still opt in via the nvidia.com/deployment-strategy annotation.
 		identity := v1alpha1.DynamoCheckpointIdentity{Model: "test-model", BackendFramework: "vllm"}
 		checkpointName, err := checkpoint.ComputeIdentityHash(identity)
 		if err != nil {
@@ -1709,8 +1713,8 @@ func TestDynamoComponentDeploymentReconciler_generateDeployment_RestoreStrategy(
 		if toDelete {
 			t.Fatalf("expected deployment to be retained")
 		}
-		if deploy.Spec.Strategy.Type != appsv1.RecreateDeploymentStrategyType {
-			t.Fatalf("expected Recreate strategy, got %s", deploy.Spec.Strategy.Type)
+		if deploy.Spec.Strategy.Type != appsv1.RollingUpdateDeploymentStrategyType {
+			t.Fatalf("expected RollingUpdate strategy, got %s", deploy.Spec.Strategy.Type)
 		}
 	})
 


### PR DESCRIPTION
Cherry-pick of #8434 into release/1.1.0.

Main PR: #8434
Source commit: bce060d2800b58308a39ea5cfeb9aa795dc82a76
Release commit: 8409547f4c1c4f538f8a8a5c557175655682f248

Dependencies: none.

Validation:
- cd deploy/operator && go test ./internal/controller -run '^TestDynamoComponentDeploymentReconciler_generateDeployment_RestoreStrategy$' -count=1
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
