### PR TITLE
feat(kv-router): carry tiered match data over the remote indexer wire

### DIFF
--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -129,6 +129,11 @@ pub struct IndexerQueryRequest {
     pub model_name: String,
     /// Block hashes to find matches for in the radix tree.
     pub block_hashes: Vec<LocalBlockHash>,
+    /// When true, the server skips the lower-tier walk and returns only the
+    /// device-tier overlap. Older clients that omit this field default to
+    /// `false`, preserving the full tiered response.
+    #[serde(default)]
+    pub device_only: bool,
 }
 
 /// Wire-friendly overlap scores for JSON serialization.
@@ -195,7 +200,9 @@ impl From<WireLowerTierMatchDetails> for super::lower_tier::LowerTierMatchDetail
 /// Wire-friendly tiered match payload: device overlap plus per-tier hits.
 ///
 /// Lower tiers are a `Vec<(StorageTier, _)>` rather than a map so we never
-/// depend on `StorageTier` being a JSON-legal map key.
+/// depend on `StorageTier` being a JSON-legal map key. Each `StorageTier` is
+/// expected to appear at most once; the inbound conversion warns and keeps the
+/// last entry if duplicates are observed.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct WireTieredMatchDetails {
     pub device: WireOverlapScores,

--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -135,7 +135,7 @@ pub struct IndexerQueryRequest {
 /// `OverlapScores` uses `FxHashMap<WorkerWithDpRank, _>` which can't be
 /// serialized as JSON (struct keys aren't valid JSON map keys), so we flatten
 /// to vecs of tuples for the wire protocol.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct WireOverlapScores {
     pub scores: Vec<(WorkerWithDpRank, u32)>,
     pub frequencies: Vec<usize>,
@@ -162,11 +162,51 @@ impl From<WireOverlapScores> for OverlapScores {
     }
 }
 
+/// Wire-friendly lower-tier match payload for JSON serialization.
+///
+/// Mirrors `LowerTierMatchDetails.hits`. `next_continuations` is server-side
+/// intermediate state (used only while walking the tier chain) and is not
+/// carried over the wire.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct WireLowerTierMatchDetails {
+    pub hits: Vec<(WorkerWithDpRank, usize)>,
+}
+
+impl From<&super::lower_tier::LowerTierMatchDetails> for WireLowerTierMatchDetails {
+    fn from(d: &super::lower_tier::LowerTierMatchDetails) -> Self {
+        Self {
+            hits: d.hits.iter().map(|(w, h)| (*w, *h)).collect(),
+        }
+    }
+}
+
+impl From<WireLowerTierMatchDetails> for super::lower_tier::LowerTierMatchDetails {
+    fn from(w: WireLowerTierMatchDetails) -> Self {
+        // `next_continuations` is server-side intermediate state; consumers of
+        // the tiered result never read it, so we reconstruct an empty map on
+        // the wire-inbound path.
+        Self {
+            hits: w.hits.into_iter().collect(),
+            next_continuations: Default::default(),
+        }
+    }
+}
+
+/// Wire-friendly tiered match payload: device overlap plus per-tier hits.
+///
+/// Lower tiers are a `Vec<(StorageTier, _)>` rather than a map so we never
+/// depend on `StorageTier` being a JSON-legal map key.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct WireTieredMatchDetails {
+    pub device: WireOverlapScores,
+    pub lower_tier: Vec<(StorageTier, WireLowerTierMatchDetails)>,
+}
+
 /// Response from a served KV indexer query.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IndexerQueryResponse {
-    /// Overlap scores per worker.
-    Scores(WireOverlapScores),
+    /// Tiered match details: device overlap plus per-tier hits.
+    TieredScores(WireTieredMatchDetails),
     /// An error occurred processing the query.
     Error(String),
 }

--- a/lib/llm/src/block_manager/kv_consolidator/tracker.rs
+++ b/lib/llm/src/block_manager/kv_consolidator/tracker.rs
@@ -380,6 +380,9 @@ impl CacheStatusTracker for DedupCacheStatusTracker {
                 })
             });
 
+            // Always tag dedup'd stores as Device: the indexer dispatches by
+            // tier, and a non-device tag here would route the block to the
+            // lower-tier indexer, orphaning every subsequent device-tier child.
             self.event_queue.push(ConsolidatedEvent::Store {
                 block_hash: block_hash.clone(),
                 parent_hash: resolved_parent_hash,
@@ -387,7 +390,7 @@ impl CacheStatusTracker for DedupCacheStatusTracker {
                 block_size,
                 lora_name,
                 source: source.to_str().to_string(),
-                tier,
+                tier: Some(StorageTier::Device),
             });
 
             tracing::debug!(
@@ -403,10 +406,13 @@ impl CacheStatusTracker for DedupCacheStatusTracker {
     }
 
     fn handle_remove(&mut self, event: RemoveEventInput) -> bool {
+        // The source's tier is intentionally discarded: dedup mode collapses
+        // every source/tier into a unified Device-tagged stream (see the STORE
+        // path), and the REMOVE must match that tagging.
         let RemoveEventInput {
             block_hash,
             source,
-            tier,
+            tier: _,
         } = event;
 
         let sequence_hash = match self.hash_mapping.get(&block_hash) {
@@ -432,36 +438,28 @@ impl CacheStatusTracker for DedupCacheStatusTracker {
                 return false;
             }
 
-            self.hash_mapping.remove(&block_hash);
-
-            tracing::debug!(
-                "Removed hash_mapping entry for {} (hash_mapping size: {})",
-                block_hash,
-                self.hash_mapping.len()
-            );
+            // Don't drop hash_mapping[block_hash] on per-source removes: when
+            // sources share the same external block_hash (e.g. KVBM publishing
+            // TRT-LLM's hash chain), removing it now would orphan the next
+            // source's REMOVE lookup. The retain() below cleans every entry
+            // pointing at this sequence_hash once the last source releases.
 
             if !metadata.exists_in_any_source() {
                 let first_block_hash = metadata.first_block_hash.clone();
                 self.blocks.remove(&sequence_hash);
 
-                let stray_count_before = self.hash_mapping.len();
                 self.hash_mapping
                     .retain(|_ext_hash, seq_hash| *seq_hash != sequence_hash);
-                let stray_count = stray_count_before - self.hash_mapping.len();
 
-                if stray_count > 0 {
-                    tracing::warn!(
-                        "Found {} stray hash_mapping entries for seq_hash={} after all sources removed - cleaned up (hash_mapping size now: {})",
-                        stray_count,
-                        sequence_hash,
-                        self.hash_mapping.len()
-                    );
-                }
-
+                // Mirror the dedup STORE: tag the unified REMOVE as Device so
+                // it routes to the same indexer the STORE landed in. Otherwise
+                // a non-device last-source release (e.g. KVBM holding a block
+                // longer than the engine) would deliver the REMOVE to the
+                // lower-tier indexer that never saw the corresponding STORE.
                 self.event_queue.push(ConsolidatedEvent::Remove {
                     block_hash: first_block_hash.clone(),
                     source: source.to_str().to_string(),
-                    tier,
+                    tier: Some(StorageTier::Device),
                 });
 
                 tracing::debug!(
@@ -709,6 +707,90 @@ mod tests {
         assert_eq!(sources.len(), 2); // vllm and kvbm
     }
 
+    /// Dedup mode must emit a Device-tagged store even when the first source
+    /// to register a block did so on a lower tier (e.g. KVBM offloading
+    /// host-pinned ahead of the engine's device store). Otherwise the
+    /// downstream indexer would dispatch the unified view to its lower-tier
+    /// indexer and orphan every subsequent device-tier child.
+    #[test]
+    fn test_dedup_normalizes_tier_to_device() {
+        let mut tracker = TestTracker::new();
+
+        tracker.handle_store(
+            "kvbm_hash1".to_string(),
+            EventSource::Kvbm,
+            vec![1, 2, 3],
+            None,
+            3,
+            None,
+            Some(StorageTier::HostPinned),
+            None,
+        );
+
+        let events = tracker.drain_events();
+        assert_eq!(events.len(), 1, "first store from any source must publish");
+        match &events[0] {
+            ConsolidatedEvent::Store { tier, .. } => {
+                assert_eq!(
+                    *tier,
+                    Some(StorageTier::Device),
+                    "dedup must collapse the source tier to Device on the wire"
+                );
+            }
+            other => panic!("expected Store event, got: {:?}", other),
+        }
+
+        // A subsequent Trtllm device-tier store for the same block deduplicates,
+        // so no further events are emitted — the unified Device view is already
+        // in flight from the first publication.
+        let should_publish = tracker.handle_store(
+            "trtllm_hash1".to_string(),
+            EventSource::Trtllm,
+            vec![1, 2, 3],
+            None,
+            3,
+            None,
+            Some(StorageTier::Device),
+            None,
+        );
+        assert!(!should_publish);
+        assert_eq!(tracker.drain_events().len(), 0);
+
+        // The unified REMOVE must also be Device-tagged, even when the
+        // last-source release is on a lower tier (e.g. KVBM holding the
+        // block longer than the engine). Otherwise the REMOVE would route
+        // to the lower-tier indexer that never received the Device STORE.
+        tracker.handle_remove(
+            "trtllm_hash1",
+            EventSource::Trtllm,
+            Some(StorageTier::Device),
+        );
+        assert_eq!(
+            tracker.drain_events().len(),
+            0,
+            "trtllm release must not publish: KVBM still owns the block"
+        );
+
+        let kvbm_remove = tracker.handle_remove(
+            "kvbm_hash1",
+            EventSource::Kvbm,
+            Some(StorageTier::HostPinned),
+        );
+        assert!(kvbm_remove, "last-source release must publish");
+        let events = tracker.drain_events();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ConsolidatedEvent::Remove { tier, .. } => {
+                assert_eq!(
+                    *tier,
+                    Some(StorageTier::Device),
+                    "dedup must collapse the source tier to Device on the REMOVE wire"
+                );
+            }
+            other => panic!("expected Remove event, got: {:?}", other),
+        }
+    }
+
     #[test]
     fn test_remove_from_single_source_publishes() {
         let mut tracker = TestTracker::new();
@@ -738,6 +820,61 @@ mod tests {
             }
             other => panic!("expected Remove event, got: {:?}", other),
         }
+    }
+
+    /// When sources publish events using the same external block_hash (e.g.
+    /// KVBM forwards TRT-LLM's sequence-hash chain so engine and KVBM events
+    /// agree on the wire), each source's REMOVE must still resolve through
+    /// `hash_mapping`. Dropping the entry on the first remove would orphan
+    /// the second remove and produce a spurious "not in hash_mapping" warn.
+    #[test]
+    fn test_shared_block_hash_across_sources_two_removes_succeed() {
+        let mut tracker = TestTracker::new();
+        let shared = "shared_hash".to_string();
+
+        tracker.handle_store(
+            shared.clone(),
+            EventSource::Trtllm,
+            vec![1, 2, 3],
+            None,
+            3,
+            None,
+            Some(StorageTier::Device),
+            None,
+        );
+        tracker.handle_store(
+            shared.clone(),
+            EventSource::Kvbm,
+            vec![1, 2, 3],
+            None,
+            3,
+            None,
+            Some(StorageTier::HostPinned),
+            None,
+        );
+        tracker.drain_events();
+
+        let trtllm_remove =
+            tracker.handle_remove(&shared, EventSource::Trtllm, Some(StorageTier::Device));
+        assert!(
+            !trtllm_remove,
+            "first remove must not publish: KVBM still owns the block"
+        );
+
+        let kvbm_remove =
+            tracker.handle_remove(&shared, EventSource::Kvbm, Some(StorageTier::HostPinned));
+        assert!(
+            kvbm_remove,
+            "second remove must resolve via the still-present hash_mapping entry and publish"
+        );
+
+        let events = tracker.drain_events();
+        assert_eq!(
+            events.len(),
+            1,
+            "exactly one REMOVE published at end-of-life"
+        );
+        assert_eq!(tracker.num_blocks(), 0);
     }
 
     #[test]

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -164,16 +164,21 @@ impl From<WireTieredMatchDetails> for TieredMatchDetails {
     fn from(w: WireTieredMatchDetails) -> Self {
         // `last_matched_hashes` is only needed server-side to seed the tier walk,
         // so we leave it empty on the inbound side.
+        let mut lower_tier = HashMap::with_capacity(w.lower_tier.len());
+        for (tier, details) in w.lower_tier {
+            if lower_tier.insert(tier, details.into()).is_some() {
+                tracing::warn!(
+                    ?tier,
+                    "Duplicate StorageTier in WireTieredMatchDetails; keeping last entry"
+                );
+            }
+        }
         Self {
             device: MatchDetails {
                 overlap_scores: w.device.into(),
                 ..Default::default()
             },
-            lower_tier: w
-                .lower_tier
-                .into_iter()
-                .map(|(tier, details)| (tier, details.into()))
-                .collect(),
+            lower_tier,
         }
     }
 }
@@ -296,10 +301,11 @@ impl Indexer {
                 Ok(primary.backend().find_match_details_impl(&sequence, false))
             }
             // Device-only queries on the remote path go through the same tiered
-            // RPC; we just project out the device result. Keeps a single wire
-            // path on the client side.
+            // RPC and project out the device result. The `device_only` request
+            // flag tells the server to skip the lower-tier walk so we don't
+            // pay tier-walk CPU/bandwidth for results we'd discard.
             Self::Remote(remote) => remote
-                .find_matches_by_tier(sequence)
+                .find_matches_by_tier(sequence, true)
                 .await
                 .map(|tiered| tiered.device)
                 .map_err(|e| {
@@ -323,10 +329,13 @@ impl Indexer {
                     lower_tier: lt,
                 })
             }
-            Self::Remote(remote) => remote.find_matches_by_tier(sequence).await.map_err(|e| {
-                tracing::warn!(error = %e, "Remote indexer tiered query failed");
-                KvRouterError::IndexerOffline
-            }),
+            Self::Remote(remote) => remote
+                .find_matches_by_tier(sequence, false)
+                .await
+                .map_err(|e| {
+                    tracing::warn!(error = %e, "Remote indexer tiered query failed");
+                    KvRouterError::IndexerOffline
+                }),
             Self::None => Ok(TieredMatchDetails::default()),
         }
     }
@@ -515,20 +524,74 @@ impl Indexer {
 }
 
 #[cfg(test)]
+pub(super) mod test_util {
+    use dynamo_kv_router::protocols::{
+        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
+        KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier,
+        compute_seq_hash_for_block,
+    };
+
+    pub(crate) fn store_event(
+        worker_id: u64,
+        dp_rank: u32,
+        event_id: u64,
+        prefix_hashes: &[u64],
+        local_hashes: &[u64],
+        storage_tier: StorageTier,
+    ) -> RouterEvent {
+        let prefix_block_hashes: Vec<LocalBlockHash> =
+            prefix_hashes.iter().copied().map(LocalBlockHash).collect();
+        let parent_hash = compute_seq_hash_for_block(&prefix_block_hashes)
+            .last()
+            .copied()
+            .map(ExternalSequenceBlockHash);
+
+        let full_hashes: Vec<LocalBlockHash> = prefix_hashes
+            .iter()
+            .chain(local_hashes.iter())
+            .copied()
+            .map(LocalBlockHash)
+            .collect();
+        let full_sequence_hashes = compute_seq_hash_for_block(&full_hashes);
+        let new_sequence_hashes = &full_sequence_hashes[prefix_hashes.len()..];
+        let blocks = local_hashes
+            .iter()
+            .zip(new_sequence_hashes.iter())
+            .map(|(&local_hash, &sequence_hash)| KvCacheStoredBlockData {
+                block_hash: ExternalSequenceBlockHash(sequence_hash),
+                tokens_hash: LocalBlockHash(local_hash),
+                mm_extra_info: None,
+            })
+            .collect();
+
+        RouterEvent::with_storage_tier(
+            worker_id,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash,
+                    start_position: None,
+                    blocks,
+                }),
+                dp_rank,
+            },
+            storage_tier,
+        )
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
     use tokio_util::sync::CancellationToken;
 
+    use super::test_util::store_event;
     use super::{Indexer, LowerTierIndexers};
     use dynamo_kv_router::{
         ConcurrentRadixTreeCompressed, ThreadPoolIndexer,
         indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics},
-        protocols::{
-            ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
-            KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier, WorkerWithDpRank,
-            compute_seq_hash_for_block,
-        },
+        protocols::{LocalBlockHash, StorageTier, WorkerWithDpRank},
     };
 
     fn make_test_indexer() -> Indexer {
@@ -575,54 +638,6 @@ mod tests {
             }
             Indexer::Remote(_) | Indexer::None => {}
         }
-    }
-
-    fn store_event(
-        worker_id: u64,
-        dp_rank: u32,
-        event_id: u64,
-        prefix_hashes: &[u64],
-        local_hashes: &[u64],
-        storage_tier: StorageTier,
-    ) -> RouterEvent {
-        let prefix_block_hashes: Vec<LocalBlockHash> =
-            prefix_hashes.iter().copied().map(LocalBlockHash).collect();
-        let parent_hash = compute_seq_hash_for_block(&prefix_block_hashes)
-            .last()
-            .copied()
-            .map(ExternalSequenceBlockHash);
-
-        let full_hashes: Vec<LocalBlockHash> = prefix_hashes
-            .iter()
-            .chain(local_hashes.iter())
-            .copied()
-            .map(LocalBlockHash)
-            .collect();
-        let full_sequence_hashes = compute_seq_hash_for_block(&full_hashes);
-        let new_sequence_hashes = &full_sequence_hashes[prefix_hashes.len()..];
-        let blocks = local_hashes
-            .iter()
-            .zip(new_sequence_hashes.iter())
-            .map(|(&local_hash, &sequence_hash)| KvCacheStoredBlockData {
-                block_hash: ExternalSequenceBlockHash(sequence_hash),
-                tokens_hash: LocalBlockHash(local_hash),
-                mm_extra_info: None,
-            })
-            .collect();
-
-        RouterEvent::with_storage_tier(
-            worker_id,
-            KvCacheEvent {
-                event_id,
-                data: KvCacheEventData::Stored(KvCacheStoreData {
-                    parent_hash,
-                    start_position: None,
-                    blocks,
-                }),
-                dp_rank,
-            },
-            storage_tier,
-        )
     }
 
     #[tokio::test]

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -329,13 +329,15 @@ impl Indexer {
                     lower_tier: lt,
                 })
             }
-            Self::Remote(remote) => remote
-                .find_matches_by_tier(sequence, false)
-                .await
-                .map_err(|e| {
-                    tracing::warn!(error = %e, "Remote indexer tiered query failed");
-                    KvRouterError::IndexerOffline
-                }),
+            Self::Remote(remote) => {
+                remote
+                    .find_matches_by_tier(sequence, false)
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!(error = %e, "Remote indexer tiered query failed");
+                        KvRouterError::IndexerOffline
+                    })
+            }
             Self::None => Ok(TieredMatchDetails::default()),
         }
     }

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -14,7 +14,7 @@ use dynamo_kv_router::{
     config::KvRouterConfig,
     indexer::{
         KvIndexer, KvIndexerInterface, KvIndexerMetrics, KvRouterError, LowerTierContinuation,
-        LowerTierMatchDetails, MatchDetails,
+        LowerTierMatchDetails, MatchDetails, WireTieredMatchDetails,
     },
     protocols::{
         DpRank, LocalBlockHash, OverlapScores, RouterEvent, StorageTier, TokensWithHashes,
@@ -147,6 +147,37 @@ pub(crate) struct TieredMatchDetails {
     pub lower_tier: HashMap<StorageTier, LowerTierMatchDetails>,
 }
 
+impl From<&TieredMatchDetails> for WireTieredMatchDetails {
+    fn from(d: &TieredMatchDetails) -> Self {
+        Self {
+            device: d.device.overlap_scores.clone().into(),
+            lower_tier: d
+                .lower_tier
+                .iter()
+                .map(|(tier, details)| (*tier, details.into()))
+                .collect(),
+        }
+    }
+}
+
+impl From<WireTieredMatchDetails> for TieredMatchDetails {
+    fn from(w: WireTieredMatchDetails) -> Self {
+        // `last_matched_hashes` is only needed server-side to seed the tier walk,
+        // so we leave it empty on the inbound side.
+        Self {
+            device: MatchDetails {
+                overlap_scores: w.device.into(),
+                ..Default::default()
+            },
+            lower_tier: w
+                .lower_tier
+                .into_iter()
+                .map(|(tier, details)| (tier, details.into()))
+                .collect(),
+        }
+    }
+}
+
 use self::remote::RemoteIndexer;
 pub use self::remote::{ServedIndexerHandle, ServedIndexerMode, ensure_served_indexer_service};
 pub(crate) use subscriber::start_subscriber;
@@ -264,13 +295,13 @@ impl Indexer {
             Self::Concurrent { primary, .. } => {
                 Ok(primary.backend().find_match_details_impl(&sequence, false))
             }
+            // Device-only queries on the remote path go through the same tiered
+            // RPC; we just project out the device result. Keeps a single wire
+            // path on the client side.
             Self::Remote(remote) => remote
-                .find_matches(sequence)
+                .find_matches_by_tier(sequence)
                 .await
-                .map(|overlap_scores| MatchDetails {
-                    overlap_scores,
-                    ..Default::default()
-                })
+                .map(|tiered| tiered.device)
                 .map_err(|e| {
                     tracing::warn!(error = %e, "Remote indexer query failed");
                     KvRouterError::IndexerOffline
@@ -283,15 +314,21 @@ impl Indexer {
         &self,
         sequence: Vec<LocalBlockHash>,
     ) -> Result<TieredMatchDetails, KvRouterError> {
-        let device = self.find_match_details(sequence.clone()).await?;
-        let lower_tier = match self {
+        match self {
             Self::KvIndexer { lower_tier, .. } | Self::Concurrent { lower_tier, .. } => {
-                query_lower_tiers(lower_tier, &sequence, &device)
+                let device = self.find_match_details(sequence.clone()).await?;
+                let lt = query_lower_tiers(lower_tier, &sequence, &device);
+                Ok(TieredMatchDetails {
+                    device,
+                    lower_tier: lt,
+                })
             }
-            Self::Remote(_) | Self::None => HashMap::new(),
-        };
-
-        Ok(TieredMatchDetails { device, lower_tier })
+            Self::Remote(remote) => remote.find_matches_by_tier(sequence).await.map_err(|e| {
+                tracing::warn!(error = %e, "Remote indexer tiered query failed");
+                KvRouterError::IndexerOffline
+            }),
+            Self::None => Ok(TieredMatchDetails::default()),
+        }
     }
 
     pub(crate) async fn record_hashed_routing_decision(

--- a/lib/llm/src/kv_router/indexer/remote.rs
+++ b/lib/llm/src/kv_router/indexer/remote.rs
@@ -88,6 +88,7 @@ impl RemoteIndexer {
     pub(super) async fn find_matches_by_tier(
         &self,
         block_hashes: Vec<LocalBlockHash>,
+        device_only: bool,
     ) -> Result<TieredMatchDetails> {
         self.validate_topology_if_ready().await.inspect_err(|_| {
             self.metrics.increment_query_failures();
@@ -96,6 +97,7 @@ impl RemoteIndexer {
         let request = IndexerQueryRequest {
             model_name: self.model_name.clone(),
             block_hashes,
+            device_only,
         };
         let mut stream: ManyOut<IndexerQueryResponse> = self
             .query_router
@@ -433,10 +435,25 @@ impl AsyncEngine<SingleIn<IndexerQueryRequest>, ManyOut<IndexerQueryResponse>, a
         let indexer = self.bindings.read().get(&request.model_name).cloned();
 
         let response = match indexer {
-            Some(indexer) => match indexer.find_matches_by_tier(request.block_hashes).await {
-                Ok(tiered) => IndexerQueryResponse::TieredScores((&tiered).into()),
-                Err(error) => IndexerQueryResponse::Error(error.to_string()),
-            },
+            Some(indexer) => {
+                // Skip the per-tier walk when the caller only needs the device
+                // overlap; saves server-side CPU and wire bytes.
+                let result: Result<TieredMatchDetails, _> = if request.device_only {
+                    indexer
+                        .find_match_details(request.block_hashes)
+                        .await
+                        .map(|device| TieredMatchDetails {
+                            device,
+                            lower_tier: HashMap::new(),
+                        })
+                } else {
+                    indexer.find_matches_by_tier(request.block_hashes).await
+                };
+                match result {
+                    Ok(tiered) => IndexerQueryResponse::TieredScores((&tiered).into()),
+                    Err(error) => IndexerQueryResponse::Error(error.to_string()),
+                }
+            }
             None => IndexerQueryResponse::Error(format!(
                 "served indexer model {} is not registered",
                 request.model_name
@@ -506,12 +523,9 @@ fn service_key(component: &Component) -> ServiceKey {
 mod tests {
     use super::*;
     use crate::kv_router::indexer::LowerTierIndexers;
+    use crate::kv_router::indexer::test_util::store_event;
     use dynamo_kv_router::indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics};
-    use dynamo_kv_router::protocols::{
-        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
-        KvCacheStoredBlockData, RouterEvent, StorageTier, WorkerWithDpRank,
-        compute_seq_hash_for_block,
-    };
+    use dynamo_kv_router::protocols::{StorageTier, WorkerWithDpRank};
     use tokio_util::sync::CancellationToken;
 
     #[tokio::test]
@@ -524,6 +538,7 @@ mod tests {
         let request = SingleIn::new(IndexerQueryRequest {
             model_name: "model-b".to_string(),
             block_hashes: vec![LocalBlockHash(1)],
+            device_only: false,
         });
 
         let mut stream = engine.generate(request).await.unwrap();
@@ -532,54 +547,6 @@ mod tests {
             stream.next().await,
             Some(IndexerQueryResponse::TieredScores(_))
         ));
-    }
-
-    fn store_event(
-        worker_id: u64,
-        dp_rank: u32,
-        event_id: u64,
-        prefix_hashes: &[u64],
-        local_hashes: &[u64],
-        storage_tier: StorageTier,
-    ) -> RouterEvent {
-        let prefix_block_hashes: Vec<LocalBlockHash> =
-            prefix_hashes.iter().copied().map(LocalBlockHash).collect();
-        let parent_hash = compute_seq_hash_for_block(&prefix_block_hashes)
-            .last()
-            .copied()
-            .map(ExternalSequenceBlockHash);
-
-        let full_hashes: Vec<LocalBlockHash> = prefix_hashes
-            .iter()
-            .chain(local_hashes.iter())
-            .copied()
-            .map(LocalBlockHash)
-            .collect();
-        let full_sequence_hashes = compute_seq_hash_for_block(&full_hashes);
-        let new_sequence_hashes = &full_sequence_hashes[prefix_hashes.len()..];
-        let blocks = local_hashes
-            .iter()
-            .zip(new_sequence_hashes.iter())
-            .map(|(&local_hash, &sequence_hash)| KvCacheStoredBlockData {
-                block_hash: ExternalSequenceBlockHash(sequence_hash),
-                tokens_hash: LocalBlockHash(local_hash),
-                mm_extra_info: None,
-            })
-            .collect();
-
-        RouterEvent::with_storage_tier(
-            worker_id,
-            KvCacheEvent {
-                event_id,
-                data: KvCacheEventData::Stored(KvCacheStoreData {
-                    parent_hash,
-                    start_position: None,
-                    blocks,
-                }),
-                dp_rank,
-            },
-            storage_tier,
-        )
     }
 
     /// Verifies the served query engine returns a tiered payload with populated
@@ -630,6 +597,7 @@ mod tests {
             .generate(SingleIn::new(IndexerQueryRequest {
                 model_name: "m".to_string(),
                 block_hashes: vec![LocalBlockHash(11), LocalBlockHash(12), LocalBlockHash(13)],
+                device_only: false,
             }))
             .await
             .unwrap();
@@ -674,6 +642,78 @@ mod tests {
                 .get(&StorageTier::HostPinned)
                 .and_then(|d| d.hits.get(&worker).copied()),
             Some(1)
+        );
+    }
+
+    /// `device_only=true` must skip the lower-tier walk: the response carries
+    /// the device overlap but no per-tier entries, even when the underlying
+    /// indexer holds host-pinned data.
+    #[tokio::test]
+    async fn query_engine_device_only_skips_lower_tiers() {
+        let worker = WorkerWithDpRank::new(7, 0);
+        let indexer = Indexer::KvIndexer {
+            primary: KvIndexer::new(
+                CancellationToken::new(),
+                4,
+                Arc::new(KvIndexerMetrics::new_unregistered()),
+            ),
+            lower_tier: LowerTierIndexers::new(1, 4),
+        };
+
+        indexer
+            .apply_event(store_event(7, 0, 1, &[], &[11, 12], StorageTier::Device))
+            .await;
+        indexer
+            .apply_event(store_event(
+                7,
+                0,
+                2,
+                &[11, 12],
+                &[13],
+                StorageTier::HostPinned,
+            ))
+            .await;
+
+        let Indexer::KvIndexer {
+            primary,
+            lower_tier,
+        } = &indexer
+        else {
+            unreachable!()
+        };
+        let _ = primary.flush().await;
+        for lt in lower_tier.all() {
+            let _ = lt.dump_events().await.unwrap();
+        }
+
+        let bindings = Arc::new(RwLock::new(HashMap::from([("m".to_string(), indexer)])));
+        let engine = ServedIndexerQueryEngine { bindings };
+        let mut stream = engine
+            .generate(SingleIn::new(IndexerQueryRequest {
+                model_name: "m".to_string(),
+                block_hashes: vec![LocalBlockHash(11), LocalBlockHash(12), LocalBlockHash(13)],
+                device_only: true,
+            }))
+            .await
+            .unwrap();
+
+        let Some(IndexerQueryResponse::TieredScores(wire)) = stream.next().await else {
+            panic!("expected TieredScores response");
+        };
+
+        assert_eq!(
+            wire.device
+                .scores
+                .iter()
+                .find(|(w, _)| *w == worker)
+                .map(|(_, s)| *s),
+            Some(2),
+            "device should still report 2 overlap blocks"
+        );
+        assert!(
+            wire.lower_tier.is_empty(),
+            "device_only=true must omit lower-tier entries, got {:?}",
+            wire.lower_tier
         );
     }
 }

--- a/lib/llm/src/kv_router/indexer/remote.rs
+++ b/lib/llm/src/kv_router/indexer/remote.rs
@@ -11,7 +11,7 @@ use dynamo_kv_router::indexer::{
     IndexerRecordRoutingDecisionResponse, KV_INDEXER_QUERY_ENDPOINT,
     KV_INDEXER_RECORD_ROUTING_DECISION_ENDPOINT,
 };
-use dynamo_kv_router::protocols::{LocalBlockHash, OverlapScores, WorkerWithDpRank};
+use dynamo_kv_router::protocols::{LocalBlockHash, WorkerWithDpRank};
 use dynamo_runtime::component::{Client, Component};
 use dynamo_runtime::discovery::{DiscoveryInstance, DiscoveryQuery};
 use dynamo_runtime::pipeline::{
@@ -27,7 +27,7 @@ use tokio::sync::Mutex;
 
 use crate::kv_router::metrics::RemoteIndexerMetrics;
 
-use super::Indexer;
+use super::{Indexer, TieredMatchDetails};
 
 pub struct RemoteIndexer {
     query_router: PushRouter<IndexerQueryRequest, IndexerQueryResponse>,
@@ -85,10 +85,10 @@ impl RemoteIndexer {
         })
     }
 
-    pub(super) async fn find_matches(
+    pub(super) async fn find_matches_by_tier(
         &self,
         block_hashes: Vec<LocalBlockHash>,
-    ) -> Result<OverlapScores> {
+    ) -> Result<TieredMatchDetails> {
         self.validate_topology_if_ready().await.inspect_err(|_| {
             self.metrics.increment_query_failures();
         })?;
@@ -106,7 +106,7 @@ impl RemoteIndexer {
             })?;
 
         match stream.next().await {
-            Some(IndexerQueryResponse::Scores(scores)) => Ok(scores.into()),
+            Some(IndexerQueryResponse::TieredScores(wire)) => Ok(wire.into()),
             Some(IndexerQueryResponse::Error(msg)) => {
                 self.metrics.increment_query_failures();
                 Err(anyhow::anyhow!("Remote indexer error: {}", msg))
@@ -433,8 +433,8 @@ impl AsyncEngine<SingleIn<IndexerQueryRequest>, ManyOut<IndexerQueryResponse>, a
         let indexer = self.bindings.read().get(&request.model_name).cloned();
 
         let response = match indexer {
-            Some(indexer) => match indexer.find_matches(request.block_hashes).await {
-                Ok(scores) => IndexerQueryResponse::Scores(scores.into()),
+            Some(indexer) => match indexer.find_matches_by_tier(request.block_hashes).await {
+                Ok(tiered) => IndexerQueryResponse::TieredScores((&tiered).into()),
                 Err(error) => IndexerQueryResponse::Error(error.to_string()),
             },
             None => IndexerQueryResponse::Error(format!(
@@ -505,6 +505,14 @@ fn service_key(component: &Component) -> ServiceKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::kv_router::indexer::LowerTierIndexers;
+    use dynamo_kv_router::indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics};
+    use dynamo_kv_router::protocols::{
+        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
+        KvCacheStoredBlockData, RouterEvent, StorageTier, WorkerWithDpRank,
+        compute_seq_hash_for_block,
+    };
+    use tokio_util::sync::CancellationToken;
 
     #[tokio::test]
     async fn query_engine_supports_multiple_model_bindings() {
@@ -522,7 +530,150 @@ mod tests {
 
         assert!(matches!(
             stream.next().await,
-            Some(IndexerQueryResponse::Scores(_))
+            Some(IndexerQueryResponse::TieredScores(_))
         ));
+    }
+
+    fn store_event(
+        worker_id: u64,
+        dp_rank: u32,
+        event_id: u64,
+        prefix_hashes: &[u64],
+        local_hashes: &[u64],
+        storage_tier: StorageTier,
+    ) -> RouterEvent {
+        let prefix_block_hashes: Vec<LocalBlockHash> =
+            prefix_hashes.iter().copied().map(LocalBlockHash).collect();
+        let parent_hash = compute_seq_hash_for_block(&prefix_block_hashes)
+            .last()
+            .copied()
+            .map(ExternalSequenceBlockHash);
+
+        let full_hashes: Vec<LocalBlockHash> = prefix_hashes
+            .iter()
+            .chain(local_hashes.iter())
+            .copied()
+            .map(LocalBlockHash)
+            .collect();
+        let full_sequence_hashes = compute_seq_hash_for_block(&full_hashes);
+        let new_sequence_hashes = &full_sequence_hashes[prefix_hashes.len()..];
+        let blocks = local_hashes
+            .iter()
+            .zip(new_sequence_hashes.iter())
+            .map(|(&local_hash, &sequence_hash)| KvCacheStoredBlockData {
+                block_hash: ExternalSequenceBlockHash(sequence_hash),
+                tokens_hash: LocalBlockHash(local_hash),
+                mm_extra_info: None,
+            })
+            .collect();
+
+        RouterEvent::with_storage_tier(
+            worker_id,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash,
+                    start_position: None,
+                    blocks,
+                }),
+                dp_rank,
+            },
+            storage_tier,
+        )
+    }
+
+    /// Verifies the served query engine returns a tiered payload with populated
+    /// lower-tier hits, and that the wire value round-trips through the client
+    /// conversion back to native `TieredMatchDetails`.
+    #[tokio::test]
+    async fn query_engine_returns_tiered_scores_with_lower_tier() {
+        let worker = WorkerWithDpRank::new(7, 0);
+        let indexer = Indexer::KvIndexer {
+            primary: KvIndexer::new(
+                CancellationToken::new(),
+                4,
+                Arc::new(KvIndexerMetrics::new_unregistered()),
+            ),
+            lower_tier: LowerTierIndexers::new(1, 4),
+        };
+
+        // Worker owns [11, 12] on device and [11, 12, 13] on host-pinned.
+        indexer
+            .apply_event(store_event(7, 0, 1, &[], &[11, 12], StorageTier::Device))
+            .await;
+        indexer
+            .apply_event(store_event(
+                7,
+                0,
+                2,
+                &[11, 12],
+                &[13],
+                StorageTier::HostPinned,
+            ))
+            .await;
+
+        let Indexer::KvIndexer {
+            primary,
+            lower_tier,
+        } = &indexer
+        else {
+            unreachable!()
+        };
+        let _ = primary.flush().await;
+        for lt in lower_tier.all() {
+            let _ = lt.dump_events().await.unwrap();
+        }
+
+        let bindings = Arc::new(RwLock::new(HashMap::from([("m".to_string(), indexer)])));
+        let engine = ServedIndexerQueryEngine { bindings };
+        let mut stream = engine
+            .generate(SingleIn::new(IndexerQueryRequest {
+                model_name: "m".to_string(),
+                block_hashes: vec![LocalBlockHash(11), LocalBlockHash(12), LocalBlockHash(13)],
+            }))
+            .await
+            .unwrap();
+
+        let Some(IndexerQueryResponse::TieredScores(wire)) = stream.next().await else {
+            panic!("expected TieredScores response");
+        };
+
+        assert_eq!(
+            wire.device
+                .scores
+                .iter()
+                .find(|(w, _)| *w == worker)
+                .map(|(_, s)| *s),
+            Some(2),
+            "device should report 2 overlap blocks"
+        );
+        let (_, host_hits) = wire
+            .lower_tier
+            .iter()
+            .find(|(tier, _)| *tier == StorageTier::HostPinned)
+            .expect("host-pinned tier should be present");
+        assert_eq!(
+            host_hits
+                .hits
+                .iter()
+                .find(|(w, _)| *w == worker)
+                .map(|(_, h)| *h),
+            Some(1),
+            "host-pinned should report 1 hit beyond device"
+        );
+
+        // Round-trip through the client conversion mirrors what RemoteIndexer does.
+        let native: TieredMatchDetails = wire.into();
+        assert_eq!(
+            native.device.overlap_scores.scores.get(&worker).copied(),
+            Some(2)
+        );
+        assert_eq!(
+            native
+                .lower_tier
+                .get(&StorageTier::HostPinned)
+                .and_then(|d| d.hits.get(&worker).copied()),
+            Some(1)
+        );
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #8380 (tier-based KV routing), addressing @PeaBrane's approval note: when `use_remote_indexer=true`, the router only received device overlap from the served indexer, so lower-tier host/disk continuation matching silently regressed to device-only. This PR teaches the remote indexer wire protocol to carry tiered match data end-to-end, aligning local and remote deployment modes.

## What changed

- **Wire types** in `lib/kv-router/src/indexer/types.rs`: new `WireLowerTierMatchDetails` and `WireTieredMatchDetails`, mirroring the existing `WireOverlapScores` flattening (vec-of-tuples; `StorageTier`-keyed lower tiers as `Vec<(tier, _)>` to avoid JSON map-key constraints). `IndexerQueryResponse::Scores(WireOverlapScores)` becomes `TieredScores(WireTieredMatchDetails)`. `next_continuations` stays server-side — consumers never read it.
- **Served query engine** (`remote.rs`) now calls `Indexer::find_matches_by_tier` and emits `TieredScores`. The server-side `Indexer` already owns a `LowerTierIndexers` and subscribes to tier-annotated events, so there's no new event plumbing.
- **Client** `RemoteIndexer`: `find_matches` is replaced by `find_matches_by_tier(...) -> Result<TieredMatchDetails>`. `Indexer::{find_match_details, find_matches_by_tier}` `Self::Remote(_)` arms both route through the single tiered RPC — device-only callers just project out `.device`.
- **Test** `query_engine_returns_tiered_scores_with_lower_tier` feeds `Device` + `HostPinned` events into a real `KvIndexer` binding, drives the served query engine, and round-trips the wire payload back through `TieredMatchDetails` to cover the exact path a remote client takes.

Data model lines up with the direction the Mooncake indexer RFC (kvcache-ai/Mooncake#1403) proposes — same tier + DP-rank shape, Dynamo-native worker-keyed payload. A future HTTP facade that re-projects `TieredMatchDetails` into Mooncake's per-instance `{GPU, DP, CPU, DISK}` shape is a separate PR.

## Design decisions (captured during planning)

- **No wire back-compat.** Router and served indexer ship in the same Dynamo binary; they upgrade together. Replacing the variant rather than adding alongside keeps a single code path.
- **Single client-side RPC.** `find_match_details` on the remote arm goes through `find_matches_by_tier` and drops lower tiers. One path to maintain.
- **Drop `next_continuations` from the wire.** Pure server intermediate state.

## Test plan

- [x] `cargo check --workspace --all-targets` clean on top-level workspace
- [x] `cargo check --lib --all-targets` clean on `lib/bindings/kvbm` sub-workspace
- [x] `cargo clippy --workspace --lib --all-targets -- -D warnings` clean on both workspaces
- [x] `cargo test -p dynamo-llm --lib kv_router::indexer` — 21/21 pass (including new `query_engine_returns_tiered_scores_with_lower_tier`)
- [x] `cargo test -p dynamo-kv-router --lib` — 369/369 pass
- [x] `pre-commit run` on staged files clean
- [ ] Manual end-to-end: start a served indexer with `serve_indexer=true` against a backend emitting lower-tier events (KVBM host-offload), point a second Dynamo router at it with `use_remote_indexer=true`, confirm `tier_overlap_blocks` in the router logs shows non-zero `host_pinned`/`disk` entries.

## Out of scope (follow-ups)

- Per-tier metrics on `RemoteIndexerMetrics` — no dashboard consumes them yet.
- Mooncake `/query_by_hash` JSON facade.
- `tenant_id` / `cache_salt` from the Mooncake RFC — would need `BlockHashOptions` changes, not a wire-protocol change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Indexer query responses now return tiered match details with per-tier organization instead of flat overlap scores.
  * Enhanced query result structure provides categorized match information organized by tier level.
  * Remote queries updated to support tiered result retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->