### PR TITLE
fix: disable snapshot with GMS in admission

### DIFF
--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocheckpoints.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocheckpoints.yaml
@@ -8211,6 +8211,9 @@ spec:
                 - identity
                 - job
               type: object
+              x-kubernetes-validations:
+                - message: checkpointing with gpuMemoryService is temporarily disabled due to known GPU driver issues
+                  rule: '!has(self.gpuMemoryService) || !self.gpuMemoryService.enabled'
             status:
               description: DynamoCheckpointStatus defines the observed state of DynamoCheckpoint
               properties:

--- a/deploy/operator/api/v1alpha1/dynamocheckpoint_types.go
+++ b/deploy/operator/api/v1alpha1/dynamocheckpoint_types.go
@@ -119,6 +119,7 @@ type DynamoCheckpointJobConfig struct {
 }
 
 // DynamoCheckpointSpec defines the desired state of DynamoCheckpoint
+// +kubebuilder:validation:XValidation:rule="!has(self.gpuMemoryService) || !self.gpuMemoryService.enabled",message="checkpointing with gpuMemoryService is temporarily disabled due to known GPU driver issues"
 type DynamoCheckpointSpec struct {
 	// Identity defines the inputs that determine checkpoint equivalence
 	// +kubebuilder:validation:Required

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocheckpoints.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocheckpoints.yaml
@@ -8211,6 +8211,9 @@ spec:
                 - identity
                 - job
               type: object
+              x-kubernetes-validations:
+                - message: checkpointing with gpuMemoryService is temporarily disabled due to known GPU driver issues
+                  rule: '!has(self.gpuMemoryService) || !self.gpuMemoryService.enabled'
             status:
               description: DynamoCheckpointStatus defines the observed state of DynamoCheckpoint
               properties:

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -745,6 +745,75 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:         "checkpoint with inter-pod GMS is temporarily rejected",
+			groveEnabled: true,
+			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gms-snapshot",
+					Namespace: "default",
+				},
+				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentSpec{
+					BackendFramework: "vllm",
+					Services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+						"worker": {
+							ComponentType: consts.ComponentTypeWorker,
+							Checkpoint: &nvidiacomv1alpha1.ServiceCheckpointConfig{
+								Enabled: true,
+								Identity: &nvidiacomv1alpha1.DynamoCheckpointIdentity{
+									Model:            "model",
+									BackendFramework: "vllm",
+								},
+							},
+							GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+								Enabled: true,
+								Mode:    nvidiacomv1alpha1.GMSModeInterPod,
+							},
+							Resources: &nvidiacomv1alpha1.Resources{
+								Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "8"},
+							},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: true,
+			errMsg:      "checkpointing with gpuMemoryService is temporarily disabled",
+		},
+		{
+			name: "checkpoint with intra-pod GMS is temporarily rejected",
+			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-intrapod-gms-snapshot",
+					Namespace: "default",
+				},
+				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentSpec{
+					BackendFramework: "vllm",
+					Services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+						"worker": {
+							ComponentType: consts.ComponentTypeWorker,
+							Checkpoint: &nvidiacomv1alpha1.ServiceCheckpointConfig{
+								Enabled: true,
+								Identity: &nvidiacomv1alpha1.DynamoCheckpointIdentity{
+									Model:            "model",
+									BackendFramework: "vllm",
+								},
+							},
+							GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+								Enabled: true,
+								Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
+							},
+							Resources: &nvidiacomv1alpha1.Resources{
+								Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "8"},
+							},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: true,
+			errMsg:      "checkpointing with gpuMemoryService is temporarily disabled",
+		},
+		{
 			name:         "GMS failover without GPU",
 			groveEnabled: true,
 			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{

--- a/deploy/operator/internal/webhook/validation/shared.go
+++ b/deploy/operator/internal/webhook/validation/shared.go
@@ -140,6 +140,12 @@ func (v *SharedSpecValidator) Validate(ctx context.Context) (admission.Warnings,
 		return nil, err
 	}
 
+	// Snapshot restore plus GMS is temporarily disabled while the underlying
+	// GPU driver restore path is being fixed.
+	if err := v.validateCheckpointWithGPUMemoryService(); err != nil {
+		return nil, err
+	}
+
 	return warnings, nil
 }
 
@@ -406,6 +412,20 @@ func (v *SharedSpecValidator) validateGPUMemoryService() error {
 	}
 
 	return nil
+}
+
+func (v *SharedSpecValidator) validateCheckpointWithGPUMemoryService() error {
+	if v.spec.Checkpoint == nil || !v.spec.Checkpoint.Enabled {
+		return nil
+	}
+	if v.spec.GPUMemoryService == nil || !v.spec.GPUMemoryService.Enabled {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%s.checkpoint: checkpointing with gpuMemoryService is temporarily disabled due to known GPU driver issues; "+
+			"disable either checkpointing or gpuMemoryService for this service",
+		v.fieldPath)
 }
 
 // validateServiceAnnotations validates known annotations on the service-level spec.

--- a/deploy/operator/internal/webhook/validation/shared_test.go
+++ b/deploy/operator/internal/webhook/validation/shared_test.go
@@ -36,6 +36,9 @@ func TestSharedSpecValidator_Validate(t *testing.T) {
 	var (
 		negativeReplicas = int32(-1)
 		validReplicas    = int32(3)
+		workerGPU        = &nvidiacomv1alpha1.Resources{
+			Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "1"},
+		}
 	)
 
 	tests := []struct {
@@ -250,6 +253,61 @@ func TestSharedSpecValidator_Validate(t *testing.T) {
 			calculatedNamespace: "default-my-dgd",
 			wantErr:             true,
 			errMsg:              `spec.services[decode].annotations[nvidia.com/vllm-distributed-executor-backend] has invalid value "invalid": must be "mp" or "ray"`,
+		},
+		{
+			name: "checkpoint with gpuMemoryService is temporarily rejected",
+			spec: &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				Resources:     workerGPU,
+				Checkpoint: &nvidiacomv1alpha1.ServiceCheckpointConfig{
+					Enabled: true,
+					Identity: &nvidiacomv1alpha1.DynamoCheckpointIdentity{
+						Model:            "model",
+						BackendFramework: "vllm",
+					},
+				},
+				GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+					Enabled: true,
+					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
+				},
+			},
+			fieldPath:           "spec.services[worker]",
+			calculatedNamespace: "default-my-dgd",
+			wantErr:             true,
+			errMsg:              "spec.services[worker].checkpoint: checkpointing with gpuMemoryService is temporarily disabled due to known GPU driver issues; disable either checkpointing or gpuMemoryService for this service",
+		},
+		{
+			name: "checkpoint without gpuMemoryService is accepted",
+			spec: &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				Checkpoint: &nvidiacomv1alpha1.ServiceCheckpointConfig{
+					Enabled: true,
+					Identity: &nvidiacomv1alpha1.DynamoCheckpointIdentity{
+						Model:            "model",
+						BackendFramework: "vllm",
+					},
+				},
+			},
+			fieldPath:           "spec.services[worker]",
+			calculatedNamespace: "default-my-dgd",
+			wantErr:             false,
+		},
+		{
+			name: "disabled checkpoint with gpuMemoryService is accepted",
+			spec: &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				Resources:     workerGPU,
+				Checkpoint: &nvidiacomv1alpha1.ServiceCheckpointConfig{
+					Enabled: false,
+				},
+				GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+					Enabled: true,
+					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
+				},
+			},
+			fieldPath:           "spec.services[worker]",
+			calculatedNamespace: "default-my-dgd",
+			wantErr:             false,
 		},
 		{
 			name: "frontendSidecar with no extraPodSpec containers is valid",


### PR DESCRIPTION
#### Overview:

Temporarily block the unsupported combination of checkpoint/snapshot restore with GPU Memory Service while GPU driver restore issues are unresolved. Checkpoint-only deployments and GMS/failover-only deployments remain valid.

#### Details:

- Add shared admission validation that rejects service specs when both `checkpoint.enabled=true` and `gpuMemoryService.enabled=true` are set.
- Keep the service-spec validation in the existing shared path so it applies to `DynamoGraphDeployment` services and direct `DynamoComponentDeployment` specs.
- Add CRD-level validation for direct `DynamoCheckpoint` objects so `spec.gpuMemoryService.enabled=true` is also rejected without adding another webhook.
- Add focused tests for the rejected service-spec combination and allowed individual feature configurations.

#### Where should the reviewer start?

Start with `deploy/operator/internal/webhook/validation/shared.go`, then the direct checkpoint CRD marker in `deploy/operator/api/v1alpha1/dynamocheckpoint_types.go` and the new cases in `shared_test.go` / `dynamographdeployment_test.go`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to internal GPU driver restore issue (no public GitHub issue).

#### Testing

- `CGO_ENABLED=0 go test ./internal/webhook/validation`
- `CGO_ENABLED=0 go test ./api/v1alpha1`
- `make manifests`
