### PR TITLE
Fix PdConnector to allow FlexKVConnectorV1 as first connector

### DIFF
--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/pd_connector.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/pd_connector.py
@@ -29,6 +29,17 @@ try:
 except ImportError:
     pass
 
+# Optional import for FlexKV support
+_FlexKVConnectorV1: Optional[Type] = None
+try:
+    from vllm.distributed.kv_transfer.kv_connector.v1.flexkv_connector import (
+        FlexKVConnectorV1,
+    )
+
+    _FlexKVConnectorV1 = FlexKVConnectorV1
+except ImportError:
+    pass
+
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
     from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_connector import (
@@ -46,10 +57,10 @@ class PdConnectorMetadata(MultiKVConnectorMetadata):
 
 class PdConnector(MultiConnector):
     """
-    A wrapper for using KV offloading Connectors (e.g. KVBM or LMCache) and NIXL Connector for PD disaggregated serving.
+    A wrapper for using KV offloading Connectors (e.g. KVBM, LMCache, or FlexKV) and NIXL Connector for PD disaggregated serving.
 
     The current logic is:
-    - The first connector must be KVBM or LMCache and would be used by prefill worker to offload and onboard KV blocks.
+    - The first connector must be KVBM, LMCache, or FlexKV and would be used by prefill worker to offload and onboard KV blocks.
     - The second connector must be NIXL and will be used by decode worker to get KV blocks from prefill worker.
     """
 
@@ -71,11 +82,15 @@ class PdConnector(MultiConnector):
         allowed_first_types: list[Type] = [DynamoConnector]
         if _LMCacheConnectorV1 is not None:
             allowed_first_types.append(_LMCacheConnectorV1)
+        if _FlexKVConnectorV1 is not None:
+            allowed_first_types.append(_FlexKVConnectorV1)
 
         if not isinstance(self._connectors[0], tuple(allowed_first_types)):
             allowed_names = ["DynamoConnector"]
             if _LMCacheConnectorV1 is not None:
                 allowed_names.append("LMCacheConnectorV1")
+            if _FlexKVConnectorV1 is not None:
+                allowed_names.append("FlexKVConnectorV1")
             raise TypeError(
                 f"Expected first connector to be {' or '.join(allowed_names)}, "
                 f"got {type(self._connectors[0]).__name__}"


### PR DESCRIPTION
Fix PdConnector to allow FlexKVConnectorV1 as first connector                                                                                                                       
                                          
Add FlexKVConnectorV1 to PdConnector's allowed first connector types,                                                                                                               
  following the same optional-import pattern as LMCacheConnectorV1.
  This fixes the TypeError when launching disagg_flexkv.sh.                                                                                                                           
                                                                                                                                                                                      
 NVBug: 6088159 
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FlexKV connector support, expanding available connector types to include KVBM, LMCache, and FlexKV.

* **Documentation**
  * Updated reference documentation to reflect all supported connector options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->