### PR TITLE
Evaluate different streaming patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,6 +2456,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "rustls 0.23.37",
  "serde",
+ "serde_bytes",
  "serde_json",
  "serial_test",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ tmq = { version = "0.5.0" }
 tokio = { version = "=1.48.0", features = ["full"] }
 tokio-stream = { version = "0.1" }
 tokio-util = { version = "0.7.17", features = ["codec", "net", "rt", "io-util"] }
-tower-http = { version = "0.6", features = ["trace"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
 axum = { version = "=0.8.4", features = ["macros"] }
 axum-core = { version = "0.5.2" }
 hyper = { version = "=1.7.0" }

--- a/examples/custom_backend/cmaf_binary_video_streaming/README.md
+++ b/examples/custom_backend/cmaf_binary_video_streaming/README.md
@@ -1,0 +1,158 @@
+# Synthetic CMAF Binary Video Streaming POC
+
+This example is a third streaming POC that sits between the existing `video_streaming` and `hls_video_streaming` experiments.
+
+- Like `video_streaming`, it keeps a single long-lived `POST` request open and streams bytes from the worker to the frontend to the browser.
+- Like `hls_video_streaming`, it uses real CMAF/fMP4 media so the browser sees one continuous timeline instead of a sequence of standalone MP4 clips.
+
+The goal is to test whether Dynamo can deliver a better browser playback experience without adopting HLS's pull-based playlist-and-segment routing model.
+
+## What CMAF means here
+
+`CMAF` stands for `Common Media Application Format`.
+
+In this example, the source MP4 is packaged at worker startup into:
+
+- one MP4 initialization fragment, `init.mp4`
+- a sequence of fragmented MP4 media segments, `.m4s`
+
+Unlike the clip-based `video_streaming` POC, those fragments are not independently playable files. They are meant to be appended to a browser `MediaSource` buffer to form one continuous stream.
+
+## Why this POC exists
+
+The existing `video_streaming` example validates Dynamo's single-request push model with minimal frontend changes, but it intentionally streams replayable standalone MP4 clips. That simplifies the transport contract, but it also limits UX:
+
+- no continuous playback timeline
+- visible clip boundaries
+- no preserved audio track in the current synthetic worker
+
+The HLS POC solves those UX issues, but it requires more Dynamo-specific machinery:
+
+- kickoff route
+- opaque stream IDs
+- pull-based playlist and segment routes
+- worker-affine routing for later `GET` requests
+
+This example explores a middle path:
+
+- keep Dynamo's natural push-streaming shape
+- upgrade the media format from standalone MP4 clips to CMAF fragments
+- use `MediaSource` in the browser instead of HLS playlists
+
+## Requirements
+
+- `ffmpeg` on `PATH`
+- `ffprobe` on `PATH` (usually installed alongside `ffmpeg`)
+- A local source MP4 file
+
+## Worker
+
+Start the standalone worker with a real MP4:
+
+```bash
+python examples/custom_backend/cmaf_binary_video_streaming/worker.py \
+  --source-mp4 /path/to/source.mp4 \
+  --segment-seconds 2 \
+  --emit-cadence-ms 750 \
+  --model synthetic-binary-cmaf-video-stream
+```
+
+The worker registers a `ModelType.Videos` backend and serves the usual `generate` endpoint. At startup it:
+
+- inspects the source MP4 with `ffprobe`
+- packages the source into CMAF fragments with `ffmpeg`
+- preserves audio when the source contains an audio track
+- prepares a metadata blob, one init fragment, and a sequence of media fragments
+
+At request time it emits those pieces over the normal video `generate` stream using tagged `VideoData` items:
+
+- `cmaf:metadata`
+- `cmaf:init`
+- `cmaf:segment:<n>`
+
+## Frontend route
+
+With Dynamo frontend running, the relevant route is:
+
+- `POST /v1/videos/stream/binary/cmaf`
+
+This is an experimental sibling of the existing binary route. It keeps one streaming `POST` response open and writes a framed byte stream:
+
+```text
+[kind:1][len_be_u32:4][payload:len]
+```
+
+Frame kinds:
+
+- `0x01`: metadata JSON
+- `0x02`: CMAF init fragment
+- `0x03`: CMAF media fragment
+- `0x04`: error JSON
+- `0x05`: end-of-stream marker
+
+The response also advertises:
+
+- `Content-Type: application/octet-stream`
+- `x-dynamo-video-binary-protocol: dynamo-video-binary-cmaf-v1`
+
+## Reference client
+
+Serve the HTML client:
+
+```bash
+python -m http.server 8080 -d examples/custom_backend/cmaf_binary_video_streaming
+```
+
+Then open `http://localhost:8080/client.html`.
+
+The client:
+
+- `POST`s once to `/v1/videos/stream/binary/cmaf`
+- parses the binary frames
+- creates a `MediaSource`
+- appends the init fragment and media fragments into a `SourceBuffer`
+- plays the result as one continuous video element timeline
+
+This is a browser-native continuous playback experience, but without introducing HLS playlists or pull-based segment fetches.
+
+## Browser note
+
+This client depends on `MediaSource` / `SourceBuffer` support. Modern Chromium-based browsers and Safari should handle this reasonably well; older or constrained browsers may not.
+
+If the page and the Dynamo frontend are served from different origins, browser testing also depends on the CORS headers currently enabled on the videos router.
+
+As with the HLS example, the `Frontend Base URL` field must be reachable from the browser, not just from the shell. In remote IDE or forwarded-port setups, browser `localhost` may not point at the machine running Dynamo.
+
+## Tradeoffs
+
+Compared with `video_streaming`:
+
+- better UX: continuous playback instead of clip-by-clip swapping
+- optional preserved audio when the source MP4 has audio
+- still one streaming `POST`, so no HLS session routing layer
+- slightly more frontend protocol complexity because the browser must use `MediaSource`
+
+Compared with `hls_video_streaming`:
+
+- fewer Dynamo changes: no playlist route, no per-segment `GET`, no stream ID routing
+- less browser standardization: this is a custom binary protocol, not HLS
+- no reuse of off-the-shelf HLS players or CDN-style segment delivery
+
+## Limitations
+
+- This is still a synthetic worker using one prerecorded MP4 packaged at startup.
+- The binary framing is custom and browser-specific. It is useful for evaluating Dynamo's push-streaming shape, not as a production-standard playback protocol.
+- `MediaSource` support and codec compatibility depend on the browser.
+- The worker reuses packaged fragments in memory. There is no durable storage tier or CDN offload.
+- The current route is experimental and intentionally scoped to this POC contract.
+- Browser testing currently depends on permissive CORS settings on the videos router when the page and API are on different origins.
+
+## Follow-ups
+
+- Compare this CMAF-over-binary path directly against the existing clip-based binary stream and the HLS pull path: startup latency, playback smoothness, audio continuity, and frontend CPU.
+- Decide whether future binary media work should prefer:
+  - standalone replayable units,
+  - single-request CMAF over binary,
+  - or HLS/CMAF with browser-standard pull semantics.
+- If this path continues, consider tightening the binary contract further with typed metadata structures and more explicit fragment sequencing / timestamp information.
+- Narrow CORS to the specific experimental routes or move the browser demo behind a same-origin proxy if we keep using standalone static clients.

--- a/examples/custom_backend/cmaf_binary_video_streaming/client.html
+++ b/examples/custom_backend/cmaf_binary_video_streaming/client.html
@@ -1,0 +1,575 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dynamo CMAF Binary Streaming POC Client</title>
+  <style>
+    :root {
+      --bg: #0d1720;
+      --panel: rgba(16, 28, 40, 0.9);
+      --panel-2: rgba(25, 40, 56, 0.92);
+      --text: #eef4f7;
+      --muted: #a9bcc8;
+      --border: rgba(255, 255, 255, 0.12);
+      --accent: #7ad2b4;
+      --accent-2: #7bbcff;
+      --danger: #ff8a7b;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at top left, rgba(122, 210, 180, 0.18), transparent 28%),
+        radial-gradient(circle at top right, rgba(123, 188, 255, 0.16), transparent 24%),
+        linear-gradient(180deg, #091119 0%, var(--bg) 100%);
+      padding: 24px;
+      display: grid;
+      place-items: center;
+    }
+
+    .app {
+      width: min(1120px, 100%);
+      display: grid;
+      gap: 18px;
+      grid-template-columns: minmax(300px, 380px) minmax(0, 1fr);
+    }
+
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 22px;
+      padding: 22px;
+      backdrop-filter: blur(16px);
+      box-shadow: 0 20px 72px rgba(0, 0, 0, 0.32);
+    }
+
+    .controls {
+      display: grid;
+      gap: 14px;
+      align-content: start;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 1.65rem;
+      line-height: 1.1;
+    }
+
+    p,
+    .hint {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.45;
+    }
+
+    label {
+      display: grid;
+      gap: 6px;
+      font-size: 0.88rem;
+      color: var(--muted);
+    }
+
+    input,
+    textarea,
+    button {
+      font: inherit;
+    }
+
+    input,
+    textarea {
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--panel-2);
+      color: var(--text);
+      padding: 10px 12px;
+    }
+
+    textarea {
+      min-height: 88px;
+      resize: vertical;
+    }
+
+    .actions {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    button {
+      border: 0;
+      border-radius: 999px;
+      padding: 10px 16px;
+      cursor: pointer;
+      transition: transform 160ms ease, opacity 160ms ease;
+      font-weight: 700;
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+    }
+
+    .primary {
+      background: var(--accent);
+      color: #08100d;
+    }
+
+    .ghost {
+      background: transparent;
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+
+    .player {
+      display: grid;
+      gap: 14px;
+    }
+
+    video {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      background: #000;
+      border-radius: 18px;
+    }
+
+    .stats {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .pill {
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      padding: 8px 12px;
+      font-size: 0.86rem;
+      color: var(--muted);
+      background: rgba(255, 255, 255, 0.03);
+    }
+
+    pre {
+      margin: 0;
+      min-height: 240px;
+      max-height: 440px;
+      overflow: auto;
+      border-radius: 18px;
+      border: 1px solid var(--border);
+      background: rgba(4, 8, 13, 0.72);
+      padding: 16px;
+      color: #d9e6ee;
+      font-size: 0.83rem;
+      line-height: 1.46;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .error {
+      color: var(--danger);
+    }
+
+    @media (max-width: 920px) {
+      .app {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <section class="panel controls">
+      <h1>Dynamo CMAF Binary Stream POC</h1>
+      <p>POST one prompt, then play a continuous CMAF/fMP4 stream over the experimental single-request binary route using Media Source Extensions.</p>
+
+      <label>
+        Frontend Base URL
+        <input id="baseUrl" placeholder="http://localhost:8000" />
+      </label>
+
+      <label>
+        Model
+        <input id="model" value="synthetic-binary-cmaf-video-stream" />
+      </label>
+
+      <label>
+        Prompt
+        <textarea id="prompt">Replay the synthetic continuous CMAF stream.</textarea>
+      </label>
+
+      <div class="actions">
+        <button class="primary" id="start">Start CMAF Binary Stream</button>
+        <button class="ghost" id="stop">Stop</button>
+      </div>
+
+      <p class="hint">This client expects `POST /v1/videos/stream/binary/cmaf` and uses `MediaSource` with one init fragment plus streamed `.m4s` media fragments. If the page and Dynamo are served from different origins, the videos router must expose CORS headers for browser testing.</p>
+    </section>
+
+    <section class="panel player">
+      <video id="player" controls playsinline></video>
+      <div class="stats">
+        <div class="pill">Mode: <span id="mode">idle</span></div>
+        <div class="pill">Buffered queue: <span id="queued">0</span></div>
+        <div class="pill">Appended: <span id="appended">0</span></div>
+        <div class="pill">Audio: <span id="audio">unknown</span></div>
+      </div>
+      <pre id="log"></pre>
+    </section>
+  </div>
+
+  <script>
+    const player = document.getElementById("player");
+    const modeEl = document.getElementById("mode");
+    const queuedEl = document.getElementById("queued");
+    const appendedEl = document.getElementById("appended");
+    const audioEl = document.getElementById("audio");
+    const logEl = document.getElementById("log");
+
+    const FRAME_KIND_METADATA = 0x01;
+    const FRAME_KIND_INIT = 0x02;
+    const FRAME_KIND_SEGMENT = 0x03;
+    const FRAME_KIND_ERROR = 0x04;
+    const FRAME_KIND_DONE = 0x05;
+    const EXPECTED_PROTOCOL = "dynamo-video-binary-cmaf-v1";
+
+    let currentAbortController = null;
+    let currentObjectUrl = null;
+    let mediaSource = null;
+    let sourceBuffer = null;
+    let appendQueue = [];
+    let appendedCount = 0;
+    let streamDone = false;
+    let playbackStarted = false;
+    let sourceOpen = false;
+    let activeMetadata = null;
+
+    function log(message, isError = false) {
+      const line = `[${new Date().toLocaleTimeString()}] ${message}`;
+      logEl.textContent += `${line}\n`;
+      logEl.scrollTop = logEl.scrollHeight;
+      if (isError) {
+        logEl.classList.add("error");
+      }
+    }
+
+    function resetLogStyle() {
+      logEl.classList.remove("error");
+    }
+
+    function setMode(mode) {
+      modeEl.textContent = mode;
+    }
+
+    function updateStats() {
+      queuedEl.textContent = String(appendQueue.length);
+      appendedEl.textContent = String(appendedCount);
+      audioEl.textContent = activeMetadata ? (activeMetadata.has_audio ? "yes" : "no") : "unknown";
+    }
+
+    function inferDefaultBaseUrl() {
+      const queryBaseUrl = new URLSearchParams(window.location.search).get("baseUrl");
+      if (queryBaseUrl) {
+        return queryBaseUrl;
+      }
+
+      if (window.location.protocol === "file:") {
+        return "http://localhost:8000";
+      }
+
+      const inferred = new URL(window.location.href);
+      inferred.pathname = "";
+      inferred.search = "";
+      inferred.hash = "";
+
+      if (!inferred.port || inferred.port === "8080") {
+        inferred.port = "8000";
+      }
+
+      return inferred.origin;
+    }
+
+    function initializeBaseUrl() {
+      const baseUrlInput = document.getElementById("baseUrl");
+      if (!baseUrlInput.value.trim()) {
+        baseUrlInput.value = inferDefaultBaseUrl();
+      }
+    }
+
+    function resetMediaPipeline() {
+      appendQueue = [];
+      appendedCount = 0;
+      streamDone = false;
+      playbackStarted = false;
+      sourceOpen = false;
+      activeMetadata = null;
+
+      if (sourceBuffer) {
+        try {
+          if (sourceBuffer.updating) {
+            sourceBuffer.abort();
+          }
+        } catch (error) {
+          log(`Ignoring SourceBuffer reset error: ${error}`, true);
+        }
+      }
+
+      if (mediaSource && mediaSource.readyState === "open") {
+        try {
+          mediaSource.endOfStream();
+        } catch (error) {
+          log(`Ignoring MediaSource reset error: ${error}`, true);
+        }
+      }
+
+      sourceBuffer = null;
+      mediaSource = null;
+
+      if (currentObjectUrl) {
+        URL.revokeObjectURL(currentObjectUrl);
+        currentObjectUrl = null;
+      }
+
+      player.pause();
+      player.removeAttribute("src");
+      player.load();
+      updateStats();
+    }
+
+    function maybeFinalizeStream() {
+      if (!streamDone || !mediaSource || !sourceBuffer) {
+        return;
+      }
+      if (appendQueue.length > 0 || sourceBuffer.updating) {
+        return;
+      }
+      if (mediaSource.readyState === "open") {
+        mediaSource.endOfStream();
+        log("MediaSource endOfStream()");
+      }
+    }
+
+    function drainAppendQueue() {
+      if (!sourceOpen || !sourceBuffer || sourceBuffer.updating || appendQueue.length === 0) {
+        maybeFinalizeStream();
+        return;
+      }
+
+      const next = appendQueue.shift();
+      updateStats();
+
+      try {
+        sourceBuffer.appendBuffer(next.bytes);
+        log(`Appending ${next.label} (${next.bytes.byteLength} bytes)`);
+      } catch (error) {
+        log(`Failed to append ${next.label}: ${error}`, true);
+      }
+    }
+
+    function enqueueFragment(bytes, label) {
+      const payload = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+      appendQueue.push({ bytes: payload, label });
+      updateStats();
+      drainAppendQueue();
+    }
+
+    function ensureMediaPipeline(metadata) {
+      if (mediaSource) {
+        return;
+      }
+
+      const mimeType = metadata.source_buffer_mime_type;
+      if (!(window.MediaSource && window.MediaSource.isTypeSupported(mimeType))) {
+        throw new Error(`MediaSource does not support ${mimeType}`);
+      }
+
+      mediaSource = new MediaSource();
+      currentObjectUrl = URL.createObjectURL(mediaSource);
+      player.src = currentObjectUrl;
+      player.load();
+      player.muted = false;
+
+      mediaSource.addEventListener("sourceopen", () => {
+        sourceOpen = true;
+        log(`MediaSource opened with ${mimeType}`);
+        sourceBuffer = mediaSource.addSourceBuffer(mimeType);
+        sourceBuffer.mode = "segments";
+
+        sourceBuffer.addEventListener("updateend", () => {
+          appendedCount += 1;
+          updateStats();
+
+          if (!playbackStarted) {
+            playbackStarted = true;
+            player.play().catch((error) => {
+              log(`Playback start blocked: ${error.message}. Press play if the browser requires a fresh gesture.`, true);
+            });
+          }
+
+          drainAppendQueue();
+        });
+
+        sourceBuffer.addEventListener("error", () => {
+          log("SourceBuffer error while appending CMAF payloads", true);
+        });
+
+        drainAppendQueue();
+      }, { once: true });
+    }
+
+    async function stopStream() {
+      if (currentAbortController) {
+        currentAbortController.abort();
+        currentAbortController = null;
+      }
+      resetMediaPipeline();
+      setMode("idle");
+      log("Stopped stream");
+    }
+
+    async function startStream() {
+      await stopStream();
+      resetLogStyle();
+      logEl.textContent = "";
+
+      if (!(window.MediaSource && window.MediaSource.isTypeSupported)) {
+        log("This browser does not support MediaSource playback", true);
+        setMode("unsupported");
+        return;
+      }
+
+      const baseUrl = document.getElementById("baseUrl").value.trim();
+      const pageOrigin = window.location.origin;
+      if (!baseUrl) {
+        log("Frontend Base URL is empty", true);
+        setMode("error");
+        return;
+      }
+
+      if (
+        window.location.protocol !== "file:" &&
+        !window.location.hostname.match(/^(localhost|127\.0\.0\.1)$/) &&
+        baseUrl.includes("localhost")
+      ) {
+        log(
+          `Frontend Base URL ${baseUrl} points at localhost, but this page is loaded from ${pageOrigin}. ` +
+          "In remote IDE or forwarded-port setups, browser localhost is usually not the same machine as the shell. Use the browser-reachable frontend URL instead.",
+          true
+        );
+      }
+
+      currentAbortController = new AbortController();
+      setMode("connecting");
+      updateStats();
+
+      const url = new URL("/v1/videos/stream/binary/cmaf", baseUrl).toString();
+      const body = {
+        model: document.getElementById("model").value.trim(),
+        prompt: document.getElementById("prompt").value.trim(),
+      };
+
+      log(`POST ${url}`);
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: currentAbortController.signal,
+      });
+
+      if (!response.ok || !response.body) {
+        const errorBody = (await response.text()).trim();
+        throw new Error(
+          errorBody
+            ? `Binary CMAF request failed with ${response.status}: ${errorBody}`
+            : `Binary CMAF request failed with ${response.status}`
+        );
+      }
+
+      const protocol = response.headers.get("x-dynamo-video-binary-protocol") || "unknown";
+      log(`Connected to binary stream (${protocol})`);
+      if (protocol !== EXPECTED_PROTOCOL) {
+        throw new Error(`Unexpected binary protocol header: ${protocol}`);
+      }
+
+      setMode("streaming");
+      const reader = response.body.getReader();
+      const textDecoder = new TextDecoder();
+      let buffer = new Uint8Array(0);
+      let segmentIndex = 0;
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          log("Binary stream closed");
+          break;
+        }
+
+        const next = new Uint8Array(buffer.length + value.length);
+        next.set(buffer);
+        next.set(value, buffer.length);
+        buffer = next;
+
+        while (buffer.length >= 5) {
+          const kind = buffer[0];
+          const length = new DataView(buffer.buffer, buffer.byteOffset + 1, 4).getUint32(0);
+          if (buffer.length < 5 + length) {
+            break;
+          }
+
+          const payload = buffer.slice(5, 5 + length);
+          buffer = buffer.slice(5 + length);
+
+          if (kind === FRAME_KIND_METADATA) {
+            activeMetadata = JSON.parse(textDecoder.decode(payload));
+            log(`Received metadata: ${JSON.stringify(activeMetadata, null, 2)}`);
+            ensureMediaPipeline(activeMetadata);
+            updateStats();
+          } else if (kind === FRAME_KIND_INIT) {
+            enqueueFragment(payload, "init fragment");
+          } else if (kind === FRAME_KIND_SEGMENT) {
+            enqueueFragment(payload, `media fragment ${segmentIndex}`);
+            segmentIndex += 1;
+          } else if (kind === FRAME_KIND_ERROR) {
+            log(`Binary error: ${textDecoder.decode(payload)}`, true);
+            setMode("error");
+          } else if (kind === FRAME_KIND_DONE) {
+            streamDone = true;
+            log("Received binary done frame");
+            maybeFinalizeStream();
+          } else {
+            log(`Unknown binary frame kind: ${kind}`, true);
+          }
+        }
+      }
+    }
+
+    player.addEventListener("error", () => {
+      const mediaError = player.error;
+      const detail = mediaError ? ` code=${mediaError.code}` : "";
+      log(`Video element error${detail}: the continuous CMAF stream could not be played`, true);
+      setMode("error");
+    });
+
+    document.getElementById("start").addEventListener("click", async () => {
+      try {
+        await startStream();
+      } catch (error) {
+        log(`Failed to start CMAF binary stream: ${error.message || error}`, true);
+        setMode("error");
+      }
+    });
+
+    document.getElementById("stop").addEventListener("click", () => {
+      void stopStream();
+    });
+
+    initializeBaseUrl();
+    updateStats();
+  </script>
+</body>
+</html>

--- a/examples/custom_backend/cmaf_binary_video_streaming/worker.py
+++ b/examples/custom_backend/cmaf_binary_video_streaming/worker.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import asyncio
+import base64
+import json
+import logging
+import math
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import AsyncGenerator
+
+import uvloop
+
+from dynamo.common.protocols.video_protocol import (
+    NvCreateVideoRequest,
+    NvVideosResponse,
+    VideoData,
+)
+from dynamo.llm import ModelInput, ModelType, register_llm  # type: ignore[attr-defined]
+from dynamo.runtime import DistributedRuntime
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_NAME = "synthetic-binary-cmaf-video-stream"
+DEFAULT_COMPONENT = "backend"
+DEFAULT_ENDPOINT = "generate"
+DEFAULT_SEGMENT_SECONDS = 2.0
+DEFAULT_EMIT_CADENCE_MS = 750
+PACKAGING_FPS = 30
+PACKAGING_VIDEO_CODEC = "avc1.4d401f"
+PACKAGING_AUDIO_CODEC = "mp4a.40.2"
+VIDEO_STREAM_BINARY_CMAF_ANNOTATION = "experimental_binary_cmaf"
+VIDEO_STREAM_BINARY_CMAF_METADATA_TAG = "cmaf:metadata"
+VIDEO_STREAM_BINARY_CMAF_INIT_TAG = "cmaf:init"
+VIDEO_STREAM_BINARY_CMAF_SEGMENT_PREFIX = "cmaf:segment:"
+
+
+def _get_worker_namespace() -> str:
+    namespace = os.environ.get("DYN_NAMESPACE", "dynamo")
+    suffix = os.environ.get("DYN_NAMESPACE_WORKER_SUFFIX")
+    if suffix:
+        namespace = f"{namespace}-{suffix}"
+    return namespace
+
+
+@dataclass(frozen=True)
+class PackagedSegment:
+    segment_id: int
+    duration_seconds: float
+    filename: str
+    bytes: bytes
+
+
+@dataclass(frozen=True)
+class PackagedStream:
+    target_duration_seconds: int
+    has_audio: bool
+    source_buffer_mime_type: str
+    metadata_bytes: bytes
+    init_bytes: bytes
+    segments: list[PackagedSegment]
+
+
+class SyntheticBinaryCmafVideoBackend:
+    def __init__(
+        self,
+        *,
+        source_mp4: Path,
+        segment_seconds: float,
+        emit_cadence_ms: int,
+        model_name: str,
+    ) -> None:
+        self.source_mp4 = source_mp4
+        self.segment_seconds = segment_seconds
+        self.emit_cadence_ms = emit_cadence_ms
+        self.model_name = model_name
+        self._packaged_stream: PackagedStream | None = None
+        self._workspace: tempfile.TemporaryDirectory[str] | None = None
+
+    @property
+    def packaged_stream(self) -> PackagedStream:
+        if self._packaged_stream is None:
+            raise RuntimeError("Synthetic CMAF binary backend is not initialized")
+        return self._packaged_stream
+
+    async def initialize(self) -> None:
+        self._packaged_stream = await asyncio.to_thread(self._package_source_into_cmaf)
+        logger.info(
+            "Prepared continuous CMAF binary stream from %s with %d segments, target_duration=%ds, has_audio=%s",
+            self.source_mp4,
+            len(self.packaged_stream.segments),
+            self.packaged_stream.target_duration_seconds,
+            self.packaged_stream.has_audio,
+        )
+
+    def _detect_audio_stream(self) -> bool:
+        if shutil.which("ffprobe") is None:
+            raise RuntimeError(
+                "ffprobe is required to inspect the source MP4 audio track for the CMAF binary POC"
+            )
+
+        cmd = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "a",
+            "-show_entries",
+            "stream=index",
+            "-of",
+            "csv=p=0",
+            str(self.source_mp4),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            stderr = result.stderr.strip() or "ffprobe exited with a non-zero status"
+            raise RuntimeError(f"ffprobe failed: {stderr}")
+        return bool(result.stdout.strip())
+
+    def _package_source_into_cmaf(self) -> PackagedStream:
+        if not self.source_mp4.exists():
+            raise FileNotFoundError(f"Source MP4 not found: {self.source_mp4}")
+        if shutil.which("ffmpeg") is None:
+            raise RuntimeError("ffmpeg is required to package CMAF fragments")
+
+        has_audio = self._detect_audio_stream()
+
+        self._workspace = tempfile.TemporaryDirectory(prefix="dynamo-binary-cmaf-")
+        workspace = Path(self._workspace.name)
+        manifest_path = workspace / "manifest.m3u8"
+        segment_template = workspace / "segment_%05d.m4s"
+        gop = max(1, int(round(self.segment_seconds * PACKAGING_FPS)))
+
+        cmd = [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            str(self.source_mp4),
+            "-map",
+            "0:v:0",
+            "-vf",
+            "scale=trunc(iw/2)*2:trunc(ih/2)*2,format=yuv420p",
+            "-r",
+            str(PACKAGING_FPS),
+            "-c:v",
+            "libx264",
+            "-profile:v",
+            "main",
+            "-level:v",
+            "3.1",
+            "-preset",
+            "veryfast",
+            "-g",
+            str(gop),
+            "-keyint_min",
+            str(gop),
+            "-sc_threshold",
+            "0",
+            "-force_key_frames",
+            f"expr:gte(t,n_forced*{self.segment_seconds})",
+        ]
+
+        if has_audio:
+            cmd.extend(
+                [
+                    "-map",
+                    "0:a:0?",
+                    "-c:a",
+                    "aac",
+                    "-b:a",
+                    "128k",
+                    "-ar",
+                    "48000",
+                    "-ac",
+                    "2",
+                ]
+            )
+
+        cmd.extend(
+            [
+                "-f",
+                "hls",
+                "-hls_time",
+                str(self.segment_seconds),
+                "-hls_playlist_type",
+                "vod",
+                "-hls_list_size",
+                "0",
+                "-hls_segment_type",
+                "fmp4",
+                "-hls_fmp4_init_filename",
+                "init.mp4",
+                "-hls_flags",
+                "independent_segments",
+                "-hls_segment_filename",
+                str(segment_template),
+                str(manifest_path),
+            ]
+        )
+
+        logger.info(
+            "Packaging %s into continuous CMAF fragments with ffmpeg (has_audio=%s)",
+            self.source_mp4,
+            has_audio,
+        )
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            stderr = result.stderr.strip() or "ffmpeg exited with a non-zero status"
+            raise RuntimeError(f"ffmpeg packaging failed: {stderr}")
+
+        manifest = manifest_path.read_text(encoding="utf-8")
+        target_duration_seconds = 0
+        init_filename: str | None = None
+        segments: list[PackagedSegment] = []
+        current_duration: float | None = None
+
+        for raw_line in manifest.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            if line.startswith("#EXT-X-TARGETDURATION:"):
+                target_duration_seconds = int(line.split(":", 1)[1])
+                continue
+            if line.startswith("#EXT-X-MAP:"):
+                match = re.search(r'URI="([^"]+)"', line)
+                if match:
+                    init_filename = match.group(1)
+                continue
+            if line.startswith("#EXTINF:"):
+                current_duration = float(line.split(":", 1)[1].split(",", 1)[0])
+                continue
+            if line.startswith("#"):
+                continue
+            if current_duration is None:
+                raise RuntimeError(
+                    f"Found segment line without preceding EXTINF in {manifest_path}"
+                )
+
+            segment_path = workspace / line
+            segments.append(
+                PackagedSegment(
+                    segment_id=len(segments),
+                    duration_seconds=current_duration,
+                    filename=line,
+                    bytes=segment_path.read_bytes(),
+                )
+            )
+            current_duration = None
+
+        if init_filename is None:
+            raise RuntimeError("ffmpeg manifest did not contain EXT-X-MAP")
+        if not segments:
+            raise RuntimeError("ffmpeg did not produce any CMAF segments")
+        if target_duration_seconds <= 0:
+            target_duration_seconds = int(
+                math.ceil(max(segment.duration_seconds for segment in segments))
+            )
+
+        init_bytes = (workspace / init_filename).read_bytes()
+        if not init_bytes:
+            raise RuntimeError("ffmpeg produced an empty init.mp4 fragment")
+
+        codec_list = [PACKAGING_VIDEO_CODEC]
+        if has_audio:
+            codec_list.append(PACKAGING_AUDIO_CODEC)
+        source_buffer_mime_type = f'video/mp4; codecs="{",".join(codec_list)}"'
+        metadata_bytes = json.dumps(
+            {
+                "mime_type": "video/mp4",
+                "source_buffer_mime_type": source_buffer_mime_type,
+                "video_codec": PACKAGING_VIDEO_CODEC,
+                "audio_codec": PACKAGING_AUDIO_CODEC if has_audio else None,
+                "has_audio": has_audio,
+                "target_duration_seconds": target_duration_seconds,
+                "segment_count": len(segments),
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+        return PackagedStream(
+            target_duration_seconds=target_duration_seconds,
+            has_audio=has_audio,
+            source_buffer_mime_type=source_buffer_mime_type,
+            metadata_bytes=metadata_bytes,
+            init_bytes=init_bytes,
+            segments=segments,
+        )
+
+    def _require_cmaf_request(self, request: NvCreateVideoRequest) -> None:
+        annotations = request.nvext.annotations if request.nvext else None
+        if not annotations or VIDEO_STREAM_BINARY_CMAF_ANNOTATION not in annotations:
+            raise ValueError(
+                "synthetic CMAF binary worker requires the experimental_binary_cmaf annotation"
+            )
+
+    @staticmethod
+    def _encode_bytes(payload: bytes) -> str:
+        return base64.b64encode(payload).decode("ascii")
+
+    @staticmethod
+    def _build_response(
+        *,
+        request_id: str,
+        model: str,
+        created: int,
+        status: str,
+        progress: int,
+        tag: str,
+        payload: bytes,
+    ) -> NvVideosResponse:
+        return NvVideosResponse(
+            id=request_id,
+            object="video",
+            model=model,
+            status=status,
+            progress=progress,
+            created=created,
+            data=[
+                VideoData(
+                    url=tag,
+                    b64_json=SyntheticBinaryCmafVideoBackend._encode_bytes(payload),
+                )
+            ],
+            error=None,
+            inference_time_s=None,
+        )
+
+    async def generate(self, request: dict, context) -> AsyncGenerator[dict, None]:
+        req = NvCreateVideoRequest(**request)
+        self._require_cmaf_request(req)
+
+        request_id = context.id() or f"video-{uuid.uuid4().hex}"
+        created = int(time.time())
+        total_parts = 2 + len(self.packaged_stream.segments)
+
+        logger.info(
+            "Synthetic CMAF binary request %s: model=%s prompt=%r segments=%d cadence_ms=%d has_audio=%s",
+            request_id,
+            req.model,
+            req.prompt,
+            len(self.packaged_stream.segments),
+            self.emit_cadence_ms,
+            self.packaged_stream.has_audio,
+        )
+
+        emissions: list[tuple[str, bytes]] = [
+            (
+                VIDEO_STREAM_BINARY_CMAF_METADATA_TAG,
+                self.packaged_stream.metadata_bytes,
+            ),
+            (VIDEO_STREAM_BINARY_CMAF_INIT_TAG, self.packaged_stream.init_bytes),
+        ]
+        emissions.extend(
+            (
+                f"{VIDEO_STREAM_BINARY_CMAF_SEGMENT_PREFIX}{segment.segment_id}",
+                segment.bytes,
+            )
+            for segment in self.packaged_stream.segments
+        )
+
+        for index, (tag, payload) in enumerate(emissions):
+            if context.is_stopped() or context.is_killed():
+                logger.info("Request %s cancelled before payload %d", request_id, index)
+                raise asyncio.CancelledError
+
+            progress = int(round(((index + 1) / total_parts) * 100))
+            is_last = index == total_parts - 1
+            response = self._build_response(
+                request_id=request_id,
+                model=req.model,
+                created=created,
+                status="completed" if is_last else "in_progress",
+                progress=progress,
+                tag=tag,
+                payload=payload,
+            )
+
+            logger.info(
+                "Request %s emitting %s payload %d/%d (%d bytes)",
+                request_id,
+                tag,
+                index + 1,
+                total_parts,
+                len(payload),
+            )
+            yield response.model_dump()
+
+            if tag.startswith(VIDEO_STREAM_BINARY_CMAF_SEGMENT_PREFIX) and not is_last:
+                await asyncio.sleep(self.emit_cadence_ms / 1000.0)
+
+
+async def _register_model(endpoint, model_name: str) -> None:
+    await register_llm(
+        ModelInput.Text,  # type: ignore[attr-defined]
+        ModelType.Videos,
+        endpoint,
+        model_name,
+        model_name,
+    )
+    logger.info("Registered synthetic binary CMAF model: %s", model_name)
+
+
+async def backend_worker(runtime: DistributedRuntime, args: argparse.Namespace) -> None:
+    namespace_name = _get_worker_namespace()
+    endpoint = runtime.endpoint(
+        f"{namespace_name}.{DEFAULT_COMPONENT}.{DEFAULT_ENDPOINT}"
+    )
+    logger.info(
+        "Serving synthetic binary CMAF endpoint %s/%s/%s",
+        namespace_name,
+        DEFAULT_COMPONENT,
+        DEFAULT_ENDPOINT,
+    )
+
+    backend = SyntheticBinaryCmafVideoBackend(
+        source_mp4=args.source_mp4,
+        segment_seconds=args.segment_seconds,
+        emit_cadence_ms=args.emit_cadence_ms,
+        model_name=args.model,
+    )
+    await backend.initialize()
+
+    await asyncio.gather(
+        endpoint.serve_endpoint(backend.generate),  # type: ignore[arg-type]
+        _register_model(endpoint, backend.model_name),
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Synthetic CMAF-over-binary harness for /v1/videos/stream/binary/cmaf"
+    )
+    parser.add_argument(
+        "--source-mp4",
+        type=Path,
+        required=True,
+        help="Path to the prerecorded MP4 used as the synthetic source stream",
+    )
+    parser.add_argument(
+        "--segment-seconds",
+        type=float,
+        default=DEFAULT_SEGMENT_SECONDS,
+        help=f"Duration of each CMAF media fragment in seconds (default: {DEFAULT_SEGMENT_SECONDS})",
+    )
+    parser.add_argument(
+        "--emit-cadence-ms",
+        type=int,
+        default=DEFAULT_EMIT_CADENCE_MS,
+        help=f"Delay between emitted media fragments in milliseconds (default: {DEFAULT_EMIT_CADENCE_MS})",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL_NAME,
+        help=f"Served model name for registration (default: {DEFAULT_MODEL_NAME})",
+    )
+    args = parser.parse_args()
+
+    if args.segment_seconds <= 0:
+        parser.error("--segment-seconds must be positive")
+    if args.emit_cadence_ms <= 0:
+        parser.error("--emit-cadence-ms must be positive")
+
+    return args
+
+
+async def main(args: argparse.Namespace) -> None:
+    loop = asyncio.get_running_loop()
+    discovery_backend = os.environ.get("DYN_DISCOVERY_BACKEND")
+    if not discovery_backend:
+        discovery_backend = (
+            "kubernetes" if os.environ.get("KUBERNETES_SERVICE_HOST") else "file"
+        )
+
+    logger.info("Using discovery backend: %s", discovery_backend)
+    logger.info("Resolved worker namespace: %s", _get_worker_namespace())
+    runtime = DistributedRuntime(loop, discovery_backend, "tcp")
+    await backend_worker(runtime, args)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        force=True,
+    )
+    uvloop.install()
+    asyncio.run(main(_parse_args()))

--- a/examples/custom_backend/hls_video_streaming/README.md
+++ b/examples/custom_backend/hls_video_streaming/README.md
@@ -1,0 +1,122 @@
+# Synthetic HLS/CMAF Video Streaming POC
+
+This example packages a prerecorded MP4 into real HLS CMAF assets at worker startup, then simulates live generation by gradually revealing `.m4s` fragments through the experimental Dynamo pull routes.
+
+`CMAF` stands for `Common Media Application Format`. In this example, that means the HLS stream is built from:
+
+- one MP4 initialization fragment, `init.mp4`
+- a sequence of fragmented MP4 media segments, `0.m4s`, `1.m4s`, and so on
+
+That is different from older HLS setups that use MPEG-TS (`.ts`) segments. We use CMAF here because it keeps the experiment focused on modern fragmented MP4 delivery, works cleanly with HLS players, and leaves room for future experiments that could reuse the same segment format for DASH as well.
+
+## Architecture note
+
+This POC intentionally uses worker-affine routing instead of shared storage.
+
+- The Python worker packages one reusable CMAF asset set at startup: `init.mp4` plus numbered `.m4s` fragments.
+- Each generation request creates a lightweight in-memory session record with timing and visibility state.
+- The worker encodes `session_id`, `worker_id`, `namespace`, and `component` into the opaque `stream_id`.
+- The Rust frontend decodes that `stream_id` on later `GET` requests and direct-routes playlist / fragment fetches back to the exact worker instance that owns the session.
+
+This keeps the experiment focused on Dynamo's worker-to-frontend binary delivery path instead of introducing a separate storage tier.
+
+## Requirements
+
+- `ffmpeg` on `PATH`
+- A local source MP4 file
+
+## Worker
+
+Start the standalone worker with a real MP4:
+
+```bash
+python examples/custom_backend/hls_video_streaming/worker.py \
+  --source-mp4 /path/to/source.mp4 \
+  --segment-seconds 2 \
+  --emit-cadence-ms 1000 \
+  --playlist-window-segments 4 \
+  --model synthetic-hls-cmaf-video-stream
+```
+
+The worker registers a `ModelType.Videos` backend and serves four Dynamo endpoints on the same worker instance:
+
+- `generate`
+- `playlist`
+- `init_fragment`
+- `segment`
+
+## Frontend routes
+
+With Dynamo frontend running, the relevant routes are:
+
+- `POST /v1/videos/stream/hls`
+  Starts a synthetic HLS session and returns `stream_id`, `playlist_url`, `target_duration_seconds`, and `expires_at`.
+- `GET /v1/videos/stream/hls/{stream_id}/playlist.m3u8`
+  Returns the live playlist as `application/vnd.apple.mpegurl`.
+- `GET /v1/videos/stream/hls/{stream_id}/init.mp4`
+  Returns the CMAF init fragment as `video/mp4`.
+- `GET /v1/videos/stream/hls/{stream_id}/segment/{segment_id}.m4s`
+  Returns each CMAF media fragment as `video/mp4`.
+
+## Reference client
+
+Serve the HTML client:
+
+```bash
+python -m http.server 8080 -d examples/custom_backend/hls_video_streaming
+```
+
+Then open `http://localhost:8080/client.html`.
+
+The page uses native HLS playback where available and falls back to `hls.js` everywhere else. For local browser testing, serve the page from the same origin as Dynamo or put a small reverse proxy in front of both ports so the browser can fetch the kickoff JSON, playlist, and fragments without cross-origin restrictions.
+
+The `Frontend Base URL` field must be reachable from the browser, not just from the shell. If you are using a remote IDE, SSH session, dev container, or forwarded-port environment, browser `http://localhost:8000` may point at your laptop instead of the machine running Dynamo. In that case:
+
+- forward the Dynamo frontend port to the browser
+- set `Frontend Base URL` to that browser-visible frontend URL
+- verify the same URL works in the browser by opening `/v1/models` before testing playback
+
+## Browser CORS note
+
+This POC enables `CORS` on the Dynamo videos router so the reference client can run in a normal browser even when the HTML page and the Dynamo frontend are served from different origins.
+
+`CORS` stands for `Cross-Origin Resource Sharing`. Browsers normally prevent JavaScript loaded from one origin from reading responses from another origin. In practice, that means a page served from one forwarded VS Code URL or port cannot call `POST /v1/videos/stream/hls` on a different frontend URL unless the server explicitly opts in with CORS response headers.
+
+We enable it here because this example is intentionally lightweight:
+
+- the reference client is a standalone static `client.html`
+- developers often serve that page from a different port or forwarded URL than the Dynamo frontend
+- the HLS workflow needs multiple browser-side requests: kickoff JSON, playlist fetches, init fragment fetch, and repeated CMAF segment fetches
+
+Without CORS, those browser requests fail even though the same URLs work with `curl`.
+
+For this POC, the current CORS setting is intentionally broad so local testing is easy:
+
+- it allows any origin
+- it allows `GET`, `POST`, and `OPTIONS`
+- it allows arbitrary request headers
+- it applies to the videos router, not only the HLS routes
+
+That is acceptable for a local experiment, but it is not the security posture we would want for a production deployment.
+
+## Limitations
+
+- This is a worker-memory POC, not a production HLS architecture. If the owning worker exits, restarts, or becomes unreachable, the stream is lost.
+- There is no shared object store, CDN, or cache layer. Every playlist and fragment request must route back to the original worker instance.
+- The implementation is intentionally synthetic. It reuses one prerecorded MP4 packaged at worker startup rather than generating fresh media per request.
+- Session state is in-memory only and protected by a simple TTL. There is no recovery, replication, checkpointing, or cross-worker failover.
+- The `stream_id` is opaque but unsigned. It is suitable for a local experiment, not for a hardened public API.
+- The frontend pull path adds per-fragment RPC overhead. That is acceptable for this experiment, but it is not the scaling model you would want for large fanout or long-lived streams.
+- This uses standard live HLS with CMAF, not Low-Latency HLS.
+- The reference client is minimal by design. It is useful for validation, not for production playback UX or telemetry.
+- The browser demo currently relies on permissive CORS settings to support cross-origin local testing. CORS is not authentication or authorization; it only controls what browser JavaScript is allowed to read.
+
+## Follow-ups
+
+- Add a second implementation that writes playlists and fragments to shared storage so we can compare worker-affine routing against a mock CDN-style design.
+- Measure the operational tradeoff between this HLS pull path and the existing SSE push path: startup latency, per-fragment overhead, frontend CPU, worker memory, and failure behavior.
+- Decide whether future binary media experiments should stay worker-affine, move to shared storage, or use a hybrid model where workers upload finalized fragments and the frontend only brokers kickoff.
+- If this path continues, harden the stream token, add authz checks, and define clearer expiration and cleanup semantics.
+- If browser reach and interoperability matter, consider a follow-on experiment with CMAF shared between both HLS and DASH manifests.
+- If this stays browser-facing, narrow the CORS policy to the HLS routes only and allow only the expected frontend origin or reverse-proxy origin instead of `*`.
+- Prefer a same-origin setup for future demos, either by serving the client from the Dynamo frontend or by putting both the client and API behind a single reverse proxy.

--- a/examples/custom_backend/hls_video_streaming/client.html
+++ b/examples/custom_backend/hls_video_streaming/client.html
@@ -1,0 +1,492 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dynamo HLS/CMAF POC Client</title>
+  <style>
+    :root {
+      --bg: #0f1720;
+      --panel: rgba(12, 22, 33, 0.88);
+      --panel-2: rgba(18, 31, 46, 0.92);
+      --text: #eef4f7;
+      --muted: #a9bcc8;
+      --border: rgba(255, 255, 255, 0.12);
+      --accent: #7ad2b4;
+      --accent-2: #7bbcff;
+      --danger: #ff8a7b;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at top left, rgba(122, 210, 180, 0.18), transparent 28%),
+        radial-gradient(circle at top right, rgba(123, 188, 255, 0.16), transparent 24%),
+        linear-gradient(180deg, #091119 0%, var(--bg) 100%);
+      padding: 24px;
+      display: grid;
+      place-items: center;
+    }
+
+    .app {
+      width: min(1120px, 100%);
+      display: grid;
+      gap: 18px;
+      grid-template-columns: minmax(300px, 380px) minmax(0, 1fr);
+    }
+
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 22px;
+      padding: 22px;
+      backdrop-filter: blur(16px);
+      box-shadow: 0 20px 72px rgba(0, 0, 0, 0.32);
+    }
+
+    .controls {
+      display: grid;
+      gap: 14px;
+      align-content: start;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 1.65rem;
+      line-height: 1.1;
+    }
+
+    p,
+    .hint {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.45;
+    }
+
+    label {
+      display: grid;
+      gap: 6px;
+      font-size: 0.88rem;
+      color: var(--muted);
+    }
+
+    input,
+    textarea,
+    button {
+      font: inherit;
+    }
+
+    input,
+    textarea {
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--panel-2);
+      color: var(--text);
+      padding: 10px 12px;
+    }
+
+    textarea {
+      min-height: 88px;
+      resize: vertical;
+    }
+
+    .actions {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    button {
+      border: 0;
+      border-radius: 999px;
+      padding: 10px 16px;
+      cursor: pointer;
+      transition: transform 160ms ease, opacity 160ms ease;
+      font-weight: 700;
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+    }
+
+    .primary {
+      background: var(--accent);
+      color: #08100d;
+    }
+
+    .ghost {
+      background: transparent;
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+
+    .player {
+      display: grid;
+      gap: 14px;
+    }
+
+    video {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      background: #000;
+      border-radius: 18px;
+    }
+
+    .stats {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .pill {
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      padding: 8px 12px;
+      font-size: 0.86rem;
+      color: var(--muted);
+      background: rgba(255, 255, 255, 0.03);
+    }
+
+    pre {
+      margin: 0;
+      min-height: 240px;
+      max-height: 440px;
+      overflow: auto;
+      border-radius: 18px;
+      border: 1px solid var(--border);
+      background: rgba(4, 8, 13, 0.72);
+      padding: 16px;
+      color: #d9e6ee;
+      font-size: 0.83rem;
+      line-height: 1.46;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .error {
+      color: var(--danger);
+    }
+
+    @media (max-width: 920px) {
+      .app {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <section class="panel controls">
+      <h1>Dynamo HLS/CMAF Stream POC</h1>
+      <p>Kick off a synthetic video generation request, then hand the returned live playlist to either native HLS playback or <code>hls.js</code>.</p>
+
+      <label>
+        Frontend Base URL
+        <input id="baseUrl" placeholder="http://localhost:8000" />
+      </label>
+
+      <label>
+        Model
+        <input id="model" value="synthetic-hls-cmaf-video-stream" />
+      </label>
+
+      <label>
+        Prompt
+        <textarea id="prompt">Replay the synthetic CMAF stream.</textarea>
+      </label>
+
+      <div class="actions">
+        <button class="primary" id="start">Start HLS Stream</button>
+        <button class="ghost" id="stop">Stop</button>
+      </div>
+
+      <p class="hint">This page expects the experimental <code>/v1/videos/stream/hls</code> route. If you serve this page from a different origin than Dynamo, use a same-origin reverse proxy for local testing.</p>
+    </section>
+
+    <section class="panel player">
+      <video id="player" controls autoplay muted playsinline></video>
+      <div class="stats">
+        <div class="pill">Mode: <span id="mode">idle</span></div>
+        <div class="pill">Stream ID: <span id="streamId">none</span></div>
+        <div class="pill">Playlist: <span id="playlistStatus">not started</span></div>
+      </div>
+      <pre id="log"></pre>
+    </section>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/hls.js@1"></script>
+  <script>
+    const player = document.getElementById("player");
+    const modeEl = document.getElementById("mode");
+    const streamIdEl = document.getElementById("streamId");
+    const playlistStatusEl = document.getElementById("playlistStatus");
+    const logEl = document.getElementById("log");
+
+    const KICKOFF_TIMEOUT_MS = 15000;
+
+    let activeHls = null;
+    let kickoffAbortController = null;
+    let kickoffAbortReason = null;
+
+    function inferDefaultBaseUrl() {
+      const queryBaseUrl = new URLSearchParams(window.location.search).get("baseUrl");
+      if (queryBaseUrl) {
+        return queryBaseUrl;
+      }
+
+      if (window.location.protocol === "file:") {
+        return "http://localhost:8000";
+      }
+
+      const inferred = new URL(window.location.href);
+      inferred.pathname = "";
+      inferred.search = "";
+      inferred.hash = "";
+
+      if (!inferred.port || inferred.port === "8080") {
+        inferred.port = "8000";
+      }
+
+      return inferred.origin;
+    }
+
+    function initializeBaseUrl() {
+      const baseUrlInput = document.getElementById("baseUrl");
+      if (!baseUrlInput.value.trim()) {
+        baseUrlInput.value = inferDefaultBaseUrl();
+      }
+    }
+
+    function log(message, isError = false) {
+      const line = `[${new Date().toLocaleTimeString()}] ${message}`;
+      logEl.textContent += `${line}\n`;
+      logEl.scrollTop = logEl.scrollHeight;
+      if (isError) {
+        logEl.classList.add("error");
+      }
+    }
+
+    function resetLogStyle() {
+      logEl.classList.remove("error");
+    }
+
+    function setMode(mode) {
+      modeEl.textContent = mode;
+    }
+
+    function stopPlayback() {
+      if (kickoffAbortController) {
+        kickoffAbortReason = "stopped";
+        kickoffAbortController.abort();
+        kickoffAbortController = null;
+        log("Cancelled pending kickoff request");
+      }
+      if (activeHls) {
+        activeHls.destroy();
+        activeHls = null;
+      }
+      player.pause();
+      player.removeAttribute("src");
+      player.load();
+      streamIdEl.textContent = "none";
+      setMode("idle");
+      playlistStatusEl.textContent = "stopped";
+    }
+
+    async function startStream() {
+      stopPlayback();
+      resetLogStyle();
+      logEl.textContent = "";
+
+      const baseUrl = document.getElementById("baseUrl").value.trim();
+      const pageOrigin = window.location.origin;
+      if (!baseUrl) {
+        log("Frontend Base URL is empty", true);
+        playlistStatusEl.textContent = "error";
+        streamIdEl.textContent = "none";
+        setMode("error");
+        return;
+      }
+
+      if (
+        window.location.protocol !== "file:" &&
+        !window.location.hostname.match(/^(localhost|127\.0\.0\.1)$/) &&
+        baseUrl.includes("localhost")
+      ) {
+        log(
+          `Frontend Base URL ${baseUrl} points at localhost, but this page is loaded from ${pageOrigin}. ` +
+          "In remote IDE or forwarded-port setups, browser localhost is usually not the same machine as the shell. Use the browser-reachable frontend URL instead.",
+          true
+        );
+      }
+
+      const kickoffUrl = new URL("/v1/videos/stream/hls", baseUrl).toString();
+      const requestBody = {
+        model: document.getElementById("model").value.trim(),
+        prompt: document.getElementById("prompt").value.trim(),
+        seconds: 6,
+        size: "832x480"
+      };
+
+      setMode("kickoff");
+      playlistStatusEl.textContent = "starting";
+      streamIdEl.textContent = "pending";
+      log(`POST ${kickoffUrl}`);
+      log(`Waiting for kickoff response (timeout ${KICKOFF_TIMEOUT_MS / 1000}s)`);
+
+      let kickoff;
+      const abortController = new AbortController();
+      kickoffAbortController = abortController;
+      kickoffAbortReason = null;
+      const timeoutId = window.setTimeout(() => {
+        kickoffAbortReason = "timeout";
+        abortController.abort();
+      }, KICKOFF_TIMEOUT_MS);
+
+      try {
+        const response = await fetch(kickoffUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(requestBody),
+          signal: abortController.signal
+        });
+        window.clearTimeout(timeoutId);
+        kickoffAbortController = null;
+        kickoffAbortReason = null;
+        log(`Kickoff HTTP status: ${response.status}`);
+        if (!response.ok) {
+          const errorBody = (await response.text()).trim();
+          if (response.status === 404) {
+            throw new Error(
+              errorBody ||
+              "Route not found. The frontend may be running an older build, or video endpoints may still be disabled because the synthetic model has not been discovered yet. Check /v1/models and the worker/frontend logs."
+            );
+          }
+          throw new Error(
+            errorBody
+              ? `Kickoff failed with ${response.status}: ${errorBody}`
+              : `Kickoff failed with ${response.status} and an empty response body`
+          );
+        }
+        kickoff = await response.json();
+      } catch (error) {
+        window.clearTimeout(timeoutId);
+        kickoffAbortController = null;
+
+        if (error && error.name === "AbortError" && kickoffAbortReason === "stopped") {
+          kickoffAbortReason = null;
+          return;
+        }
+
+        let message = error && error.message ? error.message : String(error);
+        if (error && error.name === "AbortError") {
+          message =
+            `Kickoff request timed out after ${KICKOFF_TIMEOUT_MS / 1000}s. ` +
+            "If curl to the same URL also hangs or 404s, check that the frontend was rebuilt and that /v1/models includes synthetic-hls-cmaf-video-stream. " +
+            "If curl works from the shell but the browser still times out, the page may be using the wrong frontend base URL for your browser environment.";
+        } else if (error instanceof TypeError) {
+          message =
+            `${message}. If client.html is being served from a different origin than Dynamo, ` +
+            "this is often a browser CORS/preflight issue. Try curl against the same URL or serve the page from the same origin.";
+        }
+
+        kickoffAbortReason = null;
+        log(`Kickoff error: ${message}`, true);
+        playlistStatusEl.textContent = "error";
+        streamIdEl.textContent = "none";
+        setMode("error");
+        return;
+      }
+
+      const playlistUrl = new URL(kickoff.playlist_url, baseUrl).toString();
+      streamIdEl.textContent = kickoff.stream_id;
+      playlistStatusEl.textContent = playlistUrl;
+      log(`Kickoff response: ${JSON.stringify(kickoff, null, 2)}`);
+      const nativeHlsSupport = player.canPlayType("application/vnd.apple.mpegurl");
+      const hlsJsSupport = Boolean(window.Hls && window.Hls.isSupported());
+      log(
+        `Playback capabilities: native=${nativeHlsSupport || "no"} hls.js=${hlsJsSupport ? "yes" : "no"}`
+      );
+
+      if (hlsJsSupport) {
+        log("Using hls.js playback");
+        setMode("hls.js");
+        activeHls = new window.Hls({
+          lowLatencyMode: false,
+          backBufferLength: 90
+        });
+
+        activeHls.on(window.Hls.Events.MANIFEST_LOADING, () => {
+          log("Loading live playlist");
+        });
+        activeHls.on(window.Hls.Events.MANIFEST_PARSED, (_, data) => {
+          log(`Manifest parsed, ${data.levels.length} level(s) available`);
+          player.play().catch((error) => {
+            log(`Playback start failed: ${error.message}`, true);
+          });
+        });
+        activeHls.on(window.Hls.Events.LEVEL_UPDATED, (_, data) => {
+          playlistStatusEl.textContent = `mediaSequence=${data.details.mediaSequence}`;
+          log(
+            `Playlist updated: live=${data.details.live} fragments=${data.details.fragments.length} seq=${data.details.mediaSequence}`
+          );
+        });
+        activeHls.on(window.Hls.Events.FRAG_LOADED, (_, data) => {
+          log(`Loaded fragment sn=${data.frag.sn} url=${data.frag.url}`);
+        });
+        activeHls.on(window.Hls.Events.ERROR, (_, data) => {
+          log(`hls.js error (${data.type}/${data.details}): ${data.reason || "unknown"}`, true);
+          if (data.fatal) {
+            setMode("fatal-error");
+            switch (data.type) {
+              case window.Hls.ErrorTypes.NETWORK_ERROR:
+                activeHls.startLoad();
+                break;
+              case window.Hls.ErrorTypes.MEDIA_ERROR:
+                activeHls.recoverMediaError();
+                break;
+              default:
+                stopPlayback();
+                break;
+            }
+          }
+        });
+
+        activeHls.attachMedia(player);
+        activeHls.loadSource(playlistUrl);
+        return;
+      }
+
+      if (!nativeHlsSupport) {
+        log("This browser does not support native HLS or hls.js MSE playback", true);
+        setMode("unsupported");
+        return;
+      }
+
+      log("Using native HLS playback");
+      setMode("native-hls");
+      player.addEventListener("error", () => {
+        const mediaError = player.error;
+        const detail = mediaError ? ` code=${mediaError.code}` : "";
+        log(`Native playback error${detail}: Failed to load HLS stream`, true);
+      }, { once: true });
+      player.src = playlistUrl;
+      player.play().catch((error) => {
+        log(`Native playback error: ${error.message}`, true);
+      });
+    }
+
+    document.getElementById("start").addEventListener("click", startStream);
+    document.getElementById("stop").addEventListener("click", stopPlayback);
+    initializeBaseUrl();
+  </script>
+</body>
+</html>

--- a/examples/custom_backend/hls_video_streaming/worker.py
+++ b/examples/custom_backend/hls_video_streaming/worker.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import asyncio
+import base64
+import json
+import logging
+import math
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+import uvloop
+from pydantic import BaseModel
+
+from dynamo.common.protocols.video_protocol import (
+    NvCreateVideoRequest,
+    NvVideosResponse,
+)
+from dynamo.llm import ModelInput, ModelType, register_llm  # type: ignore[attr-defined]
+from dynamo.runtime import DistributedRuntime, dynamo_endpoint
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_NAME = "synthetic-hls-cmaf-video-stream"
+DEFAULT_COMPONENT = "backend"
+DEFAULT_GENERATE_ENDPOINT = "generate"
+DEFAULT_PLAYLIST_ENDPOINT = "playlist"
+DEFAULT_INIT_ENDPOINT = "init_fragment"
+DEFAULT_SEGMENT_ENDPOINT = "segment"
+DEFAULT_SEGMENT_SECONDS = 2.0
+DEFAULT_EMIT_CADENCE_MS = 1000
+DEFAULT_PLAYLIST_WINDOW_SEGMENTS = 4
+DEFAULT_SESSION_TTL_SECONDS = 600
+PACKAGING_FPS = 30
+HLS_CMAF_ANNOTATION = "experimental_hls_cmaf"
+
+
+def _get_worker_namespace() -> str:
+    namespace = os.environ.get("DYN_NAMESPACE", "dynamo")
+    suffix = os.environ.get("DYN_NAMESPACE_WORKER_SUFFIX")
+    if suffix:
+        namespace = f"{namespace}-{suffix}"
+    return namespace
+
+
+def _base64url_encode(payload: bytes) -> str:
+    return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+
+@dataclass(frozen=True)
+class PackagedSegment:
+    segment_id: int
+    duration_seconds: float
+    filename: str
+    bytes: bytes
+
+
+@dataclass(frozen=True)
+class PackagedStream:
+    target_duration_seconds: int
+    init_filename: str
+    init_bytes: bytes
+    segments: list[PackagedSegment]
+
+
+@dataclass
+class StreamSession:
+    session_id: str
+    created: int
+    started_at_monotonic: float
+    last_access_monotonic: float
+    expires_at: int
+    visible_segments: int
+    completed: bool
+
+
+class HlsPlaylistRequest(BaseModel):
+    session_id: str
+
+
+class HlsPlaylistResponse(BaseModel):
+    playlist: str
+
+
+class HlsInitRequest(BaseModel):
+    session_id: str
+
+
+class HlsSegmentRequest(BaseModel):
+    session_id: str
+    segment_id: int
+
+
+class HlsFragmentResponse(BaseModel):
+    bytes: bytes
+
+
+class SyntheticHlsVideoBackend:
+    def __init__(
+        self,
+        *,
+        source_mp4: Path,
+        segment_seconds: float,
+        emit_cadence_ms: int,
+        playlist_window_segments: int,
+        session_ttl_seconds: int,
+        model_name: str,
+        namespace: str,
+        component: str,
+        worker_id: int,
+    ) -> None:
+        self.source_mp4 = source_mp4
+        self.segment_seconds = segment_seconds
+        self.emit_cadence_ms = emit_cadence_ms
+        self.playlist_window_segments = max(1, playlist_window_segments)
+        self.session_ttl_seconds = session_ttl_seconds
+        self.model_name = model_name
+        self.namespace = namespace
+        self.component = component
+        self.worker_id = worker_id
+        self._packaged_stream: PackagedStream | None = None
+        self._sessions: dict[str, StreamSession] = {}
+        self._sessions_lock = asyncio.Lock()
+        self._workspace: tempfile.TemporaryDirectory[str] | None = None
+
+    async def initialize(self) -> None:
+        self._packaged_stream = await asyncio.to_thread(self._package_source_into_cmaf)
+        logger.info(
+            "Prepared CMAF stream from %s with %d segments, target_duration=%ds",
+            self.source_mp4,
+            len(self.packaged_stream.segments),
+            self.packaged_stream.target_duration_seconds,
+        )
+
+    @property
+    def packaged_stream(self) -> PackagedStream:
+        if self._packaged_stream is None:
+            raise RuntimeError("Synthetic HLS backend is not initialized")
+        return self._packaged_stream
+
+    def _package_source_into_cmaf(self) -> PackagedStream:
+        if not self.source_mp4.exists():
+            raise FileNotFoundError(f"Source MP4 not found: {self.source_mp4}")
+        if shutil.which("ffmpeg") is None:
+            raise RuntimeError("ffmpeg is required to package CMAF fragments")
+
+        self._workspace = tempfile.TemporaryDirectory(prefix="dynamo-hls-cmaf-")
+        workspace = Path(self._workspace.name)
+        manifest_path = workspace / "manifest.m3u8"
+        segment_template = workspace / "segment_%05d.m4s"
+        gop = max(1, int(round(self.segment_seconds * PACKAGING_FPS)))
+
+        cmd = [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            str(self.source_mp4),
+            "-vf",
+            "scale=trunc(iw/2)*2:trunc(ih/2)*2,format=yuv420p",
+            "-r",
+            str(PACKAGING_FPS),
+            "-c:v",
+            "libx264",
+            "-profile:v",
+            "main",
+            "-preset",
+            "veryfast",
+            "-g",
+            str(gop),
+            "-keyint_min",
+            str(gop),
+            "-sc_threshold",
+            "0",
+            "-force_key_frames",
+            f"expr:gte(t,n_forced*{self.segment_seconds})",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            "-ar",
+            "48000",
+            "-ac",
+            "2",
+            "-movflags",
+            "+faststart",
+            "-f",
+            "hls",
+            "-hls_time",
+            str(self.segment_seconds),
+            "-hls_playlist_type",
+            "vod",
+            "-hls_list_size",
+            "0",
+            "-hls_segment_type",
+            "fmp4",
+            "-hls_fmp4_init_filename",
+            "init.mp4",
+            "-hls_flags",
+            "independent_segments",
+            "-hls_segment_filename",
+            str(segment_template),
+            str(manifest_path),
+        ]
+
+        logger.info("Packaging %s into CMAF fragments with ffmpeg", self.source_mp4)
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            stderr = result.stderr.strip() or "ffmpeg exited with a non-zero status"
+            raise RuntimeError(f"ffmpeg packaging failed: {stderr}")
+
+        manifest = manifest_path.read_text(encoding="utf-8")
+        target_duration_seconds = 0
+        init_filename: str | None = None
+        segments: list[PackagedSegment] = []
+        current_duration: float | None = None
+
+        for raw_line in manifest.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            if line.startswith("#EXT-X-TARGETDURATION:"):
+                target_duration_seconds = int(line.split(":", 1)[1])
+                continue
+            if line.startswith("#EXT-X-MAP:"):
+                match = re.search(r'URI="([^"]+)"', line)
+                if match:
+                    init_filename = match.group(1)
+                continue
+            if line.startswith("#EXTINF:"):
+                current_duration = float(line.split(":", 1)[1].split(",", 1)[0])
+                continue
+            if line.startswith("#"):
+                continue
+            if current_duration is None:
+                raise RuntimeError(
+                    f"Found segment line without preceding EXTINF in {manifest_path}"
+                )
+
+            segment_path = workspace / line
+            segments.append(
+                PackagedSegment(
+                    segment_id=len(segments),
+                    duration_seconds=current_duration,
+                    filename=line,
+                    bytes=segment_path.read_bytes(),
+                )
+            )
+            current_duration = None
+
+        if init_filename is None:
+            raise RuntimeError("ffmpeg manifest did not contain EXT-X-MAP")
+        if not segments:
+            raise RuntimeError("ffmpeg did not produce any CMAF segments")
+
+        if target_duration_seconds <= 0:
+            target_duration_seconds = int(
+                math.ceil(max(segment.duration_seconds for segment in segments))
+            )
+
+        init_bytes = (workspace / init_filename).read_bytes()
+        if not init_bytes:
+            raise RuntimeError("ffmpeg produced an empty init.mp4 fragment")
+
+        return PackagedStream(
+            target_duration_seconds=target_duration_seconds,
+            init_filename=init_filename,
+            init_bytes=init_bytes,
+            segments=segments,
+        )
+
+    def _require_hls_request(self, request: NvCreateVideoRequest) -> None:
+        annotations = request.nvext.annotations if request.nvext else None
+        if not annotations or HLS_CMAF_ANNOTATION not in annotations:
+            raise ValueError(
+                "synthetic HLS worker requires the experimental_hls_cmaf annotation"
+            )
+
+    def _encode_stream_id(self, session: StreamSession) -> str:
+        payload = {
+            "session_id": session.session_id,
+            "worker_id": self.worker_id,
+            "namespace": self.namespace,
+            "component": self.component,
+            "created": session.created,
+            "expires_at": session.expires_at,
+            "target_duration_seconds": self.packaged_stream.target_duration_seconds,
+        }
+        return _base64url_encode(
+            json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        )
+
+    async def _create_session(self) -> StreamSession:
+        created = int(time.time())
+        now = time.monotonic()
+        session = StreamSession(
+            session_id=uuid.uuid4().hex,
+            created=created,
+            started_at_monotonic=now,
+            last_access_monotonic=now,
+            expires_at=created + self.session_ttl_seconds,
+            visible_segments=min(1, len(self.packaged_stream.segments)),
+            completed=len(self.packaged_stream.segments) <= 1,
+        )
+        async with self._sessions_lock:
+            self._purge_expired_locked()
+            self._sessions[session.session_id] = session
+        return session
+
+    def _purge_expired_locked(self) -> None:
+        now_epoch = int(time.time())
+        expired = [
+            session_id
+            for session_id, session in self._sessions.items()
+            if session.expires_at <= now_epoch
+        ]
+        for session_id in expired:
+            self._sessions.pop(session_id, None)
+
+    def _refresh_session_locked(self, session: StreamSession) -> tuple[int, bool]:
+        if session.expires_at <= int(time.time()):
+            self._sessions.pop(session.session_id, None)
+            raise FileNotFoundError(f"session expired: {session.session_id}")
+
+        elapsed_ms = max(
+            0.0, (time.monotonic() - session.started_at_monotonic) * 1000.0
+        )
+        total_segments = len(self.packaged_stream.segments)
+        visible_segments = min(
+            total_segments,
+            int(elapsed_ms // self.emit_cadence_ms) + 1,
+        )
+        completed = visible_segments >= total_segments
+        session.visible_segments = visible_segments
+        session.completed = completed
+        session.last_access_monotonic = time.monotonic()
+        return visible_segments, completed
+
+    async def _playlist_state(self, session_id: str) -> tuple[int, bool]:
+        async with self._sessions_lock:
+            self._purge_expired_locked()
+            session = self._sessions.get(session_id)
+            if session is None:
+                raise FileNotFoundError(f"unknown session: {session_id}")
+            return self._refresh_session_locked(session)
+
+    def _render_playlist(self, visible_segments: int, completed: bool) -> str:
+        window_start = max(0, visible_segments - self.playlist_window_segments)
+        lines = [
+            "#EXTM3U",
+            "#EXT-X-VERSION:7",
+            f"#EXT-X-TARGETDURATION:{self.packaged_stream.target_duration_seconds}",
+            f"#EXT-X-MEDIA-SEQUENCE:{window_start}",
+            "#EXT-X-INDEPENDENT-SEGMENTS",
+            '#EXT-X-MAP:URI="init.mp4"',
+        ]
+
+        for segment in self.packaged_stream.segments[window_start:visible_segments]:
+            lines.append(f"#EXTINF:{segment.duration_seconds:.3f},")
+            lines.append(f"segment/{segment.segment_id}.m4s")
+
+        if completed:
+            lines.append("#EXT-X-ENDLIST")
+
+        return "\n".join(lines) + "\n"
+
+    @dynamo_endpoint(NvCreateVideoRequest, NvVideosResponse)
+    async def generate(self, request: NvCreateVideoRequest):
+        self._require_hls_request(request)
+        session = await self._create_session()
+        stream_id = self._encode_stream_id(session)
+
+        logger.info(
+            "Created synthetic HLS session %s for model=%s prompt=%r",
+            session.session_id,
+            request.model,
+            request.prompt,
+        )
+
+        yield NvVideosResponse(
+            id=stream_id,
+            object="video",
+            model=request.model,
+            status="completed",
+            progress=100,
+            created=session.created,
+            data=[],
+            error=None,
+            inference_time_s=None,
+        ).model_dump()
+
+        logger.info(
+            "Synthetic HLS kickoff completed for session %s", session.session_id
+        )
+
+    @dynamo_endpoint(HlsPlaylistRequest, HlsPlaylistResponse)
+    async def playlist(self, request: HlsPlaylistRequest):
+        visible_segments, completed = await self._playlist_state(request.session_id)
+        yield {
+            "playlist": self._render_playlist(visible_segments, completed),
+        }
+
+    @dynamo_endpoint(HlsInitRequest, HlsFragmentResponse)
+    async def init_fragment(self, request: HlsInitRequest):
+        await self._playlist_state(request.session_id)
+        # Python endpoint responses cross the worker/runtime boundary as JSON values.
+        # Emit fragment payloads as a u8 array so the Rust frontend can deserialize
+        # them back into Vec<u8> without falling back to base64.
+        yield {
+            "bytes": list(self.packaged_stream.init_bytes),
+        }
+
+    @dynamo_endpoint(HlsSegmentRequest, HlsFragmentResponse)
+    async def segment(self, request: HlsSegmentRequest):
+        visible_segments, _ = await self._playlist_state(request.session_id)
+        if request.segment_id < 0:
+            raise FileNotFoundError(f"segment not found: {request.segment_id}")
+        if request.segment_id >= len(self.packaged_stream.segments):
+            raise FileNotFoundError(f"segment not found: {request.segment_id}")
+        if request.segment_id >= visible_segments:
+            raise FileNotFoundError(f"segment not available yet: {request.segment_id}")
+
+        yield {
+            "bytes": list(self.packaged_stream.segments[request.segment_id].bytes),
+        }
+
+
+async def _register_model(endpoint, model_name: str) -> None:
+    await register_llm(
+        ModelInput.Text,  # type: ignore[attr-defined]
+        ModelType.Videos,
+        endpoint,
+        model_name,
+        model_name,
+    )
+    logger.info("Registered synthetic HLS/CMAF model: %s", model_name)
+
+
+async def backend_worker(runtime: DistributedRuntime, args: argparse.Namespace) -> None:
+    namespace = _get_worker_namespace()
+    generate_endpoint = runtime.endpoint(
+        f"{namespace}.{DEFAULT_COMPONENT}.{DEFAULT_GENERATE_ENDPOINT}"
+    )
+    playlist_endpoint = runtime.endpoint(
+        f"{namespace}.{DEFAULT_COMPONENT}.{DEFAULT_PLAYLIST_ENDPOINT}"
+    )
+    init_endpoint = runtime.endpoint(
+        f"{namespace}.{DEFAULT_COMPONENT}.{DEFAULT_INIT_ENDPOINT}"
+    )
+    segment_endpoint = runtime.endpoint(
+        f"{namespace}.{DEFAULT_COMPONENT}.{DEFAULT_SEGMENT_ENDPOINT}"
+    )
+
+    backend = SyntheticHlsVideoBackend(
+        source_mp4=args.source_mp4,
+        segment_seconds=args.segment_seconds,
+        emit_cadence_ms=args.emit_cadence_ms,
+        playlist_window_segments=args.playlist_window_segments,
+        session_ttl_seconds=args.session_ttl_seconds,
+        model_name=args.model,
+        namespace=namespace,
+        component=DEFAULT_COMPONENT,
+        worker_id=generate_endpoint.connection_id(),
+    )
+    await backend.initialize()
+
+    logger.info(
+        "Serving synthetic HLS endpoints under %s/%s",
+        namespace,
+        DEFAULT_COMPONENT,
+    )
+    await asyncio.gather(
+        generate_endpoint.serve_endpoint(backend.generate),
+        playlist_endpoint.serve_endpoint(backend.playlist),
+        init_endpoint.serve_endpoint(backend.init_fragment),
+        segment_endpoint.serve_endpoint(backend.segment),
+        _register_model(generate_endpoint, backend.model_name),
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Synthetic HLS/CMAF harness for /v1/videos/stream/hls"
+    )
+    parser.add_argument(
+        "--source-mp4",
+        type=Path,
+        required=True,
+        help="Path to the prerecorded MP4 used as the synthetic source stream",
+    )
+    parser.add_argument(
+        "--segment-seconds",
+        type=float,
+        default=DEFAULT_SEGMENT_SECONDS,
+        help=f"HLS segment duration in seconds (default: {DEFAULT_SEGMENT_SECONDS})",
+    )
+    parser.add_argument(
+        "--emit-cadence-ms",
+        type=int,
+        default=DEFAULT_EMIT_CADENCE_MS,
+        help=f"Delay between newly visible segments in milliseconds (default: {DEFAULT_EMIT_CADENCE_MS})",
+    )
+    parser.add_argument(
+        "--playlist-window-segments",
+        type=int,
+        default=DEFAULT_PLAYLIST_WINDOW_SEGMENTS,
+        help=f"Sliding live playlist window size (default: {DEFAULT_PLAYLIST_WINDOW_SEGMENTS})",
+    )
+    parser.add_argument(
+        "--session-ttl-seconds",
+        type=int,
+        default=DEFAULT_SESSION_TTL_SECONDS,
+        help=f"Time-to-live for synthetic stream sessions in seconds (default: {DEFAULT_SESSION_TTL_SECONDS})",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL_NAME,
+        help=f"Served model name for registration (default: {DEFAULT_MODEL_NAME})",
+    )
+    args = parser.parse_args()
+
+    if args.segment_seconds <= 0:
+        parser.error("--segment-seconds must be positive")
+    if args.emit_cadence_ms <= 0:
+        parser.error("--emit-cadence-ms must be positive")
+    if args.playlist_window_segments <= 0:
+        parser.error("--playlist-window-segments must be positive")
+    if args.session_ttl_seconds <= 0:
+        parser.error("--session-ttl-seconds must be positive")
+
+    return args
+
+
+async def main(args: argparse.Namespace) -> None:
+    loop = asyncio.get_running_loop()
+    discovery_backend = os.environ.get("DYN_DISCOVERY_BACKEND")
+    if not discovery_backend:
+        discovery_backend = (
+            "kubernetes" if os.environ.get("KUBERNETES_SERVICE_HOST") else "file"
+        )
+
+    logger.info("Using discovery backend: %s", discovery_backend)
+    logger.info("Resolved worker namespace: %s", _get_worker_namespace())
+    runtime = DistributedRuntime(loop, discovery_backend, "tcp")
+    await backend_worker(runtime, args)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        force=True,
+    )
+    uvloop.install()
+    asyncio.run(main(_parse_args()))

--- a/examples/custom_backend/video_streaming/README.md
+++ b/examples/custom_backend/video_streaming/README.md
@@ -1,0 +1,55 @@
+# Synthetic Video Streaming POC
+
+This example provides:
+
+- A synthetic backend worker that loads a prerecorded MP4, slices it into replayable standalone MP4 clips, and emits one `NvVideosResponse` per clip.
+- A browser reference client that can consume either the canonical SSE route or the experimental binary route and play the clips sequentially.
+
+## Why standalone clips?
+
+This POC intentionally uses self-contained MP4 clips as the replayable unit instead of low-latency fragmented MP4. That is a deliberate shortcut to validate the protocol contract first: each streamed chunk is independently playable on its own, which is what the eventual backend mux stage will need to guarantee.
+
+## Worker
+
+Start the worker with a real local MP4 file:
+
+```bash
+python examples/custom_backend/video_streaming/worker.py \
+  --source-mp4 /path/to/source.mp4 \
+  --fragment-seconds 2 \
+  --emit-cadence-ms 750 \
+  --model synthetic-video-stream
+```
+
+The worker registers itself as a `ModelType.Videos` backend and emits one `NvVideosResponse` per clip.
+
+## Frontend routes
+
+With Dynamo frontend running, the relevant routes are:
+
+- `POST /v1/videos/stream`
+  Canonical SSE route. Each `data:` event contains an `NvVideosResponse` JSON payload with `data[0].b64_json`. For this POC, the route contract assumes replayable MP4 clips.
+- `POST /v1/videos/stream/binary`
+  Experimental framed binary route. The framing protocol is:
+
+```text
+[kind:1][len_be_u32:4][payload:len]
+```
+
+Frame kinds:
+
+- `0x01`: MP4 clip bytes
+- `0x02`: error JSON
+- `0x03`: end-of-stream marker
+
+## Reference client
+
+Serve the HTML client from this directory:
+
+```bash
+python -m http.server 8080 -d examples/custom_backend/video_streaming
+```
+
+Then open `http://localhost:8080/client.html`.
+
+The client uses `fetch()` so it can `POST` to the video streaming endpoints, parse either SSE or the binary framing, and play the queued MP4 clips one after another.

--- a/examples/custom_backend/video_streaming/client.html
+++ b/examples/custom_backend/video_streaming/client.html
@@ -1,0 +1,492 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dynamo Video Streaming POC Client</title>
+  <style>
+    :root {
+      --bg: #101820;
+      --panel: #17242f;
+      --panel-2: #1f3240;
+      --text: #f3f6f9;
+      --muted: #a8b8c5;
+      --accent: #4dd0a8;
+      --accent-2: #6ec1ff;
+      --danger: #ff7d6e;
+      --border: rgba(255, 255, 255, 0.12);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+      background:
+        radial-gradient(circle at top left, rgba(77, 208, 168, 0.18), transparent 28%),
+        radial-gradient(circle at top right, rgba(110, 193, 255, 0.18), transparent 24%),
+        linear-gradient(180deg, #0c1218 0%, var(--bg) 100%);
+      color: var(--text);
+      display: grid;
+      place-items: center;
+      padding: 24px;
+    }
+
+    .app {
+      width: min(1100px, 100%);
+      display: grid;
+      gap: 18px;
+      grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+    }
+
+    .panel {
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.02));
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 20px;
+      backdrop-filter: blur(14px);
+      box-shadow: 0 18px 60px rgba(0, 0, 0, 0.35);
+    }
+
+    .controls {
+      display: grid;
+      gap: 14px;
+      align-content: start;
+    }
+
+    .controls h1 {
+      margin: 0;
+      font-size: 1.6rem;
+      line-height: 1.1;
+    }
+
+    .controls p,
+    .hint {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.95rem;
+      line-height: 1.4;
+    }
+
+    label {
+      display: grid;
+      gap: 6px;
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+
+    input,
+    textarea,
+    button {
+      font: inherit;
+    }
+
+    input,
+    textarea {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+      color: var(--text);
+      padding: 10px 12px;
+    }
+
+    textarea {
+      min-height: 82px;
+      resize: vertical;
+    }
+
+    .actions {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    button {
+      border: 0;
+      border-radius: 999px;
+      padding: 10px 16px;
+      cursor: pointer;
+      transition: transform 150ms ease, opacity 150ms ease;
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+    }
+
+    .primary {
+      background: var(--accent);
+      color: #08110d;
+      font-weight: 700;
+    }
+
+    .secondary {
+      background: var(--accent-2);
+      color: #07111b;
+      font-weight: 700;
+    }
+
+    .ghost {
+      background: transparent;
+      border: 1px solid var(--border);
+      color: var(--text);
+    }
+
+    .player {
+      display: grid;
+      gap: 14px;
+    }
+
+    video {
+      width: 100%;
+      background: #000;
+      border-radius: 16px;
+      aspect-ratio: 16 / 9;
+    }
+
+    .stats {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .pill {
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      padding: 8px 12px;
+      font-size: 0.85rem;
+      color: var(--muted);
+      background: rgba(255, 255, 255, 0.03);
+    }
+
+    pre {
+      margin: 0;
+      min-height: 220px;
+      max-height: 420px;
+      overflow: auto;
+      border-radius: 16px;
+      border: 1px solid var(--border);
+      background: rgba(3, 7, 12, 0.6);
+      padding: 16px;
+      color: #dce7f0;
+      font-size: 0.82rem;
+      line-height: 1.45;
+    }
+
+    .error {
+      color: var(--danger);
+    }
+
+    @media (max-width: 900px) {
+      .app {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <section class="panel controls">
+      <h1>Dynamo Video Stream POC</h1>
+      <p>POST one prompt, then continuously play replayable MP4 clips from either the canonical SSE route or the experimental binary route.</p>
+
+      <label>
+        Frontend Base URL
+        <input id="baseUrl" value="http://localhost:8000" />
+      </label>
+
+      <label>
+        Model
+        <input id="model" value="synthetic-video-stream" />
+      </label>
+
+      <label>
+        Prompt
+        <textarea id="prompt">Replay the synthetic MP4 clip stream.</textarea>
+      </label>
+
+      <div class="actions">
+        <button class="primary" id="startSse">Start SSE Stream</button>
+        <button class="secondary" id="startBinary">Start Binary Stream</button>
+        <button class="ghost" id="stop">Stop</button>
+      </div>
+
+      <p class="hint">This client uses plain sequential playback of standalone MP4 clips. It is intentionally validating replayable units first, not gapless MSE playback.</p>
+    </section>
+
+    <section class="panel player">
+      <video id="player" controls muted playsinline></video>
+      <div class="stats">
+        <div class="pill">Queued clips: <span id="queued">0</span></div>
+        <div class="pill">Played clips: <span id="played">0</span></div>
+        <div class="pill">Mode: <span id="mode">idle</span></div>
+      </div>
+      <pre id="log"></pre>
+    </section>
+  </div>
+
+  <script>
+    const player = document.getElementById("player");
+    const queuedEl = document.getElementById("queued");
+    const playedEl = document.getElementById("played");
+    const modeEl = document.getElementById("mode");
+    const logEl = document.getElementById("log");
+
+    const queue = [];
+    let currentUrl = null;
+    let currentAbortController = null;
+    let playedCount = 0;
+
+    function log(message, isError = false) {
+      const line = `[${new Date().toLocaleTimeString()}] ${message}`;
+      logEl.textContent += `${line}\n`;
+      logEl.scrollTop = logEl.scrollHeight;
+      if (isError) {
+        logEl.classList.add("error");
+      }
+    }
+
+    function resetLogStyle() {
+      logEl.classList.remove("error");
+    }
+
+    function updateStats(mode = modeEl.textContent) {
+      queuedEl.textContent = String(queue.length);
+      playedEl.textContent = String(playedCount);
+      modeEl.textContent = mode;
+    }
+
+    function base64ToBytes(base64) {
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+      return bytes;
+    }
+
+    function enqueueClip(bytes, mimeType = "video/mp4") {
+      const blob = new Blob([bytes], { type: mimeType });
+      const url = URL.createObjectURL(blob);
+      queue.push(url);
+      updateStats();
+      if (player.paused && !player.src) {
+        void playNextClip();
+      }
+    }
+
+    async function playNextClip() {
+      if (queue.length === 0) {
+        player.removeAttribute("src");
+        player.load();
+        updateStats();
+        return;
+      }
+
+      if (currentUrl) {
+        URL.revokeObjectURL(currentUrl);
+      }
+
+      currentUrl = queue.shift();
+      player.src = currentUrl;
+      updateStats();
+
+      try {
+        await player.play();
+      } catch (error) {
+        log(`Playback failed: ${error}`, true);
+      }
+    }
+
+    player.addEventListener("ended", () => {
+      playedCount += 1;
+      updateStats();
+      void playNextClip();
+    });
+
+    async function stopStream() {
+      if (currentAbortController) {
+        currentAbortController.abort();
+        currentAbortController = null;
+      }
+      queue.splice(0, queue.length);
+      if (currentUrl) {
+        URL.revokeObjectURL(currentUrl);
+        currentUrl = null;
+      }
+      player.pause();
+      player.removeAttribute("src");
+      player.load();
+      updateStats("idle");
+      log("Stopped stream");
+    }
+
+    function buildPayload() {
+      return {
+        prompt: document.getElementById("prompt").value,
+        model: document.getElementById("model").value,
+      };
+    }
+
+    async function startSseStream() {
+      await stopStream();
+      resetLogStyle();
+      currentAbortController = new AbortController();
+      updateStats("sse");
+
+      const url = `${document.getElementById("baseUrl").value}/v1/videos/stream`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildPayload()),
+        signal: currentAbortController.signal,
+      });
+      if (!response.ok || !response.body) {
+        throw new Error(`SSE request failed with status ${response.status}`);
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      log("Connected to canonical SSE stream");
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          log("SSE stream closed");
+          break;
+        }
+
+        buffer += decoder.decode(value, { stream: true });
+        const events = buffer.split("\n\n");
+        buffer = events.pop() || "";
+
+        for (const rawEvent of events) {
+          const lines = rawEvent.split("\n");
+          let eventType = "message";
+          const dataLines = [];
+
+          for (const line of lines) {
+            if (line.startsWith("event: ")) {
+              eventType = line.slice(7);
+            } else if (line.startsWith("data: ")) {
+              dataLines.push(line.slice(6));
+            }
+          }
+
+          if (dataLines.length === 0) {
+            continue;
+          }
+
+          const data = dataLines.join("\n");
+          if (data === "[DONE]") {
+            log("Received SSE [DONE]");
+            continue;
+          }
+
+          const payload = JSON.parse(data);
+          if (eventType === "error" || payload.error) {
+            log(`SSE error: ${payload.error?.message || payload.error || data}`, true);
+            continue;
+          }
+
+          const clip = payload.data?.[0];
+          if (!clip?.b64_json) {
+            log(`Skipping SSE event without MP4 payload: ${data}`);
+            continue;
+          }
+
+          enqueueClip(base64ToBytes(clip.b64_json));
+          log(`Queued SSE clip (video/mp4) progress=${payload.progress}`);
+        }
+      }
+    }
+
+    async function startBinaryStream() {
+      await stopStream();
+      resetLogStyle();
+      currentAbortController = new AbortController();
+      updateStats("binary");
+
+      const url = `${document.getElementById("baseUrl").value}/v1/videos/stream/binary`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildPayload()),
+        signal: currentAbortController.signal,
+      });
+      if (!response.ok || !response.body) {
+        throw new Error(`Binary request failed with status ${response.status}`);
+      }
+
+      const protocol = response.headers.get("x-dynamo-video-binary-protocol") || "unknown";
+      log(`Connected to binary stream (${protocol})`);
+
+      const reader = response.body.getReader();
+      const textDecoder = new TextDecoder();
+      let buffer = new Uint8Array(0);
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          log("Binary stream closed");
+          break;
+        }
+
+        const next = new Uint8Array(buffer.length + value.length);
+        next.set(buffer);
+        next.set(value, buffer.length);
+        buffer = next;
+
+        while (buffer.length >= 5) {
+          const kind = buffer[0];
+          const length = new DataView(buffer.buffer, buffer.byteOffset + 1, 4).getUint32(0);
+          if (buffer.length < 5 + length) {
+            break;
+          }
+
+          const payload = buffer.slice(5, 5 + length);
+          buffer = buffer.slice(5 + length);
+
+          if (kind === 0x01) {
+            enqueueClip(payload, "video/mp4");
+            log(`Queued binary clip (${payload.length} bytes)`);
+          } else if (kind === 0x02) {
+            log(`Binary error: ${textDecoder.decode(payload)}`, true);
+          } else if (kind === 0x03) {
+            log("Received binary done frame");
+          } else {
+            log(`Unknown binary frame kind: ${kind}`, true);
+          }
+        }
+      }
+    }
+
+    document.getElementById("startSse").addEventListener("click", async () => {
+      try {
+        await startSseStream();
+      } catch (error) {
+        log(`Failed to start SSE stream: ${error}`, true);
+      }
+    });
+
+    document.getElementById("startBinary").addEventListener("click", async () => {
+      try {
+        await startBinaryStream();
+      } catch (error) {
+        log(`Failed to start binary stream: ${error}`, true);
+      }
+    });
+
+    document.getElementById("stop").addEventListener("click", () => {
+      void stopStream();
+    });
+
+    updateStats();
+  </script>
+</body>
+</html>

--- a/examples/custom_backend/video_streaming/worker.py
+++ b/examples/custom_backend/video_streaming/worker.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import asyncio
+import base64
+import logging
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import AsyncGenerator
+
+import imageio.v2 as iio
+import numpy as np
+import uvloop
+
+from dynamo.common.protocols.video_protocol import (
+    NvCreateVideoRequest,
+    NvVideosResponse,
+    VideoData,
+)
+from dynamo.common.utils.video_utils import encode_to_mp4_bytes
+from dynamo.llm import ModelInput, ModelType, register_llm  # type: ignore[attr-defined]
+from dynamo.runtime import DistributedRuntime
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_NAME = "synthetic-video-stream"
+DEFAULT_FRAGMENT_SECONDS = 2.0
+DEFAULT_EMIT_CADENCE_MS = 750
+DEFAULT_COMPONENT = "backend"
+DEFAULT_ENDPOINT = "generate"
+
+
+def _get_worker_namespace() -> str:
+    namespace = os.environ.get("DYN_NAMESPACE", "dynamo")
+    suffix = os.environ.get("DYN_NAMESPACE_WORKER_SUFFIX")
+    if suffix:
+        namespace = f"{namespace}-{suffix}"
+    return namespace
+
+
+class SyntheticVideoStreamBackend:
+    def __init__(
+        self,
+        *,
+        source_mp4: Path,
+        fragment_seconds: float,
+        emit_cadence_ms: int,
+        model_name: str,
+    ) -> None:
+        self.source_mp4 = source_mp4
+        self.fragment_seconds = fragment_seconds
+        self.emit_cadence_ms = emit_cadence_ms
+        self.model_name = model_name
+        self._clips: list[bytes] = []
+        self._fps: int = 0
+
+    async def initialize(self) -> None:
+        clips, fps = await asyncio.to_thread(self._prepare_replayable_clips)
+        self._clips = clips
+        self._fps = fps
+        logger.info(
+            "Prepared %d replayable MP4 clips from %s at %d fps",
+            len(self._clips),
+            self.source_mp4,
+            self._fps,
+        )
+
+    def _prepare_replayable_clips(self) -> tuple[list[bytes], int]:
+        if not self.source_mp4.exists():
+            raise FileNotFoundError(f"Source MP4 not found: {self.source_mp4}")
+
+        reader = iio.get_reader(str(self.source_mp4), format="ffmpeg")
+        try:
+            metadata = reader.get_meta_data()
+            fps = int(round(float(metadata.get("fps") or 0)))
+            if fps <= 0:
+                raise ValueError(
+                    f"Unable to determine FPS for source video: {self.source_mp4}"
+                )
+
+            frames = [np.asarray(frame) for frame in reader]
+        finally:
+            reader.close()
+
+        if not frames:
+            raise ValueError(f"Source video contains no frames: {self.source_mp4}")
+
+        frames_np = np.stack(frames, axis=0)
+        frames_per_clip = max(1, int(round(self.fragment_seconds * fps)))
+
+        clips: list[bytes] = []
+        for start in range(0, len(frames_np), frames_per_clip):
+            clip_frames = frames_np[start : start + frames_per_clip]
+            if len(clip_frames) == 0:
+                continue
+
+            # POC shortcut: pre-encode standalone MP4 clips at startup instead of
+            # building a low-latency fragmented MP4 muxer. This intentionally
+            # validates the RFC's "replayable unit" requirement first: every
+            # streamed chunk is independently playable as its own MP4 clip.
+            clips.append(encode_to_mp4_bytes(clip_frames, fps=fps))
+
+        if not clips:
+            raise ValueError(
+                f"Unable to create replayable clips from {self.source_mp4}"
+            )
+
+        return clips, fps
+
+    async def generate(self, request: dict, context) -> AsyncGenerator[dict, None]:
+        req = NvCreateVideoRequest(**request)
+        request_id = context.id() or f"video-{uuid.uuid4().hex}"
+        created = int(time.time())
+        total = len(self._clips)
+
+        logger.info(
+            "Synthetic stream request %s: model=%s prompt=%r clips=%d cadence_ms=%d",
+            request_id,
+            req.model,
+            req.prompt,
+            total,
+            self.emit_cadence_ms,
+        )
+
+        for index, clip_bytes in enumerate(self._clips):
+            if context.is_stopped() or context.is_killed():
+                logger.info("Request %s cancelled before clip %d", request_id, index)
+                raise asyncio.CancelledError
+
+            progress = int(((index + 1) / total) * 100)
+            is_last = index == total - 1
+            response = NvVideosResponse(
+                id=request_id,
+                object="video",
+                model=req.model,
+                status="completed" if is_last else "in_progress",
+                progress=progress,
+                created=created,
+                data=[
+                    VideoData(
+                        b64_json=base64.b64encode(clip_bytes).decode("ascii"),
+                    )
+                ],
+            )
+
+            logger.info(
+                "Request %s emitting clip %d/%d (%d bytes)",
+                request_id,
+                index + 1,
+                total,
+                len(clip_bytes),
+            )
+            yield response.model_dump()
+
+            if not is_last:
+                await asyncio.sleep(self.emit_cadence_ms / 1000.0)
+
+
+async def _register_model(endpoint, model_name: str) -> None:
+    await register_llm(
+        ModelInput.Text,  # type: ignore[attr-defined]
+        ModelType.Videos,
+        endpoint,
+        model_name,
+        model_name,
+    )
+    logger.info("Registered synthetic streaming model: %s", model_name)
+
+
+async def backend_worker(runtime: DistributedRuntime, args: argparse.Namespace) -> None:
+    namespace_name = _get_worker_namespace()
+    endpoint = runtime.endpoint(
+        f"{namespace_name}.{DEFAULT_COMPONENT}.{DEFAULT_ENDPOINT}"
+    )
+    logger.info(
+        "Serving synthetic streaming endpoint %s/%s/%s",
+        namespace_name,
+        DEFAULT_COMPONENT,
+        DEFAULT_ENDPOINT,
+    )
+
+    backend = SyntheticVideoStreamBackend(
+        source_mp4=args.source_mp4,
+        fragment_seconds=args.fragment_seconds,
+        emit_cadence_ms=args.emit_cadence_ms,
+        model_name=args.model,
+    )
+    await backend.initialize()
+
+    await asyncio.gather(
+        endpoint.serve_endpoint(backend.generate),  # type: ignore[arg-type]
+        _register_model(endpoint, backend.model_name),
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Synthetic MP4 chunk-source harness for /v1/videos/stream"
+    )
+    parser.add_argument(
+        "--source-mp4",
+        type=Path,
+        required=True,
+        help="Path to the prerecorded MP4 used as the synthetic source stream",
+    )
+    parser.add_argument(
+        "--fragment-seconds",
+        type=float,
+        default=DEFAULT_FRAGMENT_SECONDS,
+        help=f"Duration of each replayable MP4 clip (default: {DEFAULT_FRAGMENT_SECONDS})",
+    )
+    parser.add_argument(
+        "--emit-cadence-ms",
+        type=int,
+        default=DEFAULT_EMIT_CADENCE_MS,
+        help=f"Delay between emitted clips in milliseconds (default: {DEFAULT_EMIT_CADENCE_MS})",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL_NAME,
+        help=f"Served model name for registration (default: {DEFAULT_MODEL_NAME})",
+    )
+    return parser.parse_args()
+
+
+async def main(args: argparse.Namespace) -> None:
+    loop = asyncio.get_running_loop()
+    discovery_backend = os.environ.get("DYN_DISCOVERY_BACKEND")
+    if not discovery_backend:
+        discovery_backend = (
+            "kubernetes" if os.environ.get("KUBERNETES_SERVICE_HOST") else "file"
+        )
+
+    logger.info("Using discovery backend: %s", discovery_backend)
+    logger.info("Resolved worker namespace: %s", _get_worker_namespace())
+    runtime = DistributedRuntime(loop, discovery_backend, "tcp")
+    await backend_worker(runtime, args)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        force=True,
+    )
+    uvloop.install()
+    asyncio.run(main(_parse_args()))

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1598,6 +1598,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "rustls",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "strum",
@@ -6033,6 +6034,16 @@ checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float 2.10.1",
  "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -80,6 +80,7 @@ oneshot = { workspace = true }
 parking_lot = { workspace = true }
 prometheus = { workspace = true }
 serde = { workspace = true }
+serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10"
 strum = { workspace = true }

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -52,6 +52,8 @@ pub async fn run(
     http_service_builder =
         http_service_builder.cancel_token(Some(distributed_runtime.primary_token()));
     http_service_builder =
+        http_service_builder.distributed_runtime(Some(distributed_runtime.clone()));
+    http_service_builder =
         http_service_builder.with_request_template(engine_config.local_model().request_template());
     // Inject the DRT's metrics registry so that component-scoped metrics
     // (e.g. KvIndexerMetrics) are exposed (default port 8000 if not overridden).

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2296,6 +2296,16 @@ const VIDEO_STREAM_BINARY_KIND_MP4: u8 = 0x01;
 const VIDEO_STREAM_BINARY_KIND_ERROR: u8 = 0x02;
 const VIDEO_STREAM_BINARY_KIND_DONE: u8 = 0x03;
 const VIDEO_STREAM_BINARY_PROTOCOL: &str = "dynamo-video-binary-v1";
+const VIDEO_STREAM_BINARY_CMAF_KIND_METADATA: u8 = 0x01;
+const VIDEO_STREAM_BINARY_CMAF_KIND_INIT: u8 = 0x02;
+const VIDEO_STREAM_BINARY_CMAF_KIND_SEGMENT: u8 = 0x03;
+const VIDEO_STREAM_BINARY_CMAF_KIND_ERROR: u8 = 0x04;
+const VIDEO_STREAM_BINARY_CMAF_KIND_DONE: u8 = 0x05;
+const VIDEO_STREAM_BINARY_CMAF_PROTOCOL: &str = "dynamo-video-binary-cmaf-v1";
+const VIDEO_STREAM_BINARY_CMAF_ANNOTATION: &str = "experimental_binary_cmaf";
+const VIDEO_STREAM_BINARY_CMAF_METADATA_TAG: &str = "cmaf:metadata";
+const VIDEO_STREAM_BINARY_CMAF_INIT_TAG: &str = "cmaf:init";
+const VIDEO_STREAM_BINARY_CMAF_SEGMENT_PREFIX: &str = "cmaf:segment:";
 const VIDEO_STREAM_HLS_CMAF_ANNOTATION: &str = "experimental_hls_cmaf";
 const VIDEO_STREAM_HLS_PLAYLIST_CONTENT_TYPE: &str = "application/vnd.apple.mpegurl";
 const VIDEO_STREAM_HLS_FRAGMENT_CONTENT_TYPE: &str = "video/mp4";
@@ -2312,6 +2322,17 @@ struct VideoHlsStreamLocator {
     created: i64,
     expires_at: i64,
     target_duration_seconds: u32,
+}
+
+fn add_video_binary_cmaf_annotation(request: &mut NvCreateVideoRequest) {
+    let nvext = request.nvext.get_or_insert_with(Default::default);
+    let annotations = nvext.annotations.get_or_insert_with(Vec::new);
+    if !annotations
+        .iter()
+        .any(|annotation| annotation == VIDEO_STREAM_BINARY_CMAF_ANNOTATION)
+    {
+        annotations.push(VIDEO_STREAM_BINARY_CMAF_ANNOTATION.to_string());
+    }
 }
 
 fn add_video_hls_cmaf_annotation(request: &mut NvCreateVideoRequest) {
@@ -2510,6 +2531,36 @@ fn normalize_video_stream_response(
     Ok(response)
 }
 
+fn normalize_video_binary_cmaf_response(
+    response: NvVideosResponse,
+) -> Result<NvVideosResponse, String> {
+    for item in &response.data {
+        let tag = item.url.as_deref().ok_or_else(|| {
+            "CMAF binary streaming requires tagged data[*].url values".to_string()
+        })?;
+
+        if !(tag == VIDEO_STREAM_BINARY_CMAF_METADATA_TAG
+            || tag == VIDEO_STREAM_BINARY_CMAF_INIT_TAG
+            || tag.starts_with(VIDEO_STREAM_BINARY_CMAF_SEGMENT_PREFIX))
+        {
+            return Err(format!(
+                "CMAF binary streaming requires data[*].url tags matching {} / {} / {}<n>, got {tag}",
+                VIDEO_STREAM_BINARY_CMAF_METADATA_TAG,
+                VIDEO_STREAM_BINARY_CMAF_INIT_TAG,
+                VIDEO_STREAM_BINARY_CMAF_SEGMENT_PREFIX
+            ));
+        }
+
+        if item.b64_json.is_none() {
+            return Err(
+                "CMAF binary streaming requires raw payload bytes in data[*].b64_json".to_string(),
+            );
+        }
+    }
+
+    Ok(response)
+}
+
 fn decode_video_stream_payloads(response: NvVideosResponse) -> Result<Vec<Vec<u8>>, String> {
     response
         .data
@@ -2522,6 +2573,45 @@ fn decode_video_stream_payloads(response: NvVideosResponse) -> Result<Vec<Vec<u8
             base64::prelude::BASE64_STANDARD
                 .decode(&b64)
                 .map_err(|e| format!("failed to decode video chunk base64: {e}"))
+        })
+        .collect()
+}
+
+fn decode_video_binary_cmaf_payloads(
+    response: NvVideosResponse,
+) -> Result<Vec<(u8, Vec<u8>)>, String> {
+    response
+        .data
+        .into_iter()
+        .map(|item| {
+            let kind = match item.url.as_deref() {
+                Some(VIDEO_STREAM_BINARY_CMAF_METADATA_TAG) => {
+                    VIDEO_STREAM_BINARY_CMAF_KIND_METADATA
+                }
+                Some(VIDEO_STREAM_BINARY_CMAF_INIT_TAG) => VIDEO_STREAM_BINARY_CMAF_KIND_INIT,
+                Some(tag) if tag.starts_with(VIDEO_STREAM_BINARY_CMAF_SEGMENT_PREFIX) => {
+                    VIDEO_STREAM_BINARY_CMAF_KIND_SEGMENT
+                }
+                Some(tag) => {
+                    return Err(format!(
+                        "unrecognized CMAF binary payload tag in data[*].url: {tag}"
+                    ));
+                }
+                None => {
+                    return Err(
+                        "CMAF binary streaming requires tagged data[*].url values".to_string()
+                    );
+                }
+            };
+
+            let b64 = item.b64_json.ok_or_else(|| {
+                "CMAF binary streaming requires raw payload bytes in data[*].b64_json".to_string()
+            })?;
+
+            let payload = base64::prelude::BASE64_STANDARD
+                .decode(&b64)
+                .map_err(|e| format!("failed to decode CMAF payload base64: {e}"))?;
+            Ok((kind, payload))
         })
         .collect()
 }
@@ -2548,6 +2638,22 @@ fn encode_binary_video_error_frame(message: impl Into<String>) -> Bytes {
 
 fn encode_binary_video_done_frame() -> Bytes {
     encode_binary_video_frame(VIDEO_STREAM_BINARY_KIND_DONE, &[])
+}
+
+fn encode_binary_video_cmaf_error_frame(message: impl Into<String>) -> Bytes {
+    let payload = serde_json::json!({
+        "error": {
+            "message": message.into(),
+        }
+    });
+    encode_binary_video_frame(
+        VIDEO_STREAM_BINARY_CMAF_KIND_ERROR,
+        payload.to_string().as_bytes(),
+    )
+}
+
+fn encode_binary_video_cmaf_done_frame() -> Bytes {
+    encode_binary_video_frame(VIDEO_STREAM_BINARY_CMAF_KIND_DONE, &[])
 }
 
 /// Canonical SSE streaming handler for `/v1/videos/stream`.
@@ -2785,6 +2891,157 @@ async fn video_stream_binary(
         })
 }
 
+/// Experimental CMAF-over-binary streaming handler for
+/// `/v1/videos/stream/binary/cmaf`.
+///
+/// This keeps Dynamo's single-request streaming model but upgrades the media
+/// unit from standalone MP4 clips to a continuous CMAF stream:
+/// `[kind:1][len_be_u32:4][payload:len]`
+/// where `kind=0x01` is a metadata JSON blob, `0x02` is the init fragment,
+/// `0x03` is a media fragment, `0x04` is an error JSON payload, and `0x05`
+/// is an end-of-stream marker.
+async fn video_stream_binary_cmaf(
+    State(state): State<Arc<service_v2::State>>,
+    headers: HeaderMap,
+    Json(mut request): Json<NvCreateVideoRequest>,
+) -> Result<Response, ErrorResponse> {
+    check_ready(&state)?;
+
+    force_streaming_video_response_format(&mut request);
+    add_video_binary_cmaf_annotation(&mut request);
+
+    let request_id = get_or_create_request_id(&headers);
+    let request = Context::with_id(request, request_id);
+    let model = request.model.clone();
+
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+
+    let engine = state
+        .manager()
+        .get_videos_engine(&model)
+        .map_err(|e| ErrorMessage::from_model_error(&e))?;
+
+    let mut inflight =
+        state
+            .metrics_clone()
+            .create_inflight_guard(&model, Endpoint::Videos, true, request.id());
+
+    let mut response_collector = state.metrics_clone().create_response_collector(&model);
+
+    let stream = engine.generate(request).await.map_err(|e| {
+        if super::metrics::request_was_rejected(e.as_ref()) {
+            state
+                .metrics_clone()
+                .inc_rejection(&model, super::metrics::Endpoint::Videos);
+        }
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to start CMAF binary video stream");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
+
+    let ctx = stream.context();
+    let (mut connection_handle, mut stream_handle) = create_connection_monitor(
+        ctx.clone(),
+        Some(state.metrics_clone()),
+        CancellationLabels {
+            model: model.clone(),
+            endpoint: Endpoint::Videos.to_string(),
+            request_type: "stream_binary_cmaf".to_string(),
+        },
+    )
+    .await;
+    connection_handle.disarm();
+
+    let mut http_queue_guard = Some(http_queue_guard);
+    let stream = stream.inspect(move |response| {
+        process_response_and_observe_metrics(
+            response,
+            &mut response_collector,
+            &mut http_queue_guard,
+        );
+    });
+
+    stream_handle.arm();
+    let binary_stream = async_stream::stream! {
+        tokio::pin!(stream);
+        loop {
+            tokio::select! {
+                item = stream.next() => {
+                    match item {
+                        Some(annotated) => {
+                            let annotated = annotated.map_data(normalize_video_binary_cmaf_response);
+                            match annotated.into_result() {
+                                Ok(Some(response)) => {
+                                    match decode_video_binary_cmaf_payloads(response) {
+                                        Ok(payloads) => {
+                                            for (kind, payload) in payloads {
+                                                yield Ok::<Bytes, std::convert::Infallible>(
+                                                    encode_binary_video_frame(kind, &payload)
+                                                );
+                                            }
+                                        }
+                                        Err(e) => {
+                                            inflight.mark_error(ErrorType::Internal);
+                                            stream_handle.disarm();
+                                            yield Ok::<Bytes, std::convert::Infallible>(
+                                                encode_binary_video_cmaf_error_frame(e.to_string())
+                                            );
+                                            yield Ok::<Bytes, std::convert::Infallible>(
+                                                encode_binary_video_cmaf_done_frame()
+                                            );
+                                            break;
+                                        }
+                                    }
+                                }
+                                Ok(None) => {}
+                                Err(e) => {
+                                    inflight.mark_error(ErrorType::Internal);
+                                    stream_handle.disarm();
+                                    yield Ok::<Bytes, std::convert::Infallible>(
+                                        encode_binary_video_cmaf_error_frame(e.to_string())
+                                    );
+                                    yield Ok::<Bytes, std::convert::Infallible>(
+                                        encode_binary_video_cmaf_done_frame()
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                        None => {
+                            inflight.mark_ok();
+                            stream_handle.disarm();
+                            yield Ok::<Bytes, std::convert::Infallible>(
+                                encode_binary_video_cmaf_done_frame()
+                            );
+                            break;
+                        }
+                    }
+                }
+                _ = ctx.stopped() => {
+                    tracing::trace!("Context stopped; breaking CMAF binary video stream");
+                    inflight.mark_error(ErrorType::Cancelled);
+                    break;
+                }
+            }
+        }
+    };
+
+    axum::http::Response::builder()
+        .status(axum::http::StatusCode::OK)
+        .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
+        .header(
+            "x-dynamo-video-binary-protocol",
+            VIDEO_STREAM_BINARY_CMAF_PROTOCOL,
+        )
+        .body(Body::from_stream(binary_stream))
+        .map(|r| r.into_response())
+        .map_err(|e| {
+            ErrorMessage::internal_server_error(&format!(
+                "Failed to build CMAF binary video response: {e}"
+            ))
+        })
+}
+
 /// Experimental HLS/CMAF kickoff route for `/v1/videos/stream/hls`.
 ///
 /// The worker returns a single `NvVideosResponse` whose `id` is an opaque stream
@@ -2950,6 +3207,7 @@ async fn video_stream_hls_segment(
 /// - `POST /v1/videos`               — non-streaming, returns a single JSON response
 /// - `POST /v1/videos/stream`        — canonical SSE streaming with `NvVideosResponse` payloads
 /// - `POST /v1/videos/stream/binary` — experimental framed binary MP4 streaming
+/// - `POST /v1/videos/stream/binary/cmaf` — experimental single-POST CMAF/fMP4 streaming
 /// - `POST /v1/videos/stream/hls`    — HLS/CMAF kickoff, returns a playlist URL + stream id
 /// - `GET  /v1/videos/stream/hls/{stream_id}/playlist.m3u8`
 /// - `GET  /v1/videos/stream/hls/{stream_id}/init.mp4`
@@ -2961,6 +3219,7 @@ pub fn videos_router(
     let path = path.unwrap_or("/v1/videos".to_string());
     let stream_path = format!("{}/stream", path);
     let binary_stream_path = format!("{}/binary", stream_path);
+    let binary_cmaf_stream_path = format!("{}/cmaf", binary_stream_path);
     let hls_path = format!("{}/hls", stream_path);
     let hls_playlist_path = format!("{}/{{stream_id}}/playlist.m3u8", hls_path);
     let hls_init_path = format!("{}/{{stream_id}}/init.mp4", hls_path);
@@ -2969,6 +3228,7 @@ pub fn videos_router(
     let doc = RouteDoc::new(axum::http::Method::POST, &path);
     let stream_doc = RouteDoc::new(axum::http::Method::POST, &stream_path);
     let binary_stream_doc = RouteDoc::new(axum::http::Method::POST, &binary_stream_path);
+    let binary_cmaf_stream_doc = RouteDoc::new(axum::http::Method::POST, &binary_cmaf_stream_path);
     let hls_doc = RouteDoc::new(axum::http::Method::POST, &hls_path);
     let hls_playlist_doc = RouteDoc::new(axum::http::Method::GET, &hls_playlist_path);
     let hls_init_doc = RouteDoc::new(axum::http::Method::GET, &hls_init_path);
@@ -2989,6 +3249,7 @@ pub fn videos_router(
         .route(&path, post(videos))
         .route(&stream_path, post(video_stream))
         .route(&binary_stream_path, post(video_stream_binary))
+        .route(&binary_cmaf_stream_path, post(video_stream_binary_cmaf))
         .route(&hls_path, post(video_stream_hls))
         .route(&hls_playlist_path, get(video_stream_hls_playlist))
         .route(&hls_init_path, get(video_stream_hls_init_fragment))
@@ -3002,6 +3263,7 @@ pub fn videos_router(
             doc,
             stream_doc,
             binary_stream_doc,
+            binary_cmaf_stream_doc,
             hls_doc,
             hls_playlist_doc,
             hls_init_doc,
@@ -4144,6 +4406,34 @@ mod tests {
     }
 
     #[test]
+    fn test_add_video_binary_cmaf_annotation_sets_nvext_annotation_once() {
+        let mut request = NvCreateVideoRequest {
+            prompt: "hello".to_string(),
+            model: "video-model".to_string(),
+            input_reference: None,
+            seconds: None,
+            size: None,
+            user: None,
+            response_format: None,
+            nvext: None,
+        };
+
+        add_video_binary_cmaf_annotation(&mut request);
+        add_video_binary_cmaf_annotation(&mut request);
+
+        let annotations = request
+            .nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.as_ref())
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(
+            annotations,
+            vec![VIDEO_STREAM_BINARY_CMAF_ANNOTATION.to_string()]
+        );
+    }
+
+    #[test]
     fn test_video_hls_stream_id_round_trip() {
         let locator = VideoHlsStreamLocator {
             session_id: "session-123".to_string(),
@@ -4294,6 +4584,104 @@ mod tests {
 
         let payloads = decode_video_stream_payloads(response).unwrap();
         assert_eq!(payloads, vec![b"mp4-bytes".to_vec()]);
+    }
+
+    #[test]
+    fn test_normalize_video_binary_cmaf_response_accepts_tagged_payloads() {
+        let response = NvVideosResponse {
+            id: "vid-1".to_string(),
+            object: "video".to_string(),
+            model: "video-model".to_string(),
+            status: "in_progress".to_string(),
+            progress: 33,
+            created: 0,
+            data: vec![
+                VideoData {
+                    url: Some(VIDEO_STREAM_BINARY_CMAF_METADATA_TAG.to_string()),
+                    b64_json: Some(base64::prelude::BASE64_STANDARD.encode(br#"{"ok":true}"#)),
+                },
+                VideoData {
+                    url: Some(VIDEO_STREAM_BINARY_CMAF_INIT_TAG.to_string()),
+                    b64_json: Some(base64::prelude::BASE64_STANDARD.encode(b"init")),
+                },
+                VideoData {
+                    url: Some(format!("{VIDEO_STREAM_BINARY_CMAF_SEGMENT_PREFIX}7")),
+                    b64_json: Some(base64::prelude::BASE64_STANDARD.encode(b"segment")),
+                },
+            ],
+            error: None,
+            inference_time_s: None,
+        };
+
+        let normalized = normalize_video_binary_cmaf_response(response).unwrap();
+        assert_eq!(normalized.data.len(), 3);
+    }
+
+    #[test]
+    fn test_normalize_video_binary_cmaf_response_rejects_untagged_payloads() {
+        let response = NvVideosResponse {
+            id: "vid-1".to_string(),
+            object: "video".to_string(),
+            model: "video-model".to_string(),
+            status: "in_progress".to_string(),
+            progress: 33,
+            created: 0,
+            data: vec![VideoData {
+                url: Some("video/mp4".to_string()),
+                b64_json: Some(base64::prelude::BASE64_STANDARD.encode(b"segment")),
+            }],
+            error: None,
+            inference_time_s: None,
+        };
+
+        let err = normalize_video_binary_cmaf_response(response).unwrap_err();
+        assert!(err.contains("cmaf"));
+    }
+
+    #[test]
+    fn test_decode_video_binary_cmaf_payloads_decodes_kinded_frames() {
+        let response = NvVideosResponse {
+            id: "vid-1".to_string(),
+            object: "video".to_string(),
+            model: "video-model".to_string(),
+            status: "completed".to_string(),
+            progress: 100,
+            created: 0,
+            data: vec![
+                VideoData {
+                    url: Some(VIDEO_STREAM_BINARY_CMAF_METADATA_TAG.to_string()),
+                    b64_json: Some(
+                        base64::prelude::BASE64_STANDARD.encode(br#"{"mime":"video/mp4"}"#),
+                    ),
+                },
+                VideoData {
+                    url: Some(VIDEO_STREAM_BINARY_CMAF_INIT_TAG.to_string()),
+                    b64_json: Some(base64::prelude::BASE64_STANDARD.encode(b"init-bytes")),
+                },
+                VideoData {
+                    url: Some(format!("{VIDEO_STREAM_BINARY_CMAF_SEGMENT_PREFIX}0")),
+                    b64_json: Some(base64::prelude::BASE64_STANDARD.encode(b"segment-bytes")),
+                },
+            ],
+            error: None,
+            inference_time_s: None,
+        };
+
+        let payloads = decode_video_binary_cmaf_payloads(response).unwrap();
+        assert_eq!(
+            payloads,
+            vec![
+                (
+                    VIDEO_STREAM_BINARY_CMAF_KIND_METADATA,
+                    br#"{"mime":"video/mp4"}"#.to_vec()
+                ),
+                (VIDEO_STREAM_BINARY_CMAF_KIND_INIT, b"init-bytes".to_vec()),
+                (
+                    VIDEO_STREAM_BINARY_CMAF_KIND_SEGMENT,
+                    b"segment-bytes".to_vec()
+                ),
+            ]
+        );
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -11,7 +11,7 @@ use std::{
 use axum::{
     Json, Router,
     body::Body,
-    extract::State,
+    extract::{OriginalUri, Path, State},
     http::Request,
     http::{HeaderMap, StatusCode},
     middleware::{self, Next},
@@ -25,11 +25,13 @@ use base64::Engine as _;
 use bytes::Bytes;
 use dynamo_runtime::config::environment_names::llm as env_llm;
 use dynamo_runtime::{
-    pipeline::{AsyncEngineContextProvider, Context},
+    DistributedRuntime,
+    pipeline::{AsyncEngineContextProvider, Context, PushRouter, SingleIn},
     protocols::annotated::AnnotationsProvider,
 };
 use futures::{StreamExt, stream};
 use serde::{Deserialize, Serialize};
+use tower_http::cors::{Any, CorsLayer};
 
 use super::{
     RouteDoc,
@@ -55,7 +57,11 @@ use crate::protocols::openai::{
     embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
     images::{NvCreateImageRequest, NvImagesResponse},
     responses::{NvCreateResponse, NvResponse, ResponseParams, chat_completion_to_response},
-    videos::{NvCreateVideoRequest, NvVideosResponse},
+    videos::{
+        NvCreateVideoRequest, NvVideoHlsFragmentResponse, NvVideoHlsInitRequest,
+        NvVideoHlsPlaylistRequest, NvVideoHlsPlaylistResponse, NvVideoHlsSegmentRequest,
+        NvVideoHlsStreamResponse, NvVideosResponse,
+    },
 };
 use crate::protocols::unified::UnifiedRequest;
 use crate::request_template::RequestTemplate;
@@ -2290,6 +2296,201 @@ const VIDEO_STREAM_BINARY_KIND_MP4: u8 = 0x01;
 const VIDEO_STREAM_BINARY_KIND_ERROR: u8 = 0x02;
 const VIDEO_STREAM_BINARY_KIND_DONE: u8 = 0x03;
 const VIDEO_STREAM_BINARY_PROTOCOL: &str = "dynamo-video-binary-v1";
+const VIDEO_STREAM_HLS_CMAF_ANNOTATION: &str = "experimental_hls_cmaf";
+const VIDEO_STREAM_HLS_PLAYLIST_CONTENT_TYPE: &str = "application/vnd.apple.mpegurl";
+const VIDEO_STREAM_HLS_FRAGMENT_CONTENT_TYPE: &str = "video/mp4";
+const VIDEO_STREAM_HLS_PLAYLIST_ENDPOINT: &str = "playlist";
+const VIDEO_STREAM_HLS_INIT_ENDPOINT: &str = "init_fragment";
+const VIDEO_STREAM_HLS_SEGMENT_ENDPOINT: &str = "segment";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct VideoHlsStreamLocator {
+    session_id: String,
+    worker_id: u64,
+    namespace: String,
+    component: String,
+    created: i64,
+    expires_at: i64,
+    target_duration_seconds: u32,
+}
+
+fn add_video_hls_cmaf_annotation(request: &mut NvCreateVideoRequest) {
+    let nvext = request.nvext.get_or_insert_with(Default::default);
+    let annotations = nvext.annotations.get_or_insert_with(Vec::new);
+    if !annotations
+        .iter()
+        .any(|annotation| annotation == VIDEO_STREAM_HLS_CMAF_ANNOTATION)
+    {
+        annotations.push(VIDEO_STREAM_HLS_CMAF_ANNOTATION.to_string());
+    }
+}
+
+#[cfg(test)]
+fn encode_video_hls_stream_id(locator: &VideoHlsStreamLocator) -> Result<String, String> {
+    let payload = serde_json::to_vec(locator)
+        .map_err(|e| format!("failed to serialize HLS stream locator: {e}"))?;
+    Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload))
+}
+
+fn decode_video_hls_stream_id(stream_id: &str) -> Result<VideoHlsStreamLocator, String> {
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(stream_id)
+        .map_err(|e| format!("invalid HLS stream id encoding: {e}"))?;
+    let locator: VideoHlsStreamLocator = serde_json::from_slice(&payload)
+        .map_err(|e| format!("invalid HLS stream id payload: {e}"))?;
+
+    if locator.session_id.trim().is_empty() {
+        return Err("HLS stream id is missing session_id".to_string());
+    }
+    if locator.worker_id == 0 {
+        return Err("HLS stream id is missing worker_id".to_string());
+    }
+    if locator.namespace.trim().is_empty() {
+        return Err("HLS stream id is missing namespace".to_string());
+    }
+    if locator.component.trim().is_empty() {
+        return Err("HLS stream id is missing component".to_string());
+    }
+    if locator.target_duration_seconds == 0 {
+        return Err("HLS stream id is missing target_duration_seconds".to_string());
+    }
+    if locator.expires_at < locator.created {
+        return Err("HLS stream id has expires_at earlier than created".to_string());
+    }
+
+    Ok(locator)
+}
+
+fn parse_video_hls_segment_id(segment_id: &str) -> Result<u32, HttpError> {
+    let raw_segment_id = segment_id.strip_suffix(".m4s").ok_or_else(|| HttpError {
+        code: StatusCode::BAD_REQUEST.as_u16(),
+        message: "segment path must end with .m4s".to_string(),
+    })?;
+
+    raw_segment_id.parse::<u32>().map_err(|_| HttpError {
+        code: StatusCode::BAD_REQUEST.as_u16(),
+        message: "segment_id must be an unsigned integer".to_string(),
+    })
+}
+
+fn hls_missing_resource_message(message: &str) -> bool {
+    let lower = message.to_lowercase();
+    lower.contains("not found")
+        || lower.contains("expired")
+        || lower.contains("not available")
+        || lower.contains("unknown session")
+        || lower.contains("missing session")
+        || lower.contains("instance_id=")
+}
+
+fn map_hls_worker_error(err: anyhow::Error, fallback: &str) -> ErrorResponse {
+    let message = err.to_string();
+    if hls_missing_resource_message(&message) {
+        return ErrorMessage::from_http_error(HttpError {
+            code: StatusCode::NOT_FOUND.as_u16(),
+            message,
+        });
+    }
+    ErrorMessage::from_anyhow(err, fallback)
+}
+
+fn video_hls_bad_request(message: impl Into<String>) -> ErrorResponse {
+    ErrorMessage::from_http_error(HttpError {
+        code: StatusCode::BAD_REQUEST.as_u16(),
+        message: message.into(),
+    })
+}
+
+fn build_video_hls_text_response(
+    body: String,
+    content_type: &'static str,
+) -> Result<Response, ErrorResponse> {
+    axum::http::Response::builder()
+        .status(StatusCode::OK)
+        .header(axum::http::header::CONTENT_TYPE, content_type)
+        .header(axum::http::header::CACHE_CONTROL, "no-store")
+        .body(Body::from(body))
+        .map_err(|e| {
+            ErrorMessage::internal_server_error(&format!("Failed to build HLS text response: {e}"))
+        })
+}
+
+fn build_video_hls_binary_response(
+    body: Vec<u8>,
+    content_type: &'static str,
+) -> Result<Response, ErrorResponse> {
+    axum::http::Response::builder()
+        .status(StatusCode::OK)
+        .header(axum::http::header::CONTENT_TYPE, content_type)
+        .header(axum::http::header::CACHE_CONTROL, "no-store")
+        .body(Body::from(body))
+        .map_err(|e| {
+            ErrorMessage::internal_server_error(&format!(
+                "Failed to build HLS binary response: {e}"
+            ))
+        })
+}
+
+fn hls_runtime(state: &service_v2::State) -> Result<DistributedRuntime, ErrorResponse> {
+    state.runtime().ok_or_else(|| {
+        ErrorMessage::not_implemented_error(
+            "HLS/CMAF pull routes require a distributed runtime-backed frontend",
+        )
+    })
+}
+
+async fn fetch_video_hls_worker_response<Req, Resp>(
+    state: &service_v2::State,
+    locator: &VideoHlsStreamLocator,
+    endpoint_name: &str,
+    request: Req,
+) -> Result<Resp, ErrorResponse>
+where
+    Req: serde::Serialize + Send + Sync + 'static,
+    Resp: for<'de> serde::Deserialize<'de> + Send + Sync + 'static,
+{
+    let runtime = hls_runtime(state)?;
+    let namespace = runtime.namespace(&locator.namespace).map_err(|e| {
+        ErrorMessage::internal_server_error(&format!(
+            "Failed to resolve HLS namespace {}: {e}",
+            locator.namespace
+        ))
+    })?;
+    let component = namespace.component(&locator.component).map_err(|e| {
+        ErrorMessage::internal_server_error(&format!(
+            "Failed to resolve HLS component {}/{}: {e}",
+            locator.namespace, locator.component
+        ))
+    })?;
+    let endpoint = component.endpoint(endpoint_name);
+    let client = endpoint
+        .client()
+        .await
+        .map_err(|e| map_hls_worker_error(e, "Failed to connect to HLS worker endpoint"))?;
+    client
+        .wait_for_instances()
+        .await
+        .map_err(|e| map_hls_worker_error(e, "No HLS worker instances are available"))?;
+
+    let router = PushRouter::<Req, Annotated<Resp>>::from_client(client, Default::default())
+        .await
+        .map_err(|e| ErrorMessage::from_anyhow(e, "Failed to create HLS worker router"))?;
+    let mut stream = router
+        .direct(SingleIn::new(request), locator.worker_id)
+        .await
+        .map_err(|e| map_hls_worker_error(e, "Failed to dispatch HLS worker request"))?;
+    let response = stream.next().await.ok_or_else(|| {
+        ErrorMessage::internal_server_error("HLS worker returned an empty response stream")
+    })?;
+
+    match response.into_result() {
+        Ok(Some(data)) => Ok(data),
+        Ok(None) => Err(ErrorMessage::internal_server_error(
+            "HLS worker returned no data",
+        )),
+        Err(err) => Err(map_hls_worker_error(err, "HLS worker request failed")),
+    }
+}
 
 fn force_streaming_video_response_format(request: &mut NvCreateVideoRequest) {
     request.response_format = Some("b64_json".to_string());
@@ -2315,8 +2516,7 @@ fn decode_video_stream_payloads(response: NvVideosResponse) -> Result<Vec<Vec<u8
         .into_iter()
         .map(|item| {
             let b64 = item.b64_json.ok_or_else(|| {
-                "video streaming requires replayable MP4 chunks in data[*].b64_json"
-                    .to_string()
+                "video streaming requires replayable MP4 chunks in data[*].b64_json".to_string()
             })?;
 
             base64::prelude::BASE64_STANDARD
@@ -2585,13 +2785,175 @@ async fn video_stream_binary(
         })
 }
 
+/// Experimental HLS/CMAF kickoff route for `/v1/videos/stream/hls`.
+///
+/// The worker returns a single `NvVideosResponse` whose `id` is an opaque stream
+/// token. The frontend decodes that token to find the owning worker and exposes
+/// pull-based playlist / fragment routes for the browser.
+async fn video_stream_hls(
+    State(state): State<Arc<service_v2::State>>,
+    OriginalUri(uri): OriginalUri,
+    headers: HeaderMap,
+    Json(mut request): Json<NvCreateVideoRequest>,
+) -> Result<Response, ErrorResponse> {
+    check_ready(&state)?;
+
+    add_video_hls_cmaf_annotation(&mut request);
+
+    let request_id = get_or_create_request_id(&headers);
+    let request = Context::with_id(request, request_id);
+    let request_id = request.id().to_string();
+    let model = request.model.clone();
+
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+    let engine = state
+        .manager()
+        .get_videos_engine(&model)
+        .map_err(|e| ErrorMessage::from_model_error(&e))?;
+    let mut inflight =
+        state
+            .metrics_clone()
+            .create_inflight_guard(&model, Endpoint::Videos, false, &request_id);
+    let mut response_collector = state.metrics_clone().create_response_collector(&model);
+
+    let stream = engine.generate(request).await.map_err(|e| {
+        if super::metrics::request_was_rejected(e.as_ref()) {
+            state
+                .metrics_clone()
+                .inc_rejection(&model, super::metrics::Endpoint::Videos);
+        }
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to start HLS stream");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
+
+    let mut http_queue_guard = Some(http_queue_guard);
+    let stream = stream.inspect(move |response| {
+        process_response_and_observe_metrics(
+            response,
+            &mut response_collector,
+            &mut http_queue_guard,
+        );
+    });
+
+    let response = NvVideosResponse::from_annotated_stream(stream)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "Failed to fold HLS kickoff stream for {}: {:?}",
+                request_id,
+                e
+            );
+            let err_response =
+                ErrorMessage::internal_server_error("Failed to fold HLS kickoff stream");
+            inflight.mark_error(extract_error_type_from_response(&err_response));
+            err_response
+        })?;
+
+    let stream_locator = decode_video_hls_stream_id(&response.id).map_err(|e| {
+        let err_response = video_hls_bad_request(format!("Invalid HLS kickoff response: {e}"));
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
+
+    let playlist_url = format!(
+        "{}/{}/playlist.m3u8",
+        uri.path().trim_end_matches('/'),
+        response.id
+    );
+    let payload = NvVideoHlsStreamResponse {
+        stream_id: response.id,
+        playlist_url,
+        model: response.model,
+        created: stream_locator.created,
+        target_duration_seconds: stream_locator.target_duration_seconds,
+        expires_at: stream_locator.expires_at,
+    };
+
+    inflight.mark_ok();
+    Ok(Json(payload).into_response())
+}
+
+async fn video_stream_hls_playlist(
+    State(state): State<Arc<service_v2::State>>,
+    Path(stream_id): Path<String>,
+) -> Result<Response, ErrorResponse> {
+    check_ready(&state)?;
+
+    let locator = decode_video_hls_stream_id(&stream_id)
+        .map_err(|e| video_hls_bad_request(format!("Invalid HLS stream_id: {e}")))?;
+    let playlist =
+        fetch_video_hls_worker_response::<NvVideoHlsPlaylistRequest, NvVideoHlsPlaylistResponse>(
+            &state,
+            &locator,
+            VIDEO_STREAM_HLS_PLAYLIST_ENDPOINT,
+            NvVideoHlsPlaylistRequest {
+                session_id: locator.session_id.clone(),
+            },
+        )
+        .await?;
+
+    build_video_hls_text_response(playlist.playlist, VIDEO_STREAM_HLS_PLAYLIST_CONTENT_TYPE)
+}
+
+async fn video_stream_hls_init_fragment(
+    State(state): State<Arc<service_v2::State>>,
+    Path(stream_id): Path<String>,
+) -> Result<Response, ErrorResponse> {
+    check_ready(&state)?;
+
+    let locator = decode_video_hls_stream_id(&stream_id)
+        .map_err(|e| video_hls_bad_request(format!("Invalid HLS stream_id: {e}")))?;
+    let fragment =
+        fetch_video_hls_worker_response::<NvVideoHlsInitRequest, NvVideoHlsFragmentResponse>(
+            &state,
+            &locator,
+            VIDEO_STREAM_HLS_INIT_ENDPOINT,
+            NvVideoHlsInitRequest {
+                session_id: locator.session_id.clone(),
+            },
+        )
+        .await?;
+
+    build_video_hls_binary_response(fragment.bytes, VIDEO_STREAM_HLS_FRAGMENT_CONTENT_TYPE)
+}
+
+async fn video_stream_hls_segment(
+    State(state): State<Arc<service_v2::State>>,
+    Path((stream_id, segment_id)): Path<(String, String)>,
+) -> Result<Response, ErrorResponse> {
+    check_ready(&state)?;
+
+    let locator = decode_video_hls_stream_id(&stream_id)
+        .map_err(|e| video_hls_bad_request(format!("Invalid HLS stream_id: {e}")))?;
+    let segment_id =
+        parse_video_hls_segment_id(&segment_id).map_err(ErrorMessage::from_http_error)?;
+    let fragment =
+        fetch_video_hls_worker_response::<NvVideoHlsSegmentRequest, NvVideoHlsFragmentResponse>(
+            &state,
+            &locator,
+            VIDEO_STREAM_HLS_SEGMENT_ENDPOINT,
+            NvVideoHlsSegmentRequest {
+                session_id: locator.session_id.clone(),
+                segment_id,
+            },
+        )
+        .await?;
+
+    build_video_hls_binary_response(fragment.bytes, VIDEO_STREAM_HLS_FRAGMENT_CONTENT_TYPE)
+}
+
 /// Create an Axum [`Router`] for the OpenAI API Videos endpoint
 /// If no path is provided, the default path is `/v1/videos`
 ///
-/// Three routes are registered:
+/// Experimental sibling routes are also registered for HLS/CMAF playback:
 /// - `POST /v1/videos`               — non-streaming, returns a single JSON response
 /// - `POST /v1/videos/stream`        — canonical SSE streaming with `NvVideosResponse` payloads
 /// - `POST /v1/videos/stream/binary` — experimental framed binary MP4 streaming
+/// - `POST /v1/videos/stream/hls`    — HLS/CMAF kickoff, returns a playlist URL + stream id
+/// - `GET  /v1/videos/stream/hls/{stream_id}/playlist.m3u8`
+/// - `GET  /v1/videos/stream/hls/{stream_id}/init.mp4`
+/// - `GET  /v1/videos/stream/hls/{stream_id}/segment/{segment_id}.m4s`
 pub fn videos_router(
     state: Arc<service_v2::State>,
     path: Option<String>,
@@ -2599,17 +2961,54 @@ pub fn videos_router(
     let path = path.unwrap_or("/v1/videos".to_string());
     let stream_path = format!("{}/stream", path);
     let binary_stream_path = format!("{}/binary", stream_path);
+    let hls_path = format!("{}/hls", stream_path);
+    let hls_playlist_path = format!("{}/{{stream_id}}/playlist.m3u8", hls_path);
+    let hls_init_path = format!("{}/{{stream_id}}/init.mp4", hls_path);
+    let hls_segment_route_path = format!("{}/{{stream_id}}/segment/{{segment_id}}", hls_path);
+    let hls_segment_doc_path = format!("{}/{{stream_id}}/segment/{{segment_id}}.m4s", hls_path);
     let doc = RouteDoc::new(axum::http::Method::POST, &path);
     let stream_doc = RouteDoc::new(axum::http::Method::POST, &stream_path);
     let binary_stream_doc = RouteDoc::new(axum::http::Method::POST, &binary_stream_path);
+    let hls_doc = RouteDoc::new(axum::http::Method::POST, &hls_path);
+    let hls_playlist_doc = RouteDoc::new(axum::http::Method::GET, &hls_playlist_path);
+    let hls_init_doc = RouteDoc::new(axum::http::Method::GET, &hls_init_path);
+    let hls_segment_doc = RouteDoc::new(axum::http::Method::GET, &hls_segment_doc_path);
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods([
+            axum::http::Method::GET,
+            axum::http::Method::POST,
+            axum::http::Method::OPTIONS,
+        ])
+        .allow_headers(Any)
+        .expose_headers([
+            axum::http::header::CONTENT_TYPE,
+            axum::http::header::HeaderName::from_static("x-dynamo-video-binary-protocol"),
+        ]);
     let router = Router::new()
         .route(&path, post(videos))
         .route(&stream_path, post(video_stream))
         .route(&binary_stream_path, post(video_stream_binary))
+        .route(&hls_path, post(video_stream_hls))
+        .route(&hls_playlist_path, get(video_stream_hls_playlist))
+        .route(&hls_init_path, get(video_stream_hls_init_fragment))
+        .route(&hls_segment_route_path, get(video_stream_hls_segment))
+        .layer(cors)
         .layer(middleware::from_fn(smart_json_error_middleware))
         .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .with_state(state);
-    (vec![doc, stream_doc, binary_stream_doc], router)
+    (
+        vec![
+            doc,
+            stream_doc,
+            binary_stream_doc,
+            hls_doc,
+            hls_playlist_doc,
+            hls_init_doc,
+            hls_segment_doc,
+        ],
+        router,
+    )
 }
 
 async fn audio_speech(
@@ -3714,6 +4113,123 @@ mod tests {
 
         force_streaming_video_response_format(&mut request);
         assert_eq!(request.response_format.as_deref(), Some("b64_json"));
+    }
+
+    #[test]
+    fn test_add_video_hls_cmaf_annotation_sets_nvext_annotation_once() {
+        let mut request = NvCreateVideoRequest {
+            prompt: "hello".to_string(),
+            model: "video-model".to_string(),
+            input_reference: None,
+            seconds: None,
+            size: None,
+            user: None,
+            response_format: None,
+            nvext: None,
+        };
+
+        add_video_hls_cmaf_annotation(&mut request);
+        add_video_hls_cmaf_annotation(&mut request);
+
+        let annotations = request
+            .nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.as_ref())
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(
+            annotations,
+            vec![VIDEO_STREAM_HLS_CMAF_ANNOTATION.to_string()]
+        );
+    }
+
+    #[test]
+    fn test_video_hls_stream_id_round_trip() {
+        let locator = VideoHlsStreamLocator {
+            session_id: "session-123".to_string(),
+            worker_id: 42,
+            namespace: "dynamo".to_string(),
+            component: "backend".to_string(),
+            created: 1_700_000_000,
+            expires_at: 1_700_000_600,
+            target_duration_seconds: 2,
+        };
+
+        let encoded = encode_video_hls_stream_id(&locator).unwrap();
+        let decoded = decode_video_hls_stream_id(&encoded).unwrap();
+        assert_eq!(decoded, locator);
+    }
+
+    #[test]
+    fn test_video_hls_stream_id_rejects_malformed_payload() {
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+            serde_json::json!({
+                "session_id": "",
+                "worker_id": 0,
+                "namespace": "",
+                "component": "",
+                "created": 10,
+                "expires_at": 1,
+                "target_duration_seconds": 0
+            })
+            .to_string(),
+        );
+
+        let err = decode_video_hls_stream_id(&encoded).unwrap_err();
+        assert!(err.contains("session_id"));
+    }
+
+    #[tokio::test]
+    async fn test_build_video_hls_playlist_response_sets_hls_mime_type() {
+        let response = build_video_hls_text_response(
+            "#EXTM3U\n#EXT-X-MAP:URI=\"init.mp4\"\n#EXTINF:2.0,\nsegment/0.m4s\n".to_string(),
+            VIDEO_STREAM_HLS_PLAYLIST_CONTENT_TYPE,
+        )
+        .unwrap();
+
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .unwrap(),
+            VIDEO_STREAM_HLS_PLAYLIST_CONTENT_TYPE
+        );
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body.contains("#EXT-X-MAP"));
+        assert!(body.contains(".m4s"));
+    }
+
+    #[tokio::test]
+    async fn test_build_video_hls_binary_response_sets_mp4_mime_type() {
+        let response = build_video_hls_binary_response(
+            b"fragment".to_vec(),
+            VIDEO_STREAM_HLS_FRAGMENT_CONTENT_TYPE,
+        )
+        .unwrap();
+
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .unwrap(),
+            VIDEO_STREAM_HLS_FRAGMENT_CONTENT_TYPE
+        );
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(body.as_ref(), b"fragment");
+    }
+
+    #[test]
+    fn test_parse_video_hls_segment_id_requires_m4s_suffix() {
+        let err = parse_video_hls_segment_id("3").unwrap_err();
+        assert_eq!(err.code, StatusCode::BAD_REQUEST.as_u16());
+
+        let parsed = parse_video_hls_segment_id("3.m4s").unwrap();
+        assert_eq!(parsed, 3);
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2286,19 +2286,83 @@ async fn videos(
     Ok(Json(response).into_response())
 }
 
-/// [EXPERIMENTAL] MJPEG streaming handler for `/v1/videos/stream`.
+const VIDEO_STREAM_BINARY_KIND_MP4: u8 = 0x01;
+const VIDEO_STREAM_BINARY_KIND_ERROR: u8 = 0x02;
+const VIDEO_STREAM_BINARY_KIND_DONE: u8 = 0x03;
+const VIDEO_STREAM_BINARY_PROTOCOL: &str = "dynamo-video-binary-v1";
+
+fn force_streaming_video_response_format(request: &mut NvCreateVideoRequest) {
+    request.response_format = Some("b64_json".to_string());
+}
+
+fn normalize_video_stream_response(
+    mut response: NvVideosResponse,
+) -> Result<NvVideosResponse, String> {
+    for item in &mut response.data {
+        if item.b64_json.is_none() {
+            return Err(
+                "video streaming requires replayable MP4 chunks in data[*].b64_json".to_string(),
+            );
+        }
+    }
+
+    Ok(response)
+}
+
+fn decode_video_stream_payloads(response: NvVideosResponse) -> Result<Vec<Vec<u8>>, String> {
+    response
+        .data
+        .into_iter()
+        .map(|item| {
+            let b64 = item.b64_json.ok_or_else(|| {
+                "video streaming requires replayable MP4 chunks in data[*].b64_json"
+                    .to_string()
+            })?;
+
+            base64::prelude::BASE64_STANDARD
+                .decode(&b64)
+                .map_err(|e| format!("failed to decode video chunk base64: {e}"))
+        })
+        .collect()
+}
+
+fn encode_binary_video_frame(kind: u8, payload: &[u8]) -> Bytes {
+    let mut frame = Vec::with_capacity(1 + 4 + payload.len());
+    frame.push(kind);
+    frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    frame.extend_from_slice(payload);
+    Bytes::from(frame)
+}
+
+fn encode_binary_video_error_frame(message: impl Into<String>) -> Bytes {
+    let payload = serde_json::json!({
+        "error": {
+            "message": message.into(),
+        }
+    });
+    encode_binary_video_frame(
+        VIDEO_STREAM_BINARY_KIND_ERROR,
+        payload.to_string().as_bytes(),
+    )
+}
+
+fn encode_binary_video_done_frame() -> Bytes {
+    encode_binary_video_frame(VIDEO_STREAM_BINARY_KIND_DONE, &[])
+}
+
+/// Canonical SSE streaming handler for `/v1/videos/stream`.
 ///
-/// The backend is expected to yield one [`NvVideosResponse`] per frame, carrying a
-/// JPEG-encoded frame as `data[0].b64_json`. This handler decodes each frame and
-/// writes it as an MJPEG multipart boundary so the client receives a live
-/// `multipart/x-mixed-replace` stream viewable directly in a browser `<img>` tag
-/// or via `ffplay http://.../v1/videos/stream`.
+/// The backend yields one [`NvVideosResponse`] per replayable fragment. For this
+/// POC we intentionally use self-contained MP4 clips as the replayable unit to
+/// validate the RFC contract directly, rather than low-latency fragmented MP4.
 async fn video_stream(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(request): Json<NvCreateVideoRequest>,
+    Json(mut request): Json<NvCreateVideoRequest>,
 ) -> Result<Response, ErrorResponse> {
     check_ready(&state)?;
+
+    force_streaming_video_response_format(&mut request);
 
     let request_id = get_or_create_request_id(&headers);
     let request = Context::with_id(request, request_id);
@@ -2336,13 +2400,96 @@ async fn video_stream(
     // video_stream returns the streaming body directly (graceful handler exit).
     // The stream_handle is armed below and lives inside the monitored stream so that
     // a client disconnect (body drop) signals the engine context to cancel.
-    let (mut connection_handle, mut stream_handle) = create_connection_monitor(
+    let (mut connection_handle, stream_handle) = create_connection_monitor(
         ctx.clone(),
         Some(state.metrics_clone()),
         CancellationLabels {
             model: model.clone(),
             endpoint: Endpoint::Videos.to_string(),
             request_type: "stream".to_string(),
+        },
+    )
+    .await;
+    connection_handle.disarm();
+
+    let mut http_queue_guard = Some(http_queue_guard);
+    let stream = stream
+        .map(|response| response.map_data(normalize_video_stream_response))
+        .filter_map(move |response| {
+            futures::future::ready(
+                match process_response_using_event_converter_and_observe_metrics(
+                    EventConverter::from(response),
+                    &mut response_collector,
+                    &mut http_queue_guard,
+                ) {
+                    Ok(Some(event)) => Some(Ok(event)),
+                    Ok(None) => None,
+                    Err(e) => Some(Err(e)),
+                },
+            )
+        });
+    let stream = monitor_for_disconnects(stream, ctx, inflight, stream_handle);
+
+    let mut sse_stream = Sse::new(stream);
+    if let Some(keep_alive) = state.sse_keep_alive() {
+        sse_stream = sse_stream.keep_alive(KeepAlive::default().interval(keep_alive));
+    }
+
+    Ok(sse_stream.into_response())
+}
+
+/// Experimental binary streaming handler for `/v1/videos/stream/binary`.
+///
+/// The payload format is a simple framed byte stream:
+/// `[kind:1][len_be_u32:4][payload:len]`
+/// where `kind=0x01` is an MP4 clip, `0x02` is an error JSON payload, and
+/// `0x03` is an end-of-stream marker.
+async fn video_stream_binary(
+    State(state): State<Arc<service_v2::State>>,
+    headers: HeaderMap,
+    Json(mut request): Json<NvCreateVideoRequest>,
+) -> Result<Response, ErrorResponse> {
+    check_ready(&state)?;
+
+    force_streaming_video_response_format(&mut request);
+
+    let request_id = get_or_create_request_id(&headers);
+    let request = Context::with_id(request, request_id);
+    let model = request.model.clone();
+
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+
+    let engine = state
+        .manager()
+        .get_videos_engine(&model)
+        .map_err(|e| ErrorMessage::from_model_error(&e))?;
+
+    let mut inflight =
+        state
+            .metrics_clone()
+            .create_inflight_guard(&model, Endpoint::Videos, true, request.id());
+
+    let mut response_collector = state.metrics_clone().create_response_collector(&model);
+
+    let stream = engine.generate(request).await.map_err(|e| {
+        if super::metrics::request_was_rejected(e.as_ref()) {
+            state
+                .metrics_clone()
+                .inc_rejection(&model, super::metrics::Endpoint::Videos);
+        }
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to start binary video stream");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
+
+    let ctx = stream.context();
+    let (mut connection_handle, mut stream_handle) = create_connection_monitor(
+        ctx.clone(),
+        Some(state.metrics_clone()),
+        CancellationLabels {
+            model: model.clone(),
+            endpoint: Endpoint::Videos.to_string(),
+            request_type: "stream_binary".to_string(),
         },
     )
     .await;
@@ -2357,59 +2504,64 @@ async fn video_stream(
         );
     });
 
-    // Map each annotated NvVideosResponse to an MJPEG boundary chunk.
-    // The backend yields one response per frame with the JPEG in data[0].b64_json.
-    let mjpeg_stream = stream.filter_map(|annotated| async move {
-        let ann = match annotated.ok() {
-            Ok(a) => a,
-            Err(e) => {
-                tracing::error!("Video stream error: {e}");
-                return None;
-            }
-        };
-        let response = ann.data?;
-        let frame = response.data.into_iter().next()?;
-        let b64 = frame.b64_json?;
-        let jpeg_bytes = match base64::prelude::BASE64_STANDARD.decode(&b64) {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::warn!("Failed to decode frame base64: {e}");
-                return None;
-            }
-        };
-        let header = format!(
-            "--frame\r\nContent-Type: image/jpeg\r\nContent-Length: {}\r\n\r\n",
-            jpeg_bytes.len()
-        );
-        let mut chunk = Vec::with_capacity(header.len() + jpeg_bytes.len() + 2);
-        chunk.extend_from_slice(header.as_bytes());
-        chunk.extend_from_slice(&jpeg_bytes);
-        chunk.extend_from_slice(b"\r\n");
-        Some(Ok::<Bytes, std::convert::Infallible>(Bytes::from(chunk)))
-    });
-
-    // Arm the stream handle and monitor for client disconnects or context cancellation.
-    // inflight.mark_ok() is deferred until the stream ends naturally. If the stream is
-    // dropped early (client disconnect), the armed stream_handle signals the connection
-    // monitor, which cancels the engine context.
     stream_handle.arm();
-    let monitored_stream = async_stream::stream! {
-        tokio::pin!(mjpeg_stream);
+    let binary_stream = async_stream::stream! {
+        tokio::pin!(stream);
         loop {
             tokio::select! {
-                frame = mjpeg_stream.next() => {
-                    match frame {
-                        Some(item) => yield item,
+                item = stream.next() => {
+                    match item {
+                        Some(annotated) => {
+                            let annotated = annotated.map_data(normalize_video_stream_response);
+                            match annotated.into_result() {
+                                Ok(Some(response)) => {
+                                    match decode_video_stream_payloads(response) {
+                                        Ok(payloads) => {
+                                            for payload in payloads {
+                                                yield Ok::<Bytes, std::convert::Infallible>(
+                                                    encode_binary_video_frame(VIDEO_STREAM_BINARY_KIND_MP4, &payload)
+                                                );
+                                            }
+                                        }
+                                        Err(e) => {
+                                            inflight.mark_error(ErrorType::Internal);
+                                            stream_handle.disarm();
+                                            yield Ok::<Bytes, std::convert::Infallible>(
+                                                encode_binary_video_error_frame(e.to_string())
+                                            );
+                                            yield Ok::<Bytes, std::convert::Infallible>(
+                                                encode_binary_video_done_frame()
+                                            );
+                                            break;
+                                        }
+                                    }
+                                }
+                                Ok(None) => {}
+                                Err(e) => {
+                                    inflight.mark_error(ErrorType::Internal);
+                                    stream_handle.disarm();
+                                    yield Ok::<Bytes, std::convert::Infallible>(
+                                        encode_binary_video_error_frame(e.to_string())
+                                    );
+                                    yield Ok::<Bytes, std::convert::Infallible>(
+                                        encode_binary_video_done_frame()
+                                    );
+                                    break;
+                                }
+                            }
+                        }
                         None => {
-                            // Stream ended naturally: mark inflight OK and disarm the handle.
                             inflight.mark_ok();
                             stream_handle.disarm();
+                            yield Ok::<Bytes, std::convert::Infallible>(
+                                encode_binary_video_done_frame()
+                            );
                             break;
                         }
                     }
                 }
                 _ = ctx.stopped() => {
-                    tracing::trace!("Context stopped; breaking MJPEG stream");
+                    tracing::trace!("Context stopped; breaking binary video stream");
                     inflight.mark_error(ErrorType::Cancelled);
                     break;
                 }
@@ -2419,40 +2571,45 @@ async fn video_stream(
 
     axum::http::Response::builder()
         .status(axum::http::StatusCode::OK)
+        .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
         .header(
-            axum::http::header::CONTENT_TYPE,
-            "multipart/x-mixed-replace; boundary=frame",
+            "x-dynamo-video-binary-protocol",
+            VIDEO_STREAM_BINARY_PROTOCOL,
         )
-        .body(Body::from_stream(monitored_stream))
+        .body(Body::from_stream(binary_stream))
         .map(|r| r.into_response())
         .map_err(|e| {
-            // inflight is already owned by the monitored_stream which handles
-            // mark_ok (stream end) and mark_error (cancellation).
-            ErrorMessage::internal_server_error(&format!("Failed to build MJPEG response: {e}"))
+            ErrorMessage::internal_server_error(&format!(
+                "Failed to build binary video response: {e}"
+            ))
         })
 }
 
 /// Create an Axum [`Router`] for the OpenAI API Videos endpoint
 /// If no path is provided, the default path is `/v1/videos`
 ///
-/// Two routes are registered:
-/// - `POST /v1/videos`        — non-streaming, returns a single JSON response
-/// - `POST /v1/videos/stream` — MJPEG streaming via `multipart/x-mixed-replace`
+/// Three routes are registered:
+/// - `POST /v1/videos`               — non-streaming, returns a single JSON response
+/// - `POST /v1/videos/stream`        — canonical SSE streaming with `NvVideosResponse` payloads
+/// - `POST /v1/videos/stream/binary` — experimental framed binary MP4 streaming
 pub fn videos_router(
     state: Arc<service_v2::State>,
     path: Option<String>,
 ) -> (Vec<RouteDoc>, Router) {
     let path = path.unwrap_or("/v1/videos".to_string());
     let stream_path = format!("{}/stream", path);
+    let binary_stream_path = format!("{}/binary", stream_path);
     let doc = RouteDoc::new(axum::http::Method::POST, &path);
     let stream_doc = RouteDoc::new(axum::http::Method::POST, &stream_path);
+    let binary_stream_doc = RouteDoc::new(axum::http::Method::POST, &binary_stream_path);
     let router = Router::new()
         .route(&path, post(videos))
         .route(&stream_path, post(video_stream))
+        .route(&binary_stream_path, post(video_stream_binary))
         .layer(middleware::from_fn(smart_json_error_middleware))
         .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .with_state(state);
-    (vec![doc, stream_doc], router)
+    (vec![doc, stream_doc, binary_stream_doc], router)
 }
 
 async fn audio_speech(
@@ -3539,6 +3696,97 @@ mod tests {
         CreateChatCompletionStreamResponse, FinishReason, FunctionCallStream, FunctionType,
     };
     use dynamo_runtime::protocols::annotated::Annotated;
+
+    use crate::protocols::openai::videos::VideoData;
+
+    #[test]
+    fn test_force_streaming_video_response_format_overrides_to_b64_json() {
+        let mut request = NvCreateVideoRequest {
+            prompt: "hello".to_string(),
+            model: "video-model".to_string(),
+            input_reference: None,
+            seconds: None,
+            size: None,
+            user: None,
+            response_format: Some("url".to_string()),
+            nvext: None,
+        };
+
+        force_streaming_video_response_format(&mut request);
+        assert_eq!(request.response_format.as_deref(), Some("b64_json"));
+    }
+
+    #[test]
+    fn test_normalize_video_stream_response_accepts_b64_payload() {
+        let response = NvVideosResponse {
+            id: "vid-1".to_string(),
+            object: "video".to_string(),
+            model: "video-model".to_string(),
+            status: "in_progress".to_string(),
+            progress: 25,
+            created: 0,
+            data: vec![VideoData {
+                url: None,
+                b64_json: Some(base64::prelude::BASE64_STANDARD.encode(b"clip")),
+            }],
+            error: None,
+            inference_time_s: None,
+        };
+
+        let normalized = normalize_video_stream_response(response).unwrap();
+        assert_eq!(normalized.data.len(), 1);
+        assert!(normalized.data[0].b64_json.is_some());
+    }
+
+    #[test]
+    fn test_normalize_video_stream_response_rejects_missing_b64_payload() {
+        let response = NvVideosResponse {
+            id: "vid-1".to_string(),
+            object: "video".to_string(),
+            model: "video-model".to_string(),
+            status: "in_progress".to_string(),
+            progress: 25,
+            created: 0,
+            data: vec![VideoData {
+                url: Some("https://example.com/video.mp4".to_string()),
+                b64_json: None,
+            }],
+            error: None,
+            inference_time_s: None,
+        };
+
+        let err = normalize_video_stream_response(response).unwrap_err();
+        assert!(err.contains("b64_json"));
+    }
+
+    #[test]
+    fn test_decode_video_stream_payloads_decodes_mp4_bytes() {
+        let response = NvVideosResponse {
+            id: "vid-1".to_string(),
+            object: "video".to_string(),
+            model: "video-model".to_string(),
+            status: "completed".to_string(),
+            progress: 100,
+            created: 0,
+            data: vec![VideoData {
+                url: None,
+                b64_json: Some(base64::prelude::BASE64_STANDARD.encode(b"mp4-bytes")),
+            }],
+            error: None,
+            inference_time_s: None,
+        };
+
+        let payloads = decode_video_stream_payloads(response).unwrap();
+        assert_eq!(payloads, vec![b"mp4-bytes".to_vec()]);
+    }
+
+    #[test]
+    fn test_encode_binary_video_frame_layout() {
+        let frame = encode_binary_video_frame(VIDEO_STREAM_BINARY_KIND_MP4, b"abc");
+        assert_eq!(frame[0], VIDEO_STREAM_BINARY_KIND_MP4);
+        assert_eq!(&frame[1..5], &(3_u32.to_be_bytes()));
+        assert_eq!(&frame[5..], b"abc");
+    }
 
     /// Extract the JSON data payload from an SSE Event's Debug output.
     ///

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -25,6 +25,7 @@ use crate::request_template::RequestTemplate;
 use anyhow::Result;
 use axum_server::tls_rustls::RustlsConfig;
 use derive_builder::Builder;
+use dynamo_runtime::DistributedRuntime;
 use dynamo_runtime::config::env_is_truthy;
 use dynamo_runtime::config::environment_names::llm as env_llm;
 use dynamo_runtime::discovery::Discovery;
@@ -58,6 +59,7 @@ pub struct State {
     metrics: Arc<Metrics>,
     manager: Arc<ModelManager>,
     discovery_client: Arc<dyn Discovery>,
+    distributed_runtime: Option<DistributedRuntime>,
     flags: StateFlags,
     cancel_token: CancellationToken,
 }
@@ -124,12 +126,14 @@ impl State {
     pub fn new(
         manager: Arc<ModelManager>,
         discovery_client: Arc<dyn Discovery>,
+        distributed_runtime: Option<DistributedRuntime>,
         cancel_token: CancellationToken,
     ) -> Self {
         Self {
             manager,
             metrics: Arc::new(Metrics::default()),
             discovery_client,
+            distributed_runtime,
             flags: StateFlags {
                 chat_endpoints_enabled: AtomicBool::new(false),
                 cmpl_endpoints_enabled: AtomicBool::new(false),
@@ -159,6 +163,10 @@ impl State {
 
     pub fn discovery(&self) -> Arc<dyn Discovery> {
         self.discovery_client.clone()
+    }
+
+    pub fn runtime(&self) -> Option<DistributedRuntime> {
+        self.distributed_runtime.clone()
     }
 
     /// Check if the service is shutting down
@@ -251,6 +259,9 @@ pub struct HttpServiceConfig {
 
     #[builder(default = "None")]
     discovery: Option<Arc<dyn Discovery>>,
+
+    #[builder(default = "None")]
+    distributed_runtime: Option<DistributedRuntime>,
 
     #[builder(default = "None")]
     cancel_token: Option<CancellationToken>,
@@ -444,7 +455,12 @@ impl HttpServiceConfigBuilder {
                 cancel_token.child_token(),
             )) as Arc<dyn Discovery>
         });
-        let state = Arc::new(State::new(model_manager, discovery_client, cancel_token));
+        let state = Arc::new(State::new(
+            model_manager,
+            discovery_client,
+            config.distributed_runtime,
+            cancel_token,
+        ));
         state
             .flags
             .set(&EndpointType::Chat, config.enable_chat_endpoints);

--- a/lib/llm/src/protocols/openai/videos.rs
+++ b/lib/llm/src/protocols/openai/videos.rs
@@ -94,6 +94,60 @@ pub struct NvVideosResponse {
     pub inference_time_s: Option<f64>,
 }
 
+/// Public kickoff response for the experimental HLS/CMAF video stream route.
+#[derive(Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvVideoHlsStreamResponse {
+    /// Opaque stream identifier returned by the worker kickoff response.
+    pub stream_id: String,
+
+    /// Frontend playlist URL that the browser should hand to an HLS player.
+    pub playlist_url: String,
+
+    /// Model used for generation.
+    pub model: String,
+
+    /// Unix timestamp of creation.
+    pub created: i64,
+
+    /// HLS target duration advertised by the synthetic stream.
+    pub target_duration_seconds: u32,
+
+    /// Unix timestamp when the synthetic session expires.
+    pub expires_at: i64,
+}
+
+/// Internal frontend-to-worker request for the current live playlist.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NvVideoHlsPlaylistRequest {
+    pub session_id: String,
+}
+
+/// Internal worker response containing a rendered playlist body.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NvVideoHlsPlaylistResponse {
+    pub playlist: String,
+}
+
+/// Internal frontend-to-worker request for the CMAF init fragment.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NvVideoHlsInitRequest {
+    pub session_id: String,
+}
+
+/// Internal frontend-to-worker request for a CMAF media fragment.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NvVideoHlsSegmentRequest {
+    pub session_id: String,
+    pub segment_id: u32,
+}
+
+/// Internal worker response carrying raw binary HLS fragment bytes.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NvVideoHlsFragmentResponse {
+    #[serde(with = "serde_bytes")]
+    pub bytes: Vec<u8>,
+}
+
 fn default_object_type() -> String {
     "video".to_string()
 }

--- a/lib/llm/src/protocols/openai/videos/aggregator.rs
+++ b/lib/llm/src/protocols/openai/videos/aggregator.rs
@@ -51,8 +51,30 @@ impl DeltaAggregator {
                     // or we accumulate data from multiple responses
                     match &mut aggregator.response {
                         Some(existing) => {
-                            // Merge video data if we have multiple responses
-                            existing.data.extend(response.data);
+                            // Merge video data and keep top-level status/progress fields
+                            // from the latest chunk so folded non-streaming responses reflect
+                            // the end state of a streamed backend.
+                            let super::NvVideosResponse {
+                                id: _,
+                                object: _,
+                                model: _,
+                                status,
+                                progress,
+                                created,
+                                data,
+                                error,
+                                inference_time_s,
+                            } = response;
+                            existing.status = status;
+                            existing.progress = progress;
+                            existing.created = created;
+                            if error.is_some() {
+                                existing.error = error;
+                            }
+                            if inference_time_s.is_some() {
+                                existing.inference_time_s = inference_time_s;
+                            }
+                            existing.data.extend(data);
                         }
                         None => {
                             aggregator.response = Some(response);

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -1379,6 +1379,105 @@ class VideoGenerationPayload(BasePayload):
 
 
 @dataclass
+class VideoStreamPayload(BasePayload):
+    """Streaming payload for /v1/videos/stream."""
+
+    endpoint: str = "/v1/videos/stream"
+    timeout: int = 600
+    http_stream: bool = True
+
+    def response_handler(self, response: Any) -> str:
+        import json
+
+        response.raise_for_status()
+
+        clips = 0
+        done = False
+        event_type = ""
+
+        for line in response.iter_lines(decode_unicode=True):
+            if not line:
+                continue
+            if line.startswith("event: "):
+                event_type = line[len("event: ") :]
+                continue
+            if not line.startswith("data: "):
+                continue
+
+            data_str = line[len("data: ") :]
+            if data_str == "[DONE]":
+                done = True
+                continue
+
+            payload = json.loads(data_str)
+            if event_type == "error" or payload.get("error"):
+                raise AssertionError(f"Video stream error payload: {payload}")
+
+            assert payload.get("object") == "video", f"Unexpected object: {payload}"
+            data = payload.get("data", [])
+            assert data, f"Streaming payload missing data array: {payload}"
+            clip = data[0]
+            assert clip.get(
+                "b64_json"
+            ), f"Streaming payload missing b64_json: {payload}"
+            clips += 1
+
+        assert clips > 0, "Expected at least one streamed video clip"
+        assert done, "Expected SSE [DONE] terminator in video stream"
+        return f"{clips}_video_clips"
+
+
+@dataclass
+class BinaryVideoStreamPayload(BasePayload):
+    """Streaming payload for /v1/videos/stream/binary."""
+
+    endpoint: str = "/v1/videos/stream/binary"
+    timeout: int = 600
+    http_stream: bool = True
+
+    def response_handler(self, response: Any) -> str:
+        response.raise_for_status()
+        protocol = response.headers.get("x-dynamo-video-binary-protocol")
+        assert (
+            protocol == "dynamo-video-binary-v1"
+        ), f"Unexpected binary protocol header: {protocol}"
+
+        clips = 0
+        done = False
+        buffer = bytearray()
+
+        for chunk in response.iter_content(chunk_size=None):
+            if not chunk:
+                continue
+            buffer.extend(chunk)
+
+            while len(buffer) >= 5:
+                kind = buffer[0]
+                length = int.from_bytes(buffer[1:5], "big")
+                if len(buffer) < 5 + length:
+                    break
+
+                payload = bytes(buffer[5 : 5 + length])
+                del buffer[: 5 + length]
+
+                if kind == 0x01:
+                    assert payload, "Binary MP4 payload is empty"
+                    clips += 1
+                elif kind == 0x02:
+                    raise AssertionError(
+                        f"Binary video stream error payload: {payload.decode('utf-8', errors='replace')}"
+                    )
+                elif kind == 0x03:
+                    done = True
+                else:
+                    raise AssertionError(f"Unknown binary video frame kind: {kind}")
+
+        assert clips > 0, "Expected at least one binary streamed video clip"
+        assert done, "Expected binary done frame"
+        return f"{clips}_binary_video_clips"
+
+
+@dataclass
 class I2VPayload(VideoGenerationPayload):
     """Payload for image-to-video via /v1/videos with input_reference."""
 

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -1478,6 +1478,127 @@ class BinaryVideoStreamPayload(BasePayload):
 
 
 @dataclass
+class VideoHlsKickoffPayload(BasePayload):
+    """Kickoff payload for /v1/videos/stream/hls."""
+
+    body: Dict[str, Any] = field(default_factory=dict)
+    expected_response: List[Any] = field(default_factory=list)
+    expected_log: List[str] = field(default_factory=list)
+    endpoint: str = "/v1/videos/stream/hls"
+    timeout: int = 600
+
+    def response_handler(self, response: Any) -> str:
+        response.raise_for_status()
+        result = response.json()
+
+        stream_id = result.get("stream_id")
+        playlist_url = result.get("playlist_url")
+        assert stream_id, f"Missing HLS stream_id in response: {result}"
+        assert playlist_url, f"Missing HLS playlist_url in response: {result}"
+        assert playlist_url.endswith(
+            "/playlist.m3u8"
+        ), f"Unexpected HLS playlist_url: {playlist_url}"
+        assert (
+            result.get("target_duration_seconds", 0) > 0
+        ), f"Missing target_duration_seconds in response: {result}"
+        assert result.get("expires_at"), f"Missing expires_at in response: {result}"
+        return stream_id
+
+
+@dataclass
+class VideoHlsPlaylistPayload(BasePayload):
+    """Pull payload for /v1/videos/stream/hls/{stream_id}/playlist.m3u8."""
+
+    body: Dict[str, Any] = field(default_factory=dict)
+    expected_response: List[Any] = field(default_factory=list)
+    expected_log: List[str] = field(default_factory=list)
+    endpoint: str = "/v1/videos/stream/hls"
+    method: str = "GET"
+    timeout: int = 120
+    stream_id: str = ""
+
+    def url(self) -> str:
+        assert self.stream_id, "stream_id must be set for HLS playlist fetches"
+        ep = self.endpoint.lstrip("/")
+        return f"http://{self.host}:{self.port}/{ep}/{self.stream_id}/playlist.m3u8"
+
+    def response_handler(self, response: Any) -> str:
+        response.raise_for_status()
+        content_type = response.headers.get("Content-Type", "")
+        assert (
+            "application/vnd.apple.mpegurl" in content_type
+        ), f"Unexpected HLS playlist content type: {content_type}"
+
+        manifest = response.text
+        assert "#EXTM3U" in manifest, f"Invalid HLS playlist: {manifest!r}"
+        assert "#EXT-X-MAP" in manifest, f"Missing EXT-X-MAP: {manifest!r}"
+        assert ".m4s" in manifest, f"Missing CMAF segment URI: {manifest!r}"
+        return manifest
+
+
+@dataclass
+class VideoHlsInitFragmentPayload(BasePayload):
+    """Pull payload for /v1/videos/stream/hls/{stream_id}/init.mp4."""
+
+    body: Dict[str, Any] = field(default_factory=dict)
+    expected_response: List[Any] = field(default_factory=list)
+    expected_log: List[str] = field(default_factory=list)
+    endpoint: str = "/v1/videos/stream/hls"
+    method: str = "GET"
+    timeout: int = 120
+    stream_id: str = ""
+
+    def url(self) -> str:
+        assert self.stream_id, "stream_id must be set for HLS init fragment fetches"
+        ep = self.endpoint.lstrip("/")
+        return f"http://{self.host}:{self.port}/{ep}/{self.stream_id}/init.mp4"
+
+    def response_handler(self, response: Any) -> str:
+        response.raise_for_status()
+        content_type = response.headers.get("Content-Type", "")
+        assert (
+            "video/mp4" in content_type
+        ), f"Unexpected HLS init fragment content type: {content_type}"
+        payload = response.content
+        assert payload, "HLS init fragment is empty"
+        return f"{len(payload)}_init_bytes"
+
+
+@dataclass
+class VideoHlsSegmentPayload(BasePayload):
+    """Pull payload for /v1/videos/stream/hls/{stream_id}/segment/{segment_id}.m4s."""
+
+    body: Dict[str, Any] = field(default_factory=dict)
+    expected_response: List[Any] = field(default_factory=list)
+    expected_log: List[str] = field(default_factory=list)
+    endpoint: str = "/v1/videos/stream/hls"
+    method: str = "GET"
+    timeout: int = 120
+    stream_id: str = ""
+    segment_id: str = "0.m4s"
+
+    def url(self) -> str:
+        assert self.stream_id, "stream_id must be set for HLS segment fetches"
+        segment_id = self.segment_id
+        if not segment_id.endswith(".m4s"):
+            segment_id = f"{segment_id}.m4s"
+        ep = self.endpoint.lstrip("/")
+        return (
+            f"http://{self.host}:{self.port}/{ep}/{self.stream_id}/segment/{segment_id}"
+        )
+
+    def response_handler(self, response: Any) -> str:
+        response.raise_for_status()
+        content_type = response.headers.get("Content-Type", "")
+        assert (
+            "video/mp4" in content_type
+        ), f"Unexpected HLS segment content type: {content_type}"
+        payload = response.content
+        assert payload, "HLS media segment is empty"
+        return f"{len(payload)}_segment_bytes"
+
+
+@dataclass
 class I2VPayload(VideoGenerationPayload):
     """Payload for image-to-video via /v1/videos with input_reference."""
 


### PR DESCRIPTION
# Binary Video Streaming POCs for Dynamo

## Summary

This PR evaluates three isolated video streaming POCs under `examples/custom_backend/` to understand how Dynamo should deliver generated video when the canonical `b64_json`-over-SSE contract is not a good fit.

The central question is:

> What is the best way for Dynamo to deliver video with better browser UX and lower encoding overhead while staying aligned with Dynamo's architecture?

The POCs explore three points in the design space:

1. `video_streaming`
   Single-request push streaming of standalone MP4 clips over the existing `/v1/videos/stream` and `/v1/videos/stream/binary` routes.
2. `hls_video_streaming`
   Browser-standard HLS/CMAF playback with playlist and fragment `GET` routes.
3. `cmaf_binary_video_streaming`
   Single-request push streaming of continuous CMAF/fMP4 fragments over a new binary route using browser `MediaSource`.

These POCs are not intended as production implementations. They are experiments to evaluate:

- binary media delivery without `b64_json`
- browser playback UX
- architectural fit with Dynamo's request/response model
- likely operational and scaling tradeoffs

One important note: the performance discussion below is architectural, not benchmarked. This PR adds working prototypes, not final performance measurements.

## Comparison Table

| POC | Transport shape | Browser playback model | Audio | Continuous timeline | Dynamo changes | Browser standardization | Operational fit with Dynamo | Notes |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `video_streaming` | Single `POST` stream | Sequential playback of standalone MP4 clips | No in current synthetic worker | No | Low | Low | Excellent | Best baseline for validating streaming transport, weakest UX |
| `hls_video_streaming` | `POST` kickoff + many `GET`s | Native HLS / `hls.js` | Yes in principle with CMAF packaging | Yes | High | High | Weak to moderate | Best browser-standard UX, most architectural friction for Dynamo |
| `cmaf_binary_video_streaming` | Single `POST` stream | `MediaSource` + `SourceBuffer` | Yes when source MP4 has audio | Yes | Medium | Medium | Strong | Best middle ground: better UX without HLS pull-routing complexity |

## What Each POC Evaluates

### 1. `video_streaming`

This is the simplest experiment and the closest to Dynamo's native shape.

- The worker emits one `NvVideosResponse` per replayable unit.
- The replayable unit is a standalone MP4 clip.
- The frontend can expose either:
  - canonical SSE with `b64_json`
  - or an experimental binary framed stream
- The browser client queues whole MP4 clips and swaps the `<video>` source one clip at a time.


https://github.com/user-attachments/assets/95cb9ca0-1ecb-4aa7-9987-933197d27e00



What it proves well:

- Dynamo can stream video data over a single request/response path.
- The binary framing route can bypass the `b64_json` transport overhead.
- The worker and frontend integration cost is low.

Main limitations:

- No continuous playback timeline.
- Visible clip boundaries and source resets.
- No preserved audio in the current synthetic implementation.
- The client logic is custom and intentionally primitive.

Bottom line:

This is the best minimal-change baseline, but it is not a strong end-user playback experience.

### 2. `hls_video_streaming`

This is the most standards-aligned browser playback experiment.

- The worker packages the source MP4 into real CMAF assets:
  - `init.mp4`
  - `.m4s` media fragments
- The frontend exposes:
  - `POST /v1/videos/stream/hls`
  - `GET playlist.m3u8`
  - `GET init.mp4`
  - `GET segment/{id}.m4s`
- The browser uses native HLS where available or `hls.js` elsewhere.


https://github.com/user-attachments/assets/ce5c4783-46df-4a97-a4db-9d5995259b06



What it proves well:

- Dynamo can deliver real browser-consumable HLS/CMAF.
- Browser UX is strong:
  - continuous playback
  - no clip swapping
  - off-the-shelf player compatibility
  - audio support
- This is closest to how web video is commonly deployed.

Why it is expensive in Dynamo terms:

- HLS is pull-based, but Dynamo is naturally push-streaming.
- The frontend needs additional route surface for playlist and fragments.
- The implementation needs worker affinity:
  - opaque `stream_id`
  - worker ID encoded in the token
  - direct routing back to the worker that owns the stream state
- It introduces more state management and more failure modes than a single open stream.

Operational implications:

- More HTTP requests per playback session.
- More per-fragment routing overhead.
- More complex state and lifecycle handling.
- More natural for CDN/shared-storage architectures than for worker-memory push streams.

Bottom line:

This delivers the best standards-based browser UX, but it is the least natural fit for Dynamo's architecture and requires the most frontend machinery.

### 3. `cmaf_binary_video_streaming`

This is the "middle path" experiment.

- The worker still packages the source MP4 into CMAF fragments.
- Instead of HLS playlists and `GET`s, it emits those fragments over one long-lived `POST` response.
- The frontend exposes a single new route:
  - `POST /v1/videos/stream/binary/cmaf`
- The browser uses `MediaSource` and `SourceBuffer` to append:
  - metadata
  - init fragment
  - media fragments


https://github.com/user-attachments/assets/cec82452-ddad-48c0-abf2-46b8497b5b90



What it proves well:

- Dynamo can preserve its natural single-request push-streaming model.
- The browser can still get a continuous timeline.
- Audio can be preserved when the source MP4 includes audio.
- The implementation avoids:
  - playlist routes
  - per-segment `GET`s
  - `stream_id`
  - worker-affinity lookups for later requests

Tradeoffs:

- This is not a standard playback protocol like HLS.
- The browser client is custom and must understand the framing contract.
- It depends on `MediaSource` support and codec compatibility.
- It is well suited to Dynamo's architecture, but less interoperable with external tooling than HLS.

Bottom line:

This is the strongest "better UX with fewer Dynamo changes" option.

## Tradeoff Analysis

### Required Dynamo Changes

From lowest to highest:

1. `video_streaming`
2. `cmaf_binary_video_streaming`
3. `hls_video_streaming`

Why:

- `video_streaming` mostly reuses the existing video engine shape and adds a simple binary route.
- `cmaf_binary_video_streaming` adds one more binary route and a new framing contract, but still stays in the single `POST` model.
- `hls_video_streaming` adds multiple new frontend endpoints, stream token handling, worker-affine routing, and new pull-based lifecycle management.

### UX Quality

From weakest to strongest:

1. `video_streaming`
2. `cmaf_binary_video_streaming`
3. `hls_video_streaming`

Why:

- `video_streaming` swaps between standalone clips.
- `cmaf_binary_video_streaming` gives one continuous browser media timeline with `MediaSource`.
- `hls_video_streaming` gives a continuous browser media timeline with a standard delivery protocol and mature playback ecosystem.

### Architectural Fit for Dynamo

From strongest to weakest:

1. `video_streaming`
2. `cmaf_binary_video_streaming`
3. `hls_video_streaming`

Why:

- Dynamo naturally prefers one request, one open stream, worker-owned execution, and push semantics.
- Both `video_streaming` and `cmaf_binary_video_streaming` preserve that model.
- HLS works, but it forces Dynamo to emulate a pull-based media origin.

### Performance and Operational Expectations

These are expected characteristics, not benchmark results.

`video_streaming`

- Lowest frontend complexity
- Lowest request fanout
- Higher payload inefficiency if using `b64_json`
- Better with binary framing than SSE
- Poor playback continuity

`hls_video_streaming`

- More HTTP request overhead
- More frontend routing work
- Better cacheability and external compatibility in principle
- Strong browser playback behavior
- More stateful and operationally complex inside Dynamo

`cmaf_binary_video_streaming`

- Single-request streaming like Dynamo prefers
- No repeated `GET`s
- Raw binary delivery
- Better playback continuity than clip-based streaming
- Requires custom framing and custom browser client logic

## Recommendation

If the goal of this effort is to choose the most promising direction for Dynamo-native video streaming, the recommended next step is:

### Recommended primary direction: `cmaf_binary_video_streaming`

This appears to be the best overall tradeoff for Dynamo:

- much better UX than the clip-based `video_streaming` baseline
- significantly less frontend and routing complexity than HLS
- preserves Dynamo's natural push-streaming model
- avoids `b64_json`
- supports continuous playback and audio

In other words, it gets most of the user-visible benefits we wanted from HLS without importing the full pull-based architectural cost of HLS.

### Recommended secondary direction: keep `hls_video_streaming` as the standards benchmark

Even if it is not the preferred Dynamo-native direction, the HLS POC remains valuable because it answers a different question:

> Can Dynamo support standard web video delivery semantics when interoperability matters more than architectural elegance?

That makes HLS useful as a comparison point and as a reference for future integrations that specifically need HLS compatibility.

### Recommended role for `video_streaming`

Keep `video_streaming` as the simplest baseline and transport sanity check.

It is still useful for:

- validating worker/frontend streaming integration
- comparing framed binary delivery against `b64_json`
- showing the minimum Dynamo changes needed to stream video-like outputs

But it should not be treated as the target UX model.

## Suggested follow-up work

1. Benchmark all three POCs with the same input video and browser:
   - startup latency
   - bytes transferred
   - frontend CPU
   - worker CPU
   - playback smoothness
   - failure behavior
2. Decide whether Dynamo wants:
   - a Dynamo-native continuous streaming path (`cmaf_binary_video_streaming`)
   - a standards-based media delivery path (`hls_video_streaming`)
   - or both
3. If the CMAF-over-binary path continues:
   - harden the framing contract
   - document metadata schema more formally
   - tighten route-level CORS scope
   - consider whether SSE should remain clip-oriented while binary becomes the continuous media path
4. If the HLS path continues:
   - evaluate shared storage or CDN offload instead of worker-memory pull routing
   - narrow CORS scope
   - harden stream token handling
