### PR TITLE
feat: add SGLang engine routes for weight updates

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -24,6 +24,10 @@ from typing import (
 )
 
 import sglang as sgl
+from sglang.srt.managers.io_struct import (
+    DestroyWeightsUpdateGroupReqInput,
+    InitWeightsUpdateGroupReqInput,
+)
 
 from dynamo._core import Context
 from dynamo.common.utils.input_params import InputParamManager
@@ -733,6 +737,12 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
             return {"priority": normalized}
         return {}
 
+    def _weight_update_unsupported_response(self) -> dict:
+        return {
+            "success": False,
+            "message": "weight update control not supported on this worker",
+        }
+
     async def release_memory_occupation(self, body: dict) -> dict:
         """Release GPU memory occupation and unregister from discovery.
 
@@ -859,18 +869,24 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
 
     async def init_weights_update_group(self, body: dict) -> dict:
         """Initialize distributed weight-update NCCL group on the worker."""
-        from sglang.srt.managers.io_struct import InitWeightsUpdateGroupReqInput
+        if self.engine is None:
+            return self._weight_update_unsupported_response()
 
         req = InitWeightsUpdateGroupReqInput(**body)
-        success, message = await self.engine.tokenizer_manager.init_weights_update_group(req, None)
+        success, message = await self.engine.tokenizer_manager.init_weights_update_group(
+            req, None
+        )
         return {"success": success, "message": message}
 
     async def destroy_weights_update_group(self, body: dict) -> dict:
         """Destroy distributed weight-update NCCL group on the worker."""
-        from sglang.srt.managers.io_struct import DestroyWeightsUpdateGroupReqInput
+        if self.engine is None:
+            return self._weight_update_unsupported_response()
 
         req = DestroyWeightsUpdateGroupReqInput(**body)
-        success, message = await self.engine.tokenizer_manager.destroy_weights_update_group(req, None)
+        success, message = (
+            await self.engine.tokenizer_manager.destroy_weights_update_group(req, None)
+        )
         return {"success": success, "message": message}
 
     async def update_weights_from_tensor(self, body: dict) -> dict:
@@ -999,7 +1015,11 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
     async def get_weight_version(self, body: dict) -> dict:
         """Return the active weight version currently served by the worker."""
         _ = body
-        return {"weight_version": self.engine.tokenizer_manager.server_args.weight_version}
+        if self.engine is None:
+            return self._weight_update_unsupported_response()
+        return {
+            "weight_version": self.engine.tokenizer_manager.server_args.weight_version
+        }
 
     def register_engine_routes(self, runtime: DistributedRuntime) -> None:
         """Register all engine routes for this handler.

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -873,9 +873,10 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
             return self._weight_update_unsupported_response()
 
         req = InitWeightsUpdateGroupReqInput(**body)
-        success, message = await self.engine.tokenizer_manager.init_weights_update_group(
-            req, None
-        )
+        (
+            success,
+            message,
+        ) = await self.engine.tokenizer_manager.init_weights_update_group(req, None)
         return {"success": success, "message": message}
 
     async def destroy_weights_update_group(self, body: dict) -> dict:
@@ -884,9 +885,10 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
             return self._weight_update_unsupported_response()
 
         req = DestroyWeightsUpdateGroupReqInput(**body)
-        success, message = (
-            await self.engine.tokenizer_manager.destroy_weights_update_group(req, None)
-        )
+        (
+            success,
+            message,
+        ) = await self.engine.tokenizer_manager.destroy_weights_update_group(req, None)
         return {"success": success, "message": message}
 
     async def update_weights_from_tensor(self, body: dict) -> dict:

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -857,6 +857,22 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
             "num_paused_requests": num_paused_requests,
         }
 
+    async def init_weights_update_group(self, body: dict) -> dict:
+        """Initialize distributed weight-update NCCL group on the worker."""
+        from sglang.srt.managers.io_struct import InitWeightsUpdateGroupReqInput
+
+        req = InitWeightsUpdateGroupReqInput(**body)
+        success, message = await self.engine.tokenizer_manager.init_weights_update_group(req, None)
+        return {"success": success, "message": message}
+
+    async def destroy_weights_update_group(self, body: dict) -> dict:
+        """Destroy distributed weight-update NCCL group on the worker."""
+        from sglang.srt.managers.io_struct import DestroyWeightsUpdateGroupReqInput
+
+        req = DestroyWeightsUpdateGroupReqInput(**body)
+        success, message = await self.engine.tokenizer_manager.destroy_weights_update_group(req, None)
+        return {"success": success, "message": message}
+
     async def update_weights_from_tensor(self, body: dict) -> dict:
         """Update model weights from tensors without restarting the server."""
         from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
@@ -980,6 +996,11 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
             result = {"status": "error", "message": f"Unknown action: {action}"}
         yield result
 
+    async def get_weight_version(self, body: dict) -> dict:
+        """Return the active weight version currently served by the worker."""
+        _ = body
+        return {"weight_version": self.engine.tokenizer_manager.server_args.weight_version}
+
     def register_engine_routes(self, runtime: DistributedRuntime) -> None:
         """Register all engine routes for this handler.
 
@@ -993,6 +1014,12 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
         )
         runtime.register_engine_route(
             "resume_memory_occupation", self.resume_memory_occupation
+        )
+        runtime.register_engine_route(
+            "init_weights_update_group", self.init_weights_update_group
+        )
+        runtime.register_engine_route(
+            "destroy_weights_update_group", self.destroy_weights_update_group
         )
         runtime.register_engine_route(
             "update_weights_from_disk", self.update_weights_from_disk
@@ -1009,6 +1036,7 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
         runtime.register_engine_route(
             "update_weight_version", self.update_weight_version
         )
+        runtime.register_engine_route("get_weight_version", self.get_weight_version)
         if getattr(self.config, "dynamo_args", None) and getattr(
             self.config.dynamo_args, "enable_rl", False
         ):

--- a/components/src/dynamo/sglang/tests/test_sglang_handler_base.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_handler_base.py
@@ -52,3 +52,21 @@ async def test_get_weight_version_reads_active_version_from_server_args():
     result = await handler.get_weight_version({})
 
     assert result == {"weight_version": 17}
+
+
+@pytest.mark.asyncio
+async def test_weight_update_routes_return_unsupported_without_engine():
+    handler = _DummyWorkerHandler.__new__(_DummyWorkerHandler)
+    handler.engine = None
+
+    init_result = await handler.init_weights_update_group({})
+    destroy_result = await handler.destroy_weights_update_group({})
+    version_result = await handler.get_weight_version({})
+
+    expected = {
+        "success": False,
+        "message": "weight update control not supported on this worker",
+    }
+    assert init_result == expected
+    assert destroy_result == expected
+    assert version_result == expected

--- a/components/src/dynamo/sglang/tests/test_sglang_handler_base.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_handler_base.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import types
+
+import pytest
+
+from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+class _DummyRuntime:
+    def __init__(self):
+        self.routes = {}
+
+    def register_engine_route(self, name, handler):
+        self.routes[name] = handler
+
+
+class _DummyWorkerHandler(BaseWorkerHandler):
+    async def generate(self, request, context):
+        if False:
+            yield request, context
+
+
+def test_register_engine_routes_includes_weight_update_routes():
+    handler = _DummyWorkerHandler.__new__(_DummyWorkerHandler)
+    runtime = _DummyRuntime()
+
+    handler.register_engine_routes(runtime)
+
+    assert "init_weights_update_group" in runtime.routes
+    assert "destroy_weights_update_group" in runtime.routes
+    assert "get_weight_version" in runtime.routes
+
+
+@pytest.mark.asyncio
+async def test_get_weight_version_reads_active_version_from_server_args():
+    handler = _DummyWorkerHandler.__new__(_DummyWorkerHandler)
+    handler.engine = types.SimpleNamespace(
+        tokenizer_manager=types.SimpleNamespace(
+            server_args=types.SimpleNamespace(weight_version=17)
+        )
+    )
+
+    result = await handler.get_weight_version({})
+
+    assert result == {"weight_version": 17}


### PR DESCRIPTION
## Summary
- closes #8547
- add the missing SGLang engine routes needed for external weight-update control
- add unit coverage for route registration and active weight-version lookup

## Testing
- added `components/src/dynamo/sglang/tests/test_sglang_handler_base.py`
- local pytest execution in the packaged `0.9.1` validation venv is blocked by source/runtime skew in that environment (`dynamo.prometheus_names.kvstats` missing from the packaged runtime)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new worker engine routes for weight management: initialize weight-update groups, destroy weight-update groups, and retrieve the currently served weight version.

* **Tests**
  * Added test coverage validating registration and functionality of the new weight management routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->