### PR TITLE
fix: enable KVBM v2 support MLA models

### DIFF
--- a/lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/worker.py
+++ b/lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/worker.py
@@ -33,6 +33,40 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 )
 from vllm.model_executor.models.utils import extract_layer_index
 
+
+@dataclass
+class KvTensorLayout:
+    """Semantic description of the KV cache tensor layout.
+
+    Python derives this from VllmConfig (which has the model architecture)
+    so that Rust doesn't have to guess from raw tensor shapes.
+
+    For MLA models, outer_dim and inner_dim are set explicitly because Rust's
+    shape-based inference cannot distinguish the fused KV latent axis from the
+    block/page axis. For standard attention the fields are None, which tells
+    Rust to fall back to its own contiguity-based inference (already correct).
+
+    Mirrors the v1 helper in
+    lib/bindings/kvbm/python/kvbm/vllm_integration/connector_worker.py.
+    """
+
+    outer_dim: Optional[int]  # None = let Rust infer; 1 for MLA
+    inner_dim: Optional[int]  # None = let Rust infer; head_size for MLA
+
+    @classmethod
+    def from_vllm_config(
+        cls, shape: "torch.Size", use_mla: bool = False
+    ) -> "KvTensorLayout":
+        if use_mla:
+            # MLA tensors are 3D: [num_blocks, page_size, head_size].
+            # No outer_dim axis — K and V are fused into a single latent.
+            return cls(outer_dim=1, inner_dim=int(shape[-1]))
+        # Standard attention: Rust already infers outer_dim/inner_dim correctly
+        # from tensor shape. Don't guess here — the block dimension can be at
+        # position 0 or 1 depending on the attention backend.
+        return cls(outer_dim=None, inner_dim=None)
+
+
 # Import KvbmRuntime and ConnectorWorker from Rust bindings (requires v2 feature)
 if kvbm.v2.is_available():
     KvbmRuntime = kvbm.v2.KvbmRuntime
@@ -178,10 +212,17 @@ class SchedulerConnectorWorker:
                 "Hybrid models with different KV cache shapes are not supported yet."
             )
 
-        # Extract parameters
-        # For NHD layout: [2 (K/V), num_blocks, block_size, num_heads, head_size]
-        # For HND layout: [2 (K/V), num_blocks, num_heads, block_size, head_size]
-        num_device_blocks = max(shape[0], shape[1])
+        # Derive layout semantics from the vLLM model config so Rust doesn't
+        # have to guess the outer_dim/inner_dim from potentially-ambiguous
+        # tensor shapes (MLA caches are 3D without a K/V axis).
+        use_mla = getattr(self.vllm_config.model_config, "use_mla", False)
+        layout = KvTensorLayout.from_vllm_config(shape, use_mla)
+
+        # Extract parameters.
+        # Standard attention: [2 (K/V), num_blocks, ...] or [num_blocks, 2, ...]
+        #   — block dim is whichever of shape[0]/shape[1] is larger.
+        # MLA: [num_blocks, page_size, head_size] — block dim is always axis 0.
+        num_device_blocks = shape[0] if use_mla else max(shape[0], shape[1])
         page_size = self.vllm_config.cache_config.block_size
         dtype_width_bytes = self.kvbm_config.cache_dtype_bytes()
 
@@ -202,6 +243,8 @@ class SchedulerConnectorWorker:
             num_device_blocks,
             page_size,
             dtype_width_bytes,
+            outer_dim=layout.outer_dim,
+            inner_dim=layout.inner_dim,
         )
 
         # Store device block count and last layer name for later use

--- a/lib/bindings/kvbm/src/v2/connector/worker/mod.rs
+++ b/lib/bindings/kvbm/src/v2/connector/worker/mod.rs
@@ -54,17 +54,24 @@ impl PyConnectorWorker {
     ///     num_device_blocks: Number of device blocks (from vLLM's cache config)
     ///     page_size: Block/page size for the KV cache
     ///     dtype_width_bytes: Data type width in bytes (e.g., 2 for fp16)
+    ///     outer_dim: Optional explicit outer_dim (1 for MLA, 2 for standard K/V).
+    ///                When provided, bypasses shape-based inference. Must be paired
+    ///                with `inner_dim`. Python should pass this when it knows the
+    ///                model is MLA (from `vllm_config.model_config.use_mla`).
+    ///     inner_dim: Optional explicit inner_dim (paired with `outer_dim`).
     ///
     /// Raises:
     ///     RuntimeError: If registration fails (e.g., UCX backend not available,
     ///                   tensors on different devices, or already registered).
-    #[pyo3(signature = (tensors, num_device_blocks, page_size, dtype_width_bytes))]
+    #[pyo3(signature = (tensors, num_device_blocks, page_size, dtype_width_bytes, outer_dim=None, inner_dim=None))]
     pub fn register_kv_caches(
         &self,
         tensors: Vec<Py<PyAny>>,
         num_device_blocks: usize,
         page_size: usize,
         dtype_width_bytes: usize,
+        outer_dim: Option<usize>,
+        inner_dim: Option<usize>,
     ) -> PyResult<()> {
         // Convert Python tensors to Rust TensorDescriptor
         let rust_tensors: Vec<Arc<dyn TensorDescriptor>> = tensors
@@ -81,6 +88,8 @@ impl PyConnectorWorker {
                 num_device_blocks,
                 page_size,
                 dtype_width_bytes,
+                outer_dim,
+                inner_dim,
             )
             .map_err(to_pyerr)
     }

--- a/lib/kvbm-connector/src/connector/worker/mod.rs
+++ b/lib/kvbm-connector/src/connector/worker/mod.rs
@@ -63,12 +63,18 @@ use kvbm_physical::TransferOptions;
 
 pub trait ConnectorWorkerInterface: Send + Sync {
     /// Register KV cache tensors (deferred mode - caches state for later).
+    ///
+    /// `explicit_outer_dim` / `explicit_inner_dim` let the caller (Python, reading
+    /// `vllm_config.model_config.use_mla`) bypass shape inference. Both must be
+    /// `Some` or both `None`. See [`crate::vllm::layout::determine_kv_layout`].
     fn register_kv_caches(
         &self,
         tensors: Vec<Arc<dyn TensorDescriptor>>,
         num_device_blocks: usize,
         page_size: usize,
         dtype_width_bytes: usize,
+        explicit_outer_dim: Option<usize>,
+        explicit_inner_dim: Option<usize>,
     ) -> Result<()>;
 
     /// Bind connector metadata from the leader.
@@ -379,6 +385,8 @@ impl ConnectorWorkerInterface for ConnectorWorker {
         num_device_blocks: usize,
         page_size: usize,
         dtype_width_bytes: usize,
+        explicit_outer_dim: Option<usize>,
+        explicit_inner_dim: Option<usize>,
     ) -> Result<()> {
         // Prevent double registration
         if self.state.service.get().is_some() {
@@ -391,9 +399,15 @@ impl ConnectorWorkerInterface for ConnectorWorker {
             bail!("Worker details already set");
         }
 
-        // Determine layout from tensor shapes
-        let (layout_config, block_dim) =
-            determine_kv_layout(num_device_blocks, page_size, dtype_width_bytes, &tensors)?;
+        // Determine layout from tensor shapes (or from explicit dims, preferred path).
+        let (layout_config, block_dim) = determine_kv_layout(
+            num_device_blocks,
+            page_size,
+            dtype_width_bytes,
+            &tensors,
+            explicit_outer_dim,
+            explicit_inner_dim,
+        )?;
 
         tracing::debug!(
             ?layout_config,

--- a/lib/kvbm-connector/src/testing/connector.rs
+++ b/lib/kvbm-connector/src/testing/connector.rs
@@ -1240,6 +1240,8 @@ impl TestConnectorInstanceBuilder {
                     self.layout_config.num_blocks,
                     self.layout_config.page_size,
                     self.layout_config.dtype_width_bytes,
+                    None,
+                    None,
                 )
                 .context("Failed to register KV caches")?;
 

--- a/lib/kvbm-connector/src/vllm/layout.rs
+++ b/lib/kvbm-connector/src/vllm/layout.rs
@@ -155,7 +155,7 @@ mod tests {
     }
 
     impl TestTensor {
-        fn new(shape: Vec<usize>) -> Arc<dyn TensorDescriptor> {
+        fn arc(shape: Vec<usize>) -> Arc<dyn TensorDescriptor> {
             // Row-major strides (unused by layout inference, but the trait requires them).
             let mut stride = vec![1usize; shape.len()];
             for i in (0..shape.len().saturating_sub(1)).rev() {
@@ -196,7 +196,7 @@ mod tests {
     }
 
     fn layers(shape: Vec<usize>, n: usize) -> Vec<Arc<dyn TensorDescriptor>> {
-        (0..n).map(|_| TestTensor::new(shape.clone())).collect()
+        (0..n).map(|_| TestTensor::arc(shape.clone())).collect()
     }
 
     /// Standard 4D cache with K/V split, block-first: [n_blocks, 2, page_size, inner_dim].

--- a/lib/kvbm-connector/src/vllm/layout.rs
+++ b/lib/kvbm-connector/src/vllm/layout.rs
@@ -97,21 +97,22 @@ pub fn determine_kv_layout(
     // `[n_blocks, page_size, latent_dim]` (or the outer-contiguous equivalent),
     // so the neighbouring candidate lands on `page_size` and exceeds 2 — treat
     // as MLA and set outer_dim=1.
-    let (outer_dim, inner_dim) = if let (Some(o), Some(i)) = (explicit_outer_dim, explicit_inner_dim) {
-        (o, i)
-    } else {
-        let candidate_outer = match block_dim {
-            BlockDimension::BlockIsFirstDim => shape[1],
-            BlockDimension::BlockIsSecondDim => shape[0],
-        };
-        let (outer_dim, content_dims_start) = if candidate_outer <= 2 {
-            (candidate_outer, 2)
+    let (outer_dim, inner_dim) =
+        if let (Some(o), Some(i)) = (explicit_outer_dim, explicit_inner_dim) {
+            (o, i)
         } else {
-            (1, 1)
+            let candidate_outer = match block_dim {
+                BlockDimension::BlockIsFirstDim => shape[1],
+                BlockDimension::BlockIsSecondDim => shape[0],
+            };
+            let (outer_dim, content_dims_start) = if candidate_outer <= 2 {
+                (candidate_outer, 2)
+            } else {
+                (1, 1)
+            };
+            let inner_dim = shape[content_dims_start..].iter().product::<usize>() / page_size;
+            (outer_dim, inner_dim)
         };
-        let inner_dim = shape[content_dims_start..].iter().product::<usize>() / page_size;
-        (outer_dim, inner_dim)
-    };
     builder.outer_dim(outer_dim);
     builder.inner_dim(inner_dim);
 

--- a/lib/kvbm-connector/src/vllm/layout.rs
+++ b/lib/kvbm-connector/src/vllm/layout.rs
@@ -15,6 +15,11 @@ use kvbm_physical::layout::{BlockDimension, LayoutConfig};
 /// * `page_size` - Block/page size for the KV cache
 /// * `dtype_width_bytes` - Data type width in bytes (e.g., 2 for fp16)
 /// * `kv_tensors` - KV cache tensors (one per layer), all must have the same shape
+/// * `explicit_outer_dim` - Optional caller-supplied outer_dim. When `Some(_)`
+///   `explicit_inner_dim` must also be `Some(_)`; the pair bypasses shape inference.
+///   For MLA models Python should pass `Some(1)` since the cache is a fused latent
+///   and shape-based inference is ambiguous (see `mla_deepseek_v2_shape` test).
+/// * `explicit_inner_dim` - Optional caller-supplied inner_dim (paired with `explicit_outer_dim`).
 ///
 /// # Returns
 /// A tuple of `(LayoutConfig, BlockDimension)` that describes:
@@ -25,7 +30,24 @@ pub fn determine_kv_layout(
     page_size: usize,
     dtype_width_bytes: usize,
     kv_tensors: &[Arc<dyn TensorDescriptor>],
+    explicit_outer_dim: Option<usize>,
+    explicit_inner_dim: Option<usize>,
 ) -> Result<(LayoutConfig, BlockDimension)> {
+    // Cross-field coupling: explicit dims must be provided together.
+    match (explicit_outer_dim, explicit_inner_dim) {
+        (Some(o), _) if !(1..=2).contains(&o) => bail!(
+            "explicit outer_dim must be in [1, 2] (1 = MLA fused, 2 = standard K/V split); got {}",
+            o
+        ),
+        (_, Some(0)) => bail!("explicit inner_dim must be > 0"),
+        (Some(_), None) | (None, Some(_)) => bail!(
+            "explicit outer_dim and inner_dim must be provided together; got outer_dim={:?}, inner_dim={:?}",
+            explicit_outer_dim,
+            explicit_inner_dim
+        ),
+        _ => {}
+    }
+
     let first_tensor = kv_tensors
         .first()
         .ok_or(anyhow::anyhow!("No tensors provided"))?;
@@ -52,11 +74,10 @@ pub fn determine_kv_layout(
         tracing::debug!("stride: {:?}", stride);
     }
 
+    // Locate the blocks dimension from shape (independent of explicit dims).
     let block_dim = if shape[0] >= num_device_blocks {
-        builder.outer_dim(shape[1]);
         BlockDimension::BlockIsFirstDim
     } else if shape[1] >= num_device_blocks {
-        builder.outer_dim(shape[0]);
         BlockDimension::BlockIsSecondDim
     } else {
         bail!(
@@ -65,8 +86,33 @@ pub fn determine_kv_layout(
         );
     };
 
-    // Calculate inner dimension (relaxed validation compared to strict page_size check)
-    let inner_dim = shape[2..].iter().product::<usize>() / page_size;
+    // Resolve outer_dim / inner_dim.
+    //
+    // Preferred path: caller (Python) supplied explicit dims by reading the vLLM
+    // model config (`use_mla`). This is unambiguous and future-proof against
+    // vLLM shape changes.
+    //
+    // Fallback path: infer from shape. Standard layouts present an explicit K/V
+    // axis (outer_dim ∈ {1, 2}); MLA layouts omit it and surface
+    // `[n_blocks, page_size, latent_dim]` (or the outer-contiguous equivalent),
+    // so the neighbouring candidate lands on `page_size` and exceeds 2 — treat
+    // as MLA and set outer_dim=1.
+    let (outer_dim, inner_dim) = if let (Some(o), Some(i)) = (explicit_outer_dim, explicit_inner_dim) {
+        (o, i)
+    } else {
+        let candidate_outer = match block_dim {
+            BlockDimension::BlockIsFirstDim => shape[1],
+            BlockDimension::BlockIsSecondDim => shape[0],
+        };
+        let (outer_dim, content_dims_start) = if candidate_outer <= 2 {
+            (candidate_outer, 2)
+        } else {
+            (1, 1)
+        };
+        let inner_dim = shape[content_dims_start..].iter().product::<usize>() / page_size;
+        (outer_dim, inner_dim)
+    };
+    builder.outer_dim(outer_dim);
     builder.inner_dim(inner_dim);
 
     let layout_config = builder.build()?;
@@ -91,4 +137,175 @@ fn validate_tensor_shapes(
     }
 
     Ok(shape.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::any::Any;
+
+    use dynamo_memory::nixl::NixlDescriptor;
+    use dynamo_memory::{MemoryDescriptor, StorageKind};
+
+    #[derive(Debug)]
+    struct TestTensor {
+        shape: Vec<usize>,
+        stride: Vec<usize>,
+    }
+
+    impl TestTensor {
+        fn new(shape: Vec<usize>) -> Arc<dyn TensorDescriptor> {
+            // Row-major strides (unused by layout inference, but the trait requires them).
+            let mut stride = vec![1usize; shape.len()];
+            for i in (0..shape.len().saturating_sub(1)).rev() {
+                stride[i] = stride[i + 1] * shape[i + 1];
+            }
+            Arc::new(Self { shape, stride })
+        }
+    }
+
+    impl MemoryDescriptor for TestTensor {
+        fn addr(&self) -> usize {
+            0
+        }
+        fn size(&self) -> usize {
+            0
+        }
+        fn storage_kind(&self) -> StorageKind {
+            StorageKind::System
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn nixl_descriptor(&self) -> Option<NixlDescriptor> {
+            None
+        }
+    }
+
+    impl TensorDescriptor for TestTensor {
+        fn shape(&self) -> &[usize] {
+            &self.shape
+        }
+        fn stride(&self) -> &[usize] {
+            &self.stride
+        }
+        fn element_size(&self) -> usize {
+            2
+        }
+    }
+
+    fn layers(shape: Vec<usize>, n: usize) -> Vec<Arc<dyn TensorDescriptor>> {
+        (0..n).map(|_| TestTensor::new(shape.clone())).collect()
+    }
+
+    /// Standard 4D cache with K/V split, block-first: [n_blocks, 2, page_size, inner_dim].
+    #[test]
+    fn inferred_standard_kv_split_block_first() {
+        let tensors = layers(vec![100, 2, 16, 128], 4);
+        let (cfg, block_dim) = determine_kv_layout(100, 16, 2, &tensors, None, None).unwrap();
+        assert_eq!(cfg.outer_dim, 2);
+        assert_eq!(cfg.inner_dim, 128);
+        assert!(matches!(block_dim, BlockDimension::BlockIsFirstDim));
+    }
+
+    /// Standard 4D cache with K/V split, outer-first: [2, n_blocks, page_size, inner_dim].
+    #[test]
+    fn inferred_standard_kv_split_outer_first() {
+        let tensors = layers(vec![2, 100, 16, 128], 4);
+        let (cfg, block_dim) = determine_kv_layout(100, 16, 2, &tensors, None, None).unwrap();
+        assert_eq!(cfg.outer_dim, 2);
+        assert_eq!(cfg.inner_dim, 128);
+        assert!(matches!(block_dim, BlockDimension::BlockIsSecondDim));
+    }
+
+    /// MLA cache (DeepSeek-V2-Lite reproduction), inference-only: 3D
+    /// `[n_blocks, page_size, latent_dim]` with latent_dim = kv_lora_rank +
+    /// qk_rope_head_dim = 512 + 64 = 576. Candidate outer_dim falls on
+    /// page_size=16 (>2) so we fall back to outer_dim=1.
+    #[test]
+    fn inferred_mla_deepseek_v2_shape() {
+        let tensors = layers(vec![26847, 16, 576], 27);
+        let (cfg, block_dim) = determine_kv_layout(26847, 16, 2, &tensors, None, None).unwrap();
+        assert_eq!(cfg.outer_dim, 1);
+        assert_eq!(cfg.inner_dim, 576);
+        assert!(matches!(block_dim, BlockDimension::BlockIsFirstDim));
+    }
+
+    /// Fused-outer MLA variant: outer_dim=1 explicitly in the tensor shape,
+    /// block-first 4D. Exercises the `candidate_outer == 1` branch in inference.
+    #[test]
+    fn inferred_mla_explicit_outer_dim_one_in_shape() {
+        let tensors = layers(vec![100, 1, 16, 576], 4);
+        let (cfg, _) = determine_kv_layout(100, 16, 2, &tensors, None, None).unwrap();
+        assert_eq!(cfg.outer_dim, 1);
+        assert_eq!(cfg.inner_dim, 576);
+    }
+
+    /// Sanity: n_blocks present in neither of the first two dims is rejected.
+    #[test]
+    fn rejects_missing_block_dim() {
+        let tensors = layers(vec![8, 16, 128], 4);
+        assert!(determine_kv_layout(100, 16, 2, &tensors, None, None).is_err());
+    }
+
+    /// Caller supplies explicit MLA dims (outer_dim=1, inner_dim=latent). This is the
+    /// preferred path — Python derives it from vLLM's `model_config.use_mla`, so the
+    /// Rust side never has to guess from a potentially-ambiguous shape.
+    #[test]
+    fn explicit_mla_dims_are_used_directly() {
+        let tensors = layers(vec![26847, 16, 576], 27);
+        let (cfg, _) = determine_kv_layout(26847, 16, 2, &tensors, Some(1), Some(576)).unwrap();
+        assert_eq!(cfg.outer_dim, 1);
+        assert_eq!(cfg.inner_dim, 576);
+    }
+
+    /// Explicit standard K/V split: caller asserts outer_dim=2, inner_dim=128.
+    #[test]
+    fn explicit_standard_dims_are_used_directly() {
+        let tensors = layers(vec![100, 2, 16, 128], 4);
+        let (cfg, _) = determine_kv_layout(100, 16, 2, &tensors, Some(2), Some(128)).unwrap();
+        assert_eq!(cfg.outer_dim, 2);
+        assert_eq!(cfg.inner_dim, 128);
+    }
+
+    /// Coupling check: passing only outer_dim (without inner_dim) is an error.
+    #[test]
+    fn explicit_outer_without_inner_is_err() {
+        let tensors = layers(vec![100, 2, 16, 128], 4);
+        let err = determine_kv_layout(100, 16, 2, &tensors, Some(1), None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("must be provided together"), "got: {err}");
+    }
+
+    /// Coupling check: passing only inner_dim (without outer_dim) is an error.
+    #[test]
+    fn explicit_inner_without_outer_is_err() {
+        let tensors = layers(vec![100, 2, 16, 128], 4);
+        let err = determine_kv_layout(100, 16, 2, &tensors, None, Some(128))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("must be provided together"), "got: {err}");
+    }
+
+    /// Range check: outer_dim=3 is rejected at the API boundary (before layout build).
+    #[test]
+    fn explicit_outer_dim_out_of_range_is_err() {
+        let tensors = layers(vec![100, 2, 16, 128], 4);
+        let err = determine_kv_layout(100, 16, 2, &tensors, Some(3), Some(128))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("outer_dim"), "got: {err}");
+    }
+
+    /// Range check: inner_dim=0 is rejected.
+    #[test]
+    fn explicit_inner_dim_zero_is_err() {
+        let tensors = layers(vec![100, 2, 16, 128], 4);
+        let err = determine_kv_layout(100, 16, 2, &tensors, Some(2), Some(0))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("inner_dim"), "got: {err}");
+    }
 }

--- a/tests/kvbm_integration/scripts/run_server.sh
+++ b/tests/kvbm_integration/scripts/run_server.sh
@@ -13,7 +13,7 @@
 #
 # spec-id matches KvbmServerSpec.id in the test module, e.g.:
 #   v1-DeepSeek-R1-Distill-Llama-8B
-#   v1-DeepSeek-V2-Lite          (gated; needs KVBM_ENABLE_MLA=1)
+#   v1-DeepSeek-V2-Lite          (MLA; enabled by default, KVBM_ENABLE_MLA=0 to skip)
 #   v1-Qwen3-0.6B                (only if KVBM_MODEL_ID=Qwen/Qwen3-0.6B)
 #   v2-Qwen3-0.6B-intra          (v2, intra onboard mode)
 #   v2-Qwen3-0.6B-inter          (v2, inter onboard mode)
@@ -25,7 +25,7 @@
 #   KVBM_CPU_BLOCKS              (override spec.cpu_blocks)
 #   KVBM_GPU_BLOCKS              (override spec.gpu_blocks)
 #   KVBM_SERVER_START_TIMEOUT    (server bring-up timeout, default 600s)
-#   KVBM_ENABLE_MLA              (required to launch any MLA spec)
+#   KVBM_ENABLE_MLA              (opt-out escape hatch; set to 0 to skip MLA specs)
 
 set -euo pipefail
 
@@ -78,15 +78,15 @@ if spec_id not in specs_by_id:
 
 spec = specs_by_id[spec_id]
 
-if spec.model_config.use_mla and os.environ.get("KVBM_ENABLE_MLA", "").lower() not in (
+if spec.model_config.use_mla and os.environ.get("KVBM_ENABLE_MLA", "1").lower() not in (
     "1",
     "true",
     "yes",
     "on",
 ):
     sys.stderr.write(
-        f"[server] {spec_id} is an MLA spec and is gated; set KVBM_ENABLE_MLA=1 "
-        f"to launch (see ACTIVE_PLAN.md phase 3)\n"
+        f"[server] {spec_id} is an MLA spec and MLA is disabled via KVBM_ENABLE_MLA=0; "
+        f"unset or set to 1 to launch\n"
     )
     sys.exit(7)
 

--- a/tests/kvbm_integration/test_determinism_agg.py
+++ b/tests/kvbm_integration/test_determinism_agg.py
@@ -97,19 +97,17 @@ _KVBM_VERSIONS_UNDER_TEST = ("v1", "v2")
 # mode-specific regression is caught immediately.
 _KVBM_V2_ONBOARD_MODES = ("intra", "inter")
 
-# MLA execution is gated for phase 3 (see ACTIVE_PLAN.md). The MLA spec
-# stays in _MODEL_CONFIGS so the test surface is preserved; specs whose
-# model_config.use_mla is True are pytest-skipped unless KVBM_ENABLE_MLA
-# is set. A later phase will flip the gate on.
-_KVBM_ENABLE_MLA = os.environ.get("KVBM_ENABLE_MLA", "").lower() in (
+# MLA execution is enabled by default now that v2 supports the fused-latent
+# cache layout (see lib/kvbm-connector/src/vllm/layout.rs). The env var is
+# retained as an opt-out escape hatch — set KVBM_ENABLE_MLA=0 to skip all
+# MLA specs locally (e.g. when running on a GPU that can't fit DeepSeek-V2-Lite).
+_KVBM_ENABLE_MLA = os.environ.get("KVBM_ENABLE_MLA", "1").lower() in (
     "1",
     "true",
     "yes",
     "on",
 )
-_MLA_SKIP_REASON = (
-    "MLA gated; set KVBM_ENABLE_MLA=1 to enable (see ACTIVE_PLAN.md phase 3)"
-)
+_MLA_SKIP_REASON = "MLA disabled; unset or set KVBM_ENABLE_MLA=1 to enable"
 
 
 def _specs(cpu_blocks_env: str, cpu_blocks_default: str) -> List[KvbmServerSpec]:


### PR DESCRIPTION
port over kvbm v1 support on MLA https://github.com/ai-dynamo/dynamo/pull/7786 to kvbm v2

closes [KVBM-403](https://linear.app/nvidia/issue/KVBM-403/evaluate-kvbm-v2-with-mla-models)