### PR TITLE
fix: include aiperf in dynamo-planner image

### DIFF
--- a/container/templates/planner.Dockerfile
+++ b/container/templates/planner.Dockerfile
@@ -54,11 +54,14 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775 \
 
 # Install the local wheels and planner/profiler runtime dependencies before the
 # repo copies so changes in tests/configs don't invalidate the dependency layer.
+# aiperf is required by the thorough profiler path (profiler/utils/aiperf.py).
 RUN --mount=type=bind,source=./container/deps/requirements.planner.txt,target=/tmp/requirements.planner.txt \
+    --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
     --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775 \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv pip install \
         --requirement /tmp/requirements.planner.txt \
+        --requirement /tmp/requirements.benchmark.txt \
         /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
         /opt/dynamo/wheelhouse/ai_dynamo*any.whl
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,9 @@ filterwarnings = [
     # SGLang quantization warnings on CPU-only runners
     "ignore:Only CUDA, HIP and XPU support AWQ currently.*:UserWarning",
     "ignore:Only CUDA support GGUF quantization currently.*:UserWarning",
+    # pandas 2.3 emits this from pd.concat on empty/all-NA frames; aiconfigurator hits it
+    # during disagg pareto search and re-raises as RuntimeError, breaking planner tests.
+    "ignore:The behavior of DataFrame concatenation with empty or all-NA entries is deprecated.*:FutureWarning",
 ]
 
 


### PR DESCRIPTION
The profiler moved into a dedicated dynamo-planner image in 1.1.0 (deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go:1260-1264), but aiperf was not migrated. The thorough profiling path invokes aiperf via subprocess.Popen at components/src/dynamo/profiler/utils/aiperf.py:193 and :360, so any DGDR with searchStrategy=thorough crashes during the prefill benchmark with FileNotFoundError: 'aiperf' on all backends (vllm/sglang/trtllm).

Mount and install requirements.benchmark.txt in the planner builder stage alongside requirements.planner.txt, mirroring the pattern already used in vllm_runtime.Dockerfile and trtllm_runtime.Dockerfile. The aiperf CLI lands in /opt/dynamo/venv/bin/, which is already on PATH and copied into the distroless final stage.

ref: OPS-4778

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the planner build stage to include benchmark dependencies alongside core dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->