### PR TITLE
fix: Silently ignores unknown params in validate_no_unsupported_fields

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -3226,7 +3226,11 @@ mod tests {
         let request: NvCreateChatCompletionRequest = serde_json::from_str(json).unwrap();
 
         // Unsupported fields are still captured
-        assert!(request.unsupported_fields.contains_key("add_special_tokens"));
+        assert!(
+            request
+                .unsupported_fields
+                .contains_key("add_special_tokens")
+        );
         assert!(request.unsupported_fields.contains_key("documents"));
         assert!(request.unsupported_fields.contains_key("chat_template"));
 
@@ -3247,7 +3251,11 @@ mod tests {
         let request: NvCreateCompletionRequest = serde_json::from_str(json).unwrap();
 
         // Unsupported fields are still captured
-        assert!(request.unsupported_fields.contains_key("add_special_tokens"));
+        assert!(
+            request
+                .unsupported_fields
+                .contains_key("add_special_tokens")
+        );
         assert!(request.unsupported_fields.contains_key("response_format"));
 
         // But validation succeeds (OpenAI compat: silently ignore unknown params)

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -3214,8 +3214,7 @@ mod tests {
     }
 
     #[test]
-    fn test_chat_completions_unknown_fields_rejected() {
-        // Test that known unsupported fields are rejected and all shown in error message
+    fn test_chat_completions_unknown_fields_ignored() {
         let json = r#"{
             "messages": [{"role": "user", "content": "Hello"}],
             "model": "test-model",
@@ -3226,31 +3225,18 @@ mod tests {
 
         let request: NvCreateChatCompletionRequest = serde_json::from_str(json).unwrap();
 
-        // Verify all unsupported fields were captured
-        assert!(
-            request
-                .unsupported_fields
-                .contains_key("add_special_tokens")
-        );
+        // Unsupported fields are still captured
+        assert!(request.unsupported_fields.contains_key("add_special_tokens"));
         assert!(request.unsupported_fields.contains_key("documents"));
         assert!(request.unsupported_fields.contains_key("chat_template"));
 
+        // But validation succeeds (OpenAI compat: silently ignore unknown params)
         let result = validate_chat_completion_fields_generic(&request);
-        assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-            let msg = &error_response.1.message;
-            assert!(msg.contains("Unsupported parameter"));
-            // Verify all fields appear in the error message
-            assert!(msg.contains("add_special_tokens"));
-            assert!(msg.contains("documents"));
-            assert!(msg.contains("chat_template"));
-        }
+        assert!(result.is_ok(), "Unknown fields should be silently ignored");
     }
 
     #[test]
-    fn test_completions_unsupported_fields_rejected() {
-        // Test that known unsupported fields are rejected and all shown in error message
+    fn test_completions_unsupported_fields_ignored() {
         let json = r#"{
             "model": "test-model",
             "prompt": "Hello",
@@ -3260,24 +3246,13 @@ mod tests {
 
         let request: NvCreateCompletionRequest = serde_json::from_str(json).unwrap();
 
-        // Verify both unsupported fields were captured
-        assert!(
-            request
-                .unsupported_fields
-                .contains_key("add_special_tokens")
-        );
+        // Unsupported fields are still captured
+        assert!(request.unsupported_fields.contains_key("add_special_tokens"));
         assert!(request.unsupported_fields.contains_key("response_format"));
 
+        // But validation succeeds (OpenAI compat: silently ignore unknown params)
         let result = validate_completion_fields_generic(&request);
-        assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-            let msg = &error_response.1.message;
-            assert!(msg.contains("Unsupported parameter"));
-            // Verify both fields appear in error message
-            assert!(msg.contains("add_special_tokens"));
-            assert!(msg.contains("response_format"));
-        }
+        assert!(result.is_ok(), "Unknown fields should be silently ignored");
     }
 
     #[tokio::test]

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -426,4 +426,40 @@ mod tests {
             assert_eq!(output_options.skip_special_tokens, Some(skip_value));
         }
     }
+
+    #[test]
+    fn test_unknown_params_silently_ignored() {
+        use crate::engines::ValidateRequest;
+
+        let json_str = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "foo": "bar"
+        });
+
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(json_str).expect("Failed to deserialize request");
+
+        assert!(request.unsupported_fields.contains_key("foo"));
+        ValidateRequest::validate(&request)
+            .expect("Unknown params should be silently ignored for OpenAI compat");
+    }
+
+    #[test]
+    fn test_unknown_params_multiple_fields_ignored() {
+        use crate::engines::ValidateRequest;
+
+        let json_str = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Extract data"}],
+            "response_model": {"name": "User", "fields": ["name", "age"]},
+            "max_retries": 3
+        });
+
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(json_str).expect("Failed to deserialize request");
+
+        ValidateRequest::validate(&request)
+            .expect("Multiple unknown params should be silently ignored");
+    }
 }

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -97,16 +97,15 @@ pub const MAX_REPETITION_PENALTY: f32 = 2.0;
 // Shared Fields
 //
 
-/// Validates that no unsupported fields are present in the request
+/// Logs unsupported fields at debug level but does not reject the request.
+/// OpenAI silently ignores unknown parameters; rejecting them breaks
+/// LangChain, LlamaIndex, Instructor, and other third-party clients.
 pub fn validate_no_unsupported_fields(
     unsupported_fields: &std::collections::HashMap<String, serde_json::Value>,
 ) -> Result<(), anyhow::Error> {
     if !unsupported_fields.is_empty() {
-        let fields: Vec<_> = unsupported_fields
-            .keys()
-            .map(|s| format!("`{}`", s))
-            .collect();
-        anyhow::bail!("Unsupported parameter(s): {}", fields.join(", "));
+        let fields: Vec<_> = unsupported_fields.keys().collect();
+        tracing::debug!("Ignoring unsupported parameter(s): {:?}", fields);
     }
     Ok(())
 }

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -907,3 +907,57 @@ async fn test_request_id_annotation() {
     cancel_token.cancel();
     task.await.unwrap().unwrap();
 }
+
+#[tokio::test]
+async fn test_unknown_params_accepted_openai_compat() {
+    let port = get_random_port().await;
+    let service = HttpService::builder()
+        .port(port)
+        .enable_chat_endpoints(true)
+        .build()
+        .unwrap();
+    let state = service.state_clone();
+    let manager = state.manager();
+
+    let token = CancellationToken::new();
+    let cancel_token = token.clone();
+    let task = tokio::spawn(async move { service.run(token.clone()).await });
+
+    wait_for_service_ready(port).await;
+
+    let card = ModelDeploymentCard::with_name_only("test-model");
+    let engine = Arc::new(CounterEngine {});
+    manager
+        .add_chat_completions_model("test-model", card.mdcsum(), engine)
+        .unwrap();
+
+    let client = reqwest::Client::new();
+
+    // Request with unknown params like LangChain/Instructor would send
+    let body = serde_json::json!({
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "stream": false,
+        "max_tokens": 10,
+        "foo": "bar",
+        "response_model": {"name": "User"},
+        "max_retries": 3
+    });
+
+    let response = client
+        .post(format!("http://localhost:{}/v1/chat/completions", port))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Unknown params should be silently ignored (OpenAI compat), got: {}",
+        response.status()
+    );
+
+    cancel_token.cancel();
+    task.await.unwrap().unwrap();
+}


### PR DESCRIPTION
#### Overview:

Silently ignore unknown request parameters instead of rejecting with 400, matching OpenAI API behavior. Fixes compatibility with `LangChain`, `LlamaIndex`, and `Instructor`.

#### Details:

- `validate_no_unsupported_fields` in `validate.rs` rejected any JSON key not matching a known field with `"Unsupported parameter(s): foo"`. OpenAI silently ignores unknown params and so does [vLLM upstream](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/engine/protocol.py#L52). Our strict rejection breaks third-party clients that routinely send extra fields like `response_model`, `max_retries`, `extra_body`, etc.                                                                                                                                                                                                                                                   
-   The fix changes the function from `anyhow::bail!` to `tracing::debug!`, logging the unknown fields for observability but returning `Ok(())`. The `serde #[serde(flatten)]` catch-all HashMap still captures unknown fields (and `skip_serializing` prevents them from leaking into responses) — we just stop treating their presence as an error.                                                         
-   Updated two existing tests that asserted the old rejection behavior, and added three new tests: two unit tests covering single and multiple unknown fields, and one HTTP integration test that sends a real request with unknown params to        
`/v1/chat/completions` and asserts `200 OK`.


#### Where should the reviewer start?

  - `lib/llm/src/protocols/openai/validate.rs` : the core one-line fix                                                                                                                                                                        
  - `lib/llm/src/http/service/openai.rs` : updated existing tests
  - `lib/llm/tests/http-service.rs` : new end-to-end HTTP integration test      

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI API requests with unknown or unsupported parameters are now silently ignored instead of being rejected with validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->