### PR TITLE
fix: etcd path in sglang dsv4

### DIFF
--- a/recipes/deepseek-v4-flash/sglang/Dockerfile.dsv4-sglang
+++ b/recipes/deepseek-v4-flash/sglang/Dockerfile.dsv4-sglang
@@ -50,7 +50,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Infra from dynamo sglang-runtime (etcd, nats, UCX, NIXL)
 COPY --from=dynamo_src /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_src /usr/local/bin/etcd /usr/local/bin/etcd
-ENV PATH=/usr/local/bin:${PATH}
+ENV PATH=/usr/local/bin/etcd:${PATH}
 
 # UCX libs
 COPY --from=dynamo_src /usr/lib/x86_64-linux-gnu/ucx /usr/lib/x86_64-linux-gnu/ucx


### PR DESCRIPTION
#### Overview:

It turns out /usr/local/bin/etcd is a directory and does need to be in the PATH

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image configuration for infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->