### PR TITLE
fix: use per-instance GPU count for multinode decisions

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -40,7 +40,11 @@ def dgdr_name_env(monkeypatch):
 
 
 def test_build_dgd_config_shapes_multinode_worker_resources() -> None:
-    """build_dgd_config applies per-node GPU shaping when topology is provided."""
+    """build_dgd_config applies per-node GPU shaping when topology is provided.
+
+    When the worker only uses data-parallelism (no TP/PP spanning nodes),
+    multinode should NOT be set — dp shards are independent replicas.
+    """
     modifier = CONFIG_MODIFIERS["sglang"]
     dgd_config = modifier.build_dgd_config(
         mode="disagg",
@@ -50,6 +54,32 @@ def test_build_dgd_config_shapes_multinode_worker_resources() -> None:
         prefill_replicas=1,
         prefill_gpus=1,
         decode_cli_args=["--data-parallel-size", "16"],
+        decode_replicas=1,
+        decode_gpus=16,
+        num_gpus_per_node=8,
+    )
+
+    decode_service = next(
+        service
+        for service in dgd_config["spec"]["services"].values()
+        if service.get("subComponentType") == "decode"
+    )
+    assert decode_service["resources"]["limits"]["gpu"] == "8"
+    # dp=16 with default tp=1: each shard fits on one node, no multinode needed
+    assert decode_service.get("multinode") is None
+
+
+def test_build_dgd_config_multinode_when_tp_exceeds_node() -> None:
+    """multinode IS set when TP exceeds GPUs per node (single instance spans nodes)."""
+    modifier = CONFIG_MODIFIERS["sglang"]
+    dgd_config = modifier.build_dgd_config(
+        mode="disagg",
+        model_name="meta-llama/Llama-3-70B",
+        image="nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.0",
+        prefill_cli_args=["--max-running-requests", "1"],
+        prefill_replicas=1,
+        prefill_gpus=1,
+        decode_cli_args=["--tp", "16"],
         decode_replicas=1,
         decode_gpus=16,
         num_gpus_per_node=8,

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -94,6 +94,58 @@ def test_build_dgd_config_multinode_when_tp_exceeds_node() -> None:
     assert decode_service["multinode"] == {"nodeCount": 2}
 
 
+def test_build_dgd_config_fallback_when_no_parallelism_flags() -> None:
+    """When no TP/PP flags are present, per-instance defaults to 1 GPU (no multinode)."""
+    modifier = CONFIG_MODIFIERS["sglang"]
+    dgd_config = modifier.build_dgd_config(
+        mode="disagg",
+        model_name="Qwen/Qwen3-30B-A3B",
+        image="nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.0",
+        prefill_cli_args=["--max-running-requests", "1"],
+        prefill_replicas=1,
+        prefill_gpus=1,
+        decode_cli_args=["--data-parallel-size", "8"],
+        decode_replicas=1,
+        decode_gpus=8,
+        num_gpus_per_node=8,
+    )
+
+    decode_service = next(
+        service
+        for service in dgd_config["spec"]["services"].values()
+        if service.get("subComponentType") == "decode"
+    )
+    # No TP/PP flags => per-instance count is 1 (defaults), fits on one node
+    assert decode_service["resources"]["limits"]["gpu"] == "8"
+    assert decode_service.get("multinode") is None
+
+
+def test_build_dgd_config_shell_joined_tp_arg() -> None:
+    """Shell-joined args (e.g. '--tp 16' as a single string) are parsed correctly."""
+    modifier = CONFIG_MODIFIERS["sglang"]
+    dgd_config = modifier.build_dgd_config(
+        mode="disagg",
+        model_name="meta-llama/Llama-3-70B",
+        image="nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.0",
+        prefill_cli_args=["--max-running-requests", "1"],
+        prefill_replicas=1,
+        prefill_gpus=1,
+        decode_cli_args=["--tp 16"],
+        decode_replicas=1,
+        decode_gpus=16,
+        num_gpus_per_node=8,
+    )
+
+    decode_service = next(
+        service
+        for service in dgd_config["spec"]["services"].values()
+        if service.get("subComponentType") == "decode"
+    )
+    # Shell-joined "--tp 16" should be split and parsed; tp=16, 16/8 = 2 nodes
+    assert decode_service["resources"]["limits"]["gpu"] == "8"
+    assert decode_service["multinode"] == {"nodeCount": 2}
+
+
 def test_apply_dgd_overrides_strips_envelope() -> None:
     """Envelope fields are stripped; nested payload keys are deep-merged."""
     dgd_config = {

--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -229,42 +229,54 @@ def _get_per_instance_gpus(worker_service: Service) -> int | None:
 
     Returns ``None`` when TP/PP cannot be determined from the service args.
     """
-    args: list[str] | None = None
+    raw_args: list[str] | None = None
     if (
         worker_service.extraPodSpec
         and worker_service.extraPodSpec.mainContainer
         and worker_service.extraPodSpec.mainContainer.args
     ):
-        args = worker_service.extraPodSpec.mainContainer.args
+        raw_args = worker_service.extraPodSpec.mainContainer.args
 
-    if not args:
+    if not raw_args:
         return None
 
-    tp = 1
-    pp = 1
+    # Normalize: protocol.py may emit shell-joined items (e.g. "--tp 16")
+    # so split each entry with shlex to produce a flat token list.
+    args: list[str] = []
+    for item in raw_args:
+        args.extend(shlex.split(item))
+
+    tp: int | None = None
+    pp: int | None = None
     for i, arg in enumerate(args):
         if arg in ("--tensor-parallel-size", "--tp") and i + 1 < len(args):
             try:
                 tp = int(args[i + 1])
             except ValueError:
-                pass
+                logger.error("Invalid value for %s: %r", arg, args[i + 1])
+                raise
         elif arg.startswith("--tensor-parallel-size=") or arg.startswith("--tp="):
             try:
                 tp = int(arg.split("=", 1)[1])
             except ValueError:
-                pass
+                logger.error("Invalid value in %r", arg)
+                raise
         elif arg in ("--pipeline-parallel-size", "--pp") and i + 1 < len(args):
             try:
                 pp = int(args[i + 1])
             except ValueError:
-                pass
+                logger.error("Invalid value for %s: %r", arg, args[i + 1])
+                raise
         elif arg.startswith("--pipeline-parallel-size=") or arg.startswith("--pp="):
             try:
                 pp = int(arg.split("=", 1)[1])
             except ValueError:
-                pass
+                logger.error("Invalid value in %r", arg)
+                raise
 
-    return tp * pp
+    # Default to 1 when a flag is absent — workers without explicit TP/PP
+    # use single-GPU instances (e.g. data-parallel-only deployments).
+    return (tp or 1) * (pp or 1)
 
 
 def set_multinode_config(
@@ -273,10 +285,10 @@ def set_multinode_config(
     """Set multinode configuration based on GPU count and GPUs per node.
 
     ``gpu_count`` may represent the *total* GPUs across all data-parallel
-    shards (e.g. dp=8 × 8 GPUs = 64), but multinode should only be set
+    shards (e.g. dp=8 x 8 GPUs = 64), but multinode should only be set
     when a *single engine instance* needs more GPUs than one node provides.
     We therefore derive the per-instance GPU count from the worker's
-    TP × PP CLI args when available and use that for the multinode decision.
+    TP x PP CLI args when available and use that for the multinode decision.
     """
     # Determine per-instance GPUs from CLI args when possible.
     per_instance = _get_per_instance_gpus(worker_service)

--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -218,11 +218,71 @@ def parse_override_engine_args(args: list[str]) -> tuple[dict, list[str]]:
     return override_dict, args
 
 
+def _get_per_instance_gpus(worker_service: Service) -> int | None:
+    """Derive per-instance GPU count from worker CLI args (TP * PP).
+
+    Data-parallel (dp) workers are independent replicas, each needing only
+    TP * PP GPUs.  When the caller passes a ``gpu_count`` that already
+    includes the dp dimension (total GPUs across all dp shards), multinode
+    decisions must use the per-instance count instead; otherwise a dp=8
+    worker on 8-GPU nodes would incorrectly request ``nodeCount=8``.
+
+    Returns ``None`` when TP/PP cannot be determined from the service args.
+    """
+    args: list[str] | None = None
+    if (
+        worker_service.extraPodSpec
+        and worker_service.extraPodSpec.mainContainer
+        and worker_service.extraPodSpec.mainContainer.args
+    ):
+        args = worker_service.extraPodSpec.mainContainer.args
+
+    if not args:
+        return None
+
+    tp = 1
+    pp = 1
+    for i, arg in enumerate(args):
+        if arg in ("--tensor-parallel-size", "--tp") and i + 1 < len(args):
+            try:
+                tp = int(args[i + 1])
+            except ValueError:
+                pass
+        elif arg.startswith("--tensor-parallel-size=") or arg.startswith("--tp="):
+            try:
+                tp = int(arg.split("=", 1)[1])
+            except ValueError:
+                pass
+        elif arg in ("--pipeline-parallel-size", "--pp") and i + 1 < len(args):
+            try:
+                pp = int(args[i + 1])
+            except ValueError:
+                pass
+        elif arg.startswith("--pipeline-parallel-size=") or arg.startswith("--pp="):
+            try:
+                pp = int(arg.split("=", 1)[1])
+            except ValueError:
+                pass
+
+    return tp * pp
+
+
 def set_multinode_config(
     worker_service: Service, gpu_count: int, num_gpus_per_node: int
 ) -> None:
-    """Helper function to set multinode configuration based on GPU count and GPUs per node."""
-    if gpu_count <= num_gpus_per_node:
+    """Set multinode configuration based on GPU count and GPUs per node.
+
+    ``gpu_count`` may represent the *total* GPUs across all data-parallel
+    shards (e.g. dp=8 × 8 GPUs = 64), but multinode should only be set
+    when a *single engine instance* needs more GPUs than one node provides.
+    We therefore derive the per-instance GPU count from the worker's
+    TP × PP CLI args when available and use that for the multinode decision.
+    """
+    # Determine per-instance GPUs from CLI args when possible.
+    per_instance = _get_per_instance_gpus(worker_service)
+    effective_gpu_count = per_instance if per_instance is not None else gpu_count
+
+    if effective_gpu_count <= num_gpus_per_node:
         # Single node: remove multinode configuration if present
         if (
             hasattr(worker_service, "multinode")
@@ -230,8 +290,8 @@ def set_multinode_config(
         ):
             worker_service.multinode = None
     else:
-        # Multi-node: set nodeCount = math.ceil(gpu_count / num_gpus_per_node)
-        node_count = math.ceil(gpu_count / num_gpus_per_node)
+        # Multi-node: set nodeCount = math.ceil(effective_gpu_count / num_gpus_per_node)
+        node_count = math.ceil(effective_gpu_count / num_gpus_per_node)
         if not hasattr(worker_service, "multinode") or worker_service.multinode is None:
             # Create multinode configuration if it doesn't exist
             worker_service.multinode = MultinodeConfig(nodeCount=node_count)

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -592,10 +592,13 @@ class BaseConfigModifier:
     ) -> None:
         """Apply CLI args, replicas, and GPU resources to a single worker service."""
         service.replicas = replicas
-        setup_worker_service_resources(service, gpus, num_gpus_per_node)
 
+        # Set CLI args *before* resource setup so that _get_per_instance_gpus
+        # can read the caller-provided TP/PP values (not the template defaults).
         if service.extraPodSpec and service.extraPodSpec.mainContainer:
             service.extraPodSpec.mainContainer.args = sanitize_cli_args(list(cli_args))
+
+        setup_worker_service_resources(service, gpus, num_gpus_per_node)
 
     @classmethod
     def _apply_disagg_workers(


### PR DESCRIPTION
## Summary
- `set_multinode_config()` was using the total `gpu_count` (which includes data-parallel shards) to decide whether a worker needs multi-node scheduling, causing massively inflated GPU requests (e.g. 512 GPUs instead of 8 for a dp=8 decode worker).
- The fix derives per-instance GPU count from the worker's TP × PP CLI args. Data-parallel shards are independent replicas that each fit on a single node, so only tensor/pipeline parallelism should drive the multinode decision.
- Falls back to original `gpu_count` behavior when CLI args are unavailable.

## Test plan
- [ ] Run `pytest -m "unit and profiler"` — includes new unit tests for the fix
- [ ] Verify Qwen3-235B fp8 DGDR deployment generates correct nodeCount values
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced multi-node distributed training configuration to accurately calculate GPU allocation when tensor parallelism exceeds per-node GPU availability
  * Improved decode service configuration for multi-node setups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->