### PR TITLE
fix(recipes): rename --disable-log-requests to --no-enable-log-requests for vLLM

### DIFF
--- a/docs/benchmarks/kv-router-ab-testing.md
+++ b/docs/benchmarks/kv-router-ab-testing.md
@@ -163,7 +163,7 @@ spec:
               --gpu-memory-utilization 0.90
               --block-size 64
               --async-scheduling
-              --disable-log-requests
+              --no-enable-log-requests
           env:
             - name: DYN_HEALTH_CHECK_ENABLED
               value: "false"
@@ -257,7 +257,7 @@ spec:
               --gpu-memory-utilization 0.90
               --block-size 64
               --async-scheduling
-              --disable-log-requests
+              --no-enable-log-requests
           env:
             - name: DYN_HEALTH_CHECK_ENABLED
               value: "false"

--- a/recipes/qwen3-32b/vllm/agg-round-robin/deploy.yaml
+++ b/recipes/qwen3-32b/vllm/agg-round-robin/deploy.yaml
@@ -49,7 +49,7 @@ spec:
           - Qwen/Qwen3-32B
           - --tensor-parallel-size
           - '2'
-          - --disable-log-requests
+          - --no-enable-log-requests
           - --gpu-memory-utilization
           - '0.90'
           - --async-scheduling

--- a/recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml
+++ b/recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml
@@ -49,7 +49,7 @@ spec:
           - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
           - --tensor-parallel-size
           - '2'
-          - --disable-log-requests
+          - --no-enable-log-requests
           - --gpu-memory-utilization
           - '0.90'
           - --no-enable-prefix-caching
@@ -105,7 +105,7 @@ spec:
           - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
           - --tensor-parallel-size
           - '2'
-          - --disable-log-requests
+          - --no-enable-log-requests
           - --gpu-memory-utilization
           - '0.90'
           - --async-scheduling

--- a/recipes/qwen3-vl-30b/vllm/agg-embedding-cache/deploy.yaml
+++ b/recipes/qwen3-vl-30b/vllm/agg-embedding-cache/deploy.yaml
@@ -48,7 +48,7 @@ spec:
                 --tensor-parallel-size 1 \
                 --gpu-memory-utilization 0.85 \
                 --max-model-len 16384 \
-                --disable-log-requests \
+                --no-enable-log-requests \
                 --enable-prefix-caching \
                 --multimodal-embedding-cache-capacity-gb "${DYN_MULTIMODAL_EMBEDDING_CACHE_GB}"
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0


### PR DESCRIPTION
## Summary

- vLLM removed the deprecated `--disable-log-requests` argument; the recipes for `qwen3-vl-30b` and `qwen3-32b` still passed it, causing pods on `vllm-runtime:1.1.0-rc5` (and main's `vllm-runtime` built against vLLM 0.19.x) to crash on startup with `__main__.py: error: unrecognized arguments: --disable-log-requests`.
- Renames the flag to `--no-enable-log-requests` (the `argparse.BooleanOptionalAction`-generated form of `--enable-log-requests`) in three recipe `deploy.yaml` files and the `kv-router-ab-testing.md` benchmark doc.
- Preserves explicit "logging off" intent rather than relying on the new vLLM default.

## Details

vLLM upstream PR [vllm-project/vllm#21739](https://github.com/vllm-project/vllm/pull/21739) (Aug 2025) deprecated `--disable-log-requests` in favor of `--enable-log-requests` (default off, for security/privacy), and the deprecated alias was later removed entirely. Both `release/1.1.0` (vLLM 0.19.0) and `main` (vLLM 0.19.1) are past removal, so `--disable-log-requests` is no longer recognized.

Dynamo's own Python-side vLLM wrapper already uses the new naming (`components/src/dynamo/vllm/main.py`, `components/src/dynamo/vllm/args.py`, `benchmarks/multimodal/sweep/workflows/vllm_serve.sh`); only the recipe YAMLs and one benchmarking doc were missed.

## Where should the reviewer start?

- `recipes/qwen3-vl-30b/vllm/agg-embedding-cache/deploy.yaml`
- `recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml`
- `recipes/qwen3-32b/vllm/agg-round-robin/deploy.yaml`
- `docs/benchmarks/kv-router-ab-testing.md`

All four files only flip the flag name; no behavior change vs. the (broken) previous intent.

## Related Issues

Fixes DYN-2881

## Test Plan

- [ ] CI passes
- [ ] Repo audit clean: `rg '\-\-disable-log-requests'` returns no recipe/doc hits
- [ ] (Optional, in cluster) Re-deploy `recipes/qwen3-vl-30b/vllm/agg-embedding-cache/deploy.yaml` against `vllm-runtime:1.1.0-rc5`; vllmworker pod reaches Running instead of crash-looping with `unrecognized arguments`
- [ ] (Optional, container probe) `docker run --rm --entrypoint python nvcr.io/nvstaging/ai-dynamo/vllm-runtime:1.1.0-rc5 -m vllm.entrypoints.openai.api_server --help | grep log-requests` shows `--enable-log-requests | --no-enable-log-requests` and no `--disable-log-requests`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vLLM worker deployment configurations across multiple recipe deployments and benchmark documentation with revised command-line startup options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->