### PR TITLE
feat(frontend): Jinja chat_template for DeepSeek V4 + V3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4978,6 +4978,7 @@ version = "2.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
 dependencies = [
+ "indexmap 2.13.1",
  "memo-map",
  "serde",
 ]

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -158,7 +158,7 @@ galil-seiferas = { version = "0.1" }
 
 # preprocessor
 bs62 = { version = "0.1" }
-minijinja = { version = "2.15.1", features = ["loader", "loop_controls"] }
+minijinja = { version = "2.15.1", features = ["loader", "loop_controls", "preserve_order"] }
 minijinja-contrib = { version = "2.15.1", features = ["pycompat"] }
 json-five = { version = "0.3" }
 

--- a/lib/llm/src/preprocessor/prompt.rs
+++ b/lib/llm/src/preprocessor/prompt.rs
@@ -27,6 +27,7 @@ use crate::preprocessor::media::MediaDecoder;
 
 pub mod deepseek_v32;
 pub mod deepseek_v4;
+pub mod jinja_chat;
 mod template;
 
 pub use template::{ChatTemplate, ContextMixins};

--- a/lib/llm/src/preprocessor/prompt/deepseek_v32.rs
+++ b/lib/llm/src/preprocessor/prompt/deepseek_v32.rs
@@ -1,10 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! DeepSeek V3.2 native prompt formatting
+//! DeepSeek V3.2 prompt formatting.
 //!
-//! This module provides native Rust implementation of DeepSeek V3.2's chat template,
-//! based on their official Python code: encoding_dsv32.py
+//! Production rendering goes through `jinja_chat::render_v32` and the inline
+//! template at `templates/deepseek_v32_inline.jinja`. This module only keeps
+//! public types (`ThinkingMode`, `DeepSeekV32Formatter`) and constants
+//! (`tokens::*`), the request-side glue (`normalize_message_contents`, the
+//! `OAIPromptFormatter` impl that injects tools / response_format into the
+//! system message), and a thin shim entry point (`encode_messages`) that
+//! routes through `jinja_chat::render_v32`.
 //!
 //! Reference: https://huggingface.co/deepseek-ai/DeepSeek-V3.2/tree/main/encoding
 
@@ -22,53 +27,6 @@ pub mod tokens {
     pub const ASSISTANT_START: &str = "<｜Assistant｜>";
 }
 
-/// System message template for tools
-const TOOLS_SYSTEM_TEMPLATE: &str = r#"## Tools
-
-You have access to a set of tools you can use to answer the user's question.
-You can invoke functions by writing a "<{dsml_token}function_calls>" block like the following as part of your reply to the user:
-<{dsml_token}function_calls>
-<{dsml_token}invoke name="$FUNCTION_NAME">
-<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
-...
-</{dsml_token}invoke>
-<{dsml_token}invoke name="$FUNCTION_NAME2">
-...
-</{dsml_token}invoke>
-</{dsml_token}function_calls>
-
-String and scalar parameters should be specified as is without any escaping or quotes, while lists and objects should use JSON format. The "string" attribute should be set to "true" for string type parameters and "false" for other types (numbers, booleans, arrays, objects).
-
-If the thinking_mode is enabled, then after function results you should strongly consider outputting a thinking block. Here is an example:
-
-<{dsml_token}function_calls>
-...
-</{dsml_token}function_calls>
-
-<function_results>
-...
-</function_results>
-
-{thinking_start_token}...thinking about results{thinking_end_token}
-
-Here are the functions available in JSONSchema format:
-<functions>
-{tool_schemas}
-</functions>
-"#;
-
-const RESPONSE_FORMAT_TEMPLATE: &str =
-    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}";
-
-const TOOL_CALL_TEMPLATE: &str =
-    "<{dsml_token}invoke name=\"{name}\">\n{arguments}\n</{dsml_token}invoke>";
-
-#[allow(dead_code)]
-const TOOL_CALLS_TEMPLATE: &str =
-    "<{dsml_token}function_calls>\n{tool_calls}\n</{dsml_token}function_calls>";
-
-const TOOL_OUTPUT_TEMPLATE: &str = "\n<result>{content}</result>";
-
 /// Thinking mode for the model
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThinkingMode {
@@ -85,82 +43,11 @@ impl ThinkingMode {
     }
 }
 
-/// Convert value to JSON string matching Python's json.dumps() format with spaces
-fn to_json(value: &JsonValue) -> String {
-    // Python's json.dumps() adds spaces after colons and commas
-    // {"name": "value", "key": "value2"}
-    // Rust's serde_json::to_string() produces:
-    // {"name":"value","key":"value2"}
-    // We need to match Python's format for test compatibility
-
-    let compact = serde_json::to_string(value).unwrap_or_else(|_| "{}".to_string());
-
-    // Add spaces after colons and commas (but not inside strings)
-    let mut result = String::with_capacity(compact.len() + compact.len() / 4);
-    let mut in_string = false;
-    let mut prev_char = '\0';
-
-    for ch in compact.chars() {
-        if ch == '"' && prev_char != '\\' {
-            in_string = !in_string;
-        }
-
-        result.push(ch);
-
-        // Add space after ':' or ',' if not inside a string
-        if !in_string && (ch == ':' || ch == ',') {
-            result.push(' ');
-        }
-
-        prev_char = ch;
-    }
-
-    result
-}
-
-/// Extract tools from OpenAI format
-fn tools_from_openai_format(tools: &[JsonValue]) -> Vec<JsonValue> {
-    tools
-        .iter()
-        .filter_map(|tool| tool.get("function").cloned())
-        .collect()
-}
-
-/// Render tools section for system prompt
-fn render_tools(tools: &[JsonValue]) -> String {
-    let tools_json: Vec<String> = tools_from_openai_format(tools)
-        .iter()
-        .map(to_json)
-        .collect();
-
-    TOOLS_SYSTEM_TEMPLATE
-        .replace("{tool_schemas}", &tools_json.join("\n"))
-        .replace("{dsml_token}", tokens::DSML_TOKEN)
-        .replace("{thinking_start_token}", tokens::THINKING_START)
-        .replace("{thinking_end_token}", tokens::THINKING_END)
-}
-
-/// Find the last user or developer message index
-fn find_last_user_index(messages: &[JsonValue]) -> Option<usize> {
-    messages
-        .iter()
-        .enumerate()
-        .rev()
-        .find(|(_, msg)| {
-            msg.get("role")
-                .and_then(|r| r.as_str())
-                .map(|r| r == "user" || r == "developer")
-                .unwrap_or(false)
-        })
-        .map(|(idx, _)| idx)
-}
-
 /// Extract visible text from OpenAI-style message content.
 ///
-/// Matches common chat-template behavior:
 /// - string content: returned as-is
 /// - array content: concatenates `type=text` parts and raw string items
-/// - other JSON types: serialized to JSON string
+/// - other JSON types: empty string (the template handles `null` etc.)
 fn extract_visible_text(content: &JsonValue) -> String {
     match content {
         JsonValue::String(text) => text.clone(),
@@ -187,7 +74,7 @@ fn extract_visible_text(content: &JsonValue) -> String {
                 None
             })
             .collect::<String>(),
-        _ => to_json(content),
+        _ => String::new(),
     }
 }
 
@@ -204,286 +91,23 @@ fn normalize_message_contents(messages: &mut [JsonValue]) {
     }
 }
 
-/// Encode arguments to DSML parameter format
-fn encode_arguments_to_dsml(tool_call: &JsonValue) -> Result<String> {
-    let arguments_str = tool_call
-        .get("arguments")
-        .and_then(|a| a.as_str())
-        .context("Missing or invalid 'arguments' field")?;
-
-    let arguments: JsonValue =
-        serde_json::from_str(arguments_str).context("Failed to parse arguments JSON")?;
-
-    let arguments_obj = arguments
-        .as_object()
-        .context("Arguments must be an object")?;
-
-    let mut params = Vec::new();
-    for (key, value) in arguments_obj {
-        let is_string = value.is_string();
-        let value_str = if is_string {
-            value.as_str().unwrap().to_string()
-        } else {
-            to_json(value)
-        };
-
-        let param = format!(
-            "<{}parameter name=\"{}\" string=\"{}\">{}</{}parameter>",
-            tokens::DSML_TOKEN,
-            key,
-            if is_string { "true" } else { "false" },
-            value_str,
-            tokens::DSML_TOKEN
-        );
-        params.push(param);
-    }
-
-    Ok(params.join("\n"))
-}
-
-/// Render a single message
-fn render_message(
-    index: usize,
-    messages: &[JsonValue],
-    thinking_mode: ThinkingMode,
-    last_user_idx: Option<usize>,
-) -> Result<String> {
-    let msg = &messages[index];
-    let role = msg
-        .get("role")
-        .and_then(|r| r.as_str())
-        .context("Missing 'role' field")?;
-
-    let mut prompt = String::new();
-
-    match role {
-        "system" => {
-            let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
-            prompt.push_str(content);
-
-            if let Some(tools) = msg.get("tools").and_then(|t| t.as_array()) {
-                prompt.push_str("\n\n");
-                prompt.push_str(&render_tools(tools));
-            }
-
-            if let Some(response_format) = msg.get("response_format") {
-                prompt.push_str("\n\n");
-                prompt.push_str(
-                    &RESPONSE_FORMAT_TEMPLATE.replace("{schema}", &to_json(response_format)),
-                );
-            }
-        }
-
-        "user" => {
-            let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
-            prompt.push_str(tokens::USER_START);
-            prompt.push_str(content);
-            prompt.push_str(tokens::ASSISTANT_START);
-
-            if Some(index) == last_user_idx && thinking_mode == ThinkingMode::Thinking {
-                prompt.push_str(tokens::THINKING_START);
-            } else {
-                prompt.push_str(tokens::THINKING_END);
-            }
-        }
-
-        "developer" => {
-            let content = msg
-                .get("content")
-                .and_then(|c| c.as_str())
-                .context("Developer role requires content")?;
-
-            let mut content_developer = String::new();
-
-            if let Some(tools) = msg.get("tools").and_then(|t| t.as_array()) {
-                content_developer.push_str("\n\n");
-                content_developer.push_str(&render_tools(tools));
-            }
-
-            if let Some(response_format) = msg.get("response_format") {
-                content_developer.push_str("\n\n");
-                content_developer.push_str(
-                    &RESPONSE_FORMAT_TEMPLATE.replace("{schema}", &to_json(response_format)),
-                );
-            }
-
-            content_developer.push_str(&format!("\n\n# The user's message is: {}", content));
-
-            prompt.push_str(tokens::USER_START);
-            prompt.push_str(&content_developer);
-            prompt.push_str(tokens::ASSISTANT_START);
-
-            if Some(index) == last_user_idx && thinking_mode == ThinkingMode::Thinking {
-                prompt.push_str(tokens::THINKING_START);
-            } else {
-                prompt.push_str(tokens::THINKING_END);
-            }
-        }
-
-        "assistant" => {
-            // Handle reasoning content
-            // NOTE: If this assistant comes after last user message, the opening <think>
-            // was already added in the user message. We only need to add content and closing tag.
-            //
-            // Handle reasoning_content which may be a plain string or an array of segments.
-            // DeepSeek V3.2 always places its <think> block before all tool calls, so
-            // joining segments produces the correct flat form here.
-            if thinking_mode == ThinkingMode::Thinking
-                && last_user_idx.is_some_and(|idx| index > idx)
-            {
-                let reasoning = msg.get("reasoning_content").and_then(|v| match v {
-                    serde_json::Value::String(s) => {
-                        if s.is_empty() {
-                            None
-                        } else {
-                            Some(s.clone())
-                        }
-                    }
-                    serde_json::Value::Array(arr) => {
-                        let joined = arr
-                            .iter()
-                            .filter_map(|v| v.as_str())
-                            .filter(|s| !s.is_empty())
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        if joined.is_empty() {
-                            None
-                        } else {
-                            Some(joined)
-                        }
-                    }
-                    _ => None,
-                });
-
-                if let Some(reasoning) = reasoning {
-                    // DON'T add THINKING_START - it was already added in user message
-                    prompt.push_str(&reasoning);
-                    prompt.push_str(tokens::THINKING_END);
-                }
-            }
-
-            // Handle content
-            if let Some(content) = msg.get("content").and_then(|c| c.as_str()) {
-                prompt.push_str(content);
-            }
-
-            // Handle tool calls
-            if let Some(tool_calls) = msg.get("tool_calls").and_then(|t| t.as_array())
-                && !tool_calls.is_empty()
-            {
-                prompt.push_str("\n\n");
-                prompt.push_str(&format!("<{}function_calls>\n", tokens::DSML_TOKEN));
-
-                for tool_call in tool_calls {
-                    let name = tool_call
-                        .get("function")
-                        .and_then(|f| f.get("name"))
-                        .and_then(|n| n.as_str())
-                        .context("Missing tool call name")?;
-
-                    let arguments = encode_arguments_to_dsml(
-                        tool_call.get("function").context("Missing function")?,
-                    )?;
-
-                    let invoke = TOOL_CALL_TEMPLATE
-                        .replace("{dsml_token}", tokens::DSML_TOKEN)
-                        .replace("{name}", name)
-                        .replace("{arguments}", &arguments);
-
-                    prompt.push_str(&invoke);
-                    prompt.push('\n');
-                }
-
-                prompt.push_str(&format!("</{}function_calls>", tokens::DSML_TOKEN));
-            }
-
-            prompt.push_str(tokens::EOS);
-        }
-
-        "tool" => {
-            // Find the previous assistant message
-            let mut prev_assistant_idx = None;
-            let mut tool_count = 0;
-
-            for i in (0..index).rev() {
-                let prev_role = messages[i].get("role").and_then(|r| r.as_str());
-                if prev_role == Some("tool") {
-                    tool_count += 1;
-                } else if prev_role == Some("assistant") {
-                    prev_assistant_idx = Some(i);
-                    break;
-                }
-            }
-
-            let tool_call_order = tool_count + 1;
-
-            // Add opening tag for first tool result
-            if tool_call_order == 1 {
-                prompt.push_str("\n\n<function_results>");
-            }
-
-            // Add result
-            let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
-            prompt.push_str(&TOOL_OUTPUT_TEMPLATE.replace("{content}", content));
-
-            // Check if this is the last tool result
-            if let Some(prev_idx) = prev_assistant_idx {
-                let tool_calls_count = messages[prev_idx]
-                    .get("tool_calls")
-                    .and_then(|t| t.as_array())
-                    .map(|a| a.len())
-                    .unwrap_or(0);
-
-                if tool_call_order == tool_calls_count {
-                    prompt.push_str("\n</function_results>");
-
-                    if last_user_idx.is_some_and(|idx| index >= idx)
-                        && thinking_mode == ThinkingMode::Thinking
-                    {
-                        prompt.push_str("\n\n");
-                        prompt.push_str(tokens::THINKING_START);
-                    } else {
-                        prompt.push_str("\n\n");
-                        prompt.push_str(tokens::THINKING_END);
-                    }
-                }
-            }
-        }
-
-        _ => anyhow::bail!("Unknown role: {}", role),
-    }
-
-    Ok(prompt)
-}
-
-/// Encode messages to prompt string
+/// Encode messages to prompt string.
 ///
-/// # Arguments
-/// * `messages` - Array of messages in OpenAI format
-/// * `thinking_mode` - Whether to use thinking mode
-/// * `add_bos_token` - Whether to add BOS token at start
-///
-/// # Returns
-/// Formatted prompt string ready for tokenization
+/// Thin shim over `jinja_chat::render_v32` — production rendering lives in
+/// the inline Jinja template at `templates/deepseek_v32_inline.jinja`.
 pub fn encode_messages(
     messages: &[JsonValue],
     thinking_mode: ThinkingMode,
     add_bos_token: bool,
 ) -> Result<String> {
-    let mut prompt = String::new();
-
-    if add_bos_token {
-        prompt.push_str(tokens::BOS);
-    }
-
-    let last_user_idx = find_last_user_index(messages);
-
-    for (index, _) in messages.iter().enumerate() {
-        let msg_prompt = render_message(index, messages, thinking_mode, last_user_idx)?;
-        prompt.push_str(&msg_prompt);
-    }
-
-    Ok(prompt)
+    use super::jinja_chat;
+    let jinja_mode = match thinking_mode {
+        ThinkingMode::Chat => jinja_chat::ThinkingMode::Chat,
+        ThinkingMode::Thinking => jinja_chat::ThinkingMode::Thinking,
+    };
+    // V3.2 has no caller-facing drop_thinking knob; the upstream Python ref
+    // applies the equivalent of drop_thinking=true unconditionally.
+    jinja_chat::render_v32(messages, jinja_mode, add_bos_token, true)
 }
 
 /// DeepSeek V3.2 Prompt Formatter

--- a/lib/llm/src/preprocessor/prompt/deepseek_v4.rs
+++ b/lib/llm/src/preprocessor/prompt/deepseek_v4.rs
@@ -1,11 +1,22 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! DeepSeek V4 native prompt formatting
+//! DeepSeek V4 prompt formatting.
 //!
-//! Native Rust port of DeepSeek V4's chat encoding (encoding_dsv4.py).
+//! Production rendering goes through `jinja_chat::render_v4` and the inline
+//! template at `templates/deepseek_v4_inline.jinja`. This module only keeps:
+//!   - public types (`ThinkingMode`, `ReasoningEffort`, `DeepSeekV4Formatter`)
+//!     and constants (`tokens::*`)
+//!   - the Rust pre-pass the template assumes already ran
+//!     (`merge_tool_messages`, `sort_tool_results_by_call_order`)
+//!   - request-side glue (`normalize_message_contents`, the
+//!     `OAIPromptFormatter` impl that injects tools / response_format into
+//!     the system message before handing the array to the renderer)
+//!   - thin shim entry points (`encode_messages`,
+//!     `encode_messages_with_options`) that route through
+//!     `jinja_chat::render_v4`.
 //!
-//! Reference: DeepSeek-V4-Pro/encoding/encoding_dsv4.py
+//! Reference: DeepSeek-V4-Pro/encoding/encoding_dsv4.py.
 
 use anyhow::{Context, Result};
 use serde_json::Value as JsonValue;
@@ -30,38 +41,6 @@ pub mod tokens {
     pub const TASK_READ_URL: &str = "<｜read_url｜>";
 }
 
-/// DSML outer block name for tool-call groups: `<｜DSML｜tool_calls>...</｜DSML｜tool_calls>`.
-const TOOL_CALLS_BLOCK_NAME: &str = "tool_calls";
-
-/// Wire-format tags that wrap a tool result inside a user content block.
-const TOOL_RESULT_OPEN: &str = "<tool_result>";
-const TOOL_RESULT_CLOSE: &str = "</tool_result>";
-
-/// Preamble line that introduces a response-format schema in both the
-/// system and developer roles. The `{}` placeholder is filled by the
-/// caller with the JSON-serialized schema.
-const RESPONSE_FORMAT_PREAMBLE: &str =
-    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{}";
-
-/// Roles whose messages are always kept by `drop_thinking_messages`. All other
-/// roles before the last user/developer message are dropped (assistant turns
-/// keep their non-`reasoning_content` fields; everything else is removed).
-const KEEP_ROLES: &[&str] = &[
-    "user",
-    "system",
-    "tool",
-    "latest_reminder",
-    "direct_search_results",
-];
-
-/// Placeholder the Python reference inserts when it can't render an
-/// unsupported content-block or tool-result item type. Rendered into the
-/// assistant-visible prompt so a human can tell something was skipped;
-/// dynamo additionally emits a `tracing::warn!` so ops see it too.
-const UNSUPPORTED_PLACEHOLDER_FMT: &str = "[Unsupported {}]";
-
-const REASONING_EFFORT_MAX: &str = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
-
 /// Thinking mode for the model
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThinkingMode {
@@ -70,8 +49,6 @@ pub enum ThinkingMode {
 }
 
 impl ThinkingMode {
-    /// Tiny branch-free mapping to a static string. `#[inline]` because this
-    /// is called from inside the per-message render hot path.
     #[inline]
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -88,529 +65,42 @@ pub enum ReasoningEffort {
     High,
 }
 
-/// Serialize a JSON value to match Python's `json.dumps(ensure_ascii=False)` spacing.
-/// Python's default separators are `(', ', ': ')`; we use a custom `Formatter`
-/// so escape sequences inside strings can't confuse state tracking.
-///
-/// Returns `Result` so serialization / UTF-8 errors propagate to the caller
-/// rather than silently collapsing to `"{}"` (the old error-swallow behavior
-/// dropped the entire request payload with no signal up the stack).
-fn to_json(value: &JsonValue) -> Result<String> {
-    use serde::Serialize;
-    use serde_json::ser::Formatter;
-    use std::io;
-
-    struct PythonFormatter;
-
-    impl Formatter for PythonFormatter {
-        fn begin_array_value<W: ?Sized + io::Write>(
-            &mut self,
-            writer: &mut W,
-            first: bool,
-        ) -> io::Result<()> {
-            if first {
-                Ok(())
-            } else {
-                writer.write_all(b", ")
-            }
-        }
-
-        fn begin_object_key<W: ?Sized + io::Write>(
-            &mut self,
-            writer: &mut W,
-            first: bool,
-        ) -> io::Result<()> {
-            if first {
-                Ok(())
-            } else {
-                writer.write_all(b", ")
-            }
-        }
-
-        fn begin_object_value<W: ?Sized + io::Write>(&mut self, writer: &mut W) -> io::Result<()> {
-            writer.write_all(b": ")
-        }
-    }
-
-    // Size the buffer from a compact pre-serialization. Python-style spacing
-    // adds exactly one byte per structural separator (`,` → `, `, `:` → `: `),
-    // which bounds the final length by ~1.125× the compact length. This keeps
-    // small payloads cheap and avoids the 5–9 reallocations the prior fixed
-    // 64-byte hint forced on KB-sized tool schemas and response formats.
-    let compact_len = serde_json::to_string(value)
-        .context("to_json: compact pre-serialization failed")?
-        .len();
-    let capacity = compact_len.saturating_add(compact_len / 8).max(256);
-    let mut buf = Vec::with_capacity(capacity);
-    let mut ser = serde_json::Serializer::with_formatter(&mut buf, PythonFormatter);
-    value
-        .serialize(&mut ser)
-        .context("to_json: Python-formatter serialization failed")?;
-    String::from_utf8(buf).context("to_json: serialized output is not valid UTF-8")
-}
-
-/// Extract function definitions from OpenAI-format tool list.
-fn tools_from_openai_format(tools: &[JsonValue]) -> Vec<JsonValue> {
-    tools
-        .iter()
-        .filter_map(|tool| tool.get("function").cloned())
-        .collect()
-}
-
-/// Render tool schemas into the system prompt format.
-///
-/// Previously built via four sequential `String::replace` passes over a
-/// `{placeholder}`-based template, which allocated a fresh copy of the whole
-/// (schema-inlined, potentially kB-scale) string on each substitution. A
-/// single `format!` with named arguments collapses that to one allocation
-/// sized from the final length.
-fn render_tools(tools: &[JsonValue]) -> Result<String> {
-    let tools_json: Vec<String> = tools_from_openai_format(tools)
-        .iter()
-        .map(to_json)
-        .collect::<Result<_>>()?;
-    let schemas = tools_json.join("\n");
-
-    Ok(format!(
-        r#"## Tools
-
-You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml}tool_calls>" block like the following:
-
-<{dsml}tool_calls>
-<{dsml}invoke name="$TOOL_NAME">
-<{dsml}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml}parameter>
-...
-</{dsml}invoke>
-<{dsml}invoke name="$TOOL_NAME2">
-...
-</{dsml}invoke>
-</{dsml}tool_calls>
-
-String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
-
-If thinking_mode is enabled (triggered by {think_open}), you MUST output your complete reasoning inside {think_open}...{think_close} BEFORE any tool calls or final response.
-
-Otherwise, output directly after {think_close} with tool calls or final response.
-
-### Available Tool Schemas
-
-{schemas}
-
-You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
-"#,
-        dsml = tokens::DSML_TOKEN,
-        think_open = tokens::THINKING_START,
-        think_close = tokens::THINKING_END,
-        schemas = schemas,
-    ))
-}
-
-/// Find the index of the last user/developer message.
-///
-/// Returns `None` when no such message exists. Callers should treat `None`
-/// as Python's `-1` sentinel: `idx >= -1` is always true in Python, so use
-/// `Option::is_none_or(|u| idx >= u)` (or `>`) to match the reference encoder.
-fn find_last_user_index(messages: &[JsonValue]) -> Option<usize> {
-    messages
-        .iter()
-        .enumerate()
-        .rev()
-        .find(|(_, msg)| {
-            msg.get("role")
-                .and_then(JsonValue::as_str)
-                .is_some_and(|r| matches!(r, "user" | "developer"))
-        })
-        .map(|(idx, _)| idx)
-}
-
-/// Extract visible text from OpenAI-style message content.
-///
-/// Returns `Result` because the `_ => to_json(content)` fallback can now fail
-/// (to_json itself returns `Result`). Callers already sit in `Result` context.
-fn extract_visible_text(content: &JsonValue) -> Result<String> {
-    Ok(match content {
-        JsonValue::String(text) => text.clone(),
-        JsonValue::Array(items) => items
-            .iter()
-            .filter_map(|item| {
-                if let Some(text) = item.as_str() {
-                    return Some(text.to_string());
-                }
-                let item_type = item.get("type").and_then(JsonValue::as_str);
-                if item_type == Some("text") {
-                    return item
-                        .get("text")
-                        .and_then(JsonValue::as_str)
-                        .map(|text| text.to_string());
-                }
-                tracing::warn!(
-                    chunk_type = item_type.unwrap_or("unknown"),
-                    "DeepSeek V4 formatter dropped non-text content chunk while normalizing message content",
-                );
-                None
-            })
-            .collect::<String>(),
-        _ => to_json(content)?,
-    })
-}
-
-/// Normalize message `content` fields for text-only DeepSeek V4 rendering.
-fn normalize_message_contents(messages: &mut [JsonValue]) -> Result<()> {
+/// Flatten message `content` from OAI multi-modal-block form (list of
+/// `{type: "text", text: ...}` etc.) into a plain string. Non-string,
+/// non-array content is left untouched (the template handles `null`).
+fn normalize_message_contents(messages: &mut [JsonValue]) {
     for msg in messages {
         let Some(content) = msg.get("content") else {
             continue;
         };
-        // Leave non-string/non-array content untouched (null, etc.)
-        if !content.is_string() && !content.is_array() {
-            continue;
-        }
-        let normalized = extract_visible_text(content)?;
+        let normalized = match content {
+            JsonValue::String(s) => s.clone(),
+            JsonValue::Array(items) => items
+                .iter()
+                .filter_map(|item| {
+                    if let Some(text) = item.as_str() {
+                        return Some(text.to_string());
+                    }
+                    let item_type = item.get("type").and_then(JsonValue::as_str);
+                    if item_type == Some("text") {
+                        return item
+                            .get("text")
+                            .and_then(JsonValue::as_str)
+                            .map(str::to_string);
+                    }
+                    tracing::warn!(
+                        chunk_type = item_type.unwrap_or("unknown"),
+                        "DeepSeek V4 formatter dropped non-text content chunk while normalizing message content",
+                    );
+                    None
+                })
+                .collect::<String>(),
+            _ => continue,
+        };
         if let Some(obj) = msg.as_object_mut() {
             obj.insert("content".to_string(), JsonValue::String(normalized));
         }
     }
-    Ok(())
-}
-
-/// Encode tool call arguments into DSML parameter format.
-fn encode_arguments_to_dsml(tool_call: &JsonValue) -> Result<String> {
-    let arguments_str = tool_call
-        .get("arguments")
-        .and_then(JsonValue::as_str)
-        .context("Missing or invalid 'arguments' field")?;
-
-    // Python falls back to `{"arguments": raw_string}` on parse failure.
-    let arguments: JsonValue = match serde_json::from_str(arguments_str) {
-        Ok(v) => v,
-        Err(_) => serde_json::json!({ "arguments": arguments_str }),
-    };
-
-    let arguments_obj = arguments
-        .as_object()
-        .context("Arguments must be a JSON object")?;
-
-    let mut params = Vec::new();
-    for (key, value) in arguments_obj {
-        // Dispatch on the concrete variant so we don't do the `is_string` / `as_str`
-        // / `unwrap` dance (unwrap is technically safe after is_string but fragile
-        // against future refactors).
-        let (is_string, value_str) = match value {
-            JsonValue::String(s) => (true, s.clone()),
-            _ => (false, to_json(value)?),
-        };
-        params.push(format!(
-            "<{}parameter name=\"{}\" string=\"{}\">{}</{}parameter>",
-            tokens::DSML_TOKEN,
-            key,
-            if is_string { "true" } else { "false" },
-            value_str,
-            tokens::DSML_TOKEN
-        ));
-    }
-
-    Ok(params.join("\n"))
-}
-
-/// Lookup the task token for a quick-instruction task.
-///
-/// Called once per assistant-turn in `render_message` and once per transition
-/// token lookup; `#[inline]` because the static-str match is smaller than the
-/// call overhead.
-#[inline]
-fn task_token(task: &str) -> Option<&'static str> {
-    match task {
-        "action" => Some(tokens::TASK_ACTION),
-        "query" => Some(tokens::TASK_QUERY),
-        "authority" => Some(tokens::TASK_AUTHORITY),
-        "domain" => Some(tokens::TASK_DOMAIN),
-        "title" => Some(tokens::TASK_TITLE),
-        "read_url" => Some(tokens::TASK_READ_URL),
-        _ => None,
-    }
-}
-
-/// Append the "Response Format" schema block to `prompt` if the message has one.
-fn append_response_format(msg: &JsonValue, prompt: &mut String) -> Result<()> {
-    if let Some(response_format) = msg.get("response_format") {
-        prompt.push_str("\n\n");
-        prompt.push_str(&RESPONSE_FORMAT_PREAMBLE.replace("{}", &to_json(response_format)?));
-    }
-    Ok(())
-}
-
-/// Append the tools section to `prompt` if the message has a `tools` array.
-fn append_tools_section(msg: &JsonValue, prompt: &mut String) -> Result<()> {
-    if let Some(tools) = msg.get("tools").and_then(JsonValue::as_array) {
-        prompt.push_str("\n\n");
-        prompt.push_str(&render_tools(tools)?);
-    }
-    Ok(())
-}
-
-/// Render the `system` role: raw content, then optional tools + response-format.
-fn render_system_role(msg: &JsonValue, prompt: &mut String) -> Result<()> {
-    let content = msg.get("content").and_then(JsonValue::as_str).unwrap_or("");
-    prompt.push_str(content);
-    append_tools_section(msg, prompt)?;
-    append_response_format(msg, prompt)?;
-    Ok(())
-}
-
-/// Render the `developer` role: wraps content in USER_START, then optional
-/// tools + response-format. Developer content is required (non-empty).
-fn render_developer_role(msg: &JsonValue, prompt: &mut String) -> Result<()> {
-    let content = msg
-        .get("content")
-        .and_then(JsonValue::as_str)
-        .filter(|s| !s.is_empty())
-        .context("Developer role requires content")?;
-
-    prompt.push_str(tokens::USER_START);
-    prompt.push_str(content);
-    append_tools_section(msg, prompt)?;
-    append_response_format(msg, prompt)?;
-    Ok(())
-}
-
-/// Render the `user` role: either content-blocks (with tool_result wrapping)
-/// or a plain string `content` field.
-fn render_user_role(msg: &JsonValue, prompt: &mut String) -> Result<()> {
-    prompt.push_str(tokens::USER_START);
-    if let Some(blocks) = msg.get("content_blocks").and_then(JsonValue::as_array) {
-        let mut parts: Vec<String> = Vec::with_capacity(blocks.len());
-        for block in blocks {
-            let block_type = block.get("type").and_then(JsonValue::as_str).unwrap_or("");
-            match block_type {
-                "text" => {
-                    let text = block.get("text").and_then(JsonValue::as_str).unwrap_or("");
-                    parts.push(text.to_string());
-                }
-                "tool_result" => {
-                    let rendered = render_tool_result_content(
-                        block.get("content").unwrap_or(&JsonValue::Null),
-                    )?;
-                    parts.push(format!(
-                        "{}{}{}",
-                        TOOL_RESULT_OPEN, rendered, TOOL_RESULT_CLOSE
-                    ));
-                }
-                other => {
-                    tracing::warn!(
-                        block_type = other,
-                        "DeepSeek V4 formatter emitted placeholder for unsupported user content block type",
-                    );
-                    parts.push(UNSUPPORTED_PLACEHOLDER_FMT.replace("{}", other));
-                }
-            }
-        }
-        prompt.push_str(&parts.join("\n\n"));
-    } else {
-        let content = msg.get("content").and_then(JsonValue::as_str).unwrap_or("");
-        prompt.push_str(content);
-    }
-    Ok(())
-}
-
-/// Render the `latest_reminder` role: LATEST_REMINDER token + content.
-fn render_latest_reminder_role(msg: &JsonValue, prompt: &mut String) {
-    let content = msg.get("content").and_then(JsonValue::as_str).unwrap_or("");
-    prompt.push_str(tokens::LATEST_REMINDER);
-    prompt.push_str(content);
-}
-
-/// Render the `assistant` role: optional thinking prefix, content, optional
-/// `tool_calls` DSML block, optional EOS.
-///
-/// Needs `index` and `messages` to peek at the previous turn's `task` field
-/// (suppresses thinking prefix when the prior message was a task message).
-fn render_assistant_role(
-    msg: &JsonValue,
-    index: usize,
-    messages: &[JsonValue],
-    thinking_mode: ThinkingMode,
-    drop_thinking: bool,
-    last_user_idx: Option<usize>,
-    prompt: &mut String,
-) -> Result<()> {
-    let content = msg.get("content").and_then(JsonValue::as_str).unwrap_or("");
-    let reasoning = msg
-        .get("reasoning_content")
-        .and_then(JsonValue::as_str)
-        .unwrap_or("");
-    let wo_eos = msg
-        .get("wo_eos")
-        .and_then(JsonValue::as_bool)
-        .unwrap_or(false);
-
-    let prev_has_task = index > 0
-        && messages[index - 1]
-            .get("task")
-            .map(|v| !v.is_null())
-            .unwrap_or(false);
-
-    if thinking_mode == ThinkingMode::Thinking && !prev_has_task {
-        let render_thinking = !drop_thinking || last_user_idx.is_none_or(|u| index > u);
-        if render_thinking {
-            prompt.push_str(reasoning);
-            prompt.push_str(tokens::THINKING_END);
-        }
-    }
-
-    prompt.push_str(content);
-
-    if let Some(tool_calls) = msg.get("tool_calls").and_then(JsonValue::as_array)
-        && !tool_calls.is_empty()
-    {
-        prompt.push_str("\n\n");
-        prompt.push_str(&format!(
-            "<{}{}>\n",
-            tokens::DSML_TOKEN,
-            TOOL_CALLS_BLOCK_NAME
-        ));
-
-        let mut invocations = Vec::with_capacity(tool_calls.len());
-        for tc in tool_calls {
-            // Accept both OpenAI-format (nested `function`) and internal
-            // `{name, arguments}` shape, matching Python's `tool_calls_from_openai_format`.
-            let fn_obj = tc.get("function").unwrap_or(tc);
-            let name = fn_obj
-                .get("name")
-                .and_then(JsonValue::as_str)
-                .context("Missing tool call name")?;
-            let arguments = encode_arguments_to_dsml(fn_obj)?;
-            invocations.push(format!(
-                "<{}invoke name=\"{}\">\n{}\n</{}invoke>",
-                tokens::DSML_TOKEN,
-                name,
-                arguments,
-                tokens::DSML_TOKEN
-            ));
-        }
-        prompt.push_str(&invocations.join("\n"));
-        prompt.push_str(&format!(
-            "\n</{}{}>",
-            tokens::DSML_TOKEN,
-            TOOL_CALLS_BLOCK_NAME
-        ));
-    }
-
-    if !wo_eos {
-        prompt.push_str(tokens::EOS);
-    }
-    Ok(())
-}
-
-/// Render a single message at the given index.
-fn render_message(
-    index: usize,
-    messages: &[JsonValue],
-    thinking_mode: ThinkingMode,
-    drop_thinking: bool,
-    reasoning_effort: Option<ReasoningEffort>,
-    last_user_idx: Option<usize>,
-) -> Result<String> {
-    let msg = &messages[index];
-
-    let role = msg
-        .get("role")
-        .and_then(JsonValue::as_str)
-        .context("Missing 'role' field")?;
-
-    let mut prompt = String::new();
-
-    // Reasoning effort prefix (only at index 0 in thinking mode with max effort).
-    if index == 0
-        && thinking_mode == ThinkingMode::Thinking
-        && reasoning_effort == Some(ReasoningEffort::Max)
-    {
-        prompt.push_str(REASONING_EFFORT_MAX);
-    }
-
-    match role {
-        "system" => render_system_role(msg, &mut prompt)?,
-        "developer" => render_developer_role(msg, &mut prompt)?,
-        "user" => render_user_role(msg, &mut prompt)?,
-        "latest_reminder" => render_latest_reminder_role(msg, &mut prompt),
-        "tool" => anyhow::bail!(
-            "deepseek_v4 merges tool messages into user; preprocess with merge_tool_messages()"
-        ),
-        "assistant" => render_assistant_role(
-            msg,
-            index,
-            messages,
-            thinking_mode,
-            drop_thinking,
-            last_user_idx,
-            &mut prompt,
-        )?,
-        other => anyhow::bail!("Unknown role: {other}"),
-    }
-
-    // Early return if the next message is not assistant/latest_reminder — no transition appended.
-    if index + 1 < messages.len() {
-        let next_role = messages[index + 1].get("role").and_then(JsonValue::as_str);
-        if !matches!(next_role, Some("assistant") | Some("latest_reminder")) {
-            return Ok(prompt);
-        }
-    }
-
-    // Transition tokens based on task field and role.
-    let task = msg.get("task").and_then(JsonValue::as_str);
-    if let Some(task) = task {
-        let sp = task_token(task).with_context(|| format!("Invalid task: '{}'", task))?;
-        if task != "action" {
-            prompt.push_str(sp);
-        } else {
-            prompt.push_str(tokens::ASSISTANT_START);
-            prompt.push_str(if thinking_mode != ThinkingMode::Thinking {
-                tokens::THINKING_END
-            } else {
-                tokens::THINKING_START
-            });
-            prompt.push_str(sp);
-        }
-    } else if matches!(role, "user" | "developer") {
-        prompt.push_str(tokens::ASSISTANT_START);
-        let seed_thinking = thinking_mode == ThinkingMode::Thinking
-            && (!drop_thinking || last_user_idx.is_none_or(|u| index >= u));
-        prompt.push_str(if seed_thinking {
-            tokens::THINKING_START
-        } else {
-            tokens::THINKING_END
-        });
-    }
-
-    Ok(prompt)
-}
-
-/// Render a tool_result `content` payload (string or content-block list).
-fn render_tool_result_content(content: &JsonValue) -> Result<String> {
-    Ok(match content {
-        JsonValue::String(s) => s.clone(),
-        JsonValue::Array(items) => {
-            let mut parts: Vec<String> = Vec::with_capacity(items.len());
-            for item in items {
-                let item_type = item.get("type").and_then(JsonValue::as_str).unwrap_or("");
-                if item_type == "text" {
-                    parts.push(
-                        item.get("text")
-                            .and_then(JsonValue::as_str)
-                            .unwrap_or("")
-                            .to_string(),
-                    );
-                } else {
-                    tracing::warn!(
-                        item_type,
-                        "DeepSeek V4 formatter emitted placeholder for unsupported tool_result content item type",
-                    );
-                    parts.push(UNSUPPORTED_PLACEHOLDER_FMT.replace("{}", item_type));
-                }
-            }
-            parts.join("\n\n")
-        }
-        JsonValue::Null => String::new(),
-        _ => to_json(content)?,
-    })
 }
 
 /// Merge `tool` role messages into preceding user `content_blocks` and collapse
@@ -644,10 +134,6 @@ pub fn merge_tool_messages(messages: &[JsonValue]) -> Vec<JsonValue> {
                 .unwrap_or(false);
 
             if can_merge {
-                // `can_merge` already checked `content_blocks.is_some()`; if
-                // the subsequent `as_array_mut()` ever fails (data invariant
-                // violation) we match the original behavior and silently
-                // drop rather than falling through to push a new user msg.
                 if let Some(last) = merged.last_mut()
                     && let Some(blocks) = last
                         .as_object_mut()
@@ -694,7 +180,6 @@ pub fn merge_tool_messages(messages: &[JsonValue]) -> Vec<JsonValue> {
                     "content": text,
                     "content_blocks": [text_block],
                 });
-                // Preserve extra fields.
                 if let Some(obj) = new_msg.as_object_mut() {
                     for key in ["task", "wo_eos", "mask"] {
                         if let Some(v) = msg.get(key) {
@@ -705,7 +190,6 @@ pub fn merge_tool_messages(messages: &[JsonValue]) -> Vec<JsonValue> {
                 merged.push(new_msg);
             }
         } else {
-            // Pass-through: clone only when we're actually moving the message.
             merged.push(msg.clone());
         }
     }
@@ -748,7 +232,6 @@ pub fn sort_tool_results_by_call_order(mut messages: Vec<JsonValue>) -> Vec<Json
                 continue;
             };
 
-            // Collect tool_result blocks with their positions.
             let tool_positions: Vec<usize> = blocks
                 .iter()
                 .enumerate()
@@ -776,39 +259,10 @@ pub fn sort_tool_results_by_call_order(mut messages: Vec<JsonValue>) -> Vec<Json
     messages
 }
 
-/// Drop reasoning and non-essential messages before the last user message.
-///
-/// Takes `last_user_idx` (the pre-drop position of the last user/developer
-/// message, as returned by [`find_last_user_index`]) from the caller so we
-/// don't rescan the vector; returns the post-drop position of the same
-/// message so the caller doesn't have to rescan either.
-fn drop_thinking_messages(
-    messages: Vec<JsonValue>,
-    last_user_idx: Option<usize>,
-) -> (Vec<JsonValue>, Option<usize>) {
-    let mut out = Vec::with_capacity(messages.len());
-    let mut new_last_user_idx: Option<usize> = None;
-    for (idx, mut msg) in messages.into_iter().enumerate() {
-        let role = msg.get("role").and_then(JsonValue::as_str).unwrap_or("");
-        if KEEP_ROLES.contains(&role) || last_user_idx.is_none_or(|u| idx >= u) {
-            if last_user_idx == Some(idx) {
-                new_last_user_idx = Some(out.len());
-            }
-            out.push(msg);
-        } else if role == "assistant" {
-            if let Some(obj) = msg.as_object_mut() {
-                obj.remove("reasoning_content");
-            }
-            out.push(msg);
-        }
-        // developer and other roles before last_user_idx are dropped.
-    }
-    (out, new_last_user_idx)
-}
-
 /// Encode messages to prompt string with default options.
 ///
-/// Equivalent to `encode_messages_with_options(.., drop_thinking=true, reasoning_effort=None)`.
+/// Thin shim over `jinja_chat::render_v4`. Equivalent to
+/// `encode_messages_with_options(.., drop_thinking=true, reasoning_effort=None)`.
 pub fn encode_messages(
     messages: &[JsonValue],
     thinking_mode: ThinkingMode,
@@ -819,12 +273,10 @@ pub fn encode_messages(
 
 /// Encode messages to prompt string.
 ///
-/// # Arguments
-/// * `messages` - Array of messages in OpenAI format
-/// * `thinking_mode` - Chat or Thinking
-/// * `add_bos_token` - Whether to prepend BOS token
-/// * `drop_thinking` - Drop reasoning_content from earlier turns (auto-disabled if tools present)
-/// * `reasoning_effort` - Optional reasoning effort level (Max prepends a verbatim block)
+/// Thin shim over `jinja_chat::render_v4` — production rendering lives in the
+/// inline Jinja template at `templates/deepseek_v4_inline.jinja`. This entry
+/// point is kept so existing callers (tests, the formatter trait impl)
+/// continue to work unchanged.
 pub fn encode_messages_with_options(
     messages: &[JsonValue],
     thinking_mode: ThinkingMode,
@@ -832,50 +284,23 @@ pub fn encode_messages_with_options(
     drop_thinking: bool,
     reasoning_effort: Option<ReasoningEffort>,
 ) -> Result<String> {
-    let merged = merge_tool_messages(messages);
-    let mut full = sort_tool_results_by_call_order(merged);
-
-    let mut prompt = String::new();
-    if add_bos_token {
-        prompt.push_str(tokens::BOS);
-    }
-
-    // Auto-disable drop_thinking when any message carries a `tools` field.
-    let has_tools = full.iter().any(|m| {
-        m.get("tools")
-            .map(|v| match v {
-                JsonValue::Array(a) => !a.is_empty(),
-                JsonValue::Null => false,
-                _ => true,
-            })
-            .unwrap_or(false)
+    use super::jinja_chat;
+    let jinja_mode = match thinking_mode {
+        ThinkingMode::Chat => jinja_chat::ThinkingMode::Chat,
+        ThinkingMode::Thinking => jinja_chat::ThinkingMode::Thinking,
+    };
+    let jinja_effort = reasoning_effort.and_then(|e| match e {
+        ReasoningEffort::Max => Some(jinja_chat::ReasoningEffort::Max),
+        // Only `Max` injects a prefix in the template; other levels are no-ops.
+        ReasoningEffort::High => None,
     });
-    let effective_drop_thinking = drop_thinking && !has_tools;
-
-    // Locate the last user/developer message once. `drop_thinking_messages`
-    // both consumes this (to know what to keep) and returns the new index
-    // (to avoid a second full scan over its output list).
-    let mut last_user_idx = find_last_user_index(&full);
-
-    if thinking_mode == ThinkingMode::Thinking && effective_drop_thinking {
-        let (dropped, new_last_user) = drop_thinking_messages(full, last_user_idx);
-        full = dropped;
-        last_user_idx = new_last_user;
-    }
-
-    for idx in 0..full.len() {
-        let part = render_message(
-            idx,
-            &full,
-            thinking_mode,
-            effective_drop_thinking,
-            reasoning_effort,
-            last_user_idx,
-        )?;
-        prompt.push_str(&part);
-    }
-
-    Ok(prompt)
+    jinja_chat::render_v4(
+        messages,
+        jinja_mode,
+        add_bos_token,
+        drop_thinking,
+        jinja_effort,
+    )
 }
 
 /// DeepSeek V4 Prompt Formatter
@@ -942,7 +367,7 @@ impl super::OAIPromptFormatter for DeepSeekV4Formatter {
             .context("Messages is not an array")?
             .clone();
 
-        normalize_message_contents(&mut messages_array)?;
+        normalize_message_contents(&mut messages_array);
 
         let tools_json = req
             .tools()
@@ -1053,9 +478,7 @@ mod tests {
     fn test_content_blocks_with_tool_result() {
         // `merge_tool_messages` turns a `tool` role followed by a plain user text
         // into a single user turn whose `content_blocks` interleave the tool result
-        // with the text, joined by "\n\n" at render time. Users don't construct
-        // `content_blocks` directly — both the Python reference and this port
-        // overwrite any user-supplied `content_blocks` with a single text block.
+        // with the text, joined by "\n\n" at render time.
         let messages = json!([
             {"role": "user", "content": "call tool"},
             {"role": "assistant", "content": "", "tool_calls": [{
@@ -1090,13 +513,10 @@ mod tests {
         assert!(out.contains("PRIOR_REASONING"));
     }
 
-    // ---- Regression tests for known divergences from the Python reference ----
-
     /// Bug: `last_user_idx = None` (no user/developer in history) should behave
     /// like Python's `-1` sentinel — `index >= -1` / `idx >= -1` always true, so
     /// earlier reasoning is preserved and the assistant's reasoning block is
-    /// rendered. Rust defaulting `None` to `usize::MAX` / `is_some_and` silently
-    /// stripped reasoning instead.
+    /// rendered.
     ///
     /// Byte-equivalent to Python reference with the same input:
     /// `<BOS>sysREASONING_BLOCK</think>hello<EOS>`
@@ -1112,160 +532,5 @@ mod tests {
             out, "<｜begin▁of▁sentence｜>sysREASONING_BLOCK</think>hello<｜end▁of▁sentence｜>",
             "Output must match Python reference byte-for-byte when no user/developer in history"
         );
-    }
-
-    /// Bug: `to_json` tracks in-string state via `prev_char != '\\'` which
-    /// mis-handles consecutive backslashes. A value containing `\\` (one literal
-    /// backslash in JSON) makes the helper think the closing `"` is escaped,
-    /// so it stops inserting Python-compatible spaces after subsequent `:`/`,`.
-    ///
-    /// Python `json.dumps({"path": "\\", "count": 5}, ensure_ascii=False)`
-    /// emits `{"path": "\\", "count": 5}` — space after every `:` and `,`.
-    #[test]
-    fn test_to_json_preserves_spacing_past_escaped_backslash() {
-        let v = json!({"path": "\\", "count": 5});
-        let got = to_json(&v).expect("to_json must succeed on well-formed input");
-        assert_eq!(
-            got, r#"{"path": "\\", "count": 5}"#,
-            "to_json must match Python's json.dumps formatting past an escaped backslash"
-        );
-    }
-
-    /// Larger-than-64-byte inputs (typical tool schemas / response formats)
-    /// must round-trip unchanged — pins that the capacity hint doesn't
-    /// truncate and that Python spacing holds across deep nesting.
-    #[test]
-    fn test_to_json_handles_large_payload() {
-        // Build a ~5 KB tool-like schema by nesting an array of items.
-        let items: Vec<serde_json::Value> = (0..200)
-            .map(|i| json!({"name": format!("field_{i}"), "type": "string", "i": i}))
-            .collect();
-        let v = json!({
-            "type": "object",
-            "properties": {"items": {"type": "array", "items": items}},
-            "required": ["items"],
-        });
-
-        let got = to_json(&v).expect("to_json must succeed on well-formed input");
-        // Baseline: default serde_json::to_string round-trips.
-        let parsed: serde_json::Value = serde_json::from_str(&got).expect("round-trip parse");
-        assert_eq!(
-            parsed, v,
-            "to_json output must round-trip back to the input"
-        );
-        // Python spacing assertions: no bare `",` or `":` sequences outside of
-        // string literals. The payload contains no commas or colons inside
-        // string values, so a byte scan is sufficient.
-        assert!(
-            !got.contains("\",\""),
-            "expected ', ' between keys — raw '\",\"' should not appear",
-        );
-        assert!(
-            !got.contains("\":\""),
-            "expected ': ' between key and value — raw '\":\"' should not appear",
-        );
-        // Sanity: large payload exercised (> 5KB).
-        assert!(
-            got.len() > 5_000,
-            "test payload is too small: {}",
-            got.len()
-        );
-    }
-
-    /// `drop_thinking_messages` now takes the pre-drop last-user index and
-    /// returns the post-drop index instead of forcing the caller to rescan
-    /// the output list. This test pins that the returned index is
-    /// equivalent to a full `find_last_user_index` rescan, for the shape
-    /// that actually shifts indices (non-KEEP role dropped before the
-    /// final user/developer).
-    #[test]
-    fn test_drop_thinking_messages_returns_post_drop_last_user_idx() {
-        // A `developer` message before the last user triggers an index
-        // shift: it's not in KEEP and is at idx < last_user_idx, so it
-        // gets dropped and every surviving message's index decreases by 1.
-        let messages = vec![
-            json!({"role": "developer", "content": "dev1"}),
-            json!({"role": "assistant", "reasoning_content": "r", "content": "a1"}),
-            json!({"role": "user", "content": "u1"}),
-            json!({"role": "developer", "content": "dev2"}),
-        ];
-        let pre_drop_idx = find_last_user_index(&messages);
-        // The last user-like message is the trailing developer at idx 3.
-        assert_eq!(pre_drop_idx, Some(3));
-
-        let (dropped, new_idx) = drop_thinking_messages(messages, pre_drop_idx);
-
-        // developer at idx 0: dropped (not KEEP, before last_user_idx).
-        // assistant at idx 1: kept with reasoning stripped.
-        // user at idx 2: kept.
-        // developer at idx 3: kept (is last_user_idx).
-        assert_eq!(dropped.len(), 3, "expected 3 messages after drop");
-        assert!(
-            dropped[0].get("reasoning_content").is_none(),
-            "assistant reasoning_content must be stripped",
-        );
-        assert_eq!(
-            dropped[0].get("role").and_then(JsonValue::as_str),
-            Some("assistant"),
-        );
-        assert_eq!(
-            dropped[1].get("role").and_then(JsonValue::as_str),
-            Some("user")
-        );
-        assert_eq!(
-            dropped[2].get("role").and_then(JsonValue::as_str),
-            Some("developer"),
-        );
-
-        // The core invariant: the returned post-drop index is identical to
-        // what a full `find_last_user_index` rescan would produce. This
-        // is what allows `encode_messages_with_options` to skip the
-        // previously-redundant second scan.
-        let rescan_idx = find_last_user_index(&dropped);
-        assert_eq!(
-            new_idx, rescan_idx,
-            "drop_thinking_messages must return the same index find_last_user_index would compute on its output",
-        );
-        assert_eq!(new_idx, Some(2), "developer shifted from idx 3 to idx 2");
-    }
-
-    /// Sanity check for the no-shift case: when nothing before the last
-    /// user/developer is droppable, the index returned by
-    /// `drop_thinking_messages` must equal the input index.
-    #[test]
-    fn test_drop_thinking_messages_preserves_idx_when_nothing_dropped() {
-        let messages = vec![
-            json!({"role": "system", "content": "s"}),
-            json!({"role": "user", "content": "u1"}),
-            json!({"role": "assistant", "reasoning_content": "r", "content": "a"}),
-            json!({"role": "user", "content": "u2"}),
-        ];
-        let pre_drop_idx = find_last_user_index(&messages);
-        assert_eq!(pre_drop_idx, Some(3));
-
-        let (dropped, new_idx) = drop_thinking_messages(messages, pre_drop_idx);
-        assert_eq!(dropped.len(), 4, "nothing should be dropped here");
-        // No shift: last user still at the same index.
-        assert_eq!(new_idx, Some(3));
-        assert_eq!(new_idx, find_last_user_index(&dropped));
-    }
-
-    /// Edge case: no user/developer anywhere in the history. Both the
-    /// pre-drop and post-drop indices must be `None` so the render loop
-    /// treats every message as "after last user" (Python `-1` sentinel).
-    #[test]
-    fn test_drop_thinking_messages_no_user_in_history() {
-        let messages = vec![
-            json!({"role": "system", "content": "s"}),
-            json!({"role": "assistant", "reasoning_content": "r", "content": "a"}),
-        ];
-        let pre_drop_idx = find_last_user_index(&messages);
-        assert_eq!(pre_drop_idx, None);
-
-        let (dropped, new_idx) = drop_thinking_messages(messages, pre_drop_idx);
-        // With `last_user_idx == None`, the `idx >= u` guard is vacuously
-        // true for every index, so the assistant is kept (with reasoning).
-        assert_eq!(dropped.len(), 2);
-        assert_eq!(new_idx, None);
     }
 }

--- a/lib/llm/src/preprocessor/prompt/jinja_chat.rs
+++ b/lib/llm/src/preprocessor/prompt/jinja_chat.rs
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Jinja-based chat-template renderer for DeepSeek V4 / V3.2.
+//!
+//! Replaces the hand-written `deepseek_v4.rs` / `deepseek_v32.rs` encoders with
+//! a thin Rust pre-pass plus a minijinja render of the bundled
+//! `deepseek_v{4,32}_inline.jinja` templates. The templates are byte-for-byte
+//! ports of upstream `encoding_dsv4.py` / `encoding_dsv32.py`; the only Rust
+//! responsibilities here are the pre-pass that the templates assume already
+//! ran (merge parallel tool messages, sort tool results by call order) and the
+//! minijinja env config that makes `tojson` produce Python-style spacing.
+
+use anyhow::{Context, Result};
+use minijinja::{Environment, Value};
+use serde_json::Value as JsonValue;
+
+use super::deepseek_v4::{merge_tool_messages, sort_tool_results_by_call_order};
+
+/// Embedded inline templates — single-file form, no Jinja `include` lookups.
+const V4_INLINE_TEMPLATE: &str =
+    include_str!("templates/deepseek_v4_inline.jinja");
+const V32_INLINE_TEMPLATE: &str =
+    include_str!("templates/deepseek_v32_inline.jinja");
+
+/// `serde_json::ser::Formatter` matching Python's `json.dumps` default spacing
+/// (`, ` between elements, `: ` between key and value). The default
+/// serde_json `CompactFormatter` emits no spaces, which would diverge from
+/// the upstream Python references' fixture output.
+struct PythonStyleFormatter;
+
+impl serde_json::ser::Formatter for PythonStyleFormatter {
+    fn begin_array_value<W: ?Sized + std::io::Write>(
+        &mut self,
+        w: &mut W,
+        first: bool,
+    ) -> std::io::Result<()> {
+        if first { Ok(()) } else { w.write_all(b", ") }
+    }
+    fn begin_object_key<W: ?Sized + std::io::Write>(
+        &mut self,
+        w: &mut W,
+        first: bool,
+    ) -> std::io::Result<()> {
+        if first { Ok(()) } else { w.write_all(b", ") }
+    }
+    fn begin_object_value<W: ?Sized + std::io::Write>(&mut self, w: &mut W) -> std::io::Result<()> {
+        w.write_all(b": ")
+    }
+}
+
+fn python_style_to_string(v: &JsonValue) -> Result<String> {
+    let mut buf = Vec::new();
+    let mut ser = serde_json::Serializer::with_formatter(&mut buf, PythonStyleFormatter);
+    serde::Serialize::serialize(v, &mut ser).context("python_style_to_string: serialize failed")?;
+    String::from_utf8(buf).context("python_style_to_string: non-utf8 output")
+}
+
+/// Build a fresh minijinja `Environment` configured the way the DeepSeek
+/// templates expect: trim/lstrip blocks on, plus `tojson` and `fromjson`
+/// filters that match jinja2 + Python `json` semantics.
+pub fn make_chat_env() -> Environment<'static> {
+    let mut env = Environment::new();
+    env.set_lstrip_blocks(true);
+    env.set_trim_blocks(true);
+    env.add_filter("tojson", |v: Value| -> Result<String, minijinja::Error> {
+        let json_v: JsonValue = serde_json::to_value(v).map_err(|e| {
+            minijinja::Error::new(
+                minijinja::ErrorKind::InvalidOperation,
+                format!("tojson: {e}"),
+            )
+        })?;
+        python_style_to_string(&json_v).map_err(|e| {
+            minijinja::Error::new(
+                minijinja::ErrorKind::InvalidOperation,
+                format!("tojson: {e}"),
+            )
+        })
+    });
+    env.add_filter(
+        "fromjson",
+        |s: String| -> Result<Value, minijinja::Error> {
+            serde_json::from_str::<JsonValue>(&s)
+                .map(Value::from_serialize)
+                .map_err(|e| {
+                    minijinja::Error::new(
+                        minijinja::ErrorKind::InvalidOperation,
+                        format!("fromjson: {e}"),
+                    )
+                })
+        },
+    );
+    env
+}
+
+/// Thinking-mode wire string accepted by both inline templates. Kept as a
+/// dedicated enum so callers don't pass a freeform string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThinkingMode {
+    Chat,
+    Thinking,
+}
+
+impl ThinkingMode {
+    fn as_template_str(self) -> &'static str {
+        match self {
+            ThinkingMode::Chat => "chat",
+            ThinkingMode::Thinking => "thinking",
+        }
+    }
+}
+
+/// Reasoning-effort prefix opt-in. Currently only `Max` has any effect on the
+/// template (it injects a verbatim instruction block at idx 0); kept as an
+/// enum so future levels (`High`, etc.) can land without a signature change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReasoningEffort {
+    Max,
+}
+
+impl ReasoningEffort {
+    fn as_template_str(self) -> &'static str {
+        match self {
+            ReasoningEffort::Max => "max",
+        }
+    }
+}
+
+/// Render messages through `deepseek_v4_inline.jinja`.
+///
+/// Applies the same pre-pass the existing `deepseek_v4::encode_messages`
+/// applies (merge parallel tool messages, sort tool results by call order),
+/// then hands the prepared messages to minijinja. The template handles
+/// last-user-index detection, drop-thinking, and tool-call rendering itself.
+pub fn render_v4(
+    messages: &[JsonValue],
+    thinking_mode: ThinkingMode,
+    add_bos_token: bool,
+    drop_thinking: bool,
+    reasoning_effort: Option<ReasoningEffort>,
+) -> Result<String> {
+    let merged = merge_tool_messages(messages);
+    let prepared = sort_tool_results_by_call_order(merged);
+
+    let mut env = make_chat_env();
+    env.add_template("deepseek_v4_inline.jinja", V4_INLINE_TEMPLATE)
+        .context("register deepseek_v4_inline.jinja")?;
+
+    let reasoning_effort_val: Value = match reasoning_effort {
+        Some(level) => Value::from(level.as_template_str()),
+        None => Value::from(()),
+    };
+
+    env.get_template("deepseek_v4_inline.jinja")
+        .context("lookup deepseek_v4_inline.jinja")?
+        .render(minijinja::context! {
+            messages => Value::from_serialize(&prepared),
+            thinking_mode => thinking_mode.as_template_str(),
+            drop_thinking => drop_thinking,
+            add_bos_token => add_bos_token,
+            reasoning_effort => reasoning_effort_val,
+        })
+        .context("render deepseek_v4_inline.jinja")
+}
+
+/// Flatten array-form `reasoning_content` (`["seg1", "seg2", ""]`, emitted by
+/// interleaved-thinking models like GLM-5) into a single newline-joined
+/// string, dropping empty segments. The V3.2 inline template only handles
+/// string-form reasoning_content; array form would render as `[object]`.
+fn flatten_reasoning_segments(messages: &[JsonValue]) -> Vec<JsonValue> {
+    messages
+        .iter()
+        .map(|msg| {
+            let JsonValue::Array(segments) = msg.get("reasoning_content").unwrap_or(&JsonValue::Null)
+            else {
+                return msg.clone();
+            };
+            let joined = segments
+                .iter()
+                .filter_map(JsonValue::as_str)
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+                .join("\n");
+            let mut out = msg.clone();
+            if let Some(obj) = out.as_object_mut() {
+                obj.insert("reasoning_content".to_string(), JsonValue::String(joined));
+            }
+            out
+        })
+        .collect()
+}
+
+/// Render messages through `deepseek_v32_inline.jinja`.
+///
+/// V3.2 has no parallel-tool merge step. The only Rust pre-pass here is
+/// flattening array-form `reasoning_content` into the string form the
+/// template expects (the upstream Python reference encoded
+/// `reasoning_content` as a string).
+pub fn render_v32(
+    messages: &[JsonValue],
+    thinking_mode: ThinkingMode,
+    add_bos_token: bool,
+    drop_thinking: bool,
+) -> Result<String> {
+    let prepared = flatten_reasoning_segments(messages);
+
+    let mut env = make_chat_env();
+    env.add_template("deepseek_v32_inline.jinja", V32_INLINE_TEMPLATE)
+        .context("register deepseek_v32_inline.jinja")?;
+
+    env.get_template("deepseek_v32_inline.jinja")
+        .context("lookup deepseek_v32_inline.jinja")?
+        .render(minijinja::context! {
+            messages => Value::from_serialize(&prepared),
+            thinking_mode => thinking_mode.as_template_str(),
+            drop_thinking => drop_thinking,
+            add_bos_token => add_bos_token,
+        })
+        .context("render deepseek_v32_inline.jinja")
+}

--- a/lib/llm/src/preprocessor/prompt/templates/_v32_tools_block.jinja
+++ b/lib/llm/src/preprocessor/prompt/templates/_v32_tools_block.jinja
@@ -1,0 +1,41 @@
+{#- V3.2 tools system block. Caller injects "\n\n" prefix. -#}
+{%- set DSML = "｜DSML｜" -%}
+{%- set THINK_OPEN = "<think>" -%}
+{%- set THINK_CLOSE = "</think>" -%}
+{%- set schemas_list = [] -%}
+{%- for tool in message.tools -%}
+    {%- set fn = tool.function if tool.function is defined else tool -%}
+    {%- set _ = schemas_list.append(fn | tojson) -%}
+{%- endfor -%}
+## Tools
+
+You have access to a set of tools you can use to answer the user's question.
+You can invoke functions by writing a "<{{ DSML }}function_calls>" block like the following as part of your reply to the user:
+<{{ DSML }}function_calls>
+<{{ DSML }}invoke name="$FUNCTION_NAME">
+<{{ DSML }}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{{ DSML }}parameter>
+...
+</{{ DSML }}invoke>
+<{{ DSML }}invoke name="$FUNCTION_NAME2">
+...
+</{{ DSML }}invoke>
+</{{ DSML }}function_calls>
+
+String and scalar parameters should be specified as is without any escaping or quotes, while lists and objects should use JSON format. The "string" attribute should be set to "true" for string type parameters and "false" for other types (numbers, booleans, arrays, objects).
+
+If the thinking_mode is enabled, then after function results you should strongly consider outputting a thinking block. Here is an example:
+
+<{{ DSML }}function_calls>
+...
+</{{ DSML }}function_calls>
+
+<function_results>
+...
+</function_results>
+
+{{ THINK_OPEN }}...thinking about results{{ THINK_CLOSE }}
+
+Here are the functions available in JSONSchema format:
+<functions>
+{{ schemas_list | join("\n") }}
+</functions>

--- a/lib/llm/src/preprocessor/prompt/templates/_v4_tools_block.jinja
+++ b/lib/llm/src/preprocessor/prompt/templates/_v4_tools_block.jinja
@@ -1,0 +1,35 @@
+{#- Tools system block. Caller injects "\n\n" prefix.
+    Output ends without trailing newline (caller adds whitespace as needed). -#}
+{%- set DSML = "｜DSML｜" -%}
+{%- set THINK_OPEN = "<think>" -%}
+{%- set THINK_CLOSE = "</think>" -%}
+{%- set schemas_list = [] -%}
+{%- for tool in message.tools -%}
+    {%- set fn = tool.function if tool.function is defined else tool -%}
+    {%- set _ = schemas_list.append(fn | tojson) -%}
+{%- endfor -%}
+## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{{ DSML }}tool_calls>" block like the following:
+
+<{{ DSML }}tool_calls>
+<{{ DSML }}invoke name="$TOOL_NAME">
+<{{ DSML }}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{{ DSML }}parameter>
+...
+</{{ DSML }}invoke>
+<{{ DSML }}invoke name="$TOOL_NAME2">
+...
+</{{ DSML }}invoke>
+</{{ DSML }}tool_calls>
+
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+
+If thinking_mode is enabled (triggered by {{ THINK_OPEN }}), you MUST output your complete reasoning inside {{ THINK_OPEN }}...{{ THINK_CLOSE }} BEFORE any tool calls or final response.
+
+Otherwise, output directly after {{ THINK_CLOSE }} with tool calls or final response.
+
+### Available Tool Schemas
+
+{{ schemas_list | join("\n") }}
+
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.

--- a/lib/llm/src/preprocessor/prompt/templates/deepseek_v32.jinja
+++ b/lib/llm/src/preprocessor/prompt/templates/deepseek_v32.jinja
@@ -1,0 +1,136 @@
+{#-
+  DeepSeek V3.2 chat template — DIS-1850 spike.
+
+  Native Jinja port of `encoding_dsv32.py` (deepseek-ai/DeepSeek-V3.2).
+  Validated byte-identical against test_input/test_output fixtures.
+
+  Differences from V4 (see deepseek_v4.jinja):
+    - tool_calls block name is `function_calls` (not `tool_calls`).
+    - user_msg_template embeds <｜User｜>...<｜Assistant｜> directly; no separate
+      transition appendix.
+    - tool role exists (no merge_tool_messages preprocessing); wrapped in
+      <function_results> blocks with <result>...</result> entries.
+    - No latest_reminder, developer-with-tools, task tokens, reasoning_effort,
+      or wo_eos.
+-#}
+{%- set BOS = "<｜begin▁of▁sentence｜>" -%}
+{%- set EOS = "<｜end▁of▁sentence｜>" -%}
+{%- set THINK_OPEN = "<think>" -%}
+{%- set THINK_CLOSE = "</think>" -%}
+{%- set DSML = "｜DSML｜" -%}
+{%- set USER_TOK = "<｜User｜>" -%}
+{%- set ASSIST_TOK = "<｜Assistant｜>" -%}
+
+{%- if thinking_mode is not defined %}{% set thinking_mode = "chat" %}{% endif -%}
+{%- if drop_thinking is not defined %}{% set drop_thinking = true %}{% endif -%}
+{%- if add_bos_token is not defined %}{% set add_bos_token = true %}{% endif -%}
+
+{#- Find last user/developer index for `<think>` vs `</think>` decision. -#}
+{%- set ns = namespace(last_user_idx=-1) -%}
+{%- for m in messages -%}
+    {%- if m.role == "user" or m.role == "developer" %}{%- set ns.last_user_idx = loop.index0 -%}{%- endif -%}
+{%- endfor -%}
+
+{#- Optionally drop reasoning_content from non-latest assistant turns. -#}
+{%- set msgs = [] -%}
+{%- for m in messages -%}
+    {%- if thinking_mode == "thinking" and drop_thinking and m.role == "assistant" and loop.index0 < ns.last_user_idx -%}
+        {%- set m_copy = {} -%}
+        {%- for k, v in m.items() if k != "reasoning_content" -%}
+            {%- set _ = m_copy.update({k: v}) -%}
+        {%- endfor -%}
+        {%- set _ = msgs.append(m_copy) -%}
+    {%- else -%}
+        {%- set _ = msgs.append(m) -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_bos_token -%}{{ BOS }}{%- endif -%}
+
+{%- for message in msgs -%}
+    {%- set idx = loop.index0 -%}
+
+    {%- if message.role == "system" -%}
+        {{ message.content or "" }}
+        {%- if message.tools %}{{ "\n\n" }}{% include "_v32_tools_block.jinja" %}{{ "\n" }}{% endif -%}
+        {%- if message.response_format -%}
+            {{ "\n\n## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n" }}{{ message.response_format | tojson }}
+        {%- endif -%}
+    {%- elif message.role == "developer" -%}
+        {%- set developer_content = "" -%}
+        {%- if message.tools -%}
+            {%- set developer_content = developer_content ~ "\n\n" -%}
+        {%- endif -%}
+        {{ USER_TOK }}
+        {%- if message.tools %}{{ "\n\n" }}{% include "_v32_tools_block.jinja" %}{{ "\n" }}{% endif -%}
+        {%- if message.response_format -%}
+            {{ "\n\n## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n" }}{{ message.response_format | tojson }}
+        {%- endif -%}
+        {{ "\n\n# The user's message is: " }}{{ message.content }}{{ ASSIST_TOK }}
+        {%- if idx == ns.last_user_idx and thinking_mode == "thinking" -%}
+            {{ THINK_OPEN }}
+        {%- else -%}
+            {{ THINK_CLOSE }}
+        {%- endif -%}
+    {%- elif message.role == "user" -%}
+        {{ USER_TOK }}{{ message.content }}{{ ASSIST_TOK }}
+        {%- if idx == ns.last_user_idx and thinking_mode == "thinking" -%}
+            {{ THINK_OPEN }}
+        {%- else -%}
+            {{ THINK_CLOSE }}
+        {%- endif -%}
+    {%- elif message.role == "tool" -%}
+        {#- Find the most recent assistant message (skipping back over tool messages). -#}
+        {%- set ns2 = namespace(prev_assistant_idx=-1, prev_assistant=none) -%}
+        {%- for j in range(idx - 1, -1, -1) -%}
+            {%- if ns2.prev_assistant_idx == -1 and msgs[j].role == "assistant" -%}
+                {%- set ns2.prev_assistant_idx = j -%}
+                {%- set ns2.prev_assistant = msgs[j] -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {%- set tool_call_order = idx - ns2.prev_assistant_idx -%}
+        {%- set assistant_tool_calls = ns2.prev_assistant.tool_calls or [] -%}
+        {%- if tool_call_order == 1 -%}
+            {{ "\n\n<function_results>" }}
+        {%- endif -%}
+        {{ "\n<result>" }}{{ message.content }}{{ "</result>" }}
+        {%- if tool_call_order == (assistant_tool_calls | length) -%}
+            {{ "\n</function_results>" }}
+            {%- if idx >= ns.last_user_idx and thinking_mode == "thinking" -%}
+                {{ "\n\n" }}{{ THINK_OPEN }}
+            {%- else -%}
+                {{ "\n\n" }}{{ THINK_CLOSE }}
+            {%- endif -%}
+        {%- endif -%}
+    {%- elif message.role == "assistant" -%}
+        {%- set thinking_part = "" -%}
+        {%- set tc_content = "" -%}
+        {%- if message.tool_calls -%}
+            {%- set tc_list = [] -%}
+            {%- for tc in message.tool_calls -%}
+                {%- set tc_name = tc.function.name if tc.function is defined else tc.name -%}
+                {%- set tc_args_raw = tc.function.arguments if tc.function is defined else tc.arguments -%}
+                {%- set parsed_args = tc_args_raw -%}
+                {%- if tc_args_raw is string -%}
+                    {%- set parsed_args = tc_args_raw | fromjson -%}
+                {%- endif -%}
+                {%- set arg_lines = [] -%}
+                {%- for k, v in parsed_args.items() -%}
+                    {%- if v is string -%}
+                        {%- set _ = arg_lines.append("<" ~ DSML ~ "parameter name=\"" ~ k ~ "\" string=\"true\">" ~ v ~ "</" ~ DSML ~ "parameter>") -%}
+                    {%- else -%}
+                        {%- set _ = arg_lines.append("<" ~ DSML ~ "parameter name=\"" ~ k ~ "\" string=\"false\">" ~ (v | tojson) ~ "</" ~ DSML ~ "parameter>") -%}
+                    {%- endif -%}
+                {%- endfor -%}
+                {%- set tc_block = "<" ~ DSML ~ "invoke name=\"" ~ tc_name ~ "\">\n" ~ (arg_lines | join("\n")) ~ "\n</" ~ DSML ~ "invoke>" -%}
+                {%- set _ = tc_list.append(tc_block) -%}
+            {%- endfor -%}
+            {%- set tc_content = "\n\n<" ~ DSML ~ "function_calls>\n" ~ (tc_list | join("\n")) ~ "\n</" ~ DSML ~ "function_calls>" -%}
+        {%- endif -%}
+        {%- set summary_content = message.content or "" -%}
+        {%- if thinking_mode == "thinking" and idx > ns.last_user_idx -%}
+            {%- set thinking_part = (message.reasoning_content or "") ~ THINK_CLOSE -%}
+        {%- endif -%}
+        {{ thinking_part }}{{ summary_content }}{{ tc_content }}{{ EOS }}
+    {%- endif -%}
+{%- endfor -%}

--- a/lib/llm/src/preprocessor/prompt/templates/deepseek_v32_inline.jinja
+++ b/lib/llm/src/preprocessor/prompt/templates/deepseek_v32_inline.jinja
@@ -1,0 +1,146 @@
+{#-
+  DeepSeek V3.2 chat template — DIS-1850 spike (single-file form, upstream-HF-PR ready).
+
+  Native Jinja port of `encoding_dsv32.py` (deepseek-ai/DeepSeek-V3.2).
+  Validated byte-identical against test_input/test_output fixtures.
+-#}
+{%- set BOS = "<｜begin▁of▁sentence｜>" -%}
+{%- set EOS = "<｜end▁of▁sentence｜>" -%}
+{%- set THINK_OPEN = "<think>" -%}
+{%- set THINK_CLOSE = "</think>" -%}
+{%- set DSML = "｜DSML｜" -%}
+{%- set USER_TOK = "<｜User｜>" -%}
+{%- set ASSIST_TOK = "<｜Assistant｜>" -%}
+
+{%- if thinking_mode is not defined %}{% set thinking_mode = "chat" %}{% endif -%}
+{%- if drop_thinking is not defined %}{% set drop_thinking = true %}{% endif -%}
+{%- if add_bos_token is not defined %}{% set add_bos_token = true %}{% endif -%}
+
+{%- macro render_tools_block(tools) -%}
+{%- set schemas_list = [] -%}
+{%- for tool in tools -%}
+    {%- set fn = tool.function if tool.function is defined else tool -%}
+    {%- set _ = schemas_list.append(fn | tojson) -%}
+{%- endfor -%}
+## Tools
+
+You have access to a set of tools you can use to answer the user's question.
+You can invoke functions by writing a "<{{ DSML }}function_calls>" block like the following as part of your reply to the user:
+<{{ DSML }}function_calls>
+<{{ DSML }}invoke name="$FUNCTION_NAME">
+<{{ DSML }}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{{ DSML }}parameter>
+...
+</{{ DSML }}invoke>
+<{{ DSML }}invoke name="$FUNCTION_NAME2">
+...
+</{{ DSML }}invoke>
+</{{ DSML }}function_calls>
+
+String and scalar parameters should be specified as is without any escaping or quotes, while lists and objects should use JSON format. The "string" attribute should be set to "true" for string type parameters and "false" for other types (numbers, booleans, arrays, objects).
+
+If the thinking_mode is enabled, then after function results you should strongly consider outputting a thinking block. Here is an example:
+
+<{{ DSML }}function_calls>
+...
+</{{ DSML }}function_calls>
+
+<function_results>
+...
+</function_results>
+
+{{ THINK_OPEN }}...thinking about results{{ THINK_CLOSE }}
+
+Here are the functions available in JSONSchema format:
+<functions>
+{{ schemas_list | join("\n") }}
+</functions>
+{%- endmacro -%}
+
+{%- set ns = namespace(last_user_idx=-1) -%}
+{%- for m in messages -%}
+    {%- if m.role == "user" or m.role == "developer" %}{%- set ns.last_user_idx = loop.index0 -%}{%- endif -%}
+{%- endfor -%}
+
+{%- set msgs = [] -%}
+{%- for m in messages -%}
+    {%- if thinking_mode == "thinking" and drop_thinking and m.role == "assistant" and loop.index0 < ns.last_user_idx -%}
+        {%- set m_copy = {} -%}
+        {%- for k, v in m.items() if k != "reasoning_content" -%}
+            {%- set _ = m_copy.update({k: v}) -%}
+        {%- endfor -%}
+        {%- set _ = msgs.append(m_copy) -%}
+    {%- else -%}
+        {%- set _ = msgs.append(m) -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_bos_token -%}{{ BOS }}{%- endif -%}
+
+{%- for message in msgs -%}
+    {%- set idx = loop.index0 -%}
+    {%- if message.role == "system" -%}
+        {{ message.content or "" }}
+        {%- if message.tools %}{{ "\n\n" }}{{ render_tools_block(message.tools) }}{{ "\n" }}{% endif -%}
+        {%- if message.response_format -%}
+            {{ "\n\n## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n" }}{{ message.response_format | tojson }}
+        {%- endif -%}
+    {%- elif message.role == "developer" -%}
+        {{ USER_TOK }}
+        {%- if message.tools %}{{ "\n\n" }}{{ render_tools_block(message.tools) }}{{ "\n" }}{% endif -%}
+        {%- if message.response_format -%}
+            {{ "\n\n## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n" }}{{ message.response_format | tojson }}
+        {%- endif -%}
+        {{ "\n\n# The user's message is: " }}{{ message.content }}{{ ASSIST_TOK }}
+        {%- if idx == ns.last_user_idx and thinking_mode == "thinking" -%}{{ THINK_OPEN }}
+        {%- else -%}{{ THINK_CLOSE }}{%- endif -%}
+    {%- elif message.role == "user" -%}
+        {{ USER_TOK }}{{ message.content }}{{ ASSIST_TOK }}
+        {%- if idx == ns.last_user_idx and thinking_mode == "thinking" -%}{{ THINK_OPEN }}
+        {%- else -%}{{ THINK_CLOSE }}{%- endif -%}
+    {%- elif message.role == "tool" -%}
+        {%- set ns2 = namespace(prev_assistant_idx=-1, prev_assistant=none) -%}
+        {%- for j in range(idx - 1, -1, -1) -%}
+            {%- if ns2.prev_assistant_idx == -1 and msgs[j].role == "assistant" -%}
+                {%- set ns2.prev_assistant_idx = j -%}
+                {%- set ns2.prev_assistant = msgs[j] -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {%- set tool_call_order = idx - ns2.prev_assistant_idx -%}
+        {%- set assistant_tool_calls = ns2.prev_assistant.tool_calls or [] -%}
+        {%- if tool_call_order == 1 -%}{{ "\n\n<function_results>" }}{%- endif -%}
+        {{ "\n<result>" }}{{ message.content }}{{ "</result>" }}
+        {%- if tool_call_order == (assistant_tool_calls | length) -%}
+            {{ "\n</function_results>" }}
+            {%- if idx >= ns.last_user_idx and thinking_mode == "thinking" -%}{{ "\n\n" }}{{ THINK_OPEN }}
+            {%- else -%}{{ "\n\n" }}{{ THINK_CLOSE }}{%- endif -%}
+        {%- endif -%}
+    {%- elif message.role == "assistant" -%}
+        {%- set thinking_part = "" -%}
+        {%- set tc_content = "" -%}
+        {%- if message.tool_calls -%}
+            {%- set tc_list = [] -%}
+            {%- for tc in message.tool_calls -%}
+                {%- set tc_name = tc.function.name if tc.function is defined else tc.name -%}
+                {%- set tc_args_raw = tc.function.arguments if tc.function is defined else tc.arguments -%}
+                {%- set parsed_args = tc_args_raw -%}
+                {%- if tc_args_raw is string -%}{%- set parsed_args = tc_args_raw | fromjson -%}{%- endif -%}
+                {%- set arg_lines = [] -%}
+                {%- for k, v in parsed_args.items() -%}
+                    {%- if v is string -%}
+                        {%- set _ = arg_lines.append("<" ~ DSML ~ "parameter name=\"" ~ k ~ "\" string=\"true\">" ~ v ~ "</" ~ DSML ~ "parameter>") -%}
+                    {%- else -%}
+                        {%- set _ = arg_lines.append("<" ~ DSML ~ "parameter name=\"" ~ k ~ "\" string=\"false\">" ~ (v | tojson) ~ "</" ~ DSML ~ "parameter>") -%}
+                    {%- endif -%}
+                {%- endfor -%}
+                {%- set tc_block = "<" ~ DSML ~ "invoke name=\"" ~ tc_name ~ "\">\n" ~ (arg_lines | join("\n")) ~ "\n</" ~ DSML ~ "invoke>" -%}
+                {%- set _ = tc_list.append(tc_block) -%}
+            {%- endfor -%}
+            {%- set tc_content = "\n\n<" ~ DSML ~ "function_calls>\n" ~ (tc_list | join("\n")) ~ "\n</" ~ DSML ~ "function_calls>" -%}
+        {%- endif -%}
+        {%- set summary_content = message.content or "" -%}
+        {%- if thinking_mode == "thinking" and idx > ns.last_user_idx -%}
+            {%- set thinking_part = (message.reasoning_content or "") ~ THINK_CLOSE -%}
+        {%- endif -%}
+        {{ thinking_part }}{{ summary_content }}{{ tc_content }}{{ EOS }}
+    {%- endif -%}
+{%- endfor -%}

--- a/lib/llm/src/preprocessor/prompt/templates/deepseek_v32_inline.jinja
+++ b/lib/llm/src/preprocessor/prompt/templates/deepseek_v32_inline.jinja
@@ -1,8 +1,12 @@
 {#-
-  DeepSeek V3.2 chat template — DIS-1850 spike (single-file form, upstream-HF-PR ready).
+  DeepSeek V3.2 chat template (single-file form, upstream-HF-PR ready).
 
   Native Jinja port of `encoding_dsv32.py` (deepseek-ai/DeepSeek-V3.2).
-  Validated byte-identical against test_input/test_output fixtures.
+  Uses ONLY syntax common to jinja2 and minijinja:
+    - namespace() for stateful accumulation across loops
+    - `| items` filter (NOT `.items()`) for dict iteration
+    - direct emission with `loop.first` / `loop.last` (no list.append)
+    - attr access `m.tools` (NOT `m.get("tools")`) for optional fields
 -#}
 {%- set BOS = "<｜begin▁of▁sentence｜>" -%}
 {%- set EOS = "<｜end▁of▁sentence｜>" -%}
@@ -17,11 +21,6 @@
 {%- if add_bos_token is not defined %}{% set add_bos_token = true %}{% endif -%}
 
 {%- macro render_tools_block(tools) -%}
-{%- set schemas_list = [] -%}
-{%- for tool in tools -%}
-    {%- set fn = tool.function if tool.function is defined else tool -%}
-    {%- set _ = schemas_list.append(fn | tojson) -%}
-{%- endfor -%}
 ## Tools
 
 You have access to a set of tools you can use to answer the user's question.
@@ -52,7 +51,10 @@ If the thinking_mode is enabled, then after function results you should strongly
 
 Here are the functions available in JSONSchema format:
 <functions>
-{{ schemas_list | join("\n") }}
+{% for tool in tools -%}
+{%- set fn = tool.function if tool.function is defined else tool -%}
+{{ fn | tojson }}
+{% endfor %}
 </functions>
 {%- endmacro -%}
 
@@ -61,22 +63,9 @@ Here are the functions available in JSONSchema format:
     {%- if m.role == "user" or m.role == "developer" %}{%- set ns.last_user_idx = loop.index0 -%}{%- endif -%}
 {%- endfor -%}
 
-{%- set msgs = [] -%}
-{%- for m in messages -%}
-    {%- if thinking_mode == "thinking" and drop_thinking and m.role == "assistant" and loop.index0 < ns.last_user_idx -%}
-        {%- set m_copy = {} -%}
-        {%- for k, v in m.items() if k != "reasoning_content" -%}
-            {%- set _ = m_copy.update({k: v}) -%}
-        {%- endfor -%}
-        {%- set _ = msgs.append(m_copy) -%}
-    {%- else -%}
-        {%- set _ = msgs.append(m) -%}
-    {%- endif -%}
-{%- endfor -%}
-
 {%- if add_bos_token -%}{{ BOS }}{%- endif -%}
 
-{%- for message in msgs -%}
+{%- for message in messages -%}
     {%- set idx = loop.index0 -%}
     {%- if message.role == "system" -%}
         {{ message.content or "" }}
@@ -98,49 +87,45 @@ Here are the functions available in JSONSchema format:
         {%- if idx == ns.last_user_idx and thinking_mode == "thinking" -%}{{ THINK_OPEN }}
         {%- else -%}{{ THINK_CLOSE }}{%- endif -%}
     {%- elif message.role == "tool" -%}
-        {%- set ns2 = namespace(prev_assistant_idx=-1, prev_assistant=none) -%}
+        {%- set ns2 = namespace(prev_assistant_idx=-1, prev_assistant_tc_count=0) -%}
         {%- for j in range(idx - 1, -1, -1) -%}
-            {%- if ns2.prev_assistant_idx == -1 and msgs[j].role == "assistant" -%}
+            {%- if ns2.prev_assistant_idx == -1 and messages[j].role == "assistant" -%}
                 {%- set ns2.prev_assistant_idx = j -%}
-                {%- set ns2.prev_assistant = msgs[j] -%}
+                {%- set ns2.prev_assistant_tc_count = (messages[j].tool_calls or []) | length -%}
             {%- endif -%}
         {%- endfor -%}
         {%- set tool_call_order = idx - ns2.prev_assistant_idx -%}
-        {%- set assistant_tool_calls = ns2.prev_assistant.tool_calls or [] -%}
         {%- if tool_call_order == 1 -%}{{ "\n\n<function_results>" }}{%- endif -%}
         {{ "\n<result>" }}{{ message.content }}{{ "</result>" }}
-        {%- if tool_call_order == (assistant_tool_calls | length) -%}
+        {%- if tool_call_order == ns2.prev_assistant_tc_count -%}
             {{ "\n</function_results>" }}
             {%- if idx >= ns.last_user_idx and thinking_mode == "thinking" -%}{{ "\n\n" }}{{ THINK_OPEN }}
             {%- else -%}{{ "\n\n" }}{{ THINK_CLOSE }}{%- endif -%}
         {%- endif -%}
     {%- elif message.role == "assistant" -%}
-        {%- set thinking_part = "" -%}
-        {%- set tc_content = "" -%}
+        {%- if thinking_mode == "thinking" and idx > ns.last_user_idx -%}
+            {{ message.reasoning_content or "" }}{{ THINK_CLOSE }}
+        {%- endif -%}
+        {{ message.content or "" }}
         {%- if message.tool_calls -%}
-            {%- set tc_list = [] -%}
+            {{ "\n\n<" ~ DSML ~ "function_calls>" }}
             {%- for tc in message.tool_calls -%}
                 {%- set tc_name = tc.function.name if tc.function is defined else tc.name -%}
                 {%- set tc_args_raw = tc.function.arguments if tc.function is defined else tc.arguments -%}
-                {%- set parsed_args = tc_args_raw -%}
-                {%- if tc_args_raw is string -%}{%- set parsed_args = tc_args_raw | fromjson -%}{%- endif -%}
-                {%- set arg_lines = [] -%}
-                {%- for k, v in parsed_args.items() -%}
+                {%- set parsed_args = (tc_args_raw | fromjson) if tc_args_raw is string else tc_args_raw -%}
+                {{ "\n<" ~ DSML ~ "invoke name=\"" ~ tc_name ~ "\">\n" }}
+                {%- for k, v in parsed_args | items -%}
+                    {%- if not loop.first %}{{ "\n" }}{%- endif -%}
                     {%- if v is string -%}
-                        {%- set _ = arg_lines.append("<" ~ DSML ~ "parameter name=\"" ~ k ~ "\" string=\"true\">" ~ v ~ "</" ~ DSML ~ "parameter>") -%}
+                        {{ "<" ~ DSML ~ "parameter name=\"" ~ k ~ "\" string=\"true\">" ~ v ~ "</" ~ DSML ~ "parameter>" }}
                     {%- else -%}
-                        {%- set _ = arg_lines.append("<" ~ DSML ~ "parameter name=\"" ~ k ~ "\" string=\"false\">" ~ (v | tojson) ~ "</" ~ DSML ~ "parameter>") -%}
+                        {{ "<" ~ DSML ~ "parameter name=\"" ~ k ~ "\" string=\"false\">" ~ (v | tojson) ~ "</" ~ DSML ~ "parameter>" }}
                     {%- endif -%}
                 {%- endfor -%}
-                {%- set tc_block = "<" ~ DSML ~ "invoke name=\"" ~ tc_name ~ "\">\n" ~ (arg_lines | join("\n")) ~ "\n</" ~ DSML ~ "invoke>" -%}
-                {%- set _ = tc_list.append(tc_block) -%}
+                {{ "\n</" ~ DSML ~ "invoke>" }}
             {%- endfor -%}
-            {%- set tc_content = "\n\n<" ~ DSML ~ "function_calls>\n" ~ (tc_list | join("\n")) ~ "\n</" ~ DSML ~ "function_calls>" -%}
+            {{ "\n</" ~ DSML ~ "function_calls>" }}
         {%- endif -%}
-        {%- set summary_content = message.content or "" -%}
-        {%- if thinking_mode == "thinking" and idx > ns.last_user_idx -%}
-            {%- set thinking_part = (message.reasoning_content or "") ~ THINK_CLOSE -%}
-        {%- endif -%}
-        {{ thinking_part }}{{ summary_content }}{{ tc_content }}{{ EOS }}
+        {{ EOS }}
     {%- endif -%}
 {%- endfor -%}

--- a/lib/llm/src/preprocessor/prompt/templates/deepseek_v4.jinja
+++ b/lib/llm/src/preprocessor/prompt/templates/deepseek_v4.jinja
@@ -1,0 +1,164 @@
+{#-
+  DeepSeek V4 chat template — DIS-1850 spike.
+
+  Native Jinja port of `encoding_dsv4.py` (deepseek-ai/DeepSeek-V4-Pro).
+  Validated byte-identical against test_input/test_output fixtures.
+
+  Inputs (all optional except `messages`):
+    - messages: list[dict]               — assumed pre-processed (merge_tool_messages
+                                            + sort_tool_results_by_call_order applied
+                                            by Rust pre-pass)
+    - thinking_mode: "thinking" | "chat" — default "chat"
+    - drop_thinking: bool                — default true (auto-disabled if any tools)
+    - reasoning_effort: "max" | "high" | none
+    - add_bos_token: bool                — default true
+-#}
+{#- Constants. -#}
+{%- set BOS = "<｜begin▁of▁sentence｜>" -%}
+{%- set EOS = "<｜end▁of▁sentence｜>" -%}
+{%- set THINK_OPEN = "<think>" -%}
+{%- set THINK_CLOSE = "</think>" -%}
+{%- set DSML = "｜DSML｜" -%}
+{%- set USER_TOK = "<｜User｜>" -%}
+{%- set ASSIST_TOK = "<｜Assistant｜>" -%}
+{%- set REMINDER_TOK = "<｜latest_reminder｜>" -%}
+{%- set TASK_TOKENS = {
+    "action":   "<｜action｜>",
+    "query":    "<｜query｜>",
+    "authority":"<｜authority｜>",
+    "domain":   "<｜domain｜>",
+    "title":    "<｜title｜>",
+    "read_url": "<｜read_url｜>"
+} -%}
+{%- set REASONING_EFFORT_MAX_PREFIX = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n" -%}
+
+{#- Default flags. -#}
+{%- if thinking_mode is not defined %}{% set thinking_mode = "chat" %}{% endif -%}
+{%- if drop_thinking is not defined %}{% set drop_thinking = true %}{% endif -%}
+{%- if add_bos_token is not defined %}{% set add_bos_token = true %}{% endif -%}
+{%- if reasoning_effort is not defined %}{% set reasoning_effort = none %}{% endif -%}
+
+{#- Auto-disable drop_thinking if any message carries tools. -#}
+{%- set ns = namespace(has_tools=false, last_user_idx=-1) -%}
+{%- for m in messages -%}
+    {%- if m.tools %}{%- set ns.has_tools = true -%}{%- endif -%}
+    {%- if m.role == "user" or m.role == "developer" %}{%- set ns.last_user_idx = loop.index0 -%}{%- endif -%}
+{%- endfor -%}
+{%- set effective_drop_thinking = drop_thinking and (not ns.has_tools) -%}
+
+{#- BOS. -#}
+{%- if add_bos_token -%}{{ BOS }}{%- endif -%}
+
+{#- Render each message. -#}
+{%- for message in messages -%}
+    {%- set idx = loop.index0 -%}
+
+    {#- Reasoning effort prefix at index 0 in thinking mode + max. -#}
+    {%- if idx == 0 and thinking_mode == "thinking" and reasoning_effort == "max" -%}
+        {{ REASONING_EFFORT_MAX_PREFIX }}
+    {%- endif -%}
+
+    {#- Role dispatch. -#}
+    {%- if message.role == "system" -%}
+        {{ message.content or "" }}
+        {%- if message.tools %}{{ "\n\n" }}{% include "_v4_tools_block.jinja" %}{{ "\n" }}{% endif -%}
+        {%- if message.response_format -%}
+            {{ "\n\n## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n" }}{{ message.response_format | tojson }}
+        {%- endif -%}
+    {%- elif message.role == "developer" -%}
+        {{ USER_TOK }}{{ message.content }}
+        {%- if message.tools %}{{ "\n\n" }}{% include "_v4_tools_block.jinja" %}{{ "\n" }}{% endif -%}
+        {%- if message.response_format -%}
+            {{ "\n\n## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n" }}{{ message.response_format | tojson }}
+        {%- endif -%}
+    {%- elif message.role == "user" -%}
+        {{ USER_TOK }}
+        {%- if message.content_blocks -%}
+            {%- set parts = [] -%}
+            {%- for block in message.content_blocks -%}
+                {%- if block.type == "text" -%}
+                    {%- set _ = parts.append(block.text or "") -%}
+                {%- elif block.type == "tool_result" -%}
+                    {%- set tc = block.content -%}
+                    {%- if tc is iterable and tc is not string -%}
+                        {%- set tparts = [] -%}
+                        {%- for b in tc -%}
+                            {%- if b.type == "text" -%}{%- set _ = tparts.append(b.text or "") -%}
+                            {%- else -%}{%- set _ = tparts.append("[Unsupported " ~ b.type ~ "]") -%}{%- endif -%}
+                        {%- endfor -%}
+                        {%- set tc = tparts | join("\n\n") -%}
+                    {%- endif -%}
+                    {%- set _ = parts.append("<tool_result>" ~ tc ~ "</tool_result>") -%}
+                {%- else -%}
+                    {%- set _ = parts.append("[Unsupported " ~ block.type ~ "]") -%}
+                {%- endif -%}
+            {%- endfor -%}
+            {{ parts | join("\n\n") }}
+        {%- else -%}
+            {{ message.content or "" }}
+        {%- endif -%}
+    {%- elif message.role == "latest_reminder" -%}
+        {{ REMINDER_TOK }}{{ message.content }}
+    {%- elif message.role == "assistant" -%}
+        {%- set thinking_part = "" -%}
+        {%- set tc_content = "" -%}
+        {#- Tool calls. -#}
+        {%- if message.tool_calls -%}
+            {%- set tc_list = [] -%}
+            {%- for tc in message.tool_calls -%}
+                {%- set tc_name = tc.function.name if tc.function is defined else tc.name -%}
+                {%- set tc_args_raw = tc.function.arguments if tc.function is defined else tc.arguments -%}
+                {%- set parsed_args = tc_args_raw -%}
+                {%- if tc_args_raw is string -%}
+                    {%- set parsed_args = tc_args_raw | fromjson -%}
+                {%- endif -%}
+                {%- set arg_lines = [] -%}
+                {%- for k, v in parsed_args.items() -%}
+                    {%- if v is string -%}
+                        {%- set _ = arg_lines.append("<" ~ DSML ~ "parameter name=\"" ~ k ~ "\" string=\"true\">" ~ v ~ "</" ~ DSML ~ "parameter>") -%}
+                    {%- else -%}
+                        {%- set _ = arg_lines.append("<" ~ DSML ~ "parameter name=\"" ~ k ~ "\" string=\"false\">" ~ (v | tojson) ~ "</" ~ DSML ~ "parameter>") -%}
+                    {%- endif -%}
+                {%- endfor -%}
+                {%- set tc_block = "<" ~ DSML ~ "invoke name=\"" ~ tc_name ~ "\">\n" ~ (arg_lines | join("\n")) ~ "\n</" ~ DSML ~ "invoke>" -%}
+                {%- set _ = tc_list.append(tc_block) -%}
+            {%- endfor -%}
+            {%- set tc_content = "\n\n<" ~ DSML ~ "tool_calls>\n" ~ (tc_list | join("\n")) ~ "\n</" ~ DSML ~ "tool_calls>" -%}
+        {%- endif -%}
+        {%- set summary_content = message.content or "" -%}
+        {%- set rc = message.reasoning_content or "" -%}
+        {%- set prev_has_task = idx > 0 and (messages[idx-1].task is defined) -%}
+        {%- if thinking_mode == "thinking" and not prev_has_task -%}
+            {%- if (not effective_drop_thinking) or idx > ns.last_user_idx -%}
+                {#- Note: leading <think> opener comes from previous message's
+                    transition appendix, not here — only emit content + closer. -#}
+                {%- set thinking_part = rc ~ THINK_CLOSE -%}
+            {%- endif -%}
+        {%- endif -%}
+        {{ thinking_part }}{{ summary_content }}{{ tc_content }}
+        {%- if not message.wo_eos -%}{{ EOS }}{%- endif -%}
+    {%- endif -%}
+
+    {#- Transition to next message: append role markers if next is assistant/latest_reminder
+        OR if current is user/developer. -#}
+    {%- set is_last = idx == (messages | length - 1) -%}
+    {%- set next_role = messages[idx+1].role if not is_last else none -%}
+    {%- if is_last or next_role == "assistant" or next_role == "latest_reminder" -%}
+        {%- if message.task is defined and message.task is not none -%}
+            {%- if message.task == "action" -%}
+                {{ ASSIST_TOK }}{{ THINK_OPEN if thinking_mode == "thinking" else THINK_CLOSE }}{{ TASK_TOKENS[message.task] }}
+            {%- else -%}
+                {{ TASK_TOKENS[message.task] }}
+            {%- endif -%}
+        {%- elif message.role == "user" or message.role == "developer" -%}
+            {{ ASSIST_TOK }}
+            {%- if (not effective_drop_thinking) and thinking_mode == "thinking" -%}
+                {{ THINK_OPEN }}
+            {%- elif effective_drop_thinking and thinking_mode == "thinking" and idx >= ns.last_user_idx -%}
+                {{ THINK_OPEN }}
+            {%- else -%}
+                {{ THINK_CLOSE }}
+            {%- endif -%}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}

--- a/lib/llm/src/preprocessor/prompt/templates/deepseek_v4_inline.jinja
+++ b/lib/llm/src/preprocessor/prompt/templates/deepseek_v4_inline.jinja
@@ -1,0 +1,171 @@
+{#-
+  DeepSeek V4 chat template — DIS-1850 spike (single-file form).
+
+  Native Jinja port of `encoding_dsv4.py` (deepseek-ai/DeepSeek-V4-Pro).
+  Validated byte-identical against test_input/test_output fixtures + 9
+  synthetic gap fixtures, in BOTH Python jinja2 and Rust minijinja.
+
+  This file uses ONLY syntax common to jinja2 and minijinja:
+    - namespace() for stateful accumulation
+    - reverse-iteration loops, dict tests, filters
+    - `| items` filter (NOT `.items()`) for dict iteration
+    - direct emission with `loop.first` / `loop.last` (no list.append)
+    - attr access `m.tools` (NOT `m.get("tools")`) for optional fields
+
+  Inputs (all optional except `messages`):
+    - messages: list[dict]               — assumed pre-processed (merge_tool_messages
+                                            + sort_tool_results_by_call_order applied
+                                            by Rust pre-pass)
+    - thinking_mode: "thinking" | "chat" — default "chat"
+    - drop_thinking: bool                — default true (auto-disabled if any tools)
+    - reasoning_effort: "max" | "high" | none
+    - add_bos_token: bool                — default true
+-#}
+{%- set BOS = "<｜begin▁of▁sentence｜>" -%}
+{%- set EOS = "<｜end▁of▁sentence｜>" -%}
+{%- set THINK_OPEN = "<think>" -%}
+{%- set THINK_CLOSE = "</think>" -%}
+{%- set DSML = "｜DSML｜" -%}
+{%- set USER_TOK = "<｜User｜>" -%}
+{%- set ASSIST_TOK = "<｜Assistant｜>" -%}
+{%- set REMINDER_TOK = "<｜latest_reminder｜>" -%}
+{%- set TASK_TOKENS = {"action":"<｜action｜>","query":"<｜query｜>","authority":"<｜authority｜>","domain":"<｜domain｜>","title":"<｜title｜>","read_url":"<｜read_url｜>"} -%}
+{%- set REASONING_EFFORT_MAX_PREFIX = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n" -%}
+
+{%- if thinking_mode is not defined %}{% set thinking_mode = "chat" %}{% endif -%}
+{%- if drop_thinking is not defined %}{% set drop_thinking = true %}{% endif -%}
+{%- if add_bos_token is not defined %}{% set add_bos_token = true %}{% endif -%}
+{%- if reasoning_effort is not defined %}{% set reasoning_effort = none %}{% endif -%}
+
+{%- macro render_tools_block(tools) -%}
+## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{{ DSML }}tool_calls>" block like the following:
+
+<{{ DSML }}tool_calls>
+<{{ DSML }}invoke name="$TOOL_NAME">
+<{{ DSML }}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{{ DSML }}parameter>
+...
+</{{ DSML }}invoke>
+<{{ DSML }}invoke name="$TOOL_NAME2">
+...
+</{{ DSML }}invoke>
+</{{ DSML }}tool_calls>
+
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+
+If thinking_mode is enabled (triggered by {{ THINK_OPEN }}), you MUST output your complete reasoning inside {{ THINK_OPEN }}...{{ THINK_CLOSE }} BEFORE any tool calls or final response.
+
+Otherwise, output directly after {{ THINK_CLOSE }} with tool calls or final response.
+
+### Available Tool Schemas
+
+{% for tool in tools -%}
+{%- set fn = tool.function if tool.function is defined else tool -%}
+{{ fn | tojson }}
+{% endfor %}
+{{ "\n" }}You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+{%- endmacro -%}
+
+{%- set ns = namespace(has_tools=false, last_user_idx=-1) -%}
+{%- for m in messages -%}
+    {%- if m.tools %}{%- set ns.has_tools = true -%}{%- endif -%}
+    {%- if m.role == "user" or m.role == "developer" %}{%- set ns.last_user_idx = loop.index0 -%}{%- endif -%}
+{%- endfor -%}
+{%- set effective_drop_thinking = drop_thinking and (not ns.has_tools) -%}
+
+{%- if add_bos_token -%}{{ BOS }}{%- endif -%}
+
+{%- for message in messages -%}
+    {%- set idx = loop.index0 -%}
+    {%- if idx == 0 and thinking_mode == "thinking" and reasoning_effort == "max" -%}
+        {{ REASONING_EFFORT_MAX_PREFIX }}
+    {%- endif -%}
+    {%- if message.role == "system" -%}
+        {{ message.content or "" }}
+        {%- if message.tools %}{{ "\n\n" }}{{ render_tools_block(message.tools) }}{{ "\n" }}{% endif -%}
+        {%- if message.response_format -%}
+            {{ "\n\n## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n" }}{{ message.response_format | tojson }}
+        {%- endif -%}
+    {%- elif message.role == "developer" -%}
+        {{ USER_TOK }}{{ message.content }}
+        {%- if message.tools %}{{ "\n\n" }}{{ render_tools_block(message.tools) }}{{ "\n" }}{% endif -%}
+        {%- if message.response_format -%}
+            {{ "\n\n## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n" }}{{ message.response_format | tojson }}
+        {%- endif -%}
+    {%- elif message.role == "user" -%}
+        {{ USER_TOK }}
+        {%- if message.content_blocks -%}
+            {%- for block in message.content_blocks -%}
+                {%- if not loop.first %}{{ "\n\n" }}{%- endif -%}
+                {%- if block.type == "text" -%}
+                    {{ block.text or "" }}
+                {%- elif block.type == "tool_result" -%}
+                    {%- set tc = block.content -%}
+                    {%- if tc is iterable and tc is not string -%}
+                        {%- set ns_t = namespace(s="") -%}
+                        {%- for b in tc -%}
+                            {%- if not loop.first %}{%- set ns_t.s = ns_t.s ~ "\n\n" -%}{%- endif -%}
+                            {%- if b.type == "text" -%}{%- set ns_t.s = ns_t.s ~ (b.text or "") -%}
+                            {%- else -%}{%- set ns_t.s = ns_t.s ~ "[Unsupported " ~ b.type ~ "]" -%}{%- endif -%}
+                        {%- endfor -%}
+                        {%- set tc = ns_t.s -%}
+                    {%- endif -%}
+                    <tool_result>{{ tc }}</tool_result>
+                {%- else -%}
+                    [Unsupported {{ block.type }}]
+                {%- endif -%}
+            {%- endfor -%}
+        {%- else -%}
+            {{ message.content or "" }}
+        {%- endif -%}
+    {%- elif message.role == "latest_reminder" -%}
+        {{ REMINDER_TOK }}{{ message.content }}
+    {%- elif message.role == "assistant" -%}
+        {%- set rc = message.reasoning_content or "" -%}
+        {%- set prev_has_task = idx > 0 and (messages[idx-1].task is defined and messages[idx-1].task is not none) -%}
+        {%- if thinking_mode == "thinking" and not prev_has_task -%}
+            {%- if (not effective_drop_thinking) or idx > ns.last_user_idx -%}
+                {{ rc }}{{ THINK_CLOSE }}
+            {%- endif -%}
+        {%- endif -%}
+        {{ message.content or "" }}
+        {%- if message.tool_calls -%}
+            {{ "\n\n<" ~ DSML ~ "tool_calls>" }}
+            {%- for tc in message.tool_calls -%}
+                {%- set tc_name = tc.function.name if tc.function is defined else tc.name -%}
+                {%- set tc_args_raw = tc.function.arguments if tc.function is defined else tc.arguments -%}
+                {%- set parsed_args = (tc_args_raw | fromjson) if tc_args_raw is string else tc_args_raw -%}
+                {{ "\n<" ~ DSML ~ "invoke name=\"" ~ tc_name ~ "\">\n" }}
+                {%- for k, v in parsed_args | items -%}
+                    {%- if not loop.first %}{{ "\n" }}{%- endif -%}
+                    {%- if v is string -%}
+                        {{ "<" ~ DSML ~ "parameter name=\"" ~ k ~ "\" string=\"true\">" ~ v ~ "</" ~ DSML ~ "parameter>" }}
+                    {%- else -%}
+                        {{ "<" ~ DSML ~ "parameter name=\"" ~ k ~ "\" string=\"false\">" ~ (v | tojson) ~ "</" ~ DSML ~ "parameter>" }}
+                    {%- endif -%}
+                {%- endfor -%}
+                {{ "\n</" ~ DSML ~ "invoke>" }}
+            {%- endfor -%}
+            {{ "\n</" ~ DSML ~ "tool_calls>" }}
+        {%- endif -%}
+        {%- if not message.wo_eos -%}{{ EOS }}{%- endif -%}
+    {%- endif -%}
+
+    {%- set is_last = idx == (messages | length - 1) -%}
+    {%- set next_role = messages[idx+1].role if not is_last else none -%}
+    {%- if is_last or next_role == "assistant" or next_role == "latest_reminder" -%}
+        {%- if message.task is defined and message.task is not none -%}
+            {%- if message.task == "action" -%}
+                {{ ASSIST_TOK }}{{ THINK_OPEN if thinking_mode == "thinking" else THINK_CLOSE }}{{ TASK_TOKENS[message.task] }}
+            {%- else -%}
+                {{ TASK_TOKENS[message.task] }}
+            {%- endif -%}
+        {%- elif message.role == "user" or message.role == "developer" -%}
+            {{ ASSIST_TOK }}
+            {%- if (not effective_drop_thinking) and thinking_mode == "thinking" -%}{{ THINK_OPEN }}
+            {%- elif effective_drop_thinking and thinking_mode == "thinking" and idx >= ns.last_user_idx -%}{{ THINK_OPEN }}
+            {%- else -%}{{ THINK_CLOSE }}{%- endif -%}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}

--- a/lib/llm/tests/jinja_v32_parity.rs
+++ b/lib/llm/tests/jinja_v32_parity.rs
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Byte-identical parity check: minijinja + `deepseek_v32_inline.jinja` against
+//! the same `tests/data/deepseek-v3.2/` fixtures the existing native-Rust port
+//! already validates against.
+
+use dynamo_llm::preprocessor::prompt::jinja_chat::{ThinkingMode, render_v32};
+use serde_json::Value as JsonValue;
+use std::fs;
+use std::path::PathBuf;
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/deepseek-v3.2")
+}
+
+fn load_messages(input_file: &str) -> Vec<JsonValue> {
+    let path = fixture_dir().join(input_file);
+    let raw: JsonValue = serde_json::from_str(
+        &fs::read_to_string(&path).unwrap_or_else(|_| panic!("read {input_file}")),
+    )
+    .unwrap_or_else(|_| panic!("parse {input_file}"));
+
+    let mut messages = raw["messages"]
+        .as_array()
+        .unwrap_or_else(|| panic!("Missing messages in {input_file}"))
+        .clone();
+
+    if let Some(tools) = raw.get("tools")
+        && let Some(first) = messages.get_mut(0)
+        && let Some(obj) = first.as_object_mut()
+    {
+        obj.insert("tools".to_string(), tools.clone());
+    }
+    messages
+}
+
+fn run_parity(input_file: &str, output_file: &str) {
+    let messages = load_messages(input_file);
+    let expected = fs::read_to_string(fixture_dir().join(output_file))
+        .unwrap_or_else(|_| panic!("read {output_file}"));
+
+    let actual = render_v32(&messages, ThinkingMode::Thinking, true, true)
+        .unwrap_or_else(|e| panic!("render_v32 failed for {input_file}: {e:?}"));
+
+    let exp = expected.trim_end();
+    let act = actual.trim_end();
+
+    if exp != act {
+        let exp_lines: Vec<&str> = exp.lines().collect();
+        let act_lines: Vec<&str> = act.lines().collect();
+        for (i, (el, al)) in exp_lines.iter().zip(act_lines.iter()).enumerate() {
+            if el != al {
+                eprintln!("=== {input_file} ===");
+                eprintln!("Line {} differs:", i + 1);
+                eprintln!("  Expected: {el:?}");
+                eprintln!("  Actual:   {al:?}");
+                break;
+            }
+        }
+        if exp_lines.len() != act_lines.len() {
+            eprintln!(
+                "Line count: expected {} vs actual {}",
+                exp_lines.len(),
+                act_lines.len()
+            );
+        }
+        panic!("Jinja V3.2 output diverges from fixture for {input_file}");
+    }
+}
+
+#[test]
+fn jinja_v32_basic_example() {
+    run_parity("test_input.json", "test_output.txt");
+}
+
+#[test]
+fn jinja_v32_search_without_date() {
+    run_parity(
+        "test_input_search_wo_date.json",
+        "test_output_search_wo_date.txt",
+    );
+}
+
+#[test]
+fn jinja_v32_search_with_date() {
+    run_parity(
+        "test_input_search_w_date.json",
+        "test_output_search_w_date.txt",
+    );
+}

--- a/lib/llm/tests/jinja_v4_parity.rs
+++ b/lib/llm/tests/jinja_v4_parity.rs
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Byte-identical parity check: minijinja + `deepseek_v4_inline.jinja` against
+//! the same `tests/data/deepseek-v4/` fixtures the existing native-Rust port
+//! already validates against. If these tests pass, the Jinja path is a drop-in
+//! replacement for `deepseek_v4::encode_messages` and the native port can be
+//! retired.
+
+use dynamo_llm::preprocessor::prompt::jinja_chat::{ThinkingMode, render_v4};
+use serde_json::Value as JsonValue;
+use std::fs;
+use std::path::PathBuf;
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/deepseek-v4")
+}
+
+/// V4 fixtures come in two shapes:
+///   1. `{"tools": [...], "messages": [...]}` — tools injected on first message
+///   2. bare `[...]` — just the messages array
+fn load_messages(input_file: &str) -> Vec<JsonValue> {
+    let path = fixture_dir().join(input_file);
+    let raw: JsonValue = serde_json::from_str(
+        &fs::read_to_string(&path).unwrap_or_else(|_| panic!("read {input_file}")),
+    )
+    .unwrap_or_else(|_| panic!("parse {input_file}"));
+
+    if let Some(messages) = raw.get("messages").and_then(|m| m.as_array()) {
+        let mut messages = messages.clone();
+        if let Some(tools) = raw.get("tools")
+            && let Some(first) = messages.get_mut(0)
+            && let Some(obj) = first.as_object_mut()
+        {
+            obj.insert("tools".to_string(), tools.clone());
+        }
+        messages
+    } else if let Some(arr) = raw.as_array() {
+        arr.clone()
+    } else {
+        panic!("Unexpected input shape in {input_file}");
+    }
+}
+
+fn run_parity(input_file: &str, output_file: &str, thinking_mode: ThinkingMode) {
+    let messages = load_messages(input_file);
+    let expected = fs::read_to_string(fixture_dir().join(output_file))
+        .unwrap_or_else(|_| panic!("read {output_file}"));
+
+    let actual = render_v4(&messages, thinking_mode, true, true, None)
+        .unwrap_or_else(|e| panic!("render_v4 failed for {input_file}: {e:?}"));
+
+    let exp = expected.trim_end();
+    let act = actual.trim_end();
+
+    if exp != act {
+        let exp_lines: Vec<&str> = exp.lines().collect();
+        let act_lines: Vec<&str> = act.lines().collect();
+        for (i, (el, al)) in exp_lines.iter().zip(act_lines.iter()).enumerate() {
+            if el != al {
+                eprintln!("=== {input_file} ===");
+                eprintln!("Line {} differs:", i + 1);
+                eprintln!("  Expected: {el:?}");
+                eprintln!("  Actual:   {al:?}");
+                break;
+            }
+        }
+        if exp_lines.len() != act_lines.len() {
+            eprintln!(
+                "Line count: expected {} vs actual {}",
+                exp_lines.len(),
+                act_lines.len()
+            );
+        }
+        panic!("Jinja V4 output diverges from fixture for {input_file}");
+    }
+}
+
+#[test]
+fn jinja_v4_fixture_1_thinking_with_tools() {
+    run_parity(
+        "test_input_1.json",
+        "test_output_1.txt",
+        ThinkingMode::Thinking,
+    );
+}
+
+#[test]
+fn jinja_v4_fixture_2_thinking_no_tools_multiturn() {
+    run_parity(
+        "test_input_2.json",
+        "test_output_2.txt",
+        ThinkingMode::Thinking,
+    );
+}
+
+#[test]
+fn jinja_v4_fixture_3_developer_with_tools_and_reminder() {
+    run_parity(
+        "test_input_3.json",
+        "test_output_3.txt",
+        ThinkingMode::Thinking,
+    );
+}
+
+#[test]
+fn jinja_v4_fixture_4_chat_mode_action_task() {
+    run_parity(
+        "test_input_4.json",
+        "test_output_4.txt",
+        ThinkingMode::Chat,
+    );
+}


### PR DESCRIPTION
#### Why:

Replace `deepseek_v4.rs` + `deepseek_v32.rs` (~2600 LOC of Rust) with two Jinja chat templates plus a thin Rust pre-pass + request glue. Less code, easier to read and debug. Every other model family (Qwen, Llama, Mistral, GLM, Kimi, gpt-oss) already rides Dynamo's existing minijinja path — DeepSeek was the special case only because they don't ship `chat_template` in their HF `tokenizer_config.json`. The templates can also be PR'd upstream so vLLM/SGLang/transformers/Dynamo all stop needing per-model encoders.

#### What:

Two inline Jinja templates (`deepseek_v4_inline.jinja`, `deepseek_v32_inline.jinja`) covering V4 and V3.2 prompt encoding. New `jinja_chat.rs` module wires minijinja with a Python-style `tojson` formatter (jinja2-compatible spacing) and a `fromjson` filter. `encode_messages` becomes a thin shim into `jinja_chat::render_v{4,32}`. Existing tests under `lib/llm/tests/data/deepseek-v{3.2,4}/` and `deepseek_v{4,32}_encoding.rs` are unchanged.

What stays in Rust: public types, V4's `merge_tool_messages` / `sort_tool_results_by_call_order` pre-pass, multi-modal content-block flattening, and the `OAIPromptFormatter::render` glue that injects `tools` / `response_format` into the system message.

#### Results:

- 7/7 in-tree fixtures byte-identical via minijinja (new tests `jinja_v{4,32}_parity.rs`).
- All existing fixture + formatter tests pass through the shimmed entry point — 4 V4 + 12 V3.2 + 970 lib unit tests.
- Net delete: ~1100 LOC of Rust (V4 1271→536, V3.2 1353→977).

Full evidence in [DIS-1850](https://linear.app/nvidia/issue/DIS-1850).

/coderabbit profile chill
