### PR TITLE
fix(omni): GLM-Image noise in dynamo disaggregated path

### DIFF
--- a/components/src/dynamo/vllm/omni/utils.py
+++ b/components/src/dynamo/vllm/omni/utils.py
@@ -31,7 +31,17 @@ def build_original_prompt(request: dict, nvext: dict, height: int, width: int) -
     prompt = OmniTextPrompt(
         prompt=request.get("prompt", ""),
         negative_prompt=request.get("negative_prompt", None),
+        # Downstream stage processors (e.g. GLM-Image's ar2diffusion) read
+        # target size from mm_processor_kwargs when upsampling AR-generated
+        # prior tokens; without it they default to 1024x1024 and decouple
+        # from the requested size.
+        mm_processor_kwargs={"target_h": height, "target_w": width},
     )
+    # Older vllm-omni ar2diffusion implementations (e.g. 0.19.0rc1) read
+    # height/width from the top level of the prompt dict rather than from
+    # mm_processor_kwargs. Keep both so the fix works across versions.
+    prompt["height"] = height
+    prompt["width"] = width
     if request.get("multi_modal_data"):
         prompt["multi_modal_data"] = request["multi_modal_data"]
     return prompt

--- a/components/src/dynamo/vllm/omni/utils.py
+++ b/components/src/dynamo/vllm/omni/utils.py
@@ -70,8 +70,16 @@ async def parse_omni_request(
                 fps=nvext.get("fps"),
                 default_fps=default_video_fps,
             )
+        # Attach target h/w as mm_processor_kwargs so the HF processor
+        # routes through the multimodal path. AR-based image-gen models
+        # (e.g. GLM-Image) need their processor to emit the image-gen
+        # scaffold; without mm_processor_kwargs the preprocessor falls
+        # back to plain tokenization and the AR stage produces noise.
         return {
-            "engine_inputs": OmniTextPrompt(prompt=request.get("prompt", "")),
+            "engine_inputs": OmniTextPrompt(
+                prompt=request.get("prompt", ""),
+                mm_processor_kwargs={"target_h": height, "target_w": width},
+            ),
             "original_prompt": build_original_prompt(request, nvext, height, width),
             "sampling_params_list": sp,
         }

--- a/examples/backends/vllm/launch/disagg_omni_glm_image.sh
+++ b/examples/backends/vllm/launch/disagg_omni_glm_image.sh
@@ -14,10 +14,7 @@ source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 
 MODEL="${MODEL:-zai-org/GLM-Image}"
 
-# Resolve vllm-omni's built-in GLM-Image stage config
-if [ -z "$STAGE_CONFIG" ]; then
-    STAGE_CONFIG="$(python -c "import vllm_omni, os; print(os.path.join(os.path.dirname(vllm_omni.__file__), 'model_executor/stage_configs/glm_image.yaml'))" 2>/dev/null | tail -1)"
-fi
+STAGE_CONFIG="${STAGE_CONFIG:-$SCRIPT_DIR/stage_configs/glm_image.yaml}"
 
 EXTRA_ARGS=()
 while [[ $# -gt 0 ]]; do

--- a/examples/backends/vllm/launch/stage_configs/glm_image.yaml
+++ b/examples/backends/vllm/launch/stage_configs/glm_image.yaml
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stage config for running GLM-Image with 2-stage architecture
+# Stage 0: AR Model (vLLM implementation) - generates prior_token_ids
+# Stage 1: Diffusion (DiT + VAE) - denoising and image decoding
+
+stage_args:
+  # Stage 0: AR Model (GlmImageForConditionalGeneration)
+  # This stage uses the vLLM-optimized AR model to generate prior tokens
+  # for conditioning the diffusion process.
+  - stage_id: 0
+    stage_type: llm
+    runtime:
+      process: true
+      devices: "0"
+      requires_multimodal_data: true # Required for i2i mode to receive source images
+    engine_args:
+      model_stage: ar
+      max_num_seqs: 1
+      model_arch: GlmImageForConditionalGeneration
+      model_subdir: vision_language_encoder # AR model config.json is in this subdirectory
+      tokenizer_subdir: processor # Use processor's tokenizer (not ByT5 from tokenizer/)
+      worker_cls: vllm_omni.worker.gpu_ar_worker.GPUARWorker
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      engine_output_type: token_ids # Output prior_token_ids for diffusion stage
+      distributed_executor_backend: "mp"
+      enable_prefix_caching: false
+      max_num_batched_tokens: 32768
+    final_output: false # AR is not the final output
+    is_comprehension: true
+    default_sampling_params:
+      temperature: 0.9 # From model's generation_config.json
+      top_p: 0.75 # From model's generation_config.json
+      top_k: 16512 # vision_vocab_size from generation_config.json
+      max_tokens: 1281 # For 1024x1024: small(16x16=256) + large(32x32=1024) + EOS(1)
+      stop_token_ids: [16385] # eos_token_id from generation_config.json
+      seed: 42
+      detokenize: false
+
+  # Stage 1: Diffusion (DiT + VAE)
+  # This stage receives prior_token_ids from AR and performs denoising + VAE decode
+  - stage_id: 1
+    stage_type: diffusion
+    runtime:
+      process: true
+      devices: "1" # Can use different GPU, or same GPU if memory allows
+      requires_multimodal_data: true # Required for i2i mode to pass condition images
+    engine_args:
+      model_stage: dit
+      max_num_seqs: 1
+      model_arch: GlmImagePipeline # Required for diffusion model class resolution
+      # Diffusion-specific parameters
+      num_gpus: 1
+      enforce_eager: true
+      trust_remote_code: true
+      distributed_executor_backend: "mp"
+    engine_input_source: [0] # Input from AR stage
+    custom_process_input_func: vllm_omni.model_executor.stage_input_processors.glm_image.ar2diffusion
+    final_output: true
+    final_output_type: image
+    default_sampling_params:
+      # Diffusion-specific parameters only (no LLM params like temperature/top_p/top_k)
+      seed: 42
+      num_inference_steps: 50
+      guidance_scale: 1.5
+      height: 1024
+      width: 1024
+
+# Top-level runtime config
+runtime:
+  enabled: true
+  defaults:
+    window_size: -1 # Trigger downstream only after full upstream completion
+    max_inflight: 1 # Process serially within each stage
+
+  edges:
+    - from: 0 # AR → Diffusion: trigger after AR completes
+      to: 1
+      window_size: -1


### PR DESCRIPTION
## Summary

Three commits fix GLM-Image in dynamo's disaggregated omni path:

- `refactor(omni)` — colocate `glm_image.yaml` under `examples/backends/vllm/launch/stage_configs/` (matching `single_stage_llm.yaml`, `qwen2_5_omni_pd.yaml`) instead of reaching into the installed `vllm_omni` package. Removes a leaky abstraction that breaks the launch script against vllm-omni builds that don't ship that specific yaml.
- `fix(omni)` — attach `mm_processor_kwargs={target_h, target_w}` to the stage-0 `OmniTextPrompt` for image/video generation requests, so `OmniInputPreprocessor._process_text` routes through the HF multimodal processor path. Without this, AR-based image-gen models (e.g. GLM-Image) never emit their image-generation scaffold and the DiT stage denoises a collapsed token stream into textured noise.
- `fix(omni)` — place target h/w on the `original_prompt` dict (both as `mm_processor_kwargs` for the post-#3034 ar2diffusion and as top-level `height`/`width` for the 0.19.0rc1 ar2diffusion shipped in the dynamo runtime). Stage processors read this to upsample AR-generated prior tokens; without it they fall back to the 1024x1024 default and decouple from the requested size.

## Evidence

`zai-org/GLM-Image`, prompt `"a red apple on a white table"`, 2×A6000:

**Default size (1024×1024)** — MD5-identical output across the native and fixed disaggregated paths:

| Path | Setup | Output MD5 |
|---|---|---|
| dynamo disagg (before fix, 3 runs) | same container, same mount stack | `36421ed1d1cfb07499fd166141f7998c` — red striated noise |
| `vllm-omni serve --omni` (native) | same container, same local vllm-omni install | `fa91343423d032e053327eb6047459b4` — coherent apple |
| **dynamo disagg (after fix)** | **byte-identical to the native path** | **`fa91343423d032e053327eb6047459b4` — coherent apple** |

**Non-default size (512×512)**:

| Path | Before first fix | After `route image-gen through multimodal processor` (commit 2) | After `pass target h/w to stage processor` (commit 3) |
|---|---|---|---|
| dynamo disagg | noise | `RuntimeError` at `glm_image_transformer.py:883` (`tensor a (1024) vs tensor b (4096)` — DiT at requested 512 but AR prior upsampled to 1024-scale) | ✅ coherent apple, ~60s |

## Root cause

The dynamo disagg path is a set of separate worker processes glued together by a custom router. It bypasses vllm-omni's OpenAI chat entrypoint entirely (goes through `dynamo.vllm.omni.stage_router` → `dynamo.vllm.omni.stage_worker` → `AsyncOmni` directly), so the upstream [vllm-omni#3034](https://github.com/vllm-project/vllm-omni/pull/3034) fix doesn't reach it. Two separate pieces of size-metadata have to make it across the stage boundary in the dynamo path and neither did:

1. Stage 0 (AR) — needs `mm_processor_kwargs={target_h, target_w}` on the engine prompt so `OmniInputPreprocessor._process_text` takes the multimodal branch and the HF processor emits GLM-Image's scaffold (`<|image|>PROMPT<sop>H W<eop><sop>h w<eop><|dit_token_N|>`). Without the scaffold, AR produces a handful of repeated VQ codes and DiT denoises them into noise.
2. Stage 1 (DiT via the `ar2diffusion` custom processor) — needs the target size on `original_prompt` (as `mm_processor_kwargs["target_h"/"target_w"]` on post-#3034 vllm-omni, or top-level `height`/`width` on 0.19.0rc1) so it slices and upsamples the AR prior token grid to the right latent shape. Without it, it defaults to 1024×1024 and produces a 64×64 prior regardless of the requested size, which then mismatches the DiT hidden-state shape for any non-1024 latent.

## Scope

Minimal, two touched files (`utils.py` for the preprocessing plumbing, `disagg_omni_glm_image.sh` + new yaml for the colocation refactor). Image/video-generation paths only; chat / text / audio branches of `parse_omni_request` are untouched. Models whose HF processor and stage processor ignore `target_h`/`target_w` and `height`/`width` are unaffected.

## Test plan

- [x] Manual: `disagg_omni_glm_image.sh` + `/v1/images/generations` at 1024x1024 — output MD5-identical to `vllm-omni serve`.
- [x] Manual: same at 512x512 — coherent image (was `RuntimeError` before).
- [x] Regression: 1024x1024 re-tested after the 512 fix — still MD5-identical to the native baseline.
- [ ] Regression (reviewer): qwen omni agg / single-stage paths — confirm the chat/text branch of `parse_omni_request` and the audio handler are unchanged (not touched in the diff).
- [x] CI: pre-commit hooks pass locally (black / ruff / codespell / yaml / shebangs all clean across all three commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)