### PR TITLE
fix(kv-router): wait for worker model card when initializing remote/served indexer

### DIFF
--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -688,68 +688,49 @@ async fn create_kv_router_from_endpoint(
 
     // Look up the worker's model card so we can derive both model_name (required
     // for remote/served indexer) and Eagle routing semantics. When the model_name
-    // is required but no worker has registered yet, poll discovery until one
-    // appears so we don't race worker startup. Bounded by
+    // is required but no worker has registered yet, wait via the discovery watch
+    // stream until one appears so we don't race worker startup. Bounded by
     // `DYN_ROUTER_MODEL_CARD_WAIT_SECS` (default 600s).
     let needs_model_name = kv_router_config
         .as_ref()
         .map(|cfg| cfg.use_remote_indexer || cfg.serve_indexer)
         .unwrap_or(false);
     let (model_name, enable_eagle) = {
-        let discovery = endpoint.inner.component().drt().discovery();
-        let query = rs::discovery::DiscoveryQuery::EndpointModels {
-            namespace: endpoint_id.namespace.clone(),
-            component: endpoint_id.component.clone(),
-            endpoint: endpoint_id.name.clone(),
-        };
-
-        let lookup_card = || async {
-            let instances = discovery.list(query.clone()).await.map_err(to_pyerr)?;
-            let card = instances.into_iter().find_map(|inst| {
-                inst.deserialize_model::<llm_rs::model_card::ModelDeploymentCard>()
-                    .ok()
-            });
-            Ok::<_, PyErr>(card)
-        };
-
         let maybe_card = if needs_model_name {
             let wait_secs: u64 = std::env::var("DYN_ROUTER_MODEL_CARD_WAIT_SECS")
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(600);
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_secs);
-            let mut warned = false;
-            loop {
-                match lookup_card().await {
-                    Ok(Some(card)) => break Some(card),
-                    Ok(None) => {}
-                    Err(e) => {
-                        tracing::debug!(
-                            error = %e,
-                            "Discovery lookup failed while waiting for worker model card; will retry"
-                        );
-                        if std::time::Instant::now() >= deadline {
-                            return Err(e);
-                        }
-                    }
-                }
-                if std::time::Instant::now() >= deadline {
-                    break None;
-                }
-                if !warned {
-                    tracing::info!(
-                        namespace = %endpoint_id.namespace,
-                        component = %endpoint_id.component,
-                        endpoint = %endpoint_id.name,
-                        wait_secs,
-                        "No model card in discovery yet; waiting for worker registration (required for remote/served indexer)"
-                    );
-                    warned = true;
-                }
-                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            }
+            tracing::info!(
+                namespace = %endpoint_id.namespace,
+                component = %endpoint_id.component,
+                endpoint = %endpoint_id.name,
+                wait_secs,
+                "Waiting for worker model card in discovery (required for remote/served indexer)"
+            );
+            llm_rs::discovery::wait_for_endpoint_model_card(
+                &endpoint.inner,
+                std::time::Duration::from_secs(wait_secs),
+                None,
+            )
+            .await
+            .map_err(to_pyerr)?
         } else {
-            lookup_card().await?
+            // Non-blocking snapshot — used only to detect Eagle routing semantics
+            // when a card happens to already be registered.
+            let discovery = endpoint.inner.component().drt().discovery();
+            let instances = discovery
+                .list(rs::discovery::DiscoveryQuery::EndpointModels {
+                    namespace: endpoint_id.namespace.clone(),
+                    component: endpoint_id.component.clone(),
+                    endpoint: endpoint_id.name.clone(),
+                })
+                .await
+                .map_err(to_pyerr)?;
+            instances.into_iter().find_map(|inst| {
+                inst.deserialize_model::<llm_rs::model_card::ModelDeploymentCard>()
+                    .ok()
+            })
         };
 
         match maybe_card {

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -686,27 +686,61 @@ async fn create_kv_router_from_endpoint(
         llm_rs::discovery::WORKER_TYPE_DECODE
     };
 
-    // Query discovery once so we can derive both model_name (for remote/served indexer)
-    // and Eagle routing semantics from the model card.
+    // Look up the worker's model card so we can derive both model_name (required
+    // for remote/served indexer) and Eagle routing semantics. When the model_name
+    // is required but no worker has registered yet, poll discovery until one
+    // appears so we don't race worker startup. Bounded by
+    // `DYN_ROUTER_MODEL_CARD_WAIT_SECS` (default 600s).
     let needs_model_name = kv_router_config
         .as_ref()
         .map(|cfg| cfg.use_remote_indexer || cfg.serve_indexer)
         .unwrap_or(false);
     let (model_name, enable_eagle) = {
         let discovery = endpoint.inner.component().drt().discovery();
-        let instances = discovery
-            .list(rs::discovery::DiscoveryQuery::EndpointModels {
-                namespace: endpoint_id.namespace.clone(),
-                component: endpoint_id.component.clone(),
-                endpoint: endpoint_id.name.clone(),
-            })
-            .await
-            .map_err(to_pyerr)?;
+        let query = rs::discovery::DiscoveryQuery::EndpointModels {
+            namespace: endpoint_id.namespace.clone(),
+            component: endpoint_id.component.clone(),
+            endpoint: endpoint_id.name.clone(),
+        };
 
-        let maybe_card = instances.into_iter().find_map(|inst| {
-            inst.deserialize_model::<llm_rs::model_card::ModelDeploymentCard>()
+        let lookup_card = || async {
+            let instances = discovery.list(query.clone()).await.map_err(to_pyerr)?;
+            let card = instances.into_iter().find_map(|inst| {
+                inst.deserialize_model::<llm_rs::model_card::ModelDeploymentCard>()
+                    .ok()
+            });
+            Ok::<_, PyErr>(card)
+        };
+
+        let maybe_card = if needs_model_name {
+            let wait_secs: u64 = std::env::var("DYN_ROUTER_MODEL_CARD_WAIT_SECS")
                 .ok()
-        });
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(600);
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_secs);
+            let mut warned = false;
+            loop {
+                if let Some(card) = lookup_card().await? {
+                    break Some(card);
+                }
+                if std::time::Instant::now() >= deadline {
+                    break None;
+                }
+                if !warned {
+                    tracing::info!(
+                        namespace = %endpoint_id.namespace,
+                        component = %endpoint_id.component,
+                        endpoint = %endpoint_id.name,
+                        wait_secs,
+                        "No model card in discovery yet; waiting for worker registration (required for remote/served indexer)"
+                    );
+                    warned = true;
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+        } else {
+            lookup_card().await?
+        };
 
         match maybe_card {
             Some(card) => {

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -720,8 +720,18 @@ async fn create_kv_router_from_endpoint(
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_secs);
             let mut warned = false;
             loop {
-                if let Some(card) = lookup_card().await? {
-                    break Some(card);
+                match lookup_card().await {
+                    Ok(Some(card)) => break Some(card),
+                    Ok(None) => {}
+                    Err(e) => {
+                        tracing::debug!(
+                            error = %e,
+                            "Discovery lookup failed while waiting for worker model card; will retry"
+                        );
+                        if std::time::Instant::now() >= deadline {
+                            return Err(e);
+                        }
+                    }
                 }
                 if std::time::Instant::now() >= deadline {
                     break None;

--- a/lib/llm/src/discovery.rs
+++ b/lib/llm/src/discovery.rs
@@ -13,6 +13,9 @@ pub use worker_set::WorkerSet;
 pub(crate) mod runtime_configs;
 pub use runtime_configs::{RuntimeConfigWatch, runtime_config_watch};
 
+mod endpoint_card;
+pub use endpoint_card::wait_for_endpoint_model_card;
+
 mod watcher;
 pub use watcher::{ModelUpdate, ModelWatcher};
 

--- a/lib/llm/src/discovery/endpoint_card.rs
+++ b/lib/llm/src/discovery/endpoint_card.rs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use anyhow::Result;
+use futures::StreamExt;
+use tokio_util::sync::CancellationToken;
+
+use dynamo_runtime::component::Endpoint;
+use dynamo_runtime::discovery::{DiscoveryEvent, DiscoveryQuery};
+use dynamo_runtime::prelude::DistributedRuntimeProvider;
+
+use crate::model_card::ModelDeploymentCard;
+
+/// Wait for a worker on `endpoint` to publish its `ModelDeploymentCard`.
+///
+/// Uses the watch-based discovery API so the wait is event-driven (no polling)
+/// and returns as soon as the first card is observed. Existing registrations
+/// are delivered as `Added` events at the start of the stream, so callers do
+/// not need to issue a separate `list` first.
+///
+/// Returns `Ok(Some(card))` once a card is observed, or `Ok(None)` if `timeout`
+/// elapses, the supplied `cancel_token` fires, or the discovery stream ends
+/// without ever delivering a deserializable model card. When `cancel_token` is
+/// `None`, the runtime's primary token is used so the wait aborts on shutdown.
+pub async fn wait_for_endpoint_model_card(
+    endpoint: &Endpoint,
+    timeout: Duration,
+    cancel_token: Option<CancellationToken>,
+) -> Result<Option<ModelDeploymentCard>> {
+    let cancel_token = cancel_token.unwrap_or_else(|| endpoint.drt().primary_token());
+    let eid = endpoint.id();
+    let query = DiscoveryQuery::EndpointModels {
+        namespace: eid.namespace,
+        component: eid.component,
+        endpoint: eid.name,
+    };
+
+    let mut stream = endpoint
+        .drt()
+        .discovery()
+        .list_and_watch(query, Some(cancel_token.clone()))
+        .await?;
+
+    let find_card = async {
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(DiscoveryEvent::Added(instance)) => {
+                    if let Ok(card) = instance.deserialize_model::<ModelDeploymentCard>() {
+                        return Some(card);
+                    }
+                }
+                Ok(DiscoveryEvent::Removed(_)) => {}
+                Err(e) => {
+                    tracing::debug!(
+                        error = %e,
+                        "Discovery event error while waiting for endpoint model card; continuing"
+                    );
+                }
+            }
+        }
+        None
+    };
+
+    Ok(tokio::select! {
+        card = find_card => card,
+        _ = tokio::time::sleep(timeout) => None,
+        _ = cancel_token.cancelled() => None,
+    })
+}


### PR DESCRIPTION
## Summary
- The standalone router crashes at startup with `model_name is required when serve_indexer is configured` when launched alongside its workers — the binding issues a single discovery query for the worker's ModelDeploymentCard and returns `None` before any worker has registered.
- Poll discovery until a card appears (or `DYN_ROUTER_MODEL_CARD_WAIT_SECS` elapses, default 600s) when `use_remote_indexer` or `serve_indexer` is set.
- The non-required path is unchanged, so callers that don't need a `model_name` pay no extra latency.

## Test plan
- [ ] Launch standalone router alongside workers and confirm it no longer crashes at startup
- [ ] Verify router still starts promptly when workers are already registered
- [ ] Confirm timeout behavior with `DYN_ROUTER_MODEL_CARD_WAIT_SECS` set to a small value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of model deployment information discovery with automatic retries and a configurable timeout (default 10 minutes).
  * Added informational logging to provide visibility during model discovery operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->