### PR TITLE
fix(sglang): disable piecewise CUDA graph in launch scripts (cherry-pick #8609)

### DIFF
--- a/examples/backends/sglang/launch/agg.sh
+++ b/examples/backends/sglang/launch/agg.sh
@@ -85,6 +85,7 @@ python3 -m "$WORKER_MODULE" \
   --trust-remote-code \
   --skip-tokenizer-init \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   $GPU_MEM_ARGS \
   "${TRACE_ARGS[@]}" \
   "${EXTRA_ARGS[@]}" &

--- a/examples/backends/sglang/launch/agg_router.sh
+++ b/examples/backends/sglang/launch/agg_router.sh
@@ -86,6 +86,7 @@ python3 -m dynamo.sglang \
   --trust-remote-code \
   "${KV_EVENTS_ARGS_1[@]}" \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   $GPU_MEM_ARGS \
   "${TRACE_ARGS[@]}" &
 
@@ -98,6 +99,7 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang \
   --trust-remote-code \
   "${KV_EVENTS_ARGS_2[@]}" \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   $GPU_MEM_ARGS \
   "${TRACE_ARGS[@]}" &
 

--- a/examples/backends/sglang/launch/disagg.sh
+++ b/examples/backends/sglang/launch/disagg.sh
@@ -81,6 +81,7 @@ python3 -m dynamo.sglang \
   --port 40000 \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   $GPU_MEM_ARGS \
   "${TRACE_ARGS[@]}" &
 
@@ -97,6 +98,7 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang \
   --host 0.0.0.0 \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   $GPU_MEM_ARGS \
   "${TRACE_ARGS[@]}" &
 

--- a/examples/backends/sglang/launch/disagg_router.sh
+++ b/examples/backends/sglang/launch/disagg_router.sh
@@ -76,6 +76,7 @@ python3 -m dynamo.sglang \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}' \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   "${TRACE_ARGS[@]}" &
 
 # run prefill worker
@@ -91,6 +92,7 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5558"}' \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   "${TRACE_ARGS[@]}" &
 
 # run decode worker
@@ -106,6 +108,7 @@ CUDA_VISIBLE_DEVICES=3 python3 -m dynamo.sglang \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5560"}' \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   "${TRACE_ARGS[@]}" &
 
 # run decode worker
@@ -121,6 +124,7 @@ CUDA_VISIBLE_DEVICES=2 python3 -m dynamo.sglang \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5559"}' \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
+  --disable-piecewise-cuda-graph \
   "${TRACE_ARGS[@]}" &
 
 # Wait for any worker to exit (keeps script running)


### PR DESCRIPTION
## Summary
- Cherry-picks f208208b2a616c5cb95f2c9d8eef786ee41cf081 (#8609) from `main` onto `release/1.1.0`.
- Disables piecewise CUDA graph in the SGLang launch scripts (`agg.sh`, `agg_router.sh`, `disagg.sh`, `disagg_router.sh`).

## Test plan
- [ ] CI green on release/1.1.0
- [ ] Smoke run of `examples/backends/sglang/launch/agg.sh` on release/1.1.0
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
