### PR TITLE
fix(sglang): stop using trace_id as SGLang rid to prevent duplicate reqid errors

### DIFF
--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -108,7 +108,6 @@ class SglangLLMEngine(LLMEngine):
             **input_param,
             sampling_params=sampling_params,
             stream=True,
-            rid=context.trace_id,
         )
 
         async for res in stream:

--- a/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
@@ -57,12 +57,10 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
             raise TypeError(f"Invalid input type: {type(embedding_request.input)}")
 
         trace_header = build_trace_headers(context) if self.enable_trace else None
-        trace_id = context.trace_id
 
         result = await self.engine.async_encode(
             prompt=prompt,
             external_trace_header=trace_header,
-            rid=trace_id,
         )
 
         # Transform the response to OpenAI format

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -269,7 +269,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             RuntimeError: If no bootstrap info received from prefill worker.
         """
         logging.debug(f"New Request ID: {context.id()}")
-        trace_id = context.trace_id
         sampling_params = self._build_sampling_params(request)
         input_param = self._get_input_param(request)
         return_routed_experts = getattr(
@@ -313,7 +312,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 bootstrap_port=bootstrap_info["bootstrap_port"],
                 bootstrap_room=bootstrap_info["bootstrap_room"],
                 external_trace_header=trace_header,
-                rid=trace_id,
                 data_parallel_rank=dp_rank,
                 **self._session_kwargs(request),
                 lora_path=lora_path,
@@ -348,7 +346,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 stream=True,
                 return_routed_experts=return_routed_experts,
                 external_trace_header=trace_header,
-                rid=trace_id,
                 data_parallel_rank=dp_rank,
                 **self._session_kwargs(request),
                 lora_path=lora_path,

--- a/components/src/dynamo/sglang/request_handlers/llm/diffusion_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/diffusion_handler.py
@@ -78,14 +78,12 @@ class DiffusionWorkerHandler(DecodeWorkerHandler):
 
         # Generate trace info if tracing is enabled
         trace_header = build_trace_headers(context) if self.enable_trace else None
-        trace_id = context.id() if trace_header else None
 
         async_gen = await self.engine.async_generate(
             **input_param,
             sampling_params=sampling_params,
             stream=True,  # Always stream for Dynamo
             external_trace_header=trace_header,
-            rid=trace_id,
         )
 
         # Process stream output (token-based or text-based)

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -72,7 +72,6 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             Bootstrap info dict with host, port, and room for decode worker connection.
         """
         logging.debug(f"New Request ID: {context.id()}")
-        trace_id = context.trace_id
 
         if "request" in request:
             # DisaggPreprocessedRequest format
@@ -161,7 +160,6 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             bootstrap_port=bootstrap_port,
             bootstrap_room=bootstrap_room,
             external_trace_header=trace_header,
-            rid=trace_id,
             data_parallel_rank=dp_rank,
             **self._session_kwargs(inner_request),
             lora_path=lora_path,

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -382,7 +382,6 @@ class MultimodalWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, str]):
             bootstrap_port=bootstrap_info["bootstrap_port"],
             bootstrap_room=bootstrap_info["bootstrap_room"],
             external_trace_header=trace_header,
-            rid=context.trace_id if context else None,
         )
 
         rng_first = _nvtx.start_range("mm:dec:first_token", color="purple")
@@ -433,8 +432,7 @@ class MultimodalWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, str]):
                 sampling_params=sampling_params,
                 stream=True,
                 external_trace_header=trace_header,
-                rid=context.trace_id if context else None,
-            )
+                )
 
             rng_first = _nvtx.start_range("mm:dec:first_token", color="purple")
             first_token = True
@@ -634,8 +632,7 @@ class MultimodalPrefillWorkerHandler(
                 bootstrap_port=self.bootstrap_port,
                 bootstrap_room=bootstrap_room,
                 external_trace_header=trace_header,
-                rid=context.trace_id if context else None,
-            )
+                )
 
         # Consume results without yielding (prefill doesn't return text, just coordinates)
         asyncio.create_task(self._consume_results(results, tensor_id))

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -432,7 +432,7 @@ class MultimodalWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, str]):
                 sampling_params=sampling_params,
                 stream=True,
                 external_trace_header=trace_header,
-                )
+            )
 
             rng_first = _nvtx.start_range("mm:dec:first_token", color="purple")
             first_token = True
@@ -632,7 +632,7 @@ class MultimodalPrefillWorkerHandler(
                 bootstrap_port=self.bootstrap_port,
                 bootstrap_room=bootstrap_room,
                 external_trace_header=trace_header,
-                )
+            )
 
         # Consume results without yielding (prefill doesn't return text, just coordinates)
         asyncio.create_task(self._consume_results(results, tensor_id))

--- a/docs/backends/sglang/sglang-observability.md
+++ b/docs/backends/sglang/sglang-observability.md
@@ -143,18 +143,17 @@ SGLang Handler (Python)
     v
 sgl.Engine.async_generate(
     ...,
-    rid=trace_id,                        # request ID = trace ID
     external_trace_header=traceparent    # W3C header for SGLang internal spans
 )
     |
     v
-SGLang Engine (internal spans attached to same trace)
+SGLang Engine (internal spans attached to same trace via traceparent)
 ```
 
 Key implementation files:
 - `components/src/dynamo/common/utils/otel_tracing.py` - W3C `traceparent` header builder
-- `components/src/dynamo/sglang/request_handlers/handler_base.py:71-84` - Extracts trace context from Dynamo `Context` object
-- `components/src/dynamo/sglang/request_handlers/llm/decode_handler.py` - Passes `external_trace_header` and `rid=trace_id` to `engine.async_generate()`
+- `components/src/dynamo/sglang/request_handlers/handler_base.py` - Extracts trace context from Dynamo `Context` object
+- `components/src/dynamo/sglang/request_handlers/llm/decode_handler.py` - Passes `external_trace_header` to `engine.async_generate()`
 
 ### Environment Variables
 
@@ -230,7 +229,7 @@ dynamo-frontend: http-request (root)
       kv_router.schedule
     dynamo-worker-1: handle_payload
       sglang: Bootstrap Room 0x0
-        sglang: Req <trace-id-prefix>
+        sglang: Req <rid-prefix>
           sglang: Scheduler [TP 0]
             request_process
             prefill_forward
@@ -250,7 +249,7 @@ dynamo-frontend: http-request (root)
 4. Use the **Search** tab:
    - Filter by **Service Name** (e.g., `dynamo-frontend`, `dynamo-worker-1`, `sglang`)
    - Filter by **Span Name** (e.g., `http-request`, `handle_payload`, `Req *`, `decode_loop`)
-   - Filter by **Tags** (e.g., `rid=<trace-id>`, `gen_ai.response.model=Qwen/Qwen3-0.6B`)
+   - Filter by **Tags** (e.g., `gen_ai.response.model=Qwen/Qwen3-0.6B`)
 5. Click a trace to view the flame graph spanning frontend -> router -> worker -> engine
 
 Send a request with `x-request-id` for easy lookup:


### PR DESCRIPTION
#### Overview:

Remove `rid=trace_id` from all SGLang handler calls. Multiple Dynamo requests can legitimately share the same trace_id, but SGLang requires rid to be unique per in-flight request. Let SGLang generate its own UUID internally; trace correlation already works through `external_trace_header`.

#### Details:

- Removed `rid=trace_id` from `DecodeWorkerHandler`, `PrefillWorkerHandler`, `EmbeddingWorkerHandler`, `DiffusionWorkerHandler`, `MultimodalWorkerHandler`, `MultimodalPrefillWorkerHandler`, and `LlmEngine`
- Updated `docs/backends/sglang/sglang-observability.md` to reflect that rid is no longer tied to trace_id in the propagation diagram, trace tree, and search tag examples.

#### Where should the reviewer start?

- `components/src/dynamo/sglang/request_handlers/llm/decode_handler.py` the most common path (agg + disagg decode)
- `docs/backends/sglang/sglang-observability.md` updated tracing docs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes https://github.com/ai-dynamo/dynamo/issues/8601


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated distributed tracing implementation to leverage industry-standard W3C `traceparent` headers for improved trace propagation across SGLang request handlers.

* **Documentation**
  * Updated SGLang observability documentation to reflect changes in tracing implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->