### PR TITLE
fix(global-planner): await endpoints concurrently so health registers (DYN-2776 follow-up)

### DIFF
--- a/components/src/dynamo/global_planner/__main__.py
+++ b/components/src/dynamo/global_planner/__main__.py
@@ -96,19 +96,10 @@ async def main(runtime: DistributedRuntime, args):
         max_total_gpus=args.max_total_gpus,
     )
 
-    # Serve scale_request endpoint
     logger.info("Serving endpoints...")
     scale_endpoint = runtime.endpoint(f"{namespace}.GlobalPlanner.scale_request")
-    await scale_endpoint.serve_endpoint(handler.scale_request)
-    logger.info("  ✓ scale_request - Receives scaling requests from Planners")
+    health_endpoint = runtime.endpoint(f"{namespace}.GlobalPlanner.health")
 
-    # Serve health check endpoint.
-    # Passing health_check_payload registers this endpoint as a health-check
-    # target so the runtime's system status server flips to HealthStatus::Ready
-    # once the handler is registered. Without it, the operator-injected HTTP
-    # probes on :system/live and :system/health return 503 forever and the pod
-    # never becomes Ready. Mirrors the pool-Planner entrypoint pattern at
-    # components/src/dynamo/planner/__main__.py.
     async def health_check(request: HealthCheckRequest):
         """Health check endpoint for monitoring"""
         yield {
@@ -118,19 +109,30 @@ async def main(runtime: DistributedRuntime, args):
             "managed_namespaces": args.managed_namespaces or "all",
         }
 
-    health_endpoint = runtime.endpoint(f"{namespace}.GlobalPlanner.health")
-    await health_endpoint.serve_endpoint(
-        health_check,
-        health_check_payload={"text": "health"},
-    )
+    logger.info("  ✓ scale_request - Receives scaling requests from Planners")
     logger.info("  ✓ health - Health check endpoint")
-
     logger.info("=" * 60)
     logger.info("GlobalPlanner is ready and waiting for scale requests")
     logger.info("=" * 60)
 
-    # Keep running forever (process scale requests as they come)
-    await asyncio.Event().wait()
+    # serve_endpoint is a long-running task — it only returns on shutdown.
+    # Awaiting them sequentially would block on scale_request forever and
+    # never register the health endpoint, so system_health would never flip
+    # to Ready and the operator-injected HTTP probes on :system/live and
+    # :system/health would 503 indefinitely. Run concurrently via
+    # asyncio.gather; pattern matches components/src/dynamo/planner/__main__.py.
+    #
+    # Passing health_check_payload to the health endpoint registers it as a
+    # health-check target so system_health flips to Ready once the endpoint
+    # is live. The payload shape matches HealthCheckRequest so if canary
+    # probing is ever enabled it can deserialize cleanly.
+    await asyncio.gather(
+        scale_endpoint.serve_endpoint(handler.scale_request),
+        health_endpoint.serve_endpoint(
+            health_check,
+            health_check_payload={"text": "health"},
+        ),
+    )
 
 
 if __name__ == "__main__":

--- a/components/src/dynamo/global_planner/tests/unit/test_main_endpoint_registration.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_main_endpoint_registration.py
@@ -20,6 +20,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from dynamo.global_planner import __main__ as gp_main
+
 pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
@@ -30,16 +32,16 @@ pytestmark = [
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(10)
 async def test_main_registers_both_endpoints_concurrently():
     """Both scale_request and health endpoints must be registered before the
     entrypoint blocks. Sequential awaits would leave health unregistered.
     """
-    from dynamo.global_planner import __main__ as gp_main
-
     # Track which endpoint names get created and their serve_endpoint calls.
     created_endpoints: dict[str, MagicMock] = {}
 
     def make_endpoint(name: str) -> MagicMock:
+        """Build a mock endpoint whose serve_endpoint never resolves."""
         ep = MagicMock()
         # serve_endpoint is a sync function that returns an awaitable (Rust's
         # future_into_py). Return a never-completing Future so ``await
@@ -47,7 +49,7 @@ async def test_main_registers_both_endpoints_concurrently():
         # If the entrypoint awaits the endpoints sequentially, the first
         # call blocks forever and the second is never registered.
         ep.serve_endpoint = MagicMock(
-            side_effect=lambda *a, **kw: asyncio.get_event_loop().create_future()
+            side_effect=lambda *a, **kw: asyncio.get_running_loop().create_future()
         )
         created_endpoints[name] = ep
         return ep

--- a/components/src/dynamo/global_planner/tests/unit/test_main_endpoint_registration.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_main_endpoint_registration.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the GlobalPlanner entrypoint's endpoint registration.
+
+serve_endpoint returns a long-running future that only completes on shutdown.
+Awaiting the two endpoints sequentially would block forever on the first and
+never register the second — leaving system_health permanently NotReady and
+the pod stuck at 0/1 Ready (operator-injected probes 503 indefinitely).
+
+These tests guard against that regression by verifying:
+1. Both endpoints' serve_endpoint are invoked (concurrent awaiting).
+2. The health endpoint receives a health_check_payload so the runtime's
+   system_health flag can flip to Ready.
+"""
+
+import asyncio
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+    pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20"),
+]
+
+
+@pytest.mark.asyncio
+async def test_main_registers_both_endpoints_concurrently():
+    """Both scale_request and health endpoints must be registered before the
+    entrypoint blocks. Sequential awaits would leave health unregistered.
+    """
+    from dynamo.global_planner import __main__ as gp_main
+
+    # Track which endpoint names get created and their serve_endpoint calls.
+    created_endpoints: dict[str, MagicMock] = {}
+
+    def make_endpoint(name: str) -> MagicMock:
+        ep = MagicMock()
+        # serve_endpoint is a sync function that returns an awaitable (Rust's
+        # future_into_py). Return a never-completing Future so ``await
+        # ep.serve_endpoint(...)`` blocks forever — matching real behavior.
+        # If the entrypoint awaits the endpoints sequentially, the first
+        # call blocks forever and the second is never registered.
+        ep.serve_endpoint = MagicMock(
+            side_effect=lambda *a, **kw: asyncio.get_event_loop().create_future()
+        )
+        created_endpoints[name] = ep
+        return ep
+
+    runtime = MagicMock()
+    runtime.endpoint = MagicMock(side_effect=make_endpoint)
+
+    args = MagicMock()
+    args.environment = "kubernetes"
+    args.managed_namespaces = None
+    args.no_operation = False
+    args.max_total_gpus = -1
+
+    with patch.dict(
+        os.environ, {"DYN_NAMESPACE": "gp-ns", "POD_NAMESPACE": "default"}
+    ), patch("dynamo.global_planner.__main__.ScaleRequestHandler") as mock_handler_cls:
+        mock_handler_cls.return_value = MagicMock()
+
+        # main never returns on its own (it awaits the endpoint futures
+        # forever). Run it in a task, yield control so the gather starts, then
+        # cancel and inspect what was registered.
+        # Calling the underlying coroutine (the @dynamo_worker-wrapped `main`
+        # expects a runtime injected by the decorator; we bypass it).
+        task = asyncio.create_task(gp_main.main.__wrapped__(runtime, args))
+        # Let the event loop run. With asyncio.gather both serve_endpoint
+        # futures are scheduled in one step; with sequential awaits only
+        # the first one is ever called, which is exactly the bug.
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if len(created_endpoints) >= 2 and all(
+                ep.serve_endpoint.call_count >= 1 for ep in created_endpoints.values()
+            ):
+                break
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # Both endpoints must have been created and served.
+    scale_key = next(k for k in created_endpoints if k.endswith(".scale_request"))
+    health_key = next(k for k in created_endpoints if k.endswith(".health"))
+    assert created_endpoints[scale_key].serve_endpoint.called, (
+        "scale_request endpoint was never served — regression: both "
+        "endpoints must be awaited concurrently via asyncio.gather."
+    )
+    assert created_endpoints[health_key].serve_endpoint.called, (
+        "health endpoint was never served — regression: sequential await on "
+        "scale_request blocks forever and never yields control back to "
+        "register the health endpoint."
+    )
+
+    # The health endpoint must register a health_check_payload so the
+    # runtime's system_health flips to Ready.
+    health_call = created_endpoints[health_key].serve_endpoint.call_args
+    assert "health_check_payload" in health_call.kwargs, (
+        "health endpoint must pass health_check_payload so system_health "
+        "flips to Ready; without it the pod stays permanently NotReady."
+    )
+    payload = health_call.kwargs["health_check_payload"]
+    assert isinstance(payload, dict) and "text" in payload, (
+        f"health_check_payload must be a dict matching HealthCheckRequest "
+        f"(has a 'text' field); got {payload!r}"
+    )


### PR DESCRIPTION
## Summary

Follow-up to #8482. QA verified DYN-2776 still reproduces on 1.1.0-rc4 — the GlobalPlanner pod stays at 0/1 Ready with `/health` returning:

\`\`\`
HTTP 503 {"status":"notready","uptime":{...},"endpoints":{"scale_request":"ready"}}
\`\`\`

Only \`scale_request\` appears in \`endpoints\` — the \`health\` endpoint was never registered, so the fix I added there (\`health_check_payload={"text": "health"}\`) was never executed.

## Root cause

\`serve_endpoint\` returns a future that completes only on shutdown. The entrypoint was awaiting the two endpoints sequentially:

\`\`\`python
await scale_endpoint.serve_endpoint(...)   # blocks forever
await health_endpoint.serve_endpoint(...)  # unreachable
\`\`\`

So the first \`await\` blocks and the health endpoint is never registered — \`system_health\` stays \`NotReady\` and the operator-injected kubelet probes 503 indefinitely.

## Fix

Run both \`serve_endpoint\` calls concurrently via \`asyncio.gather\`, matching the pool Planner pattern at \`components/src/dynamo/planner/__main__.py\`.

## Regression test

Added \`test_main_registers_both_endpoints_concurrently\` which mocks \`serve_endpoint\` to return a never-completing Future and asserts both endpoints' \`serve_endpoint\` get called and the health endpoint receives \`health_check_payload\`.

Verified the test **fails** on the sequential-await version (by stashing the fix and re-running) and **passes** on the gather version.

## Test plan

- [x] \`pytest components/src/dynamo/global_planner/tests/ components/src/dynamo/planner/tests/\` — 358 passed, 1 skipped
- [x] New regression test fails on broken version, passes on fixed version
- [ ] Re-verify on K8s with the DYN-2776 reproducer YAML once image is built

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized GlobalPlanner startup process to register and run endpoints concurrently, improving initialization performance.

* **Tests**
  * Added regression test to ensure endpoint registration works correctly at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->