### PR TITLE
fix(runtime): unstick endpoints that opt out of canary; use endpoint_health fallback

### DIFF
--- a/lib/runtime/src/system_health.rs
+++ b/lib/runtime/src/system_health.rs
@@ -100,10 +100,21 @@ impl SystemHealth {
         self.health_check_enabled
     }
 
-    /// Signal endpoint transport registration. Sets Ready when canary is disabled;
-    /// no-op when canary is enabled (canary will set Ready after verification).
+    /// Signal endpoint transport registration.
+    ///
+    /// Marks the endpoint Ready when canary is disabled globally, OR when the
+    /// endpoint has no registered canary target (i.e. the caller opted out of
+    /// canary by not passing a `health_check_payload` to `serve_endpoint`).
+    /// Endpoints that DID register a canary target stay NotReady until the
+    /// canary verifies them — preserving DIS-1185's "canary is the authoritative
+    /// readiness signal for endpoints that opt in" contract.
     pub fn set_endpoint_registered(&self, endpoint: &str) {
-        if !self.health_check_enabled {
+        let has_target = self
+            .health_check_targets
+            .read()
+            .unwrap()
+            .contains_key(endpoint);
+        if !self.health_check_enabled || !has_target {
             self.set_endpoint_health_status(endpoint, HealthStatus::Ready);
         }
     }
@@ -141,20 +152,26 @@ impl SystemHealth {
                     .get(endpoint)
                     .is_some_and(|status| *status == HealthStatus::Ready)
             })
+        } else if !health_check_targets.is_empty() {
+            // Canary-opt-in endpoints exist: every one must be Ready.
+            health_check_targets
+                .iter()
+                .all(|(endpoint_subject, _target)| {
+                    endpoint_health
+                        .get(endpoint_subject)
+                        .is_some_and(|status| *status == HealthStatus::Ready)
+                })
+        } else if !endpoint_health.is_empty() {
+            // No canary targets, but endpoints have registered. Healthy when
+            // every registered endpoint is Ready. This covers workers that
+            // opt every endpoint out of canary (e.g. disagg decode workers,
+            // secondary operational endpoints).
+            endpoint_health
+                .values()
+                .all(|status| *status == HealthStatus::Ready)
         } else {
-            // If we have registered health check targets, use them to determine health
-            if !health_check_targets.is_empty() {
-                health_check_targets
-                    .iter()
-                    .all(|(endpoint_subject, _target)| {
-                        endpoint_health
-                            .get(endpoint_subject)
-                            .is_some_and(|status| *status == HealthStatus::Ready)
-                    })
-            } else {
-                // No health check targets registered, use simple system health
-                self.system_health == HealthStatus::Ready
-            }
+            // No endpoints registered at all — use simple system health.
+            self.system_health == HealthStatus::Ready
         };
 
         (healthy, endpoints)
@@ -296,5 +313,62 @@ impl SystemHealth {
     /// Get the liveness check path
     pub fn live_path(&self) -> &str {
         &self.live_path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sh(canary_enabled: bool) -> SystemHealth {
+        SystemHealth::new(
+            HealthStatus::NotReady,
+            vec![],
+            canary_enabled,
+            "/health".into(),
+            "/live".into(),
+        )
+    }
+
+    #[test]
+    fn endpoint_without_target_is_healthy_when_canary_enabled() {
+        // Opt-out path: canary enabled globally, but endpoint registered
+        // without a target → auto-Ready on registration, and /health
+        // aggregates via the endpoint_health fallback.
+        let h = sh(true);
+        h.set_endpoint_registered("generate");
+        assert_eq!(
+            h.get_endpoint_health_status("generate"),
+            Some(HealthStatus::Ready),
+        );
+        let (healthy, _eps) = h.get_health_status();
+        assert!(healthy);
+    }
+
+    #[test]
+    fn endpoint_with_target_waits_for_canary_when_enabled() {
+        // DIS-1185 invariant: endpoints that registered a canary target
+        // must NOT auto-Ready — canary verifies first.
+        let h = sh(true);
+        let instance = component::Instance {
+            component: "test".into(),
+            endpoint: "generate".into(),
+            namespace: "test".into(),
+            instance_id: 0,
+            transport: component::TransportType::Tcp("localhost:0".into()),
+            device_type: None,
+        };
+        h.health_check_targets.write().unwrap().insert(
+            "generate".to_string(),
+            HealthCheckTarget {
+                instance,
+                payload: serde_json::json!({}),
+            },
+        );
+        h.set_endpoint_registered("generate");
+        assert_ne!(
+            h.get_endpoint_health_status("generate"),
+            Some(HealthStatus::Ready),
+        );
     }
 }

--- a/lib/runtime/src/system_health.rs
+++ b/lib/runtime/src/system_health.rs
@@ -100,14 +100,8 @@ impl SystemHealth {
         self.health_check_enabled
     }
 
-    /// Signal endpoint transport registration.
-    ///
-    /// Marks the endpoint Ready when canary is disabled globally, OR when the
-    /// endpoint has no registered canary target (i.e. the caller opted out of
-    /// canary by not passing a `health_check_payload` to `serve_endpoint`).
-    /// Endpoints that DID register a canary target stay NotReady until the
-    /// canary verifies them — preserving DIS-1185's "canary is the authoritative
-    /// readiness signal for endpoints that opt in" contract.
+    /// Mark endpoint Ready unless it opted into canary by registering a target;
+    /// opted-in endpoints wait for the canary to verify (DIS-1185 invariant).
     pub fn set_endpoint_registered(&self, endpoint: &str) {
         let has_target = self
             .health_check_targets
@@ -153,7 +147,6 @@ impl SystemHealth {
                     .is_some_and(|status| *status == HealthStatus::Ready)
             })
         } else if !health_check_targets.is_empty() {
-            // Canary-opt-in endpoints exist: every one must be Ready.
             health_check_targets
                 .iter()
                 .all(|(endpoint_subject, _target)| {
@@ -162,15 +155,11 @@ impl SystemHealth {
                         .is_some_and(|status| *status == HealthStatus::Ready)
                 })
         } else if !endpoint_health.is_empty() {
-            // No canary targets, but endpoints have registered. Healthy when
-            // every registered endpoint is Ready. This covers workers that
-            // opt every endpoint out of canary (e.g. disagg decode workers,
-            // secondary operational endpoints).
+            // Opt-out endpoints registered but no canary targets — aggregate from endpoint_health.
             endpoint_health
                 .values()
                 .all(|status| *status == HealthStatus::Ready)
         } else {
-            // No endpoints registered at all — use simple system health.
             self.system_health == HealthStatus::Ready
         };
 
@@ -320,55 +309,47 @@ impl SystemHealth {
 mod tests {
     use super::*;
 
-    fn sh(canary_enabled: bool) -> SystemHealth {
+    fn sh() -> SystemHealth {
         SystemHealth::new(
             HealthStatus::NotReady,
             vec![],
-            canary_enabled,
+            true,
             "/health".into(),
             "/live".into(),
         )
     }
 
+    fn instance(endpoint: &str) -> component::Instance {
+        component::Instance {
+            component: "test".into(),
+            endpoint: endpoint.into(),
+            namespace: "test".into(),
+            instance_id: 0,
+            transport: component::TransportType::Tcp("localhost:0".into()),
+            device_type: None,
+        }
+    }
+
     #[test]
-    fn endpoint_without_target_is_healthy_when_canary_enabled() {
-        // Opt-out path: canary enabled globally, but endpoint registered
-        // without a target → auto-Ready on registration, and /health
-        // aggregates via the endpoint_health fallback.
-        let h = sh(true);
+    fn opt_out_endpoint_auto_readies() {
+        let h = sh();
         h.set_endpoint_registered("generate");
         assert_eq!(
             h.get_endpoint_health_status("generate"),
             Some(HealthStatus::Ready),
         );
-        let (healthy, _eps) = h.get_health_status();
-        assert!(healthy);
+        assert!(h.get_health_status().0);
     }
 
     #[test]
-    fn endpoint_with_target_waits_for_canary_when_enabled() {
-        // DIS-1185 invariant: endpoints that registered a canary target
-        // must NOT auto-Ready — canary verifies first.
-        let h = sh(true);
-        let instance = component::Instance {
-            component: "test".into(),
-            endpoint: "generate".into(),
-            namespace: "test".into(),
-            instance_id: 0,
-            transport: component::TransportType::Tcp("localhost:0".into()),
-            device_type: None,
-        };
-        h.health_check_targets.write().unwrap().insert(
-            "generate".to_string(),
-            HealthCheckTarget {
-                instance,
-                payload: serde_json::json!({}),
-            },
-        );
+    fn opt_in_endpoint_waits_for_canary() {
+        let h = sh();
+        h.register_health_check_target("generate", instance("generate"), serde_json::json!({}));
         h.set_endpoint_registered("generate");
-        assert_ne!(
+        assert_eq!(
             h.get_endpoint_health_status("generate"),
-            Some(HealthStatus::Ready),
+            Some(HealthStatus::NotReady),
         );
+        assert!(!h.get_health_status().0);
     }
 }


### PR DESCRIPTION
## Summary

- Post-DIS-1185, when `DYN_HEALTH_CHECK_ENABLED=true`, an endpoint that registers without a canary payload is stuck `NotReady` forever. `set_endpoint_registered` only auto-Readies in the globally-disabled case, and nothing else ever flips the endpoint Ready.
- Fix: auto-Ready on registration when there's no canary target registered for that endpoint, even if canary is enabled globally. Endpoints that *do* register a canary target still wait for canary verification — preserving DIS-1185's "canary is authoritative for opted-in endpoints" contract.
- Also: `get_health_status` adds a fallback path that aggregates from `endpoint_health` when there are no canary targets but endpoints have registered — covers workers that opt every endpoint out of canary.

## Observed impact this removes

During the initial DIS-1737 fix iteration we tried `health_check_payload=None` for disagg decode workers. CI `test_deployment[disaggregated_same_gpu-2]` timed out at 432s because the decode endpoint was trapped `NotReady`. #8521 sidesteps the trap by registering a real probe, but the underlying runtime foot-gun remains — any future caller that legitimately wants an endpoint to opt out of canary (management APIs, metrics sidecars, etc.) hits it.

## Tests

Two focused unit tests covering both changed sites + the preserved invariant:

- `endpoint_without_target_is_healthy_when_canary_enabled` — opt-out happy path: exercises `set_endpoint_registered`'s new branch AND `get_health_status`'s new fallback.
- `endpoint_with_target_waits_for_canary_when_enabled` — DIS-1185 invariant preservation: registered-target endpoints still wait for canary.

## Scope

- `lib/runtime/src/system_health.rs`: ~30 lines of behavior change + 2 unit tests
- No API changes, no changes to other crates, no Python changes
- Verified locally: `cargo test -p dynamo-runtime --lib system_health` → 4 passed (includes the 2 new tests + 2 pre-existing config tests)

## Test plan

- [x] Cargo unit tests pass
- [ ] CI green on this branch
- [ ] No regression in downstream tests that rely on canary-authoritative readiness

Linear: [DIS-1836](https://linear.app/nvidia/issue/DIS-1836)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Endpoints without configured health checks are now automatically marked as Ready and properly contribute to overall system health status.
  * System health computation logic updated to correctly evaluate health based on registered endpoints and configured health check targets.

* **Tests**
  * Added unit tests verifying endpoint readiness behavior with and without health check configuration and system health status calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->