### PR TITLE
refactor(health-check): consolidate HEALTH_CHECK_KEY in shared module; apply marker to vllm payloads

### DIFF
--- a/components/src/dynamo/trtllm/health_check.py
+++ b/components/src/dynamo/trtllm/health_check.py
@@ -10,13 +10,14 @@ This module defines the default health check payload for TRT-LLM backends.
 import logging
 from typing import Any
 
-from dynamo.health_check import HealthCheckPayload
+from dynamo.health_check import HEALTH_CHECK_KEY, HealthCheckPayload
 from dynamo.trtllm.constants import DisaggregationMode
 
 logger = logging.getLogger(__name__)
 
-# Marker key set on health-check probe requests.
-HEALTH_CHECK_KEY = "_HEALTH_CHECK"
+# Re-exported from dynamo.health_check so existing callers (handler_base) still
+# work without churn. The canonical definition lives in dynamo.health_check.
+__all__ = ["HEALTH_CHECK_KEY", "TrtllmHealthCheckPayload"]
 
 
 def _get_bos_token_id_from_tokenizer(tokenizer) -> int:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -34,6 +34,7 @@ from tensorrt_llm.scheduling_params import SchedulingParams
 
 from dynamo._core import Client, Context
 from dynamo.common.utils.otel_tracing import build_trace_headers
+from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.llm.exceptions import EngineShutdown
 from dynamo.logits_processing.examples import HelloWorldLogitsProcessor
 from dynamo.nixl_connect import Connector
@@ -41,7 +42,6 @@ from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.trtllm.constants import DisaggregationMode
 from dynamo.trtllm.engine import TensorRTLLMEngine
-from dynamo.trtllm.health_check import HEALTH_CHECK_KEY
 from dynamo.trtllm.logits_processing.adapter import create_trtllm_adapters
 from dynamo.trtllm.metrics import AdditionalMetricsCollector
 from dynamo.trtllm.multimodal_processor import MultimodalRequestProcessor

--- a/components/src/dynamo/vllm/health_check.py
+++ b/components/src/dynamo/vllm/health_check.py
@@ -8,11 +8,25 @@ This module defines the default health check payload for vLLM backends.
 """
 
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-from dynamo.health_check import HealthCheckPayload
+from dynamo.health_check import HEALTH_CHECK_KEY, HealthCheckPayload
 
 logger = logging.getLogger(__name__)
+
+
+def _layer_probe_marker(payload: dict[str, Any]) -> dict[str, Any]:
+    """Layer HEALTH_CHECK_KEY onto a payload dict without mutating the source.
+
+    Used by each VllmHealthCheck*Payload's to_dict() override so the marker
+    survives DYN_HEALTH_CHECK_PAYLOAD env overrides. The vllm handlers don't
+    branch on the marker today — this keeps the probe wire-format consistent
+    with trtllm/sglang for any future marker-gated behavior.
+    """
+    payload = dict(payload)
+    payload[HEALTH_CHECK_KEY] = True
+    return payload
+
 
 if TYPE_CHECKING:
     from vllm.v1.engine.async_llm import AsyncLLM
@@ -101,6 +115,9 @@ class VllmHealthCheckPayload(HealthCheckPayload):
         self.default_payload = _make_default_payload(engine_client, use_text_input)
         super().__init__()
 
+    def to_dict(self) -> dict[str, Any]:
+        return _layer_probe_marker(super().to_dict())
+
 
 class VllmPrefillHealthCheckPayload(HealthCheckPayload):
     """
@@ -119,6 +136,9 @@ class VllmPrefillHealthCheckPayload(HealthCheckPayload):
         """
         self.default_payload = _make_default_payload(engine_client, use_text_input)
         super().__init__()
+
+    def to_dict(self) -> dict[str, Any]:
+        return _layer_probe_marker(super().to_dict())
 
 
 async def get_bos_token_from_omni(async_omni: "AsyncOmni") -> int:
@@ -180,6 +200,9 @@ class VllmOmniHealthCheckPayload(HealthCheckPayload):
             },
         }
         super().__init__()
+
+    def to_dict(self) -> dict[str, Any]:
+        return _layer_probe_marker(super().to_dict())
 
     @classmethod
     async def create(cls, async_omni: "AsyncOmni") -> "VllmOmniHealthCheckPayload":

--- a/lib/bindings/python/src/dynamo/health_check.py
+++ b/lib/bindings/python/src/dynamo/health_check.py
@@ -15,7 +15,14 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["HealthCheckPayload", "load_health_check_from_env"]
+# Marker key set on health-check probe requests. Backend payloads layer it
+# onto their default_payload via a to_dict() override so the marker survives
+# DYN_HEALTH_CHECK_PAYLOAD overrides. Handlers may inspect it to branch
+# probe-specific behavior (e.g. skip a synthetic first-yield that would
+# mask a hung engine rank).
+HEALTH_CHECK_KEY = "_HEALTH_CHECK"
+
+__all__ = ["HealthCheckPayload", "HEALTH_CHECK_KEY", "load_health_check_from_env"]
 
 
 def load_health_check_from_env(


### PR DESCRIPTION
## Summary

- **Move `HEALTH_CHECK_KEY = \"_HEALTH_CHECK\"` from `dynamo.trtllm.health_check` to `dynamo.health_check`** (the shared module where `HealthCheckPayload` already lives). Re-exported from `dynamo.trtllm.health_check` for any backward-compat callers.
- **Add the marker to all three vllm health-check payloads** (`VllmHealthCheckPayload`, `VllmPrefillHealthCheckPayload`, `VllmOmniHealthCheckPayload`) via a module-local `_layer_probe_marker` helper. No vllm handler behavior change — the marker is wire-format-only so probe payloads are consistent across backends.

## Why

- The canary probe marker is a cross-backend convention; it shouldn't live in a single backend's module.
- Consistent wire format: every backend's canary probe payload now carries `_HEALTH_CHECK: True`. vllm handlers don't branch on it today (vllm's canary works correctly via \"run locally when prefill_result absent\") — this is setup only.
- Enables future marker-gated handler logic (e.g., disambiguating vllm's canary-no-prefill_result vs. broken-disagg-no-prefill_result cases) without another wire-format change.

## What's NOT in scope

- **No vllm handler behavior change** — explicitly out of scope.
- **No sglang change** — sglang's marker will land via #8611 (DIS-1837). After this PR merges, #8611 rebases and sglang's import switches to the shared location as a trivial follow-up.
- **No mixin/base-class refactor** — kept the `to_dict()` override pattern inline per-backend; a shared \"probe marker mixin\" on `HealthCheckPayload` was considered but deferred (would be scope creep).

## Test plan

- [x] `pre-commit run black isort flake8 ruff` against all changed files — all pass
- [ ] CI: unit tests (no behavior change expected — pure payload/import refactor)
- [ ] Re-verify sglang-disagg-decode canary (already green on main via #8521) — wire format for trtllm is unchanged since `HEALTH_CHECK_KEY` string value `\"_HEALTH_CHECK\"` is identical

## Files changed

| File | Change |
|---|---|
| `lib/bindings/python/src/dynamo/health_check.py` | Add `HEALTH_CHECK_KEY` constant + docstring; export in `__all__` |
| `components/src/dynamo/trtllm/health_check.py` | Remove local definition; import from `dynamo.health_check`; update `__all__` comment |
| `components/src/dynamo/trtllm/request_handlers/handler_base.py` | Change import source to `dynamo.health_check` |
| `components/src/dynamo/vllm/health_check.py` | Add `_layer_probe_marker` helper + `to_dict()` override on all 3 payload classes |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized health-check marker handling across service implementations for improved consistency and maintainability.
  * Enhanced health-check payload serialization to reliably preserve configuration markers across different backend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->