### PR TITLE
fix(epp/Dockerfile): Directive to use newer buildkit version

### DIFF
--- a/deploy/inference-gateway/epp/Dockerfile
+++ b/deploy/inference-gateway/epp/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.10.0-labs
 # SPDX-FileCopyrightText:  Copyright The Kubernetes Authors.
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

The [PR](https://github.com/ai-dynamo/dynamo/pull/8604) to support sscache backed by S3 introduced compatibility issues with older Docker buildkit versions.
This introduced compatibility issues on previous buildkit frontend versions:
```
ERROR: failed to solve: unexpected key 'env' in 'env=AWS_ROLE_ARN'
```

This adds a directive to use a newer buildkit frontend image during build.


#### Details:

<!-- Describe the changes made in this PR. -->

Add `# syntax=docker/dockerfile:1.10.0-labs` directive on the top of Dockerfile to use newer buildkit frontend image that supports the "env" directive parameter.

That `env` parameter was introduced in the `docker/dockerfile:1.10` frontend.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure configuration to pin the version of the Dockerfile parser used during builds, ensuring consistent build behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->