### PR TITLE
fix(dev): symlink bundled nsys onto PATH in dev/local-dev images

### DIFF
--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -255,6 +255,12 @@ COPY --from=dynamo_tools /etc/sudoers /etc/sudoers
 COPY --from=dynamo_tools /etc/sudoers.d/ /etc/sudoers.d/
 COPY --from=dynamo_tools /opt/nvidia/ /opt/nvidia/
 
+# Expose bundled nsys on PATH (apt-installed in dynamo_tools; /usr/local/ is
+# not copied across stages, so the apt post-install symlink is lost).
+RUN NSYS_BIN=$(find /opt/nvidia/nsight-systems -maxdepth 6 -type f -name nsys -executable 2>/dev/null | head -n1) && \
+    if [ -n "$NSYS_BIN" ]; then ln -sf "$NSYS_BIN" /usr/local/bin/nsys; \
+    else echo "WARNING: no bundled nsys found under /opt/nvidia/nsight-systems"; fi
+
 # Restore the pre-tools python3 (keeps SGLang system python intact and avoids venv symlink loops).
 RUN if [ -e /tmp/python3.pretools ]; then cp -af /tmp/python3.pretools /usr/bin/python3; fi
 


### PR DESCRIPTION
## Why

`nsys` is not on `PATH` in vllm / trtllm / framework=none dev and local-dev images, even though the nsight-systems binary tree is present. Profiling a dev container requires manually locating the binary.

## What Change

- Symlink bundled `nsys` to `/usr/local/bin/nsys` in the `dev` stage, right after the `/opt/nvidia/` copy from `dynamo_tools`.
- Warns loudly if no nsys is found, so a silent apt install failure surfaces during build.

## Build stage sequence

For vllm dev/local-dev:
`args → dynamo_base → wheel_builder → vllm_framework → vllm_runtime → dev → (local_dev)`

For sglang dev/local-dev:
`args → dynamo_base → wheel_builder → sglang_runtime → dev → (local_dev)`

## Test Plan

- Build a vllm dev image, run `which nsys && nsys --version` — expect `/usr/local/bin/nsys` and a real version.
- Repeat for vllm local-dev and trtllm dev.