### PR TITLE
fix(multimodal): bound media fetch concurrency and decouple httpx timeouts

### DIFF
--- a/components/src/dynamo/common/multimodal/http_client.py
+++ b/components/src/dynamo/common/multimodal/http_client.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import logging
+import os
 from typing import Optional
 
 import httpx
@@ -22,6 +24,17 @@ logger = logging.getLogger(__name__)
 
 # Global HTTP client instance
 _global_http_client: Optional[httpx.AsyncClient] = None
+_global_http_semaphore: Optional[asyncio.Semaphore] = None
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    return float(raw) if raw is not None and raw != "" else default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    return int(raw) if raw is not None and raw != "" else default
 
 
 def get_http_client(timeout: float = 60.0) -> httpx.AsyncClient:
@@ -33,15 +46,65 @@ def get_http_client(timeout: float = 60.0) -> httpx.AsyncClient:
 
     Returns:
         Shared HTTP client instance
+
+    Pool sizing and per-field timeouts are configurable via environment
+    variables so operators can tune without patching source:
+
+    - ``DYN_MM_HTTP_CONNECT_TIMEOUT`` (default 5s)
+    - ``DYN_MM_HTTP_READ_TIMEOUT`` (default: value of ``timeout`` argument)
+    - ``DYN_MM_HTTP_POOL_TIMEOUT`` (default 60s) — decoupled from read so a
+      saturated pool surfaces quickly instead of waiting the read timeout.
+    - ``DYN_MM_HTTP_MAX_CONNECTIONS`` (default 100)
+    - ``DYN_MM_HTTP_MAX_KEEPALIVE`` (default 20)
     """
     global _global_http_client
 
     if _global_http_client is None or _global_http_client.is_closed:
+        connect_timeout = _env_float("DYN_MM_HTTP_CONNECT_TIMEOUT", 5.0)
+        read_timeout = _env_float("DYN_MM_HTTP_READ_TIMEOUT", timeout)
+        pool_timeout = _env_float("DYN_MM_HTTP_POOL_TIMEOUT", 60.0)
+        max_connections = _env_int("DYN_MM_HTTP_MAX_CONNECTIONS", 100)
+        max_keepalive = _env_int("DYN_MM_HTTP_MAX_KEEPALIVE", 20)
+
         _global_http_client = httpx.AsyncClient(
-            timeout=timeout,
+            timeout=httpx.Timeout(
+                connect=connect_timeout,
+                read=read_timeout,
+                write=None,
+                pool=pool_timeout,
+            ),
             follow_redirects=True,
-            limits=httpx.Limits(max_keepalive_connections=20, max_connections=100),
+            limits=httpx.Limits(
+                max_keepalive_connections=max_keepalive,
+                max_connections=max_connections,
+            ),
         )
-        logger.info(f"Shared HTTP client initialized with timeout={timeout}s")
+        logger.info(
+            "Shared HTTP client initialized ("
+            "connect=%ss, read=%ss, write=None, pool=%ss, "
+            "max_connections=%d, max_keepalive=%d, follow_redirects=True)",
+            connect_timeout,
+            read_timeout,
+            pool_timeout,
+            max_connections,
+            max_keepalive,
+        )
 
     return _global_http_client
+
+
+def get_http_semaphore() -> asyncio.Semaphore:
+    """Return the process-global semaphore that bounds in-flight media fetches.
+
+    Acts as backpressure in front of :data:`_global_http_client`: caps the
+    number of concurrent HTTP fetches across all media loaders (image, video,
+    audio) so a burst of requests cannot saturate the pool and push
+    ``PoolTimeout`` errors up the stack.
+
+    Tunable via ``DYN_MM_HTTP_CONCURRENCY`` (default 50).
+    """
+    global _global_http_semaphore
+    if _global_http_semaphore is None:
+        bound = _env_int("DYN_MM_HTTP_CONCURRENCY", 50)
+        _global_http_semaphore = asyncio.Semaphore(bound)
+    return _global_http_semaphore

--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -19,7 +19,7 @@ from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.media_nixl import read_decoded_media_via_nixl
 from dynamo.common.utils.runtime import run_async
 
-from .http_client import get_http_client
+from .http_client import get_http_client, get_http_semaphore
 
 logger = logging.getLogger(__name__)
 
@@ -94,11 +94,12 @@ class ImageLoader:
         try:
             with _nvtx.annotate("mm:img:http_fetch", color="lime"):
                 http_client = get_http_client(self._http_timeout)
-                response = await http_client.get(image_url)
-                response.raise_for_status()
-                if not response.content:
-                    raise ValueError("Empty response content from image URL")
-                image_data = BytesIO(response.content)
+                async with get_http_semaphore():
+                    response = await http_client.get(image_url)
+                    response.raise_for_status()
+                    if not response.content:
+                        raise ValueError("Empty response content from image URL")
+                    image_data = BytesIO(response.content)
 
             return await self._open_image(image_data)
 


### PR DESCRIPTION
Cherry-pick of #8657 onto `release/1.1.0`.

Original PR: https://github.com/ai-dynamo/dynamo/pull/8657
Merge commit: eadc21f810c27933e8541511d0d16cd3fbb2e30c

Adapted from the original because `release/1.1.0` does not have the SSRF
URL-validator from #8282. Scope on this branch:

- `http_client.py`: env-var-driven httpx `Timeout` + `Limits`, plus the
  process-wide `get_http_semaphore()`. `follow_redirects` stays `True`
  (release/1.1.0 has no per-redirect SSRF revalidator).
- `image_loader.py`: wrap the existing `http_client.get()` call in
  `get_http_semaphore()` to bound concurrent image fetches.
- `audio_loader.py` / `video_loader.py`: unchanged on this branch — they
  go through vLLM's `MediaConnector` and have no httpx path here.

## Test Plan
- Same as #8657, scoped to image fetches; no additional changes in this cherry-pick.