### PR TITLE
feat: Add support for /v1/health/ready

### DIFF
--- a/lib/llm/src/http/service/health.rs
+++ b/lib/llm/src/http/service/health.rs
@@ -37,6 +37,21 @@ pub fn live_check_router(
     (docs, router)
 }
 
+pub fn ready_check_router(
+    state: Arc<service_v2::State>,
+    path: Option<String>,
+) -> (Vec<RouteDoc>, Router) {
+    let ready_path = path.unwrap_or_else(|| "/v1/health/ready".to_string());
+
+    let docs: Vec<RouteDoc> = vec![RouteDoc::new(Method::GET, &ready_path)];
+
+    let router = Router::new()
+        .route(&ready_path, get(ready_handler))
+        .with_state(state);
+
+    (docs, router)
+}
+
 async fn live_handler(
     axum::extract::State(state): axum::extract::State<Arc<service_v2::State>>,
 ) -> impl IntoResponse {
@@ -58,6 +73,36 @@ async fn live_handler(
             "message": "Service is live"
         })),
     )
+}
+
+async fn ready_handler(
+    axum::extract::State(state): axum::extract::State<Arc<service_v2::State>>,
+) -> impl IntoResponse {
+    if state.is_ready() {
+        (
+            StatusCode::OK,
+            Json(json!({
+                "status": "ready",
+                "message": "Service is ready to accept requests"
+            })),
+        )
+    } else if state.is_cancelled() {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "status": "shutting_down",
+                "message": "Service is shutting down"
+            })),
+        )
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "status": "not_ready",
+                "message": "Service is not yet ready to accept requests"
+            })),
+        )
+    }
 }
 
 async fn health_handler(

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -168,7 +168,7 @@ impl ErrorMessage {
 
     /// Service Unavailable
     /// This is returned when the service is live, but not ready.
-    pub fn _service_unavailable() -> ErrorResponse {
+    pub fn service_unavailable() -> ErrorResponse {
         let code = StatusCode::SERVICE_UNAVAILABLE;
         let error_type = map_error_code_to_error_type(code);
         (
@@ -1863,12 +1863,10 @@ pub fn validate_response_unsupported_fields(
     None
 }
 
-// todo - abstract this to the top level lib.rs to be reused
-// todo - move the service_observer to its own state/arc
-pub(crate) fn check_ready(_state: &Arc<service_v2::State>) -> Result<(), ErrorResponse> {
-    // if state.service_observer.stage() != ServiceStage::Ready {
-    //     return Err(ErrorMessage::service_unavailable());
-    // }
+pub(crate) fn check_ready(state: &Arc<service_v2::State>) -> Result<(), ErrorResponse> {
+    if !state.is_ready() {
+        return Err(ErrorMessage::service_unavailable());
+    }
     Ok(())
 }
 
@@ -3495,6 +3493,22 @@ mod tests {
             extract_error_type_from_response(&response),
             ErrorType::Overload
         );
+    }
+
+    #[test]
+    fn test_check_ready_err_when_no_endpoints() {
+        let service = service_v2::HttpService::builder()
+            .enable_chat_endpoints(false)
+            .enable_cmpl_endpoints(false)
+            .enable_embeddings_endpoints(false)
+            .enable_responses_endpoints(false)
+            .build()
+            .unwrap();
+        let state = service.state_clone();
+        let result = check_ready(&state);
+        assert!(result.is_err());
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[test]

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -90,6 +90,17 @@ impl StateFlags {
         }
     }
 
+    pub fn any_enabled(&self) -> bool {
+        self.chat_endpoints_enabled.load(Ordering::Relaxed)
+            || self.cmpl_endpoints_enabled.load(Ordering::Relaxed)
+            || self.embeddings_endpoints_enabled.load(Ordering::Relaxed)
+            || self.images_endpoints_enabled.load(Ordering::Relaxed)
+            || self.videos_endpoints_enabled.load(Ordering::Relaxed)
+            || self.audios_endpoints_enabled.load(Ordering::Relaxed)
+            || self.responses_endpoints_enabled.load(Ordering::Relaxed)
+            || self.anthropic_endpoints_enabled.load(Ordering::Relaxed)
+    }
+
     pub fn set(&self, endpoint_type: &EndpointType, enabled: bool) {
         match endpoint_type {
             EndpointType::Chat => self
@@ -164,6 +175,12 @@ impl State {
     /// Check if the service is shutting down
     pub fn is_cancelled(&self) -> bool {
         self.cancel_token.is_cancelled()
+    }
+
+    /// Check if the service is ready to serve requests:
+    /// not shutting down and at least one model endpoint is enabled.
+    pub fn is_ready(&self) -> bool {
+        !self.is_cancelled() && self.flags.any_enabled()
     }
 
     /// Get the cancellation token
@@ -418,6 +435,8 @@ static HTTP_SVC_MODELS_PATH_ENV: &str = "DYN_HTTP_SVC_MODELS_PATH";
 static HTTP_SVC_HEALTH_PATH_ENV: &str = "DYN_HTTP_SVC_HEALTH_PATH";
 /// Environment variable to set the live endpoint path (default: `/live`)
 static HTTP_SVC_LIVE_PATH_ENV: &str = "DYN_HTTP_SVC_LIVE_PATH";
+/// Environment variable to set the ready endpoint path (default: `/v1/health/ready`)
+static HTTP_SVC_READY_PATH_ENV: &str = "DYN_HTTP_SVC_READY_PATH";
 /// Environment variable to set the chat completions endpoint path (default: `/v1/chat/completions`)
 static HTTP_SVC_CHAT_PATH_ENV: &str = "DYN_HTTP_SVC_CHAT_PATH";
 /// Environment variable to set the completions endpoint path (default: `/v1/completions`)
@@ -534,6 +553,7 @@ impl HttpServiceConfigBuilder {
             },
             super::health::health_check_router(state.clone(), var(HTTP_SVC_HEALTH_PATH_ENV).ok()),
             super::health::live_check_router(state.clone(), var(HTTP_SVC_LIVE_PATH_ENV).ok()),
+            super::health::ready_check_router(state.clone(), var(HTTP_SVC_READY_PATH_ENV).ok()),
             super::busy_threshold::busy_threshold_router(state.clone(), None),
         ];
         let mut system_router = axum::Router::new();
@@ -704,5 +724,82 @@ mod tests {
 
         // Clean up
         handle.abort();
+    }
+
+    #[test]
+    fn test_is_ready_true_when_endpoint_enabled() {
+        let state = make_test_state();
+        state.flags.set(&EndpointType::Chat, true);
+        assert!(state.is_ready());
+    }
+
+    #[test]
+    fn test_is_ready_false_when_cancelled() {
+        let state = make_test_state();
+        state.flags.set(&EndpointType::Chat, true);
+        assert!(state.is_ready());
+        state.cancel_token.cancel();
+        assert!(!state.is_ready());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_ready_endpoint_200_when_endpoint_enabled() {
+        let cancel_token = Arc::new(CancellationToken::new());
+        let service = HttpService::builder()
+            .enable_chat_endpoints(true)
+            .build()
+            .unwrap();
+        let port = service.port;
+
+        let service_token = cancel_token.clone();
+        let state = service.state_clone();
+        let handle = tokio::spawn(async move {
+            service.run((*service_token).clone()).await.unwrap();
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("http://localhost:{}/v1/health/ready", port))
+            .send()
+            .await
+            .expect("Request failed");
+
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["status"], "ready");
+
+        // Cancel and verify it transitions to shutting_down
+        state.cancel_token.cancel();
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let resp = client
+            .get(format!("http://localhost:{}/v1/health/ready", port))
+            .send()
+            .await
+            .expect("Request failed");
+
+        assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["status"], "shutting_down");
+
+        cancel_token.cancel();
+        handle.abort();
+    }
+
+    fn make_test_state() -> State {
+        use dynamo_runtime::discovery::KVStoreDiscovery;
+        let cancel_token = CancellationToken::new();
+        let discovery_client = Arc::new(KVStoreDiscovery::new(
+            dynamo_runtime::storage::kv::Manager::memory(),
+            cancel_token.child_token(),
+        )) as Arc<dyn Discovery>;
+        State::new(
+            Arc::new(ModelManager::new()),
+            discovery_client,
+            cancel_token,
+        )
     }
 }


### PR DESCRIPTION
#### Overview:

Add `/v1/health/ready` readiness probe and activate the `check_ready` guard on all inference endpoints.

#### Why:

Today the HTTP service only exposes `/health` and `/live`. 
Hitting `/v1/health/ready` returns 404 because the route was never registered. 
This is a problem for K8s and load-balancer deployments that rely on a standard readiness probe to know when a service can accept traffic. 
Without it, traffic can be routed to instances that are still starting up (no model endpoints enabled yet) or shutting down, leading to confusing errors instead of a clean 503. 

#### Details:

- Register new `GET /v1/health/ready` endpoint returning 200 when ready, 503 with `"not_ready"` or `"shutting_down"` status otherwise.
- Add `State::is_ready()` (not cancelled + at least one endpoint enabled) and `StateFlags::any_enabled()` as the shared readiness predicate.
- Activate the previously no-op `check_ready()` guard so all OpenAI and Anthropic inference handlers return 503 before the service is ready.
- Add `DYN_HTTP_SVC_READY_PATH` env var to allow overriding the default path.
- Add unit and integration tests for readiness state and the new endpoint.

#### Where should the reviewer start?

- `lib/llm/src/http/service/service_v2.rs` — `is_ready()`, `any_enabled()`, and route wiring
- `lib/llm/src/http/service/health.rs` — `ready_check_router` and `ready_handler`
- `lib/llm/src/http/service/openai.rs` — `check_ready()` activation

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a readiness health check endpoint that reports service status with appropriate HTTP responses: `200 OK` when ready, `503 Service Unavailable` when not ready or shutting down.

* **Bug Fixes**
  * Service now enforces readiness validation, ensuring proper error responses when the service is unavailable or initializing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->