### PR TITLE
docs(parser): annotate every test with its CASE.* in TEST_CASES.md

### DIFF
--- a/lib/parsers/README.md
+++ b/lib/parsers/README.md
@@ -103,14 +103,14 @@ Reasoning parsers:
    grammar truly diverges (append-think, Harmony channels). Most new models
    use plain `<think>...</think>` and can share.
 
-4. **Write tests.** Minimum viable set is in [`TESTING.md`](./TESTING.md) (T1–T20
+4. **Write tests.** Minimum viable set is in [`TEST_CASES.md`](./TEST_CASES.md) (T1–T20
    taxonomy). At minimum: T1/T2/T3 for correctness, T5 for truncation
    behavior, T8/T9 for streaming, T14 for interleaved text. `N/A` categories
    should be explicitly called out in a comment rather than silently skipped.
 
 ## Related docs
 
-- [`TESTING.md`](./TESTING.md) — corner-case taxonomy (T1–T20). What every
+- [`TEST_CASES.md`](./TEST_CASES.md) — corner-case taxonomy (T1–T20). What every
   parser should be tested against, what's N/A per family, what's a universal
   gap today.
 - `lib/llm/tests/data/` — captured streaming fixtures per (engine × model)

--- a/lib/parsers/TEST_CASES.md
+++ b/lib/parsers/TEST_CASES.md
@@ -17,31 +17,39 @@ Per-model gap tracking lives elsewhere (not in this repo).
 
 ### Generic (all parsers)
 
-- **`CASE.1`** Single tool call — happy path (one complete, well-formed call). Ex: `xml::test_parse_simple_tool_call`.
-- **`CASE.2`** Multiple tool calls — sequential or parallel (2+ in one response). Ex: `tool_choice::test_streaming_required_tool_parallel`.
-- **`CASE.3`** No tool call (response is text only). Ex: `xml::test_parse_no_tool_calls`.
-- **`CASE.4`** Malformed / partial JSON args (truncated, missing close brace, invalid syntax). Ex: `deepseek_v3::test_parse_..._with_invalid_json`, `xml::test_parse_missing_..._closing_tag`.
-- **`CASE.5`** Missing end-token recovery (recover calls when `section_end` is absent due to max_tokens / EOS). Ex: `kimi_k2::test_parse_malformed_no_section_end`.
-- **`CASE.6`** Empty args (`arguments={}` / no-arg call). Ex: `kimi_k2::test_parse_no_arg_call`.
-- **`CASE.7`** Complex arg types (nested objects, arrays, bool, number, Unicode / newlines in values). Ex: `kimi_k2::test_parse_complex_json_arguments`.
-- **`CASE.8`** Streaming — token-by-token assembly + chunk-boundary splits. Ex: `basic::test_buffer_state_persistence_across_calls`, `basic::test_partial_token_matching_closing_tag`, `basic::test_kimi_k2_one_shot_split`.
-- **`CASE.9`** Paired reasoning + tool in same response. Ex: `test_reasoning_parser::test_nemotron_with_reasoning_and_tool_calls`.
-- **`CASE.10`** Reasoning only (think tags, no tool call). Ex: `basic::test_detect_and_parse_reasoning_reasoning`.
-- **`CASE.11`** `tool_choice` = auto / required / named / none. Ex: `tool_choice::test_named_tool_choice_parses_json` (**hermes only today**).
-- **`CASE.12`** `finish_reason` semantics (`stop` / `tool_calls` / `length` mapping). Ex: `tool_choice_finish_reasons::*` (hermes only); `test_streaming_tool_parsers::test_qwen_finish_reason_length_vllm`.
-- **`CASE.13`** Normal text interleaved with tool calls. Ex: `xml::test_parse_with_normal_text`.
-- **`CASE.14`** Empty content / empty `tool_calls` array / null response. Ex: `parallel_tool_call_integration::test_empty_tool_calls`.
+- **`CASE.1`** Single tool call — happy path (one complete, well-formed call).
+- **`CASE.2`** Multiple tool calls — sequential or parallel (2+ in one response).
+- **`CASE.3`** No tool call (response is text only).
+- **`CASE.4`** Malformed / partial JSON args (truncated, missing close brace, invalid syntax).
+- **`CASE.5`** Missing end-token recovery (recover calls when `section_end` is absent due to max_tokens / EOS).
+- **`CASE.6`** Empty args (`arguments={}` / no-arg call).
+- **`CASE.7`** Complex arg types (nested objects, arrays, bool, number, Unicode / newlines in values).
+- **`CASE.8`** Streaming — token-by-token assembly + chunk-boundary splits.
+- **`CASE.9`** Paired reasoning + tool in same response.
+- **`CASE.10`** Reasoning only (think tags, no tool call).
+- **`CASE.11`** `tool_choice` = auto / required / named / none.
+- **`CASE.12`** `finish_reason` semantics (`stop` / `tool_calls` / `length` mapping).
+- **`CASE.13`** Normal text interleaved with tool calls.
+- **`CASE.14`** Empty content / empty `tool_calls` array / null response.
 - **`CASE.15`** Duplicate tool calls (same name twice). No test anywhere in the repo; universal gap.
-- **`CASE.16`** Regression for a specific customer bug (ticket ID referenced in test name or body). Ex: `kimi_k2::test_parse_malformed_no_section_end`.
+- **`CASE.16`** Regression for a specific customer bug (ticket ID referenced in test name or body).
 
 ### XML-family (`CASE.xml*`)
 
-- **`CASE.xml1`** XML entity / HTML unescape handling (`&lt;`, `&amp;`, `&quot;` in parameter values). Ex: `xml::test_html_unescape`, `glm47::test_xml_entity_decoding`.
-- **`CASE.xml2`** Schema-aware type coercion (string → number/bool/array based on declared parameter schema). Ex: `xml::test_schema_aware_type_conversion`, `glm47::test_type_coercion_*`.
+- **`CASE.xml1`** XML entity / HTML unescape handling (`&lt;`, `&amp;`, `&quot;` in parameter values).
+- **`CASE.xml2`** Schema-aware type coercion (string → number/bool/array based on declared parameter schema).
 
 ### Harmony (`CASE.harmony*`)
 
-- **`CASE.harmony1`** Channel / recipient parsing (analysis / commentary / final channels). Ex: `harmony_parser::test_parse_tool_calls_harmony_*`.
+- **`CASE.harmony1`** Channel / recipient parsing (analysis / commentary / final channels).
+
+### Parser-internal & format-variant categories
+
+- **`CASE.20`** Detection helpers — direct tests of `detect_tool_call_start_*` / `find_tool_call_end_position_*` (the streaming jail's entry points). Distinct from `CASE.8` which exercises the full streaming pipeline.
+- **`CASE.21`** Function-name conventions — allowed identifier chars (hyphens, underscores, dots), prefix variants (`functions.NAME` vs bare `NAME`), and rejection of malformed function IDs. Models differ on what they emit; parsers must take a position.
+- **`CASE.22`** Whitespace / formatting tolerance — whitespace inside or between tokens (newlines after `<|tool_call_begin|>`, spaces around the function ID, etc.). Parser must accept the same call regardless of formatting.
+- **`CASE.23`** Token format variants — multiple acceptable spellings for the same semantic (e.g., Kimi K2's singular `<|tool_call_section_*|>` vs plural `<|tool_calls_section_*|>` section tokens). Parser must accept all configured variants.
+- **`CASE.24`** Empty section / no-content wrappers — start+end fences with nothing between them (`<|tool_calls_section_begin|><|tool_calls_section_end|>`). Must produce zero calls and preserve any surrounding text.
 
 ### Universal gaps (no test anywhere, not promoted to numbered categories)
 
@@ -62,7 +70,6 @@ One complete, well-formed call in the response.
 
 - Applies to every tool-call parser.
 - Baseline correctness check. If `CASE.1` fails, nothing else below matters.
-- Example: `dsml/parser.rs::test_parse_single_tool_call_string_param`.
 
 ## `CASE.2` — Multiple tool calls (sequential or parallel)
 
@@ -71,8 +78,6 @@ Two or more calls in one response, in the same block or back-to-back.
 - Applies to every tool-call parser.
 - Some grammars emit parallel calls in one block (DSML, XML); others emit
   sequential top-level sentinels (JSON dialects). Either way, extract all.
-- Example: `dsml/parser.rs::test_parse_multiple_tool_calls`,
-  `tool_choice::test_streaming_required_tool_parallel`.
 
 ## `CASE.3` — No tool call
 
@@ -81,7 +86,6 @@ Response is plain text, no tool-call grammar present.
 - Applies to every tool-call parser.
 - Must return empty `Vec<ToolCall>` and the input as `normal_text`. Zero false
   positives.
-- Example: `dsml/parser.rs::test_parse_no_tool_calls`.
 
 ## `CASE.4` — Malformed / partial JSON args
 
@@ -94,8 +98,6 @@ payload.
 - Behavior must be documented: either graceful fallback to string (DSML's
   current behavior via `serde_json::from_str(...).unwrap_or_else(|_| String(...))`)
   or explicit error. Silent drop is the failure mode.
-- Example: `dsml/parser.rs::test_parse_deepseek_v4_malformed_json_value_falls_back_to_string`,
-  `deepseek_v3_parser.rs::test_parse_tool_calls_deepseek_v3_with_invalid_json`.
 
 ## `CASE.5` — Missing end-token recovery
 
@@ -111,8 +113,6 @@ emitted EOS mid-generation.
   outer close fence (Kimi K2 does this post-fix), or (b) return an explicit
   error. Either way, pin the behavior with a test so a future change is
   intentional.
-- Example (post-recovery): `kimi_k2_parser.rs::test_parse_malformed_no_section_end`.
-- Example (behavior-pinning, pre-recovery): `dsml/parser.rs::test_parse_deepseek_v4_missing_end_token`.
 
 ## `CASE.6` — Empty args
 
@@ -120,8 +120,6 @@ Tool call with `arguments={}`, or a no-parameter invoke.
 
 - Applies to every tool-call parser.
 - Must still return the call — empty args is a valid call, not a missing one.
-- Example: `kimi_k2_parser.rs::test_parse_no_arg_call`,
-  `dsml/parser.rs::test_parse_deepseek_v4_no_parameters`.
 
 ## `CASE.7` — Complex argument types
 
@@ -133,8 +131,6 @@ newlines inside argument values.
   JSON round-tripping. For XML grammars without hints, the type-coercion
   half of the test is covered under `CASE.xml2` instead — here just verify
   that complex values make it through without truncation or escape bugs.
-- Example: `dsml/parser.rs::test_parse_mixed_types_realistic`,
-  `kimi_k2_parser.rs::test_parse_complex_json_arguments`.
 
 ## `CASE.8` — Streaming
 
@@ -149,10 +145,6 @@ together:
    match on the next chunk.
 
 - Applies to every tool-call parser. Dominant production path.
-- Example: `basic::test_buffer_state_persistence_across_calls`,
-  `basic::test_partial_token_matching_closing_tag`,
-  `basic::test_kimi_k2_one_shot_split`,
-  `test_streaming_tool_parsers::test_deepseek_v4_e2e_fragmented_tokens_vllm`.
 
 ## `CASE.9` — Paired reasoning + tool in same response
 
@@ -162,8 +154,6 @@ must be extracted: `reasoning_content` populated AND `tool_calls` populated.
 - Applies to every (tool, reasoning) parser pair.
 - Watch for the "unclosed think-tag swallows tool call" bug — if the reasoning
   parser is greedy it may eat the tool-call content that follows.
-- Example: `test_reasoning_parser::test_nemotron_with_reasoning_and_tool_calls`,
-  `test_reasoning_parser::test_kimi_k25_with_reasoning_and_tool_calls`.
 
 ## `CASE.10` — Reasoning only
 
@@ -171,8 +161,6 @@ must be extracted: `reasoning_content` populated AND `tool_calls` populated.
 `reasoning_content` and leave `tool_calls` empty.
 
 - Applies to every reasoning parser.
-- Example: `reasoning/base_parser.rs::test_detect_and_parse_reasoning_reasoning`,
-  `reasoning/mod.rs::test_deepseek_v4_detect_and_parse`.
 
 ## `CASE.11` — `tool_choice` = auto / required / named / none
 
@@ -184,8 +172,6 @@ Each of the four OpenAI `tool_choice` modes exercised per parser.
   run `hermes` only today. Adding a new parser requires parametrizing those
   suites or adding a per-parser equivalent.
 - Universal gap across most parsers in the repo as of 2026-04.
-- Example: `tool_choice::test_named_tool_choice_parses_json`,
-  `tool_choice::test_required_tool_choice_parses_json_array`.
 
 ## `CASE.12` — `finish_reason` semantics
 
@@ -196,8 +182,6 @@ non-streaming paths.
 - When a tool call lands, `finish_reason` must become `tool_calls`. When
   `max_tokens` truncates mid-stream, `length` must propagate — this is
   often the signal that should trigger `CASE.5` recovery on the parser side.
-- Example: `tool_choice_finish_reasons::test_named_tool_choice_normal_stop_becomes_tool_calls`,
-  `test_streaming_tool_parsers::test_qwen_finish_reason_length_vllm`.
 
 ## `CASE.13` — Normal text interleaved with tool calls
 
@@ -205,8 +189,6 @@ Model emits narration text before / after / between tool-call blocks. Parser
 must split content correctly: text → `normal_content`, calls → `tool_calls`.
 
 - Applies to every tool-call parser.
-- Example: `dsml/parser.rs::test_parse_with_normal_text`,
-  `test_streaming_tool_parsers.rs::test_deepseek_v4_e2e_content_before_tool_vllm`.
 
 ## `CASE.14` — Empty content / empty `tool_calls` array / null response
 
@@ -217,8 +199,6 @@ Engine emits a chunk with `delta.content = ""`, or a final response with
 - Null-value handling inside parameters is parser-level (`parse_parameters`
   in DSML handles it via `serde_json::Value::Null`). Empty-choices /
   empty-stream handling is typically at the e2e integration layer.
-- Example: `dsml/parser.rs::test_parse_null_parameter`,
-  `parallel_tool_call_integration::test_empty_tool_calls`.
 
 ## `CASE.15` — Duplicate tool calls (same name twice)
 
@@ -255,8 +235,6 @@ value is surfaced to the client.
   whether to JSON-decode or pass through verbatim; no entity decoding pass.
 - **N/A for JSON-family and Harmony** — JSON has its own escape semantics
   handled by `serde_json`.
-- Example: `xml/parser.rs::test_html_unescape`,
-  `glm47_parser.rs::test_xml_entity_decoding`.
 
 ## `CASE.xml2` — Schema-aware type coercion
 
@@ -269,8 +247,6 @@ number / bool / array based on the declared parameter type.
   intent per parameter, so no schema lookup is needed.
 - **N/A for JSON-family** — JSON has native types.
 - **N/A for Harmony** — payload is JSON inside the channel envelope.
-- Example: `xml/parser.rs::test_schema_aware_type_conversion`,
-  `glm47_parser.rs::test_type_coercion_array_comma_separated`.
 
 ---
 
@@ -283,8 +259,6 @@ into tool-call extraction while surfacing `analysis` as reasoning and
 `final` as the user-visible output.
 
 - **Harmony only.** N/A for every other family.
-- Example: `harmony/harmony_parser.rs::test_parse_tool_calls_harmony_with_multi_args`,
-  `harmony/harmony_parser.rs::test_parse_tool_calls_harmony_with_normal_text`.
 
 ---
 

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -345,7 +345,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    #[test]
+    #[test] // CASE.10
     fn test_detect_and_parse_reasoning_reasoning() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -354,7 +354,7 @@ mod tests {
         assert_eq!(result.normal_text, "and more text.");
         assert_eq!(result.reasoning_text, "with reasoning");
     }
-    #[test]
+    #[test] // CASE.3 — no reasoning content
     fn test_detect_and_parse_reasoning_reasoning_no_reasoning() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -362,7 +362,7 @@ mod tests {
         assert_eq!(result.normal_text, "This is a test without reasoning.");
         assert_eq!(result.reasoning_text, "");
     }
-    #[test]
+    #[test] // CASE.4, CASE.10
     fn test_detect_and_parse_reasoning_reasoning_truncated_reasoning() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -371,7 +371,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "with truncated reasoning");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.10
     fn test_parse_reasoning_streaming_incremental() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -380,7 +380,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.10
     fn test_parse_reasoning_streaming_incremental_complete() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -392,7 +392,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "with reasoning");
     }
 
-    #[test]
+    #[test] // CASE.4, CASE.5, CASE.8, CASE.10
     fn test_parse_reasoning_streaming_incremental_no_end_token() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true);
@@ -401,7 +401,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "with reasoning");
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.10 — multi-block
     fn test_detect_and_parse_reasoning_multiple_reasoning_blocks() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -413,7 +413,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "first reasoningsecond reasoning");
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.8, CASE.10
     fn test_streaming_multiple_reasoning_blocks() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, false);
@@ -429,7 +429,7 @@ mod tests {
         assert_eq!(result2.normal_text, "  end"); // " " prefix + " end" suffix
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.20
     fn test_partial_token_matching_opening_tag() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -448,7 +448,7 @@ mod tests {
         assert_eq!(result2.reasoning_text, "reasoning content");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.20
     fn test_partial_token_matching_closing_tag() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, false);
@@ -465,7 +465,7 @@ mod tests {
         assert_eq!(result2.reasoning_text, "reasoning content");
     }
 
-    #[test]
+    #[test] // CASE.8
     fn test_buffer_state_persistence_across_calls() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, false);
@@ -491,7 +491,7 @@ mod tests {
         assert_eq!(result4.reasoning_text, "part1 part2 part3");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.10
     fn test_streaming_with_stream_reasoning_enabled() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -512,7 +512,7 @@ mod tests {
         assert_eq!(result3.reasoning_text, "more");
     }
 
-    #[test]
+    #[test] // CASE.10 — nested
     fn test_nested_reasoning_blocks() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -527,7 +527,7 @@ mod tests {
         assert_eq!(result.normal_text, "reasoning</think> normal");
     }
 
-    #[test]
+    #[test] // CASE.4, CASE.5
     fn test_malformed_missing_closing_tag() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -536,7 +536,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "reasoning without closing tag");
     }
 
-    #[test]
+    #[test] // CASE.4
     fn test_malformed_stray_closing_tag() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -545,7 +545,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.4
     fn test_malformed_multiple_opening_tags() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -557,7 +557,7 @@ mod tests {
         assert_eq!(result.normal_text, "normal");
     }
 
-    #[test]
+    #[test] // CASE.6, CASE.10
     fn test_empty_reasoning_block() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -566,7 +566,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.10, CASE.22
     fn test_whitespace_only_reasoning_block() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -575,7 +575,7 @@ mod tests {
         assert_eq!(result.reasoning_text, ""); // Should be empty after trim
     }
 
-    #[test]
+    #[test] // CASE.10 — force-mode
     fn test_force_reasoning_mode() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true);
@@ -584,7 +584,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "no think tags here");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.10
     fn test_streaming_reset_state_after_complete_block() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -624,7 +624,7 @@ mod tests {
         assert_eq!(r3.normal_text, " final");
     }
 
-    #[test]
+    #[test] // CASE.9, CASE.13
     fn test_post_reasoning_angle_bracket_not_buffered() {
         // After reasoning ends, a standalone `<` should pass through immediately
         // as normal text. It must NOT be buffered as a potential prefix of <think>
@@ -650,7 +650,7 @@ mod tests {
         assert_eq!(r3.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.9
     fn test_post_reasoning_tool_call_xml_preserved() {
         // Simulates the MiniMax tool call scenario: reasoning followed by XML tool call.
         // The `<` in `<invoke` must not be consumed by the reasoning parser.
@@ -679,7 +679,7 @@ mod tests {
         assert_eq!(r6.normal_text, "invoke name=\"get_weather\">");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.13
     fn test_interleaved_streaming_across_chunks() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -709,7 +709,7 @@ mod tests {
         assert_eq!(r6.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.10
     fn test_three_reasoning_blocks_non_streaming() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -721,7 +721,7 @@ mod tests {
         assert_eq!(result.normal_text, "one  two  three");
     }
 
-    #[test]
+    #[test] // CASE.8
     fn test_streaming_transition_chunk() {
         // </think> and <think> arrive in the same chunk.
         // With loop-based processing, the second block's opening content is emitted
@@ -745,7 +745,7 @@ mod tests {
         assert_eq!(r3.normal_text, " end");
     }
 
-    #[test]
+    #[test] // CASE.10, CASE.13
     fn test_interleaved_with_force_reasoning() {
         // deepseek_r1 mode: force_reasoning=true, first tokens are reasoning without <think>
         let mut parser =
@@ -768,7 +768,7 @@ mod tests {
         assert_eq!(r3.normal_text, " done");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.13
     fn test_interleaved_partial_think_tag_between_blocks() {
         // After first reasoning block, partial <think> tag arrives across chunks
         let mut parser =
@@ -789,7 +789,7 @@ mod tests {
         assert_eq!(r3.normal_text, " end");
     }
 
-    #[test]
+    #[test] // CASE.13, CASE.20
     fn test_lone_angle_bracket_between_reasoning_blocks() {
         // A lone `<` between reasoning blocks should pass through (not buffer)
         let mut parser =
@@ -814,7 +814,7 @@ mod tests {
         assert_eq!(r4.normal_text, " done");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.10
     fn test_force_reasoning_stream_false_buffers_until_end_token() {
         // force_reasoning=true, stream_reasoning=false: content is buffered until </think>
         // arrives, then returned as a single chunk. This is the expected behavior.
@@ -836,7 +836,7 @@ mod tests {
         assert_eq!(r3.normal_text, " answer");
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.8, CASE.10
     fn test_multiple_full_blocks_in_single_streaming_chunk() {
         // Two complete <think>...</think> blocks arrive in one chunk.
         // The loop exhausts all transitions in a single call — both blocks are fully
@@ -857,7 +857,7 @@ mod tests {
         assert_eq!(r2.normal_text, "");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.20
     fn test_partial_end_token_stream_reasoning_true() {
         // Partial </think> split across chunks with stream_reasoning=true.
         // The partial-end-token buffer check only fires when the parser is ALREADY in
@@ -882,7 +882,7 @@ mod tests {
         assert_eq!(r3.normal_text, " normal");
     }
 
-    #[test]
+    #[test] // CASE.3, CASE.14
     fn test_empty_string_input_various_states() {
         // Empty string input should always return empty results without changing state
         let mut parser =
@@ -910,7 +910,7 @@ mod tests {
         assert_eq!(r3.normal_text, "");
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.8, CASE.10
     fn test_force_reasoning_stream_false_multiple_blocks() {
         // force_reasoning=true (deepseek_r1 mode), stream_reasoning=false.
         // First block uses forced-reasoning (no explicit <think>); subsequent blocks
@@ -931,7 +931,7 @@ mod tests {
         assert_eq!(r2.normal_text, " normal2");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.16 — GLM-5 burst pattern
     fn test_glm5_pattern_a_burst_single_chunk() {
         // GLM-5 Pattern A: the entire completion arrives in one SSE event.
         // Format: <think>T1</think><tool_call>A</tool_call><think>T2</think><tool_call>B</tool_call>
@@ -958,7 +958,7 @@ mod tests {
         assert_eq!(r2.normal_text, "");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.9, CASE.13
     fn test_tool_call_xml_between_reasoning_blocks_streaming() {
         // GLM-5 Pattern A chunk-by-chunk: verifies that tool call XML between reasoning
         // blocks lands in normal_text, not reasoning_text, across separate SSE events.
@@ -992,7 +992,7 @@ mod tests {
     // Ported from PR #6448 (ryanolson) with additional fakeout tests.
     // =========================================================================
 
-    #[test]
+    #[test] // CASE.8, CASE.20
     fn test_mid_string_partial_opening_tag_batched() {
         // Backend batches tokens: "Hello world <th" arrives as one chunk
         let mut parser =
@@ -1009,7 +1009,7 @@ mod tests {
         assert_eq!(r2.normal_text, " answer");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.20
     fn test_batched_tag_boundary_split() {
         // Aggressive batching: <think> tag split with normal text prefix
         let mut parser =
@@ -1024,7 +1024,7 @@ mod tests {
         assert_eq!(r2.normal_text, "42");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.20
     fn test_mid_string_partial_closing_tag_stream_reasoning_false() {
         // With stream_reasoning=false, content stays buffered until </think>.
         // Partial </think> split mid-string while in reasoning mode.
@@ -1041,7 +1041,7 @@ mod tests {
         assert_eq!(r2.normal_text, " normal text");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.20
     fn test_mid_string_partial_closing_tag_stream_reasoning_true() {
         // With stream_reasoning=true, reasoning content is emitted incrementally.
         // The partial "</th" at the end must NOT be emitted as reasoning text.
@@ -1059,7 +1059,7 @@ mod tests {
         assert_eq!(r2.normal_text, " normal text");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.13
     fn test_batched_interleaved_with_mid_string_partial() {
         // First block complete in chunk 1, second block's <think> split at boundary
         let mut parser =
@@ -1075,7 +1075,7 @@ mod tests {
         assert_eq!(r2.normal_text, "answer2");
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_partial_tag_false_positive() {
         // "<th" looks like partial <think> but "thesis" is not <think>
         let mut parser =
@@ -1091,7 +1091,7 @@ mod tests {
         assert_eq!(r2.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_partial_closing_tag_fakeout() {
         // Ollama-style fakeout: "</th" buffered, but "ing>" completes "</thing>" not "</think>"
         let mut parser =
@@ -1112,7 +1112,7 @@ mod tests {
         assert_eq!(r3.normal_text, "done");
     }
 
-    #[test]
+    #[test] // CASE.20 — internal helper
     fn test_overlap_helper_function() {
         // Direct tests for the overlap utility
         assert_eq!(overlap("abc</th", "</think>"), 4);
@@ -1136,7 +1136,7 @@ mod tests {
             .with_tool_start_token(crate::reasoning::KIMI_K2_TOOL_SECTION_BEGIN)
     }
 
-    #[rstest]
+    #[rstest] // CASE.8, CASE.16 — Kimi K2 split
     #[case(
         "thinking text <|tool_calls_section_begin|><|tool_call_begin|>functions.foo:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>",
         "thinking text",
@@ -1159,7 +1159,7 @@ mod tests {
         assert_eq!(r.normal_text, expected_normal);
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.10
     fn test_force_exit_streaming_single_chunk() {
         let mut parser = kimi_k2_parser();
         let r = parser.parse_reasoning_streaming_incremental(
@@ -1173,7 +1173,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.10
     fn test_force_exit_streaming_split_across_chunks() {
         let mut parser = kimi_k2_parser();
 
@@ -1191,7 +1191,7 @@ mod tests {
         assert_eq!(r3.normal_text, "<|tool_calls_section_begin|>rest");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.20
     fn test_force_exit_partial_marker_resolves_as_non_marker() {
         // First chunk ends with "<|tool_ca" (prefix of marker) — must be buffered.
         // Second chunk "xxx" makes the combined "<|tool_caxxx" which is NOT a marker.
@@ -1207,7 +1207,7 @@ mod tests {
         assert_eq!(r2.normal_text, "");
     }
 
-    #[test]
+    #[test] // CASE.10
     fn test_no_tool_start_token_behaves_as_before() {
         // Without the tool_start_token setter, BasicReasoningParser is byte-identical
         // to the pre-patch behavior — the marker is just reasoning content.

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -295,7 +295,7 @@ impl ReasoningParser for GptOssReasoningParser {
 mod tests {
     use super::*;
 
-    #[test]
+    #[test] // CASE.10, CASE.19
     fn test_gpt_oss_reasoning_parser() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let text = "<|channel|>analysis<|message|>The user asks a simple factual question: capital of Brazil. The answer is Brasília. No additional explanation needed.<|end|><|start|>assistant<|channel|>final<|message|>The capital of Brazil is Brasília.";
@@ -307,7 +307,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.10, CASE.19
     fn test_gpt_oss_reasoning_parser_streaming() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let chunks = vec![
@@ -331,7 +331,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.10, CASE.19
     fn test_gpt_oss_reasoning_parser_streaming_chunked() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let enc = get_harmony_encoding()
@@ -360,7 +360,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.10, CASE.19
     fn test_gpt_oss_reasoning_parser_streaming_variable_length_chunks() {
         let text = "<|channel|>analysis<|message|>User asks: \"Hey, quick check: is everything up and running?\" We should check system health using the provided function get_system_health. Use function.<|end|><|start|>assistant<|channel|>commentary to=functions.get_system_health <|constrain|>json<|message|>{}";
         let enc = get_harmony_encoding()

--- a/lib/parsers/src/reasoning/granite_parser.rs
+++ b/lib/parsers/src/reasoning/granite_parser.rs
@@ -182,7 +182,7 @@ impl ReasoningParser for GraniteReasoningParser {
 mod tests {
     use super::*;
 
-    #[test]
+    #[test] // CASE.20
     fn test_basic_reasoning_detection() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: I need to think about this. Here's my response: The answer is 42.";
@@ -192,7 +192,7 @@ mod tests {
         assert_eq!(result.normal_text, " The answer is 42.");
     }
 
-    #[test]
+    #[test] // CASE.20, CASE.23
     fn test_alternative_start_token() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here is my thought process: Different thinking here. Here is my response: Final answer.";
@@ -202,7 +202,7 @@ mod tests {
         assert_eq!(result.normal_text, " Final answer.");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.20
     fn test_streaming_partial_tokens() {
         let mut parser = GraniteReasoningParser::new();
 
@@ -218,7 +218,7 @@ mod tests {
         assert_eq!(result2.normal_text, "");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.20
     fn test_streaming_partial_end_tokens() {
         let mut parser = GraniteReasoningParser::new();
 
@@ -239,7 +239,7 @@ mod tests {
         assert_eq!(result2.normal_text, " Done!");
     }
 
-    #[test]
+    #[test] // CASE.3, CASE.20
     fn test_no_reasoning_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "This is just normal text without any special tokens.";
@@ -249,7 +249,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.4, CASE.5, CASE.20
     fn test_only_start_token_no_end() {
         let mut parser = GraniteReasoningParser::new();
 
@@ -266,7 +266,7 @@ mod tests {
         assert_eq!(result2.normal_text, "");
     }
 
-    #[test]
+    #[test] // CASE.6, CASE.10
     fn test_empty_reasoning_block() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process:Here's my response: Direct answer.";
@@ -276,7 +276,7 @@ mod tests {
         assert_eq!(result.normal_text, " Direct answer.");
     }
 
-    #[test]
+    #[test] // CASE.10, CASE.22
     fn test_reasoning_with_whitespace() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process:   \n  Indented reasoning  \n  Here's my response:   Final result  ";
@@ -286,7 +286,7 @@ mod tests {
         assert_eq!(result.normal_text, "   Final result  ");
     }
 
-    #[test]
+    #[test] // CASE.21 — token case sensitivity
     fn test_case_sensitive_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "here's my thought process: lowercase. here's my response: answer.";
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.10
     fn test_nested_or_repeated_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: I think Here's my thought process: is confusing. Here's my response: Done.";
@@ -310,7 +310,7 @@ mod tests {
         assert_eq!(result.normal_text, " Done.");
     }
 
-    #[test]
+    #[test] // CASE.10
     fn test_detect_and_parse_reasoning_basic() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: I need to analyze this problem. Here's my response: The solution is clear.";
@@ -320,7 +320,7 @@ mod tests {
         assert_eq!(result.normal_text, "The solution is clear.");
     }
 
-    #[test]
+    #[test] // CASE.10, CASE.23
     fn test_detect_and_parse_reasoning_alternative_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here is my thought process: Different reasoning approach. Here is my response: Final conclusion.";
@@ -330,7 +330,7 @@ mod tests {
         assert_eq!(result.normal_text, "Final conclusion.");
     }
 
-    #[test]
+    #[test] // CASE.3
     fn test_detect_and_parse_reasoning_no_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "This is just normal text without special markers.";
@@ -340,7 +340,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.4, CASE.5, CASE.10
     fn test_detect_and_parse_reasoning_only_start_token() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: This reasoning has no end marker.";
@@ -350,7 +350,7 @@ mod tests {
         assert_eq!(result.normal_text, "");
     }
 
-    #[test]
+    #[test] // CASE.6, CASE.10
     fn test_detect_and_parse_reasoning_empty_sections() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process:Here's my response:";
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(result.normal_text, "");
     }
 
-    #[test]
+    #[test] // CASE.10, CASE.22
     fn test_detect_and_parse_reasoning_whitespace_handling() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process:   \n\tSpaced reasoning\n   Here's my response:  \n  Spaced response\n";
@@ -370,7 +370,7 @@ mod tests {
         assert_eq!(result.normal_text, "Spaced response");
     }
 
-    #[test]
+    #[test] // CASE.10, CASE.23
     fn test_detect_and_parse_reasoning_multiple_end_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: Thinking about Here's my response: in the middle. Here's my response: Real end.";
@@ -383,7 +383,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.21
     fn test_detect_and_parse_reasoning_case_sensitivity() {
         let mut parser = GraniteReasoningParser::new();
         let text =
@@ -394,7 +394,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.10, CASE.23
     fn test_detect_and_parse_reasoning_mixed_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: First reasoning. Here is my response: Mixed token response.";
@@ -404,7 +404,7 @@ mod tests {
         assert_eq!(result.normal_text, "Mixed token response.");
     }
 
-    #[test]
+    #[test] // CASE.10
     fn test_detect_and_parse_reasoning_long_content() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: This is a very long reasoning section that spans multiple sentences. I need to consider various factors. The analysis requires careful thought. Here's my response: After all that thinking, here is the comprehensive answer with multiple parts and detailed explanation.";

--- a/lib/parsers/src/reasoning/minimax_append_think_parser.rs
+++ b/lib/parsers/src/reasoning/minimax_append_think_parser.rs
@@ -69,7 +69,7 @@ impl ReasoningParser for MiniMaxAppendThinkParser {
 mod tests {
     use super::*;
 
-    #[test]
+    #[test] // CASE.10 — minimax inline-reasoning
     fn test_detect_and_parse_prepends_think_all_as_normal_text() {
         let mut parser = MiniMaxAppendThinkParser::new();
         let result = parser.detect_and_parse_reasoning("reasoning content here", &[]);
@@ -78,7 +78,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.10 — minimax inline-reasoning
     fn test_detect_and_parse_with_end_token_is_still_normal_text() {
         let mut parser = MiniMaxAppendThinkParser::new();
         let result =
@@ -92,7 +92,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.10
     fn test_streaming_first_chunk_gets_prefix_rest_pass_through() {
         let mut parser = MiniMaxAppendThinkParser::new();
 
@@ -110,7 +110,7 @@ mod tests {
         assert_eq!(r3.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.13 — minimax leaves tool-call shape inline
     fn test_streaming_bare_json_tool_call_is_normal_text() {
         // Regression: under SGLang guided decoding the model emits a bare
         // JSON array with no `</think>`. The parser must not capture it as
@@ -128,7 +128,7 @@ mod tests {
         assert_eq!(r.reasoning_text, "");
     }
 
-    #[test]
+    #[test] // CASE.9, CASE.13 — minimax inline-reasoning
     fn test_streaming_tool_call_after_reasoning_is_all_normal_text() {
         let mut parser = MiniMaxAppendThinkParser::new();
 

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -266,7 +266,7 @@ impl ReasoningParserType {
 mod tests {
     use super::*;
 
-    #[test]
+    #[test] // CASE.20 — registry helper
     fn test_get_available_reasoning_parsers() {
         let parsers = get_available_reasoning_parsers();
         assert!(!parsers.is_empty());
@@ -296,7 +296,7 @@ mod tests {
     }
     /// `CASE.10` — reasoning-only (V4 `<think>`/`</think>`).
 
-    #[test]
+    #[test] // CASE.10
     fn test_deepseek_v4_detect_and_parse() {
         for parser_name in ["deepseek_v4", "deepseek-v4", "deepseekv4"] {
             let mut parser = ReasoningParserType::get_reasoning_parser_from_name(parser_name);
@@ -307,7 +307,7 @@ mod tests {
     }
     /// `CASE.3` / `CASE.10` — no reasoning tags ⇒ no `reasoning_content`.
 
-    #[test]
+    #[test] // CASE.3, CASE.10
     fn test_deepseek_v4_no_forced_reasoning_without_tags() {
         let mut parser = ReasoningParserType::get_reasoning_parser_from_name("deepseek_v4");
         let result = parser.detect_and_parse_reasoning("answer only", &[]);
@@ -316,7 +316,7 @@ mod tests {
     }
     /// `CASE.8` — streaming reasoning parse (chunked).
 
-    #[test]
+    #[test] // CASE.8, CASE.10
     fn test_deepseek_v4_streaming() {
         let mut parser = ReasoningParserType::get_reasoning_parser_from_name("deepseek_v4");
 
@@ -334,7 +334,7 @@ mod tests {
         assert_eq!(normal, "answer");
     }
 
-    #[test]
+    #[test] // CASE.10
     fn test_kimi_k25_detect_and_parse() {
         // (description, input, expected_reasoning, expected_normal)
         let cases = [
@@ -375,7 +375,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.10
     fn test_kimi_k25_streaming_force_reasoning() {
         // Streaming: force_reasoning means tokens before <think> are treated as reasoning
         let mut parser = ReasoningParserType::KimiK25.get_reasoning_parser();
@@ -396,7 +396,7 @@ mod tests {
         assert_eq!(r3.normal_text, "Hello!");
     }
 
-    #[test]
+    #[test] // CASE.8, CASE.10
     fn test_kimi_k25_streaming() {
         // (description, tokens, expected_reasoning, expected_content)
         let cases: Vec<(&str, &[&str], &str, &str)> = vec![
@@ -439,7 +439,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[test] // CASE.20 — registry lookup
     fn test_kimi_k25_parser_lookup_by_name() {
         // Verify the parser can be looked up by name
         let mut parser = ReasoningParserType::get_reasoning_parser_from_name("kimi_k25");
@@ -448,7 +448,7 @@ mod tests {
         assert_eq!(result.normal_text, "answer");
     }
 
-    #[test]
+    #[test] // CASE.23 — token-spelling differences across model variants
     fn test_kimi_vs_kimi_k25_different_tags() {
         // Kimi (original) uses ◁think▷/◁/think▷, KimiK25 uses <think>/</think>
         let mut kimi = ReasoningParserType::Kimi.get_reasoning_parser();
@@ -469,7 +469,7 @@ mod tests {
     // Simulates the OpenAI path where the preprocessor detects prompt-injected
     // reasoning and calls set_in_reasoning(true). The parser should correctly
     // transition from reasoning to content when </think> arrives.
-    #[test]
+    #[test] // CASE.8, CASE.10
     fn test_nemotron_streaming_with_set_in_reasoning() {
         let mut parser = ReasoningParserType::DeepseekR1.get_reasoning_parser();
         parser.set_in_reasoning(true); // OpenAI path calls this
@@ -492,7 +492,7 @@ mod tests {
     // set_in_reasoning is never called. The parser still starts in reasoning
     // mode (force_reasoning=true) but stripped_think_start=false. The </think>
     // boundary must still be detected correctly.
-    #[test]
+    #[test] // CASE.8, CASE.10
     fn test_nemotron_streaming_force_reasoning_without_set_in_reasoning() {
         // DeepseekR1 has force_reasoning=true but we do NOT call set_in_reasoning
         let mut parser = ReasoningParserType::DeepseekR1.get_reasoning_parser();
@@ -515,7 +515,7 @@ mod tests {
     // is false, the parser's prefix-check could buffer '<' and interfere with
     // </think> detection. This test verifies the boundary is detected even when
     // </think> arrives as individual characters.
-    #[test]
+    #[test] // CASE.8, CASE.20
     fn test_nemotron_streaming_split_end_think_tokens() {
         let mut parser = ReasoningParserType::DeepseekR1.get_reasoning_parser();
         parser.set_in_reasoning(true);

--- a/lib/parsers/src/tool_calling/dsml/parser.rs
+++ b/lib/parsers/src/tool_calling/dsml/parser.rs
@@ -274,7 +274,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start() {
         let config = get_test_config();
         assert!(detect_tool_call_start_dsml(
@@ -290,7 +290,7 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
-    // DeepSeek V4 coverage (see lib/parsers/TESTING.md for CASE.* taxonomy).
+    // DeepSeek V4 coverage (see lib/parsers/TEST_CASES.md for CASE.* taxonomy).
     //
     // Covered by the V4 tests below (or by a shared DSML generic test):
     //   - CASE.1   single-call            (parsers.rs :: test_deepseek_v4_single_tool_call)
@@ -341,7 +341,7 @@ mod tests {
     // -------------------------------------------------------------------
 
     /// `CASE.8` — streaming start-token detection (V4 variant).
-    #[test]
+    #[test] // CASE.20, CASE.23 — V4 token variant
     fn test_detect_tool_call_start_v4() {
         let config = get_v4_test_config();
         assert!(detect_tool_call_start_dsml("<｜DSML｜tool_calls>", &config));
@@ -357,7 +357,7 @@ mod tests {
         assert!(!detect_tool_call_start_dsml("no tool call here", &config));
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_find_tool_call_end_position() {
         let config = get_test_config();
         let text = "<｜DSML｜function_calls><｜DSML｜invoke name=\"test\"></｜DSML｜invoke></｜DSML｜function_calls>more";
@@ -366,7 +366,7 @@ mod tests {
     }
 
     /// `CASE.8` — streaming end-position lookup (V4 variant).
-    #[test]
+    #[test] // CASE.20, CASE.23 — V4 token variant
     fn test_find_tool_call_end_position_v4() {
         let config = get_v4_test_config();
         let text = "<｜DSML｜tool_calls><｜DSML｜invoke name=\"test\"></｜DSML｜invoke></｜DSML｜tool_calls>more";
@@ -374,7 +374,7 @@ mod tests {
         assert_eq!(&text[pos..], "more");
     }
 
-    #[test]
+    #[test] // CASE.1
     fn test_parse_single_tool_call_string_param() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="get_weather">
@@ -402,7 +402,7 @@ mod tests {
         assert_eq!(args["location"], "San Francisco");
     }
 
-    #[test]
+    #[test] // CASE.1, CASE.7
     fn test_parse_single_tool_call_mixed_params() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="search">
@@ -421,7 +421,7 @@ mod tests {
         assert_eq!(args["topn"], 10);
     }
 
-    #[test]
+    #[test] // CASE.2
     fn test_parse_multiple_tool_calls() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="get_weather">
@@ -448,7 +448,7 @@ mod tests {
     }
 
     /// `CASE.2` multi-calls + `CASE.13` interleaved-text (prefix text before the block).
-    #[test]
+    #[test] // CASE.2, CASE.23 — V4 variant
     fn test_parse_deepseek_v4_multiple_tool_calls() {
         let input = r#"Let's check this. <｜DSML｜tool_calls>
 <｜DSML｜invoke name="get_favorite_tourist_spot">
@@ -478,7 +478,7 @@ mod tests {
     }
 
     /// `CASE.6` — empty args (no-parameter invoke).
-    #[test]
+    #[test] // CASE.6, CASE.23 — V4 variant
     fn test_parse_deepseek_v4_no_parameters() {
         let input = r#"<｜DSML｜tool_calls>
 <｜DSML｜invoke name="get_current_time">
@@ -495,7 +495,7 @@ mod tests {
         assert_eq!(args, serde_json::json!({}));
     }
 
-    #[test]
+    #[test] // CASE.13
     fn test_parse_with_normal_text() {
         let input = r#"Here's the result: <｜DSML｜function_calls>
 <｜DSML｜invoke name="test">
@@ -509,7 +509,7 @@ mod tests {
         assert_eq!(normal, Some("Here's the result:".to_string()));
     }
 
-    #[test]
+    #[test] // CASE.3
     fn test_parse_no_tool_calls() {
         let input = "This is just normal text without any tool calls.";
         let config = get_test_config();
@@ -518,7 +518,7 @@ mod tests {
         assert_eq!(normal, Some(input.to_string()));
     }
 
-    #[test]
+    #[test] // CASE.7
     fn test_parse_json_parameter_value() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="process">
@@ -536,7 +536,7 @@ mod tests {
         assert_eq!(args["config"]["count"], 42);
     }
 
-    #[test]
+    #[test] // CASE.7
     fn test_parse_array_parameter_value() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="process">
@@ -554,7 +554,7 @@ mod tests {
         assert_eq!(args["items"][2], 3);
     }
 
-    #[test]
+    #[test] // CASE.7
     fn test_parse_boolean_parameters() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="config">
@@ -572,7 +572,7 @@ mod tests {
         assert_eq!(args["disabled"], false);
     }
 
-    #[test]
+    #[test] // CASE.7
     fn test_parse_number_parameters() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="calculate">
@@ -592,7 +592,7 @@ mod tests {
         assert_eq!(args["negative"], -100);
     }
 
-    #[test]
+    #[test] // CASE.7
     fn test_parse_mixed_types_realistic() {
         // Realistic example based on test data
         let input = r#"<｜DSML｜function_calls>
@@ -614,7 +614,7 @@ mod tests {
         assert_eq!(args["source"], "web");
     }
 
-    #[test]
+    #[test] // CASE.7
     fn test_parse_nested_object_parameter() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="configure">
@@ -634,7 +634,7 @@ mod tests {
         assert_eq!(args["settings"]["endpoints"][0], "a");
     }
 
-    #[test]
+    #[test] // CASE.7
     fn test_parse_empty_string_parameter() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="test">
@@ -650,7 +650,7 @@ mod tests {
         assert_eq!(args["empty"], "");
     }
 
-    #[test]
+    #[test] // CASE.7, CASE.14
     fn test_parse_null_parameter() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="test">
@@ -683,7 +683,7 @@ mod tests {
     /// parser gained end-token recovery; see
     /// `kimi_k2_parser.rs::test_parse_malformed_no_section_end` for the
     /// post-fix recovery pattern.
-    #[test]
+    #[test] // CASE.5, CASE.23 — V4 variant
     fn test_parse_deepseek_v4_missing_end_token() {
         // Start fence + complete invoke, but no </｜DSML｜tool_calls>.
         let input = "<｜DSML｜tool_calls>\n\
@@ -713,7 +713,7 @@ mod tests {
     /// absence of the closing fence prevents the block regex from matching.
     /// All calls are dropped. If the parser ever gains partial-block
     /// recovery, this test will fail and force an intentional update.
-    #[test]
+    #[test] // CASE.2, CASE.5, CASE.23
     fn test_parse_deepseek_v4_missing_end_token_multiple_calls() {
         let input = "<｜DSML｜tool_calls>\n\
 <｜DSML｜invoke name=\"a\">\n\
@@ -738,7 +738,7 @@ mod tests {
     /// (unwrap_or_else → Value::String). Pin the fallback so removing it
     /// (which would cause the whole call to 500 on ragged-edge JSON) is a
     /// deliberate change.
-    #[test]
+    #[test] // CASE.4, CASE.23
     fn test_parse_deepseek_v4_malformed_json_value_falls_back_to_string() {
         let input = "<｜DSML｜tool_calls>\n\
 <｜DSML｜invoke name=\"test\">\n\
@@ -762,7 +762,7 @@ mod tests {
     /// `CASE.4` — malformed invoke (missing `</｜DSML｜invoke>` but block fences
     /// intact). The invoke regex requires its own close tag, so the call is
     /// silently dropped. Pin the behavior.
-    #[test]
+    #[test] // CASE.4, CASE.23
     fn test_parse_deepseek_v4_missing_invoke_close_drops_call() {
         let input = "<｜DSML｜tool_calls>\n\
 <｜DSML｜invoke name=\"test\">\n\

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -210,7 +210,7 @@ mod tests {
         (call.function.name, args)
     }
 
-    #[tokio::test]
+    #[tokio::test] // CASE.1, CASE.19
     async fn test_parse_tool_calls_harmony_complete_basic() {
         let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"format":"celsius","location":"San Francisco"}"#;
         let (tool_calls, normal_content) =
@@ -224,7 +224,7 @@ mod tests {
         assert_eq!(args["format"], "celsius");
     }
 
-    #[tokio::test]
+    #[tokio::test] // CASE.4, CASE.19
     async fn test_parse_tools_harmony_without_start_token() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|message|>{"location":"San Francisco"}<|call|>"#;
         let (tool_calls, normal_content) =
@@ -235,7 +235,7 @@ mod tests {
         assert_eq!(tool_calls.len(), 0);
     }
 
-    #[tokio::test]
+    #[tokio::test] // CASE.7, CASE.9, CASE.19
     async fn test_parse_tool_calls_harmony_with_multi_args() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco", "unit":"fahrenheit"}<|call|>"#;
         let (tool_calls, normal_content) =
@@ -253,7 +253,7 @@ mod tests {
         assert_eq!(args["unit"], "fahrenheit");
     }
 
-    #[tokio::test]
+    #[tokio::test] // CASE.9, CASE.13, CASE.19
     async fn test_parse_tool_calls_harmony_with_normal_text() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|>"#;
         let (tool_calls, normal_content) =
@@ -270,7 +270,7 @@ mod tests {
         assert_eq!(args["location"], "San Francisco");
     }
 
-    #[tokio::test]
+    #[tokio::test] // CASE.4, CASE.19
     async fn test_parse_tool_calls_harmony_without_call_token() {
         let text = r#"<|channel|>analysis<|message|>We need to call get_weather function. The user asks "What's the weather like in San Francisco in Celsius?" So location: "San Francisco, CA" unit: "celsius". Let's call function.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"San Francisco, CA","unit":"celsius"}"#;
         let (tool_calls, normal_content) =
@@ -290,7 +290,7 @@ mod tests {
 mod detect_parser_tests {
     use super::*;
 
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start_harmony_chunk_with_tool_call_start_token() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json"#;
         let config = JsonParserConfig {
@@ -302,7 +302,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start_harmony_chunk_without_tool_call_start_token() {
         // This is a warkaround for now. Right now everything is treated as tool call start token.
         // We need to improve this in the future.
@@ -316,7 +316,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20, CASE.8
     fn test_detect_tool_call_start_harmony_partial_tokens() {
         // Test partial token detection for streaming scenarios
         let config = JsonParserConfig {

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -391,7 +391,7 @@ pub fn detect_tool_call_start_basic_json(chunk: &str, config: &JsonParserConfig)
 mod detect_parser_tests {
     use super::*;
 
-    #[test]
+    #[test] // CASE.20
     fn detect_tool_call_start_basic_json_chunk_with_tool_call_start_token_hermes() {
         let text =
             r#"<tool_call>{"name": "search", "parameters": { "query": "rust" } }</tool_call>"#;
@@ -404,7 +404,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn detect_tool_call_start_basic_json_chunk_without_tool_call_start_token() {
         let text = r#"{"name": "search", "parameters": { "query": "rust" } }"#;
         let config = JsonParserConfig {
@@ -416,7 +416,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20, CASE.13
     fn detect_tool_call_start_basic_json_chunk_without_tool_call_start_token_with_normal_text() {
         let text = r#"Here it is {"name": "#;
         let config = JsonParserConfig {
@@ -428,7 +428,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn detect_tool_call_start_basic_json_chunk_with_square_brackets() {
         // These kind of false positives are expected when calling this function for stream=True
         let text = r#"Here it is [{"name": "search","#;
@@ -441,7 +441,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn detect_tool_call_start_basic_json_chunk_false_positive() {
         // These kind of false positives are expected when calling this function for stream=True
         let text = r#"Here it is { Whats up"#;
@@ -454,7 +454,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn detect_tool_call_start_basic_json_chunk_with_tool_call_start_token_nemotron_deci() {
         let text =
             r#"<TOOLCALL>[{"name": "search", "parameters": { "query": "rust" } }]</TOOLCALL>"#;
@@ -467,7 +467,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn detect_tool_call_start_basic_json_chunk_with_lllama3_json_token() {
         let text = r#"<|python_tag|>{ "name": }"#;
         let config = JsonParserConfig {
@@ -479,7 +479,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn detect_tool_call_start_basic_json_chunk_mistral_token() {
         let text = r#"Hello Yo ! [TOOL_CALLS]{"name": "search", "#;
         let config = JsonParserConfig {
@@ -491,7 +491,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn detect_tool_call_start_basic_json_chunk_phi4_token() {
         let text = r#"functools{"name": "search", "#;
         let config = JsonParserConfig {
@@ -503,7 +503,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20, CASE.8
     fn detect_tool_call_start_basic_json_chunk_phi4_partial_token_fun() {
         // Test the streaming scenario where "fun" arrives first
         let text = r#"fun"#;
@@ -519,7 +519,7 @@ mod detect_parser_tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.20, CASE.8
     fn detect_tool_call_start_basic_json_chunk_phi4_partial_token_func() {
         let text = r#"func"#;
         let config = JsonParserConfig {
@@ -534,7 +534,7 @@ mod detect_parser_tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.20, CASE.8
     fn detect_tool_call_start_basic_json_chunk_phi4_partial_token_f() {
         let text = r#"f"#;
         let config = JsonParserConfig {
@@ -549,7 +549,7 @@ mod detect_parser_tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.20, CASE.8
     fn detect_tool_call_start_basic_json_chunk_phi4_partial_with_prefix() {
         // Test case where text ends with a partial token (more realistic streaming scenario)
         let text = r#"Hello fun"#;
@@ -565,7 +565,7 @@ mod detect_parser_tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.20
     fn detect_tool_call_start_basic_json_chunk_phi4_avoid_false_positive() {
         // Test to ensure we don't get false positives for unrelated text
         let text = r#"funny joke"#;
@@ -581,7 +581,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn detect_tool_call_start_basic_json_chunk_phi4_no_match() {
         let text = r#"hello world"#;
         let config = JsonParserConfig {

--- a/lib/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
+++ b/lib/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
@@ -270,7 +270,7 @@ mod tests {
         (call.function.name, args)
     }
 
-    #[test]
+    #[test] // CASE.2
     fn test_parse_tool_calls_deepseek_v3_1_basic() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Paris"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {
@@ -288,7 +288,7 @@ mod tests {
         assert_eq!(args["location"], "Paris");
     }
 
-    #[test]
+    #[test] // CASE.13
     fn test_parse_tool_calls_deepseek_v3_1_with_normal_text() {
         let text = r#"The following tool call retrieves weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "New York"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {
@@ -306,7 +306,7 @@ mod tests {
         assert_eq!(args["location"], "New York");
     }
 
-    #[test]
+    #[test] // CASE.4 — recovery from missing start
     fn test_parse_tool_calls_deepseek_v3_1_without_tool_call_start_token() {
         let text = r#"<｜tool▁call▁begin｜>get_current_weather宽带}{location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {
@@ -318,7 +318,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.7
     fn test_parse_tool_calls_deepseek_v3_1_with_multi_tool_calls_with_multiple_args() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Berlin", "units": "metric"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather_forecast<｜tool▁sep｜>{"location": "Berlin", "days": 7, "units": "imperial"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_air_quality<｜tool▁sep｜>{"location": "Berlin", "radius": 50}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {
@@ -343,7 +343,7 @@ mod tests {
         assert_eq!(args["radius"], 50);
     }
 
-    #[test]
+    #[test] // CASE.4
     fn test_parse_tool_calls_deepseek_v3_1_with_invalid_json() {
         // Everything is normal text in case of invalid json
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather}{location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
@@ -356,7 +356,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.13
     fn test_parse_tool_calls_deepseek_v3_1_with_multi_tool_calls_with_normal_text() {
         // Everything is normal text in case of invalid json
         let text = r#"The following tool calls retrieve weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather宽带}{location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather_forecast宽带}{location": "Berlin", "days": 7, "units": "imperial"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_air_quality宽带}{location": "Berlin", "radius": 50}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
@@ -369,7 +369,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
-    #[test]
+    #[test] // CASE.7, CASE.22
     fn test_parse_tool_calls_deepseek_v3_1_with_multiline_json() {
         let text = r#"I'll help you understand this codebase. Let me start by exploring the structure and key
   files to provide you with a comprehensive
@@ -434,7 +434,7 @@ mod tests {
 mod detect_parser_tests {
     use super::super::config::ToolCallConfig;
     use super::*;
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start_deepseek_v3_1_chunk_with_tool_call_start_token() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather宽带}"#;
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {
@@ -445,7 +445,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start_deepseek_v3_1_chunk_without_tool_call_start_token() {
         let text = r#"<｜tool▁call▁begin｜>get_current_weather宽带}"#;
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {
@@ -456,7 +456,7 @@ mod detect_parser_tests {
         assert!(!result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start_deepseek_v3_1_chunk_with_tool_call_start_token_in_middle() {
         let text = r#"The following tool calls retrieve weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather宽带}"#;
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {
@@ -467,7 +467,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20, CASE.8
     fn test_detect_tool_call_start_deepseek_v3_1_partial_tokens() {
         // Test partial token detection for streaming scenarios with unicode characters
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {

--- a/lib/parsers/src/tool_calling/json/deepseek_v3_parser.rs
+++ b/lib/parsers/src/tool_calling/json/deepseek_v3_parser.rs
@@ -274,7 +274,7 @@ mod tests {
         (call.function.name, args)
     }
 
-    #[test]
+    #[test] // CASE.2
     fn test_parse_tool_calls_deepseek_v3_basic() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
 ```json
@@ -298,7 +298,7 @@ mod tests {
         assert_eq!(args["location"], "Paris");
     }
 
-    #[test]
+    #[test] // CASE.13
     fn test_parse_tool_calls_deepseek_v3_with_normal_text() {
         let text = r#"The following tool call retrieves weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
 ```json
@@ -319,7 +319,7 @@ mod tests {
         assert_eq!(args["location"], "New York");
     }
 
-    #[test]
+    #[test] // CASE.4 — recovery from missing start
     fn test_parse_tool_calls_deepseek_v3_without_tool_call_start_token() {
         let text = r#"<｜tool▁call▁begin｜>function宽带}{location": "HongKong"}
 ```json
@@ -334,7 +334,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.7
     fn test_parse_tool_calls_deepseek_v3_with_multi_tool_calls_with_multiple_args() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
 ```json
@@ -368,7 +368,7 @@ mod tests {
         assert_eq!(args["radius"], 50);
     }
 
-    #[test]
+    #[test] // CASE.4
     fn test_parse_tool_calls_deepseek_v3_with_invalid_json() {
         // Everything is normal text in case of invalid json
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather}{location": "HongKong"}
@@ -384,7 +384,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.13
     fn test_parse_tool_calls_deepseek_v3_with_multi_tool_calls_with_normal_text() {
         // Everything is normal text in case of invalid json
         let text = r#"The following tool calls retrieve weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function宽带}{location": "HongKong"}
@@ -406,7 +406,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
-    #[test]
+    #[test] // CASE.7, CASE.22
     fn test_parse_tool_calls_deepseek_v3_with_multiline_json() {
         let text = r#"I'll help you understand this Xiaohongshu codebase. Let me start by exploring the structure
   and key files to provide you with a comprehensive
@@ -474,7 +474,7 @@ mod tests {
 mod detect_parser_tests {
     use super::super::config::ToolCallConfig;
     use super::*;
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start_deepseek_v3_chunk_with_tool_call_start_token() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function宽带}"#;
         let config = match ToolCallConfig::deepseek_v3().parser_config {
@@ -485,7 +485,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start_deepseek_v3_chunk_without_tool_call_start_token() {
         let text = r#"<｜tool▁call▁begin｜>function宽带}"#;
         let config = match ToolCallConfig::deepseek_v3().parser_config {
@@ -496,7 +496,7 @@ mod detect_parser_tests {
         assert!(!result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start_deepseek_v3_chunk_with_tool_call_start_token_in_middle() {
         let text = r#"The following tool calls retrieve weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function宽带}"#;
         let config = match ToolCallConfig::deepseek_v3().parser_config {
@@ -507,7 +507,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20, CASE.8
     fn test_detect_tool_call_start_deepseek_v3_partial_tokens() {
         // Test partial token detection for streaming scenarios with unicode characters
         let config = match ToolCallConfig::deepseek_v3().parser_config {

--- a/lib/parsers/src/tool_calling/json/mod.rs
+++ b/lib/parsers/src/tool_calling/json/mod.rs
@@ -101,7 +101,7 @@ mod tests {
     /// all be captured by find_tool_call_end_position_json so that the jail passes the
     /// entire group to the parser rather than emitting the second (and later) calls
     /// as raw trailing text.
-    #[test]
+    #[test] // CASE.2, CASE.20
     fn test_find_tool_call_end_position_parallel_calls() {
         let config = JsonParserConfig {
             tool_call_start_tokens: vec!["<tool_call>".to_string()],

--- a/lib/parsers/src/tool_calling/pythonic/pythonic_parser.rs
+++ b/lib/parsers/src/tool_calling/pythonic/pythonic_parser.rs
@@ -208,7 +208,7 @@ mod tests {
         (call.function.name, args)
     }
 
-    #[test]
+    #[test] // CASE.20 — helper
     fn test_strip_text() {
         let message = "Hello, world!";
         let stripped = strip_text(message);
@@ -227,7 +227,7 @@ mod tests {
         assert_eq!(stripped, "foo(a=1, b=2)");
     }
 
-    #[test]
+    #[test] // CASE.20 — helper
     fn test_get_regex_matches_simple_case() {
         // Simple Case
         let message = "[foo(a=1, b=2), bar(x=3)]";
@@ -236,7 +236,7 @@ mod tests {
         assert_eq!(matches[0], "[foo(a=1, b=2), bar(x=3)]");
     }
 
-    #[test]
+    #[test] // CASE.20 — helper
     fn test_get_regex_matches_text_before_and_after() {
         // Spacing in arg and value and text before and after
         let message = "Hey yo ! [foo(a=1, b=2), bar(x= 3)] Hey yo";
@@ -245,7 +245,7 @@ mod tests {
         assert_eq!(matches[0], "[foo(a=1, b=2), bar(x= 3)]");
     }
 
-    #[test]
+    #[test] // CASE.20, CASE.7 — helper
     fn test_get_regex_matches_new_line_in_arg_and_value() {
         // New Line in Arg and value
         let message = "Hey \n yo ! [foo(a=1,b=2), \n bar(x=3)] Hey yo";
@@ -254,7 +254,7 @@ mod tests {
         assert_eq!(matches[0], "[foo(a=1,b=2), \n bar(x=3)]");
     }
 
-    #[test]
+    #[test] // CASE.20 — helper
     fn test_get_regex_matches_no_call() {
         // No Call
         let message = "Hey yo !";
@@ -262,7 +262,7 @@ mod tests {
         assert_eq!(matches.len(), 0);
     }
 
-    #[test]
+    #[test] // CASE.2
     fn test_parse_tool_call_parse_pythonic_basic() {
         let message = "[foo(a=1, b=2), bar(x=3)]";
         let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
@@ -278,7 +278,7 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.13
     fn test_parse_tool_call_parse_pythonic_with_text() {
         let message = "Hey yo ! [foo(a=1, b=2), bar(x=3)] Hey yo";
         let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
@@ -294,7 +294,7 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.13, CASE.22
     fn test_parse_tool_call_parse_pythonic_with_text_and_new_line() {
         let message = "Hey \n yo ! [foo(a=1, b=2), bar(x=3)] Hey yo";
         let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
@@ -310,7 +310,7 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
-    #[test]
+    #[test] // CASE.3
     fn test_parse_tool_call_parse_pythonic_with_no_calls() {
         let message = "Hey \n yo !";
         let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
@@ -319,7 +319,7 @@ mod tests {
         assert_eq!(result.len(), 0)
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.23
     fn test_parse_tool_call_parse_pythonic_with_python_tags() {
         let message = "<|python_start|>[foo(a=1, b=2), bar(x=3)]<|python_end|>";
         let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
@@ -335,7 +335,7 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
-    #[test]
+    #[test] // CASE.7
     fn test_parse_tool_call_parse_pythonic_with_list_arg_values() {
         let message = "[foo(a=[1, 2, 3], b=2), bar(x=[3, 4, 5])]";
         let (result, _) = try_tool_call_parse_pythonic(message, None).unwrap();
@@ -350,7 +350,7 @@ mod tests {
         assert_eq!(args["x"], json!([3, 4, 5]));
     }
 
-    #[test]
+    #[test] // CASE.7
     fn test_parse_tool_call_parse_pythonic_with_dict_arg_values() {
         let message = "[foo(a={'a': 1, 'b': 2}, b=2), bar(x={'x': 3, 'y': {'e': 'f'}})]";
         let (result, _) = try_tool_call_parse_pythonic(message, None).unwrap();
@@ -370,28 +370,28 @@ mod tests {
 mod detect_parser_tests {
     use super::*;
 
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start_pythonic_chunk_with_tool_call_start_token() {
         let text = r#"[foo(a=1, b=2), bar(x=3)]"#;
         let result = detect_tool_call_start_pythonic(text);
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start_pythonic_chunk_without_tool_call_start_token() {
         let text = r#"foo(a=1, b=2)"#;
         let result = detect_tool_call_start_pythonic(text);
         assert!(!result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start_pythonic_chunk_with_tool_call_start_token_in_middle() {
         let text = r#"information: [foo(a=1, b=2), bar(x=3)]"#;
         let result = detect_tool_call_start_pythonic(text);
         assert!(result);
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start_pythonic_false_positive() {
         // Since we detect just "[" as tool call start token, this will be a false positive
         let text = r#"Hey [ There is one tool call here . foo(a=1, b=2)"#;

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -288,7 +288,7 @@ mod tests {
         Glm47ParserConfig::default()
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start() {
         let config = get_test_config();
 
@@ -306,7 +306,7 @@ mod tests {
         assert!(!detect_tool_call_start_glm47("Just normal text", &config));
     }
 
-    #[test]
+    #[test] // CASE.1
     fn test_parse_simple_tool_call() {
         let config = get_test_config();
         let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>San Francisco</arg_value></tool_call>";
@@ -325,7 +325,7 @@ mod tests {
         assert_eq!(normal_text, Some("".to_string()));
     }
 
-    #[test]
+    #[test] // CASE.1, CASE.7
     fn test_parse_tool_call_with_multiple_args() {
         let config = get_test_config();
         let message = "<tool_call>book_flight<arg_key>from</arg_key><arg_value>NYC</arg_value><arg_key>to</arg_key><arg_value>LAX</arg_value><arg_key>date</arg_key><arg_value>2026-03-15</arg_value></tool_call>";
@@ -342,7 +342,7 @@ mod tests {
         assert_eq!(args.get("date").unwrap().as_str().unwrap(), "2026-03-15");
     }
 
-    #[test]
+    #[test] // CASE.7
     fn test_parse_tool_call_with_json_value() {
         let config = get_test_config();
         let message = r#"<tool_call>search<arg_key>filters</arg_key><arg_value>{"category": "books", "price_max": 50}</arg_value></tool_call>"#;
@@ -358,7 +358,7 @@ mod tests {
         assert!(filters.is_object());
     }
 
-    #[test]
+    #[test] // CASE.2
     fn test_parse_multiple_tool_calls() {
         let config = get_test_config();
         let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>timezone</arg_key><arg_value>EST</arg_value></tool_call>";
@@ -370,7 +370,7 @@ mod tests {
         assert_eq!(calls[1].function.name, "get_time");
     }
 
-    #[test]
+    #[test] // CASE.13
     fn test_parse_with_normal_text() {
         let config = get_test_config();
         let message = "I'll check the weather for you. <tool_call>get_weather<arg_key>location</arg_key><arg_value>Paris</arg_value></tool_call>";
@@ -385,7 +385,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.6
     fn test_parse_tool_call_no_args() {
         let config = get_test_config();
         let message = "<tool_call>get_current_time</tool_call>";
@@ -400,7 +400,7 @@ mod tests {
         assert!(args.is_empty());
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_find_tool_call_end_position() {
         let config = get_test_config();
         let chunk =
@@ -413,7 +413,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.7, CASE.22
     fn test_parse_multiline_arg_value() {
         let config = get_test_config();
         let message = "<tool_call>write_file<arg_key>path</arg_key><arg_value>/tmp/hello.py</arg_value><arg_key>content</arg_key><arg_value>#!/usr/bin/env python3\nprint(\"Hello, World!\")\n</arg_value></tool_call>";
@@ -434,7 +434,7 @@ mod tests {
         assert!(content.contains("print(\"Hello, World!\")"));
     }
 
-    #[test]
+    #[test] // CASE.4
     fn test_malformed_tool_call() {
         let config = get_test_config();
 
@@ -447,7 +447,7 @@ mod tests {
         assert_eq!(calls.len(), 0);
     }
 
-    #[test]
+    #[test] // CASE.4, CASE.13
     fn test_unparseable_block_preserved_as_normal_text() {
         let config = get_test_config();
         let tools = vec![ToolDefinition {
@@ -469,7 +469,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.17
     fn test_xml_entity_decoding() {
         let config = get_test_config();
         let message = r#"<tool_call>write_file<arg_key>content</arg_key><arg_value>x &lt; y &amp;&amp; y &gt; z</arg_value></tool_call>"#;
@@ -485,7 +485,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.18
     fn test_type_coercion_with_schema() {
         let config = get_test_config();
         let tools = vec![ToolDefinition {
@@ -519,7 +519,7 @@ mod tests {
         assert_eq!(args.get("label").unwrap().as_str().unwrap(), "warm");
     }
 
-    #[test]
+    #[test] // CASE.18
     fn test_type_coercion_array_comma_separated() {
         let config = get_test_config();
         let tools = vec![ToolDefinition {
@@ -545,7 +545,7 @@ mod tests {
         assert_eq!(tags[2].as_str().unwrap(), "go");
     }
 
-    #[test]
+    #[test] // CASE.18
     fn test_type_coercion_array_json() {
         let config = get_test_config();
         let tools = vec![ToolDefinition {
@@ -569,7 +569,7 @@ mod tests {
         assert_eq!(ids[0].as_i64().unwrap(), 1);
     }
 
-    #[test]
+    #[test] // CASE.18
     fn test_type_coercion_falls_back_to_string() {
         let config = get_test_config();
         let tools = vec![ToolDefinition {

--- a/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -307,7 +307,7 @@ mod tests {
         KimiK2ParserConfig::default()
     }
 
-    #[test]
+    #[test] // CASE.20 — detection helper
     fn test_detect_tool_call_start() {
         let config = default_config();
         assert!(detect_tool_call_start_kimi_k2(
@@ -329,7 +329,7 @@ mod tests {
         assert!(!detect_tool_call_start_kimi_k2("toolcall", &config));
     }
 
-    #[test]
+    #[test] // CASE.20 — detection helper
     fn test_find_tool_call_end_position() {
         let config = default_config();
         let text = "<|tool_calls_section_begin|><|tool_call_begin|>functions.test:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>more text";
@@ -342,7 +342,7 @@ mod tests {
         assert_eq!(pos, None, "should return None when section_end is missing");
     }
 
-    #[test]
+    #[test] // CASE.1
     fn test_parse_simple_tool_call() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -356,7 +356,7 @@ mod tests {
         assert_eq!(args["location"], "NYC");
     }
 
-    #[test]
+    #[test] // CASE.1, CASE.7
     fn test_parse_multiple_args() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"San Francisco, CA","unit":"fahrenheit"}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -370,7 +370,7 @@ mod tests {
         assert_eq!(args["unit"], "fahrenheit");
     }
 
-    #[test]
+    #[test] // CASE.2
     fn test_parse_multiple_tool_calls() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -387,7 +387,7 @@ mod tests {
         assert_eq!(args1["timezone"], "EST");
     }
 
-    #[test]
+    #[test] // CASE.13
     fn test_parse_with_normal_text() {
         let config = default_config();
         let input = r#"I'll help you with that. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|> Let me check."#;
@@ -401,7 +401,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test] // CASE.6
     fn test_parse_no_arg_call() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_current_time:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -414,7 +414,7 @@ mod tests {
         assert!(args.as_object().unwrap().is_empty());
     }
 
-    #[test]
+    #[test] // CASE.3
     fn test_parse_no_tool_calls() {
         let config = default_config();
         let input = "This is just normal text without any tool calls.";
@@ -424,7 +424,7 @@ mod tests {
         assert_eq!(normal, Some(input.to_string()));
     }
 
-    #[test]
+    #[test] // CASE.21 — function-name conventions (`functions.X` vs bare `X`)
     fn test_parse_without_functions_prefix() {
         let config = default_config();
         // Some models may emit without the "functions." prefix
@@ -435,7 +435,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
-    #[test]
+    #[test] // CASE.1 (with declared `ToolDefinition` tools provided)
     fn test_parse_with_tool_validation() {
         let config = default_config();
         let tools = vec![ToolDefinition {
@@ -455,7 +455,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
-    #[test]
+    #[test] // CASE.5, CASE.16 (PR #8208)
     fn test_parse_malformed_no_section_end() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|>"#;
@@ -472,7 +472,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
-    #[test]
+    #[test] // CASE.4, CASE.5
     fn test_parse_truncated_mid_argument_no_section_end() {
         let config = default_config();
         // Model hit max_tokens mid-argument — no call_end, no section_end.
@@ -491,7 +491,7 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.5
     fn test_parse_multiple_calls_no_section_end() {
         let config = default_config();
         // Two complete individual tool calls, but model stopped before section_end.
@@ -507,7 +507,7 @@ mod tests {
         assert_eq!(calls[1].function.name, "get_time");
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.4, CASE.5
     fn test_parse_complete_plus_truncated_no_section_end() {
         let config = default_config();
         // First call is complete, second is truncated mid-argument.
@@ -522,7 +522,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
-    #[test]
+    #[test] // CASE.22 — whitespace tolerance
     fn test_parse_with_whitespace() {
         let config = default_config();
         let input = "<|tool_calls_section_begin|>\n<|tool_call_begin|> functions.search:0 <|tool_call_argument_begin|> {\"query\":\"rust programming\"} <|tool_call_end|>\n<|tool_calls_section_end|>";
@@ -535,7 +535,7 @@ mod tests {
         assert_eq!(args["query"], "rust programming");
     }
 
-    #[test]
+    #[test] // CASE.7
     fn test_parse_complex_json_arguments() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.process_data:0<|tool_call_argument_begin|>{"items":[1,2,3],"config":{"nested":true}}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -549,7 +549,7 @@ mod tests {
         assert_eq!(args["config"]["nested"], true);
     }
 
-    #[test]
+    #[test] // CASE.2, CASE.7
     fn test_parse_deeply_nested_json_multiple_calls() {
         let config = default_config();
         // Multiple tool calls with deeply nested JSON - stress test for regex backtracking
@@ -576,7 +576,7 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
-    #[test]
+    #[test] // CASE.20, CASE.23 — detection helper, singular section-token variant
     fn test_detect_singular_section_start() {
         let config = default_config();
         // Singular variant: <|tool_call_section_begin|> (without 's')
@@ -591,7 +591,7 @@ mod tests {
         ));
     }
 
-    #[test]
+    #[test] // CASE.23 — singular section-token variant
     fn test_parse_with_singular_section_tokens() {
         let config = default_config();
         // Use singular form: tool_call_section_begin/end (without 's')
@@ -603,7 +603,7 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
-    #[test]
+    #[test] // CASE.20, CASE.23 — detection helper, singular section-token variant
     fn test_find_end_position_singular_variant() {
         let config = default_config();
         // Singular variant end token
@@ -614,7 +614,7 @@ mod tests {
 
     // --- Tests inspired by vllm/sglang coverage gaps ---
 
-    #[test]
+    #[test] // CASE.4
     fn test_parse_invalid_json_falls_back_to_raw_string() {
         // vllm: test_extract_tool_calls_invalid_json
         // Invalid JSON in arguments should fall back to raw string, not panic
@@ -628,7 +628,7 @@ mod tests {
         assert_eq!(calls[0].function.arguments, "{invalid json here}");
     }
 
-    #[test]
+    #[test] // CASE.21 — function-name conventions (ID regex validation)
     fn test_parse_invalid_function_id_rejected_by_regex() {
         // vllm: test_extract_tool_calls_invalid_funcall
         // sglang: test_invalid_tool_call
@@ -657,7 +657,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "valid");
     }
 
-    #[test]
+    #[test] // CASE.7 — special characters in arg values
     fn test_parse_angle_brackets_in_json_arguments() {
         // vllm: angle_brackets_in_json
         // JSON values containing <tag> constructs should not confuse the parser,
@@ -675,7 +675,7 @@ mod tests {
         assert_eq!(args["format"], "html");
     }
 
-    #[test]
+    #[test] // CASE.2 — parallel calls, zero-spacing edge case
     fn test_parse_three_concatenated_calls_no_spacing() {
         // vllm: concatenated_tool_calls_bug_fix, three_concatenated_tool_calls
         // Three tool calls concatenated with zero whitespace between them
@@ -704,7 +704,7 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
-    #[test]
+    #[test] // CASE.7 — newlines in arg values
     fn test_parse_newlines_in_json_arguments() {
         // vllm: newlines_in_json
         // Multi-line formatted JSON arguments (model may emit pretty-printed JSON)
@@ -721,7 +721,7 @@ mod tests {
         assert_eq!(args["tags"], serde_json::json!(["admin", "active"]));
     }
 
-    #[test]
+    #[test] // CASE.24 — empty wrapper (start+end with no calls between)
     fn test_parse_empty_tool_section() {
         // vllm: test_empty_tool_section
         // Section begin immediately followed by section end, no tool calls inside
@@ -737,7 +737,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[rstest] // CASE.21 — function-name conventions (hyphens, double-underscores)
     #[case(
         r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.list-tasklists:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"#,
         "list-tasklists",

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -589,7 +589,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    #[test]
+    #[test] // CASE.20
     fn test_detect_tool_call_start() {
         let config = XmlParserConfig::default();
         assert!(detect_tool_call_start_xml("<tool_call>", &config));
@@ -600,7 +600,7 @@ mod tests {
         assert!(!detect_tool_call_start_xml("toolcall", &config));
     }
 
-    #[test]
+    #[test] // CASE.20
     fn test_find_tool_call_end_position() {
         let config = XmlParserConfig::default();
         let text = "<tool_call><function=test></function></tool_call>more text";
@@ -617,7 +617,7 @@ mod tests {
     /// all be captured by find_tool_call_end_position_xml so that the jail passes the
     /// entire group to extract_tool_calls rather than emitting the second (and later)
     /// calls as raw trailing text.
-    #[test]
+    #[test] // CASE.2, CASE.20
     fn test_find_tool_call_end_position_parallel_calls() {
         let config = XmlParserConfig::default();
 
@@ -658,7 +658,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[rstest] // CASE.18 — helper
     #[case(r#"{"key": "value"}"#, serde_json::json!({"key": "value"}), "JSON object")]
     #[case(r#"[1, 2, 3]"#, serde_json::json!([1, 2, 3]), "JSON array")]
     #[case("42", serde_json::json!(42), "integer")]
@@ -676,7 +676,7 @@ mod tests {
         assert_eq!(safe_parse_value(input), expected);
     }
 
-    #[rstest]
+    #[rstest] // CASE.17 — helper
     #[case("&lt;div&gt;", "<div>", "HTML tags")]
     #[case("a &amp; b", "a & b", "ampersand")]
     #[case("&quot;quoted&quot;", "\"quoted\"", "quotes")]
@@ -684,7 +684,7 @@ mod tests {
         assert_eq!(html_unescape(input), expected);
     }
 
-    #[test]
+    #[test] // CASE.1
     fn test_parse_simple_tool_call() {
         let input = r#"<tool_call>
 <function=execute_bash>
@@ -704,7 +704,7 @@ pwd && ls
         assert_eq!(args["command"], "pwd && ls");
     }
 
-    #[test]
+    #[test] // CASE.1, CASE.7
     fn test_parse_multiple_parameters() {
         let input = r#"<tool_call>
 <function=get_weather>
@@ -730,7 +730,7 @@ fahrenheit
         assert_eq!(args["unit"], "fahrenheit");
     }
 
-    #[test]
+    #[test] // CASE.13
     fn test_parse_with_normal_text() {
         let input = r#"I'll help you with that. <tool_call>
 <function=get_weather>
@@ -750,7 +750,7 @@ Dallas
         );
     }
 
-    #[test]
+    #[test] // CASE.2
     fn test_parse_multiple_tool_calls() {
         let input = r#"<tool_call>
 <function=get_weather>
@@ -778,7 +778,7 @@ Orlando
         assert_eq!(args1["city"], "Orlando");
     }
 
-    #[test]
+    #[test] // CASE.7
     fn test_parse_json_parameter_value() {
         // With schema-aware parsing, we need to provide a schema to parse JSON objects
         let tools = vec![ToolDefinition {
@@ -809,7 +809,7 @@ Orlando
         assert_eq!(args["config"]["count"], 42);
     }
 
-    #[test]
+    #[test] // CASE.3
     fn test_parse_no_tool_calls() {
         let input = "This is just normal text without any tool calls.";
         let (calls, normal) =
@@ -818,7 +818,7 @@ Orlando
         assert_eq!(normal, Some(input.to_string()));
     }
 
-    #[test]
+    #[test] // CASE.4
     fn test_parse_malformed_tool_call() {
         let input = r#"<tool_call>
 <function=incomplete>
@@ -831,7 +831,7 @@ value
         assert!(result.is_ok());
     }
 
-    #[test]
+    #[test] // CASE.4
     fn test_parse_missing_parameter_closing_tag() {
         let input = r#"<tool_call>
 <function=execute_bash>
@@ -848,7 +848,7 @@ ls -la
         assert_eq!(args["command"], "ls -la");
     }
 
-    #[test]
+    #[test] // CASE.4
     fn test_parse_missing_function_closing_tag() {
         let input = r#"<tool_call>
 <function=get_weather>
@@ -865,7 +865,7 @@ Boston
         assert_eq!(args["city"], "Boston");
     }
 
-    #[test]
+    #[test] // CASE.4
     fn test_parse_missing_both_closing_tags() {
         let input = r#"<tool_call>
 <function=run_query>
@@ -882,7 +882,7 @@ SELECT * FROM users
         assert_eq!(args["sql"], "SELECT * FROM users\n</tool_call>");
     }
 
-    #[test]
+    #[test] // CASE.4
     fn test_parse_multiple_parameters_missing_closing_tags() {
         let input = r#"<tool_call>
 <function=search>
@@ -902,7 +902,7 @@ rust programming
         assert_eq!(args["query"], "rust programming\n<parameter=limit>\n10");
     }
 
-    #[test]
+    #[test] // CASE.18
     fn test_schema_aware_type_conversion() {
         // This test matches the Python test_parse_streaming_increment_multiple_parameters
         // from the diff, showing schema-aware type conversion
@@ -972,7 +972,7 @@ rust programming
         );
     }
 
-    #[test]
+    #[test] // CASE.18
     fn test_schema_aware_type_conversion_fallback() {
         // Test that invalid values fall back to strings with warnings
         let tools = vec![ToolDefinition {
@@ -1008,7 +1008,7 @@ rust programming
         assert_eq!(args["bool_param"], false);
     }
 
-    #[test]
+    #[test] // CASE.18
     fn test_anyof_param_parsed_as_object_not_string() {
         // When a tool parameter uses "anyOf" instead of a direct "type", the value
         // should be JSON-parsed (treated as object), not double-encoded as a string.
@@ -1062,7 +1062,7 @@ rust programming
         assert_eq!(args["location"]["city"], "Paris");
     }
 
-    #[test]
+    #[test] // CASE.18
     fn test_no_schema_fallback_behavior() {
         // Without schema, behavior should match old safe_parse_value logic
         let input = r#"<tool_call>


### PR DESCRIPTION
hey guys, I'm just doing a trivial (NO CODE CHANGE) doc reorg so the docs read more clearly and the tests are categorized so we have an idea of coverage. all 389 tests still pass.

paired with DIS-1842's contract test scaffold (#8728) — that PR adds runnable cross-parser tests, this one makes existing per-parser tests greppable.
