### PR TITLE
[codex] docs: fix quick start references

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh && source $HOME/.
 # Create venv and build
 uv venv dynamo && source dynamo/bin/activate
 uv pip install pip maturin
-cd lib/bindings/python && maturin develop --uv && cd $PROJECT_ROOT
+cd lib/bindings/python && maturin develop --uv && cd "$(git rev-parse --show-toplevel)"
 uv pip install -e lib/gpu_memory_service
 uv pip install -e .
 ```

--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -99,7 +99,7 @@ docker pull nvcr.io/nvidia/ai-dynamo/snapshot-agent:1.0.2
 ### Python Wheels (PyPI)
 
 > [!TIP]
-> For detailed installation instructions, see the [Local Quick Start](https://github.com/ai-dynamo/dynamo#local-quick-start) in the README.
+> For detailed installation instructions, see the [Quick Start](https://github.com/ai-dynamo/dynamo#quick-start) in the README.
 
 ```bash
 # Install Dynamo with a specific backend (Recommended)

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -217,4 +217,4 @@ For version-specific artifact details, installation commands, and release histor
   - [dynamo-mocker](https://crates.io/crates/dynamo-mocker/) *(New in v1.0.0)*
   - [dynamo-kv-router](https://crates.io/crates/dynamo-kv-router/) *(New in v1.0.0)*
 
-Once you've confirmed that your platform and architecture are compatible, you can install **Dynamo** by following the [Local Quick Start](https://github.com/ai-dynamo/dynamo/blob/main/README.md#local-quick-start) in the README.
+Once you've confirmed that your platform and architecture are compatible, you can install **Dynamo** by following the [Quick Start](https://github.com/ai-dynamo/dynamo/blob/main/README.md#quick-start) in the README.


### PR DESCRIPTION
## Summary

- Fix stale README quick-start anchors in reference docs.
- Replace an undefined `$PROJECT_ROOT` in the README source-build snippet with `git rev-parse --show-toplevel`.

## Why

The reference docs pointed readers to `#local-quick-start`, but the README heading is `#quick-start`. The source-build snippet also assumed users had already defined `$PROJECT_ROOT`, which made the copy/paste path less reliable.

## Validation

- `git diff --cached --check`
- `uvx pre-commit run --files README.md docs/reference/support-matrix.md docs/reference/release-artifacts.md`
