### PR TITLE
fix(tests): remove invalid --warmup-request-count 0 from aiperf

### DIFF
--- a/tests/fault_tolerance/deploy/client.py
+++ b/tests/fault_tolerance/deploy/client.py
@@ -261,9 +261,6 @@ def run_aiperf(
         str(output_token_length),
         "--output-tokens-stddev",
         "0",  # Set to 0 for consistent token counts
-        # Skip warmup to avoid initial failures
-        "--warmup-request-count",
-        "0",
         # Output configuration
         "--artifact-dir",
         str(output_dir),


### PR DESCRIPTION
Cherry-pick of #8653 to `release/1.1.0-dev.1`.

#### Overview:

Fix the fault tolerance test failure (DYN-2749) caused by aiperf rejecting `--warmup-request-count 0`. A recent aiperf update tightened pydantic validation on `loadgen.warmup_request_count` to require `> 0`; passing `0` raises a validation error before any requests are sent, causing every fault-tolerance scenario (`vllm`, `sglang`, `trtllm`) to report 0% success.

#### Details:

**`tests/fault_tolerance/deploy/client.py`** — Remove `--warmup-request-count 0` from the `aiperf profile` command. Per the [aiperf CLI docs](https://github.com/ai-dynamo/aiperf/blob/083d3c479d2995c3074363b491d5aea833020ab4/docs/cli-options.md#--warmup-request-count---num-warmup-requests-int): _"If not set and no `--warmup-duration` is set, then no warmup phase will be used."_ Omitting the flag preserves the original intent (no warmup) while avoiding the pydantic `greater_than` validation error.

#### Where should the reviewer start?

1. [tests/fault_tolerance/deploy/client.py](tests/fault_tolerance/deploy/client.py) — the one-liner fix
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
