### PR TITLE
fix: register kv_publisher dropped-events counter without auto injected field

### DIFF
--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -288,7 +288,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                         "Input event gap detected: raw events dropped before batching"
                     );
                     if let Some(metrics) = kv_publisher_metrics() {
-                        metrics.increment_engines_dropped_events(worker_id, gap);
+                        metrics.increment_engines_dropped_events(gap);
                     } else {
                         tracing::warn!(
                             worker_id,

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -65,7 +65,7 @@ fn create_kv_stream_name(component: &Component, subject: &str) -> String {
 /// hierarchy labels for free.
 pub(super) struct KvPublisherMetrics {
     /// Total number of raw events dropped by engines before reaching publisher
-    pub engines_dropped_events_total: prometheus::IntCounterVec,
+    pub engines_dropped_events_total: prometheus::IntCounter,
 }
 
 static KV_PUBLISHER_METRICS: OnceLock<Arc<KvPublisherMetrics>> = OnceLock::new();
@@ -73,22 +73,22 @@ static KV_PUBLISHER_METRICS: OnceLock<Arc<KvPublisherMetrics>> = OnceLock::new()
 impl KvPublisherMetrics {
     /// Create from a Component, memoized in a static OnceLock.
     /// Uses the MetricsHierarchy API which auto-prepends `dynamo_component_`,
-    /// injects hierarchy labels, and registers with the DRT `MetricsRegistry`.
+    /// injects hierarchy labels (including `worker_id`), and registers with the
+    /// DRT `MetricsRegistry`.
     pub fn from_component(component: &Component) -> Arc<Self> {
         KV_PUBLISHER_METRICS
             .get_or_init(|| {
                 let metrics = component.metrics();
-                match metrics.create_intcountervec(
+                match metrics.create_intcounter(
                     kv_publisher::ENGINES_DROPPED_EVENTS_TOTAL,
                     "Total number of raw events dropped by engines before reaching publisher (detected via event_id gaps)",
-                    &["worker_id"],
                     &[],
                 ) {
                     Ok(engines_dropped_events_total) => {
                         Arc::new(Self { engines_dropped_events_total })
                     }
                     Err(e) => {
-                        tracing::warn!("Failed to create kv_publisher metrics from component: {}. Using unregistered metrics as fallback.", e);
+                        tracing::error!("Failed to register kv_publisher metrics with component: {}. Dropped-event counts will not be observable on /metrics.", e);
                         Arc::new(Self::new_unregistered())
                     }
                 }
@@ -96,26 +96,23 @@ impl KvPublisherMetrics {
             .clone()
     }
 
-    /// Creates unregistered metrics for use when the MetricsRegistry is not available.
-    /// This is used as a fallback when metric creation fails.
+    /// Creates unregistered metrics for use when registration fails.
+    /// Increments still work in-process but are not exposed on `/metrics`.
     pub fn new_unregistered() -> Self {
         Self {
-            engines_dropped_events_total: prometheus::IntCounterVec::new(
+            engines_dropped_events_total: prometheus::IntCounter::with_opts(
                 prometheus::Opts::new(
                     kv_publisher::ENGINES_DROPPED_EVENTS_TOTAL,
                     "Total number of raw events dropped by engines before reaching publisher (detected via event_id gaps)",
                 ),
-                &["worker_id"],
             )
             .expect("failed to create engines_dropped_events_total counter"),
         }
     }
 
     /// Increment the engines dropped events counter by the given amount.
-    pub fn increment_engines_dropped_events(&self, worker_id: u64, count: u64) {
-        self.engines_dropped_events_total
-            .with_label_values(&[&worker_id.to_string()])
-            .inc_by(count);
+    pub fn increment_engines_dropped_events(&self, count: u64) {
+        self.engines_dropped_events_total.inc_by(count);
     }
 }
 

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -88,7 +88,7 @@ impl KvPublisherMetrics {
                         Arc::new(Self { engines_dropped_events_total })
                     }
                     Err(e) => {
-                        tracing::error!("Failed to register kv_publisher metrics with component: {}. Dropped-event counts will not be observable on /metrics.", e);
+                        tracing::warn!("Failed to create kv_publisher metrics from component: {}. Using unregistered metrics as fallback.", e);
                         Arc::new(Self::new_unregistered())
                     }
                 }


### PR DESCRIPTION
#### Overview:

register kv_publisher dropped-events counter without auto injected field

#### Details:

`KvPublisherMetrics::from_component()` declared `worker_id` as a variable label, colliding with the runtime's auto-injected const label of the same name. The error was caught and swallowed into an unregistered fallback counter that incremented in-process but never appeared on `/metrics`.  Drop the now-redundant variable label; switch `IntCounterVec` → `IntCounter` since no variable labels remain.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: DYN-2873

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal metrics reporting infrastructure refactoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->