### PR TITLE
refactor: Frontend to return 400 on request related error than 500 ba…

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -60,6 +60,9 @@ use crate::protocols::openai::{
 use crate::protocols::unified::UnifiedRequest;
 use crate::request_template::RequestTemplate;
 use crate::types::Annotated;
+use dynamo_runtime::error::{
+    BackendError as DynamoBackendError, DynamoError, ErrorType as DynamoErrorType,
+};
 use dynamo_runtime::logging::get_distributed_tracing_context;
 use tracing::Instrument;
 
@@ -126,6 +129,28 @@ fn classify_error_for_metrics(code: StatusCode, message: &str) -> ErrorType {
 /// Extract ErrorType from ErrorResponse for metrics
 fn extract_error_type_from_response(response: &ErrorResponse) -> ErrorType {
     classify_error_for_metrics(response.0, &response.1.message)
+}
+
+/// Return the matching `DynamoError` message so callers can surface it verbatim.
+fn find_invalid_argument_message(err: &(dyn std::error::Error + 'static)) -> Option<String> {
+    const INVALID_ARGUMENT_ERROR_TYPES: &[DynamoErrorType] = &[
+        DynamoErrorType::InvalidArgument,
+        DynamoErrorType::Backend(DynamoBackendError::InvalidArgument),
+    ];
+    const NON_INVALID_ARGUMENT_ERROR_TYPES: &[DynamoErrorType] = &[];
+
+    if !dynamo_runtime::error::match_error_chain(
+        err,
+        INVALID_ARGUMENT_ERROR_TYPES,
+        NON_INVALID_ARGUMENT_ERROR_TYPES,
+    ) {
+        return None;
+    }
+
+    std::iter::successors(Some(err), |e| e.source())
+        .filter_map(|e| e.downcast_ref::<DynamoError>())
+        .find(|dynamo_err| INVALID_ARGUMENT_ERROR_TYPES.contains(&dynamo_err.error_type()))
+        .map(|dynamo_err| dynamo_err.message().to_string())
 }
 
 impl ErrorMessage {
@@ -233,14 +258,14 @@ impl ErrorMessage {
             );
         }
 
-        // Check for DynamoError with InvalidArgument → HTTP 400
-        if let Some(dynamo_err) = err.downcast_ref::<dynamo_runtime::error::DynamoError>()
-            && dynamo_err.error_type() == dynamo_runtime::error::ErrorType::InvalidArgument
-        {
+        // Check for DynamoError with InvalidArgument anywhere in the chain → HTTP 400.
+        // This also matches Backend(InvalidArgument), which Python bindings produce when a
+        // worker (e.g. vLLM) raises ValueError/TypeError on invalid sampling params.
+        if let Some(message) = find_invalid_argument_message(err.as_ref()) {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorMessage {
-                    message: dynamo_err.message().to_string(),
+                    message,
                     error_type: map_error_code_to_error_type(StatusCode::BAD_REQUEST),
                     code: StatusCode::BAD_REQUEST.as_u16(),
                 }),
@@ -2685,6 +2710,76 @@ mod tests {
         assert_eq!(response.1.code, 499);
         assert_eq!(response.1.error_type, "Client Closed Request");
         assert!(response.1.message.contains("stopped or killed"));
+    }
+
+    #[test]
+    fn test_invalid_argument_error_response_from_anyhow() {
+        use dynamo_runtime::error::{DynamoError, ErrorType};
+
+        let err: anyhow::Error = DynamoError::builder()
+            .error_type(ErrorType::InvalidArgument)
+            .message("max_tokens must be greater than 0")
+            .build()
+            .into();
+        let response = ErrorMessage::from_anyhow(err, BACKUP_ERROR_MESSAGE);
+        assert_eq!(response.0, StatusCode::BAD_REQUEST);
+        assert_eq!(response.1.code, 400);
+        assert_eq!(response.1.error_type, "Bad Request");
+        assert_eq!(response.1.message, "max_tokens must be greater than 0");
+    }
+
+    #[test]
+    fn test_backend_invalid_argument_error_response_from_anyhow() {
+        // vLLM-style: a worker raises ValueError on invalid sampling params, which
+        // Python bindings wrap as Backend(InvalidArgument). The frontend must surface
+        // this as HTTP 400, not 500.
+        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
+
+        let err: anyhow::Error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("max_tokens must be greater than 0")
+            .build()
+            .into();
+        let response = ErrorMessage::from_anyhow(err, BACKUP_ERROR_MESSAGE);
+        assert_eq!(response.0, StatusCode::BAD_REQUEST);
+        assert_eq!(response.1.code, 400);
+        assert_eq!(response.1.error_type, "Bad Request");
+        assert_eq!(response.1.message, "max_tokens must be greater than 0");
+    }
+
+    #[test]
+    fn test_backend_invalid_argument_nested_in_chain_from_anyhow() {
+        // The InvalidArgument may sit deeper in the error chain (wrapped by anyhow
+        // context or another DynamoError). Ensure the chain walk still catches it.
+        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
+
+        let inner = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("bad sampling param")
+            .build();
+        let outer = DynamoError::builder()
+            .error_type(ErrorType::Unknown)
+            .message("generate failed")
+            .cause(inner)
+            .build();
+        let err: anyhow::Error = outer.into();
+        let response = ErrorMessage::from_anyhow(err, BACKUP_ERROR_MESSAGE);
+        assert_eq!(response.0, StatusCode::BAD_REQUEST);
+        assert_eq!(response.1.message, "bad sampling param");
+    }
+
+    #[test]
+    fn test_other_backend_error_still_returns_500_from_anyhow() {
+        // Backend variants other than InvalidArgument must keep their existing 500 behavior.
+        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
+
+        let err: anyhow::Error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::EngineShutdown))
+            .message("engine gone")
+            .build()
+            .into();
+        let response = ErrorMessage::from_anyhow(err, BACKUP_ERROR_MESSAGE);
+        assert_eq!(response.0, StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[test]

--- a/tests/frontend/test_vllm.py
+++ b/tests/frontend/test_vllm.py
@@ -455,3 +455,62 @@ def test_reasoning(request, start_services: ServicePorts, predownload_models) ->
     assert any(
         char.isdigit() for char in content
     ), "Expected response to contain numerical calculations"
+
+
+@pytest.mark.profiled_vram_gib(20.4)
+@pytest.mark.timeout(120)
+@pytest.mark.post_merge
+def test_max_tokens_zero_returns_400(
+    request, start_services: ServicePorts, predownload_models
+) -> None:
+    """Invalid sampling params must surface as HTTP 400, not 500.
+
+    For chat completions, frontend validation currently skips `max_tokens` (deprecated in
+    favor of `max_completion_tokens`), so the request reaches the vLLM worker, which
+    rejects `max_tokens=0` with a Python ValueError. The bindings tag that as
+    Backend(InvalidArgument); the OpenAI frontend must map it to HTTP 400.
+
+    The /v1/completions path also asserts 400 as a regression guard: that endpoint
+    enforces `max_tokens` at the frontend, and the fix must not regress it.
+    """
+    base_url = f"http://localhost:{start_services.frontend_port}"
+
+    chat_payload = {
+        "model": TEST_MODEL,
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 0,
+    }
+    chat_response = _send_chat_request(chat_payload, base_url=base_url)
+    assert chat_response.status_code == 400, (
+        f"Expected HTTP 400 for chat completions with max_tokens=0, got "
+        f"{chat_response.status_code}: {chat_response.text}"
+    )
+    chat_body = chat_response.json()
+    assert chat_body.get("code") == 400, f"Unexpected chat body: {chat_body}"
+    assert chat_body.get("type") == "Bad Request", f"Unexpected chat body: {chat_body}"
+    assert (
+        isinstance(chat_body.get("message"), str) and chat_body["message"]
+    ), f"Chat 400 body must carry an error message: {chat_body}"
+
+    completions_payload = {
+        "model": TEST_MODEL,
+        "prompt": "hello",
+        "max_tokens": 0,
+    }
+    completions_response = requests.post(
+        f"{base_url}/v1/completions",
+        headers={"Content-Type": "application/json"},
+        json=completions_payload,
+        timeout=60,
+    )
+    assert completions_response.status_code == 400, (
+        f"Expected HTTP 400 for completions with max_tokens=0, got "
+        f"{completions_response.status_code}: {completions_response.text}"
+    )
+    completions_body = completions_response.json()
+    assert (
+        completions_body.get("code") == 400
+    ), f"Unexpected completions body: {completions_body}"
+    assert (
+        completions_body.get("type") == "Bad Request"
+    ), f"Unexpected completions body: {completions_body}"


### PR DESCRIPTION
#### Overview:

Map vLLM-style backend validation errors to OpenAI-compatible HTTP 400 responses instead of falling through to HTTP 500.

#### Details:

This updates OpenAI error conversion to recognize `Backend(InvalidArgument)` errors in the `anyhow` error chain using `dynamo_runtime::error::match_error_chain`. This covers vLLM validation failures like `max_tokens=0`, where the backend raises a Python validation error that is wrapped by the bindings as a backend invalid-argument error.

The PR also adds regression coverage for `max_tokens=0` on the vLLM frontend path, plus Rust unit coverage confirming:
- top-level `InvalidArgument` still maps to 400
- backend `InvalidArgument` maps to 400
- nested backend invalid-argument errors map to 400
- other backend errors continue to return 500

#### Where should the reviewer start?

Start with:
- `lib/llm/src/http/service/openai.rs`
- `tests/frontend/test_vllm.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes DYN-2788