### PR TITLE
feat(snapshot): make multi-container checkpoint/restore an annotation contract

### DIFF
--- a/deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml
+++ b/deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml
@@ -44,7 +44,7 @@ spec:
             persistentVolumeClaim:
               claimName: hf-cache-pvc
         containers:
-          - name: worker
+          - name: main
             image: registry.example.com/dynamo/vllm-placeholder:1.0.0
             command:
               - python3

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -257,6 +257,41 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Equal(t, []string{"run"}, podSpec.Containers[1].Args)
 	})
 
+	t.Run("failover targets shape every engine container", func(t *testing.T) {
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "engine-0", Image: "main:latest", Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}},
+				{Name: "engine-1", Image: "main:latest", Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}},
+				{Name: "sidecar", Image: "sidecar:latest", Command: []string{"sidecar"}, Args: []string{"run"}},
+			},
+		}
+		info := &CheckpointInfo{
+			Enabled:                 true,
+			Ready:                   true,
+			Hash:                    testHash,
+			RestoreTargetContainers: []string{"engine-0", "engine-1"},
+		}
+		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
+
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info))
+		for _, name := range []string{"engine-0", "engine-1"} {
+			c := findContainer(podSpec, name)
+			require.NotNil(t, c, "container %q not found", name)
+			assert.Equal(t, []string{"sleep", "infinity"}, c.Command, "engine %s command", name)
+			assert.Nil(t, c.Args, "engine %s args", name)
+			gotSubPath := ""
+			for _, m := range c.VolumeMounts {
+				if m.Name == snapshotprotocol.SnapshotControlVolumeName {
+					gotSubPath = m.SubPath
+				}
+			}
+			assert.Equal(t, name, gotSubPath, "engine %s control-volume subPath", name)
+		}
+		sidecar := findContainer(podSpec, "sidecar")
+		require.NotNil(t, sidecar)
+		assert.Equal(t, []string{"sidecar"}, sidecar.Command, "sidecar must not be rewritten")
+	})
+
 	t.Run("ready gms checkpoint injects restore sidecars and loader mount", func(t *testing.T) {
 		podSpec := testPodSpec()
 		podSpec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu"}}
@@ -264,10 +299,23 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
 
 		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info))
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info))
 		gmsServer := findContainer(podSpec, gms.ServerContainerName)
 		require.NotNil(t, gmsServer)
 		loader := findContainer(podSpec, GMSLoaderContainer)
 		require.NotNil(t, loader)
+		serverCount := 0
+		loaderCount := 0
+		for _, container := range podSpec.InitContainers {
+			switch container.Name {
+			case gms.ServerContainerName:
+				serverCount++
+			case GMSLoaderContainer:
+				loaderCount++
+			}
+		}
+		assert.Equal(t, 1, serverCount)
+		assert.Equal(t, 1, loaderCount)
 
 		// Restore: server and loader are init sidecars (restartPolicy=Always)
 		assert.NotNil(t, gmsServer.RestartPolicy, "restore gms-server should have RestartPolicy")
@@ -301,7 +349,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 			errMsg  string
 		}{
 			{"hash empty and identity nil", testPodSpec(), &CheckpointInfo{Enabled: true, Ready: true}, fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "identity is nil"},
-			{"no containers", &corev1.PodSpec{}, testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "no container named"},
+			{"no containers", &corev1.PodSpec{}, testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "do not all exist in pod spec"},
 			{"snapshot daemonset missing", testPodSpec(), testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).Build(), "no snapshot-agent daemonset found"},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
@@ -472,6 +520,37 @@ func TestResolveCheckpointForService(t *testing.T) {
 		_, err := ResolveCheckpointForService(ctx, c, testNamespace, &nvidiacomv1alpha1.ServiceCheckpointConfig{Enabled: true})
 		assert.ErrorContains(t, err, "no checkpointRef or identity")
 	})
+}
+
+// --- ApplyRestorePodMetadata target-containers annotation ---
+
+func TestApplyRestorePodMetadata_DefaultsToMainContainer(t *testing.T) {
+	labels := map[string]string{}
+	annotations := map[string]string{}
+	ApplyRestorePodMetadata(labels, annotations, &CheckpointInfo{Enabled: true, Ready: true, Hash: testHash})
+	assert.Equal(t, consts.MainContainerName, annotations[snapshotprotocol.TargetContainersAnnotation])
+}
+
+func TestApplyRestorePodMetadata_FailoverTargets(t *testing.T) {
+	labels := map[string]string{}
+	annotations := map[string]string{}
+	ApplyRestorePodMetadata(labels, annotations, &CheckpointInfo{
+		Enabled:                 true,
+		Ready:                   true,
+		Hash:                    testHash,
+		RestoreTargetContainers: []string{"engine-0", "engine-1"},
+	})
+	assert.Equal(t, "engine-0,engine-1", annotations[snapshotprotocol.TargetContainersAnnotation])
+}
+
+func TestApplyRestorePodMetadata_DisabledClearsAnnotation(t *testing.T) {
+	labels := map[string]string{}
+	annotations := map[string]string{
+		snapshotprotocol.TargetContainersAnnotation: "stale",
+	}
+	ApplyRestorePodMetadata(labels, annotations, &CheckpointInfo{Enabled: false})
+	_, ok := annotations[snapshotprotocol.TargetContainersAnnotation]
+	assert.False(t, ok, "target-containers annotation must be cleared when checkpoint disabled")
 }
 
 // findContainer is a test helper that locates a container by name across both

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -27,10 +27,9 @@ const (
 	envCheckpointDir = "GMS_CHECKPOINT_DIR"
 )
 
-// EnsureGMSRestoreSidecars adds GMS server + loader containers to the pod spec
-// for a checkpoint restore. The server runs as a regular container (not init)
-// because the CRIU-restored main process already has GPU memory mapped and
-// all containers must start in parallel.
+// EnsureGMSRestoreSidecars appends restartable init sidecars for GMS restore.
+// The server must be ready before CRIU resumes the target process, while the
+// loader continues running alongside regular containers.
 func EnsureGMSRestoreSidecars(
 	podSpec *corev1.PodSpec,
 	mainContainer *corev1.Container,
@@ -40,15 +39,14 @@ func EnsureGMSRestoreSidecars(
 		return
 	}
 
-	// The DGD path adds the GMS server as an init sidecar (blocks until
-	// sockets are ready). For restore, move it to a regular container so
-	// all containers start in parallel.
-	for i := range podSpec.InitContainers {
-		if podSpec.InitContainers[i].Name == gms.ServerContainerName {
-			podSpec.InitContainers = append(podSpec.InitContainers[:i], podSpec.InitContainers[i+1:]...)
-			break
+	// Re-append restore sidecars in a deterministic order.
+	initContainers := podSpec.InitContainers[:0]
+	for _, container := range podSpec.InitContainers {
+		if container.Name != gms.ServerContainerName && container.Name != GMSLoaderContainer {
+			initContainers = append(initContainers, container)
 		}
 	}
+	podSpec.InitContainers = initContainers
 	gms.EnsureSharedVolume(podSpec, mainContainer)
 
 	snapshotprotocol.InjectCheckpointVolume(podSpec, storage.PVCName)

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -36,19 +36,27 @@ func ApplyRestorePodMetadata(labels map[string]string, annotations map[string]st
 		artifactVersion = checkpointInfo.ArtifactVersion
 	}
 	snapshotprotocol.ApplyRestoreTargetMetadata(labels, annotations, enabled, hash, artifactVersion)
+	if !enabled {
+		delete(annotations, snapshotprotocol.TargetContainersAnnotation)
+		return
+	}
+	targets := checkpointInfo.RestoreTargetContainers
+	if len(targets) == 0 {
+		targets = []string{commonconsts.MainContainerName}
+	}
+	annotations[snapshotprotocol.TargetContainersAnnotation] = snapshotprotocol.FormatTargetContainers(targets)
 }
 
-// resolveMainContainer finds the container named "main" in the pod spec.
-// ExtraPodSpec.PodSpec.Containers can inject user containers before the main
-// container (mergo merge happens before main is appended), so index 0 is
-// not guaranteed to be the main container here.
-func resolveMainContainer(podSpec *corev1.PodSpec) *corev1.Container {
+func RequireMainContainer(podSpec *corev1.PodSpec) (*corev1.Container, error) {
+	if podSpec == nil {
+		return nil, fmt.Errorf("pod spec is nil")
+	}
 	for i := range podSpec.Containers {
 		if podSpec.Containers[i].Name == commonconsts.MainContainerName {
-			return &podSpec.Containers[i]
+			return &podSpec.Containers[i], nil
 		}
 	}
-	return nil
+	return nil, fmt.Errorf("pod spec has no container named %q", commonconsts.MainContainerName)
 }
 
 func InjectCheckpointIntoPodSpec(
@@ -83,19 +91,34 @@ func InjectCheckpointIntoPodSpec(
 		info.Hash = hash
 	}
 
-	mainContainer := resolveMainContainer(podSpec)
-	if mainContainer == nil {
-		return fmt.Errorf("no container named %q found in pod spec", commonconsts.MainContainerName)
-	}
 	if reader == nil {
 		return fmt.Errorf("checkpoint client is required")
+	}
+	targets := checkpointInfo.RestoreTargetContainers
+	if len(targets) == 0 {
+		targets = []string{commonconsts.MainContainerName}
+	}
+	podInfoContainers := make([]*corev1.Container, 0, len(targets))
+	for _, name := range targets {
+		for i := range podSpec.Containers {
+			if podSpec.Containers[i].Name == name {
+				podInfoContainers = append(podInfoContainers, &podSpec.Containers[i])
+				break
+			}
+		}
+	}
+	if len(podInfoContainers) != len(targets) {
+		return fmt.Errorf("checkpoint restore targets %v do not all exist in pod spec", targets)
+	}
+	syntheticAnnotations := map[string]string{
+		snapshotprotocol.TargetContainersAnnotation: snapshotprotocol.FormatTargetContainers(targets),
 	}
 	if err := snapshotprotocol.PrepareRestorePodSpecForCheckpoint(
 		ctx,
 		reader,
 		namespace,
 		podSpec,
-		mainContainer,
+		syntheticAnnotations,
 		info.Hash,
 		info.ArtifactVersion,
 		snapshotprotocol.DefaultSeccompLocalhostProfile,
@@ -105,8 +128,15 @@ func InjectCheckpointIntoPodSpec(
 	}
 
 	EnsurePodInfoVolume(podSpec)
-	EnsurePodInfoMount(mainContainer)
+	for _, c := range podInfoContainers {
+		EnsurePodInfoMount(c)
+	}
 	if info.Ready && info.GPUMemoryService != nil && info.GPUMemoryService.Enabled {
+		// GMS restore is still single-main-container only.
+		mainContainer, err := RequireMainContainer(podSpec)
+		if err != nil {
+			return fmt.Errorf("gpuMemoryService enabled: %w", err)
+		}
 		storage, err := snapshotprotocol.DiscoverAndResolveStorage(
 			ctx,
 			reader,

--- a/deploy/operator/internal/checkpoint/resolve.go
+++ b/deploy/operator/internal/checkpoint/resolve.go
@@ -36,6 +36,8 @@ type CheckpointInfo struct {
 	ArtifactVersion  string
 	CheckpointName   string
 	Ready            bool
+	// Empty means the restore pod targets the default main container.
+	RestoreTargetContainers []string
 }
 
 func checkpointInfoFromObject(ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (*CheckpointInfo, error) {

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -75,6 +75,11 @@ func buildCheckpointJob(
 	if podTemplate.Annotations == nil {
 		podTemplate.Annotations = make(map[string]string)
 	}
+	// Checkpoint Jobs always capture exactly the main container. Other
+	// containers in the pod template (e.g. GMS saver sidecars the operator
+	// adds below) are preserved but not checkpointed. The annotation is
+	// the contract the snapshot-agent reads.
+	podTemplate.Annotations[snapshotprotocol.TargetContainersAnnotation] = snapshotprotocol.FormatTargetContainers([]string{consts.MainContainerName})
 	if podTemplate.Spec.ServiceAccountName == "" {
 		podTemplate.Spec.ServiceAccountName = discovery.GetK8sDiscoveryServiceAccountName(ckpt.Name)
 	}
@@ -84,7 +89,10 @@ func buildCheckpointJob(
 	if len(podTemplate.Spec.Containers) == 0 {
 		return nil, fmt.Errorf("checkpoint job requires at least one container")
 	}
-	mainContainer := &podTemplate.Spec.Containers[0]
+	mainContainer, err := checkpoint.RequireMainContainer(&podTemplate.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("checkpoint job pod template: %w", err)
+	}
 	mainContainer.Env = dynamo.MergeEnvs(
 		buildCheckpointWorkerDefaultEnv(ckpt, podTemplate),
 		mainContainer.Env,

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -943,6 +943,9 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to resolve checkpoint")
 		}
+		if dynamo.IsIntraPodFailoverEnabled(&opt.dynamoComponentDeployment.Spec.DynamoComponentDeploymentSharedSpec) {
+			info.RestoreTargetContainers = dynamo.IntraPodFailoverEngineContainerNames()
+		}
 		checkpointInfo = info
 	}
 

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1119,7 +1119,6 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 					Labels: map[string]string{
 						commonconsts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
 						commonconsts.KubeLabelDynamoWorkerHash:          "workerhash",
-						snapshotprotocol.RestoreTargetLabel:             commonconsts.KubeLabelValueTrue,
 					},
 					Checkpoint: &v1alpha1.ServiceCheckpointConfig{
 						Enabled:       true,
@@ -1181,11 +1180,14 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
 		}
 
-		if got := podTemplateSpec.Labels[snapshotprotocol.RestoreTargetLabel]; got != commonconsts.KubeLabelValueTrue {
-			t.Fatalf("expected %s label to be true, got %q", snapshotprotocol.RestoreTargetLabel, got)
-		}
 		if got := podTemplateSpec.Labels[snapshotprotocol.CheckpointIDLabel]; got != checkpointName {
 			t.Fatalf("expected %s to be checkpoint id, got %q", snapshotprotocol.CheckpointIDLabel, got)
+		}
+		if _, has := podTemplateSpec.Labels[snapshotprotocol.CheckpointSourceLabel]; has {
+			t.Fatalf("restore pod template must not carry %s label: %#v", snapshotprotocol.CheckpointSourceLabel, podTemplateSpec.Labels)
+		}
+		if got := podTemplateSpec.Annotations[snapshotprotocol.TargetContainersAnnotation]; got != commonconsts.MainContainerName {
+			t.Fatalf("expected %s=main annotation, got %q", snapshotprotocol.TargetContainersAnnotation, got)
 		}
 	})
 
@@ -1310,8 +1312,11 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		if podTemplateSpec.Spec.Containers[1].Args != nil {
 			t.Fatalf("expected main container args to be cleared, got %#v", podTemplateSpec.Spec.Containers[1].Args)
 		}
-		if got := podTemplateSpec.Labels[snapshotprotocol.RestoreTargetLabel]; got != commonconsts.KubeLabelValueTrue {
-			t.Fatalf("expected %s label to be true, got %q", snapshotprotocol.RestoreTargetLabel, got)
+		if got := podTemplateSpec.Labels[snapshotprotocol.CheckpointIDLabel]; got != checkpointName {
+			t.Fatalf("expected %s to be checkpoint id, got %q", snapshotprotocol.CheckpointIDLabel, got)
+		}
+		if _, has := podTemplateSpec.Labels[snapshotprotocol.CheckpointSourceLabel]; has {
+			t.Fatalf("restore pod template must not carry %s label: %#v", snapshotprotocol.CheckpointSourceLabel, podTemplateSpec.Labels)
 		}
 	})
 
@@ -1393,11 +1398,11 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
 		}
 
-		if _, ok := podTemplateSpec.Labels[snapshotprotocol.RestoreTargetLabel]; ok {
-			t.Fatalf("did not expect %s label when checkpoint is not ready", snapshotprotocol.RestoreTargetLabel)
-		}
 		if _, ok := podTemplateSpec.Labels[snapshotprotocol.CheckpointIDLabel]; ok {
 			t.Fatalf("did not expect %s label when checkpoint is not ready", snapshotprotocol.CheckpointIDLabel)
+		}
+		if _, ok := podTemplateSpec.Annotations[snapshotprotocol.TargetContainersAnnotation]; ok {
+			t.Fatalf("did not expect %s annotation when checkpoint is not ready", snapshotprotocol.TargetContainersAnnotation)
 		}
 	})
 }

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -1359,6 +1359,9 @@ func (r *DynamoGraphDeploymentReconciler) reconcileCheckpoints(
 			logger.Error(err, "Failed to resolve checkpoint for service", "service", serviceName)
 			return nil, nil, fmt.Errorf("failed to resolve checkpoint for service %s: %w", serviceName, err)
 		}
+		if dynamo.IsIntraPodFailoverEnabled(component) {
+			info.RestoreTargetContainers = dynamo.IntraPodFailoverEngineContainerNames()
+		}
 
 		// Store checkpoint info for later use in pod spec generation
 		checkpointInfos[serviceName] = info

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -397,13 +397,20 @@ const (
 	failoverEngineCount = 2
 )
 
-// isFailoverEnabled returns true only for intra-pod failover mode, where the
-// main container is cloned into active + standby containers within the same pod.
-// Inter-pod failover (Mode=interPod) is handled separately via expandRolesForService
-// and generatePodSpecForRole — it does not use container cloning.
-func isFailoverEnabled(component *v1alpha1.DynamoComponentDeploymentSharedSpec) bool {
-	return component.Failover != nil && component.Failover.Enabled &&
+// IsIntraPodFailoverEnabled is true only when failover clones engine
+// containers inside one pod. Inter-pod failover keeps one main container per
+// engine pod.
+func IsIntraPodFailoverEnabled(component *v1alpha1.DynamoComponentDeploymentSharedSpec) bool {
+	return component != nil && component.Failover != nil && component.Failover.Enabled &&
 		component.Failover.Mode == v1alpha1.GMSModeIntraPod
+}
+
+func IntraPodFailoverEngineContainerNames() []string {
+	names := make([]string, 0, failoverEngineCount)
+	for i := 0; i < failoverEngineCount; i++ {
+		names = append(names, fmt.Sprintf("engine-%d", i))
+	}
+	return names
 }
 
 // buildFailoverPod clones the main container into two engine containers (active + standby).

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -632,17 +632,24 @@ func TestBuildFailoverPod_SingleNodeNoNNODES(t *testing.T) {
 	}
 }
 
-func TestIsFailoverEnabled(t *testing.T) {
-	assert.True(t, isFailoverEnabled(&v1alpha1.DynamoComponentDeploymentSharedSpec{
+// --- IsIntraPodFailoverEnabled ---
+
+func TestIsIntraPodFailoverEnabled(t *testing.T) {
+	assert.True(t, IsIntraPodFailoverEnabled(&v1alpha1.DynamoComponentDeploymentSharedSpec{
 		Failover: &v1alpha1.FailoverSpec{Enabled: true, Mode: v1alpha1.GMSModeIntraPod},
 	}))
-	assert.False(t, isFailoverEnabled(&v1alpha1.DynamoComponentDeploymentSharedSpec{
+	assert.False(t, IsIntraPodFailoverEnabled(&v1alpha1.DynamoComponentDeploymentSharedSpec{
 		Failover: &v1alpha1.FailoverSpec{Enabled: true, Mode: v1alpha1.GMSModeInterPod},
 	}), "inter-pod mode must not trigger intra-pod container cloning")
-	assert.False(t, isFailoverEnabled(&v1alpha1.DynamoComponentDeploymentSharedSpec{
+	assert.False(t, IsIntraPodFailoverEnabled(&v1alpha1.DynamoComponentDeploymentSharedSpec{
 		Failover: &v1alpha1.FailoverSpec{Enabled: false, Mode: v1alpha1.GMSModeIntraPod},
 	}))
-	assert.False(t, isFailoverEnabled(&v1alpha1.DynamoComponentDeploymentSharedSpec{}))
+	assert.False(t, IsIntraPodFailoverEnabled(&v1alpha1.DynamoComponentDeploymentSharedSpec{}))
+	assert.False(t, IsIntraPodFailoverEnabled(nil))
+}
+
+func TestIntraPodFailoverEngineContainerNames(t *testing.T) {
+	assert.Equal(t, []string{"engine-0", "engine-1"}, IntraPodFailoverEngineContainerNames())
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1361,7 +1361,7 @@ func GenerateBasePodSpec(
 
 	// Clone main container into two engine containers (active + standby) for failover.
 	// Runs after GMS so the main container already has DRA claims and shared volume.
-	if isFailoverEnabled(component) {
+	if IsIntraPodFailoverEnabled(component) {
 		if err := buildFailoverPod(&podSpec, numberOfNodes, backendFramework); err != nil {
 			return nil, fmt.Errorf("failed to build failover pod: %w", err)
 		}
@@ -1565,7 +1565,8 @@ func buildCliqueForRole(p cliqueParams) (*grovev1alpha1.PodCliqueTemplateSpec, e
 		return nil, fmt.Errorf("failed to generate podSpec for role %s: %w", p.r.Name, err)
 	}
 
-	if p.operatorConfig.Checkpoint.Enabled {
+	// GMS weight servers load weights fresh from disk and are not CRIU targets.
+	if p.operatorConfig.Checkpoint.Enabled && p.r.Role != RoleGMS {
 		if err := checkpoint.InjectCheckpointIntoPodSpec(
 			p.ctx, p.kubeClient, p.dynamoDeployment.Namespace, podSpec, p.checkpointInfo,
 		); err != nil {
@@ -1644,7 +1645,9 @@ func buildCliqueForRole(p cliqueParams) (*grovev1alpha1.PodCliqueTemplateSpec, e
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate annotations: %w", err)
 	}
-	checkpoint.ApplyRestorePodMetadata(labels, annotations, p.checkpointInfo)
+	if p.r.Role != RoleGMS {
+		checkpoint.ApplyRestorePodMetadata(labels, annotations, p.checkpointInfo)
+	}
 	annotations = applyRestartAnnotation(annotations, p.serviceName, p.restartState, p.existingRestartAnnotations)
 	clique.Annotations = annotations
 

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -36,11 +36,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ptr "k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGenerateDynamoComponentsDeployments(t *testing.T) {
@@ -7093,8 +7096,8 @@ func TestGenerateLabels_RemovesStaleRestoreLabelsWhenCheckpointNotReady(t *testi
 			ComponentType:   commonconsts.ComponentTypeWorker,
 			DynamoNamespace: ptr.To("default-test-dgd"),
 			Labels: map[string]string{
-				"user-label":                        "keep",
-				snapshotprotocol.RestoreTargetLabel: commonconsts.KubeLabelValueTrue,
+				"user-label":                       "keep",
+				snapshotprotocol.CheckpointIDLabel: "stale-hash",
 			},
 			ExtraPodMetadata: &v1alpha1.ExtraPodMetadata{
 				Labels: map[string]string{
@@ -7118,10 +7121,10 @@ func TestGenerateLabels_RemovesStaleRestoreLabelsWhenCheckpointNotReady(t *testi
 	})
 	assert.Equal(t, "keep", labels["user-label"])
 	assert.Equal(t, "keep-too", labels["extra-label"])
-	_, hasRestoreTarget := labels[snapshotprotocol.RestoreTargetLabel]
 	_, hasCheckpointHash := labels[snapshotprotocol.CheckpointIDLabel]
-	assert.False(t, hasRestoreTarget)
-	assert.False(t, hasCheckpointHash)
+	assert.False(t, hasCheckpointHash, "checkpoint-id label must be cleared when checkpoint is not Ready")
+	_, hasTargetAnnotation := annotations[snapshotprotocol.TargetContainersAnnotation]
+	assert.False(t, hasTargetAnnotation, "target-containers annotation must be cleared when checkpoint is not Ready")
 }
 
 func TestGenerateLabels_OverwritesStaleRestoreLabelsWhenCheckpointReady(t *testing.T) {
@@ -7129,9 +7132,6 @@ func TestGenerateLabels_OverwritesStaleRestoreLabelsWhenCheckpointReady(t *testi
 		&v1alpha1.DynamoComponentDeploymentSharedSpec{
 			ComponentType:   commonconsts.ComponentTypeWorker,
 			DynamoNamespace: ptr.To("default-test-dgd"),
-			Labels: map[string]string{
-				snapshotprotocol.RestoreTargetLabel: "false",
-			},
 			ExtraPodMetadata: &v1alpha1.ExtraPodMetadata{
 				Labels: map[string]string{
 					snapshotprotocol.CheckpointIDLabel: "stale-hash",
@@ -7151,8 +7151,10 @@ func TestGenerateLabels_OverwritesStaleRestoreLabelsWhenCheckpointReady(t *testi
 		Ready:   true,
 		Hash:    "resolved-hash",
 	})
-	assert.Equal(t, commonconsts.KubeLabelValueTrue, labels[snapshotprotocol.RestoreTargetLabel])
-	assert.Equal(t, "resolved-hash", labels[snapshotprotocol.CheckpointIDLabel])
+	assert.Equal(t, "resolved-hash", labels[snapshotprotocol.CheckpointIDLabel],
+		"ready checkpoint must overwrite stale checkpoint-id with the resolved hash")
+	assert.Equal(t, commonconsts.MainContainerName, annotations[snapshotprotocol.TargetContainersAnnotation],
+		"ready checkpoint must stamp the default target-containers annotation")
 }
 
 func TestGenerateLabels_ReassertsRestoreIdentityLabelsAfterMetadataMerge(t *testing.T) {
@@ -7254,6 +7256,240 @@ func TestGenerateGrovePodCliqueSet_GMSPodsDoNotCarryDiscoveryLabels(t *testing.T
 	}
 	assert.True(t, sawGMS, "test setup should produce at least one GMS clique")
 	assert.True(t, sawEngine, "test setup should produce at least one engine clique")
+}
+
+// TestGenerateGrovePodCliqueSet_GMSPodsAreNotCheckpointTargets pins the
+// contract that inter-pod GMS weight-server cliques (RoleGMS) are never
+// shaped as snapshot restore targets, even when the service has
+// checkpoint.enabled=true with a Ready checkpoint. GMS pods run
+// gpu_memory_service.cli.server, load weights fresh from disk, and have
+// no CRIU state to capture; shaping them as restore targets would replace
+// the GMS wrapper command with `sleep infinity` and break the layout.
+//
+// Engine cliques in the same service must still be shaped: target-
+// containers annotation set to "main", restore-target label set to true,
+// and the placeholder `sleep infinity` command injected so the snapshot
+// agent can drive the restore.
+func TestGenerateGrovePodCliqueSet_GMSPodsAreNotCheckpointTargets(t *testing.T) {
+	dgd := &v1alpha1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha1.DynamoGraphDeploymentSpec{
+			BackendFramework: "vllm",
+			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"decode": {
+					ComponentType: commonconsts.ComponentTypeDecode,
+					Replicas:      ptr.To(int32(1)),
+					Resources: &v1alpha1.Resources{
+						Limits: &v1alpha1.ResourceItem{GPU: "1"},
+					},
+					GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{
+						Enabled: true,
+						Mode:    v1alpha1.GMSModeInterPod,
+					},
+					Checkpoint: &v1alpha1.ServiceCheckpointConfig{Enabled: true},
+				},
+			},
+		},
+	}
+
+	controllerConfig := &configv1alpha1.OperatorConfiguration{
+		Discovery: configv1alpha1.DiscoveryConfiguration{Backend: "kubernetes"},
+		Infrastructure: configv1alpha1.InfrastructureConfiguration{
+			ETCDAddress: "etcd-address",
+			NATSAddress: "nats-address",
+		},
+		Checkpoint: configv1alpha1.CheckpointConfiguration{Enabled: true},
+	}
+
+	// snapshot-agent DaemonSet fixture so InjectCheckpointIntoPodSpec can
+	// discover the checkpoint PVC storage in the target namespace.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snapshot-agent",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				snapshotprotocol.SnapshotAgentLabelKey: snapshotprotocol.SnapshotAgentLabelValue,
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: snapshotprotocol.SnapshotAgentContainerName,
+						VolumeMounts: []corev1.VolumeMount{{
+							Name: snapshotprotocol.SnapshotAgentVolumeName, MountPath: "/checkpoints",
+						}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: snapshotprotocol.SnapshotAgentVolumeName,
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "snapshot-pvc"},
+						},
+					}},
+				},
+			},
+		},
+	}).Build()
+
+	infoByService := map[string]*checkpoint.CheckpointInfo{
+		"decode": {Enabled: true, Ready: true, Hash: "abc123def4567890"},
+	}
+
+	got, err := GenerateGrovePodCliqueSet(context.Background(), dgd, controllerConfig, &controller_common.RuntimeConfig{DRAEnabled: true}, kubeClient, nil, nil, nil, infoByService)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	var sawGMS, sawEngine bool
+	for _, clique := range got.Spec.Template.Cliques {
+		targetAnnotation := clique.Annotations[snapshotprotocol.TargetContainersAnnotation]
+		checkpointID := clique.Labels[snapshotprotocol.CheckpointIDLabel]
+		mainContainer := findContainerInClique(t, clique, commonconsts.MainContainerName)
+
+		if strings.Contains(clique.Name, "gms") {
+			sawGMS = true
+			assert.Empty(t, targetAnnotation, "GMS clique %q must not carry snapshot-target-containers annotation", clique.Name)
+			assert.Empty(t, checkpointID, "GMS clique %q must not carry checkpoint-id label (would make it look like a restore target)", clique.Name)
+			assert.NotEqual(t, []string{"sleep", "infinity"}, mainContainer.Command,
+				"GMS clique %q main container command must not be rewritten to sleep infinity (should remain the gms wrapper)", clique.Name)
+		} else {
+			sawEngine = true
+			assert.Equal(t, commonconsts.MainContainerName, targetAnnotation,
+				"engine clique %q must carry snapshot-target-containers=main annotation", clique.Name)
+			assert.NotEmpty(t, checkpointID,
+				"engine clique %q must carry checkpoint-id label (selected by snapshot-agent restore informer)", clique.Name)
+			assert.Equal(t, []string{"sleep", "infinity"}, mainContainer.Command,
+				"engine clique %q main container must be shaped as a snapshot restore target", clique.Name)
+		}
+	}
+	assert.True(t, sawGMS, "test setup should produce at least one GMS clique")
+	assert.True(t, sawEngine, "test setup should produce at least one engine clique")
+}
+
+func findContainerInClique(t *testing.T, clique *grovev1alpha1.PodCliqueTemplateSpec, name string) *corev1.Container {
+	t.Helper()
+	for i := range clique.Spec.PodSpec.Containers {
+		if clique.Spec.PodSpec.Containers[i].Name == name {
+			return &clique.Spec.PodSpec.Containers[i]
+		}
+	}
+	t.Fatalf("container %q not found in clique %q", name, clique.Name)
+	return nil
+}
+
+// TestGenerateGrovePodCliqueSet_IntraPodFailoverCheckpointTargets pins the
+// contract that intra-pod failover services (Failover.Mode=intraPod) stamp
+// the snapshot-target-containers annotation with "engine-0,engine-1" on
+// the restore pod and shape every engine container as a restore target.
+// Intra-pod failover clones the main container into engine-0 + engine-1 and
+// both engines must be driven by the snapshot agent from the same checkpoint.
+func TestGenerateGrovePodCliqueSet_IntraPodFailoverCheckpointTargets(t *testing.T) {
+	dgd := &v1alpha1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha1.DynamoGraphDeploymentSpec{
+			BackendFramework: "vllm",
+			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"decode": {
+					ComponentType: commonconsts.ComponentTypeDecode,
+					Replicas:      ptr.To(int32(1)),
+					Resources: &v1alpha1.Resources{
+						Limits: &v1alpha1.ResourceItem{GPU: "1"},
+					},
+					Failover: &v1alpha1.FailoverSpec{
+						Enabled: true,
+						Mode:    v1alpha1.GMSModeIntraPod,
+					},
+					Checkpoint: &v1alpha1.ServiceCheckpointConfig{Enabled: true},
+				},
+			},
+		},
+	}
+
+	controllerConfig := &configv1alpha1.OperatorConfiguration{
+		Discovery: configv1alpha1.DiscoveryConfiguration{Backend: "kubernetes"},
+		Infrastructure: configv1alpha1.InfrastructureConfiguration{
+			ETCDAddress: "etcd-address",
+			NATSAddress: "nats-address",
+		},
+		Checkpoint: configv1alpha1.CheckpointConfiguration{Enabled: true},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snapshot-agent",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				snapshotprotocol.SnapshotAgentLabelKey: snapshotprotocol.SnapshotAgentLabelValue,
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: snapshotprotocol.SnapshotAgentContainerName,
+						VolumeMounts: []corev1.VolumeMount{{
+							Name: snapshotprotocol.SnapshotAgentVolumeName, MountPath: "/checkpoints",
+						}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: snapshotprotocol.SnapshotAgentVolumeName,
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "snapshot-pvc"},
+						},
+					}},
+				},
+			},
+		},
+	}).Build()
+
+	infoByService := map[string]*checkpoint.CheckpointInfo{
+		"decode": {
+			Enabled:                 true,
+			Ready:                   true,
+			Hash:                    "abc123def4567890",
+			RestoreTargetContainers: IntraPodFailoverEngineContainerNames(),
+		},
+	}
+
+	got, err := GenerateGrovePodCliqueSet(context.Background(), dgd, controllerConfig, &controller_common.RuntimeConfig{DRAEnabled: true}, kubeClient, nil, nil, nil, infoByService)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	var sawDecode bool
+	for _, clique := range got.Spec.Template.Cliques {
+		if strings.Contains(clique.Name, "gms") {
+			t.Fatalf("intra-pod failover must not produce a GMS clique: %q", clique.Name)
+		}
+		sawDecode = true
+		assert.Equal(t, "engine-0,engine-1", clique.Annotations[snapshotprotocol.TargetContainersAnnotation],
+			"clique %q must carry snapshot-target-containers=engine-0,engine-1", clique.Name)
+		for _, engineName := range IntraPodFailoverEngineContainerNames() {
+			c := findContainerInClique(t, clique, engineName)
+			assert.Equal(t, []string{"sleep", "infinity"}, c.Command,
+				"%s in clique %q must be shaped as a snapshot restore target", engineName, clique.Name)
+			foundMount := false
+			for _, m := range c.VolumeMounts {
+				if m.Name == snapshotprotocol.SnapshotControlVolumeName {
+					foundMount = true
+					assert.Equal(t, engineName, m.SubPath,
+						"%s in clique %q must have its own subPath on the control volume", engineName, clique.Name)
+				}
+			}
+			assert.True(t, foundMount, "%s in clique %q must mount the snapshot-control volume", engineName, clique.Name)
+		}
+	}
+	assert.True(t, sawDecode, "test setup should produce the decode engine clique")
 }
 
 // TestGenerateGrovePodCliqueSet_MinAvailable_FailoverShadowsAreRedundant pins

--- a/deploy/snapshot/cmd/snapshotctl/README.md
+++ b/deploy/snapshot/cmd/snapshotctl/README.md
@@ -24,12 +24,36 @@ accept a Kubernetes `Pod` manifest, not a Deployment or Job manifest.
 That pod manifest must:
 
 - describe the worker pod you want to checkpoint or restore
-- contain exactly one worker container
 - use the placeholder image for checkpoint-aware flows
 - match the runtime-relevant worker settings you care about preserving
 
 In practice, start from the real worker pod spec you would normally run, then
 keep only the pod-level fields needed to recreate that worker accurately.
+
+## Target containers
+
+Which container(s) the operation acts on is controlled by a single annotation
+that the snapshot layer treats as mandatory:
+
+```yaml
+metadata:
+  annotations:
+    nvidia.com/snapshot-target-containers: "main"
+    # or "engine-0,engine-1" for a failover-style restore
+```
+
+- Checkpoints must target **exactly one** container.
+- Restores must target **at least one** container; the same checkpoint is
+  replayed into every named container.
+
+`snapshotctl` will stamp the annotation for you from the CLI flag:
+
+- `--container <name>` on the `checkpoint` subcommand (single name)
+- `--containers <name>[,<name>...]` on the `restore` subcommand (one or more)
+
+You can also pre-stamp the annotation on the manifest and omit the flag. If
+both are provided they must agree — `snapshotctl` rejects mismatches instead
+of silently picking one.
 
 ## Commands
 
@@ -38,6 +62,7 @@ Checkpoint from a manifest:
 ```bash
 snapshotctl checkpoint \
   --manifest ./worker-pod.yaml \
+  --container main \
   --namespace ${NAMESPACE}
 ```
 
@@ -48,6 +73,17 @@ Restore by creating a new pod from a manifest:
 ```bash
 snapshotctl restore \
   --manifest ./worker-pod.yaml \
+  --containers main \
+  --namespace ${NAMESPACE} \
+  --checkpoint-id manual-snapshot-123
+```
+
+For an intra-pod failover restore, list every engine container:
+
+```bash
+snapshotctl restore \
+  --manifest ./failover-pod.yaml \
+  --containers engine-0,engine-1 \
   --namespace ${NAMESPACE} \
   --checkpoint-id manual-snapshot-123
 ```
@@ -57,6 +93,7 @@ Restore an existing snapshot-compatible pod in place:
 ```bash
 snapshotctl restore \
   --pod existing-restore-target \
+  --containers main \
   --namespace ${NAMESPACE} \
   --checkpoint-id manual-snapshot-123
 ```
@@ -65,5 +102,8 @@ snapshotctl restore \
 
 - `restore --pod` expects a pod that is already compatible with snapshot restore
 - `restore --manifest` creates a new restore target pod from the manifest you provide
+- `restore` returns after the restore request is submitted; it does not wait for completion
+- observe restore progress with pod readiness, events/logs, and per-container
+  `nvidia.com/snapshot-restore-status.<container>` annotations
 - `snapshotctl` is useful for debugging and lower-level validation, but it does
   not replace the operator-managed checkpoint flow

--- a/deploy/snapshot/cmd/snapshotctl/annotations.go
+++ b/deploy/snapshot/cmd/snapshotctl/annotations.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
+)
+
+// reconcileTargetContainers returns the normalized target-container annotation.
+// A flag value and manifest annotation may both be present only when they match.
+func reconcileTargetContainers(annotations map[string]string, flagValue string, minCount, maxCount int) (string, error) {
+	flagNames, flagErr := snapshotprotocol.ParseTargetContainers(flagValue)
+	if flagErr != nil {
+		return "", fmt.Errorf("--container(s) flag: %w", flagErr)
+	}
+
+	manifestRaw := ""
+	if annotations != nil {
+		manifestRaw = annotations[snapshotprotocol.TargetContainersAnnotation]
+	}
+	manifestNames, manifestErr := snapshotprotocol.ParseTargetContainers(manifestRaw)
+	if manifestErr != nil {
+		return "", fmt.Errorf("manifest %s annotation: %w", snapshotprotocol.TargetContainersAnnotation, manifestErr)
+	}
+
+	chosen := flagNames
+	if len(flagNames) == 0 {
+		chosen = manifestNames
+	} else if len(manifestNames) > 0 {
+		if snapshotprotocol.FormatTargetContainers(flagNames) != snapshotprotocol.FormatTargetContainers(manifestNames) {
+			return "", fmt.Errorf(
+				"--container(s) flag %q does not match manifest %s %q; pass one or the other",
+				snapshotprotocol.FormatTargetContainers(flagNames),
+				snapshotprotocol.TargetContainersAnnotation,
+				snapshotprotocol.FormatTargetContainers(manifestNames),
+			)
+		}
+	}
+
+	if len(chosen) == 0 {
+		return "", fmt.Errorf("target containers are required: pass --container(s) or set %s on the manifest", snapshotprotocol.TargetContainersAnnotation)
+	}
+	if minCount > 0 && len(chosen) < minCount {
+		return "", fmt.Errorf("expected at least %d target container(s), got %d", minCount, len(chosen))
+	}
+	if maxCount > 0 && len(chosen) > maxCount {
+		return "", fmt.Errorf("expected at most %d target container(s), got %d", maxCount, len(chosen))
+	}
+	return snapshotprotocol.FormatTargetContainers(chosen), nil
+}

--- a/deploy/snapshot/cmd/snapshotctl/checkpoint.go
+++ b/deploy/snapshot/cmd/snapshotctl/checkpoint.go
@@ -25,6 +25,7 @@ type checkpointOptions struct {
 	Namespace                    string
 	KubeContext                  string
 	CheckpointID                 string
+	Container                    string
 	DisableCudaCheckpointJobFile bool
 	Timeout                      time.Duration
 }
@@ -65,11 +66,23 @@ func runCheckpointFlow(ctx context.Context, opts checkpointOptions) (*result, er
 		return nil, err
 	}
 
+	// Stamp (or validate) the required snapshot-target-containers annotation.
+	// Checkpoint contract: exactly one target container per Job.
+	targetValue, err := reconcileTargetContainers(pod.Annotations, opts.Container, 1, 1)
+	if err != nil {
+		return nil, err
+	}
+	annotations := map[string]string{}
+	for k, v := range pod.Annotations {
+		annotations[k] = v
+	}
+	annotations[snapshotprotocol.TargetContainersAnnotation] = targetValue
+
 	checkpointJobName := pod.Name + "-checkpoint"
 	job, err := snapshotprotocol.NewCheckpointJob(&corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      pod.Labels,
-			Annotations: pod.Annotations,
+			Annotations: annotations,
 		},
 		Spec: *pod.Spec.DeepCopy(),
 	}, snapshotprotocol.CheckpointJobOptions{

--- a/deploy/snapshot/cmd/snapshotctl/kube.go
+++ b/deploy/snapshot/cmd/snapshotctl/kube.go
@@ -101,28 +101,17 @@ func loadPod(manifestPath string) (*corev1.Pod, error) {
 			manifestPath,
 		)
 	}
-	workerContainer := &pod.Spec.Containers[0]
-	if len(pod.Spec.Containers) > 1 {
-		workerContainer = nil
-		for index := range pod.Spec.Containers {
-			if pod.Spec.Containers[index].Name == "main" {
-				workerContainer = &pod.Spec.Containers[index]
-				break
-			}
-		}
-		if workerContainer == nil {
-			return nil, fmt.Errorf(
-				"manifest %s has %d containers; snapshotctl requires a worker container named main",
-				manifestPath,
-				len(pod.Spec.Containers),
-			)
-		}
-	}
-	if strings.TrimSpace(workerContainer.Image) == "" {
-		return nil, fmt.Errorf("manifest %s: worker container image is required", manifestPath)
-	}
+	// snapshotctl no longer guesses the workload container. Callers pass
+	// --container / --containers (or pre-stamp the
+	// nvidia.com/snapshot-target-containers annotation), which the protocol
+	// layer then validates against the pod spec.
 	if strings.TrimSpace(pod.Name) == "" {
 		return nil, fmt.Errorf("manifest %s: metadata.name is required", manifestPath)
+	}
+	for i := range pod.Spec.Containers {
+		if strings.TrimSpace(pod.Spec.Containers[i].Image) == "" {
+			return nil, fmt.Errorf("manifest %s: container %q image is required", manifestPath, pod.Spec.Containers[i].Name)
+		}
 	}
 
 	pod.Namespace = strings.TrimSpace(pod.Namespace)

--- a/deploy/snapshot/cmd/snapshotctl/main.go
+++ b/deploy/snapshot/cmd/snapshotctl/main.go
@@ -46,6 +46,7 @@ func runCheckpoint(args []string) error {
 	namespace := flags.String("namespace", "", "Namespace override; defaults to the manifest namespace or current kube context namespace")
 	kubeContext := flags.String("kube-context", "", "Kubernetes context override")
 	checkpointID := flags.String("checkpoint-id", "", "Explicit checkpoint ID; defaults to a generated value")
+	container := flags.String("container", "", "Required. Name of the workload container inside the manifest to checkpoint. May be omitted if the manifest already sets the nvidia.com/snapshot-target-containers annotation")
 	disableCudaCheckpointJobFile := flags.Bool("disable-cuda-checkpoint-job-file", false, "Preserve the manifest command instead of wrapping it with cuda-checkpoint --launch-job")
 	timeout := flags.Duration("timeout", 45*time.Minute, "Maximum time to wait for checkpoint completion")
 
@@ -65,6 +66,7 @@ func runCheckpoint(args []string) error {
 		Namespace:                    *namespace,
 		KubeContext:                  *kubeContext,
 		CheckpointID:                 *checkpointID,
+		Container:                    *container,
 		DisableCudaCheckpointJobFile: *disableCudaCheckpointJobFile,
 		Timeout:                      *timeout,
 	})
@@ -91,7 +93,7 @@ func runRestore(args []string) error {
 	namespace := flags.String("namespace", "", "Namespace override; defaults to the manifest namespace or current kube context namespace")
 	kubeContext := flags.String("kube-context", "", "Kubernetes context override")
 	checkpointID := flags.String("checkpoint-id", "", "Checkpoint ID to restore")
-	timeout := flags.Duration("timeout", 45*time.Minute, "Maximum time to wait for restore completion")
+	containers := flags.String("containers", "", "Required. Comma-separated target container names to restore the checkpoint into. May be omitted if the manifest/pod already sets the nvidia.com/snapshot-target-containers annotation")
 
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -110,12 +112,12 @@ func runRestore(args []string) error {
 		Namespace:    *namespace,
 		KubeContext:  *kubeContext,
 		CheckpointID: *checkpointID,
-		Timeout:      *timeout,
+		Containers:   *containers,
 	})
 	if err != nil {
 		return err
 	}
-	snapshotctlLog.Info("Restore completed", "pod", result.RestorePod, "checkpoint_id", result.CheckpointID)
+	snapshotctlLog.Info("Restore requested", "pod", result.RestorePod, "checkpoint_id", result.CheckpointID)
 
 	fmt.Printf("status=%s\n", result.Status)
 	fmt.Printf("namespace=%s\n", result.Namespace)
@@ -134,8 +136,8 @@ Subcommands:
   restore
 
 Examples:
-  snapshotctl checkpoint --manifest /tmp/vllm-worker-pod.yaml
-  snapshotctl restore --manifest /tmp/sglang-worker-pod.yaml --checkpoint-id manual-snapshot-123
-  snapshotctl restore --pod existing-restore-target --checkpoint-id manual-snapshot-123
+  snapshotctl checkpoint --manifest /tmp/vllm-worker-pod.yaml --container main
+  snapshotctl restore --manifest /tmp/sglang-worker-pod.yaml --checkpoint-id manual-snapshot-123 --containers main
+  snapshotctl restore --pod existing-restore-target --checkpoint-id manual-snapshot-123 --containers engine-0,engine-1
 `)
 }

--- a/deploy/snapshot/cmd/snapshotctl/restore.go
+++ b/deploy/snapshot/cmd/snapshotctl/restore.go
@@ -3,18 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes"
 
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
@@ -25,7 +20,7 @@ type restoreOptions struct {
 	Namespace    string
 	KubeContext  string
 	CheckpointID string
-	Timeout      time.Duration
+	Containers   string
 }
 
 func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
@@ -36,9 +31,6 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 	}
 	if strings.TrimSpace(opts.CheckpointID) == "" {
 		return nil, fmt.Errorf("missing required flags: --checkpoint-id")
-	}
-	if opts.Timeout <= 0 {
-		return nil, fmt.Errorf("--timeout must be greater than zero")
 	}
 
 	checkpointID := strings.TrimSpace(opts.CheckpointID)
@@ -81,12 +73,25 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 	}
 
 	if createPodFromManifest {
-		restorePod := snapshotprotocol.NewRestorePod(&corev1.Pod{
+		// Stamp (or validate) the required snapshot-target-containers
+		// annotation on the manifest before handing it to the protocol.
+		targetValue, err := reconcileTargetContainers(pod.Annotations, opts.Containers, 1, 0)
+		if err != nil {
+			return nil, err
+		}
+		annotations := map[string]string{}
+		for k, v := range pod.Annotations {
+			annotations[k] = v
+		}
+		annotations[snapshotprotocol.TargetContainersAnnotation] = targetValue
+
+		restorePod, err := snapshotprotocol.NewRestorePod(&corev1.Pod{
 			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        pod.Name,
-				Labels:      pod.Labels,
-				Annotations: pod.Annotations,
+				Name:         pod.Name,
+				GenerateName: pod.GenerateName,
+				Labels:       pod.Labels,
+				Annotations:  annotations,
 			},
 			Spec: *pod.Spec.DeepCopy(),
 		}, snapshotprotocol.PodOptions{
@@ -96,13 +101,17 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 			Storage:         resolvedStorage,
 			SeccompProfile:  snapshotprotocol.DefaultSeccompLocalhostProfile,
 		})
-		_, err = clientset.CoreV1().Pods(namespace).Create(ctx, restorePod, metav1.CreateOptions{})
+		if err != nil {
+			return nil, err
+		}
+		restorePod, err = clientset.CoreV1().Pods(namespace).Create(ctx, restorePod, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
 			return nil, fmt.Errorf("restore pod %s/%s already exists", namespace, pod.Name)
 		}
 		if err != nil {
 			return nil, err
 		}
+		podName = restorePod.Name
 	} else {
 		pod, err = clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
@@ -111,10 +120,10 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 		if len(pod.Spec.Containers) == 0 {
 			return nil, fmt.Errorf("restore target pod %s/%s has no containers", namespace, podName)
 		}
-		if err := snapshotprotocol.ValidateRestorePodSpec(&pod.Spec, resolvedStorage, snapshotprotocol.DefaultSeccompLocalhostProfile); err != nil {
-			return nil, fmt.Errorf("restore target pod %s/%s is not snapshot-compatible: %w", namespace, podName, err)
+		targetValue, err := reconcileTargetContainers(pod.Annotations, opts.Containers, 1, 0)
+		if err != nil {
+			return nil, err
 		}
-
 		labels := map[string]string{}
 		for key, value := range pod.Labels {
 			labels[key] = value
@@ -124,6 +133,10 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 			annotations[key] = value
 		}
 		snapshotprotocol.ApplyRestoreTargetMetadata(labels, annotations, true, checkpointID, snapshotprotocol.DefaultCheckpointArtifactVersion)
+		annotations[snapshotprotocol.TargetContainersAnnotation] = targetValue
+		if err := snapshotprotocol.ValidateRestorePodSpec(&pod.Spec, annotations, resolvedStorage, snapshotprotocol.DefaultSeccompLocalhostProfile); err != nil {
+			return nil, fmt.Errorf("restore target pod %s/%s is not snapshot-compatible: %w", namespace, podName, err)
+		}
 		patch, err := json.Marshal(map[string]any{
 			"metadata": map[string]any{
 				"labels":      labels,
@@ -138,98 +151,12 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 		}
 	}
 
-	waitCtx, cancel := context.WithTimeout(ctx, opts.Timeout)
-	defer cancel()
-	status, err := waitForRestore(waitCtx, clientset, namespace, podName)
-	if err != nil {
-		return nil, err
-	}
-
 	return &result{
 		Name:               podName,
 		Namespace:          namespace,
 		CheckpointID:       checkpointID,
 		CheckpointLocation: resolvedStorage.Location,
 		RestorePod:         podName,
-		Status:             status,
+		Status:             "requested",
 	}, nil
-}
-
-func waitForRestore(ctx context.Context, clientset kubernetes.Interface, namespace string, podName string) (string, error) {
-	var status string
-	err := watchNamedObject(
-		ctx,
-		podName,
-		&corev1.Pod{},
-		func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
-			return clientset.CoreV1().Pods(namespace).List(ctx, options)
-		},
-		func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
-			return clientset.CoreV1().Pods(namespace).Watch(ctx, options)
-		},
-		func(event watch.Event) (bool, error) {
-			if event.Type == watch.Error {
-				return false, apierrors.FromObject(event.Object)
-			}
-
-			pod, ok := event.Object.(*corev1.Pod)
-			if !ok {
-				return false, fmt.Errorf("unexpected restore watch object %T", event.Object)
-			}
-
-			status = strings.TrimSpace(pod.Annotations[snapshotprotocol.RestoreStatusAnnotation])
-			if status == snapshotprotocol.RestoreStatusCompleted {
-				return true, nil
-			}
-			if status == snapshotprotocol.RestoreStatusFailed {
-				return false, fmt.Errorf("restore pod %s/%s failed", namespace, podName)
-			}
-			if pod.Status.Phase == corev1.PodFailed {
-				return false, fmt.Errorf("restore pod %s/%s entered phase Failed (%s)", namespace, podName, pod.Status.Reason)
-			}
-			return false, nil
-		},
-	)
-	if err != nil {
-		if !errors.Is(err, context.DeadlineExceeded) {
-			return "", err
-		}
-		return "", fmt.Errorf("restore pod %s/%s timed out: %s", namespace, podName, restoreTimeoutSummary(clientset, namespace, podName, status))
-	}
-	return status, nil
-}
-
-func restoreTimeoutSummary(clientset kubernetes.Interface, namespace string, podName string, status string) string {
-	summaryCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	pod, err := clientset.CoreV1().Pods(namespace).Get(summaryCtx, podName, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return fmt.Sprintf("restore_status=%q pod not found", status)
-		}
-		return "unable to get restore pod: " + err.Error()
-	}
-
-	parts := []string{
-		fmt.Sprintf("restore_status=%q", status),
-		fmt.Sprintf("pod=%s phase=%s", pod.Name, pod.Status.Phase),
-	}
-	if reason := strings.TrimSpace(pod.Status.Reason); reason != "" {
-		parts = append(parts, fmt.Sprintf("reason=%s", reason))
-	}
-	for _, condition := range pod.Status.Conditions {
-		if condition.Status == corev1.ConditionTrue || condition.Status == corev1.ConditionFalse {
-			parts = append(parts, fmt.Sprintf("%s=%s", condition.Type, condition.Status))
-		}
-	}
-	for _, containerStatus := range pod.Status.ContainerStatuses {
-		if containerStatus.State.Waiting != nil {
-			parts = append(parts, fmt.Sprintf("container=%s waiting=%s", containerStatus.Name, containerStatus.State.Waiting.Reason))
-		}
-		if containerStatus.State.Terminated != nil {
-			parts = append(parts, fmt.Sprintf("container=%s terminated=%s", containerStatus.Name, containerStatus.State.Terminated.Reason))
-		}
-	}
-	return strings.Join(parts, " ")
 }

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -77,8 +77,8 @@ func NewNodeController(
 func (w *NodeController) Run(ctx context.Context) error {
 	w.log.Info("Starting snapshot node controller",
 		"node", w.config.NodeName,
-		"checkpoint", snapshotprotocol.CheckpointSourceLabel,
-		"restore", snapshotprotocol.RestoreTargetLabel,
+		"checkpoint_source_label", snapshotprotocol.CheckpointSourceLabel,
+		"checkpoint_id_label", snapshotprotocol.CheckpointIDLabel,
 	)
 
 	var nsOptions []informers.SharedInformerOption
@@ -128,10 +128,12 @@ func (w *NodeController) Run(ctx context.Context) error {
 	go ckptFactory.Start(w.stopCh)
 	syncFuncs = append(syncFuncs, ckptInformer.HasSynced)
 
-	// Restore informer
-	restoreSelector := labels.SelectorFromSet(labels.Set{
-		snapshotprotocol.RestoreTargetLabel: "true",
-	}).String()
+	// Restore pods carry a checkpoint ID but are not checkpoint sources.
+	restoreSel, err := labels.Parse(snapshotprotocol.CheckpointIDLabel + ",!" + snapshotprotocol.CheckpointSourceLabel)
+	if err != nil {
+		return fmt.Errorf("failed to build restore label selector: %w", err)
+	}
+	restoreSelector := restoreSel.String()
 
 	restoreFactoryOpts := append([]informers.SharedInformerOption{
 		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
@@ -202,6 +204,14 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 		return
 	}
 
+	// Checkpoint contract: exactly one target container per job.
+	targets, err := snapshotprotocol.TargetContainersFromAnnotations(pod.Annotations, 1, 1)
+	if err != nil {
+		w.log.Error(err, "Checkpoint pod missing target-containers annotation", "pod", podKey)
+		return
+	}
+	containerName := targets[0]
+
 	if !w.tryAcquire(podKey) {
 		return
 	}
@@ -229,7 +239,7 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 	emitPodEvent(ctx, w.clientset, w.log, pod, "snapshot", corev1.EventTypeNormal, "CheckpointRequested", fmt.Sprintf("Checkpoint requested: %s", checkpointID))
 
 	go func() {
-		if err := w.runCheckpoint(ctx, pod, job, checkpointID, checkpointLocation, podKey, startedAt); err != nil {
+		if err := w.runCheckpoint(ctx, pod, job, checkpointID, containerName, checkpointLocation, podKey, startedAt); err != nil {
 			opLog := w.log.WithValues("pod", podKey, "checkpoint_id", checkpointID)
 			opLog.Error(err, "Checkpoint controller worker failed")
 			emitPodEvent(ctx, w.clientset, opLog, pod, "snapshot", corev1.EventTypeWarning, "CheckpointWorkerFailed", err.Error())
@@ -269,12 +279,37 @@ func (w *NodeController) reconcileRestorePod(ctx context.Context, pod *corev1.Po
 		return
 	}
 
-	containerName := resolveMainContainerName(pod)
-	if containerName == "" {
-		w.log.Info("Restore pod has no containers", "pod", podKey)
+	targets, err := snapshotprotocol.TargetContainersFromAnnotations(pod.Annotations, 1, 0)
+	if err != nil {
+		w.log.Error(err, "Restore pod missing target-containers annotation", "pod", podKey)
 		return
 	}
+	for _, containerName := range targets {
+		if _, err := snapshotprotocol.RestoreStatusAnnotationKeysFor(containerName); err != nil {
+			w.log.Error(
+				err,
+				"Restore target container name cannot be used in restore status annotation key",
+				"pod", podKey,
+				"container", containerName,
+			)
+			return
+		}
+	}
 
+	for _, containerName := range targets {
+		w.maybeStartRestoreForContainer(ctx, pod, containerName, checkpointID, checkpointLocation, podKey)
+	}
+}
+
+// maybeStartRestoreForContainer starts one restore worker per fresh container.
+func (w *NodeController) maybeStartRestoreForContainer(
+	ctx context.Context,
+	pod *corev1.Pod,
+	containerName string,
+	checkpointID string,
+	checkpointLocation string,
+	podKey string,
+) {
 	containerID := ""
 	for _, cs := range pod.Status.ContainerStatuses {
 		if cs.Name != containerName || cs.ContainerID == "" {
@@ -284,28 +319,37 @@ func (w *NodeController) reconcileRestorePod(ctx context.Context, pod *corev1.Po
 		break
 	}
 	if containerID == "" {
-		w.log.V(1).Info("Restore pod has no running main container yet", "pod", podKey, "container", containerName)
+		w.log.V(1).Info("Restore pod has no running container yet", "pod", podKey, "container", containerName)
 		return
 	}
 
-	annotationStatus := pod.Annotations[snapshotprotocol.RestoreStatusAnnotation]
-	annotationContainerID := pod.Annotations[snapshotprotocol.RestoreContainerIDAnnotation]
+	annotationKeys, err := snapshotprotocol.RestoreStatusAnnotationKeysFor(containerName)
+	if err != nil {
+		w.log.Error(err, "Restore target container name cannot be used in restore status annotation key", "pod", podKey, "container", containerName)
+		return
+	}
+	annotationStatus := pod.Annotations[annotationKeys.Status]
+	annotationContainerID := pod.Annotations[annotationKeys.ContainerID]
 	if annotationContainerID == containerID && (annotationStatus == snapshotprotocol.RestoreStatusCompleted || annotationStatus == snapshotprotocol.RestoreStatusFailed) {
 		return
 	}
 
-	restoreAttemptKey := fmt.Sprintf("%s/%s", podKey, containerID)
+	restoreAttemptKey := fmt.Sprintf("%s/%s/%s", podKey, containerName, containerID)
 	if !w.tryAcquire(restoreAttemptKey) {
 		return
 	}
 
 	startedAt := time.Now()
-	w.log.Info("Restore target detected, triggering external restore", "pod", podKey, "checkpoint_id", checkpointID)
-	emitPodEvent(ctx, w.clientset, w.log, pod, "snapshot", corev1.EventTypeNormal, "RestoreRequested", fmt.Sprintf("Restore requested from checkpoint %s", checkpointID))
+	w.log.Info("Restore target detected, triggering external restore",
+		"pod", podKey,
+		"checkpoint_id", checkpointID,
+		"container", containerName,
+	)
+	emitPodEvent(ctx, w.clientset, w.log, pod, "snapshot", corev1.EventTypeNormal, "RestoreRequested", fmt.Sprintf("Restore requested from checkpoint %s for container %s", checkpointID, containerName))
 
 	go func() {
 		if err := w.runRestore(ctx, pod, containerName, containerID, checkpointID, checkpointLocation, restoreAttemptKey, startedAt); err != nil {
-			opLog := w.log.WithValues("pod", podKey, "checkpoint_id", checkpointID)
+			opLog := w.log.WithValues("pod", podKey, "checkpoint_id", checkpointID, "container", containerName)
 			opLog.Error(err, "Restore controller worker failed")
 			emitPodEvent(ctx, w.clientset, opLog, pod, "snapshot", corev1.EventTypeWarning, "RestoreWorkerFailed", err.Error())
 		}
@@ -320,7 +364,7 @@ func (w *NodeController) reconcileRestorePod(ctx context.Context, pod *corev1.Po
 //     volume on success (observed by the workload via inotify), or SIGKILL
 //     on failure (unrecoverable CUDA-locked process)
 //  5. Mark job as completed or failed
-func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job *batchv1.Job, checkpointID, checkpointLocation, podKey string, startedAt time.Time) error {
+func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job *batchv1.Job, checkpointID, containerName, checkpointLocation, podKey string, startedAt time.Time) error {
 	releasePodOnExit := true
 	defer func() {
 		if releasePodOnExit {
@@ -356,17 +400,7 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 		return nil
 	}
 
-	// Resolve the target container
-	containerName := resolveMainContainerName(pod)
-	if containerName == "" {
-		err := fmt.Errorf("no containers found in pod spec")
-		log.Error(err, "Checkpoint failed")
-		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", err.Error())
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
-			return statusErr
-		}
-		return nil
-	}
+	// Resolve the target container ID from pod status.
 	var containerID string
 	for _, cs := range pod.Status.ContainerStatuses {
 		if cs.Name == containerName {
@@ -375,7 +409,7 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 		}
 	}
 	if containerID == "" {
-		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", "Could not resolve target container ID")
+		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", fmt.Sprintf("Could not resolve container %q ID", containerName))
 		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
 			return statusErr
 		}
@@ -461,13 +495,8 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 	return nil
 }
 
-// runRestore runs the full restore workflow for a pod:
-//  1. Mark the current container instance as in_progress
-//  2. Call executor.Restore (inspect placeholder → nsrestore inside namespace)
-//  3. Write a restore-complete sentinel into the pod's snapshot-control
-//     volume to wake the workload (observed via inotify)
-//  4. Wait for the pod to become Ready
-//  5. Mark the container instance as completed
+// runRestore restores one target container. Kubernetes readiness is gated by
+// the shaped startup probe, not by the snapshot-agent worker.
 func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, containerName, containerID, checkpointID, checkpointLocation, restoreAttemptKey string, startedAt time.Time) error {
 	releaseOnExit := true
 	defer func() {
@@ -484,9 +513,9 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 	podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 	log := w.log.WithValues("pod", podKey, "checkpoint_id", checkpointID, "container_id", containerID)
 	setRestoreStatus := func(value string) error {
-		annotations := map[string]string{
-			snapshotprotocol.RestoreStatusAnnotation:      value,
-			snapshotprotocol.RestoreContainerIDAnnotation: containerID,
+		annotations, err := snapshotprotocol.RestoreStatusAnnotations(containerName, value, containerID)
+		if err != nil {
+			return err
 		}
 		if err := annotatePod(ctx, w.clientset, log, pod, annotations); err != nil {
 			if value == snapshotprotocol.RestoreStatusCompleted || value == snapshotprotocol.RestoreStatusFailed {
@@ -502,7 +531,7 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return fmt.Errorf("failed to annotate pod with restore in_progress: %w", err)
 	}
 
-	// Step 1: Run the restore orchestrator (inspect + nsrestore)
+	// Run the restore orchestrator (inspect + nsrestore).
 	req := executor.RestoreRequest{
 		CheckpointID:       checkpointID,
 		CheckpointLocation: checkpointLocation,
@@ -531,9 +560,8 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return nil
 	}
 
-	// Step 2: Write restore-complete sentinel. placeholderHostPID came back
-	// from executor.Restore — any PID inside the container's mount namespace
-	// reaches /snapshot-control via /host/proc/<pid>/root.
+	// Any PID inside the container mount namespace reaches the control
+	// volume through /host/proc/<pid>/root.
 	if err := snapshotruntime.WriteControlSentinel(placeholderHostPID, snapshotprotocol.RestoreCompleteFile); err != nil {
 		log.Error(err, "Failed to write restore-complete sentinel")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())
@@ -544,19 +572,6 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 			log.Error(killErr, "Failed to kill placeholder after restore sentinel failure")
 		}
 		return fmt.Errorf("failed to write restore-complete sentinel: %w", err)
-	}
-
-	// Step 3: Wait for the pod to become Ready
-	if err := waitForPodReady(restoreCtx, w.clientset, pod.Namespace, pod.Name, containerName); err != nil {
-		log.Error(err, "Restore post-sentinel readiness check failed")
-		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())
-		if statusErr := setRestoreStatus(snapshotprotocol.RestoreStatusFailed); statusErr != nil {
-			return statusErr
-		}
-		if killErr := snapshotruntime.SendSignalToPID(log, placeholderHostPID, syscall.SIGKILL, "restore readiness failed"); killErr != nil {
-			log.Error(killErr, "Failed to kill placeholder after restore readiness failure")
-		}
-		return fmt.Errorf("restore post-sentinel readiness check failed: %w", err)
 	}
 
 	emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeNormal, "RestoreSucceeded", fmt.Sprintf("Restore completed from checkpoint %s", checkpointID))

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -87,12 +87,21 @@ func makePod(name, namespace, nodeName string, phase corev1.PodPhase, ready bool
 			Status: corev1.ConditionTrue,
 		})
 	}
+	// The snapshot contract requires the target-containers annotation on
+	// every checkpoint/restore pod; stamp it here so individual cases do
+	// not have to repeat themselves.
+	merged := map[string]string{
+		snapshotprotocol.TargetContainersAnnotation: "main",
+	}
+	for k, v := range annotations {
+		merged[k] = v
+	}
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
 			Labels:      labels,
-			Annotations: annotations,
+			Annotations: merged,
 		},
 		Spec: corev1.PodSpec{
 			NodeName: nodeName,
@@ -418,9 +427,12 @@ func TestReconcileRestorePod(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			labels := map[string]string{
-				snapshotprotocol.RestoreTargetLabel: "true",
-			}
+			// Restore pods are identified by snapshot-agent as
+			// (CheckpointIDLabel present, CheckpointSourceLabel absent),
+			// so the restore informer's label selector does the filtering.
+			// The hash-missing case deliberately omits the label to exercise
+			// the early-return branch in reconcileRestorePod.
+			labels := map[string]string{}
 			if tc.hash != "" {
 				labels[snapshotprotocol.CheckpointIDLabel] = tc.hash
 			}
@@ -429,8 +441,8 @@ func TestReconcileRestorePod(t *testing.T) {
 			var annotations map[string]string
 			if tc.annotationStatus != "" {
 				annotations = map[string]string{
-					snapshotprotocol.RestoreStatusAnnotation:      tc.annotationStatus,
-					snapshotprotocol.RestoreContainerIDAnnotation: tc.annotationContainerID,
+					snapshotprotocol.RestoreStatusAnnotationPrefix + "main":      tc.annotationStatus,
+					snapshotprotocol.RestoreContainerIDAnnotationPrefix + "main": tc.annotationContainerID,
 				}
 			}
 
@@ -451,7 +463,7 @@ func TestReconcileRestorePod(t *testing.T) {
 			ctx := context.Background()
 
 			if tc.preSeed {
-				w.inFlight["default/test-pod/"+testContainerID] = struct{}{}
+				w.inFlight["default/test-pod/main/"+testContainerID] = struct{}{}
 			}
 
 			w.reconcileRestorePod(ctx, pod)
@@ -470,6 +482,36 @@ func TestReconcileRestorePod(t *testing.T) {
 				time.Sleep(50 * time.Millisecond)
 			}
 		})
+	}
+}
+
+func TestReconcileRestorePodRejectsTargetNameThatCannotFitStatusAnnotation(t *testing.T) {
+	checkpointID := "abc123"
+	containerName := "restore-target-with-long-name-123456"
+	w := makeTestController(t)
+	dir := filepath.Join(w.config.Storage.BasePath, checkpointID, "versions", snapshotprotocol.DefaultCheckpointArtifactVersion)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create checkpoint dir: %v", err)
+	}
+
+	pod := makePod(
+		"test-pod",
+		"default",
+		testNodeName,
+		corev1.PodRunning,
+		false,
+		map[string]string{snapshotprotocol.CheckpointIDLabel: checkpointID},
+		map[string]string{snapshotprotocol.TargetContainersAnnotation: containerName},
+	)
+	pod.Spec.Containers[0].Name = containerName
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:        containerName,
+		ContainerID: "containerd://" + testContainerID,
+	}}
+
+	w.reconcileRestorePod(context.Background(), pod)
+	if len(w.inFlight) != 0 {
+		t.Fatalf("expected restore not to start for overlong annotation key, got inFlight=%v", w.inFlight)
 	}
 }
 
@@ -516,7 +558,7 @@ func TestRunCheckpointKeepsLeaseAndInFlightOnTerminalStatusPatchFailure(t *testi
 		stopCh: make(chan struct{}),
 	}
 
-	err := w.runCheckpoint(context.Background(), pod, job, "abc123", filepath.Join(t.TempDir(), "abc123"), "default/test-pod", time.Now())
+	err := w.runCheckpoint(context.Background(), pod, job, "abc123", "main", filepath.Join(t.TempDir(), "abc123"), "default/test-pod", time.Now())
 	if err == nil {
 		t.Fatal("expected terminal checkpoint status update to fail")
 	}

--- a/deploy/snapshot/internal/controller/util.go
+++ b/deploy/snapshot/internal/controller/util.go
@@ -48,15 +48,6 @@ func podFromInformerObj(obj interface{}) (*corev1.Pod, bool) {
 	return pod, ok
 }
 
-// resolveMainContainerName returns the name of the workload container, which
-// is always Containers[0]. GMS sidecars are appended after the workload.
-func resolveMainContainerName(pod *corev1.Pod) string {
-	if len(pod.Spec.Containers) == 0 {
-		return ""
-	}
-	return pod.Spec.Containers[0].Name
-}
-
 func isPodReady(pod *corev1.Pod) bool {
 	if pod.Status.Phase != corev1.PodRunning {
 		return false
@@ -247,43 +238,6 @@ func annotateJob(ctx context.Context, clientset kubernetes.Interface, log logr.L
 		)
 	}
 	return err
-}
-
-func waitForPodReady(ctx context.Context, clientset kubernetes.Interface, namespace, podName, containerName string) error {
-	lastPhase := ""
-
-	for {
-		pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to get pod %s/%s: %w", namespace, podName, err)
-		}
-
-		lastPhase = string(pod.Status.Phase)
-		for _, condition := range pod.Status.Conditions {
-			if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
-				return nil
-			}
-		}
-
-		for _, cs := range pod.Status.ContainerStatuses {
-			if cs.Name != containerName {
-				continue
-			}
-			if cs.State.Terminated != nil {
-				return fmt.Errorf(
-					"pod %s/%s container %s terminated: reason=%s exitCode=%d",
-					namespace, podName, containerName,
-					cs.State.Terminated.Reason, cs.State.Terminated.ExitCode,
-				)
-			}
-		}
-
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("pod %s/%s did not become Ready (last phase: %s): %w", namespace, podName, lastPhase, ctx.Err())
-		case <-time.After(1 * time.Second):
-		}
-	}
 }
 
 func emitPodEvent(ctx context.Context, clientset kubernetes.Interface, log logr.Logger, pod *corev1.Pod, component, eventType, reason, message string) {

--- a/deploy/snapshot/protocol/checkpoint.go
+++ b/deploy/snapshot/protocol/checkpoint.go
@@ -59,7 +59,26 @@ func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOpt
 	if len(podTemplate.Spec.Containers) == 0 {
 		return nil, fmt.Errorf("checkpoint job requires at least one container")
 	}
-	mainContainer := &podTemplate.Spec.Containers[0]
+
+	// Checkpoint contract: exactly one target container per Job. The
+	// annotation is required — callers (the operator, snapshotctl) stamp
+	// nvidia.com/snapshot-target-containers before handing the template
+	// to us so there is no Containers[0]-vs-"main" ambiguity.
+	targets, err := TargetContainersFromAnnotations(podTemplate.Annotations, 1, 1)
+	if err != nil {
+		return nil, fmt.Errorf("checkpoint job pod template: %w", err)
+	}
+	targetName := targets[0]
+	var targetContainer *corev1.Container
+	for i := range podTemplate.Spec.Containers {
+		if podTemplate.Spec.Containers[i].Name == targetName {
+			targetContainer = &podTemplate.Spec.Containers[i]
+			break
+		}
+	}
+	if targetContainer == nil {
+		return nil, fmt.Errorf("checkpoint job pod template has no container named %q (from %s annotation)", targetName, TargetContainersAnnotation)
+	}
 
 	// Snapshot contract: control volume + ready-file readiness probe. The
 	// agent reads the pod's Ready condition before starting CRIU dump, so
@@ -67,8 +86,8 @@ func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOpt
 	// $DYN_SNAPSHOT_CONTROL_DIR/ready-for-checkpoint. Any per-container
 	// liveness/startup probes are cleared — a checkpoint job runs to a
 	// quiesce-and-sit state, not a long-lived serving state.
-	EnsureControlVolume(&podTemplate.Spec, mainContainer)
-	mainContainer.ReadinessProbe = &corev1.Probe{
+	EnsureControlVolume(&podTemplate.Spec, targetContainer)
+	targetContainer.ReadinessProbe = &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
 				Command: []string{"cat", filepath.Join(SnapshotControlMountPath, ReadyForCheckpointFile)},
@@ -76,16 +95,16 @@ func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOpt
 		},
 		PeriodSeconds: 1,
 	}
-	mainContainer.LivenessProbe = nil
-	mainContainer.StartupProbe = nil
+	targetContainer.LivenessProbe = nil
+	targetContainer.StartupProbe = nil
 
 	if opts.WrapLaunchJob {
-		if len(mainContainer.Command) == 0 {
+		if len(targetContainer.Command) == 0 {
 			return nil, fmt.Errorf("checkpoint job requires container.command when cuda-checkpoint launch-job wrapping is enabled")
 		}
-		mainContainer.Command, mainContainer.Args = wrapWithCudaCheckpointLaunchJob(
-			mainContainer.Command,
-			mainContainer.Args,
+		targetContainer.Command, targetContainer.Args = wrapWithCudaCheckpointLaunchJob(
+			targetContainer.Command,
+			targetContainer.Args,
 		)
 	}
 

--- a/deploy/snapshot/protocol/checkpoint_job_test.go
+++ b/deploy/snapshot/protocol/checkpoint_job_test.go
@@ -4,6 +4,7 @@
 package protocol
 
 import (
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -25,8 +26,11 @@ func requireCheckpointContainer(t *testing.T, containers []corev1.Container, nam
 func TestNewCheckpointJob(t *testing.T) {
 	job, err := NewCheckpointJob(&corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      map[string]string{"existing": "label"},
-			Annotations: map[string]string{"existing": "annotation"},
+			Labels: map[string]string{"existing": "label"},
+			Annotations: map[string]string{
+				"existing":                 "annotation",
+				TargetContainersAnnotation: "main",
+			},
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyAlways,
@@ -63,6 +67,9 @@ func TestNewCheckpointJob(t *testing.T) {
 	if job.Spec.Template.Annotations[CheckpointArtifactVersionAnnotation] != "2" {
 		t.Fatalf("expected checkpoint artifact version annotation on template: %#v", job.Spec.Template.Annotations)
 	}
+	if got := job.Spec.Template.Annotations[TargetContainersAnnotation]; got != "main" {
+		t.Fatalf("target-containers annotation must be preserved on template, got %q", got)
+	}
 	if len(job.Spec.Template.Spec.Volumes) != 1 || job.Spec.Template.Spec.Volumes[0].Name != SnapshotControlVolumeName {
 		t.Fatalf("expected only %s volume, got %#v", SnapshotControlVolumeName, job.Spec.Template.Spec.Volumes)
 	}
@@ -70,17 +77,15 @@ func TestNewCheckpointJob(t *testing.T) {
 	if len(main.VolumeMounts) != 1 || main.VolumeMounts[0].MountPath != SnapshotControlMountPath {
 		t.Fatalf("expected only %s mount at %s, got %#v", SnapshotControlVolumeName, SnapshotControlMountPath, main.VolumeMounts)
 	}
+	if main.VolumeMounts[0].SubPath != "main" {
+		t.Fatalf("expected control mount subPath=main, got %#v", main.VolumeMounts[0])
+	}
 	if main.ReadinessProbe == nil || main.ReadinessProbe.Exec == nil {
 		t.Fatalf("expected ready-file readiness probe, got %#v", main.ReadinessProbe)
 	}
 	expectedProbe := []string{"cat", SnapshotControlMountPath + "/" + ReadyForCheckpointFile}
-	if len(main.ReadinessProbe.Exec.Command) != len(expectedProbe) {
+	if strings.Join(main.ReadinessProbe.Exec.Command, " ") != strings.Join(expectedProbe, " ") {
 		t.Fatalf("expected readiness probe %#v, got %#v", expectedProbe, main.ReadinessProbe.Exec.Command)
-	}
-	for i := range expectedProbe {
-		if main.ReadinessProbe.Exec.Command[i] != expectedProbe[i] {
-			t.Fatalf("expected readiness probe %#v, got %#v", expectedProbe, main.ReadinessProbe.Exec.Command)
-		}
 	}
 	if main.LivenessProbe != nil || main.StartupProbe != nil {
 		t.Fatalf("expected liveness and startup probes cleared, got liveness=%#v startup=%#v", main.LivenessProbe, main.StartupProbe)
@@ -91,17 +96,12 @@ func TestNewCheckpointJob(t *testing.T) {
 	if job.Spec.Template.Spec.SecurityContext == nil || job.Spec.Template.Spec.SecurityContext.SeccompProfile == nil {
 		t.Fatalf("expected seccomp profile to be injected: %#v", job.Spec.Template.Spec.SecurityContext)
 	}
-	if len(job.Spec.Template.Spec.Containers[0].Command) != 1 || job.Spec.Template.Spec.Containers[0].Command[0] != "cuda-checkpoint" {
-		t.Fatalf("expected cuda-checkpoint wrapper command: %#v", job.Spec.Template.Spec.Containers[0].Command)
+	if len(main.Command) != 1 || main.Command[0] != "cuda-checkpoint" {
+		t.Fatalf("expected cuda-checkpoint wrapper command: %#v", main.Command)
 	}
 	expectedArgs := []string{"--launch-job", "python3", "-m", "dynamo.vllm", "--model", "Qwen"}
-	if len(job.Spec.Template.Spec.Containers[0].Args) != len(expectedArgs) {
-		t.Fatalf("expected launch-job args %#v, got %#v", expectedArgs, job.Spec.Template.Spec.Containers[0].Args)
-	}
-	for i := range expectedArgs {
-		if job.Spec.Template.Spec.Containers[0].Args[i] != expectedArgs[i] {
-			t.Fatalf("expected launch-job args %#v, got %#v", expectedArgs, job.Spec.Template.Spec.Containers[0].Args)
-		}
+	if strings.Join(main.Args, "|") != strings.Join(expectedArgs, "|") {
+		t.Fatalf("expected launch-job args %#v, got %#v", expectedArgs, main.Args)
 	}
 	if job.Spec.BackoffLimit == nil || *job.Spec.BackoffLimit != 0 {
 		t.Fatalf("expected backoffLimit 0, got %#v", job.Spec.BackoffLimit)
@@ -114,12 +114,15 @@ func TestNewCheckpointJob(t *testing.T) {
 	}
 }
 
-func TestNewCheckpointJobWrapsFirstContainer(t *testing.T) {
+func TestNewCheckpointJobWrapsTargetContainer(t *testing.T) {
 	job, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{TargetContainersAnnotation: "worker"},
+		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
-				{Name: "worker", Command: []string{"python3", "-m", "dynamo.vllm"}, Args: []string{"--model", "Qwen"}},
 				{Name: "sidecar", Command: []string{"sleep"}, Args: []string{"infinity"}},
+				{Name: "worker", Command: []string{"python3", "-m", "dynamo.vllm"}, Args: []string{"--model", "Qwen"}},
 			},
 		},
 	}, CheckpointJobOptions{
@@ -136,16 +139,11 @@ func TestNewCheckpointJobWrapsFirstContainer(t *testing.T) {
 
 	worker := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, "worker")
 	if len(worker.Command) != 1 || worker.Command[0] != "cuda-checkpoint" {
-		t.Fatalf("expected first container to be wrapped, got %#v", worker.Command)
+		t.Fatalf("expected target container to be wrapped, got %#v", worker.Command)
 	}
 	expectedArgs := []string{"--launch-job", "python3", "-m", "dynamo.vllm", "--model", "Qwen"}
-	if len(worker.Args) != len(expectedArgs) {
+	if strings.Join(worker.Args, "|") != strings.Join(expectedArgs, "|") {
 		t.Fatalf("expected launch-job args %#v, got %#v", expectedArgs, worker.Args)
-	}
-	for i := range expectedArgs {
-		if worker.Args[i] != expectedArgs[i] {
-			t.Fatalf("expected launch-job args %#v, got %#v", expectedArgs, worker.Args)
-		}
 	}
 
 	sidecar := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, "sidecar")
@@ -155,36 +153,75 @@ func TestNewCheckpointJobWrapsFirstContainer(t *testing.T) {
 	if len(sidecar.Args) != 1 || sidecar.Args[0] != "infinity" {
 		t.Fatalf("expected sidecar args to remain unchanged, got %#v", sidecar.Args)
 	}
+	// Sidecar does not get a control volume mount, snapshot env, or ready probe.
+	for _, mount := range sidecar.VolumeMounts {
+		if mount.Name == SnapshotControlVolumeName {
+			t.Fatalf("sidecar should not have control volume mount: %#v", sidecar.VolumeMounts)
+		}
+	}
+	for _, env := range sidecar.Env {
+		if env.Name == SnapshotControlDirEnv {
+			t.Fatalf("sidecar should not have control env: %#v", sidecar.Env)
+		}
+	}
+	if sidecar.ReadinessProbe != nil {
+		t.Fatalf("sidecar should not have a readiness probe forced on it")
+	}
 }
 
-func TestNewCheckpointJobAllowsSingleNonMainContainer(t *testing.T) {
-	job, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+func TestNewCheckpointJobRequiresTargetAnnotation(t *testing.T) {
+	_, err := NewCheckpointJob(&corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:    "worker",
-				Command: []string{"python3", "-m", "dynamo.vllm"},
-				Args:    []string{"--model", "Qwen"},
-			}},
+			Containers: []corev1.Container{{Name: "worker", Command: []string{"python3"}}},
 		},
 	}, CheckpointJobOptions{
-		Namespace:             "test-ns",
-		CheckpointID:          "hash",
-		ArtifactVersion:       "2",
-		Name:                  "test-job",
-		TTLSecondsAfterFinish: ptr.To(int32(300)),
-		WrapLaunchJob:         true,
+		Namespace:    "test-ns",
+		CheckpointID: "hash",
+		Name:         "test-job",
 	})
-	if err != nil {
-		t.Fatalf("expected checkpoint job, got error: %v", err)
-	}
-
-	container := &job.Spec.Template.Spec.Containers[0]
-	if len(container.Command) != 1 || container.Command[0] != "cuda-checkpoint" {
-		t.Fatalf("expected single container to be wrapped, got %#v", container.Command)
+	if err == nil || !strings.Contains(err.Error(), TargetContainersAnnotation) {
+		t.Fatalf("expected missing-annotation error, got %v", err)
 	}
 }
 
+func TestNewCheckpointJobRequiresSingleTarget(t *testing.T) {
+	_, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{TargetContainersAnnotation: "engine-0,engine-1"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "engine-0", Command: []string{"python3"}},
+				{Name: "engine-1", Command: []string{"python3"}},
+			},
+		},
+	}, CheckpointJobOptions{
+		Namespace:    "test-ns",
+		CheckpointID: "hash",
+		Name:         "test-job",
+	})
+	if err == nil || !strings.Contains(err.Error(), "at most 1") {
+		t.Fatalf("expected single-target error, got %v", err)
+	}
+}
 
+func TestNewCheckpointJobRejectsUnknownTarget(t *testing.T) {
+	_, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{TargetContainersAnnotation: "missing"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "worker", Command: []string{"python3"}}},
+		},
+	}, CheckpointJobOptions{
+		Namespace:    "test-ns",
+		CheckpointID: "hash",
+		Name:         "test-job",
+	})
+	if err == nil || !strings.Contains(err.Error(), `"missing"`) {
+		t.Fatalf("expected unknown-target error, got %v", err)
+	}
+}
 
 func TestGetCheckpointJobName(t *testing.T) {
 	name := GetCheckpointJobName("abc123def4567890", "2")

--- a/deploy/snapshot/protocol/common.go
+++ b/deploy/snapshot/protocol/common.go
@@ -6,21 +6,34 @@ package protocol
 import (
 	"fmt"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 const (
-	CheckpointSourceLabel               = "nvidia.com/snapshot-is-checkpoint-source"
-	CheckpointIDLabel                   = "nvidia.com/snapshot-checkpoint-id"
-	RestoreTargetLabel                  = "nvidia.com/snapshot-is-restore-target"
+	CheckpointSourceLabel = "nvidia.com/snapshot-is-checkpoint-source"
+
+	// Restore pods carry CheckpointIDLabel without CheckpointSourceLabel.
+	CheckpointIDLabel = "nvidia.com/snapshot-checkpoint-id"
+
 	CheckpointArtifactVersionAnnotation = "nvidia.com/snapshot-artifact-version"
-	CheckpointStatusAnnotation          = "nvidia.com/snapshot-checkpoint-status"
-	RestoreStatusAnnotation             = "nvidia.com/snapshot-restore-status"
-	RestoreContainerIDAnnotation        = "nvidia.com/snapshot-restore-container-id"
-	CheckpointVolumeName                = "checkpoint-storage"
-	DefaultCheckpointArtifactVersion    = "1"
-	DefaultCheckpointJobTTLSeconds      = int32(300)
-	DefaultSeccompLocalhostProfile      = "profiles/block-iouring.json"
-	StorageTypePVC                      = "pvc"
+
+	// Required comma-separated checkpoint/restore target container list.
+	TargetContainersAnnotation = "nvidia.com/snapshot-target-containers"
+
+	CheckpointStatusAnnotation = "nvidia.com/snapshot-checkpoint-status"
+
+	// Full keys are nvidia.com/snapshot-restore-status.<containerName>.
+	RestoreStatusAnnotationPrefix = "nvidia.com/snapshot-restore-status."
+
+	// Full keys are nvidia.com/snapshot-restore-container-id.<containerName>.
+	RestoreContainerIDAnnotationPrefix = "nvidia.com/snapshot-restore-container-id."
+
+	CheckpointVolumeName             = "checkpoint-storage"
+	DefaultCheckpointArtifactVersion = "1"
+	DefaultCheckpointJobTTLSeconds   = int32(300)
+	DefaultSeccompLocalhostProfile   = "profiles/block-iouring.json"
+	StorageTypePVC                   = "pvc"
 
 	CheckpointStatusCompleted = "completed"
 	CheckpointStatusFailed    = "failed"
@@ -34,6 +47,11 @@ type Storage struct {
 	Location string
 	PVCName  string
 	BasePath string
+}
+
+type RestoreStatusAnnotationKeys struct {
+	Status      string
+	ContainerID string
 }
 
 func ArtifactVersion(version string) string {
@@ -66,20 +84,109 @@ func ResolveRestoreStorage(checkpointID string, version string, location string,
 	return resolved, nil
 }
 
+// FormatTargetContainers renders the canonical annotation value.
+func FormatTargetContainers(names []string) string {
+	cleaned := make([]string, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		cleaned = append(cleaned, name)
+	}
+	return strings.Join(cleaned, ",")
+}
+
+// ParseTargetContainers trims names and rejects empty or duplicate entries.
+func ParseTargetContainers(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	parts := strings.Split(value, ",")
+	seen := make(map[string]struct{}, len(parts))
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			return nil, fmt.Errorf("empty container name in %s=%q", TargetContainersAnnotation, value)
+		}
+		if _, dup := seen[name]; dup {
+			return nil, fmt.Errorf("duplicate container name %q in %s=%q", name, TargetContainersAnnotation, value)
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out, nil
+}
+
+// TargetContainersFromAnnotations requires the target list and enforces bounds.
+func TargetContainersFromAnnotations(annotations map[string]string, minCount, maxCount int) ([]string, error) {
+	raw, ok := annotations[TargetContainersAnnotation]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("missing required %s annotation", TargetContainersAnnotation)
+	}
+	names, err := ParseTargetContainers(raw)
+	if err != nil {
+		return nil, err
+	}
+	if minCount > 0 && len(names) < minCount {
+		return nil, fmt.Errorf("%s must list at least %d container name(s), got %d", TargetContainersAnnotation, minCount, len(names))
+	}
+	if maxCount > 0 && len(names) > maxCount {
+		return nil, fmt.Errorf("%s must list at most %d container name(s), got %d", TargetContainersAnnotation, maxCount, len(names))
+	}
+	return names, nil
+}
+
+func RestoreStatusAnnotationKeysFor(containerName string) (RestoreStatusAnnotationKeys, error) {
+	keys := RestoreStatusAnnotationKeys{
+		Status:      RestoreStatusAnnotationPrefix + containerName,
+		ContainerID: RestoreContainerIDAnnotationPrefix + containerName,
+	}
+	for _, annotationKey := range []string{keys.Status, keys.ContainerID} {
+		if errs := validation.IsQualifiedName(annotationKey); len(errs) > 0 {
+			return RestoreStatusAnnotationKeys{}, fmt.Errorf("container name %q cannot be used in restore status annotation key %q: %s", containerName, annotationKey, strings.Join(errs, "; "))
+		}
+	}
+	return keys, nil
+}
+
+func RestoreStatusAnnotations(containerName, status, containerID string) (map[string]string, error) {
+	keys, err := RestoreStatusAnnotationKeysFor(containerName)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{
+		keys.Status:      status,
+		keys.ContainerID: containerID,
+	}, nil
+}
+
+func clearRestoreStatusKeys(annotations map[string]string) {
+	delete(annotations, "nvidia.com/snapshot-restore-status")
+	delete(annotations, "nvidia.com/snapshot-restore-container-id")
+	for key := range annotations {
+		if strings.HasPrefix(key, RestoreStatusAnnotationPrefix) ||
+			strings.HasPrefix(key, RestoreContainerIDAnnotationPrefix) {
+			delete(annotations, key)
+		}
+	}
+}
+
+// ApplyRestoreTargetMetadata resets restore metadata and stamps checkpoint ID.
+// The caller owns TargetContainersAnnotation.
 func ApplyRestoreTargetMetadata(labels map[string]string, annotations map[string]string, enabled bool, checkpointID string, artifactVersion string) {
 	delete(labels, CheckpointSourceLabel)
-	delete(labels, RestoreTargetLabel)
 	delete(labels, CheckpointIDLabel)
 	delete(annotations, CheckpointArtifactVersionAnnotation)
 	delete(annotations, CheckpointStatusAnnotation)
-	delete(annotations, RestoreStatusAnnotation)
-	delete(annotations, RestoreContainerIDAnnotation)
+	clearRestoreStatusKeys(annotations)
 
 	if !enabled {
 		return
 	}
 
-	labels[RestoreTargetLabel] = "true"
 	if checkpointID != "" {
 		labels[CheckpointIDLabel] = checkpointID
 	}
@@ -87,7 +194,6 @@ func ApplyRestoreTargetMetadata(labels map[string]string, annotations map[string
 }
 
 func applyCheckpointSourceMetadata(labels map[string]string, annotations map[string]string, checkpointID string, artifactVersion string) {
-	delete(labels, RestoreTargetLabel)
 	delete(labels, CheckpointIDLabel)
 	delete(annotations, CheckpointArtifactVersionAnnotation)
 

--- a/deploy/snapshot/protocol/constants_test.go
+++ b/deploy/snapshot/protocol/constants_test.go
@@ -3,7 +3,11 @@
 
 package protocol
 
-import "testing"
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
 
 func TestApplyRestoreTargetMetadata(t *testing.T) {
 	labels := map[string]string{
@@ -11,17 +15,20 @@ func TestApplyRestoreTargetMetadata(t *testing.T) {
 		CheckpointIDLabel:     "old",
 	}
 	annotations := map[string]string{
-		CheckpointArtifactVersionAnnotation: "old",
-		CheckpointStatusAnnotation:          "completed",
-		RestoreStatusAnnotation:             "failed",
-		RestoreContainerIDAnnotation:        "dead-container",
+		CheckpointArtifactVersionAnnotation:             "old",
+		CheckpointStatusAnnotation:                      "completed",
+		RestoreStatusAnnotationPrefix + "main":          "failed",
+		RestoreStatusAnnotationPrefix + "engine-1":      "completed",
+		RestoreContainerIDAnnotationPrefix + "main":     "dead-container",
+		RestoreContainerIDAnnotationPrefix + "engine-1": "dead-container",
+		"nvidia.com/snapshot-restore-status":            "completed",
+		"nvidia.com/snapshot-restore-container-id":      "dead-container",
+		// Preserve the target-containers annotation across ApplyRestoreTargetMetadata.
+		TargetContainersAnnotation: "main",
 	}
 
 	ApplyRestoreTargetMetadata(labels, annotations, true, "hash", "2")
 
-	if labels[RestoreTargetLabel] != "true" {
-		t.Fatalf("expected restore target label, got %#v", labels)
-	}
 	if labels[CheckpointIDLabel] != "hash" {
 		t.Fatalf("expected checkpoint hash label, got %#v", labels)
 	}
@@ -34,31 +41,36 @@ func TestApplyRestoreTargetMetadata(t *testing.T) {
 	if _, ok := annotations[CheckpointStatusAnnotation]; ok {
 		t.Fatalf("checkpoint status annotation was not cleared: %#v", annotations)
 	}
-	if _, ok := annotations[RestoreStatusAnnotation]; ok {
-		t.Fatalf("restore status annotation was not cleared: %#v", annotations)
+	for _, key := range []string{
+		RestoreStatusAnnotationPrefix + "main",
+		RestoreStatusAnnotationPrefix + "engine-1",
+		RestoreContainerIDAnnotationPrefix + "main",
+		RestoreContainerIDAnnotationPrefix + "engine-1",
+		"nvidia.com/snapshot-restore-status",
+		"nvidia.com/snapshot-restore-container-id",
+	} {
+		if _, ok := annotations[key]; ok {
+			t.Fatalf("restore annotation %s was not cleared: %#v", key, annotations)
+		}
 	}
-	if _, ok := annotations[RestoreContainerIDAnnotation]; ok {
-		t.Fatalf("restore container id annotation was not cleared: %#v", annotations)
+	if got := annotations[TargetContainersAnnotation]; got != "main" {
+		t.Fatalf("target-containers annotation must be preserved, got %q", got)
 	}
 }
 
 func TestApplyRestoreTargetMetadataDisabledClearsState(t *testing.T) {
 	labels := map[string]string{
-		RestoreTargetLabel: "true",
-		CheckpointIDLabel:  "hash",
+		CheckpointIDLabel: "hash",
 	}
 	annotations := map[string]string{
-		CheckpointArtifactVersionAnnotation: "2",
-		CheckpointStatusAnnotation:          "completed",
-		RestoreStatusAnnotation:             "failed",
-		RestoreContainerIDAnnotation:        "dead-container",
+		CheckpointArtifactVersionAnnotation:         "2",
+		CheckpointStatusAnnotation:                  "completed",
+		RestoreStatusAnnotationPrefix + "main":      "failed",
+		RestoreContainerIDAnnotationPrefix + "main": "dead-container",
 	}
 
 	ApplyRestoreTargetMetadata(labels, annotations, false, "", "")
 
-	if _, ok := labels[RestoreTargetLabel]; ok {
-		t.Fatalf("restore target label was not cleared: %#v", labels)
-	}
 	if _, ok := labels[CheckpointIDLabel]; ok {
 		t.Fatalf("checkpoint hash label was not cleared: %#v", labels)
 	}
@@ -68,10 +80,105 @@ func TestApplyRestoreTargetMetadataDisabledClearsState(t *testing.T) {
 	if _, ok := annotations[CheckpointStatusAnnotation]; ok {
 		t.Fatalf("checkpoint status annotation was not cleared: %#v", annotations)
 	}
-	if _, ok := annotations[RestoreStatusAnnotation]; ok {
-		t.Fatalf("restore status annotation was not cleared: %#v", annotations)
+	if _, ok := annotations[RestoreStatusAnnotationPrefix+"main"]; ok {
+		t.Fatalf("per-container restore status was not cleared: %#v", annotations)
 	}
-	if _, ok := annotations[RestoreContainerIDAnnotation]; ok {
-		t.Fatalf("restore container id annotation was not cleared: %#v", annotations)
+	if _, ok := annotations[RestoreContainerIDAnnotationPrefix+"main"]; ok {
+		t.Fatalf("per-container restore container id was not cleared: %#v", annotations)
+	}
+}
+
+func TestParseTargetContainers(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty", in: "", want: nil},
+		{name: "whitespace", in: "   ", want: nil},
+		{name: "single", in: "main", want: []string{"main"}},
+		{name: "two", in: "engine-0,engine-1", want: []string{"engine-0", "engine-1"}},
+		{name: "whitespace preserved in split", in: " engine-0 , engine-1 ", want: []string{"engine-0", "engine-1"}},
+		{name: "duplicate rejected", in: "a,a", wantErr: true},
+		{name: "empty token rejected", in: "a,,b", wantErr: true},
+		{name: "trailing comma rejected", in: "a,", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseTargetContainers(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatTargetContainers(t *testing.T) {
+	if got := FormatTargetContainers([]string{"a", " b ", "", "c"}); got != "a,b,c" {
+		t.Fatalf("got %q", got)
+	}
+	if got := FormatTargetContainers(nil); got != "" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestTargetContainersFromAnnotationsMissing(t *testing.T) {
+	_, err := TargetContainersFromAnnotations(map[string]string{}, 1, 1)
+	if err == nil {
+		t.Fatalf("expected missing annotation error")
+	}
+	if _, err := TargetContainersFromAnnotations(map[string]string{TargetContainersAnnotation: ""}, 1, 1); err == nil {
+		t.Fatalf("expected missing annotation error for empty value")
+	}
+}
+
+func TestTargetContainersFromAnnotationsBounds(t *testing.T) {
+	annotations := map[string]string{TargetContainersAnnotation: "engine-0,engine-1"}
+	if _, err := TargetContainersFromAnnotations(annotations, 1, 1); err == nil {
+		t.Fatalf("expected max-1 enforcement to reject 2 containers")
+	}
+	got, err := TargetContainersFromAnnotations(annotations, 1, 0)
+	if err != nil {
+		t.Fatalf("unexpected error for unbounded max: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"engine-0", "engine-1"}) {
+		t.Fatalf("got %#v", got)
+	}
+	if _, err := TargetContainersFromAnnotations(map[string]string{TargetContainersAnnotation: "a,a"}, 1, 0); err == nil {
+		t.Fatalf("expected dup rejection")
+	}
+}
+
+func TestRestoreStatusAnnotations(t *testing.T) {
+	got, err := RestoreStatusAnnotations("engine-1", RestoreStatusCompleted, "container-id")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]string{
+		RestoreStatusAnnotationPrefix + "engine-1":      RestoreStatusCompleted,
+		RestoreContainerIDAnnotationPrefix + "engine-1": "container-id",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestRestoreStatusAnnotationsRejectsInvalidContainerName(t *testing.T) {
+	_, err := RestoreStatusAnnotations(strings.Repeat("a", 200), RestoreStatusInProgress, "container-id")
+	if err == nil {
+		t.Fatalf("expected invalid annotation key error")
+	}
+	if !strings.Contains(err.Error(), "restore status annotation key") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/deploy/snapshot/protocol/control_volume.go
+++ b/deploy/snapshot/protocol/control_volume.go
@@ -12,6 +12,11 @@ const (
 	// checkpoint/restore lifecycle sentinels written by the snapshot agent
 	// and observed by the workload. It replaces the SIGUSR1/SIGCONT signals
 	// that previously required the workload to run as PID 1.
+	//
+	// When a pod targets multiple containers (e.g. failover engine-0 +
+	// engine-1), each container mounts the emptyDir with
+	// subPath=<containerName>, so sentinels are isolated per-container on
+	// disk while each container still sees them at SnapshotControlMountPath.
 	SnapshotControlVolumeName = "snapshot-control"
 
 	// SnapshotControlMountPath is where the control volume is mounted inside
@@ -39,9 +44,14 @@ const (
 )
 
 // EnsureControlVolume adds the snapshot-control emptyDir to the pod spec,
-// mounts it on the given container at SnapshotControlMountPath, and sets
-// DYN_SNAPSHOT_CONTROL_DIR on the container's env. Idempotent — safe to call
-// from multiple code paths (operator checkpoint job, restore pod shaping, etc.).
+// mounts it on the given container at SnapshotControlMountPath (using
+// subPath=<containerName> so concurrent target containers in a failover pod
+// each see an isolated view), and sets DYN_SNAPSHOT_CONTROL_DIR on the
+// container's env. Idempotent — safe to call from multiple code paths
+// (operator checkpoint job, restore pod shaping, etc.).
+//
+// Callers must pass the container's own name; the subPath makes the mount
+// container-scoped on disk even though the in-container path is the same.
 func EnsureControlVolume(podSpec *corev1.PodSpec, container *corev1.Container) {
 	if podSpec == nil || container == nil {
 		return
@@ -61,6 +71,12 @@ func EnsureControlVolume(podSpec *corev1.PodSpec, container *corev1.Container) {
 		})
 	}
 
+	// Per-container subPath so each target container has its own sentinel
+	// directory on the emptyDir's backing disk. An empty container name
+	// degrades to the volume root, which is the correct (and only safe)
+	// behavior for single-container pods.
+	subPath := container.Name
+
 	hasMount := false
 	for _, m := range container.VolumeMounts {
 		if m.Name == SnapshotControlVolumeName {
@@ -72,6 +88,7 @@ func EnsureControlVolume(podSpec *corev1.PodSpec, container *corev1.Container) {
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 			Name:      SnapshotControlVolumeName,
 			MountPath: SnapshotControlMountPath,
+			SubPath:   subPath,
 		})
 	}
 

--- a/deploy/snapshot/protocol/control_volume_test.go
+++ b/deploy/snapshot/protocol/control_volume_test.go
@@ -21,8 +21,30 @@ func TestEnsureControlVolume(t *testing.T) {
 		if len(c.VolumeMounts) != 1 || c.VolumeMounts[0].Name != SnapshotControlVolumeName || c.VolumeMounts[0].MountPath != SnapshotControlMountPath {
 			t.Fatalf("expected one %s mount at %s, got %#v", SnapshotControlVolumeName, SnapshotControlMountPath, c.VolumeMounts)
 		}
+		if c.VolumeMounts[0].SubPath != "main" {
+			t.Fatalf("expected subPath=%q, got %q", "main", c.VolumeMounts[0].SubPath)
+		}
 		if len(c.Env) != 1 || c.Env[0].Name != SnapshotControlDirEnv || c.Env[0].Value != SnapshotControlMountPath {
 			t.Fatalf("expected env %s=%s, got %#v", SnapshotControlDirEnv, SnapshotControlMountPath, c.Env)
+		}
+	})
+
+	t.Run("per-container subPath isolates multi-container pods", func(t *testing.T) {
+		ps := &corev1.PodSpec{Containers: []corev1.Container{
+			{Name: "engine-0"},
+			{Name: "engine-1"},
+		}}
+		EnsureControlVolume(ps, &ps.Containers[0])
+		EnsureControlVolume(ps, &ps.Containers[1])
+
+		if len(ps.Volumes) != 1 {
+			t.Fatalf("expected single shared emptyDir, got %#v", ps.Volumes)
+		}
+		if got := ps.Containers[0].VolumeMounts[0].SubPath; got != "engine-0" {
+			t.Fatalf("engine-0 subPath=%q", got)
+		}
+		if got := ps.Containers[1].VolumeMounts[0].SubPath; got != "engine-1" {
+			t.Fatalf("engine-1 subPath=%q", got)
 		}
 	})
 

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"path/filepath"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,7 +31,8 @@ type PodOptions struct {
 	SeccompProfile  string
 }
 
-func NewRestorePod(pod *corev1.Pod, opts PodOptions) *corev1.Pod {
+// NewRestorePod shapes every annotated target container for restore.
+func NewRestorePod(pod *corev1.Pod, opts PodOptions) (*corev1.Pod, error) {
 	pod = pod.DeepCopy()
 	if pod.Labels == nil {
 		pod.Labels = map[string]string{}
@@ -39,47 +41,59 @@ func NewRestorePod(pod *corev1.Pod, opts PodOptions) *corev1.Pod {
 		pod.Annotations = map[string]string{}
 	}
 	ApplyRestoreTargetMetadata(pod.Labels, pod.Annotations, true, opts.CheckpointID, opts.ArtifactVersion)
-	container := resolveWorkerContainer(&pod.Spec)
-	if container == nil {
-		return nil
+	if err := PrepareRestorePodSpec(&pod.Spec, pod.Annotations, opts.Storage, opts.SeccompProfile, true); err != nil {
+		return nil, err
 	}
-	PrepareRestorePodSpec(&pod.Spec, container, opts.Storage, opts.SeccompProfile, true)
 	pod.Namespace = opts.Namespace
 	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
-	return pod
+	return pod, nil
 }
 
-// resolveWorkerContainer returns the workload container, which is always
-// Containers[0]. GMS sidecars are appended after the workload.
-func resolveWorkerContainer(podSpec *corev1.PodSpec) *corev1.Container {
-	if podSpec == nil || len(podSpec.Containers) == 0 {
-		return nil
-	}
-	return &podSpec.Containers[0]
-}
-
+// PrepareRestorePodSpec applies restore shaping to annotated target containers.
 func PrepareRestorePodSpec(
 	podSpec *corev1.PodSpec,
-	container *corev1.Container,
+	annotations map[string]string,
 	storage Storage,
 	seccompProfile string,
 	isCheckpointReady bool,
-) {
+) error {
+	if podSpec == nil {
+		return fmt.Errorf("pod spec is nil")
+	}
+	targets, err := TargetContainersFromAnnotations(annotations, 1, 0)
+	if err != nil {
+		return fmt.Errorf("restore pod spec: %w", err)
+	}
 	EnsureLocalhostSeccompProfile(podSpec, seccompProfile)
 	if storage.PVCName != "" {
 		InjectCheckpointVolume(podSpec, storage.PVCName)
 	}
-	if storage.BasePath != "" {
-		injectCheckpointVolumeMount(container, storage.BasePath)
+	for _, name := range targets {
+		var container *corev1.Container
+		for i := range podSpec.Containers {
+			if podSpec.Containers[i].Name == name {
+				container = &podSpec.Containers[i]
+				break
+			}
+		}
+		if container == nil {
+			return fmt.Errorf("restore target container %q not found in pod spec (from %s annotation)", name, TargetContainersAnnotation)
+		}
+		if storage.BasePath != "" {
+			injectCheckpointVolumeMount(container, storage.BasePath)
+		}
+		EnsureControlVolume(podSpec, container)
+		if isCheckpointReady {
+			container.Command = []string{"sleep", "infinity"}
+			container.Args = nil
+			ensureRestoreStartupProbe(container)
+		}
 	}
-	EnsureControlVolume(podSpec, container)
-	if isCheckpointReady {
-		container.Command = []string{"sleep", "infinity"}
-		container.Args = nil
-		ensureRestoreStartupProbe(container)
-	}
+	return nil
 }
 
+// ensureRestoreStartupProbe reuses the workload's probe when possible and
+// falls back to the restore-complete sentinel when the workload has no probe.
 func ensureRestoreStartupProbe(container *corev1.Container) {
 	startup := container.StartupProbe
 	if startup == nil {
@@ -89,6 +103,16 @@ func ensureRestoreStartupProbe(container *corev1.Container) {
 		}
 	}
 	if startup == nil {
+		container.StartupProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"cat", filepath.Join(SnapshotControlMountPath, RestoreCompleteFile)},
+				},
+			},
+			PeriodSeconds:    1,
+			FailureThreshold: math.MaxInt32,
+			SuccessThreshold: 1,
+		}
 		return
 	}
 
@@ -98,17 +122,19 @@ func ensureRestoreStartupProbe(container *corev1.Container) {
 	container.StartupProbe = startup
 }
 
+// ValidateRestorePodSpec verifies the target containers are restore-shaped.
 func ValidateRestorePodSpec(
 	podSpec *corev1.PodSpec,
+	annotations map[string]string,
 	storage Storage,
 	seccompProfile string,
 ) error {
 	if podSpec == nil {
 		return fmt.Errorf("pod spec is nil")
 	}
-	container := resolveWorkerContainer(podSpec)
-	if container == nil {
-		return fmt.Errorf("restore target must have at least one container")
+	targets, err := TargetContainersFromAnnotations(annotations, 1, 0)
+	if err != nil {
+		return err
 	}
 	if storage.PVCName != "" {
 		hasVolume := false
@@ -124,18 +150,6 @@ func ValidateRestorePodSpec(
 			return fmt.Errorf("missing %s volume for PVC %s", CheckpointVolumeName, storage.PVCName)
 		}
 	}
-	if storage.BasePath != "" {
-		hasMount := false
-		for _, mount := range container.VolumeMounts {
-			if mount.Name == CheckpointVolumeName && mount.MountPath == storage.BasePath {
-				hasMount = true
-				break
-			}
-		}
-		if !hasMount {
-			return fmt.Errorf("missing %s mount at %s", CheckpointVolumeName, storage.BasePath)
-		}
-	}
 	hasControlVolume := false
 	for _, volume := range podSpec.Volumes {
 		if volume.Name == SnapshotControlVolumeName && volume.EmptyDir != nil {
@@ -146,25 +160,55 @@ func ValidateRestorePodSpec(
 	if !hasControlVolume {
 		return fmt.Errorf("missing %s emptyDir volume; add it via snapshotprotocol.EnsureControlVolume", SnapshotControlVolumeName)
 	}
-	hasControlMount := false
-	for _, mount := range container.VolumeMounts {
-		if mount.Name == SnapshotControlVolumeName && mount.MountPath == SnapshotControlMountPath {
-			hasControlMount = true
-			break
+	for _, name := range targets {
+		var container *corev1.Container
+		for i := range podSpec.Containers {
+			if podSpec.Containers[i].Name == name {
+				container = &podSpec.Containers[i]
+				break
+			}
 		}
-	}
-	if !hasControlMount {
-		return fmt.Errorf("missing %s mount at %s", SnapshotControlVolumeName, SnapshotControlMountPath)
-	}
-	hasControlEnv := false
-	for _, env := range container.Env {
-		if env.Name == SnapshotControlDirEnv {
-			hasControlEnv = true
-			break
+		if container == nil {
+			return fmt.Errorf("restore target container %q not found in pod spec (from %s annotation)", name, TargetContainersAnnotation)
 		}
-	}
-	if !hasControlEnv {
-		return fmt.Errorf("missing %s env var on worker container", SnapshotControlDirEnv)
+		if storage.BasePath != "" {
+			hasMount := false
+			for _, mount := range container.VolumeMounts {
+				if mount.Name == CheckpointVolumeName && mount.MountPath == storage.BasePath {
+					hasMount = true
+					break
+				}
+			}
+			if !hasMount {
+				return fmt.Errorf("missing %s mount at %s on container %q", CheckpointVolumeName, storage.BasePath, name)
+			}
+		}
+		hasControlMount := false
+		for _, mount := range container.VolumeMounts {
+			if mount.Name == SnapshotControlVolumeName && mount.MountPath == SnapshotControlMountPath {
+				hasControlMount = true
+				if mount.SubPath != name {
+					return fmt.Errorf("expected SubPath %q for %s at %s on container %q, got %q", name, SnapshotControlVolumeName, SnapshotControlMountPath, name, mount.SubPath)
+				}
+				break
+			}
+		}
+		if !hasControlMount {
+			return fmt.Errorf("missing %s mount at %s on container %q", SnapshotControlVolumeName, SnapshotControlMountPath, name)
+		}
+		hasControlEnv := false
+		for _, env := range container.Env {
+			if env.Name == SnapshotControlDirEnv {
+				hasControlEnv = true
+				break
+			}
+		}
+		if !hasControlEnv {
+			return fmt.Errorf("missing %s env var on container %q", SnapshotControlDirEnv, name)
+		}
+		if container.StartupProbe == nil {
+			return fmt.Errorf("missing restore-complete startup probe on container %q", name)
+		}
 	}
 	if seccompProfile == "" {
 		return nil
@@ -266,12 +310,13 @@ func DiscoverAndResolveStorage(
 	return ResolveCheckpointStorage(checkpointID, artifactVersion, storage)
 }
 
+// PrepareRestorePodSpecForCheckpoint discovers storage, then shapes targets.
 func PrepareRestorePodSpecForCheckpoint(
 	ctx context.Context,
 	reader ctrlclient.Reader,
 	namespace string,
 	podSpec *corev1.PodSpec,
-	container *corev1.Container,
+	annotations map[string]string,
 	checkpointID string,
 	artifactVersion string,
 	seccompProfile string,
@@ -282,8 +327,7 @@ func PrepareRestorePodSpecForCheckpoint(
 		return err
 	}
 
-	PrepareRestorePodSpec(podSpec, container, storage, seccompProfile, isCheckpointReady)
-	return nil
+	return PrepareRestorePodSpec(podSpec, annotations, storage, seccompProfile, isCheckpointReady)
 }
 
 // InjectCheckpointVolume adds the checkpoint PVC volume to the pod spec if

--- a/deploy/snapshot/protocol/restore_test.go
+++ b/deploy/snapshot/protocol/restore_test.go
@@ -1,8 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package protocol
 
 import (
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -14,11 +18,14 @@ func TestNewRestorePod(t *testing.T) {
 	readinessProbe := &corev1.Probe{PeriodSeconds: 7, TimeoutSeconds: 3}
 	livenessProbe := &corev1.Probe{InitialDelaySeconds: 11}
 	startupProbe := &corev1.Probe{FailureThreshold: 120}
-	restorePod := NewRestorePod(&corev1.Pod{
+	restorePod, err := NewRestorePod(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "worker",
-			Labels:      map[string]string{"existing": "label"},
-			Annotations: map[string]string{"existing": "annotation"},
+			Name:   "worker",
+			Labels: map[string]string{"existing": "label"},
+			Annotations: map[string]string{
+				"existing":                 "annotation",
+				TargetContainersAnnotation: "main",
+			},
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyAlways,
@@ -43,74 +50,188 @@ func TestNewRestorePod(t *testing.T) {
 		},
 		SeccompProfile: DefaultSeccompLocalhostProfile,
 	})
+	if err != nil {
+		t.Fatalf("NewRestorePod returned error: %v", err)
+	}
 
 	if restorePod.Name != "worker" || restorePod.Namespace != "test-ns" {
 		t.Fatalf("unexpected restore pod identity: %#v", restorePod.ObjectMeta)
 	}
-	if restorePod.Labels[RestoreTargetLabel] != "true" {
-		t.Fatalf("expected restore target label: %#v", restorePod.Labels)
-	}
 	if restorePod.Labels[CheckpointIDLabel] != "hash" {
 		t.Fatalf("expected checkpoint id label: %#v", restorePod.Labels)
+	}
+	if _, has := restorePod.Labels[CheckpointSourceLabel]; has {
+		t.Fatalf("restore pod must not carry the checkpoint-source label: %#v", restorePod.Labels)
 	}
 	if restorePod.Annotations[CheckpointArtifactVersionAnnotation] != "2" {
 		t.Fatalf("expected checkpoint artifact version annotation: %#v", restorePod.Annotations)
 	}
+	if restorePod.Annotations[TargetContainersAnnotation] != "main" {
+		t.Fatalf("expected target-containers annotation to be preserved: %#v", restorePod.Annotations)
+	}
 	if restorePod.Spec.RestartPolicy != corev1.RestartPolicyNever {
 		t.Fatalf("expected restartPolicy Never, got %#v", restorePod.Spec.RestartPolicy)
 	}
-	if len(restorePod.Spec.Containers[0].Command) != 2 || restorePod.Spec.Containers[0].Command[0] != "sleep" || restorePod.Spec.Containers[0].Command[1] != "infinity" {
-		t.Fatalf("expected placeholder command, got %#v", restorePod.Spec.Containers[0].Command)
+	main := &restorePod.Spec.Containers[0]
+	if len(main.Command) != 2 || main.Command[0] != "sleep" || main.Command[1] != "infinity" {
+		t.Fatalf("expected placeholder command, got %#v", main.Command)
 	}
-	if restorePod.Spec.Containers[0].Args != nil {
-		t.Fatalf("expected restore args to be cleared: %#v", restorePod.Spec.Containers[0].Args)
+	if main.Args != nil {
+		t.Fatalf("expected restore args to be cleared: %#v", main.Args)
 	}
-	if restorePod.Spec.Containers[0].ReadinessProbe == nil {
+	if main.ReadinessProbe == nil {
 		t.Fatalf("expected readiness probe to be preserved")
 	}
-	if got := restorePod.Spec.Containers[0].ReadinessProbe.PeriodSeconds; got != readinessProbe.PeriodSeconds {
+	if got := main.ReadinessProbe.PeriodSeconds; got != readinessProbe.PeriodSeconds {
 		t.Fatalf("expected readiness probe period %d, got %d", readinessProbe.PeriodSeconds, got)
 	}
-	if restorePod.Spec.Containers[0].LivenessProbe == nil {
+	if main.LivenessProbe == nil {
 		t.Fatalf("expected liveness probe to be preserved")
 	}
-	if got := restorePod.Spec.Containers[0].LivenessProbe.InitialDelaySeconds; got != livenessProbe.InitialDelaySeconds {
+	if got := main.LivenessProbe.InitialDelaySeconds; got != livenessProbe.InitialDelaySeconds {
 		t.Fatalf("expected liveness initial delay %d, got %d", livenessProbe.InitialDelaySeconds, got)
 	}
-	if restorePod.Spec.Containers[0].StartupProbe == nil {
-		t.Fatalf("expected startup probe to be preserved")
+	if main.StartupProbe == nil {
+		t.Fatalf("expected startup probe to gate restore completion")
 	}
-	if got := restorePod.Spec.Containers[0].StartupProbe.FailureThreshold; got != math.MaxInt32 {
-		t.Fatalf("expected startup failure threshold %d, got %d", math.MaxInt32, got)
-	}
+	assertRestoreStartupGate(t, main.StartupProbe)
 	if restorePod.Spec.SecurityContext == nil || restorePod.Spec.SecurityContext.SeccompProfile == nil {
 		t.Fatalf("expected seccomp profile to be injected: %#v", restorePod.Spec.SecurityContext)
 	}
 	if len(restorePod.Spec.Volumes) != 2 {
 		t.Fatalf("expected checkpoint and snapshot-control volumes, got %#v", restorePod.Spec.Volumes)
 	}
-	if len(restorePod.Spec.Containers[0].VolumeMounts) != 2 {
-		t.Fatalf("expected checkpoint and snapshot-control mounts, got %#v", restorePod.Spec.Containers[0].VolumeMounts)
+	if len(main.VolumeMounts) != 2 {
+		t.Fatalf("expected checkpoint and snapshot-control mounts, got %#v", main.VolumeMounts)
 	}
 	foundMount := false
-	for _, m := range restorePod.Spec.Containers[0].VolumeMounts {
+	for _, m := range main.VolumeMounts {
 		if m.Name == SnapshotControlVolumeName {
 			foundMount = true
+			if m.SubPath != "main" {
+				t.Fatalf("expected subPath=main, got %q", m.SubPath)
+			}
 			break
 		}
 	}
 	if !foundMount {
-		t.Fatalf("expected %s mount, got %#v", SnapshotControlVolumeName, restorePod.Spec.Containers[0].VolumeMounts)
+		t.Fatalf("expected %s mount, got %#v", SnapshotControlVolumeName, main.VolumeMounts)
 	}
 	foundEnv := false
-	for _, e := range restorePod.Spec.Containers[0].Env {
+	for _, e := range main.Env {
 		if e.Name == SnapshotControlDirEnv {
 			foundEnv = true
 			break
 		}
 	}
 	if !foundEnv {
-		t.Fatalf("expected %s env, got %#v", SnapshotControlDirEnv, restorePod.Spec.Containers[0].Env)
+		t.Fatalf("expected %s env, got %#v", SnapshotControlDirEnv, main.Env)
+	}
+}
+
+func TestNewRestorePodShapesMultipleTargets(t *testing.T) {
+	restorePod, err := NewRestorePod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "failover-worker",
+			Annotations: map[string]string{TargetContainersAnnotation: "engine-0,engine-1"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "engine-0", Image: "test:latest", Command: []string{"python3"}, Args: []string{"--serve"}},
+				{Name: "engine-1", Image: "test:latest", Command: []string{"python3"}, Args: []string{"--serve"}},
+				{Name: "sidecar", Image: "sidecar:latest", Command: []string{"sidecar"}, Args: []string{"run"}},
+			},
+		},
+	}, PodOptions{
+		Namespace:       "test-ns",
+		CheckpointID:    "hash",
+		ArtifactVersion: "2",
+		Storage: Storage{
+			Type:     StorageTypePVC,
+			PVCName:  "snapshot-pvc",
+			BasePath: "/checkpoints",
+		},
+		SeccompProfile: DefaultSeccompLocalhostProfile,
+	})
+	if err != nil {
+		t.Fatalf("NewRestorePod returned error: %v", err)
+	}
+
+	for _, name := range []string{"engine-0", "engine-1"} {
+		c := findRestoreContainer(t, restorePod.Spec.Containers, name)
+		if len(c.Command) != 2 || c.Command[0] != "sleep" || c.Command[1] != "infinity" {
+			t.Fatalf("expected placeholder command on %s, got %#v", name, c.Command)
+		}
+		if c.Args != nil {
+			t.Fatalf("expected args cleared on %s, got %#v", name, c.Args)
+		}
+		assertRestoreStartupGate(t, c.StartupProbe)
+		found := false
+		for _, m := range c.VolumeMounts {
+			if m.Name == SnapshotControlVolumeName {
+				found = true
+				if m.SubPath != name {
+					t.Fatalf("expected subPath=%s on %s, got %q", name, name, m.SubPath)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("expected %s mount on %s, got %#v", SnapshotControlVolumeName, name, c.VolumeMounts)
+		}
+	}
+
+	sidecar := findRestoreContainer(t, restorePod.Spec.Containers, "sidecar")
+	if len(sidecar.Command) != 1 || sidecar.Command[0] != "sidecar" {
+		t.Fatalf("sidecar command must not be rewritten, got %#v", sidecar.Command)
+	}
+	for _, m := range sidecar.VolumeMounts {
+		if m.Name == SnapshotControlVolumeName {
+			t.Fatalf("sidecar must not get a control mount: %#v", sidecar.VolumeMounts)
+		}
+	}
+	for _, e := range sidecar.Env {
+		if e.Name == SnapshotControlDirEnv {
+			t.Fatalf("sidecar must not get a control env: %#v", sidecar.Env)
+		}
+	}
+}
+
+func TestNewRestorePodRequiresAnnotation(t *testing.T) {
+	_, err := NewRestorePod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-annotation"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main", Image: "test:latest"}},
+		},
+	}, PodOptions{
+		Namespace:       "test-ns",
+		CheckpointID:    "hash",
+		ArtifactVersion: "2",
+		Storage:         Storage{Type: StorageTypePVC, PVCName: "snapshot-pvc", BasePath: "/checkpoints"},
+		SeccompProfile:  DefaultSeccompLocalhostProfile,
+	})
+	if err == nil || !strings.Contains(err.Error(), TargetContainersAnnotation) {
+		t.Fatalf("expected missing-annotation error, got %v", err)
+	}
+}
+
+func TestNewRestorePodRejectsUnknownContainer(t *testing.T) {
+	_, err := NewRestorePod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "bad-target",
+			Annotations: map[string]string{TargetContainersAnnotation: "ghost"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main", Image: "test:latest"}},
+		},
+	}, PodOptions{
+		Namespace:       "test-ns",
+		CheckpointID:    "hash",
+		ArtifactVersion: "2",
+		Storage:         Storage{Type: StorageTypePVC, PVCName: "snapshot-pvc", BasePath: "/checkpoints"},
+		SeccompProfile:  DefaultSeccompLocalhostProfile,
+	})
+	if err == nil || !strings.Contains(err.Error(), `"ghost"`) {
+		t.Fatalf("expected unknown-container error, got %v", err)
 	}
 }
 
@@ -119,21 +240,27 @@ func TestPrepareRestorePodSpec(t *testing.T) {
 	readinessProbe := &corev1.Probe{PeriodSeconds: 13, SuccessThreshold: 1}
 	livenessProbe := &corev1.Probe{TimeoutSeconds: 5}
 	startupProbe := &corev1.Probe{FailureThreshold: 60}
-	container := corev1.Container{
+	podSpec.Containers = []corev1.Container{{
+		Name:           "main",
 		Command:        []string{"python3", "-m", "dynamo.vllm"},
 		Args:           []string{"--model", "Qwen"},
 		ReadinessProbe: readinessProbe.DeepCopy(),
 		LivenessProbe:  livenessProbe.DeepCopy(),
 		StartupProbe:   startupProbe.DeepCopy(),
-	}
+	}}
 
 	storage := Storage{
 		Type:     StorageTypePVC,
 		PVCName:  "snapshot-pvc",
 		BasePath: "/checkpoints",
 	}
-	PrepareRestorePodSpec(&podSpec, &container, storage, DefaultSeccompLocalhostProfile, true)
-	PrepareRestorePodSpec(&podSpec, &container, storage, DefaultSeccompLocalhostProfile, true)
+	annotations := map[string]string{TargetContainersAnnotation: "main"}
+	if err := PrepareRestorePodSpec(&podSpec, annotations, storage, DefaultSeccompLocalhostProfile, true); err != nil {
+		t.Fatalf("first PrepareRestorePodSpec error: %v", err)
+	}
+	if err := PrepareRestorePodSpec(&podSpec, annotations, storage, DefaultSeccompLocalhostProfile, true); err != nil {
+		t.Fatalf("second PrepareRestorePodSpec error: %v", err)
+	}
 
 	if podSpec.SecurityContext == nil || podSpec.SecurityContext.SeccompProfile == nil {
 		t.Fatalf("expected seccomp profile to be injected: %#v", podSpec.SecurityContext)
@@ -141,6 +268,7 @@ func TestPrepareRestorePodSpec(t *testing.T) {
 	if len(podSpec.Volumes) != 2 {
 		t.Fatalf("expected checkpoint and snapshot-control volumes, got %#v", podSpec.Volumes)
 	}
+	container := &podSpec.Containers[0]
 	if len(container.VolumeMounts) != 2 {
 		t.Fatalf("expected checkpoint and snapshot-control mounts, got %#v", container.VolumeMounts)
 	}
@@ -190,18 +318,12 @@ func TestPrepareRestorePodSpec(t *testing.T) {
 		t.Fatalf("expected liveness timeout %d, got %d", livenessProbe.TimeoutSeconds, got)
 	}
 	if container.StartupProbe == nil {
-		t.Fatalf("expected startup probe to be preserved")
+		t.Fatalf("expected startup probe to gate restore completion")
 	}
-	if got := container.StartupProbe.FailureThreshold; got != math.MaxInt32 {
-		t.Fatalf("expected startup failure threshold %d, got %d", math.MaxInt32, got)
-	}
-	if got := container.StartupProbe.SuccessThreshold; got != 1 {
-		t.Fatalf("expected startup success threshold 1, got %d", got)
-	}
+	assertRestoreStartupGate(t, container.StartupProbe)
 }
 
 func TestPrepareRestorePodSpecSynthesizesStartupProbeFromLiveness(t *testing.T) {
-	podSpec := corev1.PodSpec{}
 	livenessProbe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{Path: "/livez"},
@@ -210,65 +332,39 @@ func TestPrepareRestorePodSpecSynthesizesStartupProbeFromLiveness(t *testing.T) 
 		TimeoutSeconds:   4,
 		FailureThreshold: 2,
 	}
-	container := corev1.Container{
-		Command:       []string{"python3", "-m", "dynamo.vllm"},
-		Args:          []string{"--model", "Qwen"},
-		LivenessProbe: livenessProbe.DeepCopy(),
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:          "main",
+			Command:       []string{"python3", "-m", "dynamo.vllm"},
+			Args:          []string{"--model", "Qwen"},
+			LivenessProbe: livenessProbe.DeepCopy(),
+		}},
 	}
 
-	PrepareRestorePodSpec(&podSpec, &container, Storage{}, "", true)
+	if err := PrepareRestorePodSpec(&podSpec, map[string]string{TargetContainersAnnotation: "main"}, Storage{}, "", true); err != nil {
+		t.Fatalf("PrepareRestorePodSpec error: %v", err)
+	}
 
+	container := &podSpec.Containers[0]
 	if container.LivenessProbe == nil {
 		t.Fatalf("expected liveness probe to be preserved")
 	}
 	if container.StartupProbe == nil {
-		t.Fatalf("expected startup probe to be synthesized")
+		t.Fatalf("expected startup probe to gate restore completion")
 	}
+	assertRestoreStartupGate(t, container.StartupProbe)
 	if container.StartupProbe.HTTPGet == nil || container.StartupProbe.HTTPGet.Path != "/livez" {
-		t.Fatalf("expected startup probe HTTP path /livez, got %#v", container.StartupProbe.HTTPGet)
+		t.Fatalf("expected synthesized startup probe to inherit liveness HTTPGet handler, got %#v", container.StartupProbe)
 	}
-	if got := container.StartupProbe.FailureThreshold; got != math.MaxInt32 {
-		t.Fatalf("expected startup failure threshold %d, got %d", math.MaxInt32, got)
+	if got := container.StartupProbe.PeriodSeconds; got != livenessProbe.PeriodSeconds {
+		t.Fatalf("expected startup PeriodSeconds %d (from liveness), got %d", livenessProbe.PeriodSeconds, got)
 	}
-	if got := container.StartupProbe.SuccessThreshold; got != 1 {
-		t.Fatalf("expected startup success threshold 1, got %d", got)
-	}
-}
-
-func TestNewRestorePodTargetsFirstContainerWhenSidecarsPresent(t *testing.T) {
-	restorePod := NewRestorePod(&corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{Name: "worker", Image: "test:latest", Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}},
-				{Name: "sidecar", Image: "sidecar:latest", Command: []string{"sidecar"}, Args: []string{"run"}},
-			},
-		},
-	}, PodOptions{
-		Namespace:       "test-ns",
-		CheckpointID:    "hash",
-		ArtifactVersion: "2",
-		Storage: Storage{
-			Type:     StorageTypePVC,
-			PVCName:  "snapshot-pvc",
-			BasePath: "/checkpoints",
-		},
-		SeccompProfile: DefaultSeccompLocalhostProfile,
-	})
-
-	if got := restorePod.Spec.Containers[0].Command; len(got) != 2 || got[0] != "sleep" || got[1] != "infinity" {
-		t.Fatalf("expected first container placeholder command, got %#v", got)
-	}
-	if restorePod.Spec.Containers[0].Args != nil {
-		t.Fatalf("expected first container args to be cleared: %#v", restorePod.Spec.Containers[0].Args)
-	}
-	if got := restorePod.Spec.Containers[1].Command; len(got) != 1 || got[0] != "sidecar" {
-		t.Fatalf("expected sidecar command to remain unchanged, got %#v", got)
+	if got := container.StartupProbe.TimeoutSeconds; got != livenessProbe.TimeoutSeconds {
+		t.Fatalf("expected startup TimeoutSeconds %d (from liveness), got %d", livenessProbe.TimeoutSeconds, got)
 	}
 }
 
 func TestPrepareRestorePodSpecSynthesizesStartupProbeFromReadiness(t *testing.T) {
-	podSpec := corev1.PodSpec{}
 	readinessProbe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{Command: []string{"cat", "/tmp/ready"}},
@@ -277,14 +373,20 @@ func TestPrepareRestorePodSpecSynthesizesStartupProbeFromReadiness(t *testing.T)
 		SuccessThreshold: 3,
 		FailureThreshold: 4,
 	}
-	container := corev1.Container{
-		Command:        []string{"python3", "-m", "dynamo.vllm"},
-		Args:           []string{"--model", "Qwen"},
-		ReadinessProbe: readinessProbe.DeepCopy(),
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:           "main",
+			Command:        []string{"python3", "-m", "dynamo.vllm"},
+			Args:           []string{"--model", "Qwen"},
+			ReadinessProbe: readinessProbe.DeepCopy(),
+		}},
 	}
 
-	PrepareRestorePodSpec(&podSpec, &container, Storage{}, "", true)
+	if err := PrepareRestorePodSpec(&podSpec, map[string]string{TargetContainersAnnotation: "main"}, Storage{}, "", true); err != nil {
+		t.Fatalf("PrepareRestorePodSpec error: %v", err)
+	}
 
+	container := &podSpec.Containers[0]
 	if container.ReadinessProbe == nil {
 		t.Fatalf("expected readiness probe to be preserved")
 	}
@@ -292,20 +394,90 @@ func TestPrepareRestorePodSpecSynthesizesStartupProbeFromReadiness(t *testing.T)
 		t.Fatalf("expected readiness success threshold %d, got %d", readinessProbe.SuccessThreshold, got)
 	}
 	if container.StartupProbe == nil {
-		t.Fatalf("expected startup probe to be synthesized")
+		t.Fatalf("expected startup probe to gate restore completion")
 	}
-	if container.StartupProbe.Exec == nil || len(container.StartupProbe.Exec.Command) != 2 || container.StartupProbe.Exec.Command[0] != "cat" || container.StartupProbe.Exec.Command[1] != "/tmp/ready" {
-		t.Fatalf("expected startup probe exec command to match readiness probe: %#v", container.StartupProbe.Exec)
+	assertRestoreStartupGate(t, container.StartupProbe)
+	if container.StartupProbe.Exec == nil || len(container.StartupProbe.Exec.Command) != 2 ||
+		container.StartupProbe.Exec.Command[0] != "cat" || container.StartupProbe.Exec.Command[1] != "/tmp/ready" {
+		t.Fatalf("expected synthesized startup probe to inherit readiness Exec command, got %#v", container.StartupProbe)
 	}
-	if got := container.StartupProbe.FailureThreshold; got != math.MaxInt32 {
+	if got := container.StartupProbe.PeriodSeconds; got != readinessProbe.PeriodSeconds {
+		t.Fatalf("expected startup PeriodSeconds %d (from readiness), got %d", readinessProbe.PeriodSeconds, got)
+	}
+}
+
+func TestPrepareRestorePodSpecFallsBackToSentinelWhenNoProbe(t *testing.T) {
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:    "main",
+			Command: []string{"python3", "-m", "dynamo.vllm"},
+			Args:    []string{"--model", "Qwen"},
+		}},
+	}
+
+	if err := PrepareRestorePodSpec(&podSpec, map[string]string{TargetContainersAnnotation: "main"}, Storage{}, "", true); err != nil {
+		t.Fatalf("PrepareRestorePodSpec error: %v", err)
+	}
+
+	container := &podSpec.Containers[0]
+	if container.StartupProbe == nil {
+		t.Fatalf("expected sentinel-cat fallback startup probe to be installed")
+	}
+	assertRestoreStartupGate(t, container.StartupProbe)
+	if container.StartupProbe.Exec == nil {
+		t.Fatalf("expected fallback startup probe to use Exec handler, got %#v", container.StartupProbe)
+	}
+	want := []string{"cat", SnapshotControlMountPath + "/" + RestoreCompleteFile}
+	if len(container.StartupProbe.Exec.Command) != len(want) {
+		t.Fatalf("fallback startup probe command = %#v, want %#v", container.StartupProbe.Exec.Command, want)
+	}
+	for i := range want {
+		if container.StartupProbe.Exec.Command[i] != want[i] {
+			t.Fatalf("fallback startup probe command = %#v, want %#v", container.StartupProbe.Exec.Command, want)
+		}
+	}
+	if got := container.StartupProbe.PeriodSeconds; got != 1 {
+		t.Fatalf("expected fallback startup PeriodSeconds=1, got %d", got)
+	}
+}
+
+// assertRestoreStartupGate verifies the threshold invariants every restore
+// StartupProbe must satisfy: FailureThreshold=MaxInt32 (effectively infinite
+// retries during CRIU restore) and SuccessThreshold=1. The handler shape is
+// not checked here because ensureRestoreStartupProbe synthesizes the probe
+// from whatever Startup/Liveness/Readiness handler the workload defined; only
+// when no user probe is present does it fall back to the sentinel-cat exec
+// probe (covered by assertSentinelRestoreStartupGate).
+func assertRestoreStartupGate(t *testing.T, probe *corev1.Probe) {
+	t.Helper()
+	if probe == nil {
+		t.Fatalf("expected non-nil startup probe")
+	}
+	if got := probe.FailureThreshold; got != math.MaxInt32 {
 		t.Fatalf("expected startup failure threshold %d, got %d", math.MaxInt32, got)
 	}
-	if got := container.StartupProbe.SuccessThreshold; got != 1 {
+	if got := probe.SuccessThreshold; got != 1 {
 		t.Fatalf("expected startup success threshold 1, got %d", got)
 	}
 }
 
-func validRestoreSpecFixture(profile string) *corev1.PodSpec {
+func validRestoreSpecFixture(profile string, targets ...string) (*corev1.PodSpec, map[string]string) {
+	if len(targets) == 0 {
+		targets = []string{"main"}
+	}
+	containers := make([]corev1.Container, 0, len(targets))
+	for _, name := range targets {
+		container := corev1.Container{
+			Name: name,
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: CheckpointVolumeName, MountPath: "/checkpoints"},
+				{Name: SnapshotControlVolumeName, MountPath: SnapshotControlMountPath, SubPath: name},
+			},
+			Env: []corev1.EnvVar{{Name: SnapshotControlDirEnv, Value: SnapshotControlMountPath}},
+		}
+		ensureRestoreStartupProbe(&container)
+		containers = append(containers, container)
+	}
 	return &corev1.PodSpec{
 		SecurityContext: &corev1.PodSecurityContext{
 			SeccompProfile: &corev1.SeccompProfile{
@@ -327,87 +499,124 @@ func validRestoreSpecFixture(profile string) *corev1.PodSpec {
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 			},
 		},
-		Containers: []corev1.Container{{
-			Name: "main",
-			VolumeMounts: []corev1.VolumeMount{
-				{Name: CheckpointVolumeName, MountPath: "/checkpoints"},
-				{Name: SnapshotControlVolumeName, MountPath: SnapshotControlMountPath},
-			},
-			Env: []corev1.EnvVar{{Name: SnapshotControlDirEnv, Value: SnapshotControlMountPath}},
-		}},
-	}
+		Containers: containers,
+	}, map[string]string{TargetContainersAnnotation: FormatTargetContainers(targets)}
 }
 
 func TestValidateRestorePodSpec(t *testing.T) {
 	profile := DefaultSeccompLocalhostProfile
-	podSpec := validRestoreSpecFixture(profile)
+	podSpec, annotations := validRestoreSpecFixture(profile)
 	storage := Storage{
 		Type:     StorageTypePVC,
 		PVCName:  "snapshot-pvc",
 		BasePath: "/checkpoints",
 	}
 
-	if err := ValidateRestorePodSpec(podSpec, storage, DefaultSeccompLocalhostProfile); err != nil {
+	if err := ValidateRestorePodSpec(podSpec, annotations, storage, DefaultSeccompLocalhostProfile); err != nil {
 		t.Fatalf("expected restore pod spec to be valid, got %v", err)
 	}
 
 	badSpec := podSpec.DeepCopy()
 	badSpec.Volumes = []corev1.Volume{badSpec.Volumes[1]}
-	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing checkpoint-storage volume for PVC snapshot-pvc" {
+	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing checkpoint-storage volume for PVC snapshot-pvc" {
 		t.Fatalf("expected missing volume error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()
 	badSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{badSpec.Containers[0].VolumeMounts[1]}
-	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing checkpoint-storage mount at /checkpoints" {
+	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != `missing checkpoint-storage mount at /checkpoints on container "main"` {
 		t.Fatalf("expected missing mount error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()
 	badSpec.Volumes = []corev1.Volume{badSpec.Volumes[0]}
-	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != fmt.Sprintf("missing %s emptyDir volume; add it via snapshotprotocol.EnsureControlVolume", SnapshotControlVolumeName) {
+	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != fmt.Sprintf("missing %s emptyDir volume; add it via snapshotprotocol.EnsureControlVolume", SnapshotControlVolumeName) {
 		t.Fatalf("expected missing control volume error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()
 	badSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{badSpec.Containers[0].VolumeMounts[0]}
-	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != fmt.Sprintf("missing %s mount at %s", SnapshotControlVolumeName, SnapshotControlMountPath) {
+	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != fmt.Sprintf(`missing %s mount at %s on container "main"`, SnapshotControlVolumeName, SnapshotControlMountPath) {
 		t.Fatalf("expected missing control mount error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()
 	badSpec.Containers[0].Env = nil
-	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != fmt.Sprintf("missing %s env var on worker container", SnapshotControlDirEnv) {
+	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != fmt.Sprintf(`missing %s env var on container "main"`, SnapshotControlDirEnv) {
 		t.Fatalf("expected missing control env error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()
+	badSpec.Containers[0].StartupProbe = nil
+	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != `missing restore-complete startup probe on container "main"` {
+		t.Fatalf("expected missing restore startup probe error, got %v", err)
+	}
+
+	// A non-sentinel startup probe is now accepted: ensureRestoreStartupProbe
+	// synthesizes the probe from the workload's existing Startup/Liveness/
+	// Readiness handler, so the validator only checks for presence, not a
+	// fixed exec-command shape. Only fully-missing probes are rejected.
+	okSpec := podSpec.DeepCopy()
+	okSpec.Containers[0].StartupProbe = &corev1.Probe{
+		ProbeHandler:     corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/livez"}},
+		PeriodSeconds:    5,
+		FailureThreshold: math.MaxInt32,
+		SuccessThreshold: 1,
+	}
+	if err := ValidateRestorePodSpec(okSpec, annotations, storage, DefaultSeccompLocalhostProfile); err != nil {
+		t.Fatalf("expected synthesized HTTPGet startup probe to validate, got %v", err)
+	}
+
+	badSpec = podSpec.DeepCopy()
 	badSpec.SecurityContext = nil
-	if err := ValidateRestorePodSpec(badSpec, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing localhost seccomp profile" {
+	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing localhost seccomp profile" {
 		t.Fatalf("expected missing seccomp error, got %v", err)
+	}
+
+	if err := ValidateRestorePodSpec(podSpec, map[string]string{}, storage, DefaultSeccompLocalhostProfile); err == nil || !strings.Contains(err.Error(), TargetContainersAnnotation) {
+		t.Fatalf("expected missing-annotation error, got %v", err)
 	}
 }
 
-func TestValidateRestorePodSpecAcceptsFirstContainerAsWorker(t *testing.T) {
-	podSpec := validRestoreSpecFixture(DefaultSeccompLocalhostProfile)
-	podSpec.Containers[0].Name = "worker"
-	podSpec.Containers = append(podSpec.Containers, corev1.Container{Name: "sidecar"})
-
+func TestValidateRestorePodSpecMultipleTargets(t *testing.T) {
+	podSpec, annotations := validRestoreSpecFixture(DefaultSeccompLocalhostProfile, "engine-0", "engine-1")
 	storage := Storage{
 		Type:     StorageTypePVC,
 		PVCName:  "snapshot-pvc",
 		BasePath: "/checkpoints",
 	}
+	if err := ValidateRestorePodSpec(podSpec, annotations, storage, DefaultSeccompLocalhostProfile); err != nil {
+		t.Fatalf("expected multi-target validation to pass, got %v", err)
+	}
 
-	// Containers[0] is always the worker, regardless of name
-	if err := ValidateRestorePodSpec(podSpec, storage, DefaultSeccompLocalhostProfile); err != nil {
-		t.Fatalf("expected validation to pass for first container as worker, got %v", err)
+	// Drop the engine-1 control mount → validation should fail for that target specifically.
+	bad := podSpec.DeepCopy()
+	for i := range bad.Containers {
+		if bad.Containers[i].Name == "engine-1" {
+			bad.Containers[i].VolumeMounts = []corev1.VolumeMount{bad.Containers[i].VolumeMounts[0]}
+		}
+	}
+	if err := ValidateRestorePodSpec(bad, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || !strings.Contains(err.Error(), `"engine-1"`) {
+		t.Fatalf("expected missing-mount error on engine-1, got %v", err)
+	}
+
+	badSubPath := podSpec.DeepCopy()
+	for i := range badSubPath.Containers {
+		if badSubPath.Containers[i].Name == "engine-1" {
+			for j := range badSubPath.Containers[i].VolumeMounts {
+				if badSubPath.Containers[i].VolumeMounts[j].Name == SnapshotControlVolumeName {
+					badSubPath.Containers[i].VolumeMounts[j].SubPath = "wrong-engine"
+				}
+			}
+		}
+	}
+	if err := ValidateRestorePodSpec(badSubPath, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || !strings.Contains(err.Error(), `"engine-1"`) || !strings.Contains(err.Error(), "SubPath") {
+		t.Fatalf("expected bad subPath error on engine-1, got %v", err)
 	}
 }
 
 func TestValidateRestorePodSpecAllowsWorkerWithSidecars(t *testing.T) {
-	podSpec := validRestoreSpecFixture(DefaultSeccompLocalhostProfile)
-	podSpec.Containers[0].Name = "worker"
+	podSpec, annotations := validRestoreSpecFixture(DefaultSeccompLocalhostProfile, "worker")
 	podSpec.Containers = append(podSpec.Containers, corev1.Container{Name: "sidecar"})
 
 	storage := Storage{
@@ -416,7 +625,7 @@ func TestValidateRestorePodSpecAllowsWorkerWithSidecars(t *testing.T) {
 		BasePath: "/checkpoints",
 	}
 
-	if err := ValidateRestorePodSpec(podSpec, storage, DefaultSeccompLocalhostProfile); err != nil {
+	if err := ValidateRestorePodSpec(podSpec, annotations, storage, DefaultSeccompLocalhostProfile); err != nil {
 		t.Fatalf("expected worker with sidecars to validate, got %v", err)
 	}
 }
@@ -460,4 +669,15 @@ func TestDiscoverStorageFromDaemonSetsUsesCheckpointsVolume(t *testing.T) {
 	if storage.PVCName != "snapshot-pvc" || storage.BasePath != "/checkpoints" {
 		t.Fatalf("expected snapshot PVC discovery, got %#v", storage)
 	}
+}
+
+func findRestoreContainer(t *testing.T, containers []corev1.Container, name string) *corev1.Container {
+	t.Helper()
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	t.Fatalf("container %q not found in spec", name)
+	return nil
 }

--- a/docs/kubernetes/snapshot.md
+++ b/docs/kubernetes/snapshot.md
@@ -119,7 +119,7 @@ kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/component=snapshot-agent -
 
 ### 4. Create a `DynamoCheckpoint`
 
-The checkpoint Job pod template should match the worker container you want to checkpoint. For the snapshot flow, the important parts are the checkpoint identity, the first container in `spec.containers`, and the placeholder image; the rest of the pod template should mirror your normal worker config.
+The checkpoint Job pod template should match the worker container you want to checkpoint. For the snapshot flow, the important parts are the checkpoint identity, a container named `main`, and the placeholder image; the rest of the pod template should mirror your normal worker config. Extra containers are allowed, but only `main` is checkpointed.
 
 ```yaml
 apiVersion: nvidia.com/v1alpha1
@@ -140,7 +140,7 @@ spec:
       spec:
         ...
         containers:
-          - name: worker
+          - name: main
             image: registry.example.com/dynamo/vllm-placeholder:1.0.0
             ...
 ```
@@ -293,6 +293,12 @@ kubectl patch dgd vllm-auto-demo -n ${NAMESPACE} --type=merge \
   -p '{"spec":{"services":{"VllmDecodeWorker":{"replicas":2}}}}'
 ```
 
+## Failover Restore
+
+Dynamo supports both intra-pod and inter-pod failover restore topologies. In
+operator-managed deployments, the operator prepares the restore workload
+automatically. Users enable failover in the `DynamoGraphDeployment` spec.
+
 ## Lower-Level Testing With `snapshotctl`
 
 It is possible to checkpoint and restore pods without the Dynamo operator via the lower-level `snapshotctl` utility. However, the snapshot helm chart must be installed, with a running `snapshot-agent` DaemonSet in the namespace with the checkpoint PVC mounted.
@@ -304,10 +310,12 @@ It is possible to checkpoint and restore pods without the Dynamo operator via th
 ```bash
 snapshotctl checkpoint \
   --manifest ./worker-pod.yaml \
+  --container main \
   --namespace ${NAMESPACE}
 ```
 
-The checkpoint manifest must be for a pod, contain exactly one worker container, and use a placeholder image.
+The checkpoint manifest must be for a pod and use a placeholder image. `--container` names the workload container to checkpoint.
+
 If you do not pass `--checkpoint-id`, `snapshotctl` generates one and prints it:
 
 ```text
@@ -325,10 +333,11 @@ checkpoint_location=/checkpoints/...
 snapshotctl restore \
   --manifest ./worker-pod.yaml \
   --namespace ${NAMESPACE} \
-  --checkpoint-id manual-snapshot-...
+  --checkpoint-id manual-snapshot-... \
+  --containers main
 ```
 
-This creates a new restore pod from the manifest and waits for the restore annotation to reach `completed`.
+This creates a new restore pod and returns after the request is submitted. Observe progress through Kubernetes readiness, events, and logs.
 
 ### Restore an existing pod in place
 
@@ -336,10 +345,11 @@ This creates a new restore pod from the manifest and waits for the restore annot
 snapshotctl restore \
   --pod existing-restore-target \
   --namespace ${NAMESPACE} \
-  --checkpoint-id manual-snapshot-...
+  --checkpoint-id manual-snapshot-... \
+  --containers main
 ```
 
-This patches restore metadata onto an existing pod that is already snapshot-compatible.
+This patches restore metadata onto an existing pod that is already snapshot-compatible and returns after the patch is accepted.
 
 ## Checkpoint Identity
 
@@ -440,12 +450,14 @@ This is also the path that `snapshotctl` uses when it resolves checkpoint storag
 
 ### `snapshotctl` manifest is rejected or the restore target is wrong
 
-`snapshotctl` only accepts a single-container `Pod` manifest.
+`snapshotctl` requires a `Pod` manifest and a target-container list. Multi-container manifests are supported as long as every name passed via `--container` or `--containers` exists in the pod spec.
 
 ```bash
-snapshotctl checkpoint --manifest ./worker-pod.yaml --namespace ${NAMESPACE}
-snapshotctl restore --manifest ./worker-pod.yaml --namespace ${NAMESPACE} --checkpoint-id <checkpoint-id>
+snapshotctl checkpoint --manifest ./worker-pod.yaml --container main --namespace ${NAMESPACE}
+snapshotctl restore  --manifest ./worker-pod.yaml --containers main --namespace ${NAMESPACE} --checkpoint-id <checkpoint-id>
 ```
+
+If the manifest already carries snapshot target metadata, it must agree with the CLI flag; `snapshotctl` rejects mismatches instead of silently picking one.
 
 ## Planned Features
 


### PR DESCRIPTION
## Problem

`snapshot-agent` keyed checkpoint and restore operations off of one implicit workload container (`Containers[0]` in some call sites, `"main"` in others). That blocks intra-pod failover restore, where the operator clones `main` into `engine-0` / `engine-1`, and made earlier approaches thread container-name lists through too much of the stack.

Supersedes:

- #8319 (Containers[0] / main fallback stopgap — no longer needed)
- #8421 (per-container list threaded through function signatures — replaced by a single annotation read by the helpers themselves)

## Design

One mandatory pod annotation:

```text
nvidia.com/snapshot-target-containers = "<name>[,<name>...]"
```

- Checkpoint Jobs must list exactly one target container. Extra containers in the Job pod template are fine, just not checkpointed.
- Restore pods must list one or more target containers; the same checkpoint artifact is replayed into every named target container in parallel.
- The annotation is required. `snapshotprotocol.NewCheckpointJob`, `NewRestorePod`, `PrepareRestorePodSpec`, and `ValidateRestorePodSpec` all refuse to run when it is missing. No silent `Containers[0]` / `"main"` fallback.

Persisted status is per-container only:

| Annotation | Object | Meaning |
|---|---|---|
| `nvidia.com/snapshot-checkpoint-status` | Job | `completed` / `failed` (checkpoint is single-container, so this stays a singleton) |
| `nvidia.com/snapshot-restore-status.<container>` | Pod | `in_progress` / `completed` / `failed` for one target container |
| `nvidia.com/snapshot-restore-container-id.<container>` | Pod | containerd ID for kubelet-restart dedupe |

There is no stored pod-level restore aggregate annotation, and the public `snapshotprotocol` API does not expose restore-summary helpers. The operator does not need them: Kubernetes readiness is the serving-readiness source of truth, and the per-container annotations remain available for debugging/inspection.

The `snapshot-control` emptyDir is mounted into every target container with `subPath: <containerName>`, so sentinels from `engine-0` and `engine-1` live on disjoint disk paths while each container still sees `/snapshot-control` via `$DYN_SNAPSHOT_CONTROL_DIR`.

Kubernetes readiness remains the serving-readiness source of truth. Restore-target containers get a startup probe that waits for their own `/snapshot-control/restore-complete` sentinel. Once the snapshot agent writes that sentinel, the container's normal readiness probe (if any) takes over. Cold-started non-target containers keep their normal readiness behavior, so the Pod `Ready` condition only becomes true after every restored and cold-started container is ready.

## Operator wiring (no CRD changes)

- `buildCheckpointJob` stamps `main` on the Job pod template and looks the main container up by name. `ExtraPodSpec.PodSpec.Containers` can inject containers before main, so `Containers[0]` was not safe.
- `ApplyRestorePodMetadata` / `InjectCheckpointIntoPodSpec` honor `CheckpointInfo.RestoreTargetContainers`. Default is `["main"]`.
- DGD + DCD controllers populate that field with `dynamo.IntraPodFailoverEngineContainerNames()` (`engine-0`, `engine-1`) only when `failover.mode: intraPod` is enabled. Inter-pod failover engine pods keep the default `main` target per pod.
- Inter-pod GMS weight-server pods are skipped as checkpoint/restore targets; they run the GMS server and load weights fresh from disk rather than being CRIU-restored.

## `snapshotctl`

- `--container <name>` on `checkpoint` (exactly one).
- `--containers <name>[,<name>...]` on `restore` (one or more).
- Flag and manifest annotation must agree when both are set.
- `restore` now returns after creating/patching the restore target (`status=requested`); it does not wait for restore completion.
- `loadPod` no longer picks `Containers[0]` or a container named `main` by convention; callers name targets explicitly via flag or annotation.

## Docs

Updated `docs/kubernetes/snapshot.md` (target-container contract, failover restore topology, per-container status, readiness behavior, refreshed `snapshotctl` examples) and `deploy/snapshot/cmd/snapshotctl/README.md`.

## Compatibility notes

- No CRD changes. The stable user-facing API remains the CRDs; snapshot annotations are an implementation contract between the operator, snapshot-agent, and snapshotctl, so this PR intentionally changes them where needed.
- `snapshotprotocol` Go API: `NewRestorePod`, `PrepareRestorePodSpec`, `ValidateRestorePodSpec`, and `PrepareRestorePodSpecForCheckpoint` changed signatures. Callers need to set `nvidia.com/snapshot-target-containers` before calling.
- Old singleton restore annotations (`nvidia.com/snapshot-restore-status`, `nvidia.com/snapshot-restore-container-id`) are gone. New restore status is per-container only; `snapshotctl` no longer waits on or derives a pod-level restore status.
- Existing checkpoint/restore pods that lack `nvidia.com/snapshot-target-containers` are rejected by the new helpers. The operator stamps it, so this primarily affects hand-rolled pods and old `snapshotctl` flows.
- Existing-pod restore (`snapshotctl restore --pod ...`) now requires the target containers to already be snapshot-compatible, including the checkpoint/control mounts, `DYN_SNAPSHOT_CONTROL_DIR`, and the restore-complete startup probe. Manifest-based restore and operator-generated restore pods shape this automatically.

## Validation

- `cd deploy/snapshot && go test -count=1 ./protocol/`
- `cd deploy/snapshot && CGO_ENABLED=0 GOOS=linux go vet ./...`
- `cd deploy/snapshot && CGO_ENABLED=0 GOOS=linux go build ./...`
- `cd deploy/operator && CGO_ENABLED=0 go test -count=1 -skip TestControllers ./internal/checkpoint/... ./internal/dynamo/... ./internal/controller/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Container-targeted checkpoint and restore operations: checkpoints and restores now explicitly target specific containers by name via annotation or CLI flag.
  * Multi-container restore support: restore operations can now replay checkpoints across multiple containers (failover scenarios).
  * New CLI flags: `--container` for checkpoint, `--containers` for restore operations.

* **Documentation**
  * Updated snapshot documentation and `snapshotctl` command examples to reflect container-targeting model.
  * Per-container restore status tracking via new status annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->