### PR TITLE
fix(frontendSidecar): mount worker PVCs on the frontend sidecar for E…

### DIFF
--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1085,6 +1085,10 @@ func GenerateBasePodSpec(
 	AddStandardEnvVars(&container, operatorConfig)
 
 	volumes := make([]corev1.Volume, 0, len(component.VolumeMounts)+1) // +1 for shared memory volume
+	// Track only the user-declared mounts so we can propagate exactly these to the
+	// frontend sidecar — backend.UpdateContainer may later add container mounts
+	// (e.g. TRT-LLM's /ssh-pk secret) that must not leak into the sidecar.
+	userMounts := make([]corev1.VolumeMount, 0, len(component.VolumeMounts))
 
 	for _, volumeMount := range component.VolumeMounts {
 		if volumeMount.Name == "" {
@@ -1113,10 +1117,12 @@ func GenerateBasePodSpec(
 			},
 		})
 
-		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		mount := corev1.VolumeMount{
 			Name:      volumeMount.Name,
 			MountPath: mountPoint,
-		})
+		}
+		container.VolumeMounts = append(container.VolumeMounts, mount)
+		userMounts = append(userMounts, mount)
 	}
 	// Apply backend-specific container modifications
 	multinodeDeployer := MultinodeDeployerFactory(multinodeDeploymentType)
@@ -1170,7 +1176,7 @@ func GenerateBasePodSpec(
 
 	// Inject auto-generated frontend sidecar if configured
 	if component.FrontendSidecar != nil {
-		sidecar, err := generateFrontendSidecar(component.FrontendSidecar, componentContext, operatorConfig, container.VolumeMounts)
+		sidecar, err := generateFrontendSidecar(component.FrontendSidecar, componentContext, operatorConfig, userMounts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate frontend sidecar: %w", err)
 		}

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1170,7 +1170,7 @@ func GenerateBasePodSpec(
 
 	// Inject auto-generated frontend sidecar if configured
 	if component.FrontendSidecar != nil {
-		sidecar, err := generateFrontendSidecar(component.FrontendSidecar, componentContext, operatorConfig)
+		sidecar, err := generateFrontendSidecar(component.FrontendSidecar, componentContext, operatorConfig, container.VolumeMounts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate frontend sidecar: %w", err)
 		}
@@ -1243,6 +1243,7 @@ func generateFrontendSidecar(
 	spec *v1alpha1.FrontendSidecarSpec,
 	parentContext ComponentContext,
 	operatorConfig *configv1alpha1.OperatorConfiguration,
+	parentMounts []corev1.VolumeMount,
 ) (corev1.Container, error) {
 	frontendContext := ComponentContext{
 		numberOfNodes:                  1,
@@ -1279,6 +1280,11 @@ func generateFrontendSidecar(
 	}
 
 	AddStandardEnvVars(&container, operatorConfig)
+
+	// Mirror the worker's VolumeMounts so the sidecar can read files the worker
+	// registers in its ModelDeploymentCard (tokenizer, config, chat_template)
+	// when those live on a PVC.
+	container.VolumeMounts = append(container.VolumeMounts, parentMounts...)
 
 	return container, nil
 }

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -7130,19 +7130,21 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 	envFromSecret := "hf-token-secret"
 
 	tests := []struct {
-		name               string
-		component          *v1alpha1.DynamoComponentDeploymentSharedSpec
-		parentDGDName      string
-		namespace          string
-		wantSidecarCount   int
-		wantSidecarName    string
-		wantSidecarImage   string
-		wantSidecarArgs    []string
-		wantSidecarEnvVars map[string]string
-		wantSidecarEnvFrom int
-		wantSidecarProbes  bool
-		wantSidecarPorts   bool
-		wantErr            bool
+		name                string
+		component           *v1alpha1.DynamoComponentDeploymentSharedSpec
+		parentDGDName       string
+		namespace           string
+		wantSidecarCount    int
+		wantSidecarName     string
+		wantSidecarImage    string
+		wantSidecarArgs     []string
+		wantSidecarEnvVars  map[string]string
+		wantSidecarEnvFrom  int
+		wantSidecarProbes   bool
+		wantSidecarPorts    bool
+		wantSidecarMounts   []corev1.VolumeMount
+		wantUniqueVolumes   map[string]int
+		wantErr             bool
 	}{
 		{
 			name: "worker without frontendSidecar has no sidecar",
@@ -7216,6 +7218,60 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 			wantSidecarImage: "my-frontend:latest",
 			wantSidecarEnvVars: map[string]string{
 				"CUSTOM_VAR": "custom_value",
+			},
+			wantSidecarProbes: true,
+			wantSidecarPorts:  true,
+		},
+		{
+			name: "frontendSidecar inherits worker PVC volume mount",
+			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: commonconsts.ComponentTypeWorker,
+				VolumeMounts: []v1alpha1.VolumeMount{
+					{Name: "model-cache", MountPoint: "/opt/models"},
+				},
+				SharedMemory: &v1alpha1.SharedMemorySpec{Disabled: true},
+				FrontendSidecar: &v1alpha1.FrontendSidecarSpec{
+					Image: "my-frontend:latest",
+				},
+			},
+			parentDGDName:    "test-dgd",
+			namespace:        "test-ns",
+			wantSidecarCount: 2,
+			wantSidecarName:  commonconsts.FrontendSidecarContainerName,
+			wantSidecarImage: "my-frontend:latest",
+			wantSidecarMounts: []corev1.VolumeMount{
+				{Name: "model-cache", MountPath: "/opt/models"},
+			},
+			wantUniqueVolumes: map[string]int{"model-cache": 1},
+			wantSidecarProbes: true,
+			wantSidecarPorts:  true,
+		},
+		{
+			name: "frontendSidecar inherits multiple PVC mounts and shared memory",
+			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: commonconsts.ComponentTypeWorker,
+				VolumeMounts: []v1alpha1.VolumeMount{
+					{Name: "model-cache", MountPoint: "/opt/models"},
+					{Name: "extra-data", MountPoint: "/mnt/data"},
+				},
+				FrontendSidecar: &v1alpha1.FrontendSidecarSpec{
+					Image: "my-frontend:latest",
+				},
+			},
+			parentDGDName:    "test-dgd",
+			namespace:        "test-ns",
+			wantSidecarCount: 2,
+			wantSidecarName:  commonconsts.FrontendSidecarContainerName,
+			wantSidecarImage: "my-frontend:latest",
+			wantSidecarMounts: []corev1.VolumeMount{
+				{Name: "model-cache", MountPath: "/opt/models"},
+				{Name: "extra-data", MountPath: "/mnt/data"},
+				{Name: commonconsts.KubeValueNameSharedMemory, MountPath: commonconsts.DefaultSharedMemoryMountPath},
+			},
+			wantUniqueVolumes: map[string]int{
+				"model-cache":                           1,
+				"extra-data":                            1,
+				commonconsts.KubeValueNameSharedMemory: 1,
 			},
 			wantSidecarProbes: true,
 			wantSidecarPorts:  true,
@@ -7301,6 +7357,29 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 			}
 			for name, found := range hasDownwardAPI {
 				assert.True(t, found, "sidecar should have downward API env var %s", name)
+			}
+
+			// Verify the sidecar inherited the expected volume mounts from the worker.
+			for _, want := range tt.wantSidecarMounts {
+				found := false
+				for _, got := range sidecar.VolumeMounts {
+					if got.Name == want.Name && got.MountPath == want.MountPath {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "sidecar should have volume mount %s at %s", want.Name, want.MountPath)
+			}
+
+			// Verify pod-level volumes aren't duplicated when propagating to the sidecar.
+			if tt.wantUniqueVolumes != nil {
+				counts := make(map[string]int)
+				for _, v := range podSpec.Volumes {
+					counts[v.Name]++
+				}
+				for name, want := range tt.wantUniqueVolumes {
+					assert.Equal(t, want, counts[name], "pod volume %s count", name)
+				}
 			}
 		})
 	}

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -7125,26 +7125,32 @@ func TestFrontendDefaults_NamespacePrefixEnvVar(t *testing.T) {
 
 func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 	secretsRetriever := &mockSecretsRetriever{}
-	controllerConfig := &configv1alpha1.OperatorConfiguration{}
+	controllerConfig := &configv1alpha1.OperatorConfiguration{
+		MPI: configv1alpha1.MPIConfiguration{SSHSecretName: "mpi-ssh-secret"},
+	}
 
 	envFromSecret := "hf-token-secret"
 
 	tests := []struct {
-		name                string
-		component           *v1alpha1.DynamoComponentDeploymentSharedSpec
-		parentDGDName       string
-		namespace           string
-		wantSidecarCount    int
-		wantSidecarName     string
-		wantSidecarImage    string
-		wantSidecarArgs     []string
-		wantSidecarEnvVars  map[string]string
-		wantSidecarEnvFrom  int
-		wantSidecarProbes   bool
-		wantSidecarPorts    bool
-		wantSidecarMounts   []corev1.VolumeMount
-		wantUniqueVolumes   map[string]int
-		wantErr             bool
+		name                    string
+		component               *v1alpha1.DynamoComponentDeploymentSharedSpec
+		parentDGDName           string
+		namespace               string
+		backendFramework        BackendFramework
+		numberOfNodes           int32
+		wantSidecarCount        int
+		wantSidecarName         string
+		wantSidecarImage        string
+		wantSidecarArgs         []string
+		wantSidecarEnvVars      map[string]string
+		wantSidecarEnvFrom      int
+		wantSidecarProbes       bool
+		wantSidecarPorts        bool
+		wantSidecarMounts       []corev1.VolumeMount
+		wantSidecarMountsAbsent []string
+		wantWorkerMounts        []corev1.VolumeMount
+		wantUniqueVolumes       map[string]int
+		wantErr                 bool
 	}{
 		{
 			name: "worker without frontendSidecar has no sidecar",
@@ -7247,7 +7253,7 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 			wantSidecarPorts:  true,
 		},
 		{
-			name: "frontendSidecar inherits multiple PVC mounts and shared memory",
+			name: "frontendSidecar inherits user PVC mounts but not shared memory",
 			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
 				ComponentType: commonconsts.ComponentTypeWorker,
 				VolumeMounts: []v1alpha1.VolumeMount{
@@ -7266,12 +7272,43 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 			wantSidecarMounts: []corev1.VolumeMount{
 				{Name: "model-cache", MountPath: "/opt/models"},
 				{Name: "extra-data", MountPath: "/mnt/data"},
-				{Name: commonconsts.KubeValueNameSharedMemory, MountPath: commonconsts.DefaultSharedMemoryMountPath},
 			},
+			wantSidecarMountsAbsent: []string{commonconsts.KubeValueNameSharedMemory},
 			wantUniqueVolumes: map[string]int{
-				"model-cache":                           1,
-				"extra-data":                            1,
+				"model-cache":                          1,
+				"extra-data":                           1,
 				commonconsts.KubeValueNameSharedMemory: 1,
+			},
+			wantSidecarProbes: true,
+			wantSidecarPorts:  true,
+		},
+		{
+			// TRT-LLM multinode injects the /ssh-pk MPI secret onto the worker.
+			// The sidecar must not inherit it; only user-declared mounts propagate.
+			name: "frontendSidecar does not inherit TRT-LLM multinode SSH mount",
+			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: commonconsts.ComponentTypeWorker,
+				VolumeMounts: []v1alpha1.VolumeMount{
+					{Name: "model-cache", MountPoint: "/opt/models"},
+				},
+				FrontendSidecar: &v1alpha1.FrontendSidecarSpec{
+					Image: "my-frontend:latest",
+				},
+			},
+			parentDGDName:    "test-dgd",
+			namespace:        "test-ns",
+			backendFramework: BackendFrameworkTRTLLM,
+			numberOfNodes:    2,
+			wantSidecarCount: 2,
+			wantSidecarName:  commonconsts.FrontendSidecarContainerName,
+			wantSidecarImage: "my-frontend:latest",
+			wantSidecarMounts: []corev1.VolumeMount{
+				{Name: "model-cache", MountPath: "/opt/models"},
+			},
+			wantSidecarMountsAbsent: []string{"mpi-ssh-secret", commonconsts.KubeValueNameSharedMemory},
+			wantWorkerMounts: []corev1.VolumeMount{
+				{Name: "model-cache", MountPath: "/opt/models"},
+				{Name: "mpi-ssh-secret", MountPath: "/ssh-pk"},
 			},
 			wantSidecarProbes: true,
 			wantSidecarPorts:  true,
@@ -7280,14 +7317,26 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			backendFramework := tt.backendFramework
+			if backendFramework == "" {
+				backendFramework = BackendFrameworkVLLM
+			}
+			numberOfNodes := tt.numberOfNodes
+			if numberOfNodes == 0 {
+				numberOfNodes = 1
+			}
+			role := RoleMain
+			if numberOfNodes > 1 {
+				role = RoleLeader
+			}
 			podSpec, err := GenerateBasePodSpec(
 				tt.component,
-				BackendFrameworkVLLM,
+				backendFramework,
 				secretsRetriever,
 				tt.parentDGDName,
 				tt.namespace,
-				RoleMain,
-				1,
+				role,
+				numberOfNodes,
 				controllerConfig,
 				commonconsts.MultinodeDeploymentTypeGrove,
 				"test-service",
@@ -7369,6 +7418,31 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 					}
 				}
 				assert.True(t, found, "sidecar should have volume mount %s at %s", want.Name, want.MountPath)
+			}
+
+			// Verify the sidecar did NOT inherit mounts that belong only to the worker
+			// (shared memory, backend-injected secrets like TRT-LLM's /ssh-pk, etc.).
+			for _, absentName := range tt.wantSidecarMountsAbsent {
+				for _, got := range sidecar.VolumeMounts {
+					assert.NotEqual(t, absentName, got.Name,
+						"sidecar must not inherit worker-only mount %s", absentName)
+				}
+			}
+
+			// Verify the worker container still has its expected mounts — propagation
+			// must not strip anything off the worker.
+			if len(tt.wantWorkerMounts) > 0 {
+				worker := podSpec.Containers[0]
+				for _, want := range tt.wantWorkerMounts {
+					found := false
+					for _, got := range worker.VolumeMounts {
+						if got.Name == want.Name && got.MountPath == want.MountPath {
+							found = true
+							break
+						}
+					}
+					assert.True(t, found, "worker should have volume mount %s at %s", want.Name, want.MountPath)
+				}
 			}
 
 			// Verify pod-level volumes aren't duplicated when propagating to the sidecar.


### PR DESCRIPTION
  #### Overview:

  Make the auto-generated `frontendSidecar` container (used by EPP / inference-gateway deployments) usable with PVC-backed models. Previously, the sidecar was
  injected without any volume mounts, so when the worker registered a `ModelDeploymentCard` whose tokenizer / config / chat-template paths resolved under a PVC
  mount, the frontend sidecar's file reads failed. HuggingFace-hub-hosted models worked because no local paths were referenced.

  #### Details:

  `generateFrontendSidecar` now accepts the parent worker container's resolved `[]corev1.VolumeMount` and mirrors those mounts onto the sidecar. The pod's `Volumes`
  already include the PVCs (added to `podSpec.Volumes` during worker construction in `GenerateBasePodSpec`), so no pod-level change is needed — only the
  container-level mounts on the sidecar.

  Because `container.VolumeMounts` is read *after* `ApplySharedMemoryVolumeAndMount` has run, the sidecar also picks up `/dev/shm`, which is a no-op but keeps the
  sidecar's filesystem view symmetric with the worker.

  No API change, no CRD regeneration, no changes to existing HuggingFace-hub recipes (they don't set `volumeMounts` on the worker, so nothing is propagated).
  Behavior is opt-in via the worker's existing `volumeMounts` field.

  #### Where should the reviewer start?

  - `deploy/operator/internal/dynamo/graph.go` — the two-line functional change:
    - `generateFrontendSidecar` signature + new `container.VolumeMounts = append(...)`
    - call site in `GenerateBasePodSpec` now passes `container.VolumeMounts`
  - `deploy/operator/internal/dynamo/graph_test.go` — `TestGenerateBasePodSpec_FrontendSidecar` gains two cases: single PVC mount with shared memory disabled, and
  multiple PVC mounts + default shared memory. Both assert that mounts propagate and that pod volumes aren't duplicated.

  #### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

  - Relates to: #6581 (introduced `frontendSidecar`; this PR closes the PVC-backed-model gap)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Frontend sidecar now inherits volume mounts from worker containers, enabling access to mounted paths (e.g., tokenizer configs, chat templates) required by model deployments.

* **Tests**
  * Updated test coverage to validate proper volume mount inheritance and prevent volume duplication in pod specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->