### PR TITLE
docs: temporary launch banner for DeepSeek-V4 recipes on main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ limitations under the License.
 
 # Dynamo
 
+<!-- TEMPORARY BANNER: remove once V4 recipes mature / SGLang variant lands. -->
+> [!NOTE]
+> **Day-0 DeepSeek-V4 recipes available.** Tested Kubernetes deployment paths for [DeepSeek-V4-Pro](recipes/deepseek-v4-pro/) and [DeepSeek-V4-Flash](recipes/deepseek-v4-flash/) on vLLM are merged to main. SGLang recipes coming shortly.
+
 **The open-source, datacenter-scale inference stack.** Dynamo is the orchestration layer above inference engines — it doesn't replace SGLang, TensorRT-LLM, or vLLM, it turns them into a coordinated multi-node inference system. Disaggregated serving, intelligent routing, multi-tier KV caching, and automatic scaling work together to maximize throughput and minimize latency for LLM, reasoning, multimodal, and video generation workloads.
 
 Built in Rust for performance, Python for extensibility.


### PR DESCRIPTION
## Summary
Adds a brief GitHub-admonition banner to the top of the main `README.md` announcing that Day-0 vLLM recipes for **DeepSeek-V4-Pro** and **DeepSeek-V4-Flash** are now in main.

Sits right under the `# Dynamo` h1, before the description paragraph — unmissable on the repo landing page but not loud.

## Why a banner
The recipes folder is one click off the front page (in the nav table), but a Day-0 launch this big benefits from a temporary nudge directly on the README so first-time visitors hitting `github.com/ai-dynamo/dynamo` see it without having to know to look in `/recipes/`.

## Lifecycle
The banner is tagged with an HTML comment for future cleanup:

```markdown
<!-- TEMPORARY BANNER: remove once V4 recipes mature / SGLang variant lands. -->
```

Greppable for anyone who inherits this. Suggested removal trigger: when SGLang DSv4 recipe lands or when these stop being "Day-0 / Experimental" status.

## Test plan
- [x] Branch builds against latest main
- [x] Banner uses `> [!NOTE]` GFM admonition syntax (renders as styled note box on github.com, regular blockquote in markdown viewers that don't support it)
- [x] Both recipe links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated README with information about Day-0 DeepSeek-V4 recipes availability, including Kubernetes deployment support for DeepSeek-V4-Pro and DeepSeek-V4-Flash variants. SGLang variants coming soon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->