### PR TITLE
fix: forward SGLang chat logprobs

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 #   (tool_choice="required" or named function)
 ToolCallParserType: TypeAlias = FunctionCallParser | JsonArrayParser
 
+
 @dataclass
 class SglangPreprocessResult:
     """Result of SGLang preprocessing."""

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -511,6 +511,69 @@ def _try_parse_json_array(text: str) -> list | None:
     return None
 
 
+def _decode_single_token(tokenizer, token_id: int) -> str | None:
+    try:
+        return tokenizer.decode([token_id], skip_special_tokens=False)
+    except Exception as exc:
+        logger.exception(
+            "Failed to decode token for chat logprobs: token_id=%s tokenizer=%s",
+            token_id,
+            type(tokenizer).__name__,
+        )
+        raise RuntimeError(
+            f"Failed to decode token_id={token_id} with tokenizer={type(tokenizer).__name__}"
+        ) from exc
+
+
+def _build_chat_logprobs(
+    *,
+    tokenizer,
+    token_ids: list[int],
+    log_probs: list[float] | None,
+    top_logprobs: list[list[dict[str, Any]]] | None,
+) -> dict[str, Any] | None:
+    if not log_probs:
+        return None
+
+    content: list[dict[str, Any]] = []
+    for idx, logprob in enumerate(log_probs):
+        if idx >= len(token_ids):
+            break
+
+        token_id = token_ids[idx]
+        token_text = _decode_single_token(tokenizer, token_id)
+        token_top_logprobs = []
+        if top_logprobs and idx < len(top_logprobs):
+            for item in top_logprobs[idx]:
+                token_text_alt = item.get("token")
+                if token_text_alt is None and item.get("token_id") is not None:
+                    token_text_alt = _decode_single_token(tokenizer, item["token_id"])
+                token_top_logprobs.append(
+                    {
+                        "token": token_text_alt,
+                        "logprob": item.get("logprob"),
+                        "bytes": (
+                            list(token_text_alt.encode("utf-8"))
+                            if token_text_alt is not None
+                            else None
+                        ),
+                    }
+                )
+
+        content.append(
+            {
+                "token": token_text,
+                "logprob": float(logprob),
+                "bytes": (
+                    list(token_text.encode("utf-8")) if token_text is not None else None
+                ),
+                "top_logprobs": token_top_logprobs,
+            }
+        )
+
+    return {"content": content}
+
+
 class SglangStreamingPostProcessor:
     """Streaming post-processor using SGLang parsers and HF tokenizer detokenization.
 
@@ -621,6 +684,12 @@ class SglangStreamingPostProcessor:
         raw_ids = engine_response.get("token_ids")
         token_ids = raw_ids if isinstance(raw_ids, list) else list(raw_ids or [])
         finish_reason = engine_response.get("finish_reason")
+        logprobs = _build_chat_logprobs(
+            tokenizer=self.tokenizer,
+            token_ids=token_ids,
+            log_probs=engine_response.get("log_probs"),
+            top_logprobs=engine_response.get("top_logprobs"),
+        )
 
         delta_text = self._incremental_decode(token_ids) if token_ids else ""
 
@@ -630,14 +699,14 @@ class SglangStreamingPostProcessor:
                     "index": 0,
                     "delta": {"role": "assistant", "content": delta_text},
                     "finish_reason": finish_reason,
-                    "logprobs": None,
+                    "logprobs": logprobs,
                 }
             elif finish_reason:
                 return {
                     "index": 0,
                     "delta": {},
                     "finish_reason": finish_reason,
-                    "logprobs": None,
+                    "logprobs": logprobs,
                 }
             return None
 
@@ -854,7 +923,7 @@ class SglangStreamingPostProcessor:
                 "index": 0,
                 "delta": delta if has_content else {},
                 "finish_reason": effective_finish,
-                "logprobs": None,
+                "logprobs": logprobs,
             }
 
         return None

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -33,7 +33,6 @@ logger = logging.getLogger(__name__)
 #   (tool_choice="required" or named function)
 ToolCallParserType: TypeAlias = FunctionCallParser | JsonArrayParser
 
-
 @dataclass
 class SglangPreprocessResult:
     """Result of SGLang preprocessing."""

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -1416,6 +1416,32 @@ class TestFastPlainTextPath:
         assert choice["index"] == 0
         assert choice["logprobs"] is None
 
+    def test_fast_path_includes_logprobs(self, tokenizer):
+        """Fast path maps engine log_probs/top_logprobs into OpenAI chat logprobs."""
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer, tool_call_parser=None, reasoning_parser=None
+        )
+        token_ids = tokenizer.encode("Hello")
+        choice = post.process_output(
+            {
+                "token_ids": token_ids,
+                "log_probs": [-0.1] * len(token_ids),
+                "top_logprobs": [
+                    [{"token": tokenizer.decode([tid]), "logprob": -0.1}]
+                    for tid in token_ids
+                ],
+                "finish_reason": None,
+            }
+        )
+
+        assert choice is not None
+        assert choice["logprobs"] is not None
+        content = choice["logprobs"]["content"]
+        assert len(content) == len(token_ids)
+        assert content[0]["logprob"] == -0.1
+        assert "top_logprobs" in content[0]
+        assert "bytes" in content[0]
+
 
 # ---------------------------------------------------------------------------
 # SglangStreamingPostProcessor: reasoning parsing

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -201,63 +201,74 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         return kwargs
 
     @staticmethod
+    def _format_top_logprobs(raw_top_logprobs: Any) -> list[dict[str, Any]]:
+        formatted: list[dict[str, Any]] = []
+        if not raw_top_logprobs:
+            return formatted
+
+        for rank, item in enumerate(raw_top_logprobs):
+            if not item:
+                continue
+
+            logprob = float(item[0]) if item[0] is not None else None
+            token_id = item[1] if len(item) > 1 else None
+            token = item[2] if len(item) > 2 else None
+            formatted.append(
+                {
+                    "rank": rank,
+                    "token_id": token_id,
+                    "token": token,
+                    "logprob": logprob,
+                    "bytes": list(token.encode("utf-8")) if token else None,
+                }
+            )
+
+        return formatted
+
+    @classmethod
     def _extract_logprobs(
-        meta_info: Dict[str, Any], num_output_logprobs_so_far: int
-    ) -> tuple:
-        """Extract logprobs from SGLang meta_info for new tokens.
+        cls, meta_info: Dict[str, Any], start_offset: int, num_new_tokens: int
+    ) -> tuple[list[float] | None, list[list[dict[str, Any]]] | None, int]:
+        """Extract logprobs from SGLang meta_info for newly emitted tokens."""
+        if num_new_tokens <= 0 or start_offset < 0:
+            return None, None, start_offset
 
-        While Dynamo forces stream_output=True (args.py) so that output_ids
-        are disjoint per chunk, SGLang's output_token_logprobs and
-        output_top_logprobs in meta_info are always cumulative. We track an
-        offset to slice out only the new entries each chunk.
+        output_token_logprobs = meta_info.get("output_token_logprobs") or []
+        if not output_token_logprobs or start_offset >= len(output_token_logprobs):
+            return None, None, start_offset
 
-        Args:
-            meta_info: SGLang response meta_info dict.
-            num_output_logprobs_so_far: Number of logprob entries already
-                processed in previous chunks.
+        end_offset = start_offset + num_new_tokens
+        selected_logprobs = output_token_logprobs[start_offset:end_offset]
 
-        Returns:
-            Tuple of (log_probs, top_logprobs, new_total):
-            - log_probs: List of floats (selected token logprob per position)
-            - top_logprobs: List of lists of dicts with rank/token_id/token/logprob
-            - new_total: Updated count of logprob entries processed so far
-        """
-        output_token_logprobs = meta_info.get("output_token_logprobs")
-        if not output_token_logprobs:
-            return None, None, num_output_logprobs_so_far
+        output_top_logprobs = meta_info.get("output_top_logprobs") or []
+        selected_top_logprobs = (
+            output_top_logprobs[start_offset:end_offset] if output_top_logprobs else []
+        )
 
-        new_logprobs = output_token_logprobs[num_output_logprobs_so_far:]
-        if not new_logprobs:
-            return None, None, num_output_logprobs_so_far
+        log_probs: list[float] = []
+        top_logprobs: list[list[dict[str, Any]]] = []
 
-        # Extract selected-token logprobs: each entry is (logprob, token_id, text_or_None)
-        log_probs = [float(entry[0]) for entry in new_logprobs]
+        for idx, token_logprob in enumerate(selected_logprobs):
+            if not token_logprob:
+                continue
 
-        # Extract top logprobs if available
-        top_logprobs: list[list[dict[str, Any]]] | None = None
-        output_top = meta_info.get("output_top_logprobs")
-        if output_top:
-            new_top = output_top[num_output_logprobs_so_far:]
-            if new_top:
-                top_logprobs = []
-                for position_entries in new_top:
-                    if position_entries is None:
-                        top_logprobs.append([])
-                        continue
-                    position_list = []
-                    for rank_idx, entry in enumerate(position_entries):
-                        position_list.append(
-                            {
-                                "rank": rank_idx + 1,
-                                "token_id": entry[1],
-                                "token": entry[2],
-                                "logprob": float(entry[0]),
-                            }
-                        )
-                    top_logprobs.append(position_list)
+            log_probs.append(float(token_logprob[0]))
+            if selected_top_logprobs:
+                raw_top = (
+                    selected_top_logprobs[idx]
+                    if idx < len(selected_top_logprobs)
+                    else None
+                )
+                top_logprobs.append(cls._format_top_logprobs(raw_top))
 
-        new_total = len(output_token_logprobs)
-        return log_probs, top_logprobs, new_total
+        if not log_probs:
+            return None, None, start_offset
+
+        return (
+            log_probs,
+            top_logprobs if selected_top_logprobs else None,
+            start_offset + len(selected_logprobs),
+        )
 
     async def generate(
         self, request: Dict[str, Any], context: Context
@@ -277,6 +288,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         logging.debug(f"New Request ID: {context.id()}")
         trace_id = context.trace_id
         sampling_params = self._build_sampling_params(request)
+        generate_kwargs = self._build_generate_kwargs(request)
         input_param = self._get_input_param(request)
         return_routed_experts = getattr(
             self.config.server_args, "enable_return_routed_experts", False
@@ -390,8 +402,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         """
         # Use Future pattern for request ID - will be set when first response arrives
         request_id_future: asyncio.Future[str] = asyncio.Future()
-        # Logprob offset: output_ids are disjoint (stream_output=True) but
-        # meta_info logprobs are cumulative — track how many we've emitted.
+        # output_ids are disjoint per chunk, while SGLang logprob arrays are
+        # cumulative. Track the emitted-token offset so each chunk slices the
+        # matching cumulative window.
         num_output_logprobs_so_far = 0
         async with self._cancellation_monitor(request_id_future, context):
             async for res in stream_source:
@@ -425,18 +438,19 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
                 # Pass through disjoint token segments directly
                 out["token_ids"] = output_ids
-
-                # Extract logprobs for new tokens if available
                 (
                     log_probs,
                     top_logprobs,
                     num_output_logprobs_so_far,
-                ) = self._extract_logprobs(res["meta_info"], num_output_logprobs_so_far)
+                ) = self._extract_logprobs(
+                    res.get("meta_info", {}),
+                    num_output_logprobs_so_far,
+                    len(output_ids),
+                )
                 if log_probs is not None:
                     out["log_probs"] = log_probs
                 if top_logprobs is not None:
                     out["top_logprobs"] = top_logprobs
-
                 routed_experts = res["meta_info"].get("routed_experts")
                 if routed_experts is not None:
                     # Base64-encode tensor bytes to match sglang's output format.

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -288,7 +288,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         logging.debug(f"New Request ID: {context.id()}")
         trace_id = context.trace_id
         sampling_params = self._build_sampling_params(request)
-        generate_kwargs = self._build_generate_kwargs(request)
         input_param = self._get_input_param(request)
         return_routed_experts = getattr(
             self.config.server_args, "enable_return_routed_experts", False

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -3,7 +3,10 @@
 
 import pytest
 
-from dynamo.sglang.request_handlers.llm.decode_handler import _extract_media_urls
+from dynamo.sglang.request_handlers.llm.decode_handler import (
+    DecodeWorkerHandler,
+    _extract_media_urls,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -34,3 +37,31 @@ def test_extract_media_urls_returns_none_for_missing_or_invalid_items():
     assert (
         _extract_media_urls({"image_url": [{"ignored": "value"}]}, "image_url") is None
     )
+
+
+def test_build_generate_kwargs_token_request_uses_output_options_logprobs():
+    handler = DecodeWorkerHandler.__new__(DecodeWorkerHandler)
+    handler.skip_tokenizer_init = True
+
+    assert handler._build_generate_kwargs({"output_options": {"logprobs": 3}}) == {
+        "return_logprob": True,
+        "top_logprobs_num": 3,
+    }
+
+
+def test_extract_logprobs_from_meta_info():
+    log_probs, top_logprobs = DecodeWorkerHandler._extract_logprobs(
+        {
+            "output_token_logprobs": [[-0.25, 11, " hello"], [-0.5, 12, " world"]],
+            "output_top_logprobs": [
+                [[-0.25, 11, " hello"], [-1.0, 99, " hi"]],
+                [[-0.5, 12, " world"]],
+            ],
+        },
+        2,
+    )
+
+    assert log_probs == [-0.25, -0.5]
+    assert top_logprobs is not None
+    assert top_logprobs[0][0]["token"] == " hello"
+    assert top_logprobs[0][0]["bytes"] == list(" hello".encode("utf-8"))

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -57,8 +57,8 @@ def test_extract_logprobs_from_meta_info():
                 [[-0.5, 12, " world"]],
             ],
         },
-        2,
         0,
+        2,
     )
 
     assert log_probs == [-0.25, -0.5]

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -59,9 +59,43 @@ def test_extract_logprobs_from_meta_info():
             ],
         },
         2,
+        0,
     )
 
     assert log_probs == [-0.25, -0.5]
     assert top_logprobs is not None
     assert top_logprobs[0][0]["token"] == " hello"
     assert top_logprobs[0][0]["bytes"] == list(" hello".encode("utf-8"))
+
+
+def test_extract_logprobs_uses_start_offset_for_streaming_chunks():
+    log_probs, top_logprobs = DecodeWorkerHandler._extract_logprobs(
+        {
+            "output_token_logprobs": [
+                [-0.1, 10, " a"],
+                [-0.2, 11, " b"],
+                [-0.3, 12, " c"],
+            ],
+            "output_top_logprobs": [
+                [[-0.1, 10, " a"]],
+                [[-0.2, 11, " b"]],
+                [[-0.3, 12, " c"]],
+            ],
+        },
+        1,
+        1,
+    )
+
+    assert log_probs == [-0.2]
+    assert top_logprobs == [[{"rank": 0, "token_id": 11, "token": " b", "logprob": -0.2, "bytes": list(" b".encode("utf-8"))}]]
+
+
+def test_extract_logprobs_returns_none_when_offset_exceeds_available_entries():
+    log_probs, top_logprobs = DecodeWorkerHandler._extract_logprobs(
+        {"output_token_logprobs": [[-0.25, 11, " hello"]]},
+        1,
+        5,
+    )
+
+    assert log_probs is None
+    assert top_logprobs is None

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -39,11 +39,10 @@ def test_extract_media_urls_returns_none_for_missing_or_invalid_items():
     )
 
 
-def test_build_generate_kwargs_token_request_uses_output_options_logprobs():
-    handler = DecodeWorkerHandler.__new__(DecodeWorkerHandler)
-    handler.skip_tokenizer_init = True
-
-    assert handler._build_generate_kwargs({"output_options": {"logprobs": 3}}) == {
+def test_build_logprob_kwargs_token_request_uses_output_options_logprobs():
+    assert DecodeWorkerHandler._build_logprob_kwargs(
+        {"output_options": {"logprobs": 3}}
+    ) == {
         "return_logprob": True,
         "top_logprobs_num": 3,
     }
@@ -87,7 +86,17 @@ def test_extract_logprobs_uses_start_offset_for_streaming_chunks():
     )
 
     assert log_probs == [-0.2]
-    assert top_logprobs == [[{"rank": 0, "token_id": 11, "token": " b", "logprob": -0.2, "bytes": list(" b".encode("utf-8"))}]]
+    assert top_logprobs == [
+        [
+            {
+                "rank": 0,
+                "token_id": 11,
+                "token": " b",
+                "logprob": -0.2,
+                "bytes": list(" b".encode("utf-8")),
+            }
+        ]
+    ]
 
 
 def test_extract_logprobs_returns_none_when_offset_exceeds_available_entries():


### PR DESCRIPTION
## Summary
- closes #8548
- plumb requested logprobs through the SGLang decode path
- add and keep unit coverage for logprob extraction and request projection

## Testing
- branch includes coverage in `components/src/dynamo/sglang/tests/test_sglang_decode_handler.py`
- branch includes coverage in `components/src/dynamo/frontend/tests/test_sglang_processor_unit.py`
- local pytest execution in the packaged `0.9.1` validation venv is blocked by source/runtime skew in that environment (`dynamo.prometheus_names.kvstats` missing from the packaged runtime)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Users can now request log probabilities (logprobs) in decode operations
* API responses include OpenAI-compatible logprob structures with per-token probability values
* Top logprobs feature now available, displaying alternative tokens and their respective probabilities

## Tests
* Added unit test coverage for logprob handling in decode operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->