### PR TITLE
fix(recipes): correct PATH in dsv4-sglang Dockerfile

### DIFF
--- a/recipes/deepseek-v4-flash/sglang/Dockerfile.dsv4-sglang
+++ b/recipes/deepseek-v4-flash/sglang/Dockerfile.dsv4-sglang
@@ -50,7 +50,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Infra from dynamo sglang-runtime (etcd, nats, UCX, NIXL)
 COPY --from=dynamo_src /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_src /usr/local/bin/etcd /usr/local/bin/etcd
-ENV PATH=/usr/local/bin/etcd:${PATH}
+ENV PATH=/usr/local/bin:${PATH}
 
 # UCX libs
 COPY --from=dynamo_src /usr/lib/x86_64-linux-gnu/ucx /usr/lib/x86_64-linux-gnu/ucx


### PR DESCRIPTION
## Summary
- Fix `ENV PATH` in `recipes/deepseek-v4-flash/sglang/Dockerfile.dsv4-sglang` so it points at the directory `/usr/local/bin`, not the `etcd` binary file
- Addresses CodeRabbit feedback on #8704 (post-merge): https://github.com/ai-dynamo/dynamo/pull/8704#discussion_r3140843808

## Test plan
- [ ] Build the overlay image and confirm `etcd` resolves on PATH
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment configuration to ensure system binaries are properly discoverable within the application container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->