### PR TITLE
fix: add FlexKVConnectorV1 to PdConnector allowed first connector types

### DIFF
--- a/docs/integrations/flexkv-integration.md
+++ b/docs/integrations/flexkv-integration.md
@@ -23,7 +23,13 @@ title: FlexKV
    ```bash
    docker compose -f deploy/docker-compose.yml up -d
    ```
-3. **FlexKV dependencies** (for SSD offloading):
+3. **FlexKV installed**:
+   ```bash
+   git clone https://github.com/taco-project/FlexKV.git
+   cd FlexKV
+   ./build.sh
+   ```
+4. **Optional: SSD offloading dependencies** (only required for CPU + SSD tiered offloading):
    ```bash
    apt install liburing-dev libxxhash-dev
    ```
@@ -88,25 +94,42 @@ python -m dynamo.vllm \
 
 ## Disaggregated Serving
 
-FlexKV can be used with disaggregated prefill/decode serving. The prefill worker uses FlexKV for KV cache offloading, while NIXL handles KV transfer between prefill and decode workers.
+> **Note:** Disaggregated FlexKV serving is experimental. The prefill worker must use `PdConnector` with two sub-connectors: `FlexKVConnectorV1` (KV cache offloading) and `NixlConnector` (P/D KV transfer). Using `FlexKVConnectorV1` alone as the top-level connector in disaggregated mode is **not supported** and will result in a `TypeError`.
+
+FlexKV can be used with disaggregated prefill/decode serving. The prefill worker uses FlexKV for KV cache offloading, while NIXL handles KV transfer between prefill and decode workers. The `PdConnector` wraps both connectors so they work together.
+
+### Supported connector configuration
+
+| Role | Connector | Description |
+|------|-----------|-------------|
+| Decode worker | `NixlConnector` | Pulls KV blocks from prefill worker via NIXL |
+| Prefill worker | `PdConnector` wrapping `[FlexKVConnectorV1, NixlConnector]` | FlexKV offloads/onboards KV blocks; NIXL serves them to decode |
 
 ```bash
 # Terminal 1: Start frontend
 python -m dynamo.frontend &
 
 # Terminal 2: Decode worker (without FlexKV)
-CUDA_VISIBLE_DEVICES=0 python -m dynamo.vllm --model Qwen/Qwen3-0.6B --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
+CUDA_VISIBLE_DEVICES=0 python -m dynamo.vllm --model Qwen/Qwen3-0.6B \
+  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
 
-# Terminal 3: Prefill worker (with FlexKV)
+# Terminal 3: Prefill worker (with FlexKV + NIXL via PdConnector)
+DYN_VLLM_KV_EVENT_PORT=20081 \
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 DYNAMO_USE_FLEXKV=1 \
 FLEXKV_CPU_CACHE_GB=32 \
 CUDA_VISIBLE_DEVICES=1 \
   python -m dynamo.vllm \
   --model Qwen/Qwen3-0.6B \
-  --disaggregation-mode prefill \
-  --kv-transfer-config '{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both"}' \
+  --is-prefill-worker \
+  --kv-transfer-config '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}' \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'
+```
+
+You can also use the provided launch script directly:
+
+```bash
+examples/backends/vllm/launch/disagg_flexkv.sh
 ```
 
 ## Configuration

--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/pd_connector.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/pd_connector.py
@@ -39,6 +39,17 @@ try:
 except ImportError:
     pass
 
+# Optional import for FlexKV support
+_FlexKVConnectorV1: Optional[Type] = None
+try:
+    from vllm.distributed.kv_transfer.kv_connector.v1.flexkv_connector import (
+        FlexKVConnectorV1,
+    )
+
+    _FlexKVConnectorV1 = FlexKVConnectorV1
+except ImportError:
+    pass
+
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
     from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_connector import (
@@ -56,10 +67,10 @@ class PdConnectorMetadata(MultiKVConnectorMetadata):
 
 class PdConnector(MultiConnector):
     """
-    A wrapper for using KV offloading Connectors (e.g. KVBM or LMCache) and NIXL Connector for PD disaggregated serving.
+    A wrapper for using KV offloading Connectors (e.g. KVBM, LMCache, or FlexKV) and NIXL Connector for PD disaggregated serving.
 
     The current logic is:
-    - The first connector must be KVBM or LMCache and would be used by prefill worker to offload and onboard KV blocks.
+    - The first connector must be KVBM, LMCache, or FlexKV and would be used by prefill worker to offload and onboard KV blocks.
     - The second connector must be NIXL and will be used by decode worker to get KV blocks from prefill worker.
     """
 
@@ -81,11 +92,15 @@ class PdConnector(MultiConnector):
         allowed_first_types: list[Type] = [DynamoConnector]
         if _LMCacheConnectorV1 is not None:
             allowed_first_types.append(_LMCacheConnectorV1)
+        if _FlexKVConnectorV1 is not None:
+            allowed_first_types.append(_FlexKVConnectorV1)
 
         if not isinstance(self._connectors[0], tuple(allowed_first_types)):
             allowed_names = ["DynamoConnector"]
             if _LMCacheConnectorV1 is not None:
                 allowed_names.append("LMCacheConnectorV1")
+            if _FlexKVConnectorV1 is not None:
+                allowed_names.append("FlexKVConnectorV1")
             raise TypeError(
                 f"Expected first connector to be {' or '.join(allowed_names)}, "
                 f"got {type(self._connectors[0]).__name__}"


### PR DESCRIPTION
Fix `PdConnector` TypeError when launching disaggregated FlexKV serving (`disagg_flexkv.sh`).                                                                                         
   
  `PdConnector.__init__` only allowed `DynamoConnector` and `LMCacheConnectorV1` as the first connector. When `FlexKVConnectorV1` is configured as the first connector (KV offloading   
  role), it raises:                                      
                                                                                                                                                                                        
  TypeError: Expected first connector to be DynamoConnector or LMCacheConnectorV1, got FlexKVConnectorV1                                                                                
   
  This PR adds `FlexKVConnectorV1` to the allowed first connector types using the same optional-import pattern established for `LMCacheConnectorV1` in PR #4319.                        
                                                                                                                                                                                        
  Fixes: NVBug 6088159
                                                                                                                                                                                        
  ## Changes                                             

  - Add optional import for `FlexKVConnectorV1` from `vllm.distributed.kv_transfer.kv_connector.v1.flexkv_connector` (soft dependency, no error if FlexKV is not installed)
  - Extend `allowed_first_types` and error message to include `FlexKVConnectorV1`

  ## Test plan

  - [ ] Launch `examples/backends/vllm/launch/disagg_flexkv.sh` — confirm prefill worker starts without TypeError
  - [ ] Launch existing `disagg_kvbm.sh` / `disagg_lmcache.sh` — confirm no regression for DynamoConnector and LMCacheConnectorV1 paths
  - [ ] Verify FlexKV-not-installed case: import falls back gracefully, `PdConnector` still works with DynamoConnector/LMCacheConnectorV1 
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FlexKV as an alternative KV offloading connector option.

* **Documentation**
  * Updated documentation to reflect the new connector option availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->