### PR TITLE
feat(gms): stage weight publish for draft models

### DIFF
--- a/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
@@ -17,6 +17,7 @@ from gpu_memory_service.common.locks import (  # noqa: E402
 )
 from gpu_memory_service.integrations.sglang.memory_saver import (  # noqa: E402
     GMSMemorySaverImpl,
+    disable_gms_weight_region,
 )
 
 pytestmark = [
@@ -37,6 +38,7 @@ class _FakeManager:
         self.is_unmapped = is_unmapped
         self.granted_lock_type = granted_lock_type
         self.calls: list[object] = []
+        self.total_bytes = 4096
 
     def unmap_all_vas(self) -> None:
         self.calls.append("unmap_all_vas")
@@ -161,3 +163,50 @@ def test_region_requires_rw_allocator(build_impl, tag):
     with pytest.raises(RuntimeError, match=rf"requires '{tag}' to be RW"):
         with impl.region(tag, enable_cpu_backup=False):
             pass
+
+
+def test_disable_gms_weight_region_bypasses_weight_pool(build_impl):
+    impl, _, _, pool_calls = build_impl(weights_lock=GrantedLockType.RW)
+
+    with disable_gms_weight_region():
+        with impl.region("weights", enable_cpu_backup=False):
+            pass
+
+    assert pool_calls == []
+
+
+def test_stage_write_model_stages_without_commit(build_impl, monkeypatch):
+    impl, weights, _, _ = build_impl(weights_lock=GrantedLockType.RW)
+    model = object()
+    calls: list[object] = []
+
+    monkeypatch.setattr(
+        gms_memory_saver,
+        "stage_gms_write_model",
+        lambda allocator, target_model, *, namespace: calls.append(
+            ("stage_gms_write_model", allocator, target_model, namespace)
+        ),
+    )
+
+    impl.stage_write_model(model, namespace="draft")
+
+    assert calls == [("stage_gms_write_model", weights, model, "draft")]
+    assert impl.imported_weights_bytes == weights.total_bytes
+
+
+def test_finalize_write_mode_commits_staged_models(build_impl, monkeypatch):
+    impl, weights, _, _ = build_impl(weights_lock=GrantedLockType.RW)
+    calls: list[object] = []
+
+    monkeypatch.setattr(
+        gms_memory_saver,
+        "finalize_staged_gms_write",
+        lambda allocator: calls.append(("finalize_staged_gms_write", allocator))
+        or allocator.total_bytes,
+    )
+
+    finalized_bytes = impl.finalize_write_mode()
+
+    assert finalized_bytes == weights.total_bytes
+    assert calls == [("finalize_staged_gms_write", weights)]
+    assert impl.imported_weights_bytes == weights.total_bytes

--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -12,7 +12,7 @@ This module provides module-level tensor operations:
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Iterator, Tuple
+from typing import TYPE_CHECKING, Collection, Iterator, Tuple
 
 import torch
 from gpu_memory_service.client.torch.tensor import GMSTensorSpec, TensorMetadata
@@ -120,15 +120,27 @@ def _resolve_module_attr(
 def register_module_tensors(
     gms_client_memory_manager: "GMSClientMemoryManager",
     model: torch.nn.Module,
+    *,
+    namespace: str | None = None,
+    tensor_names: Collection[str] | None = None,
 ) -> None:
     """Register all model tensors into the GMS metadata store.
 
     Args:
         gms_client_memory_manager: GMS client memory manager in write mode.
         model: PyTorch model to register.
+        namespace: Optional model namespace. When set, metadata keys are
+            written under ``"{namespace}/"`` so multiple models can share the
+            same GMS layout without key collisions.
+        tensor_names: Optional set of module tensor names to register. This is
+            useful for staged publication where the engine may add auxiliary
+            non-GMS parameters after the loader returns.
     """
     for name, tensor, tensor_type in _iter_module_tensors(model):
+        if tensor_names is not None and name not in tensor_names:
+            continue
         ptr = int(tensor.data_ptr())
+        metadata_key = f"{namespace}/{name}" if namespace is not None else name
 
         # Find allocation containing this tensor
         for va, mapping in gms_client_memory_manager.mappings.items():
@@ -136,7 +148,7 @@ def register_module_tensors(
                 offset = ptr - va
                 meta = TensorMetadata.from_tensor(tensor, tensor_type)
                 gms_client_memory_manager.metadata_put(
-                    key=name,
+                    key=metadata_key,
                     allocation_id=mapping.allocation_id,
                     offset_bytes=offset,
                     value=meta.to_bytes(),
@@ -153,11 +165,17 @@ def register_module_tensors(
             )
 
 
+def collect_module_tensor_names(model: torch.nn.Module) -> frozenset[str]:
+    """Collect current CUDA tensor names from a module tree."""
+    return frozenset(name for name, _, _ in _iter_module_tensors(model))
+
+
 def materialize_module_from_gms(
     gms_client_memory_manager: "GMSClientMemoryManager",
     model: torch.nn.Module,
     *,
     device_index: int,
+    namespace: str | None = None,
 ) -> None:
     """Materialize model tensors from GMS.
 
@@ -165,12 +183,14 @@ def materialize_module_from_gms(
         gms_client_memory_manager: GMS client memory manager in read mode.
         model: Model to populate with tensors.
         device_index: CUDA device index.
+        namespace: Optional model namespace to import. When set, only metadata
+            keys under ``"{namespace}/"`` are loaded.
     """
-    specs = GMSTensorSpec.load_all(gms_client_memory_manager)
+    specs = GMSTensorSpec.load_all(gms_client_memory_manager, namespace=namespace)
 
     for name, spec in specs.items():
         tensor = spec.materialize(gms_client_memory_manager, device_index)
-        mod, attr = _resolve_module_attr(model, name)
+        mod, attr = _resolve_module_attr(model, spec.name)
         tensor_type = spec.meta.tensor_type
 
         # Tensor attrs and buffers: clone since they may be mutated
@@ -191,7 +211,7 @@ def materialize_module_from_gms(
             if param is not None:
                 if param.shape != tensor.shape or param.dtype != tensor.dtype:
                     raise RuntimeError(
-                        f"Shape/dtype mismatch for {name}: "
+                        f"Shape/dtype mismatch for {spec.name}: "
                         f"param={tuple(param.shape)}/{param.dtype}, "
                         f"gms={tuple(tensor.shape)}/{tensor.dtype}"
                     )

--- a/lib/gpu_memory_service/client/torch/tensor.py
+++ b/lib/gpu_memory_service/client/torch/tensor.py
@@ -179,28 +179,39 @@ class GMSTensorSpec:
 
     @classmethod
     def load_all(
-        cls, gms_client_memory_manager: "GMSClientMemoryManager"
+        cls,
+        gms_client_memory_manager: "GMSClientMemoryManager",
+        *,
+        namespace: str | None = None,
     ) -> Dict[str, "GMSTensorSpec"]:
         """Load all metadata entries.
+
+        Args:
+            gms_client_memory_manager: GMS client memory manager.
+            namespace: Optional model namespace. When set, only metadata keys
+                under ``"{namespace}/"`` are loaded and the returned spec names
+                have that prefix stripped.
 
         Returns:
             Mapping of tensor name -> GMSTensorSpec.
         """
         specs: Dict[str, GMSTensorSpec] = {}
+        metadata_prefix = f"{namespace}/" if namespace is not None else ""
 
-        for key in gms_client_memory_manager.metadata_list():
+        for key in gms_client_memory_manager.metadata_list(prefix=metadata_prefix):
             got = gms_client_memory_manager.metadata_get(key)
             if got is None:
                 raise RuntimeError(f"Metadata key disappeared: {key}")
 
             allocation_id, offset_bytes, value = got
+            name = key[len(metadata_prefix) :] if metadata_prefix else key
 
-            if key in specs:
-                raise RuntimeError(f"Duplicate tensor name: {key}")
+            if name in specs:
+                raise RuntimeError(f"Duplicate tensor name: {name}")
 
-            specs[key] = cls(
+            specs[name] = cls(
                 key=key,
-                name=key,
+                name=name,
                 allocation_id=str(allocation_id),
                 offset_bytes=int(offset_bytes),
                 meta=TensorMetadata.from_bytes(value),

--- a/lib/gpu_memory_service/integrations/common/__init__.py
+++ b/lib/gpu_memory_service/integrations/common/__init__.py
@@ -7,7 +7,9 @@ from gpu_memory_service.integrations.common.patches import patch_empty_cache
 from gpu_memory_service.integrations.common.utils import (
     GMS_TAGS,
     finalize_gms_write,
+    finalize_staged_gms_write,
     setup_meta_tensor_workaround,
+    stage_gms_write_model,
 )
 
 __all__ = [
@@ -15,4 +17,6 @@ __all__ = [
     "patch_empty_cache",
     "setup_meta_tensor_workaround",
     "finalize_gms_write",
+    "stage_gms_write_model",
+    "finalize_staged_gms_write",
 ]

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -6,11 +6,14 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import replace
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
 
 import torch
-from gpu_memory_service.client.torch.module import register_module_tensors
+from gpu_memory_service.client.torch.module import (
+    collect_module_tensor_names,
+    register_module_tensors,
+)
 from gpu_memory_service.common.locks import RequestedLockType
 
 if TYPE_CHECKING:
@@ -18,6 +21,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 GMS_TAGS = ("weights", "kv_cache")
+
+
+@dataclass
+class _StagedGMSWrite:
+    allocator: "GMSClientMemoryManager"
+    models: list[tuple[str | None, torch.nn.Module, frozenset[str]]] = field(
+        default_factory=list
+    )
+
+
+_staged_gms_writes: dict[int, _StagedGMSWrite] = {}
 
 
 def get_gms_lock_mode(extra_config: dict):
@@ -68,21 +82,77 @@ def setup_meta_tensor_workaround() -> None:
         pass
 
 
-def finalize_gms_write(
-    allocator: "GMSClientMemoryManager", model: torch.nn.Module
-) -> int:
-    """Finalize GMS write mode: register tensors, commit, reconnect in read mode.
+def stage_gms_write_model(
+    allocator: "GMSClientMemoryManager",
+    model: torch.nn.Module,
+    *,
+    namespace: str | None = None,
+) -> None:
+    """Stage a model for a later GMS weight publish.
 
-    Flow: register tensors -> sync -> unmap + commit -> connect(RO) -> remap
+    The model object is intentionally stored by reference so engine-level
+    post-load mutations, such as target/draft embedding sharing, are visible
+    when metadata is registered just before the final commit.
 
     Args:
         allocator: The GMS client memory manager in write mode.
-        model: The loaded model with weights to register.
+        model: The loaded model whose tensors should be registered later.
+        namespace: Optional metadata namespace for this model.
+    """
+    staged = _staged_gms_writes.setdefault(
+        id(allocator), _StagedGMSWrite(allocator=allocator)
+    )
+    for staged_namespace, _, _ in staged.models:
+        if staged_namespace == namespace:
+            raise RuntimeError(f"GMS write namespace {namespace!r} is already staged")
+    tensor_names = collect_module_tensor_names(model)
+    staged.models.append((namespace, model, tensor_names))
+    logger.info(
+        "[GMS] Staged model for write publish "
+        "(namespace=%r, tensors=%d, staged=%d)",
+        namespace,
+        len(tensor_names),
+        len(staged.models),
+    )
+
+
+def has_staged_gms_write(allocator: "GMSClientMemoryManager") -> bool:
+    """Return whether there are models staged for this allocator."""
+    staged = _staged_gms_writes.get(id(allocator))
+    return bool(staged is not None and staged.models)
+
+
+def finalize_staged_gms_write(allocator: "GMSClientMemoryManager") -> int:
+    """Register all staged model tensors, then finalize one GMS write layout.
+
+    Returns 0 when nothing is staged for the allocator.
+    """
+    staged = _staged_gms_writes.pop(id(allocator), None)
+    if staged is None or not staged.models:
+        return 0
+
+    for namespace, model, tensor_names in staged.models:
+        register_module_tensors(
+            allocator,
+            model,
+            namespace=namespace,
+            tensor_names=tensor_names,
+        )
+
+    return finalize_gms_write(allocator)
+
+
+def finalize_gms_write(allocator: "GMSClientMemoryManager") -> int:
+    """Commit the current GMS write layout, then reconnect and remap read-only.
+
+    Flow: sync -> unmap + commit -> connect(RO) -> remap
+
+    Args:
+        allocator: The GMS client memory manager in write mode.
 
     Returns:
         Total bytes committed.
     """
-    register_module_tensors(allocator, model)
     total_bytes = allocator.total_bytes
 
     # Synchronize before commit — caller's writes must be visible
@@ -96,7 +166,7 @@ def finalize_gms_write(
     logger.info(
         "[GMS] Committed %.2f GiB, switched to read mode with %d mappings",
         total_bytes / (1 << 30),
-        len(allocator._mappings),
+        len(allocator.mappings),
     )
 
     return int(total_bytes)

--- a/lib/gpu_memory_service/integrations/sglang/memory_saver.py
+++ b/lib/gpu_memory_service/integrations/sglang/memory_saver.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import gc
 import logging
+from contextvars import ContextVar
 from contextlib import contextmanager
 from typing import Optional
 
@@ -28,13 +29,21 @@ from gpu_memory_service.client.torch.allocator import (
 )
 from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
 from gpu_memory_service.common.utils import get_socket_path
-from gpu_memory_service.integrations.common.utils import GMS_TAGS, finalize_gms_write
+from gpu_memory_service.integrations.common.utils import (
+    GMS_TAGS,
+    finalize_staged_gms_write,
+    stage_gms_write_model,
+)
 
 logger = logging.getLogger(__name__)
 
 # Published weights must come back RO, while KV cache always resumes in a fresh
 # RW epoch so the restored engine can rebuild mutable cache state.
 _TAG_LOCK_TYPES = {"weights": RequestedLockType.RO, "kv_cache": RequestedLockType.RW}
+_disable_gms_weight_region: ContextVar[bool] = ContextVar(
+    "disable_gms_weight_region",
+    default=False,
+)
 
 
 def _pause_resume_tags(tag: Optional[str]) -> tuple[str, ...]:
@@ -58,6 +67,16 @@ def get_gms_memory_saver_impl() -> Optional["GMSMemorySaverImpl"]:
         return torch_memory_saver.torch_memory_saver.gms_impl
     except (ImportError, AttributeError):
         return None
+
+
+@contextmanager
+def disable_gms_weight_region():
+    """Temporarily bypass the GMS mempool for SGLang weight allocations."""
+    token = _disable_gms_weight_region.set(True)
+    try:
+        yield
+    finally:
+        _disable_gms_weight_region.reset(token)
 
 
 class GMSMemorySaverImpl:
@@ -107,6 +126,10 @@ class GMSMemorySaverImpl:
                 tag,
                 list(GMS_TAGS),
             )
+            yield
+            return
+
+        if tag == "weights" and _disable_gms_weight_region.get():
             yield
             return
 
@@ -182,12 +205,31 @@ class GMSMemorySaverImpl:
                 self.allocators[target_tag].reallocate_all_handles(tag=target_tag)
             self.allocators[target_tag].remap_all_vas()
 
-    def finalize_write_mode(self, model: torch.nn.Module) -> None:
-        """Finalize write mode: register tensors, commit, and switch to read."""
+    def stage_write_model(
+        self,
+        model: torch.nn.Module,
+        *,
+        namespace: str,
+    ) -> None:
+        """Stage a weight model for a later engine-level commit."""
         if self.allocators["weights"].granted_lock_type != GrantedLockType.RW:
             # Read-only import mode never republishes weights.
             return
 
-        self.imported_weights_bytes = finalize_gms_write(
-            self.allocators["weights"], model
+        stage_gms_write_model(
+            self.allocators["weights"],
+            model,
+            namespace=namespace,
         )
+        self.imported_weights_bytes = int(self.allocators["weights"].total_bytes)
+
+    def finalize_write_mode(self) -> int:
+        """Publish staged weight models and switch the layout to read mode."""
+        if self.allocators["weights"].granted_lock_type != GrantedLockType.RW:
+            # Read-only import mode never republishes weights.
+            return 0
+
+        finalized_bytes = finalize_staged_gms_write(self.allocators["weights"])
+        if finalized_bytes > 0:
+            self.imported_weights_bytes = finalized_bytes
+        return finalized_bytes

--- a/lib/gpu_memory_service/integrations/sglang/model_loader.py
+++ b/lib/gpu_memory_service/integrations/sglang/model_loader.py
@@ -28,6 +28,7 @@ from gpu_memory_service.integrations.sglang.memory_saver import (
 )
 from gpu_memory_service.integrations.sglang.patches import (
     patch_model_runner,
+    patch_scheduler,
     patch_static_state_for_gms,
     patch_torch_memory_saver,
 )
@@ -42,6 +43,7 @@ logger = logging.getLogger(__name__)
 patch_empty_cache()
 patch_torch_memory_saver()
 patch_model_runner()
+patch_scheduler()
 patch_static_state_for_gms()
 logger.info("[GMS] Applied patches")
 
@@ -79,14 +81,36 @@ class GMSModelLoader:
             )
 
         mode = impl.allocators["weights"].granted_lock_type
-        logger.info("[GMS] Loading model in %s mode", mode.name)
+        namespace = _resolve_model_namespace(model_config, self.load_config)
+        logger.info(
+            "[GMS] Loading model in %s mode (namespace=%s)",
+            mode.name,
+            namespace,
+        )
 
         if mode == GrantedLockType.RO:
-            return self._load_import_only(model_config, device_config, impl)
-        return self._load_write_mode(model_config, device_config, impl)
+            return self._load_import_only(
+                model_config,
+                device_config,
+                impl,
+                namespace=namespace,
+            )
+        return self._load_write_mode(
+            model_config,
+            device_config,
+            impl,
+            namespace=namespace,
+        )
 
-    def _load_write_mode(self, model_config, device_config, impl) -> torch.nn.Module:
-        """Load model from disk and register with GMS (WRITE mode)."""
+    def _load_write_mode(
+        self,
+        model_config,
+        device_config,
+        impl,
+        *,
+        namespace: str,
+    ) -> torch.nn.Module:
+        """Load model from disk and stage it for GMS publication."""
         default_loader = self._get_default_loader()
 
         model = default_loader.load_model(
@@ -94,22 +118,35 @@ class GMSModelLoader:
             device_config=device_config,
         )
 
-        impl.finalize_write_mode(model)
+        impl.stage_write_model(model, namespace=namespace)
         return model
 
-    def _load_import_only(self, model_config, device_config, impl) -> torch.nn.Module:
+    def _load_import_only(
+        self,
+        model_config,
+        device_config,
+        impl,
+        *,
+        namespace: str,
+    ) -> torch.nn.Module:
         """Import model weights from GMS metadata (READ mode)."""
         allocator = impl.allocators["weights"]
 
         device_index = torch.cuda.current_device()
         model = self._create_meta_model(model_config, device_config)
 
-        materialize_module_from_gms(allocator, model, device_index=device_index)
+        materialize_module_from_gms(
+            allocator,
+            model,
+            device_index=device_index,
+            namespace=namespace,
+        )
         impl.imported_weights_bytes = allocator.total_bytes
 
         logger.info(
-            "[GMS] READ mode: imported %.2f GiB from metadata",
+            "[GMS] READ mode: imported %.2f GiB from metadata (namespace=%s)",
             allocator.total_bytes / (1 << 30),
+            namespace,
         )
         return model.eval()
 
@@ -144,3 +181,13 @@ class GMSModelLoader:
             logger.debug("[GMS] Post-processing on meta tensors: %s", e)
 
         return model
+
+
+def _resolve_model_namespace(model_config, load_config) -> str:
+    """Return the GMS metadata namespace for an SGLang model load."""
+    if getattr(model_config, "is_draft_model", False):
+        draft_model_idx = getattr(load_config, "draft_model_idx", None)
+        if draft_model_idx is not None:
+            return f"draft_{draft_model_idx}"
+        return "draft"
+    return "target"

--- a/lib/gpu_memory_service/integrations/sglang/patches.py
+++ b/lib/gpu_memory_service/integrations/sglang/patches.py
@@ -12,13 +12,14 @@ from __future__ import annotations
 
 import inspect
 import logging
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from typing import Optional
 
 import gpu_memory_service.integrations.sglang as gms_sglang
 import torch
 from gpu_memory_service.integrations.sglang.memory_saver import (
     GMSMemorySaverImpl,
+    disable_gms_weight_region,
     get_gms_memory_saver_impl,
 )
 
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 _torch_memory_saver_patched = False
 _model_runner_patched = False
+_scheduler_patched = False
 _static_state_patched = False
 
 
@@ -162,6 +164,7 @@ def patch_model_runner() -> None:
         return
 
     original_init_memory_pool = ModelRunner.init_memory_pool
+    original_load_model = ModelRunner.load_model
     memory_arg_name = next(
         (
             name
@@ -212,10 +215,68 @@ def patch_model_runner() -> None:
 
         return original_init_memory_pool(self, *args, **kwargs)
 
+    def patched_load_model(self, *args, **kwargs):
+        """Bypass GMS weight allocation for non-GMS draft model loads."""
+        is_draft_worker = getattr(self, "is_draft_worker", False)
+        load_format = getattr(getattr(self, "load_config", None), "load_format", None)
+        use_gms_loader = isinstance(load_format, type) and load_format.__name__ == (
+            "GMSModelLoader"
+        )
+        context = (
+            disable_gms_weight_region()
+            if is_draft_worker and not use_gms_loader
+            else nullcontext()
+        )
+        with context:
+            return original_load_model(self, *args, **kwargs)
+
     ModelRunner.init_memory_pool = patched_init_memory_pool
+    ModelRunner.load_model = patched_load_model
     ModelRunner._gms_patched = True
     _model_runner_patched = True
     logger.info("[GMS] Patched ModelRunner.init_memory_pool")
+
+
+def patch_scheduler() -> None:
+    """Patch SGLang scheduler to publish staged GMS weights after model init.
+
+    SGLang constructs the target worker first and then constructs any draft
+    worker from Scheduler.init_model_worker(). GMS keeps the single "weights"
+    layout writable during those individual model loads; this patch commits the
+    staged target/draft models once that engine-level initialization succeeds.
+    """
+    global _scheduler_patched
+
+    if _scheduler_patched:
+        return
+
+    try:
+        from sglang.srt.managers.scheduler import Scheduler
+    except ImportError:
+        logger.warning("[GMS] Could not import Scheduler, skipping patch")
+        return
+
+    if hasattr(Scheduler, "_gms_scheduler_patched"):
+        return
+
+    original_init_model_worker = Scheduler.init_model_worker
+
+    def patched_init_model_worker(self, *args, **kwargs):
+        result = original_init_model_worker(self, *args, **kwargs)
+        impl = get_gms_memory_saver_impl()
+        if impl is not None:
+            finalized_bytes = impl.finalize_write_mode()
+            if finalized_bytes > 0:
+                logger.info(
+                    "[GMS] Published staged SGLang weights: %.2f GiB",
+                    finalized_bytes / (1 << 30),
+                )
+        return result
+
+    Scheduler.init_model_worker = patched_init_model_worker
+    Scheduler._gms_scheduler_patched = True
+    _scheduler_patched = True
+    logger.info("[GMS] Patched Scheduler.init_model_worker")
 
 
 def patch_static_state_for_gms() -> None:

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -22,7 +22,10 @@ from gpu_memory_service.client.torch.allocator import (
     get_or_create_gms_client_memory_manager,
     gms_use_mem_pool,
 )
-from gpu_memory_service.client.torch.module import materialize_module_from_gms
+from gpu_memory_service.client.torch.module import (
+    materialize_module_from_gms,
+    register_module_tensors,
+)
 from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.integrations.common.utils import finalize_gms_write
@@ -165,7 +168,8 @@ def _load_rw(
         _move_untracked_params(model, gms_client, target_device)
         torch.cuda.empty_cache()
 
-    _last_imported_weights_bytes = finalize_gms_write(gms_client, model)
+    register_module_tensors(gms_client, model)
+    _last_imported_weights_bytes = finalize_gms_write(gms_client)
 
     logger.info(
         "[GMS] TRT-LLM RW: published %.2f GiB",

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -23,9 +23,9 @@ from gpu_memory_service.client.torch.module import materialize_module_from_gms
 from gpu_memory_service.common.locks import GrantedLockType
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.integrations.common.utils import (
-    finalize_gms_write,
     get_gms_lock_mode,
     setup_meta_tensor_workaround,
+    stage_gms_write_model,
     strip_gms_model_loader_config,
 )
 
@@ -55,6 +55,12 @@ _last_imported_weights_bytes: int = 0
 def get_imported_weights_bytes() -> int:
     """Return bytes of weights imported in the last load_model call."""
     return _last_imported_weights_bytes
+
+
+def set_imported_weights_bytes(value: int) -> None:
+    """Set bytes imported/published by the complete engine model load."""
+    global _last_imported_weights_bytes
+    _last_imported_weights_bytes = int(value)
 
 
 # =============================================================================
@@ -131,6 +137,7 @@ def register_gms_loader(load_format: str = "gms") -> None:
             device = torch.cuda.current_device()
             extra = getattr(self.load_config, "model_loader_extra_config", {}) or {}
             mode = get_gms_lock_mode(extra)
+            namespace = _resolve_model_namespace(vllm_config, model_config, prefix)
             gms_client = get_or_create_gms_client_memory_manager(
                 get_socket_path(device, "weights"),
                 device,
@@ -139,7 +146,14 @@ def register_gms_loader(load_format: str = "gms") -> None:
             )
 
             if gms_client.granted_lock_type == GrantedLockType.RO:
-                return _load_read_mode(gms_client, vllm_config, model_config, device)
+                return _load_read_mode(
+                    gms_client,
+                    vllm_config,
+                    model_config,
+                    device,
+                    namespace=namespace,
+                    prefix=prefix,
+                )
             else:
                 return _load_write_mode(
                     gms_client,
@@ -147,6 +161,8 @@ def register_gms_loader(load_format: str = "gms") -> None:
                     model_config,
                     self.default_loader,
                     torch.device("cuda", device),
+                    namespace=namespace,
+                    prefix=prefix,
                 )
 
 
@@ -160,6 +176,9 @@ def _load_read_mode(
     vllm_config,
     model_config,
     device_index: int,
+    *,
+    namespace: str,
+    prefix: str,
 ) -> torch.nn.Module:
     """Load model by importing weights from GMS (RO mode).
 
@@ -169,8 +188,13 @@ def _load_read_mode(
     global _last_imported_weights_bytes
 
     try:
-        model = _create_meta_model(vllm_config, model_config)
-        materialize_module_from_gms(gms_client, model, device_index=device_index)
+        model = _create_meta_model(vllm_config, model_config, prefix=prefix)
+        materialize_module_from_gms(
+            gms_client,
+            model,
+            device_index=device_index,
+            namespace=namespace,
+        )
 
         # MX: register materialized tensors (available for P2P transfer)
         mx_ctx = get_mx_load_context(vllm_config, model_config)
@@ -180,8 +204,9 @@ def _load_read_mode(
 
         _last_imported_weights_bytes = gms_client.total_bytes
         logger.info(
-            "[GMS] Read mode: imported %.2f GiB",
+            "[GMS] Read mode: imported %.2f GiB (namespace=%s)",
             _last_imported_weights_bytes / (1 << 30),
+            namespace,
         )
         return model.eval()
     except Exception:
@@ -195,6 +220,9 @@ def _load_write_mode(
     model_config,
     default_loader,
     target_device: torch.device,
+    *,
+    namespace: str,
+    prefix: str,
 ) -> torch.nn.Module:
     """Load model from disk and publish weights to GMS (RW mode).
 
@@ -220,7 +248,9 @@ def _load_write_mode(
         with gms_use_mem_pool("weights", target_device):
             with target_device:
                 model = initialize_model(
-                    vllm_config=vllm_config, model_config=model_config
+                    vllm_config=vllm_config,
+                    model_config=model_config,
+                    prefix=prefix,
                 )
 
             if mx_ctx is not None:
@@ -232,16 +262,18 @@ def _load_write_mode(
 
             torch.cuda.empty_cache()
 
-    _last_imported_weights_bytes = finalize_gms_write(gms_client, model)
+    stage_gms_write_model(gms_client, model, namespace=namespace)
+    _last_imported_weights_bytes = int(gms_client.total_bytes)
 
     logger.info(
-        "[GMS] Write mode: published %.2f GiB",
+        "[GMS] Write mode: staged %.2f GiB (namespace=%s)",
         _last_imported_weights_bytes / (1 << 30),
+        namespace,
     )
     return model.eval()
 
 
-def _create_meta_model(vllm_config, model_config) -> torch.nn.Module:
+def _create_meta_model(vllm_config, model_config, *, prefix: str) -> torch.nn.Module:
     """Create model on meta device for RO mode materialization."""
     from vllm.model_executor.model_loader.utils import (
         initialize_model,
@@ -254,7 +286,11 @@ def _create_meta_model(vllm_config, model_config) -> torch.nn.Module:
 
     with set_default_torch_dtype(model_config.dtype):
         with meta_device:
-            model = initialize_model(vllm_config=vllm_config, model_config=model_config)
+            model = initialize_model(
+                vllm_config=vllm_config,
+                model_config=model_config,
+                prefix=prefix,
+            )
 
     try:
         process_weights_after_loading(model, model_config, meta_device)
@@ -262,3 +298,27 @@ def _create_meta_model(vllm_config, model_config) -> torch.nn.Module:
         logger.debug("[GMS] Post-processing on meta tensors: %s", e)
 
     return model
+
+
+def _resolve_model_namespace(vllm_config, model_config, prefix: str) -> str:
+    """Return the GMS metadata namespace for a vLLM model load."""
+    if prefix.startswith("draft"):
+        return prefix
+
+    if model_config is getattr(vllm_config, "model_config", None):
+        return "target"
+
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    if speculative_config is not None:
+        draft_model_config = getattr(speculative_config, "draft_model_config", None)
+        if model_config is draft_model_config:
+            return "draft"
+
+        draft_model = getattr(draft_model_config, "model", None)
+        if (
+            draft_model is not None
+            and getattr(model_config, "model", None) == draft_model
+        ):
+            return "draft"
+
+    return "target"

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -34,6 +34,7 @@ from gpu_memory_service.common.utils import get_socket_path, is_scratch_kv_enabl
 from gpu_memory_service.integrations.common import patch_empty_cache
 from gpu_memory_service.integrations.common.utils import (
     GMS_TAGS,
+    finalize_staged_gms_write,
     get_gms_lock_mode,
     get_gms_ro_connect_timeout_ms,
 )
@@ -235,6 +236,16 @@ class GMSWorker(Worker):
         by vLLM's memory tracking).
         """
         super().load_model(*args, **kwargs)
+
+        weights_manager = get_gms_client_memory_manager("weights")
+        if weights_manager is not None:
+            from gpu_memory_service.integrations.vllm.model_loader import (
+                set_imported_weights_bytes,
+            )
+
+            finalized_bytes = finalize_staged_gms_write(weights_manager)
+            if finalized_bytes > 0:
+                set_imported_weights_bytes(finalized_bytes)
 
         # Correct memory accounting for GMS-imported weights
         try:

--- a/lib/gpu_memory_service/tests/test_integration_utils.py
+++ b/lib/gpu_memory_service/tests/test_integration_utils.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+from _deps import HAS_GMS, HAS_TORCH
+
+if not HAS_GMS:
+    pytest.skip(
+        "gpu_memory_service package is not available in this test image",
+        allow_module_level=True,
+    )
+
+if not HAS_TORCH:
+    pytest.skip("torch is required", allow_module_level=True)
+
+import torch
+from gpu_memory_service.common.locks import RequestedLockType
+from gpu_memory_service.integrations.common import utils as integration_utils
+
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+]
+
+
+class _FakeAllocator:
+    def __init__(self) -> None:
+        self.total_bytes = 4096
+        self.mappings = {"first": object(), "second": object()}
+        self.calls: list[object] = []
+
+    def commit(self) -> bool:
+        self.calls.append("commit")
+        return True
+
+    def connect(self, lock_type) -> None:
+        self.calls.append(("connect", lock_type))
+
+    def remap_all_vas(self) -> None:
+        self.calls.append("remap_all_vas")
+
+
+def test_finalize_gms_write_commits_and_remaps(monkeypatch):
+    allocator = _FakeAllocator()
+    monkeypatch.setattr(integration_utils.torch.cuda, "synchronize", lambda: None)
+
+    total_bytes = integration_utils.finalize_gms_write(allocator)
+
+    assert total_bytes == 4096
+    assert allocator.calls == [
+        "commit",
+        ("connect", RequestedLockType.RO),
+        "remap_all_vas",
+    ]
+
+
+def test_staged_gms_write_registers_all_models_before_commit(monkeypatch):
+    allocator = _FakeAllocator()
+    target_model = torch.nn.Linear(2, 2)
+    draft_model = torch.nn.Linear(2, 2)
+    calls: list[object] = []
+
+    monkeypatch.setattr(integration_utils.torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(
+        integration_utils,
+        "register_module_tensors",
+        lambda allocator_arg, model, *, namespace=None, tensor_names=None: calls.append(
+            ("register", allocator_arg, model, namespace, tensor_names)
+        ),
+    )
+    monkeypatch.setattr(
+        integration_utils,
+        "collect_module_tensor_names",
+        lambda model: {
+            id(target_model): frozenset({"target.weight"}),
+            id(draft_model): frozenset({"draft.weight"}),
+        }[id(model)],
+    )
+
+    integration_utils.stage_gms_write_model(
+        allocator,
+        target_model,
+        namespace="target",
+    )
+    integration_utils.stage_gms_write_model(
+        allocator,
+        draft_model,
+        namespace="draft",
+    )
+
+    total_bytes = integration_utils.finalize_staged_gms_write(allocator)
+
+    assert total_bytes == 4096
+    assert calls == [
+        (
+            "register",
+            allocator,
+            target_model,
+            "target",
+            frozenset({"target.weight"}),
+        ),
+        (
+            "register",
+            allocator,
+            draft_model,
+            "draft",
+            frozenset({"draft.weight"}),
+        ),
+    ]
+    assert allocator.calls == [
+        "commit",
+        ("connect", RequestedLockType.RO),
+        "remap_all_vas",
+    ]
+
+
+def test_staged_gms_write_rejects_duplicate_namespace():
+    allocator = _FakeAllocator()
+    model = torch.nn.Linear(2, 2)
+
+    try:
+        integration_utils.stage_gms_write_model(allocator, model, namespace="target")
+        with pytest.raises(RuntimeError, match="already staged"):
+            integration_utils.stage_gms_write_model(
+                allocator,
+                model,
+                namespace="target",
+            )
+    finally:
+        integration_utils._staged_gms_writes.pop(id(allocator), None)
+
+
+def test_staged_gms_write_filters_to_stage_time_tensor_names(monkeypatch):
+    allocator = _FakeAllocator()
+    model = torch.nn.Module()
+    model.weight = torch.nn.Parameter(torch.empty(2, 2))
+    monkeypatch.setattr(
+        integration_utils,
+        "collect_module_tensor_names",
+        lambda model: frozenset({"weight"}),
+    )
+    integration_utils.stage_gms_write_model(allocator, model, namespace="target")
+    model.lora_weight = torch.nn.Parameter(torch.empty(2, 2))
+
+    calls: list[object] = []
+    monkeypatch.setattr(integration_utils.torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(
+        integration_utils,
+        "register_module_tensors",
+        lambda allocator_arg,
+        model_arg,
+        *,
+        namespace=None,
+        tensor_names=None: calls.append((namespace, tensor_names)),
+    )
+
+    integration_utils.finalize_staged_gms_write(allocator)
+
+    assert calls == [("target", frozenset({"weight"}))]

--- a/lib/gpu_memory_service/tests/test_torch_integration.py
+++ b/lib/gpu_memory_service/tests/test_torch_integration.py
@@ -201,6 +201,77 @@ def test_gms_tensor_matches_plain_torch_ops(running_gms):
     reader.close()
 
 
+def test_materialized_module_uses_requested_namespace(running_gms):
+    socket_path = running_gms
+    torch.manual_seed(17)
+    target = _TinyModule().cuda()
+    draft = _TinyModule().cuda()
+    gms_target = _TinyModule().cuda()
+    gms_draft = _TinyModule().cuda()
+    gms_target.load_state_dict(target.state_dict())
+    gms_draft.load_state_dict(draft.state_dict())
+    inputs = torch.randn(2, 8, device="cuda", dtype=torch.float32)
+    expected_target = target(inputs).detach().clone()
+    expected_draft = draft(inputs).detach().clone()
+
+    writer = GMSClientMemoryManager(socket_path, device=0)
+    writer.connect(RequestedLockType.RW)
+
+    for plain_model, gms_model in ((target, gms_target), (draft, gms_draft)):
+        baseline_weight = cast(torch.Tensor, plain_model.linear.weight)
+        baseline_scale = cast(torch.Tensor, plain_model.scale)
+        baseline_extra = cast(torch.Tensor, plain_model.extra)
+        _, gms_weight = _make_gms_tensor(writer, baseline_weight, tag="weights")
+        gms_model.linear.weight = torch.nn.Parameter(
+            gms_weight, requires_grad=baseline_weight.requires_grad
+        )
+        _, gms_scale = _make_gms_tensor(writer, baseline_scale, tag="weights")
+        gms_model._buffers["scale"] = gms_scale
+        _, gms_extra = _make_gms_tensor(writer, baseline_extra, tag="weights")
+        gms_model.extra = gms_extra
+
+    register_module_tensors(writer, gms_target, namespace="target")
+    register_module_tensors(writer, gms_draft, namespace="draft")
+    metadata_keys = set(writer.metadata_list())
+    assert "target/linear.weight" in metadata_keys
+    assert "draft/linear.weight" in metadata_keys
+    assert writer.commit()
+    del gms_target
+    del gms_draft
+    writer.close()
+
+    reader = GMSClientMemoryManager(socket_path, device=0)
+    reader.connect(RequestedLockType.RO)
+
+    target_materialized = _TinyModule().cuda()
+    materialize_module_from_gms(
+        reader,
+        target_materialized,
+        device_index=0,
+        namespace="target",
+    )
+    draft_materialized = _TinyModule().cuda()
+    materialize_module_from_gms(
+        reader,
+        draft_materialized,
+        device_index=0,
+        namespace="draft",
+    )
+
+    _assert_exact_tensor_equal(expected_target, target_materialized(inputs))
+    _assert_exact_tensor_equal(expected_draft, draft_materialized(inputs))
+    _assert_exact_tensor_equal(
+        cast(torch.Tensor, target.linear.weight),
+        cast(torch.Tensor, target_materialized.linear.weight),
+    )
+    _assert_exact_tensor_equal(
+        cast(torch.Tensor, draft.linear.weight),
+        cast(torch.Tensor, draft_materialized.linear.weight),
+    )
+
+    reader.close()
+
+
 def test_live_gms_tensor_survives_unmap_and_remap(running_gms):
     socket_path = running_gms
     baseline = torch.arange(64, device="cuda", dtype=torch.float32).reshape(8, 8)


### PR DESCRIPTION
## Summary
- keep a single GMS `weights` layout for target + speculative draft weights
- split/stage weight publication so vLLM and SGLang model loaders register models for a later publish instead of committing inside each individual model load
- finalize staged GMS weights once at the engine-level boundary:
  - vLLM: after `GMSWorker.load_model()` completes target + speculator/draft loading
  - SGLang: after `Scheduler.init_model_worker()` completes target + draft-worker initialization
- add GMS metadata namespaces so target and draft tensors can coexist in the same layout without key collisions:
  - `target/...`
  - `draft/...`
  - SGLang multi-layer draft loads use `draft_<idx>/...`
- preserve non-speculative/TRT-LLM behavior by keeping explicit register-then-finalize support for immediate publish paths
- keep SGLang's non-GMS draft workaround safe: when `--speculative-draft-load-format` selects a non-GMS loader, draft weight allocation bypasses the still-open GMS `weights` region

## Notes
- This updates the existing stale PR rather than opening a duplicate PR.
- Failed startup does not attempt rollback; if model loading raises before the late finalizer, the pod/process is expected to exit and Kubernetes can restart it.
- AI assistance was used for this update; the submitting human should review every changed line and validate the behavior in the target deployment environment before merge.

## Testing
- `cd dynamo && ../.venv/bin/python -m ruff check lib/gpu_memory_service/client/torch/module.py lib/gpu_memory_service/client/torch/tensor.py lib/gpu_memory_service/integrations/common/__init__.py lib/gpu_memory_service/integrations/common/utils.py lib/gpu_memory_service/integrations/vllm/model_loader.py lib/gpu_memory_service/integrations/vllm/worker.py lib/gpu_memory_service/integrations/sglang/model_loader.py lib/gpu_memory_service/integrations/sglang/memory_saver.py lib/gpu_memory_service/integrations/sglang/patches.py lib/gpu_memory_service/integrations/trtllm/model_loader.py lib/gpu_memory_service/tests/test_integration_utils.py lib/gpu_memory_service/tests/test_torch_integration.py components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py`
  - result: passed
- `cd dynamo && ../.venv/bin/python -m compileall lib/gpu_memory_service/client/torch/module.py lib/gpu_memory_service/client/torch/tensor.py lib/gpu_memory_service/integrations/common/utils.py lib/gpu_memory_service/integrations/vllm/model_loader.py lib/gpu_memory_service/integrations/vllm/worker.py lib/gpu_memory_service/integrations/sglang/model_loader.py lib/gpu_memory_service/integrations/sglang/memory_saver.py lib/gpu_memory_service/integrations/sglang/patches.py lib/gpu_memory_service/integrations/trtllm/model_loader.py lib/gpu_memory_service/tests/test_integration_utils.py components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py`
  - result: passed
- `cd dynamo && PYTHONPATH=lib/gpu_memory_service:lib:. ../.venv/bin/python -m pytest lib/gpu_memory_service/tests/test_integration_utils.py lib/gpu_memory_service/tests/test_torch_integration.py components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py -q`
  - result: `18 passed in 1.90s`
