### PR TITLE
fix: Resolve TRT-LLM max_seq_len at startup when Dynamo config omits it

### DIFF
--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -465,6 +465,31 @@ async def init_llm_worker(
         if shutdown_endpoints is not None:
             shutdown_endpoints[:] = [endpoint]
 
+        resolved_max_seq_len = config.max_seq_len
+        if resolved_max_seq_len is None:
+            # If max_seq_len is not set, try to resolve it from the model config
+            model_config = AutoConfig.from_pretrained(
+                config.model, trust_remote_code=True
+            )
+            for field_name in (
+                "max_position_embeddings",
+                "max_sequence_length",
+                "max_seq_len",
+            ):
+                max_seq_len = getattr(model_config, field_name, None)
+                if max_seq_len is not None:
+                    resolved_max_seq_len = int(max_seq_len)
+                    logging.info(
+                        "Resolved TensorRT-LLM max_seq_len from model config: %s",
+                        resolved_max_seq_len,
+                    )
+                    break
+            if resolved_max_seq_len is None:
+                logging.warning(
+                    "Unable to resolve TensorRT-LLM max_seq_len from model config; "
+                    "using TensorRT-LLM default"
+                )
+
         # should ideally call get_engine_runtime_config
         # this is because we don't have a good way to
         # get total_kv_blocks from the engine yet without calling get_stats_async
@@ -594,7 +619,7 @@ async def init_llm_worker(
             shutdown_event=shutdown_event,
             encoder_cache_capacity_gb=config.multimodal_embedding_cache_capacity_gb,
             additional_metrics=additional_metrics,
-            max_seq_len=config.max_seq_len,
+            max_seq_len=resolved_max_seq_len,
             disagg_machine_id=int(endpoint.connection_id()) % 1021,
         )
 
@@ -625,7 +650,7 @@ async def init_llm_worker(
                 endpoint,
                 config.model,
                 config.served_model_name,
-                context_length=config.max_seq_len,
+                context_length=resolved_max_seq_len,
                 kv_cache_block_size=config.kv_block_size,
                 runtime_config=runtime_config,
                 custom_template_path=config.custom_jinja_template,

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -20,6 +20,7 @@ from tests.utils.payload_builder import (
     TEXT_PROMPT,
     chat_payload,
     chat_payload_default,
+    chat_payload_default_no_max_token,
     completion_payload,
     completion_payload_default,
     metric_payload_default,
@@ -89,6 +90,29 @@ trtllm_configs = {
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
+        ],
+    ),
+    "aggregated_no_max_tokens": TRTLLMConfig(
+        name="aggregated_no_max_tokens",
+        directory=trtllm_dir,
+        script_name="agg.sh",
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.pre_merge,
+            pytest.mark.trtllm,
+            pytest.mark.profiled_vram_gib(3.9),
+            pytest.mark.requested_trtllm_kv_tokens(2592),
+            pytest.mark.timeout(300),
+        ],
+        model="Qwen/Qwen3-0.6B",
+        frontend_port=DefaultPort.FRONTEND.value,
+        delayed_start=5,
+        request_payloads=[
+            chat_payload_default_no_max_token(
+                repeat_count=1,
+                expected_response=[],
+                expected_finish_reason="stop",
+            ),
         ],
     ),
     "disaggregated": TRTLLMConfig(

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -10,6 +10,7 @@ from tests.utils.payloads import (
     AnthropicMessagesStreamPayload,
     CachedTokensChatPayload,
     ChatPayload,
+    ChatPayloadWithFinishReason,
     ChatPayloadWithLogprobs,
     CompletionPayload,
     CompletionPayloadWithLogprobs,
@@ -64,6 +65,34 @@ def chat_payload_default(
         expected_response=expected_response
         or ["AI", "knock", "joke", "think", "artificial", "intelligence"],
     )
+
+
+def chat_payload_default_no_max_token(
+    repeat_count: int = 3,
+    expected_response: Optional[List[str]] = None,
+    expected_log: Optional[List[str]] = None,
+    expected_finish_reason: Optional[str] = None,
+    temperature: float = 0.0,
+    stream: bool = False,
+) -> ChatPayload:
+    payload = chat_payload_default(
+        repeat_count=repeat_count,
+        expected_response=expected_response,
+        expected_log=expected_log,
+        temperature=temperature,
+        stream=stream,
+    )
+    payload.body.pop("max_tokens", None)
+    if expected_finish_reason is not None:
+        return ChatPayloadWithFinishReason(
+            body=payload.body,
+            repeat_count=payload.repeat_count,
+            expected_log=payload.expected_log,
+            expected_response=payload.expected_response,
+            timeout=payload.timeout,
+            expected_finish_reason=expected_finish_reason,
+        )
+    return payload
 
 
 def cached_tokens_chat_payload(

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -167,6 +167,23 @@ class ChatPayload(BasePayload):
 
 
 @dataclass
+class ChatPayloadWithFinishReason(ChatPayload):
+    """Chat payload that validates the OpenAI choice finish_reason."""
+
+    expected_finish_reason: str = "stop"
+
+    def validate(self, response: Any, content: str) -> None:
+        super().validate(response, content)
+
+        result = response.json()
+        finish_reason = result["choices"][0].get("finish_reason")
+        assert finish_reason == self.expected_finish_reason, (
+            f"Expected finish_reason={self.expected_finish_reason!r}, "
+            f"got {finish_reason!r}"
+        )
+
+
+@dataclass
 class ChatPayloadWithLogprobs(ChatPayload):
     """Chat payload that validates logprobs in response."""
 


### PR DESCRIPTION
#### Overview:

Fix TRT-LLM requests that omit `max_tokens` when Dynamo’s explicit `config.max_seq_len` is unset.

#### WHY: 

If the Dynamo worker config does not set `max_seq_len` and also a request omits `max_tokens`, the TRT-LLM request handler does not know the model context window. In that case, Dynamo skips the dynamic `max_tokens` default and TRT-LLM falls back to its `SamplingParams` default, which can stop generation early.

This PR makes `self.max_seq_len` non-None by resolving it from the model config in `llm_worker.py`, then passing it into RequestHandlerConfig. So the existing `dynamic_default = max(1, self.max_seq_len - input_length)` code starts working for
the unset-config case.

#### Details:

- `components/src/dynamo/trtllm/workers/llm_worker.py` : Resolves the effective TRT-LLM context length from `config.max_seq_len` when it is set.
- `tests/utils/payload_builder.py` : Adds `chat_payload_default_no_max_token()` by reusing the default chat payload and removing request `max_tokens`.
- `tests/utils/payloads.py` : Adds a payload validation helper that keeps the existing chat response validation and optionally checks `finish_reason`.
- `tests/serve/test_trtllm.py` : Adds a TRT-LLM `gpu_1` / `pre_merge` E2E test that sends a chat request without `max_tokens` and verifies `finish_reason == "stop"`.

#### Where should the reviewer start?

- `components/src/dynamo/trtllm/workers/llm_worker.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic sequence length inference from model configurations when not explicitly provided, with fallback to system defaults.

* **Tests**
  * Added test scenarios for requests without explicit token limit parameters.
  * Enhanced test utilities for validating response finish reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->