### PR TITLE
feat: add reusable telemetry primitives

### DIFF
--- a/lib/llm/src/audit/bus.rs
+++ b/lib/llm/src/audit/bus.rs
@@ -2,22 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::handle::AuditRecord;
-use std::sync::OnceLock;
+use crate::telemetry::bus::TelemetryBus;
 use tokio::sync::broadcast;
 
-static BUS: OnceLock<broadcast::Sender<AuditRecord>> = OnceLock::new();
+static BUS: TelemetryBus<AuditRecord> = TelemetryBus::new();
 
 pub fn init(capacity: usize) {
-    let (tx, _rx) = broadcast::channel::<AuditRecord>(capacity);
-    let _ = BUS.set(tx);
+    BUS.init(capacity);
 }
 
 pub fn subscribe() -> broadcast::Receiver<AuditRecord> {
-    BUS.get().expect("audit bus not initialized").subscribe()
+    BUS.subscribe()
 }
 
 pub fn publish(rec: AuditRecord) {
-    if let Some(tx) = BUS.get() {
-        let _ = tx.send(rec);
-    }
+    BUS.publish(rec);
 }

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -31,6 +31,7 @@ pub mod preprocessor;
 pub mod protocols;
 pub mod recorder;
 pub mod request_template;
+pub mod telemetry;
 pub use dynamo_tokenizers as tokenizers;
 pub use dynamo_tokenizers::{file_json_field, log_json_err};
 pub mod tokens;

--- a/lib/llm/src/recorder.rs
+++ b/lib/llm/src/recorder.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 use tokio::fs::{self, File, OpenOptions};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::sync::{Mutex, mpsc};
+use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 
 /// Record entry that will be serialized to JSONL
@@ -19,6 +20,30 @@ where
 {
     timestamp: u64,
     event: T,
+}
+
+/// Options for the generic JSONL recorder.
+#[derive(Debug, Clone)]
+pub struct RecorderOptions {
+    pub max_lines_per_file: Option<usize>,
+    pub max_count: Option<usize>,
+    pub max_time: Option<f64>,
+    pub buffer_bytes: usize,
+    pub flush_interval: Option<Duration>,
+    pub append: bool,
+}
+
+impl Default for RecorderOptions {
+    fn default() -> Self {
+        Self {
+            max_lines_per_file: None,
+            max_count: None,
+            max_time: None,
+            buffer_bytes: 32768,
+            flush_interval: None,
+            append: false,
+        }
+    }
 }
 
 /// A generic recorder for events that streams directly to a JSONL file
@@ -61,6 +86,24 @@ where
         max_count: Option<usize>,
         max_time: Option<f64>,
     ) -> io::Result<Self> {
+        Self::new_with_options(
+            token,
+            output_path,
+            RecorderOptions {
+                max_lines_per_file,
+                max_count,
+                max_time,
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    pub async fn new_with_options<P: AsRef<Path>>(
+        token: CancellationToken,
+        output_path: P,
+        options: RecorderOptions,
+    ) -> io::Result<Self> {
         let (event_tx, mut event_rx) = mpsc::channel::<T>(2048);
         let event_count = Arc::new(Mutex::new(0));
         let event_count_clone = event_count.clone();
@@ -76,26 +119,33 @@ where
             fs::create_dir_all(parent).await?;
         }
 
-        // Create the file for writing
-        let file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&output_path)
-            .await?;
+        let mut open_options = OpenOptions::new();
+        open_options.create(true).write(true);
+        if options.append {
+            open_options.append(true);
+        } else {
+            open_options.truncate(true);
+        }
+        let file = open_options.open(&output_path).await?;
 
         let file_path = output_path.as_ref().to_path_buf();
 
         // Spawn a task to receive events and write them to the file
         tokio::spawn(async move {
             let start_time = start_time;
-            let mut writer = BufWriter::with_capacity(32768, file);
+            let mut writer = BufWriter::with_capacity(options.buffer_bytes.max(1), file);
             let mut line_count = 0;
             let mut file_index = 0;
             let base_path = file_path.clone();
+            let flush_interval = options
+                .flush_interval
+                .filter(|duration| !duration.is_zero());
+            let mut flush_tick =
+                tokio::time::interval(flush_interval.unwrap_or(Duration::from_secs(1)));
+            flush_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
             // Set up max time deadline if specified
-            let max_time_deadline = max_time.map(|secs| {
+            let max_time_deadline = options.max_time.map(|secs| {
                 let duration = Duration::from_secs_f64(secs);
                 start_time + duration
             });
@@ -127,6 +177,12 @@ where
                         return;
                     }
 
+                    _ = flush_tick.tick(), if flush_interval.is_some() => {
+                        if let Err(e) = writer.flush().await {
+                            tracing::error!("Failed to flush on interval: {}", e);
+                        }
+                    }
+
                     Some(event) = event_rx.recv() => {
                         // Update first_event_time if this is the first event
                         {
@@ -139,7 +195,6 @@ where
                         // Calculate elapsed time in milliseconds
                         let elapsed_ms = start_time.elapsed().as_millis() as u64;
 
-                        // Create the record entry
                         let entry = RecordEntry {
                             timestamp: elapsed_ms,
                             event,
@@ -170,7 +225,7 @@ where
                         line_count += 1;
 
                         // Check if we need to rotate to a new file
-                        if let Some(max_lines) = max_lines_per_file
+                        if let Some(max_lines) = options.max_lines_per_file
                             && line_count >= max_lines {
                                 // Flush the current file
                                 if let Err(e) = writer.flush().await {
@@ -190,7 +245,7 @@ where
                                     .await
                                 {
                                     Ok(new_file) => {
-                                        writer = BufWriter::with_capacity(32768, new_file);
+                                        writer = BufWriter::with_capacity(options.buffer_bytes.max(1), new_file);
                                         line_count = 0;
                                         tracing::info!("Rotated to new file: {}", new_path.display());
                                     },
@@ -206,7 +261,7 @@ where
                         *count += 1;
 
                         // Check if we've reached the maximum count
-                        if let Some(max) = max_count
+                        if let Some(max) = options.max_count
                             && *count >= max {
                                 tracing::info!("Recorder reached max event count ({}), shutting down", max);
                                 // Flush buffer before shutting down

--- a/lib/llm/src/telemetry/bus.rs
+++ b/lib/llm/src/telemetry/bus.rs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::OnceLock;
+
+use tokio::sync::broadcast;
+
+/// Typed, in-process fanout bus for low-overhead telemetry paths.
+pub struct TelemetryBus<T> {
+    sender: OnceLock<broadcast::Sender<T>>,
+}
+
+impl<T> TelemetryBus<T>
+where
+    T: Clone + Send + 'static,
+{
+    pub const fn new() -> Self {
+        Self {
+            sender: OnceLock::new(),
+        }
+    }
+
+    pub fn init(&self, capacity: usize) {
+        let (tx, _rx) = broadcast::channel::<T>(capacity.max(1));
+        if self.sender.set(tx).is_err() {
+            tracing::debug!(
+                capacity,
+                "telemetry bus already initialized; keeping existing sender"
+            );
+        }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<T> {
+        self.sender
+            .get()
+            .expect("telemetry bus not initialized")
+            .subscribe()
+    }
+
+    pub fn publish(&self, record: T) {
+        if let Some(tx) = self.sender.get() {
+            let _ = tx.send(record);
+        }
+    }
+}
+
+impl<T> Default for TelemetryBus<T>
+where
+    T: Clone + Send + 'static,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TelemetryBus;
+
+    #[tokio::test]
+    async fn publishes_to_subscribers() {
+        static BUS: TelemetryBus<u64> = TelemetryBus::new();
+        BUS.init(4);
+        let mut rx = BUS.subscribe();
+
+        BUS.publish(7);
+
+        assert_eq!(rx.recv().await.unwrap(), 7);
+    }
+
+    #[tokio::test]
+    async fn publish_before_init_is_dropped() {
+        static BUS: TelemetryBus<u64> = TelemetryBus::new();
+
+        BUS.publish(7);
+        BUS.init(4);
+        let mut rx = BUS.subscribe();
+        BUS.publish(8);
+
+        assert_eq!(rx.recv().await.unwrap(), 8);
+    }
+}

--- a/lib/llm/src/telemetry/jsonl.rs
+++ b/lib/llm/src/telemetry/jsonl.rs
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use anyhow::Context as _;
+use serde::{Serialize, de::DeserializeOwned};
+use tokio::sync::broadcast::{
+    Receiver,
+    error::{RecvError, TryRecvError},
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::recorder::{Recorder, RecorderOptions};
+
+#[derive(Clone, Copy, Debug)]
+pub struct JsonlSinkOptions {
+    pub buffer_bytes: usize,
+    pub flush_interval: Duration,
+}
+
+impl Default for JsonlSinkOptions {
+    fn default() -> Self {
+        Self {
+            buffer_bytes: 32768,
+            flush_interval: Duration::from_millis(1000),
+        }
+    }
+}
+
+/// Spawn an async JSONL sink for records received from a typed telemetry bus.
+pub async fn spawn_jsonl_worker_with_shutdown<T>(
+    mut rx: Receiver<T>,
+    path: String,
+    options: JsonlSinkOptions,
+    shutdown: CancellationToken,
+) -> anyhow::Result<()>
+where
+    T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
+{
+    let recorder_shutdown = CancellationToken::new();
+    let recorder: Recorder<T> = Recorder::new_with_options(
+        recorder_shutdown.clone(),
+        &path,
+        RecorderOptions {
+            buffer_bytes: options.buffer_bytes.max(1),
+            flush_interval: Some(options.flush_interval.max(Duration::from_millis(1))),
+            append: true,
+            ..Default::default()
+        },
+    )
+    .await
+    .with_context(|| format!("opening jsonl telemetry sink at {path}"))?;
+
+    let tx = recorder.event_sender();
+    tokio::spawn(async move {
+        let _recorder = recorder;
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => {
+                    loop {
+                        match rx.try_recv() {
+                            Ok(rec) => {
+                                if tx.send(rec).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(TryRecvError::Lagged(n)) => {
+                                tracing::warn!(dropped = n, "telemetry bus lagged during shutdown; dropped records");
+                            }
+                            Err(TryRecvError::Empty | TryRecvError::Closed) => break,
+                        }
+                    }
+                    recorder_shutdown.cancel();
+                    return;
+                }
+                msg = rx.recv() => {
+                    match msg {
+                        Ok(rec) => {
+                            if tx.send(rec).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(RecvError::Lagged(n)) => {
+                            tracing::warn!(dropped = n, "telemetry bus lagged; dropped records")
+                        }
+                        Err(RecvError::Closed) => break,
+                    }
+                }
+            }
+        }
+        recorder_shutdown.cancel();
+    });
+
+    tracing::info!(
+        path,
+        buffer_bytes = options.buffer_bytes,
+        flush_interval_ms = options.flush_interval.as_millis(),
+        "async JSONL telemetry sink ready"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serde::{Deserialize, Serialize};
+    use tempfile::tempdir;
+
+    use crate::telemetry::bus::TelemetryBus;
+
+    use super::{JsonlSinkOptions, spawn_jsonl_worker_with_shutdown};
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    struct TestRecord {
+        id: u64,
+        name: String,
+    }
+
+    #[tokio::test]
+    async fn writes_jsonl_from_bus() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("telemetry.jsonl");
+        let path_string = path.to_string_lossy().to_string();
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let bus = TelemetryBus::<TestRecord>::new();
+        bus.init(4);
+
+        spawn_jsonl_worker_with_shutdown(
+            bus.subscribe(),
+            path_string,
+            JsonlSinkOptions {
+                buffer_bytes: 64,
+                flush_interval: Duration::from_millis(5),
+            },
+            shutdown.clone(),
+        )
+        .await
+        .unwrap();
+
+        bus.publish(TestRecord {
+            id: 1,
+            name: "record".to_string(),
+        });
+
+        let mut content = String::new();
+        for _ in 0..50 {
+            content = tokio::fs::read_to_string(&path).await.unwrap_or_default();
+            if content.contains("\"name\":\"record\"") {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        shutdown.cancel();
+
+        let line = content.lines().next().expect("jsonl line");
+        let wrapper: serde_json::Value = serde_json::from_str(line).unwrap();
+        assert!(wrapper.get("timestamp").is_some());
+        assert_eq!(
+            serde_json::from_value::<TestRecord>(wrapper["event"].clone()).unwrap(),
+            TestRecord {
+                id: 1,
+                name: "record".to_string()
+            }
+        );
+    }
+}

--- a/lib/llm/src/telemetry/mod.rs
+++ b/lib/llm/src/telemetry/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod bus;
+pub mod jsonl;
+pub mod stream;

--- a/lib/llm/src/telemetry/stream.rs
+++ b/lib/llm/src/telemetry/stream.rs
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::Stream;
+use tokio::sync::oneshot;
+
+type CompletionStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
+type DoneFuture = Pin<Box<dyn std::future::Future<Output = ()> + Send>>;
+
+struct PassThroughWithCompletion<S> {
+    inner: S,
+    done_tx: Option<oneshot::Sender<()>>,
+}
+
+impl<S> PassThroughWithCompletion<S> {
+    fn new(inner: S, done_tx: oneshot::Sender<()>) -> Self {
+        Self {
+            inner,
+            done_tx: Some(done_tx),
+        }
+    }
+
+    fn notify_done(&mut self) {
+        if let Some(done_tx) = self.done_tx.take() {
+            let _ = done_tx.send(());
+        }
+    }
+}
+
+impl<S> Drop for PassThroughWithCompletion<S> {
+    fn drop(&mut self) {
+        self.notify_done();
+    }
+}
+
+impl<S, T> Stream for PassThroughWithCompletion<S>
+where
+    S: Stream<Item = T> + Unpin,
+{
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.inner).poll_next(cx) {
+            Poll::Ready(None) => {
+                self.notify_done();
+                Poll::Ready(None)
+            }
+            other => other,
+        }
+    }
+}
+
+/// Return a pass-through stream and a future that resolves when the stream ends or is dropped.
+pub fn notify_on_completion<S, T>(stream: S) -> (CompletionStream<T>, DoneFuture)
+where
+    S: Stream<Item = T> + Unpin + Send + 'static,
+    T: Send + 'static,
+{
+    let (tx, rx) = oneshot::channel::<()>();
+    let passthrough = PassThroughWithCompletion::new(stream, tx);
+    (
+        Box::pin(passthrough),
+        Box::pin(async move {
+            let _ = rx.await;
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::{StreamExt, stream};
+
+    use super::notify_on_completion;
+
+    #[tokio::test]
+    async fn notifies_when_stream_is_dropped_before_exhaustion() {
+        let (wrapped, done) = notify_on_completion(stream::iter([1_u8]));
+        drop(wrapped);
+        done.await;
+    }
+
+    #[tokio::test]
+    async fn notifies_when_stream_is_exhausted() {
+        let (mut wrapped, done) = notify_on_completion(stream::iter([1_u8]));
+        assert_eq!(wrapped.next().await, Some(1));
+        assert_eq!(wrapped.next().await, None);
+        done.await;
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable typed telemetry bus, stream completion helper, and async JSONL sink
- keep recorder JSONL format unchanged: lines remain { "timestamp": ..., "event": ... }
- add recorder options for append mode, buffer sizing, and periodic flush without adding a raw-event format
- move the audit bus onto the shared typed telemetry bus

## Tests
- cargo fmt --check
- RUSTFLAGS='-C target-cpu=x86-64-v3 --cfg tokio_unstable' cargo test -p dynamo-llm telemetry::jsonl --lib
- RUSTFLAGS='-C target-cpu=x86-64-v3 --cfg tokio_unstable' cargo test -p dynamo-llm recorder::tests --lib
- RUSTFLAGS='-C target-cpu=x86-64-v3 --cfg tokio_unstable' cargo clippy -p dynamo-llm --lib -- -D warnings