### PR TITLE
fix: treat streamed completion usage metadata as optional

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -446,18 +446,20 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     # Internal transport field consumed by frontend nvext mapping.
                     out["disaggregated_params"] = {"routed_experts": routed_experts}
                 if finish_reason:
-                    input_tokens = res["meta_info"]["prompt_tokens"]
-                    completion_tokens = res["meta_info"]["completion_tokens"]
-                    cached_tokens = res["meta_info"]["cached_tokens"]
+                    meta_info = res.get("meta_info", {})
+                    input_tokens = meta_info.get("prompt_tokens")
+                    completion_tokens = meta_info.get("completion_tokens")
+                    cached_tokens = meta_info.get("cached_tokens")
                     prefill_prompt_tokens_details = None
                     if cached_tokens is not None and cached_tokens > 0:
                         prefill_prompt_tokens_details = {"cached_tokens": cached_tokens}
-                    out["completion_usage"] = {
-                        "prompt_tokens": input_tokens,
-                        "completion_tokens": completion_tokens,
-                        "total_tokens": input_tokens + completion_tokens,
-                        "prompt_tokens_details": prefill_prompt_tokens_details,
-                    }
+                    if input_tokens is not None and completion_tokens is not None:
+                        out["completion_usage"] = {
+                            "prompt_tokens": input_tokens,
+                            "completion_tokens": completion_tokens,
+                            "total_tokens": input_tokens + completion_tokens,
+                            "prompt_tokens_details": prefill_prompt_tokens_details,
+                        }
                 if not context.is_stopped():
                     yield out
 

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -1,9 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from contextlib import asynccontextmanager
+
 import pytest
 
-from dynamo.sglang.request_handlers.llm.decode_handler import _extract_media_urls
+from dynamo.sglang.request_handlers.llm.decode_handler import (
+    DecodeWorkerHandler,
+    _extract_media_urls,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -34,3 +39,37 @@ def test_extract_media_urls_returns_none_for_missing_or_invalid_items():
     assert (
         _extract_media_urls({"image_url": [{"ignored": "value"}]}, "image_url") is None
     )
+
+
+class _FakeContext:
+    def id(self):
+        return "ctx"
+
+    def is_stopped(self):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_treats_completion_usage_fields_as_optional():
+    handler = DecodeWorkerHandler.__new__(DecodeWorkerHandler)
+
+    @asynccontextmanager
+    async def _noop_monitor(request_id_future, context):
+        yield None
+
+    handler._cancellation_monitor = _noop_monitor
+
+    async def _stream():
+        yield {
+            "meta_info": {
+                "id": "rid",
+                "finish_reason": {"type": "stop"},
+            },
+            "output_ids": [],
+        }
+
+    outputs = [
+        item async for item in handler._process_token_stream(_stream(), _FakeContext())
+    ]
+
+    assert outputs == [{"finish_reason": "stop", "token_ids": []}]


### PR DESCRIPTION
## Summary
- closes #8550
- treat streamed completion usage metadata as optional on final/error chunks
- add unit coverage for the decode stream behavior when usage fields are absent

## Testing
- added coverage in `components/src/dynamo/sglang/tests/test_sglang_decode_handler.py`
- local pytest execution in the packaged `0.9.1` validation venv is blocked by source/runtime skew in that environment (`dynamo.prometheus_names.kvstats` missing from the packaged runtime)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the token streaming system to gracefully handle responses with missing or incomplete metadata, preventing potential failures during token processing.

* **Tests**
  * Added test coverage for edge cases where streaming responses lack complete usage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->