### PR TITLE
fix(profiler): enforce totalGpus budget as hard cap in rapid mode DGD generation

### DIFF
--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -25,6 +25,7 @@ from aiconfigurator.generator.module_bridge import task_config_to_generator_conf
 from aiconfigurator.generator.naive import build_naive_generator_params
 from aiconfigurator.sdk.task import TaskConfig, TaskRunner
 
+from dynamo.profiler.utils.config import clamp_total_gpus_to_budget
 from dynamo.profiler.utils.dgdr_v1beta1_types import DynamoGraphDeploymentRequestSpec
 from dynamo.profiler.utils.profile_common import (
     derive_backend_image,
@@ -76,8 +77,22 @@ def _generate_dgd_from_pick(
         return None
 
     original_total_gpus = tc.total_gpus
-    if "total_gpus_needed" in row.index and row["total_gpus_needed"] > 0:
-        tc.total_gpus = int(row["total_gpus_needed"])
+    if "total_gpus_needed" in row.index:
+        clamped_total_gpus, was_clamped = clamp_total_gpus_to_budget(
+            row["total_gpus_needed"],
+            original_total_gpus,
+        )
+        # Enforce DGDR hardware budget as a hard cap in rapid mode.
+        # Some AIC pickers expose total_gpus_needed as a ranking signal rather
+        # than a strict feasibility constraint.
+        if was_clamped:
+            logger.warning(
+                "Picked config requests %d GPUs but DGDR budget is %d; "
+                "clamping generated deployment to budget.",
+                int(row["total_gpus_needed"]),
+                original_total_gpus,
+            )
+        tc.total_gpus = clamped_total_gpus
 
     k8s_overrides = _build_k8s_overrides(dgdr, tc.backend_name)
     cfg = task_config_to_generator_config(

--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -77,30 +77,32 @@ def _generate_dgd_from_pick(
         return None
 
     original_total_gpus = tc.total_gpus
-    if "total_gpus_needed" in row.index:
-        clamped_total_gpus, was_clamped = clamp_total_gpus_to_budget(
-            row["total_gpus_needed"],
-            original_total_gpus,
-        )
-        # Enforce DGDR hardware budget as a hard cap in rapid mode.
-        # Some AIC pickers expose total_gpus_needed as a ranking signal rather
-        # than a strict feasibility constraint.
-        if was_clamped:
-            logger.warning(
-                "Picked config requests %d GPUs but DGDR budget is %d; "
-                "clamping generated deployment to budget.",
-                int(row["total_gpus_needed"]),
+    try:
+        if "total_gpus_needed" in row.index:
+            clamped_total_gpus, was_clamped = clamp_total_gpus_to_budget(
+                row["total_gpus_needed"],
                 original_total_gpus,
             )
-        tc.total_gpus = clamped_total_gpus
+            # Enforce DGDR hardware budget as a hard cap in rapid mode.
+            # Some AIC pickers expose total_gpus_needed as a ranking signal rather
+            # than a strict feasibility constraint.
+            if was_clamped:
+                logger.warning(
+                    "Picked config requests %d GPUs but DGDR budget is %d; "
+                    "clamping generated deployment to budget.",
+                    int(row["total_gpus_needed"]),
+                    original_total_gpus,
+                )
+            tc.total_gpus = clamped_total_gpus
 
-    k8s_overrides = _build_k8s_overrides(dgdr, tc.backend_name)
-    cfg = task_config_to_generator_config(
-        task_config=tc,
-        result_df=row,
-        generator_overrides={"K8sConfig": k8s_overrides} if k8s_overrides else None,
-    )
-    tc.total_gpus = original_total_gpus
+        k8s_overrides = _build_k8s_overrides(dgdr, tc.backend_name)
+        cfg = task_config_to_generator_config(
+            task_config=tc,
+            result_df=row,
+            generator_overrides={"K8sConfig": k8s_overrides} if k8s_overrides else None,
+        )
+    finally:
+        tc.total_gpus = original_total_gpus
 
     artifacts = generate_backend_artifacts(
         params=cfg,

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -40,7 +40,7 @@ def dgdr_name_env(monkeypatch):
 
 
 def test_build_dgd_config_shapes_multinode_worker_resources() -> None:
-    """build_dgd_config applies per-node GPU shaping when topology is provided."""
+    """DP-only workers keep per-node GPU shaping without multinode inflation."""
     modifier = CONFIG_MODIFIERS["sglang"]
     dgd_config = modifier.build_dgd_config(
         mode="disagg",
@@ -61,7 +61,57 @@ def test_build_dgd_config_shapes_multinode_worker_resources() -> None:
         if service.get("subComponentType") == "decode"
     )
     assert decode_service["resources"]["limits"]["gpu"] == "8"
+    assert decode_service.get("multinode") is None
+
+
+def test_build_dgd_config_multinode_when_tp_exceeds_node() -> None:
+    """Single instances that exceed node capacity still get multinode config."""
+    modifier = CONFIG_MODIFIERS["sglang"]
+    dgd_config = modifier.build_dgd_config(
+        mode="disagg",
+        model_name="meta-llama/Llama-3-70B",
+        image="nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.0",
+        prefill_cli_args=["--max-running-requests", "1"],
+        prefill_replicas=1,
+        prefill_gpus=1,
+        decode_cli_args=["--tp", "16"],
+        decode_replicas=1,
+        decode_gpus=16,
+        num_gpus_per_node=8,
+    )
+
+    decode_service = next(
+        service
+        for service in dgd_config["spec"]["services"].values()
+        if service.get("subComponentType") == "decode"
+    )
+    assert decode_service["resources"]["limits"]["gpu"] == "8"
     assert decode_service["multinode"] == {"nodeCount": 2}
+
+
+def test_build_dgd_config_multinode_parses_shell_joined_parallelism_args() -> None:
+    """Multinode detection should handle shell-joined CLI args from templates."""
+    modifier = CONFIG_MODIFIERS["sglang"]
+    dgd_config = modifier.build_dgd_config(
+        mode="disagg",
+        model_name="meta-llama/Llama-3-70B",
+        image="nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.0",
+        prefill_cli_args=["--max-running-requests", "1"],
+        prefill_replicas=1,
+        prefill_gpus=1,
+        decode_cli_args=["--tp 16", "--pp 2"],
+        decode_replicas=1,
+        decode_gpus=32,
+        num_gpus_per_node=8,
+    )
+
+    decode_service = next(
+        service
+        for service in dgd_config["spec"]["services"].values()
+        if service.get("subComponentType") == "decode"
+    )
+    assert decode_service["resources"]["limits"]["gpu"] == "8"
+    assert decode_service["multinode"] == {"nodeCount": 4}
 
 
 def test_apply_dgd_overrides_strips_envelope() -> None:

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -9,21 +9,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-try:
-    from dynamo.profiler.utils.config_modifiers import CONFIG_MODIFIERS
-except ImportError:
-    pytest.skip("dynamo.llm bindings not available", allow_module_level=True)
-from dynamo.profiler.utils.config_modifiers.parallelization_mapping import (
-    PickedParallelConfig,
-)
-from dynamo.profiler.utils.config_modifiers.protocol import apply_dgd_overrides
-from dynamo.profiler.utils.defaults import SearchStrategy
-from dynamo.profiler.utils.dgdr_v1beta1_types import (
-    DynamoGraphDeploymentRequestSpec,
-    OverridesSpec,
-)
-from dynamo.profiler.utils.profile_common import ProfilerOperationalConfig
-
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.gpu_0,
@@ -31,6 +16,21 @@ pytestmark = [
     pytest.mark.planner,
     pytest.mark.parallel,
 ]
+
+try:
+    from dynamo.profiler.utils.config_modifiers import CONFIG_MODIFIERS
+    from dynamo.profiler.utils.config_modifiers.parallelization_mapping import (
+        PickedParallelConfig,
+    )
+    from dynamo.profiler.utils.config_modifiers.protocol import apply_dgd_overrides
+    from dynamo.profiler.utils.defaults import SearchStrategy
+    from dynamo.profiler.utils.dgdr_v1beta1_types import (
+        DynamoGraphDeploymentRequestSpec,
+        OverridesSpec,
+    )
+    from dynamo.profiler.utils.profile_common import ProfilerOperationalConfig
+except ImportError:
+    pytest.skip("dynamo.llm bindings not available", allow_module_level=True)
 
 
 @pytest.fixture(autouse=True)

--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -261,7 +261,9 @@ def _get_per_instance_gpus(worker_service: Service) -> int | None:
     if not args:
         return None
 
-    def _match_flag(arg: str, next_arg: str | None, names: tuple[str, ...]) -> str | None:
+    def _match_flag(
+        arg: str, next_arg: str | None, names: tuple[str, ...]
+    ) -> str | None:
         """Return the value for `arg` if it matches any of `names` in either
         `--name value` or `--name=value` form, else None."""
         for name in names:

--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -218,11 +218,99 @@ def parse_override_engine_args(args: list[str]) -> tuple[dict, list[str]]:
     return override_dict, args
 
 
+def get_requested_total_gpus(total_gpus_needed: Any) -> int | None:
+    """Normalize a picked total GPU request from AIC output."""
+    if total_gpus_needed is None:
+        return None
+    try:
+        requested_total_gpus = int(total_gpus_needed)
+    except (TypeError, ValueError):
+        return None
+    return requested_total_gpus if requested_total_gpus > 0 else None
+
+
+def clamp_total_gpus_to_budget(
+    requested_total_gpus: Any,
+    total_gpu_budget: int,
+) -> tuple[int, bool]:
+    """Clamp a requested total GPU count to the deployment budget."""
+    normalized_request = get_requested_total_gpus(requested_total_gpus)
+    if normalized_request is None:
+        return total_gpu_budget, False
+    return (
+        min(normalized_request, total_gpu_budget),
+        normalized_request > total_gpu_budget,
+    )
+
+
+def _get_per_instance_gpus(worker_service: Service) -> int | None:
+    """Derive per-instance GPU count from worker CLI args (TP x PP).
+
+    Data-parallel workers are independent replicas, so multinode placement
+    must be based on the GPUs required by a single instance rather than the
+    total GPUs consumed across all replicas.
+    """
+    args: list[str] | None = None
+    if (
+        worker_service.extraPodSpec
+        and worker_service.extraPodSpec.mainContainer
+        and worker_service.extraPodSpec.mainContainer.args
+    ):
+        args = break_arguments(worker_service.extraPodSpec.mainContainer.args)
+
+    if not args:
+        return None
+
+    tp = 1
+    pp = 1
+    saw_parallelism_flag = False
+    for index, arg in enumerate(args):
+        if arg in ("--tensor-parallel-size", "--tp") and index + 1 < len(args):
+            try:
+                tp = int(args[index + 1])
+                saw_parallelism_flag = True
+            except ValueError:
+                pass
+        elif arg.startswith("--tensor-parallel-size=") or arg.startswith("--tp="):
+            try:
+                tp = int(arg.split("=", 1)[1])
+                saw_parallelism_flag = True
+            except ValueError:
+                pass
+        elif arg in ("--pipeline-parallel-size", "--pp") and index + 1 < len(args):
+            try:
+                pp = int(args[index + 1])
+                saw_parallelism_flag = True
+            except ValueError:
+                pass
+        elif arg.startswith("--pipeline-parallel-size=") or arg.startswith("--pp="):
+            try:
+                pp = int(arg.split("=", 1)[1])
+                saw_parallelism_flag = True
+            except ValueError:
+                pass
+        elif arg in (
+            "--data-parallel-size",
+            "--data-parallel-size-local",
+            "--dp",
+        ) and index + 1 < len(args):
+            saw_parallelism_flag = True
+        elif arg.startswith("--data-parallel-size=") or arg.startswith("--dp="):
+            saw_parallelism_flag = True
+
+    if not saw_parallelism_flag:
+        return None
+
+    return tp * pp
+
+
 def set_multinode_config(
     worker_service: Service, gpu_count: int, num_gpus_per_node: int
 ) -> None:
-    """Helper function to set multinode configuration based on GPU count and GPUs per node."""
-    if gpu_count <= num_gpus_per_node:
+    """Set multinode configuration based on per-instance GPU placement needs."""
+    effective_gpu_count = _get_per_instance_gpus(worker_service) or gpu_count
+
+    if effective_gpu_count <= num_gpus_per_node:
         # Single node: remove multinode configuration if present
         if (
             hasattr(worker_service, "multinode")
@@ -230,8 +318,8 @@ def set_multinode_config(
         ):
             worker_service.multinode = None
     else:
-        # Multi-node: set nodeCount = math.ceil(gpu_count / num_gpus_per_node)
-        node_count = math.ceil(gpu_count / num_gpus_per_node)
+        # Multi-node: set nodeCount = math.ceil(per-instance GPUs / GPUs per node)
+        node_count = math.ceil(effective_gpu_count / num_gpus_per_node)
         if not hasattr(worker_service, "multinode") or worker_service.multinode is None:
             # Create multinode configuration if it doesn't exist
             worker_service.multinode = MultinodeConfig(nodeCount=node_count)

--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -261,45 +261,45 @@ def _get_per_instance_gpus(worker_service: Service) -> int | None:
     if not args:
         return None
 
+    def _match_flag(arg: str, next_arg: str | None, names: tuple[str, ...]) -> str | None:
+        """Return the value for `arg` if it matches any of `names` in either
+        `--name value` or `--name=value` form, else None."""
+        for name in names:
+            if arg == name:
+                return next_arg
+            if arg.startswith(name + "="):
+                return arg.split("=", 1)[1]
+        return None
+
+    TP_FLAGS = ("--tensor-parallel-size", "--tp")
+    PP_FLAGS = ("--pipeline-parallel-size", "--pp")
+    DP_FLAGS = ("--data-parallel-size", "--data-parallel-size-local", "--dp")
+
     tp = 1
     pp = 1
     saw_parallelism_flag = False
     for index, arg in enumerate(args):
-        if arg in ("--tensor-parallel-size", "--tp") and index + 1 < len(args):
+        next_arg = args[index + 1] if index + 1 < len(args) else None
+
+        tp_value = _match_flag(arg, next_arg, TP_FLAGS)
+        if tp_value is not None:
             try:
-                tp = int(args[index + 1])
+                tp = int(tp_value)
                 saw_parallelism_flag = True
             except ValueError:
                 pass
-        elif arg.startswith("--tensor-parallel-size=") or arg.startswith("--tp="):
+            continue
+
+        pp_value = _match_flag(arg, next_arg, PP_FLAGS)
+        if pp_value is not None:
             try:
-                tp = int(arg.split("=", 1)[1])
+                pp = int(pp_value)
                 saw_parallelism_flag = True
             except ValueError:
                 pass
-        elif arg in ("--pipeline-parallel-size", "--pp") and index + 1 < len(args):
-            try:
-                pp = int(args[index + 1])
-                saw_parallelism_flag = True
-            except ValueError:
-                pass
-        elif arg.startswith("--pipeline-parallel-size=") or arg.startswith("--pp="):
-            try:
-                pp = int(arg.split("=", 1)[1])
-                saw_parallelism_flag = True
-            except ValueError:
-                pass
-        elif arg in (
-            "--data-parallel-size",
-            "--data-parallel-size-local",
-            "--dp",
-        ) and index + 1 < len(args):
-            saw_parallelism_flag = True
-        elif (
-            arg.startswith("--data-parallel-size=")
-            or arg.startswith("--data-parallel-size-local=")
-            or arg.startswith("--dp=")
-        ):
+            continue
+
+        if _match_flag(arg, next_arg, DP_FLAGS) is not None:
             saw_parallelism_flag = True
 
     if not saw_parallelism_flag:

--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -295,7 +295,11 @@ def _get_per_instance_gpus(worker_service: Service) -> int | None:
             "--dp",
         ) and index + 1 < len(args):
             saw_parallelism_flag = True
-        elif arg.startswith("--data-parallel-size=") or arg.startswith("--dp="):
+        elif (
+            arg.startswith("--data-parallel-size=")
+            or arg.startswith("--data-parallel-size-local=")
+            or arg.startswith("--dp=")
+        ):
             saw_parallelism_flag = True
 
     if not saw_parallelism_flag:

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -592,10 +592,11 @@ class BaseConfigModifier:
     ) -> None:
         """Apply CLI args, replicas, and GPU resources to a single worker service."""
         service.replicas = replicas
-        setup_worker_service_resources(service, gpus, num_gpus_per_node)
-
         if service.extraPodSpec and service.extraPodSpec.mainContainer:
             service.extraPodSpec.mainContainer.args = sanitize_cli_args(list(cli_args))
+
+        # Apply resources after args so multinode sizing can inspect final TP/PP flags.
+        setup_worker_service_resources(service, gpus, num_gpus_per_node)
 
     @classmethod
     def _apply_disagg_workers(


### PR DESCRIPTION
## Problem

Rapid mode ignored the `totalGpus` budget from the DGDR spec when generating DGDs. In `_generate_dgd_from_pick`, the AIC row's `total_gpus_needed` unconditionally overwrote `TaskConfig.total_gpus`, which `task_config_to_generator_config` then used to scale replica counts. On a 32-GPU cluster, this produced a DGD requesting 50 GPUs, leaving 3/12 pods permanently Pending and deadlocking the planner.

Closes #8583. Related to #8479 (which fixed the same bug in thorough mode).

## Root Cause

```python
# Before — no cap on what AIC can request
if "total_gpus_needed" in row.index and row["total_gpus_needed"] > 0:
    tc.total_gpus = int(row["total_gpus_needed"])  # could be 50 on a 32-GPU cluster
```

`pick_default` uses `total_gpus_needed` as an efficiency ranking signal, not a feasibility constraint, so it can return values exceeding the available hardware.

## Fix

Clamp the override to never exceed the original DGDR budget:

```python
tc.total_gpus = min(requested_total_gpus, original_total_gpus)
```

A warning is logged when clamping occurs so operators can see it in profiler job logs.

## Testing

**Unit tests added** (`test_helpers_rapid.py` — `TestGenerateDgdFromPick`):
- `test_clamps_total_gpus_needed_to_budget`: Patches `task_config_to_generator_config` and verifies that when AIC returns `total_gpus_needed=50` with a 32-GPU budget, the generator receives `32`, and `TaskConfig.total_gpus` is restored to `32` after generation.
- `test_uses_smaller_total_gpus_needed_when_within_budget`: Verifies that when AIC returns `total_gpus_needed=20` within a 32-GPU budget, the smaller value `20` passes through unchanged.

All pre-existing tests in `test_helpers_rapid.py` are unaffected.

## Notes

The secondary planner deadlock (waiting for full deployment readiness before making scaling decisions) is a separate resilience issue and is not addressed here.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GPU demand requests are now automatically clamped to respect budget limits
  * Warnings issued when GPU requests exceed available budget

* **Tests**
  * Added tests verifying GPU budget enforcement and clamping behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->