### PR TITLE
fix: normalize backend error finish reasons for frontend parsing

### DIFF
--- a/components/src/dynamo/common/utils/engine_response.py
+++ b/components/src/dynamo/common/utils/engine_response.py
@@ -4,10 +4,12 @@
 """Utilities for engine response processing."""
 
 import logging
-from typing import Any
+from typing import Optional
+
+NormalizedFinishReason = str | dict[str, str] | None
 
 
-def normalize_finish_reason(finish_reason: str) -> Any:
+def normalize_finish_reason(finish_reason: Optional[str]) -> NormalizedFinishReason:
     """
     Normalize engine finish reasons to Dynamo-compatible values.
 

--- a/components/src/dynamo/common/utils/engine_response.py
+++ b/components/src/dynamo/common/utils/engine_response.py
@@ -4,9 +4,10 @@
 """Utilities for engine response processing."""
 
 import logging
+from typing import Any
 
 
-def normalize_finish_reason(finish_reason: str) -> str:
+def normalize_finish_reason(finish_reason: str) -> Any:
     """
     Normalize engine finish reasons to Dynamo-compatible values.
 
@@ -18,4 +19,13 @@ def normalize_finish_reason(finish_reason: str) -> str:
     if finish_reason and finish_reason.startswith("abort"):
         logging.debug(f"Normalizing finish reason: {finish_reason} to cancelled")
         return "cancelled"
+    # Rust serializes FinishReason::Error(String) as {"error": "..."}.
+    # Returning the bare string "error" causes deserialization to fail on the
+    # frontend when backend workers report a generation error.
+    if finish_reason == "error":
+        logging.debug("Normalizing bare error finish reason to structured error")
+        return {"error": "backend error"}
+    if finish_reason and finish_reason.startswith("error:"):
+        logging.debug("Normalizing string error finish reason to structured error")
+        return {"error": finish_reason.split(":", 1)[1].strip() or "backend error"}
     return finish_reason

--- a/components/src/dynamo/common/utils/tests/test_engine_response.py
+++ b/components/src/dynamo/common/utils/tests/test_engine_response.py
@@ -12,8 +12,16 @@ def test_normalize_finish_reason_wraps_bare_error():
     assert normalize_finish_reason("error") == {"error": "backend error"}
 
 
-def test_normalize_finish_reason_extracts_error_payload():
-    assert normalize_finish_reason("error: timeout") == {"error": "timeout"}
+@pytest.mark.parametrize(
+    ("finish_reason", "expected"),
+    [
+        ("error: timeout", "timeout"),
+        ("error:", "backend error"),
+        ("error:   ", "backend error"),
+    ],
+)
+def test_normalize_finish_reason_extracts_error_payload(finish_reason, expected):
+    assert normalize_finish_reason(finish_reason) == {"error": expected}
 
 
 def test_normalize_finish_reason_preserves_non_error_values():

--- a/components/src/dynamo/common/utils/tests/test_engine_response.py
+++ b/components/src/dynamo/common/utils/tests/test_engine_response.py
@@ -1,0 +1,20 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from dynamo.common.utils.engine_response import normalize_finish_reason
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge]
+
+
+def test_normalize_finish_reason_wraps_bare_error():
+    assert normalize_finish_reason("error") == {"error": "backend error"}
+
+
+def test_normalize_finish_reason_extracts_error_payload():
+    assert normalize_finish_reason("error: timeout") == {"error": "timeout"}
+
+
+def test_normalize_finish_reason_preserves_non_error_values():
+    assert normalize_finish_reason("stop") == "stop"


### PR DESCRIPTION
## Summary
- closes #8549
- normalize bare/string SGLang error finish reasons into the structured form expected by the frontend
- add focused unit coverage for the normalization helper

## Testing
- added `components/src/dynamo/common/utils/tests/test_engine_response.py`
- local pytest execution in the packaged `0.9.1` validation venv is blocked by source/runtime skew in that environment (`dynamo.prometheus_names.kvstats` missing from the packaged runtime)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error response handling to return structured error information, improving clarity in error reporting from the backend.

* **Tests**
  * Added test coverage for error response handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->