### PR TITLE
fix: qwen 3.5 needs special handling for tool calling 

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -67,15 +67,21 @@ def convert_tools(tools: list[dict[str, Any]] | None) -> list[SglangTool] | None
 
 
 def _materialize_messages(messages: list[Any]) -> list[dict[str, Any]]:
-    """Convert message objects to plain dicts for apply_chat_template."""
+    """Convert message objects to plain dicts for apply_chat_template.
+
+    Returns deep-copied dicts so subsequent in-place normalization (e.g.
+    _normalize_assistant_tool_call_arguments) does not leak back into
+    the caller-owned request object.
+    """
     normalized: list[dict[str, Any]] = []
     for msg in messages:
         if hasattr(msg, "model_dump"):
+            # model_dump() already returns a fresh dict tree.
             normalized.append(msg.model_dump(exclude_none=False))
         elif isinstance(msg, dict):
-            normalized.append(msg)
+            normalized.append(copy.deepcopy(msg))
         else:
-            normalized.append(dict(msg))
+            normalized.append(copy.deepcopy(dict(msg)))
     _normalize_assistant_tool_call_arguments(normalized)
     return normalized
 

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -68,7 +68,7 @@ def convert_tools(tools: list[dict[str, Any]] | None) -> list[SglangTool] | None
 
 def _materialize_messages(messages: list[Any]) -> list[dict[str, Any]]:
     """Convert message objects to plain dicts for apply_chat_template."""
-    normalized = []
+    normalized: list[dict[str, Any]] = []
     for msg in messages:
         if hasattr(msg, "model_dump"):
             normalized.append(msg.model_dump(exclude_none=False))
@@ -76,7 +76,40 @@ def _materialize_messages(messages: list[Any]) -> list[dict[str, Any]]:
             normalized.append(msg)
         else:
             normalized.append(dict(msg))
+    _normalize_assistant_tool_call_arguments(normalized)
     return normalized
+
+
+def _normalize_assistant_tool_call_arguments(messages: list[dict[str, Any]]) -> None:
+    """Parse assistant tool_call ``arguments`` from JSON string to dict in place.
+
+    Some chat templates (notably qwen3-coder) call ``arguments | items`` on
+    assistant tool_calls, which requires ``arguments`` to be a mapping rather
+    than the JSON string carried by the OpenAI wire format.  Mirror SGLang
+    native's behaviour (``serving_chat.py``) so multi-turn conversations
+    containing prior tool calls render correctly.
+
+    Malformed JSON is left untouched so the chat-template error remains
+    visible to the caller instead of being silently corrupted.
+    """
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        tool_calls = msg.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function")
+            if not isinstance(fn, dict):
+                continue
+            args = fn.get("arguments")
+            if isinstance(args, str) and args:
+                try:
+                    fn["arguments"] = json.loads(args)
+                except (json.JSONDecodeError, ValueError):
+                    pass
 
 
 def create_parsers(

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -466,7 +466,10 @@ class SglangProcessor:
                 else:
                     engine_response = dynamo_response
 
-                if engine_response is None or "token_ids" not in engine_response:
+                if (
+                    not isinstance(engine_response, dict)
+                    or "token_ids" not in engine_response
+                ):
                     msg = _engine_error_message(engine_response, request_id)
                     logger.error(
                         "Engine returned an invalid response for request %s: %s",

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -348,7 +348,7 @@ class SglangProcessor:
             raise
         except Exception as exc:
             logger.exception("SGLang preprocessing failed for request %s", request_id)
-            raise InvalidArgument(f"Preprocessing error: {exc}") from exc
+            raise Unknown(f"Preprocessing error: {exc}") from exc
 
         post = SglangStreamingPostProcessor(
             tokenizer=self.tokenizer,
@@ -392,7 +392,7 @@ class SglangProcessor:
             logger.exception(
                 "SGLang worker preprocessing failed for request %s", request_id
             )
-            raise InvalidArgument(f"Worker error: {exc}") from exc
+            raise Unknown(f"Worker error: {exc}") from exc
 
         # --- Phase 2: Recreate parsers in main process (not picklable) ---
         tool_call_parser, reasoning_parser = create_parsers(

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -28,6 +28,7 @@ from dynamo.llm import (
     RouterMode,
     fetch_model,
 )
+from dynamo.llm.exceptions import InvalidArgument, Unknown
 from dynamo.runtime import DistributedRuntime
 
 from .sglang_prepost import (
@@ -38,14 +39,7 @@ from .sglang_prepost import (
     create_parsers,
     preprocess_chat_request,
 )
-from .utils import (
-    PreprocessError,
-    extract_mm_urls,
-    handle_engine_error,
-    make_internal_error,
-    random_uuid,
-    worker_warmup,
-)
+from .utils import PreprocessError, extract_mm_urls, random_uuid, worker_warmup
 
 logger = logging.getLogger(__name__)
 
@@ -61,18 +55,19 @@ def _runtime_config_parser_name(
     return value if isinstance(value, str) and value else None
 
 
-def _unsupported_n_error(n: int) -> dict[str, Any]:
-    return {
-        "error": {
-            "message": (
-                f"Unsupported value: 'n={n}'. "
-                "This endpoint currently supports only n=1."
-            ),
-            "type": "invalid_request_error",
-            "param": "n",
-            "code": "unsupported_value",
-        }
-    }
+def _unsupported_n_message(n: int) -> str:
+    return f"Unsupported value: 'n={n}'. " "This endpoint currently supports only n=1."
+
+
+def _engine_error_message(
+    engine_response: Any,
+    request_id: str,
+) -> str:
+    """Extract a human-readable message from an invalid engine response."""
+    if isinstance(engine_response, dict) and engine_response.get("status") == "error":
+        backend_msg = engine_response.get("message") or "unknown backend error"
+        return f"Backend error for request {request_id}: {backend_msg}"
+    return f"Invalid engine response for request {request_id}"
 
 
 _FINISH_REASON_MAP: dict[str, str] = {
@@ -154,7 +149,7 @@ def _preprocess_worker(
 
     n = request.get("n", 1)
     if n != 1:
-        raise PreprocessError(_unsupported_n_error(n))
+        raise PreprocessError(_unsupported_n_message(n))
 
     dynamo_preproc = _build_dynamo_preproc(
         request,
@@ -339,8 +334,7 @@ class SglangProcessor:
             n = request.get("n", 1)
             if n != 1:
                 logger.error("Unsupported n=%d, only n=1 is supported", n)
-                yield _unsupported_n_error(n)
-                return
+                raise InvalidArgument(_unsupported_n_message(n))
 
             dynamo_preproc = _build_dynamo_preproc(
                 request,
@@ -350,15 +344,11 @@ class SglangProcessor:
                 pre.guided_decoding,
                 pre.tool_call_parser,
             )
+        except InvalidArgument:
+            raise
         except Exception as exc:
             logger.exception("SGLang preprocessing failed for request %s", request_id)
-            yield {
-                "error": {
-                    "message": f"Preprocessing error: {exc}",
-                    "type": "internal_error",
-                }
-            }
-            return
+            raise InvalidArgument(f"Preprocessing error: {exc}") from exc
 
         post = SglangStreamingPostProcessor(
             tokenizer=self.tokenizer,
@@ -397,19 +387,12 @@ class SglangProcessor:
                     await asyncio.wrap_future(future)
                 )
         except PreprocessError as exc:
-            yield exc.error_dict
-            return
+            raise InvalidArgument(str(exc)) from exc
         except Exception as exc:
             logger.exception(
                 "SGLang worker preprocessing failed for request %s", request_id
             )
-            yield {
-                "error": {
-                    "message": f"Worker error: {exc}",
-                    "type": "internal_error",
-                }
-            }
-            return
+            raise InvalidArgument(f"Worker error: {exc}") from exc
 
         # --- Phase 2: Recreate parsers in main process (not picklable) ---
         tool_call_parser, reasoning_parser = create_parsers(
@@ -484,8 +467,13 @@ class SglangProcessor:
                     engine_response = dynamo_response
 
                 if engine_response is None or "token_ids" not in engine_response:
-                    yield handle_engine_error(engine_response, request_id, logger)
-                    break
+                    msg = _engine_error_message(engine_response, request_id)
+                    logger.error(
+                        "Engine returned an invalid response for request %s: %s",
+                        request_id,
+                        engine_response,
+                    )
+                    raise Unknown(msg)
 
                 new_ids = engine_response["token_ids"]
                 raw_finish = engine_response.get("finish_reason")
@@ -531,9 +519,13 @@ class SglangProcessor:
                     pending_token_ids = []
                     pending_usage = None
                     first_chunk = False
+        except Unknown:
+            raise
         except Exception as e:
             logger.exception("Error generating response for request %s", request_id)
-            yield make_internal_error(request_id, str(e))
+            raise Unknown(
+                f"Error generating response for request {request_id}: {e}"
+            ) from e
         finally:
             if self.debug_perf and token_count > 0:
                 logger.info(

--- a/components/src/dynamo/frontend/tests/TEST_CASES.md
+++ b/components/src/dynamo/frontend/tests/TEST_CASES.md
@@ -1,0 +1,143 @@
+# Frontend Chat-Processor Test Cases
+
+Reference taxonomy for unit testing the **frontend chat-processor layer** —
+the code under `components/src/dynamo/frontend/` that sits between the
+OpenAI-shaped HTTP request and the backend engine. Tests for this layer
+live under `components/src/dynamo/frontend/tests/`.
+
+This is the **frontend** companion to `lib/parsers/TEST_CASES.md`. The
+two taxonomies cover different surfaces:
+
+| File | Scope | Prefix |
+|---|---|---|
+| `lib/parsers/TEST_CASES.md` | Tool-call & reasoning parser behavior on **model output** | `CASE.X` |
+| `components/src/dynamo/frontend/tests/TEST_CASES.md` | Chat-processor layer: request preprocessing, output assembly, error surface, worker plumbing | `FE.X` |
+
+Backends covered by this taxonomy: **vllm** (`prepost.py` + `vllm_processor.py`)
+and **sglang** (`sglang_prepost.py` + `sglang_processor.py`). trtllm has its
+own architecture under `components/src/dynamo/trtllm/` and is out of scope here.
+
+## Quick reference
+
+- **`FE.1`** Chat-template input preprocessing — multi-turn assistant `tool_calls` with JSON-string `arguments`, message materialization, role handling, tool messages, system-merging. (Where Richard's qwen3.5 fix in #8792 lives.)
+- **`FE.2`** Parser construction & dispatch — instantiate the right tool-call / reasoning parser from a request's `chat_template_kwargs`, model name, runtime config; handle "no parser" gracefully.
+- **`FE.3`** Request shaping & sampling-param projection — OpenAI fields → backend kwargs, tool stripping when `tool_choice="none"`, guided-decoding setup.
+- **`FE.4`** Tool-call output assembly — model output stream → OpenAI-shaped `tool_calls` deltas. Single, multiple, content-mixed, fallback paths.
+- **`FE.5`** Finish-reason mapping — frontend-layer remap (`stop`/`length`/`tool_calls`). Distinct from parser-layer `CASE.12` which covers the parser's view of the raw signal.
+- **`FE.6`** Incremental detokenization — token-id stream → text, prompt-token-id normalization, fast plain-text path.
+- **`FE.7`** Worker subprocess boundary — preprocessing runs in a subprocess; result picklability, init, error propagation across the boundary.
+- **`FE.8`** Error surface — `BackendError` / `InternalError` / engine-error handling, malformed responses, stream errors, deprecation warnings.
+- **`FE.9`** Reasoning ↔ tool-call orchestration — both parsers active on the same response; distinct from parser-layer `CASE.9` which is purely on output text.
+
+## Annotation convention
+
+Tests carry a one-line trailing comment naming the FE.X(s) they cover:
+
+```python
+class TestMapFinishReason:  # FE.5
+    def test_stop_to_tool_calls_when_emitted(self): ...
+```
+
+Or per-test when a class spans multiple categories:
+
+```python
+class TestUtilities:
+    def test_make_backend_error(self): ...  # FE.8
+    def test_normalize_prompt_token_ids(self): ...  # FE.6
+```
+
+`grep -r 'FE.1' components/src/dynamo/frontend/tests/` returns every
+chat-template-preprocessing test across vllm + sglang in one shot.
+
+---
+
+## `FE.1` — Chat-template input preprocessing
+
+The frontend rebuilds the prompt from a multi-turn message history before
+handing it to the backend. Several quirks live here:
+
+- Some chat templates expect assistant `tool_calls.function.arguments` as
+  a **dict** (because the template does `arguments | items`), but the
+  OpenAI wire format ships them as **JSON strings**. Frontend has to
+  normalize per backend / per model.
+- Materialization: pydantic models / dataclasses / mapping types must all
+  end up as plain dicts before the template runs.
+- Mutations to the materialized dicts must NOT leak back to the
+  caller-owned request object.
+
+Examples: `TestPreprocessChatRequest` (sglang),
+`TestPrepareRequestToolStripping` (vllm).
+
+## `FE.2` — Parser construction & dispatch
+
+For a given request, frontend must pick the right tool-call parser and the
+right reasoning parser — based on the model name, `chat_template_kwargs`,
+and runtime config. Tests pin the dispatch matrix.
+
+Examples: `TestCreateParsers`, `TestRuntimeConfigParserName`,
+`TestNoReasoningParser`.
+
+## `FE.3` — Request shaping & sampling-param projection
+
+OpenAI request fields → backend `SamplingParams` / equivalent. Tool
+stripping when `tool_choice="none"`. Guided-decoding configuration when
+`tool_choice` requires it.
+
+Examples: `TestConvertTools`, `TestBuildToolCallGuidedDecoding`,
+`TestPrepareRequestToolStripping`.
+
+## `FE.4` — Tool-call output assembly
+
+Backend output stream → OpenAI-shaped `tool_calls` deltas. Single, multiple,
+parallel, content-then-tool, fallback when no parser fires.
+
+Examples: `TestSingleToolCall`, `TestMultipleToolCalls`,
+`TestContentWithToolCalls`, `TestSingleChunkFallback`,
+`TestMalformedToolCalls`, `TestJsonArrayParserReparse`,
+`TestKimiToolCallIds`.
+
+## `FE.5` — Finish-reason mapping
+
+Frontend layer maps the engine's raw finish_reason into OpenAI's enum,
+remapping `stop` → `tool_calls` once any tool call has been emitted on a
+choice (per-choice tracking). Distinct from `CASE.12` in the parser
+taxonomy: that's about the parser's view; this is about the frontend's
+post-parser remap.
+
+Example: `TestMapFinishReason`.
+
+## `FE.6` — Incremental detokenization
+
+Token-id streams arriving from the engine → user-facing text deltas.
+Includes prompt-token-id normalization, fast plain-text path (skip parser
+when no tool/reasoning markers detected), and chunk-boundary handling.
+
+Examples: `TestIncrementalDetokenization`, `TestFastPlainTextPath`,
+`TestNormalizePromptTokenIds`, `TestParseJsonArrayBuffer`.
+
+## `FE.7` — Worker subprocess boundary
+
+Preprocessing runs in a worker subprocess (avoids the GIL on tokenizer
+calls). Result objects must pickle; init must be robust; errors must
+propagate cleanly across the boundary.
+
+Examples: `TestBuildDynamoPreproc`, `TestWorkerResultPicklability`.
+
+## `FE.8` — Error surface
+
+How the frontend reports errors back to the client: `BackendError` for
+backend issues, `InternalError` for our bugs, engine errors mapped to
+HTTP-friendly shapes. Also covers deprecation warnings on legacy fields.
+
+Examples: `TestMakeBackendError`, `TestMakeInternalError`,
+`TestHandleEngineError`, `TestDeprecationWarning`.
+
+## `FE.9` — Reasoning ↔ tool-call orchestration
+
+When both a reasoning parser and a tool-call parser fire on the same
+response, the frontend orchestrates routing (text → reasoning vs text →
+tool-call markup vs text → user-visible content). Distinct from parser
+`CASE.9`: that's the parser-internal view; this is the frontend assembly
+view.
+
+Examples: `TestReasoningParsing`.

--- a/components/src/dynamo/frontend/tests/test_frontend_utils.py
+++ b/components/src/dynamo/frontend/tests/test_frontend_utils.py
@@ -18,7 +18,7 @@ pytestmark = [
 ]
 
 
-class TestMakeBackendError:
+class TestMakeBackendError:  # FE.8 — BackendError construction
     def test_extracts_message(self):
         resp = {"status": "error", "message": "image load failed: 403"}
         err = make_backend_error(resp)
@@ -41,7 +41,7 @@ class TestMakeBackendError:
         assert err["error"]["message"] == "unknown backend error"
 
 
-class TestMakeInternalError:
+class TestMakeInternalError:  # FE.8 — InternalError construction
     def test_default_message(self):
         err = make_internal_error("req-42")
         assert err["error"]["message"] == "Invalid engine response for request req-42"
@@ -56,7 +56,7 @@ class TestMakeInternalError:
         assert err["error"]["message"] == "Invalid engine response for request req-42"
 
 
-class TestHandleEngineError:
+class TestHandleEngineError:  # FE.8 — engine error → HTTP-friendly mapping
     def test_backend_error_dict(self):
         resp = {"status": "error", "message": "403 Forbidden"}
         err = handle_engine_error(resp, "req-1", logging.getLogger("test"))

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -915,6 +915,108 @@ class TestPreprocessChatRequest:
         assert len(with_tools.prompt_token_ids) > len(without_tools.prompt_token_ids)
         assert with_tools.tool_call_parser is not None
 
+    def test_assistant_tool_calls_with_string_arguments(self, tokenizer):
+        """Multi-turn with prior assistant tool_calls renders without raising.
+
+        Regression: the qwen3-coder Jinja template calls ``arguments | items``
+        on assistant tool_calls and required ``arguments`` to be a mapping.
+        Dynamo carries arguments as a JSON string per the OpenAI wire
+        contract; the prepost must parse them to dict before templating.
+        """
+        request = {
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": "Weather in Tokyo?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_001",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": json.dumps({"city": "Tokyo"}),
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_001",
+                    "content": json.dumps({"temperature": 22}),
+                },
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather for a city",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                    },
+                }
+            ],
+        }
+        result = preprocess_chat_request(
+            request,
+            tokenizer=tokenizer,
+            tool_call_parser_name="hermes",
+            reasoning_parser_name=None,
+        )
+        assert len(result.prompt_token_ids) > 0
+        # Original request dict must not be mutated by the normaliser
+        # (callers reuse it for downstream processing).
+        original_args = request["messages"][1]["tool_calls"][0]["function"]["arguments"]
+        assert isinstance(original_args, str)
+
+    def test_normalize_assistant_tool_call_arguments_helper(self):
+        """The string→dict normaliser parses valid JSON and skips bad input."""
+        from dynamo.frontend.sglang_prepost import (
+            _normalize_assistant_tool_call_arguments,
+        )
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "f",
+                            "arguments": json.dumps({"a": 1}),
+                        }
+                    },
+                    {
+                        "function": {
+                            "name": "g",
+                            "arguments": "not-json",
+                        }
+                    },
+                    {
+                        "function": {
+                            "name": "h",
+                            "arguments": {"already": "dict"},
+                        }
+                    },
+                ],
+            },
+            # Tool messages are not assistant; arguments key shouldn't exist
+            # but if it did we wouldn't touch it.
+            {"role": "tool", "tool_call_id": "x", "content": "ok"},
+        ]
+        _normalize_assistant_tool_call_arguments(messages)
+        tcs = messages[1]["tool_calls"]
+        assert tcs[0]["function"]["arguments"] == {"a": 1}
+        # Malformed JSON left as-is so the template error stays visible.
+        assert tcs[1]["function"]["arguments"] == "not-json"
+        # Already-dict values pass through untouched.
+        assert tcs[2]["function"]["arguments"] == {"already": "dict"}
+
     def test_tool_choice_none_strips_tools_from_template(self, tokenizer):
         """When exclude flag is on and tool_choice=none, tools are excluded from template."""
         tool_request = {
@@ -1479,9 +1581,8 @@ class TestUtilities:
         int(cid[5:], 16)  # Should not raise
 
     def test_preprocess_error(self):
-        """PreprocessError stores error_dict and stringifies."""
-        err = PreprocessError({"error": {"message": "n=2 unsupported"}})
-        assert err.error_dict == {"error": {"message": "n=2 unsupported"}}
+        """PreprocessError stores message and stringifies."""
+        err = PreprocessError("n=2 unsupported")
         assert "n=2" in str(err)
 
 

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -24,6 +24,7 @@ import dynamo.frontend.sglang_processor as sglang_processor_module
 from dynamo.frontend.sglang_prepost import (
     SglangPreprocessResult,
     SglangStreamingPostProcessor,
+    _normalize_assistant_tool_call_arguments,
     _normalize_prompt_token_ids,
     _parse_json_array_buffer,
     build_tool_call_guided_decoding,
@@ -976,10 +977,6 @@ class TestPreprocessChatRequest:
 
     def test_normalize_assistant_tool_call_arguments_helper(self):
         """The string→dict normaliser parses valid JSON and skips bad input."""
-        from dynamo.frontend.sglang_prepost import (
-            _normalize_assistant_tool_call_arguments,
-        )
-
         messages = [
             {"role": "user", "content": "hi"},
             {

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -62,7 +62,7 @@ def tokenizer():
 # ---------------------------------------------------------------------------
 
 
-class TestBuildDynamoPreproc:
+class TestBuildDynamoPreproc:  # FE.7 — worker subprocess preproc construction
     """Test sampling parameter projection from request to Dynamo format."""
 
     def test_defaults(self):
@@ -258,7 +258,7 @@ class TestBuildDynamoPreproc:
 # ---------------------------------------------------------------------------
 
 
-class TestMapFinishReason:
+class TestMapFinishReason:  # FE.5 — finish_reason remap (frontend layer)
     """Test Dynamo-to-OpenAI finish reason mapping."""
 
     def test_none_passthrough(self):
@@ -303,7 +303,7 @@ class TestMapFinishReason:
 # ---------------------------------------------------------------------------
 
 
-class TestConvertTools:
+class TestConvertTools:  # FE.3 — OpenAI tool schema → SGLang Tool/Function
     """Test OpenAI tool dict to SGLang Tool conversion."""
 
     def test_none_returns_none(self):
@@ -373,7 +373,7 @@ class TestConvertTools:
 # ---------------------------------------------------------------------------
 
 
-class TestCreateParsers:
+class TestCreateParsers:  # FE.2 — tool/reasoning parser dispatch
     """Test parser creation logic."""
 
     def test_no_parsers(self):
@@ -391,7 +391,7 @@ class TestCreateParsers:
         assert rp is not None
 
 
-class TestBuildToolCallGuidedDecoding:
+class TestBuildToolCallGuidedDecoding:  # FE.3 — guided-decoding setup for tool_choice
     def test_none_when_no_tools(self):
         assert (
             build_tool_call_guided_decoding(
@@ -713,7 +713,7 @@ class TestBuildToolCallGuidedDecoding:
 # ---------------------------------------------------------------------------
 
 
-class TestParseJsonArrayBuffer:
+class TestParseJsonArrayBuffer:  # FE.6 — incremental JSON-array buffer parsing
     """Test JSON array fallback parser for constrained decoding output."""
 
     def test_single_tool_call(self):
@@ -789,7 +789,7 @@ class TestParseJsonArrayBuffer:
         assert calls[0].name == "g"
 
 
-class TestNormalizePromptTokenIds:
+class TestNormalizePromptTokenIds:  # FE.6 — prompt-token-id normalization
     def test_batch_encoding_like_object_uses_input_ids(self):
         class FakeBatchEncoding:
             def __init__(self):
@@ -806,7 +806,7 @@ class TestNormalizePromptTokenIds:
         ) == [1, 2, 3]
 
 
-class TestRuntimeConfigParserName:
+class TestRuntimeConfigParserName:  # FE.2 — parser name resolution from runtime config
     def test_missing_runtime_config_returns_none(self):
         class FakeMdc:
             def runtime_config(self):
@@ -834,7 +834,7 @@ class TestRuntimeConfigParserName:
 # ---------------------------------------------------------------------------
 
 
-class TestPreprocessChatRequest:
+class TestPreprocessChatRequest:  # FE.1 — chat-template input preprocessing (multi-turn assistant tool_calls, role handling)
     """Test end-to-end preprocessing with a real tokenizer."""
 
     def test_basic_chat(self, tokenizer):
@@ -1411,7 +1411,7 @@ class TestPreprocessChatRequest:
 # ---------------------------------------------------------------------------
 
 
-class TestIncrementalDetokenization:
+class TestIncrementalDetokenization:  # FE.6 — token-id stream → text
     """Test the sliding-window incremental detokenizer."""
 
     def test_basic_decode(self, tokenizer):
@@ -1482,7 +1482,7 @@ class TestIncrementalDetokenization:
 # ---------------------------------------------------------------------------
 
 
-class TestFastPlainTextPath:
+class TestFastPlainTextPath:  # FE.6 — fast path that skips parser when no markers
     """Test the fast path when no parsers are active."""
 
     def test_fast_path_active(self, tokenizer):
@@ -1521,7 +1521,7 @@ class TestFastPlainTextPath:
 # ---------------------------------------------------------------------------
 
 
-class TestReasoningParsing:
+class TestReasoningParsing:  # FE.9 — reasoning ↔ tool-call orchestration
     """Test reasoning content extraction via post-processor."""
 
     def test_reasoning_separated(self, tokenizer):
@@ -1557,27 +1557,27 @@ class TestReasoningParsing:
 # ---------------------------------------------------------------------------
 
 
-class TestUtilities:
+class TestUtilities:  # (mixed — see per-test annotations)
     """Test shared utility functions."""
 
-    def test_random_uuid_format(self):
+    def test_random_uuid_format(self):  # FE.4
         """random_uuid produces 16-char hex string."""
         uid = random_uuid()
         assert len(uid) == 16
         int(uid, 16)  # Should not raise
 
-    def test_random_uuid_unique(self):
+    def test_random_uuid_unique(self):  # FE.4
         """Two calls produce different UUIDs."""
         assert random_uuid() != random_uuid()
 
-    def test_random_call_id_format(self):
+    def test_random_call_id_format(self):  # FE.4
         """random_call_id produces call_<16hex> format."""
         cid = random_call_id()
         assert cid.startswith("call_")
         assert len(cid) == 21  # "call_" + 16 hex chars
         int(cid[5:], 16)  # Should not raise
 
-    def test_preprocess_error(self):
+    def test_preprocess_error(self):  # FE.8
         """PreprocessError stores message and stringifies."""
         err = PreprocessError("n=2 unsupported")
         assert "n=2" in str(err)
@@ -1588,7 +1588,7 @@ class TestUtilities:
 # ---------------------------------------------------------------------------
 
 
-class TestWorkerResultPicklability:
+class TestWorkerResultPicklability:  # FE.7 — worker subprocess boundary picklability
     """Test that worker results survive ProcessPoolExecutor round-trip."""
 
     def test_full_result(self):
@@ -1642,7 +1642,7 @@ class TestWorkerResultPicklability:
 # ---------------------------------------------------------------------------
 
 
-class TestDeprecationWarning:
+class TestDeprecationWarning:  # FE.8 — legacy/deprecated field warnings
     """Test that --use-sglang-tokenizer deprecation warning is in place."""
 
     def test_deprecation_warning_in_source(self):

--- a/components/src/dynamo/frontend/tests/test_sglang_tool_calls.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_tool_calls.py
@@ -113,7 +113,7 @@ def _extract_tool_calls(results):
 # ---------------------------------------------------------------------------
 
 
-class TestSingleToolCall:
+class TestSingleToolCall:  # FE.4 — single tool-call output assembly
     """Single tool call with reasoning, various batch sizes."""
 
     TEXT = (
@@ -154,7 +154,7 @@ class TestSingleToolCall:
         assert tc[0]["index"] == 0
 
 
-class TestKimiToolCallIds:
+class TestKimiToolCallIds:  # FE.4 — Kimi-specific tool-call ID format on output
     def test_kimi_uses_history_adjusted_ids(self):
         class DummyTokenizer:
             def decode(self, token_ids, skip_special_tokens=True):
@@ -267,7 +267,7 @@ class TestKimiToolCallIds:
 # ---------------------------------------------------------------------------
 
 
-class TestNoReasoningParser:
+class TestNoReasoningParser:  # FE.2 — graceful behavior when no reasoning parser configured
     """Tool calls without reasoning parser active."""
 
     TEXT = (
@@ -299,7 +299,7 @@ class TestNoReasoningParser:
 # ---------------------------------------------------------------------------
 
 
-class TestMultipleToolCalls:
+class TestMultipleToolCalls:  # FE.4 — parallel/multiple tool-call assembly
     """Two tool calls in a single response."""
 
     TEXT = (
@@ -337,7 +337,7 @@ class TestMultipleToolCalls:
 # ---------------------------------------------------------------------------
 
 
-class TestContentWithToolCalls:
+class TestContentWithToolCalls:  # FE.4 — text content interleaved with tool calls
     """Reasoning content and regular content are preserved alongside tool calls."""
 
     TEXT = (
@@ -369,7 +369,7 @@ class TestContentWithToolCalls:
 # ---------------------------------------------------------------------------
 
 
-class TestNoToolCalls:
+class TestNoToolCalls:  # FE.4 — text-only response (no tool calls)
     """When no tool call markup is present, no tool_calls should appear."""
 
     TEXT = "<think>\nJust thinking.\n</think>\n\nHello, world!"
@@ -392,7 +392,7 @@ class TestNoToolCalls:
 # ---------------------------------------------------------------------------
 
 
-class TestSingleChunkFallback:
+class TestSingleChunkFallback:  # FE.4 — non-streaming fallback assembly
     """When all tool call tokens + finish arrive in one batch, the streaming
     parser only processes one event.  The finish-time re-parse must recover
     arguments and any additional tool calls."""
@@ -467,7 +467,7 @@ class TestSingleChunkFallback:
         assert choice["finish_reason"] == "tool_calls"
 
 
-class TestMalformedToolCalls:
+class TestMalformedToolCalls:  # FE.4 — malformed model output → graceful degradation
     def test_incomplete_arguments_are_not_emitted(self):
         class DummyTokenizer:
             def decode(self, token_ids, skip_special_tokens=True):
@@ -516,7 +516,7 @@ class TestMalformedToolCalls:
 # ---------------------------------------------------------------------------
 
 
-class TestJsonArrayParserReparse:
+class TestJsonArrayParserReparse:  # FE.4 — JSON-array parser reparse path
     """Exercise the JsonArrayParser branch of the finish-time re-parse.
 
     Under ``tool_choice="required"`` or a named function, guided decoding

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -51,7 +51,7 @@ def tokenizer():
 # ---------------------------------------------------------------------------
 
 
-class TestPrepareRequestToolStripping:
+class TestPrepareRequestToolStripping:  # FE.1 + FE.3 — tool stripping when tool_choice=none on chat-template input
     """Test that _prepare_request strips/keeps tools based on the flag."""
 
     def test_tool_choice_none_strips_tools_from_template(self, tokenizer):

--- a/components/src/dynamo/frontend/utils.py
+++ b/components/src/dynamo/frontend/utils.py
@@ -26,11 +26,15 @@ def worker_warmup() -> bool:
 
 
 class PreprocessError(Exception):
-    """Raised by preprocess workers for user-facing errors (e.g., n!=1)."""
+    """Raised by preprocess workers for user-facing errors (e.g., n!=1).
 
-    def __init__(self, error_dict: dict[str, Any]):
-        self.error_dict = error_dict
-        super().__init__(str(error_dict))
+    Carries a plain message because the worker→main-process boundary
+    pickles the exception; the main process re-raises a Dynamo-typed
+    exception so PyO3 can route it through the proper backend-error path.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)
 
 
 # Content part types that carry media URLs, mapped to the key used in the


### PR DESCRIPTION
#### Overview:

qwen 3.5 needs special handling for tool calling rendering, as the tool calling message could be a list of dict

Also add some error handling code in chat processor so that we could surface these kind of problem faster next time. 

#### Details:



#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Related: DIS-1716


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed assistant tool-call argument handling in multi-turn conversations to ensure proper JSON serialization compatibility with chat templates.
  * Improved error handling for unsupported parameters and processing failures.

* **Tests**
  * Added unit tests validating assistant tool-call argument processing and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->