### PR TITLE
fix(sglang): preserve max_new_tokens=None to avoid silent 128-token cap

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -119,7 +119,12 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 **self._get_guided_decoding_params(request.get("guided_decoding")),
             }
 
-        return {k: v for k, v in param_mapping.items() if v is not None}
+        # Keep max_new_tokens even when None — SGLang treats None as "generate
+        # until EOS/context-length" whereas omitting it triggers a default of 128.
+        keep_if_none = {"max_new_tokens"}
+        return {
+            k: v for k, v in param_mapping.items() if v is not None or k in keep_if_none
+        }
 
     @staticmethod
     def _build_logprob_kwargs(request: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
#### Overview:

When a client omits `max_tokens` from a chat completion request (valid per the OpenAI spec), the dynamo SGLang worker silently caps output at 128 tokens instead of generating until EOS. This is because the `_build_sampling_params` dict comprehension filters out `max_new_tokens=None`, causing SGLang to fall back to its internal default of 128.

Repro:
```
bash
curl -s http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen/Qwen3-0.6B",
    "messages": [{"role": "user", "content": "Write a detailed essay about the history of computing."}],
    "stream": false,
    "temperature": 0.7
  }' | python3 -c "
import sys, json
d = json.load(sys.stdin)
c = d['choices'][0]
u = d.get('usage', {})
print(f'completion_tokens: {u.get(\"completion_tokens\")}')
print(f'finish_reason: {c.get(\"finish_reason\")}')"
```
Before this PR:
```
completion_tokens: 128
finish_reason: length
```
With this PR:
```
completion_tokens: 2053
finish_reason: stop
```

#### Details:

`decode_handler.py:_build_sampling_params()` builds a dict of SGLang sampling parameters from the incoming request. It filters out None values with `{k: v for k, v in ... if v is not None}`. This is correct for most parameters (temperature, top_p, etc.) — omitting them lets SGLang use its own defaults. But `max_new_tokens` is different: SGLang treats an explicit `None` as "no limit, generate until EOS/context-length," whereas omitting it triggers a hard default of 128 tokens.

The fix adds a keep_if_none set containing max_new_tokens and preserves it in the output dict even when its value is None.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token generation limits to properly respect specified values and prevent fallback to default limits across both standard and OpenAI API request formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->