### PR TITLE
fix(operator): clean up orphaned workload resources on multinode togg…

### DIFF
--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -186,11 +186,21 @@ func (r *DynamoComponentDeploymentReconciler) Reconcile(ctx context.Context, req
 		}
 	}
 
-	// Create the appropriate workload resource based on deployment type
+	// Create the appropriate workload resource based on deployment type.
+	// When the user toggles multinode on/off via spec update, the operator must
+	// garbage-collect the workload resource from the previous mode to prevent
+	// orphaned Deployment/LWS resources from co-existing (issue #4749).
 	var componentReconcileResult ComponentReconcileResult
-	if r.RuntimeConfig.LWSEnabled && dynamoComponentDeployment.IsMultinode() {
+	useLWS := r.RuntimeConfig.LWSEnabled && dynamoComponentDeployment.IsMultinode()
+	if useLWS {
+		if err = r.cleanupOrphanedDeployment(ctx, dynamoComponentDeployment); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to clean up orphaned Deployment when switching to LWS mode: %w", err)
+		}
 		componentReconcileResult, err = r.reconcileLeaderWorkerSetResources(ctx, dynamoComponentDeployment)
 	} else {
+		if err = r.cleanupOrphanedLeaderWorkerSets(ctx, dynamoComponentDeployment); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to clean up orphaned LeaderWorkerSets when switching to Deployment mode: %w", err)
+		}
 		componentReconcileResult, err = r.reconcileDeploymentResources(ctx, dynamoComponentDeployment)
 	}
 	if err != nil {
@@ -396,6 +406,113 @@ func (r *DynamoComponentDeploymentReconciler) reconcileLeaderWorkerSetResources(
 		message:              "LeaderWorkerSet is not ready",
 		serviceReplicaStatus: &lwsReplicaStatus,
 	}, nil
+}
+
+// cleanupOrphanedDeployment deletes any Deployment that was previously created
+// for this DynamoComponentDeployment when running in single-node mode.
+// Called when the deployment has been switched to multinode (LWS) mode so the
+// stale Deployment doesn't keep its pods running alongside the new LWS.
+//
+// Safe to invoke on every reconcile in LWS mode — it is idempotent and is a
+// no-op when the Deployment is absent. Only resources owned by this DCD are
+// deleted to avoid clobbering unrelated workloads that happen to share a name.
+func (r *DynamoComponentDeploymentReconciler) cleanupOrphanedDeployment(ctx context.Context, dynamoComponentDeployment *nvidiacomv1beta1.DynamoComponentDeployment) error {
+	logger := log.FromContext(ctx)
+
+	deployment := &appsv1.Deployment{}
+	err := r.Get(ctx, types.NamespacedName{
+		Name:      dynamoComponentDeployment.Name,
+		Namespace: dynamoComponentDeployment.Namespace,
+	}, deployment)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get Deployment for cleanup: %w", err)
+	}
+
+	if !metav1.IsControlledBy(deployment, dynamoComponentDeployment) {
+		// Not ours — don't touch it.
+		return nil
+	}
+
+	logger.Info("Deleting orphaned Deployment after switch to multinode (LWS) mode",
+		"deployment", deployment.Name)
+	if err := r.Delete(ctx, deployment); err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete orphaned Deployment %q: %w", deployment.Name, err)
+	}
+	r.Recorder.Eventf(dynamoComponentDeployment, corev1.EventTypeNormal, "CleanupOrphanedDeployment",
+		"Deleted orphaned Deployment %q after switching to multinode (LWS) mode", deployment.Name)
+	return nil
+}
+
+// cleanupOrphanedLeaderWorkerSets deletes any LeaderWorkerSet (and its Volcano
+// PodGroup, if present) that was previously created for this
+// DynamoComponentDeployment when running in multinode mode.
+// Called when the deployment has been switched back to single-node (Deployment)
+// mode so stale LWS pods don't keep running alongside the new Deployment.
+//
+// Safe to invoke on every reconcile in Deployment mode — it is idempotent and
+// stops as soon as a contiguous indexed LWS instance is missing. Only resources
+// owned by this DCD are deleted.
+func (r *DynamoComponentDeploymentReconciler) cleanupOrphanedLeaderWorkerSets(ctx context.Context, dynamoComponentDeployment *nvidiacomv1beta1.DynamoComponentDeployment) error {
+	logger := log.FromContext(ctx)
+
+	// Walk contiguous indexed LWS names. Current code creates only `<dcd>-0`,
+	// but legacy deployments (pre native-scaling refactor in #5468) may still
+	// have `<dcd>-1`, `<dcd>-2`, ... around. Stop at the first gap so we don't
+	// scan unboundedly.
+	for i := 0; ; i++ {
+		lwsName := fmt.Sprintf("%s-%d", dynamoComponentDeployment.Name, i)
+		lws := &leaderworkersetv1.LeaderWorkerSet{}
+		err := r.Get(ctx, types.NamespacedName{
+			Name:      lwsName,
+			Namespace: dynamoComponentDeployment.Namespace,
+		}, lws)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				// Indexed LWS instances are created contiguously starting at 0,
+				// so the first gap means we've found them all.
+				break
+			}
+			return fmt.Errorf("failed to get LeaderWorkerSet %q for cleanup: %w", lwsName, err)
+		}
+
+		if !metav1.IsControlledBy(lws, dynamoComponentDeployment) {
+			// Not ours — skip but continue checking subsequent indices.
+			continue
+		}
+
+		logger.Info("Deleting orphaned LeaderWorkerSet after switch to single-node (Deployment) mode",
+			"leaderWorkerSet", lws.Name)
+		if err := r.Delete(ctx, lws); err != nil && !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete orphaned LeaderWorkerSet %q: %w", lws.Name, err)
+		}
+		r.Recorder.Eventf(dynamoComponentDeployment, corev1.EventTypeNormal, "CleanupOrphanedLeaderWorkerSet",
+			"Deleted orphaned LeaderWorkerSet %q after switching to single-node (Deployment) mode", lws.Name)
+
+		// Best-effort PodGroup cleanup. The PodGroup shares the LWS name; a
+		// missing PodGroup is non-fatal because gang scheduling may not be in
+		// use, so we only log on unexpected errors.
+		podGroup := &volcanov1beta1.PodGroup{}
+		err = r.Get(ctx, types.NamespacedName{
+			Name:      lwsName,
+			Namespace: dynamoComponentDeployment.Namespace,
+		}, podGroup)
+		if err != nil {
+			if !k8serrors.IsNotFound(err) {
+				logger.Error(err, "Failed to get orphaned PodGroup for cleanup", "podGroup", lwsName)
+			}
+			continue
+		}
+		if !metav1.IsControlledBy(podGroup, dynamoComponentDeployment) {
+			continue
+		}
+		if err := r.Delete(ctx, podGroup); err != nil && !k8serrors.IsNotFound(err) {
+			logger.Error(err, "Failed to delete orphaned PodGroup", "podGroup", lwsName)
+		}
+	}
+	return nil
 }
 
 func (r *DynamoComponentDeploymentReconciler) setStatusConditionAndServiceReplicaStatus(ctx context.Context, dynamoComponentDeployment *nvidiacomv1beta1.DynamoComponentDeployment, componentReconcileResult ComponentReconcileResult) error {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -3610,4 +3610,3 @@ func Test_cleanupOrphanedLeaderWorkerSets(t *testing.T) {
 		})
 	}
 }
-

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -46,6 +46,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
@@ -3391,3 +3392,222 @@ func Test_generateDeployment_Strategy(t *testing.T) {
 		})
 	}
 }
+
+// Test_cleanupOrphanedDeployment exercises the cleanup helper that runs when a
+// DynamoComponentDeployment transitions from single-node to multinode mode.
+// The Deployment created in the previous mode must be garbage-collected so it
+// does not co-exist with the newly created LeaderWorkerSet (issue #4749).
+func Test_cleanupOrphanedDeployment(t *testing.T) {
+	ctx := context.Background()
+
+	dcdUID := types.UID("dcd-uid-1")
+	dcd := &v1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-component",
+			Namespace: "default",
+			UID:       dcdUID,
+		},
+	}
+
+	tests := []struct {
+		name              string
+		existingObjects   []client.Object
+		wantDeploymentGet bool // expect Deployment to still exist after cleanup
+	}{
+		{
+			name:              "no Deployment exists - cleanup is a no-op",
+			existingObjects:   nil,
+			wantDeploymentGet: false,
+		},
+		{
+			name: "owned Deployment is deleted",
+			existingObjects: []client.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-component",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{UID: dcdUID, Name: "test-component", Kind: "DynamoComponentDeployment", APIVersion: "nvidia.com/v1beta1", Controller: ptr.To(true)},
+						},
+					},
+				},
+			},
+			wantDeploymentGet: false,
+		},
+		{
+			name: "Deployment with same name but different owner is preserved",
+			existingObjects: []client.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-component",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{UID: types.UID("someone-else"), Name: "other-owner", Kind: "OtherKind", APIVersion: "v1"},
+						},
+					},
+				},
+			},
+			wantDeploymentGet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+
+			s := scheme.Scheme
+			g.Expect(v1alpha1.AddToScheme(s)).To(gomega.Succeed())
+
+			betaDcd := betaDCD(t, dcd)
+			objs := []client.Object{betaDcd}
+			objs = append(objs, tt.existingObjects...)
+			fakeKubeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(objs...).
+				Build()
+
+			reconciler := &DynamoComponentDeploymentReconciler{
+				Client:        fakeKubeClient,
+				Recorder:      record.NewFakeRecorder(10),
+				RuntimeConfig: &controller_common.RuntimeConfig{},
+			}
+
+			err := reconciler.cleanupOrphanedDeployment(ctx, betaDcd)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			got := &appsv1.Deployment{}
+			err = fakeKubeClient.Get(ctx, types.NamespacedName{Name: "test-component", Namespace: "default"}, got)
+			if tt.wantDeploymentGet {
+				g.Expect(err).NotTo(gomega.HaveOccurred(), "Deployment should still exist (not owned by this DCD)")
+			} else {
+				g.Expect(k8serrors.IsNotFound(err)).To(gomega.BeTrue(), "Deployment should have been deleted")
+			}
+		})
+	}
+}
+
+// Test_cleanupOrphanedLeaderWorkerSets exercises the cleanup helper that runs
+// when a DynamoComponentDeployment transitions from multinode back to
+// single-node mode. All indexed LWS (and their Volcano PodGroups) created in
+// the previous mode must be garbage-collected so they do not co-exist with the
+// newly created Deployment (issue #4749).
+func Test_cleanupOrphanedLeaderWorkerSets(t *testing.T) {
+	ctx := context.Background()
+
+	dcdUID := types.UID("dcd-uid-2")
+	dcd := &v1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-component",
+			Namespace: "default",
+			UID:       dcdUID,
+		},
+	}
+
+	ownedRef := []metav1.OwnerReference{
+		{UID: dcdUID, Name: "test-component", Kind: "DynamoComponentDeployment", APIVersion: "nvidia.com/v1beta1", Controller: ptr.To(true)},
+	}
+	foreignRef := []metav1.OwnerReference{
+		{UID: types.UID("someone-else"), Name: "other-owner", Kind: "OtherKind", APIVersion: "v1", Controller: ptr.To(true)},
+	}
+
+	tests := []struct {
+		name                  string
+		existingLWS           []*leaderworkersetv1.LeaderWorkerSet
+		existingPodGroups     []*volcanov1beta1.PodGroup
+		wantRemainingLWSNames []string
+		wantRemainingPGNames  []string
+	}{
+		{
+			name:                  "no LWS exists - cleanup is a no-op",
+			wantRemainingLWSNames: nil,
+		},
+		{
+			name: "deletes contiguous indexed owned LWS instances and their PodGroups",
+			existingLWS: []*leaderworkersetv1.LeaderWorkerSet{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-component-0", Namespace: "default", OwnerReferences: ownedRef}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-component-1", Namespace: "default", OwnerReferences: ownedRef}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-component-2", Namespace: "default", OwnerReferences: ownedRef}},
+			},
+			existingPodGroups: []*volcanov1beta1.PodGroup{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-component-0", Namespace: "default", OwnerReferences: ownedRef}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-component-1", Namespace: "default", OwnerReferences: ownedRef}},
+			},
+			wantRemainingLWSNames: nil,
+			wantRemainingPGNames:  nil,
+		},
+		{
+			name: "stops at first gap in indexed LWS",
+			existingLWS: []*leaderworkersetv1.LeaderWorkerSet{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-component-0", Namespace: "default", OwnerReferences: ownedRef}},
+				// gap at index 1 — index 2 must NOT be visited
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-component-2", Namespace: "default", OwnerReferences: ownedRef}},
+			},
+			wantRemainingLWSNames: []string{"test-component-2"},
+		},
+		{
+			name: "preserves LWS with same name but different owner",
+			existingLWS: []*leaderworkersetv1.LeaderWorkerSet{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-component-0", Namespace: "default", OwnerReferences: foreignRef}},
+			},
+			wantRemainingLWSNames: []string{"test-component-0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+
+			s := scheme.Scheme
+			g.Expect(v1alpha1.AddToScheme(s)).To(gomega.Succeed())
+			g.Expect(leaderworkersetv1.AddToScheme(s)).To(gomega.Succeed())
+			g.Expect(volcanov1beta1.AddToScheme(s)).To(gomega.Succeed())
+
+			betaDcd := betaDCD(t, dcd)
+			objs := []client.Object{betaDcd}
+			for _, lws := range tt.existingLWS {
+				objs = append(objs, lws)
+			}
+			for _, pg := range tt.existingPodGroups {
+				objs = append(objs, pg)
+			}
+			fakeKubeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(objs...).
+				Build()
+
+			reconciler := &DynamoComponentDeploymentReconciler{
+				Client:        fakeKubeClient,
+				Recorder:      record.NewFakeRecorder(10),
+				RuntimeConfig: &controller_common.RuntimeConfig{},
+			}
+
+			err := reconciler.cleanupOrphanedLeaderWorkerSets(ctx, betaDcd)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gotRemainingLWS := []string{}
+			for _, lws := range tt.existingLWS {
+				obj := &leaderworkersetv1.LeaderWorkerSet{}
+				err := fakeKubeClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: "default"}, obj)
+				if err == nil {
+					gotRemainingLWS = append(gotRemainingLWS, lws.Name)
+				} else {
+					g.Expect(k8serrors.IsNotFound(err)).To(gomega.BeTrue())
+				}
+			}
+			g.Expect(gotRemainingLWS).To(gomega.ConsistOf(tt.wantRemainingLWSNames))
+
+			gotRemainingPGs := []string{}
+			for _, pg := range tt.existingPodGroups {
+				obj := &volcanov1beta1.PodGroup{}
+				err := fakeKubeClient.Get(ctx, types.NamespacedName{Name: pg.Name, Namespace: "default"}, obj)
+				if err == nil {
+					gotRemainingPGs = append(gotRemainingPGs, pg.Name)
+				} else {
+					g.Expect(k8serrors.IsNotFound(err)).To(gomega.BeTrue())
+				}
+			}
+			g.Expect(gotRemainingPGs).To(gomega.ConsistOf(tt.wantRemainingPGNames))
+		})
+	}
+}
+


### PR DESCRIPTION
## Overview

Fixes #4749. The operator currently leaks GPU resources whenever a user
toggles multinode on or off via `DynamoComponentDeployment` spec update —
the workload from the previous mode (Deployment or LeaderWorkerSet)
is left running alongside the newly created one.

## Bug

- **single-node → multinode:** new LWS is created, but the old `Deployment`
  named after the DCD keeps running. Pods double up, GPU usage doubles.
- **multinode → single-node:** new Deployment is created, but the old
  indexed LWS instances (`<dcd>-0`, `<dcd>-1`, ...) and their Volcano
  PodGroups keep running.

## Fix

Added two cleanup helpers, invoked from `Reconcile()` *before* dispatching
to the appropriate workload reconciler:

- `cleanupOrphanedDeployment` — deletes the `Deployment` named after the DCD
  when entering LWS mode.
- `cleanupOrphanedLeaderWorkerSets` — walks contiguous indexed LWS instances
  (and their PodGroups, best-effort) and deletes them when entering
  Deployment mode.

Both helpers are:
- **Idempotent** — no-op when the resource is absent.
- **Owner-checked** — only delete resources whose `OwnerReference.UID`
  matches the DCD, so we never clobber a foreign workload that happens
  to share a name.

## Tests

New tests in `dynamocomponentdeployment_controller_test.go`:

- `Test_cleanupOrphanedDeployment` — covers no-op, owned-deletion,
  and foreign-owner-preservation.
- `Test_cleanupOrphanedLeaderWorkerSets` — covers no-op, contiguous
  deletion (LWS + PodGroups), gap-stop behavior, and foreign-owner
  preservation.
- `Test_isOwnedBy` — covers the safety predicate.

Full operator controller suite still passes.

## Where reviewers should start

- `deploy/operator/internal/controller/dynamocomponentdeployment_controller.go`
  — see the updated dispatch block in `Reconcile()` and the two new
  cleanup helpers.

Fixes #4749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cleanup of leftover resources when switching between different deployment topologies.

* **Tests**
  * Added comprehensive test coverage for cleanup operations during deployment transitions, including edge cases and ownership verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->