### PR TITLE
fix(operator): Deduplicate concurrent DCGM GPU discovery scrapes

### DIFF
--- a/deploy/operator/go.mod
+++ b/deploy/operator/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/prometheus/common v0.67.5
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.48.0
+	golang.org/x/sync v0.19.0
 	google.golang.org/protobuf v1.36.11
 	istio.io/api v1.23.1
 	istio.io/client-go v1.23.1
@@ -97,7 +98,6 @@ require (
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/deploy/operator/internal/gpu/discovery.go
+++ b/deploy/operator/internal/gpu/discovery.go
@@ -31,6 +31,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
+	"golang.org/x/sync/singleflight"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -179,6 +180,7 @@ type GPUDiscoveryCache struct {
 
 type GPUDiscovery struct {
 	Scraper ScrapeMetricsFunc
+	group   singleflight.Group
 }
 
 func NewGPUDiscovery(scraper ScrapeMetricsFunc) *GPUDiscovery {
@@ -266,12 +268,52 @@ func (g *GPUDiscovery) DiscoverGPUsFromDCGM(ctx context.Context, k8sClient clien
 //   - *GPUInfo for the selected node
 //   - error if no GPU data can be retrieved
 func (g *GPUDiscovery) DiscoverGPUsFromDCGMFiltered(ctx context.Context, k8sClient client.Reader, cache *GPUDiscoveryCache, filterSKU nvidiacomv1beta1.GPUSKUType) (*GPUInfo, error) {
+	logger := log.FromContext(ctx)
 	if cache != nil {
 		if cached, ok := cache.Get(filterSKU); ok {
+			logger.V(1).Info("GPU discovery cache hit", "gpuSku", filterSKU)
 			return cached, nil
 		}
 	}
 
+	resultCh := g.group.DoChan(string(filterSKU), func() (any, error) {
+		if cache != nil {
+			if cached, ok := cache.Get(filterSKU); ok {
+				logger.V(1).Info("GPU discovery cache hit after waiting for in-flight request", "gpuSku", filterSKU)
+				return cached, nil
+			}
+		}
+
+		logger.V(1).Info("GPU discovery cache miss; scraping DCGM exporter pods", "gpuSku", filterSKU)
+		info, err := g.discoverGPUsFromDCGMFilteredUncached(ctx, k8sClient, filterSKU)
+		if err != nil {
+			return nil, err
+		}
+		if cache != nil {
+			cache.Set(filterSKU, info, 60*time.Second)
+		}
+		return info, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-resultCh:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		if result.Shared {
+			logger.V(1).Info("GPU discovery shared in-flight result", "gpuSku", filterSKU)
+		}
+		info, ok := result.Val.(*GPUInfo)
+		if !ok || info == nil {
+			return nil, fmt.Errorf("unexpected GPU discovery result type %T", result.Val)
+		}
+		return info, nil
+	}
+}
+
+func (g *GPUDiscovery) discoverGPUsFromDCGMFilteredUncached(ctx context.Context, k8sClient client.Reader, filterSKU nvidiacomv1beta1.GPUSKUType) (*GPUInfo, error) {
 	// List DCGM exporter pods
 	dcgmPods, err := listDCGMExporterPods(ctx, k8sClient)
 	if err != nil && !strings.Contains(err.Error(), "no DCGM exporter pods found") {
@@ -375,9 +417,6 @@ func (g *GPUDiscovery) DiscoverGPUsFromDCGMFiltered(ctx context.Context, k8sClie
 	bestNode.RDMAEnabled = rdmaDetected
 	bestNode.RDMAType = rdmaType
 
-	if cache != nil {
-		cache.Set(filterSKU, bestNode, 60*time.Second)
-	}
 	return bestNode, nil
 }
 func buildDCGMEndpoint(podIP string) string {

--- a/deploy/operator/internal/gpu/discovery_test.go
+++ b/deploy/operator/internal/gpu/discovery_test.go
@@ -24,7 +24,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	dto "github.com/prometheus/client_model/go"
@@ -928,6 +931,98 @@ func TestDiscoverGPUsFromDCGM_CacheHit(t *testing.T) {
 	require.Equal(t, 1, callCount)
 
 	require.Equal(t, info1, info2)
+}
+
+func TestDiscoverGPUsFromDCGM_SharesConcurrentScrape(t *testing.T) {
+	ctx := context.Background()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dcgm-exporter-1",
+			Namespace: "gpu-operator",
+			Labels: map[string]string{
+				LabelApp: LabelValueNvidiaDCGMExporter,
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: "10.0.0.1",
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pod).
+		Build()
+
+	var callCount atomic.Int32
+	scrapeStarted := make(chan struct{})
+	releaseScrape := make(chan struct{})
+
+	mockScraper := func(ctx context.Context, endpoint string) (*GPUInfo, error) {
+		if callCount.Add(1) == 1 {
+			close(scrapeStarted)
+		}
+		<-releaseScrape
+		return &GPUInfo{
+			NodeName:    "node-a",
+			GPUsPerNode: 4,
+			Model:       "A100",
+			VRAMPerGPU:  40960,
+			MIGEnabled:  false,
+			MIGProfiles: map[string]int{},
+		}, nil
+	}
+
+	discovery := NewGPUDiscovery(mockScraper)
+	cache := NewGPUDiscoveryCache()
+
+	const callers = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var attempted atomic.Int32
+	errs := make(chan error, callers)
+	infos := make(chan *GPUInfo, callers)
+
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			attempted.Add(1)
+			info, err := discovery.DiscoverGPUsFromDCGM(ctx, k8sClient, cache)
+			if err != nil {
+				errs <- err
+				return
+			}
+			infos <- info
+		}()
+	}
+
+	close(start)
+	select {
+	case <-scrapeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first scrape to start")
+	}
+	require.Eventually(t, func() bool { return attempted.Load() == callers }, time.Second, 5*time.Millisecond)
+	close(releaseScrape)
+	wg.Wait()
+	close(errs)
+	close(infos)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Len(t, infos, callers)
+	require.Equal(t, int32(1), callCount.Load())
+	for info := range infos {
+		require.NotNil(t, info)
+		assert.Equal(t, "a100_pcie", string(info.System))
+	}
 }
 
 func TestDiscoverGPUsFromDCGMFiltered_MixedSKU(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `singleflight` to GPU discovery so concurrent DGDR reconciles for the same GPU SKU share one in-flight DCGM scrape.
- Re-check the discovery cache inside the shared request before scraping to avoid redundant work after another caller populates the cache.
- Add a concurrency test verifying simultaneous discovery calls only invoke the scraper once.


Closes DYN-2894

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized GPU discovery to efficiently handle concurrent requests and reduce redundant operations.
* **Chores**
  * Updated Go module dependencies to latest stable versions for improved compatibility.
* **Tests**
  * Added concurrency testing for GPU discovery validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
