### PR TITLE
fix(tests): update test_orchestrator for request_count→conversation_num rename

### DIFF
--- a/tests/benchmarks/multimodal/sweep/test_orchestrator.py
+++ b/tests/benchmarks/multimodal/sweep/test_orchestrator.py
@@ -52,7 +52,7 @@ def _make_config(
         request_rates=request_rates,
         concurrencies=None,
         osl=10,
-        request_count=5,
+        conversation_num=1,
         warmup_count=1,
         port=8000,
         timeout=60,


### PR DESCRIPTION
#### Overview
PR #8458 renamed `SweepConfig.request_count` to `conversation_num` but did not update the test helper in `test_orchestrator.py`, breaking all 5 multimodal sweep orchestrator tests on main with `TypeError: SweepConfig.__init__() got an unexpected keyword argument 'request_count'`.

Before:
```
tests/benchmarks/multimodal/sweep/test_orchestrator.py::test_loop_order_bench_cfg_outer FAILED
E   TypeError: SweepConfig.__init__() got an unexpected keyword argument 'request_count'
```

After: all 5 tests pass.

#### Details
Replace `request_count=5` with `conversation_num=1` in the `_make_config()` test helper. The value is set to 1 (not the old 5) because `_resolve_conversation_num` now validates that `conversation_num <= count_session_ids(jsonl)`, and the dummy test JSONL files contain a single anonymous row (`{}\n`), yielding a detected count of 1. Setting it explicitly also avoids the `None` auto-derive path, keeping these unit tests hermetic (no file I/O dependency).

#### Where should the reviewer start?
`tests/benchmarks/multimodal/sweep/test_orchestrator.py:55` — the single changed line in `_make_config()`.

#### Test Plan
- Reproduced all 5 failures locally on `origin/main` (unmodified test): 5/5 FAILED with `TypeError`
- Applied fix, re-ran: 5/5 PASSED
- Verified `conversation_num=5` does NOT work (triggers `ValueError: conversation_num=5 exceeds unique session_id count (1)`)
- Verified `conversation_num=1` bypasses both the `None` auto-derive branch and the `> detected` validation

#### Related Issues
- Root cause: #8458

Signed-off-by: Krishnan Prashanth <kprashanth@nvidia.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated benchmark test configuration for the multimodal test suite to reflect schema changes in test parameters, ensuring consistency across test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->