### PR TITLE
fix: spread frontend routing across registered backends

### DIFF
--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -39,6 +39,7 @@ from .sglang_prepost import (
     preprocess_chat_request,
 )
 from .utils import (
+    FrontendRoundRobinRouter,
     PreprocessError,
     extract_mm_urls,
     handle_engine_error,
@@ -624,9 +625,16 @@ class SglangEngineFactory:
                 kv_router_config=self.router_config.kv_router_config,
             )
         else:
-            router = await generate_endpoint.client(
+            client = await generate_endpoint.client(
                 router_mode=self.router_config.router_mode
             )
+            if self.router_config.router_mode == RouterMode.RoundRobin:
+                router = FrontendRoundRobinRouter(
+                    client,
+                    f"{namespace_name}.{component_name}.{endpoint_name}",
+                )
+            else:
+                router = client
 
         preprocess_pool = None
         preprocess_workers = self.config.preprocess_workers

--- a/components/src/dynamo/frontend/tests/test_frontend_routing_utils.py
+++ b/components/src/dynamo/frontend/tests/test_frontend_routing_utils.py
@@ -1,0 +1,66 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from dynamo.frontend.utils import FrontendRoundRobinRouter
+
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge]
+
+
+class _FakeClient:
+    def __init__(self, instance_sequences):
+        self._instance_sequences = list(instance_sequences)
+        self._instance_idx = 0
+        self.direct_calls = []
+
+    def instance_ids(self):
+        if self._instance_idx < len(self._instance_sequences):
+            ids = self._instance_sequences[self._instance_idx]
+            self._instance_idx += 1
+            return ids
+        return self._instance_sequences[-1]
+
+    async def wait_for_instances(self):
+        return [9, 10]
+
+    async def direct(self, request, instance):
+        self.direct_calls.append((request, instance))
+        return {"instance": instance, "request": request}
+
+
+@pytest.mark.asyncio
+async def test_frontend_round_robin_router_balances_sorted_instance_ids():
+    client = _FakeClient([[20, 10, 30], [20, 10, 30], [20, 10, 30], [20, 10, 30]])
+    router = FrontendRoundRobinRouter(client, "dynamo.backend.generate")
+
+    results = []
+    for idx in range(4):
+        results.append(await router.generate({"seq": idx}, annotated=False))
+
+    assert [item["instance"] for item in results] == ["10", "20", "30", "10"]
+
+
+@pytest.mark.asyncio
+async def test_frontend_round_robin_router_refreshes_membership_each_request():
+    client = _FakeClient([[2, 1], [3, 2, 1], [3, 2, 1]])
+    router = FrontendRoundRobinRouter(client, "dynamo.backend.generate")
+
+    first = await router.generate({"seq": 0}, annotated=False)
+    second = await router.generate({"seq": 1}, annotated=False)
+    third = await router.generate({"seq": 2}, annotated=False)
+
+    assert first["instance"] == "1"
+    assert second["instance"] == "2"
+    assert third["instance"] == "3"
+
+
+@pytest.mark.asyncio
+async def test_frontend_round_robin_router_waits_for_instances_when_empty():
+    client = _FakeClient([[]])
+    router = FrontendRoundRobinRouter(client, "dynamo.backend.generate")
+
+    result = await router.generate({"seq": 0}, annotated=False)
+
+    assert result["instance"] == "9"

--- a/components/src/dynamo/frontend/tests/test_frontend_routing_utils.py
+++ b/components/src/dynamo/frontend/tests/test_frontend_routing_utils.py
@@ -24,9 +24,13 @@ class _FakeClient:
     async def wait_for_instances(self):
         return [9, 10]
 
-    async def direct(self, request, instance):
-        self.direct_calls.append((request, instance))
-        return {"instance": instance, "request": request}
+    async def direct(self, request, instance_id, annotated=True):
+        self.direct_calls.append((request, instance_id, annotated))
+        return {
+            "instance": str(instance_id),
+            "request": request,
+            "annotated": annotated,
+        }
 
 
 @pytest.mark.asyncio
@@ -39,6 +43,7 @@ async def test_frontend_round_robin_router_balances_sorted_instance_ids():
         results.append(await router.generate({"seq": idx}, annotated=False))
 
     assert [item["instance"] for item in results] == ["10", "20", "30", "10"]
+    assert [call[2] for call in client.direct_calls] == [False, False, False, False]
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/frontend/tests/test_frontend_routing_utils.py
+++ b/components/src/dynamo/frontend/tests/test_frontend_routing_utils.py
@@ -6,7 +6,7 @@ import pytest
 from dynamo.frontend.utils import FrontendRoundRobinRouter
 
 
-pytestmark = [pytest.mark.unit, pytest.mark.pre_merge]
+pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
 
 
 class _FakeClient:
@@ -64,3 +64,26 @@ async def test_frontend_round_robin_router_waits_for_instances_when_empty():
     result = await router.generate({"seq": 0}, annotated=False)
 
     assert result["instance"] == "9"
+
+
+@pytest.mark.asyncio
+async def test_frontend_round_robin_router_raises_when_no_instances_ever_appear():
+    client = _FakeClient([[]])
+    client.wait_for_instances = lambda: _empty_instances()
+    router = FrontendRoundRobinRouter(client, "dynamo.backend.generate")
+
+    with pytest.raises(RuntimeError, match="No active backend instances available"):
+        await router.generate({"seq": 0}, annotated=False)
+
+
+@pytest.mark.asyncio
+async def test_frontend_round_robin_router_rejects_unexpected_kwargs():
+    client = _FakeClient([[1]])
+    router = FrontendRoundRobinRouter(client, "dynamo.backend.generate")
+
+    with pytest.raises(TypeError, match="Unsupported kwargs"):
+        await router.generate({"seq": 0}, annotated=False, foo=1)
+
+
+async def _empty_instances():
+    return []

--- a/components/src/dynamo/frontend/tests/test_frontend_routing_utils.py
+++ b/components/src/dynamo/frontend/tests/test_frontend_routing_utils.py
@@ -5,7 +5,6 @@ import pytest
 
 from dynamo.frontend.utils import FrontendRoundRobinRouter
 
-
 pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
 
 
@@ -69,7 +68,7 @@ async def test_frontend_round_robin_router_waits_for_instances_when_empty():
 @pytest.mark.asyncio
 async def test_frontend_round_robin_router_raises_when_no_instances_ever_appear():
     client = _FakeClient([[]])
-    client.wait_for_instances = lambda: _empty_instances()
+    client.wait_for_instances = _empty_instances
     router = FrontendRoundRobinRouter(client, "dynamo.backend.generate")
 
     with pytest.raises(RuntimeError, match="No active backend instances available"):

--- a/components/src/dynamo/frontend/utils.py
+++ b/components/src/dynamo/frontend/utils.py
@@ -84,7 +84,11 @@ class FrontendRoundRobinRouter:
                 annotated,
             )
 
-        return await self._client.direct(request, instance=str(instance_id))
+        return await self._client.direct(
+            request,
+            instance_id=instance_id,
+            annotated=annotated,
+        )
 
 
 # Content part types that carry media URLs, mapped to the key used in the

--- a/components/src/dynamo/frontend/utils.py
+++ b/components/src/dynamo/frontend/utils.py
@@ -3,11 +3,14 @@
 
 """Shared utilities for frontend chat processors (vLLM, SGLang)."""
 
+import asyncio
 import logging
+import os
 import uuid
 from typing import Any
 
 _MASK_64_BITS = (1 << 64) - 1
+logger = logging.getLogger(__name__)
 
 
 def random_uuid() -> str:
@@ -31,6 +34,57 @@ class PreprocessError(Exception):
     def __init__(self, error_dict: dict[str, Any]):
         self.error_dict = error_dict
         super().__init__(str(error_dict))
+
+
+class FrontendRoundRobinRouter:
+    """Frontend-managed round-robin over the current runtime client membership.
+
+    This avoids sticky routing behavior in the opaque runtime round-robin client by
+    selecting an instance in Python and sending the request via ``Client.direct``.
+    """
+
+    def __init__(self, client: Any, endpoint_name: str):
+        self._client = client
+        self._endpoint_name = endpoint_name
+        self._cursor = 0
+        self._lock = asyncio.Lock()
+        self._debug = os.getenv("DYN_FRONTEND_ROUTING_DEBUG", "").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+    async def generate(self, request: dict[str, Any], **kwargs: Any):
+        annotated = kwargs.pop("annotated", None)
+        if kwargs:
+            raise TypeError(
+                f"Unsupported kwargs for frontend round-robin router: {sorted(kwargs)}"
+            )
+
+        async with self._lock:
+            instance_ids = list(self._client.instance_ids())
+            if not instance_ids:
+                instance_ids = list(await self._client.wait_for_instances())
+            if not instance_ids:
+                raise RuntimeError(
+                    f"No active backend instances available for {self._endpoint_name}"
+                )
+
+            instance_ids = sorted(instance_ids)
+            instance_id = instance_ids[self._cursor % len(instance_ids)]
+            self._cursor += 1
+
+        if self._debug:
+            logger.info(
+                "Frontend routing selected endpoint=%s instance=%s instances=%s annotated=%s",
+                self._endpoint_name,
+                instance_id,
+                instance_ids,
+                annotated,
+            )
+
+        return await self._client.direct(request, instance=str(instance_id))
 
 
 # Content part types that carry media URLs, mapped to the key used in the

--- a/components/src/dynamo/frontend/utils.py
+++ b/components/src/dynamo/frontend/utils.py
@@ -62,16 +62,16 @@ class FrontendRoundRobinRouter:
                 f"Unsupported kwargs for frontend round-robin router: {sorted(kwargs)}"
             )
 
-        async with self._lock:
-            instance_ids = list(self._client.instance_ids())
-            if not instance_ids:
-                instance_ids = list(await self._client.wait_for_instances())
-            if not instance_ids:
-                raise RuntimeError(
-                    f"No active backend instances available for {self._endpoint_name}"
-                )
+        instance_ids = list(self._client.instance_ids())
+        if not instance_ids:
+            instance_ids = list(await self._client.wait_for_instances())
+        if not instance_ids:
+            raise RuntimeError(
+                f"No active backend instances available for {self._endpoint_name}"
+            )
 
-            instance_ids = sorted(instance_ids)
+        instance_ids = sorted(instance_ids)
+        async with self._lock:
             instance_id = instance_ids[self._cursor % len(instance_ids)]
             self._cursor += 1
 

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -46,6 +46,7 @@ from dynamo.runtime import Client, DistributedRuntime
 
 from .prepost import StreamingPostProcessor, preprocess_chat_request
 from .utils import (
+    FrontendRoundRobinRouter,
     extract_mm_urls,
     handle_engine_error,
     make_internal_error,
@@ -800,9 +801,16 @@ class EngineFactory:
                 kv_router_config=self.router_config.kv_router_config,
             )
         else:
-            router = await generate_endpoint.client(
+            client = await generate_endpoint.client(
                 router_mode=self.router_config.router_mode
             )
+            if self.router_config.router_mode == RouterMode.RoundRobin:
+                router = FrontendRoundRobinRouter(
+                    client,
+                    f"{namespace_name}.{component_name}.{endpoint_name}",
+                )
+            else:
+                router = client
 
         block_size = self.config.kv_cache_block_size or 16
 


### PR DESCRIPTION
## Summary
- closes #8551
- move SGLang frontend selection to a Python-side round-robin wrapper over the current instance set
- add a regression test for backend distribution and membership refresh

## Testing
- `PYTHONPATH=components/src python -m pytest -q components/src/dynamo/frontend/tests/test_frontend_routing_utils.py`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added round-robin request routing that distributes traffic evenly across available backend instances with automatic fallback when instances become unavailable.

* **Tests**
  * Added comprehensive test coverage for round-robin routing, including instance selection ordering, dynamic membership updates, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->