### PR TITLE
docs(parsers): clear rustdoc invalid_html_tags warnings on doc comments

### DIFF
--- a/lib/parsers/src/reasoning/minimax_append_think_parser.rs
+++ b/lib/parsers/src/reasoning/minimax_append_think_parser.rs
@@ -19,9 +19,9 @@ use crate::{ParserResult, ReasoningParser};
 ///
 /// References:
 /// - SGLang MiniMaxAppendThinkDetector:
-///   https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/parser/reasoning_parser.py
+///   <https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/parser/reasoning_parser.py>
 /// - vLLM MiniMaxM2AppendThinkReasoningParser:
-///   https://github.com/vllm-project/vllm/blob/main/vllm/reasoning/minimax_m2_reasoning_parser.py
+///   <https://github.com/vllm-project/vllm/blob/main/vllm/reasoning/minimax_m2_reasoning_parser.py>
 #[derive(Debug, Default)]
 pub struct MiniMaxAppendThinkParser {
     /// Flips to true after the first streamed chunk has received the `<think>`

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -5,9 +5,9 @@ use super::json::JsonParserType;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct JsonParserConfig {
-    /// Start token for individual tool calls (e.g., "<TOOLCALL>")
+    /// Start token for individual tool calls (e.g., `<TOOLCALL>`)
     pub tool_call_start_tokens: Vec<String>,
-    /// End token for individual tool calls (e.g., "</TOOLCALL>")
+    /// End token for individual tool calls (e.g., `</TOOLCALL>`)
     pub tool_call_end_tokens: Vec<String>,
     /// Separator tokens between function name and arguments
     /// (e.g., "<｜tool▁sep｜>" for DeepSeek v3.1)
@@ -52,15 +52,15 @@ impl Default for JsonParserConfig {
 pub struct XmlParserConfig {
     /// Start token for individual tool calls (e.g., "<tool_call>")
     pub tool_call_start_token: String,
-    /// End token for individual tool calls (e.g., "</tool_call>")
+    /// End token for individual tool calls (e.g., `</tool_call>`)
     pub tool_call_end_token: String,
-    /// Start token for function name (e.g., "<function=")
+    /// Start token for function name (e.g., `<function=`)
     pub function_start_token: String,
-    /// End token for function (e.g., "</function>")
+    /// End token for function (e.g., `</function>`)
     pub function_end_token: String,
-    /// Start token for parameter (e.g., "<parameter=")
+    /// Start token for parameter (e.g., `<parameter=`)
     pub parameter_start_token: String,
-    /// End token for parameter (e.g., "</parameter>")
+    /// End token for parameter (e.g., `</parameter>`)
     pub parameter_end_token: String,
 }
 

--- a/lib/parsers/src/tool_calling/dsml/parser.rs
+++ b/lib/parsers/src/tool_calling/dsml/parser.rs
@@ -323,7 +323,7 @@ mod tests {
     // TODO — not yet covered for V4:
     //   - CASE.5  Fix mid-stream truncation: parser currently drops all calls when
     //             </｜DSML｜tool_calls> is absent (max_tokens / EOS before close).
-    //             Same class as Kimi K2 pre-DIS-1765. Recovery pattern: scan for
+    //             Same class as Kimi K2 pre-PR #8208. Recovery pattern: scan for
     //             complete <｜DSML｜invoke>...</｜DSML｜invoke> pairs even without
     //             the outer close fence (see kimi_k2_parser.rs for precedent).
     //             Pinning tests below capture the current silent-drop behavior;

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -27,7 +27,7 @@ fn strip_quotes(s: &str) -> &str {
 }
 
 /// Check if a chunk contains the start of a xml-style tool call.
-/// Format: <tool_call><function=name><parameter=foo>...</parameter></function></tool_call>
+/// Format: `<tool_call><function=name><parameter=foo>...</parameter></function></tool_call>`
 pub fn detect_tool_call_start_xml(chunk: &str, config: &XmlParserConfig) -> bool {
     // Check for complete or partial start token.
     let start_token = &config.tool_call_start_token;
@@ -87,7 +87,7 @@ pub fn find_tool_call_end_position_xml(chunk: &str, config: &XmlParserConfig) ->
 }
 
 /// Try to parse Qwen3Coder formatted tool calls from a message.
-/// Format: <tool_call><function=name><parameter=key>value</parameter></function></tool_call>
+/// Format: `<tool_call><function=name><parameter=key>value</parameter></function></tool_call>`
 /// Returns (parsed_tool_calls, normal_text_content)
 pub fn try_tool_call_parse_xml(
     message: &str,
@@ -154,7 +154,7 @@ fn extract_tool_calls(
 }
 
 /// Parse a single tool call block
-/// Format: <tool_call><function=name><parameter=key>value</parameter>...</function></tool_call>
+/// Format: `<tool_call><function=name><parameter=key>value</parameter>...</function></tool_call>`
 fn parse_tool_call_block(
     block: &str,
     config: &XmlParserConfig,


### PR DESCRIPTION
#### Overview:

Non-functional cleanup — wrap inline XML/markup markers in backticks and angle-bracket bare URLs in doc comments so rustdoc stops emitting `invalid_html_tags` warnings.

#### Details:

- `lib/parsers/src/reasoning/minimax_append_think_parser.rs` — angle-bracket the two SGLang/vLLM reference URLs
- `lib/parsers/src/tool_calling/config.rs` — backtick `<TOOLCALL>`, `<function=`, `<parameter=`, `</tool_call>`, `</function>`, `</parameter>` markers in `JsonParserConfig` and `XmlParserConfig` doc comments
- `lib/parsers/src/tool_calling/xml/parser.rs` — backtick `<tool_call>...</tool_call>` format markers on `detect_tool_call_start_xml`, `try_tool_call_parse_xml`, `parse_tool_call_block` doc comments
- `lib/parsers/src/tool_calling/dsml/parser.rs` — replace internal Linear ref `DIS-1765` with the public PR reference (#8208)

#### Where should the reviewer start?

`lib/parsers/src/tool_calling/config.rs`

/coderabbit profile chill