### PR TITLE
ci: restrict dynamo-pipeline test markers to pre_merge only

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -131,9 +131,13 @@ jobs:
       fresh_builder: true
       no_cache: true
       build_timeout_minutes: 90
-      cpu_parallel_test_markers: 'parallel and not (vllm or sglang or trtllm) and (gpu_0)'
-      cpu_sequential_test_markers: 'not parallel and not (vllm or sglang or trtllm) and (gpu_0)'
-      gpu_test_markers: 'none and gpu_1'
+      # TODO: widen beyond `pre_merge` — today it picks up tests
+      # (e.g. fault_tolerance/deploy/*) that fail in this container-only
+      # context. Matches the coverage of the old container-validation-dynamo
+      # workflow.
+      cpu_parallel_test_markers: 'pre_merge and parallel and not (vllm or sglang or trtllm) and (gpu_0)'
+      cpu_sequential_test_markers: 'pre_merge and not parallel and not (vllm or sglang or trtllm) and (gpu_0)'
+      gpu_test_markers: 'pre_merge and none and gpu_1'
     secrets: inherit
 
   # ============================================================================

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -125,9 +125,13 @@ jobs:
     uses: ./.github/workflows/dynamo-pipeline.yml
     with:
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
-      cpu_parallel_test_markers: '(pre_merge or post_merge) and parallel and not (vllm or sglang or trtllm) and (gpu_0)'
-      cpu_sequential_test_markers: '(pre_merge or post_merge) and not parallel and not (vllm or sglang or trtllm) and (gpu_0)'
-      gpu_test_markers: '(pre_merge or post_merge) and none and gpu_1'
+      # TODO: widen to include `post_merge` — today it picks up tests
+      # (e.g. fault_tolerance/deploy/*) that fail in this container-only
+      # context. Matches the coverage of the old container-validation-dynamo
+      # workflow.
+      cpu_parallel_test_markers: 'pre_merge and parallel and not (vllm or sglang or trtllm) and (gpu_0)'
+      cpu_sequential_test_markers: 'pre_merge and not parallel and not (vllm or sglang or trtllm) and (gpu_0)'
+      gpu_test_markers: 'pre_merge and none and gpu_1'
     secrets: inherit
 
   # ============================================================================


### PR DESCRIPTION
The post-merge and nightly dynamo-pipeline callers were using `(pre_merge or post_merge)` / unconstrained markers, which started picking up tests/fault_tolerance/deploy/test_deployment.py (marked k8s + fault_tolerance + post_merge + e2e + slow + gpu_0). Those tests fail in the container-only context that dynamo-pipeline runs in.

Restrict both callers' markers to pre_merge — matches the coverage of the old container-validation-dynamo workflow before the consolidation. TODO comments on each caller note the follow-up: widen once post_merge tests can run in this context.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD test selection configuration to refine test execution parameters across pipeline workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->