### PR TITLE
fix(planner): wait for pool workers in global-planner connector [DYN-2874]

### DIFF
--- a/components/src/dynamo/planner/connectors/global_planner.py
+++ b/components/src/dynamo/planner/connectors/global_planner.py
@@ -218,15 +218,32 @@ class GlobalPlannerConnector(PlannerConnector):
 
     async def wait_for_deployment_ready(self, include_planner: bool = True):
         """
-        Wait for deployment to be ready (no-op for GlobalPlanner).
+        Wait for the pool's own workers to be ready.
 
-        The GlobalPlanner manages deployment state, so we don't need to
-        wait locally in delegating mode.
+        Even though GlobalPlanner handles cluster-wide orchestration, the
+        pool Planner still reads its own workers' DynamoWorkerMetadata CRs
+        for capability discovery (``get_worker_info``). Without a local
+        wait, ``_async_init`` runs within milliseconds of pod entry — long
+        before workers register MDC — so ``get_worker_info`` falls back to
+        defaults with ``context_length`` / ``max_kv_tokens`` unset and
+        load-scaling silently disables itself for the pod's lifetime.
+
+        Mirror the standalone path by delegating to the pool-local
+        KubernetesConnector. If no local connector is available (e.g.
+        running outside a cluster), fall back to the previous no-op so
+        out-of-cluster callers are not blocked.
         """
+        local = self._get_local_k8s_connector()
+        if local is None:
+            logger.info(
+                "GlobalPlannerConnector: no local KubernetesConnector available, "
+                "skipping deployment ready check"
+            )
+            return
         logger.info(
-            "GlobalPlannerConnector: Skipping deployment ready check "
-            "(GlobalPlanner manages deployment state)"
+            "GlobalPlannerConnector: waiting for pool-local workers to be ready"
         )
+        await local.wait_for_deployment_ready(include_planner=include_planner)
 
     def _get_local_k8s_connector(self) -> Optional[KubernetesConnector]:
         """Lazily build a KubernetesConnector scoped to the pool's own DGD.

--- a/components/src/dynamo/planner/tests/unit/test_remote_planner.py
+++ b/components/src/dynamo/planner/tests/unit/test_remote_planner.py
@@ -337,14 +337,18 @@ async def test_connector_unsupported_and_noop_operations(connector):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("include_planner", [False, True])
 async def test_connector_wait_for_deployment_ready_delegates_to_local_k8s(
-    connector_runtime,
+    connector_runtime, include_planner
 ):
     """wait_for_deployment_ready must wait for the pool's own workers to be
     ready before returning. Without this, _async_init returns within
     milliseconds and get_worker_info races with MDC registration, caching a
     fallback WorkerInfo (context_length/max_kv_tokens unset) for the pod's
     lifetime and silently disabling load scaling.
+
+    Parametrized to guard against a refactor that hardcodes ``include_planner``
+    or drops the kwarg when forwarding.
     """
     c = GlobalPlannerConnector(connector_runtime, "ns", "gns", "GP", model_name="test")
     fake_local = MagicMock()
@@ -352,8 +356,31 @@ async def test_connector_wait_for_deployment_ready_delegates_to_local_k8s(
     c._local_k8s_connector = fake_local
     c._local_k8s_init_attempted = True
 
-    await c.wait_for_deployment_ready(include_planner=False)
-    fake_local.wait_for_deployment_ready.assert_awaited_once_with(include_planner=False)
+    await c.wait_for_deployment_ready(include_planner=include_planner)
+    fake_local.wait_for_deployment_ready.assert_awaited_once_with(
+        include_planner=include_planner
+    )
+
+
+@pytest.mark.asyncio
+async def test_connector_wait_for_deployment_ready_propagates_exceptions(
+    connector_runtime,
+):
+    """A TimeoutError (or similar) from the pool-local wait must propagate so
+    _async_init surfaces a broken pool DGD rather than silently swallowing the
+    failure and falling back into the original bug (fallback WorkerInfo cached
+    forever). Mirrors the standalone environment=kubernetes behavior.
+    """
+    c = GlobalPlannerConnector(connector_runtime, "ns", "gns", "GP", model_name="test")
+    fake_local = MagicMock()
+    fake_local.wait_for_deployment_ready = AsyncMock(
+        side_effect=TimeoutError("workers not ready")
+    )
+    c._local_k8s_connector = fake_local
+    c._local_k8s_init_attempted = True
+
+    with pytest.raises(TimeoutError, match="workers not ready"):
+        await c.wait_for_deployment_ready(include_planner=False)
 
 
 def test_connector_model_name_and_predicted_load(connector_runtime):

--- a/components/src/dynamo/planner/tests/unit/test_remote_planner.py
+++ b/components/src/dynamo/planner/tests/unit/test_remote_planner.py
@@ -323,11 +323,37 @@ async def test_connector_unsupported_and_noop_operations(connector):
     with pytest.raises(NotImplementedError, match="batch operations"):
         await connector.remove_component(SubComponentType.DECODE)
 
-    # No-op operations
+    # validate_deployment remains a local no-op (GlobalPlanner validates).
     await connector.validate_deployment(
         prefill_component_name="p", decode_component_name="d"
     )
+
+    # wait_for_deployment_ready with no local k8s connector available must
+    # degrade to a no-op rather than raise, so out-of-cluster callers still
+    # work.
+    connector._local_k8s_connector = None
+    connector._local_k8s_init_attempted = True
     await connector.wait_for_deployment_ready()
+
+
+@pytest.mark.asyncio
+async def test_connector_wait_for_deployment_ready_delegates_to_local_k8s(
+    connector_runtime,
+):
+    """wait_for_deployment_ready must wait for the pool's own workers to be
+    ready before returning. Without this, _async_init returns within
+    milliseconds and get_worker_info races with MDC registration, caching a
+    fallback WorkerInfo (context_length/max_kv_tokens unset) for the pod's
+    lifetime and silently disabling load scaling.
+    """
+    c = GlobalPlannerConnector(connector_runtime, "ns", "gns", "GP", model_name="test")
+    fake_local = MagicMock()
+    fake_local.wait_for_deployment_ready = AsyncMock()
+    c._local_k8s_connector = fake_local
+    c._local_k8s_init_attempted = True
+
+    await c.wait_for_deployment_ready(include_planner=False)
+    fake_local.wait_for_deployment_ready.assert_awaited_once_with(include_planner=False)
 
 
 def test_connector_model_name_and_predicted_load(connector_runtime):


### PR DESCRIPTION
## Summary

- `GlobalPlannerConnector.wait_for_deployment_ready` was a no-op. In pool Planners (`environment: global-planner`), `_async_init` therefore returned within ~13 ms of pod entry — long before the pool's own workers registered their `DynamoWorkerMetadata` CRs.
- `get_worker_info` then fell back to defaults with `context_length` / `max_kv_tokens` unset. There is no retry, so every subsequent `load_scaling._prefill_easy_decision` / `_decode_easy_decision` tick short-circuits and the pool Planner silently sends zero `scale_request` RPCs for the lifetime of the pod. `GlobalPlanner` budget enforcement cannot be exercised.
- Fix: delegate `wait_for_deployment_ready` to the pool-local `KubernetesConnector` (already built lazily for MDC capability lookup). This mirrors the standalone `environment: kubernetes` path — we wait for the pool's workers to be ready so MDC is populated before `WorkerInfo` is resolved. Falls back to a no-op when no local connector is available (out-of-cluster callers still work).
- `validate_deployment` remains a local no-op: `GlobalPlanner` owns cluster-wide validation.

## Test plan

- [x] `pytest components/src/dynamo/planner/tests/unit/test_remote_planner.py` — all 12 tests pass, including new `test_connector_wait_for_deployment_ready_delegates_to_local_k8s` that asserts the pool-local `wait_for_deployment_ready` is awaited with the caller's `include_planner` argument.
- [x] `pytest components/src/dynamo/planner/tests/unit/` — all 348 planner unit tests pass.
- [ ] QA reproducer on cluster: pool Planner log should show `Built prefill WorkerInfo from MDC: ... max_num_batched_tokens=<N>, context_length=<M>` instead of the fallback WARN, and `context_length not available` messages should no longer accumulate each 5s tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment readiness checks now properly execute in cluster environments instead of being skipped.
  * Graceful fallback when cluster connectivity is unavailable.

* **Tests**
  * Added tests to verify deployment readiness behavior with and without cluster connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->