### PR TITLE
chore: drop unused genai-perf pin from benchmark deps

### DIFF
--- a/container/deps/requirements.benchmark.txt
+++ b/container/deps/requirements.benchmark.txt
@@ -4,4 +4,3 @@
 # Benchmark and profiling tool dependencies.
 
 aiperf==0.6.0
-genai-perf==0.0.15


### PR DESCRIPTION
genai-perf==0.0.15 was pinned in container/deps/requirements.benchmark.txt but not invoked anywhere in the repo.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused benchmark profiling dependency to streamline build requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->