### PR TITLE
ci: fix the nightly wheel versioning to drop locl sha identifier

### DIFF
--- a/.github/scripts/apply_dev_version.py
+++ b/.github/scripts/apply_dev_version.py
@@ -4,10 +4,10 @@
 """Apply a dev-version suffix to every Dynamo package version and cross-ref.
 
 Invoked by nightly CI on the runner, before `docker buildx build`. Takes one
-argument -- a suffix like '.dev20260423+g1234567' -- and rewrites, in place:
+argument -- a suffix like '.dev20260423' -- and rewrites, in place:
   - [project].version in every Dynamo pyproject.toml (PEP 440 form)
   - [package].version / [workspace.package].version in every Cargo.toml
-    (SemVer form: dash instead of dot before 'dev', so '1.1.0-dev...+g...')
+    (SemVer form: dash instead of dot before 'dev', so '1.1.0-dev20260423')
   - The `ai-dynamo-runtime==1.1.0` pin in the root pyproject
   - The `version = "1.1.0"` pins on dynamo-*/kvbm-* path deps in root Cargo.toml
 
@@ -60,7 +60,7 @@ def pep440(suffix: str, base: str) -> str:
 
 
 def semver(suffix: str, base: str) -> str:
-    # Convert a PEP 440-style '.devN+g...' into SemVer '-devN+g...'.
+    # Convert a PEP 440-style '.devN' into SemVer '-devN'.
     if suffix.startswith("."):
         return base + "-" + suffix[1:]
     return base + suffix
@@ -150,7 +150,7 @@ def rewrite_root_cargo(root: Path, suffix: str) -> None:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("suffix", help="e.g. .dev20260423+g1234567 (empty = no-op)")
+    ap.add_argument("suffix", help="e.g. .dev20260423 (empty = no-op)")
     ap.add_argument("root", nargs="?", default=".", help="repo root")
     args = ap.parse_args()
 

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -44,7 +44,7 @@ jobs:
   # ============================================================================
   # COMPUTE NIGHTLY DEV VERSION
   # ============================================================================
-  # Emits a PEP 440 dev suffix (e.g. .dev20260423+g1234567) forwarded to every
+  # Emits a PEP 440 dev suffix (e.g. .dev20260423) forwarded to every
   # pipeline below. At the leaf, the suffix is stamped into pyproject / Cargo
   # versions on the runner before docker build, so wheels produced by the
   # wheel_builder stage carry the dev version.
@@ -59,9 +59,8 @@ jobs:
       - id: compute
         shell: bash
         run: |
-          SHORT_SHA=${GITHUB_SHA:0:7}
           DATE=$(date -u +%Y%m%d)
-          echo "dev_suffix=.dev${DATE}+g${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "dev_suffix=.dev${DATE}" >> $GITHUB_OUTPUT
 
   # ============================================================================
   # FRAMEWORK PIPELINES (Build → Test → Copy)


### PR DESCRIPTION
#### Overview:

Kitmaker fails the whl publish when the nightly whl version has a local identifier. 
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation and CLI help for developer version scripts to reflect simplified version format.

* **Refactor**
  * Modified nightly build pipeline version generation to produce cleaner development identifiers using date-based suffix only, removing the Git SHA component. This affects all downstream builds and version references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->