### PR TITLE
fix: auto truncate Grove resource names to fit within 45-char limit

### DIFF
--- a/components/src/dynamo/planner/config/backend_components.py
+++ b/components/src/dynamo/planner/config/backend_components.py
@@ -54,10 +54,11 @@ class TrtllmComponentName(ComponentName):
     # Unified frontend architecture (consistent with vLLM/SGLang):
     # - Prefill workers use "prefill" component
     # - Decode workers use "tensorrt_llm" component
-    prefill_worker_k8s_name = "TRTLLMPrefillWorker"
+    # Use short k8s names to stay within Grove's 45-char resource name limit
+    prefill_worker_k8s_name = "prefill"
     prefill_worker_component_name = "prefill"
     prefill_worker_endpoint = "generate"
-    decode_worker_k8s_name = "TRTLLMDecodeWorker"
+    decode_worker_k8s_name = "decode"
     decode_worker_component_name = "tensorrt_llm"
     decode_worker_endpoint = "generate"
 

--- a/components/src/dynamo/profiler/tests/integration/test_profile_sla_dgdr.py
+++ b/components/src/dynamo/profiler/tests/integration/test_profile_sla_dgdr.py
@@ -340,13 +340,13 @@ def _save_dummy_npz(output_dir: str):
 _DECODE_SVC_NAMES = {
     "sglang": "decode",
     "vllm": "VllmDecodeWorker",
-    "trtllm": "TRTLLMDecodeWorker",
+    "trtllm": "decode",
 }
 
 
 def _make_thorough_patches(backend: str = "trtllm"):
     """Build mock-patches for thorough mode, parameterised by backend."""
-    svc_name = _DECODE_SVC_NAMES.get(backend, "TRTLLMDecodeWorker")
+    svc_name = _DECODE_SVC_NAMES.get(backend, "decode")
     return [
         patch(
             "dynamo.profiler.thorough.DynamoDeploymentClient",

--- a/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
@@ -414,8 +414,8 @@ class TestEnableVllmBenchmarkMode:
         cfg = {
             "spec": {
                 "services": {
-                    "TRTLLMPrefillWorker": {},
-                    "TRTLLMDecodeWorker": {},
+                    "prefill": {},
+                    "decode": {},
                     "Frontend": {},
                 }
             }

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -662,7 +662,7 @@ class BaseConfigModifier:
 
         In agg mode, the default config template may use a generic worker
         service name (e.g. ``TRTLLMWorker``) that does not match the disagg
-        naming convention (``TRTLLMDecodeWorker``).  We first try the standard
+        naming convention (``prefill`` / ``decode``).  We first try the standard
         DECODE lookup, then fall back to any non-Frontend/Planner service.
         """
         svc_name = cls._resolve_service_name(cfg, SubComponentType.DECODE)

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -125,6 +125,13 @@ const (
 	GroveRoleSuffixWorker = "wkr"
 	GroveRoleSuffixGMS    = "gms"
 
+	// MaxCombinedGroveResourceNameLength is the maximum allowed combined length for Grove
+	// resource names (PCS name + PCSG config name + PCLQ template name).
+	// This constraint comes from Grove's PodCliqueSet webhook validation.
+	// Pod names follow: <pcs-name>-<pcs-index>-<pcsg-name>-<pcsg-index>-<pclq-name>-<random>
+	// The hyphens, indices, and random suffix consume additional characters beyond this limit.
+	MaxCombinedGroveResourceNameLength = 45
+
 	KubeLabelDynamoFailoverEngineGroupMember = "nvidia.com/dynamo-failover-engine-group-member"
 
 	DiscoveryBackendKubernetes   = "kubernetes" // label value for KubeLabelDynamoDiscoveryBackend

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -1858,7 +1858,7 @@ func (r *DynamoGraphDeploymentReconciler) mapPodCliqueScalingGroupToRequests(ctx
 
 	pcsOwnerRef := metav1.GetControllerOf(pcs)
 	if pcsOwnerRef == nil ||
-		pcsOwnerRef.Kind != "DynamoGraphDeployment" {
+		pcsOwnerRef.Kind != consts.ResourceTypeDynamoGraphDeployment {
 		log.FromContext(ctx).V(1).Info("PodCliqueSet missing DynamoGraphDeployment controller ownerReference",
 			"pcsName", pcs.Name,
 			"namespace", pcs.Namespace)

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -1822,10 +1822,10 @@ func (r *DynamoGraphDeploymentReconciler) mapPodCliqueToRequests(ctx context.Con
 // mapPodCliqueScalingGroupToRequests maps a PodCliqueScalingGroup to reconcile
 // requests for its owning DGD.
 //
-// The PCSG is owned by a PodCliqueSet (controller ownerRef). The PCS name may
-// differ from the DGD name when auto-truncation is applied (see PCSNameForDGD),
-// so we look up the PCS and read its KubeLabelDynamoGraphDeploymentName label
-// to find the actual DGD name.
+// The PCSG is owned by a PodCliqueSet (controller ownerRef), which is in turn
+// owned by the DynamoGraphDeployment. The PCS name may differ from the DGD name
+// when auto-truncation is applied (see PCSNameForDGD), so we walk the ownerRef
+// chain (PCSG -> PCS -> DGD) to find the actual DGD name.
 func (r *DynamoGraphDeploymentReconciler) mapPodCliqueScalingGroupToRequests(ctx context.Context, obj client.Object) []ctrl.Request {
 	pcsg, ok := obj.(*grovev1alpha1.PodCliqueScalingGroup)
 	if !ok {
@@ -1842,8 +1842,8 @@ func (r *DynamoGraphDeploymentReconciler) mapPodCliqueScalingGroupToRequests(ctx
 		return nil
 	}
 
-	// Look up the PCS to find the DGD name via label, since PCS name may be
-	// truncated and no longer match the DGD name.
+	// Look up the PCS to walk the ownerRef chain to the DGD, since PCS name
+	// may be truncated and no longer match the DGD name.
 	pcs := &grovev1alpha1.PodCliqueSet{}
 	if err := r.Client.Get(ctx, types.NamespacedName{
 		Name:      controllerRef.Name,
@@ -1856,17 +1856,18 @@ func (r *DynamoGraphDeploymentReconciler) mapPodCliqueScalingGroupToRequests(ctx
 		return nil
 	}
 
-	dgdName, ok := pcs.GetLabels()[consts.KubeLabelDynamoGraphDeploymentName]
-	if !ok || dgdName == "" {
-		log.FromContext(ctx).V(1).Info("PodCliqueSet missing DGD name label",
-			"pcsName", controllerRef.Name,
-			"namespace", pcsg.Namespace)
+	pcsOwnerRef := metav1.GetControllerOf(pcs)
+	if pcsOwnerRef == nil ||
+		pcsOwnerRef.Kind != "DynamoGraphDeployment" {
+		log.FromContext(ctx).V(1).Info("PodCliqueSet missing DynamoGraphDeployment controller ownerReference",
+			"pcsName", pcs.Name,
+			"namespace", pcs.Namespace)
 		return nil
 	}
 
 	return []ctrl.Request{{
 		NamespacedName: types.NamespacedName{
-			Name:      dgdName,
+			Name:      pcsOwnerRef.Name,
 			Namespace: pcsg.Namespace,
 		},
 	}}

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -400,7 +400,7 @@ func (r *DynamoGraphDeploymentReconciler) getUpdatedInProgressForGrove(ctx conte
 	logger := log.FromContext(ctx)
 
 	pcs := &grovev1alpha1.PodCliqueSet{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs)
+	err := r.Client.Get(ctx, types.NamespacedName{Name: dynamo.PCSNameForDGD(dgd.Name, dgd.Spec.Services), Namespace: dgd.Namespace}, pcs)
 	if err != nil {
 		logger.Error(err, "failed to get PodCliqueSet")
 		return inProgress
@@ -419,7 +419,7 @@ func (r *DynamoGraphDeploymentReconciler) getUpdatedInProgressForGrove(ctx conte
 	updatedInProgress := make([]string, 0, len(inProgress))
 	for _, serviceName := range inProgress {
 		component := dgd.Spec.Services[serviceName]
-		resourceName := fmt.Sprintf("%s-0-%s", dgd.Name, strings.ToLower(serviceName))
+		resourceName := fmt.Sprintf("%s-0-%s", dynamo.PCSNameForDGD(dgd.Name, dgd.Spec.Services), strings.ToLower(serviceName))
 
 		var isReady bool
 		var reason string
@@ -453,7 +453,7 @@ func (r *DynamoGraphDeploymentReconciler) propagateTopologyCondition(ctx context
 	logger := log.FromContext(ctx)
 
 	pcs := &grovev1alpha1.PodCliqueSet{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs); err != nil {
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: dynamo.PCSNameForDGD(dgd.Name, dgd.Spec.Services), Namespace: dgd.Namespace}, pcs); err != nil {
 		if errors.IsNotFound(err) {
 			return
 		}
@@ -600,7 +600,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGrovePodCliqueSet(ctx context
 func (r *DynamoGraphDeploymentReconciler) getExistingRestartAnnotationsPCS(ctx context.Context, dgd *nvidiacomv1alpha1.DynamoGraphDeployment) (map[string]string, error) {
 	restartAnnotations := make(map[string]string)
 	pcs := &grovev1alpha1.PodCliqueSet{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, pcs)
+	err := r.Client.Get(ctx, types.NamespacedName{Name: dynamo.PCSNameForDGD(dgd.Name, dgd.Spec.Services), Namespace: dgd.Namespace}, pcs)
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get PodCliqueSet: %w", err)
 	}
@@ -625,6 +625,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGroveScaling(ctx context.Cont
 	logger.V(1).Info("Reconciling Grove scaling operations")
 
 	replicaIndex := 0
+	pcsName := dynamo.PCSNameForDGD(dynamoDeployment.Name, dynamoDeployment.Spec.Services)
 	for serviceName, component := range dynamoDeployment.Spec.Services {
 		// Skip if replicas are not specified
 		if component.Replicas == nil {
@@ -632,7 +633,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGroveScaling(ctx context.Cont
 		}
 
 		usesPCSG := component.GetNumberOfNodes() > 1 || component.IsInterPodFailoverEnabled()
-		resourceName := fmt.Sprintf("%s-%d-%s", dynamoDeployment.Name, replicaIndex, strings.ToLower(serviceName))
+		resourceName := fmt.Sprintf("%s-%d-%s", pcsName, replicaIndex, strings.ToLower(serviceName))
 
 		if usesPCSG {
 			err := r.scaleGroveResource(ctx,
@@ -1821,10 +1822,10 @@ func (r *DynamoGraphDeploymentReconciler) mapPodCliqueToRequests(ctx context.Con
 // mapPodCliqueScalingGroupToRequests maps a PodCliqueScalingGroup to reconcile
 // requests for its owning DGD.
 //
-// The PCSG is owned by a PodCliqueSet (controller ownerRef), and Dynamo always
-// creates the PodCliqueSet with the same name as the DGD
-// (see graph.go: gangSet.Name = dynamoDeployment.Name), so the PodCliqueSet
-// owner reference name is the DGD name.
+// The PCSG is owned by a PodCliqueSet (controller ownerRef). The PCS name may
+// differ from the DGD name when auto-truncation is applied (see PCSNameForDGD),
+// so we look up the PCS and read its KubeLabelDynamoGraphDeploymentName label
+// to find the actual DGD name.
 func (r *DynamoGraphDeploymentReconciler) mapPodCliqueScalingGroupToRequests(ctx context.Context, obj client.Object) []ctrl.Request {
 	pcsg, ok := obj.(*grovev1alpha1.PodCliqueScalingGroup)
 	if !ok {
@@ -1841,9 +1842,31 @@ func (r *DynamoGraphDeploymentReconciler) mapPodCliqueScalingGroupToRequests(ctx
 		return nil
 	}
 
+	// Look up the PCS to find the DGD name via label, since PCS name may be
+	// truncated and no longer match the DGD name.
+	pcs := &grovev1alpha1.PodCliqueSet{}
+	if err := r.Client.Get(ctx, types.NamespacedName{
+		Name:      controllerRef.Name,
+		Namespace: pcsg.Namespace,
+	}, pcs); err != nil {
+		log.FromContext(ctx).V(1).Info("failed to look up PodCliqueSet for PCSG",
+			"podCliqueScalingGroup", pcsg.Name,
+			"pcsName", controllerRef.Name,
+			"error", err)
+		return nil
+	}
+
+	dgdName, ok := pcs.GetLabels()[consts.KubeLabelDynamoGraphDeploymentName]
+	if !ok || dgdName == "" {
+		log.FromContext(ctx).V(1).Info("PodCliqueSet missing DGD name label",
+			"pcsName", controllerRef.Name,
+			"namespace", pcsg.Namespace)
+		return nil
+	}
+
 	return []ctrl.Request{{
 		NamespacedName: types.NamespacedName{
-			Name:      controllerRef.Name,
+			Name:      dgdName,
 			Namespace: pcsg.Namespace,
 		},
 	}}

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -2724,9 +2724,15 @@ func TestPropagateTopologyCondition(t *testing.T) {
 }
 
 func TestMapPodCliqueScalingGroupToRequests(t *testing.T) {
+	// Register Grove types with the scheme so fake client can handle them
+	if err := grovev1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("Failed to add grovev1alpha1 to scheme: %v", err)
+	}
+
 	tests := []struct {
 		name         string
 		obj          client.Object
+		existingPCS  *grovev1alpha1.PodCliqueSet // PCS object that exists in the cluster
 		wantRequests int
 		wantName     string
 		wantNs       string
@@ -2747,9 +2753,47 @@ func TestMapPodCliqueScalingGroupToRequests(t *testing.T) {
 					},
 				},
 			},
+			existingPCS: &grovev1alpha1.PodCliqueSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynamo-recipe",
+					Namespace: "mwieczorek-dsv32-trtllm-agg",
+					Labels: map[string]string{
+						commonconsts.KubeLabelDynamoGraphDeploymentName: "dynamo-recipe",
+					},
+				},
+			},
 			wantRequests: 1,
 			wantName:     "dynamo-recipe",
 			wantNs:       "mwieczorek-dsv32-trtllm-agg",
+		},
+		{
+			name: "PCSG with truncated PCS name resolves to original DGD name",
+			obj: &grovev1alpha1.PodCliqueScalingGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "truncated-pcs-0-worker",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: grovev1alpha1.SchemeGroupVersion.String(),
+							Kind:       "PodCliqueSet",
+							Name:       "truncated-pcs",
+							Controller: ptr.To(true),
+						},
+					},
+				},
+			},
+			existingPCS: &grovev1alpha1.PodCliqueSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "truncated-pcs",
+					Namespace: "default",
+					Labels: map[string]string{
+						commonconsts.KubeLabelDynamoGraphDeploymentName: "my-very-long-original-dgd-name",
+					},
+				},
+			},
+			wantRequests: 1,
+			wantName:     "my-very-long-original-dgd-name",
+			wantNs:       "default",
 		},
 		{
 			name: "PCSG with no ownerRef returns no requests",
@@ -2806,7 +2850,15 @@ func TestMapPodCliqueScalingGroupToRequests(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
-			r := &DynamoGraphDeploymentReconciler{}
+
+			// Build fake client with existing PCS if provided
+			builder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+			if tt.existingPCS != nil {
+				builder = builder.WithObjects(tt.existingPCS)
+			}
+			r := &DynamoGraphDeploymentReconciler{
+				Client: builder.Build(),
+			}
 			reqs := r.mapPodCliqueScalingGroupToRequests(context.Background(), tt.obj)
 
 			g.Expect(reqs).To(gomega.HaveLen(tt.wantRequests))

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -2760,6 +2760,14 @@ func TestMapPodCliqueScalingGroupToRequests(t *testing.T) {
 					Labels: map[string]string{
 						commonconsts.KubeLabelDynamoGraphDeploymentName: "dynamo-recipe",
 					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: v1alpha1.GroupVersion.String(),
+							Kind:       "DynamoGraphDeployment",
+							Name:       "dynamo-recipe",
+							Controller: ptr.To(true),
+						},
+					},
 				},
 			},
 			wantRequests: 1,
@@ -2788,6 +2796,14 @@ func TestMapPodCliqueScalingGroupToRequests(t *testing.T) {
 					Namespace: "default",
 					Labels: map[string]string{
 						commonconsts.KubeLabelDynamoGraphDeploymentName: "my-very-long-original-dgd-name",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: v1alpha1.GroupVersion.String(),
+							Kind:       "DynamoGraphDeployment",
+							Name:       "my-very-long-original-dgd-name",
+							Controller: ptr.To(true),
+						},
 					},
 				},
 			},

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"maps"
 	"regexp"
 	"sort"
@@ -1001,6 +1002,47 @@ func expandMultinodeGMSRoles(serviceName string, numberOfNodes int32, totalEngin
 	return roles
 }
 
+// PCSNameForDGD computes the PodCliqueSet name for a DGD, auto-truncating if
+// the DGD name is too long to fit within Grove's combined resource name limit.
+//
+// For short DGD names the PCS name equals the DGD name (backwards compatible).
+// For long names, the PCS name is truncated with a deterministic 4-char hash
+// suffix to guarantee uniqueness and reconcile-loop stability.
+func PCSNameForDGD(dgdName string, services map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec) string {
+	maxServiceBudget := 0
+	for serviceName, svc := range services {
+		lowerName := strings.ToLower(serviceName)
+		var budget int
+		if svc != nil && svc.GetNumberOfNodes() > 1 {
+			// Multinode: PCSG = lowerName, PCLQ = lowerName + "-" + "ldr"
+			budget = len(lowerName) + len(lowerName) + 1 + len(commonconsts.GroveRoleSuffixLeader)
+		} else {
+			// Single-node: PCLQ = lowerName (no PCSG)
+			budget = len(lowerName)
+		}
+		if budget > maxServiceBudget {
+			maxServiceBudget = budget
+		}
+	}
+
+	pcsBudget := commonconsts.MaxCombinedGroveResourceNameLength - maxServiceBudget
+	// Clamp to a minimum so we always produce a usable name
+	const minPCSNameLength = 8
+	if pcsBudget < minPCSNameLength {
+		pcsBudget = minPCSNameLength
+	}
+
+	if len(dgdName) <= pcsBudget {
+		return dgdName
+	}
+
+	// Truncate with a deterministic hash suffix for uniqueness
+	hash := fnv.New32a()
+	hash.Write([]byte(dgdName))
+	suffix := fmt.Sprintf("%04x", hash.Sum32()&0xFFFF)
+	return dgdName[:pcsBudget-5] + "-" + suffix
+}
+
 // Define BackendFramework enum for sglang, vllm, trtllm
 
 type BackendFramework string
@@ -1692,9 +1734,13 @@ func GenerateGrovePodCliqueSet(
 	checkpointInfoByService map[string]*checkpoint.CheckpointInfo, // Optional checkpoint info per service
 ) (*grovev1alpha1.PodCliqueSet, error) {
 	gangSet := &grovev1alpha1.PodCliqueSet{}
-	gangSet.Name = dynamoDeployment.Name
+	gangSet.Name = PCSNameForDGD(dynamoDeployment.Name, dynamoDeployment.Spec.Services)
 	gangSet.Namespace = dynamoDeployment.Namespace
 	gangSet.Labels = maps.Clone(dynamoDeployment.Spec.Labels)
+	if gangSet.Labels == nil {
+		gangSet.Labels = make(map[string]string)
+	}
+	gangSet.Labels[commonconsts.KubeLabelDynamoGraphDeploymentName] = dynamoDeployment.Name
 	gangSet.Annotations = maps.Clone(dynamoDeployment.Spec.Annotations)
 	gangSet.Spec.Replicas = 1
 	gangSet.Spec.Template.HeadlessServiceConfig = &grovev1alpha1.HeadlessServiceConfig{

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -1402,6 +1402,9 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dynamo-graph-deployment",
 					Namespace: "test-namespace",
+					Labels: map[string]string{
+						commonconsts.KubeLabelDynamoGraphDeploymentName: "test-dynamo-graph-deployment",
+					},
 				},
 				Spec: grovev1alpha1.PodCliqueSetSpec{
 					Replicas: 1,
@@ -2019,6 +2022,9 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dynamo-graph-deployment",
 					Namespace: "test-namespace",
+					Labels: map[string]string{
+						commonconsts.KubeLabelDynamoGraphDeploymentName: "test-dynamo-graph-deployment",
+					},
 				},
 				Spec: grovev1alpha1.PodCliqueSetSpec{
 					Replicas: 1,
@@ -3055,6 +3061,9 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dynamo-graph-deployment",
 					Namespace: "test-namespace",
+					Labels: map[string]string{
+						commonconsts.KubeLabelDynamoGraphDeploymentName: "test-dynamo-graph-deployment",
+					},
 				},
 				Spec: grovev1alpha1.PodCliqueSetSpec{
 					Replicas: 1,
@@ -8320,6 +8329,119 @@ func TestGenerateGrovePodCliqueSet_TopologyConstraints(t *testing.T) {
 				if _, found := actualPCSGNames[expectedName]; !found {
 					t.Errorf("expected PCSG %q not found in PCS", expectedName)
 				}
+			}
+		})
+	}
+}
+
+func TestPCSNameForDGD(t *testing.T) {
+	singleNodeSvc := &v1alpha1.DynamoComponentDeploymentSharedSpec{}
+	multinodeSvc := &v1alpha1.DynamoComponentDeploymentSharedSpec{
+		Multinode: &v1alpha1.MultinodeSpec{NodeCount: 2},
+	}
+
+	tests := []struct {
+		name     string
+		dgdName  string
+		services map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec
+		want     string
+		wantLen  int // 0 means check exact match via want; >0 means check length
+	}{
+		{
+			name:    "short name passes through unchanged",
+			dgdName: "trtllm-disagg",
+			services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"prefill": singleNodeSvc,
+				"decode":  singleNodeSvc,
+			},
+			want: "trtllm-disagg",
+		},
+		{
+			name:    "short name with multinode passes through unchanged",
+			dgdName: "my-dgd",
+			services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"prefill": multinodeSvc,
+				"decode":  multinodeSvc,
+			},
+			want: "my-dgd",
+		},
+		{
+			name:    "long name gets truncated with hash",
+			dgdName: "deepseek-v32-fp4-trtllm-dgd",
+			services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"prefill": multinodeSvc,
+				"decode":  multinodeSvc,
+			},
+			// prefill multinode: PCSG=7, PCLQ=7+1+3=11 → budget=18, pcsBudget=45-18=27
+			// dgdName is 28 chars → needs truncation to 27
+			wantLen: 27,
+		},
+		{
+			name:    "deterministic - same input always produces same output",
+			dgdName: "deepseek-v32-fp4-trtllm-dgd",
+			services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"prefill": multinodeSvc,
+			},
+			// Just verify determinism by calling twice
+			wantLen: 27,
+		},
+		{
+			name:    "old long vllm service names get truncated more aggressively",
+			dgdName: "my-deployment-dgd",
+			services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"VllmPrefillWorker": multinodeSvc,
+			},
+			// VllmPrefillWorker multinode: PCSG=17, PCLQ=17+1+3=21 → budget=38, pcsBudget=45-38=7
+			// 7 < minPCSNameLength(8), so clamped to 8
+			wantLen: 8,
+		},
+		{
+			name:     "empty services - no truncation needed",
+			dgdName:  "my-dgd",
+			services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{},
+			want:     "my-dgd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PCSNameForDGD(tt.dgdName, tt.services)
+
+			if tt.want != "" {
+				if got != tt.want {
+					t.Errorf("PCSNameForDGD() = %q, want %q", got, tt.want)
+				}
+			}
+			if tt.wantLen > 0 {
+				if len(got) != tt.wantLen {
+					t.Errorf("PCSNameForDGD() = %q (len %d), want len %d", got, len(got), tt.wantLen)
+				}
+			}
+
+			// Verify determinism
+			got2 := PCSNameForDGD(tt.dgdName, tt.services)
+			if got != got2 {
+				t.Errorf("PCSNameForDGD() not deterministic: %q != %q", got, got2)
+			}
+
+			// Verify the result actually fits within the Grove limit
+			maxServiceBudget := 0
+			for svcName, svc := range tt.services {
+				lowerName := strings.ToLower(svcName)
+				var budget int
+				if svc != nil && svc.GetNumberOfNodes() > 1 {
+					budget = len(lowerName) + len(lowerName) + 1 + len(commonconsts.GroveRoleSuffixLeader)
+				} else {
+					budget = len(lowerName)
+				}
+				if budget > maxServiceBudget {
+					maxServiceBudget = budget
+				}
+			}
+			combinedLength := len(got) + maxServiceBudget
+			if combinedLength > commonconsts.MaxCombinedGroveResourceNameLength && len(got) > 8 {
+				t.Errorf("PCSNameForDGD() result %q (len %d) + max service budget %d = %d, exceeds %d",
+					got, len(got), maxServiceBudget, combinedLength, commonconsts.MaxCombinedGroveResourceNameLength)
 			}
 		})
 	}

--- a/deploy/operator/internal/dynamo/grove.go
+++ b/deploy/operator/internal/dynamo/grove.go
@@ -88,7 +88,7 @@ func GetComponentReadinessAndServiceReplicaStatuses(ctx context.Context, client 
 
 	for serviceName, component := range dgd.Spec.Services {
 		usesPCSG := component.GetNumberOfNodes() > 1 || component.IsInterPodGMSEnabled()
-		resourceName := fmt.Sprintf("%s-0-%s", dgd.Name, strings.ToLower(serviceName))
+		resourceName := fmt.Sprintf("%s-0-%s", PCSNameForDGD(dgd.Name, dgd.Spec.Services), strings.ToLower(serviceName))
 
 		if usesPCSG {
 			ok, reason, serviceStatus := CheckPCSGReady(ctx, client, resourceName, dgd.Namespace, logger)

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -27,6 +27,7 @@ import (
 	semver "github.com/Masterminds/semver/v3"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -37,12 +38,8 @@ import (
 )
 
 const (
-	// maxCombinedResourceNameLength is the maximum allowed combined length for Grove resource names.
-	// This constraint comes from Grove's PodCliqueSet webhook validation which enforces a 45-character
-	// limit on the combined length of PodCliqueSet name + PodCliqueScalingGroup name + PodClique name.
-	// Pod names follow formats like: <pcs-name>-<pcs-index>-<pcsg-name>-<pcsg-index>-<pclq-name>-<random>
-	// The random string and hyphens consume additional characters, leaving 45 for the resource names.
-	maxCombinedResourceNameLength = 45
+	// maxCombinedResourceNameLength is kept as a local alias for readability.
+	maxCombinedResourceNameLength = consts.MaxCombinedGroveResourceNameLength
 
 	// backendFrameworkVLLM is the spec.backendFramework value that identifies
 	// a vLLM deployment. Duplicated here (instead of importing from
@@ -382,13 +379,16 @@ func (v *DynamoGraphDeploymentValidator) validateService(ctx context.Context, se
 	return sharedValidator.Validate(ctx)
 }
 
-// validateServiceNameLength validates that the service name combined with the DGD name
-// won't exceed Grove's 45-character limit for resource naming.
+// validateServiceNameLength validates that the service name combined with the
+// auto-truncated PCS name won't exceed Grove's 45-character limit.
 //
-// Grove generates PodCliqueSet resources with the following naming patterns:
-// - PodCliqueSet name: DGD name (e.g., "vllm-agg")
+// The operator auto-truncates the PCS name (see PCSNameForDGD), so this
+// validation acts as a safety net — it should rarely fire in practice.
+//
+// Grove generates resource names from:
+// - PodCliqueSet name: auto-truncated from DGD name
 // - For multinode services:
-//   - PodCliqueScalingGroup name: lowercase(serviceName) (e.g., "vllmprefillworker")
+//   - PodCliqueScalingGroup name: lowercase(serviceName)
 //   - PodClique names: lowercase(serviceName + "-ldr") and lowercase(serviceName + "-wkr")
 //
 // - For single-node services:
@@ -396,7 +396,7 @@ func (v *DynamoGraphDeploymentValidator) validateService(ctx context.Context, se
 //
 // The combined length of these names must not exceed 45 characters.
 func (v *DynamoGraphDeploymentValidator) validateServiceNameLength(serviceName string, service *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec) error {
-	dgdName := v.deployment.Name
+	pcsName := dynamo.PCSNameForDGD(v.deployment.Name, v.deployment.Spec.Services)
 	lowerServiceName := strings.ToLower(serviceName)
 
 	isMultinode := service.GetNumberOfNodes() > 1
@@ -429,27 +429,31 @@ func (v *DynamoGraphDeploymentValidator) validateServiceNameLength(serviceName s
 
 	default:
 		// Single-node non-GMS: no PCSG, only PCS + PCLQ
-		combinedLength := len(dgdName) + len(lowerServiceName)
+		combinedLength := len(pcsName) + len(lowerServiceName)
 		if combinedLength > maxCombinedResourceNameLength {
 			return fmt.Errorf("spec.services[%s]: combined resource name length %d exceeds %d-character limit required for pod naming. "+
 				"Consider shortening the DynamoGraphDeployment name '%s' (length %d) or service name '%s' (length %d). "+
-				"The combined length of DGD name + service name must not exceed %d characters",
+				"The combined length of PCS name + service name must not exceed %d characters. "+
+				"The PCS name '%s' was auto-truncated from DGD name '%s'",
 				serviceName, combinedLength, maxCombinedResourceNameLength,
-				dgdName, len(dgdName), serviceName, len(serviceName),
-				maxCombinedResourceNameLength)
+				v.deployment.Name, len(v.deployment.Name), serviceName, len(serviceName),
+				maxCombinedResourceNameLength,
+				pcsName, v.deployment.Name)
 		}
 		return nil
 	}
 
 	// For services with PCSG: PCS name + PCSG name + longest PCLQ name
-	combinedLength := len(dgdName) + len(pcsgName) + len(longestPCLQName)
+	combinedLength := len(pcsName) + len(pcsgName) + len(longestPCLQName)
 	if combinedLength > maxCombinedResourceNameLength {
 		return fmt.Errorf("spec.services[%s]: combined resource name length %d exceeds %d-character limit required for pod naming. "+
 			"Consider shortening the DynamoGraphDeployment name '%s' (length %d) or service name '%s' (length %d). "+
-			"The combined length of DGD name + PCSG name + longest PodClique name ('%s') must not exceed %d characters",
+			"The combined length of PCS name + PCSG name + longest PodClique name ('%s') must not exceed %d characters. "+
+			"The PCS name '%s' was auto-truncated from DGD name '%s'",
 			serviceName, combinedLength, maxCombinedResourceNameLength,
-			dgdName, len(dgdName), serviceName, len(serviceName),
-			longestPCLQName, maxCombinedResourceNameLength)
+			v.deployment.Name, len(v.deployment.Name), serviceName, len(serviceName),
+			longestPCLQName, maxCombinedResourceNameLength,
+			pcsName, v.deployment.Name)
 	}
 
 	return nil

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -511,7 +511,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 		},
 		// Service name length validation tests
 		{
-			name:         "service name too long for single-node deployment",
+			name:         "long DGD name auto-truncated for single-node - no error",
 			groveEnabled: true,
 			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -521,6 +521,25 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentSpec{
 					Services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 						"VeryLongServiceNameThatExceedsLimit": {},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:         "service name so long that even truncated PCS name exceeds limit",
+			groveEnabled: true,
+			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-long-dgd-name",
+					Namespace: "default",
+				},
+				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentSpec{
+					Services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+						// 38 chars lowercase → pcsBudget = 45-38 = 7 < 8 → clamped to 8.
+						// DGD name 16 chars > 8 → truncated to 8.
+						// Combined: 8 + 38 = 46 > 45 → error even after truncation.
+						"VeryVeryExtremelyLongServiceNameXXXXXX": {},
 					},
 				},
 			},

--- a/examples/backends/trtllm/deploy/README.md
+++ b/examples/backends/trtllm/deploy/README.md
@@ -23,16 +23,16 @@ High-performance deployment with separated prefill and decode workers.
 
 **Architecture:**
 - `Frontend`: HTTP API server coordinating between workers
-- `TRTLLMDecodeWorker`: Specialized decode-only worker
-- `TRTLLMPrefillWorker`: Specialized prefill-only worker
+- `decode`: Specialized decode-only worker
+- `prefill`: Specialized prefill-only worker
 
 ### 4. **Disaggregated Router Deployment** (`disagg_router.yaml`)
 Advanced disaggregated deployment with KV cache routing capabilities.
 
 **Architecture:**
 - `Frontend`: HTTP API server (with kv router mode enabled)
-- `TRTLLMDecodeWorker`: Specialized decode-only worker
-- `TRTLLMPrefillWorker`: Specialized prefill-only worker (2 replicas for load balancing)
+- `decode`: Specialized decode-only worker
+- `prefill`: Specialized prefill-only worker (2 replicas for load balancing)
 
 ### 5. **Aggregated Deployment with Config** (`agg-with-config.yaml`)
 Aggregated deployment with custom configuration.
@@ -49,8 +49,8 @@ Advanced disaggregated deployment with SLA-based automatic scaling.
 - `Frontend`: HTTP API server coordinating between workers
 - `Planner`: SLA-based planner that monitors performance and scales workers automatically
 - `Prometheus`: Metrics collection and monitoring
-- `TRTLLMDecodeWorker`: Specialized decode-only worker
-- `TRTLLMPrefillWorker`: Specialized prefill-only worker
+- `decode`: Specialized decode-only worker
+- `prefill`: Specialized prefill-only worker
 
 > [!NOTE]
 > This deployment requires pre-deployment profiling to be completed first. See [Pre-Deployment Profiling](../../../../docs/components/profiler/profiler-guide.md) for detailed instructions.

--- a/examples/backends/trtllm/deploy/disagg.yaml
+++ b/examples/backends/trtllm/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/tensorrtllm-runtime:my-tag
-    TRTLLMPrefillWorker:
+    prefill:
       envFromSecret: hf-token-secret
       componentType: worker
       subComponentType: prefill
@@ -38,7 +38,7 @@ spec:
             - ./examples/backends/trtllm/engine_configs/qwen3/prefill.yaml
             - --disaggregation-mode
             - prefill
-    TRTLLMDecodeWorker:
+    decode:
       envFromSecret: hf-token-secret
       componentType: worker
       subComponentType: decode

--- a/examples/backends/trtllm/deploy/disagg_planner.yaml
+++ b/examples/backends/trtllm/deploy/disagg_planner.yaml
@@ -105,7 +105,7 @@ spec:
           - name: planner-profile-data
             configMap:
               name: planner-profile-data
-    TRTLLMDecodeWorker:
+    decode:
       envFromSecret: hf-token-secret
       componentType: worker
       subComponentType: decode
@@ -145,7 +145,7 @@ spec:
             - ./examples/backends/trtllm/engine_configs/qwen3/decode.yaml
             - --disaggregation-mode
             - decode
-    TRTLLMPrefillWorker:
+    prefill:
       envFromSecret: hf-token-secret
       componentType: worker
       subComponentType: prefill

--- a/examples/backends/trtllm/deploy/disagg_router.yaml
+++ b/examples/backends/trtllm/deploy/disagg_router.yaml
@@ -16,7 +16,7 @@ spec:
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
-    TRTLLMPrefillWorker:
+    prefill:
       envFromSecret: hf-token-secret
       componentType: worker
       replicas: 2
@@ -41,7 +41,7 @@ spec:
             - --disaggregation-mode
             - prefill
             - --publish-events-and-metrics
-    TRTLLMDecodeWorker:
+    decode:
       envFromSecret: hf-token-secret
       componentType: worker
       replicas: 2

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/deploy.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/deploy.yaml
@@ -82,7 +82,7 @@ spec:
           command:
             - /bin/sh
             - -c
-    TRTLLMPrefillWorker:
+    prefill:
       componentType: worker
       subComponentType: prefill
       envFromSecret: hf-token-secret
@@ -138,7 +138,7 @@ spec:
           - name: model-cache
             persistentVolumeClaim:
               claimName: model-cache
-    TRTLLMDecodeWorker:
+    decode:
       componentType: worker
       subComponentType: decode
       envFromSecret: hf-token-secret

--- a/tests/fault_tolerance/deploy/checker_factory.py
+++ b/tests/fault_tolerance/deploy/checker_factory.py
@@ -143,7 +143,7 @@ def get_results_checker(test_name: str, scenario: Scenario) -> BaseChecker:
         # TensorRT-LLM uses different names for agg vs disagg
         # Check test name to determine deployment type
         if "disagg" in test_name:
-            worker_service_name = "TRTLLMDecodeWorker"
+            worker_service_name = "decode"
         else:
             # Agg deployment uses TRTLLMWorker
             worker_service_name = "TRTLLMWorker"

--- a/tests/fault_tolerance/deploy/legacy_parse_results.py
+++ b/tests/fault_tolerance/deploy/legacy_parse_results.py
@@ -234,12 +234,6 @@ def parse_process_log(log_dir, process_name):
         "TRTLLMWorker": re.compile(
             r"TrtllmWorker for (?P<model_name>.*?) has been initialized|Model registration succeeded"
         ),
-        "TRTLLMDecodeWorker": re.compile(
-            r"TrtllmWorker for (?P<model_name>.*?) has been initialized|Model registration succeeded"
-        ),
-        "TRTLLMPrefillWorker": re.compile(
-            r"TrtllmWorker for (?P<model_name>.*?) has been initialized|Model registration succeeded"
-        ),
     }
 
     if not os.path.isdir(log_dir):
@@ -333,8 +327,6 @@ def calculate_recovery_time(test_dir, failure_type, fault_time):
         "decode",
         "prefill",
         "TRTLLMWorker",
-        "TRTLLMDecodeWorker",
-        "TRTLLMPrefillWorker",
     ]
 
     process_start = {}

--- a/tests/fault_tolerance/deploy/parse_results.py
+++ b/tests/fault_tolerance/deploy/parse_results.py
@@ -234,7 +234,7 @@ def get_decode_worker_dir(backend: str, deploy_type: str) -> Optional[str]:
         return WORKER_MAP[backend]["decode_agg"]  # "TRTLLMWorker"
     else:
         return WORKER_MAP[backend]["decode"]
-        # "TRTLLMDecodeWorker", "VllmDecodeWorker", or "decode"
+        # "decode" (trtllm disagg), "VllmDecodeWorker", or "decode" (sglang)
 
 
 def calculate_recovery_time(

--- a/tests/fault_tolerance/deploy/scenarios.py
+++ b/tests/fault_tolerance/deploy/scenarios.py
@@ -95,9 +95,9 @@ WORKER_MAP = {
         "prefill": "prefill",
     },
     "trtllm": {
-        "decode": "TRTLLMDecodeWorker",
+        "decode": "decode",
         "decode_agg": "TRTLLMWorker",  # Aggregated uses different name
-        "prefill": "TRTLLMPrefillWorker",
+        "prefill": "prefill",
     },
 }
 
@@ -121,12 +121,6 @@ WORKER_READY_PATTERNS: Dict[str, Pattern] = {
     ),
     # TensorRT-LLM workers
     "TRTLLMWorker": re.compile(
-        r"TrtllmWorker for (?P<model_name>.*?) has been initialized|Model registration succeeded"
-    ),
-    "TRTLLMDecodeWorker": re.compile(
-        r"TrtllmWorker for (?P<model_name>.*?) has been initialized|Model registration succeeded"
-    ),
-    "TRTLLMPrefillWorker": re.compile(
         r"TrtllmWorker for (?P<model_name>.*?) has been initialized|Model registration succeeded"
     ),
 }

--- a/tests/fault_tolerance/deploy/test_deployment.py
+++ b/tests/fault_tolerance/deploy/test_deployment.py
@@ -73,7 +73,7 @@ def get_model_from_deployment(
                 ):
                     model = deployment_spec["TRTLLMWorker"].model
                 else:
-                    model = deployment_spec["TRTLLMDecodeWorker"].model
+                    model = deployment_spec["decode"].model
             if model:
                 return model
         except (KeyError, AttributeError) as e:


### PR DESCRIPTION
## Summary
- TRTLLMPrefillWorker (19 chars) and TRTLLMDecodeWorker (18 chars) caused the combined Grove resource name (DGD name + service name + role suffix) to exceed the 45-character PodCliqueSet limit, breaking DGDR deployments with trtllm disagg.
- Shortened to "prefill" and "decode", matching the pattern SGLang already uses.

## Test plan
- [ ] Verify trtllm disagg deployment creates PodCliqueSets with names under 45 chars
- [ ] Verify existing SGLang disagg deployments are unaffected
- [ ] Run `pytest -m "integration and trtllm"` tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Configuration**
  * Simplified TRT-LLM worker Kubernetes resource naming from verbose identifiers to `prefill` and `decode` to comply with resource name length limits.
  * Updated deployment manifests and configuration files to reflect new worker service names.

* **Documentation**
  * Updated architecture documentation to reference simplified worker labels.

* **Tests**
  * Updated test fixtures and utilities to align with new worker naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->