### PR TITLE
fix: apply PD model updates directly for endpoint enablement

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -4,7 +4,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Notify;
-use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 
 use anyhow::Context as _;
@@ -76,7 +75,7 @@ pub struct ModelWatcher {
     migration_limit: u32,
     migration_max_seq_len: Option<u32>,
     notify_on_model: Notify,
-    model_update_tx: Option<Sender<ModelUpdate>>,
+    model_update_callback: Option<Arc<dyn Fn(ModelUpdate) + Send + Sync>>,
     chat_engine_factory: Option<ChatEngineFactoryCallback>,
     prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
     metrics: Arc<Metrics>,
@@ -160,7 +159,7 @@ impl ModelWatcher {
             migration_limit,
             migration_max_seq_len,
             notify_on_model: Notify::new(),
-            model_update_tx: None,
+            model_update_callback: None,
             chat_engine_factory,
             prefill_load_estimator,
             metrics,
@@ -170,8 +169,8 @@ impl ModelWatcher {
         }
     }
 
-    pub fn set_notify_on_model_update(&mut self, tx: Sender<ModelUpdate>) {
-        self.model_update_tx = Some(tx);
+    pub fn set_notify_on_model_update(&mut self, callback: Arc<dyn Fn(ModelUpdate) + Send + Sync>) {
+        self.model_update_callback = Some(callback);
     }
 
     /// Wait until we have at least one chat completions model and return it's name.
@@ -444,12 +443,12 @@ impl ModelWatcher {
         // No instances remain anywhere — remove the entire Model
         let _ = self.manager.remove_model(&model_name);
 
-        if let Some(tx) = &self.model_update_tx {
+        if let Some(callback) = &self.model_update_callback {
             for model_type in ALL_MODEL_TYPES {
                 if card.model_type.intersects(*model_type)
                     && is_model_type_list_empty(&self.manager, *model_type)
                 {
-                    tx.send(ModelUpdate::Removed(card.clone())).await.ok();
+                    callback(ModelUpdate::Removed(card.clone()));
                 }
             }
         }
@@ -1017,8 +1016,8 @@ impl ModelWatcher {
             self.manager
                 .add_worker_set(card.name(), &ws_key, worker_set);
 
-            if let Some(tx) = &self.model_update_tx {
-                tx.send(ModelUpdate::Added(card.clone())).await.ok();
+            if let Some(callback) = &self.model_update_callback {
+                callback(ModelUpdate::Added(card.clone()));
             }
 
             // Note: activate_prefill_router is keyed by deployment namespace (not ws_key)
@@ -1055,8 +1054,8 @@ impl ModelWatcher {
         self.manager
             .add_worker_set(card.name(), &ws_key, worker_set);
 
-        if let Some(tx) = &self.model_update_tx {
-            tx.send(ModelUpdate::Added(card.clone())).await.ok();
+        if let Some(callback) = &self.model_update_callback {
+            callback(ModelUpdate::Added(card.clone()));
         }
 
         Ok(())

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -193,18 +193,13 @@ async fn run_watcher(
         )
         .await?;
 
-    // Create a channel to receive model type updates
-    let (tx, mut rx) = tokio::sync::mpsc::channel(32);
-    watch_obj.set_notify_on_model_update(tx);
+    let http_service_for_updates = http_service.clone();
+    let metrics_for_updates = metrics.clone();
+    watch_obj.set_notify_on_model_update(Arc::new(move |model_update| {
+        update_http_endpoints(http_service_for_updates.clone(), model_update.clone());
+        update_model_metrics(model_update, metrics_for_updates.clone());
+    }));
     let watch_obj = Arc::new(watch_obj);
-
-    // Spawn a task to watch for model type changes and update HTTP service endpoints and metrics
-    let _endpoint_enabler_task = tokio::spawn(async move {
-        while let Some(model_update) = rx.recv().await {
-            update_http_endpoints(http_service.clone(), model_update.clone());
-            update_model_metrics(model_update, metrics.clone());
-        }
-    });
 
     // Pass the discovery stream to the watcher
     let _watcher_task = tokio::spawn(async move {


### PR DESCRIPTION
## Summary
- closes #8552
- apply PD model updates through the direct callback path used by endpoint enablement
- target the case where decode workers register but `/v1/chat/completions` remains disabled

## Testing
- local runtime rebuild and PD revalidation are still in progress in the validation environment
- opening as draft until the rebuilt source path is revalidated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified model update notification mechanism by consolidating internal logic, removing auxiliary async components and streamlining how model changes are propagated through the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->