### PR TITLE
fix(recipes): pin transformers==4.57.6 in deepseek-v32-fp4 perf jobs

### DIFF
--- a/recipes/deepseek-v32-fp4/trtllm/agg-round-robin/perf.yaml
+++ b/recipes/deepseek-v32-fp4/trtllm/agg-round-robin/perf.yaml
@@ -49,7 +49,13 @@ spec:
           echo 1024 > /proc/sys/fs/inotify/max_user_instances 2>/dev/null || true
           apt-get update && apt-get install -y curl jq procps git && apt-get clean
           # pip install git+https://github.com/ai-dynamo/aiperf.git
-          pip install aiperf==0.6.0
+          # Pin transformers==4.57.6 (verified to load the deepseek_v32 tokenizer).
+          # The trtllm-runtime base ships transformers 4.55.0; aiperf 0.6.0's
+          # `transformers>=4.56.0` floor would otherwise upgrade to 5.x, which lacks
+          # native support for model_type=deepseek_v32 (huggingface/transformers#41251)
+          # and fails AutoTokenizer.from_pretrained() before reading tokenizer.json.
+          # aiperf surfaces this as "Failed to load tokenizer". DYN-2878.
+          pip install "aiperf==0.6.0" "transformers==4.57.6"
           echo "aiperf installation completed"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200

--- a/recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml
+++ b/recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml
@@ -49,7 +49,13 @@ spec:
           echo 1024 > /proc/sys/fs/inotify/max_user_instances 2>/dev/null || true
           apt-get update && apt-get install -y curl jq procps git && apt-get clean
           # pip install git+https://github.com/ai-dynamo/aiperf.git
-          pip install aiperf==0.6.0
+          # Pin transformers==4.57.6 (verified to load the deepseek_v32 tokenizer).
+          # The trtllm-runtime base ships transformers 4.55.0; aiperf 0.6.0's
+          # `transformers>=4.56.0` floor would otherwise upgrade to 5.x, which lacks
+          # native support for model_type=deepseek_v32 (huggingface/transformers#41251)
+          # and fails AutoTokenizer.from_pretrained() before reading tokenizer.json.
+          # aiperf surfaces this as "Failed to load tokenizer". DYN-2878.
+          pip install "aiperf==0.6.0" "transformers==4.57.6"
           echo "aiperf installation completed"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200


### PR DESCRIPTION
## Summary

- QA (DYN-2878) reported `recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml` exiting with `TokenizerError: Failed to load tokenizer 'nvidia/DeepSeek-V3.2-NVFP4'` against `nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.1.0-rc4`.
- Root cause is **not** missing tokenizer files (the NVIDIA repo has shipped `tokenizer.json` + `tokenizer_config.json` since 2026-01-02). It's a silent transformers upgrade past native `model_type=deepseek_v32` support.
- Fix: exact-pin `transformers==4.57.6` (the version verified to load the deepseek_v32 tokenizer) on the `pip install aiperf==0.6.0` line in both perf.yaml files. Same change in `disagg-kv-router` and `agg-round-robin`.

## Root cause

1. `nvcr.io/.../tensorrtllm-runtime:1.1.0-rc4` ships `transformers==4.55.0` (per [NVIDIA/TensorRT-LLM v1.1.0rc4 requirements.txt](https://github.com/NVIDIA/TensorRT-LLM/blob/v1.1.0rc4/requirements.txt)).
2. The perf.yaml install step `pip install aiperf==0.6.0` upgrades transformers to satisfy aiperf 0.6.0's `transformers>=4.56.0` floor. With default pip resolution and no upper bound, this picks the **latest** matching release — currently 5.7.0.
3. transformers 5.x has no native support for `model_type=deepseek_v32` (still pending in [huggingface/transformers#41251](https://github.com/huggingface/transformers/pull/41251) and [#42767](https://github.com/huggingface/transformers/pull/42767)). `AutoTokenizer.from_pretrained()` reads `config.json` first and raises `AttributeError: 'PreTrainedConfig' object has no attribute 'max_position_embeddings'` before it ever opens `tokenizer.json`.
4. aiperf catches the exception in `aiperf/common/tokenizer.py` and re-raises as `TokenizerError: Failed to load tokenizer '<name>'` — exactly the QA error.

This regressed silently when transformers 5.0 shipped, with no change in this repo.

## Fix

Exact-pin to a transformers version verified to load the `deepseek_v32` tokenizer:

```yaml
pip install "aiperf==0.6.0" "transformers==4.57.6"
```

4.57.6 is the latest 4.x release. The exact pin is deterministic across job re-runs and removes any dependency on what `<5` happens to resolve to in the future.

## Verification (reproduced locally)

| Setup | transformers ends up at | aiperf tokenizer load |
|---|---|---|
| rc4 base + `pip install aiperf==0.6.0` | 5.7.0 | **FAIL** — `Failed to load tokenizer 'nvidia/DeepSeek-V3.2-NVFP4'` (caused by `AttributeError: 'PreTrainedConfig' object has no attribute 'max_position_embeddings'`) |
| rc4 base + `pip install "aiperf==0.6.0" "transformers==4.57.6"` | 4.57.6 | **OK** — `LlamaTokenizerFast`, vocab=128000, `'Hello world'` -> `[19923, 2058]` |

Note: the original version of this PR (changing `--tokenizer` to `deepseek-ai/DeepSeek-V3.2`) did not fix the failure — both repos carry `model_type=deepseek_v32` and fail identically on transformers 5.x. That commit has been replaced.

## Where Should the Reviewer Start?

- `recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml` (line 52)
- `recipes/deepseek-v32-fp4/trtllm/agg-round-robin/perf.yaml` (line 52)

Diff is +14/-2 across the two files: the install line plus a 6-line explanatory comment.

## Related Issues

Fixes DYN-2878

## Test Plan

- [ ] CI passes
- [ ] QA re-runs `kubectl apply -f recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml -n <ns>` against `dynamo-nscale-dev-cluster` and confirms the perf job exits with code 0
- [ ] QA also validates `recipes/deepseek-v32-fp4/trtllm/agg-round-robin/perf.yaml` since it had the same bug

## Follow-ups (out of scope here)

The same `pip install aiperf==0.6.0` pattern (without a transformers pin) appears in `recipes/qwen3-vl-30b/vllm/agg-embedding-cache/perf.yaml`. That recipe doesn't hit the bug today (qwen3 is supported in transformers >= 4.56) but would benefit from the same defensive pin. Worth a follow-up PR.