### PR TITLE
minimal implementation of cmaf streaming

### DIFF
--- a/examples/custom_backend/cmaf_binary_video_streaming/README.md
+++ b/examples/custom_backend/cmaf_binary_video_streaming/README.md
@@ -1,0 +1,233 @@
+# CMAF Binary Video Streaming
+
+This example is a minimal Proof of Concept for continuous video playback over a
+single Dynamo `POST` response. It keeps Dynamo aligned with its natural
+push-streaming model while improving the browser experience beyond the existing
+clip-by-clip video streaming shape.
+
+## What This POC Evaluates
+
+The worker packages a prerecorded MP4 into real CMAF-style fragmented MP4:
+
+- one initialization fragment, `init.mp4`
+- a sequence of media fragments, `.m4s`
+
+`CMAF` stands for `Common Media Application Format`. In practice, that means the
+video is broken into streamable MP4 fragments that a browser can append into one
+continuous playback timeline.
+
+Unlike HLS, this example does not introduce playlist polling or per-segment
+`GET` requests. The browser opens a single `POST /v1/videos/stream/binary/cmaf`
+request, and the Dynamo frontend returns a framed binary stream containing:
+
+1. metadata JSON
+2. the CMAF init fragment
+3. each media fragment
+4. a final done frame
+
+## Why This Branch Exists
+
+This branch reimplements the CMAF binary POC from scratch on top of `main` so
+we can see the smallest Dynamo-side change set clearly.
+
+Minimal Dynamo changes in this branch:
+
+- one new frontend route in `lib/llm/src/http/service/openai.rs`
+- no new shared Rust protocol structs
+- no pull-based HLS routes
+- no worker-affinity routing
+- no frontend session storage
+- no added CORS behavior
+
+The worker uses the existing video response contract and tags each payload with:
+
+- `cmaf:metadata`
+- `cmaf:init`
+- `cmaf:segment:<n>`
+
+The frontend decodes those tagged `b64_json` payloads and rewrites them into a
+compact binary response body for the browser client.
+
+## Requirements
+
+- `ffmpeg`
+- `ffprobe`
+- a local MP4 file to use as prerecorded source material
+
+## Run The Worker
+
+```bash
+python examples/custom_backend/cmaf_binary_video_streaming/worker.py \
+  --source-mp4 /path/to/source.mp4 \
+  --segment-seconds 2 \
+  --emit-cadence-ms 750 \
+  --model synthetic-binary-cmaf-video-stream
+```
+
+The worker registers the model on the standard Dynamo backend endpoint:
+
+- namespace: `${DYN_NAMESPACE:-dynamo}`
+- component: `backend`
+- endpoint: `generate`
+
+Discovery backend defaults:
+
+- local runs: `file`
+- in-cluster runs: `kubernetes`
+
+That matches the existing `examples/diffusers/worker.py` behavior and avoids a
+common local failure mode where the frontend and worker use different discovery
+backends, so the frontend never enables the video routes for the registered
+model.
+
+## Frontend Route
+
+This branch adds:
+
+- `POST /v1/videos/stream/binary/cmaf`
+
+That route forces `response_format="b64_json"` and adds the request annotation:
+
+- `experimental_binary_cmaf`
+
+The synthetic worker checks for that annotation so it only responds to the new
+binary CMAF path.
+
+## Binary Frame Format
+
+Each response frame is encoded as:
+
+1. `1 byte` frame kind
+2. `4 bytes` big-endian payload length
+3. `N bytes` payload
+
+Frame kinds:
+
+- `0x01` metadata JSON
+- `0x02` CMAF init fragment
+- `0x03` CMAF media fragment
+- `0x04` error JSON
+- `0x05` stream done
+
+## Browser Client
+
+The reference client is [client.html](./client.html). It:
+
+- opens one `POST` request to `/v1/videos/stream/binary/cmaf`
+- parses the framed response body
+- creates a `MediaSource`
+- appends the init fragment and media fragments into a continuous timeline
+- lets you request a specific duration in seconds, or leave it blank to stream
+  the full source video
+
+The client uses `MediaSource`, so browser support depends on MSE availability.
+
+## Same-Origin Demo Launcher
+
+This example also includes [run_demo.py](./run_demo.py), which gives the browser
+one origin without changing Dynamo CORS behavior.
+
+What it does:
+
+- starts `python -m dynamo.frontend` on an internal port
+- serves `client.html` on a browser-facing port
+- reverse-proxies `/v1/*` to the internal frontend
+
+That means the browser only talks to one origin, so the CMAF `POST` stream works
+without enabling CORS in Dynamo itself.
+
+Example:
+
+```bash
+python examples/custom_backend/cmaf_binary_video_streaming/run_demo.py \
+  --proxy-port 8080 \
+  --frontend-port 18001
+```
+
+Then open:
+
+```text
+http://localhost:8080/
+```
+
+The client defaults its `Frontend Base URL` to the page origin, so no manual URL
+editing should be needed in the simple case.
+
+If you want to reuse an already-running frontend instead of starting a new one:
+
+```bash
+python examples/custom_backend/cmaf_binary_video_streaming/run_demo.py \
+  --proxy-port 8080 \
+  --frontend-port 8001 \
+  --no-start-frontend
+```
+
+If you need extra frontend flags, pass them after `--`:
+
+```bash
+python examples/custom_backend/cmaf_binary_video_streaming/run_demo.py \
+  --proxy-port 8080 \
+  --frontend-port 18001 \
+  -- --router-mode round-robin
+```
+
+## Browser Testing Note
+
+This minimal branch intentionally does **not** add CORS support. That keeps the
+Dynamo delta smaller, but it means the browser client needs to be served from
+the same origin as the Dynamo frontend, or you need an external same-origin
+proxy for local testing. `run_demo.py` is the built-in same-origin helper for
+this example.
+
+`curl` does not enforce browser CORS rules, so protocol inspection works even
+when a browser page served from another origin would fail.
+
+## Quick `curl` Check
+
+Inspect the headers:
+
+```bash
+curl -i -N -X POST http://localhost:8000/v1/videos/stream/binary/cmaf \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"synthetic-binary-cmaf-video-stream","prompt":"test binary cmaf stream","seconds":8,"size":"832x480"}'
+```
+
+Save the binary stream:
+
+```bash
+curl -N -X POST http://localhost:8000/v1/videos/stream/binary/cmaf \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"synthetic-binary-cmaf-video-stream","prompt":"test binary cmaf stream","seconds":8,"size":"832x480"}' \
+  -o /tmp/cmaf-stream.bin
+```
+
+Inspect the first bytes:
+
+```bash
+xxd -g 1 -l 96 /tmp/cmaf-stream.bin
+```
+
+## Tradeoffs
+
+Compared with clip-based `video_streaming`:
+
+- better UX: one continuous timeline instead of separate MP4 clips
+- supports audio as part of the CMAF fragments
+- still fits Dynamo’s single-request push model
+
+Compared with `hls_video_streaming`:
+
+- much smaller Dynamo delta
+- no playlist generation or segment fetch routes
+- no sticky routing or session lookup
+- but the browser client is more custom because it uses `MediaSource` directly
+
+## Follow-Ups
+
+- Compare wire efficiency against the HLS/CMAF pull model
+- Decide whether the frontend should keep this binary framing protocol or move
+  to a more general binary media contract
+- If browser testing from different origins is important, add a narrow CORS
+  layer only for `/v1/videos/stream/binary/cmaf`
+- Consider carrying richer metadata frames, such as duration, timestamp, or
+  optional subtitles, if the protocol moves beyond this POC

--- a/examples/custom_backend/cmaf_binary_video_streaming/client.html
+++ b/examples/custom_backend/cmaf_binary_video_streaming/client.html
@@ -1,0 +1,563 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CMAF Binary Video Streaming POC</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f5f1e8;
+        --panel: rgba(255, 250, 242, 0.92);
+        --text: #1f2a2e;
+        --muted: #617177;
+        --accent: #0f766e;
+        --accent-strong: #115e59;
+        --border: rgba(31, 42, 46, 0.12);
+        --danger: #b91c1c;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+        color: var(--text);
+        background:
+          radial-gradient(circle at top left, rgba(15, 118, 110, 0.16), transparent 36%),
+          linear-gradient(160deg, #f8f2e7 0%, #efe6d8 100%);
+      }
+
+      main {
+        width: min(1100px, calc(100vw - 32px));
+        margin: 32px auto;
+        display: grid;
+        gap: 20px;
+      }
+
+      .panel {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 20px;
+        box-shadow: 0 18px 48px rgba(31, 42, 46, 0.08);
+        padding: 22px;
+      }
+
+      h1 {
+        margin: 0 0 8px;
+        font-size: clamp(2rem, 4vw, 3.2rem);
+        line-height: 1;
+      }
+
+      p,
+      label,
+      button,
+      input {
+        font: inherit;
+      }
+
+      .hero p,
+      .hint {
+        margin: 0;
+        color: var(--muted);
+      }
+
+      .controls {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 14px;
+      }
+
+      .field {
+        display: grid;
+        gap: 6px;
+      }
+
+      .field label {
+        font-size: 0.9rem;
+        font-weight: 600;
+      }
+
+      .field input {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 11px 12px;
+        background: white;
+      }
+
+      .actions {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+
+      button {
+        border: 0;
+        border-radius: 999px;
+        padding: 11px 18px;
+        font-weight: 700;
+        cursor: pointer;
+      }
+
+      #start {
+        background: var(--accent);
+        color: white;
+      }
+
+      #start:hover {
+        background: var(--accent-strong);
+      }
+
+      #stop {
+        background: rgba(31, 42, 46, 0.08);
+        color: var(--text);
+      }
+
+      .stats {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+
+      .stat {
+        border-radius: 999px;
+        padding: 9px 12px;
+        background: rgba(15, 118, 110, 0.08);
+        color: var(--accent-strong);
+        font-weight: 600;
+      }
+
+      video {
+        width: 100%;
+        border-radius: 18px;
+        background: #000;
+      }
+
+      pre {
+        margin: 0;
+        padding: 16px;
+        min-height: 240px;
+        max-height: 320px;
+        overflow: auto;
+        background: #172126;
+        color: #d9ecf1;
+        border-radius: 16px;
+        font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+        font-size: 0.92rem;
+        line-height: 1.45;
+      }
+
+      .danger {
+        color: var(--danger);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="panel hero">
+        <h1>Single-POST CMAF Binary Streaming</h1>
+        <p>
+          This client opens one <code>POST /v1/videos/stream/binary/cmaf</code> request and
+          appends the returned <code>init.mp4 + .m4s</code> fragments into a
+          browser <code>MediaSource</code> timeline.
+        </p>
+      </section>
+
+      <section class="panel">
+        <div class="controls">
+          <div class="field">
+            <label for="baseUrl">Frontend Base URL</label>
+            <input id="baseUrl" type="text" />
+          </div>
+          <div class="field">
+            <label for="model">Model</label>
+            <input id="model" type="text" value="synthetic-binary-cmaf-video-stream" />
+          </div>
+          <div class="field">
+            <label for="prompt">Prompt</label>
+            <input id="prompt" type="text" value="continuous binary CMAF stream" />
+          </div>
+          <div class="field">
+            <label for="seconds">Duration Seconds</label>
+            <input
+              id="seconds"
+              type="number"
+              min="1"
+              step="1"
+              placeholder="blank = full source"
+            />
+          </div>
+        </div>
+        <div class="actions" style="margin-top: 16px">
+          <button id="start">Start CMAF Stream</button>
+          <button id="stop">Stop</button>
+          <span class="hint" id="browserHint"></span>
+        </div>
+        <div class="stats" style="margin-top: 16px">
+          <div class="stat" id="modeStat">Mode: idle</div>
+          <div class="stat" id="queueStat">Queued: 0</div>
+          <div class="stat" id="appendStat">Appended: 0</div>
+          <div class="stat" id="audioStat">Audio: unknown</div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <video id="player" controls playsinline></video>
+      </section>
+
+      <section class="panel">
+        <pre id="log"></pre>
+      </section>
+    </main>
+
+    <script>
+      const FRAME_KIND = {
+        METADATA: 0x01,
+        INIT: 0x02,
+        SEGMENT: 0x03,
+        ERROR: 0x04,
+        DONE: 0x05,
+      };
+
+      const logEl = document.getElementById("log");
+      const player = document.getElementById("player");
+      const baseUrlInput = document.getElementById("baseUrl");
+      const modelInput = document.getElementById("model");
+      const promptInput = document.getElementById("prompt");
+      const secondsInput = document.getElementById("seconds");
+      const modeStat = document.getElementById("modeStat");
+      const queueStat = document.getElementById("queueStat");
+      const appendStat = document.getElementById("appendStat");
+      const audioStat = document.getElementById("audioStat");
+      const browserHint = document.getElementById("browserHint");
+
+      let abortController = null;
+      let activeReader = null;
+      let mediaSource = null;
+      let sourceBuffer = null;
+      let objectUrl = null;
+      let frameBuffer = new Uint8Array(0);
+      let appendQueue = [];
+      let appendedCount = 0;
+      let streamDone = false;
+      let metadata = null;
+      const CONNECT_TIMEOUT_MS = 15000;
+
+      function describeError(error) {
+        if (error instanceof Error) {
+          return error.message || error.name || "Unknown error";
+        }
+        if (typeof error === "string") {
+          return error;
+        }
+        try {
+          return JSON.stringify(error);
+        } catch (_) {
+          return String(error);
+        }
+      }
+
+      function inferBaseUrl() {
+        if (window.location.origin && window.location.origin !== "null") {
+          return window.location.origin;
+        }
+        return "http://localhost:8000";
+      }
+
+      function appendLog(message, isError = false) {
+        const stamp = new Date().toLocaleTimeString("en-GB", { hour12: false });
+        logEl.textContent += `[${stamp}] ${message}\n`;
+        if (isError) {
+          logEl.classList.add("danger");
+        }
+        logEl.scrollTop = logEl.scrollHeight;
+      }
+
+      function setStat(element, text) {
+        element.textContent = text;
+      }
+
+      function joinUrl(base, path) {
+        return `${base.replace(/\/$/, "")}${path.startsWith("/") ? path : `/${path}`}`;
+      }
+
+      function resetPlaybackState() {
+        if (activeReader) {
+          activeReader.cancel().catch(() => {});
+          activeReader = null;
+        }
+        if (abortController) {
+          abortController.abort();
+          abortController = null;
+        }
+        if (sourceBuffer) {
+          sourceBuffer.removeEventListener("updateend", onSourceBufferUpdateEnd);
+          sourceBuffer = null;
+        }
+        if (mediaSource && mediaSource.readyState === "open") {
+          try {
+            mediaSource.endOfStream();
+          } catch (_) {}
+        }
+        mediaSource = null;
+        frameBuffer = new Uint8Array(0);
+        appendQueue = [];
+        appendedCount = 0;
+        streamDone = false;
+        metadata = null;
+        if (objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+          objectUrl = null;
+        }
+        player.removeAttribute("src");
+        player.load();
+        setStat(modeStat, "Mode: idle");
+        setStat(queueStat, "Queued: 0");
+        setStat(appendStat, "Appended: 0");
+        setStat(audioStat, "Audio: unknown");
+      }
+
+      function setQueuedStat() {
+        setStat(queueStat, `Queued: ${appendQueue.length}`);
+      }
+
+      function onSourceBufferUpdateEnd() {
+        appendedCount += 1;
+        setStat(appendStat, `Appended: ${appendedCount}`);
+        pumpAppendQueue();
+        if (player.paused) {
+          player.play().catch((error) => {
+            appendLog(`Playback is waiting for a manual play click: ${error.message}`);
+          });
+        }
+      }
+
+      function ensureMediaSource(meta) {
+        if (!("MediaSource" in window)) {
+          throw new Error("This browser does not support MediaSource Extensions");
+        }
+        if (mediaSource) {
+          return;
+        }
+
+        mediaSource = new MediaSource();
+        objectUrl = URL.createObjectURL(mediaSource);
+        player.src = objectUrl;
+        player.load();
+
+        mediaSource.addEventListener(
+          "sourceopen",
+          () => {
+            try {
+              sourceBuffer = mediaSource.addSourceBuffer(meta.source_buffer_mime_type);
+              sourceBuffer.mode = "segments";
+              sourceBuffer.addEventListener("updateend", onSourceBufferUpdateEnd);
+              appendLog(`MediaSource ready with ${meta.source_buffer_mime_type}`);
+              pumpAppendQueue();
+            } catch (error) {
+              appendLog(`Failed to create SourceBuffer: ${error.message}`, true);
+            }
+          },
+          { once: true }
+        );
+      }
+
+      function queueAppend(bytes) {
+        appendQueue.push(bytes);
+        setQueuedStat();
+        pumpAppendQueue();
+      }
+
+      function pumpAppendQueue() {
+        if (!sourceBuffer || sourceBuffer.updating) {
+          return;
+        }
+        if (appendQueue.length === 0) {
+          setQueuedStat();
+          if (streamDone && mediaSource && mediaSource.readyState === "open") {
+            try {
+              mediaSource.endOfStream();
+              appendLog("MediaSource ended cleanly");
+            } catch (error) {
+              appendLog(`endOfStream failed: ${error.message}`, true);
+            }
+          }
+          return;
+        }
+
+        const next = appendQueue.shift();
+        setQueuedStat();
+        try {
+          sourceBuffer.appendBuffer(next);
+        } catch (error) {
+          appendLog(`appendBuffer failed: ${error.message}`, true);
+        }
+      }
+
+      function concatUint8Arrays(left, right) {
+        const merged = new Uint8Array(left.length + right.length);
+        merged.set(left, 0);
+        merged.set(right, left.length);
+        return merged;
+      }
+
+      function drainFrames(chunk) {
+        frameBuffer = concatUint8Arrays(frameBuffer, chunk);
+        while (frameBuffer.length >= 5) {
+          const kind = frameBuffer[0];
+          const length =
+            (frameBuffer[1] << 24) |
+            (frameBuffer[2] << 16) |
+            (frameBuffer[3] << 8) |
+            frameBuffer[4];
+          if (frameBuffer.length < 5 + length) {
+            return;
+          }
+          const payload = frameBuffer.slice(5, 5 + length);
+          frameBuffer = frameBuffer.slice(5 + length);
+          handleFrame(kind, payload);
+        }
+      }
+
+      function handleFrame(kind, payload) {
+        const textDecoder = new TextDecoder();
+        switch (kind) {
+          case FRAME_KIND.METADATA: {
+            metadata = JSON.parse(textDecoder.decode(payload));
+            setStat(modeStat, "Mode: streaming");
+            setStat(audioStat, `Audio: ${metadata.has_audio ? "yes" : "no"}`);
+            appendLog(`Metadata: ${JSON.stringify(metadata, null, 2)}`);
+            ensureMediaSource(metadata);
+            break;
+          }
+          case FRAME_KIND.INIT:
+            appendLog(`Received init fragment (${payload.length} bytes)`);
+            queueAppend(payload);
+            break;
+          case FRAME_KIND.SEGMENT:
+            appendLog(`Received media fragment (${payload.length} bytes)`);
+            queueAppend(payload);
+            break;
+          case FRAME_KIND.ERROR: {
+            const decoded = JSON.parse(textDecoder.decode(payload));
+            appendLog(`Worker stream error: ${decoded.error}`, true);
+            break;
+          }
+          case FRAME_KIND.DONE:
+            appendLog("Received stream done frame");
+            streamDone = true;
+            pumpAppendQueue();
+            break;
+          default:
+            appendLog(`Unknown frame kind ${kind}`, true);
+        }
+      }
+
+      async function startStream() {
+        resetPlaybackState();
+
+        const baseUrl = baseUrlInput.value.trim().replace(/\/$/, "");
+        const url = joinUrl(baseUrl, "/v1/videos/stream/binary/cmaf");
+        const secondsRaw = secondsInput.value.trim();
+        const seconds = secondsRaw ? Number.parseInt(secondsRaw, 10) : null;
+        const body = {
+          model: modelInput.value.trim(),
+          prompt: promptInput.value.trim(),
+          size: "832x480",
+        };
+        if (secondsRaw) {
+          if (!Number.isFinite(seconds) || seconds <= 0) {
+            appendLog("Duration Seconds must be a positive integer or blank for full source.", true);
+            return;
+          }
+          body.seconds = seconds;
+        }
+
+        appendLog(`POST ${url}`);
+        appendLog(`Waiting for stream response (timeout ${CONNECT_TIMEOUT_MS / 1000}s)`);
+        setStat(modeStat, "Mode: connecting");
+        abortController = new AbortController();
+        let connectTimedOut = false;
+        const timeoutId = setTimeout(() => {
+          if (abortController) {
+            connectTimedOut = true;
+            abortController.abort();
+          }
+        }, CONNECT_TIMEOUT_MS);
+
+        try {
+          const response = await fetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+            signal: abortController.signal,
+          });
+          clearTimeout(timeoutId);
+          appendLog(`HTTP status: ${response.status}`);
+          if (!response.ok) {
+            const text = await response.text();
+            throw new Error(`Request failed with ${response.status}: ${text}`);
+          }
+          appendLog(
+            `Protocol: ${response.headers.get("x-dynamo-video-binary-protocol") || "missing"}`
+          );
+          if (!response.body) {
+            throw new Error("Browser did not expose a readable response body");
+          }
+
+          activeReader = response.body.getReader();
+          while (true) {
+            const { value, done } = await activeReader.read();
+            if (done) {
+              appendLog("ReadableStream closed by server");
+              break;
+            }
+            drainFrames(value);
+          }
+        } catch (error) {
+          clearTimeout(timeoutId);
+          const errorMessage = describeError(error);
+          if (connectTimedOut) {
+            appendLog(
+              `Stream request timed out after 15s. This minimal branch does not enable CORS, so browser playback requires the page and API to share the same origin. Note that localhost:8080 and localhost:8001 are different origins because the port is part of the origin.`,
+              true
+            );
+          } else if (error instanceof TypeError || /failed to fetch/i.test(errorMessage)) {
+            appendLog(
+              `Failed to fetch. If client.html is not served from the exact same origin as ${baseUrl}, this minimal branch will usually fail in the browser because it does not enable CORS. The origin must match scheme, host, and port.`,
+              true
+            );
+          } else if (error instanceof DOMException && error.name === "AbortError") {
+            appendLog("Stream aborted");
+          } else {
+            appendLog(errorMessage, true);
+          }
+        } finally {
+          streamDone = true;
+          pumpAppendQueue();
+          setStat(modeStat, "Mode: complete");
+        }
+      }
+
+      function stopStream() {
+        resetPlaybackState();
+        appendLog("Stopped stream");
+      }
+
+      baseUrlInput.value = inferBaseUrl();
+      browserHint.textContent = `MediaSource support: ${"MediaSource" in window ? "yes" : "no"}`;
+      if (window.location.hostname && window.location.hostname !== "localhost" && /localhost/.test(baseUrlInput.value)) {
+        appendLog(
+          "This page is not on localhost, but the frontend base URL is. If you are using port forwarding, replace it with the browser-reachable forwarded URL."
+        );
+      }
+
+      document.getElementById("start").addEventListener("click", startStream);
+      document.getElementById("stop").addEventListener("click", stopStream);
+    </script>
+  </body>
+</html>

--- a/examples/custom_backend/cmaf_binary_video_streaming/run_demo.py
+++ b/examples/custom_backend/cmaf_binary_video_streaming/run_demo.py
@@ -1,0 +1,313 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import http.client
+import http.server
+import mimetypes
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = EXAMPLE_DIR.parents[2]
+CLIENT_HTML = EXAMPLE_DIR / "client.html"
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+class DemoProxyServer(http.server.ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        frontend_host: str,
+        frontend_port: int,
+    ) -> None:
+        super().__init__(server_address, DemoProxyHandler)
+        self.frontend_host = frontend_host
+        self.frontend_port = frontend_port
+        self.static_root = EXAMPLE_DIR
+
+
+class DemoProxyHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.0"
+    server_version = "cmaf-binary-demo/0.1"
+
+    def do_GET(self) -> None:
+        self._handle()
+
+    def do_HEAD(self) -> None:
+        self._handle(head_only=True)
+
+    def do_POST(self) -> None:
+        self._handle()
+
+    def do_OPTIONS(self) -> None:
+        self._handle()
+
+    def _handle(self, head_only: bool = False) -> None:
+        if self.path == "/" or self.path == "/client.html":
+            self._serve_static(CLIENT_HTML, head_only=head_only)
+            return
+
+        if self.path.startswith("/v1/") or self.path in {
+            "/live",
+            "/ready",
+            "/health",
+            "/metrics",
+        }:
+            self._proxy_request(head_only=head_only)
+            return
+
+        candidate = self._safe_static_path(self.path)
+        if candidate and candidate.is_file():
+            self._serve_static(candidate, head_only=head_only)
+            return
+
+        self.send_error(404, "Not found")
+
+    def _safe_static_path(self, raw_path: str) -> Path | None:
+        cleaned = raw_path.split("?", 1)[0].split("#", 1)[0].lstrip("/")
+        if not cleaned:
+            return None
+        candidate = (self.server.static_root / cleaned).resolve()
+        try:
+            candidate.relative_to(self.server.static_root)
+        except ValueError:
+            return None
+        return candidate
+
+    def _serve_static(self, path: Path, head_only: bool = False) -> None:
+        body = path.read_bytes()
+        mime_type, _ = mimetypes.guess_type(path.name)
+        self.send_response(200)
+        self.send_header("Content-Type", mime_type or "application/octet-stream")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if not head_only:
+            self.wfile.write(body)
+
+    def _proxy_request(self, head_only: bool = False) -> None:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(content_length) if content_length else None
+        upstream_headers = {
+            key: value
+            for key, value in self.headers.items()
+            if key.lower() not in HOP_BY_HOP_HEADERS and key.lower() != "host"
+        }
+        upstream_headers[
+            "Host"
+        ] = f"{self.server.frontend_host}:{self.server.frontend_port}"
+
+        conn = http.client.HTTPConnection(
+            self.server.frontend_host,
+            self.server.frontend_port,
+            timeout=300,
+        )
+        try:
+            conn.request(self.command, self.path, body=body, headers=upstream_headers)
+            response = conn.getresponse()
+            self.send_response(response.status, response.reason)
+            for key, value in response.getheaders():
+                if key.lower() in HOP_BY_HOP_HEADERS:
+                    continue
+                self.send_header(key, value)
+            self.end_headers()
+
+            if head_only:
+                response.read()
+                return
+
+            while True:
+                chunk = response.read(64 * 1024)
+                if not chunk:
+                    break
+                self.wfile.write(chunk)
+                self.wfile.flush()
+        except BrokenPipeError:
+            pass
+        finally:
+            conn.close()
+
+    def log_message(self, fmt: str, *args) -> None:
+        sys.stderr.write(f"[demo-proxy] {self.address_string()} - {fmt % args}\n")
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Serve the CMAF binary demo page and proxy Dynamo under one browser origin."
+    )
+    parser.add_argument(
+        "--bind",
+        default="127.0.0.1",
+        help="Browser-facing bind address for the demo proxy (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--proxy-port",
+        type=int,
+        default=8080,
+        help="Browser-facing port for the demo proxy (default: 8080)",
+    )
+    parser.add_argument(
+        "--frontend-host",
+        default="127.0.0.1",
+        help="Internal host where the Dynamo frontend listens (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--frontend-port",
+        type=int,
+        default=18001,
+        help="Internal port for the Dynamo frontend subprocess or existing frontend (default: 18001)",
+    )
+    parser.add_argument(
+        "--frontend-timeout-seconds",
+        type=float,
+        default=30.0,
+        help="How long to wait for the frontend to start responding (default: 30)",
+    )
+    parser.add_argument(
+        "--discovery-backend",
+        default=os.environ.get("DYN_DISCOVERY_BACKEND", "file"),
+        help="Discovery backend used when auto-starting the frontend (default: file)",
+    )
+    parser.add_argument(
+        "--request-plane",
+        default=os.environ.get("DYN_REQUEST_PLANE", "tcp"),
+        help="Request plane used when auto-starting the frontend (default: tcp)",
+    )
+    parser.add_argument(
+        "--no-start-frontend",
+        action="store_true",
+        help="Reuse an already-running frontend instead of starting a subprocess",
+    )
+    parser.add_argument(
+        "frontend_args",
+        nargs=argparse.REMAINDER,
+        help="Extra arguments forwarded to `python -m dynamo.frontend` after `--`",
+    )
+    return parser
+
+
+def build_frontend_command(args: argparse.Namespace) -> list[str]:
+    cmd = [
+        sys.executable,
+        "-m",
+        "dynamo.frontend",
+        "--http-port",
+        str(args.frontend_port),
+        "--discovery-backend",
+        args.discovery_backend,
+    ]
+    if args.frontend_args:
+        extras = list(args.frontend_args)
+        if extras and extras[0] == "--":
+            extras = extras[1:]
+        cmd.extend(extras)
+    return cmd
+
+
+def wait_for_frontend(
+    host: str, port: int, timeout_seconds: float, proc: subprocess.Popen[str] | None
+) -> None:
+    deadline = time.time() + timeout_seconds
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        if proc is not None and proc.poll() is not None:
+            raise RuntimeError(f"Frontend exited early with code {proc.returncode}")
+
+        try:
+            conn = http.client.HTTPConnection(host, port, timeout=1)
+            conn.request("GET", "/live")
+            response = conn.getresponse()
+            response.read()
+            conn.close()
+            return
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            time.sleep(0.25)
+    raise RuntimeError(
+        f"Timed out waiting for frontend on http://{host}:{port} ({last_error})"
+    )
+
+
+def terminate_process(proc: subprocess.Popen[str]) -> None:
+    if proc.poll() is not None:
+        return
+    with contextlib.suppress(ProcessLookupError):
+        proc.terminate()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        proc.wait(timeout=5)
+
+
+def main() -> int:
+    args = create_parser().parse_args()
+
+    frontend_proc: subprocess.Popen[str] | None = None
+    if not args.no_start_frontend:
+        frontend_env = os.environ.copy()
+        frontend_env.setdefault("DYN_DISCOVERY_BACKEND", args.discovery_backend)
+        frontend_env.setdefault("DYN_REQUEST_PLANE", args.request_plane)
+        cmd = build_frontend_command(args)
+        print(f"Starting Dynamo frontend: {' '.join(cmd)}")
+        frontend_proc = subprocess.Popen(cmd, cwd=REPO_ROOT, env=frontend_env)
+        wait_for_frontend(
+            args.frontend_host,
+            args.frontend_port,
+            args.frontend_timeout_seconds,
+            frontend_proc,
+        )
+    else:
+        wait_for_frontend(
+            args.frontend_host,
+            args.frontend_port,
+            args.frontend_timeout_seconds,
+            None,
+        )
+
+    server = DemoProxyServer(
+        (args.bind, args.proxy_port),
+        frontend_host=args.frontend_host,
+        frontend_port=args.frontend_port,
+    )
+
+    print()
+    print("CMAF binary demo proxy is ready")
+    print(f"  Browser URL: http://{args.bind}:{args.proxy_port}/")
+    print(f"  Proxied frontend: http://{args.frontend_host}:{args.frontend_port}/")
+    print("  The browser now sees one origin, so no Dynamo CORS change is needed.")
+    print()
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+        if frontend_proc is not None:
+            terminate_process(frontend_proc)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/custom_backend/cmaf_binary_video_streaming/worker.py
+++ b/examples/custom_backend/cmaf_binary_video_streaming/worker.py
@@ -1,0 +1,406 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import logging
+import math
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+import uvloop
+
+from dynamo.common.protocols.video_protocol import (
+    NvCreateVideoRequest,
+    NvVideosResponse,
+    VideoData,
+)
+from dynamo.llm import ModelInput, ModelType, register_llm  # type: ignore[attr-defined]
+from dynamo.runtime import DistributedRuntime, dynamo_endpoint
+from dynamo.runtime.logging import configure_dynamo_logging
+
+logger = logging.getLogger(__name__)
+configure_dynamo_logging(service_name="backend")
+
+CMAF_ANNOTATION = "experimental_binary_cmaf"
+CMAF_METADATA_TAG = "cmaf:metadata"
+CMAF_INIT_TAG = "cmaf:init"
+CMAF_SEGMENT_PREFIX = "cmaf:segment:"
+DEFAULT_NAMESPACE = "dynamo"
+VIDEO_CODEC = "avc1.4d401f"
+AUDIO_CODEC = "mp4a.40.2"
+
+
+@dataclass(frozen=True)
+class CmafSegment:
+    index: int
+    duration_s: float
+    payload: bytes
+
+
+@dataclass(frozen=True)
+class PackagedCmafAsset:
+    init_payload: bytes
+    segments: list[CmafSegment]
+    source_buffer_mime_type: str
+    has_audio: bool
+    target_duration_seconds: int
+
+
+class SyntheticBinaryCmafBackend:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.model_name: str = args.model
+        self.source_mp4 = Path(args.source_mp4).expanduser().resolve()
+        self.segment_seconds: int = args.segment_seconds
+        self.emit_cadence_s = args.emit_cadence_ms / 1000.0
+        self._packaged_asset: PackagedCmafAsset | None = None
+        self._workdir = Path(tempfile.mkdtemp(prefix="dynamo_cmaf_binary_"))
+
+    async def initialize(self) -> None:
+        await asyncio.to_thread(self._package_source)
+
+    def _package_source(self) -> None:
+        if shutil.which("ffmpeg") is None:
+            raise RuntimeError(
+                "ffmpeg is required for the CMAF worker but was not found in PATH"
+            )
+        if shutil.which("ffprobe") is None:
+            raise RuntimeError(
+                "ffprobe is required for the CMAF worker but was not found in PATH"
+            )
+        if not self.source_mp4.exists():
+            raise FileNotFoundError(f"Source MP4 not found: {self.source_mp4}")
+
+        probe = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-print_format",
+                "json",
+                "-show_streams",
+                str(self.source_mp4),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        probe_json = json.loads(probe.stdout or "{}")
+        has_audio = any(
+            stream.get("codec_type") == "audio"
+            for stream in probe_json.get("streams", [])
+        )
+
+        manifest_path = self._workdir / "manifest.m3u8"
+        init_path = self._workdir / "init.mp4"
+        segment_pattern = self._workdir / "segment_%03d.m4s"
+
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-i",
+            str(self.source_mp4),
+            "-map",
+            "0:v:0",
+        ]
+        if has_audio:
+            cmd.extend(["-map", "0:a:0?"])
+
+        gop = max(1, self.segment_seconds * 24)
+        cmd.extend(
+            [
+                "-c:v",
+                "libx264",
+                "-profile:v",
+                "main",
+                "-level:v",
+                "3.1",
+                "-pix_fmt",
+                "yuv420p",
+                "-preset",
+                "veryfast",
+                "-r",
+                "24",
+                "-g",
+                str(gop),
+                "-keyint_min",
+                str(gop),
+                "-sc_threshold",
+                "0",
+                "-force_key_frames",
+                f"expr:gte(t,n_forced*{self.segment_seconds})",
+            ]
+        )
+        if has_audio:
+            cmd.extend(
+                [
+                    "-c:a",
+                    "aac",
+                    "-b:a",
+                    "128k",
+                    "-ar",
+                    "48000",
+                    "-ac",
+                    "2",
+                ]
+            )
+        else:
+            cmd.append("-an")
+
+        cmd.extend(
+            [
+                "-f",
+                "hls",
+                "-hls_time",
+                str(self.segment_seconds),
+                "-hls_playlist_type",
+                "vod",
+                "-hls_flags",
+                "independent_segments",
+                "-hls_segment_type",
+                "fmp4",
+                "-hls_fmp4_init_filename",
+                init_path.name,
+                "-hls_segment_filename",
+                str(segment_pattern),
+                str(manifest_path),
+            ]
+        )
+
+        subprocess.run(cmd, check=True)
+
+        if not init_path.exists():
+            raise RuntimeError(
+                f"ffmpeg did not create expected init segment: {init_path}"
+            )
+
+        segments: list[CmafSegment] = []
+        lines = manifest_path.read_text().splitlines()
+        pending_duration: float | None = None
+        for line in lines:
+            if line.startswith("#EXTINF:"):
+                pending_duration = float(line.split(":", 1)[1].split(",", 1)[0])
+                continue
+            if not line or line.startswith("#"):
+                continue
+            if pending_duration is None:
+                raise RuntimeError(
+                    f"Manifest referenced segment without EXTINF: {line}"
+                )
+            segment_path = self._workdir / line
+            if not segment_path.exists():
+                raise RuntimeError(
+                    f"Manifest referenced missing segment: {segment_path}"
+                )
+            segments.append(
+                CmafSegment(
+                    index=len(segments),
+                    duration_s=pending_duration,
+                    payload=segment_path.read_bytes(),
+                )
+            )
+            pending_duration = None
+
+        if not segments:
+            raise RuntimeError("ffmpeg packaging produced no media segments")
+
+        codecs = [VIDEO_CODEC]
+        if has_audio:
+            codecs.append(AUDIO_CODEC)
+        source_buffer_mime_type = f'video/mp4; codecs="{", ".join(codecs)}"'
+
+        self._packaged_asset = PackagedCmafAsset(
+            init_payload=init_path.read_bytes(),
+            segments=segments,
+            source_buffer_mime_type=source_buffer_mime_type,
+            has_audio=has_audio,
+            target_duration_seconds=max(
+                self.segment_seconds,
+                math.ceil(max(segment.duration_s for segment in segments)),
+            ),
+        )
+        logger.info(
+            "Prepared CMAF asset: source=%s segments=%d has_audio=%s mime=%s",
+            self.source_mp4,
+            len(segments),
+            has_audio,
+            source_buffer_mime_type,
+        )
+
+    def _select_segments(self, requested_seconds: int | None) -> list[CmafSegment]:
+        assert self._packaged_asset is not None
+        if requested_seconds is None or requested_seconds <= 0:
+            return self._packaged_asset.segments
+        segment_count = max(1, math.ceil(requested_seconds / self.segment_seconds))
+        return self._packaged_asset.segments[:segment_count]
+
+    def _metadata_bytes(self, segments: list[CmafSegment]) -> bytes:
+        assert self._packaged_asset is not None
+        payload = {
+            "protocol": "dynamo-video-binary-cmaf-v1",
+            "mime_type": "video/mp4",
+            "source_buffer_mime_type": self._packaged_asset.source_buffer_mime_type,
+            "video_codec": VIDEO_CODEC,
+            "audio_codec": AUDIO_CODEC if self._packaged_asset.has_audio else None,
+            "has_audio": self._packaged_asset.has_audio,
+            "target_duration_seconds": self._packaged_asset.target_duration_seconds,
+            "segment_count": len(segments),
+        }
+        return json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+    @dynamo_endpoint(NvCreateVideoRequest, NvVideosResponse)
+    async def create_video(self, request: NvCreateVideoRequest):
+        if self._packaged_asset is None:
+            raise RuntimeError("CMAF asset was not initialized")
+
+        annotations = (
+            request.nvext.annotations
+            if request.nvext and request.nvext.annotations
+            else []
+        )
+        if CMAF_ANNOTATION not in annotations:
+            raise ValueError(
+                "This synthetic backend only serves requests annotated with experimental_binary_cmaf"
+            )
+
+        video_id = f"video_{uuid.uuid4().hex}"
+        created_ts = int(time.time())
+        segments = self._select_segments(request.seconds)
+        metadata_b64 = base64.b64encode(self._metadata_bytes(segments)).decode("ascii")
+        init_b64 = base64.b64encode(self._packaged_asset.init_payload).decode("ascii")
+
+        logger.info(
+            "[%s] Starting binary CMAF stream for prompt='%s' segment_count=%d",
+            video_id,
+            request.prompt[:60],
+            len(segments),
+        )
+
+        yield NvVideosResponse(
+            id=video_id,
+            model=request.model,
+            created=created_ts,
+            status="in_progress",
+            progress=0,
+            data=[VideoData(url=CMAF_METADATA_TAG, b64_json=metadata_b64)],
+        ).model_dump()
+
+        yield NvVideosResponse(
+            id=video_id,
+            model=request.model,
+            created=created_ts,
+            status="in_progress",
+            progress=1,
+            data=[VideoData(url=CMAF_INIT_TAG, b64_json=init_b64)],
+        ).model_dump()
+
+        for index, segment in enumerate(segments):
+            await asyncio.sleep(self.emit_cadence_s)
+            progress = min(99, int(((index + 1) / max(1, len(segments))) * 100))
+            payload_b64 = base64.b64encode(segment.payload).decode("ascii")
+            yield NvVideosResponse(
+                id=video_id,
+                model=request.model,
+                created=created_ts,
+                status="in_progress",
+                progress=progress,
+                data=[
+                    VideoData(
+                        url=f"{CMAF_SEGMENT_PREFIX}{segment.index}",
+                        b64_json=payload_b64,
+                    )
+                ],
+            ).model_dump()
+
+        logger.info("[%s] Binary CMAF stream completed", video_id)
+
+
+async def _register_model(endpoint, model_name: str) -> None:
+    await register_llm(
+        ModelInput.Text,  # type: ignore[attr-defined]
+        ModelType.Videos,
+        endpoint,
+        model_name,
+        model_name,
+    )
+    logger.info("Registered synthetic binary CMAF model: %s", model_name)
+
+
+def _worker_namespace() -> str:
+    return os.environ.get("DYN_NAMESPACE", DEFAULT_NAMESPACE)
+
+
+async def worker(runtime: DistributedRuntime, args: argparse.Namespace) -> None:
+    namespace = _worker_namespace()
+    component_name = "backend"
+    endpoint_name = "generate"
+    endpoint = runtime.endpoint(f"{namespace}.{component_name}.{endpoint_name}")
+
+    backend = SyntheticBinaryCmafBackend(args)
+    await backend.initialize()
+
+    logger.info("Serving endpoint %s/%s/%s", namespace, component_name, endpoint_name)
+    await asyncio.gather(
+        endpoint.serve_endpoint(backend.create_video),  # type: ignore[arg-type]
+        _register_model(endpoint, backend.model_name),
+    )
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Synthetic Dynamo worker for single-POST binary CMAF video streaming"
+    )
+    parser.add_argument("--source-mp4", required=True, help="Path to a source MP4 file")
+    parser.add_argument(
+        "--segment-seconds",
+        type=int,
+        default=2,
+        help="Target CMAF fragment duration in seconds",
+    )
+    parser.add_argument(
+        "--emit-cadence-ms",
+        type=int,
+        default=750,
+        help="Delay between emitted media fragments in milliseconds",
+    )
+    parser.add_argument(
+        "--model",
+        default="synthetic-binary-cmaf-video-stream",
+        help="Model name to register with the Dynamo frontend",
+    )
+    return parser
+
+
+async def main(args: argparse.Namespace) -> None:
+    loop = asyncio.get_running_loop()
+    discovery_backend = os.environ.get("DYN_DISCOVERY_BACKEND")
+    if not discovery_backend:
+        discovery_backend = (
+            "kubernetes" if os.environ.get("KUBERNETES_SERVICE_HOST") else "file"
+        )
+    request_plane = os.environ.get("DYN_REQUEST_PLANE", "tcp")
+    logger.info("Using discovery backend: %s", discovery_backend)
+    logger.info("Using request plane: %s", request_plane)
+    logger.info("Resolved worker namespace: %s", _worker_namespace())
+    runtime = DistributedRuntime(loop, discovery_backend, request_plane)
+    await worker(runtime, args)
+
+
+if __name__ == "__main__":
+    uvloop.install()
+    parser = create_parser()
+    args = parser.parse_args()
+    asyncio.run(main(args))

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -69,6 +69,16 @@ pub const DYNAMO_REQUEST_ID_HEADER: &str = "x-dynamo-request-id";
 pub const ANNOTATION_REQUEST_ID: &str = "request_id";
 
 const VALIDATION_PREFIX: &str = "Validation: ";
+const VIDEO_STREAM_BINARY_CMAF_PROTOCOL: &str = "dynamo-video-binary-cmaf-v1";
+const VIDEO_STREAM_BINARY_CMAF_ANNOTATION: &str = "experimental_binary_cmaf";
+const VIDEO_STREAM_BINARY_CMAF_METADATA_TAG: &str = "cmaf:metadata";
+const VIDEO_STREAM_BINARY_CMAF_INIT_TAG: &str = "cmaf:init";
+const VIDEO_STREAM_BINARY_CMAF_SEGMENT_PREFIX: &str = "cmaf:segment:";
+const VIDEO_STREAM_BINARY_CMAF_KIND_METADATA: u8 = 0x01;
+const VIDEO_STREAM_BINARY_CMAF_KIND_INIT: u8 = 0x02;
+const VIDEO_STREAM_BINARY_CMAF_KIND_SEGMENT: u8 = 0x03;
+const VIDEO_STREAM_BINARY_CMAF_KIND_ERROR: u8 = 0x04;
+const VIDEO_STREAM_BINARY_CMAF_KIND_DONE: u8 = 0x05;
 
 // Default axum max body limit without configuring is 2MB: https://docs.rs/axum/latest/axum/extract/struct.DefaultBodyLimit.html
 /// Default body limit in bytes (45MB) to support 500k+ token payloads.
@@ -2211,6 +2221,78 @@ pub fn images_router(
     (vec![doc, edits_doc], router)
 }
 
+fn force_streaming_video_response_format(request: &mut NvCreateVideoRequest) {
+    request.response_format = Some("b64_json".to_string());
+}
+
+fn add_video_binary_cmaf_annotation(request: &mut NvCreateVideoRequest) {
+    let nvext = request.nvext.get_or_insert_with(Default::default);
+    let annotations = nvext.annotations.get_or_insert_with(Vec::new);
+    if !annotations
+        .iter()
+        .any(|annotation| annotation == VIDEO_STREAM_BINARY_CMAF_ANNOTATION)
+    {
+        annotations.push(VIDEO_STREAM_BINARY_CMAF_ANNOTATION.to_string());
+    }
+}
+
+fn encode_video_binary_cmaf_frame(kind: u8, payload: &[u8]) -> Bytes {
+    let mut frame = Vec::with_capacity(1 + 4 + payload.len());
+    frame.push(kind);
+    frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    frame.extend_from_slice(payload);
+    Bytes::from(frame)
+}
+
+fn encode_video_binary_cmaf_error_frame(message: impl Into<String>) -> Bytes {
+    let payload = serde_json::json!({ "error": message.into() }).to_string();
+    encode_video_binary_cmaf_frame(VIDEO_STREAM_BINARY_CMAF_KIND_ERROR, payload.as_bytes())
+}
+
+fn encode_video_binary_cmaf_done_frame() -> Bytes {
+    encode_video_binary_cmaf_frame(VIDEO_STREAM_BINARY_CMAF_KIND_DONE, &[])
+}
+
+fn decode_video_binary_cmaf_payloads(
+    response: NvVideosResponse,
+) -> Result<Vec<(u8, Vec<u8>)>, String> {
+    if response.status == "failed" {
+        return Err(response
+            .error
+            .unwrap_or_else(|| "Video backend reported failed status".to_string()));
+    }
+
+    let mut payloads = Vec::with_capacity(response.data.len());
+    for item in response.data {
+        let tag = item
+            .url
+            .ok_or_else(|| "Missing CMAF tag in video response data".to_string())?;
+        let b64 = item
+            .b64_json
+            .ok_or_else(|| format!("Missing b64_json payload for tag `{tag}`"))?;
+        let payload = base64::prelude::BASE64_STANDARD
+            .decode(&b64)
+            .map_err(|e| format!("Failed to decode payload for tag `{tag}`: {e}"))?;
+
+        let kind = match tag.as_str() {
+            VIDEO_STREAM_BINARY_CMAF_METADATA_TAG => VIDEO_STREAM_BINARY_CMAF_KIND_METADATA,
+            VIDEO_STREAM_BINARY_CMAF_INIT_TAG => VIDEO_STREAM_BINARY_CMAF_KIND_INIT,
+            _ if tag.starts_with(VIDEO_STREAM_BINARY_CMAF_SEGMENT_PREFIX) => {
+                VIDEO_STREAM_BINARY_CMAF_KIND_SEGMENT
+            }
+            _ => {
+                return Err(format!(
+                    "Unexpected CMAF payload tag `{tag}`; expected metadata, init, or segment"
+                ));
+            }
+        };
+
+        payloads.push((kind, payload));
+    }
+
+    Ok(payloads)
+}
+
 async fn videos(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
@@ -2432,27 +2514,182 @@ async fn video_stream(
         })
 }
 
+/// [EXPERIMENTAL] Single-POST binary CMAF streaming handler for
+/// `/v1/videos/stream/binary/cmaf`.
+///
+/// The backend yields a sequence of [`NvVideosResponse`] items whose `data[*].url`
+/// fields act as internal tags (`cmaf:metadata`, `cmaf:init`,
+/// `cmaf:segment:{n}`) and whose `data[*].b64_json` fields carry the encoded
+/// payload bytes. This handler decodes those payloads and rewrites them into a
+/// compact framed binary response so the browser can append them directly to a
+/// `MediaSource` buffer over a single HTTP POST response.
+async fn video_stream_binary_cmaf(
+    State(state): State<Arc<service_v2::State>>,
+    headers: HeaderMap,
+    Json(mut request): Json<NvCreateVideoRequest>,
+) -> Result<Response, ErrorResponse> {
+    check_ready(&state)?;
+
+    force_streaming_video_response_format(&mut request);
+    add_video_binary_cmaf_annotation(&mut request);
+
+    let request_id = get_or_create_request_id(&headers);
+    let request = Context::with_id(request, request_id);
+    let model = request.model.clone();
+
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+
+    let engine = state
+        .manager()
+        .get_videos_engine(&model)
+        .map_err(|e| ErrorMessage::from_model_error(&e))?;
+
+    let mut inflight =
+        state
+            .metrics_clone()
+            .create_inflight_guard(&model, Endpoint::Videos, true, request.id());
+
+    let mut response_collector = state.metrics_clone().create_response_collector(&model);
+
+    let stream = engine.generate(request).await.map_err(|e| {
+        if super::metrics::request_was_rejected(e.as_ref()) {
+            state
+                .metrics_clone()
+                .inc_rejection(&model, super::metrics::Endpoint::Videos);
+        }
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to start binary CMAF stream");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
+
+    let ctx = stream.context();
+
+    let (mut connection_handle, mut stream_handle) = create_connection_monitor(
+        ctx.clone(),
+        Some(state.metrics_clone()),
+        CancellationLabels {
+            model: model.clone(),
+            endpoint: Endpoint::Videos.to_string(),
+            request_type: "stream_binary_cmaf".to_string(),
+        },
+    )
+    .await;
+    connection_handle.disarm();
+
+    let mut http_queue_guard = Some(http_queue_guard);
+    let stream = stream.inspect(move |response| {
+        process_response_and_observe_metrics(
+            response,
+            &mut response_collector,
+            &mut http_queue_guard,
+        );
+    });
+
+    stream_handle.arm();
+    let monitored_stream = async_stream::stream! {
+        tokio::pin!(stream);
+        loop {
+            tokio::select! {
+                item = stream.next() => {
+                    match item {
+                        Some(annotated) => {
+                            let ann = match annotated.ok() {
+                                Ok(ann) => ann,
+                                Err(error) => {
+                                    tracing::error!("Binary CMAF stream error: {error}");
+                                    inflight.mark_error(ErrorType::Internal);
+                                    yield Ok::<Bytes, std::convert::Infallible>(
+                                        encode_video_binary_cmaf_error_frame(error),
+                                    );
+                                    stream_handle.disarm();
+                                    break;
+                                }
+                            };
+
+                            let response = match ann.data {
+                                Some(response) => response,
+                                None => continue,
+                            };
+
+                            match decode_video_binary_cmaf_payloads(response) {
+                                Ok(payloads) => {
+                                    for (kind, payload) in payloads {
+                                        yield Ok::<Bytes, std::convert::Infallible>(
+                                            encode_video_binary_cmaf_frame(kind, &payload),
+                                        );
+                                    }
+                                }
+                                Err(error) => {
+                                    tracing::warn!("Binary CMAF payload decode failed: {error}");
+                                    inflight.mark_error(ErrorType::Internal);
+                                    yield Ok::<Bytes, std::convert::Infallible>(
+                                        encode_video_binary_cmaf_error_frame(error),
+                                    );
+                                    stream_handle.disarm();
+                                    break;
+                                }
+                            }
+                        }
+                        None => {
+                            yield Ok::<Bytes, std::convert::Infallible>(
+                                encode_video_binary_cmaf_done_frame(),
+                            );
+                            inflight.mark_ok();
+                            stream_handle.disarm();
+                            break;
+                        }
+                    }
+                }
+                _ = ctx.stopped() => {
+                    tracing::trace!("Context stopped; breaking binary CMAF stream");
+                    inflight.mark_error(ErrorType::Cancelled);
+                    break;
+                }
+            }
+        }
+    };
+
+    axum::http::Response::builder()
+        .status(axum::http::StatusCode::OK)
+        .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
+        .header(
+            "x-dynamo-video-binary-protocol",
+            VIDEO_STREAM_BINARY_CMAF_PROTOCOL,
+        )
+        .body(Body::from_stream(monitored_stream))
+        .map(|r| r.into_response())
+        .map_err(|e| {
+            ErrorMessage::internal_server_error(&format!(
+                "Failed to build binary CMAF response: {e}"
+            ))
+        })
+}
+
 /// Create an Axum [`Router`] for the OpenAI API Videos endpoint
 /// If no path is provided, the default path is `/v1/videos`
 ///
-/// Two routes are registered:
-/// - `POST /v1/videos`        — non-streaming, returns a single JSON response
-/// - `POST /v1/videos/stream` — MJPEG streaming via `multipart/x-mixed-replace`
+/// Three routes are registered:
+/// - `POST /v1/videos`                     — non-streaming, returns a single JSON response
+/// - `POST /v1/videos/stream`              — MJPEG streaming via `multipart/x-mixed-replace`
+/// - `POST /v1/videos/stream/binary/cmaf`  — binary CMAF fragments over one response body
 pub fn videos_router(
     state: Arc<service_v2::State>,
     path: Option<String>,
 ) -> (Vec<RouteDoc>, Router) {
     let path = path.unwrap_or("/v1/videos".to_string());
     let stream_path = format!("{}/stream", path);
+    let binary_cmaf_stream_path = format!("{}/binary/cmaf", stream_path);
     let doc = RouteDoc::new(axum::http::Method::POST, &path);
     let stream_doc = RouteDoc::new(axum::http::Method::POST, &stream_path);
+    let binary_cmaf_stream_doc = RouteDoc::new(axum::http::Method::POST, &binary_cmaf_stream_path);
     let router = Router::new()
         .route(&path, post(videos))
         .route(&stream_path, post(video_stream))
+        .route(&binary_cmaf_stream_path, post(video_stream_binary_cmaf))
         .layer(middleware::from_fn(smart_json_error_middleware))
         .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .with_state(state);
-    (vec![doc, stream_doc], router)
+    (vec![doc, stream_doc, binary_cmaf_stream_doc], router)
 }
 
 async fn audio_speech(
@@ -4227,5 +4464,106 @@ mod tests {
 
         let json = extract_sse_data_json(events[0].as_ref().unwrap());
         assert_eq!(json["reasoning_content"], "让我想想 🤔 分析完成 ✅");
+    }
+
+    #[test]
+    fn test_add_video_binary_cmaf_annotation_sets_request_state() {
+        let mut request = NvCreateVideoRequest {
+            prompt: "test".to_string(),
+            model: "synthetic-binary-cmaf-video-stream".to_string(),
+            input_reference: None,
+            seconds: Some(4),
+            size: Some("832x480".to_string()),
+            user: None,
+            response_format: None,
+            nvext: None,
+        };
+
+        force_streaming_video_response_format(&mut request);
+        add_video_binary_cmaf_annotation(&mut request);
+        add_video_binary_cmaf_annotation(&mut request);
+
+        assert_eq!(request.response_format.as_deref(), Some("b64_json"));
+        let annotations = request
+            .nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.as_ref())
+            .expect("annotations should be present");
+        assert_eq!(
+            annotations,
+            &vec![VIDEO_STREAM_BINARY_CMAF_ANNOTATION.to_string()]
+        );
+    }
+
+    #[test]
+    fn test_decode_video_binary_cmaf_payloads_decodes_kinded_frames() {
+        let metadata_payload =
+            br#"{"source_buffer_mime_type":"video/mp4; codecs=\"avc1.4d401f\""}"#;
+        let init_payload = b"init";
+        let segment_payload = b"segment";
+        let response = NvVideosResponse {
+            id: "video_123".to_string(),
+            object: "video".to_string(),
+            model: "synthetic-binary-cmaf-video-stream".to_string(),
+            status: "completed".to_string(),
+            progress: 100,
+            created: 1_777_000_000,
+            data: vec![
+                crate::protocols::openai::videos::VideoData {
+                    url: Some(VIDEO_STREAM_BINARY_CMAF_METADATA_TAG.to_string()),
+                    b64_json: Some(base64::prelude::BASE64_STANDARD.encode(metadata_payload)),
+                },
+                crate::protocols::openai::videos::VideoData {
+                    url: Some(VIDEO_STREAM_BINARY_CMAF_INIT_TAG.to_string()),
+                    b64_json: Some(base64::prelude::BASE64_STANDARD.encode(init_payload)),
+                },
+                crate::protocols::openai::videos::VideoData {
+                    url: Some(format!("{VIDEO_STREAM_BINARY_CMAF_SEGMENT_PREFIX}0")),
+                    b64_json: Some(base64::prelude::BASE64_STANDARD.encode(segment_payload)),
+                },
+            ],
+            error: None,
+            inference_time_s: None,
+        };
+
+        let payloads = decode_video_binary_cmaf_payloads(response).expect("payloads should parse");
+        assert_eq!(payloads.len(), 3);
+        assert_eq!(payloads[0].0, VIDEO_STREAM_BINARY_CMAF_KIND_METADATA);
+        assert_eq!(payloads[0].1, metadata_payload);
+        assert_eq!(payloads[1].0, VIDEO_STREAM_BINARY_CMAF_KIND_INIT);
+        assert_eq!(payloads[1].1, init_payload);
+        assert_eq!(payloads[2].0, VIDEO_STREAM_BINARY_CMAF_KIND_SEGMENT);
+        assert_eq!(payloads[2].1, segment_payload);
+    }
+
+    #[test]
+    fn test_decode_video_binary_cmaf_payloads_rejects_unexpected_tags() {
+        let response = NvVideosResponse {
+            id: "video_123".to_string(),
+            object: "video".to_string(),
+            model: "synthetic-binary-cmaf-video-stream".to_string(),
+            status: "completed".to_string(),
+            progress: 100,
+            created: 1_777_000_000,
+            data: vec![crate::protocols::openai::videos::VideoData {
+                url: Some("not-cmaf".to_string()),
+                b64_json: Some(base64::prelude::BASE64_STANDARD.encode(b"payload")),
+            }],
+            error: None,
+            inference_time_s: None,
+        };
+
+        let error =
+            decode_video_binary_cmaf_payloads(response).expect_err("tag should be rejected");
+        assert!(error.contains("Unexpected CMAF payload tag"));
+    }
+
+    #[test]
+    fn test_encode_video_binary_cmaf_frame_layout() {
+        let payload = b"abc";
+        let frame = encode_video_binary_cmaf_frame(VIDEO_STREAM_BINARY_CMAF_KIND_SEGMENT, payload);
+        assert_eq!(frame[0], VIDEO_STREAM_BINARY_CMAF_KIND_SEGMENT);
+        assert_eq!(&frame[1..5], &(payload.len() as u32).to_be_bytes());
+        assert_eq!(&frame[5..], payload);
     }
 }


### PR DESCRIPTION
# Minimal CMAF Binary Streaming POC

## Summary

This PR adds a minimal Proof of Concept for continuous video playback over a
single Dynamo `POST` response.

The goal is to evaluate whether we can get a significantly better browser UX
than the existing clip-by-clip `video_streaming` example without pulling in the
larger architectural changes required by HLS.

The core idea is:

- keep Dynamo in its natural push-streaming shape
- keep the request as one `POST`
- package media as CMAF-style fragmented MP4 (`init.mp4` + `.m4s`)
- stream those fragments over a compact binary response body
- append them in the browser with `MediaSource`

This branch is intentionally scoped to the smallest Dynamo delta that supports
that experiment.

## Why

We currently have two extremes in #8606:

- `video_streaming`: small Dynamo delta, but poor playback UX because it streams
  standalone MP4 clips rather than one continuous timeline
- `hls_video_streaming`: much better browser UX and protocol interoperability,
  but it requires new pull-based routes, playlist/segment handling, and more
  frontend/backend coordination

This PR explores the middle ground:

- continuous playback
- audio support
- one streaming HTTP response
- no HLS playlist polling
- no per-segment `GET`s
- no worker-affinity pull routing

https://github.com/user-attachments/assets/0cbe7d79-5bd7-4db4-9dcb-17a037c89295


## What Changed

### 1. New experimental frontend route

Added:

- `POST /v1/videos/stream/binary/cmaf`

Implementation lives in:

- `lib/llm/src/http/service/openai.rs`

The route:

- forces `response_format = "b64_json"`
- adds the annotation `experimental_binary_cmaf`
- calls the existing videos engine path
- interprets worker payloads tagged as:
  - `cmaf:metadata`
  - `cmaf:init`
  - `cmaf:segment:<n>`
- rewrites them into a framed binary stream:
  - `0x01` metadata JSON
  - `0x02` init fragment
  - `0x03` media fragment
  - `0x04` error JSON
  - `0x05` done

This keeps the shared Rust/OpenAI protocol surface unchanged. The worker still
speaks the existing `NvVideosResponse` shape; the translation into a more
efficient browser-facing binary stream happens only at the HTTP edge.

### 2. Standalone synthetic worker

Added:

- `examples/custom_backend/cmaf_binary_video_streaming/worker.py`

The worker:

- is fully isolated from TRT-LLM and SGLang
- packages a prerecorded source MP4 into real CMAF fragments using `ffmpeg`
- registers as a `Videos` model
- emits:
  - metadata
  - init fragment
  - media fragments
- uses the existing video protocol fields:
  - `url` as an internal payload tag
  - `b64_json` for the actual bytes

The worker defaults to:

- `file` discovery locally
- `kubernetes` discovery in-cluster

That mirrors the existing video example behavior and avoids frontend/worker
discovery mismatches during local testing.

### 3. Browser reference client

Added:

- `examples/custom_backend/cmaf_binary_video_streaming/client.html`

The client:

- issues one `POST` to `/v1/videos/stream/binary/cmaf`
- reads the streaming response body with `ReadableStream`
- parses the custom binary frame format
- creates a `MediaSource` / `SourceBuffer`
- appends `init.mp4` and `.m4s` payloads into a continuous playback timeline

It also supports requesting a specific duration, or leaving the field blank to
stream the full source asset.

### 4. Same-origin demo launcher

Added:

- `examples/custom_backend/cmaf_binary_video_streaming/run_demo.py`

This helper exists so the example can be exercised in a browser without adding
CORS to Dynamo on this branch.

It:

- starts a Dynamo frontend on an internal port
- serves `client.html` on a public port
- reverse-proxies `/v1/*` to the internal frontend

From the browser’s perspective, the page and the API now share one origin.

### 5. Example documentation

Added:

- `examples/custom_backend/cmaf_binary_video_streaming/README.md`

It documents:

- what CMAF means in this POC
- how to run the worker
- how the binary framing works
- how to use the same-origin demo helper
- the tradeoffs of this approach compared with the other video streaming POCs

## What This PR Intentionally Does Not Do

To keep the Dynamo delta minimal, this PR does **not** add:

- HLS routes
- playlist generation
- per-segment `GET` APIs
- worker-affinity pull routing
- frontend session storage
- shared storage / CDN simulation
- new shared Rust protocol structs
- broad videos-router CORS

This is a push-streaming experiment, not a general-purpose browser media serving
stack.

## Tradeoffs

### Benefits

- Continuous playback over one request
- Audio works naturally as part of fragmented MP4
- Smaller Dynamo delta than HLS
- Better browser UX than standalone MP4 chunks
- Reuses existing video request/response contracts on the worker side

### Costs

- The browser protocol is custom rather than standardized like HLS
- The client must understand the binary frame format
- Browser testing still needs same-origin serving or a proxy if CORS is not
  enabled
- This is still a synthetic worker using prerecorded media, not a live model

## Why This Is Useful

This PR helps answer an important architectural question:

If we want continuous browser playback and binary media delivery, do we need to
pay the full complexity cost of HLS, or can we get most of the UX benefit while
staying inside Dynamo’s natural single-request push-streaming model?

This branch gives us a clean measurement point for that question because it
keeps the Dynamo changes intentionally narrow.

## Testing

Executed:

- `cargo test -p dynamo-llm binary_cmaf -- --nocapture`
- `python3 -m py_compile examples/custom_backend/cmaf_binary_video_streaming/worker.py`
- `python3 -m py_compile examples/custom_backend/cmaf_binary_video_streaming/run_demo.py`

Manual validation:

- browser playback via the same-origin `run_demo.py` helper
- worker registration through the frontend
- continuous CMAF playback from a prerecorded MP4 source

## Recommendation

This POC looks like the best Dynamo-native middle ground so far:

- better UX than the original clip-based video streaming path
- far smaller frontend and backend changes than HLS
- no need to remodel Dynamo around pull-based media fetches

If we want a standards-based browser delivery protocol, HLS is still the right
benchmark. But if the goal is to preserve Dynamo’s push-streaming architecture
while improving browser playback quality, single-POST binary CMAF is a very
promising direction.
