### PR TITLE
test(fault_tolerance): raise migration TTFT threshold 6s -> 10s

### DIFF
--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -235,19 +235,6 @@ def test_request_migration_sglang_aggregated(
         stream: True for streaming, False for non-streaming
     """
 
-    # OPS-4446: first-token delay routinely exceeds the 6s threshold in
-    # utils.validate_response for this parameter combination. Originally only
-    # the NATS variant tripped; once the NATS skip landed, the TCP variant
-    # started failing the same way (now bears the cold-start cost first).
-    if (
-        migration_limit == 3
-        and migration_max_seq_len is None
-        and immediate_kill is True
-        and request_api == "chat"
-        and stream is True
-    ):
-        pytest.skip("Flaky: first-token delay > 6s threshold. OPS-4446")
-
     # Step 1: Start the frontend
     with DynamoFrontendProcess(
         request,

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -323,7 +323,9 @@ def validate_response(
             # Cold workers can take longer on first token - only warn but don't fail
             logger.warning(f"Delay before response: {delay:.3f} secs")
             # Capture cases like migration is blocked by engine graceful shutdown
-            assert delay <= 6.0, f"Delay before response > 6 secs, got {delay:.3f} secs"
+            assert (
+                delay <= 10.0
+            ), f"Delay before response > 10 secs, got {delay:.3f} secs"
         prev_timestamp = timestamp
 
         assert res is not None, "Response entry should not be None"


### PR DESCRIPTION
## Summary
- `validate_response` asserted every streamed-chunk delay ≤ 6.0s, applied to both TTFT and TPOT. Cold CI runs spent ~6.2s on the combined path of worker-1 cold prefill + kill + migration + worker-2 cold prefill — 0.2s over, which fails the assertion consistently on cold hardware (locally: first run in a fresh container fails, runs 2+ pass with TTFT < 2s).
- Raise the threshold to 10s. The assertion still catches the class of regression it was written for — the inline comment calls out "migration blocked by engine graceful shutdown", which manifests as tens-of-seconds stalls, not a 2s delta.
- Drop the OPS-4446 skip in `test_sglang.py` — it was a localised workaround for the same root cause, and keeping the pattern would require adding more conditions as new parameter combinations surface (this was already the second time the skip had to be widened).

## Test plan
Verified on a single-GPU box (RTX 6000 Ada), dynamo:6ba534a63b sglang/vllm runtime-test images:
- [x] `test_request_migration_sglang_aggregated[migration_enabled-max_seq_len_disabled-graceful_shutdown-chat-stream-nats]` (the originally failing case) — passes.
- [x] `test_request_migration_sglang_aggregated` matrix: worker_failure/graceful_shutdown × nats/tcp, chat+stream, migration_enabled, max_seq_len_disabled — 4/4 pass.
- [x] `test_request_migration_vllm_aggregated[migration_enabled-max_seq_len_disabled-worker_failure-chat-stream-nats]` (user-reported flake) — passes.
- [ ] Full CI matrix on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed conditional skip for first-token delay scenarios; parameter combination now runs fully during testing
  * Increased delay tolerance threshold in response validation to reduce test flakiness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->