### PR TITLE
fix: add benchmarks filter and gate dynamo-pipeline on it

### DIFF
--- a/.github/FILTERS.md
+++ b/.github/FILTERS.md
@@ -12,6 +12,7 @@ When you open a PR, CI checks which files changed and runs only relevant jobs:
 | `operator` | Kubernetes operator tests |
 | `deploy` | Deploy-specific tests |
 | `vllm` / `sglang` / `trtllm` | Backend-specific tests |
+| `benchmarks` | Dynamo runtime pipeline (runs `tests/benchmarks/**` pytest suite) |
 | `docs` | Nothing (classification only) |
 | `examples` | Nothing (classification only) |
 | `ignore` | Nothing (classification only) |

--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -31,6 +31,9 @@ outputs:
   frontend:
     description: 'Whether frontend files changed'
     value: ${{ steps.filter.outputs.frontend_any_modified }}
+  benchmarks:
+    description: 'Whether benchmarks files changed'
+    value: ${{ steps.filter.outputs.benchmarks_any_modified }}
   rust:
     description: 'Whether rust files changed'
     value: ${{ steps.filter.outputs.rust_any_modified }}
@@ -114,6 +117,7 @@ runs:
         echo "sglang: ${{ steps.filter.outputs.sglang_any_modified }}"
         echo "trtllm: ${{ steps.filter.outputs.trtllm_any_modified }}"
         echo "frontend: ${{ steps.filter.outputs.frontend_any_modified }}"
+        echo "benchmarks: ${{ steps.filter.outputs.benchmarks_any_modified }}"
         echo "rust: ${{ steps.filter.outputs.rust_any_modified }}"
         echo ""
         echo "=== Files Matching Each Filter ==="
@@ -127,13 +131,14 @@ runs:
         echo "sglang: ${{ steps.filter.outputs.sglang_all_modified_files }}"
         echo "trtllm: ${{ steps.filter.outputs.trtllm_all_modified_files }}"
         echo "frontend: ${{ steps.filter.outputs.frontend_all_modified_files }}"
+        echo "benchmarks: ${{ steps.filter.outputs.benchmarks_all_modified_files }}"
         echo "rust: ${{ steps.filter.outputs.rust_all_modified_files }}"
 
     - name: Check for uncovered files
       shell: bash
       run: |
         # Combine all filter-specific files into one list
-        COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
+        COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.benchmarks_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
 
         # Get all modified files
         ALL_FILES=$(echo "${{ steps.filter.outputs.all_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -9,6 +9,7 @@
 #   sglang   -> sglang build and test
 #   trtllm   -> trtllm build and test
 #   frontend -> frontend EPP image build, dynamo build-test
+#   benchmarks -> dynamo build-test (runs tests/benchmarks/** pytest suite)
 #   docs     -> fern docs lint, sync, and version release (docs/ directory)
 #
 # Filters for coverage only (no CI triggered):
@@ -32,7 +33,6 @@ docs:
 examples:
   - 'recipes/**'
   - 'examples/**'
-  - 'benchmarks/**'
   - '.devcontainer/**'
   - 'deploy/discovery/**'
   - 'deploy/inference-gateway/**'
@@ -173,3 +173,8 @@ rust:
   - '**/Cargo.toml'
   - '**/Cargo.lock'
   - 'deny.toml'
+
+benchmarks:
+  - 'benchmarks/**'
+  - '!**/*.md'
+  - '!**/*.rst'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -31,6 +31,7 @@ jobs:
       sglang: ${{ steps.changes.outputs.sglang }}
       trtllm: ${{ steps.changes.outputs.trtllm }}
       frontend: ${{ steps.changes.outputs.frontend }}
+      benchmarks: ${{ steps.changes.outputs.benchmarks }}
       builder_name: ${{ steps.export-builder-name.outputs.builder_name }}
     steps:
       - name: Checkout code
@@ -396,7 +397,8 @@ jobs:
       needs.changed-files.outputs.frontend == 'true' ||
       needs.changed-files.outputs.vllm == 'true' ||
       needs.changed-files.outputs.sglang == 'true' ||
-      needs.changed-files.outputs.trtllm == 'true'
+      needs.changed-files.outputs.trtllm == 'true' ||
+      needs.changed-files.outputs.benchmarks == 'true'
     uses: ./.github/workflows/dynamo-pipeline.yml
     with:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}


### PR DESCRIPTION
Previously `benchmarks/**` matched only the `examples` filter, which is coverage-only (no CI triggered). A PR that changed only files under `benchmarks/` — like the recent request_count→conversation_num rename — would skip `dynamo-pipeline` entirely, so the `tests/benchmarks/**` suite that exercises those files never ran pre-merge.

Lift `benchmarks/**` out of the `examples` classifier into its own top-level filter, expose it through the shared changed-files action (and add it to COVERED_FILES so coverage still passes), and extend `dynamo-pipeline`'s `if:` gate. Markdown-only changes under `benchmarks/` still classify as `docs` and skip CI.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline configuration to detect and validate changes to benchmark test files
  * Updated documentation to reflect new benchmark detection workflow in continuous integration processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->