### PR TITLE
fix(container): add tail and env to planner distroless image

### DIFF
--- a/container/templates/planner.Dockerfile
+++ b/container/templates/planner.Dockerfile
@@ -76,6 +76,8 @@ FROM ${PLANNER_RUNTIME_IMAGE}:${PLANNER_RUNTIME_IMAGE_TAG} AS planner
 
 COPY --from=planner_builder /etc/group /etc/passwd /etc/
 COPY --from=planner_builder /bin/dash /bin/sh
+COPY --from=planner_builder /usr/bin/tail /bin/tail
+COPY --from=planner_builder /usr/bin/env /bin/env
 COPY --from=planner_builder /bin/uv /bin/uvx /usr/local/bin/
 COPY --chown=1000:0 --from=planner_builder /home/dynamo /home/dynamo
 COPY --chown=1000:0 --from=planner_builder /opt/dynamo/venv /opt/dynamo/venv


### PR DESCRIPTION
#### Overview:

Add `tail` and `env` to the planner container's distroless final stage.

#### Details:

The planner image — which runs the scheduling and scaling services for Dynamo's disaggregated and aggregated inference pipelines — uses a distroless Python base to keep the footprint minimal. Because distroless images ship almost no POSIX utilities, the image only had `sh` (dash) available beyond the Python runtime itself. Adding `tail` and `env`, copied from the slim builder stage at no meaningful size cost, makes the image compatible with container orchestration tooling and exec-based workflows that depend on these standard utilities being present to attach to and run commands inside a running container.

#### Where should the reviewer start?

`container/templates/planner.Dockerfile` — two `COPY` lines in the final `planner` stage.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #ops-3433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container runtime configuration with additional shell utilities to improve operational reliability and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
