### PR TITLE
fix(operator): Keep profiling output-copier authenticated when pod token automount is disabled

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -87,9 +87,12 @@ const (
 	SidecarImage = "bitnami/kubectl:latest"
 
 	// Volume names
-	VolumeNameProfilingOutput = "profiling-output"
-	VolumeNameProfilingConfig = "profiling-config"
-	VolumeNameModelCache      = "model-cache"
+	VolumeNameProfilingOutput            = "profiling-output"
+	VolumeNameProfilingConfig            = "profiling-config"
+	VolumeNameModelCache                 = "model-cache"
+	VolumeNameOutputCopierKubeAPIAccess  = "output-copier-kube-api-access"
+	ConfigMapNameKubeRootCA              = "kube-root-ca.crt"
+	ServiceAccountTokenExpirationSeconds = 3600
 
 	// Volume paths
 	ProfilingOutputPath        = "/data"
@@ -97,6 +100,7 @@ const (
 	ProfilingConfigMountPath   = "/config"
 	ProfilingConfigDefaultKey  = "disagg.yaml"
 	DefaultModelCacheMountPath = "/opt/model-cache"
+	ServiceAccountTokenPath    = "/var/run/secrets/kubernetes.io/serviceaccount"
 
 	// Command line arguments
 	ArgModel   = "--model"
@@ -1404,6 +1408,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 			jobOverrides = dgdr.Spec.Overrides.ProfilingJob
 		}
 		applyProfilingJobOverrides(job, jobOverrides)
+		ensureOutputCopierKubeAPIAccess(job)
 
 		return job, false, nil
 	})

--- a/deploy/operator/internal/controller/profiling_job_overrides.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides.go
@@ -122,7 +122,7 @@ func removeVolumeMountByName(mounts []corev1.VolumeMount, name string) []corev1.
 		return mounts
 	}
 
-	result := mounts[:0]
+	result := make([]corev1.VolumeMount, 0, len(mounts))
 	for _, mount := range mounts {
 		if mount.Name != name {
 			result = append(result, mount)

--- a/deploy/operator/internal/controller/profiling_job_overrides.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides.go
@@ -46,6 +46,91 @@ func applyProfilingJobOverrides(job *batchv1.Job, overrides *batchv1.JobSpec) {
 	applyPodTemplateOverrides(&job.Spec.Template, &overrides.Template)
 }
 
+// ensureOutputCopierKubeAPIAccess preserves the user's pod-level
+// automountServiceAccountToken=false setting while keeping the controller-owned
+// output-copier sidecar able to update the DGDR output ConfigMap.
+func ensureOutputCopierKubeAPIAccess(job *batchv1.Job) {
+	spec := &job.Spec.Template.Spec
+	if spec.AutomountServiceAccountToken == nil || *spec.AutomountServiceAccountToken {
+		return
+	}
+
+	spec.Volumes = mergeNamedSlice(
+		spec.Volumes,
+		[]corev1.Volume{outputCopierKubeAPIAccessVolume()},
+		func(v corev1.Volume) string { return v.Name },
+	)
+
+	for i := range spec.Containers {
+		spec.Containers[i].VolumeMounts = removeVolumeMountByName(
+			spec.Containers[i].VolumeMounts,
+			VolumeNameOutputCopierKubeAPIAccess,
+		)
+		if spec.Containers[i].Name == ContainerNameOutputCopier {
+			spec.Containers[i].VolumeMounts = append(spec.Containers[i].VolumeMounts, corev1.VolumeMount{
+				Name:      VolumeNameOutputCopierKubeAPIAccess,
+				MountPath: ServiceAccountTokenPath,
+				ReadOnly:  true,
+			})
+		}
+	}
+}
+
+func outputCopierKubeAPIAccessVolume() corev1.Volume {
+	expirationSeconds := int64(ServiceAccountTokenExpirationSeconds)
+	return corev1.Volume{
+		Name: VolumeNameOutputCopierKubeAPIAccess,
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{
+					{
+						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+							Path:              "token",
+							ExpirationSeconds: &expirationSeconds,
+						},
+					},
+					{
+						ConfigMap: &corev1.ConfigMapProjection{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: ConfigMapNameKubeRootCA,
+							},
+							Items: []corev1.KeyToPath{{
+								Key:  "ca.crt",
+								Path: "ca.crt",
+							}},
+						},
+					},
+					{
+						DownwardAPI: &corev1.DownwardAPIProjection{
+							Items: []corev1.DownwardAPIVolumeFile{{
+								Path: "namespace",
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1",
+									FieldPath:  "metadata.namespace",
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func removeVolumeMountByName(mounts []corev1.VolumeMount, name string) []corev1.VolumeMount {
+	if len(mounts) == 0 {
+		return mounts
+	}
+
+	result := mounts[:0]
+	for _, mount := range mounts {
+		if mount.Name != name {
+			result = append(result, mount)
+		}
+	}
+	return result
+}
+
 // applyJobSpecOverrides merges JobSpec-level scalar fields.
 func applyJobSpecOverrides(spec *batchv1.JobSpec, overrides *batchv1.JobSpec) {
 	if overrides.BackoffLimit != nil {

--- a/deploy/operator/internal/controller/profiling_job_overrides_test.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides_test.go
@@ -401,6 +401,103 @@ func TestApplyProfilingJobOverrides_AutomountServiceAccountToken(t *testing.T) {
 	}
 }
 
+func TestEnsureOutputCopierKubeAPIAccess_AutomountServiceAccountTokenFalse(t *testing.T) {
+	job := baseJob()
+	applyProfilingJobOverrides(job, &batchv1.JobSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				AutomountServiceAccountToken: ptr.To(false),
+			},
+		},
+	})
+	ensureOutputCopierKubeAPIAccess(job)
+
+	spec := job.Spec.Template.Spec
+	tokenVolume := findVolume(spec.Volumes, VolumeNameOutputCopierKubeAPIAccess)
+	if tokenVolume == nil {
+		t.Fatal("expected output-copier kube API access volume")
+	}
+	if tokenVolume.Projected == nil {
+		t.Fatal("expected output-copier kube API access volume to be projected")
+	}
+	if len(tokenVolume.Projected.Sources) != 3 {
+		t.Fatalf("expected service account token, root CA, and namespace projections, got %d", len(tokenVolume.Projected.Sources))
+	}
+	if tokenVolume.Projected.Sources[0].ServiceAccountToken == nil {
+		t.Error("expected service account token projection")
+	}
+	if tokenVolume.Projected.Sources[1].ConfigMap == nil || tokenVolume.Projected.Sources[1].ConfigMap.Name != ConfigMapNameKubeRootCA {
+		t.Error("expected kube root CA ConfigMap projection")
+	}
+	if tokenVolume.Projected.Sources[2].DownwardAPI == nil {
+		t.Error("expected namespace DownwardAPI projection")
+	}
+
+	profiler := findContainer(spec.Containers, ContainerNameProfiler)
+	if profiler == nil {
+		t.Fatal("expected profiler container")
+	}
+	if findOutputCopierKubeAPIAccessMount(profiler.VolumeMounts) != nil {
+		t.Error("profiler should not mount output-copier kube API access token")
+	}
+
+	sidecar := findContainer(spec.Containers, ContainerNameOutputCopier)
+	if sidecar == nil {
+		t.Fatal("expected output-copier container")
+	}
+	sidecarMount := findOutputCopierKubeAPIAccessMount(sidecar.VolumeMounts)
+	if sidecarMount == nil {
+		t.Fatal("expected output-copier kube API access token mount")
+	}
+	if sidecarMount.MountPath != ServiceAccountTokenPath || !sidecarMount.ReadOnly {
+		t.Errorf("unexpected sidecar token mount: %+v", *sidecarMount)
+	}
+}
+
+func TestEnsureOutputCopierKubeAPIAccess_ProtectsTokenVolumeFromOverrides(t *testing.T) {
+	job := baseJob()
+	applyProfilingJobOverrides(job, &batchv1.JobSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				AutomountServiceAccountToken: ptr.To(false),
+				Volumes: []corev1.Volume{{
+					Name:         VolumeNameOutputCopierKubeAPIAccess,
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+				}},
+				Containers: []corev1.Container{{
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      VolumeNameOutputCopierKubeAPIAccess,
+						MountPath: "/unexpected-token",
+					}},
+				}},
+			},
+		},
+	})
+	ensureOutputCopierKubeAPIAccess(job)
+
+	spec := job.Spec.Template.Spec
+	tokenVolume := findVolume(spec.Volumes, VolumeNameOutputCopierKubeAPIAccess)
+	if tokenVolume == nil || tokenVolume.Projected == nil {
+		t.Fatalf("expected protected volume to be restored as projected volume, got %+v", tokenVolume)
+	}
+
+	profiler := findContainer(spec.Containers, ContainerNameProfiler)
+	if profiler == nil {
+		t.Fatal("expected profiler container")
+	}
+	if findOutputCopierKubeAPIAccessMount(profiler.VolumeMounts) != nil {
+		t.Error("profiler should not retain a mount for the protected output-copier token volume")
+	}
+
+	sidecar := findContainer(spec.Containers, ContainerNameOutputCopier)
+	if sidecar == nil {
+		t.Fatal("expected output-copier container")
+	}
+	if mount := findOutputCopierKubeAPIAccessMount(sidecar.VolumeMounts); mount == nil || mount.MountPath != ServiceAccountTokenPath {
+		t.Errorf("expected output-copier to mount protected token volume at %s, got %+v", ServiceAccountTokenPath, mount)
+	}
+}
+
 func TestApplyProfilingJobOverrides_VolumesDedup(t *testing.T) {
 	job := baseJob()
 	applyProfilingJobOverrides(job, &batchv1.JobSpec{
@@ -828,4 +925,31 @@ func TestMergeNamedSlice_PreservesOrder(t *testing.T) {
 	if result[1].Value != "override" {
 		t.Errorf("A not overridden: %s", result[1].Value)
 	}
+}
+
+func findContainer(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+func findVolume(volumes []corev1.Volume, name string) *corev1.Volume {
+	for i := range volumes {
+		if volumes[i].Name == name {
+			return &volumes[i]
+		}
+	}
+	return nil
+}
+
+func findOutputCopierKubeAPIAccessMount(mounts []corev1.VolumeMount) *corev1.VolumeMount {
+	for i := range mounts {
+		if mounts[i].Name == VolumeNameOutputCopierKubeAPIAccess {
+			return &mounts[i]
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- Add an explicit projected service account token volume for the profiling `output-copier` sidecar when `automountServiceAccountToken: false` is set.
- Ensure the protected kube API token volume is mounted only into `output-copier`, not the main `profiler` container.
- Add regression tests covering the disabled automount path and user override attempts against the protected sidecar token volume.

Closes DYN-2895
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The operator now correctly handles Kubernetes deployments with service account token auto-mounting disabled. API access credentials are properly provisioned for internal components to function as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->