### PR TITLE
fix: disable snapshot with GMS in admission (cherry-pick of #8689)

### DIFF
--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocheckpoints.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocheckpoints.yaml
@@ -8211,6 +8211,9 @@ spec:
                 - identity
                 - job
               type: object
+              x-kubernetes-validations:
+                - message: checkpointing with gpuMemoryService is temporarily disabled due to known GPU driver issues
+                  rule: '!has(self.gpuMemoryService) || !self.gpuMemoryService.enabled'
             status:
               description: DynamoCheckpointStatus defines the observed state of DynamoCheckpoint
               properties:

--- a/deploy/operator/api/v1alpha1/dynamocheckpoint_types.go
+++ b/deploy/operator/api/v1alpha1/dynamocheckpoint_types.go
@@ -119,6 +119,7 @@ type DynamoCheckpointJobConfig struct {
 }
 
 // DynamoCheckpointSpec defines the desired state of DynamoCheckpoint
+// +kubebuilder:validation:XValidation:rule="!has(self.gpuMemoryService) || !self.gpuMemoryService.enabled",message="checkpointing with gpuMemoryService is temporarily disabled due to known GPU driver issues"
 type DynamoCheckpointSpec struct {
 	// Identity defines the inputs that determine checkpoint equivalence
 	// +kubebuilder:validation:Required

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocheckpoints.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocheckpoints.yaml
@@ -8211,6 +8211,9 @@ spec:
                 - identity
                 - job
               type: object
+              x-kubernetes-validations:
+                - message: checkpointing with gpuMemoryService is temporarily disabled due to known GPU driver issues
+                  rule: '!has(self.gpuMemoryService) || !self.gpuMemoryService.enabled'
             status:
               description: DynamoCheckpointStatus defines the observed state of DynamoCheckpoint
               properties:

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -676,6 +676,73 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "checkpoint with GMS is temporarily rejected",
+			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gms-snapshot",
+					Namespace: "default",
+				},
+				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentSpec{
+					BackendFramework: "vllm",
+					Services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+						"worker": {
+							ComponentType: consts.ComponentTypeWorker,
+							Checkpoint: &nvidiacomv1alpha1.ServiceCheckpointConfig{
+								Enabled: true,
+								Identity: &nvidiacomv1alpha1.DynamoCheckpointIdentity{
+									Model:            "model",
+									BackendFramework: "vllm",
+								},
+							},
+							GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+								Enabled: true,
+							},
+							Resources: &nvidiacomv1alpha1.Resources{
+								Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "8"},
+							},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: true,
+			errMsg:      "checkpointing with gpuMemoryService is temporarily disabled",
+		},
+		{
+			name: "checkpoint with intra-pod GMS is temporarily rejected",
+			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-intrapod-gms-snapshot",
+					Namespace: "default",
+				},
+				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentSpec{
+					BackendFramework: "vllm",
+					Services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+						"worker": {
+							ComponentType: consts.ComponentTypeWorker,
+							Checkpoint: &nvidiacomv1alpha1.ServiceCheckpointConfig{
+								Enabled: true,
+								Identity: &nvidiacomv1alpha1.DynamoCheckpointIdentity{
+									Model:            "model",
+									BackendFramework: "vllm",
+								},
+							},
+							GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+								Enabled: true,
+								Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
+							},
+							Resources: &nvidiacomv1alpha1.Resources{
+								Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "8"},
+							},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: true,
+			errMsg:      "checkpointing with gpuMemoryService is temporarily disabled",
+		},
 		// Annotation validation test cases
 		{
 			name: "valid annotation vllm-distributed-executor-backend=mp",

--- a/deploy/operator/internal/webhook/validation/shared.go
+++ b/deploy/operator/internal/webhook/validation/shared.go
@@ -139,6 +139,12 @@ func (v *SharedSpecValidator) Validate(ctx context.Context) (admission.Warnings,
 		return nil, err
 	}
 
+	// Snapshot restore plus GMS is temporarily disabled while the underlying
+	// GPU driver restore path is being fixed.
+	if err := v.validateCheckpointWithGPUMemoryService(); err != nil {
+		return nil, err
+	}
+
 	return warnings, nil
 }
 
@@ -347,6 +353,20 @@ func (v *SharedSpecValidator) validateGPUMemoryService() error {
 	}
 
 	return nil
+}
+
+func (v *SharedSpecValidator) validateCheckpointWithGPUMemoryService() error {
+	if v.spec.Checkpoint == nil || !v.spec.Checkpoint.Enabled {
+		return nil
+	}
+	if v.spec.GPUMemoryService == nil || !v.spec.GPUMemoryService.Enabled {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%s.checkpoint: checkpointing with gpuMemoryService is temporarily disabled due to known GPU driver issues; "+
+			"disable either checkpointing or gpuMemoryService for this service",
+		v.fieldPath)
 }
 
 // validateServiceAnnotations validates known annotations on the service-level spec.

--- a/deploy/operator/internal/webhook/validation/shared_test.go
+++ b/deploy/operator/internal/webhook/validation/shared_test.go
@@ -36,6 +36,9 @@ func TestSharedSpecValidator_Validate(t *testing.T) {
 	var (
 		negativeReplicas = int32(-1)
 		validReplicas    = int32(3)
+		workerGPU        = &nvidiacomv1alpha1.Resources{
+			Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "1"},
+		}
 	)
 
 	tests := []struct {
@@ -250,6 +253,61 @@ func TestSharedSpecValidator_Validate(t *testing.T) {
 			calculatedNamespace: "default-my-dgd",
 			wantErr:             true,
 			errMsg:              `spec.services[decode].annotations[nvidia.com/vllm-distributed-executor-backend] has invalid value "invalid": must be "mp" or "ray"`,
+		},
+		{
+			name: "checkpoint with gpuMemoryService is temporarily rejected",
+			spec: &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				Resources:     workerGPU,
+				Checkpoint: &nvidiacomv1alpha1.ServiceCheckpointConfig{
+					Enabled: true,
+					Identity: &nvidiacomv1alpha1.DynamoCheckpointIdentity{
+						Model:            "model",
+						BackendFramework: "vllm",
+					},
+				},
+				GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+					Enabled: true,
+					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
+				},
+			},
+			fieldPath:           "spec.services[worker]",
+			calculatedNamespace: "default-my-dgd",
+			wantErr:             true,
+			errMsg:              "spec.services[worker].checkpoint: checkpointing with gpuMemoryService is temporarily disabled due to known GPU driver issues; disable either checkpointing or gpuMemoryService for this service",
+		},
+		{
+			name: "checkpoint without gpuMemoryService is accepted",
+			spec: &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				Checkpoint: &nvidiacomv1alpha1.ServiceCheckpointConfig{
+					Enabled: true,
+					Identity: &nvidiacomv1alpha1.DynamoCheckpointIdentity{
+						Model:            "model",
+						BackendFramework: "vllm",
+					},
+				},
+			},
+			fieldPath:           "spec.services[worker]",
+			calculatedNamespace: "default-my-dgd",
+			wantErr:             false,
+		},
+		{
+			name: "disabled checkpoint with gpuMemoryService is accepted",
+			spec: &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				Resources:     workerGPU,
+				Checkpoint: &nvidiacomv1alpha1.ServiceCheckpointConfig{
+					Enabled: false,
+				},
+				GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+					Enabled: true,
+					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
+				},
+			},
+			fieldPath:           "spec.services[worker]",
+			calculatedNamespace: "default-my-dgd",
+			wantErr:             false,
 		},
 		{
 			name: "frontendSidecar with no extraPodSpec containers is valid",


### PR DESCRIPTION
Cherry-pick of #8689 to `release/1.1.0`.

## Summary

- Temporarily reject service specs where `checkpoint.enabled=true` and `gpuMemoryService.enabled=true` are both set.
- Add CRD validation for direct `DynamoCheckpoint` specs so `spec.gpuMemoryService.enabled=true` is rejected at the CRD layer.
- Preserve the generated CRD updates for the operator config and Helm chart copies.

## Release-branch adaptation

`release/1.1.0` already rejects explicit `gpuMemoryService.mode: interPod` before reaching the checkpoint/GMS guard, and its DGD validation test harness does not include the newer `groveEnabled` table field from main. The cherry-pick keeps the same behavioral coverage by testing GMS enabled with the release-supported/default mode plus the explicit `intraPod` mode.

## Original PR

- Main PR: #8689
- Main merge commit: 48aacd65b9d3e697ea6f2fe6262d680cc7c2b025
- Cherry-pick commit: e71ff88ffba0cdee36c7f5ad8ee743cba7c6dac9

## Test plan

- [x] `CGO_ENABLED=0 go test ./internal/webhook/validation ./api/v1alpha1`
- [x] `make manifests` (completed with no additional generated diff)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
