### PR TITLE
fix(sglang): canary probe for disagg prefill + consolidate HEALTH_CHECK_KEY

### DIFF
--- a/components/src/dynamo/sglang/health_check.py
+++ b/components/src/dynamo/sglang/health_check.py
@@ -10,13 +10,16 @@ This module defines the default health check payload for sglang backends.
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 import sglang as sgl
 
 from dynamo.health_check import HealthCheckPayload
 
 logger = logging.getLogger(__name__)
+
+# Marker key set on health-check probe requests.
+HEALTH_CHECK_KEY = "_HEALTH_CHECK"
 
 
 def _get_bos_token_id_from_engine(engine: Optional[sgl.Engine]) -> int:
@@ -163,6 +166,14 @@ class SglangDisaggHealthCheckPayload(HealthCheckPayload):
         )
 
         super().__init__()
+
+    def to_dict(self) -> dict[str, Any]:
+        # Layer the canary marker on top of whatever the base class returns
+        # (which may be DYN_HEALTH_CHECK_PAYLOAD-overridden), so the canary
+        # contract survives user payload overrides.
+        payload = dict(super().to_dict())
+        payload[HEALTH_CHECK_KEY] = True
+        return payload
 
 
 class SglangPrefillHealthCheckPayload(SglangDisaggHealthCheckPayload):

--- a/components/src/dynamo/sglang/health_check.py
+++ b/components/src/dynamo/sglang/health_check.py
@@ -14,12 +14,9 @@ from typing import Any, Optional
 
 import sglang as sgl
 
-from dynamo.health_check import HealthCheckPayload
+from dynamo.health_check import HEALTH_CHECK_KEY, HealthCheckPayload
 
 logger = logging.getLogger(__name__)
-
-# Marker key set on health-check probe requests.
-HEALTH_CHECK_KEY = "_HEALTH_CHECK"
 
 
 def _get_bos_token_id_from_engine(engine: Optional[sgl.Engine]) -> int:

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -10,6 +10,7 @@ import sglang as sgl
 from dynamo._core import Context
 from dynamo.common.utils.otel_tracing import build_trace_headers
 from dynamo.sglang.args import Config
+from dynamo.sglang.health_check import HEALTH_CHECK_KEY
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
 
@@ -128,15 +129,6 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             "bootstrap_room": bootstrap_room,
         }
 
-        # Yield bootstrap_info for PrefillRouter - required for async generator contract
-        # and Rust-side expects disaggregated_params in first output
-        yield {
-            "token_ids": [],
-            "text": None,
-            "finish_reason": None,
-            "disaggregated_params": bootstrap_info,
-        }
-
         input_param = self._get_input_param(inner_request)
         routing = inner_request.get("routing") or {}
         priority = routing.get("priority")
@@ -167,6 +159,21 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             lora_path=lora_path,
             **self._priority_kwargs(priority),
         )
+
+        if inner_request.get(HEALTH_CHECK_KEY):
+            # Canary: stream engine output so the Rust canary sees scheduler output.
+            async for res in results:
+                yield res
+            return
+
+        # Yield bootstrap_info for PrefillRouter - required for async generator
+        # contract and Rust-side expects disaggregated_params in first output.
+        yield {
+            "token_ids": [],
+            "text": None,
+            "finish_reason": None,
+            "disaggregated_params": bootstrap_info,
+        }
 
         task = asyncio.create_task(self._consume_results(results, context))
         self._consume_tasks.add(task)

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -9,8 +9,8 @@ import sglang as sgl
 
 from dynamo._core import Context
 from dynamo.common.utils.otel_tracing import build_trace_headers
+from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.sglang.args import Config
-from dynamo.sglang.health_check import HEALTH_CHECK_KEY
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
 
@@ -162,6 +162,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
 
         if inner_request.get(HEALTH_CHECK_KEY):
             # Canary: stream engine output so the Rust canary sees scheduler output.
+            # No _cancellation_monitor — probe is bounded (max_tokens=1, FAKE_BOOTSTRAP_HOST).
             async for res in results:
                 yield res
             return

--- a/components/src/dynamo/sglang/tests/test_sglang_health_check.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_health_check.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sglang health-check payload shape tests.
+
+Asserts the canary HEALTH_CHECK_KEY marker is layered onto the disagg payload
+(which the prefill handler reads), absent from the decode/agg payload (which
+no handler reads), and survives DYN_HEALTH_CHECK_PAYLOAD env overrides.
+"""
+
+import json
+
+import pytest
+
+from dynamo.health_check import HEALTH_CHECK_KEY
+from dynamo.sglang.health_check import (
+    SglangDisaggHealthCheckPayload,
+    SglangHealthCheckPayload,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_disagg_payload_has_marker():
+    assert SglangDisaggHealthCheckPayload().to_dict()[HEALTH_CHECK_KEY] is True
+
+
+def test_decode_payload_has_no_marker():
+    # Decode/agg handler doesn't read the marker; payload stays unmarked.
+    assert HEALTH_CHECK_KEY not in SglangHealthCheckPayload().to_dict()
+
+
+def test_disagg_env_override_preserves_marker(monkeypatch):
+    """DYN_HEALTH_CHECK_PAYLOAD must not drop the canary marker."""
+    monkeypatch.setenv(
+        "DYN_HEALTH_CHECK_PAYLOAD",
+        json.dumps(
+            {
+                "token_ids": [1],
+                "sampling_options": {"temperature": 0.0},
+                "stop_conditions": {"max_tokens": 1},
+            }
+        ),
+    )
+    assert SglangDisaggHealthCheckPayload().to_dict()[HEALTH_CHECK_KEY] is True

--- a/components/src/dynamo/trtllm/health_check.py
+++ b/components/src/dynamo/trtllm/health_check.py
@@ -10,13 +10,10 @@ This module defines the default health check payload for TRT-LLM backends.
 import logging
 from typing import Any
 
-from dynamo.health_check import HealthCheckPayload
+from dynamo.health_check import HEALTH_CHECK_KEY, HealthCheckPayload
 from dynamo.trtllm.constants import DisaggregationMode
 
 logger = logging.getLogger(__name__)
-
-# Marker key set on health-check probe requests.
-HEALTH_CHECK_KEY = "_HEALTH_CHECK"
 
 
 def _get_bos_token_id_from_tokenizer(tokenizer) -> int:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -34,6 +34,7 @@ from tensorrt_llm.scheduling_params import SchedulingParams
 
 from dynamo._core import Client, Context
 from dynamo.common.utils.otel_tracing import build_trace_headers
+from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.llm.exceptions import EngineShutdown
 from dynamo.logits_processing.examples import HelloWorldLogitsProcessor
 from dynamo.nixl_connect import Connector
@@ -41,7 +42,6 @@ from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.trtllm.constants import DisaggregationMode
 from dynamo.trtllm.engine import TensorRTLLMEngine
-from dynamo.trtllm.health_check import HEALTH_CHECK_KEY
 from dynamo.trtllm.logits_processing.adapter import create_trtllm_adapters
 from dynamo.trtllm.metrics import AdditionalMetricsCollector
 from dynamo.trtllm.multimodal_processor import MultimodalRequestProcessor

--- a/components/src/dynamo/trtllm/tests/test_health_check_disagg.py
+++ b/components/src/dynamo/trtllm/tests/test_health_check_disagg.py
@@ -5,8 +5,9 @@ import json
 
 import pytest
 
+from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.trtllm.constants import DisaggregationMode
-from dynamo.trtllm.health_check import HEALTH_CHECK_KEY, TrtllmHealthCheckPayload
+from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
 
 pytestmark = [
     pytest.mark.unit,

--- a/components/src/dynamo/vllm/health_check.py
+++ b/components/src/dynamo/vllm/health_check.py
@@ -8,11 +8,19 @@ This module defines the default health check payload for vLLM backends.
 """
 
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-from dynamo.health_check import HealthCheckPayload
+from dynamo.health_check import HEALTH_CHECK_KEY, HealthCheckPayload
 
 logger = logging.getLogger(__name__)
+
+
+def _layer_probe_marker(payload: dict[str, Any]) -> dict[str, Any]:
+    """Layer HEALTH_CHECK_KEY onto a payload dict (reserved for future use)."""
+    payload = dict(payload)
+    payload[HEALTH_CHECK_KEY] = True
+    return payload
+
 
 if TYPE_CHECKING:
     from vllm.v1.engine.async_llm import AsyncLLM
@@ -101,6 +109,9 @@ class VllmHealthCheckPayload(HealthCheckPayload):
         self.default_payload = _make_default_payload(engine_client, use_text_input)
         super().__init__()
 
+    def to_dict(self) -> dict[str, Any]:
+        return _layer_probe_marker(super().to_dict())
+
 
 class VllmPrefillHealthCheckPayload(HealthCheckPayload):
     """
@@ -119,6 +130,9 @@ class VllmPrefillHealthCheckPayload(HealthCheckPayload):
         """
         self.default_payload = _make_default_payload(engine_client, use_text_input)
         super().__init__()
+
+    def to_dict(self) -> dict[str, Any]:
+        return _layer_probe_marker(super().to_dict())
 
 
 async def get_bos_token_from_omni(async_omni: "AsyncOmni") -> int:
@@ -180,6 +194,9 @@ class VllmOmniHealthCheckPayload(HealthCheckPayload):
             },
         }
         super().__init__()
+
+    def to_dict(self) -> dict[str, Any]:
+        return _layer_probe_marker(super().to_dict())
 
     @classmethod
     async def create(cls, async_omni: "AsyncOmni") -> "VllmOmniHealthCheckPayload":

--- a/components/src/dynamo/vllm/tests/test_vllm_health_check_payloads.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_health_check_payloads.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Vllm health-check payload shape tests.
+
+Asserts the canary HEALTH_CHECK_KEY marker is layered onto each Vllm probe
+payload via the to_dict() override and survives DYN_HEALTH_CHECK_PAYLOAD env
+overrides. No vllm handler branches on the marker today; this is wire-format
+parity with trtllm/sglang for any future marker-gated behavior.
+"""
+
+import json
+
+import pytest
+
+from dynamo.health_check import HEALTH_CHECK_KEY
+from dynamo.vllm.health_check import (
+    VllmHealthCheckPayload,
+    VllmOmniHealthCheckPayload,
+    VllmPrefillHealthCheckPayload,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+PAYLOAD_CLASSES = [
+    VllmHealthCheckPayload,
+    VllmPrefillHealthCheckPayload,
+    VllmOmniHealthCheckPayload,
+]
+
+
+@pytest.mark.parametrize("cls", PAYLOAD_CLASSES, ids=lambda c: c.__name__)
+def test_payload_has_marker(cls):
+    assert cls().to_dict()[HEALTH_CHECK_KEY] is True
+
+
+@pytest.mark.parametrize("cls", PAYLOAD_CLASSES, ids=lambda c: c.__name__)
+def test_env_override_preserves_marker(monkeypatch, cls):
+    """DYN_HEALTH_CHECK_PAYLOAD must not drop the canary marker."""
+    monkeypatch.setenv(
+        "DYN_HEALTH_CHECK_PAYLOAD",
+        json.dumps(
+            {
+                "token_ids": [1],
+                "sampling_options": {"temperature": 0.0},
+                "stop_conditions": {"max_tokens": 1},
+            }
+        ),
+    )
+    assert cls().to_dict()[HEALTH_CHECK_KEY] is True

--- a/lib/bindings/python/src/dynamo/health_check.py
+++ b/lib/bindings/python/src/dynamo/health_check.py
@@ -15,7 +15,14 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["HealthCheckPayload", "load_health_check_from_env"]
+# Marker key set on health-check probe requests. Backend payloads layer it
+# onto their default_payload via a to_dict() override so the marker survives
+# DYN_HEALTH_CHECK_PAYLOAD overrides. Handlers may inspect it to branch
+# probe-specific behavior (e.g. skip a synthetic first-yield that would
+# mask a hung engine rank).
+HEALTH_CHECK_KEY = "_HEALTH_CHECK"
+
+__all__ = ["HealthCheckPayload", "HEALTH_CHECK_KEY", "load_health_check_from_env"]
 
 
 def load_health_check_from_env(

--- a/tests/fault_tolerance/test_canary_rank_pause.py
+++ b/tests/fault_tolerance/test_canary_rank_pause.py
@@ -56,11 +56,6 @@ class RankPauseScenario:
 
 def _scenarios_for(backend: str) -> list:
     mark = getattr(pytest.mark, backend)
-    prefill_marks = [mark]
-    if backend == "sglang":
-        prefill_marks.append(
-            pytest.mark.skip(reason="sglang prefill canary fix needed")
-        )
     return [
         pytest.param(
             RankPauseScenario(f"{backend}-agg", backend, "aggregated", 0),
@@ -71,7 +66,7 @@ def _scenarios_for(backend: str) -> list:
             RankPauseScenario(
                 f"{backend}-disagg-prefill", backend, "disaggregated_same_gpu", 0
             ),
-            marks=prefill_marks,
+            marks=mark,
             id=f"{backend}-disagg-prefill",
         ),
         pytest.param(


### PR DESCRIPTION
## Summary

Two logically-separable commits for reviewability:

1. **`fix(sglang)`** — honor `_HEALTH_CHECK` marker in the sglang prefill handler so the canary's first observed response comes from the scheduler, not a synthetic bootstrap yield. Without this, a hung sglang prefill scheduler rank leaves `/health` at 200 indefinitely.
2. **`refactor(health-check)`** — move `HEALTH_CHECK_KEY = "_HEALTH_CHECK"` to the shared `dynamo.health_check` module (next to `HealthCheckPayload`), and apply the marker to all three vllm payloads for wire-format consistency across backends. No vllm handler behavior change. sglang and trtllm also switch to importing from the shared module; both keep a re-export in their backend module for backwards-compat.

Supersedes #8699 (merged content into this PR per maintainer request; #8699 closed).

## Why (fix)

`PrefillWorkerHandler.generate()` yields `bootstrap_info` as its first streamed response before calling `engine.async_generate()` and silently drains engine output via `_consume_results`. The Rust canary inspects only the first response, sees the synthetic yield, and reports Ready — scheduler rank never exercised.

## Why (refactor)

`HEALTH_CHECK_KEY` is a cross-backend convention; it shouldn't live in a single backend's module. Consistent wire format: every backend's canary probe payload now carries `_HEALTH_CHECK: True`. vllm handlers don't branch on it today — this is setup only.

## Test plan

- [x] Pre-commit (black / isort / flake8 / ruff / pytest-marker-report) — all pass
- [x] `test_health_check_disagg.py` (trtllm, 5 tests: payload shape + `DYN_HEALTH_CHECK_PAYLOAD` env-override preservation) — **5/5 pass** on the combined branch in `prb-trtllm-dev` container
- [x] Rank-pause E2E (sglang-disagg-prefill) — verified locally before consolidation (SIGSTOP `sglang::scheduler` → `/health` 503 within 45s; SIGCONT → recovers)
- [x] Negative control — with fix reverted, test fails with `AssertionError: canary did not flip /health to 503`
- [x] Functional smoke across all 6 classes: all three vllm payloads + `SglangDisaggHealthCheckPayload` + `TrtllmHealthCheckPayload` carry the marker after `to_dict()`; `SglangHealthCheckPayload` (decode/agg) correctly does not
- [ ] CI: full rank-pause matrix `{trtllm, vllm, sglang} × {agg, disagg-prefill, disagg-decode}` (nightly)

## KV cache cleanup (fix side) — verified

Canary probes do not leak KV blocks. `SglangDisaggHealthCheckPayload` uses `FAKE_BOOTSTRAP_HOST` → sglang picks `TransferBackend.FAKE` → `FakeKVSender.poll()` returns `KVPoll.Success` immediately → scheduler runs normal `release_kv_cache` cleanup. Same mechanism already in production for the sglang decode canary (DIS-1737).

## Files

| File | Purpose |
|---|---|
| `lib/bindings/python/src/dynamo/health_check.py` | Add canonical `HEALTH_CHECK_KEY` constant + docstring, export in `__all__` |
| `components/src/dynamo/trtllm/health_check.py` | Import from shared, keep re-export |
| `components/src/dynamo/trtllm/request_handlers/handler_base.py` | Update import source |
| `components/src/dynamo/vllm/health_check.py` | Add `_layer_probe_marker` helper + `to_dict()` override on all 3 payload classes |
| `components/src/dynamo/sglang/health_check.py` | Import from shared, keep re-export; `to_dict()` override on disagg payload (new in this PR) |
| `components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py` | Handler guard on `HEALTH_CHECK_KEY`; stream engine output on probes |
| `tests/fault_tolerance/test_canary_rank_pause.py` | Unskip `sglang-disagg-prefill` |

DIS-1837