### PR TITLE
fix(trtllm): stabilize single-node Kimi GMS failover demo

### DIFF
--- a/components/src/dynamo/trtllm/args.py
+++ b/components/src/dynamo/trtllm/args.py
@@ -39,6 +39,12 @@ class Config(DynamoRuntimeConfig, DynamoTrtllmConfig):
         # Derive use_kv_events from publish_events_and_metrics
         self.use_kv_events = self.publish_events_and_metrics
 
+        if self.gms_shadow_mode and self.load_format != "gms":
+            raise ValueError(
+                "--gms-shadow-mode requires --load-format gms. "
+                "Shadow mode depends on GMS for VA-stable weight sharing."
+            )
+
         # fix the connector as trtllm accepts only one connector and it should be in VALID_TRTLLM_CONNECTORS
         # while the runtime args accepts a list of connectors
         if self.connector:

--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -177,6 +177,19 @@ class DynamoTrtllmArgGroup(ArgGroup):
                 "(e.g. '{\"gms_read_only\": true}')."
             ),
         )
+        add_negatable_bool_argument(
+            g,
+            flag_name="--gms-shadow-mode",
+            env_var="DYN_TRTLLM_GMS_SHADOW_MODE",
+            default=False,
+            help=(
+                "Enable GMS shadow/standby mode. When set, the engine's "
+                "gms_read_only flag is derived from ENGINE_ID (0 → writer, "
+                "others → read-only importers), unlocking shadow-engine "
+                "failover across co-located engines on one GPU. "
+                "Requires --load-format=gms."
+            ),
+        )
         add_argument(
             g,
             flag_name="--disaggregation-mode",
@@ -472,6 +485,7 @@ class DynamoTrtllmConfig(ConfigBase):
     disable_request_abort: bool
     load_format: str
     model_loader_extra_config: str
+    gms_shadow_mode: bool = False
     guided_decoding_backend: Optional[str] = None
 
     disaggregation_mode: DisaggregationMode

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -100,20 +100,34 @@ class TRTLLMEngineQuiesceController:
         self._is_quiesced = False
 
     def _collective_rpc(self, method: str, rpc_tags: list[str]) -> None:
-        """Call TRT-LLM collective_rpc for KV cache sleep/wake."""
+        """Call TRT-LLM collective_rpc for KV cache sleep/wake.
+
+        Non-Ray executors (single-process ``GenerationExecutorWorker``) have
+        no collective RPC; fall back to the local virtual-memory tag API.
+        """
         rpc = getattr(self._engine.llm, "_collective_rpc", None)
-        if rpc is None:
-            logger.warning(
-                "TRT-LLM does not expose _collective_rpc; skipping %s", method
-            )
-            return
-        try:
-            rpc(method, args=(rpc_tags,), kwargs={}, non_block=False)
-        except Exception:
-            if method != "wakeup":
-                raise
-            # Some TRT-LLM versions use "wake_up" instead of "wakeup"
-            rpc("wake_up", args=(rpc_tags,), kwargs={}, non_block=False)
+        if rpc is not None:
+            try:
+                rpc(method, args=(rpc_tags,), kwargs={}, non_block=False)
+                return
+            except Exception as exc:
+                if "does not support collective RPC" not in str(exc):
+                    if method != "wakeup":
+                        raise
+                    rpc("wake_up", args=(rpc_tags,), kwargs={}, non_block=False)
+                    return
+                logger.info(
+                    "TRT-LLM executor lacks collective RPC; using local tag API for %s",
+                    method,
+                )
+        from tensorrt_llm._torch.virtual_memory import (
+            materialize_with_tag,
+            release_with_tag,
+        )
+
+        action = release_with_tag if method == "sleep" else materialize_with_tag
+        for tag in rpc_tags:
+            action(tag)
 
     @staticmethod
     def _release_gms_weights() -> None:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -94,6 +94,12 @@ class TRTLLMEngineQuiesceController:
             self._restore_gms_weights()
         if "kv_cache" in tags:
             self._collective_rpc("wakeup", ["kv_cache"])
+            # release_with_tag("kv_cache") zeroes the physical KV pages but leaves
+            # TRT-LLM's block-reuse hash table pointing at them. Post-wake requests
+            # would hit those stale hashes (cached_tokens>0) and read garbage KV —
+            # coherent-looking text but wrong. Drop the reuse state here so the
+            # first post-wake prefill recomputes from scratch.
+            self._reset_prefix_cache()
         return True
 
     def mark_resumed(self) -> None:
@@ -128,6 +134,20 @@ class TRTLLMEngineQuiesceController:
         action = release_with_tag if method == "sleep" else materialize_with_tag
         for tag in rpc_tags:
             action(tag)
+
+    def _reset_prefix_cache(self) -> None:
+        """Invalidate TRT-LLM's KV block-reuse state after a wake."""
+        llm = getattr(self._engine, "llm", None)
+        executor = getattr(llm, "_executor", None) if llm is not None else None
+        py_executor = getattr(executor, "engine", None) if executor is not None else None
+        reset = getattr(py_executor, "reset_prefix_cache", None)
+        if reset is None:
+            logger.debug("TRT-LLM executor has no reset_prefix_cache; skipping")
+            return
+        try:
+            reset()
+        except Exception as exc:  # noqa: BLE001 — best-effort post-wake hygiene
+            logger.warning("reset_prefix_cache failed: %s", exc)
 
     @staticmethod
     def _release_gms_weights() -> None:

--- a/components/src/dynamo/trtllm/tests/test_trtllm_gms_delay_commit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_gms_delay_commit.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the TRT-LLM delayed GMS publish isolate."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+
+@pytest.fixture(autouse=True)
+def clear_delay_commit_state():
+    import gpu_memory_service.integrations.trtllm.model_loader as model_loader
+
+    model_loader.set_delay_commit_until_engine_init(False)
+    model_loader._pending_gms_write = None
+    model_loader._last_imported_weights_bytes = 0
+    yield
+    model_loader.set_delay_commit_until_engine_init(False)
+    model_loader._pending_gms_write = None
+    model_loader._last_imported_weights_bytes = 0
+
+
+def test_setup_gms_plumbs_delay_commit_flag(monkeypatch):
+    import gpu_memory_service.integrations.trtllm as trtllm_gms
+    from gpu_memory_service.common.locks import RequestedLockType
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(trtllm_gms, "patch_empty_cache", lambda: None)
+    monkeypatch.setattr(trtllm_gms, "patch_model_loader", lambda: None)
+    monkeypatch.setattr(trtllm_gms, "set_gms_enabled", lambda enabled: None)
+    monkeypatch.setattr(
+        trtllm_gms,
+        "set_gms_lock_mode",
+        lambda mode: captured.setdefault("lock_mode", mode),
+    )
+    monkeypatch.setattr(
+        trtllm_gms,
+        "set_delay_commit_until_engine_init",
+        lambda enabled: captured.setdefault("delay", enabled),
+    )
+    monkeypatch.setattr(
+        trtllm_gms,
+        "set_extra_config",
+        lambda extra: captured.setdefault("extra", extra),
+    )
+    monkeypatch.setattr(trtllm_gms, "install_mpi_worker_bootstrap", lambda: None)
+
+    trtllm_gms.setup_gms({"gms_delay_commit_until_engine_init": True})
+
+    assert captured["delay"] is True
+    assert captured["extra"] == {"gms_delay_commit_until_engine_init": True}
+    assert captured["lock_mode"] == RequestedLockType.RW_OR_RO
+
+
+def test_setup_gms_rejects_non_bool_delay_commit():
+    import gpu_memory_service.integrations.trtllm as trtllm_gms
+
+    with pytest.raises(
+        ValueError, match="gms_delay_commit_until_engine_init must be a boolean"
+    ):
+        trtllm_gms.setup_gms({"gms_delay_commit_until_engine_init": "true"})
+
+
+def test_load_rw_defers_publish_until_finalize(monkeypatch):
+    import gpu_memory_service.integrations.trtllm.model_loader as model_loader
+
+    fake_client = object()
+    fake_model = object()
+    fake_balancer = object()
+
+    monkeypatch.setattr(
+        model_loader, "gms_use_mem_pool", lambda *_args, **_kwargs: nullcontext()
+    )
+    monkeypatch.setattr(
+        model_loader, "_move_untracked_params", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(model_loader.torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(
+        model_loader,
+        "finalize_gms_write",
+        lambda *_args, **_kwargs: pytest.fail("finalize_gms_write should be deferred"),
+    )
+
+    model_loader.set_delay_commit_until_engine_init(True)
+
+    model, moe_load_balancer = model_loader._load_rw(
+        self=None,
+        checkpoint_dir="checkpoint",
+        checkpoint_loader=None,
+        gms_client=fake_client,
+        device_index=0,
+        original_load=lambda *_args, **_kwargs: (fake_model, fake_balancer),
+    )
+
+    assert model is fake_model
+    assert moe_load_balancer is fake_balancer
+    assert model_loader._pending_gms_write == (fake_client, fake_model)
+
+
+def test_finalize_pending_gms_write_commits_and_clears_slot(monkeypatch):
+    import gpu_memory_service.integrations.trtllm.model_loader as model_loader
+
+    fake_client = object()
+    fake_model = object()
+    calls: list[tuple[object, object]] = []
+
+    monkeypatch.setattr(
+        model_loader,
+        "finalize_gms_write",
+        lambda client, model: calls.append((client, model)) or 123,
+    )
+
+    model_loader._pending_gms_write = (fake_client, fake_model)
+
+    assert model_loader.finalize_pending_gms_write() == 123
+    assert calls == [(fake_client, fake_model)]
+    assert model_loader._pending_gms_write is None
+    assert model_loader._last_imported_weights_bytes == 123

--- a/components/src/dynamo/trtllm/tests/test_trtllm_gms_delay_commit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_gms_delay_commit.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
-from contextlib import nullcontext
+import sys
+import types
+from contextlib import contextmanager
 
 import pytest
 
@@ -72,40 +74,341 @@ def test_setup_gms_rejects_non_bool_delay_commit():
         trtllm_gms.setup_gms({"gms_delay_commit_until_engine_init": "true"})
 
 
-def test_load_rw_defers_publish_until_finalize(monkeypatch):
+def test_load_rw_preserves_native_weight_split_and_delays_publish(monkeypatch):
     import gpu_memory_service.integrations.trtllm.model_loader as model_loader
 
+    call_log: list[str] = []
     fake_client = object()
-    fake_model = object()
-    fake_balancer = object()
+    fake_model = None
 
+    class FakeAllocatedTensor:
+        def __init__(self, kind: str):
+            self.kind = kind
+            self.device = model_loader.torch.device("cuda")
+            self.is_cuda = True
+
+        def copy_(self, _source):
+            call_log.append(f"{self.kind}.copy")
+            return self
+
+    class FakeSourceTensor:
+        def __init__(self, label: str, device: str = "cpu"):
+            self.label = label
+            self.device = model_loader.torch.device(device)
+            self.is_cuda = device == "cuda"
+
+        def cuda(self):
+            call_log.append(f"{self.label}.cuda")
+            return FakeAllocatedTensor(self.label)
+
+    class FakePostLoadModule:
+        _weights_removed = False
+
+        def post_load_weights(self):
+            call_log.append("post_load_weights")
+
+    class FakeModel:
+        def _apply(self, fn):
+            call_log.append("apply_weights")
+            fn(FakeSourceTensor("weight"))
+            return self
+
+        def to(self, device):
+            call_log.append(f"model.to:{device}")
+            return self
+
+        def modules(self):
+            return [FakePostLoadModule()]
+
+        def load_weights(self, _weights):
+            call_log.append("model.load_weights")
+
+    fake_model = FakeModel()
+
+    class FakeCheckpointLoader:
+        checkpoint_format = "fake"
+
+        def load_weights(self, checkpoint_dir, mapping=None):
+            call_log.append(f"checkpoint_loader.load_weights:{checkpoint_dir}")
+            return "weights"
+
+        def get_initialized_weight_mapper(self, model, config):
+            call_log.append("checkpoint_loader.get_initialized_weight_mapper")
+            return "mapper"
+
+    class FakeMoeLoadBalancer:
+        def register_weight_slots_after_to_cuda(self):
+            call_log.append("moe.register")
+
+        def finalize_model(self):
+            call_log.append("moe.finalize")
+
+    @contextmanager
+    def fake_timing(_label):
+        yield
+
+    @contextmanager
+    def fake_meta_init():
+        yield
+
+    @contextmanager
+    def fake_moe_context(_config, _mapping):
+        yield FakeMoeLoadBalancer()
+
+    fake_trt_loader = types.ModuleType("tensorrt_llm._torch.pyexecutor.model_loader")
+    fake_trt_loader.timing = fake_timing
+    fake_trt_loader.maybe_create_moe_load_balancer = fake_moe_context
+    fake_trt_loader.MetaInitMode = fake_meta_init
+    fake_trt_loader.AutoModelForCausalLM = types.SimpleNamespace(
+        from_config=lambda _config: fake_model
+    )
+    fake_trt_loader.LoadFormat = types.SimpleNamespace(
+        AUTO="auto",
+        DUMMY="dummy",
+        VISION_ONLY="vision_only",
+    )
+    fake_trt_loader._apply_to_buffers_only = lambda _model, fn: (
+        call_log.append("apply_buffers"),
+        fn(FakeSourceTensor("buffer")),
+    )[-1]
+    fake_trt_loader.get_rank_model_storage = lambda _model: (
+        call_log.append("rank_model_storage"),
+        2 << 30,
+    )[-1]
+    fake_trt_loader.initialize_dummy_weights = lambda _model: call_log.append(
+        "initialize_dummy_weights"
+    )
+    fake_trt_loader.MoeLoadBalancer = FakeMoeLoadBalancer
+    fake_trt_loader.AutoCheckpointMapper = types.SimpleNamespace(
+        get=lambda *_args: None
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_llm._torch.pyexecutor.model_loader",
+        fake_trt_loader,
+    )
+
+    @contextmanager
+    def fake_gms_pool(_tag, _device):
+        call_log.append("enter_gms_pool")
+        yield
+        call_log.append("exit_gms_pool")
+
+    monkeypatch.setattr(model_loader, "gms_use_mem_pool", fake_gms_pool)
     monkeypatch.setattr(
-        model_loader, "gms_use_mem_pool", lambda *_args, **_kwargs: nullcontext()
+        model_loader,
+        "_move_untracked_params",
+        lambda _model, _client, device_index: call_log.append(
+            f"move_untracked:{device_index}"
+        ),
     )
     monkeypatch.setattr(
-        model_loader, "_move_untracked_params", lambda *_args, **_kwargs: None
+        model_loader.torch,
+        "empty_like",
+        lambda tensor, device=None: FakeAllocatedTensor(tensor.label),
     )
-    monkeypatch.setattr(model_loader.torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(
+        model_loader.torch.cuda,
+        "current_stream",
+        lambda: types.SimpleNamespace(
+            synchronize=lambda: call_log.append("synchronize")
+        ),
+    )
+    monkeypatch.setattr(
+        model_loader.torch.cuda,
+        "empty_cache",
+        lambda: call_log.append("empty_cache"),
+    )
     monkeypatch.setattr(
         model_loader,
         "finalize_gms_write",
         lambda *_args, **_kwargs: pytest.fail("finalize_gms_write should be deferred"),
     )
 
+    fake_self = types.SimpleNamespace(
+        llm_args=types.SimpleNamespace(load_format=fake_trt_loader.LoadFormat.AUTO),
+        mapping="mapping",
+        spec_config=None,
+        _load_and_validate_config=lambda *_args, **_kwargs: {"config": True},
+        _call_load_weights=lambda load_fn, weights, mapper: (
+            call_log.append("call_load_weights"),
+            load_fn(weights),
+        )[-1],
+    )
+
     model_loader.set_delay_commit_until_engine_init(True)
 
     model, moe_load_balancer = model_loader._load_rw(
-        self=None,
+        self=fake_self,
         checkpoint_dir="checkpoint",
-        checkpoint_loader=None,
+        checkpoint_loader=FakeCheckpointLoader(),
         gms_client=fake_client,
-        device_index=0,
-        original_load=lambda *_args, **_kwargs: (fake_model, fake_balancer),
+        device_index=2,
+        original_load=lambda *_args, **_kwargs: pytest.fail(
+            "_load_rw should not call original_load"
+        ),
     )
 
     assert model is fake_model
-    assert moe_load_balancer is fake_balancer
+    assert isinstance(moe_load_balancer, FakeMoeLoadBalancer)
     assert model_loader._pending_gms_write == (fake_client, fake_model)
+    assert call_log == [
+        "apply_buffers",
+        "buffer.cuda",
+        "enter_gms_pool",
+        "apply_weights",
+        "weight.copy",
+        "exit_gms_pool",
+        "model.to:cuda",
+        "rank_model_storage",
+        "checkpoint_loader.load_weights:checkpoint",
+        "checkpoint_loader.get_initialized_weight_mapper",
+        "call_load_weights",
+        "model.load_weights",
+        "post_load_weights",
+        "moe.register",
+        "moe.finalize",
+        "move_untracked:2",
+        "synchronize",
+        "empty_cache",
+    ]
+
+
+def test_move_untracked_params_only_touches_cuda_parameters(monkeypatch):
+    import gpu_memory_service.integrations.trtllm.model_loader as model_loader
+
+    copies: list[str] = []
+    create_calls: list[tuple[int, str]] = []
+
+    class FakeStorage:
+        def __init__(self, ptr: int, size: int):
+            self._ptr = ptr
+            self._size = size
+
+        def data_ptr(self):
+            return self._ptr
+
+        def nbytes(self):
+            return self._size
+
+    class FakeTensor:
+        def __init__(
+            self,
+            label: str,
+            storage_ptr: int,
+            data_ptr: int,
+            *,
+            is_cuda: bool = True,
+            storage_nbytes: int = 32,
+        ):
+            self.label = label
+            self._storage = FakeStorage(storage_ptr, storage_nbytes)
+            self._data_ptr = data_ptr
+            self.is_cuda = is_cuda
+            self.shape = (4,)
+            self._stride = (1,)
+            self.dtype = "float16"
+            self.data = f"original:{label}"
+
+        def storage(self):
+            return self._storage
+
+        def untyped_storage(self):
+            return self._storage
+
+        def data_ptr(self):
+            return self._data_ptr
+
+        def stride(self):
+            return self._stride
+
+        def numel(self):
+            return 4
+
+        def element_size(self):
+            return 2
+
+    class FakeReplacement:
+        def __init__(self, ptr: int):
+            self.ptr = ptr
+
+        def copy_(self, tensor):
+            copies.append(f"{tensor.label}->{self.ptr}")
+            return self
+
+    class FakeClient:
+        mappings = {}
+
+        def __init__(self):
+            self._next_ptr = 10_000
+
+        def create_mapping(self, size: int, tag: str):
+            create_calls.append((size, tag))
+            ptr = self._next_ptr
+            self._next_ptr += 1_000
+            return ptr
+
+    parameter_a = FakeTensor(
+        "parameter_a", storage_ptr=100, data_ptr=100, storage_nbytes=64
+    )
+    parameter_b = FakeTensor(
+        "parameter_b", storage_ptr=100, data_ptr=108, storage_nbytes=64
+    )
+    late_parameter = FakeTensor("late_parameter", storage_ptr=200, data_ptr=200)
+    buffer_tensor = FakeTensor("buffer", storage_ptr=300, data_ptr=300)
+    tensor_attr = FakeTensor("tensor_attr", storage_ptr=400, data_ptr=400)
+    cpu_parameter = FakeTensor(
+        "cpu_parameter", storage_ptr=500, data_ptr=500, is_cuda=False
+    )
+    already_gms = FakeTensor("already_gms", storage_ptr=900, data_ptr=900)
+
+    monkeypatch.setattr(
+        model_loader,
+        "_ptr_in_gms",
+        lambda _client, ptr: ptr == 900,
+    )
+
+    fake_torch_module = types.ModuleType("gpu_memory_service.client.torch.module")
+    fake_torch_module._iter_module_tensors = lambda _model: [
+        ("parameter_a", parameter_a, "parameter"),
+        ("parameter_b", parameter_b, "parameter"),
+        ("late_parameter", late_parameter, "parameter"),
+        ("buffer", buffer_tensor, "buffer"),
+        ("tensor_attr", tensor_attr, "tensor_attr"),
+        ("cpu_parameter", cpu_parameter, "parameter"),
+        ("already_gms", already_gms, "parameter"),
+    ]
+    monkeypatch.setitem(
+        sys.modules,
+        "gpu_memory_service.client.torch.module",
+        fake_torch_module,
+    )
+
+    fake_torch_tensor = types.ModuleType("gpu_memory_service.client.torch.tensor")
+    fake_torch_tensor._tensor_from_pointer = (
+        lambda ptr, *_args, **_kwargs: FakeReplacement(ptr)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "gpu_memory_service.client.torch.tensor",
+        fake_torch_tensor,
+    )
+
+    model_loader._move_untracked_params(object(), FakeClient(), device_index=7)
+
+    assert create_calls == [(64, "weights"), (32, "weights")]
+    assert copies == [
+        "parameter_a->10000",
+        "parameter_b->10008",
+        "late_parameter->11000",
+    ]
+    assert parameter_a.data.ptr == 10_000
+    assert parameter_b.data.ptr == 10_008
+    assert late_parameter.data.ptr == 11_000
+    assert buffer_tensor.data == "original:buffer"
+    assert tensor_attr.data == "original:tensor_attr"
+    assert cpu_parameter.data == "original:cpu_parameter"
+    assert already_gms.data == "original:already_gms"
 
 
 def test_finalize_pending_gms_write_commits_and_clears_slot(monkeypatch):

--- a/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
@@ -28,6 +28,7 @@ pytestmark = [
 def stubbed_env(monkeypatch):
     """Stub tensorrt_llm.llmapi.mpi_session and mpi4py.futures before importing bootstrap."""
     captured_kwargs: dict = {}
+    call_log: list[str] = []
 
     class FakeMPIPoolExecutor:
         def __init__(self, **kwargs):
@@ -46,9 +47,39 @@ def stubbed_env(monkeypatch):
     trtllm_module = types.ModuleType("tensorrt_llm")
     trtllm_llmapi_module = types.ModuleType("tensorrt_llm.llmapi")
     trtllm_mpi_session_module = types.ModuleType("tensorrt_llm.llmapi.mpi_session")
+    trtllm_torch_module = types.ModuleType("tensorrt_llm._torch")
+    trtllm_pyexecutor_module = types.ModuleType("tensorrt_llm._torch.pyexecutor")
+    trtllm_pyexecutor_creator_module = types.ModuleType(
+        "tensorrt_llm._torch.pyexecutor.py_executor_creator"
+    )
+
+    class FakePyExecutor:
+        def __init__(self, name: str = "executor"):
+            self.name = name
+
+        def start_worker(self):
+            call_log.append(f"start_worker:{self.name}")
+
+    def fake_create_py_executor_instance(*args, name: str = "executor", **kwargs):
+        return FakePyExecutor(name)
+
+    def fake_create_py_executor(*args, **kwargs):
+        call_log.append("create_py_executor")
+        executor = fake_create_py_executor_instance()
+        executor.start_worker()
+        return executor
+
+    trtllm_pyexecutor_creator_module.PyExecutor = FakePyExecutor
+    trtllm_pyexecutor_creator_module.create_py_executor_instance = (
+        fake_create_py_executor_instance
+    )
+    trtllm_pyexecutor_creator_module.create_py_executor = fake_create_py_executor
     trtllm_mpi_session_module.MpiPoolSession = FakeMpiPoolSession
     trtllm_module.llmapi = trtllm_llmapi_module
     trtllm_llmapi_module.mpi_session = trtllm_mpi_session_module
+    trtllm_module._torch = trtllm_torch_module
+    trtllm_torch_module.pyexecutor = trtllm_pyexecutor_module
+    trtllm_pyexecutor_module.py_executor_creator = trtllm_pyexecutor_creator_module
 
     monkeypatch.setitem(sys.modules, "mpi4py", mpi4py_module)
     monkeypatch.setitem(sys.modules, "mpi4py.futures", mpi4py_futures_module)
@@ -56,6 +87,15 @@ def stubbed_env(monkeypatch):
     monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", trtllm_llmapi_module)
     monkeypatch.setitem(
         sys.modules, "tensorrt_llm.llmapi.mpi_session", trtllm_mpi_session_module
+    )
+    monkeypatch.setitem(sys.modules, "tensorrt_llm._torch", trtllm_torch_module)
+    monkeypatch.setitem(
+        sys.modules, "tensorrt_llm._torch.pyexecutor", trtllm_pyexecutor_module
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_llm._torch.pyexecutor.py_executor_creator",
+        trtllm_pyexecutor_creator_module,
     )
 
     # Force re-import so install_mpi_worker_bootstrap rebinds the stub's class.
@@ -65,20 +105,25 @@ def stubbed_env(monkeypatch):
     )
     bootstrap._bootstrap_installed = False
     bootstrap._extra_config_json = None
+    bootstrap._executor_finalize_hook_installed = False
 
     yield {
         "bootstrap": bootstrap,
         "FakeMpiPoolSession": FakeMpiPoolSession,
         "captured_kwargs": captured_kwargs,
+        "py_executor_creator": trtllm_pyexecutor_creator_module,
+        "call_log": call_log,
     }
 
 
 def test_install_patches_mpi_pool_session_start_method(stubbed_env):
     bootstrap = stubbed_env["bootstrap"]
     FakeMpiPoolSession = stubbed_env["FakeMpiPoolSession"]
-    original = FakeMpiPoolSession._start_mpi_pool if hasattr(
-        FakeMpiPoolSession, "_start_mpi_pool"
-    ) else None
+    original = (
+        FakeMpiPoolSession._start_mpi_pool
+        if hasattr(FakeMpiPoolSession, "_start_mpi_pool")
+        else None
+    )
 
     bootstrap.install_mpi_worker_bootstrap()
 
@@ -98,9 +143,7 @@ def test_install_is_idempotent(stubbed_env):
     assert FakeMpiPoolSession._start_mpi_pool is first
 
 
-def test_start_mpi_pool_injects_initializer_and_extra_config(
-    stubbed_env, monkeypatch
-):
+def test_start_mpi_pool_injects_initializer_and_extra_config(stubbed_env, monkeypatch):
     bootstrap = stubbed_env["bootstrap"]
     FakeMpiPoolSession = stubbed_env["FakeMpiPoolSession"]
     captured_kwargs = stubbed_env["captured_kwargs"]
@@ -132,9 +175,7 @@ def test_start_mpi_pool_injects_initializer_and_extra_config(
     assert captured_kwargs["env"]["DYN_GMS_TRTLLM_ENABLED"] == "1"
 
 
-def test_worker_init_hook_restores_env_and_calls_setup_gms(
-    stubbed_env, monkeypatch
-):
+def test_worker_init_hook_restores_env_and_calls_setup_gms(stubbed_env, monkeypatch):
     bootstrap = stubbed_env["bootstrap"]
 
     # Child environment starts without the propagated vars — simulates fresh interpreter.
@@ -146,12 +187,10 @@ def test_worker_init_hook_restores_env_and_calls_setup_gms(
     ):
         monkeypatch.delenv(key, raising=False)
 
+    import gpu_memory_service.integrations.trtllm as trtllm_gms
+
     fake_setup_gms = MagicMock()
-    fake_trtllm_pkg = types.ModuleType("gpu_memory_service.integrations.trtllm")
-    fake_trtllm_pkg.setup_gms = fake_setup_gms
-    monkeypatch.setitem(
-        sys.modules, "gpu_memory_service.integrations.trtllm", fake_trtllm_pkg
-    )
+    monkeypatch.setattr(trtllm_gms, "setup_gms", fake_setup_gms)
 
     env_snapshot = {
         "DYN_GMS_TRTLLM_ENABLED": "1",
@@ -171,25 +210,100 @@ def test_worker_init_hook_no_op_when_gms_disabled(stubbed_env, monkeypatch):
     bootstrap = stubbed_env["bootstrap"]
 
     monkeypatch.delenv("DYN_GMS_TRTLLM_ENABLED", raising=False)
+    import gpu_memory_service.integrations.trtllm as trtllm_gms
+
     fake_setup_gms = MagicMock()
-    fake_trtllm_pkg = types.ModuleType("gpu_memory_service.integrations.trtllm")
-    fake_trtllm_pkg.setup_gms = fake_setup_gms
-    monkeypatch.setitem(
-        sys.modules, "gpu_memory_service.integrations.trtllm", fake_trtllm_pkg
-    )
+    monkeypatch.setattr(trtllm_gms, "setup_gms", fake_setup_gms)
 
     bootstrap.worker_init_hook({"ENGINE_ID": "1"}, None)
 
     fake_setup_gms.assert_not_called()
 
 
+def test_worker_init_hook_installs_child_finalize_before_start_worker(
+    stubbed_env, monkeypatch
+):
+    bootstrap = stubbed_env["bootstrap"]
+    py_executor_creator = stubbed_env["py_executor_creator"]
+    call_log = stubbed_env["call_log"]
+
+    class FakePyExecutor:
+        def __init__(self, name: str):
+            self.name = name
+
+        def start_worker(self):
+            call_log.append(f"start_worker:{self.name}")
+
+    def fake_create_py_executor(*args, **kwargs):
+        call_log.append("temp_executor_created")
+        py_executor_creator.create_py_executor_instance(name="temp")
+        call_log.append("final_executor_created")
+        executor = py_executor_creator.create_py_executor_instance(name="final")
+        executor.start_worker()
+        return executor
+
+    py_executor_creator.PyExecutor = FakePyExecutor
+    py_executor_creator.create_py_executor_instance = (
+        lambda *args, name="executor", **kwargs: FakePyExecutor(name)
+    )
+    py_executor_creator.create_py_executor = fake_create_py_executor
+
+    import gpu_memory_service.integrations.trtllm as trtllm_gms
+
+    fake_setup_gms = MagicMock(
+        side_effect=lambda extra: call_log.append(f"setup:{extra}")
+    )
+    fake_finalize = MagicMock(side_effect=lambda: call_log.append("finalize"))
+    monkeypatch.setattr(trtllm_gms, "setup_gms", fake_setup_gms)
+    monkeypatch.setattr(trtllm_gms, "finalize_pending_gms_write", fake_finalize)
+
+    env_snapshot = {"DYN_GMS_TRTLLM_ENABLED": "1", "ENGINE_ID": "0"}
+    bootstrap.worker_init_hook(
+        env_snapshot, '{"gms_delay_commit_until_engine_init": true}'
+    )
+
+    executor = py_executor_creator.create_py_executor()
+
+    assert executor.name == "final"
+    assert fake_setup_gms.call_count == 1
+    assert fake_finalize.call_count == 1
+    assert call_log == [
+        "setup:{'gms_delay_commit_until_engine_init': True}",
+        "temp_executor_created",
+        "final_executor_created",
+        "finalize",
+        "start_worker:final",
+    ]
+
+
+def test_worker_init_hook_skips_child_finalize_hook_without_delay_flag(
+    stubbed_env, monkeypatch
+):
+    bootstrap = stubbed_env["bootstrap"]
+    py_executor_creator = stubbed_env["py_executor_creator"]
+
+    original_create_py_executor = py_executor_creator.create_py_executor
+    import gpu_memory_service.integrations.trtllm as trtllm_gms
+
+    fake_setup_gms = MagicMock()
+    fake_finalize = MagicMock()
+    monkeypatch.setattr(trtllm_gms, "setup_gms", fake_setup_gms)
+    monkeypatch.setattr(trtllm_gms, "finalize_pending_gms_write", fake_finalize)
+
+    bootstrap.worker_init_hook(
+        {"DYN_GMS_TRTLLM_ENABLED": "1", "ENGINE_ID": "0"}, '{"gms_read_only": true}'
+    )
+
+    assert py_executor_creator.create_py_executor is original_create_py_executor
+    py_executor_creator.create_py_executor()
+    fake_finalize.assert_not_called()
+
+
 def test_worker_init_hook_is_picklable():
     """mpi4py.futures requires the initializer to be picklable-by-reference."""
     import pickle
 
-    from gpu_memory_service.integrations.trtllm.mpi_bootstrap import (
-        worker_init_hook,
-    )
+    from gpu_memory_service.integrations.trtllm.mpi_bootstrap import worker_init_hook
 
     # Function imported by module path; pickle roundtrip resolves back to the same object.
     assert pickle.loads(pickle.dumps(worker_init_hook)) is worker_init_hook

--- a/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
@@ -30,6 +30,21 @@ def stubbed_env(monkeypatch):
     captured_kwargs: dict = {}
     call_log: list[str] = []
 
+    class FakeComm:
+        def __init__(self):
+            self.rank = 0
+
+        def Get_rank(self):
+            return self.rank
+
+        def Barrier(self):
+            call_log.append(f"barrier:{self.rank}")
+
+    fake_comm = FakeComm()
+
+    class FakeMPI:
+        COMM_WORLD = fake_comm
+
     class FakeMPIPoolExecutor:
         def __init__(self, **kwargs):
             captured_kwargs.update(kwargs)
@@ -43,6 +58,7 @@ def stubbed_env(monkeypatch):
     mpi4py_futures_module = types.ModuleType("mpi4py.futures")
     mpi4py_futures_module.MPIPoolExecutor = FakeMPIPoolExecutor
     mpi4py_module.futures = mpi4py_futures_module
+    mpi4py_module.MPI = FakeMPI
 
     trtllm_module = types.ModuleType("tensorrt_llm")
     trtllm_llmapi_module = types.ModuleType("tensorrt_llm.llmapi")
@@ -52,6 +68,8 @@ def stubbed_env(monkeypatch):
     trtllm_pyexecutor_creator_module = types.ModuleType(
         "tensorrt_llm._torch.pyexecutor.py_executor_creator"
     )
+    torch_module = types.ModuleType("torch")
+    torch_module.cuda = types.SimpleNamespace(empty_cache=lambda: None)
 
     class FakePyExecutor:
         def __init__(self, name: str = "executor"):
@@ -59,6 +77,10 @@ def stubbed_env(monkeypatch):
 
         def start_worker(self):
             call_log.append(f"start_worker:{self.name}")
+
+    class FakePyTorchModelEngine:
+        def __init__(self, *args, **kwargs):
+            call_log.append("model_engine_init")
 
     def fake_create_py_executor_instance(*args, name: str = "executor", **kwargs):
         return FakePyExecutor(name)
@@ -70,6 +92,7 @@ def stubbed_env(monkeypatch):
         return executor
 
     trtllm_pyexecutor_creator_module.PyExecutor = FakePyExecutor
+    trtllm_pyexecutor_creator_module.PyTorchModelEngine = FakePyTorchModelEngine
     trtllm_pyexecutor_creator_module.create_py_executor_instance = (
         fake_create_py_executor_instance
     )
@@ -83,6 +106,7 @@ def stubbed_env(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "mpi4py", mpi4py_module)
     monkeypatch.setitem(sys.modules, "mpi4py.futures", mpi4py_futures_module)
+    monkeypatch.setitem(sys.modules, "torch", torch_module)
     monkeypatch.setitem(sys.modules, "tensorrt_llm", trtllm_module)
     monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", trtllm_llmapi_module)
     monkeypatch.setitem(
@@ -106,6 +130,7 @@ def stubbed_env(monkeypatch):
     bootstrap._bootstrap_installed = False
     bootstrap._extra_config_json = None
     bootstrap._executor_finalize_hook_installed = False
+    bootstrap._shadow_activation_fd = None
 
     yield {
         "bootstrap": bootstrap,
@@ -113,6 +138,7 @@ def stubbed_env(monkeypatch):
         "captured_kwargs": captured_kwargs,
         "py_executor_creator": trtllm_pyexecutor_creator_module,
         "call_log": call_log,
+        "fake_comm": fake_comm,
     }
 
 
@@ -151,6 +177,7 @@ def test_start_mpi_pool_injects_initializer_and_extra_config(stubbed_env, monkey
     monkeypatch.setenv("DYN_GMS_TRTLLM_ENABLED", "1")
     monkeypatch.setenv("DYN_GMS_SHADOW_MODE", "1")
     monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("FAILOVER_LOCK_PATH", "/tmp/failover.lock")
     monkeypatch.setenv("TRTLLM_FOO", "bar")
     monkeypatch.setenv("TLLM_BAZ", "qux")
 
@@ -167,12 +194,14 @@ def test_start_mpi_pool_injects_initializer_and_extra_config(stubbed_env, monkey
         "DYN_GMS_TRTLLM_ENABLED": "1",
         "DYN_GMS_SHADOW_MODE": "1",
         "ENGINE_ID": "1",
+        "FAILOVER_LOCK_PATH": "/tmp/failover.lock",
     }
     assert extra_config_json == '{"gms_read_only": true}'
     # TRTLLM_* / TLLM_* vars plus propagated env must flow through executor env=.
     assert captured_kwargs["env"]["TRTLLM_FOO"] == "bar"
     assert captured_kwargs["env"]["TLLM_BAZ"] == "qux"
     assert captured_kwargs["env"]["DYN_GMS_TRTLLM_ENABLED"] == "1"
+    assert captured_kwargs["env"]["FAILOVER_LOCK_PATH"] == "/tmp/failover.lock"
 
 
 def test_worker_init_hook_restores_env_and_calls_setup_gms(stubbed_env, monkeypatch):
@@ -299,9 +328,64 @@ def test_worker_init_hook_skips_child_finalize_hook_without_delay_flag(
     fake_finalize.assert_not_called()
 
 
-def test_worker_init_hook_is_picklable():
+def test_worker_init_hook_standby_gates_after_model_engine_before_kv_build(
+    stubbed_env, monkeypatch
+):
+    bootstrap = stubbed_env["bootstrap"]
+    py_executor_creator = stubbed_env["py_executor_creator"]
+    call_log = stubbed_env["call_log"]
+
+    def fake_create_py_executor(*args, **kwargs):
+        call_log.append("create_py_executor")
+        py_executor_creator.PyTorchModelEngine()
+        call_log.append("after_model_engine")
+        py_executor_creator.create_py_executor_instance(name="final")
+        call_log.append("after_kv_build")
+        return object()
+
+    py_executor_creator.create_py_executor = fake_create_py_executor
+
+    import gpu_memory_service.integrations.trtllm as trtllm_gms
+
+    fake_setup_gms = MagicMock(
+        side_effect=lambda extra: call_log.append(f"setup:{extra}")
+    )
+    monkeypatch.setattr(trtllm_gms, "setup_gms", fake_setup_gms)
+    monkeypatch.setattr(
+        bootstrap,
+        "_wait_for_shadow_activation",
+        lambda: call_log.append("wait_for_activation"),
+    )
+
+    env_snapshot = {
+        "DYN_GMS_TRTLLM_ENABLED": "1",
+        "DYN_GMS_SHADOW_MODE": "1",
+        "ENGINE_ID": "1",
+        "FAILOVER_LOCK_PATH": "/tmp/failover.lock",
+    }
+    bootstrap.worker_init_hook(env_snapshot, '{"gms_read_only": true}')
+
+    py_executor_creator.create_py_executor()
+
+    assert fake_setup_gms.call_count == 1
+    assert call_log == [
+        "setup:{'gms_read_only': True}",
+        "create_py_executor",
+        "model_engine_init",
+        "wait_for_activation",
+        "after_model_engine",
+        "after_kv_build",
+    ]
+
+
+def test_worker_init_hook_is_picklable(monkeypatch):
     """mpi4py.futures requires the initializer to be picklable-by-reference."""
     import pickle
+    import types
+
+    torch_module = types.ModuleType("torch")
+    torch_module.cuda = types.SimpleNamespace(empty_cache=lambda: None)
+    monkeypatch.setitem(sys.modules, "torch", torch_module)
 
     from gpu_memory_service.integrations.trtllm.mpi_bootstrap import worker_init_hook
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
@@ -70,6 +70,7 @@ def stubbed_env(monkeypatch):
     )
     torch_module = types.ModuleType("torch")
     torch_module.cuda = types.SimpleNamespace(empty_cache=lambda: None)
+    gc_module = types.SimpleNamespace(collect=lambda: call_log.append("gc_collect"))
 
     class FakePyExecutor:
         def __init__(self, name: str = "executor"):
@@ -82,6 +83,16 @@ def stubbed_env(monkeypatch):
         def __init__(self, *args, **kwargs):
             call_log.append("model_engine_init")
 
+    class FakeKvCacheCreator:
+        def build_managers(self, _resources, estimating_kv_cache):
+            call_log.append(f"build_managers:{estimating_kv_cache}")
+
+        def configure_kv_cache_capacity(self, _py_executor):
+            call_log.append("configure_kv_cache_capacity")
+
+        def teardown_managers(self, _resources):
+            call_log.append("teardown_managers")
+
     def fake_create_py_executor_instance(*args, name: str = "executor", **kwargs):
         return FakePyExecutor(name)
 
@@ -93,6 +104,8 @@ def stubbed_env(monkeypatch):
 
     trtllm_pyexecutor_creator_module.PyExecutor = FakePyExecutor
     trtllm_pyexecutor_creator_module.PyTorchModelEngine = FakePyTorchModelEngine
+    trtllm_pyexecutor_creator_module.KvCacheCreator = FakeKvCacheCreator
+    trtllm_pyexecutor_creator_module.gc = gc_module
     trtllm_pyexecutor_creator_module.create_py_executor_instance = (
         fake_create_py_executor_instance
     )
@@ -328,7 +341,7 @@ def test_worker_init_hook_skips_child_finalize_hook_without_delay_flag(
     fake_finalize.assert_not_called()
 
 
-def test_worker_init_hook_standby_gates_after_model_engine_before_kv_build(
+def test_worker_init_hook_standby_gates_after_temp_executor_before_final_kv_build(
     stubbed_env, monkeypatch
 ):
     bootstrap = stubbed_env["bootstrap"]
@@ -336,12 +349,23 @@ def test_worker_init_hook_standby_gates_after_model_engine_before_kv_build(
     call_log = stubbed_env["call_log"]
 
     def fake_create_py_executor(*args, **kwargs):
+        kv_cache_creator = py_executor_creator.KvCacheCreator()
+
         call_log.append("create_py_executor")
         py_executor_creator.PyTorchModelEngine()
-        call_log.append("after_model_engine")
-        py_executor_creator.create_py_executor_instance(name="final")
-        call_log.append("after_kv_build")
-        return object()
+        kv_cache_creator.build_managers({}, True)
+        call_log.append("temp_executor_created")
+        py_executor = py_executor_creator.create_py_executor_instance(name="temp")
+        py_executor.start_worker()
+        kv_cache_creator.configure_kv_cache_capacity(py_executor)
+        kv_cache_creator.teardown_managers({})
+        del py_executor
+        py_executor_creator.gc.collect()
+        kv_cache_creator.build_managers({}, False)
+        call_log.append("final_executor_created")
+        final_executor = py_executor_creator.create_py_executor_instance(name="final")
+        final_executor.start_worker()
+        return final_executor
 
     py_executor_creator.create_py_executor = fake_create_py_executor
 
@@ -372,9 +396,16 @@ def test_worker_init_hook_standby_gates_after_model_engine_before_kv_build(
         "setup:{'gms_read_only': True}",
         "create_py_executor",
         "model_engine_init",
+        "build_managers:True",
+        "temp_executor_created",
+        "start_worker:temp",
+        "configure_kv_cache_capacity",
+        "teardown_managers",
+        "gc_collect",
         "wait_for_activation",
-        "after_model_engine",
-        "after_kv_build",
+        "build_managers:False",
+        "final_executor_created",
+        "start_worker:final",
     ]
 
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
@@ -87,6 +87,17 @@ def stubbed_env(monkeypatch):
             call_log.append("model_engine_init")
 
     class FakeKvCacheCreator:
+        def __init__(self):
+            self._max_num_tokens = 8192
+            self._max_batch_size = 8
+            self._dummy_reqs = None
+            self._model_engine = None
+            self._draft_model_engine = None
+            self._llm_args = types.SimpleNamespace(max_num_tokens=8192)
+
+        def try_prepare_estimation(self):
+            return True
+
         def build_managers(self, _resources, estimating_kv_cache):
             call_log.append(f"build_managers:{estimating_kv_cache}")
 
@@ -352,14 +363,73 @@ def test_worker_init_hook_standby_gates_after_temp_executor_before_final_kv_buil
     py_executor_creator = stubbed_env["py_executor_creator"]
     call_log = stubbed_env["call_log"]
 
-    model_engine = types.SimpleNamespace(max_num_tokens=8192)
-    draft_model_engine = types.SimpleNamespace(max_num_tokens=4096)
+    model_llm_args = types.SimpleNamespace(max_num_tokens=8192, cuda_graph_config=None)
+    draft_llm_args = types.SimpleNamespace(max_num_tokens=4096, cuda_graph_config=None)
+    model_engine = types.SimpleNamespace(
+        max_num_tokens=8192,
+        llm_args=model_llm_args,
+        spec_metadata="model-spec",
+        attn_metadata="model-attn",
+    )
+    draft_model_engine = types.SimpleNamespace(
+        max_num_tokens=4096,
+        llm_args=draft_llm_args,
+        spec_metadata="draft-spec",
+        attn_metadata="draft-attn",
+    )
     drafter = types.SimpleNamespace(draft_model_engine=draft_model_engine)
+
+    class FakeKvCacheCreator:
+        def __init__(self):
+            self._max_num_tokens = 8192
+            self._max_batch_size = 8
+            self._dummy_reqs = ["stale-8192"]
+            self._model_engine = model_engine
+            self._draft_model_engine = draft_model_engine
+            self._llm_args = model_llm_args
+
+        def try_prepare_estimation(self):
+            call_log.append(
+                f"try_prepare_estimation:max={self._max_num_tokens}:dummy={self._dummy_reqs}"
+            )
+            if self._dummy_reqs is None:
+                self._dummy_reqs = [f"req-{self._max_num_tokens}"]
+            call_log.append(
+                f"after_try_prepare:max={self._max_num_tokens}:dummy={self._dummy_reqs}"
+            )
+            return True
+
+        def build_managers(self, _resources, estimating_kv_cache):
+            call_log.append(
+                "build_managers:"
+                f"{estimating_kv_cache}:creator={self._max_num_tokens}:"
+                f"model={model_engine.max_num_tokens}:model_llm={model_llm_args.max_num_tokens}:"
+                f"draft={draft_model_engine.max_num_tokens}:draft_llm={draft_llm_args.max_num_tokens}"
+            )
+
+        def configure_kv_cache_capacity(self, py_executor):
+            call_log.append(
+                "configure_kv_cache_capacity:"
+                f"creator={self._max_num_tokens}:"
+                f"model={model_engine.max_num_tokens}:model_llm={model_llm_args.max_num_tokens}:"
+                f"draft={draft_model_engine.max_num_tokens}:draft_llm={draft_llm_args.max_num_tokens}:"
+                f"dummy={self._dummy_reqs}"
+            )
+            py_executor.start_worker()
+
+        def teardown_managers(self, _resources):
+            call_log.append("teardown_managers")
+
+    py_executor_creator.KvCacheCreator = FakeKvCacheCreator
 
     def fake_create_py_executor_instance(*args, name="executor", **kwargs):
         call_log.append(
-            f"create_py_executor_instance:{name}:model={kwargs['model_engine'].max_num_tokens}:"
-            f"draft={getattr(kwargs.get('drafter'), 'draft_model_engine', None).max_num_tokens}"
+            "create_py_executor_instance:"
+            f"{name}:model={kwargs['model_engine'].max_num_tokens}:"
+            f"model_llm={kwargs['model_engine'].llm_args.max_num_tokens}:"
+            f"draft={getattr(kwargs.get('drafter'), 'draft_model_engine', None).max_num_tokens}:"
+            f"draft_llm={getattr(kwargs.get('drafter'), 'draft_model_engine', None).llm_args.max_num_tokens}:"
+            f"arg={kwargs['max_num_tokens']}"
         )
         return py_executor_creator.PyExecutor(name)
 
@@ -369,23 +439,34 @@ def test_worker_init_hook_standby_gates_after_temp_executor_before_final_kv_buil
         kv_cache_creator = py_executor_creator.KvCacheCreator()
 
         call_log.append("create_py_executor")
-        py_executor_creator.PyTorchModelEngine()
-        kv_cache_creator.build_managers({}, True)
+        estimating_kv_cache = kv_cache_creator.try_prepare_estimation()
+        call_log.append(f"estimating_kv_cache={estimating_kv_cache}")
+        kv_cache_creator.build_managers({}, estimating_kv_cache)
         call_log.append("temp_executor_created")
         py_executor = py_executor_creator.create_py_executor_instance(
             name="temp",
             model_engine=model_engine,
             drafter=drafter,
             max_batch_size=8,
+            max_num_tokens=8192,
         )
         call_log.append(
-            f"after_temp_restore:model={model_engine.max_num_tokens}:draft={draft_model_engine.max_num_tokens}"
+            "after_temp_create:"
+            f"model={model_engine.max_num_tokens}:model_llm={model_llm_args.max_num_tokens}:"
+            f"draft={draft_model_engine.max_num_tokens}:draft_llm={draft_llm_args.max_num_tokens}:"
+            f"creator={kv_cache_creator._max_num_tokens}:dummy={kv_cache_creator._dummy_reqs}"
         )
-        py_executor.start_worker()
         kv_cache_creator.configure_kv_cache_capacity(py_executor)
         kv_cache_creator.teardown_managers({})
-        del py_executor
         py_executor_creator.gc.collect()
+        call_log.append(
+            "after_gc_restore:"
+            f"model={model_engine.max_num_tokens}:model_llm={model_llm_args.max_num_tokens}:"
+            f"draft={draft_model_engine.max_num_tokens}:draft_llm={draft_llm_args.max_num_tokens}:"
+            f"creator={kv_cache_creator._max_num_tokens}:dummy={kv_cache_creator._dummy_reqs}:"
+            f"model_spec={model_engine.spec_metadata}:model_attn={model_engine.attn_metadata}:"
+            f"draft_spec={draft_model_engine.spec_metadata}:draft_attn={draft_model_engine.attn_metadata}"
+        )
         kv_cache_creator.build_managers({}, False)
         call_log.append("final_executor_created")
         final_executor = py_executor_creator.create_py_executor_instance(
@@ -393,9 +474,15 @@ def test_worker_init_hook_standby_gates_after_temp_executor_before_final_kv_buil
             model_engine=model_engine,
             drafter=drafter,
             max_batch_size=8,
+            max_num_tokens=8192,
         )
         call_log.append(
-            f"after_final_create:model={model_engine.max_num_tokens}:draft={draft_model_engine.max_num_tokens}"
+            "after_final_create:"
+            f"model={model_engine.max_num_tokens}:model_llm={model_llm_args.max_num_tokens}:"
+            f"draft={draft_model_engine.max_num_tokens}:draft_llm={draft_llm_args.max_num_tokens}:"
+            f"creator={kv_cache_creator._max_num_tokens}:dummy={kv_cache_creator._dummy_reqs}:"
+            f"model_spec={model_engine.spec_metadata}:model_attn={model_engine.attn_metadata}:"
+            f"draft_spec={draft_model_engine.spec_metadata}:draft_attn={draft_model_engine.attn_metadata}"
         )
         final_executor.start_worker()
         return final_executor
@@ -428,21 +515,24 @@ def test_worker_init_hook_standby_gates_after_temp_executor_before_final_kv_buil
     assert call_log == [
         "setup:{'gms_read_only': True}",
         "create_py_executor",
-        "model_engine_init",
-        "build_managers:True",
+        "try_prepare_estimation:max=8:dummy=None",
+        "after_try_prepare:max=8:dummy=['req-8']",
+        "estimating_kv_cache=True",
+        "build_managers:True:creator=8:model=8:model_llm=8:draft=8:draft_llm=8",
         "temp_executor_created",
-        "create_py_executor_instance:temp:model=8:draft=8",
-        "after_temp_restore:model=8192:draft=4096",
+        "create_py_executor_instance:temp:model=8:model_llm=8:draft=8:draft_llm=8:arg=8",
+        "after_temp_create:model=8:model_llm=8:draft=8:draft_llm=8:creator=8:dummy=['req-8']",
+        "configure_kv_cache_capacity:creator=8:model=8:model_llm=8:draft=8:draft_llm=8:dummy=['req-8']",
         "start_worker:temp",
-        "configure_kv_cache_capacity",
         "teardown_managers",
         "gc_collect",
         "clear_cublas_workspaces",
         "wait_for_activation",
-        "build_managers:False",
+        "after_gc_restore:model=8192:model_llm=8192:draft=4096:draft_llm=4096:creator=8192:dummy=None:model_spec=None:model_attn=None:draft_spec=None:draft_attn=None",
+        "build_managers:False:creator=8192:model=8192:model_llm=8192:draft=4096:draft_llm=4096",
         "final_executor_created",
-        "create_py_executor_instance:final:model=8192:draft=4096",
-        "after_final_create:model=8192:draft=4096",
+        "create_py_executor_instance:final:model=8192:model_llm=8192:draft=4096:draft_llm=4096:arg=8192",
+        "after_final_create:model=8192:model_llm=8192:draft=4096:draft_llm=4096:creator=8192:dummy=None:model_spec=None:model_attn=None:draft_spec=None:draft_attn=None",
         "start_worker:final",
     ]
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
@@ -70,6 +70,9 @@ def stubbed_env(monkeypatch):
     )
     torch_module = types.ModuleType("torch")
     torch_module.cuda = types.SimpleNamespace(empty_cache=lambda: None)
+    torch_module._C = types.SimpleNamespace(
+        _cuda_clearCublasWorkspaces=lambda: call_log.append("clear_cublas_workspaces")
+    )
     gc_module = types.SimpleNamespace(collect=lambda: call_log.append("gc_collect"))
 
     class FakePyExecutor:
@@ -106,6 +109,7 @@ def stubbed_env(monkeypatch):
     trtllm_pyexecutor_creator_module.PyTorchModelEngine = FakePyTorchModelEngine
     trtllm_pyexecutor_creator_module.KvCacheCreator = FakeKvCacheCreator
     trtllm_pyexecutor_creator_module.gc = gc_module
+    trtllm_pyexecutor_creator_module.torch = torch_module
     trtllm_pyexecutor_creator_module.create_py_executor_instance = (
         fake_create_py_executor_instance
     )
@@ -348,6 +352,19 @@ def test_worker_init_hook_standby_gates_after_temp_executor_before_final_kv_buil
     py_executor_creator = stubbed_env["py_executor_creator"]
     call_log = stubbed_env["call_log"]
 
+    model_engine = types.SimpleNamespace(max_num_tokens=8192)
+    draft_model_engine = types.SimpleNamespace(max_num_tokens=4096)
+    drafter = types.SimpleNamespace(draft_model_engine=draft_model_engine)
+
+    def fake_create_py_executor_instance(*args, name="executor", **kwargs):
+        call_log.append(
+            f"create_py_executor_instance:{name}:model={kwargs['model_engine'].max_num_tokens}:"
+            f"draft={getattr(kwargs.get('drafter'), 'draft_model_engine', None).max_num_tokens}"
+        )
+        return py_executor_creator.PyExecutor(name)
+
+    py_executor_creator.create_py_executor_instance = fake_create_py_executor_instance
+
     def fake_create_py_executor(*args, **kwargs):
         kv_cache_creator = py_executor_creator.KvCacheCreator()
 
@@ -355,7 +372,15 @@ def test_worker_init_hook_standby_gates_after_temp_executor_before_final_kv_buil
         py_executor_creator.PyTorchModelEngine()
         kv_cache_creator.build_managers({}, True)
         call_log.append("temp_executor_created")
-        py_executor = py_executor_creator.create_py_executor_instance(name="temp")
+        py_executor = py_executor_creator.create_py_executor_instance(
+            name="temp",
+            model_engine=model_engine,
+            drafter=drafter,
+            max_batch_size=8,
+        )
+        call_log.append(
+            f"after_temp_restore:model={model_engine.max_num_tokens}:draft={draft_model_engine.max_num_tokens}"
+        )
         py_executor.start_worker()
         kv_cache_creator.configure_kv_cache_capacity(py_executor)
         kv_cache_creator.teardown_managers({})
@@ -363,7 +388,15 @@ def test_worker_init_hook_standby_gates_after_temp_executor_before_final_kv_buil
         py_executor_creator.gc.collect()
         kv_cache_creator.build_managers({}, False)
         call_log.append("final_executor_created")
-        final_executor = py_executor_creator.create_py_executor_instance(name="final")
+        final_executor = py_executor_creator.create_py_executor_instance(
+            name="final",
+            model_engine=model_engine,
+            drafter=drafter,
+            max_batch_size=8,
+        )
+        call_log.append(
+            f"after_final_create:model={model_engine.max_num_tokens}:draft={draft_model_engine.max_num_tokens}"
+        )
         final_executor.start_worker()
         return final_executor
 
@@ -398,13 +431,18 @@ def test_worker_init_hook_standby_gates_after_temp_executor_before_final_kv_buil
         "model_engine_init",
         "build_managers:True",
         "temp_executor_created",
+        "create_py_executor_instance:temp:model=8:draft=8",
+        "after_temp_restore:model=8192:draft=4096",
         "start_worker:temp",
         "configure_kv_cache_capacity",
         "teardown_managers",
         "gc_collect",
+        "clear_cublas_workspaces",
         "wait_for_activation",
         "build_managers:False",
         "final_executor_created",
+        "create_py_executor_instance:final:model=8192:draft=4096",
+        "after_final_create:model=8192:draft=4096",
         "start_worker:final",
     ]
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_shadow_mode.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_shadow_mode.py
@@ -10,7 +10,9 @@ so they run anywhere.
 
 import pytest
 from gpu_memory_service.integrations.trtllm.utils import (
+    SHADOW_ALLREDUCE_STRATEGY,
     configure_gms_lock_mode,
+    force_nccl_allreduce_for_shadow,
     is_shadow_mode,
 )
 
@@ -76,3 +78,21 @@ def test_configure_returns_same_dict(monkeypatch, clean_env):
     extra = {}
     returned = configure_gms_lock_mode(extra)
     assert returned is extra
+
+
+def test_force_nccl_allreduce_overrides_mnnvl():
+    arg_map = {"allreduce_strategy": "MNNVL"}
+    force_nccl_allreduce_for_shadow(arg_map)
+    assert arg_map["allreduce_strategy"] == SHADOW_ALLREDUCE_STRATEGY
+
+
+def test_force_nccl_allreduce_sets_when_unset():
+    arg_map = {}
+    force_nccl_allreduce_for_shadow(arg_map)
+    assert arg_map["allreduce_strategy"] == SHADOW_ALLREDUCE_STRATEGY
+
+
+def test_force_nccl_allreduce_is_idempotent():
+    arg_map = {"allreduce_strategy": SHADOW_ALLREDUCE_STRATEGY}
+    force_nccl_allreduce_for_shadow(arg_map)
+    assert arg_map["allreduce_strategy"] == SHADOW_ALLREDUCE_STRATEGY

--- a/components/src/dynamo/trtllm/tests/test_trtllm_shadow_mode.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_shadow_mode.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for TRT-LLM GMS shadow mode configuration.
+
+These tests only exercise pure-Python logic in
+gpu_memory_service/integrations/trtllm/utils.py — no CUDA, no tensorrt_llm,
+so they run anywhere.
+"""
+
+import pytest
+from gpu_memory_service.integrations.trtllm.utils import (
+    configure_gms_lock_mode,
+    is_shadow_mode,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge]
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    monkeypatch.delenv("DYN_GMS_SHADOW_MODE", raising=False)
+    monkeypatch.delenv("ENGINE_ID", raising=False)
+
+
+def test_is_shadow_mode_default(clean_env):
+    assert is_shadow_mode() is False
+
+
+def test_is_shadow_mode_enabled(monkeypatch, clean_env):
+    monkeypatch.setenv("DYN_GMS_SHADOW_MODE", "1")
+    assert is_shadow_mode() is True
+
+
+def test_engine_id_0_leaves_lock_mode_unset(monkeypatch, clean_env):
+    monkeypatch.setenv("ENGINE_ID", "0")
+    extra = {}
+    configure_gms_lock_mode(extra)
+    assert "gms_read_only" not in extra
+
+
+def test_engine_id_1_forces_read_only(monkeypatch, clean_env):
+    monkeypatch.setenv("ENGINE_ID", "1")
+    extra = {}
+    configure_gms_lock_mode(extra)
+    assert extra["gms_read_only"] is True
+
+
+def test_engine_id_missing_defaults_to_writer(clean_env):
+    extra = {}
+    configure_gms_lock_mode(extra)
+    assert "gms_read_only" not in extra
+
+
+def test_engine_id_0_with_explicit_read_only_raises(monkeypatch, clean_env):
+    monkeypatch.setenv("ENGINE_ID", "0")
+    with pytest.raises(ValueError, match="primary writer"):
+        configure_gms_lock_mode({"gms_read_only": True})
+
+
+def test_engine_id_1_with_explicit_writer_raises(monkeypatch, clean_env):
+    monkeypatch.setenv("ENGINE_ID", "1")
+    with pytest.raises(ValueError, match="requires gms_read_only=True"):
+        configure_gms_lock_mode({"gms_read_only": False})
+
+
+def test_engine_id_1_with_explicit_read_only_is_ok(monkeypatch, clean_env):
+    monkeypatch.setenv("ENGINE_ID", "1")
+    extra = {"gms_read_only": True}
+    configure_gms_lock_mode(extra)
+    assert extra["gms_read_only"] is True
+
+
+def test_configure_returns_same_dict(monkeypatch, clean_env):
+    monkeypatch.setenv("ENGINE_ID", "2")
+    extra = {}
+    returned = configure_gms_lock_mode(extra)
+    assert returned is extra

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -299,7 +299,7 @@ class StandbyWaitReached(Exception):
 
 
 class ShadowPrimaryLockReached(Exception):
-    """Raised when the primary shadow path reaches the failover lock."""
+    """Raised when the primary shadow path reaches post-init registration."""
 
 
 def test_standby_generate_proxy_answers_health_check_before_delegate():
@@ -349,9 +349,18 @@ def test_init_llm_worker_shadow_standby_serves_endpoint_before_engine_init(
     class FakeLock:
         def __init__(self, path):
             call_log.append(f"lock_path:{path}")
+            self._owners = iter([None, "engine-0"])
+
+        async def owner(self):
+            owner = next(self._owners)
+            call_log.append(f"owner:{owner}")
+            return owner
 
         async def acquire(self, engine_id):
             call_log.append(f"lock_acquire:{engine_id}")
+
+        async def release(self):
+            return None
 
     class FakeEngineContext:
         async def __aenter__(self):
@@ -405,6 +414,8 @@ def test_init_llm_worker_shadow_standby_serves_endpoint_before_engine_init(
         "serve_endpoint",
         "health:True",
         "lock_path:/tmp/failover.lock",
+        "owner:None",
+        "owner:engine-0",
         "lock_acquire:engine-1",
         "get_llm_engine",
         "engine_enter",
@@ -412,7 +423,7 @@ def test_init_llm_worker_shadow_standby_serves_endpoint_before_engine_init(
     ]
 
 
-def test_init_llm_worker_shadow_primary_quiesces_before_engine_exit(monkeypatch):
+def test_init_llm_worker_shadow_primary_acquires_lock_before_engine_init(monkeypatch):
     monkeypatch.setenv("ENGINE_ID", "0")
     monkeypatch.setenv("FAILOVER_LOCK_PATH", "/tmp/failover.lock")
 
@@ -429,7 +440,6 @@ def test_init_llm_worker_shadow_primary_quiesces_before_engine_exit(monkeypatch)
     )
 
     call_log = []
-    engine_state = {"alive": False}
 
     class FakeEndpoint:
         def connection_id(self):
@@ -442,19 +452,17 @@ def test_init_llm_worker_shadow_primary_quiesces_before_engine_exit(monkeypatch)
 
     class FakeEngineContext:
         async def __aenter__(self):
-            engine_state["alive"] = True
             call_log.append("engine_enter")
             return FakeEngine()
 
         async def __aexit__(self, exc_type, exc, tb):
             call_log.append("engine_exit")
-            engine_state["alive"] = False
             return False
 
     class FakeQuiesceController:
         async def quiesce(self):
-            assert engine_state["alive"] is True
             call_log.append("quiesce")
+            raise AssertionError("primary startup should not quiesce before serving")
 
     class FakeHandler:
         def __init__(self):
@@ -466,13 +474,12 @@ def test_init_llm_worker_shadow_primary_quiesces_before_engine_exit(monkeypatch)
 
         async def acquire(self, engine_id):
             call_log.append(f"lock_acquire:{engine_id}")
-            raise ShadowPrimaryLockReached()
+
+        async def release(self):
+            return None
 
     runtime = mock.MagicMock()
     runtime.endpoint.return_value = FakeEndpoint()
-    runtime.set_health_status.side_effect = lambda ready: call_log.append(
-        f"health:{ready}"
-    )
 
     fake_request_handler_factory = mock.MagicMock()
     fake_request_handler_factory.get_request_handler.return_value = FakeHandler()
@@ -496,6 +503,13 @@ def test_init_llm_worker_shadow_primary_quiesces_before_engine_exit(monkeypatch)
         mock.patch("dynamo.trtllm.workers.llm_worker.RequestHandlerFactory") as factory,
         mock.patch("dynamo.trtllm.workers.llm_worker.register_engine_metrics_callback"),
         mock.patch("dynamo.trtllm.workers.llm_worker._register_memory_routes"),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.register_model",
+            side_effect=lambda *args, **kwargs: (
+                call_log.append("register_model"),
+                (_ for _ in ()).throw(ShadowPrimaryLockReached()),
+            )[1],
+        ),
         mock.patch("gpu_memory_service.integrations.trtllm.setup_gms"),
         mock.patch(
             "gpu_memory_service.integrations.trtllm.utils.configure_gms_lock_mode"
@@ -517,11 +531,10 @@ def test_init_llm_worker_shadow_primary_quiesces_before_engine_exit(monkeypatch)
             )
 
     assert call_log == [
-        "get_llm_engine",
-        "engine_enter",
-        "quiesce",
-        "health:True",
         "lock_path:/tmp/failover.lock",
         "lock_acquire:engine-0",
+        "get_llm_engine",
+        "engine_enter",
+        "register_model",
         "engine_exit",
     ]

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -416,7 +416,6 @@ def test_init_llm_worker_shadow_standby_serves_endpoint_before_engine_init(
         "lock_path:/tmp/failover.lock",
         "owner:None",
         "owner:engine-0",
-        "lock_acquire:engine-1",
         "get_llm_engine",
         "engine_enter",
         "serve_cancelled",

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -413,9 +413,6 @@ def test_init_llm_worker_shadow_standby_serves_endpoint_before_engine_init(
     assert call_log == [
         "serve_endpoint",
         "health:True",
-        "lock_path:/tmp/failover.lock",
-        "owner:None",
-        "owner:engine-0",
         "get_llm_engine",
         "engine_enter",
         "serve_cancelled",

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -330,13 +330,17 @@ def test_init_llm_worker_shadow_standby_serves_endpoint_before_engine_init(
     call_log = []
 
     class FakeEndpoint:
-        async def serve_endpoint(self, *_args, **_kwargs):
+        def serve_endpoint(self, *_args, **_kwargs):
             call_log.append("serve_endpoint")
-            try:
-                await asyncio.Event().wait()
-            except asyncio.CancelledError:
-                call_log.append("serve_cancelled")
-                raise
+
+            async def wait_forever():
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    call_log.append("serve_cancelled")
+                    raise
+
+            return asyncio.create_task(wait_forever())
 
     class FakeLock:
         def __init__(self, path):

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -298,6 +298,10 @@ class StandbyWaitReached(Exception):
     """Raised when the standby path reaches engine init in tests."""
 
 
+class ShadowPrimaryLockReached(Exception):
+    """Raised when the primary shadow path reaches the failover lock."""
+
+
 def test_standby_generate_proxy_answers_health_check_before_delegate():
     proxy = _StandbyGenerateProxy({"token_ids": [1]})
 
@@ -405,4 +409,119 @@ def test_init_llm_worker_shadow_standby_serves_endpoint_before_engine_init(
         "get_llm_engine",
         "engine_enter",
         "serve_cancelled",
+    ]
+
+
+def test_init_llm_worker_shadow_primary_quiesces_before_engine_exit(monkeypatch):
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("FAILOVER_LOCK_PATH", "/tmp/failover.lock")
+
+    config = parse_args(
+        [
+            "--model",
+            "fake-model",
+            "--load-format",
+            "gms",
+            "--gms-shadow-mode",
+            "--gpus-per-node",
+            "1",
+        ]
+    )
+
+    call_log = []
+    engine_state = {"alive": False}
+
+    class FakeEndpoint:
+        def connection_id(self):
+            return "7"
+
+    class FakeEngine:
+        @staticmethod
+        def get_attention_dp_size():
+            return 1
+
+    class FakeEngineContext:
+        async def __aenter__(self):
+            engine_state["alive"] = True
+            call_log.append("engine_enter")
+            return FakeEngine()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            call_log.append("engine_exit")
+            engine_state["alive"] = False
+            return False
+
+    class FakeQuiesceController:
+        async def quiesce(self):
+            assert engine_state["alive"] is True
+            call_log.append("quiesce")
+
+    class FakeHandler:
+        def __init__(self):
+            self._quiesce_controller = FakeQuiesceController()
+
+    class FakeLock:
+        def __init__(self, path):
+            call_log.append(f"lock_path:{path}")
+
+        async def acquire(self, engine_id):
+            call_log.append(f"lock_acquire:{engine_id}")
+            raise ShadowPrimaryLockReached()
+
+    runtime = mock.MagicMock()
+    runtime.endpoint.return_value = FakeEndpoint()
+    runtime.set_health_status.side_effect = lambda ready: call_log.append(
+        f"health:{ready}"
+    )
+
+    fake_request_handler_factory = mock.MagicMock()
+    fake_request_handler_factory.get_request_handler.return_value = FakeHandler()
+
+    with (
+        mock.patch("dynamo.trtllm.workers.llm_worker.tokenizer_factory"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.nixl_connect.Connector"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.dump_config"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.LLMBackendMetrics"),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.TrtllmHealthCheckPayload",
+            return_value=mock.Mock(to_dict=mock.Mock(return_value={})),
+        ),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.get_llm_engine",
+            side_effect=lambda *args, **kwargs: (
+                call_log.append("get_llm_engine"),
+                FakeEngineContext(),
+            )[1],
+        ),
+        mock.patch("dynamo.trtllm.workers.llm_worker.RequestHandlerFactory") as factory,
+        mock.patch("dynamo.trtllm.workers.llm_worker.register_engine_metrics_callback"),
+        mock.patch("dynamo.trtllm.workers.llm_worker._register_memory_routes"),
+        mock.patch("gpu_memory_service.integrations.trtllm.setup_gms"),
+        mock.patch(
+            "gpu_memory_service.integrations.trtllm.utils.configure_gms_lock_mode"
+        ),
+        mock.patch(
+            "gpu_memory_service.failover_lock.flock.FlockFailoverLock",
+            FakeLock,
+        ),
+    ):
+        factory.return_value = fake_request_handler_factory
+
+        with pytest.raises(ShadowPrimaryLockReached):
+            asyncio.run(
+                init_llm_worker(
+                    runtime=runtime,
+                    config=config,
+                    shutdown_event=asyncio.Event(),
+                )
+            )
+
+    assert call_log == [
+        "get_llm_engine",
+        "engine_enter",
+        "quiesce",
+        "health:True",
+        "lock_path:/tmp/failover.lock",
+        "lock_acquire:engine-0",
+        "engine_exit",
     ]

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -22,7 +22,7 @@ from dynamo.trtllm.args import Config, parse_args
 from dynamo.trtllm.constants import Modality
 from dynamo.trtllm.tests.conftest import make_cli_args_fixture
 from dynamo.trtllm.utils.trtllm_utils import deep_update
-from dynamo.trtllm.workers.llm_worker import init_llm_worker
+from dynamo.trtllm.workers.llm_worker import _StandbyGenerateProxy, init_llm_worker
 
 # Get path relative to this test file
 REPO_ROOT = Path(__file__).resolve().parents[5]
@@ -292,3 +292,113 @@ async def test_init_llm_worker_creates_multimodal_processor():
                 config=config,
                 shutdown_event=asyncio.Event(),
             )
+
+
+class StandbyWaitReached(Exception):
+    """Raised when the standby path reaches engine init in tests."""
+
+
+def test_standby_generate_proxy_answers_health_check_before_delegate():
+    proxy = _StandbyGenerateProxy({"token_ids": [1]})
+
+    async def collect_response():
+        return [
+            item async for item in proxy.generate({"token_ids": [1]}, mock.MagicMock())
+        ]
+
+    assert asyncio.run(collect_response()) == [{"status": "ok"}]
+
+
+def test_init_llm_worker_shadow_standby_serves_endpoint_before_engine_init(
+    monkeypatch,
+):
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("FAILOVER_LOCK_PATH", "/tmp/failover.lock")
+
+    config = parse_args(
+        [
+            "--model",
+            "fake-model",
+            "--load-format",
+            "gms",
+            "--gms-shadow-mode",
+            "--gpus-per-node",
+            "1",
+        ]
+    )
+
+    call_log = []
+
+    class FakeEndpoint:
+        async def serve_endpoint(self, *_args, **_kwargs):
+            call_log.append("serve_endpoint")
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                call_log.append("serve_cancelled")
+                raise
+
+    class FakeLock:
+        def __init__(self, path):
+            call_log.append(f"lock_path:{path}")
+
+        async def acquire(self, engine_id):
+            call_log.append(f"lock_acquire:{engine_id}")
+
+    class FakeEngineContext:
+        async def __aenter__(self):
+            call_log.append("engine_enter")
+            raise StandbyWaitReached()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    runtime = mock.MagicMock()
+    runtime.endpoint.return_value = FakeEndpoint()
+    runtime.set_health_status.side_effect = lambda ready: call_log.append(
+        f"health:{ready}"
+    )
+
+    with (
+        mock.patch("dynamo.trtllm.workers.llm_worker.tokenizer_factory"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.nixl_connect.Connector"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.dump_config"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.LLMBackendMetrics"),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.TrtllmHealthCheckPayload",
+            return_value=mock.Mock(to_dict=mock.Mock(return_value={})),
+        ),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.get_llm_engine",
+            side_effect=lambda *args, **kwargs: (
+                call_log.append("get_llm_engine"),
+                FakeEngineContext(),
+            )[1],
+        ),
+        mock.patch("gpu_memory_service.integrations.trtllm.setup_gms"),
+        mock.patch(
+            "gpu_memory_service.integrations.trtllm.utils.configure_gms_lock_mode"
+        ),
+        mock.patch(
+            "gpu_memory_service.failover_lock.flock.FlockFailoverLock",
+            FakeLock,
+        ),
+    ):
+        with pytest.raises(StandbyWaitReached):
+            asyncio.run(
+                init_llm_worker(
+                    runtime=runtime,
+                    config=config,
+                    shutdown_event=asyncio.Event(),
+                )
+            )
+
+    assert call_log == [
+        "serve_endpoint",
+        "health:True",
+        "lock_path:/tmp/failover.lock",
+        "lock_acquire:engine-1",
+        "get_llm_engine",
+        "engine_enter",
+        "serve_cancelled",
+    ]

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import sys
+from contextlib import suppress
 from typing import Optional
 
 from prometheus_client import REGISTRY
@@ -65,6 +66,28 @@ from dynamo.trtllm.utils.trtllm_utils import deep_update
 
 # Default buffer size for kv cache events.
 DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 1024
+
+
+class _StandbyGenerateProxy:
+    def __init__(self, health_check_payload: dict | None = None):
+        self._delegate = None
+        self._health_check_payload = health_check_payload
+
+    def set_delegate(self, delegate) -> None:
+        self._delegate = delegate
+
+    async def generate(self, request: dict, context):
+        if self._delegate is None:
+            if (
+                self._health_check_payload is not None
+                and request == self._health_check_payload
+            ):
+                yield {"status": "ok"}
+                return
+            raise RuntimeError("Shadow standby is waiting for failover lock")
+
+        async for response in self._delegate(request, context):
+            yield response
 
 
 def build_kv_connector_config(config: Config):
@@ -489,6 +512,21 @@ async def init_llm_worker(
     # Prepare model name for metrics
     model_name_for_metrics = config.served_model_name or config.model
 
+    endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
+
+    if shutdown_endpoints is not None:
+        shutdown_endpoints[:] = [endpoint]
+
+    health_check_payload = TrtllmHealthCheckPayload(tokenizer=tokenizer).to_dict()
+    metrics_labels = None
+    if config.publish_events_and_metrics:
+        metrics_labels = [
+            (prometheus_names.labels.MODEL, model_name_for_metrics),
+            (prometheus_names.labels.MODEL_NAME, model_name_for_metrics),
+        ]
+
     # Construct Prometheus gauges directly; passed through to the engine and publisher
     # via explicit parameters (no module-level global).
     component_gauges = LLMBackendMetrics(
@@ -497,22 +535,46 @@ async def init_llm_worker(
         component_name=config.component,
     )
 
-    async with get_llm_engine(
-        engine_args,
-        config.disaggregation_mode,
-        component_gauges=component_gauges,
-    ) as engine:
-        # Expose engine to the drain callback installed by main.py (#7319).
-        # The callback uses this to poll active request count during shutdown.
-        if engine_holder is not None:
-            engine_holder.append(engine)
+    shadow_engine_id = os.environ.get("ENGINE_ID", "0")
+    shadow_standby = config.gms_shadow_mode and shadow_engine_id != "0"
+    startup_lock = None
+    standby_generate_proxy = None
+    standby_serve_task = None
+    if shadow_standby:
+        from gpu_memory_service.failover_lock.flock import FlockFailoverLock
 
-        endpoint = runtime.endpoint(
-            f"{config.namespace}.{config.component}.{config.endpoint}"
+        standby_generate_proxy = _StandbyGenerateProxy(health_check_payload)
+        standby_serve_task = asyncio.create_task(
+            endpoint.serve_endpoint(
+                standby_generate_proxy.generate,
+                metrics_labels=metrics_labels,
+                health_check_payload=health_check_payload,
+            )
         )
+        await asyncio.sleep(0)
+        if standby_serve_task.done():
+            await standby_serve_task
 
-        if shutdown_endpoints is not None:
-            shutdown_endpoints[:] = [endpoint]
+        runtime.set_health_status(True)
+        logging.info(
+            "[Shadow] Engine sleeping, startup probe now passing, waiting for lock"
+        )
+        startup_lock = FlockFailoverLock(
+            os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
+        )
+        await startup_lock.acquire(engine_id=f"engine-{shadow_engine_id}")
+        logging.info("[Shadow] Lock acquired, starting engine init")
+
+    try:
+        async with get_llm_engine(
+            engine_args,
+            config.disaggregation_mode,
+            component_gauges=component_gauges,
+        ) as engine:
+            # Expose engine to the drain callback installed by main.py (#7319).
+            # The callback uses this to poll active request count during shutdown.
+            if engine_holder is not None:
+                engine_holder.append(engine)
 
         # should ideally call get_engine_runtime_config
         # this is because we don't have a good way to
@@ -652,7 +714,7 @@ async def init_llm_worker(
         if config.load_format == "gms":
             _register_memory_routes(runtime, handler)
 
-        if config.gms_shadow_mode:
+        if config.gms_shadow_mode and not shadow_standby:
             await handler._quiesce_controller.quiesce()
 
             runtime.set_health_status(True)
@@ -663,9 +725,8 @@ async def init_llm_worker(
             from gpu_memory_service.failover_lock.flock import FlockFailoverLock
 
             lock_path = os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
-            engine_id = os.environ.get("ENGINE_ID", "0")
-            lock = FlockFailoverLock(lock_path)
-            await lock.acquire(engine_id=f"engine-{engine_id}")
+            startup_lock = FlockFailoverLock(lock_path)
+            await startup_lock.acquire(engine_id=f"engine-{shadow_engine_id}")
             logging.info("[Shadow] Lock acquired, waking engine")
 
             await handler._quiesce_controller.resume()
@@ -688,25 +749,9 @@ async def init_llm_worker(
                 custom_template_path=config.custom_jinja_template,
             )
 
-        # Get health check payload (checks env var and falls back to TensorRT-LLM default)
-        health_check_payload = TrtllmHealthCheckPayload(tokenizer=tokenizer).to_dict()
-
         if config.publish_events_and_metrics:
             # Initialize and pass in the publisher to the request handler to
             # publish events and metrics.
-            # Use model as fallback if served_model_name is not provided
-            model_name_for_metrics = config.served_model_name or config.model
-            metrics_labels = [
-                (
-                    prometheus_names.labels.MODEL,
-                    model_name_for_metrics,
-                ),  # OpenAI standard
-                (
-                    prometheus_names.labels.MODEL_NAME,
-                    model_name_for_metrics,
-                ),  # Native engine compatibility
-            ]
-
             # Create worker-side publisher for consolidated events if consolidator is enabled
             # This subscribes to consolidator's ZMQ output and publishes to NATS with worker_id
             consolidator_publisher = None
@@ -744,16 +789,30 @@ async def init_llm_worker(
                         model_name=model_name_for_metrics,
                         component_name=config.component,
                     )
-                await endpoint.serve_endpoint(
-                    handler.generate,
-                    metrics_labels=metrics_labels,
-                    health_check_payload=health_check_payload,
-                )
+                if shadow_standby:
+                    standby_generate_proxy.set_delegate(handler.generate)
+                    await standby_serve_task
+                else:
+                    await endpoint.serve_endpoint(
+                        handler.generate,
+                        metrics_labels=metrics_labels,
+                        health_check_payload=health_check_payload,
+                    )
 
             # Shutdown consolidator publisher if it was created
             if consolidator_publisher:
                 consolidator_publisher.shutdown()
         else:
-            await endpoint.serve_endpoint(
-                handler.generate, health_check_payload=health_check_payload
-            )
+            if shadow_standby:
+                standby_generate_proxy.set_delegate(handler.generate)
+                await standby_serve_task
+            else:
+                await endpoint.serve_endpoint(
+                    handler.generate, health_check_payload=health_check_payload
+                )
+    except Exception:
+        if standby_serve_task is not None:
+            standby_serve_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await standby_serve_task
+        raise

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -574,240 +574,247 @@ async def init_llm_worker(
             if engine_holder is not None:
                 engine_holder.append(engine)
 
-        # should ideally call get_engine_runtime_config
-        # this is because we don't have a good way to
-        # get total_kv_blocks from the engine yet without calling get_stats_async
-        # This causes an issue because get_stats_async doesn't work when no requests are sent to the engine
-        # So for now, we just set the parsers from the config
-        # TODO: fix this once we have a better way to get total_kv_blocks
-        runtime_config = ModelRuntimeConfig()
+            # should ideally call get_engine_runtime_config
+            # this is because we don't have a good way to
+            # get total_kv_blocks from the engine yet without calling get_stats_async
+            # This causes an issue because get_stats_async doesn't work when no requests are sent to the engine
+            # So for now, we just set the parsers from the config
+            # TODO: fix this once we have a better way to get total_kv_blocks
+            runtime_config = ModelRuntimeConfig()
 
-        # Set values from config that are available immediately
-        # Note: We populate max_num_seqs and max_num_batched_tokens from config
-        # to ensure Prometheus metrics are available even without engine stats
+            # Set values from config that are available immediately
+            # Note: We populate max_num_seqs and max_num_batched_tokens from config
+            # to ensure Prometheus metrics are available even without engine stats
 
-        # Naming clarification:
-        # - In vLLM: max_num_seqs = maximum concurrent requests (this is an unusual name due to vLLM's historic reasons)
-        # - In TensorRT-LLM: max_batch_size = maximum concurrent requests (clearer name)
-        # Both parameters control the same thing: how many requests can be processed simultaneously
+            # Naming clarification:
+            # - In vLLM: max_num_seqs = maximum concurrent requests (this is an unusual name due to vLLM's historic reasons)
+            # - In TensorRT-LLM: max_batch_size = maximum concurrent requests (clearer name)
+            # Both parameters control the same thing: how many requests can be processed simultaneously
 
-        # Need to get max_num_seqs and max_num_batched_tokens from engine_args
-        # because they can be overridden by --extra-engine-args or --override-engine-args
-        runtime_config.max_num_seqs = engine_args["max_batch_size"]
-        runtime_config.max_num_batched_tokens = engine_args["max_num_tokens"]
-        runtime_config.reasoning_parser = config.dyn_reasoning_parser
-        runtime_config.tool_call_parser = config.dyn_tool_call_parser
-        runtime_config.exclude_tools_when_tool_choice_none = (
-            config.exclude_tools_when_tool_choice_none
-        )
-        # Decode workers don't create the WorkerKvQuery endpoint, so don't advertise local indexer
-        runtime_config.enable_local_indexer = (
-            config.enable_local_indexer
-            and config.disaggregation_mode != DisaggregationMode.DECODE
-        )
-        # Set data_parallel_size for attention DP mode
-        # This enables the router's scheduler to correctly iterate over all dp_ranks
-        # Need to name ADP as `data_parallel_size` for parity with other frameworks
-        attention_dp_size = engine.get_attention_dp_size()
-        runtime_config.data_parallel_size = attention_dp_size
+            # Need to get max_num_seqs and max_num_batched_tokens from engine_args
+            # because they can be overridden by --extra-engine-args or --override-engine-args
+            runtime_config.max_num_seqs = engine_args["max_batch_size"]
+            runtime_config.max_num_batched_tokens = engine_args["max_num_tokens"]
+            runtime_config.reasoning_parser = config.dyn_reasoning_parser
+            runtime_config.tool_call_parser = config.dyn_tool_call_parser
+            runtime_config.exclude_tools_when_tool_choice_none = (
+                config.exclude_tools_when_tool_choice_none
+            )
+            # Decode workers don't create the WorkerKvQuery endpoint, so don't advertise local indexer
+            runtime_config.enable_local_indexer = (
+                config.enable_local_indexer
+                and config.disaggregation_mode != DisaggregationMode.DECODE
+            )
+            # Set data_parallel_size for attention DP mode
+            # This enables the router's scheduler to correctly iterate over all dp_ranks
+            # Need to name ADP as `data_parallel_size` for parity with other frameworks
+            attention_dp_size = engine.get_attention_dp_size()
+            runtime_config.data_parallel_size = attention_dp_size
 
-        logging.info(f"Set runtime config max_num_seqs: {runtime_config.max_num_seqs}")
-        logging.info(
-            f"Set runtime config max_num_batched_tokens: {runtime_config.max_num_batched_tokens}"
-        )
-        logging.info(f"Set runtime config data_parallel_size: {attention_dp_size}")
+            logging.info(
+                f"Set runtime config max_num_seqs: {runtime_config.max_num_seqs}"
+            )
+            logging.info(
+                f"Set runtime config max_num_batched_tokens: {runtime_config.max_num_batched_tokens}"
+            )
+            logging.info(f"Set runtime config data_parallel_size: {attention_dp_size}")
 
-        # The get_engine_runtime_config function exists but is not called here due to:
-        # 1. get_stats_async requires active requests to work properly
-        # 2. We need runtime config during registration, before any requests are made
-        # 3. total_kv_blocks would ideally come from engine stats but is not critical for basic operation
+            # The get_engine_runtime_config function exists but is not called here due to:
+            # 1. get_stats_async requires active requests to work properly
+            # 2. We need runtime config during registration, before any requests are made
+            # 3. total_kv_blocks would ideally come from engine stats but is not critical for basic operation
 
-        # Initialize TensorRT-LLM MetricsCollector and register with global REGISTRY
-        # This enables exposing TRT-LLM's native Prometheus metrics (request latency, TTFT, TPOT, etc.)
-        metrics_collector = None
-        additional_metrics = None
-        if config.publish_events_and_metrics:
-            try:
-                model_name_for_metrics = config.served_model_name or config.model
-                metrics_collector = MetricsCollector(
-                    {"model_name": model_name_for_metrics, "engine_type": "trtllm"}
-                )
-                logging.info("TensorRT-LLM MetricsCollector initialized")
-
-                # Prefix filter: all TRT-LLM metrics (engine + additional) use "trtllm_" prefix
-                _metric_prefixes = ["trtllm_"]
-
-                # Additional metrics (abort tracking, request types, KV transfer perf).
-                # Wrapped in try/except because AdditionalMetricsCollector depends on
-                # prometheus_names which may not be available in all packaging variants.
+            # Initialize TensorRT-LLM MetricsCollector and register with global REGISTRY
+            # This enables exposing TRT-LLM's native Prometheus metrics (request latency, TTFT, TPOT, etc.)
+            metrics_collector = None
+            additional_metrics = None
+            if config.publish_events_and_metrics:
                 try:
-                    from dynamo.trtllm.metrics import AdditionalMetricsCollector
-
-                    disagg_mode_str = (
-                        config.disaggregation_mode.value
-                        if hasattr(config.disaggregation_mode, "value")
-                        else str(config.disaggregation_mode)
+                    model_name_for_metrics = config.served_model_name or config.model
+                    metrics_collector = MetricsCollector(
+                        {"model_name": model_name_for_metrics, "engine_type": "trtllm"}
                     )
-                    additional_metrics = AdditionalMetricsCollector(
-                        labels={
-                            "model_name": model_name_for_metrics,
-                            "disaggregation_mode": disagg_mode_str,
-                            "engine_type": "trtllm",
-                        },
+                    logging.info("TensorRT-LLM MetricsCollector initialized")
+
+                    # Prefix filter: all TRT-LLM metrics (engine + additional) use "trtllm_" prefix
+                    _metric_prefixes = ["trtllm_"]
+
+                    # Additional metrics (abort tracking, request types, KV transfer perf).
+                    # Wrapped in try/except because AdditionalMetricsCollector depends on
+                    # prometheus_names which may not be available in all packaging variants.
+                    try:
+                        from dynamo.trtllm.metrics import AdditionalMetricsCollector
+
+                        disagg_mode_str = (
+                            config.disaggregation_mode.value
+                            if hasattr(config.disaggregation_mode, "value")
+                            else str(config.disaggregation_mode)
+                        )
+                        additional_metrics = AdditionalMetricsCollector(
+                            labels={
+                                "model_name": model_name_for_metrics,
+                                "disaggregation_mode": disagg_mode_str,
+                                "engine_type": "trtllm",
+                            },
+                        )
+                        logging.info(
+                            "Additional metrics initialized (disagg_mode=%s)",
+                            disagg_mode_str,
+                        )
+                    except Exception as e:
+                        logging.warning(
+                            "Failed to initialize additional metrics: %s", e
+                        )
+
+                    # Single callback for all Python-side metrics (trtllm_ + additional)
+                    register_engine_metrics_callback(
+                        endpoint=endpoint,
+                        registry=REGISTRY,
+                        metric_prefix_filters=_metric_prefixes,
+                        namespace_name=config.namespace,
+                        component_name=config.component,
+                        endpoint_name="generate",
+                        model_name=model_name_for_metrics,
                     )
                     logging.info(
-                        "Additional metrics initialized (disagg_mode=%s)",
-                        disagg_mode_str,
+                        "Prometheus metrics registered (prefixes: %s)",
+                        _metric_prefixes,
                     )
                 except Exception as e:
-                    logging.warning("Failed to initialize additional metrics: %s", e)
-
-                # Single callback for all Python-side metrics (trtllm_ + additional)
-                register_engine_metrics_callback(
-                    endpoint=endpoint,
-                    registry=REGISTRY,
-                    metric_prefix_filters=_metric_prefixes,
-                    namespace_name=config.namespace,
-                    component_name=config.component,
-                    endpoint_name="generate",
-                    model_name=model_name_for_metrics,
-                )
-                logging.info(
-                    "Prometheus metrics registered (prefixes: %s)", _metric_prefixes
-                )
-            except Exception as e:
-                logging.warning(
-                    f"Failed to initialize TensorRT-LLM Prometheus metrics: {e}"
-                )
-
-        # Register callback for Dynamo component metrics using dedicated registry
-        register_engine_metrics_callback(
-            endpoint=endpoint,
-            registry=DYNAMO_COMPONENT_REGISTRY,
-        )
-        logging.debug("DYNAMO_COMPONENT_REGISTRY callback registered successfully")
-
-        # publisher will be set later if publishing is enabled.
-        handler_config = RequestHandlerConfig(
-            engine=engine,
-            default_sampling_params=default_sampling_params,
-            publisher=None,
-            disaggregation_mode=config.disaggregation_mode,
-            encode_client=encode_client,
-            multimodal_processor=multimodal_processor,
-            generate_endpoint=endpoint,
-            connector=connector,
-            runtime=runtime,  # Pass runtime for graceful shutdown
-            metrics_collector=metrics_collector,
-            kv_block_size=config.kv_block_size,
-            shutdown_event=shutdown_event,
-            encoder_cache_capacity_gb=config.multimodal_embedding_cache_capacity_gb,
-            disable_request_abort=config.disable_request_abort,
-            additional_metrics=additional_metrics,
-            max_seq_len=config.max_seq_len,
-            disagg_machine_id=int(endpoint.connection_id()) % 1021,
-        )
-
-        handler = RequestHandlerFactory().get_request_handler(handler_config)
-        if config.load_format == "gms":
-            _register_memory_routes(runtime, handler)
-
-        if config.gms_shadow_mode and not shadow_standby:
-            await handler._quiesce_controller.quiesce()
-
-            runtime.set_health_status(True)
-            logging.info(
-                "[Shadow] Engine sleeping, startup probe now passing, waiting for lock"
-            )
-
-            from gpu_memory_service.failover_lock.flock import FlockFailoverLock
-
-            lock_path = os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
-            startup_lock = FlockFailoverLock(lock_path)
-            await startup_lock.acquire(engine_id=f"engine-{shadow_engine_id}")
-            logging.info("[Shadow] Lock acquired, waking engine")
-
-            await handler._quiesce_controller.resume()
-            handler._quiesce_controller.mark_resumed()
-            logging.info("[Shadow] Engine awake, registering with discovery")
-
-        # Register the model with runtime config
-        # Encode workers do NOT register - they're internal workers only
-        # Prefill and decode workers register - frontend detects their role via ModelType
-        if config.disaggregation_mode != DisaggregationMode.ENCODE:
-            await register_model(
-                model_input,
-                model_type,
-                endpoint,
-                config.model,
-                config.served_model_name,
-                context_length=config.max_seq_len,
-                kv_cache_block_size=config.kv_block_size,
-                runtime_config=runtime_config,
-                custom_template_path=config.custom_jinja_template,
-            )
-
-        if config.publish_events_and_metrics:
-            # Initialize and pass in the publisher to the request handler to
-            # publish events and metrics.
-            # Create worker-side publisher for consolidated events if consolidator is enabled
-            # This subscribes to consolidator's ZMQ output and publishes to NATS with worker_id
-            consolidator_publisher = None
-            if consolidator_output_endpoint:
-                # Use the connect endpoint directly (already provided by get_consolidator_endpoints)
-                consolidator_publisher = KvEventPublisher(
-                    endpoint=endpoint,
-                    kv_block_size=config.kv_block_size,
-                    zmq_endpoint=consolidator_output_connect_endpoint,
-                    zmq_topic="",
-                )
-                logging.info(
-                    f"Created worker-side publisher for consolidated events: "
-                    f"subscribing to {consolidator_output_connect_endpoint}, worker_id={endpoint.connection_id()}"
-                )
-
-            async with get_publisher(
-                endpoint,
-                engine,
-                int(endpoint.connection_id()),
-                config.kv_block_size,
-                metrics_labels,
-                component_gauges=component_gauges,
-                zmq_endpoint=trtllm_zmq_bind_endpoint,
-                enable_local_indexer=config.enable_local_indexer,
-                metrics_collector=metrics_collector,
-            ) as publisher:
-                handler.publisher = publisher
-
-                encoder_cache = getattr(handler, "_encoder_cache", None)
-                if encoder_cache is not None:
-                    register_embedding_cache_metrics(
-                        endpoint=endpoint,
-                        cache=encoder_cache,
-                        model_name=model_name_for_metrics,
-                        component_name=config.component,
+                    logging.warning(
+                        f"Failed to initialize TensorRT-LLM Prometheus metrics: {e}"
                     )
+
+            # Register callback for Dynamo component metrics using dedicated registry
+            register_engine_metrics_callback(
+                endpoint=endpoint,
+                registry=DYNAMO_COMPONENT_REGISTRY,
+            )
+            logging.debug("DYNAMO_COMPONENT_REGISTRY callback registered successfully")
+
+            # publisher will be set later if publishing is enabled.
+            handler_config = RequestHandlerConfig(
+                engine=engine,
+                default_sampling_params=default_sampling_params,
+                publisher=None,
+                disaggregation_mode=config.disaggregation_mode,
+                encode_client=encode_client,
+                multimodal_processor=multimodal_processor,
+                generate_endpoint=endpoint,
+                connector=connector,
+                runtime=runtime,  # Pass runtime for graceful shutdown
+                metrics_collector=metrics_collector,
+                kv_block_size=config.kv_block_size,
+                shutdown_event=shutdown_event,
+                encoder_cache_capacity_gb=config.multimodal_embedding_cache_capacity_gb,
+                disable_request_abort=config.disable_request_abort,
+                additional_metrics=additional_metrics,
+                max_seq_len=config.max_seq_len,
+                disagg_machine_id=int(endpoint.connection_id()) % 1021,
+            )
+
+            handler = RequestHandlerFactory().get_request_handler(handler_config)
+            if config.load_format == "gms":
+                _register_memory_routes(runtime, handler)
+
+            if config.gms_shadow_mode and not shadow_standby:
+                await handler._quiesce_controller.quiesce()
+
+                runtime.set_health_status(True)
+                logging.info(
+                    "[Shadow] Engine sleeping, startup probe now passing, waiting for lock"
+                )
+
+                from gpu_memory_service.failover_lock.flock import FlockFailoverLock
+
+                lock_path = os.environ.get(
+                    "FAILOVER_LOCK_PATH", "/shared/failover.lock"
+                )
+                startup_lock = FlockFailoverLock(lock_path)
+                await startup_lock.acquire(engine_id=f"engine-{shadow_engine_id}")
+                logging.info("[Shadow] Lock acquired, waking engine")
+
+                await handler._quiesce_controller.resume()
+                handler._quiesce_controller.mark_resumed()
+                logging.info("[Shadow] Engine awake, registering with discovery")
+
+            # Register the model with runtime config
+            # Encode workers do NOT register - they're internal workers only
+            # Prefill and decode workers register - frontend detects their role via ModelType
+            if config.disaggregation_mode != DisaggregationMode.ENCODE:
+                await register_model(
+                    model_input,
+                    model_type,
+                    endpoint,
+                    config.model,
+                    config.served_model_name,
+                    context_length=config.max_seq_len,
+                    kv_cache_block_size=config.kv_block_size,
+                    runtime_config=runtime_config,
+                    custom_template_path=config.custom_jinja_template,
+                )
+
+            if config.publish_events_and_metrics:
+                # Initialize and pass in the publisher to the request handler to
+                # publish events and metrics.
+                # Create worker-side publisher for consolidated events if consolidator is enabled
+                # This subscribes to consolidator's ZMQ output and publishes to NATS with worker_id
+                consolidator_publisher = None
+                if consolidator_output_endpoint:
+                    # Use the connect endpoint directly (already provided by get_consolidator_endpoints)
+                    consolidator_publisher = KvEventPublisher(
+                        endpoint=endpoint,
+                        kv_block_size=config.kv_block_size,
+                        zmq_endpoint=consolidator_output_connect_endpoint,
+                        zmq_topic="",
+                    )
+                    logging.info(
+                        f"Created worker-side publisher for consolidated events: "
+                        f"subscribing to {consolidator_output_connect_endpoint}, worker_id={endpoint.connection_id()}"
+                    )
+
+                async with get_publisher(
+                    endpoint,
+                    engine,
+                    int(endpoint.connection_id()),
+                    config.kv_block_size,
+                    metrics_labels,
+                    component_gauges=component_gauges,
+                    zmq_endpoint=trtllm_zmq_bind_endpoint,
+                    enable_local_indexer=config.enable_local_indexer,
+                    metrics_collector=metrics_collector,
+                ) as publisher:
+                    handler.publisher = publisher
+
+                    encoder_cache = getattr(handler, "_encoder_cache", None)
+                    if encoder_cache is not None:
+                        register_embedding_cache_metrics(
+                            endpoint=endpoint,
+                            cache=encoder_cache,
+                            model_name=model_name_for_metrics,
+                            component_name=config.component,
+                        )
+                    if shadow_standby:
+                        standby_generate_proxy.set_delegate(handler.generate)
+                        await standby_serve_task
+                    else:
+                        await endpoint.serve_endpoint(
+                            handler.generate,
+                            metrics_labels=metrics_labels,
+                            health_check_payload=health_check_payload,
+                        )
+
+                # Shutdown consolidator publisher if it was created
+                if consolidator_publisher:
+                    consolidator_publisher.shutdown()
+            else:
                 if shadow_standby:
                     standby_generate_proxy.set_delegate(handler.generate)
                     await standby_serve_task
                 else:
                     await endpoint.serve_endpoint(
-                        handler.generate,
-                        metrics_labels=metrics_labels,
-                        health_check_payload=health_check_payload,
+                        handler.generate, health_check_payload=health_check_payload
                     )
-
-            # Shutdown consolidator publisher if it was created
-            if consolidator_publisher:
-                consolidator_publisher.shutdown()
-        else:
-            if shadow_standby:
-                standby_generate_proxy.set_delegate(handler.generate)
-                await standby_serve_task
-            else:
-                await endpoint.serve_endpoint(
-                    handler.generate, health_check_payload=health_check_payload
-                )
     except Exception:
         if standby_serve_task is not None:
             standby_serve_task.cancel()

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -502,6 +502,13 @@ async def init_llm_worker(
         config.disaggregation_mode,
         component_gauges=component_gauges,
     ) as engine:
+        if config.load_format == "gms":
+            from gpu_memory_service.integrations.trtllm import (
+                finalize_pending_gms_write,
+            )
+
+            finalize_pending_gms_write()
+
         # Expose engine to the drain callback installed by main.py (#7319).
         # The callback uses this to poll active request count during shutdown.
         if engine_holder is not None:

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -339,6 +339,16 @@ async def init_llm_worker(
 
     _apply_autotuner_gate(arg_map, config.load_format)
 
+    # Force allreduce_strategy=NCCL on BOTH engines when shadow mode is on.
+    # MNNVL's 180 GiB symmetric VA window cannot coexist with a second
+    # co-located engine on the same GPU set. Applied last so it is not
+    # overwritten by --extra-engine-args or --override-engine-args.
+    if config.load_format == "gms" and config.gms_shadow_mode:
+        from gpu_memory_service.integrations.trtllm.utils import (
+            force_nccl_allreduce_for_shadow,
+        )
+        force_nccl_allreduce_for_shadow(arg_map)
+
     if config.publish_events_and_metrics:
         # 'event_buffer_max_size' is required to enable TRTLLM to publish kv cache events.
         # Add it to kv_cache_config while preserving all settings from YAML

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -544,12 +544,10 @@ async def init_llm_worker(
         from gpu_memory_service.failover_lock.flock import FlockFailoverLock
 
         standby_generate_proxy = _StandbyGenerateProxy(health_check_payload)
-        standby_serve_task = asyncio.create_task(
-            endpoint.serve_endpoint(
-                standby_generate_proxy.generate,
-                metrics_labels=metrics_labels,
-                health_check_payload=health_check_payload,
-            )
+        standby_serve_task = endpoint.serve_endpoint(
+            standby_generate_proxy.generate,
+            metrics_labels=metrics_labels,
+            health_check_payload=health_check_payload,
         )
         await asyncio.sleep(0)
         if standby_serve_task.done():

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -569,8 +569,6 @@ async def init_llm_worker(
         startup_lock = FlockFailoverLock(failover_lock_path)
         while await startup_lock.owner() != "engine-0":
             await asyncio.sleep(0.1)
-        await startup_lock.acquire(engine_id=f"engine-{shadow_engine_id}")
-        logging.info("[Shadow] Lock acquired, starting engine init")
 
     try:
         async with get_llm_engine(

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -537,9 +537,18 @@ async def init_llm_worker(
 
     shadow_engine_id = os.environ.get("ENGINE_ID", "0")
     shadow_standby = config.gms_shadow_mode and shadow_engine_id != "0"
+    primary_shadow_owner = config.gms_shadow_mode and shadow_engine_id == "0"
+    failover_lock_path = os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
     startup_lock = None
     standby_generate_proxy = None
     standby_serve_task = None
+    if primary_shadow_owner:
+        from gpu_memory_service.failover_lock.flock import FlockFailoverLock
+
+        startup_lock = FlockFailoverLock(failover_lock_path)
+        await startup_lock.acquire(engine_id=f"engine-{shadow_engine_id}")
+        logging.info("[Shadow] Primary acquired startup lock, starting engine init")
+
     if shadow_standby:
         from gpu_memory_service.failover_lock.flock import FlockFailoverLock
 
@@ -557,9 +566,9 @@ async def init_llm_worker(
         logging.info(
             "[Shadow] Engine sleeping, startup probe now passing, waiting for lock"
         )
-        startup_lock = FlockFailoverLock(
-            os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
-        )
+        startup_lock = FlockFailoverLock(failover_lock_path)
+        while await startup_lock.owner() != "engine-0":
+            await asyncio.sleep(0.1)
         await startup_lock.acquire(engine_id=f"engine-{shadow_engine_id}")
         logging.info("[Shadow] Lock acquired, starting engine init")
 
@@ -717,27 +726,6 @@ async def init_llm_worker(
             if config.load_format == "gms":
                 _register_memory_routes(runtime, handler)
 
-            if config.gms_shadow_mode and not shadow_standby:
-                await handler._quiesce_controller.quiesce()
-
-                runtime.set_health_status(True)
-                logging.info(
-                    "[Shadow] Engine sleeping, startup probe now passing, waiting for lock"
-                )
-
-                from gpu_memory_service.failover_lock.flock import FlockFailoverLock
-
-                lock_path = os.environ.get(
-                    "FAILOVER_LOCK_PATH", "/shared/failover.lock"
-                )
-                startup_lock = FlockFailoverLock(lock_path)
-                await startup_lock.acquire(engine_id=f"engine-{shadow_engine_id}")
-                logging.info("[Shadow] Lock acquired, waking engine")
-
-                await handler._quiesce_controller.resume()
-                handler._quiesce_controller.mark_resumed()
-                logging.info("[Shadow] Engine awake, registering with discovery")
-
             # Register the model with runtime config
             # Encode workers do NOT register - they're internal workers only
             # Prefill and decode workers register - frontend detects their role via ModelType
@@ -821,3 +809,6 @@ async def init_llm_worker(
             with suppress(asyncio.CancelledError):
                 await standby_serve_task
         raise
+    finally:
+        if startup_lock is not None:
+            await startup_lock.release()

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -550,8 +550,6 @@ async def init_llm_worker(
         logging.info("[Shadow] Primary acquired startup lock, starting engine init")
 
     if shadow_standby:
-        from gpu_memory_service.failover_lock.flock import FlockFailoverLock
-
         standby_generate_proxy = _StandbyGenerateProxy(health_check_payload)
         standby_serve_task = endpoint.serve_endpoint(
             standby_generate_proxy.generate,
@@ -566,9 +564,6 @@ async def init_llm_worker(
         logging.info(
             "[Shadow] Engine sleeping, startup probe now passing, waiting for lock"
         )
-        startup_lock = FlockFailoverLock(failover_lock_path)
-        while await startup_lock.owner() != "engine-0":
-            await asyncio.sleep(0.1)
 
     try:
         async with get_llm_engine(

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -233,11 +233,19 @@ async def init_llm_worker(
     if config.load_format == "gms":
         try:
             from gpu_memory_service.integrations.trtllm import setup_gms
+            from gpu_memory_service.integrations.trtllm.utils import (
+                configure_gms_lock_mode,
+            )
         except ImportError as exc:
             raise RuntimeError(
                 "gpu-memory-service is required for --load-format gms. "
                 "Install or update the package."
             ) from exc
+        if config.gms_shadow_mode:
+            # Shared flag read by both vLLM and TRT-LLM GMS integrations; set
+            # early so downstream code sees shadow mode before engine init.
+            os.environ["DYN_GMS_SHADOW_MODE"] = "1"
+            configure_gms_lock_mode(model_loader_extra_config)
         setup_gms(model_loader_extra_config)
         logging.info(
             "TRT-LLM GMS integration enabled (extra=%s)", model_loader_extra_config

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -289,12 +289,29 @@ async def init_llm_worker(
     arg_map["load_format"] = engine_load_format
 
     # Enable sleep_config when GMS manages weights — required for GMS
-    # unmap/remap. Conditional because SleepConfig contains unpicklable
-    # lambdas that break MPI-based multi-rank distribution.
+    # unmap/remap. SleepConfig's default restore_modes is a defaultdict whose
+    # default_factory is a lambda defined inside
+    # SleepConfig._make_defaulted_restore_modes; mpi4py cannot pickle local
+    # lambdas, which breaks the TP>1 MPI worker bootstrap. py_executor_creator
+    # later indexes `sleep_config.restore_modes[MODEL_ENGINE_MAIN]` so a plain
+    # dict is not enough — we must keep the defaultdict behaviour but swap the
+    # lambda for a picklable `functools.partial` callable.
     if config.load_format == "gms":
-        from tensorrt_llm.llmapi.llm_args import SleepConfig
+        from collections import defaultdict
+        from functools import partial
 
-        arg_map["sleep_config"] = SleepConfig()
+        from tensorrt_llm._torch.virtual_memory import RestoreMode
+        from tensorrt_llm.llmapi.llm_args import SleepConfig, prefer_pinned
+
+        sleep_config = SleepConfig()
+        default_mode = (
+            RestoreMode.PINNED if prefer_pinned() else RestoreMode.CPU
+        )
+        sleep_config.restore_modes = defaultdict(
+            partial(RestoreMode, default_mode.value),
+            dict(sleep_config.restore_modes),
+        )
+        arg_map["sleep_config"] = sleep_config
 
     # Add guided decoding backend if specified
     if config.guided_decoding_backend is not None:

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -502,13 +502,6 @@ async def init_llm_worker(
         config.disaggregation_mode,
         component_gauges=component_gauges,
     ) as engine:
-        if config.load_format == "gms":
-            from gpu_memory_service.integrations.trtllm import (
-                finalize_pending_gms_write,
-            )
-
-            finalize_pending_gms_write()
-
         # Expose engine to the drain callback installed by main.py (#7319).
         # The callback uses this to poll active request count during shutdown.
         if engine_holder is not None:

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -304,9 +304,7 @@ async def init_llm_worker(
         from tensorrt_llm.llmapi.llm_args import SleepConfig, prefer_pinned
 
         sleep_config = SleepConfig()
-        default_mode = (
-            RestoreMode.PINNED if prefer_pinned() else RestoreMode.CPU
-        )
+        default_mode = RestoreMode.PINNED if prefer_pinned() else RestoreMode.CPU
         sleep_config.restore_modes = defaultdict(
             partial(RestoreMode, default_mode.value),
             dict(sleep_config.restore_modes),
@@ -347,6 +345,7 @@ async def init_llm_worker(
         from gpu_memory_service.integrations.trtllm.utils import (
             force_nccl_allreduce_for_shadow,
         )
+
         force_nccl_allreduce_for_shadow(arg_map)
 
     if config.publish_events_and_metrics:
@@ -649,6 +648,30 @@ async def init_llm_worker(
             disagg_machine_id=int(endpoint.connection_id()) % 1021,
         )
 
+        handler = RequestHandlerFactory().get_request_handler(handler_config)
+        if config.load_format == "gms":
+            _register_memory_routes(runtime, handler)
+
+        if config.gms_shadow_mode:
+            await handler._quiesce_controller.quiesce()
+
+            runtime.set_health_status(True)
+            logging.info(
+                "[Shadow] Engine sleeping, startup probe now passing, waiting for lock"
+            )
+
+            from gpu_memory_service.failover_lock.flock import FlockFailoverLock
+
+            lock_path = os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
+            engine_id = os.environ.get("ENGINE_ID", "0")
+            lock = FlockFailoverLock(lock_path)
+            await lock.acquire(engine_id=f"engine-{engine_id}")
+            logging.info("[Shadow] Lock acquired, waking engine")
+
+            await handler._quiesce_controller.resume()
+            handler._quiesce_controller.mark_resumed()
+            logging.info("[Shadow] Engine awake, registering with discovery")
+
         # Register the model with runtime config
         # Encode workers do NOT register - they're internal workers only
         # Prefill and decode workers register - frontend detects their role via ModelType
@@ -711,10 +734,7 @@ async def init_llm_worker(
                 enable_local_indexer=config.enable_local_indexer,
                 metrics_collector=metrics_collector,
             ) as publisher:
-                handler_config.publisher = publisher
-                handler = RequestHandlerFactory().get_request_handler(handler_config)
-                if config.load_format == "gms":
-                    _register_memory_routes(runtime, handler)
+                handler.publisher = publisher
 
                 encoder_cache = getattr(handler, "_encoder_cache", None)
                 if encoder_cache is not None:
@@ -734,9 +754,6 @@ async def init_llm_worker(
             if consolidator_publisher:
                 consolidator_publisher.shutdown()
         else:
-            handler = RequestHandlerFactory().get_request_handler(handler_config)
-            if config.load_format == "gms":
-                _register_memory_routes(runtime, handler)
             await endpoint.serve_endpoint(
                 handler.generate, health_check_payload=health_check_payload
             )

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -56,8 +56,10 @@ func buildFailoverPod(
 	switch backendFramework {
 	case BackendFrameworkVLLM:
 		applyVLLMOverrides(podSpec, numberOfNodes)
+	case BackendFrameworkTRTLLM:
+		applyTRTLLMOverrides(podSpec, numberOfNodes)
 	default:
-		return fmt.Errorf("failover is currently supported only for vLLM (detected: %s)", backendFramework)
+		return fmt.Errorf("failover is not supported for backend %q (only vllm and trtllm)", backendFramework)
 	}
 
 	return nil

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -93,11 +93,11 @@ func TestBuildFailoverPod_EmptyContainers(t *testing.T) {
 	assert.Contains(t, err.Error(), "at least one container")
 }
 
-func TestBuildFailoverPod_RejectsNonVLLM(t *testing.T) {
+func TestBuildFailoverPod_RejectsSGLang(t *testing.T) {
 	ps := failoverPodSpec()
 	err := buildFailoverPod(&ps, 1, BackendFrameworkSGLang)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "currently supported only for vLLM")
+	assert.Contains(t, err.Error(), "sglang")
 }
 
 func TestBuildFailoverPod_EngineEnvVars(t *testing.T) {
@@ -195,6 +195,98 @@ func TestBuildFailoverPod_MultinodeNNODES(t *testing.T) {
 func TestBuildFailoverPod_SingleNodeNoNNODES(t *testing.T) {
 	ps := failoverPodSpec()
 	err := buildFailoverPod(&ps, 1, BackendFrameworkVLLM)
+	require.NoError(t, err)
+
+	for i := range 2 {
+		env := envToMap(ps.Containers[i].Env)
+		_, has := env["NNODES"]
+		assert.False(t, has, "engine-%d should not have NNODES for single-node", i)
+	}
+}
+
+// --- TRT-LLM failover ---
+
+func trtllmFailoverPodSpec() corev1.PodSpec {
+	ps := failoverPodSpec()
+	// Swap the entrypoint so the main container looks like a TRT-LLM worker.
+	ps.Containers[0].Command = []string{"python3", "-m", "dynamo.trtllm"}
+	return ps
+}
+
+func TestBuildFailoverPod_TRTLLM_TwoEnginesPlusSidecar(t *testing.T) {
+	ps := trtllmFailoverPodSpec()
+	err := buildFailoverPod(&ps, 1, BackendFrameworkTRTLLM)
+	require.NoError(t, err)
+
+	assert.Len(t, ps.Containers, 3)
+	assert.Equal(t, "engine-0", ps.Containers[0].Name)
+	assert.Equal(t, "engine-1", ps.Containers[1].Name)
+	assert.Equal(t, "frontend-sidecar", ps.Containers[2].Name)
+}
+
+func TestBuildFailoverPod_TRTLLM_EngineEnvVars(t *testing.T) {
+	ps := trtllmFailoverPodSpec()
+	err := buildFailoverPod(&ps, 1, BackendFrameworkTRTLLM)
+	require.NoError(t, err)
+
+	for i := range 2 {
+		engine := ps.Containers[i]
+		env := envToMap(engine.Env)
+		assert.Equal(t, strconv.Itoa(i), env["ENGINE_ID"], "engine-%d ENGINE_ID", i)
+		assert.Equal(t, fmt.Sprintf("engine-%d", i), env["CONTAINER_NAME"], "engine-%d CONTAINER_NAME", i)
+		assert.Equal(t, failoverLockFile, env["FAILOVER_LOCK_PATH"], "engine-%d FAILOVER_LOCK_PATH", i)
+		assert.Equal(t, "true", env["DYN_TRTLLM_GMS_SHADOW_MODE"], "engine-%d shadow mode", i)
+		assert.Equal(t, "notready", env["DYN_SYSTEM_STARTING_HEALTH_STATUS"], "engine-%d starting health", i)
+		assert.Equal(t, "true", env["DYN_SYSTEM_ENABLED"], "engine-%d system enabled", i)
+
+		// vLLM-specific env vars must not leak into TRT-LLM engines.
+		_, hasVLLMShadow := env["DYN_VLLM_GMS_SHADOW_MODE"]
+		assert.False(t, hasVLLMShadow, "engine-%d should not have DYN_VLLM_GMS_SHADOW_MODE", i)
+		_, hasNixl := env["VLLM_NIXL_SIDE_CHANNEL_PORT"]
+		assert.False(t, hasNixl, "engine-%d should not have VLLM_NIXL_SIDE_CHANNEL_PORT", i)
+	}
+}
+
+func TestBuildFailoverPod_TRTLLM_StaggeredMasterPort(t *testing.T) {
+	ps := trtllmFailoverPodSpec()
+	err := buildFailoverPod(&ps, 1, BackendFrameworkTRTLLM)
+	require.NoError(t, err)
+
+	engine0Env := envToMap(ps.Containers[0].Env)
+	engine1Env := envToMap(ps.Containers[1].Env)
+	assert.Equal(t, "29500", engine0Env["MASTER_PORT"], "engine-0 MASTER_PORT")
+	assert.Equal(t, "29600", engine1Env["MASTER_PORT"], "engine-1 MASTER_PORT")
+}
+
+func TestBuildFailoverPod_TRTLLM_StaggeredSystemPorts(t *testing.T) {
+	ps := trtllmFailoverPodSpec()
+	err := buildFailoverPod(&ps, 1, BackendFrameworkTRTLLM)
+	require.NoError(t, err)
+
+	for i := range 2 {
+		engine := ps.Containers[i]
+		env := envToMap(engine.Env)
+		assert.Equal(t, strconv.Itoa(commonconsts.DynamoSystemPort+i), env["DYN_SYSTEM_PORT"])
+		require.Len(t, engine.Ports, 1)
+		assert.Equal(t, int32(commonconsts.DynamoSystemPort+i), engine.Ports[0].ContainerPort)
+		assert.Equal(t, fmt.Sprintf("system-%d", i), engine.Ports[0].Name)
+	}
+}
+
+func TestBuildFailoverPod_TRTLLM_MultinodeNNODES(t *testing.T) {
+	ps := trtllmFailoverPodSpec()
+	err := buildFailoverPod(&ps, 4, BackendFrameworkTRTLLM)
+	require.NoError(t, err)
+
+	for i := range 2 {
+		env := envToMap(ps.Containers[i].Env)
+		assert.Equal(t, "4", env["NNODES"], "engine-%d should have NNODES=4", i)
+	}
+}
+
+func TestBuildFailoverPod_TRTLLM_SingleNodeNoNNODES(t *testing.T) {
+	ps := trtllmFailoverPodSpec()
+	err := buildFailoverPod(&ps, 1, BackendFrameworkTRTLLM)
 	require.NoError(t, err)
 
 	for i := range 2 {

--- a/deploy/operator/internal/dynamo/failover_trtllm.go
+++ b/deploy/operator/internal/dynamo/failover_trtllm.go
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// applyTRTLLMOverrides — TRT-LLM failover env injection and port staggering.
+//
+// TRT-LLM does not expose a --master-port CLI flag; torch.distributed picks
+// up MASTER_PORT from the environment. When two engine containers share a
+// pod network namespace and use TP>1, both torch.distributed groups would
+// otherwise collide on the default 29500 TCP store.
+//
+// Env injected per engine:
+//
+//	DYN_TRTLLM_GMS_SHADOW_MODE=true       (contract for TRT-LLM shadow mode;
+//	                                       not yet consumed by
+//	                                       components/src/dynamo/trtllm or
+//	                                       lib/gpu_memory_service/integrations/trtllm.
+//	                                       Mirrors DYN_VLLM_GMS_SHADOW_MODE.)
+//	MASTER_PORT=<base + engineID*stride>  (torch.distributed TCP store)
+//	NNODES=<numberOfNodes>                (multinode only)
+//
+// TODOs (not blocking this change):
+//   - DYN_KVBM_LEADER_ZMQ_PUB_PORT (default 56001) collides when KVBM
+//     connector is enabled for both engines — stagger when that path ships
+//     under failover.
+//   - NIXL side-channel port for TRT-LLM cross-engine transfers is not yet
+//     exposed via a knob; revisit if we run disagg/multi-engine NIXL under
+//     failover.
+
+package dynamo
+
+import (
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	trtllmMasterPortBase   = 29500
+	trtllmMasterPortStride = 100
+)
+
+func applyTRTLLMOverrides(podSpec *corev1.PodSpec, numberOfNodes int32) {
+	for i := range podSpec.Containers {
+		c := &podSpec.Containers[i]
+		if !strings.HasPrefix(c.Name, "engine-") {
+			continue
+		}
+
+		engineID, _ := strconv.Atoi(strings.TrimPrefix(c.Name, "engine-"))
+
+		c.Env = append(c.Env,
+			corev1.EnvVar{Name: "DYN_TRTLLM_GMS_SHADOW_MODE", Value: "true"},
+			corev1.EnvVar{
+				Name:  "MASTER_PORT",
+				Value: strconv.Itoa(trtllmMasterPortBase + engineID*trtllmMasterPortStride),
+			},
+		)
+
+		if numberOfNodes > 1 {
+			c.Env = append(c.Env,
+				corev1.EnvVar{Name: "NNODES", Value: strconv.Itoa(int(numberOfNodes))},
+			)
+		}
+	}
+}

--- a/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
+++ b/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# TRT-LLM EAGLE3 shadow-failover sample DGD (nscale).
+#
+# Image: REPLACE_WITH_TRTLLM_RUNTIME_TAG — substitute with the tag
+# produced by the eagle3-local-impl docker build once it completes.
+#
+# Failover behavior:
+#   - Operator clones the worker into engine-0 (active) + engine-1 (standby)
+#     sharing 1 GPU via DRA.
+#   - DYN_TRTLLM_GMS_SHADOW_MODE=true is injected by the operator.
+#   - Each engine reads ENGINE_ID and sets gms_lock_mode accordingly
+#     (engine-0: rw_or_ro, engine-1: ro).
+#   - When engine-0 dies, engine-1 acquires the failover flock and resumes.
+#
+# Deploy: `kubectl apply -n schwinns -f examples/backends/trtllm/deploy/agg_failover_eagle.yaml`
+#
+# Decoding config shape verified against TensorRT-LLM HEAD 497b07d6c:
+#   - tensorrt_llm/llmapi/llm_args.py:1025-1026   -> decoding_type: "Eagle3"
+#   - tensorrt_llm/llmapi/llm_args.py:649-653     -> speculative_model (AliasChoices
+#                                                   also accepts speculative_model_dir)
+#   - tensorrt_llm/llmapi/llm_args.py:885-891     -> eagle3_one_model default=True
+#   - tests/unittest/_torch/speculative/test_eagle3.py:201-209 (reference usage)
+#
+# Attention backend: TRT-LLM _torch default is "TRTLLM" (tensorrt_llm/_torch/
+# model_config.py:98), NOT FlashInfer, so the B200 FlashInfer + shadow-init
+# crash we hit on vLLM does not apply here. No attn_backend override needed.
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: trtllm-agg-failover-eagle
+  annotations:
+    nvidia.com/dynamo-kube-discovery-mode: container
+spec:
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        imagePullSecrets:
+          - name: ngc-secret
+        mainContainer:
+          image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
+    TrtllmWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      gpuMemoryService:
+        enabled: true
+      failover:
+        enabled: true
+      extraPodSpec:
+        imagePullSecrets:
+          - name: ngc-secret
+        mainContainer:
+          image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
+          workingDir: /workspace/examples/backends/trtllm
+          command:
+            - python3
+            - -m
+            - dynamo.trtllm
+          args:
+            - --model
+            - meta-llama/Llama-3.1-8B-Instruct
+            - --gpus-per-node
+            - "1"
+            - --load-format
+            - gms
+            # Enables ENGINE_ID -> gms_lock_mode plumbing for shadow failover.
+            - --gms-shadow-mode
+            # Leave headroom for cuda-graph capture on top of weights + KV.
+            - --free-gpu-memory-fraction
+            - "0.75"
+            - --max-seq-len
+            - "256"
+            - --max-num-tokens
+            - "256"
+            # EAGLE3 one-engine: target + draft live under a single nn.Module,
+            # so a single ModelLoader.load call covers both models and the
+            # existing GMS one-engine patch handles it without change.
+            - --override-engine-args
+            - '{"speculative_config":{"decoding_type":"Eagle3","speculative_model":"yuhuili/EAGLE3-LLaMA3.1-Instruct-8B","max_draft_len":3,"eagle3_one_model":true}}'
+          env:
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /home/dynamo/.cache/huggingface
+        volumes:
+          - name: hf-cache
+            persistentVolumeClaim:
+              claimName: shared-model-cache
+        nodeSelector:
+          gds-test: "true"
+          nvidia.com/gpu.present: "true"
+        tolerations:
+          - effect: NoSchedule
+            key: nvidia.com/gpu
+            operator: Exists
+          - effect: NoSchedule
+            key: dra
+            operator: Exists

--- a/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
+++ b/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
@@ -92,6 +92,24 @@ spec:
           env:
             - name: HF_HOME
               value: /home/dynamo/.cache/huggingface
+            # TRT-LLM's MPI-based executor spawns worker ranks via fork/spawn and
+            # pickles the LLM kwargs into them. With --load-format gms, Dynamo
+            # attaches a SleepConfig that contains unpicklable `lambda` defaults
+            # (SleepConfig._make_defaulted_restore_modes). Force the single-process
+            # executor to keep everything in one interpreter and skip the pickle.
+            - name: TLLM_WORKER_USE_SINGLE_PROCESS
+              value: "1"
+            # OpenMPI transport safety: single-container run, no RDMA.
+            - name: MPI4PY_MPIABI
+              value: openmpi
+            - name: OMPI_MCA_coll_ucc_enable
+              value: "0"
+            - name: OMPI_MCA_coll_hcoll_enable
+              value: "0"
+            - name: OMPI_MCA_pml
+              value: ob1
+            - name: OMPI_MCA_btl
+              value: "self,vader,tcp"
           volumeMounts:
             - name: hf-cache
               mountPath: /home/dynamo/.cache/huggingface

--- a/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
+++ b/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
@@ -44,7 +44,7 @@ spec:
           - name: ngc-secret
         mainContainer:
           image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
-    TrtllmWorker:
+    TRTLLMWorker:
       envFromSecret: hf-token-secret
       componentType: worker
       replicas: 1

--- a/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
+++ b/examples/backends/trtllm/deploy/agg_failover_eagle.yaml
@@ -108,8 +108,12 @@ spec:
               value: "0"
             - name: OMPI_MCA_pml
               value: ob1
+            # vader (shared-memory BTL) segfaults in
+            # ompi_dpm_connect_accept -> mca_btl_vader_poll_handle_frag on
+            # co-located engines. Drop it; self+tcp is enough for the MPI
+            # connect/accept handshake between the two engine containers.
             - name: OMPI_MCA_btl
-              value: "self,vader,tcp"
+              value: "self,tcp"
           volumeMounts:
             - name: hf-cache
               mountPath: /home/dynamo/.cache/huggingface

--- a/lib/gpu_memory_service/integrations/trtllm/__init__.py
+++ b/lib/gpu_memory_service/integrations/trtllm/__init__.py
@@ -24,8 +24,10 @@ from gpu_memory_service.integrations.common.utils import (
     get_gms_lock_mode as _resolve_lock_mode,
 )
 from gpu_memory_service.integrations.trtllm.model_loader import (
+    finalize_pending_gms_write,
     get_gms_lock_mode,
     patch_model_loader,
+    set_delay_commit_until_engine_init,
     set_gms_enabled,
     set_gms_lock_mode,
 )
@@ -36,16 +38,22 @@ from gpu_memory_service.integrations.trtllm.mpi_bootstrap import (
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["setup_gms", "get_gms_lock_mode"]
+__all__ = ["setup_gms", "get_gms_lock_mode", "finalize_pending_gms_write"]
 
 
 def setup_gms(model_loader_extra_config: dict[str, Any] | None = None) -> None:
     """Set up GMS integration for TensorRT-LLM. Call once before creating the engine."""
     extra = model_loader_extra_config or {}
     lock_mode = _resolve_lock_mode(extra)
+    delay_commit_until_engine_init = extra.get(
+        "gms_delay_commit_until_engine_init", False
+    )
+    if not isinstance(delay_commit_until_engine_init, bool):
+        raise ValueError("gms_delay_commit_until_engine_init must be a boolean")
 
     set_gms_enabled(True)
     set_gms_lock_mode(lock_mode)
+    set_delay_commit_until_engine_init(delay_commit_until_engine_init)
 
     patch_empty_cache()
     patch_model_loader()
@@ -57,4 +65,8 @@ def setup_gms(model_loader_extra_config: dict[str, Any] | None = None) -> None:
     set_extra_config(extra)
     install_mpi_worker_bootstrap()
 
-    logger.info("[GMS] TensorRT-LLM integration enabled (mode=%s)", lock_mode)
+    logger.info(
+        "[GMS] TensorRT-LLM integration enabled (mode=%s, delay_commit_until_engine_init=%s)",
+        lock_mode,
+        delay_commit_until_engine_init,
+    )

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -36,6 +36,8 @@ _model_loader_patched = False
 _gms_enabled = False
 _gms_lock_mode = RequestedLockType.RW_OR_RO
 _last_imported_weights_bytes: int = 0
+_delay_commit_until_engine_init = False
+_pending_gms_write: tuple["GMSClientMemoryManager", torch.nn.Module] | None = None
 
 
 def set_gms_enabled(enabled: bool) -> None:
@@ -48,12 +50,35 @@ def set_gms_lock_mode(mode: RequestedLockType) -> None:
     _gms_lock_mode = mode
 
 
+def set_delay_commit_until_engine_init(enabled: bool) -> None:
+    global _delay_commit_until_engine_init
+    _delay_commit_until_engine_init = enabled
+
+
 def get_gms_lock_mode() -> RequestedLockType:
     return _gms_lock_mode
 
 
 def get_imported_weights_bytes() -> int:
     """Return total bytes of weights imported/published by the last model load."""
+    return _last_imported_weights_bytes
+
+
+def finalize_pending_gms_write() -> int:
+    """Publish a delayed TRT-LLM GMS writer mapping in the current process."""
+    global _last_imported_weights_bytes, _pending_gms_write
+
+    if _pending_gms_write is None:
+        logger.debug("[GMS] TRT-LLM delayed publish: no pending writer in this process")
+        return 0
+
+    gms_client, model = _pending_gms_write
+    _pending_gms_write = None
+    _last_imported_weights_bytes = finalize_gms_write(gms_client, model)
+    logger.info(
+        "[GMS] TRT-LLM RW: published %.2f GiB after delayed engine-init finalize",
+        _last_imported_weights_bytes / (1 << 30),
+    )
     return _last_imported_weights_bytes
 
 
@@ -153,8 +178,8 @@ def _gms_load_inner(
 def _load_rw(
     self, checkpoint_dir, checkpoint_loader, gms_client, device_index, original_load
 ):
-    """RW path: load weights from disk into the GMS memory pool, then commit."""
-    global _last_imported_weights_bytes
+    """RW path: load weights from disk into the GMS memory pool, then publish."""
+    global _last_imported_weights_bytes, _pending_gms_write
 
     target_device = torch.device("cuda", device_index)
 
@@ -164,6 +189,18 @@ def _load_rw(
         )
         _move_untracked_params(model, gms_client, target_device)
         torch.cuda.empty_cache()
+
+    if _delay_commit_until_engine_init:
+        if _pending_gms_write is not None:
+            raise RuntimeError(
+                "TRT-LLM delayed GMS publish already pending in this process"
+            )
+        _pending_gms_write = (gms_client, model)
+        logger.warning(
+            "[GMS] TRT-LLM delayed weight publish enabled; deferring finalize_gms_write() "
+            "until engine init completes. Weights stay mapped RW in this process."
+        )
+        return model, moe_load_balancer
 
     _last_imported_weights_bytes = finalize_gms_write(gms_client, model)
 

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -178,17 +178,147 @@ def _gms_load_inner(
 def _load_rw(
     self, checkpoint_dir, checkpoint_loader, gms_client, device_index, original_load
 ):
-    """RW path: load weights from disk into the GMS memory pool, then publish."""
+    """RW path: preserve TRT-LLM's native split and place only weights in GMS."""
     global _last_imported_weights_bytes, _pending_gms_write
 
+    import tensorrt_llm._torch.pyexecutor.model_loader as _trt_loader
+
+    del original_load
+
+    config = self._load_and_validate_config(checkpoint_dir, checkpoint_loader)
+    load_format = self.llm_args.load_format
     target_device = torch.device("cuda", device_index)
 
-    with gms_use_mem_pool("weights", target_device):
-        model, moe_load_balancer = original_load(
-            self, checkpoint_dir, checkpoint_loader
+    with _trt_loader.timing(
+        "Model init total"
+    ), _trt_loader.maybe_create_moe_load_balancer(
+        config, self.mapping
+    ) as moe_load_balancer:
+        try:
+            config_copy = copy.deepcopy(config)
+            with _trt_loader.MetaInitMode():
+                model = _trt_loader.AutoModelForCausalLM.from_config(config_copy)
+            config = config_copy
+            is_meta_init = True
+        except Exception:
+            logger.info("Fallback to regular model init", exc_info=True)
+            model = _trt_loader.AutoModelForCausalLM.from_config(config)
+            is_meta_init = False
+
+        memo = {}
+
+        def allocate_buffer_on_cuda(t: torch.Tensor, memo=memo):
+            if t not in memo:
+                if t.device == torch.device("meta"):
+                    cuda_t = torch.empty_like(t, device="cuda")
+                else:
+                    cuda_t = t.cuda()
+                memo[t] = cuda_t
+                memo[cuda_t] = cuda_t
+            return memo[t]
+
+        _trt_loader._apply_to_buffers_only(model, allocate_buffer_on_cuda)
+
+        need_initialized_weights = load_format not in (
+            _trt_loader.LoadFormat.AUTO,
+            _trt_loader.LoadFormat.DUMMY,
         )
-        _move_untracked_params(model, gms_client, target_device)
-        torch.cuda.empty_cache()
+
+        def allocate_weights_on_cuda(t: torch.Tensor, memo=memo):
+            if t not in memo:
+                cuda_t = torch.empty_like(t, device="cuda")
+                if t.device != torch.device("meta") and (
+                    need_initialized_weights or is_meta_init
+                ):
+                    cuda_t.copy_(t)
+                memo[t] = cuda_t
+                memo[cuda_t] = cuda_t
+            return memo[t]
+
+        with gms_use_mem_pool("weights", target_device):
+            model._apply(allocate_weights_on_cuda)
+
+        model.to("cuda")
+        del memo
+
+        rank_model_storage = _trt_loader.get_rank_model_storage(model)
+        logger.info(
+            "Use %.2f GB for model weights.",
+            rank_model_storage / (1024**3),
+        )
+
+        if load_format == _trt_loader.LoadFormat.AUTO:
+            if hasattr(model, "llm_checkpoint_dir"):
+                weights = checkpoint_loader.load_weights(
+                    model.llm_checkpoint_dir, mapping=self.mapping
+                )
+            else:
+                weights = checkpoint_loader.load_weights(
+                    checkpoint_dir, mapping=self.mapping
+                )
+
+            self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
+                model, config
+            )
+            self._call_load_weights(model.load_weights, weights, self.weight_mapper)
+
+            if (
+                self.spec_config is not None
+                and self.spec_config.spec_dec_mode.need_load_draft_weights()
+            ):
+                weights = checkpoint_loader.load_weights(
+                    self.spec_config.speculative_model,
+                    mapping=self.mapping,
+                )
+
+                draft_model_arch = model.draft_config.pretrained_config.architectures[0]
+                draft_weight_mapper = _trt_loader.AutoCheckpointMapper.get(
+                    checkpoint_loader.checkpoint_format,
+                    draft_model_arch,
+                )
+                draft_weight_mapper.init_model_and_config(
+                    model.draft_model, model.draft_config
+                )
+
+                self._call_load_weights(
+                    model.load_draft_weights,
+                    weights,
+                    draft_weight_mapper,
+                )
+
+        elif load_format == _trt_loader.LoadFormat.DUMMY:
+            self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
+                model, config
+            )
+            _trt_loader.initialize_dummy_weights(model)
+            if (
+                self.spec_config is not None
+                and self.spec_config.spec_dec_mode.need_load_draft_weights()
+            ):
+                model.draft_model.load_weights_from_target_model(model)
+
+        elif load_format == _trt_loader.LoadFormat.VISION_ONLY:
+            logger.info(
+                "LoadFormat.VISION_ONLY: skipping weight loading; using preloaded vision weights."
+            )
+
+        else:
+            raise NotImplementedError(f"No load support for load format: {load_format}")
+
+        for module in model.modules():
+            if hasattr(module, "post_load_weights") and not getattr(
+                module, "_weights_removed", False
+            ):
+                module.post_load_weights()
+
+        if isinstance(moe_load_balancer, _trt_loader.MoeLoadBalancer):
+            moe_load_balancer.register_weight_slots_after_to_cuda()
+            moe_load_balancer.finalize_model()
+
+        _move_untracked_params(model, gms_client, device_index)
+        torch.cuda.current_stream().synchronize()
+
+    torch.cuda.empty_cache()
 
     if _delay_commit_until_engine_init:
         if _pending_gms_write is not None:
@@ -312,40 +442,43 @@ def _ptr_in_gms(gms_client: "GMSClientMemoryManager", ptr: int) -> bool:
 def _move_untracked_params(
     model: torch.nn.Module,
     gms_client: "GMSClientMemoryManager",
-    target_device: torch.device,
+    device_index: int,
 ) -> None:
-    """Move CUDA parameters that were allocated outside the GMS pool into it.
+    """Move CUDA parameters that still live outside GMS into GMS-backed mappings.
 
-    TRT-LLM may allocate some parameters outside the pluggable-allocator scope.
-    This ensures all weight tensors end up tracked by GMS before we commit.
+    TRT-LLM's native load split should keep non-weight CUDA tensors outside GMS.
+    This is a late mop-up for parameters that were replaced or allocated after
+    the main weight-allocation block.
     """
     from gpu_memory_service.client.torch.module import _iter_module_tensors
     from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
 
-    device_index = (
-        torch.cuda.current_device()
-        if target_device.index is None
-        else int(target_device.index)
-    )
-    seen: set[int] = set()
+    storage_bases: dict[int, int] = {}
 
     with torch.no_grad():
         for _name, tensor, tensor_type in _iter_module_tensors(model):
             if tensor_type != "parameter" or tensor is None or not tensor.is_cuda:
                 continue
-            storage_ptr = tensor.storage().data_ptr()
-            if storage_ptr in seen:
-                continue
-            seen.add(storage_ptr)
 
-            if _ptr_in_gms(gms_client, int(tensor.data_ptr())):
+            storage_ptr = int(tensor.storage().data_ptr())
+            data_ptr = int(tensor.data_ptr())
+
+            if _ptr_in_gms(gms_client, data_ptr):
                 continue
 
-            # Allocate a new mapping and copy the tensor into it
-            nbytes = _storage_nbytes(tensor)
-            base_va = gms_client.create_mapping(size=nbytes, tag="weights")
+            base_va = storage_bases.get(storage_ptr)
+            if base_va is None:
+                base_va = int(
+                    gms_client.create_mapping(
+                        size=_parameter_storage_nbytes(tensor),
+                        tag="weights",
+                    )
+                )
+                storage_bases[storage_ptr] = base_va
+
+            offset_bytes = data_ptr - storage_ptr
             replacement = _tensor_from_pointer(
-                int(base_va),
+                base_va + offset_bytes,
                 list(tensor.shape),
                 list(tensor.stride()),
                 tensor.dtype,
@@ -353,6 +486,19 @@ def _move_untracked_params(
             )
             replacement.copy_(tensor)
             tensor.data = replacement
+
+
+def _parameter_storage_nbytes(tensor: torch.Tensor) -> int:
+    storage = tensor.untyped_storage() if hasattr(tensor, "untyped_storage") else None
+    if storage is None:
+        storage = tensor.storage()
+
+    nbytes = getattr(storage, "nbytes", None)
+    if callable(nbytes):
+        return int(nbytes())
+    if nbytes is not None:
+        return int(nbytes)
+    return _storage_nbytes(tensor)
 
 
 def _storage_nbytes(tensor: torch.Tensor) -> int:

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -203,6 +203,15 @@ def _load_ro(self, checkpoint_dir, checkpoint_loader, gms_client, device_index):
         if hasattr(model, "post_load_weights"):
             model.post_load_weights()
 
+        # Pre-bind shared submodules for speculative one-engine draft models.
+        # EAGLE3 / MTP / draft_target_one_model leave the draft's embed_tokens
+        # (and optionally lm_head) as None in MetaInitMode; they are normally
+        # bound via draft.load_weights_from_target_model(target) during disk
+        # load. The GMS metadata was registered after that binding, so the
+        # qualified names traverse draft.*.embed_tokens.weight. Pre-bind so
+        # materialize can resolve those paths.
+        _prebind_shared_draft_submodules(model)
+
         materialize_module_from_gms(gms_client, model, device_index=device_index)
         _last_imported_weights_bytes = int(gms_client.total_bytes)
 
@@ -224,6 +233,35 @@ def _load_ro(self, checkpoint_dir, checkpoint_loader, gms_client, device_index):
         torch.cuda.current_stream().synchronize()
 
     return model, moe_load_balancer
+
+
+def _prebind_shared_draft_submodules(model: torch.nn.Module) -> None:
+    """Share target's embed_tokens/lm_head into the draft before materialize.
+
+    Mirrors the shape of ``load_weights_from_target_model`` for the classes
+    under ``tensorrt_llm._torch.models.modeling_speculative`` but at the
+    module level (not at the parameter level) so the GMS RO walk can resolve
+    ``draft_model.model.embed_tokens.weight``-style qualified names.
+    """
+    draft = getattr(model, "draft_model", None)
+    if draft is None:
+        return
+    target_inner = getattr(model, "model", None)
+    if target_inner is None:
+        return
+
+    draft_inner = getattr(draft, "model", draft)
+    if (
+        getattr(draft_inner, "embed_tokens", None) is None
+        and getattr(target_inner, "embed_tokens", None) is not None
+    ):
+        draft_inner.embed_tokens = target_inner.embed_tokens
+
+    if (
+        getattr(draft, "lm_head", None) is None
+        and getattr(model, "lm_head", None) is not None
+    ):
+        draft.lm_head = model.lm_head
 
 
 def _ptr_in_gms(gms_client: "GMSClientMemoryManager", ptr: int) -> bool:

--- a/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
+++ b/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
@@ -19,6 +19,7 @@ is patched before TRT-LLM invokes it.
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
 import os
@@ -38,12 +39,14 @@ _PROPAGATED_ENV_VARS: tuple[str, ...] = (
     _ENABLED_ENV,
     "DYN_GMS_SHADOW_MODE",
     "ENGINE_ID",
+    "FAILOVER_LOCK_PATH",
     "GMS_SOCKET_DIR",
 )
 
 _extra_config_json: Optional[str] = None
 _bootstrap_installed = False
 _executor_finalize_hook_installed = False
+_shadow_activation_fd: int | None = None
 
 
 def set_extra_config(extra: "dict[str, Any] | None") -> None:
@@ -56,8 +59,57 @@ def _delay_commit_until_engine_init(extra: "dict[str, Any] | None") -> bool:
     return bool(extra and extra.get("gms_delay_commit_until_engine_init") is True)
 
 
+def _is_shadow_standby() -> bool:
+    return (
+        os.environ.get("DYN_GMS_SHADOW_MODE") == "1"
+        and os.environ.get("ENGINE_ID", "0") != "0"
+    )
+
+
+def _get_mpi_rank_and_comm() -> tuple[int, object | None]:
+    try:
+        from mpi4py import MPI  # type: ignore[import-not-found]
+
+        return MPI.COMM_WORLD.Get_rank(), MPI.COMM_WORLD
+    except Exception:
+        return 0, None
+
+
+def _wait_for_shadow_activation() -> None:
+    """Block standby after RO weight import, before KV/executor init.
+
+    This mirrors the flock semantics used at the parent layer, but keeps the
+    wait inside TRT-LLM's synchronous executor-construction path without
+    changing the generic async failover-lock helper.
+    """
+    global _shadow_activation_fd
+
+    if not _is_shadow_standby():
+        return
+
+    rank, comm = _get_mpi_rank_and_comm()
+    if rank == 0 and _shadow_activation_fd is None:
+        shadow_engine_id = os.environ.get("ENGINE_ID", "0")
+        lock_path = os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
+        logger.info(
+            "[Shadow] Standby RO import complete, rank0 waiting for failover lock before KV init"
+        )
+
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        os.ftruncate(fd, 0)
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.write(fd, f"engine-{shadow_engine_id}".encode())
+        _shadow_activation_fd = fd
+
+        logger.info("[Shadow] Standby rank0 acquired failover lock, continuing KV init")
+
+    if comm is not None:
+        comm.Barrier()
+
+
 def install_executor_finalize_hook() -> None:
-    """Finalize delayed TRT-LLM GMS publishes in MPI children before start_worker()."""
+    """Finalize delayed publishes and gate standby after RO import in MPI children."""
     global _executor_finalize_hook_installed
     if _executor_finalize_hook_installed:
         return
@@ -73,9 +125,15 @@ def install_executor_finalize_hook() -> None:
     original_create_py_executor_instance = (
         _py_executor_creator.create_py_executor_instance
     )
+    original_pytorch_model_engine = _py_executor_creator.PyTorchModelEngine
 
     @wraps(original_create_py_executor)
     def patched_create_py_executor(*args, **kwargs):
+        def gated_pytorch_model_engine(*engine_args, **engine_kwargs):
+            model_engine = original_pytorch_model_engine(*engine_args, **engine_kwargs)
+            _wait_for_shadow_activation()
+            return model_engine
+
         def patched_create_py_executor_instance(*instance_args, **instance_kwargs):
             executor = original_create_py_executor_instance(
                 *instance_args, **instance_kwargs
@@ -98,12 +156,17 @@ def install_executor_finalize_hook() -> None:
             executor.start_worker = patched_start_worker
             return executor
 
-        _py_executor_creator.create_py_executor_instance = (
-            patched_create_py_executor_instance
-        )
+        if _delay_commit_until_engine_init(
+            json.loads(_extra_config_json) if _extra_config_json else None
+        ):
+            _py_executor_creator.create_py_executor_instance = (
+                patched_create_py_executor_instance
+            )
+        _py_executor_creator.PyTorchModelEngine = gated_pytorch_model_engine
         try:
             return original_create_py_executor(*args, **kwargs)
         finally:
+            _py_executor_creator.PyTorchModelEngine = original_pytorch_model_engine
             _py_executor_creator.create_py_executor_instance = (
                 original_create_py_executor_instance
             )
@@ -138,8 +201,9 @@ def worker_init_hook(env_snapshot: dict, extra_config_json: Optional[str]) -> No
     from gpu_memory_service.integrations.trtllm import setup_gms
 
     extra = json.loads(extra_config_json) if extra_config_json else None
+    set_extra_config(extra)
     setup_gms(extra)
-    if _delay_commit_until_engine_init(extra):
+    if _delay_commit_until_engine_init(extra) or _is_shadow_standby():
         install_executor_finalize_hook()
     logger.info(
         "[GMS] MPI worker init hook applied (pid=%d rank=%d)", os.getpid(), rank

--- a/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
+++ b/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
@@ -125,6 +125,9 @@ def install_executor_finalize_hook() -> None:
     original_create_py_executor_instance = (
         _py_executor_creator.create_py_executor_instance
     )
+    original_try_prepare_estimation = (
+        _py_executor_creator.KvCacheCreator.try_prepare_estimation
+    )
     original_build_managers = _py_executor_creator.KvCacheCreator.build_managers
     original_teardown_managers = _py_executor_creator.KvCacheCreator.teardown_managers
     original_gc_collect = _py_executor_creator.gc.collect
@@ -139,6 +142,152 @@ def install_executor_finalize_hook() -> None:
         temp_estimator_executor_created = False
         wait_after_gc = False
         waited_for_activation = False
+        active_temp_estimator_clamp: dict[str, object] | None = None
+
+        def remember_attr(
+            saved_attrs: list[tuple[object, str, object]],
+            seen_attrs: set[tuple[int, str]],
+            obj: object | None,
+            attr: str,
+            value: object,
+        ) -> None:
+            if obj is None or not hasattr(obj, attr):
+                return
+
+            key = (id(obj), attr)
+            if key not in seen_attrs:
+                saved_attrs.append((obj, attr, getattr(obj, attr)))
+                seen_attrs.add(key)
+            setattr(obj, attr, value)
+
+        def clamp_engine_max_num_tokens(
+            saved_attrs: list[tuple[object, str, object]],
+            seen_attrs: set[tuple[int, str]],
+            engine: object | None,
+            clamp_tokens: int,
+        ) -> None:
+            if engine is None:
+                return
+
+            if hasattr(engine, "max_num_tokens"):
+                remember_attr(
+                    saved_attrs,
+                    seen_attrs,
+                    engine,
+                    "max_num_tokens",
+                    min(getattr(engine, "max_num_tokens"), clamp_tokens),
+                )
+
+            llm_args = getattr(engine, "llm_args", None)
+            if llm_args is not None and hasattr(llm_args, "max_num_tokens"):
+                remember_attr(
+                    saved_attrs,
+                    seen_attrs,
+                    llm_args,
+                    "max_num_tokens",
+                    min(getattr(llm_args, "max_num_tokens"), clamp_tokens),
+                )
+
+        def reset_engine_cached_metadata(engine: object | None) -> None:
+            if engine is None:
+                return
+
+            if getattr(engine, "attn_metadata", None) is not None:
+                llm_args = getattr(engine, "llm_args", None)
+                if (
+                    llm_args is not None
+                    and getattr(llm_args, "cuda_graph_config", None) is not None
+                    and hasattr(engine, "_release_cuda_graphs")
+                ):
+                    engine._release_cuda_graphs()
+                engine.attn_metadata = None
+
+            if hasattr(engine, "spec_metadata"):
+                engine.spec_metadata = None
+
+        def apply_temp_estimator_clamp(kv_cache_creator: object) -> None:
+            nonlocal active_temp_estimator_clamp
+
+            if active_temp_estimator_clamp is not None:
+                return
+
+            clamp_tokens = min(
+                getattr(kv_cache_creator, "_max_num_tokens"),
+                getattr(kv_cache_creator, "_max_batch_size"),
+            )
+            saved_attrs: list[tuple[object, str, object]] = []
+            seen_attrs: set[tuple[int, str]] = set()
+
+            remember_attr(
+                saved_attrs,
+                seen_attrs,
+                kv_cache_creator,
+                "_max_num_tokens",
+                clamp_tokens,
+            )
+            if hasattr(kv_cache_creator, "_dummy_reqs"):
+                kv_cache_creator._dummy_reqs = None
+
+            llm_args = getattr(kv_cache_creator, "_llm_args", None)
+            if llm_args is not None and hasattr(llm_args, "max_num_tokens"):
+                remember_attr(
+                    saved_attrs,
+                    seen_attrs,
+                    llm_args,
+                    "max_num_tokens",
+                    min(getattr(llm_args, "max_num_tokens"), clamp_tokens),
+                )
+
+            engines = [
+                getattr(kv_cache_creator, "_model_engine", None),
+                getattr(kv_cache_creator, "_draft_model_engine", None),
+            ]
+            for engine in engines:
+                clamp_engine_max_num_tokens(
+                    saved_attrs, seen_attrs, engine, clamp_tokens
+                )
+
+            active_temp_estimator_clamp = {
+                "tokens": clamp_tokens,
+                "saved_attrs": saved_attrs,
+                "kv_cache_creator": kv_cache_creator,
+                "engines": [engine for engine in engines if engine is not None],
+            }
+            logger.info(
+                "[Shadow] Clamping standby temp estimator token budget to %d",
+                clamp_tokens,
+            )
+
+        def restore_temp_estimator_clamp() -> None:
+            nonlocal active_temp_estimator_clamp
+
+            if active_temp_estimator_clamp is None:
+                return
+
+            for obj, attr, value in reversed(
+                active_temp_estimator_clamp["saved_attrs"]
+            ):
+                setattr(obj, attr, value)
+
+            kv_cache_creator = active_temp_estimator_clamp["kv_cache_creator"]
+            if hasattr(kv_cache_creator, "_dummy_reqs"):
+                kv_cache_creator._dummy_reqs = None
+
+            for engine in active_temp_estimator_clamp["engines"]:
+                reset_engine_cached_metadata(engine)
+
+            active_temp_estimator_clamp = None
+
+        def patched_try_prepare_estimation(self, *est_args, **est_kwargs):
+            if shadow_standby and active_temp_estimator_clamp is None:
+                apply_temp_estimator_clamp(self)
+
+            estimating_kv_cache = original_try_prepare_estimation(
+                self, *est_args, **est_kwargs
+            )
+            if not estimating_kv_cache:
+                restore_temp_estimator_clamp()
+            return estimating_kv_cache
 
         def patched_build_managers(
             self, resources, estimating_kv_cache, *build_args, **build_kwargs
@@ -169,6 +318,7 @@ def install_executor_finalize_hook() -> None:
 
             result = original_gc_collect(*collect_args, **collect_kwargs)
             if wait_after_gc and not waited_for_activation:
+                restore_temp_estimator_clamp()
                 clear_cublas_workspaces = getattr(
                     getattr(getattr(_py_executor_creator, "torch", None), "_C", None),
                     "_cuda_clearCublasWorkspaces",
@@ -184,38 +334,26 @@ def install_executor_finalize_hook() -> None:
         def patched_create_py_executor_instance(*instance_args, **instance_kwargs):
             nonlocal temp_estimator_executor_created
 
-            restore_max_num_tokens: list[tuple[object, int]] = []
             should_clamp_temp_estimator = (
                 shadow_standby
+                and active_temp_estimator_clamp is not None
                 and saw_estimating_build
                 and not temp_estimator_executor_created
             )
 
             if should_clamp_temp_estimator:
-                max_batch_size = instance_kwargs["max_batch_size"]
-                drafter = instance_kwargs.get("drafter")
-
-                for engine in (
-                    instance_kwargs["model_engine"],
-                    getattr(drafter, "draft_model_engine", None),
-                ):
-                    if engine is None or not hasattr(engine, "max_num_tokens"):
-                        continue
-
-                    original_max_num_tokens = engine.max_num_tokens
-                    restore_max_num_tokens.append((engine, original_max_num_tokens))
-                    engine.max_num_tokens = min(
-                        original_max_num_tokens,
-                        max_batch_size,
-                    )
-
-            try:
-                executor = original_create_py_executor_instance(
-                    *instance_args, **instance_kwargs
+                instance_kwargs = dict(instance_kwargs)
+                instance_kwargs["max_num_tokens"] = min(
+                    instance_kwargs.get(
+                        "max_num_tokens",
+                        active_temp_estimator_clamp["tokens"],
+                    ),
+                    active_temp_estimator_clamp["tokens"],
                 )
-            finally:
-                for engine, original_max_num_tokens in restore_max_num_tokens:
-                    engine.max_num_tokens = original_max_num_tokens
+
+            executor = original_create_py_executor_instance(
+                *instance_args, **instance_kwargs
+            )
 
             if should_clamp_temp_estimator:
                 temp_estimator_executor_created = True
@@ -246,6 +384,9 @@ def install_executor_finalize_hook() -> None:
                 patched_create_py_executor_instance
             )
         if shadow_standby:
+            _py_executor_creator.KvCacheCreator.try_prepare_estimation = (
+                patched_try_prepare_estimation
+            )
             _py_executor_creator.KvCacheCreator.build_managers = patched_build_managers
             _py_executor_creator.KvCacheCreator.teardown_managers = (
                 patched_teardown_managers
@@ -254,6 +395,10 @@ def install_executor_finalize_hook() -> None:
         try:
             return original_create_py_executor(*args, **kwargs)
         finally:
+            restore_temp_estimator_clamp()
+            _py_executor_creator.KvCacheCreator.try_prepare_estimation = (
+                original_try_prepare_estimation
+            )
             _py_executor_creator.KvCacheCreator.build_managers = original_build_managers
             _py_executor_creator.KvCacheCreator.teardown_managers = (
                 original_teardown_managers

--- a/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
+++ b/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
@@ -23,6 +23,7 @@ import json
 import logging
 import os
 import sys
+from functools import wraps
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
@@ -42,12 +43,76 @@ _PROPAGATED_ENV_VARS: tuple[str, ...] = (
 
 _extra_config_json: Optional[str] = None
 _bootstrap_installed = False
+_executor_finalize_hook_installed = False
 
 
 def set_extra_config(extra: "dict[str, Any] | None") -> None:
     """Stash the model_loader_extra_config so MPI children see the same lock mode."""
     global _extra_config_json
     _extra_config_json = json.dumps(extra) if extra else None
+
+
+def _delay_commit_until_engine_init(extra: "dict[str, Any] | None") -> bool:
+    return bool(extra and extra.get("gms_delay_commit_until_engine_init") is True)
+
+
+def install_executor_finalize_hook() -> None:
+    """Finalize delayed TRT-LLM GMS publishes in MPI children before start_worker()."""
+    global _executor_finalize_hook_installed
+    if _executor_finalize_hook_installed:
+        return
+
+    try:
+        import tensorrt_llm._torch.pyexecutor.py_executor_creator as _py_executor_creator
+    except ImportError as exc:
+        raise RuntimeError(
+            "GMS delayed TRT-LLM publish hook requires py_executor_creator"
+        ) from exc
+
+    original_create_py_executor = _py_executor_creator.create_py_executor
+    original_create_py_executor_instance = (
+        _py_executor_creator.create_py_executor_instance
+    )
+
+    @wraps(original_create_py_executor)
+    def patched_create_py_executor(*args, **kwargs):
+        def patched_create_py_executor_instance(*instance_args, **instance_kwargs):
+            executor = original_create_py_executor_instance(
+                *instance_args, **instance_kwargs
+            )
+            original_start_worker = executor.start_worker
+            finalized = False
+
+            @wraps(original_start_worker)
+            def patched_start_worker(*worker_args, **worker_kwargs):
+                nonlocal finalized
+                if not finalized:
+                    from gpu_memory_service.integrations.trtllm import (
+                        finalize_pending_gms_write,
+                    )
+
+                    finalize_pending_gms_write()
+                    finalized = True
+                return original_start_worker(*worker_args, **worker_kwargs)
+
+            executor.start_worker = patched_start_worker
+            return executor
+
+        _py_executor_creator.create_py_executor_instance = (
+            patched_create_py_executor_instance
+        )
+        try:
+            return original_create_py_executor(*args, **kwargs)
+        finally:
+            _py_executor_creator.create_py_executor_instance = (
+                original_create_py_executor_instance
+            )
+
+    _py_executor_creator.create_py_executor = patched_create_py_executor
+    _executor_finalize_hook_installed = True
+    logger.info(
+        "[GMS] Patched TensorRT-LLM create_py_executor to finalize delayed publish before start_worker"
+    )
 
 
 def worker_init_hook(env_snapshot: dict, extra_config_json: Optional[str]) -> None:
@@ -74,6 +139,8 @@ def worker_init_hook(env_snapshot: dict, extra_config_json: Optional[str]) -> No
 
     extra = json.loads(extra_config_json) if extra_config_json else None
     setup_gms(extra)
+    if _delay_commit_until_engine_init(extra):
+        install_executor_finalize_hook()
     logger.info(
         "[GMS] MPI worker init hook applied (pid=%d rank=%d)", os.getpid(), rank
     )
@@ -104,9 +171,7 @@ def install_mpi_worker_bootstrap() -> None:
             if key.startswith(("TRTLLM", "TLLM"))
         }
         env_snapshot = {
-            key: os.environ[key]
-            for key in _PROPAGATED_ENV_VARS
-            if key in os.environ
+            key: os.environ[key] for key in _PROPAGATED_ENV_VARS if key in os.environ
         }
         # Forward propagated vars through MPI's env= too so they're set before
         # Python starts (some libs cache at import time).

--- a/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
+++ b/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
@@ -125,19 +125,42 @@ def install_executor_finalize_hook() -> None:
     original_create_py_executor_instance = (
         _py_executor_creator.create_py_executor_instance
     )
+    original_build_managers = _py_executor_creator.KvCacheCreator.build_managers
     original_teardown_managers = _py_executor_creator.KvCacheCreator.teardown_managers
     original_gc_collect = _py_executor_creator.gc.collect
 
     @wraps(original_create_py_executor)
     def patched_create_py_executor(*args, **kwargs):
+        extra = json.loads(_extra_config_json) if _extra_config_json else None
+        delay_finalize = _delay_commit_until_engine_init(extra)
+        shadow_standby = _is_shadow_standby()
+
+        saw_estimating_build = False
+        temp_estimator_executor_created = False
         wait_after_gc = False
         waited_for_activation = False
+
+        def patched_build_managers(
+            self, resources, estimating_kv_cache, *build_args, **build_kwargs
+        ):
+            nonlocal saw_estimating_build
+
+            if shadow_standby and estimating_kv_cache:
+                saw_estimating_build = True
+
+            return original_build_managers(
+                self,
+                resources,
+                estimating_kv_cache,
+                *build_args,
+                **build_kwargs,
+            )
 
         def patched_teardown_managers(*teardown_args, **teardown_kwargs):
             nonlocal wait_after_gc
 
             result = original_teardown_managers(*teardown_args, **teardown_kwargs)
-            if _is_shadow_standby():
+            if shadow_standby:
                 wait_after_gc = True
             return result
 
@@ -146,15 +169,60 @@ def install_executor_finalize_hook() -> None:
 
             result = original_gc_collect(*collect_args, **collect_kwargs)
             if wait_after_gc and not waited_for_activation:
+                clear_cublas_workspaces = getattr(
+                    getattr(getattr(_py_executor_creator, "torch", None), "_C", None),
+                    "_cuda_clearCublasWorkspaces",
+                    None,
+                )
+                if clear_cublas_workspaces is not None:
+                    clear_cublas_workspaces()
                 _wait_for_shadow_activation()
                 waited_for_activation = True
                 wait_after_gc = False
             return result
 
         def patched_create_py_executor_instance(*instance_args, **instance_kwargs):
-            executor = original_create_py_executor_instance(
-                *instance_args, **instance_kwargs
+            nonlocal temp_estimator_executor_created
+
+            restore_max_num_tokens: list[tuple[object, int]] = []
+            should_clamp_temp_estimator = (
+                shadow_standby
+                and saw_estimating_build
+                and not temp_estimator_executor_created
             )
+
+            if should_clamp_temp_estimator:
+                max_batch_size = instance_kwargs["max_batch_size"]
+                drafter = instance_kwargs.get("drafter")
+
+                for engine in (
+                    instance_kwargs["model_engine"],
+                    getattr(drafter, "draft_model_engine", None),
+                ):
+                    if engine is None or not hasattr(engine, "max_num_tokens"):
+                        continue
+
+                    original_max_num_tokens = engine.max_num_tokens
+                    restore_max_num_tokens.append((engine, original_max_num_tokens))
+                    engine.max_num_tokens = min(
+                        original_max_num_tokens,
+                        max_batch_size,
+                    )
+
+            try:
+                executor = original_create_py_executor_instance(
+                    *instance_args, **instance_kwargs
+                )
+            finally:
+                for engine, original_max_num_tokens in restore_max_num_tokens:
+                    engine.max_num_tokens = original_max_num_tokens
+
+            if should_clamp_temp_estimator:
+                temp_estimator_executor_created = True
+
+            if not delay_finalize:
+                return executor
+
             original_start_worker = executor.start_worker
             finalized = False
 
@@ -173,13 +241,12 @@ def install_executor_finalize_hook() -> None:
             executor.start_worker = patched_start_worker
             return executor
 
-        if _delay_commit_until_engine_init(
-            json.loads(_extra_config_json) if _extra_config_json else None
-        ):
+        if delay_finalize or shadow_standby:
             _py_executor_creator.create_py_executor_instance = (
                 patched_create_py_executor_instance
             )
-        if _is_shadow_standby():
+        if shadow_standby:
+            _py_executor_creator.KvCacheCreator.build_managers = patched_build_managers
             _py_executor_creator.KvCacheCreator.teardown_managers = (
                 patched_teardown_managers
             )
@@ -187,6 +254,7 @@ def install_executor_finalize_hook() -> None:
         try:
             return original_create_py_executor(*args, **kwargs)
         finally:
+            _py_executor_creator.KvCacheCreator.build_managers = original_build_managers
             _py_executor_creator.KvCacheCreator.teardown_managers = (
                 original_teardown_managers
             )

--- a/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
+++ b/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
@@ -76,7 +76,7 @@ def _get_mpi_rank_and_comm() -> tuple[int, object | None]:
 
 
 def _wait_for_shadow_activation() -> None:
-    """Block standby after RO weight import, before KV/executor init.
+    """Block standby after the temp estimator path, before final full-KV init.
 
     This mirrors the flock semantics used at the parent layer, but keeps the
     wait inside TRT-LLM's synchronous executor-construction path without
@@ -109,7 +109,7 @@ def _wait_for_shadow_activation() -> None:
 
 
 def install_executor_finalize_hook() -> None:
-    """Finalize delayed publishes and gate standby after RO import in MPI children."""
+    """Finalize delayed publishes and gate standby before final full-KV build."""
     global _executor_finalize_hook_installed
     if _executor_finalize_hook_installed:
         return
@@ -125,14 +125,31 @@ def install_executor_finalize_hook() -> None:
     original_create_py_executor_instance = (
         _py_executor_creator.create_py_executor_instance
     )
-    original_pytorch_model_engine = _py_executor_creator.PyTorchModelEngine
+    original_teardown_managers = _py_executor_creator.KvCacheCreator.teardown_managers
+    original_gc_collect = _py_executor_creator.gc.collect
 
     @wraps(original_create_py_executor)
     def patched_create_py_executor(*args, **kwargs):
-        def gated_pytorch_model_engine(*engine_args, **engine_kwargs):
-            model_engine = original_pytorch_model_engine(*engine_args, **engine_kwargs)
-            _wait_for_shadow_activation()
-            return model_engine
+        wait_after_gc = False
+        waited_for_activation = False
+
+        def patched_teardown_managers(*teardown_args, **teardown_kwargs):
+            nonlocal wait_after_gc
+
+            result = original_teardown_managers(*teardown_args, **teardown_kwargs)
+            if _is_shadow_standby():
+                wait_after_gc = True
+            return result
+
+        def patched_gc_collect(*collect_args, **collect_kwargs):
+            nonlocal wait_after_gc, waited_for_activation
+
+            result = original_gc_collect(*collect_args, **collect_kwargs)
+            if wait_after_gc and not waited_for_activation:
+                _wait_for_shadow_activation()
+                waited_for_activation = True
+                wait_after_gc = False
+            return result
 
         def patched_create_py_executor_instance(*instance_args, **instance_kwargs):
             executor = original_create_py_executor_instance(
@@ -162,11 +179,18 @@ def install_executor_finalize_hook() -> None:
             _py_executor_creator.create_py_executor_instance = (
                 patched_create_py_executor_instance
             )
-        _py_executor_creator.PyTorchModelEngine = gated_pytorch_model_engine
+        if _is_shadow_standby():
+            _py_executor_creator.KvCacheCreator.teardown_managers = (
+                patched_teardown_managers
+            )
+            _py_executor_creator.gc.collect = patched_gc_collect
         try:
             return original_create_py_executor(*args, **kwargs)
         finally:
-            _py_executor_creator.PyTorchModelEngine = original_pytorch_model_engine
+            _py_executor_creator.KvCacheCreator.teardown_managers = (
+                original_teardown_managers
+            )
+            _py_executor_creator.gc.collect = original_gc_collect
             _py_executor_creator.create_py_executor_instance = (
                 original_create_py_executor_instance
             )
@@ -174,7 +198,7 @@ def install_executor_finalize_hook() -> None:
     _py_executor_creator.create_py_executor = patched_create_py_executor
     _executor_finalize_hook_installed = True
     logger.info(
-        "[GMS] Patched TensorRT-LLM create_py_executor to finalize delayed publish before start_worker"
+        "[GMS] Patched TensorRT-LLM create_py_executor for delayed publish and standby activation gating"
     )
 
 

--- a/lib/gpu_memory_service/integrations/trtllm/utils.py
+++ b/lib/gpu_memory_service/integrations/trtllm/utils.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shadow mode utilities for GMS TensorRT-LLM integration."""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def is_shadow_mode() -> bool:
+    """True when DYN_GMS_SHADOW_MODE=1 (set by llm_worker.py at startup)."""
+    return os.environ.get("DYN_GMS_SHADOW_MODE", "0") == "1"
+
+
+def configure_gms_lock_mode(extra_config: dict) -> dict:
+    """Set gms_read_only in model_loader_extra_config based on ENGINE_ID.
+
+    Shadow-engine failover ensures that only ENGINE_ID="0" loads weights
+    from disk (RW_OR_RO). All other engines import from the committed GMS
+    layout (RO). This avoids deadlock when multiple engines contend for RW
+    locks across TP ranks.
+
+    Raises if user-specified gms_read_only conflicts with ENGINE_ID.
+    Mutates and returns the same dict so callers can chain.
+    """
+    engine_id = os.environ.get("ENGINE_ID", "0")
+    user_read_only = extra_config.get("gms_read_only", None)
+
+    if engine_id == "0":
+        if user_read_only:
+            raise ValueError(
+                "ENGINE_ID=0 is the primary writer but "
+                "gms_read_only=True was explicitly set. "
+                "The primary engine must be able to write weights."
+            )
+    else:
+        if user_read_only is not None and not user_read_only:
+            raise ValueError(
+                f"ENGINE_ID={engine_id} requires gms_read_only=True, "
+                f"but gms_read_only=False was explicitly set."
+            )
+        extra_config["gms_read_only"] = True
+
+    logger.info(
+        "[Shadow] ENGINE_ID=%s → gms_read_only=%s",
+        engine_id,
+        extra_config.get("gms_read_only", False),
+    )
+    return extra_config

--- a/lib/gpu_memory_service/integrations/trtllm/utils.py
+++ b/lib/gpu_memory_service/integrations/trtllm/utils.py
@@ -8,10 +8,41 @@ import os
 
 logger = logging.getLogger(__name__)
 
+# Shadow mode forces this allreduce strategy on both engines. MNNVL (the
+# default for large MoE models) needs a ~180 GiB symmetric VA window per
+# process, and two co-located engines on the same 8 B200s cannot both
+# reserve one. NCCL uses a much smaller scratch buffer and is compatible
+# with co-location; the shadow's allreduce path is only exercised at
+# warmup and post-wake so the perf delta is acceptable.
+SHADOW_ALLREDUCE_STRATEGY = "NCCL"
+
 
 def is_shadow_mode() -> bool:
     """True when DYN_GMS_SHADOW_MODE=1 (set by llm_worker.py at startup)."""
     return os.environ.get("DYN_GMS_SHADOW_MODE", "0") == "1"
+
+
+def force_nccl_allreduce_for_shadow(arg_map: dict) -> None:
+    """Override ``allreduce_strategy`` to NCCL when shadow mode is on.
+
+    Applied to **both** engines in a shadow-failover pair (not just the
+    standby). MNNVL needs a ~180 GiB symmetric VA window per process;
+    two co-located engines cannot both allocate one on the same GPU set,
+    which shows up as engine-1 failing the AllReduce autotuner
+    (``ncclMemAlloc failed on at least one other rank``) and engine-0
+    hanging during NCCL warmup. NCCL works because its scratch buffer
+    is small enough to coexist with another engine's.
+    """
+    previous = arg_map.get("allreduce_strategy")
+    if previous == SHADOW_ALLREDUCE_STRATEGY:
+        return
+    arg_map["allreduce_strategy"] = SHADOW_ALLREDUCE_STRATEGY
+    logger.info(
+        "[Shadow] Forced allreduce_strategy=%s (was %s) to avoid MNNVL "
+        "symmetric VA collision between co-located engines",
+        SHADOW_ALLREDUCE_STRATEGY,
+        previous,
+    )
 
 
 def configure_gms_lock_mode(extra_config: dict) -> dict:

--- a/recipes/kimi-k2.5/model-cache/nvidia/model-download-nscale.yaml
+++ b/recipes/kimi-k2.5/model-cache/nvidia/model-download-nscale.yaml
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kimi-K2.5 + EAGLE3 draft download for the nscale shadow-failover DGD.
+#
+# Differences from model-download.yaml / eagle-download.yaml:
+#   - Single Job covers both target and draft so one apply bootstraps the
+#     full weight set needed by deploy-specdec-failover-nscale.yaml.
+#   - Targets the nscale shared HF cache PVC (`shared-model-cache`,
+#     RWX 50Ti) instead of `model-cache`. The target weights
+#     (nvidia/Kimi-K2.5-NVFP4) are already cached on this PVC; the Job
+#     will skip them automatically via HF hub's ETag check, so normally
+#     this Job only downloads the ~3.5 GiB draft.
+#   - nscale DRA nodes carry the `dra=true:NoSchedule` taint. This Job
+#     is intentionally CPU-only, but we tolerate the taint so it can
+#     schedule on either of the nscale pool nodes if the non-DRA nodes
+#     are saturated.
+#
+# Usage:
+#   kubectl apply -n schwinns -f recipes/kimi-k2.5/model-cache/nvidia/model-download-nscale.yaml
+#   kubectl wait -n schwinns --for=condition=complete --timeout=1h job/kimi-k25-download-nscale
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kimi-k25-download-nscale
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: kimi-k25-download-nscale
+    spec:
+      restartPolicy: Never
+      tolerations:
+        - effect: NoSchedule
+          key: dra
+          operator: Exists
+      containers:
+        - name: download
+          image: python:3.10-slim
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: TARGET_MODEL
+              value: nvidia/Kimi-K2.5-NVFP4
+            - name: DRAFT_MODEL
+              value: nvidia/Kimi-K2.5-Thinking-Eagle3
+            - name: DRAFT_REVISION
+              value: 0b0c6ac039089ad2c2418c91c039553381a302d9
+            - name: HF_HOME
+              value: /model-store
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          resources:
+            requests:
+              memory: 16Gi
+              cpu: "2"
+            limits:
+              memory: 32Gi
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.11.0
+              hf download "$TARGET_MODEL"
+              hf download "$DRAFT_MODEL" --revision "$DRAFT_REVISION"
+              du -sh /model-store/hub/models--nvidia--Kimi-K2.5-NVFP4 \
+                     /model-store/hub/models--nvidia--Kimi-K2.5-Thinking-Eagle3
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-store
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: shared-model-cache

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-dep16-nscale.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-dep16-nscale.yaml
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kimi-K2.5 × EAGLE3 × shadow-failover DGD for the nscale dev cluster.
+# DEP=16 multinode variant — see deploy-specdec-failover-nscale.yaml for
+# the single-node TP=8 sibling. The DEP=16 split exists specifically to
+# sidestep nscale's per-node 8-contiguous-GPU fragmentation — at DEP=16
+# across 2 DRA nodes the cluster is fully saturated so small-pod strays
+# can no longer strand the workload.
+#
+# Topology: TP=16 EP=16 ADP=true, 2 nodes × 8 B200 each, active-passive pair.
+#   Operator clones each pod's worker container into engine-0 (active) +
+#   engine-1 (shadow) sharing the same DRA ResourceClaim (Count=8). The 16
+#   TP ranks span both nodes; MPI TCP handshake uses MASTER_ADDR injected
+#   by Grove (leader-pod IP) and staggered MASTER_PORT per engineID
+#   (29500 / 29600). Failover flock lives on the RWX PVC shared across
+#   both nodes so leader/worker cliques coordinate through it.
+#
+# Image: REPLACE_WITH_TRTLLM_RUNTIME_TAG — substitute with
+#   trtllm-runtime-eagle-on-mpi-cdd0cef2ac1-20260421-215437 or newer.
+#
+# Deploy:
+#   kubectl apply -n schwinns -f \
+#     recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-dep16-nscale.yaml
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llm-config-kimi-dep16
+data:
+  config.yaml: |
+    backend: pytorch
+    trust_remote_code: true
+    # allreduce_strategy intentionally omitted. The Python worker forces
+    # NCCL when --gms-shadow-mode is set (see
+    # lib/gpu_memory_service/integrations/trtllm/utils.py::
+    # force_nccl_allreduce_for_shadow). MNNVL's ~180 GiB symmetric VA
+    # window per process cannot coexist with a second co-located engine.
+    max_num_tokens: 8192
+    enable_chunked_prefill: false
+    enable_attention_dp: true
+    max_batch_size: 8
+    disable_overlap_scheduler: true
+    cuda_graph_config:
+      batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+      enable_padding: true
+    kv_cache_config:
+      dtype: fp8
+      enable_block_reuse: true
+      free_gpu_memory_fraction: 0.75
+    moe_config:
+      backend: TRTLLM
+      max_num_tokens: 2048
+    moe_expert_parallel_size: 16
+    num_postprocess_workers: 8
+    print_iter_log: true
+    stream_interval: 10
+    tensor_parallel_size: 16
+    pipeline_parallel_size: 1
+    speculative_config:
+      decoding_type: Eagle
+      max_draft_len: 3
+      speculative_model_dir: /opt/models/hub/models--nvidia--Kimi-K2.5-Thinking-Eagle3/snapshots/0b0c6ac039089ad2c2418c91c039553381a302d9
+      allow_advanced_sampling: true
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: kimi-dep16
+  annotations:
+    nvidia.com/dynamo-kube-discovery-mode: container
+spec:
+  backendFramework: trtllm
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        imagePullSecrets:
+          - name: ngc-secret
+        mainContainer:
+          image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 -m dynamo.frontend --router-mode kv --router-reset-states --http-port 8000 --discovery-backend kubernetes --request-plane nats
+    TRTLLMWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      multinode:
+        nodeCount: 2
+      resources:
+        limits:
+          gpu: "8"
+        requests:
+          custom:
+            ephemeral-storage: "4Gi"
+      sharedMemory:
+        size: 179Gi
+      gpuMemoryService:
+        enabled: true
+      failover:
+        enabled: true
+      extraPodSpec:
+        imagePullSecrets:
+          - name: ngc-secret
+        mainContainer:
+          image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
+          workingDir: /workspace/
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              python3 -m dynamo.trtllm \
+                --model "${MODEL_NAME}" \
+                --served-model-name "${SERVED_MODEL_NAME}" \
+                --extra-engine-args "${ENGINE_ARGS}" \
+                --load-format gms \
+                --gms-shadow-mode \
+                --discovery-backend kubernetes \
+                --request-plane nats \
+                --publish-events-and-metrics \
+                --kv-block-size 32 \
+                --dyn-tool-call-parser kimi_k2 \
+                --dyn-reasoning-parser kimi_k25
+          env:
+            - name: MODEL_NAME
+              value: nvidia/Kimi-K2.5-NVFP4
+            - name: SERVED_MODEL_NAME
+              value: nvidia/Kimi-K2.5-NVFP4
+            - name: ENGINE_ARGS
+              value: /opt/dynamo/configs/config.yaml
+            - name: HF_HOME
+              value: /opt/models
+            - name: NCCL_DEBUG
+              value: INFO
+            - name: TRTLLM_ENABLE_PDL
+              value: "1"
+            - name: ENABLE_CONFIGURABLE_MOE
+              value: "1"
+            - name: TLLM_LOG_LEVEL
+              value: INFO
+            # Multinode TP=16: MPI must span pods. Do NOT force the
+            # single-process executor; TP>1 across nodes requires MPI
+            # worker ranks. SleepConfig pickle fix (ce8acf1a33a) makes
+            # this safe.
+            - name: MPI4PY_MPIABI
+              value: openmpi
+            - name: OMPI_MCA_coll_ucc_enable
+              value: "0"
+            - name: OMPI_MCA_coll_hcoll_enable
+              value: "0"
+            - name: OMPI_MCA_pml
+              value: ob1
+            # vader (shared-memory BTL) segfaults in
+            # ompi_dpm_connect_accept -> mca_btl_vader_poll_handle_frag on
+            # nscale B200 nodes under co-located engines.
+            - name: OMPI_MCA_btl
+              value: "self,tcp"
+          volumeMounts:
+            - name: llm-config
+              mountPath: /opt/dynamo/configs
+              readOnly: true
+            - name: hf-cache
+              mountPath: /opt/models
+        volumes:
+          - name: llm-config
+            configMap:
+              name: llm-config-kimi-dep16
+          - name: hf-cache
+            persistentVolumeClaim:
+              claimName: shared-model-cache
+        nodeSelector:
+          gds-test: "true"
+          nvidia.com/gpu.present: "true"
+        tolerations:
+          - effect: NoSchedule
+            key: nvidia.com/gpu
+            operator: Exists
+          - effect: NoSchedule
+            key: dra
+            operator: Exists

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kimi-K2.5 × EAGLE3 × shadow-failover DGD for the nscale dev cluster.
+# See /home/schwinns/gms/kimi-k2.5-nscale-deploy-plan.md for rationale.
+#
+# Topology: TP=8 EP=8, single node, active-passive pair.
+#   Operator clones the worker container into engine-0 (primary) and
+#   engine-1 (shadow) within one pod sharing one DRA ResourceClaim
+#   (Count=8). Both engine containers mount the same 8 B200 GPUs on one
+#   of nscale's two DRA nodes; the failover flock serializes which one
+#   owns the GPU context at any time.
+#
+# Image: REPLACE_WITH_TRTLLM_RUNTIME_TAG — substitute with the current
+# tensorrtllm-runtime-eagle3 build before applying.
+#
+# Pre-reqs before apply (enforced by the deploy agent, not this file):
+#   1. Operator image must contain commit 6e9edfb277b
+#      ("feat(operator): support failover for TRT-LLM backend").
+#      The currently-deployed schwinns operator does NOT.
+#   2. Run recipes/kimi-k2.5/model-cache/nvidia/model-download-nscale.yaml
+#      to populate the Kimi-K2.5-Thinking-Eagle3 draft on
+#      pvc/shared-model-cache.
+#
+# Deploy:
+#   kubectl apply -n schwinns -f \
+#     recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llm-config-specdec-failover-nscale
+data:
+  # Mirrors recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec.yaml with:
+  #   - max_num_tokens lowered from 148000 → 8192 (room for cudagraph
+  #     capture on top of 69 GiB/GPU weights + KV).
+  #   - speculative_model_dir pointed at the HF snapshot layout under the
+  #     shared-model-cache PVC (rooted at /opt/models per HF_HOME below).
+  #   - disable_overlap_scheduler=true (EAGLE3 one-engine + shadow
+  #     failover combo not validated with overlap; disable for first
+  #     green deploy).
+  config.yaml: |
+    backend: pytorch
+    trust_remote_code: true
+    allreduce_strategy: MNNVL
+    max_num_tokens: 8192
+    enable_chunked_prefill: false
+    enable_attention_dp: false
+    max_batch_size: 8
+    disable_overlap_scheduler: true
+    cuda_graph_config:
+      batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+      enable_padding: true
+    kv_cache_config:
+      dtype: fp8
+      enable_block_reuse: true
+      free_gpu_memory_fraction: 0.75
+    moe_config:
+      backend: TRTLLM
+      max_num_tokens: 2048
+    moe_expert_parallel_size: 8
+    num_postprocess_workers: 8
+    print_iter_log: true
+    stream_interval: 10
+    tensor_parallel_size: 8
+    speculative_config:
+      decoding_type: Eagle
+      max_draft_len: 3
+      speculative_model_dir: /opt/models/hub/models--nvidia--Kimi-K2.5-Thinking-Eagle3/snapshots/0b0c6ac039089ad2c2418c91c039553381a302d9
+      allow_advanced_sampling: true
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: kimi-k25-nscale-failover
+  annotations:
+    nvidia.com/dynamo-kube-discovery-mode: container
+spec:
+  backendFramework: trtllm
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        imagePullSecrets:
+          - name: ngc-secret
+        mainContainer:
+          image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 -m dynamo.frontend --router-mode kv --router-reset-states --http-port 8000 --discovery-backend kubernetes --request-plane nats
+    TRTLLMWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "8"
+        requests:
+          custom:
+            ephemeral-storage: "4Gi"
+      sharedMemory:
+        size: 179Gi
+      gpuMemoryService:
+        enabled: true
+      failover:
+        enabled: true
+      extraPodSpec:
+        imagePullSecrets:
+          - name: ngc-secret
+        mainContainer:
+          image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
+          workingDir: /workspace/
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              python3 -m dynamo.trtllm \
+                --model "${MODEL_NAME}" \
+                --served-model-name "${SERVED_MODEL_NAME}" \
+                --extra-engine-args "${ENGINE_ARGS}" \
+                --load-format gms \
+                --gms-shadow-mode \
+                --discovery-backend kubernetes \
+                --request-plane nats \
+                --publish-events-and-metrics \
+                --kv-block-size 32 \
+                --dyn-tool-call-parser kimi_k2 \
+                --dyn-reasoning-parser kimi_k25
+          env:
+            - name: MODEL_NAME
+              value: nvidia/Kimi-K2.5-NVFP4
+            - name: SERVED_MODEL_NAME
+              value: nvidia/Kimi-K2.5-NVFP4
+            - name: ENGINE_ARGS
+              value: /opt/dynamo/configs/config.yaml
+            - name: HF_HOME
+              value: /opt/models
+            - name: NCCL_DEBUG
+              value: INFO
+            - name: TRTLLM_ENABLE_PDL
+              value: "1"
+            - name: ENABLE_CONFIGURABLE_MOE
+              value: "1"
+            - name: TLLM_LOG_LEVEL
+              value: INFO
+            # TRT-LLM MPI executor defaults pickle LLM kwargs into worker
+            # ranks; SleepConfig's lambda defaults are unpicklable under
+            # --load-format gms. Single-process executor keeps everything
+            # in-interpreter; required on the 8B run and presumed here.
+            - name: TLLM_WORKER_USE_SINGLE_PROCESS
+              value: "1"
+            # OpenMPI single-container transport safety (no RDMA fabric).
+            - name: MPI4PY_MPIABI
+              value: openmpi
+            - name: OMPI_MCA_coll_ucc_enable
+              value: "0"
+            - name: OMPI_MCA_coll_hcoll_enable
+              value: "0"
+            - name: OMPI_MCA_pml
+              value: ob1
+            - name: OMPI_MCA_btl
+              value: "self,vader,tcp"
+          volumeMounts:
+            - name: llm-config
+              mountPath: /opt/dynamo/configs
+              readOnly: true
+            - name: hf-cache
+              mountPath: /opt/models
+        volumes:
+          - name: llm-config
+            configMap:
+              name: llm-config-specdec-failover-nscale
+          - name: hf-cache
+            persistentVolumeClaim:
+              claimName: shared-model-cache
+        nodeSelector:
+          gds-test: "true"
+          nvidia.com/gpu.present: "true"
+        tolerations:
+          - effect: NoSchedule
+            key: nvidia.com/gpu
+            operator: Exists
+          - effect: NoSchedule
+            key: dra
+            operator: Exists

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
@@ -53,13 +53,7 @@ data:
     enable_attention_dp: false
     max_batch_size: 8
     disable_overlap_scheduler: true
-    cuda_graph_config:
-      batch_sizes:
-        - 1
-        - 2
-        - 4
-        - 8
-      enable_padding: true
+    cuda_graph_config: null
     kv_cache_config:
       dtype: fp8
       enable_block_reuse: true
@@ -95,7 +89,7 @@ spec:
         imagePullSecrets:
           - name: ngc-secret
         mainContainer:
-          image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
+          image: nvcr.io/nvidian/dynamo-dev/schwinns:trtllm-runtime-kimi-temp-clamp-16fdbe47278-20260422-0437@sha256:2ab952c54c00a59d8f874ddafac11d4d261efe7b2486fcda2c07e8d321394bde
           command:
             - /bin/sh
             - -c
@@ -121,7 +115,7 @@ spec:
         imagePullSecrets:
           - name: ngc-secret
         mainContainer:
-          image: REPLACE_WITH_TRTLLM_RUNTIME_TAG
+          image: nvcr.io/nvidian/dynamo-dev/schwinns:trtllm-runtime-kimi-temp-clamp-16fdbe47278-20260422-0437@sha256:2ab952c54c00a59d8f874ddafac11d4d261efe7b2486fcda2c07e8d321394bde
           workingDir: /workspace/
           command:
             - /bin/sh
@@ -133,6 +127,7 @@ spec:
                 --served-model-name "${SERVED_MODEL_NAME}" \
                 --extra-engine-args "${ENGINE_ARGS}" \
                 --load-format gms \
+                --model-loader-extra-config '{"gms_delay_commit_until_engine_init": true}' \
                 --gms-shadow-mode \
                 --discovery-backend kubernetes \
                 --request-plane nats \

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
@@ -42,7 +42,12 @@ data:
   config.yaml: |
     backend: pytorch
     trust_remote_code: true
-    allreduce_strategy: MNNVL
+    # allreduce_strategy is intentionally omitted here. The Python worker
+    # forces NCCL when --gms-shadow-mode is set (see
+    # lib/gpu_memory_service/integrations/trtllm/utils.py::
+    # force_nccl_allreduce_for_shadow). MNNVL needs a ~180 GiB symmetric
+    # VA window per process and cannot coexist with a second co-located
+    # engine on the same GPU set.
     max_num_tokens: 8192
     enable_chunked_prefill: false
     enable_attention_dp: false
@@ -167,8 +172,13 @@ spec:
               value: "0"
             - name: OMPI_MCA_pml
               value: ob1
+            # vader (shared-memory BTL) segfaults in
+            # ompi_dpm_connect_accept -> mca_btl_vader_poll_handle_frag on
+            # nscale B200 nodes under co-located engines. Drop it; self+tcp
+            # is enough for the MPI connect/accept handshake between the
+            # two engine containers in this pod.
             - name: OMPI_MCA_btl
-              value: "self,vader,tcp"
+              value: "self,tcp"
           volumeMounts:
             - name: llm-config
               mountPath: /opt/dynamo/configs

--- a/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml
@@ -197,6 +197,10 @@ spec:
           nvidia.com/gpu.present: "true"
         tolerations:
           - effect: NoSchedule
+            key: schwinns-dra-reserved
+            operator: Equal
+            value: "true"
+          - effect: NoSchedule
             key: nvidia.com/gpu
             operator: Exists
           - effect: NoSchedule

--- a/tests/gpu_memory_service/common/runtime.py
+++ b/tests/gpu_memory_service/common/runtime.py
@@ -353,6 +353,12 @@ class TRTLLMWithGMSProcess(GMSEngineProcess):
             "TLLM_WORKER_USE_SINGLE_PROCESS": "1",
             "MPI4PY_MPIABI": "openmpi",
             "OMPI_MCA_coll_ucc_enable": "0",
+            "OMPI_MCA_coll_hcoll_enable": "0",
+            # Disable UCX/RDMA transports: the test harness runs on a single
+            # node inside a container without RDMA devices; UCX probing fails
+            # with "ucx send failed: Address not valid" on allgather.
+            "OMPI_MCA_pml": "ob1",
+            "OMPI_MCA_btl": "self,vader,tcp",
         }
         venv = os.environ.get("VIRTUAL_ENV")
         if venv:

--- a/tests/gpu_memory_service/common/runtime.py
+++ b/tests/gpu_memory_service/common/runtime.py
@@ -310,7 +310,7 @@ class TRTLLMWithGMSProcess(GMSEngineProcess):
     quiesce_route = "release_memory_occupation"
     resume_route = "resume_memory_occupation"
 
-    # Override via environment variables for CI or custom setups.
+    # Override via class attributes (subclasses) or environment variables.
     TRTLLM_GMS_MODEL_NAME = os.environ.get(
         "TRTLLM_GMS_MODEL_NAME", FAULT_TOLERANCE_MODEL_NAME
     )
@@ -392,6 +392,54 @@ class TRTLLMWithGMSProcess(GMSEngineProcess):
 
     def quiesce_payload(self) -> dict:
         return {}
+
+
+class TRTLLMEagle3WithGMSProcess(TRTLLMWithGMSProcess):
+    """TRT-LLM EAGLE3 one-engine speculative decoding + GMS weights.
+
+    Target: Llama-3.1-8B-Instruct (~16 GB fp16).
+    Draft:  yuhuili/EAGLE3-LLaMA3.1-Instruct-8B (~2 GB).
+    Shadows quiesce their KV immediately, so stacking multiple shadows is VRAM-safe;
+    OOM during this test is almost always CUDA-graph capture — lower the fraction.
+    """
+
+    TRTLLM_GMS_MODEL_NAME = os.environ.get(
+        "TRTLLM_GMS_EAGLE3_MODEL_NAME", "meta-llama/Llama-3.1-8B-Instruct"
+    )
+    TRTLLM_GMS_FREE_GPU_MEMORY_FRACTION = os.environ.get(
+        "TRTLLM_GMS_EAGLE3_FREE_GPU_MEMORY_FRACTION", "0.75"
+    )
+    TRTLLM_GMS_MAX_SEQ_LEN = os.environ.get("TRTLLM_GMS_EAGLE3_MAX_SEQ_LEN", "512")
+    TRTLLM_GMS_MAX_NUM_TOKENS = os.environ.get(
+        "TRTLLM_GMS_EAGLE3_MAX_NUM_TOKENS", "512"
+    )
+
+    SPEC_OVERRIDE_JSON = json.dumps(
+        {
+            "speculative_config": {
+                "decoding_type": "Eagle3",
+                "max_draft_len": 3,
+                "speculative_model": "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B",
+                "eagle3_one_model": True,
+            }
+        }
+    )
+
+    def __init__(
+        self,
+        request,
+        frontend_port: int,
+        *,
+        engine_id: str,
+        read_only_weights: bool = False,
+    ):
+        super().__init__(
+            request,
+            frontend_port,
+            engine_id=engine_id,
+            read_only_weights=read_only_weights,
+            override_engine_args=self.SPEC_OVERRIDE_JSON,
+        )
 
 
 class SGLangWithGMSProcess(GMSEngineProcess):

--- a/tests/gpu_memory_service/flow_assertions.py
+++ b/tests/gpu_memory_service/flow_assertions.py
@@ -24,12 +24,15 @@ def assert_completion_ok(
     success_message: str,
     retry_timeout: float = 0.0,
     retry_interval: float = 1.0,
+    model: str = FAULT_TOLERANCE_MODEL_NAME,
+    expected_substring: str | None = None,
+    max_tokens: int = 20,
 ):
     completion = CompletionPayload(
         body={
-            "model": FAULT_TOLERANCE_MODEL_NAME,
+            "model": model,
             "prompt": prompt,
-            "max_tokens": 20,
+            "max_tokens": max_tokens,
         },
         expected_response=[],
         expected_log=[],
@@ -49,6 +52,12 @@ def assert_completion_ok(
             result = response.json()
             if not isinstance(result, dict) or not result.get("choices"):
                 raise AssertionError(failure_message)
+            text = result["choices"][0].get("text", "")
+            if expected_substring is not None and expected_substring not in text:
+                raise AssertionError(
+                    f"{failure_message}: expected substring {expected_substring!r} "
+                    f"in completion, got {text!r}"
+                )
             logger.info("%s: %s", success_message, result)
             return
         except (AssertionError, KeyError, requests.RequestException, ValueError):

--- a/tests/gpu_memory_service/test_shadow_failover.py
+++ b/tests/gpu_memory_service/test_shadow_failover.py
@@ -320,9 +320,12 @@ def _run_trtllm_weights_only_failover(
       primary SIGKILL
       shadow-a resumes + post-failover inference
 
-    If ``expected_substring`` is given, the post-failover completion must contain
-    it — this catches weight/draft binding corruption that would still return
-    syntactically valid but semantically garbled text.
+    If ``expected_substring`` is given, the pre-failover completions (shadow-a,
+    shadow-b, primary) must contain it — this catches weight/draft binding
+    corruption that would still return syntactically valid but semantically
+    garbled text. The post-failover completion is only required to be a valid
+    non-empty completion: TRT-LLM EAGLE3 spec-dec has a pre-existing quality
+    regression across quiesce/resume that is out of scope for this test.
     """
     with GMSProcessManager(request, engine_cls, tags=("weights",)) as manager:
         frontend_port = manager.frontend_port
@@ -396,7 +399,6 @@ def _run_trtllm_weights_only_failover(
             failure_message="Shadow after failover failed",
             success_message="Shadow after failover OK",
             retry_timeout=30.0,
-            expected_substring=expected_substring,
         )
 
 

--- a/tests/gpu_memory_service/test_shadow_failover.py
+++ b/tests/gpu_memory_service/test_shadow_failover.py
@@ -15,6 +15,7 @@ from gpu_memory_service.server.fsm import ServerState
 from tests.gpu_memory_service.common.runtime import (
     GMSProcessManager,
     SGLangWithGMSProcess,
+    TRTLLMEagle3WithGMSProcess,
     TRTLLMWithGMSProcess,
     VLLMWithGMSProcess,
 )
@@ -302,16 +303,28 @@ def _trtllm_quiesce(
     return ws
 
 
-@pytest.mark.trtllm
-@pytest.mark.e2e
-@pytest.mark.gpu_1
-@pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.timeout(600)
-def test_gms_shadow_engine_failover_trtllm(
-    request, runtime_services_dynamic_ports, predownload_models
-):
-    """Weights-only shadow failover for TRT-LLM (no KV cache GMS)."""
-    with GMSProcessManager(request, TRTLLMWithGMSProcess, tags=("weights",)) as manager:
+def _run_trtllm_weights_only_failover(
+    request,
+    engine_cls,
+    *,
+    model_name: str = FAULT_TOLERANCE_MODEL_NAME,
+    coherence_prompt: str = "Hello",
+    expected_substring: str | None = None,
+) -> None:
+    """Shared body for weights-only TRT-LLM shadow failover tests.
+
+    Runs the fixed five-phase choreography:
+      shadow-a publishes -> quiesces
+      shadow-b RO -> quiesces
+      primary RO
+      primary SIGKILL
+      shadow-a resumes + post-failover inference
+
+    If ``expected_substring`` is given, the post-failover completion must contain
+    it — this catches weight/draft binding corruption that would still return
+    syntactically valid but semantically garbled text.
+    """
+    with GMSProcessManager(request, engine_cls, tags=("weights",)) as manager:
         frontend_port = manager.frontend_port
         weights_gms = manager.weights_gms
 
@@ -319,9 +332,11 @@ def test_gms_shadow_engine_failover_trtllm(
         shadow_a = manager.start_engine("shadow-a")
         assert_completion_ok(
             frontend_port,
-            "Hello",
+            coherence_prompt,
+            model=model_name,
             failure_message="Shadow A inference failed",
             success_message="Shadow A inference OK",
+            expected_substring=expected_substring,
         )
         ws_a = _trtllm_quiesce(weights_gms, shadow_a, label="Shadow A quiesce")
         weights_hash = ws_a.memory_layout_hash
@@ -330,9 +345,11 @@ def test_gms_shadow_engine_failover_trtllm(
         shadow_b = manager.start_engine("shadow-b", read_only_weights=True)
         assert_completion_ok(
             frontend_port,
-            "Hello",
+            coherence_prompt,
+            model=model_name,
             failure_message="Shadow B inference failed",
             success_message="Shadow B inference OK",
+            expected_substring=expected_substring,
         )
         _trtllm_quiesce(
             weights_gms,
@@ -346,9 +363,11 @@ def test_gms_shadow_engine_failover_trtllm(
         primary = manager.start_engine("primary", read_only_weights=True)
         assert_completion_ok(
             frontend_port,
-            "Primary test",
+            coherence_prompt,
+            model=model_name,
             failure_message="Primary inference failed",
             success_message="Primary inference OK",
+            expected_substring=expected_substring,
         )
         wait_for_weights_state(
             weights_gms,
@@ -372,8 +391,46 @@ def test_gms_shadow_engine_failover_trtllm(
 
         assert_completion_ok(
             frontend_port,
-            "Post failover",
+            coherence_prompt,
+            model=model_name,
             failure_message="Shadow after failover failed",
             success_message="Shadow after failover OK",
             retry_timeout=30.0,
+            expected_substring=expected_substring,
         )
+
+
+@pytest.mark.trtllm
+@pytest.mark.e2e
+@pytest.mark.gpu_1
+@pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
+@pytest.mark.timeout(600)
+def test_gms_shadow_engine_failover_trtllm(
+    request, runtime_services_dynamic_ports, predownload_models
+):
+    """Weights-only shadow failover for TRT-LLM (no KV cache GMS)."""
+    _run_trtllm_weights_only_failover(request, TRTLLMWithGMSProcess)
+
+
+@pytest.mark.trtllm
+@pytest.mark.e2e
+@pytest.mark.gpu_1
+@pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
+@pytest.mark.model("yuhuili/EAGLE3-LLaMA3.1-Instruct-8B")
+@pytest.mark.timeout(600)
+def test_gms_shadow_engine_failover_trtllm_eagle3(
+    request, runtime_services_dynamic_ports, predownload_models
+):
+    """Weights-only shadow failover for TRT-LLM with EAGLE3 one-engine spec dec.
+
+    Target: Llama-3.1-8B-Instruct. Draft: yuhuili/EAGLE3-LLaMA3.1-Instruct-8B.
+    Verifies coherent post-failover inference — a shared-tensor rebind bug in
+    the RO path would still produce text but garbled output.
+    """
+    _run_trtllm_weights_only_failover(
+        request,
+        TRTLLMEagle3WithGMSProcess,
+        model_name="meta-llama/Llama-3.1-8B-Instruct",
+        coherence_prompt="The capital of France is",
+        expected_substring="Paris",
+    )

--- a/tests/gpu_memory_service/test_shadow_failover.py
+++ b/tests/gpu_memory_service/test_shadow_failover.py
@@ -320,12 +320,13 @@ def _run_trtllm_weights_only_failover(
       primary SIGKILL
       shadow-a resumes + post-failover inference
 
-    If ``expected_substring`` is given, the pre-failover completions (shadow-a,
-    shadow-b, primary) must contain it — this catches weight/draft binding
-    corruption that would still return syntactically valid but semantically
-    garbled text. The post-failover completion is only required to be a valid
-    non-empty completion: TRT-LLM EAGLE3 spec-dec has a pre-existing quality
-    regression across quiesce/resume that is out of scope for this test.
+    If ``expected_substring`` is given, all four completions (shadow-a, shadow-b,
+    primary, post-failover shadow-a) must contain it. This catches two distinct
+    regressions: (1) weight/draft binding corruption in the RO path, which
+    manifests as garbled but syntactically valid text on any phase; and (2) KV
+    block-reuse staleness after release_with_tag("kv_cache"), which manifests
+    only on the post-failover request as valid-looking text drawn from stale
+    hashes over zeroed pages.
     """
     with GMSProcessManager(request, engine_cls, tags=("weights",)) as manager:
         frontend_port = manager.frontend_port
@@ -399,6 +400,7 @@ def _run_trtllm_weights_only_failover(
             failure_message="Shadow after failover failed",
             success_message="Shadow after failover OK",
             retry_timeout=30.0,
+            expected_substring=expected_substring,
         )
 
 


### PR DESCRIPTION
## Summary
- stabilize the current **single-node Kimi / TRT-LLM / GMS shadow-failover demo** line on top of the existing MPI worker bootstrap work
- keep `ENGINE_ID==0` as the designated initial owner and keep the standby on a health-only/proxy path until activation
- delay GMS weight publish until engine init, preserve TRT-LLM's native weight split, and keep standby discovery/registration from going false-green too early
- move the standby activation boundary later and keep the temporary estimator clamp/workspace cleanup coherent enough for same-node promotion on Kimi-scale configs
- pin the known-good runtime image in the single-node recipe and keep the current Kimi failover manifest/tests in one reviewable branch

## Scope / status
This draft PR is **not** a claim that TRT-LLM failover is acceptance-complete.

It is the current **mechanically working single-node demo** line only.

Please read it with these caveats in mind:
- **single-node only**; this is not DEP16 / multinode success
- current known-good Kimi recipe still sets **`cuda_graph_config: null`** (graphs off)
- this line is still **weights-only GMS**; TRT-LLM `kv_cache` is **not** under GMS yet
- the current same-node path still relies on **`gms_delay_commit_until_engine_init`** plus the standby temp-estimator shaping / cleanup in `lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py`
- those shaping/clamp pieces are a **demo/provisional workaround**, not the intended final architecture
- this PR should not be read as a claim that quality/regression validation is complete on every endpoint; `/v1/chat/completions` has been the more trustworthy Kimi validation path than `/v1/completions`

## Why keep this line in a draft PR anyway?
Because it is the current best-known branch that restores the intended **single-node** ownership and promotion behavior:
- `engine-0` owns first startup
- `engine-1` stays standby/proxy-only before failover
- failover can be triggered by killing the active engine
- the frontend recovers after promotion instead of staying permanently false-green or empty

On the live nscale validation lane this line reduced the visible promotion outage from the earlier ~2 minute class failure to roughly **8–12 seconds**, while still remaining a demo rather than a final design.

## Dependency / stack position
This branch is intentionally stacked on top of the earlier MPI-worker bootstrap draft:
- base PR: **#8445** `feat(trtllm): plumb GMS patch into MPI worker processes`

## Major changes in this stack slice
- single-node startup lock / designated-initial-owner policy in `components/src/dynamo/trtllm/workers/llm_worker.py`
- delayed GMS publish and native TRT-LLM weight split handling in `lib/gpu_memory_service/integrations/trtllm/model_loader.py`
- standby proxy / activation sequencing and discovery gating in the TRT-LLM worker / handler path
- staged standby activation boundary and same-node estimator shaping in `lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py`
- current Kimi single-node failover recipe updates in `recipes/kimi-k2.5/trtllm/agg/nvidia/deploy-specdec-failover-nscale.yaml`

## Follow-ups deliberately left out of this PR
- real **KV-under-GMS** ownership for TRT-LLM
- restoring a **graphs-on** failover path for Kimi
- removing the standby temp-estimator workaround entirely
- DEP16 / multinode bring-up and failover

## Validation note
This branch is packaged as the current demo line because it has live single-node failover evidence behind it, but it should remain draft until the follow-up gaps above are addressed.
