### PR TITLE
fix(vllm): use data_parallel_index for FPM ZMQ port offset (cherry-pick of #8696)

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -269,7 +269,7 @@ class InstrumentedScheduler(AsyncScheduler):
             **kwargs,
         )
 
-        dp_rank = getattr(vllm_config.parallel_config, "data_parallel_rank", 0) or 0
+        dp_rank = self._resolve_dp_rank(vllm_config.parallel_config)
         self._fpm_worker_id = vllm_config.additional_config.get("fpm_worker_id", "")
         self._fpm_dp_rank = dp_rank
 
@@ -296,6 +296,21 @@ class InstrumentedScheduler(AsyncScheduler):
         )
 
         self._bench_init(vllm_config)
+
+    @staticmethod
+    def _resolve_dp_rank(parallel_config) -> int:
+        # ``data_parallel_index`` always holds the true global DP rank of the
+        # engine process. For dense (non-MoE) models in external DP mode,
+        # vLLM resets ``data_parallel_rank`` to 0 in every child process but
+        # preserves ``data_parallel_index`` (see ``vllm/v1/engine/core.py``:
+        # ``parallel_config.data_parallel_index = dp_rank`` then
+        # ``parallel_config.data_parallel_rank = 0``). Reading the rank field
+        # would make every DP child compute ``base_port + 0`` and the second
+        # ``bind()`` would fail with "Address already in use".
+        dp_rank = getattr(parallel_config, "data_parallel_index", None)
+        if dp_rank is None:
+            dp_rank = getattr(parallel_config, "data_parallel_rank", 0) or 0
+        return dp_rank
 
     # ------------------------------------------------------------------
     # Overrides

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``InstrumentedScheduler._resolve_dp_rank``.
+
+The DP rank resolver picks the per-engine ZMQ PUB port for forward-pass
+metrics. For dense (non-MoE) models in external DP mode, vLLM resets
+``parallel_config.data_parallel_rank`` to 0 in every child process while
+preserving ``data_parallel_index`` as the true global rank
+(see ``vllm/v1/engine/core.py`` ``parallel_config.data_parallel_index = dp_rank``
+followed by ``parallel_config.data_parallel_rank = 0``). Reading the rank
+field would make every DP child compute ``base_port + 0`` and the second
+``bind()`` would fail with "Address already in use".
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+# Module-level import: triggers real site-packages ``vllm`` to load before
+# pytest's rootpath insertion adds ``components/src/dynamo`` to ``sys.path``
+# (which would shadow the real ``vllm`` with the ``dynamo.vllm`` submodule
+# for any later bare ``import vllm``). Mirrors the pattern in
+# ``test_vllm_unit.py``.
+from dynamo.vllm.instrumented_scheduler import InstrumentedScheduler  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.pre_merge,
+]
+
+
+def test_dp_rank_prefers_data_parallel_index():
+    """External DP + dense model: vLLM resets ``data_parallel_rank`` to 0 in
+    every child but keeps ``data_parallel_index`` as the true global rank.
+    The resolver must prefer the index so each DP child gets its own port.
+    """
+    pc = SimpleNamespace(data_parallel_index=1, data_parallel_rank=0)
+    assert InstrumentedScheduler._resolve_dp_rank(pc) == 1
+
+
+def test_dp_rank_falls_back_to_rank_when_index_absent():
+    pc = SimpleNamespace(data_parallel_rank=2)
+    assert InstrumentedScheduler._resolve_dp_rank(pc) == 2
+
+
+def test_dp_rank_handles_none_rank():
+    pc = SimpleNamespace(data_parallel_index=None, data_parallel_rank=None)
+    assert InstrumentedScheduler._resolve_dp_rank(pc) == 0
+
+
+def test_dp_rank_default_zero():
+    pc = SimpleNamespace()
+    assert InstrumentedScheduler._resolve_dp_rank(pc) == 0
+
+
+def test_dp_rank_multi_node_start_offset():
+    """Multi-node: node 2 runs DP ranks 8..15 with ``--data-parallel-start-rank 8``.
+    vLLM spawns each child engine with ``dp_rank = start_rank + local_index``
+    (``vllm/v1/engine/utils.py``: ``global_index = start_index + index``) and
+    sets ``parallel_config.data_parallel_index = dp_rank`` (``vllm/v1/engine/
+    core.py``). The resolver must return the global rank so each child's ZMQ
+    port offset matches the parent-side FPM relay subscription, which iterates
+    the same global range.
+    """
+    for global_rank in (8, 9, 15):
+        pc = SimpleNamespace(data_parallel_index=global_rank, data_parallel_rank=0)
+        assert InstrumentedScheduler._resolve_dp_rank(pc) == global_rank


### PR DESCRIPTION
Cherry-pick of #8696 to release/1.1.0.

## Summary

- Each vLLM DP child needs a unique ZMQ PUB port for forward-pass metrics, but vLLM resets `parallel_config.data_parallel_rank` to 0 in every child for dense (non-MoE) models in external DP mode. Only `data_parallel_index` keeps the true global rank.
- With `--data-parallel-size > 1`, every child computed `base_port + 0`, the second `bind()` failed with `Address already in use`, and EngineCore aborted at startup.
- Fix reads `data_parallel_index` first and falls back to `data_parallel_rank`.

Fixes DYN-2871.

## Adjustments for release/1.1.0

The new test file `test_vllm_instrumented_scheduler.py` retains only the `_resolve_dp_rank` tests; the `_compute_queued`/`skipped_waiting` tests from main do not apply (release/1.1.0 has the older `_compute_queued` that does not iterate `skipped_waiting`).

## Test plan

- [x] `pytest components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py -v` (5 passed)
- [ ] Manual repro on H100x8 with `--data-parallel-size 2` — confirm DP0 binds 20380 and DP1 binds 20381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
