### PR TITLE
fix(sglang): disable piecewise CUDA graph in launch scripts

### DIFF
--- a/examples/backends/sglang/launch/agg.sh
+++ b/examples/backends/sglang/launch/agg.sh
@@ -85,6 +85,7 @@ python3 -m "$WORKER_MODULE" \
   --trust-remote-code \
   --skip-tokenizer-init \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   $GPU_MEM_ARGS \
   "${TRACE_ARGS[@]}" \
   "${EXTRA_ARGS[@]}" &

--- a/examples/backends/sglang/launch/agg_router.sh
+++ b/examples/backends/sglang/launch/agg_router.sh
@@ -86,6 +86,7 @@ python3 -m dynamo.sglang \
   --trust-remote-code \
   "${KV_EVENTS_ARGS_1[@]}" \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   $GPU_MEM_ARGS \
   "${TRACE_ARGS[@]}" &
 
@@ -98,6 +99,7 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang \
   --trust-remote-code \
   "${KV_EVENTS_ARGS_2[@]}" \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   $GPU_MEM_ARGS \
   "${TRACE_ARGS[@]}" &
 

--- a/examples/backends/sglang/launch/disagg.sh
+++ b/examples/backends/sglang/launch/disagg.sh
@@ -81,6 +81,7 @@ python3 -m dynamo.sglang \
   --port 40000 \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   $GPU_MEM_ARGS \
   "${TRACE_ARGS[@]}" &
 
@@ -97,6 +98,7 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang \
   --host 0.0.0.0 \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   $GPU_MEM_ARGS \
   "${TRACE_ARGS[@]}" &
 

--- a/examples/backends/sglang/launch/disagg_router.sh
+++ b/examples/backends/sglang/launch/disagg_router.sh
@@ -76,6 +76,7 @@ python3 -m dynamo.sglang \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}' \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   "${TRACE_ARGS[@]}" &
 
 # run prefill worker
@@ -91,6 +92,7 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5558"}' \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   "${TRACE_ARGS[@]}" &
 
 # run decode worker
@@ -106,6 +108,7 @@ CUDA_VISIBLE_DEVICES=3 python3 -m dynamo.sglang \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5560"}' \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   "${TRACE_ARGS[@]}" &
 
 # run decode worker
@@ -121,6 +124,7 @@ CUDA_VISIBLE_DEVICES=2 python3 -m dynamo.sglang \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5559"}' \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   "${TRACE_ARGS[@]}" &
 
 # Wait for any worker to exit (keeps script running)


### PR DESCRIPTION
closes: DYN-2777

## Summary
- SGLang crashes during piecewise CUDA graph warmup (`CUBLAS_STATUS_EXECUTION_FAILED` in `piecewise_cuda_graph_runner.warmup_compile`) when `--context-length` is smaller than the piecewise bucket size (default min 4, default max 8192), killing the worker with SIGKILL.
- Adds `--disable-piecewise-cuda-graph` to `agg.sh`, `agg_router.sh`, `disagg.sh`, and `disagg_router.sh` so small-context runs come up cleanly. Standard fixed-batch-size CUDA graphs are still captured.
- Matches the flag already set in `agg-test.sh`. No auto-detect logic added to `dynamo.sglang` args — the upstream SGLang bug should be filtered there (bucket sizes > `context_length` should not be warmed up).
- This makes sense. Our launch scripts are purposefully kept at low memory usage and therefore piecewise cuda graphs take a bit much. No need to have them during these tests since its not performance sensitive

## Repro (without this change)
```
python3 -m dynamo.sglang \
  --model-path Qwen/Qwen3-0.6B --served-model-name Qwen/Qwen3-0.6B \
  --context-length 64 --page-size 16 --max-running-requests 100 \
  --mem-fraction-static 0.9 --trust-remote-code --skip-tokenizer-init
```
Crashes during `piecewise_context_manager.enable_piecewise_cuda_graph` warmup; scheduler process exits with SIGKILL.

## Test plan
- [x] `bash examples/backends/sglang/launch/agg.sh --context-length 64 --max-running-requests 100` — worker starts, `Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set`, `/v1/models` + `/v1/chat/completions` round-trip succeed.
- [ ] CI smoke for `agg_router.sh`, `disagg.sh`, `disagg_router.sh`.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated SGLang backend worker launch configurations to modify GPU computation behavior. Changes apply consistently across aggregated and disaggregated serving deployments, affecting all worker initialization procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->