### PR TITLE
fix(kv-router): filter KV events by cache spec kind [DYN-3176]

### DIFF
--- a/components/src/dynamo/vllm/tests/test_vllm_kv_events_api.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_kv_events_api.py
@@ -54,6 +54,10 @@ def _has_kv_cache_spec_kind(event_cls):
     return "kv_cache_spec_kind" in event_cls.__struct_fields__
 
 
+def _has_kv_cache_spec_sliding_window(event_cls):
+    return "kv_cache_spec_sliding_window" in event_cls.__struct_fields__
+
+
 class TestVllmKvEventsApi:
     """Test vLLM KV events API compatibility."""
 
@@ -71,6 +75,7 @@ class TestVllmKvEventsApi:
         8. extra_keys (added in vLLM 0.17.0)
         9. group_idx (added for hybrid KV cache groups; optional for older vLLM)
         10. kv_cache_spec_kind (semantic cache type; optional for older vLLM)
+        11. kv_cache_spec_sliding_window (semantic cache window; optional for older vLLM)
 
         If vLLM adds/removes/reorders fields, this test will fail.
         """
@@ -88,6 +93,8 @@ class TestVllmKvEventsApi:
             expected_fields.append("group_idx")
         if _has_kv_cache_spec_kind(BlockStored):
             expected_fields.append("kv_cache_spec_kind")
+        if _has_kv_cache_spec_sliding_window(BlockStored):
+            expected_fields.append("kv_cache_spec_sliding_window")
         expected_fields = tuple(expected_fields)
 
         actual_fields = BlockStored.__struct_fields__
@@ -111,6 +118,8 @@ class TestVllmKvEventsApi:
             expected_fields.append("group_idx")
         if _has_kv_cache_spec_kind(BlockRemoved):
             expected_fields.append("kv_cache_spec_kind")
+        if _has_kv_cache_spec_sliding_window(BlockRemoved):
+            expected_fields.append("kv_cache_spec_sliding_window")
         expected_fields = tuple(expected_fields)
 
         actual_fields = BlockRemoved.__struct_fields__
@@ -192,6 +201,8 @@ class TestVllmKvEventsApi:
             event_kwargs["group_idx"] = 0
         if _has_kv_cache_spec_kind(BlockStored):
             event_kwargs["kv_cache_spec_kind"] = "full_attention"
+        if _has_kv_cache_spec_sliding_window(BlockStored):
+            event_kwargs["kv_cache_spec_sliding_window"] = 128
         event = BlockStored(**event_kwargs)
 
         encoded = msgspec.msgpack.encode(event)
@@ -207,6 +218,7 @@ class TestVllmKvEventsApi:
             9
             + int(_has_group_idx(BlockStored))
             + int(_has_kv_cache_spec_kind(BlockStored))
+            + int(_has_kv_cache_spec_sliding_window(BlockStored))
         )
         assert len(decoded) == expected_len, (
             f"Expected {expected_len} elements, got {len(decoded)}.\n"
@@ -233,6 +245,11 @@ class TestVllmKvEventsApi:
             assert (
                 decoded[next_idx] == "full_attention"
             ), f"kv_cache_spec_kind at wrong position: {decoded[next_idx]}"
+            next_idx += 1
+        if _has_kv_cache_spec_sliding_window(BlockStored):
+            assert (
+                decoded[next_idx] == 128
+            ), f"kv_cache_spec_sliding_window at wrong position: {decoded[next_idx]}"
 
     def test_block_stored_tuple_extra_keys_serialization_format(self):
         """Verify multimodal tuple extra_keys keep the vLLM 0.19 wire shape."""
@@ -253,6 +270,8 @@ class TestVllmKvEventsApi:
             event_kwargs["group_idx"] = 0
         if _has_kv_cache_spec_kind(BlockStored):
             event_kwargs["kv_cache_spec_kind"] = "full_attention"
+        if _has_kv_cache_spec_sliding_window(BlockStored):
+            event_kwargs["kv_cache_spec_sliding_window"] = 128
         event = BlockStored(**event_kwargs)
 
         decoded = msgspec.msgpack.decode(msgspec.msgpack.encode(event))
@@ -269,6 +288,16 @@ class TestVllmKvEventsApi:
             assert (
                 decoded[kind_idx] == "full_attention"
             ), f"kv_cache_spec_kind at wrong position: {decoded[kind_idx]}"
+        if _has_kv_cache_spec_sliding_window(BlockStored):
+            window_idx = 9
+            if _has_group_idx(BlockStored):
+                window_idx += 1
+            if _has_kv_cache_spec_kind(BlockStored):
+                window_idx += 1
+            assert decoded[window_idx] == 128, (
+                "kv_cache_spec_sliding_window at wrong position: "
+                f"{decoded[window_idx]}"
+            )
 
     def test_block_removed_serialization_format(self):
         """Verify BlockRemoved serializes to expected msgpack array format."""
@@ -282,6 +311,8 @@ class TestVllmKvEventsApi:
             event_kwargs["group_idx"] = 0
         if _has_kv_cache_spec_kind(BlockRemoved):
             event_kwargs["kv_cache_spec_kind"] = "full_attention"
+        if _has_kv_cache_spec_sliding_window(BlockRemoved):
+            event_kwargs["kv_cache_spec_sliding_window"] = 128
         event = BlockRemoved(**event_kwargs)
 
         decoded = msgspec.msgpack.decode(msgspec.msgpack.encode(event))
@@ -291,6 +322,7 @@ class TestVllmKvEventsApi:
             3
             + int(_has_group_idx(BlockRemoved))
             + int(_has_kv_cache_spec_kind(BlockRemoved))
+            + int(_has_kv_cache_spec_sliding_window(BlockRemoved))
         )
         assert len(decoded) == expected_len, (
             f"Expected {expected_len} elements, got {len(decoded)}.\n"
@@ -309,3 +341,8 @@ class TestVllmKvEventsApi:
             assert (
                 decoded[next_idx] == "full_attention"
             ), f"kv_cache_spec_kind at wrong position: {decoded[next_idx]}"
+            next_idx += 1
+        if _has_kv_cache_spec_sliding_window(BlockRemoved):
+            assert (
+                decoded[next_idx] == 128
+            ), f"kv_cache_spec_sliding_window at wrong position: {decoded[next_idx]}"

--- a/components/src/dynamo/vllm/tests/test_vllm_kv_events_api.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_kv_events_api.py
@@ -50,6 +50,10 @@ def _has_group_idx(event_cls):
     return "group_idx" in event_cls.__struct_fields__
 
 
+def _has_kv_cache_spec_kind(event_cls):
+    return "kv_cache_spec_kind" in event_cls.__struct_fields__
+
+
 class TestVllmKvEventsApi:
     """Test vLLM KV events API compatibility."""
 
@@ -66,6 +70,7 @@ class TestVllmKvEventsApi:
         7. lora_name (added in vLLM 0.14.0)
         8. extra_keys (added in vLLM 0.17.0)
         9. group_idx (added for hybrid KV cache groups; optional for older vLLM)
+        10. kv_cache_spec_kind (semantic cache type; optional for older vLLM)
 
         If vLLM adds/removes/reorders fields, this test will fail.
         """
@@ -81,6 +86,8 @@ class TestVllmKvEventsApi:
         ]
         if _has_group_idx(BlockStored):
             expected_fields.append("group_idx")
+        if _has_kv_cache_spec_kind(BlockStored):
+            expected_fields.append("kv_cache_spec_kind")
         expected_fields = tuple(expected_fields)
 
         actual_fields = BlockStored.__struct_fields__
@@ -102,6 +109,8 @@ class TestVllmKvEventsApi:
         ]
         if _has_group_idx(BlockRemoved):
             expected_fields.append("group_idx")
+        if _has_kv_cache_spec_kind(BlockRemoved):
+            expected_fields.append("kv_cache_spec_kind")
         expected_fields = tuple(expected_fields)
 
         actual_fields = BlockRemoved.__struct_fields__
@@ -181,6 +190,8 @@ class TestVllmKvEventsApi:
         }
         if _has_group_idx(BlockStored):
             event_kwargs["group_idx"] = 0
+        if _has_kv_cache_spec_kind(BlockStored):
+            event_kwargs["kv_cache_spec_kind"] = "full_attention"
         event = BlockStored(**event_kwargs)
 
         encoded = msgspec.msgpack.encode(event)
@@ -192,7 +203,11 @@ class TestVllmKvEventsApi:
             decoded[0] == "BlockStored"
         ), f"Expected tag 'BlockStored', got {decoded[0]}"
 
-        expected_len = 10 if _has_group_idx(BlockStored) else 9
+        expected_len = (
+            9
+            + int(_has_group_idx(BlockStored))
+            + int(_has_kv_cache_spec_kind(BlockStored))
+        )
         assert len(decoded) == expected_len, (
             f"Expected {expected_len} elements, got {len(decoded)}.\n"
             f"Decoded: {decoded}\n"
@@ -208,8 +223,16 @@ class TestVllmKvEventsApi:
         assert decoded[6] == "GPU", f"medium at wrong position: {decoded[6]}"
         assert decoded[7] is None, f"lora_name at wrong position: {decoded[7]}"
         assert decoded[8] is None, f"extra_keys at wrong position: {decoded[8]}"
+        next_idx = 9
         if _has_group_idx(BlockStored):
-            assert decoded[9] == 0, f"group_idx at wrong position: {decoded[9]}"
+            assert (
+                decoded[next_idx] == 0
+            ), f"group_idx at wrong position: {decoded[next_idx]}"
+            next_idx += 1
+        if _has_kv_cache_spec_kind(BlockStored):
+            assert (
+                decoded[next_idx] == "full_attention"
+            ), f"kv_cache_spec_kind at wrong position: {decoded[next_idx]}"
 
     def test_block_stored_tuple_extra_keys_serialization_format(self):
         """Verify multimodal tuple extra_keys keep the vLLM 0.19 wire shape."""
@@ -228,6 +251,8 @@ class TestVllmKvEventsApi:
         }
         if _has_group_idx(BlockStored):
             event_kwargs["group_idx"] = 0
+        if _has_kv_cache_spec_kind(BlockStored):
+            event_kwargs["kv_cache_spec_kind"] = "full_attention"
         event = BlockStored(**event_kwargs)
 
         decoded = msgspec.msgpack.decode(msgspec.msgpack.encode(event))
@@ -239,6 +264,11 @@ class TestVllmKvEventsApi:
         )
         if _has_group_idx(BlockStored):
             assert decoded[9] == 0, f"group_idx at wrong position: {decoded[9]}"
+        if _has_kv_cache_spec_kind(BlockStored):
+            kind_idx = 10 if _has_group_idx(BlockStored) else 9
+            assert (
+                decoded[kind_idx] == "full_attention"
+            ), f"kv_cache_spec_kind at wrong position: {decoded[kind_idx]}"
 
     def test_block_removed_serialization_format(self):
         """Verify BlockRemoved serializes to expected msgpack array format."""
@@ -250,12 +280,18 @@ class TestVllmKvEventsApi:
         }
         if _has_group_idx(BlockRemoved):
             event_kwargs["group_idx"] = 0
+        if _has_kv_cache_spec_kind(BlockRemoved):
+            event_kwargs["kv_cache_spec_kind"] = "full_attention"
         event = BlockRemoved(**event_kwargs)
 
         decoded = msgspec.msgpack.decode(msgspec.msgpack.encode(event))
 
         assert decoded[0] == "BlockRemoved"
-        expected_len = 4 if _has_group_idx(BlockRemoved) else 3
+        expected_len = (
+            3
+            + int(_has_group_idx(BlockRemoved))
+            + int(_has_kv_cache_spec_kind(BlockRemoved))
+        )
         assert len(decoded) == expected_len, (
             f"Expected {expected_len} elements, got {len(decoded)}.\n"
             f"Decoded: {decoded}\n"
@@ -263,5 +299,13 @@ class TestVllmKvEventsApi:
         )
         assert decoded[1] == [123, 456], f"block_hashes at wrong position: {decoded[1]}"
         assert decoded[2] == "GPU", f"medium at wrong position: {decoded[2]}"
+        next_idx = 3
         if _has_group_idx(BlockRemoved):
-            assert decoded[3] == 0, f"group_idx at wrong position: {decoded[3]}"
+            assert (
+                decoded[next_idx] == 0
+            ), f"group_idx at wrong position: {decoded[next_idx]}"
+            next_idx += 1
+        if _has_kv_cache_spec_kind(BlockRemoved):
+            assert (
+                decoded[next_idx] == "full_attention"
+            ), f"kv_cache_spec_kind at wrong position: {decoded[next_idx]}"

--- a/lib/kv-router/src/zmq_wire.rs
+++ b/lib/kv-router/src/zmq_wire.rs
@@ -204,9 +204,10 @@ struct KvCacheEventFilter {
 impl KvCacheEventFilter {
     fn record_trailing(&mut self, trailing: KvCacheEventTrailingField) {
         match trailing {
-            KvCacheEventTrailingField::GroupIdx(group_idx) => {
+            KvCacheEventTrailingField::GroupIdx(group_idx) if self.kv_cache_spec_kind.is_none() => {
                 self.group_idx = Some(group_idx);
             }
+            KvCacheEventTrailingField::GroupIdx(_) => {}
             KvCacheEventTrailingField::KvCacheSpecKind(kind) => {
                 self.kv_cache_spec_kind = Some(kind);
             }
@@ -356,6 +357,9 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                 }
                 "kv_cache_spec_kind" => {
                     filter.kv_cache_spec_kind = map.next_value()?;
+                }
+                "kv_cache_spec_sliding_window" => {
+                    map.next_value::<Option<u32>>()?;
                 }
                 _ => {
                     map.next_value::<IgnoredAny>()?;
@@ -507,7 +511,7 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                 let medium: Option<String> = seq.next_element()?.unwrap_or(None);
                 let mut filter = KvCacheEventFilter::default();
 
-                for _ in 0..2 {
+                for _ in 0..3 {
                     let trailing: Option<KvCacheEventTrailingField> =
                         seq.next_element()?.unwrap_or(None);
                     if let Some(trailing) = trailing {
@@ -943,6 +947,40 @@ mod tests {
         }
     }
 
+    fn sequence_with_cache_spec_kind_and_sliding_window(
+        event_kind: TestEventKind,
+        group_idx: u32,
+        kv_cache_spec_kind: &'static str,
+        kv_cache_spec_sliding_window: u32,
+    ) -> Vec<u8> {
+        match event_kind {
+            TestEventKind::BlockStored => to_vec(&(
+                "BlockStored",
+                vec![BlockHashValue::Unsigned(11)],
+                Option::<BlockHashValue>::None,
+                vec![10u32, 11],
+                2usize,
+                Option::<u64>::None,
+                Option::<String>::None,
+                Option::<String>::None,
+                Option::<u8>::None,
+                group_idx,
+                kv_cache_spec_kind,
+                kv_cache_spec_sliding_window,
+            ))
+            .unwrap(),
+            TestEventKind::BlockRemoved => to_vec(&(
+                "BlockRemoved",
+                vec![BlockHashValue::Unsigned(11)],
+                Option::<String>::None,
+                group_idx,
+                kv_cache_spec_kind,
+                kv_cache_spec_sliding_window,
+            ))
+            .unwrap(),
+        }
+    }
+
     fn assert_parsed_event_kind(event: RawKvEvent, expected_kind: TestEventKind) {
         match (event, expected_kind) {
             (RawKvEvent::BlockStored { .. }, TestEventKind::BlockStored)
@@ -1005,6 +1043,23 @@ mod tests {
         let event: RawKvEvent = from_slice(&sequence_with_cache_spec_kind_without_group_idx_slot(
             event_kind,
             "full_attention",
+        ))
+        .unwrap();
+
+        assert_parsed_event_kind(event, event_kind);
+    }
+
+    #[rstest]
+    #[case(TestEventKind::BlockStored)]
+    #[case(TestEventKind::BlockRemoved)]
+    fn test_deserialize_sequence_accepts_main_attention_kind_with_sliding_window(
+        #[case] event_kind: TestEventKind,
+    ) {
+        let event: RawKvEvent = from_slice(&sequence_with_cache_spec_kind_and_sliding_window(
+            event_kind,
+            3,
+            "full_attention",
+            128,
         ))
         .unwrap();
 

--- a/lib/kv-router/src/zmq_wire.rs
+++ b/lib/kv-router/src/zmq_wire.rs
@@ -129,9 +129,15 @@ pub enum ExtraKeyItem {
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
-enum BlockStoredTrailingField {
+enum KvCacheEventTrailingField {
     GroupIdx(u32),
     KvCacheSpecKind(KvCacheSpecKind),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum BlockStoredTrailingField {
+    Common(KvCacheEventTrailingField),
     BlockMmInfos(Vec<Option<BlockExtraInfo>>),
 }
 
@@ -183,15 +189,31 @@ impl<'de> Deserialize<'de> for KvCacheSpecKind {
     }
 }
 
-fn should_ignore_event(
+#[derive(Debug, Default, Clone, Copy)]
+struct KvCacheEventFilter {
     group_idx: Option<u32>,
     kv_cache_spec_kind: Option<KvCacheSpecKind>,
-) -> bool {
-    if let Some(kind) = kv_cache_spec_kind {
-        return !kind.is_main_attention();
+}
+
+impl KvCacheEventFilter {
+    fn record_trailing(&mut self, trailing: KvCacheEventTrailingField) {
+        match trailing {
+            KvCacheEventTrailingField::GroupIdx(group_idx) => {
+                self.group_idx = Some(group_idx);
+            }
+            KvCacheEventTrailingField::KvCacheSpecKind(kind) => {
+                self.kv_cache_spec_kind = Some(kind);
+            }
+        }
     }
 
-    matches!(group_idx, Some(group_idx) if group_idx != 0)
+    fn should_ignore(self) -> bool {
+        if let Some(kind) = self.kv_cache_spec_kind {
+            return !kind.is_main_attention();
+        }
+
+        matches!(self.group_idx, Some(group_idx) if group_idx != 0)
+    }
 }
 
 /// Convert vLLM BlockStored extra_keys to block-level MM infos.
@@ -292,8 +314,7 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
         let mut lora_name: Option<Option<String>> = None;
         let mut extra_keys: Option<Option<Vec<Option<Vec<ExtraKeyItem>>>>> = None;
         let mut block_mm_infos: Option<Option<Vec<Option<BlockExtraInfo>>>> = None;
-        let mut group_idx: Option<Option<u32>> = None;
-        let mut kv_cache_spec_kind: Option<Option<KvCacheSpecKind>> = None;
+        let mut filter = KvCacheEventFilter::default();
 
         while let Some(key) = map.next_key::<String>()? {
             match key.as_str() {
@@ -325,10 +346,10 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                     block_mm_infos = Some(map.next_value()?);
                 }
                 "group_idx" => {
-                    group_idx = Some(map.next_value()?);
+                    filter.group_idx = map.next_value()?;
                 }
                 "kv_cache_spec_kind" => {
-                    kv_cache_spec_kind = Some(map.next_value()?);
+                    filter.kv_cache_spec_kind = map.next_value()?;
                 }
                 _ => {
                     map.next_value::<IgnoredAny>()?;
@@ -355,10 +376,7 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                 let block_size =
                     block_size.ok_or_else(|| de::Error::missing_field("block_size"))?;
                 let medium = medium.unwrap_or(None);
-                if should_ignore_event(
-                    group_idx.unwrap_or(None),
-                    kv_cache_spec_kind.unwrap_or(None),
-                ) {
+                if filter.should_ignore() {
                     return Ok(RawKvEvent::Ignored);
                 }
                 let block_mm_infos = block_mm_infos
@@ -379,10 +397,7 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                 let block_hashes =
                     block_hashes.ok_or_else(|| de::Error::missing_field("block_hashes"))?;
                 let medium = medium.unwrap_or(None);
-                if should_ignore_event(
-                    group_idx.unwrap_or(None),
-                    kv_cache_spec_kind.unwrap_or(None),
-                ) {
+                if filter.should_ignore() {
                     return Ok(RawKvEvent::Ignored);
                 }
                 Ok(RawKvEvent::BlockRemoved {
@@ -431,18 +446,14 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                 let extra_keys: Option<Vec<Option<Vec<ExtraKeyItem>>>> =
                     seq.next_element()?.unwrap_or(None);
                 let mut block_mm_infos: Option<Vec<Option<BlockExtraInfo>>> = None;
-                let mut group_idx: Option<u32> = None;
-                let mut kv_cache_spec_kind: Option<KvCacheSpecKind> = None;
+                let mut filter = KvCacheEventFilter::default();
 
                 for _ in 0..3 {
                     let trailing: Option<BlockStoredTrailingField> =
                         seq.next_element()?.unwrap_or(None);
                     match trailing {
-                        Some(BlockStoredTrailingField::GroupIdx(idx)) => {
-                            group_idx = Some(idx);
-                        }
-                        Some(BlockStoredTrailingField::KvCacheSpecKind(kind)) => {
-                            kv_cache_spec_kind = Some(kind);
+                        Some(BlockStoredTrailingField::Common(trailing)) => {
+                            filter.record_trailing(trailing);
                         }
                         Some(BlockStoredTrailingField::BlockMmInfos(infos)) => {
                             block_mm_infos = Some(infos);
@@ -453,7 +464,7 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
 
                 while seq.next_element::<IgnoredAny>()?.is_some() {}
 
-                if should_ignore_event(group_idx, kv_cache_spec_kind) {
+                if filter.should_ignore() {
                     return Ok(RawKvEvent::Ignored);
                 }
 
@@ -488,13 +499,19 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(1, &"missing block_hashes"))?;
                 let medium: Option<String> = seq.next_element()?.unwrap_or(None);
-                let group_idx: Option<u32> = seq.next_element()?.unwrap_or(None);
-                let kv_cache_spec_kind: Option<KvCacheSpecKind> =
-                    seq.next_element()?.unwrap_or(None);
+                let mut filter = KvCacheEventFilter::default();
+
+                for _ in 0..2 {
+                    let trailing: Option<KvCacheEventTrailingField> =
+                        seq.next_element()?.unwrap_or(None);
+                    if let Some(trailing) = trailing {
+                        filter.record_trailing(trailing);
+                    }
+                }
 
                 while seq.next_element::<IgnoredAny>()?.is_some() {}
 
-                if should_ignore_event(group_idx, kv_cache_spec_kind) {
+                if filter.should_ignore() {
                     return Ok(RawKvEvent::Ignored);
                 }
 
@@ -892,6 +909,34 @@ mod tests {
         }
     }
 
+    fn sequence_with_cache_spec_kind_without_group_idx_slot(
+        event_kind: TestEventKind,
+        kv_cache_spec_kind: &'static str,
+    ) -> Vec<u8> {
+        match event_kind {
+            TestEventKind::BlockStored => to_vec(&(
+                "BlockStored",
+                vec![BlockHashValue::Unsigned(11)],
+                Option::<BlockHashValue>::None,
+                vec![10u32, 11],
+                2usize,
+                Option::<u64>::None,
+                Option::<String>::None,
+                Option::<String>::None,
+                Option::<u8>::None,
+                kv_cache_spec_kind,
+            ))
+            .unwrap(),
+            TestEventKind::BlockRemoved => to_vec(&(
+                "BlockRemoved",
+                vec![BlockHashValue::Unsigned(11)],
+                Option::<String>::None,
+                kv_cache_spec_kind,
+            ))
+            .unwrap(),
+        }
+    }
+
     fn assert_parsed_event_kind(event: RawKvEvent, expected_kind: TestEventKind) {
         match (event, expected_kind) {
             (RawKvEvent::BlockStored { .. }, TestEventKind::BlockStored)
@@ -938,6 +983,21 @@ mod tests {
         let event: RawKvEvent = from_slice(&sequence_with_cache_spec_kind(
             event_kind,
             Some(3),
+            "full_attention",
+        ))
+        .unwrap();
+
+        assert_parsed_event_kind(event, event_kind);
+    }
+
+    #[rstest]
+    #[case(TestEventKind::BlockStored)]
+    #[case(TestEventKind::BlockRemoved)]
+    fn test_deserialize_sequence_accepts_main_attention_kind_without_group_idx_slot(
+        #[case] event_kind: TestEventKind,
+    ) {
+        let event: RawKvEvent = from_slice(&sequence_with_cache_spec_kind_without_group_idx_slot(
+            event_kind,
             "full_attention",
         ))
         .unwrap();

--- a/lib/kv-router/src/zmq_wire.rs
+++ b/lib/kv-router/src/zmq_wire.rs
@@ -131,10 +131,66 @@ pub enum ExtraKeyItem {
 #[serde(untagged)]
 enum BlockStoredTrailingField {
     GroupIdx(u32),
+    KvCacheSpecKind(KvCacheSpecKind),
     BlockMmInfos(Vec<Option<BlockExtraInfo>>),
 }
 
-fn is_non_main_group(group_idx: Option<u32>) -> bool {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KvCacheSpecKind {
+    FullAttention,
+    MlaAttention,
+    SlidingWindow,
+    SlidingWindowMla,
+    Mamba,
+    ChunkedLocalAttention,
+    SinkFullAttention,
+    EncoderOnlyAttention,
+    CrossAttention,
+    Unknown,
+}
+
+impl KvCacheSpecKind {
+    fn from_wire(value: &str) -> Self {
+        match value {
+            "full_attention" => Self::FullAttention,
+            "mla_attention" => Self::MlaAttention,
+            "sliding_window" => Self::SlidingWindow,
+            "sliding_window_mla" => Self::SlidingWindowMla,
+            "mamba" => Self::Mamba,
+            "chunked_local_attention" => Self::ChunkedLocalAttention,
+            "sink_full_attention" => Self::SinkFullAttention,
+            "encoder_only_attention" => Self::EncoderOnlyAttention,
+            "cross_attention" => Self::CrossAttention,
+            _ => Self::Unknown,
+        }
+    }
+
+    fn is_main_attention(self) -> bool {
+        matches!(
+            self,
+            Self::FullAttention | Self::MlaAttention | Self::SinkFullAttention
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for KvCacheSpecKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(Self::from_wire(&value))
+    }
+}
+
+fn should_ignore_event(
+    group_idx: Option<u32>,
+    kv_cache_spec_kind: Option<KvCacheSpecKind>,
+) -> bool {
+    if let Some(kind) = kv_cache_spec_kind {
+        return !kind.is_main_attention();
+    }
+
     matches!(group_idx, Some(group_idx) if group_idx != 0)
 }
 
@@ -237,6 +293,7 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
         let mut extra_keys: Option<Option<Vec<Option<Vec<ExtraKeyItem>>>>> = None;
         let mut block_mm_infos: Option<Option<Vec<Option<BlockExtraInfo>>>> = None;
         let mut group_idx: Option<Option<u32>> = None;
+        let mut kv_cache_spec_kind: Option<Option<KvCacheSpecKind>> = None;
 
         while let Some(key) = map.next_key::<String>()? {
             match key.as_str() {
@@ -270,6 +327,9 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                 "group_idx" => {
                     group_idx = Some(map.next_value()?);
                 }
+                "kv_cache_spec_kind" => {
+                    kv_cache_spec_kind = Some(map.next_value()?);
+                }
                 _ => {
                     map.next_value::<IgnoredAny>()?;
                 }
@@ -295,7 +355,10 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                 let block_size =
                     block_size.ok_or_else(|| de::Error::missing_field("block_size"))?;
                 let medium = medium.unwrap_or(None);
-                if is_non_main_group(group_idx.unwrap_or(None)) {
+                if should_ignore_event(
+                    group_idx.unwrap_or(None),
+                    kv_cache_spec_kind.unwrap_or(None),
+                ) {
                     return Ok(RawKvEvent::Ignored);
                 }
                 let block_mm_infos = block_mm_infos
@@ -316,7 +379,10 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                 let block_hashes =
                     block_hashes.ok_or_else(|| de::Error::missing_field("block_hashes"))?;
                 let medium = medium.unwrap_or(None);
-                if is_non_main_group(group_idx.unwrap_or(None)) {
+                if should_ignore_event(
+                    group_idx.unwrap_or(None),
+                    kv_cache_spec_kind.unwrap_or(None),
+                ) {
                     return Ok(RawKvEvent::Ignored);
                 }
                 Ok(RawKvEvent::BlockRemoved {
@@ -366,13 +432,17 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                     seq.next_element()?.unwrap_or(None);
                 let mut block_mm_infos: Option<Vec<Option<BlockExtraInfo>>> = None;
                 let mut group_idx: Option<u32> = None;
+                let mut kv_cache_spec_kind: Option<KvCacheSpecKind> = None;
 
-                for _ in 0..2 {
+                for _ in 0..3 {
                     let trailing: Option<BlockStoredTrailingField> =
                         seq.next_element()?.unwrap_or(None);
                     match trailing {
                         Some(BlockStoredTrailingField::GroupIdx(idx)) => {
                             group_idx = Some(idx);
+                        }
+                        Some(BlockStoredTrailingField::KvCacheSpecKind(kind)) => {
+                            kv_cache_spec_kind = Some(kind);
                         }
                         Some(BlockStoredTrailingField::BlockMmInfos(infos)) => {
                             block_mm_infos = Some(infos);
@@ -383,7 +453,7 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
 
                 while seq.next_element::<IgnoredAny>()?.is_some() {}
 
-                if is_non_main_group(group_idx) {
+                if should_ignore_event(group_idx, kv_cache_spec_kind) {
                     return Ok(RawKvEvent::Ignored);
                 }
 
@@ -419,10 +489,12 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                     .ok_or_else(|| de::Error::invalid_length(1, &"missing block_hashes"))?;
                 let medium: Option<String> = seq.next_element()?.unwrap_or(None);
                 let group_idx: Option<u32> = seq.next_element()?.unwrap_or(None);
+                let kv_cache_spec_kind: Option<KvCacheSpecKind> =
+                    seq.next_element()?.unwrap_or(None);
 
                 while seq.next_element::<IgnoredAny>()?.is_some() {}
 
-                if is_non_main_group(group_idx) {
+                if should_ignore_event(group_idx, kv_cache_spec_kind) {
                     return Ok(RawKvEvent::Ignored);
                 }
 
@@ -701,9 +773,26 @@ mod tests {
         }
     }
 
-    fn block_stored_sequence_with_group_idx(group_idx: Option<u32>) -> Vec<u8> {
-        match group_idx {
-            Some(group_idx) => to_vec(&(
+    fn block_stored_sequence(
+        group_idx: Option<u32>,
+        kv_cache_spec_kind: Option<&'static str>,
+    ) -> Vec<u8> {
+        match (group_idx, kv_cache_spec_kind) {
+            (Some(group_idx), Some(kv_cache_spec_kind)) => to_vec(&(
+                "BlockStored",
+                vec![BlockHashValue::Unsigned(11)],
+                Option::<BlockHashValue>::None,
+                vec![10u32, 11],
+                2usize,
+                Option::<u64>::None,
+                Option::<String>::None,
+                Option::<String>::None,
+                Option::<u8>::None,
+                group_idx,
+                kv_cache_spec_kind,
+            ))
+            .unwrap(),
+            (Some(group_idx), None) => to_vec(&(
                 "BlockStored",
                 vec![BlockHashValue::Unsigned(11)],
                 Option::<BlockHashValue>::None,
@@ -716,7 +805,21 @@ mod tests {
                 group_idx,
             ))
             .unwrap(),
-            None => to_vec(&(
+            (None, Some(kv_cache_spec_kind)) => to_vec(&(
+                "BlockStored",
+                vec![BlockHashValue::Unsigned(11)],
+                Option::<BlockHashValue>::None,
+                vec![10u32, 11],
+                2usize,
+                Option::<u64>::None,
+                Option::<String>::None,
+                Option::<String>::None,
+                Option::<u8>::None,
+                Option::<u32>::None,
+                kv_cache_spec_kind,
+            ))
+            .unwrap(),
+            (None, None) => to_vec(&(
                 "BlockStored",
                 vec![BlockHashValue::Unsigned(11)],
                 Option::<BlockHashValue>::None,
@@ -730,16 +833,35 @@ mod tests {
         }
     }
 
-    fn block_removed_sequence_with_group_idx(group_idx: Option<u32>) -> Vec<u8> {
-        match group_idx {
-            Some(group_idx) => to_vec(&(
+    fn block_removed_sequence(
+        group_idx: Option<u32>,
+        kv_cache_spec_kind: Option<&'static str>,
+    ) -> Vec<u8> {
+        match (group_idx, kv_cache_spec_kind) {
+            (Some(group_idx), Some(kv_cache_spec_kind)) => to_vec(&(
+                "BlockRemoved",
+                vec![BlockHashValue::Unsigned(11)],
+                Option::<String>::None,
+                group_idx,
+                kv_cache_spec_kind,
+            ))
+            .unwrap(),
+            (Some(group_idx), None) => to_vec(&(
                 "BlockRemoved",
                 vec![BlockHashValue::Unsigned(11)],
                 Option::<String>::None,
                 group_idx,
             ))
             .unwrap(),
-            None => to_vec(&(
+            (None, Some(kv_cache_spec_kind)) => to_vec(&(
+                "BlockRemoved",
+                vec![BlockHashValue::Unsigned(11)],
+                Option::<String>::None,
+                Option::<u32>::None,
+                kv_cache_spec_kind,
+            ))
+            .unwrap(),
+            (None, None) => to_vec(&(
                 "BlockRemoved",
                 vec![BlockHashValue::Unsigned(11)],
                 Option::<String>::None,
@@ -750,8 +872,23 @@ mod tests {
 
     fn sequence_with_group_idx(event_kind: TestEventKind, group_idx: Option<u32>) -> Vec<u8> {
         match event_kind {
-            TestEventKind::BlockStored => block_stored_sequence_with_group_idx(group_idx),
-            TestEventKind::BlockRemoved => block_removed_sequence_with_group_idx(group_idx),
+            TestEventKind::BlockStored => block_stored_sequence(group_idx, None),
+            TestEventKind::BlockRemoved => block_removed_sequence(group_idx, None),
+        }
+    }
+
+    fn sequence_with_cache_spec_kind(
+        event_kind: TestEventKind,
+        group_idx: Option<u32>,
+        kv_cache_spec_kind: &'static str,
+    ) -> Vec<u8> {
+        match event_kind {
+            TestEventKind::BlockStored => {
+                block_stored_sequence(group_idx, Some(kv_cache_spec_kind))
+            }
+            TestEventKind::BlockRemoved => {
+                block_removed_sequence(group_idx, Some(kv_cache_spec_kind))
+            }
         }
     }
 
@@ -790,6 +927,34 @@ mod tests {
         let event: RawKvEvent = from_slice(&sequence_with_group_idx(event_kind, None)).unwrap();
 
         assert_parsed_event_kind(event, event_kind);
+    }
+
+    #[rstest]
+    #[case(TestEventKind::BlockStored)]
+    #[case(TestEventKind::BlockRemoved)]
+    fn test_deserialize_sequence_accepts_main_attention_kind_with_nonzero_group_idx(
+        #[case] event_kind: TestEventKind,
+    ) {
+        let event: RawKvEvent = from_slice(&sequence_with_cache_spec_kind(
+            event_kind,
+            Some(3),
+            "full_attention",
+        ))
+        .unwrap();
+
+        assert_parsed_event_kind(event, event_kind);
+    }
+
+    #[rstest]
+    #[case(TestEventKind::BlockStored)]
+    #[case(TestEventKind::BlockRemoved)]
+    fn test_deserialize_sequence_ignores_non_main_attention_kind_with_group_idx_zero(
+        #[case] event_kind: TestEventKind,
+    ) {
+        let event: RawKvEvent =
+            from_slice(&sequence_with_cache_spec_kind(event_kind, Some(0), "mamba")).unwrap();
+
+        assert!(matches!(event, RawKvEvent::Ignored));
     }
 
     #[test]

--- a/lib/kv-router/src/zmq_wire.rs
+++ b/lib/kv-router/src/zmq_wire.rs
@@ -167,7 +167,13 @@ impl KvCacheSpecKind {
             "sink_full_attention" => Self::SinkFullAttention,
             "encoder_only_attention" => Self::EncoderOnlyAttention,
             "cross_attention" => Self::CrossAttention,
-            _ => Self::Unknown,
+            unknown => {
+                tracing::warn!(
+                    kv_cache_spec_kind = unknown,
+                    "Unknown KV cache spec kind; treating KV event as non-main"
+                );
+                Self::Unknown
+            }
         }
     }
 


### PR DESCRIPTION
Adds forward-compatible parsing for vLLM semantic KV cache metadata. Dynamo now uses kv_cache_spec_kind when present to keep the ZMQ radix indexer on full/MLA-style prefix events even when hybrid cache group_idx ordering is not 0, and it tolerates the new optional kv_cache_spec_sliding_window trailing field without changing routing behavior.

This remains backward compatible with current vLLM event streams: if kv_cache_spec_kind is absent, Dynamo keeps the existing group_idx behavior and listens to absent group_idx or group_idx 0. That means this PR does not need to wait for the matching vLLM PR to merge; it continues to work for existing DSV4 group_idx-based events and becomes semantically safer once vLLM emits the new fields.

Related vLLM producer-side metadata PR: https://github.com/vllm-project/vllm/pull/40984

Tests:
- cargo test -p dynamo-kv-router zmq_wire --no-default-features
- .venv/bin/python -m pre_commit run --files lib/kv-router/src/zmq_wire.rs components/src/dynamo/vllm/tests/test_vllm_kv_events_api.py

Note: components/src/dynamo/vllm/tests/test_vllm_kv_events_api.py could not be collected locally because this Dynamo venv does not have vLLM installed; it is intended for the vLLM CI job.