### PR TITLE
ci: flag internal Linear ticket refs in source via CodeRabbit

### DIFF
--- a/.ai/linear-ticket-refs.md
+++ b/.ai/linear-ticket-refs.md
@@ -1,0 +1,30 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Linear Ticket References in Source Code
+
+Source code in this repository must not carry references to internal Linear
+tickets (`DIS-XXXX`, `DYN-XXXX`, or any `<PROJECT>-NNNN` Linear ID). Linear is
+NVIDIA-internal, so those IDs are unresolvable for external contributors and
+public users.
+
+## What to do when one is flagged
+
+1. **Look for an existing GitHub issue** that already tracks the same work —
+   the GitHub issue search on the repo's *Issues* tab is usually enough.
+2. **If none exists, file a new GitHub issue** with a public-friendly summary.
+   Don't include the Linear URL or ID in the public issue body; assign it to
+   yourself when you file it.
+3. **Replace the Linear ref in the source** with the GitHub issue number
+   (`GH-NNNN` in identifiers and code comments, or `#NNNN` where prose allows).
+4. **Carry both refs in the PR description** (`Closes #NNNN`, plus a short
+   note that an internal Linear ticket also exists) and cross-link the GitHub
+   issue back on the Linear ticket so they stay connected.
+
+## Scope
+
+Applies to the working tree — anything that ships to `main`. Does **not** apply
+to commit-message bodies, branch names, or PR titles/descriptions.
+
+Markdown documentation (`*.md`) may reference Linear tickets for internal
+context, but prefer to also include the matching GitHub link when one exists.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -33,6 +33,8 @@ reviews:
       instructions: "Review against .ai/pytest-guidelines.md"
     - path: "**/launch/**/*.sh"
       instructions: "Review against .ai/bash-launch-guidelines.md"
+    - path: "**/*.{py,rs,go,ts,tsx,js,mjs,cjs,sh,yaml,yml,toml}"
+      instructions: "Flag internal Linear ticket references (DIS-XXXX, DYN-XXXX, etc.) in the added lines; see .ai/linear-ticket-refs.md for what to recommend."
 knowledge_base:
   code_guidelines:
     filePatterns:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -34,7 +34,7 @@ reviews:
     - path: "**/launch/**/*.sh"
       instructions: "Review against .ai/bash-launch-guidelines.md"
     - path: "**/*.{py,rs,go,ts,tsx,js,mjs,cjs,sh,yaml,yml,toml}"
-      instructions: "Flag internal Linear ticket references (DIS-XXXX, DYN-XXXX, etc.) in the added lines; see .ai/linear-ticket-refs.md for what to recommend."
+      instructions: "Flag internal Linear ticket references (e.g. DIS-XXXX, DYN-XXXX, OPS-XXXX, DEP-XXXX, or any <PROJECT>-NNNN ID) in the added lines; see .ai/linear-ticket-refs.md for what to recommend."
 knowledge_base:
   code_guidelines:
     filePatterns:


### PR DESCRIPTION
#### Overview:

Teach CodeRabbit to flag internal Linear ticket references (DIS-XXXX / DYN-XXXX / any <PROJECT>-NNNN ID) that slip into source code, and point authors at a brief runbook.

#### Details:

- Add a path_instructions rule in `.coderabbit.yaml` matching common source extensions (`py, rs, go, ts, tsx, js, mjs, cjs, sh, yaml, yml, toml`)
- The rule is a one-liner: detect the ref, leave a recommendation on the line, defer specifics to the runbook
- Add `.ai/linear-ticket-refs.md` — short narrative on what to do: search Issues tab for a matching GitHub issue, file one with a public-friendly body if absent (no Linear URL/ID in the public issue), replace the Linear ref with `GH-NNNN` / `#NNNN`, and cross-link Linear and GitHub in the PR description
- Explicitly scoped to the working tree; does not apply to commit messages, branch names, or PR titles/descriptions

#### Where should the reviewer start?

`.coderabbit.yaml`, then `.ai/linear-ticket-refs.md`

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code review infrastructure with updated configuration and new internal documentation to improve quality assurance processes and enforce best practices across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->