### PR TITLE
fix(ci): Fixed build and test timeouts for post-merge and nightly

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -76,7 +76,7 @@ jobs:
       cuda_version: '["12.9", "13.0"]'
       platform: 'linux/amd64,linux/arm64'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
-      build_timeout_minutes: 60
+      build_timeout_minutes: 120
     secrets: inherit
 
   sglang-build:
@@ -89,7 +89,7 @@ jobs:
       cuda_version: '["12.9", "13.0"]'
       platform: 'linux/amd64,linux/arm64'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
-      build_timeout_minutes: 60
+      build_timeout_minutes: 120
     secrets: inherit
 
   trtllm-build:
@@ -102,7 +102,7 @@ jobs:
       cuda_version: '["13.1"]'
       platform: 'linux/amd64,linux/arm64'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
-      build_timeout_minutes: 60
+      build_timeout_minutes: 120
     secrets: inherit
 
   # ============================================================================
@@ -124,7 +124,7 @@ jobs:
       run_cpu_only_tests: true
       cpu_only_test_markers: vllm and gpu_0
       gpu_test_markers: vllm and gpu_1
-      gpu_test_timeout_minutes: 35
+      gpu_test_timeout_minutes: 240
     secrets: inherit
 
   vllm-multi-gpu-test:
@@ -141,7 +141,7 @@ jobs:
       enable_coverage: true
       run_sanity_check: false
       gpu_test_markers: vllm and (gpu_2 or gpu_4)
-      gpu_test_timeout_minutes: 60
+      gpu_test_timeout_minutes: 240
     secrets: inherit
 
   sglang-test:
@@ -175,7 +175,7 @@ jobs:
       enable_coverage: true
       run_sanity_check: false
       gpu_test_markers: sglang and (gpu_2 or gpu_4)
-      gpu_test_timeout_minutes: 60
+      gpu_test_timeout_minutes: 240
     secrets: inherit
 
   trtllm-test:
@@ -209,7 +209,7 @@ jobs:
       enable_coverage: true
       run_sanity_check: false
       gpu_test_markers: trtllm and (gpu_2 or gpu_4)
-      gpu_test_timeout_minutes: 60
+      gpu_test_timeout_minutes: 240
     secrets: inherit
 
   # ============================================================================
@@ -223,7 +223,7 @@ jobs:
       builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
       fresh_builder: true
       no_cache: true
-      build_timeout_minutes: 90
+      build_timeout_minutes: 120
       # TODO: widen beyond `pre_merge` — today it picks up tests
       # (e.g. fault_tolerance/deploy/*) that fail in this container-only
       # context. Matches the coverage of the old container-validation-dynamo

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -141,7 +141,7 @@ jobs:
       enable_coverage: true
       run_sanity_check: false
       gpu_test_markers: vllm and (gpu_2 or gpu_4)
-      gpu_test_timeout_minutes: 240
+      gpu_test_timeout_minutes: 120
     secrets: inherit
 
   sglang-test:
@@ -175,7 +175,7 @@ jobs:
       enable_coverage: true
       run_sanity_check: false
       gpu_test_markers: sglang and (gpu_2 or gpu_4)
-      gpu_test_timeout_minutes: 240
+      gpu_test_timeout_minutes: 120
     secrets: inherit
 
   trtllm-test:
@@ -209,7 +209,7 @@ jobs:
       enable_coverage: true
       run_sanity_check: false
       gpu_test_markers: trtllm and (gpu_2 or gpu_4)
-      gpu_test_timeout_minutes: 240
+      gpu_test_timeout_minutes: 120
     secrets: inherit
 
   # ============================================================================

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -94,7 +94,7 @@ jobs:
       cuda_version: '["12.9", "13.0"]'
       platform: 'linux/amd64,linux/arm64'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
-      build_timeout_minutes: 60
+      build_timeout_minutes: 120
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-vllm-runtime' || '' }}
         ${{ github.ref_name == 'main' && format('main-vllm-runtime-{0}', github.sha) || '' }}
@@ -141,7 +141,7 @@ jobs:
       cuda_version: '["12.9", "13.0"]'
       platform: 'linux/amd64,linux/arm64'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
-      build_timeout_minutes: 60
+      build_timeout_minutes: 120
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-sglang-runtime' || '' }}
         ${{ github.ref_name == 'main' && format('main-sglang-runtime-{0}', github.sha) || '' }}
@@ -172,7 +172,7 @@ jobs:
       cuda_version: '["13.1"]'
       platform: 'linux/amd64,linux/arm64'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
-      build_timeout_minutes: 60
+      build_timeout_minutes: 120
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-trtllm-runtime' || '' }}
         ${{ github.ref_name == 'main' && format('main-trtllm-runtime-{0}', github.sha) || '' }}
@@ -258,7 +258,7 @@ jobs:
       run_cpu_only_tests: true
       cpu_only_test_markers: '(pre_merge or post_merge) and vllm and gpu_0'
       gpu_test_markers: '(pre_merge or post_merge) and vllm and gpu_1'
-      gpu_test_timeout_minutes: 60
+      gpu_test_timeout_minutes: 120
     secrets: inherit
 
   vllm-multi-gpu-test:
@@ -307,6 +307,7 @@ jobs:
       run_cpu_only_tests: true
       cpu_only_test_markers: '(pre_merge or post_merge) and sglang and gpu_0'
       gpu_test_markers: '(pre_merge or post_merge) and sglang and gpu_1'
+      gpu_test_timeout_minutes: 120
     secrets: inherit
 
   sglang-multi-gpu-test:
@@ -339,6 +340,7 @@ jobs:
       run_cpu_only_tests: true
       cpu_only_test_markers: '(pre_merge or post_merge) and trtllm and gpu_0'
       gpu_test_markers: '(pre_merge or post_merge) and trtllm and gpu_1'
+      gpu_test_timeout_minutes: 120
     secrets: inherit
 
   trtllm-multi-gpu-test:

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -258,7 +258,7 @@ jobs:
       run_cpu_only_tests: true
       cpu_only_test_markers: '(pre_merge or post_merge) and vllm and gpu_0'
       gpu_test_markers: '(pre_merge or post_merge) and vllm and gpu_1'
-      gpu_test_timeout_minutes: 35
+      gpu_test_timeout_minutes: 60
     secrets: inherit
 
   vllm-multi-gpu-test:
@@ -472,7 +472,7 @@ jobs:
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["12.9"]' # Deploy tests only use CUDA 12
       override_arch: amd64 # We are using AMD64 images only on the rest of the clusters.
-      copy_timeout_minutes: 10
+      copy_timeout_minutes: 20
     secrets: inherit
 
   sglang-copy-to-acr:
@@ -487,7 +487,7 @@ jobs:
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["12.9"]' # Deploy tests only use CUDA 12
       override_arch: amd64 # We are using AMD64 images only on the rest of the clusters.
-      copy_timeout_minutes: 10
+      copy_timeout_minutes: 20
     secrets: inherit
 
   trtllm-copy-to-acr:
@@ -502,7 +502,7 @@ jobs:
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
       override_arch: amd64 # We are using AMD64 images only on the rest of the clusters.
-      copy_timeout_minutes: 10
+      copy_timeout_minutes: 20
     secrets: inherit
 
   frontend-copy-to-acr:
@@ -517,7 +517,7 @@ jobs:
       target_tag_plain: ${{ needs.frontend-build.outputs.target_tag_plain }}
       cuda_version: '[""]'
       override_arch: amd64 # We are using AMD64 images only on the rest of the clusters.
-      copy_timeout_minutes: 10
+      copy_timeout_minutes: 20
     secrets: inherit
 
   # ============================================================================


### PR DESCRIPTION
#### Overview:

post-merge test timeouts were 120 for build and 1 gpu test. 60 min for multi gpu test:
https://github.com/ai-dynamo/dynamo/blob/5721dfe3cb46e9fe9f36d46e6bf012a2feb49ebb/.github/workflows/post-merge-ci.yml

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configurations to increase build and test timeout limits, improving reliability and reducing premature job terminations during long-running operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->