### PR TITLE
refactor(gms): split weight publish API

### DIFF
--- a/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
@@ -37,6 +37,7 @@ class _FakeManager:
         self.is_unmapped = is_unmapped
         self.granted_lock_type = granted_lock_type
         self.calls: list[object] = []
+        self.total_bytes = 4096
 
     def unmap_all_vas(self) -> None:
         self.calls.append("unmap_all_vas")
@@ -161,3 +162,30 @@ def test_region_requires_rw_allocator(build_impl, tag):
     with pytest.raises(RuntimeError, match=rf"requires '{tag}' to be RW"):
         with impl.region(tag, enable_cpu_backup=False):
             pass
+
+
+def test_finalize_write_mode_registers_then_commits(build_impl, monkeypatch):
+    impl, weights, _, _ = build_impl(weights_lock=GrantedLockType.RW)
+    model = object()
+    calls: list[object] = []
+
+    monkeypatch.setattr(
+        gms_memory_saver,
+        "register_module_tensors",
+        lambda allocator, target_model: calls.append(
+            ("register_module_tensors", allocator, target_model)
+        ),
+    )
+    monkeypatch.setattr(
+        gms_memory_saver,
+        "finalize_gms_write",
+        lambda allocator: calls.append(("finalize_gms_write", allocator)),
+    )
+
+    impl.finalize_write_mode(model)
+
+    assert calls == [
+        ("register_module_tensors", weights, model),
+        ("finalize_gms_write", weights),
+    ]
+    assert impl.imported_weights_bytes == weights.total_bytes

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -9,8 +9,6 @@ import logging
 from dataclasses import replace
 from typing import TYPE_CHECKING
 
-import torch
-from gpu_memory_service.client.torch.module import register_module_tensors
 from gpu_memory_service.common.locks import RequestedLockType
 
 if TYPE_CHECKING:
@@ -56,34 +54,15 @@ def setup_meta_tensor_workaround() -> None:
 
 
 def finalize_gms_write(
-    allocator: "GMSClientMemoryManager", model: torch.nn.Module
-) -> int:
-    """Finalize GMS write mode: register tensors, commit, reconnect in read mode.
-
-    Flow: register tensors -> sync -> unmap + commit -> connect(RO) -> remap
-
-    Args:
-        allocator: The GMS client memory manager in write mode.
-        model: The loaded model with weights to register.
-
-    Returns:
-        Total bytes committed.
-    """
-    register_module_tensors(allocator, model)
-    total_bytes = allocator.total_bytes
-
-    # Synchronize before commit — caller's writes must be visible
-    torch.cuda.synchronize()
-
+    allocator: "GMSClientMemoryManager",
+) -> None:
+    """Commit the current GMS write layout, then reconnect and remap it read-only."""
     allocator.commit()
 
     allocator.connect(RequestedLockType.RO)
     allocator.remap_all_vas()
 
     logger.info(
-        "[GMS] Committed %.2f GiB, switched to read mode with %d mappings",
-        total_bytes / (1 << 30),
-        len(allocator._mappings),
+        "[GMS] Switched published layout to read mode with %d mappings",
+        len(allocator.mappings),
     )
-
-    return int(total_bytes)

--- a/lib/gpu_memory_service/integrations/sglang/memory_saver.py
+++ b/lib/gpu_memory_service/integrations/sglang/memory_saver.py
@@ -26,6 +26,7 @@ from gpu_memory_service.client.torch.allocator import (
     get_or_create_gms_client_memory_manager,
     gms_use_mem_pool,
 )
+from gpu_memory_service.client.torch.module import register_module_tensors
 from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.integrations.common.utils import GMS_TAGS, finalize_gms_write
@@ -178,11 +179,11 @@ class GMSMemorySaverImpl:
             self.allocators[target_tag].remap_all_vas()
 
     def finalize_write_mode(self, model: torch.nn.Module) -> None:
-        """Finalize write mode: register tensors, commit, and switch to read."""
+        """Register tensors, then publish the committed weights read-only."""
         if self.allocators["weights"].granted_lock_type != GrantedLockType.RW:
             # Read-only import mode never republishes weights.
             return
 
-        self.imported_weights_bytes = finalize_gms_write(
-            self.allocators["weights"], model
-        )
+        register_module_tensors(self.allocators["weights"], model)
+        self.imported_weights_bytes = int(self.allocators["weights"].total_bytes)
+        finalize_gms_write(self.allocators["weights"])

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -22,7 +22,10 @@ from gpu_memory_service.client.torch.allocator import (
     get_or_create_gms_client_memory_manager,
     gms_use_mem_pool,
 )
-from gpu_memory_service.client.torch.module import materialize_module_from_gms
+from gpu_memory_service.client.torch.module import (
+    materialize_module_from_gms,
+    register_module_tensors,
+)
 from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.integrations.common.utils import finalize_gms_write
@@ -165,7 +168,9 @@ def _load_rw(
         _move_untracked_params(model, gms_client, target_device)
         torch.cuda.empty_cache()
 
-    _last_imported_weights_bytes = finalize_gms_write(gms_client, model)
+    register_module_tensors(gms_client, model)
+    _last_imported_weights_bytes = int(gms_client.total_bytes)
+    finalize_gms_write(gms_client)
 
     logger.info(
         "[GMS] TRT-LLM RW: published %.2f GiB",

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -18,7 +18,10 @@ from gpu_memory_service.client.torch.allocator import (
     get_or_create_gms_client_memory_manager,
     gms_use_mem_pool,
 )
-from gpu_memory_service.client.torch.module import materialize_module_from_gms
+from gpu_memory_service.client.torch.module import (
+    materialize_module_from_gms,
+    register_module_tensors,
+)
 from gpu_memory_service.common.locks import GrantedLockType
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.integrations.common.utils import (
@@ -153,7 +156,9 @@ def _load_write_mode(
             process_weights_after_loading(model, model_config, target_device)
             torch.cuda.empty_cache()
 
-    _last_imported_weights_bytes = finalize_gms_write(gms_client, model)
+    register_module_tensors(gms_client, model)
+    _last_imported_weights_bytes = int(gms_client.total_bytes)
+    finalize_gms_write(gms_client)
 
     logger.info(
         "[GMS] Write mode: published %.2f GiB",

--- a/lib/gpu_memory_service/tests/test_integration_utils.py
+++ b/lib/gpu_memory_service/tests/test_integration_utils.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure-Python tests for shared GMS integration helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from gpu_memory_service.common.locks import RequestedLockType
+
+_UTILS_PATH = (
+    Path(__file__).resolve().parents[1] / "integrations" / "common" / "utils.py"
+)
+_UTILS_SPEC = importlib.util.spec_from_file_location(
+    "gpu_memory_service_integrations_common_utils",
+    _UTILS_PATH,
+)
+assert _UTILS_SPEC is not None and _UTILS_SPEC.loader is not None
+_utils = importlib.util.module_from_spec(_UTILS_SPEC)
+_UTILS_SPEC.loader.exec_module(_utils)
+finalize_gms_write = _utils.finalize_gms_write
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.none,
+    pytest.mark.gpu_0,
+]
+
+
+class _FakeManager:
+    def __init__(self) -> None:
+        self.calls: list[object] = []
+        self.mappings = {0: object(), 1: object()}
+
+    def commit(self) -> None:
+        self.calls.append("commit")
+
+    def connect(self, lock_type: RequestedLockType) -> None:
+        self.calls.append(("connect", lock_type))
+
+    def remap_all_vas(self) -> None:
+        self.calls.append("remap_all_vas")
+
+
+def test_finalize_gms_write_reconnects_read_only() -> None:
+    manager = _FakeManager()
+
+    finalize_gms_write(manager)
+
+    assert manager.calls == [
+        "commit",
+        ("connect", RequestedLockType.RO),
+        "remap_all_vas",
+    ]


### PR DESCRIPTION
## Summary
- keep the shared GMS publish flow as an explicit two-step API: `register_module_tensors(...)` first, then `finalize_gms_write(...)`
- redefine `finalize_gms_write(...)` so it only performs the commit / reconnect-RO / remap phase
- update the vLLM, TRT-LLM, and SGLang weight-publish call sites to do registration explicitly before finalization
- add unit coverage for the new finalize-only helper contract and the SGLang publish sequence

## Testing
- `PYTHONPATH=$PWD/lib:$PWD/components/src /home/schwinns/dynamo/.venv/bin/python -m py_compile lib/gpu_memory_service/integrations/common/utils.py lib/gpu_memory_service/integrations/common/__init__.py lib/gpu_memory_service/integrations/vllm/model_loader.py lib/gpu_memory_service/integrations/trtllm/model_loader.py lib/gpu_memory_service/integrations/sglang/memory_saver.py components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py lib/gpu_memory_service/tests/test_integration_utils.py`
- `PYTHONPATH=$PWD/lib:$PWD/components/src uv run --no-project --with pytest python -m pytest -c /dev/null -q -o cache_dir=/tmp/pytest-cache lib/gpu_memory_service/tests/test_integration_utils.py`
- `PYTHONPATH=$PWD/lib:$PWD/components/src uv run --no-project --with pytest python -m pytest -c /dev/null -q -o cache_dir=/tmp/pytest-cache components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py` *(skipped: `torch` unavailable in this lightweight ad hoc env)*
