### PR TITLE
fix(trtllm): bootstrap MPIComm standby gating for DEP16

### DIFF
--- a/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
@@ -54,6 +54,10 @@ def stubbed_env(monkeypatch):
             self.n_workers = n_workers
             self.mpi_pool = None
 
+    def fake_worker_main(*args, **kwargs):
+        call_log.append(f"worker_main:{args}:{kwargs}")
+        return "worker-main-result"
+
     mpi4py_module = types.ModuleType("mpi4py")
     mpi4py_futures_module = types.ModuleType("mpi4py.futures")
     mpi4py_futures_module.MPIPoolExecutor = FakeMPIPoolExecutor
@@ -63,6 +67,9 @@ def stubbed_env(monkeypatch):
     trtllm_module = types.ModuleType("tensorrt_llm")
     trtllm_llmapi_module = types.ModuleType("tensorrt_llm.llmapi")
     trtllm_mpi_session_module = types.ModuleType("tensorrt_llm.llmapi.mpi_session")
+    trtllm_executor_module = types.ModuleType("tensorrt_llm.executor")
+    trtllm_executor_worker_module = types.ModuleType("tensorrt_llm.executor.worker")
+    trtllm_executor_proxy_module = types.ModuleType("tensorrt_llm.executor.proxy")
     trtllm_torch_module = types.ModuleType("tensorrt_llm._torch")
     trtllm_pyexecutor_module = types.ModuleType("tensorrt_llm._torch.pyexecutor")
     trtllm_pyexecutor_creator_module = types.ModuleType(
@@ -126,8 +133,14 @@ def stubbed_env(monkeypatch):
     )
     trtllm_pyexecutor_creator_module.create_py_executor = fake_create_py_executor
     trtllm_mpi_session_module.MpiPoolSession = FakeMpiPoolSession
+    trtllm_executor_worker_module.GenerationExecutorWorker = object
+    trtllm_executor_worker_module.worker_main = fake_worker_main
+    trtllm_executor_proxy_module.worker_main = fake_worker_main
     trtllm_module.llmapi = trtllm_llmapi_module
+    trtllm_module.executor = trtllm_executor_module
     trtllm_llmapi_module.mpi_session = trtllm_mpi_session_module
+    trtllm_executor_module.worker = trtllm_executor_worker_module
+    trtllm_executor_module.proxy = trtllm_executor_proxy_module
     trtllm_module._torch = trtllm_torch_module
     trtllm_torch_module.pyexecutor = trtllm_pyexecutor_module
     trtllm_pyexecutor_module.py_executor_creator = trtllm_pyexecutor_creator_module
@@ -139,6 +152,13 @@ def stubbed_env(monkeypatch):
     monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", trtllm_llmapi_module)
     monkeypatch.setitem(
         sys.modules, "tensorrt_llm.llmapi.mpi_session", trtllm_mpi_session_module
+    )
+    monkeypatch.setitem(sys.modules, "tensorrt_llm.executor", trtllm_executor_module)
+    monkeypatch.setitem(
+        sys.modules, "tensorrt_llm.executor.worker", trtllm_executor_worker_module
+    )
+    monkeypatch.setitem(
+        sys.modules, "tensorrt_llm.executor.proxy", trtllm_executor_proxy_module
     )
     monkeypatch.setitem(sys.modules, "tensorrt_llm._torch", trtllm_torch_module)
     monkeypatch.setitem(
@@ -159,11 +179,24 @@ def stubbed_env(monkeypatch):
     bootstrap._extra_config_json = None
     bootstrap._executor_finalize_hook_installed = False
     bootstrap._shadow_activation_fd = None
+    bootstrap._comm_task_bootstrapped = False
+    for key in (
+        "DYN_GMS_TRTLLM_ENABLED",
+        "DYN_GMS_TRTLLM_EXTRA_CONFIG_JSON",
+        "CONTAINER_NAME",
+        "DYN_GMS_SHADOW_MODE",
+        "ENGINE_ID",
+        "FAILOVER_LOCK_PATH",
+        "GMS_SOCKET_DIR",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
     yield {
         "bootstrap": bootstrap,
         "FakeMpiPoolSession": FakeMpiPoolSession,
         "captured_kwargs": captured_kwargs,
+        "executor_proxy": trtllm_executor_proxy_module,
+        "executor_worker": trtllm_executor_worker_module,
         "py_executor_creator": trtllm_pyexecutor_creator_module,
         "call_log": call_log,
         "fake_comm": fake_comm,
@@ -173,17 +206,21 @@ def stubbed_env(monkeypatch):
 def test_install_patches_mpi_pool_session_start_method(stubbed_env):
     bootstrap = stubbed_env["bootstrap"]
     FakeMpiPoolSession = stubbed_env["FakeMpiPoolSession"]
+    executor_proxy = stubbed_env["executor_proxy"]
     original = (
         FakeMpiPoolSession._start_mpi_pool
         if hasattr(FakeMpiPoolSession, "_start_mpi_pool")
         else None
     )
+    original_worker_main = executor_proxy.worker_main
 
     bootstrap.install_mpi_worker_bootstrap()
 
     patched = FakeMpiPoolSession._start_mpi_pool
     assert patched is not original
     assert callable(patched)
+    assert executor_proxy.worker_main is bootstrap.bootstrapped_proxy_worker_main
+    assert executor_proxy.worker_main is not original_worker_main
 
 
 def test_install_is_idempotent(stubbed_env):
@@ -220,6 +257,7 @@ def test_start_mpi_pool_injects_initializer_and_extra_config(stubbed_env, monkey
     env_snapshot, extra_config_json = captured_kwargs["initargs"]
     assert env_snapshot == {
         "DYN_GMS_TRTLLM_ENABLED": "1",
+        "DYN_GMS_TRTLLM_EXTRA_CONFIG_JSON": '{"gms_read_only": true}',
         "DYN_GMS_SHADOW_MODE": "1",
         "ENGINE_ID": "1",
         "FAILOVER_LOCK_PATH": "/tmp/failover.lock",
@@ -229,6 +267,10 @@ def test_start_mpi_pool_injects_initializer_and_extra_config(stubbed_env, monkey
     assert captured_kwargs["env"]["TRTLLM_FOO"] == "bar"
     assert captured_kwargs["env"]["TLLM_BAZ"] == "qux"
     assert captured_kwargs["env"]["DYN_GMS_TRTLLM_ENABLED"] == "1"
+    assert (
+        captured_kwargs["env"]["DYN_GMS_TRTLLM_EXTRA_CONFIG_JSON"]
+        == '{"gms_read_only": true}'
+    )
     assert captured_kwargs["env"]["FAILOVER_LOCK_PATH"] == "/tmp/failover.lock"
 
 
@@ -275,6 +317,73 @@ def test_worker_init_hook_no_op_when_gms_disabled(stubbed_env, monkeypatch):
     bootstrap.worker_init_hook({"ENGINE_ID": "1"}, None)
 
     fake_setup_gms.assert_not_called()
+
+
+def test_worker_init_hook_infers_shadow_read_only_without_extra_config(
+    stubbed_env, monkeypatch
+):
+    bootstrap = stubbed_env["bootstrap"]
+
+    import gpu_memory_service.integrations.trtllm as trtllm_gms
+
+    fake_setup_gms = MagicMock()
+    monkeypatch.setattr(trtllm_gms, "setup_gms", fake_setup_gms)
+
+    env_snapshot = {
+        "DYN_GMS_TRTLLM_ENABLED": "1",
+        "DYN_GMS_SHADOW_MODE": "1",
+        "ENGINE_ID": "1",
+    }
+    bootstrap.worker_init_hook(env_snapshot, None)
+
+    fake_setup_gms.assert_called_once_with({"gms_read_only": True})
+
+
+def test_bootstrapped_proxy_worker_main_bootstraps_comm_workers(
+    stubbed_env, monkeypatch
+):
+    bootstrap = stubbed_env["bootstrap"]
+    executor_proxy = stubbed_env["executor_proxy"]
+    call_log = stubbed_env["call_log"]
+
+    bootstrap.install_mpi_worker_bootstrap()
+    bootstrap._comm_task_bootstrapped = False
+    monkeypatch.setenv("DYN_GMS_TRTLLM_ENABLED", "1")
+    monkeypatch.setenv("DYN_GMS_SHADOW_MODE", "1")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("FAILOVER_LOCK_PATH", "/tmp/failover.lock")
+    monkeypatch.setenv(
+        "DYN_GMS_TRTLLM_EXTRA_CONFIG_JSON",
+        '{"gms_delay_commit_until_engine_init": true}',
+    )
+
+    init_calls = []
+
+    def fake_worker_init_hook(env_snapshot, extra_config_json):
+        init_calls.append((env_snapshot, extra_config_json))
+
+    monkeypatch.setattr(bootstrap, "worker_init_hook", fake_worker_init_hook)
+
+    result = executor_proxy.worker_main(
+        "engine", "queues", "INFO", ready_signal="READY"
+    )
+
+    assert result == "worker-main-result"
+    assert init_calls == [
+        (
+            {
+                "DYN_GMS_TRTLLM_ENABLED": "1",
+                "DYN_GMS_TRTLLM_EXTRA_CONFIG_JSON": '{"gms_delay_commit_until_engine_init": true}',
+                "DYN_GMS_SHADOW_MODE": "1",
+                "ENGINE_ID": "1",
+                "FAILOVER_LOCK_PATH": "/tmp/failover.lock",
+            },
+            '{"gms_delay_commit_until_engine_init": true}',
+        )
+    ]
+    assert call_log == [
+        "worker_main:('engine', 'queues', 'INFO'):{'ready_signal': 'READY'}"
+    ]
 
 
 def test_worker_init_hook_installs_child_finalize_before_start_worker(

--- a/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py
@@ -537,6 +537,126 @@ def test_worker_init_hook_standby_gates_after_temp_executor_before_final_kv_buil
     ]
 
 
+def test_worker_init_hook_waits_before_final_kv_build_when_estimation_skipped(
+    stubbed_env, monkeypatch
+):
+    bootstrap = stubbed_env["bootstrap"]
+    py_executor_creator = stubbed_env["py_executor_creator"]
+    call_log = stubbed_env["call_log"]
+
+    model_llm_args = types.SimpleNamespace(max_num_tokens=8192, cuda_graph_config=None)
+    draft_llm_args = types.SimpleNamespace(max_num_tokens=4096, cuda_graph_config=None)
+    model_engine = types.SimpleNamespace(
+        max_num_tokens=8192,
+        llm_args=model_llm_args,
+    )
+    draft_model_engine = types.SimpleNamespace(
+        max_num_tokens=4096,
+        llm_args=draft_llm_args,
+    )
+    drafter = types.SimpleNamespace(draft_model_engine=draft_model_engine)
+
+    class FakeKvCacheCreator:
+        def __init__(self):
+            self._max_num_tokens = 8192
+            self._max_batch_size = 8
+            self._dummy_reqs = None
+            self._model_engine = model_engine
+            self._draft_model_engine = draft_model_engine
+            self._llm_args = model_llm_args
+
+        def try_prepare_estimation(self):
+            call_log.append(
+                f"try_prepare_estimation:max={self._max_num_tokens}:dummy={self._dummy_reqs}"
+            )
+            return False
+
+        def build_managers(self, _resources, estimating_kv_cache):
+            call_log.append(
+                "build_managers:"
+                f"{estimating_kv_cache}:creator={self._max_num_tokens}:"
+                f"model={model_engine.max_num_tokens}:model_llm={model_llm_args.max_num_tokens}:"
+                f"draft={draft_model_engine.max_num_tokens}:draft_llm={draft_llm_args.max_num_tokens}"
+            )
+
+        def configure_kv_cache_capacity(self, _py_executor):
+            raise AssertionError(
+                "skip-estimation path should not configure KV cache capacity"
+            )
+
+        def teardown_managers(self, _resources):
+            raise AssertionError("skip-estimation path should not tear down managers")
+
+    py_executor_creator.KvCacheCreator = FakeKvCacheCreator
+
+    def fake_create_py_executor_instance(*args, name="executor", **kwargs):
+        call_log.append(
+            "create_py_executor_instance:"
+            f"{name}:model={kwargs['model_engine'].max_num_tokens}:"
+            f"model_llm={kwargs['model_engine'].llm_args.max_num_tokens}:"
+            f"draft={getattr(kwargs.get('drafter'), 'draft_model_engine', None).max_num_tokens}:"
+            f"draft_llm={getattr(kwargs.get('drafter'), 'draft_model_engine', None).llm_args.max_num_tokens}:"
+            f"arg={kwargs['max_num_tokens']}"
+        )
+        return py_executor_creator.PyExecutor(name)
+
+    py_executor_creator.create_py_executor_instance = fake_create_py_executor_instance
+
+    def fake_create_py_executor(*args, **kwargs):
+        kv_cache_creator = py_executor_creator.KvCacheCreator()
+
+        call_log.append("create_py_executor")
+        estimating_kv_cache = kv_cache_creator.try_prepare_estimation()
+        call_log.append(f"estimating_kv_cache={estimating_kv_cache}")
+        kv_cache_creator.build_managers({}, estimating_kv_cache)
+        call_log.append("final_executor_created")
+        final_executor = py_executor_creator.create_py_executor_instance(
+            name="final",
+            model_engine=model_engine,
+            drafter=drafter,
+            max_batch_size=8,
+            max_num_tokens=8192,
+        )
+        final_executor.start_worker()
+        return final_executor
+
+    py_executor_creator.create_py_executor = fake_create_py_executor
+
+    import gpu_memory_service.integrations.trtllm as trtllm_gms
+
+    fake_setup_gms = MagicMock(
+        side_effect=lambda extra: call_log.append(f"setup:{extra}")
+    )
+    monkeypatch.setattr(trtllm_gms, "setup_gms", fake_setup_gms)
+    monkeypatch.setattr(
+        bootstrap,
+        "_wait_for_shadow_activation",
+        lambda: call_log.append("wait_for_activation"),
+    )
+
+    env_snapshot = {
+        "DYN_GMS_TRTLLM_ENABLED": "1",
+        "CONTAINER_NAME": "engine-1",
+        "FAILOVER_LOCK_PATH": "/tmp/failover.lock",
+    }
+    bootstrap.worker_init_hook(env_snapshot, '{"gms_read_only": true}')
+
+    py_executor_creator.create_py_executor()
+
+    assert fake_setup_gms.call_count == 1
+    assert call_log == [
+        "setup:{'gms_read_only': True}",
+        "create_py_executor",
+        "try_prepare_estimation:max=8:dummy=None",
+        "estimating_kv_cache=False",
+        "wait_for_activation",
+        "build_managers:False:creator=8192:model=8192:model_llm=8192:draft=4096:draft_llm=4096",
+        "final_executor_created",
+        "create_py_executor_instance:final:model=8192:model_llm=8192:draft=4096:draft_llm=4096:arg=8192",
+        "start_worker:final",
+    ]
+
+
 def test_worker_init_hook_is_picklable(monkeypatch):
     """mpi4py.futures requires the initializer to be picklable-by-reference."""
     import pickle

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -306,8 +306,8 @@ class Dep16PrimaryStartupReached(Exception):
     """Raised when the DEP16 primary path reaches engine init in tests."""
 
 
-class Dep16PrimaryRegisterReached(Exception):
-    """Raised when the DEP16 primary path registers after delegate install."""
+class Dep16PrimaryEndpointRegisterReached(Exception):
+    """Raised when the DEP16 primary path re-registers the real endpoint."""
 
 
 def test_deferred_generate_proxy_answers_health_check_before_delegate():
@@ -427,7 +427,7 @@ def test_init_llm_worker_shadow_standby_serves_endpoint_before_engine_init(
     ]
 
 
-def test_init_llm_worker_dep16_shadow_primary_serves_health_before_engine_init_without_runtime_lock(
+def test_init_llm_worker_dep16_shadow_primary_hides_startup_proxy_from_discovery(
     monkeypatch,
 ):
     monkeypatch.setenv("ENGINE_ID", "0")
@@ -463,6 +463,9 @@ def test_init_llm_worker_dep16_shadow_primary_serves_health_before_engine_init_w
                     raise
 
             return asyncio.create_task(wait_forever())
+
+        async def unregister_endpoint_instance(self):
+            call_log.append("unregister_endpoint_instance")
 
     class FakeLock:
         def __init__(self, *_args, **_kwargs):
@@ -515,13 +518,14 @@ def test_init_llm_worker_dep16_shadow_primary_serves_health_before_engine_init_w
 
     assert call_log == [
         "serve_endpoint",
+        "unregister_endpoint_instance",
         "get_llm_engine",
         "engine_enter",
         "serve_cancelled",
     ]
 
 
-def test_init_llm_worker_dep16_shadow_primary_registers_after_delegate_install(
+def test_init_llm_worker_dep16_shadow_primary_registers_model_then_endpoint_after_delegate_install(
     monkeypatch,
 ):
     monkeypatch.setenv("ENGINE_ID", "0")
@@ -557,6 +561,13 @@ def test_init_llm_worker_dep16_shadow_primary_registers_after_delegate_install(
                     raise
 
             return asyncio.create_task(wait_forever())
+
+        async def unregister_endpoint_instance(self):
+            call_log.append("unregister_endpoint_instance")
+
+        async def register_endpoint_instance(self):
+            call_log.append("register_endpoint_instance")
+            raise Dep16PrimaryEndpointRegisterReached()
 
     class FakeLock:
         def __init__(self, *_args, **_kwargs):
@@ -594,7 +605,6 @@ def test_init_llm_worker_dep16_shadow_primary_registers_after_delegate_install(
 
     async def fake_register_model(*_args, **_kwargs):
         call_log.append("register_model")
-        raise Dep16PrimaryRegisterReached()
 
     with (
         mock.patch("dynamo.trtllm.workers.llm_worker.tokenizer_factory"),
@@ -636,7 +646,7 @@ def test_init_llm_worker_dep16_shadow_primary_registers_after_delegate_install(
     ):
         factory.return_value = fake_request_handler_factory
 
-        with pytest.raises(Dep16PrimaryRegisterReached):
+        with pytest.raises(Dep16PrimaryEndpointRegisterReached):
             asyncio.run(
                 init_llm_worker(
                     runtime=runtime,
@@ -647,10 +657,12 @@ def test_init_llm_worker_dep16_shadow_primary_registers_after_delegate_install(
 
     assert call_log == [
         "serve_endpoint",
+        "unregister_endpoint_instance",
         "get_llm_engine",
         "engine_enter",
         "set_delegate",
         "register_model",
+        "register_endpoint_instance",
         "engine_exit",
         "serve_cancelled",
     ]

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -306,6 +306,10 @@ class Dep16PrimaryStartupReached(Exception):
     """Raised when the DEP16 primary path reaches engine init in tests."""
 
 
+class Dep16PrimaryRegisterReached(Exception):
+    """Raised when the DEP16 primary path registers after delegate install."""
+
+
 def test_deferred_generate_proxy_answers_health_check_before_delegate():
     proxy = _DeferredGenerateProxy({"token_ids": [1]})
 
@@ -423,7 +427,7 @@ def test_init_llm_worker_shadow_standby_serves_endpoint_before_engine_init(
     ]
 
 
-def test_init_llm_worker_dep16_shadow_primary_serves_and_registers_before_engine_init(
+def test_init_llm_worker_dep16_shadow_primary_serves_health_before_engine_init_without_runtime_lock(
     monkeypatch,
 ):
     monkeypatch.setenv("ENGINE_ID", "0")
@@ -461,14 +465,8 @@ def test_init_llm_worker_dep16_shadow_primary_serves_and_registers_before_engine
             return asyncio.create_task(wait_forever())
 
     class FakeLock:
-        def __init__(self, path):
-            call_log.append(f"lock_path:{path}")
-
-        async def acquire(self, engine_id):
-            call_log.append(f"lock_acquire:{engine_id}")
-
-        async def release(self):
-            return None
+        def __init__(self, *_args, **_kwargs):
+            raise AssertionError("DEP16 active path should skip runtime lock reacquire")
 
     class FakeEngineContext:
         async def __aenter__(self):
@@ -480,9 +478,6 @@ def test_init_llm_worker_dep16_shadow_primary_serves_and_registers_before_engine
 
     runtime = mock.MagicMock()
     runtime.endpoint.return_value = FakeEndpoint()
-
-    async def fake_register_model(*_args, **_kwargs):
-        call_log.append("register_model")
 
     with (
         mock.patch("dynamo.trtllm.workers.llm_worker.tokenizer_factory"),
@@ -499,10 +494,6 @@ def test_init_llm_worker_dep16_shadow_primary_serves_and_registers_before_engine
                 call_log.append("get_llm_engine"),
                 FakeEngineContext(),
             )[1],
-        ),
-        mock.patch(
-            "dynamo.trtllm.workers.llm_worker.register_model",
-            side_effect=fake_register_model,
         ),
         mock.patch("gpu_memory_service.integrations.trtllm.setup_gms"),
         mock.patch(
@@ -523,12 +514,144 @@ def test_init_llm_worker_dep16_shadow_primary_serves_and_registers_before_engine
             )
 
     assert call_log == [
-        "lock_path:/tmp/failover.lock",
-        "lock_acquire:engine-0",
         "serve_endpoint",
-        "register_model",
         "get_llm_engine",
         "engine_enter",
+        "serve_cancelled",
+    ]
+
+
+def test_init_llm_worker_dep16_shadow_primary_registers_after_delegate_install(
+    monkeypatch,
+):
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("NNODES", "2")
+    monkeypatch.setenv("FAILOVER_LOCK_PATH", "/tmp/failover.lock")
+
+    config = parse_args(
+        [
+            "--model",
+            "fake-model",
+            "--load-format",
+            "gms",
+            "--gms-shadow-mode",
+            "--gpus-per-node",
+            "1",
+        ]
+    )
+
+    call_log = []
+
+    class FakeEndpoint:
+        def connection_id(self):
+            return "7"
+
+        def serve_endpoint(self, *_args, **_kwargs):
+            call_log.append("serve_endpoint")
+
+            async def wait_forever():
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    call_log.append("serve_cancelled")
+                    raise
+
+            return asyncio.create_task(wait_forever())
+
+    class FakeLock:
+        def __init__(self, *_args, **_kwargs):
+            raise AssertionError("DEP16 active path should skip runtime lock reacquire")
+
+    class FakeEngine:
+        @staticmethod
+        def get_attention_dp_size():
+            return 1
+
+    class FakeEngineContext:
+        async def __aenter__(self):
+            call_log.append("engine_enter")
+            return FakeEngine()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            call_log.append("engine_exit")
+            return False
+
+    class FakeHandler:
+        async def generate(self, *_args, **_kwargs):
+            yield {"status": "ok"}
+
+    runtime = mock.MagicMock()
+    runtime.endpoint.return_value = FakeEndpoint()
+
+    fake_request_handler_factory = mock.MagicMock()
+    fake_request_handler_factory.get_request_handler.return_value = FakeHandler()
+
+    original_set_delegate = _DeferredGenerateProxy.set_delegate
+
+    def recording_set_delegate(self, delegate):
+        call_log.append("set_delegate")
+        original_set_delegate(self, delegate)
+
+    async def fake_register_model(*_args, **_kwargs):
+        call_log.append("register_model")
+        raise Dep16PrimaryRegisterReached()
+
+    with (
+        mock.patch("dynamo.trtllm.workers.llm_worker.tokenizer_factory"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.nixl_connect.Connector"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.dump_config"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.LLMBackendMetrics"),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.TrtllmHealthCheckPayload",
+            return_value=mock.Mock(to_dict=mock.Mock(return_value={})),
+        ),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.get_llm_engine",
+            side_effect=lambda *args, **kwargs: (
+                call_log.append("get_llm_engine"),
+                FakeEngineContext(),
+            )[1],
+        ),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.RequestHandlerFactory"
+        ) as factory,
+        mock.patch("dynamo.trtllm.workers.llm_worker.register_engine_metrics_callback"),
+        mock.patch("dynamo.trtllm.workers.llm_worker._register_memory_routes"),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.register_model",
+            side_effect=fake_register_model,
+        ),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker._DeferredGenerateProxy.set_delegate",
+            new=recording_set_delegate,
+        ),
+        mock.patch("gpu_memory_service.integrations.trtllm.setup_gms"),
+        mock.patch(
+            "gpu_memory_service.integrations.trtllm.utils.configure_gms_lock_mode"
+        ),
+        mock.patch(
+            "gpu_memory_service.failover_lock.flock.FlockFailoverLock",
+            FakeLock,
+        ),
+    ):
+        factory.return_value = fake_request_handler_factory
+
+        with pytest.raises(Dep16PrimaryRegisterReached):
+            asyncio.run(
+                init_llm_worker(
+                    runtime=runtime,
+                    config=config,
+                    shutdown_event=asyncio.Event(),
+                )
+            )
+
+    assert call_log == [
+        "serve_endpoint",
+        "get_llm_engine",
+        "engine_enter",
+        "set_delegate",
+        "register_model",
+        "engine_exit",
         "serve_cancelled",
     ]
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -342,8 +342,10 @@ def test_init_llm_worker_shadow_standby_serves_endpoint_before_engine_init(
     call_log = []
 
     class FakeEndpoint:
-        def serve_endpoint(self, *_args, **_kwargs):
-            call_log.append("serve_endpoint")
+        def serve_endpoint(self, *_args, **kwargs):
+            call_log.append(
+                f"serve_endpoint:discoverable={kwargs.get('discoverable', True)}"
+            )
 
             async def wait_forever():
                 try:
@@ -419,10 +421,144 @@ def test_init_llm_worker_shadow_standby_serves_endpoint_before_engine_init(
             )
 
     assert call_log == [
-        "serve_endpoint",
+        "serve_endpoint:discoverable=False",
         "health:True",
         "get_llm_engine",
         "engine_enter",
+        "serve_cancelled",
+    ]
+
+
+def test_init_llm_worker_shadow_standby_reregisters_endpoint_after_delegate_install(
+    monkeypatch,
+):
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("FAILOVER_LOCK_PATH", "/tmp/failover.lock")
+
+    config = parse_args(
+        [
+            "--model",
+            "fake-model",
+            "--load-format",
+            "gms",
+            "--gms-shadow-mode",
+            "--gpus-per-node",
+            "1",
+        ]
+    )
+
+    call_log = []
+
+    class FakeEndpoint:
+        def connection_id(self):
+            return "7"
+
+        def serve_endpoint(self, *_args, **kwargs):
+            call_log.append(
+                f"serve_endpoint:discoverable={kwargs.get('discoverable', True)}"
+            )
+
+            async def wait_forever():
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    call_log.append("serve_cancelled")
+                    raise
+
+            return asyncio.create_task(wait_forever())
+
+        async def register_endpoint_instance(self):
+            call_log.append("register_endpoint_instance")
+            raise Dep16PrimaryEndpointRegisterReached()
+
+    class FakeEngine:
+        @staticmethod
+        def get_attention_dp_size():
+            return 1
+
+    class FakeEngineContext:
+        async def __aenter__(self):
+            call_log.append("engine_enter")
+            return FakeEngine()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            call_log.append("engine_exit")
+            return False
+
+    class FakeHandler:
+        async def generate(self, *_args, **_kwargs):
+            yield {"status": "ok"}
+
+    runtime = mock.MagicMock()
+    runtime.endpoint.return_value = FakeEndpoint()
+    runtime.set_health_status.side_effect = lambda ready: call_log.append(
+        f"health:{ready}"
+    )
+
+    fake_request_handler_factory = mock.MagicMock()
+    fake_request_handler_factory.get_request_handler.return_value = FakeHandler()
+
+    original_set_delegate = _DeferredGenerateProxy.set_delegate
+
+    def recording_set_delegate(self, delegate):
+        call_log.append("set_delegate")
+        original_set_delegate(self, delegate)
+
+    async def fake_register_model(*_args, **_kwargs):
+        call_log.append("register_model")
+
+    with (
+        mock.patch("dynamo.trtllm.workers.llm_worker.tokenizer_factory"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.nixl_connect.Connector"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.dump_config"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.LLMBackendMetrics"),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.TrtllmHealthCheckPayload",
+            return_value=mock.Mock(to_dict=mock.Mock(return_value={})),
+        ),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.get_llm_engine",
+            side_effect=lambda *args, **kwargs: (
+                call_log.append("get_llm_engine"),
+                FakeEngineContext(),
+            )[1],
+        ),
+        mock.patch("dynamo.trtllm.workers.llm_worker.RequestHandlerFactory") as factory,
+        mock.patch("dynamo.trtllm.workers.llm_worker.register_engine_metrics_callback"),
+        mock.patch("dynamo.trtllm.workers.llm_worker._register_memory_routes"),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.register_model",
+            side_effect=fake_register_model,
+        ),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker._DeferredGenerateProxy.set_delegate",
+            new=recording_set_delegate,
+        ),
+        mock.patch("gpu_memory_service.integrations.trtllm.setup_gms"),
+        mock.patch(
+            "gpu_memory_service.integrations.trtllm.utils.configure_gms_lock_mode"
+        ),
+    ):
+        factory.return_value = fake_request_handler_factory
+
+        with pytest.raises(Dep16PrimaryEndpointRegisterReached):
+            asyncio.run(
+                init_llm_worker(
+                    runtime=runtime,
+                    config=config,
+                    shutdown_event=asyncio.Event(),
+                )
+            )
+
+    assert call_log == [
+        "serve_endpoint:discoverable=False",
+        "health:True",
+        "get_llm_engine",
+        "engine_enter",
+        "register_model",
+        "set_delegate",
+        "register_endpoint_instance",
+        "engine_exit",
         "serve_cancelled",
     ]
 
@@ -452,8 +588,10 @@ def test_init_llm_worker_dep16_shadow_primary_hides_startup_proxy_from_discovery
         def connection_id(self):
             return "7"
 
-        def serve_endpoint(self, *_args, **_kwargs):
-            call_log.append("serve_endpoint")
+        def serve_endpoint(self, *_args, **kwargs):
+            call_log.append(
+                f"serve_endpoint:discoverable={kwargs.get('discoverable', True)}"
+            )
 
             async def wait_forever():
                 try:
@@ -463,9 +601,6 @@ def test_init_llm_worker_dep16_shadow_primary_hides_startup_proxy_from_discovery
                     raise
 
             return asyncio.create_task(wait_forever())
-
-        async def unregister_endpoint_instance(self):
-            call_log.append("unregister_endpoint_instance")
 
     class FakeLock:
         def __init__(self, *_args, **_kwargs):
@@ -517,8 +652,7 @@ def test_init_llm_worker_dep16_shadow_primary_hides_startup_proxy_from_discovery
             )
 
     assert call_log == [
-        "serve_endpoint",
-        "unregister_endpoint_instance",
+        "serve_endpoint:discoverable=False",
         "get_llm_engine",
         "engine_enter",
         "serve_cancelled",
@@ -550,8 +684,10 @@ def test_init_llm_worker_dep16_shadow_primary_registers_model_then_endpoint_afte
         def connection_id(self):
             return "7"
 
-        def serve_endpoint(self, *_args, **_kwargs):
-            call_log.append("serve_endpoint")
+        def serve_endpoint(self, *_args, **kwargs):
+            call_log.append(
+                f"serve_endpoint:discoverable={kwargs.get('discoverable', True)}"
+            )
 
             async def wait_forever():
                 try:
@@ -561,9 +697,6 @@ def test_init_llm_worker_dep16_shadow_primary_registers_model_then_endpoint_afte
                     raise
 
             return asyncio.create_task(wait_forever())
-
-        async def unregister_endpoint_instance(self):
-            call_log.append("unregister_endpoint_instance")
 
         async def register_endpoint_instance(self):
             call_log.append("register_endpoint_instance")
@@ -622,9 +755,7 @@ def test_init_llm_worker_dep16_shadow_primary_registers_model_then_endpoint_afte
                 FakeEngineContext(),
             )[1],
         ),
-        mock.patch(
-            "dynamo.trtllm.workers.llm_worker.RequestHandlerFactory"
-        ) as factory,
+        mock.patch("dynamo.trtllm.workers.llm_worker.RequestHandlerFactory") as factory,
         mock.patch("dynamo.trtllm.workers.llm_worker.register_engine_metrics_callback"),
         mock.patch("dynamo.trtllm.workers.llm_worker._register_memory_routes"),
         mock.patch(
@@ -656,8 +787,7 @@ def test_init_llm_worker_dep16_shadow_primary_registers_model_then_endpoint_afte
             )
 
     assert call_log == [
-        "serve_endpoint",
-        "unregister_endpoint_instance",
+        "serve_endpoint:discoverable=False",
         "get_llm_engine",
         "engine_enter",
         "set_delegate",

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -22,7 +22,7 @@ from dynamo.trtllm.args import Config, parse_args
 from dynamo.trtllm.constants import Modality
 from dynamo.trtllm.tests.conftest import make_cli_args_fixture
 from dynamo.trtllm.utils.trtllm_utils import deep_update
-from dynamo.trtllm.workers.llm_worker import _StandbyGenerateProxy, init_llm_worker
+from dynamo.trtllm.workers.llm_worker import _DeferredGenerateProxy, init_llm_worker
 
 # Get path relative to this test file
 REPO_ROOT = Path(__file__).resolve().parents[5]
@@ -302,8 +302,12 @@ class ShadowPrimaryLockReached(Exception):
     """Raised when the primary shadow path reaches post-init registration."""
 
 
-def test_standby_generate_proxy_answers_health_check_before_delegate():
-    proxy = _StandbyGenerateProxy({"token_ids": [1]})
+class Dep16PrimaryStartupReached(Exception):
+    """Raised when the DEP16 primary path reaches engine init in tests."""
+
+
+def test_deferred_generate_proxy_answers_health_check_before_delegate():
+    proxy = _DeferredGenerateProxy({"token_ids": [1]})
 
     async def collect_response():
         return [
@@ -413,6 +417,116 @@ def test_init_llm_worker_shadow_standby_serves_endpoint_before_engine_init(
     assert call_log == [
         "serve_endpoint",
         "health:True",
+        "get_llm_engine",
+        "engine_enter",
+        "serve_cancelled",
+    ]
+
+
+def test_init_llm_worker_dep16_shadow_primary_serves_and_registers_before_engine_init(
+    monkeypatch,
+):
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("NNODES", "2")
+    monkeypatch.setenv("FAILOVER_LOCK_PATH", "/tmp/failover.lock")
+
+    config = parse_args(
+        [
+            "--model",
+            "fake-model",
+            "--load-format",
+            "gms",
+            "--gms-shadow-mode",
+            "--gpus-per-node",
+            "1",
+        ]
+    )
+
+    call_log = []
+
+    class FakeEndpoint:
+        def connection_id(self):
+            return "7"
+
+        def serve_endpoint(self, *_args, **_kwargs):
+            call_log.append("serve_endpoint")
+
+            async def wait_forever():
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    call_log.append("serve_cancelled")
+                    raise
+
+            return asyncio.create_task(wait_forever())
+
+    class FakeLock:
+        def __init__(self, path):
+            call_log.append(f"lock_path:{path}")
+
+        async def acquire(self, engine_id):
+            call_log.append(f"lock_acquire:{engine_id}")
+
+        async def release(self):
+            return None
+
+    class FakeEngineContext:
+        async def __aenter__(self):
+            call_log.append("engine_enter")
+            raise Dep16PrimaryStartupReached()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    runtime = mock.MagicMock()
+    runtime.endpoint.return_value = FakeEndpoint()
+
+    async def fake_register_model(*_args, **_kwargs):
+        call_log.append("register_model")
+
+    with (
+        mock.patch("dynamo.trtllm.workers.llm_worker.tokenizer_factory"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.nixl_connect.Connector"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.dump_config"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.LLMBackendMetrics"),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.TrtllmHealthCheckPayload",
+            return_value=mock.Mock(to_dict=mock.Mock(return_value={})),
+        ),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.get_llm_engine",
+            side_effect=lambda *args, **kwargs: (
+                call_log.append("get_llm_engine"),
+                FakeEngineContext(),
+            )[1],
+        ),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.register_model",
+            side_effect=fake_register_model,
+        ),
+        mock.patch("gpu_memory_service.integrations.trtllm.setup_gms"),
+        mock.patch(
+            "gpu_memory_service.integrations.trtllm.utils.configure_gms_lock_mode"
+        ),
+        mock.patch(
+            "gpu_memory_service.failover_lock.flock.FlockFailoverLock",
+            FakeLock,
+        ),
+    ):
+        with pytest.raises(Dep16PrimaryStartupReached):
+            asyncio.run(
+                init_llm_worker(
+                    runtime=runtime,
+                    config=config,
+                    shutdown_event=asyncio.Event(),
+                )
+            )
+
+    assert call_log == [
+        "lock_path:/tmp/failover.lock",
+        "lock_acquire:engine-0",
+        "serve_endpoint",
+        "register_model",
         "get_llm_engine",
         "engine_enter",
         "serve_cancelled",

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -564,8 +564,6 @@ async def init_llm_worker(
             (prometheus_names.labels.MODEL_NAME, model_name_for_metrics),
         ]
 
-    startup_runtime_config = _build_runtime_config(config, engine_args)
-
     # Construct Prometheus gauges directly; passed through to the engine and publisher
     # via explicit parameters (no module-level global).
     component_gauges = LLMBackendMetrics(
@@ -586,8 +584,9 @@ async def init_llm_worker(
     startup_lock = None
     startup_generate_proxy = None
     startup_serve_task = None
-    model_registered = False
-    if primary_shadow_owner:
+    # Keep DEP16 active startup health-only until the real handler is live.
+    register_model_after_delegate = False
+    if primary_shadow_owner and not dep16_shadow_primary:
         from gpu_memory_service.failover_lock.flock import FlockFailoverLock
 
         startup_lock = FlockFailoverLock(failover_lock_path)
@@ -613,6 +612,9 @@ async def init_llm_worker(
             "[Shadow] Engine sleeping, startup probe now passing, waiting for lock"
         )
     elif dep16_shadow_primary:
+        register_model_after_delegate = (
+            config.disaggregation_mode != DisaggregationMode.ENCODE
+        )
         startup_generate_proxy = _DeferredGenerateProxy(
             health_check_payload,
             waiting_message="Active engine is still initializing",
@@ -629,21 +631,9 @@ async def init_llm_worker(
         logging.info(
             "[DEP16] Active startup proxy is serving health checks before engine init"
         )
-
-        if config.disaggregation_mode != DisaggregationMode.ENCODE:
-            await register_model(
-                model_input,
-                model_type,
-                endpoint,
-                config.model,
-                config.served_model_name,
-                context_length=config.max_seq_len,
-                kv_cache_block_size=config.kv_block_size,
-                runtime_config=startup_runtime_config,
-                custom_template_path=config.custom_jinja_template,
-            )
-            model_registered = True
-            logging.info("[DEP16] Active model registered before engine init")
+        logging.info(
+            "[DEP16] Skipping runtime primary startup lock reacquire during multinode active startup"
+        )
 
     try:
         async with get_llm_engine(
@@ -780,7 +770,7 @@ async def init_llm_worker(
             # Prefill and decode workers register - frontend detects their role via ModelType
             if (
                 config.disaggregation_mode != DisaggregationMode.ENCODE
-                and not model_registered
+                and not register_model_after_delegate
             ):
                 await register_model(
                     model_input,
@@ -836,6 +826,21 @@ async def init_llm_worker(
                         )
                     if startup_generate_proxy is not None:
                         startup_generate_proxy.set_delegate(handler.generate)
+                        if register_model_after_delegate:
+                            await register_model(
+                                model_input,
+                                model_type,
+                                endpoint,
+                                config.model,
+                                config.served_model_name,
+                                context_length=config.max_seq_len,
+                                kv_cache_block_size=config.kv_block_size,
+                                runtime_config=runtime_config,
+                                custom_template_path=config.custom_jinja_template,
+                            )
+                            logging.info(
+                                "[DEP16] Active model registered after engine init"
+                            )
                         await startup_serve_task
                     else:
                         await endpoint.serve_endpoint(
@@ -850,6 +855,21 @@ async def init_llm_worker(
             else:
                 if startup_generate_proxy is not None:
                     startup_generate_proxy.set_delegate(handler.generate)
+                    if register_model_after_delegate:
+                        await register_model(
+                            model_input,
+                            model_type,
+                            endpoint,
+                            config.model,
+                            config.served_model_name,
+                            context_length=config.max_seq_len,
+                            kv_cache_block_size=config.kv_block_size,
+                            runtime_config=runtime_config,
+                            custom_template_path=config.custom_jinja_template,
+                        )
+                        logging.info(
+                            "[DEP16] Active model registered after engine init"
+                        )
                     await startup_serve_task
                 else:
                     await endpoint.serve_endpoint(

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -586,6 +586,7 @@ async def init_llm_worker(
     startup_serve_task = None
     # Keep DEP16 active startup health-only until the real handler is live.
     register_model_after_delegate = False
+    register_endpoint_after_delegate = False
     if primary_shadow_owner and not dep16_shadow_primary:
         from gpu_memory_service.failover_lock.flock import FlockFailoverLock
 
@@ -615,6 +616,7 @@ async def init_llm_worker(
         register_model_after_delegate = (
             config.disaggregation_mode != DisaggregationMode.ENCODE
         )
+        register_endpoint_after_delegate = True
         startup_generate_proxy = _DeferredGenerateProxy(
             health_check_payload,
             waiting_message="Active engine is still initializing",
@@ -628,11 +630,16 @@ async def init_llm_worker(
         if startup_serve_task.done():
             await startup_serve_task
 
+        await endpoint.unregister_endpoint_instance()
+
         logging.info(
             "[DEP16] Active startup proxy is serving health checks before engine init"
         )
         logging.info(
             "[DEP16] Skipping runtime primary startup lock reacquire during multinode active startup"
+        )
+        logging.info(
+            "[DEP16] Startup proxy unregistered from discovery until real handler is ready"
         )
 
     try:
@@ -841,6 +848,11 @@ async def init_llm_worker(
                             logging.info(
                                 "[DEP16] Active model registered after engine init"
                             )
+                        if register_endpoint_after_delegate:
+                            await endpoint.register_endpoint_instance()
+                            logging.info(
+                                "[DEP16] Active endpoint re-registered after engine init"
+                            )
                         await startup_serve_task
                     else:
                         await endpoint.serve_endpoint(
@@ -869,6 +881,11 @@ async def init_llm_worker(
                         )
                         logging.info(
                             "[DEP16] Active model registered after engine init"
+                        )
+                    if register_endpoint_after_delegate:
+                        await endpoint.register_endpoint_instance()
+                        logging.info(
+                            "[DEP16] Active endpoint re-registered after engine init"
                         )
                     await startup_serve_task
                 else:

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -68,10 +68,15 @@ from dynamo.trtllm.utils.trtllm_utils import deep_update
 DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 1024
 
 
-class _StandbyGenerateProxy:
-    def __init__(self, health_check_payload: dict | None = None):
+class _DeferredGenerateProxy:
+    def __init__(
+        self,
+        health_check_payload: dict | None = None,
+        waiting_message: str = "Engine is not ready",
+    ):
         self._delegate = None
         self._health_check_payload = health_check_payload
+        self._waiting_message = waiting_message
 
     def set_delegate(self, delegate) -> None:
         self._delegate = delegate
@@ -84,10 +89,42 @@ class _StandbyGenerateProxy:
             ):
                 yield {"status": "ok"}
                 return
-            raise RuntimeError("Shadow standby is waiting for failover lock")
+            raise RuntimeError(self._waiting_message)
 
         async for response in self._delegate(request, context):
             yield response
+
+
+def _initial_attention_dp_size(engine_args: dict) -> int:
+    if not engine_args.get("enable_attention_dp", False):
+        return 1
+
+    return int(engine_args.get("tensor_parallel_size", 1))
+
+
+def _build_runtime_config(
+    config: Config,
+    engine_args: dict,
+    attention_dp_size: int | None = None,
+) -> ModelRuntimeConfig:
+    runtime_config = ModelRuntimeConfig()
+    runtime_config.max_num_seqs = engine_args["max_batch_size"]
+    runtime_config.max_num_batched_tokens = engine_args["max_num_tokens"]
+    runtime_config.reasoning_parser = config.dyn_reasoning_parser
+    runtime_config.tool_call_parser = config.dyn_tool_call_parser
+    runtime_config.exclude_tools_when_tool_choice_none = (
+        config.exclude_tools_when_tool_choice_none
+    )
+    runtime_config.enable_local_indexer = (
+        config.enable_local_indexer
+        and config.disaggregation_mode != DisaggregationMode.DECODE
+    )
+    runtime_config.data_parallel_size = (
+        attention_dp_size
+        if attention_dp_size is not None
+        else _initial_attention_dp_size(engine_args)
+    )
+    return runtime_config
 
 
 def build_kv_connector_config(config: Config):
@@ -527,6 +564,8 @@ async def init_llm_worker(
             (prometheus_names.labels.MODEL_NAME, model_name_for_metrics),
         ]
 
+    startup_runtime_config = _build_runtime_config(config, engine_args)
+
     # Construct Prometheus gauges directly; passed through to the engine and publisher
     # via explicit parameters (no module-level global).
     component_gauges = LLMBackendMetrics(
@@ -538,10 +577,16 @@ async def init_llm_worker(
     shadow_engine_id = os.environ.get("ENGINE_ID", "0")
     shadow_standby = config.gms_shadow_mode and shadow_engine_id != "0"
     primary_shadow_owner = config.gms_shadow_mode and shadow_engine_id == "0"
+    try:
+        node_count = int(os.environ.get("NNODES", "1"))
+    except ValueError:
+        node_count = 1
+    dep16_shadow_primary = primary_shadow_owner and node_count > 1
     failover_lock_path = os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
     startup_lock = None
-    standby_generate_proxy = None
-    standby_serve_task = None
+    startup_generate_proxy = None
+    startup_serve_task = None
+    model_registered = False
     if primary_shadow_owner:
         from gpu_memory_service.failover_lock.flock import FlockFailoverLock
 
@@ -550,20 +595,55 @@ async def init_llm_worker(
         logging.info("[Shadow] Primary acquired startup lock, starting engine init")
 
     if shadow_standby:
-        standby_generate_proxy = _StandbyGenerateProxy(health_check_payload)
-        standby_serve_task = endpoint.serve_endpoint(
-            standby_generate_proxy.generate,
+        startup_generate_proxy = _DeferredGenerateProxy(
+            health_check_payload,
+            waiting_message="Shadow standby is waiting for failover lock",
+        )
+        startup_serve_task = endpoint.serve_endpoint(
+            startup_generate_proxy.generate,
             metrics_labels=metrics_labels,
             health_check_payload=health_check_payload,
         )
         await asyncio.sleep(0)
-        if standby_serve_task.done():
-            await standby_serve_task
+        if startup_serve_task.done():
+            await startup_serve_task
 
         runtime.set_health_status(True)
         logging.info(
             "[Shadow] Engine sleeping, startup probe now passing, waiting for lock"
         )
+    elif dep16_shadow_primary:
+        startup_generate_proxy = _DeferredGenerateProxy(
+            health_check_payload,
+            waiting_message="Active engine is still initializing",
+        )
+        startup_serve_task = endpoint.serve_endpoint(
+            startup_generate_proxy.generate,
+            metrics_labels=metrics_labels,
+            health_check_payload=health_check_payload,
+        )
+        await asyncio.sleep(0)
+        if startup_serve_task.done():
+            await startup_serve_task
+
+        logging.info(
+            "[DEP16] Active startup proxy is serving health checks before engine init"
+        )
+
+        if config.disaggregation_mode != DisaggregationMode.ENCODE:
+            await register_model(
+                model_input,
+                model_type,
+                endpoint,
+                config.model,
+                config.served_model_name,
+                context_length=config.max_seq_len,
+                kv_cache_block_size=config.kv_block_size,
+                runtime_config=startup_runtime_config,
+                custom_template_path=config.custom_jinja_template,
+            )
+            model_registered = True
+            logging.info("[DEP16] Active model registered before engine init")
 
     try:
         async with get_llm_engine(
@@ -582,36 +662,12 @@ async def init_llm_worker(
             # This causes an issue because get_stats_async doesn't work when no requests are sent to the engine
             # So for now, we just set the parsers from the config
             # TODO: fix this once we have a better way to get total_kv_blocks
-            runtime_config = ModelRuntimeConfig()
-
-            # Set values from config that are available immediately
-            # Note: We populate max_num_seqs and max_num_batched_tokens from config
-            # to ensure Prometheus metrics are available even without engine stats
-
-            # Naming clarification:
-            # - In vLLM: max_num_seqs = maximum concurrent requests (this is an unusual name due to vLLM's historic reasons)
-            # - In TensorRT-LLM: max_batch_size = maximum concurrent requests (clearer name)
-            # Both parameters control the same thing: how many requests can be processed simultaneously
-
-            # Need to get max_num_seqs and max_num_batched_tokens from engine_args
-            # because they can be overridden by --extra-engine-args or --override-engine-args
-            runtime_config.max_num_seqs = engine_args["max_batch_size"]
-            runtime_config.max_num_batched_tokens = engine_args["max_num_tokens"]
-            runtime_config.reasoning_parser = config.dyn_reasoning_parser
-            runtime_config.tool_call_parser = config.dyn_tool_call_parser
-            runtime_config.exclude_tools_when_tool_choice_none = (
-                config.exclude_tools_when_tool_choice_none
-            )
-            # Decode workers don't create the WorkerKvQuery endpoint, so don't advertise local indexer
-            runtime_config.enable_local_indexer = (
-                config.enable_local_indexer
-                and config.disaggregation_mode != DisaggregationMode.DECODE
-            )
-            # Set data_parallel_size for attention DP mode
-            # This enables the router's scheduler to correctly iterate over all dp_ranks
-            # Need to name ADP as `data_parallel_size` for parity with other frameworks
             attention_dp_size = engine.get_attention_dp_size()
-            runtime_config.data_parallel_size = attention_dp_size
+            runtime_config = _build_runtime_config(
+                config,
+                engine_args,
+                attention_dp_size=attention_dp_size,
+            )
 
             logging.info(
                 f"Set runtime config max_num_seqs: {runtime_config.max_num_seqs}"
@@ -722,7 +778,10 @@ async def init_llm_worker(
             # Register the model with runtime config
             # Encode workers do NOT register - they're internal workers only
             # Prefill and decode workers register - frontend detects their role via ModelType
-            if config.disaggregation_mode != DisaggregationMode.ENCODE:
+            if (
+                config.disaggregation_mode != DisaggregationMode.ENCODE
+                and not model_registered
+            ):
                 await register_model(
                     model_input,
                     model_type,
@@ -775,9 +834,9 @@ async def init_llm_worker(
                             model_name=model_name_for_metrics,
                             component_name=config.component,
                         )
-                    if shadow_standby:
-                        standby_generate_proxy.set_delegate(handler.generate)
-                        await standby_serve_task
+                    if startup_generate_proxy is not None:
+                        startup_generate_proxy.set_delegate(handler.generate)
+                        await startup_serve_task
                     else:
                         await endpoint.serve_endpoint(
                             handler.generate,
@@ -789,18 +848,18 @@ async def init_llm_worker(
                 if consolidator_publisher:
                     consolidator_publisher.shutdown()
             else:
-                if shadow_standby:
-                    standby_generate_proxy.set_delegate(handler.generate)
-                    await standby_serve_task
+                if startup_generate_proxy is not None:
+                    startup_generate_proxy.set_delegate(handler.generate)
+                    await startup_serve_task
                 else:
                     await endpoint.serve_endpoint(
                         handler.generate, health_check_payload=health_check_payload
                     )
     except Exception:
-        if standby_serve_task is not None:
-            standby_serve_task.cancel()
+        if startup_serve_task is not None:
+            startup_serve_task.cancel()
             with suppress(asyncio.CancelledError):
-                await standby_serve_task
+                await startup_serve_task
         raise
     finally:
         if startup_lock is not None:

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -595,6 +595,7 @@ async def init_llm_worker(
         logging.info("[Shadow] Primary acquired startup lock, starting engine init")
 
     if shadow_standby:
+        register_endpoint_after_delegate = True
         startup_generate_proxy = _DeferredGenerateProxy(
             health_check_payload,
             waiting_message="Shadow standby is waiting for failover lock",
@@ -603,6 +604,7 @@ async def init_llm_worker(
             startup_generate_proxy.generate,
             metrics_labels=metrics_labels,
             health_check_payload=health_check_payload,
+            discoverable=False,
         )
         await asyncio.sleep(0)
         if startup_serve_task.done():
@@ -625,12 +627,11 @@ async def init_llm_worker(
             startup_generate_proxy.generate,
             metrics_labels=metrics_labels,
             health_check_payload=health_check_payload,
+            discoverable=False,
         )
         await asyncio.sleep(0)
         if startup_serve_task.done():
             await startup_serve_task
-
-        await endpoint.unregister_endpoint_instance()
 
         logging.info(
             "[DEP16] Active startup proxy is serving health checks before engine init"
@@ -639,7 +640,7 @@ async def init_llm_worker(
             "[DEP16] Skipping runtime primary startup lock reacquire during multinode active startup"
         )
         logging.info(
-            "[DEP16] Startup proxy unregistered from discovery until real handler is ready"
+            "[DEP16] Startup proxy stays out of discovery until real handler is ready"
         )
 
     try:

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -832,7 +832,7 @@ impl DistributedRuntime {
 
 #[pymethods]
 impl Endpoint {
-    #[pyo3(signature = (generator, graceful_shutdown = true, metrics_labels = None, health_check_payload = None))]
+    #[pyo3(signature = (generator, graceful_shutdown = true, metrics_labels = None, health_check_payload = None, discoverable = true))]
     fn serve_endpoint<'p>(
         &self,
         py: Python<'p>,
@@ -840,6 +840,7 @@ impl Endpoint {
         graceful_shutdown: Option<bool>,
         metrics_labels: Option<Vec<(String, String)>>,
         health_check_payload: Option<&Bound<'p, PyDict>>,
+        discoverable: Option<bool>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let engine = Arc::new(engine::PythonAsyncEngine::new(
             generator,
@@ -881,9 +882,11 @@ impl Endpoint {
         builder = builder.register_local_engine(engine).map_err(to_pyerr)?;
 
         let graceful_shutdown = graceful_shutdown.unwrap_or(true);
+        let discoverable = discoverable.unwrap_or(true);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             builder
                 .graceful_shutdown(graceful_shutdown)
+                .discoverable(discoverable)
                 .start()
                 .await
                 .map_err(to_pyerr)?;

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -129,7 +129,7 @@ class Endpoint:
 
     ...
 
-    async def serve_endpoint(self, handler: RequestHandler, graceful_shutdown: bool = True, metrics_labels: Optional[List[Tuple[str, str]]] = None, health_check_payload: Optional[Dict[str, Any]] = None) -> None:
+    async def serve_endpoint(self, handler: RequestHandler, graceful_shutdown: bool = True, metrics_labels: Optional[List[Tuple[str, str]]] = None, health_check_payload: Optional[Dict[str, Any]] = None, discoverable: bool = True) -> None:
         """
         Serve an endpoint discoverable by all connected clients at
         `{{ namespace }}/components/{{ component_name }}/endpoints/{{ endpoint_name }}`
@@ -140,6 +140,10 @@ class Endpoint:
             metrics_labels: Optional list of metrics labels to add to the metrics
             health_check_payload: Optional dict containing the health check request payload
                                   that will be used to verify endpoint health
+            discoverable: Whether to publish the endpoint to discovery immediately.
+                            When False, request-plane serving and health checks still start,
+                            but clients will not discover the endpoint until
+                            register_endpoint_instance() is called later.
         """
         ...
 

--- a/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
+++ b/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
@@ -48,6 +48,7 @@ _extra_config_json: Optional[str] = None
 _bootstrap_installed = False
 _executor_finalize_hook_installed = False
 _shadow_activation_fd: int | None = None
+_comm_task_bootstrapped = False
 
 
 def set_extra_config(extra: "dict[str, Any] | None") -> None:
@@ -472,6 +473,22 @@ def worker_init_hook(env_snapshot: dict, extra_config_json: Optional[str]) -> No
     )
 
 
+def run_bootstrapped_mpi_task(
+    env_snapshot: dict,
+    extra_config_json: Optional[str],
+    task,
+    *args,
+    **kwargs,
+):
+    """Ensure MPICommSession tasks see the same bootstrap as MPIPool workers."""
+
+    global _comm_task_bootstrapped
+    if not _comm_task_bootstrapped:
+        worker_init_hook(env_snapshot, extra_config_json)
+        _comm_task_bootstrapped = True
+    return task(*args, **kwargs)
+
+
 def install_mpi_worker_bootstrap() -> None:
     """Monkey-patch MpiPoolSession to run worker_init_hook in every child. Idempotent."""
     global _bootstrap_installed
@@ -486,6 +503,7 @@ def install_mpi_worker_bootstrap() -> None:
         ) from exc
 
     MpiPoolSession = _mpi_session.MpiPoolSession
+    MpiCommSession = getattr(_mpi_session, "MpiCommSession", None)
 
     def _patched_start_mpi_pool(self) -> None:
         assert not self.mpi_pool, "MPI session already started"
@@ -512,7 +530,28 @@ def install_mpi_worker_bootstrap() -> None:
         )
 
     MpiPoolSession._start_mpi_pool = _patched_start_mpi_pool
+    if MpiCommSession is not None:
+        original_submit = MpiCommSession.submit
+
+        @wraps(original_submit)
+        def _patched_submit(self, task, *args, **kwargs):
+            env_snapshot = {
+                key: os.environ[key]
+                for key in _PROPAGATED_ENV_VARS
+                if key in os.environ
+            }
+            return original_submit(
+                self,
+                run_bootstrapped_mpi_task,
+                env_snapshot,
+                _extra_config_json,
+                task,
+                *args,
+                **kwargs,
+            )
+
+        MpiCommSession.submit = _patched_submit
     _bootstrap_installed = True
     logger.info(
-        "[GMS] Patched TensorRT-LLM MpiPoolSession._start_mpi_pool to bootstrap GMS in MPI workers"
+        "[GMS] Patched TensorRT-LLM MPI sessions to bootstrap GMS in MPI workers"
     )

--- a/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
+++ b/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
@@ -10,11 +10,17 @@ so setup_gms() — which monkey-patches ModelLoader.load — only runs in the pa
 Every child rank then hits the unpatched load path and allocates its own full
 weight shard, duplicating weights between active and shadow engines.
 
-This module fixes that by monkey-patching MpiPoolSession._start_mpi_pool so the
-MPIPoolExecutor is constructed with an ``initializer=worker_init_hook`` that runs
-first in every child. The hook restores the GMS-relevant env vars from the
-parent's snapshot and calls setup_gms() so that the child's own ModelLoader.load
-is patched before TRT-LLM invokes it.
+This module fixes that in both TRT-LLM worker-launch paths:
+
+- ``MpiPoolSession`` / ``MPIPoolExecutor`` children get
+  ``initializer=worker_init_hook``.
+- ``MpiCommSession`` / ``MPICommExecutor`` workers run a top-level
+  ``worker_main`` wrapper that calls the same hook before delegating to
+  TRT-LLM's real executor entrypoint.
+
+In both cases the hook restores the GMS-relevant env vars from the parent's
+snapshot and calls setup_gms() so that the child's own ModelLoader.load is
+patched before TRT-LLM invokes it.
 """
 
 from __future__ import annotations
@@ -33,10 +39,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _ENABLED_ENV = "DYN_GMS_TRTLLM_ENABLED"
+_EXTRA_CONFIG_ENV = "DYN_GMS_TRTLLM_EXTRA_CONFIG_JSON"
 # Env vars the children must inherit for the child-side setup_gms to behave
 # identically to the parent. Upstream MpiPoolSession only forwards TRTLLM_*/TLLM_*.
 _PROPAGATED_ENV_VARS: tuple[str, ...] = (
     _ENABLED_ENV,
+    _EXTRA_CONFIG_ENV,
     "CONTAINER_NAME",
     "DYN_GMS_SHADOW_MODE",
     "ENGINE_ID",
@@ -55,6 +63,18 @@ def set_extra_config(extra: "dict[str, Any] | None") -> None:
     """Stash the model_loader_extra_config so MPI children see the same lock mode."""
     global _extra_config_json
     _extra_config_json = json.dumps(extra) if extra else None
+    if _extra_config_json is None:
+        os.environ.pop(_EXTRA_CONFIG_ENV, None)
+    else:
+        os.environ[_EXTRA_CONFIG_ENV] = _extra_config_json
+
+
+def _current_bootstrap_context() -> tuple[dict[str, str], Optional[str]]:
+    env_snapshot = {
+        key: os.environ[key] for key in _PROPAGATED_ENV_VARS if key in os.environ
+    }
+    extra_config_json = _extra_config_json or env_snapshot.get(_EXTRA_CONFIG_ENV)
+    return env_snapshot, extra_config_json
 
 
 def _delay_commit_until_engine_init(extra: "dict[str, Any] | None") -> bool:
@@ -462,8 +482,11 @@ def worker_init_hook(env_snapshot: dict, extra_config_json: Optional[str]) -> No
         return
 
     from gpu_memory_service.integrations.trtllm import setup_gms
+    from gpu_memory_service.integrations.trtllm.utils import configure_gms_lock_mode
 
     extra = json.loads(extra_config_json) if extra_config_json else None
+    if os.environ.get("DYN_GMS_SHADOW_MODE") == "1":
+        extra = configure_gms_lock_mode(extra or {})
     set_extra_config(extra)
     setup_gms(extra)
     if _delay_commit_until_engine_init(extra) or _is_shadow_standby(extra):
@@ -489,6 +512,31 @@ def run_bootstrapped_mpi_task(
     return task(*args, **kwargs)
 
 
+def bootstrapped_proxy_worker_main(*args, **kwargs):
+    """Run TRT-LLM's worker_main through worker_init_hook on MPIComm paths.
+
+    External MPI worker nodes do not import Dynamo's llm_worker module before
+    accepting tasks through MPICommExecutor, so the parent-side
+    ``MpiCommSession.submit`` monkey-patch never reaches those processes. Patch
+    the pickled task itself instead: GenerationExecutorProxy submits
+    ``tensorrt_llm.executor.proxy.worker_main``, so replacing that symbol with a
+    top-level wrapper ensures remote MPI workers import this module and execute
+    ``worker_init_hook`` before TRT-LLM enters ``worker_main``.
+    """
+
+    env_snapshot, extra_config_json = _current_bootstrap_context()
+
+    from tensorrt_llm.executor.worker import worker_main as original_worker_main
+
+    return run_bootstrapped_mpi_task(
+        env_snapshot,
+        extra_config_json,
+        original_worker_main,
+        *args,
+        **kwargs,
+    )
+
+
 def install_mpi_worker_bootstrap() -> None:
     """Monkey-patch MpiPoolSession to run worker_init_hook in every child. Idempotent."""
     global _bootstrap_installed
@@ -496,6 +544,7 @@ def install_mpi_worker_bootstrap() -> None:
         return
 
     try:
+        import tensorrt_llm.executor.proxy as _executor_proxy
         import tensorrt_llm.llmapi.mpi_session as _mpi_session
     except ImportError as exc:
         raise RuntimeError(
@@ -530,6 +579,7 @@ def install_mpi_worker_bootstrap() -> None:
         )
 
     MpiPoolSession._start_mpi_pool = _patched_start_mpi_pool
+    _executor_proxy.worker_main = bootstrapped_proxy_worker_main
     if MpiCommSession is not None:
         original_submit = MpiCommSession.submit
 
@@ -553,5 +603,5 @@ def install_mpi_worker_bootstrap() -> None:
         MpiCommSession.submit = _patched_submit
     _bootstrap_installed = True
     logger.info(
-        "[GMS] Patched TensorRT-LLM MPI sessions to bootstrap GMS in MPI workers"
+        "[GMS] Patched TensorRT-LLM MPI sessions and proxy worker_main to bootstrap GMS in MPI workers"
     )

--- a/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
+++ b/lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py
@@ -37,6 +37,7 @@ _ENABLED_ENV = "DYN_GMS_TRTLLM_ENABLED"
 # identically to the parent. Upstream MpiPoolSession only forwards TRTLLM_*/TLLM_*.
 _PROPAGATED_ENV_VARS: tuple[str, ...] = (
     _ENABLED_ENV,
+    "CONTAINER_NAME",
     "DYN_GMS_SHADOW_MODE",
     "ENGINE_ID",
     "FAILOVER_LOCK_PATH",
@@ -59,10 +60,24 @@ def _delay_commit_until_engine_init(extra: "dict[str, Any] | None") -> bool:
     return bool(extra and extra.get("gms_delay_commit_until_engine_init") is True)
 
 
-def _is_shadow_standby() -> bool:
-    return (
-        os.environ.get("DYN_GMS_SHADOW_MODE") == "1"
-        and os.environ.get("ENGINE_ID", "0") != "0"
+def _get_shadow_engine_id() -> str:
+    engine_id = os.environ.get("ENGINE_ID")
+    if engine_id:
+        return engine_id.removeprefix("engine-")
+
+    container_name = os.environ.get("CONTAINER_NAME", "")
+    if container_name.startswith("engine-"):
+        return container_name.removeprefix("engine-")
+
+    return "0"
+
+
+def _is_shadow_standby(extra: "dict[str, Any] | None" = None) -> bool:
+    if os.environ.get("DYN_GMS_SHADOW_MODE") == "1":
+        return _get_shadow_engine_id() != "0"
+
+    return bool(
+        extra and extra.get("gms_read_only") is True and _get_shadow_engine_id() != "0"
     )
 
 
@@ -89,7 +104,7 @@ def _wait_for_shadow_activation() -> None:
 
     rank, comm = _get_mpi_rank_and_comm()
     if rank == 0 and _shadow_activation_fd is None:
-        shadow_engine_id = os.environ.get("ENGINE_ID", "0")
+        shadow_engine_id = _get_shadow_engine_id()
         lock_path = os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
         logger.info(
             "[Shadow] Standby RO import complete, rank0 waiting for failover lock before KV init"
@@ -136,7 +151,7 @@ def install_executor_finalize_hook() -> None:
     def patched_create_py_executor(*args, **kwargs):
         extra = json.loads(_extra_config_json) if _extra_config_json else None
         delay_finalize = _delay_commit_until_engine_init(extra)
-        shadow_standby = _is_shadow_standby()
+        shadow_standby = _is_shadow_standby(extra)
 
         saw_estimating_build = False
         temp_estimator_executor_created = False
@@ -292,10 +307,20 @@ def install_executor_finalize_hook() -> None:
         def patched_build_managers(
             self, resources, estimating_kv_cache, *build_args, **build_kwargs
         ):
-            nonlocal saw_estimating_build
+            nonlocal saw_estimating_build, waited_for_activation
 
             if shadow_standby and estimating_kv_cache:
                 saw_estimating_build = True
+            elif (
+                shadow_standby
+                and not waited_for_activation
+                and not saw_estimating_build
+            ):
+                logger.info(
+                    "[Shadow] Standby skipping KV estimation, waiting for failover lock before full KV init"
+                )
+                _wait_for_shadow_activation()
+                waited_for_activation = True
 
             return original_build_managers(
                 self,
@@ -440,7 +465,7 @@ def worker_init_hook(env_snapshot: dict, extra_config_json: Optional[str]) -> No
     extra = json.loads(extra_config_json) if extra_config_json else None
     set_extra_config(extra)
     setup_gms(extra)
-    if _delay_commit_until_engine_init(extra) or _is_shadow_standby():
+    if _delay_commit_until_engine_init(extra) or _is_shadow_standby(extra):
         install_executor_finalize_hook()
     logger.info(
         "[GMS] MPI worker init hook applied (pid=%d rank=%d)", os.getpid(), rank

--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -66,6 +66,10 @@ pub struct EndpointConfig {
     #[builder(default = "true")]
     graceful_shutdown: bool,
 
+    /// Whether to register this endpoint instance in the discovery plane.
+    #[builder(default = "true")]
+    discoverable: bool,
+
     /// Health check payload for this endpoint
     /// This payload will be sent to the endpoint during health checks
     /// to verify it's responding properly
@@ -96,8 +100,14 @@ impl EndpointConfigBuilder {
     }
 
     pub async fn start(self) -> Result<()> {
-        let (endpoint, handler, metrics_labels, graceful_shutdown, health_check_payload) =
-            self.build_internal()?.dissolve();
+        let (
+            endpoint,
+            handler,
+            metrics_labels,
+            graceful_shutdown,
+            discoverable,
+            health_check_payload,
+        ) = self.build_internal()?.dissolve();
         let connection_id = endpoint.drt().connection_id();
         let endpoint_id = endpoint.id();
 
@@ -234,31 +244,38 @@ impl EndpointConfigBuilder {
             anyhow::Ok(())
         });
 
-        // Register this endpoint instance in the discovery plane
-        // The discovery interface abstracts storage backend (etcd, k8s, etc) and provides
-        // consistent registration/discovery across the system.
-        let discovery = endpoint.drt().discovery();
+        if discoverable {
+            // Register this endpoint instance in the discovery plane.
+            // The discovery interface abstracts storage backend (etcd, k8s, etc) and provides
+            // consistent registration/discovery across the system.
+            let discovery = endpoint.drt().discovery();
 
-        // Build transport for discovery service based on request plane mode
-        let transport = build_transport_type(&endpoint, &endpoint_id, connection_id).await?;
+            // Build transport for discovery service based on request plane mode
+            let transport = build_transport_type(&endpoint, &endpoint_id, connection_id).await?;
 
-        let discovery_spec = crate::discovery::DiscoverySpec::Endpoint {
-            namespace: endpoint_id.namespace.clone(),
-            component: endpoint_id.component.clone(),
-            endpoint: endpoint_id.name.clone(),
-            transport,
-            device_type: endpoint_device_type(),
-        };
+            let discovery_spec = crate::discovery::DiscoverySpec::Endpoint {
+                namespace: endpoint_id.namespace.clone(),
+                component: endpoint_id.component.clone(),
+                endpoint: endpoint_id.name.clone(),
+                transport,
+                device_type: endpoint_device_type(),
+            };
 
-        if let Err(e) = discovery.register(discovery_spec).await {
-            tracing::error!(
+            if let Err(e) = discovery.register(discovery_spec).await {
+                tracing::error!(
+                    %endpoint_id,
+                    error = %e,
+                    "Unable to register service for discovery"
+                );
+                endpoint_shutdown_token.cancel();
+                anyhow::bail!(
+                    "Unable to register service for discovery. Check discovery service status"
+                );
+            }
+        } else {
+            tracing::debug!(
                 %endpoint_id,
-                error = %e,
-                "Unable to register service for discovery"
-            );
-            endpoint_shutdown_token.cancel();
-            anyhow::bail!(
-                "Unable to register service for discovery. Check discovery service status"
+                "Skipping initial endpoint discovery registration"
             );
         }
 


### PR DESCRIPTION
## Summary
- extend the TRT-LLM GMS bootstrap so the **external MPIComm worker path** also runs the standby / GMS initialization hooks
- keep the no-estimation standby wait path active when `TRTLLM_SKIP_KV_CACHE_ESTIMATION=1` is used as a temporary isolation knob
- add the health-only startup endpoint support needed for the DEP16 active/standby startup proxy path
- package the current best-known DEP16 main-lane patch point as a draft PR instead of leaving it only in a local worktree

## Scope / status
This draft PR is an **intermediate DEP16 patch point**, not end-to-end DEP16 success.

Please read it with these caveats in mind:
- current DEP16 failover is **not** being claimed as working here
- this is the current best-known runtime patch set for the MPIComm bootstrap gap, not the final DEP16 solution
- the live DEP16 lane still uses the fallback transport settings
  - `TRTLLM_FORCE_COMM_METHOD=ALLGATHER`
  - `NCCL_MNNVL_ENABLE=0`
  - `NCCL_NVLS_ENABLE=0`
- `TRTLLM_SKIP_KV_CACHE_ESTIMATION=1` is still only a **temporary isolation knob**; it is not an acceptable final answer by itself
- this PR also does **not** solve the larger remaining acceptance gaps such as TRT-LLM KV-under-GMS semantics

## Why this PR exists
The decisive gap on the current DEP16 main lane was that the external `MpiCommSession` / `worker_main` path could bypass Dynamo's earlier standby bootstrap hooks. In the bad runs, shadow ranks still executed warmup before the expected wait markers.

This branch is the current stable fix point for that gap:
- `lib/gpu_memory_service/integrations/trtllm/mpi_bootstrap.py` now wraps the external `tensorrt_llm.executor.proxy.worker_main` path with a top-level bootstrapped entrypoint
- the standby no-estimation wait branch remains active before the direct final KV build path
- the runtime-side health-only startup endpoint support is included so the DEP16 active-proxy path can stay visible to probes without pretending the model is already fully serving

## Stack position
This branch is intentionally stacked on top of the current single-node demo line:
- base branch / PR head: `schwinns/kimi-temp-clamp-20260422-042844`

## Included commits after the single-node base
- `250fcebb39b` `fix(trtllm): proxy dep16 active startup`
- `dc4017c4274` `fix(trtllm): keep dep16 active proxy health-only`
- `0c7106d3454` `fix(trtllm): hide dep16 startup proxy from discovery`
- `6c089623659` `fix(runtime): support health-only startup endpoints`
- `32a1fd8eb34` `fix(trtllm): keep skip-est standby wait in mpi child`
- `b1a4b60b0fa` `fix(trtllm): bootstrap mpi comm workers for standby gating`
- `69ddf9375a5` `fix(trtllm): bootstrap mpi comm worker_main`

## Validation
- `components/src/dynamo/trtllm/tests/test_trtllm_gms_mpi_bootstrap.py` passed with **12 tests** on this branch
- runtime image used for live continuation work:
  - `nvcr.io/nvidian/dynamo-dev/schwinns:trtllm-runtime-dep16-mpicomm-worker-main-69ddf9375a5-20260423-000300@sha256:8d87b5f938bf7437684ca5543ac1a6d634f3a51296394611cbebec79daa4d290`

## What is deliberately left for later
- actual end-to-end DEP16 failover success criteria
- KV-under-GMS for TRT-LLM
- removal of the temporary skip-estimation isolation path
- restoring the desired RDMA / IBGDA path instead of the current ALLGATHER fallback
