### PR TITLE
fix: [DYN-2883] Triton backend directory default

### DIFF
--- a/examples/backends/tritonserver/Dockerfile
+++ b/examples/backends/tritonserver/Dockerfile
@@ -11,6 +11,7 @@ FROM ${DYNAMO_BASE_IMAGE} AS dynamo_base
 COPY --from=triton_source /opt/tritonserver /opt/tritonserver
 COPY --from=triton_source /usr/local/dcgm /usr/local/dcgm
 COPY --from=triton_source /lib/x86_64-linux-gnu/libdcgm*.so* /lib/x86_64-linux-gnu/
+ENV BACKEND_DIR=/opt/tritonserver/backends
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/opt/tritonserver/lib:/opt/tritonserver/backends:/usr/local/dcgm/lib64
 ENV PATH=/opt/tritonserver/bin:$PATH
 

--- a/examples/backends/tritonserver/README.md
+++ b/examples/backends/tritonserver/README.md
@@ -129,6 +129,7 @@ Options:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `BACKEND_DIR` | Path to Triton backends. The container image sets this to `/opt/tritonserver/backends`; local source builds use `backends/`. | `backends/` |
 | `DYN_DISCOVERY_BACKEND` | Discovery backend: `kubernetes`, `etcd`, `file`, or `mem` | `file` |
 | `DYN_LOG` | Log level (debug, info, warn, error) | `info` |
 | `DYN_HTTP_PORT` | Frontend HTTP port | `8000` |

--- a/examples/backends/tritonserver/launch/identity.sh
+++ b/examples/backends/tritonserver/launch/identity.sh
@@ -23,7 +23,7 @@ TRITON_DIR="$(dirname "$SCRIPT_DIR")"
 # Default values
 MODEL_NAME="identity"
 MODEL_REPO="${TRITON_DIR}/model_repo"
-BACKEND_DIR="${TRITON_DIR}/backends"
+BACKEND_DIR="${BACKEND_DIR:-${TRITON_DIR}/backends}"
 LOG_VERBOSE=1
 DISCOVERY_BACKEND="${DYN_DISCOVERY_BACKEND:-file}"  # Default to file-based discovery (no etcd required)
 
@@ -65,6 +65,7 @@ while [[ $# -gt 0 ]]; do
             echo "  -h, --help                  Show this help message"
             echo ""
             echo "Environment variables:"
+            echo "  BACKEND_DIR             Override default Triton backends path"
             echo "  DYN_DISCOVERY_BACKEND  Discovery backend (default: file)"
             echo "  DYN_HTTP_PORT    Frontend HTTP port (default: 8000)"
             echo "  DYN_SYSTEM_PORT  Worker metrics port (default: 8081)"
@@ -126,4 +127,3 @@ python3 "${TRITON_DIR}/src/tritonworker.py" \
     --backend-directory "$BACKEND_DIR" \
     --log-verbose "$LOG_VERBOSE" \
     "${EXTRA_ARGS[@]}"
-


### PR DESCRIPTION
## Summary
- Set `BACKEND_DIR=/opt/tritonserver/backends` in the Triton worker container image.
- Let `launch/identity.sh` honor `BACKEND_DIR` from the environment while preserving the local source-build fallback.
- Document the container/local backend directory behavior in the Triton example README.

Fixes DYN-2883

## Root Cause
The container image copies prebuilt Triton backends into `/opt/tritonserver/backends`, but the launch script always defaulted to `examples/backends/tritonserver/backends`, which is only populated by the local `make all` workflow. The container quick-start therefore exited before the worker could start.

## Validation
- `bash -n examples/backends/tritonserver/launch/identity.sh`
- `BACKEND_DIR=/opt/tritonserver/backends bash examples/backends/tritonserver/launch/identity.sh --help`
- `BACKEND_DIR=/tmp/dynamo-missing-backends bash examples/backends/tritonserver/launch/identity.sh` confirmed the override path is used for validation
- `git show --check --stat --oneline HEAD`

Did not run the full Docker/GPU launch locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration documentation for the `BACKEND_DIR` environment variable to specify Tritonserver backends directory location.

* **Chores**
  * Updated configuration files to support the `BACKEND_DIR` environment variable with default path `/opt/tritonserver/backends`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->