### PR TITLE
docs(dsv4-pro): add Day-0 thinking-mode caveat to README

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -70,7 +70,7 @@ These recipes are under active development and may require additional setup step
 | **[GLM-5-NVFP4](glm-5-nvfp4/sglang/disagg/)** | SGLang | Disagg Prefill/Decode | 20x GB200 | ✅ | NVFP4, EAGLE speculative decoding, TP16 decode + TP4 prefill. Requires [custom container build](glm-5-nvfp4/). |
 | **[nvidia/Kimi-K2.5-NVFP4](kimi-k2.5/trtllm/agg/nvidia/)** | TensorRT-LLM | Aggregated | 8x B200 | ✅ | Text only — MoE model, TP8×EP8, reasoning + tool calling. Vision input not yet functional. |
 | **[DeepSeek-V4-Flash](deepseek-v4-flash/vllm/agg/)** | vLLM | Aggregated | 4x B200 | ✅ | Text only — MoE model (284B / 13B active), DP=4 + EP, FP8 KV cache, reasoning + tool calling. Requires [custom container build](deepseek-v4-flash/container/). |
-| **[DeepSeek-V4-Pro](deepseek-v4-pro/vllm/agg/)** | vLLM | Aggregated | 8x B200 | ✅ | Text only — MoE model (1.6T / 49B active, 1M context), TP=8 + EP, FP4+FP8 mixed checkpoint, FP8 KV cache, CSA+HCA attention, three reasoning effort modes, tool calling. Requires [custom container build](deepseek-v4-pro/container/). |
+| **[DeepSeek-V4-Pro](deepseek-v4-pro/vllm/agg/)** | vLLM | Aggregated | 8x B200 | ✅ | Text only — MoE model (1.6T / 49B active, 1M context), TP=8 + EP, FP4+FP8 mixed checkpoint, FP8 KV cache, CSA+HCA attention, tool calling. Thinking modes unstable on Day-0 — run with `thinking: false`. Requires [custom container build](deepseek-v4-pro/container/). |
 
 ## Recipe Structure
 

--- a/recipes/deepseek-v4-pro/README.md
+++ b/recipes/deepseek-v4-pro/README.md
@@ -8,6 +8,9 @@ Aggregated-serving recipe for **DeepSeek-V4-Pro** on vLLM with Dynamo.
 
 Aggregated, single-replica: 1 decode pod running TP=8 + Expert Parallel on all 8 GPUs of one node.
 
+> **⚠️ Known Day-0 issue: thinking modes produce corrupted output.**
+> Requests with `chat_template_kwargs: {"thinking": true, ...}` emit malformed tokens (numeric tokens spliced mid-word, occasional special-token leakage) on this engine. The bug is in the OSS port of DeepSeek-V4-Pro's sparse-attention path and does not affect DeepSeek-V4-Flash on the same stack. Until the upstream fix lands, send `chat_template_kwargs: {"thinking": false}` in chat completion requests. Tool calling, structured output, and non-thinking responses work normally.
+
 ## Prerequisites
 
 1. **Dynamo Platform installed** — see the [Kubernetes Deployment Guide](../../docs/kubernetes/README.md).
@@ -68,7 +71,8 @@ curl http://localhost:8000/v1/chat/completions \
   -d '{
     "model": "deepseek-ai/DeepSeek-V4-Pro",
     "messages": [{"role": "user", "content": "Hello!"}],
-    "max_tokens": 100
+    "max_tokens": 100,
+    "chat_template_kwargs": {"thinking": false}
   }'
 ```
 


### PR DESCRIPTION
## Summary
- Adds a callout to `recipes/deepseek-v4-pro/README.md` documenting the Day-0 thinking-mode corruption bug on this engine and directing users to `chat_template_kwargs: {"thinking": false}` until the upstream fix lands.
- Updates the "Test the Deployment" curl example in the same README to set `thinking: false` explicitly so the included quickstart doesn't surprise anyone with corrupted output.
- Adds a brief mention in the top-level `recipes/README.md` table so the caveat is visible from the index.

## Context
Yongye Zhu first surfaced the bug in vLLM (`#deepseekv4-war-room`). I confirmed it reproduces independently on SGLang DSv4-Pro on nscale and on this vLLM image (`nvcr.io/nvidian/dynamo-dev/biswa:vllm-dsv4-2`), and does *not* reproduce on DSv4-Flash. The bug is engine-side (sparse-attention state lifecycle), not Dynamo-specific. Repro + analysis snippet: https://gitlab-master.nvidia.com/-/snippets/14025.

Tool calling, structured output, and non-thinking responses work normally — recipe ships otherwise as-is.

## Test plan
- [x] Confirmed bug reproduces on this image deployed in a fresh namespace (`bhamm-vllm-dsv4pro-b200`)
- [x] Confirmed `thinking: false` request path works cleanly across multiple requests
- [x] Smoke test (`dsv4_pro_deploy_smoke.py`): 7/7 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)