### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,7 +2310,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamo-bench"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -2344,14 +2344,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-config"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-kv-router"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aho-corasick",
  "aligned-vec",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -2503,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-mocker"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "dynamo-protocols",
@@ -2551,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bs58",
  "bytemuck",
@@ -4477,7 +4477,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-common"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "dynamo-tokens",
  "serde",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-config"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "dynamo-memory",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-engine"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -4545,7 +4545,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-kernels"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "clap 4.6.0",
  "cudarc",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-logical"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-physical"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aligned-vec",
  "anyhow",
@@ -4642,7 +4642,7 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libdynamo_llm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-once-cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 description = "Dynamo Inference Framework"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
@@ -37,26 +37,26 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 
 [workspace.dependencies]
 # Local crates
-dynamo-runtime = { path = "lib/runtime", version = "1.1.0" }
-dynamo-llm = { path = "lib/llm", version = "1.1.0" }
-dynamo-config = { path = "lib/config", version = "1.1.0" }
-dynamo-tokenizers = { path = "lib/tokenizers", version = "1.1.0" }
-dynamo-tokens = { path = "lib/tokens", version = "1.1.0" }
-dynamo-memory = { path = "lib/memory", version = "1.1.0" }
-dynamo-mocker = { path = "lib/mocker", version = "1.1.0" }
-dynamo-kv-router = { path = "lib/kv-router", version = "1.1.0", features = ["metrics", "runtime-protocols"] }
-dynamo-protocols = { path = "lib/protocols", version = "1.1.0" }
-dynamo-parsers = { path = "lib/parsers", version = "1.1.0" }
+dynamo-runtime = { path = "lib/runtime", version = "1.2.0" }
+dynamo-llm = { path = "lib/llm", version = "1.2.0" }
+dynamo-config = { path = "lib/config", version = "1.2.0" }
+dynamo-tokenizers = { path = "lib/tokenizers", version = "1.2.0" }
+dynamo-tokens = { path = "lib/tokens", version = "1.2.0" }
+dynamo-memory = { path = "lib/memory", version = "1.2.0" }
+dynamo-mocker = { path = "lib/mocker", version = "1.2.0" }
+dynamo-kv-router = { path = "lib/kv-router", version = "1.2.0", features = ["metrics", "runtime-protocols"] }
+dynamo-protocols = { path = "lib/protocols", version = "1.2.0" }
+dynamo-parsers = { path = "lib/parsers", version = "1.2.0" }
 fastokens = { version = "0.1.0" }
 
 
 # kvbm
-kvbm-common = { path = "lib/kvbm-common", version = "1.1.0" }
-kvbm-config = { path = "lib/kvbm-config", version = "1.1.0" }
-kvbm-engine = { path = "lib/kvbm-engine", version = "1.1.0" }
-kvbm-kernels = { path = "lib/kvbm-kernels", version = "1.1.0" }
-kvbm-logical = { path = "lib/kvbm-logical", version = "1.1.0" }
-kvbm-physical = { path = "lib/kvbm-physical", version = "1.1.0" }
+kvbm-common = { path = "lib/kvbm-common", version = "1.2.0" }
+kvbm-config = { path = "lib/kvbm-config", version = "1.2.0" }
+kvbm-engine = { path = "lib/kvbm-engine", version = "1.2.0" }
+kvbm-kernels = { path = "lib/kvbm-kernels", version = "1.2.0" }
+kvbm-logical = { path = "lib/kvbm-logical", version = "1.2.0" }
+kvbm-physical = { path = "lib/kvbm-physical", version = "1.2.0" }
 
 # velo
 velo = { version = "0.1.0" }

--- a/deploy/helm/charts/platform/Chart.yaml
+++ b/deploy/helm/charts/platform/Chart.yaml
@@ -19,11 +19,11 @@ maintainers:
     url: https://www.nvidia.com
 description: A Helm chart for NVIDIA Dynamo Platform.
 type: application
-version: 1.1.0
+version: 1.2.0
 home: https://nvidia.com
 dependencies:
   - name: dynamo-operator
-    version: 1.1.0
+    version: 1.2.0
     repository: file://components/operator
     condition: dynamo-operator.enabled
   - name: nats

--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 A Helm chart for NVIDIA Dynamo Platform.
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## 🚀 Overview
 
@@ -97,7 +97,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://components/operator | dynamo-operator | 1.1.0 |
+| file://components/operator | dynamo-operator | 1.2.0 |
 | https://charts.bitnami.com/bitnami | etcd | 12.0.18 |
 | https://nats-io.github.io/k8s/helm/charts/ | nats | 1.3.2 |
 | oci://ghcr.io/ai-dynamo/grove | grove(grove-charts) | v0.1.0-alpha.8 |

--- a/deploy/helm/charts/platform/components/operator/Chart.yaml
+++ b/deploy/helm/charts/platform/components/operator/Chart.yaml
@@ -27,9 +27,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.0"
+appVersion: "1.2.0"

--- a/deploy/helm/charts/snapshot/Chart.yaml
+++ b/deploy/helm/charts/snapshot/Chart.yaml
@@ -16,8 +16,8 @@ apiVersion: v2
 name: snapshot
 description: Checkpoint/Restore infrastructure for Dynamo (PVC + DaemonSet + CRIU Agent)
 type: application
-version: 1.1.0
-appVersion: "1.1.0"
+version: 1.2.0
+appVersion: "1.2.0"
 keywords:
   - nvidia
   - dynamo

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1490,14 +1490,14 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamo-config"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-kv-router"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aho-corasick",
  "aligned-vec",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-mocker"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "dynamo-protocols",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bs58",
  "bytemuck",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-logical"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-py3"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "cudarc",

--- a/lib/bindings/kvbm/Cargo.toml
+++ b/lib/bindings/kvbm/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "kvbm-py3"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/bindings/kvbm/pyproject.toml
+++ b/lib/bindings/kvbm/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "kvbm"
-version = "1.1.0"
+version = "1.2.0"
 description = "Dynamo KVBM"
 readme = "README.md"
 authors = [

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1498,14 +1498,14 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamo-config"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-kv-router"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aho-corasick",
  "aligned-vec",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-mocker"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "dynamo-protocols",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-py3"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bs58",
  "bytemuck",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-logical"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "dynamo-py3"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "ai-dynamo-runtime"
-version = "1.1.0"
+version = "1.2.0"
 description = "Dynamo Inference Framework Runtime"
 readme = "README.md"
 authors = [

--- a/lib/kvbm-common/Cargo.toml
+++ b/lib/kvbm-common/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kvbm-common"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 description.workspace = true
 authors.workspace = true

--- a/lib/kvbm-engine/Cargo.toml
+++ b/lib/kvbm-engine/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kvbm-engine"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/lib/kvbm-kernels/Cargo.toml
+++ b/lib/kvbm-kernels/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kvbm-kernels"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/lib/kvbm-logical/Cargo.toml
+++ b/lib/kvbm-logical/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kvbm-logical"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/lib/kvbm-physical/Cargo.toml
+++ b/lib/kvbm-physical/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kvbm-physical"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -788,14 +788,14 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamo-config"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-runtime"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1279,7 +1279,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello_world"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "dynamo-runtime",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "service_metrics"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "dynamo-runtime",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "system_metrics"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "dynamo-runtime",

--- a/lib/runtime/examples/Cargo.toml
+++ b/lib/runtime/examples/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "ai-dynamo"
-version = "1.1.0"
+version = "1.2.0"
 description = "Distributed Inference Framework"
 readme = "README.md"
 authors = [
@@ -13,7 +13,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "ai-dynamo-runtime==1.1.0",
+    "ai-dynamo-runtime==1.2.0",
     "transformers>=4.56.0",
     "kubernetes>=32.0.1,<33.0.0",
     "prometheus_client>=0.23.1,<1.0",


### PR DESCRIPTION
Artifact-only bump from 1.1.0 across Rust workspace/subcrates, Python packages, and Helm charts. Cargo.lock files regenerated accordingly fo nightly release 

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.2.0 across the platform, updating workspace dependencies, Helm charts, and Python bindings to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->