### PR TITLE
test: mark multimodal_agg_frontend_decoding as post_merge

### DIFF
--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -371,7 +371,7 @@ vllm_configs = {
         name="multimodal_agg_frontend_decoding",
         directory=vllm_dir,
         script_name="agg_multimodal.sh",
-        # TODO(DYN-2863): revert to post_merge once pre-merge validates the fix.
+        # post_merge because needs real NIXL not stub
         marks=[
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(9.6),  # actual profiled peak with kv-bytes
@@ -379,7 +379,7 @@ vllm_configs = {
                 1_710_490_000
             ),  # KV cache cap (2x safety over min=855_244_800)
             pytest.mark.timeout(220),  # ~5x observed 43.7s; 2B model loads slower on CI
-            pytest.mark.pre_merge,
+            pytest.mark.post_merge,
         ],
         model="Qwen/Qwen2-VL-2B-Instruct",
         env={"DYN_MM_ALLOW_INTERNAL": "1"},

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -371,7 +371,10 @@ vllm_configs = {
         name="multimodal_agg_frontend_decoding",
         directory=vllm_dir,
         script_name="agg_multimodal.sh",
-        # post_merge because needs real NIXL not stub
+        # post_merge-only: local pre-merge runs that compile outside docker
+        # can pick up NIXL stubs, which don't support the multimodal transfer
+        # path this case exercises. CI post_merge runs in a container with
+        # real NIXL, so keep this test there.
         marks=[
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(9.6),  # actual profiled peak with kv-bytes


### PR DESCRIPTION
## Summary
- Revert `multimodal_agg_frontend_decoding` test back to `post_merge` (from `pre_merge`)

## Context
In #8535 (159d9e06), this test was temporarily flipped to `pre_merge` with a TODO to validate the `DYN_MM_ALLOW_INTERNAL` fix for DYN-2863 on pre-merge CI. Now that it's been validated, the test should return to `post_merge` since it requires real NIXL (not a stub) to run.

## Testing
- [ ] CI runs: confirm the test no longer runs in pre-merge and is scheduled in post-merge

## Checklist
- [ ] Human has reviewed AI code
- [ ] Relevant context for this fix has been tracked in this issue and/or in associated linear ticket for future debugging
- [ ] Code follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for multimodal decoding validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->